### PR TITLE
This file allows  to run the test environment simply with '$ nix develop'

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "Flake for Marmot Development Kit (MDK) Rust project";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
+        rust = pkgs.rust-bin.stable.latest.default;
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            rust
+            cargo
+            openssl
+            pkg-config
+            sqlite
+            just
+          ];
+
+          shellHook = ''
+            echo "✅ MDK dev shell loaded. Use 'cargo build', 'cargo test', or 'just' for development."
+          '';
+        };
+      }
+    );
+}
+


### PR DESCRIPTION


https://github.com/user-attachments/assets/4a35b2d5-938e-4bb8-b543-21769001ba1e

…p' from within the directory. You need to have nix (the package manager) installed on your machine for this to work off course (or run it from a machine that runs NixOS).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a Nix flake-based development environment providing a consistent Rust toolchain and common dependencies.
  * Introduced per-system dev shells for easier setup and onboarding.
  * Dev shell now displays a readiness message on entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->