### PR TITLE
Fix: Propagate mandatory group-data extension parse failures in sync_group_metadata_from_mls

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -28,6 +28,10 @@
 ### Breaking changes
 
 - Changed `get_messages()` signature to accept `Option<Pagination>` parameter. Callers must now pass `None` for default pagination or `Some(Pagination::new(...))` for custom pagination ([#111](https://github.com/marmot-protocol/mdk/pull/111))
+
+### Fixed
+
+- **Security (Audit Issue AQ)**: Fixed `sync_group_metadata_from_mls()` to properly propagate errors when the mandatory group-data extension fails to parse, instead of silently ignoring the failure and continuing with stale metadata. This prevents potential data loss and security issues when extension data is corrupted or malformed. ([#125](https://github.com/marmot-protocol/mdk/pull/125))
 - **Content Encoding**: Removed support for hex encoding in key package and welcome event content ([#98](https://github.com/marmot-protocol/mdk/pull/98))
   - Key packages and welcome events now require explicit `["encoding", "base64"]` tag
   - Events without encoding tags or with hex encoding are rejected


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sync now validates mandatory metadata extensions before applying updates and performs relay updates atomically, preventing silent acceptance of corrupted extension data.

* **Tests**
  * Added tests to ensure extension parse failures are propagated and do not result in stale or partially applied metadata.

* **Changelog**
  * Documented this robustness/security fix under "Fixed" for Unreleased.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->