### PR TITLE
feat: add clear_pending_commit for publish failure recovery

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 ### Added
 
+- **`clear_pending_commit` method**: Added `MDK::clear_pending_commit(group_id)` to allow callers to roll back an uncommitted pending MLS commit. This is essential for recovering from failed relay publishes — without it, a single failed publish permanently blocks all future group operations with "pending commit exists" errors. Wraps OpenMLS's `MlsGroup::clear_pending_commit` with MDK's group-loading and error handling. ([#192](https://github.com/marmot-protocol/mdk/pull/192))
+
 ### Fixed
 
 ### Removed


### PR DESCRIPTION
## Problem

MDK documents that `merge_pending_commit` should be called **after** publishing the Kind:445 message. But if the publish fails (relay down, network error, auth rejection after retries), the pending commit remains in storage permanently. Every subsequent `add_members`, `remove_members`, or `self_update` call fails with:

> Can't execute operation because a pending commit exists.

The group is stuck with no recovery path. The only option is to create a new group.

This was discovered while implementing MIP-02/MIP-03 relay-confirmation-before-merge ordering in Vector: [VectorPrivacy/Vector#46](https://github.com/VectorPrivacy/Vector/pull/46)

## Fix

Expose OpenMLS's existing `MlsGroup::clear_pending_commit` (which already persists the state change via `StorageProvider::write_group_state`) as a one-line wrapper:

```rust
pub fn clear_pending_commit(&self, group_id: &GroupId) -> Result<(), Error>
```

This returns the group to its pre-commit state — no epoch advance, no member changes. Clients call it when publish exhausts retries, then surface the error to the user who can retry the operation.

## Usage

```rust
let result = engine.add_members(&group_id, &key_packages)?;

match publish_to_relays(&result.evolution_event).await {
    Ok(_) => engine.merge_pending_commit(&group_id)?,
    Err(_) => engine.clear_pending_commit(&group_id)?,  // rollback
}
```

## Test plan

- [x] `cargo check -p mdk-core`
- [x] Tested in Vector: disable relays → kick member → publish fails → `clear_pending_commit` called → group remains functional → re-enable relays → retry kick → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR exposes OpenMLS's existing `MlsGroup::clear_pending_commit` via a new MDK wrapper method to enable recovery from failed relay publishes. When a publish fails after creating a pending commit, the group becomes stuck and unable to perform any operations; this method allows clients to roll back the pending commit and retry the failed operation.

**What changed**:
- Added `MDK::clear_pending_commit(&self, group_id: &GroupId) -> Result<(), Error>` public method to mdk-core that loads the MLS group and delegates to OpenMLS's clear_pending_commit, returning the group to its pre-commit state without advancing epoch or applying member changes.
- Updated CHANGELOG.md to document the new method.

**API surface**:
- New public method added to MDK: `clear_pending_commit(group_id)` allows explicit rollback of uncommitted pending MLS commits.

**Testing**:
- Four unit tests added to verify behavior: rollback of failed add-member commit, rollback of failed remove-member commit, no-op behavior when no pending commit exists, and error handling for non-existent groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->