### PR TITLE
Implement admin update validation in group management

### DIFF
--- a/crates/mdk-core/src/test_util.rs
+++ b/crates/mdk-core/src/test_util.rs
@@ -3,7 +3,7 @@
 //! This module provides shared test utilities used across multiple test modules
 //! to avoid code duplication and ensure consistency in test setup.
 
-use crate::GroupId;
+use mdk_storage_traits::GroupId;
 use mdk_storage_traits::MdkStorageProvider;
 use nostr::{Event, EventBuilder, Keys, Kind, PublicKey, RelayUrl};
 


### PR DESCRIPTION
Fixes Issue C in MDK audit

- Added validation to ensure admin updates do not include empty sets or non-member public keys.
- Introduced `validate_admin_update` function to enforce these rules.
- Enhanced existing tests to cover scenarios for empty admin sets, non-member admins, and valid admin updates.
- Updated group data handling to incorporate validation before applying changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for group admin management to prevent invalid configurations such as empty admin sets and non-member designations.

* **Tests**
  * Extended test coverage for admin update validation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->