### PR TITLE
fix(ci): remove local-cache from Android NDK setup to fix Kotlin build

### DIFF
--- a/.github/workflows/package-mdk-bindings.yml
+++ b/.github/workflows/package-mdk-bindings.yml
@@ -530,7 +530,6 @@ jobs:
         ndk-version: r27d
         add-to-path: false
         link-to-sdk: true
-        local-cache: true
 
     - name: Setup OpenSSL for Android
       id: setup-openssl


### PR DESCRIPTION
## Summary

- Removes `local-cache: true` from the `nttld/setup-ndk` step in the `package-kotlin` CI job
- The cached NDK was missing `toolchains/llvm/prebuilt/linux-x86_64/bin/clang`, causing `build-openssl-android.sh` to fail immediately with "NDK clang not found" on every run since Feb 19
- Forcing a fresh NDK download each run eliminates the stale/incomplete cache problem; cost is ~2–3 min extra per run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes a Kotlin build failure caused by a stale NDK cache by removing `local-cache: true` from the Android NDK setup step in the CI workflow. The cached NDK was missing required toolchain files, causing the OpenSSL Android build script to fail; forcing a fresh NDK download on each run resolves the issue, with a trade-off of an additional 2–3 minutes per workflow run.

**What changed**:
- Removed the `local-cache: true` configuration from the `nttld/setup-ndk@v1` action in `.github/workflows/package-mdk-bindings.yml`, disabling NDK caching for the Kotlin bindings build job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->