### PR TITLE
Image key separation

### DIFF
--- a/crates/mdk-core/src/error.rs
+++ b/crates/mdk-core/src/error.rs
@@ -178,6 +178,9 @@ pub enum Error {
     /// Invalid image nonce length
     #[error("invalid image nonce length")]
     InvalidImageNonceLength,
+    /// Invalid image upload key length
+    #[error("invalid image upload key length")]
+    InvalidImageUploadKeyLength,
     /// Invalid extension version
     #[error("invalid extension version: {0}")]
     InvalidExtensionVersion(u16),

--- a/crates/mdk-core/src/extension/types.rs
+++ b/crates/mdk-core/src/extension/types.rs
@@ -349,7 +349,7 @@ impl NostrGroupDataExtension {
             Some(
                 raw.image_upload_key
                     .try_into()
-                    .map_err(|_| Error::InvalidImageKeyLength)?,
+                    .map_err(|_| Error::InvalidImageUploadKeyLength)?,
             )
         };
 


### PR DESCRIPTION
Take into account Least Authority's issue with my previous implementation of this and fix everything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * v2 group image format adds a separate upload seed so uploaded images use a derived upload keypair.
  * Migration tool to upgrade v1 images to v2 automatically.

* **Improvements**
  * Backward-compatible handling of v1 and v2 images with v2-first decryption and v1 fallback.
  * Public API surfaces updated to expose upload-seed handling and clearer error feedback.

* **Tests**
  * Tests updated to cover v1/v2 compatibility, migration, and derivation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->