### PR TITLE
docs(mdk-core): document privacy-preserving group creation behavior

### DIFF
--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -1003,7 +1003,33 @@ where
         let (_, welcome_out, _group_info) =
             mls_group.add_members(&self.provider, &signer, &key_packages_vec)?;
 
-        // Merge the pending commit to finalize the group state - we do this during creation because we don't have a commit event to fan out to the group relays
+        // IMPORTANT: Privacy-preserving group creation
+        //
+        // We intentionally DO NOT publish the initial commit to relays. Instead, we:
+        // 1. Merge the pending commit locally (immediately below)
+        // 2. Send Welcome messages directly to invited members
+        //
+        // This differs from the MLS specification (RFC 9420), which recommends waiting
+        // for Delivery Service confirmation before applying commits. However, that
+        // guidance assumes a centralized Delivery Service model.
+        //
+        // For initial group creation with Nostr relays, not publishing the commit is
+        // the correct choice for security and privacy reasons:
+        //
+        // - PRIVACY: Publishing the commit would expose additional metadata on relays
+        //   (timing, event patterns, correlation opportunities) with no functional benefit
+        // - SECURITY: Invited members receive complete group state via Welcome messages;
+        //   they do not need the commit to join the group
+        // - NO RACE CONDITIONS: At creation time, only the creator exists in the group,
+        //   so there are no other members who need to process this commit
+        //
+        // This approach minimizes observable events on relays while maintaining full
+        // MLS security properties. The Welcome messages contain all cryptographic
+        // material needed for invitees to participate in the group.
+        //
+        // NOTE: This is specific to initial group creation. For commits in established
+        // groups (adding/removing members, updates), commits MUST be published to relays
+        // so existing members can process them and stay in sync.
         mls_group.merge_pending_commit(&self.provider)?;
 
         // Serialize the welcome message and send it to the members


### PR DESCRIPTION
## Summary

Fixes #77 

- Adds detailed comment in `create_group` explaining why initial group creation does not publish the commit to relays
- Documents the intentional design choice to rely only on Welcome messages for invitees
- Clarifies how this differs from RFC 9420 guidance and why it's the correct approach for Nostr-based systems

## Context

The MLS specification (RFC 9420) recommends waiting for Delivery Service confirmation before applying commits. However, this guidance assumes a centralized Delivery Service model.

For initial group creation with Nostr relays, not publishing the commit is the correct choice for security and privacy reasons:

- **Privacy**: Publishing the commit would expose additional metadata on relays (timing, event patterns, correlation opportunities) with no functional benefit
- **Security**: Invited members receive complete group state via Welcome messages; they do not need the commit to join
- **No race conditions**: At creation time, only the creator exists in the group

This is specific to initial group creation. Commits in established groups must still be published so existing members can process them.

## Test plan

- [x] Documentation-only change (comment update)
- [ ] Verify `just precommit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)