### PR TITLE
fix(ci): skip pre-publish build check for mdk-storage-traits

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -31,7 +31,10 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y pkg-config
 
     - name: Publish mdk-storage-traits
-      run: cargo publish -p mdk-storage-traits
+      # --no-verify skips the pre-publish build check, which would otherwise
+      # fail trying to resolve dev-dependencies (mdk-memory-storage,
+      # mdk-sqlite-storage) from crates.io before they have been published.
+      run: cargo publish -p mdk-storage-traits --no-verify
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
## Problem

The `publish-storage-traits` job fails at the packaging step because `mdk-storage-traits` has `mdk-memory-storage` and `mdk-sqlite-storage` as dev-dependencies. When `cargo publish` prepares the package, it tries to resolve all dependencies (including dev-deps) from crates.io — but those two crates haven't been published yet at that point in the workflow.

```
error: failed to prepare local package for uploading
Caused by:
  no matching package named `mdk-memory-storage` found
  location searched: crates.io index
  required by package `mdk-storage-traits v0.6.0`
```

## Fix

Add `--no-verify` to the `cargo publish` command for `mdk-storage-traits` only. This skips the pre-publish build check (which is what triggers the dev-dep resolution). The crate itself is already verified by CI before the release is created, so skipping this redundant check is safe.

The downstream crates (`mdk-memory-storage`, `mdk-sqlite-storage`, `mdk-core`) do not need `--no-verify` since by the time they publish, all their dependencies are already on crates.io.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes the CI publish workflow to successfully release `mdk-storage-traits` by adding the `--no-verify` flag to `cargo publish`, which skips the pre-publish build check that would otherwise fail when attempting to resolve unpublished dev-dependencies from crates.io. Since the crate is already verified by CI before release creation, this redundant check can be safely skipped.

**What changed**:
- Modified `.github/workflows/publish-crates.yml` to pass `--no-verify` flag to `cargo publish` for `mdk-storage-traits` only, with comments explaining that this skips the pre-publish build check to avoid resolution failures for dev-dependencies (`mdk-memory-storage` and `mdk-sqlite-storage`) that are not yet published on crates.io.
- Downstream crates (`mdk-memory-storage`, `mdk-sqlite-storage`, and `mdk-core`) remain unchanged and do not require this flag since their dependencies will be available on crates.io by the time they are published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->