### PR TITLE
ci: add UniFFI bindings coverage checker

### DIFF
--- a/.github/workflows/uniffi-bindings-check.yml
+++ b/.github/workflows/uniffi-bindings-check.yml
@@ -1,0 +1,154 @@
+name: UniFFI Bindings Check
+
+on:
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: uniffi-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # ── Change Detection ────────────────────────────────────────────────
+  changes:
+    name: Detect Changed Paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            rust:
+              - 'crates/mdk-core/src/**'
+              - 'crates/mdk-uniffi/src/**'
+              - 'crates/mdk-uniffi/unbound-methods.txt'
+              - 'scripts/check-uniffi-bindings.ts'
+              - '.github/workflows/uniffi-bindings-check.yml'
+
+  # ── Check UniFFI binding coverage ───────────────────────────────────
+  check-bindings:
+    name: Check Bindings
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: uniffi-check
+
+      - name: Generate rustdoc JSON for mdk-core
+        run: |
+          RUSTDOCFLAGS='-Z unstable-options --output-format json' \
+            cargo +nightly doc -p mdk-core --no-deps --all-features
+
+      - name: Generate rustdoc JSON for mdk-uniffi
+        run: |
+          RUSTDOCFLAGS='-Z unstable-options --output-format json' \
+            cargo +nightly doc -p mdk-uniffi --no-deps --all-features
+
+      - name: Check UniFFI binding coverage
+        id: check
+        run: bun scripts/check-uniffi-bindings.ts
+
+      - name: Comment on PR
+        if: steps.check.outcome == 'success' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const commentMarker = '<!-- uniffi-bindings-check -->';
+
+            // Skip commenting on PRs from forks
+            const isFork = context.payload.pull_request.head.repo.full_name
+              !== context.payload.repository.full_name;
+            if (isFork) {
+              console.log('Skipping PR comment: PR is from a fork');
+              return;
+            }
+
+            // Check if there are unbound methods to report
+            let body;
+            try {
+              body = fs.readFileSync('/tmp/uniffi-check-comment.md', 'utf-8');
+            } catch (e) {
+              body = null;
+            }
+
+            // Find existing comment from a previous run
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const existing = comments.find(c =>
+              c.body.includes(commentMarker) && c.user.type === 'Bot'
+            );
+
+            try {
+              if (!body) {
+                // All methods covered — delete stale comment if one exists
+                if (existing) {
+                  await github.rest.issues.deleteComment({
+                    comment_id: existing.id,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                  });
+                }
+                return;
+              }
+
+              body = commentMarker + '\n' + body;
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  comment_id: existing.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: body,
+                });
+              }
+            } catch (error) {
+              if (error.status === 403) {
+                console.log('Unable to comment on PR (likely from fork):', error.message);
+              } else {
+                throw error;
+              }
+            }

--- a/crates/mdk-uniffi/unbound-methods.txt
+++ b/crates/mdk-uniffi/unbound-methods.txt
@@ -1,0 +1,13 @@
+# Methods intentionally not bound in UniFFI
+#
+# Format: method_name # reason
+# Lines starting with # are comments. Blank lines are ignored.
+#
+# This file is read by scripts/check-uniffi-bindings.js during CI to suppress
+# warnings for methods that are deliberately excluded from the UniFFI bindings.
+
+builder # Wrapped by new_mdk(), new_mdk_with_key(), new_mdk_unencrypted() free functions
+new # Wrapped by new_mdk(), new_mdk_with_key(), new_mdk_unencrypted() free functions
+media_manager # Returns borrowed reference with lifetime — cannot cross FFI boundary
+load_mls_group # Only available behind debug-examples feature flag, not for production use
+migrate_group_image_v1_to_v2 # Migration utility for internal use only, not needed in client bindings

--- a/scripts/check-uniffi-bindings.ts
+++ b/scripts/check-uniffi-bindings.ts
@@ -1,0 +1,329 @@
+#!/usr/bin/env bun
+
+// Compares the public API surface of mdk-core against mdk-uniffi bindings.
+// Reads rustdoc JSON output (generated with nightly + --output-format json)
+// and reports methods that exist in core but are not bound in uniffi.
+//
+// Usage:
+//   bun scripts/check-uniffi-bindings.ts [--core PATH] [--uniffi PATH] [--allowlist PATH]
+//
+// Defaults:
+//   --core     target/doc/mdk_core.json
+//   --uniffi   target/doc/mdk_uniffi.json
+//   --allowlist crates/mdk-uniffi/unbound-methods.txt
+
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { resolve } from "path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type BindingStatus = "bound" | "unbound" | "allowlisted";
+
+interface MethodInfo {
+  name: string;
+  file: string;
+  line: number;
+}
+
+interface ClassifiedMethod extends MethodInfo {
+  status: BindingStatus;
+  reason?: string;
+}
+
+interface RustdocItem {
+  name: string;
+  visibility: string;
+  inner: Record<string, unknown>;
+  span?: { filename: string; begin: [number, number] };
+}
+
+interface RustdocData {
+  root: number;
+  index: Record<string, RustdocItem>;
+}
+
+interface Options {
+  core: string;
+  uniffi: string;
+  allowlist: string;
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(): Options {
+  const args = process.argv.slice(2);
+  const opts: Options = {
+    core: "target/doc/mdk_core.json",
+    uniffi: "target/doc/mdk_uniffi.json",
+    allowlist: "crates/mdk-uniffi/unbound-methods.txt",
+  };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--core" && args[i + 1]) opts.core = args[++i];
+    else if (args[i] === "--uniffi" && args[i + 1]) opts.uniffi = args[++i];
+    else if (args[i] === "--allowlist" && args[i + 1])
+      opts.allowlist = args[++i];
+  }
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// Allowlist parsing
+// ---------------------------------------------------------------------------
+
+function loadAllowlist(path: string): Map<string, string> {
+  if (!existsSync(path)) return new Map();
+  const lines = readFileSync(path, "utf-8").split("\n");
+  const entries = new Map<string, string>();
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const [name, ...rest] = line.split("#");
+    const method = name.trim();
+    const reason = rest.join("#").trim() || "no reason given";
+    if (method) entries.set(method, reason);
+  }
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Rustdoc JSON extraction helpers
+// ---------------------------------------------------------------------------
+
+/** Extract all public methods from inherent impl blocks of a named struct. */
+function extractStructMethods(
+  index: Record<string, RustdocItem>,
+  structName: string,
+): MethodInfo[] {
+  const structEntry = Object.values(index).find(
+    (item) => item.name === structName && item.inner?.struct,
+  );
+  if (!structEntry) return [];
+
+  const structInner = structEntry.inner.struct as {
+    impls?: number[];
+  };
+  const implIds = structInner.impls ?? [];
+  const methods: MethodInfo[] = [];
+
+  for (const implId of implIds) {
+    const impl = index[String(implId)];
+    if (!impl?.inner?.impl) continue;
+    const implData = impl.inner.impl as {
+      trait?: unknown;
+      items?: number[];
+    };
+    // Skip trait impls (From, Debug, etc.)
+    if (implData.trait) continue;
+
+    for (const itemId of implData.items ?? []) {
+      const item = index[String(itemId)];
+      if (!item) continue;
+      if (item.visibility !== "public") continue;
+      if (!item.inner?.function) continue;
+      methods.push({
+        name: item.name,
+        file: item.span?.filename ?? "unknown",
+        line: item.span?.begin?.[0] ?? 0,
+      });
+    }
+  }
+
+  return methods;
+}
+
+/** Extract all public free functions from a specific source file pattern. */
+function extractFreeFunctions(
+  index: Record<string, RustdocItem>,
+  filePattern: string,
+): MethodInfo[] {
+  return Object.values(index)
+    .filter(
+      (item) =>
+        item.visibility === "public" &&
+        item.inner?.function &&
+        item.span?.filename?.includes(filePattern),
+    )
+    .map((item) => ({
+      name: item.name,
+      file: item.span?.filename ?? "unknown",
+      line: item.span?.begin?.[0] ?? 0,
+    }));
+}
+
+/** Extract all public free functions exported from the crate root module. */
+function extractRootFreeFunctions(data: RustdocData): string[] {
+  const rootId = String(data.root);
+  const root = data.index[rootId];
+  const moduleInner = root?.inner?.module as { items?: number[] } | undefined;
+  if (!moduleInner) return [];
+
+  return (moduleInner.items ?? [])
+    .map((id) => data.index[String(id)])
+    .filter((item) => item?.visibility === "public" && item?.inner?.function)
+    .map((item) => item.name);
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+function classify(
+  items: MethodInfo[],
+  boundNames: Set<string>,
+  allowlist: Map<string, string>,
+): ClassifiedMethod[] {
+  return items.map((item) => {
+    if (allowlist.has(item.name)) {
+      return { ...item, status: "allowlisted" as const, reason: allowlist.get(item.name) };
+    }
+    if (boundNames.has(item.name)) {
+      return { ...item, status: "bound" as const };
+    }
+    return { ...item, status: "unbound" as const };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Markdown report
+// ---------------------------------------------------------------------------
+
+function buildReport(
+  unboundItems: ClassifiedMethod[],
+  boundItems: ClassifiedMethod[],
+  allowlistedItems: ClassifiedMethod[],
+  totalBindable: number,
+  coveragePct: string,
+): string {
+  let md = "";
+
+  md += "## UniFFI Binding Coverage\n\n";
+  md += `**${unboundItems.length} public method(s) not bound in UniFFI**\n\n`;
+  md += `Coverage: ${boundItems.length}/${totalBindable} bindable methods (${coveragePct}%)\n\n`;
+
+  // Unbound first — these are the actionable ones
+  md += "### ⚠️ Not Bound\n\n";
+  md += "| Method | Source |\n";
+  md += "|--------|--------|\n";
+  for (const item of unboundItems) {
+    md += `| \`${item.name}\` | \`${item.file}:${item.line}\` |\n`;
+  }
+
+  // Bound — collapsed
+  md += `\n<details>\n<summary>✅ Bound methods (${boundItems.length})</summary>\n\n`;
+  md += "| Method | Source |\n";
+  md += "|--------|--------|\n";
+  for (const item of boundItems) {
+    md += `| \`${item.name}\` | \`${item.file}:${item.line}\` |\n`;
+  }
+  md += "\n</details>\n";
+
+  // Allowlisted — collapsed
+  if (allowlistedItems.length > 0) {
+    md += `\n<details>\n<summary>➖ Intentionally excluded (${allowlistedItems.length})</summary>\n\n`;
+    md += "| Method | Reason |\n";
+    md += "|--------|--------|\n";
+    for (const item of allowlistedItems) {
+      md += `| \`${item.name}\` | ${item.reason} |\n`;
+    }
+    md += "\n</details>\n";
+  }
+
+  return md;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const opts = parseArgs();
+
+// Load rustdoc JSON files
+let coreData: RustdocData;
+let uniffiData: RustdocData;
+try {
+  coreData = JSON.parse(readFileSync(resolve(opts.core), "utf-8"));
+} catch (e) {
+  console.error(`Failed to read core rustdoc JSON: ${opts.core}`);
+  console.error((e as Error).message);
+  process.exit(1);
+}
+try {
+  uniffiData = JSON.parse(readFileSync(resolve(opts.uniffi), "utf-8"));
+} catch (e) {
+  console.error(`Failed to read uniffi rustdoc JSON: ${opts.uniffi}`);
+  console.error((e as Error).message);
+  process.exit(1);
+}
+
+const allowlist = loadAllowlist(resolve(opts.allowlist));
+
+// Extract core public API
+const coreMethods = extractStructMethods(coreData.index, "MDK");
+const coreFreeFns = extractFreeFunctions(coreData.index, "group_image");
+
+// Extract uniffi bound API
+const uniffiMethodNames = new Set(
+  extractStructMethods(uniffiData.index, "Mdk").map((m) => m.name),
+);
+const uniffiFreeFnNames = new Set(extractRootFreeFunctions(uniffiData));
+
+// Classify
+const methodReport = classify(coreMethods, uniffiMethodNames, allowlist);
+const freeFnReport = classify(coreFreeFns, uniffiFreeFnNames, allowlist);
+
+// Compute stats
+const allItems = [...methodReport, ...freeFnReport];
+const allSorted = allItems.sort((a, b) => a.name.localeCompare(b.name));
+
+const unboundItems = allSorted.filter((i) => i.status === "unbound");
+const boundItems = allSorted.filter((i) => i.status === "bound");
+const allowlistedItems = allSorted.filter((i) => i.status === "allowlisted");
+
+const totalBindable = allItems.length - allowlistedItems.length;
+const coveragePct =
+  totalBindable > 0
+    ? ((boundItems.length / totalBindable) * 100).toFixed(1)
+    : "100.0";
+
+// All covered: silent success
+if (unboundItems.length === 0) {
+  process.exit(0);
+}
+
+// Emit GitHub Actions annotations for unbound methods
+for (const item of unboundItems) {
+  console.log(
+    `::warning file=${item.file},line=${item.line}::${item.name}() is a public method in mdk-core but is not bound in mdk-uniffi`,
+  );
+}
+
+// Write PR comment body
+const md = buildReport(
+  unboundItems,
+  boundItems,
+  allowlistedItems,
+  totalBindable,
+  coveragePct,
+);
+const commentPath =
+  process.env.UNIFFI_COMMENT_PATH || "/tmp/uniffi-check-comment.md";
+writeFileSync(commentPath, md);
+
+// Console summary
+console.log(
+  `UniFFI binding coverage: ${boundItems.length}/${totalBindable} (${coveragePct}%)`,
+);
+console.log(
+  `  Bound: ${boundItems.length}, Unbound: ${unboundItems.length}, Allowlisted: ${allowlistedItems.length}`,
+);
+console.log("\nUnbound methods:");
+for (const item of unboundItems) {
+  console.log(`  - ${item.name} (${item.file}:${item.line})`);
+}
+
+// Always exit 0 — this check is informational only
+process.exit(0);


### PR DESCRIPTION
![marmot](https://blossom.primal.net/519f7f685f24215dc4856235247cdef15f00a50f861440d2c567cbe9dc37d484.png)

Adds a CI workflow that inspects the mdk-core public API surface using nightly rustdoc JSON and compares it against mdk-uniffi bindings — like a diligent marmot inspector checking every tunnel in the colony for completeness.

When unbound methods are found, the workflow posts a PR comment with a full coverage table and emits warning annotations pointing to the exact source locations. When everything is covered, the check is completely silent — no output, no comment, just a green tick. If a previous run left a comment that's now stale (because gaps were resolved), it cleans up after itself.

## What's included

- `.github/workflows/uniffi-bindings-check.yml` — GitHub Actions workflow triggered on PRs to master (with path-based change detection)
- `scripts/check-uniffi-bindings.js` — Bun script that parses rustdoc JSON from both crates, classifies every public method as bound/unbound/allowlisted, and generates annotations + PR comment markdown
- `crates/mdk-uniffi/unbound-methods.txt` — Plain text allowlist for methods intentionally excluded from bindings (with reasons)

## How it works

1. Installs nightly Rust and generates `cargo doc --output-format json` for both `mdk-core` (with `--all-features`) and `mdk-uniffi`
2. Extracts all public methods on `MDK<Storage>` and public free functions from `extension/group_image.rs`
3. Compares against what's bound in the `impl Mdk` block and root-level exports in mdk-uniffi
4. Filters out allowlisted methods
5. Reports gaps (if any) via warnings + PR comment with full coverage table

## Current coverage

Running against the current codebase: **30/37 bindable methods (81.1%)** with 7 unbound and 4 intentionally excluded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a CI workflow and supporting tooling to automatically monitor coverage of the UniFFI bindings against the mdk-core public API surface. The workflow generates rustdoc JSON for both crates, runs a coverage analysis script, and posts PR comments and warning annotations when public methods are not yet bound to UniFFI. The current implementation identifies 30/37 bindable methods (81.1%) as covered.

**What changed**:
- Added `.github/workflows/uniffi-bindings-check.yml` — GitHub Actions workflow that detects changes to UniFFI-related paths, generates nightly rustdoc JSON for mdk-core and mdk-uniffi, runs coverage analysis, and posts PR comments with results and inline warning annotations for unbound methods
- Added `scripts/check-uniffi-bindings.ts` — Bun script that parses rustdoc JSON from both crates, classifies public methods and free functions as bound/unbound/allowlisted, generates coverage statistics, and produces markdown reports and GitHub Actions annotations
- Added `crates/mdk-uniffi/unbound-methods.txt` — Allowlist file documenting methods intentionally excluded from UniFFI bindings with reasons (e.g., cross-boundary lifetime issues, feature-flag gating)

**API surface**:
- No breaking or new public API changes to the core libraries; this PR only adds tooling to monitor existing API coverage in the UniFFI layer
<!-- end of auto-generated comment: release notes by coderabbit.ai -->