### PR TITLE
feat(crates/mdk-core): make NIP-70 protected tag optonal in key package creation for relay compatibility

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 ### Breaking changes
 
+- **`create_key_package_for_event` Return Type Change**: The return type changed from `(String, [Tag; 7])` to `(String, Vec<Tag>)`. Most code patterns (iteration, indexing) continue to work unchanged. This change was necessary because the protected tag is now optional. ([#173](https://github.com/marmot-protocol/mdk/pull/173), related: [#168](https://github.com/marmot-protocol/mdk/issues/168))
+- **`create_key_package_for_event` No Longer Adds Protected Tag**: The `create_key_package_for_event()` function no longer adds the NIP-70 protected tag (`["-"]`) by default. This is a behavioral change - existing code that relied on the protected tag being present will now produce key packages without it. Key packages can now be republished by third parties to any relay. This improves relay compatibility since many popular relays (Damus, Primal, nos.lol) reject protected events outright. For users who need the protected tag, use the new `create_key_package_for_event_with_options()` function with `protected: true`. ([#173](https://github.com/marmot-protocol/mdk/pull/173), related: [#168](https://github.com/marmot-protocol/mdk/issues/168))
 - **OpenMLS 0.8.0 Upgrade**: Upgraded from a git-pinned openmls 0.7.1 to the crates.io openmls 0.8.0 release. This resolves security advisory [GHSA-8x3w-qj7j-gqhf](https://github.com/openmls/openmls/security/advisories/GHSA-8x3w-qj7j-gqhf) (improper tag validation) and moves GREASE support from a git pin to an official release. Companion crates updated: `openmls_traits` 0.5, `openmls_basic_credential` 0.5, `openmls_rust_crypto` 0.5. ([#174](https://github.com/marmot-protocol/mdk/pull/174))
 
 ### Changed
@@ -39,6 +41,7 @@
 
 ### Added
 
+- **`create_key_package_for_event_with_options`**: New function that allows specifying whether to include the NIP-70 protected tag. Use this if you need to publish to relays that accept protected events. ([#173](https://github.com/marmot-protocol/mdk/pull/173), related: [#168](https://github.com/marmot-protocol/mdk/issues/168))
 - **MIP-04 Epoch Fallback for Media Decryption**: `decrypt_from_download` now resolves the correct decryption key via an O(1) epoch hint lookup instead of only using the current epoch's exporter secret. Added `NoExporterSecretForEpoch` variant to `EncryptedMediaError` for programmatic error matching. ([#167](https://github.com/marmot-protocol/mdk/pull/167))
 - **`PreviouslyFailed` Result Variant**: Added `MessageProcessingResult::PreviouslyFailed` variant to handle cases where a previously failed message arrives again but the MLS group ID cannot be extracted. This prevents crashes in client applications by returning a result instead of throwing an error. ([#165](https://github.com/marmot-protocol/mdk/pull/165), fixes [#154](https://github.com/marmot-protocol/mdk/issues/154), [#159](https://github.com/marmot-protocol/mdk/issues/159))
 - **Message Retry Support**: Implemented better handling for retryable message states. When a message fails processing, it now preserves the `message_event_id` and other context. Added logic to allow reprocessing of messages marked as `Retryable`, with automatic state recovery to `Processed` upon success. ([#161](https://github.com/marmot-protocol/mdk/pull/161))

--- a/crates/mdk-core/examples/group_inspection.rs
+++ b/crates/mdk-core/examples/group_inspection.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Error> {
 
     let member1_event =
         nostr::event::builder::EventBuilder::new(nostr::Kind::MlsKeyPackage, member1_kp_encoded)
-            .tags(member1_tags.to_vec())
+            .tags(member1_tags)
             .build(member1_keys.public_key())
             .sign(&member1_keys)
             .await?;
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Error> {
 
     let member2_event =
         nostr::event::builder::EventBuilder::new(nostr::Kind::MlsKeyPackage, member2_kp_encoded)
-            .tags(member2_tags.to_vec())
+            .tags(member2_tags)
             .build(member2_keys.public_key())
             .sign(&member2_keys)
             .await?;

--- a/crates/mdk-core/examples/key_package_inspection.rs
+++ b/crates/mdk-core/examples/key_package_inspection.rs
@@ -41,8 +41,12 @@ async fn main() -> Result<(), Error> {
     // ====================================
     println!("=== Creating Key Package ===\n");
 
-    let (key_package_encoded, tags) =
-        mdk.create_key_package_for_event(&keys.public_key(), [relay_url.clone()])?;
+    // Create key package with protected=true to demonstrate NIP-70 tag
+    let (key_package_encoded, tags) = mdk.create_key_package_for_event_with_options(
+        &keys.public_key(),
+        [relay_url.clone()],
+        true,
+    )?;
 
     println!("Key Package Created Successfully!");
     println!("  Encoded length: {} bytes", key_package_encoded.len());
@@ -73,7 +77,7 @@ async fn main() -> Result<(), Error> {
     println!("=== Creating Nostr Event ===\n");
 
     let key_package_event = EventBuilder::new(Kind::MlsKeyPackage, key_package_encoded.clone())
-        .tags(tags.to_vec())
+        .tags(tags)
         .build(keys.public_key())
         .sign(&keys)
         .await?;

--- a/crates/mdk-core/src/test_util.rs
+++ b/crates/mdk-core/src/test_util.rs
@@ -40,7 +40,7 @@ where
         .expect("Failed to create key package");
 
     EventBuilder::new(Kind::MlsKeyPackage, key_package_hex)
-        .tags(tags.to_vec())
+        .tags(tags)
         .sign_with_keys(member_keys)
         .expect("Failed to sign event")
 }
@@ -63,7 +63,7 @@ where
         .expect("Failed to create key package");
 
     EventBuilder::new(Kind::MlsKeyPackage, key_package_hex)
-        .tags(tags.to_vec())
+        .tags(tags)
         .sign_with_keys(signing_keys)
         .expect("Failed to sign event")
 }

--- a/crates/mdk-uniffi/CHANGELOG.md
+++ b/crates/mdk-uniffi/CHANGELOG.md
@@ -25,14 +25,9 @@
 
 ## Unreleased
 
-### Added
-
-- **Group `last_message_processed_at` Field**: The `Group` record now includes an optional `last_message_processed_at: u64` field (Unix timestamp) indicating when the last message was received/processed by this client. This complements `last_message_at` (sender's timestamp) and ensures `last_message_id` is consistent with the first message returned by `get_messages()`. ([#166](https://github.com/marmot-protocol/mdk/pull/166))
-
-- **Message `processed_at` Field**: The `Message` record now includes a `processed_at: u64` field (Unix timestamp) indicating when this client received/processed the message. This complements the existing `created_at` field (sender's timestamp) and helps clients handle clock skew between devices - messages can now be displayed in reception order if desired. ([#166](https://github.com/marmot-protocol/mdk/pull/166))
-
 ### Breaking changes
 
+- **`create_key_package_for_event` No Longer Adds Protected Tag**: The `create_key_package_for_event()` function no longer adds the NIP-70 protected tag by default. This is a behavioral change - existing code that relied on the protected tag being present will now produce key packages without it. Key packages can now be republished by third parties to any relay. For users who need the protected tag, use the new `create_key_package_for_event_with_options()` function with `protected: true`. ([#173](https://github.com/marmot-protocol/mdk/pull/173), related: [#168](https://github.com/marmot-protocol/mdk/issues/168))
 - **Security (Audit Issue M)**: Changed `get_message()` to require both `mls_group_id` and `event_id` parameters. This prevents messages from different groups from overwriting each other by scoping lookups to a specific group. ([#124](https://github.com/marmot-protocol/mdk/pull/124))
 - Renamed `Message.processed_at` to `Message.created_at` for semantic accuracy. The field represents when a message was created, not when it was processed by the system. ([`#163`](https://github.com/marmot-protocol/mdk/pull/163))
 
@@ -43,10 +38,11 @@
 - Changed `get_pending_welcomes()` to accept optional `limit` and `offset` parameters for pagination control. Existing calls must be updated to pass `None, None` for default behavior (limit: 1000, offset: 0), or specify values for custom pagination. ([#119](https://github.com/marmot-protocol/mdk/pull/119))
 - Changed `new_mdk()`, `new_mdk_with_key()`, and `new_mdk_unencrypted()` to accept an optional `MdkConfig` parameter for customizing MDK behavior. Existing calls must be updated to pass `None` for default behavior. ([`#155`](https://github.com/marmot-protocol/mdk/pull/155))
 
-### Changed
-
 ### Added
 
+- **`create_key_package_for_event_with_options`**: New function that allows specifying whether to include the NIP-70 protected tag. Use this if you need to publish to relays that accept protected events. ([#173](https://github.com/marmot-protocol/mdk/pull/173), related: [#168](https://github.com/marmot-protocol/mdk/issues/168))
+- **Group `last_message_processed_at` Field**: The `Group` record now includes an optional `last_message_processed_at: u64` field (Unix timestamp) indicating when the last message was received/processed by this client. This complements `last_message_at` (sender's timestamp) and ensures `last_message_id` is consistent with the first message returned by `get_messages()`. ([#166](https://github.com/marmot-protocol/mdk/pull/166))
+- **Message `processed_at` Field**: The `Message` record now includes a `processed_at: u64` field (Unix timestamp) indicating when this client received/processed the message. This complements the existing `created_at` field (sender's timestamp) and helps clients handle clock skew between devices - messages can now be displayed in reception order if desired. ([#166](https://github.com/marmot-protocol/mdk/pull/166))
 - **`PreviouslyFailed` Result Variant**: Added `ProcessMessageResult.PreviouslyFailed` enum variant to handle cases where a previously failed message arrives again but the MLS group ID cannot be extracted. This prevents crashes in client applications (fixes [#153](https://github.com/marmot-protocol/mdk/issues/153)) by returning a result instead of throwing an exception. ([#165](https://github.com/marmot-protocol/mdk/pull/165), fixes [#154](https://github.com/marmot-protocol/mdk/issues/154), [#159](https://github.com/marmot-protocol/mdk/issues/159))
 - Added `MdkConfig` record for configuring MDK behavior, including `out_of_order_tolerance` and `maximum_forward_distance` settings for MLS sender ratchet configuration. All fields are optional and default to sensible values. ([`#155`](https://github.com/marmot-protocol/mdk/pull/155))
 - Exposed pagination control for `get_messages()` to foreign language bindings via optional `limit` and `offset` parameters. ([#111](https://github.com/marmot-protocol/mdk/pull/111))


### PR DESCRIPTION
Addresses https://github.com/marmot-protocol/mdk/issues/168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR makes the NIP-70 "protected" tag optional when creating Nostr MLS key-package events to improve relay compatibility, defaulting to omitting the protected tag while providing an options-based API so callers can opt into it. It updates mdk-core internals and public API, adapts examples and tests, and exposes the options in UniFFI so external callers can request the protected tag when needed.

**What changed**:
- create_key_package_for_event now omits the NIP-70 protected tag by default and delegates to a shared internal implementation that accepts a protected: bool flag (mdk-core).  
- Added create_key_package_for_event_with_options(public_key, relays, protected) to let callers include the protected tag when desired (mdk-core, mdk-uniffi).  
- Return type changed from (String, [Tag; 7]) to (String, Vec<Tag>) to reflect optional protected tag and variable tag count (mdk-core; mdk-uniffi bindings updated).  
- Public APIs now accept relay inputs as IntoIterator<Item = RelayUrl> for flexibility (mdk-core).  
- Examples and test utilities updated to pass tags directly (EventBuilder::tags) and to demonstrate protected: true usage in the key_package_inspection example (mdk-core examples, test_util).  
- CHANGELOG entries updated in mdk-core and mdk-uniffi to document behavior and API changes.

**Security impact**:
- No cryptographic algorithm, key derivation, nonce, or key storage behavior was changed; this is a behavioral/tagging change only.  
- Logging now includes the protected flag state in a debug message, which does not expose sensitive key material.

**Protocol changes**:
- Nostr integration: NIP-70 protected tag (["-"]) is now optional and omitted by default for wider relay compatibility; callers can include it via the new options API (NIP-70).  
- No MLS protocol (RFC 9420) algorithmic changes.

**API surface**:
- Breaking: create_key_package_for_event signature/return type changed to return Vec<Tag> instead of fixed [Tag; 7], and it no longer includes the protected tag by default (mdk-core).  
- Breaking behavior: callers that relied on a guaranteed protected tag must migrate to create_key_package_for_event_with_options(..., protected: true).  
- New public API: create_key_package_for_event_with_options<I>(public_key, relays, protected) (mdk-core) and corresponding UniFFI method create_key_package_for_event_with_options(public_key: String, relays: Vec<String>, protected: bool) (mdk-uniffi).  
- UniFFI/FFI: tag conversion and KeyPackageResult mapping updated to account for Vec<Tag>.

**Testing**:
- Tests and examples updated to assert 6-tag output for default create_key_package_for_event and 7-tag output when protected: true is used; test utilities and examples adjusted accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->