### PR TITLE
fix: use std::sync::Mutex for SQLite connection to avoid tokio runtime panics

### DIFF
--- a/crates/mdk-sqlite-storage/CHANGELOG.md
+++ b/crates/mdk-sqlite-storage/CHANGELOG.md
@@ -74,6 +74,7 @@
 - **Security (Audit Issue AB)**: Added size limits to prevent disk and CPU exhaustion from unbounded user input ([#94](https://github.com/marmot-protocol/mdk/pull/94))
 - **Security (Audit Issue AG)**: `all_groups` now skips corrupted rows instead of failing on the first deserialization error, improving availability when database contains malformed data ([#115](https://github.com/marmot-protocol/mdk/pull/115))
 - Propagate `last_message_id` parse errors in `row_to_group` instead of silently converting to `None` ([#105](https://github.com/marmot-protocol/mdk/pull/105))
+- Changed `tokio::sync::Mutex` to `std::sync::Mutex` for SQLite connection to avoid panics when called from within tokio async runtime contexts ([#164](https://github.com/marmot-protocol/mdk/pull/164))
 
 ### Removed
 


### PR DESCRIPTION
## Problem

`MdkSqliteStorage` uses `tokio::sync::Mutex` for the SQLite connection and calls `blocking_lock()` to access it. This panics when called from within a tokio async runtime context:

```
Cannot block the current thread from within a runtime
```

This forces consumers (like whitenoise-rs) to wrap ALL MDK calls in `std::thread::spawn()` to escape the tokio runtime context, adding significant complexity and overhead.

## Solution

Replace `tokio::sync::Mutex` with `std::sync::Mutex`. Since rusqlite operations are inherently synchronous, there's no benefit to using tokio's async Mutex. `std::sync::Mutex::lock()` does not panic in async contexts - it simply blocks until the lock is acquired.

## Changes

- Changed `connection: Arc<tokio::sync::Mutex<Connection>>` to `Arc<std::sync::Mutex<Connection>>`
- Changed all `.blocking_lock()` calls to `.lock().unwrap()`

## Impact

- Consumers can now call MDK methods directly from async code without runtime panics
- No architectural changes required
- No API changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes runtime panics in MdkSqliteStorage by switching the SQLite connection synchronization from tokio::sync::Mutex to std::sync::Mutex, allowing blocking rusqlite operations to run from within a Tokio async runtime without triggering "Cannot block the current thread from within a runtime". Consumers can now call MDK storage methods directly from async contexts without spawning dedicated threads to avoid panics.

**What changed**:
- Replaced the connection field type from Arc<tokio::sync::Mutex<Connection>> to Arc<std::sync::Mutex<Connection>> in mdk-sqlite-storage.
- Replaced all usages of .blocking_lock() with .lock().unwrap() when acquiring the SQLite connection lock inside the crate.
- Updated imports and internal code paths in crates/mdk-sqlite-storage to use std::sync::Mutex for synchronous DB access.

**Security impact**:
- None: no changes to cryptography, key handling, SQLCipher configuration, file permissions, or secret management.

**Protocol changes**:
- None.

**API surface**:
- None: public types and method signatures are unchanged and no UniFFI/FFI boundaries or storage schema changes were introduced.

**Testing**:
- No tests were added or modified as part of this change; existing tests that use storage APIs should continue to function without changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->