### PR TITLE
fix(mdk-sqlite-storage/migrations): rename migration table to _refinery_schema_history_nostr_mls

### DIFF
--- a/crates/mdk-sqlite-storage/migrations/V100__initial.sql
+++ b/crates/mdk-sqlite-storage/migrations/V100__initial.sql
@@ -1,4 +1,4 @@
--- Initial database schema for mdk-sqlite-storage
+-- Initial database schema for nostr-mls-sqlite-storage
 
 -- Groups table
 CREATE TABLE IF NOT EXISTS groups (

--- a/crates/mdk-sqlite-storage/src/migrations.rs
+++ b/crates/mdk-sqlite-storage/src/migrations.rs
@@ -16,9 +16,12 @@ refinery::embed_migrations!("migrations");
 ///
 /// Result indicating success or failure of the migration process.
 pub fn run_migrations(conn: &mut Connection) -> Result<(), Error> {
-    // Run the migrations
+    // We use this custom migration table name for legacy reasons
+    // As the code used to be part of the rust-nostr project
+    // and we need to keep the same migration table name for backwards compatibility
+    let migration_table_name = "_refinery_schema_history_nostr_mls";
     let report = migrations::runner()
-        .set_migration_table_name("_refinery_schema_history_mdk")
+        .set_migration_table_name(migration_table_name)
         .run(conn)?;
 
     // Log the results


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improves upgrade reliability by recognizing legacy migration history names, reducing migration errors for existing installations.

- **Chores**
  - Centralizes migration history configuration for consistency and future flexibility.
  - Maintains backward compatibility; no user action required and no impact on current workflows or data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->