### PR TITLE
Fix windows builds of python and ruby bindings

### DIFF
--- a/crates/mdk-uniffi/CHANGELOG.md
+++ b/crates/mdk-uniffi/CHANGELOG.md
@@ -59,6 +59,7 @@
 - **Build**: Added `RANLIB` configuration for Android NDK toolchain to fix OpenSSL library installation ([#140](https://github.com/marmot-protocol/mdk/pull/140))
 - **Build**: Added Rust target installation checks for both Android and iOS builds with helpful error messages showing how to install missing targets ([#140](https://github.com/marmot-protocol/mdk/pull/140))
 - **Build**: Fixed Windows CI builds for Python and Ruby bindings by installing OpenSSL via vcpkg, resolving `libsqlite3-sys` build failures caused by missing `OPENSSL_DIR` ([#144](https://github.com/marmot-protocol/mdk/pull/144))
+- **Build**: Fixed Windows linker errors for Python and Ruby bindings by adding missing `crypt32` and `user32` system library links required by statically-linked OpenSSL ([#172](https://github.com/marmot-protocol/mdk/pull/172))
 
 ### Removed
 

--- a/crates/mdk-uniffi/build.rs
+++ b/crates/mdk-uniffi/build.rs
@@ -1,0 +1,14 @@
+fn main() {
+    // When statically linking OpenSSL on Windows (required by bundled-sqlcipher
+    // in mdk-sqlite-storage), the linker needs additional Windows system
+    // libraries that OpenSSL's libcrypto depends on. The libsqlite3-sys build
+    // script links libcrypto but doesn't emit these system library dependencies.
+    //
+    // - crypt32: Certificate store functions (CertOpenStore, CertCloseStore, etc.)
+    // - user32: Window station and message box functions (GetProcessWindowStation,
+    //   GetUserObjectInformationW, MessageBoxW)
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() == "windows" {
+        println!("cargo:rustc-link-lib=crypt32");
+        println!("cargo:rustc-link-lib=user32");
+    }
+}


### PR DESCRIPTION
Fix Windows linker errors (`LNK1120: 11 unresolved externals`) in the Python and Ruby bindings CI jobs by adding missing `crypt32` and `user32` system library links

Follow-up to [#144](https://github.com/marmot-protocol/mdk/pull/144), which added the vcpkg OpenSSL installation but missed the system library dependencies that statically-linked OpenSSL requires.

## Problem

Both Windows CI jobs (`Build Python Bindings (windows-latest)` and `Build Ruby Bindings (windows-latest)`) fail at the "Build host library (debug for bindgen)" step:

- [Build Python Bindings (windows-latest)](https://github.com/marmot-protocol/mdk/actions/runs/21763165020/job/62791830270)
- [Build Ruby Bindings (windows-latest)](https://github.com/marmot-protocol/mdk/actions/runs/21763165020/job/62791830255)

The linker reports 11 unresolved external symbols from OpenSSL's `libcrypto.lib`:

```
libcrypto.lib(libcrypto-lib-cryptlib.obj) : error LNK2019: unresolved external symbol __imp_GetProcessWindowStation
libcrypto.lib(libcrypto-lib-cryptlib.obj) : error LNK2019: unresolved external symbol __imp_GetUserObjectInformationW
libcrypto.lib(libcrypto-lib-cryptlib.obj) : error LNK2019: unresolved external symbol __imp_MessageBoxW
libcrypto.lib(libcrypto-lib-e_capi.obj)   : error LNK2019: unresolved external symbol __imp_CertOpenStore
libcrypto.lib(libcrypto-lib-e_capi.obj)   : error LNK2019: unresolved external symbol __imp_CertCloseStore
...
fatal error LNK1120: 11 unresolved externals
```

## Root Cause

The dependency chain is:

```
mdk-uniffi (cdylib) → mdk-sqlite-storage → rusqlite[bundled-sqlcipher] → libsqlite3-sys
```

On Windows, `bundled-sqlcipher` requires OpenSSL for SQLCipher's cryptographic backend. The CI workflow (added in [#144](https://github.com/marmot-protocol/mdk/pull/144)) correctly installs a **static** OpenSSL via vcpkg and sets `OPENSSL_DIR` + `OPENSSL_STATIC=1`.

However, `libsqlite3-sys`'s build script ([build.rs:216](https://github.com/rusqlite/rusqlite/blob/master/libsqlite3-sys/build.rs#L216)) emits:

```rust
println!("cargo:rustc-link-lib=dylib={}", lib_name); // links libcrypto
```

It links `libcrypto` but does **not** emit the Windows system libraries that a statically-linked OpenSSL depends on:

- **`crypt32.lib`** — provides certificate store functions (`CertOpenStore`, `CertCloseStore`, `CertEnumCertificatesInStore`, `CertFindCertificateInStore`, `CertDuplicateCertificateContext`, `CertFreeCertificateContext`, `CertGetCertificateContextProperty`, `CertOpenSystemStoreW`)
- **`user32.lib`** — provides window station and message box functions (`GetProcessWindowStation`, `GetUserObjectInformationW`, `MessageBoxW`)

This is a gap in `libsqlite3-sys`'s build script — it assumes dynamic linking but the CI provides a static library, which pulls in OpenSSL's full dependency tree at link time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes Windows linker errors (LNK1120: unresolved externals) in Python and Ruby bindings by adding missing system library links required when OpenSSL is statically linked. When bundled-sqlcipher statically links OpenSSL, the Windows linker needs additional system libraries beyond libcrypto.lib, but the libsqlite3-sys build script was not emitting these dependencies.

**What changed**:
- Added a Windows-specific build script (`crates/mdk-uniffi/build.rs`) that emits linker directives for `crypt32` (certificate store functions) and `user32` (window station and message box functions) when building on Windows targets
- Updated `crates/mdk-uniffi/CHANGELOG.md` to document the Windows linker error fix
- Affects: mdk-uniffi crate

<!-- end of auto-generated comment: release notes by coderabbit.ai -->