### PR TITLE
fix: install OpenSSL on Windows for UniFFI bindings build

### DIFF
--- a/.github/workflows/package-mdk-bindings.yml
+++ b/.github/workflows/package-mdk-bindings.yml
@@ -121,6 +121,16 @@ jobs:
         rustup target add aarch64-apple-ios
         rustup target add aarch64-apple-ios-sim
 
+    - name: Install OpenSSL (Windows)
+      if: runner.os == 'Windows'
+      shell: powershell
+      run: |
+        echo "Installing OpenSSL via vcpkg..."
+        vcpkg install openssl:x64-windows-static
+        vcpkg integrate install
+        echo "OPENSSL_DIR=C:\vcpkg\packages\openssl_x64-windows-static" >> $env:GITHUB_ENV
+        echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
+
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
 
@@ -321,6 +331,16 @@ jobs:
       run: |
         rustup target add aarch64-apple-ios
         rustup target add aarch64-apple-ios-sim
+
+    - name: Install OpenSSL (Windows)
+      if: runner.os == 'Windows'
+      shell: powershell
+      run: |
+        echo "Installing OpenSSL via vcpkg..."
+        vcpkg install openssl:x64-windows-static
+        vcpkg integrate install
+        echo "OPENSSL_DIR=C:\vcpkg\packages\openssl_x64-windows-static" >> $env:GITHUB_ENV
+        echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
 
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2

--- a/crates/mdk-uniffi/CHANGELOG.md
+++ b/crates/mdk-uniffi/CHANGELOG.md
@@ -43,6 +43,7 @@
 - **Build**: Improved Android cross-compilation by requiring `ANDROID_OPENSSL_DIR` environment variable pointing to prebuilt OpenSSL libraries, with clear error messages explaining the required directory structure ([#140](https://github.com/marmot-protocol/mdk/pull/140))
 - **Build**: Added `RANLIB` configuration for Android NDK toolchain to fix OpenSSL library installation ([#140](https://github.com/marmot-protocol/mdk/pull/140))
 - **Build**: Added Rust target installation checks for both Android and iOS builds with helpful error messages showing how to install missing targets ([#140](https://github.com/marmot-protocol/mdk/pull/140))
+- **Build**: Fixed Windows CI builds for Python and Ruby bindings by installing OpenSSL via vcpkg, resolving `libsqlite3-sys` build failures caused by missing `OPENSSL_DIR` ([#144](https://github.com/marmot-protocol/mdk/pull/144))
 
 ### Removed
 


### PR DESCRIPTION
## Summary

- Add OpenSSL installation step for Windows runners in `package-python` and `package-ruby` jobs
- Uses vcpkg (pre-installed on GitHub Windows runners) to install `openssl:x64-windows-static`
- Sets `OPENSSL_DIR` and `OPENSSL_STATIC` environment variables for the Rust build

## Problem

The Windows builds for Python and Ruby UniFFI bindings were failing with:

```
thread 'main' panicked at libsqlite3-sys-0.30.1\build.rs:164:29:
Missing environment variable OPENSSL_DIR or OPENSSL_DIR is not set
```

This occurs because `mdk-sqlite-storage` uses `rusqlite` with the `bundled-sqlcipher` feature, which requires OpenSSL for encryption support.

## Solution

Install OpenSSL via vcpkg before the Rust build step on Windows runners, similar to how OpenSSL is set up for Android builds in the Kotlin job.