### PR TITLE
Remove mentions of nostr-mls

### DIFF
--- a/crates/mdk-core/src/constant.rs
+++ b/crates/mdk-core/src/constant.rs
@@ -1,4 +1,4 @@
-//! Nostr MLS constants
+//! MDK constants
 
 use openmls::extensions::ExtensionType;
 use openmls_traits::types::Ciphersuite;

--- a/crates/mdk-core/src/error.rs
+++ b/crates/mdk-core/src/error.rs
@@ -23,7 +23,7 @@ use openmls::key_packages::errors::{KeyPackageNewError, KeyPackageVerifyError};
 use openmls::prelude::{MlsGroupStateError, ValidationError};
 use openmls_traits::types::CryptoError;
 
-/// Nostr MLS error
+/// MDK error
 #[derive(Debug, PartialEq, thiserror::Error)]
 pub enum Error {
     /// Hex error

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -1,4 +1,4 @@
-//! Nostr MLS Group Management
+//! MDK groups
 //!
 //! This module provides functionality for managing MLS groups in Nostr:
 //! - Group creation and configuration
@@ -7,7 +7,7 @@
 //! - Group metadata handling
 //! - Group secret management
 //!
-//! Groups in Nostr MLS have both an MLS group ID and a Nostr group ID. The MLS group ID
+//! Groups in MDK have both an MLS group ID and a Nostr group ID. The MLS group ID
 //! is used internally by the MLS protocol, while the Nostr group ID is used for
 //! relay-based message routing and group discovery.
 
@@ -380,7 +380,7 @@ where
         }
     }
 
-    /// Retrieves a Nostr MLS group by its MLS group ID
+    /// Retrieves a MDK group by its MLS group ID
     ///
     /// # Arguments
     ///
@@ -397,7 +397,7 @@ where
             .map_err(|e| Error::Group(e.to_string()))
     }
 
-    /// Retrieves all Nostr MLS groups from storage
+    /// Retrieves all MDK groups from storage
     ///
     /// # Returns
     ///

--- a/crates/mdk-core/src/key_packages.rs
+++ b/crates/mdk-core/src/key_packages.rs
@@ -1,4 +1,4 @@
-//! Nostr MLS Key Packages
+//! MDK Key Packages
 
 use mdk_storage_traits::MdkStorageProvider;
 use nostr::{Event, Kind, PublicKey, RelayUrl, Tag, TagKind};

--- a/crates/mdk-core/src/lib.rs
+++ b/crates/mdk-core/src/lib.rs
@@ -259,9 +259,9 @@ where
     }
 }
 
-/// The main struct for the Nostr MLS implementation.
+/// The main struct for the MDK implementation.
 ///
-/// This struct provides the core functionality for MLS operations in Nostr:
+/// This struct provides the core functionality for MLS operations in the Marmot protocol:
 /// - Group management (creation, updates, member management)
 /// - Message handling (encryption, decryption, processing)
 /// - Key management (key packages, welcome messages)
@@ -380,7 +380,7 @@ where
         .with_grease(&self.provider.crypto)
     }
 
-    /// Get nostr mls group's required capabilities extension
+    /// Get the group's required capabilities extension
     #[inline]
     pub(crate) fn required_capabilities_extension(&self) -> Extension {
         Extension::RequiredCapabilities(RequiredCapabilitiesExtension::new(
@@ -406,7 +406,7 @@ where
     }
 }
 
-/// Tests module for nostr-mls
+/// Tests module for mdk-core
 #[cfg(test)]
 pub mod tests {
     use mdk_memory_storage::MdkMemoryStorage;

--- a/crates/mdk-core/src/messages/mod.rs
+++ b/crates/mdk-core/src/messages/mod.rs
@@ -1,4 +1,4 @@
-//! Nostr MLS Messages
+//! MDK messages
 //!
 //! This module provides functionality for creating, processing, and managing encrypted
 //! messages in MLS groups. It handles:
@@ -7,7 +7,7 @@
 //! - Message state tracking
 //! - Integration with Nostr events
 //!
-//! Messages in Nostr MLS are wrapped in Nostr events (kind:445) for relay transmission.
+//! Messages in MDK are wrapped in Nostr events (kind:445) for relay transmission.
 //! The message content is encrypted using both MLS group keys and NIP-44 encryption.
 //! Message state is tracked to handle processing status and failure scenarios.
 

--- a/crates/mdk-core/src/prelude.rs
+++ b/crates/mdk-core/src/prelude.rs
@@ -17,7 +17,7 @@
 // === Core MDK Types ===
 /// MDK error type
 pub use crate::Error;
-/// The main MDK struct for Nostr MLS operations
+/// The main MDK struct for Marmot protocol operations
 pub use crate::MDK;
 /// MDK provider for OpenMLS integration
 pub use crate::MdkProvider;

--- a/crates/mdk-core/src/test_util.rs
+++ b/crates/mdk-core/src/test_util.rs
@@ -1,4 +1,4 @@
-//! Test utilities for the nostr-mls crate
+//! Test utilities for the mdk-core crate
 //!
 //! This module provides shared test utilities used across multiple test modules
 //! to avoid code duplication and ensure consistency in test setup.

--- a/crates/mdk-core/src/welcomes.rs
+++ b/crates/mdk-core/src/welcomes.rs
@@ -1,4 +1,4 @@
-//! Nostr MLS Welcomes
+//! MDK welcomes
 
 use nostr::{EventId, Kind, Tag, TagKind, Timestamp, UnsignedEvent};
 use openmls::prelude::*;

--- a/crates/mdk-memory-storage/Cargo.toml
+++ b/crates/mdk-memory-storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mdk-memory-storage"
 version = "0.5.1"
 edition = "2024"
-description = "In-memory database for nostr-mls that implements the MdkStorageProvider Trait"
+description = "In-memory database for MDK that implements the MdkStorageProvider trait"
 authors = ["Jeff Gardner <j@jeffg.me>", "Yuki Kishimoto <yukikishimoto@protonmail.com>", "MDK Developers"]
 homepage.workspace = true
 repository.workspace = true

--- a/crates/mdk-memory-storage/README.md
+++ b/crates/mdk-memory-storage/README.md
@@ -1,6 +1,6 @@
-# Nostr MLS Memory Storage
+# MDK Memory Storage
 
-Memory-based storage implementation for [Nostr MLS](../nostr-mls). This crate provides a storage backend that implements the `MdkStorageProvider` trait from the [mdk-storage](../mdk-storage) crate.
+Memory-based storage implementation for MDK. This crate provides a storage backend that implements the `MdkStorageProvider` trait from the [mdk-storage-traits](../mdk-storage-traits) crate.
 
 ## Features
 

--- a/crates/mdk-memory-storage/src/groups.rs
+++ b/crates/mdk-memory-storage/src/groups.rs
@@ -1,4 +1,4 @@
-//! Memory-based storage implementation of the MdkStorageProvider trait for Nostr MLS groups
+//! Memory-based storage implementation of the MdkStorageProvider trait for MDK groups
 
 use std::collections::BTreeSet;
 

--- a/crates/mdk-memory-storage/src/lib.rs
+++ b/crates/mdk-memory-storage/src/lib.rs
@@ -1,7 +1,7 @@
-//! Memory-based storage implementation for Nostr MLS.
+//! Memory-based storage implementation for MDK.
 //!
-//! This module provides a memory-based storage implementation for the Nostr MLS (Messaging Layer Security)
-//! crate. It implements the `MdkStorageProvider` trait, allowing it to be used within the Nostr MLS context.
+//! This module provides a memory-based storage implementation for MDK (Marmot Development Kit).
+//! It implements the `MdkStorageProvider` trait, allowing it to be used as an in-memory storage backend.
 //!
 //! Memory-based storage is non-persistent and will be cleared when the application terminates.
 //! It's useful for testing or ephemeral applications where persistence isn't required.
@@ -280,7 +280,7 @@ impl ValidationLimits {
     }
 }
 
-/// A memory-based storage implementation for Nostr MLS.
+/// A memory-based storage implementation for MDK.
 ///
 /// This struct implements both the OpenMLS `StorageProvider<1>` trait and MDK storage
 /// traits directly, providing unified storage for MLS cryptographic state and

--- a/crates/mdk-memory-storage/src/messages.rs
+++ b/crates/mdk-memory-storage/src/messages.rs
@@ -1,4 +1,4 @@
-//! Memory-based storage implementation of the MdkStorageProvider trait for Nostr MLS messages
+//! Memory-based storage implementation of the MdkStorageProvider trait for MDK messages
 
 use std::collections::HashMap;
 

--- a/crates/mdk-memory-storage/src/welcomes.rs
+++ b/crates/mdk-memory-storage/src/welcomes.rs
@@ -1,4 +1,4 @@
-//! Memory-based storage implementation of the MdkStorageProvider trait for Nostr MLS welcomes
+//! Memory-based storage implementation of the MdkStorageProvider trait for MDK welcomes
 
 use mdk_storage_traits::welcomes::error::WelcomeError;
 use mdk_storage_traits::welcomes::types::*;

--- a/crates/mdk-sqlite-storage/Cargo.toml
+++ b/crates/mdk-sqlite-storage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mdk-sqlite-storage"
 version = "0.5.1"
 edition = "2024"
-description = "Sqlite database for nostr-mls that implements the MdkStorageProvider Trait"
+description = "SQLite database for MDK that implements the MdkStorageProvider trait"
 authors = ["Jeff Gardner <j@jeffg.me>", "Yuki Kishimoto <yukikishimoto@protonmail.com>", "MDK Developers"]
 homepage.workspace = true
 repository.workspace = true

--- a/crates/mdk-sqlite-storage/README.md
+++ b/crates/mdk-sqlite-storage/README.md
@@ -1,4 +1,4 @@
-# Nostr MLS Sqlite Storage
+# MDK SQLite Storage
 
 Sqlite MLS storage backend for nostr apps
 

--- a/crates/mdk-sqlite-storage/src/lib.rs
+++ b/crates/mdk-sqlite-storage/src/lib.rs
@@ -1,7 +1,7 @@
-//! SQLite-based storage implementation for Nostr MLS.
+//! SQLite-based storage implementation for MDK.
 //!
-//! This module provides a SQLite-based storage implementation for the Nostr MLS (Messaging Layer Security)
-//! crate. It implements the [`MdkStorageProvider`] trait, allowing it to be used within the Nostr MLS context.
+//! This module provides a SQLite-based storage implementation for MDK (Marmot Development Kit).
+//! It implements the [`MdkStorageProvider`] trait, allowing it to be used as a persistent storage backend.
 //!
 //! SQLite-based storage is persistent and will be saved to a file. It's useful for production applications
 //! where data persistence is required.
@@ -95,7 +95,7 @@ use self::permissions::{
     FileCreationOutcome, precreate_secure_database_file, set_secure_file_permissions,
 };
 
-/// A SQLite-based storage implementation for Nostr MLS.
+/// A SQLite-based storage implementation for MDK.
 ///
 /// This struct implements the MdkStorageProvider trait for SQLite databases.
 /// It directly interfaces with a SQLite database for storing MLS data, using

--- a/crates/mdk-storage-traits/Cargo.toml
+++ b/crates/mdk-storage-traits/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mdk-storage-traits"
 version = "0.5.1"
 edition = "2024"
-description = "Storage abstraction for nostr-mls that wraps OpenMLS storage backends"
+description = "Storage abstraction for MDK that wraps OpenMLS storage backends"
 authors = ["Jeff Gardner <j@jeffg.me>", "Yuki Kishimoto <yukikishimoto@protonmail.com>", "MDK Developers"]
 homepage.workspace = true
 repository.workspace = true

--- a/crates/mdk-storage-traits/README.md
+++ b/crates/mdk-storage-traits/README.md
@@ -1,4 +1,4 @@
-# Nostr MLS Storage
+# MDK Storage Traits
 
 This crate provides an abstraction for the storage layer that MLS requires.
 

--- a/crates/mdk-storage-traits/src/groups/types.rs
+++ b/crates/mdk-storage-traits/src/groups/types.rs
@@ -74,7 +74,7 @@ impl<'de> Deserialize<'de> for GroupState {
     }
 }
 
-/// A Nostr MLS group
+/// An MDK group
 ///
 /// Stores metadata about the group
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -154,7 +154,7 @@ impl Group {
     }
 }
 
-/// A Nostr MLS group relay
+/// An MDK group relay
 ///
 /// Stores a relay URL and the MLS group ID it belongs to
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]

--- a/crates/mdk-storage-traits/src/lib.rs
+++ b/crates/mdk-storage-traits/src/lib.rs
@@ -1,4 +1,4 @@
-//! Nostr MLS storage - A set of storage provider traits and types for implementing MLS storage
+//! MDK storage - A set of storage provider traits and types for implementing MLS storage
 //! It is designed to be used in conjunction with the `openmls` crate.
 
 #![deny(unsafe_code)]
@@ -48,7 +48,7 @@ impl Backend {
     }
 }
 
-/// Storage provider for the Nostr MLS storage.
+/// Storage provider for MDK.
 ///
 /// This trait combines all MDK storage requirements with the OpenMLS
 /// `StorageProvider` trait, enabling unified storage implementations


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR removes all references to "Nostr MLS" throughout the codebase and replaces them with "MDK" (Marmot Development Kit), updating the project's branding and terminology to reflect its role within the Marmot protocol. The changes are purely documentation-focused, affecting module comments, README files, and Cargo.toml descriptions across multiple crates. No functional code, public APIs, or behavior are affected.

**What changed**:
- Updated module-level documentation comments in mdk-core crates (constant.rs, error.rs, groups.rs, key_packages.rs, lib.rs, messages/mod.rs, prelude.rs, test_util.rs, welcomes.rs) to reference MDK instead of Nostr MLS
- Updated documentation in mdk-memory-storage crates (groups.rs, lib.rs, messages.rs, welcomes.rs) and mdk-sqlite-storage src/lib.rs to use MDK terminology
- Updated README.md files in mdk-memory-storage, mdk-sqlite-storage, and mdk-storage-traits to use MDK branding
- Updated Cargo.toml package descriptions in mdk-memory-storage, mdk-sqlite-storage, and mdk-storage-traits to reference MDK instead of nostr-mls
- Updated inline documentation in mdk-storage-traits/src/groups/types.rs for Group and GroupRelay type descriptions
- Minor formatting adjustments including capitalization changes (e.g., "Trait" → "trait", "Sqlite" → "SQLite")

<!-- end of auto-generated comment: release notes by coderabbit.ai -->