### PR TITLE
Fix: Return initial commit from create_group for MIP-01/02/03 compliance

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Breaking changes
 
+- **MIP-01/02/03 Compliance**: `create_group()` now returns the initial commit as a Kind:445 event in `GroupResult.evolution_event`. Callers must publish this event to relays BEFORE publishing welcome messages, then call `merge_pending_commit()` to finalize the group state. This fixes [#77](https://github.com/marmot-protocol/mdk/issues/77) where the initial commit was discarded and never published. ([#131](https://github.com/marmot-protocol/mdk/pull/131))
 - Changed `get_messages()` signature to accept `Option<Pagination>` parameter. Callers must now pass `None` for default pagination or `Some(Pagination::new(...))` for custom pagination ([#111](https://github.com/marmot-protocol/mdk/pull/111))
 - **Content Encoding**: Removed support for hex encoding in key package and welcome event content ([#98](https://github.com/marmot-protocol/mdk/pull/98))
   - Key packages and welcome events now require explicit `["encoding", "base64"]` tag

--- a/crates/mdk-core/examples/mls_memory.rs
+++ b/crates/mdk-core/examples/mls_memory.rs
@@ -75,7 +75,16 @@ async fn main() -> Result<(), Error> {
     // The group is created, and the welcome messages are in welcome_rumors.
     // We also have the Nostr group data, which we can use to show info about the group.
     let alice_group = group_create_result.group;
+
+    // The evolution_event (Kind:445) contains the initial commit and MUST be published
+    // to relays BEFORE the welcome messages per MIP-01/02/03.
+    let _evolution_event = group_create_result.evolution_event;
+
     let welcome_rumors = group_create_result.welcome_rumors;
+
+    // After publishing the evolution_event to relays, merge the pending commit
+    // to finalize the group state locally.
+    alice_mdk.merge_pending_commit(&alice_group.mls_group_id)?;
 
     // Welcome rumors are the Kind:444 events that would then be Gift-wrapped to just Bob.
     // If you added multiple users to the group, the welcome rumors vec would contain a kind:444 for each.

--- a/crates/mdk-core/examples/mls_sqlite.rs
+++ b/crates/mdk-core/examples/mls_sqlite.rs
@@ -84,7 +84,16 @@ async fn main() -> Result<(), Error> {
     // The group is created, and the welcome messages are in welcome_rumors.
     // We also have the Nostr group data, which we can use to show info about the group.
     let alice_group = group_create_result.group;
+
+    // The evolution_event (Kind:445) contains the initial commit and MUST be published
+    // to relays BEFORE the welcome messages per MIP-01/02/03.
+    let _evolution_event = group_create_result.evolution_event;
+
     let welcome_rumors = group_create_result.welcome_rumors;
+
+    // After publishing the evolution_event to relays, merge the pending commit
+    // to finalize the group state locally.
+    alice_mdk.merge_pending_commit(&alice_group.mls_group_id)?;
 
     // Alice now creates a Kind: 444 event that is Gift-wrapped to just Bob with the welcome event in the rumor event.
     // If you added multiple users to the group, you'd create a separate gift-wrapped welcome event for each user.


### PR DESCRIPTION
## Summary

- Fixes issue where `create_group()` discarded the initial commit and immediately merged, violating MIP-01/02/03
- Adds `evolution_event` field to `GroupResult` containing the Kind:445 commit event
- Removes immediate `merge_pending_commit()` call - callers must do this after publishing
- Updates examples to demonstrate proper publish-then-merge flow

## Breaking Change

Callers of `create_group()` must now:
1. Access `group_create_result.evolution_event` (the Kind:445 commit)
2. Publish the evolution_event to relays **BEFORE** publishing welcome messages
3. Call `mdk.merge_pending_commit(&group_id)` after publishing

## Test plan

- [x] All existing tests pass (`just precommit`)
- [x] Examples updated and working (`just example-memory`, `just example-sqlite`)
- [x] Test for epoch sync updated to call `merge_pending_commit` after group creation

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)