### PR TITLE
feat(mdk_core/messages groups): add mls_group_id to MessageProcessingResult variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "mdk-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "blurhash",
  "chacha20poly1305",

--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -31,6 +31,24 @@
 
 ### Added
 
+### Fixed
+
+### Removed
+
+### Deprecated
+
+## [0.5.2] - 2025-10-16
+
+### Breaking changes
+
+- **Message Processing Results**: Enhanced `MessageProcessingResult` and `UpdateGroupResult` to include group context
+  - `UpdateGroupResult` now includes `mls_group_id: GroupId` field
+  - `MessageProcessingResult` variants `ExternalJoinProposal`, `Commit`, and `Unprocessable` are now struct variants with `mls_group_id: GroupId` field
+  - External code pattern matching on these variants must be updated to use struct syntax: `MessageProcessingResult::Commit { .. }` instead of `MessageProcessingResult::Commit`
+  - The `Proposal` variant remains unchanged but now contains `UpdateGroupResult` with the new field
+
+### Added
+
 - **Extension Versioning (MIP-01)**: Added version field to `NostrGroupDataExtension`
   - New `version` field (current version: 1) for forward/backward compatibility
   - Constant `NostrGroupDataExtension::CURRENT_VERSION` for version management

--- a/crates/mdk-core/Cargo.toml
+++ b/crates/mdk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdk-core"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 description = "A simplified interface to build secure messaging apps on nostr with MLS."
 authors = ["Jeff Gardner <j@jeffg.me>", "Yuki Kishimoto <yukikishimoto@protonmail.com>", "MDK Developers"]

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -43,6 +43,8 @@ pub struct UpdateGroupResult {
     pub evolution_event: Event,
     /// A vec of Kind:444 Welcome Events to be published for any members added as part of the update.
     pub welcome_rumors: Option<Vec<UnsignedEvent>>,
+    /// The MLS group ID this update applies to
+    pub mls_group_id: GroupId,
 }
 
 /// Configuration data for the Group
@@ -535,6 +537,7 @@ where
         Ok(UpdateGroupResult {
             evolution_event: commit_event,
             welcome_rumors, // serialized_group_info,
+            mls_group_id: group_id.clone(),
         })
     }
 
@@ -636,6 +639,7 @@ where
         Ok(UpdateGroupResult {
             evolution_event: commit_event,
             welcome_rumors: None, // serialized_group_info,
+            mls_group_id: group_id.clone(),
         })
     }
 
@@ -684,6 +688,7 @@ where
         Ok(UpdateGroupResult {
             evolution_event: commit_event,
             welcome_rumors: None,
+            mls_group_id: group_id.clone(),
         })
     }
 
@@ -1062,6 +1067,7 @@ where
         Ok(UpdateGroupResult {
             evolution_event: commit_event,
             welcome_rumors: None, // serialized_group_info,
+            mls_group_id: group_id.clone(),
         })
     }
 
@@ -1106,6 +1112,7 @@ where
         Ok(UpdateGroupResult {
             evolution_event,
             welcome_rumors: None,
+            mls_group_id: group_id.clone(),
         })
     }
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -51,11 +51,13 @@ You can manually specify which Rust version to use:
 ### CI/CD
 
 GitHub Actions runs the full test matrix:
+
 - **Rust versions**: 1.90.0 (MSRV) + stable
 - **Operating systems**: Ubuntu, macOS (latest), macOS (M1)
 - **Feature combinations**: all-features, no-features, mip04-only
 
 This gives us confidence that the code works across:
+
 - 2 Rust versions (MSRV and latest)
 - 3 operating systems
 - 3 feature configurations
@@ -77,4 +79,3 @@ When you need to bump the MSRV, update these locations:
 3. **Before pushing**: Ensure CI will pass by checking locally first
 
 This approach balances speed during development with comprehensive validation before committing.
-


### PR DESCRIPTION
Adds mls_group_id to:
- UpdateGroupResult
- ExternalJoinProposal
- Commit
- Unprocessable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message processing and group update results now include the associated group identifier for improved context and traceability.
  * Added versioning support for group data extension with a current-version constant for compatibility.
* **Refactor**
  * Several result variants now use struct-style shapes carrying the group identifier — breaking API change; update match patterns.
* **Documentation**
  * Clarified CI/CD test matrix and coverage in the development guide.
* **Tests**
  * Updated tests to use and assert the new result shapes.
* **Chores**
  * Package version bumped to 0.5.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->