### PR TITLE
fix(mdk-core/groups): remove the correct member on remove_members when the tree has holes

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -67,6 +67,7 @@
 - **Security (Audit Issue O)**: Missing Hash Verification in decrypt_group_image Allows Storage-Level Blob Substitution ([#97](https://github.com/marmot-protocol/mdk/pull/97))
 - **Security (Audit Issue R)**: Refactor encoding handling to enforce base64 usage for key packages and welcome ([#98](https://github.com/marmot-protocol/mdk/pull/98))
 - **Security (Audit Issue AA)**: Added pagination to prevent memory exhaustion from unbounded loading of pending welcomes ([#110](https://github.com/marmot-protocol/mdk/pull/110))
+- **Security (Audit Issue Q)**: Fixed `remove_members` to use actual leaf indices from the ratchet tree instead of enumeration indices. Previously, using `enumerate()` to derive `LeafNodeIndex` caused removal of incorrect members when the tree had holes from prior removals. Now uses `member.index` directly. ([#120](https://github.com/marmot-protocol/mdk/pull/120))
 
 ### Removed
 

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -604,12 +604,11 @@ where
 
         // Convert pubkeys to leaf indices
         let mut leaf_indices = Vec::new();
-        let members = mls_group.members();
 
-        for (index, member) in members.enumerate() {
+        for member in mls_group.members() {
             let pubkey = self.pubkey_for_member(&member)?;
             if pubkeys.contains(&pubkey) {
-                leaf_indices.push(LeafNodeIndex::new(index as u32));
+                leaf_indices.push(member.index);
             }
         }
 
@@ -4003,6 +4002,109 @@ mod tests {
         assert!(
             after_remove_members.contains(&bob_keys.public_key()),
             "Bob should still be in group"
+        );
+    }
+
+    /// Test that remove_members correctly handles ratchet tree holes
+    ///
+    /// This is a regression test for a bug where enumerate() was used to derive
+    /// LeafNodeIndex instead of using member.index. When the ratchet tree has holes
+    /// (from prior removals), the enumeration index diverges from the actual leaf index.
+    ///
+    /// Scenario: Alice creates group with Bob, Charlie, Dave. Remove Charlie (creates hole).
+    /// Then remove Dave - must remove Dave (leaf 3), not the wrong member.
+    #[test]
+    fn test_remove_members_with_tree_holes() {
+        use crate::test_util::create_key_package_event;
+
+        let alice_keys = Keys::generate();
+        let bob_keys = Keys::generate();
+        let charlie_keys = Keys::generate();
+        let dave_keys = Keys::generate();
+
+        let alice_mdk = create_test_mdk();
+        let bob_mdk = create_test_mdk();
+        let charlie_mdk = create_test_mdk();
+        let dave_mdk = create_test_mdk();
+
+        let admin_pubkeys = vec![alice_keys.public_key()];
+        let config = create_nostr_group_config_data(admin_pubkeys);
+
+        // Create key packages for all members
+        let bob_key_package = create_key_package_event(&bob_mdk, &bob_keys);
+        let charlie_key_package = create_key_package_event(&charlie_mdk, &charlie_keys);
+        let dave_key_package = create_key_package_event(&dave_mdk, &dave_keys);
+
+        // Alice creates group with Bob, Charlie, Dave
+        let create_result = alice_mdk
+            .create_group(
+                &alice_keys.public_key(),
+                vec![bob_key_package, charlie_key_package, dave_key_package],
+                config,
+            )
+            .expect("Alice should create group");
+
+        let group_id = create_result.group.mls_group_id.clone();
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("Alice should merge commit");
+
+        // Verify initial state: Alice, Bob, Charlie, Dave
+        let initial_members = alice_mdk
+            .get_members(&group_id)
+            .expect("Should get members");
+        assert_eq!(initial_members.len(), 4, "Should have 4 members initially");
+
+        // Step 1: Remove Charlie (creates a hole in the ratchet tree)
+        alice_mdk
+            .remove_members(&group_id, &[charlie_keys.public_key()])
+            .expect("Should remove Charlie");
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("Should merge commit");
+
+        let after_charlie_removal = alice_mdk
+            .get_members(&group_id)
+            .expect("Should get members");
+        assert_eq!(
+            after_charlie_removal.len(),
+            3,
+            "Should have 3 members after removing Charlie"
+        );
+        assert!(
+            !after_charlie_removal.contains(&charlie_keys.public_key()),
+            "Charlie should be removed"
+        );
+
+        // Step 2: Remove Dave (the bug would cause wrong member removal here)
+        // With the bug: enumerate() would give Dave index 2, but his actual leaf index is 3
+        alice_mdk
+            .remove_members(&group_id, &[dave_keys.public_key()])
+            .expect("Should remove Dave");
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("Should merge commit");
+
+        // Verify final state: only Alice and Bob remain
+        let final_members = alice_mdk
+            .get_members(&group_id)
+            .expect("Should get members");
+        assert_eq!(
+            final_members.len(),
+            2,
+            "Should have 2 members after removals"
+        );
+        assert!(
+            final_members.contains(&alice_keys.public_key()),
+            "Alice should still be in group"
+        );
+        assert!(
+            final_members.contains(&bob_keys.public_key()),
+            "Bob should still be in group"
+        );
+        assert!(
+            !final_members.contains(&dave_keys.public_key()),
+            "Dave should be removed"
         );
     }
 

--- a/crates/mdk-core/src/lib.rs
+++ b/crates/mdk-core/src/lib.rs
@@ -192,8 +192,7 @@ where
     /// ```no_run
     /// # use mdk_core::MDK;
     /// # use mdk_memory_storage::MdkMemoryStorage;
-    /// let mdk = MDK::builder(MdkMemoryStorage::default())
-    ///     .build();
+    /// let mdk = MDK::builder(MdkMemoryStorage::default()).build();
     /// ```
     pub fn builder(storage: Storage) -> MdkBuilder<Storage> {
         MdkBuilder::new(storage)


### PR DESCRIPTION
Fixes https://github.com/marmot-protocol/mdk/issues/60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect member removal when group trees contain gaps by using correct leaf indices.

* **Tests**
  * Added a regression test ensuring member removal works correctly with tree gaps.

* **Documentation**
  * Reformatted a builder example in the docs to a single chained call.

* **Changelog**
  * Recorded the fix under Unreleased -> Fixed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->