### PR TITLE
feat(mdk-core): allow creating single-member groups

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -44,6 +44,8 @@
 
 ### Changed
 
+- `create_group()` now supports creating single-member groups (groups with only the creator). This enables "message to self" functionality, setting up groups before inviting members, and multi-device scenarios. When no members are provided, the method returns an empty `welcome_rumors` vec. ([#138](https://github.com/marmot-protocol/mdk/pull/138))
+
 ### Added
 
 - New `MessageProcessingResult::PendingProposal` variant returned when a non-admin member receives a proposal. The proposal is stored as pending and awaits commitment by an admin. ([#122](https://github.com/marmot-protocol/mdk/pull/122))

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -922,29 +922,34 @@ where
     /// It generates the necessary cryptographic credentials, configures the group with Nostr-specific extensions,
     /// and adds the specified members.
     ///
-    /// NOTE: This function doesn't merge the pending commit. Clients must call this function manually only after successful publish of the commit message to relays.
+    /// # Single-Member Groups
+    ///
+    /// This method supports creating groups with only the creator (no additional members).
+    /// When `member_key_package_events` is empty, the group is created with just the creator,
+    /// and `welcome_rumors` in the result will be empty. This is useful for:
+    /// - "Message to self" functionality
+    /// - Setting up groups before inviting members
     ///
     /// # Arguments
     ///
-    /// * `name` - The name of the group
-    /// * `description` - A description of the group
     /// * `creator_public_key` - The Nostr public key of the group creator
-    /// * `member_key_package_events` - A vector of Nostr events (Kind:443) containing key packages for the initial group members
-    /// * `admins` - A vector of Nostr public keys for group administrators
-    /// * `group_relays` - A vector of relay URLs where group messages will be published
+    /// * `member_key_package_events` - A vector of Nostr events (Kind:443) containing key packages
+    ///   for the initial group members. Can be empty to create a single-member group.
+    /// * `config` - Group configuration including name, description, admins, and relays
     ///
     /// # Returns
     ///
     /// A `GroupResult` containing:
-    /// - The created MLS group
-    /// - A Vec of UnsignedEvents representing the welcomes to be sent to new users
+    /// - The created group
+    /// - A Vec of UnsignedEvents (`welcome_rumors`) representing the welcomes to be sent to new
+    ///   members. Empty if no members were added.
     ///
     /// # Errors
     ///
-    /// Returns a `Error` if:
+    /// Returns an `Error` if:
     /// - Credential generation fails
     /// - Group creation fails
-    /// - Adding members fails
+    /// - Adding members fails (when members are provided)
     /// - Message serialization fails
     pub fn create_group(
         &self,
@@ -1000,50 +1005,57 @@ where
             key_packages_vec.push(key_package);
         }
 
-        // Add members to the group
-        let (_, welcome_out, _group_info) =
-            mls_group.add_members(&self.provider, &signer, &key_packages_vec)?;
+        // Handle member addition and welcome message creation
+        // For single-member groups (no additional members), we skip adding members
+        // and return an empty welcome_rumors vec
+        let welcome_rumors = if key_packages_vec.is_empty() {
+            // Single-member group: no members to add, no welcome messages needed
+            Vec::new()
+        } else {
+            // Add members to the group
+            let (_, welcome_out, _group_info) =
+                mls_group.add_members(&self.provider, &signer, &key_packages_vec)?;
 
-        // IMPORTANT: Privacy-preserving group creation
-        //
-        // We intentionally DO NOT publish the initial commit to relays. Instead, we:
-        // 1. Merge the pending commit locally (immediately below)
-        // 2. Send Welcome messages directly to invited members
-        //
-        // This differs from the MLS specification (RFC 9420), which recommends waiting
-        // for Delivery Service confirmation before applying commits. However, that
-        // guidance assumes a centralized Delivery Service model.
-        //
-        // For initial group creation with Nostr relays, not publishing the commit is
-        // the correct choice for security and privacy reasons:
-        //
-        // - PRIVACY: Publishing the commit would expose additional metadata on relays
-        //   (timing, event patterns, correlation opportunities) with no functional benefit
-        // - SECURITY: Invited members receive complete group state via Welcome messages;
-        //   they do not need the commit to join the group
-        // - NO RACE CONDITIONS: At creation time, only the creator exists in the group,
-        //   so there are no other members who need to process this commit
-        //
-        // This approach minimizes observable events on relays while maintaining full
-        // MLS security properties. The Welcome messages contain all cryptographic
-        // material needed for invitees to participate in the group.
-        //
-        // NOTE: This is specific to initial group creation. For commits in established
-        // groups (adding/removing members, updates), commits MUST be published to relays
-        // so existing members can process them and stay in sync.
-        mls_group.merge_pending_commit(&self.provider)?;
+            // IMPORTANT: Privacy-preserving group creation
+            //
+            // We intentionally DO NOT publish the initial commit to relays. Instead, we:
+            // 1. Merge the pending commit locally (immediately below)
+            // 2. Send Welcome messages directly to invited members
+            //
+            // This differs from the MLS specification (RFC 9420), which recommends waiting
+            // for Delivery Service confirmation before applying commits. However, that
+            // guidance assumes a centralized Delivery Service model.
+            //
+            // For initial group creation with Nostr relays, not publishing the commit is
+            // the correct choice for security and privacy reasons:
+            //
+            // - PRIVACY: Publishing the commit would expose additional metadata on relays
+            //   (timing, event patterns, correlation opportunities) with no functional benefit
+            // - SECURITY: Invited members receive complete group state via Welcome messages;
+            //   they do not need the commit to join the group
+            // - NO RACE CONDITIONS: At creation time, only the creator exists in the group,
+            //   so there are no other members who need to process this commit
+            //
+            // This approach minimizes observable events on relays while maintaining full
+            // MLS security properties. The Welcome messages contain all cryptographic
+            // material needed for invitees to participate in the group.
+            //
+            // NOTE: This is specific to initial group creation. For commits in established
+            // groups (adding/removing members, updates), commits MUST be published to relays
+            // so existing members can process them and stay in sync.
+            mls_group.merge_pending_commit(&self.provider)?;
 
-        // Serialize the welcome message and send it to the members
-        let serialized_welcome_message = welcome_out.tls_serialize_detached()?;
+            // Serialize the welcome message and send it to the members
+            let serialized_welcome_message = welcome_out.tls_serialize_detached()?;
 
-        let welcome_rumors = self
-            .build_welcome_rumors_for_key_packages(
+            self.build_welcome_rumors_for_key_packages(
                 &mls_group,
                 serialized_welcome_message,
                 member_key_package_events,
                 &config.relays,
             )?
-            .ok_or(Error::Welcome("Error creating welcome rumors".to_string()))?;
+            .ok_or(Error::Welcome("Error creating welcome rumors".to_string()))?
+        };
 
         // Save the NostrMLS Group
         let group = group_types::Group {
@@ -1572,6 +1584,57 @@ mod tests {
         for member_keys in &initial_members {
             assert!(members.contains(&member_keys.public_key()));
         }
+    }
+
+    /// Test creating a group with only the creator (no additional members).
+    /// This is useful for "message to self" functionality, setting up groups
+    /// before inviting members, and multi-device scenarios.
+    #[test]
+    fn test_create_single_member_group() {
+        let creator_mdk = create_test_mdk();
+        let creator = Keys::generate();
+        let creator_pk = creator.public_key();
+
+        // Create a group with no additional members - only the creator
+        let create_result = creator_mdk
+            .create_group(
+                &creator_pk,
+                Vec::new(), // No additional members
+                create_nostr_group_config_data(vec![creator_pk]),
+            )
+            .expect("Failed to create single-member group");
+
+        let group_id = &create_result.group.mls_group_id;
+
+        // Verify welcome_rumors is empty (no members to welcome)
+        assert!(
+            create_result.welcome_rumors.is_empty(),
+            "Single-member group should have no welcome rumors"
+        );
+
+        // Verify only the creator is in the group
+        let members = creator_mdk
+            .get_members(group_id)
+            .expect("Failed to get members");
+
+        assert_eq!(
+            members.len(),
+            1,
+            "Single-member group should have exactly 1 member"
+        );
+        assert!(
+            members.contains(&creator_pk),
+            "Creator should be in the group"
+        );
+
+        // Verify group metadata was saved correctly
+        let group = creator_mdk
+            .get_group(group_id)
+            .expect("Failed to get group")
+            .expect("Group should exist");
+
+        assert_eq!(group.name, "Test Group");
+        assert!(group.admin_pubkeys.contains(&creator_pk));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Enable creating MLS groups with only the creator (no additional members)
- When `member_key_package_events` is empty, skip member addition and return empty `welcome_rumors`
- Add comprehensive test for single-member group creation
- Update `create_group` documentation to describe new capability

## Use Cases

This change enables:
- **"Message to self" functionality** - Users can create a group for personal notes
- **Setting up groups before inviting members** - Prepare posts, configure settings, etc.
- **Multi-device scenarios** - Not truly single-user from MLS perspective when multiple devices are involved

## Test plan

- [x] Added `test_create_single_member_group` test that verifies:
  - Group creation with empty member list succeeds
  - `welcome_rumors` is empty (no members to welcome)
  - Only the creator is in the group
  - Group metadata is saved correctly
- [x] All existing tests pass (265 tests)
- [x] `just check` passes (fmt, clippy, docs)

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)