### PR TITLE
fix(mdk-core): improve error message for failed welcome retry attempts

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Breaking changes
 
+- Replaced `Error::MissingWelcomeForProcessedWelcome` with `Error::WelcomePreviouslyFailed(String)`. When retrying a welcome that previously failed, the new error includes the original failure reason instead of a generic message. ([#136](https://github.com/marmot-protocol/mdk/pull/136))
 - Changed `get_messages()` signature to accept `Option<Pagination>` parameter. Callers must now pass `None` for default pagination or `Some(Pagination::new(...))` for custom pagination ([#111](https://github.com/marmot-protocol/mdk/pull/111))
 - **Content Encoding**: Removed support for hex encoding in key package and welcome event content ([#98](https://github.com/marmot-protocol/mdk/pull/98))
   - Key packages and welcome events now require explicit `["encoding", "base64"]` tag

--- a/crates/mdk-core/src/error.rs
+++ b/crates/mdk-core/src/error.rs
@@ -113,9 +113,9 @@ pub enum Error {
     /// Welcome error
     #[error("{0}")]
     Welcome(String),
-    /// We're missing a Welcome for an existing ProcessedWelcome
-    #[error("missing welcome for processed welcome")]
-    MissingWelcomeForProcessedWelcome,
+    /// Welcome previously failed to process (retries are not supported)
+    #[error("welcome previously failed to process: {0}")]
+    WelcomePreviouslyFailed(String),
     /// Processed welcome not found
     #[error("processed welcome not found")]
     ProcessedWelcomeNotFound,
@@ -378,8 +378,11 @@ mod tests {
         let error = Error::Welcome("welcome error".to_string());
         assert_eq!(error.to_string(), "welcome error");
 
-        let error = Error::MissingWelcomeForProcessedWelcome;
-        assert_eq!(error.to_string(), "missing welcome for processed welcome");
+        let error = Error::WelcomePreviouslyFailed("original error reason".to_string());
+        assert_eq!(
+            error.to_string(),
+            "welcome previously failed to process: original error reason"
+        );
 
         let error = Error::ProcessedWelcomeNotFound;
         assert_eq!(error.to_string(), "processed welcome not found");

--- a/crates/mdk-core/src/welcomes.rs
+++ b/crates/mdk-core/src/welcomes.rs
@@ -184,23 +184,31 @@ where
         // Validate welcome event structure per MIP-02
         Self::validate_welcome_event(rumor_event)?;
 
-        if self.is_welcome_processed(wrapper_event_id)? {
-            let processed_welcome = self
-                .storage()
-                .find_processed_welcome_by_event_id(wrapper_event_id)
-                .map_err(|e| Error::Welcome(e.to_string()))?;
-            return match processed_welcome {
-                Some(processed_welcome) => {
-                    if let Some(welcome_event_id) = processed_welcome.welcome_event_id {
-                        self.storage()
-                            .find_welcome_by_event_id(&welcome_event_id)
-                            .map_err(|e| Error::Welcome(e.to_string()))?
-                            .ok_or(Error::MissingWelcomeForProcessedWelcome)
-                    } else {
-                        Err(Error::MissingWelcomeForProcessedWelcome)
-                    }
-                }
-                None => Err(Error::ProcessedWelcomeNotFound),
+        if let Some(processed_welcome) = self
+            .storage()
+            .find_processed_welcome_by_event_id(wrapper_event_id)
+            .map_err(|e| Error::Welcome(e.to_string()))?
+        {
+            // Check if this welcome previously failed - retries are not supported
+            if processed_welcome.state == welcome_types::ProcessedWelcomeState::Failed {
+                let reason = processed_welcome
+                    .failure_reason
+                    .unwrap_or_else(|| "unknown reason".to_string());
+                return Err(Error::WelcomePreviouslyFailed(reason));
+            }
+
+            // Welcome was successfully processed before - return the stored welcome
+            return match processed_welcome.welcome_event_id {
+                Some(welcome_event_id) => self
+                    .storage()
+                    .find_welcome_by_event_id(&welcome_event_id)
+                    .map_err(|e| Error::Welcome(e.to_string()))?
+                    .ok_or_else(|| {
+                        Error::Welcome("welcome record missing for processed welcome".to_string())
+                    }),
+                None => Err(Error::Welcome(
+                    "processed welcome missing welcome_event_id".to_string(),
+                )),
             };
         }
 
@@ -501,15 +509,6 @@ where
         };
 
         Ok(welcome_preview)
-    }
-
-    /// Check if a welcome has been processed
-    fn is_welcome_processed(&self, wrapper_event_id: &EventId) -> Result<bool, Error> {
-        let processed_welcome = self
-            .storage()
-            .find_processed_welcome_by_event_id(wrapper_event_id)
-            .map_err(|e| Error::Welcome(e.to_string()))?;
-        Ok(processed_welcome.is_some())
     }
 }
 
@@ -1522,5 +1521,71 @@ mod tests {
             1,
             "Should return exactly 1 welcome with limit 1"
         );
+    }
+
+    /// Test that retrying a failed welcome returns the original failure reason
+    ///
+    /// When a welcome fails to process (e.g., due to decoding errors), it is stored
+    /// with a Failed state and the failure reason. Retrying the same welcome should
+    /// return a clear error with the original failure reason, not a confusing
+    /// "missing welcome" error.
+    #[test]
+    fn test_failed_welcome_retry_returns_original_error() {
+        use nostr::RelayUrl;
+
+        let mdk = create_test_mdk();
+        let wrapper_event_id = EventId::from_slice(&[1u8; 32]).unwrap();
+
+        // Create a welcome with valid structure but invalid (non-base64) content
+        // This will pass validation but fail during preview_welcome when decoding
+        let mut tags = nostr::Tags::new();
+        tags.push(nostr::Tag::relays(vec![
+            RelayUrl::parse("wss://relay.example.com").unwrap(),
+        ]));
+        tags.push(nostr::Tag::event(EventId::all_zeros()));
+        tags.push(nostr::Tag::client("mdk".to_string()));
+        tags.push(nostr::Tag::custom(
+            nostr::TagKind::Custom("encoding".into()),
+            ["base64"],
+        ));
+
+        let invalid_welcome = UnsignedEvent {
+            id: Some(EventId::all_zeros()),
+            pubkey: Keys::generate().public_key(),
+            created_at: Timestamp::now(),
+            kind: Kind::MlsWelcome,
+            tags,
+            content: "not_valid_base64!!!".to_string(),
+        };
+
+        // First attempt should fail with a decoding error
+        let first_result = mdk.process_welcome(&wrapper_event_id, &invalid_welcome);
+        assert!(first_result.is_err(), "First attempt should fail");
+        let first_error = first_result.unwrap_err();
+        // The error should be a Welcome error about decoding
+        assert!(
+            matches!(first_error, Error::Welcome(ref msg) if msg.contains("decoding")),
+            "First error should be about decoding, got: {:?}",
+            first_error
+        );
+
+        // Second attempt (retry) should return WelcomePreviouslyFailed with the original reason
+        let second_result = mdk.process_welcome(&wrapper_event_id, &invalid_welcome);
+        assert!(second_result.is_err(), "Second attempt should also fail");
+        let second_error = second_result.unwrap_err();
+
+        // Verify we get the new error type with the original failure reason
+        match second_error {
+            Error::WelcomePreviouslyFailed(reason) => {
+                assert!(
+                    reason.contains("decoding"),
+                    "Failure reason should contain original error about decoding, got: {}",
+                    reason
+                );
+            }
+            other => {
+                panic!("Expected WelcomePreviouslyFailed error, got: {:?}", other);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Replace generic `MissingWelcomeForProcessedWelcome` error with `WelcomePreviouslyFailed(String)` that includes the original failure reason
- Provides clearer feedback when a user attempts to reprocess a welcome that previously failed
- Removes unused `is_welcome_processed` function

## Context

This addresses issue #90, though not in the way originally suggested. After analysis, we determined that implementing retry semantics for failed welcomes doesn't make practical sense because:

1. **Missing keys**: If you're on the wrong device without the KeyPackage's private key, retrying won't help
2. **Malformed data**: Corrupted or invalid welcome content won't become valid on retry  
3. **Cryptographic failures**: MLS validation errors are deterministic

Instead of allowing retry (which would fail again with the same underlying error), we now return a clear error message that includes the original failure reason, helping users understand what went wrong.

The MIP-02 spec will be updated separately to clarify/remove the retry language.

## Test plan

- [x] Added `test_failed_welcome_retry_returns_original_error` test
- [x] All existing tests pass
- [x] `just precommit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)