### PR TITLE
feat: skip storage for ephemeral message kinds

### DIFF
--- a/crates/mdk-core/src/messages/mod.rs
+++ b/crates/mdk-core/src/messages/mod.rs
@@ -14,6 +14,7 @@
 mod application;
 mod commit;
 mod create;
+pub use create::CreateMessageOptions;
 mod decryption;
 mod error_handling;
 mod process;

--- a/crates/mdk-core/src/prelude.rs
+++ b/crates/mdk-core/src/prelude.rs
@@ -32,6 +32,8 @@ pub use crate::groups::{
     GroupResult, NostrGroupConfigData, NostrGroupDataUpdate, PendingMemberChanges,
     UpdateGroupResult,
 };
+/// Options for create_message_with_options
+pub use crate::messages::CreateMessageOptions;
 /// Message processing result variants
 pub use crate::messages::MessageProcessingResult;
 /// Welcome operation results


### PR DESCRIPTION
On the receive side, check `rumor.kind.is_ephemeral()` to avoid
persisting messages (and updating group metadata) for transient signals
like typing indicators.  On the send side, expose
`create_message_with_options` with a `skip_storage` flag so callers can
opt out of persistence while still advancing the MLS ratchet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR introduces support for ephemeral (transient) message kinds so callers can send and receivers can handle signals (e.g., typing indicators) that advance the MLS ratchet without persisting to storage or updating group last-message metadata. It adds an API to opt out of persistence when creating messages and conditions receive-side processing to skip storage for ephemeral kinds.

**What changed**:
- Receive side (crates/mdk-core/src/messages/application.rs): messages with `rumor.kind.is_ephemeral()` are returned to callers but are not persisted and will not update group last-message metadata.
- Send side (crates/mdk-core/src/messages/create.rs): added `CreateMessageOptions { skip_storage: bool }`, new `create_message_with_options(...)` caller API, and `create_message(...)` now delegates to it; when `skip_storage=true` the MLS ratchet still advances but Message and ProcessedMessage records and group last-message fields are not saved.
- Module/API exports (crates/mdk-core/src/messages/mod.rs, crates/mdk-core/src/prelude.rs): `CreateMessageOptions` re-exported from messages and exposed in the public prelude.
- Crates affected: mdk-core only.

**Security impact**:
- No changes to cryptographic primitives, key derivation, or MLS ratchet semantics; MLS messages are still created and signed as before.
- No changes to key handling or storage of long-lived secrets; only persistence of message metadata is conditionally skipped.
- No changes to SQLCipher, file permissions, or error messages.

**Protocol changes**:
- None to the MLS protocol implementation or external protocol integrations; behavior change is limited to local persistence and metadata updates for ephemeral kinds.

**API surface**:
- New public API: `CreateMessageOptions` and `create_message_with_options(...)` (non-breaking; `create_message(...)` continues to exist and delegates to the new method).
- Public re-exports: `CreateMessageOptions` added to messages mod and prelude.
- No storage schema or UniFFI/FFI boundary changes.

**Testing**:
- Tests added/updated in mdk-core: `test_create_message_skip_storage` verifies messages created with `skip_storage=true` are not stored and do not update last-message metadata; `test_ephemeral_kind_skips_storage_on_receive` verifies ephemeral-kind messages are returned to the caller on receive but not persisted, while normal messages continue to be stored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->