### PR TITLE
fix(mdk-core): remove legacy 64-byte credential identity format support

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -27,6 +27,10 @@
 
 ### Breaking changes
 
+- **Credential Identity Encoding**: Removed support for legacy 64-byte UTF-8 hex-encoded credential identities ([#15](https://github.com/marmot-protocol/mdk/issues/15))
+  - Credential identities must now be exactly 32 bytes (raw public key) per MIP-00
+  - Key packages with 64-byte hex-encoded identities are no longer accepted
+  - This completes the migration period that began in November 2024
 - **Encrypted Media (MIP-04)**: The `derive_encryption_nonce()` function has been removed. All encrypted media must now include a random nonce in the IMETA tag (`n` field). Legacy media encrypted with deterministic nonces can no longer be decrypted. This is a breaking change to fix the security issue (Audit Issue U) where deterministic nonce derivation caused nonce reuse. ([#114](https://github.com/marmot-protocol/mdk/pull/114))
 - **BREAKING**: Changed `get_messages()` signature to accept `Option<Pagination>` parameter. Callers must now pass `None` for default pagination or `Some(Pagination::new(...))` for custom pagination ([#111](https://github.com/marmot-protocol/mdk/pull/111))
 - **BREAKING**: Changed `get_pending_welcomes()` to accept `Option<Pagination>` parameter for pagination support. Existing calls should pass `None` for default pagination. ([#110](https://github.com/marmot-protocol/mdk/pull/110))


### PR DESCRIPTION
## Summary

- Remove backwards compatibility for the incorrect 64-byte UTF-8 hex-encoded credential identity format
- Credential identities must now be exactly 32 bytes (raw public key) per MIP-00
- This completes the migration period that began in November 2024

## Breaking Change

Key packages with 64-byte hex-encoded credential identities are no longer accepted. All clients should have migrated to the correct 32-byte format by now.

Closes #15