### PR TITLE
chore(Cargo): bump rust-nostr to version 0.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.43.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62a97d745f1bd8d5e05a978632bbb87b0614567d5142906fe7c86fb2440faac6"
+checksum = "3aa5e3b6a278ed061835fe1ee293b71641e6bf8b401cfe4e1834bbf4ef0a34e1"
 dependencies = [
  "base64",
  "bech32",
@@ -1609,6 +1609,7 @@ dependencies = [
  "chacha20",
  "chacha20poly1305",
  "getrandom 0.2.16",
+ "hex",
  "instant",
  "scrypt",
  "secp256k1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ openmls_basic_credential = { git = "https://github.com/openmls/openmls", rev = "
 openmls_rust_crypto = { git = "https://github.com/openmls/openmls", rev = "b90ca23b1238d9e189142d06234527b2d344d748", default-features = false }
 
 # Nostr
-nostr = { version = "0.43", default-features = false }
+nostr = { version = "0.44", default-features = false }
 
 # Serialization
 serde = { version = "1.0", default-features = false }

--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Removed
 
-### Deprecated
+### Deprecated -->
 
 ## Unreleased
 
@@ -35,6 +35,7 @@
   - When multiple valid commits are published for the same epoch, clients converge on the same "winning" commit.
   - If a "better" commit (earlier timestamp) arrives after a "worse" commit has been applied, the client automatically rolls back to the previous epoch and applies the winning commit.
   - This ensures consistent group state across all clients even with out-of-order message delivery.
+- Upgraded `nostr` dependency from 0.43 to 0.44, replacing deprecated `Timestamp::as_u64()` calls with `Timestamp::as_secs()` ([#162](https://github.com/marmot-protocol/mdk/pull/162))
 
 ### Added
 

--- a/crates/mdk-core/src/test_util.rs
+++ b/crates/mdk-core/src/test_util.rs
@@ -233,7 +233,7 @@ impl RaceConditionSimulator {
 
     /// Get a timestamp offset from the base by the specified number of seconds
     pub fn timestamp_offset(&self, offset_seconds: i64) -> nostr::Timestamp {
-        let new_timestamp = (self.base_timestamp.as_u64() as i64 + offset_seconds).max(0) as u64;
+        let new_timestamp = (self.base_timestamp.as_secs() as i64 + offset_seconds).max(0) as u64;
         nostr::Timestamp::from(new_timestamp)
     }
 }

--- a/crates/mdk-sqlite-storage/CHANGELOG.md
+++ b/crates/mdk-sqlite-storage/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Changed
 
+- Upgraded `nostr` dependency from 0.43 to 0.44, replacing deprecated `Timestamp::as_u64()` calls with `Timestamp::as_secs()` ([#162](https://github.com/marmot-protocol/mdk/pull/162))
 - **Persistent Snapshots**: Implemented snapshot support by copying group-specific rows to a dedicated snapshot table. `create_group_snapshot`, `rollback_group_to_snapshot`, and `release_group_snapshot` persist across app restarts. ([#152](https://github.com/marmot-protocol/mdk/pull/152))
 - **Unified Storage Architecture**: `MdkSqliteStorage` now directly implements OpenMLS's `StorageProvider<1>` trait instead of wrapping `openmls_sqlite_storage`. This enables atomic transactions across MLS and MDK state, which is required for proper commit race resolution per MIP-03. ([#148](https://github.com/marmot-protocol/mdk/pull/148))
   - Removed `openmls_sqlite_storage` dependency

--- a/crates/mdk-sqlite-storage/src/groups.rs
+++ b/crates/mdk-sqlite-storage/src/groups.rs
@@ -113,7 +113,7 @@ impl GroupStorage for MdkSqliteStorage {
 
         let last_message_id: Option<&[u8; 32]> =
             group.last_message_id.as_ref().map(|id| id.as_bytes());
-        let last_message_at: Option<u64> = group.last_message_at.as_ref().map(|ts| ts.as_u64());
+        let last_message_at: Option<u64> = group.last_message_at.as_ref().map(|ts| ts.as_secs());
 
         self.with_connection(|conn| {
             conn.execute(

--- a/crates/mdk-sqlite-storage/src/messages.rs
+++ b/crates/mdk-sqlite-storage/src/messages.rs
@@ -65,7 +65,7 @@ impl MessageStorage for MdkSqliteStorage {
                     message.pubkey.as_bytes(),
                     message.kind.as_u16(),
                     message.mls_group_id.as_slice(),
-                    message.created_at.as_u64(),
+                    message.created_at.as_secs(),
                     &message.content,
                     &tags_json,
                     &event_json,
@@ -123,7 +123,7 @@ impl MessageStorage for MdkSqliteStorage {
                 params![
                     &processed_message.wrapper_event_id.to_bytes(),
                     &message_event_id,
-                    &processed_message.processed_at.as_u64(),
+                    &processed_message.processed_at.as_secs(),
                     &processed_message.epoch,
                     &mls_group_id,
                     &processed_message.state.to_string(),

--- a/crates/mdk-sqlite-storage/src/welcomes.rs
+++ b/crates/mdk-sqlite-storage/src/welcomes.rs
@@ -171,7 +171,7 @@ impl WelcomeStorage for MdkSqliteStorage {
                 params![
                     processed_welcome.wrapper_event_id.as_bytes(),
                     welcome_event_id,
-                    processed_welcome.processed_at.as_u64(),
+                    processed_welcome.processed_at.as_secs(),
                     processed_welcome.state.as_str(),
                     &processed_welcome.failure_reason
                 ],

--- a/crates/mdk-uniffi/CHANGELOG.md
+++ b/crates/mdk-uniffi/CHANGELOG.md
@@ -28,6 +28,10 @@
 ### Breaking changes
 
 - **Security (Audit Issue M)**: Changed `get_message()` to require both `mls_group_id` and `event_id` parameters. This prevents messages from different groups from overwriting each other by scoping lookups to a specific group. ([#124](https://github.com/marmot-protocol/mdk/pull/124))
+
+### Changed
+
+- Upgraded `nostr` dependency from 0.43 to 0.44, replacing deprecated `Timestamp::as_u64()` calls with `Timestamp::as_secs()` ([#162](https://github.com/marmot-protocol/mdk/pull/162))
 - Changed `get_messages()` to accept optional `limit` and `offset` parameters for pagination control. Existing calls must be updated to pass `None, None` for default behavior (limit: 1000, offset: 0), or specify values for custom pagination. ([#111](https://github.com/marmot-protocol/mdk/pull/111))
 - Changed `get_pending_welcomes()` to accept optional `limit` and `offset` parameters for pagination control. Existing calls must be updated to pass `None, None` for default behavior (limit: 1000, offset: 0), or specify values for custom pagination. ([#119](https://github.com/marmot-protocol/mdk/pull/119))
 - Changed `new_mdk()`, `new_mdk_with_key()`, and `new_mdk_unencrypted()` to accept an optional `MdkConfig` parameter for customizing MDK behavior. Existing calls must be updated to pass `None` for default behavior. ([`#155`](https://github.com/marmot-protocol/mdk/pull/155))

--- a/crates/mdk-uniffi/src/lib.rs
+++ b/crates/mdk-uniffi/src/lib.rs
@@ -1081,7 +1081,7 @@ impl From<group_types::Group> for Group {
             image_nonce: g.image_nonce.map(|n| n.as_ref().to_vec()),
             admin_pubkeys: g.admin_pubkeys.iter().map(|pk| pk.to_hex()).collect(),
             last_message_id: g.last_message_id.map(|id| id.to_hex()),
-            last_message_at: g.last_message_at.map(|ts| ts.as_u64()),
+            last_message_at: g.last_message_at.map(|ts| ts.as_secs()),
             epoch: g.epoch,
             state: g.state.as_str().to_string(),
         }
@@ -1134,7 +1134,7 @@ impl From<message_types::Message> for Message {
             event_id: m.wrapper_event_id.to_hex(),
             sender_pubkey: m.pubkey.to_hex(),
             event_json,
-            processed_at: m.created_at.as_u64(),
+            processed_at: m.created_at.as_secs(),
             kind: m.kind.as_u16(),
             state: m.state.as_str().to_string(),
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR upgrades the workspace dependency `nostr` from 0.43 to 0.44 and updates timestamp usage across the codebase to the new Timestamp API, replacing deprecated `Timestamp::as_u64()` calls with `Timestamp::as_secs()` to use seconds-based representations. The change is an internal refactor of timestamp handling and storage serialization with no changes to public APIs or behavioral logic beyond timestamp units.

**What changed**:
- Bumped nostr dependency in workspace Cargo.toml from "0.43" to "0.44".
- mdk-core: Replaced `Timestamp::as_u64()` usages with `as_secs()` in message validation, timestamp comparisons, epoch snapshot code, error messages, and related tests.
- mdk-sqlite-storage: Switched timestamp serialization for groups, messages, processed messages, and welcomes to `as_secs()` when persisting timestamps to the database.
- mdk-uniffi: Updated FFI-facing conversions (Group and Message timestamp fields) to expose seconds via `as_secs()`.
- mdk-memory-storage: Adjusted internal timestamp handling to use `as_secs()` where applicable.
- CHANGELOGs: Added entries documenting the nostr upgrade and the migration from `as_u64()` to `as_secs()`.

**Security impact**:
- No cryptographic, key handling, SQLCipher configuration, credential, or identity-binding changes were made; this PR only changes timestamp representations (no security-sensitive code modifications).

**Protocol changes**:
- No changes to MLS implementation or MIPs; Nostr integration change limited to dependency upgrade and adapting to the nostr Timestamp API (use of seconds rather than deprecated method).

**API surface**:
- No breaking changes to public function signatures, types, traits, or FFI boundaries were introduced; timestamp representation changes are internal and the UniFFI layer still exposes numeric timestamp fields (now in seconds).
- Storage schema remains the same (same columns), but persisted timestamp values are now written as seconds.

**Testing**:
- Tests and test helpers in mdk-core and related crates were updated to assert seconds-based timestamps (replacing prior as_u64-based expectations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->