### PR TITLE
fix minor clippy warning

### DIFF
--- a/crates/mdk-storage-traits/tests/cross_storage.rs
+++ b/crates/mdk-storage-traits/tests/cross_storage.rs
@@ -46,27 +46,30 @@ impl StorageTestHarness {
             "save_group results differ"
         );
 
-        if let Err(sqlite_err) = &sqlite_result {
-            assert_eq!(
-                format!("{:?}", sqlite_err),
-                format!("{:?}", memory_result.as_ref().unwrap_err()),
-                "Error messages differ"
-            );
-        } else {
-            let sqlite_group = self
-                .sqlite
-                .find_group_by_mls_group_id(&group.mls_group_id)
-                .unwrap()
-                .unwrap();
-            let memory_group = self
-                .memory
-                .find_group_by_mls_group_id(&group.mls_group_id)
-                .unwrap()
-                .unwrap();
-            assert_eq!(
-                sqlite_group, memory_group,
-                "Stored groups differ after successful save"
-            );
+        match &sqlite_result {
+            Err(sqlite_err) => {
+                assert_eq!(
+                    format!("{:?}", sqlite_err),
+                    format!("{:?}", memory_result.as_ref().unwrap_err()),
+                    "Error messages differ"
+                );
+            }
+            Ok(_) => {
+                let sqlite_group = self
+                    .sqlite
+                    .find_group_by_mls_group_id(&group.mls_group_id)
+                    .unwrap()
+                    .unwrap();
+                let memory_group = self
+                    .memory
+                    .find_group_by_mls_group_id(&group.mls_group_id)
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(
+                    sqlite_group, memory_group,
+                    "Stored groups differ after successful save"
+                );
+            }
         }
     }
 
@@ -80,19 +83,22 @@ impl StorageTestHarness {
             "replace_group_relays results differ"
         );
 
-        if let Err(sqlite_err) = &sqlite_result {
-            assert_eq!(
-                format!("{:?}", sqlite_err),
-                format!("{:?}", memory_result.as_ref().unwrap_err()),
-                "Error messages differ"
-            );
-        } else {
-            let sqlite_relays = self.sqlite.group_relays(group_id).unwrap();
-            let memory_relays = self.memory.group_relays(group_id).unwrap();
-            assert_eq!(
-                sqlite_relays, memory_relays,
-                "Stored relays differ after successful replacement"
-            );
+        match &sqlite_result {
+            Err(sqlite_err) => {
+                assert_eq!(
+                    format!("{:?}", sqlite_err),
+                    format!("{:?}", memory_result.as_ref().unwrap_err()),
+                    "Error messages differ"
+                );
+            }
+            Ok(_) => {
+                let sqlite_relays = self.sqlite.group_relays(group_id).unwrap();
+                let memory_relays = self.memory.group_relays(group_id).unwrap();
+                assert_eq!(
+                    sqlite_relays, memory_relays,
+                    "Stored relays differ after successful replacement"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
a CI was failing in a previous PR due to a minor clippy warning in cross_storage tests, this fixes it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored test helper error handling to centralize error-path comparisons between storage implementations.
  * Preserved existing success-path assertions and observable behavior; changes improve structure and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->