### PR TITLE
chore: prepare 0.7.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "mdk-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "blurhash",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "mdk-memory-storage"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "lru",
  "mdk-storage-traits",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "mdk-sqlite-storage"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "getrandom 0.4.1",
  "hex",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "mdk-storage-traits"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "nostr",
  "openmls",
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "mdk-uniffi"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "hex",
  "mdk-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ rust-version = "1.90.0"
 
 [workspace.dependencies]
 # Internal crates
-mdk-memory-storage = { version = "0.6.0", path = "./crates/mdk-memory-storage", default-features = false }
-mdk-sqlite-storage = { version = "0.6.0", path = "./crates/mdk-sqlite-storage", default-features = false }
-mdk-storage-traits = { version = "0.6.0", path = "./crates/mdk-storage-traits", default-features = false }
-mdk-core = { version = "0.6.0", path = "./crates/mdk-core", default-features = false }
+mdk-memory-storage = { version = "0.7.0", path = "./crates/mdk-memory-storage", default-features = false }
+mdk-sqlite-storage = { version = "0.7.0", path = "./crates/mdk-sqlite-storage", default-features = false }
+mdk-storage-traits = { version = "0.7.0", path = "./crates/mdk-storage-traits", default-features = false }
+mdk-core = { version = "0.7.0", path = "./crates/mdk-core", default-features = false }
 
 # OpenMLS family
 openmls = { version = "0.8.1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ Add MDK to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mdk-core = "0.6.0"
-mdk-memory-storage = "0.6.0"  # For in-memory storage
+mdk-core = "0.7.0"
+mdk-memory-storage = "0.7.0"  # For in-memory storage
 # OR
-mdk-sqlite-storage = "0.6.0"  # For persistent SQLite storage
+mdk-sqlite-storage = "0.7.0"  # For persistent SQLite storage
 ```
 
 ### Feature Flags
@@ -110,7 +110,7 @@ mdk-sqlite-storage = "0.6.0"  # For persistent SQLite storage
 
 ```toml
 [dependencies]
-mdk-core = { version = "0.6.0", features = ["mip04"] }
+mdk-core = { version = "0.7.0", features = ["mip04"] }
 ```
 
 ## 🚀 Quick Start

--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -25,6 +25,20 @@
 
 ### Breaking changes
 
+### Changed
+
+### Added
+
+### Fixed
+
+### Removed
+
+### Deprecated
+
+## [0.7.0] - 2026-03-04
+
+### Breaking changes
+
 - **MIP-03**: kind:445 Group Message Event content format changed from NIP-44 to `base64(nonce || ChaCha20-Poly1305-ciphertext)`. The encryption key is now derived via `MLS-Exporter("marmot", "group-event", 32)` instead of being used as a NIP-44 secp256k1 private key. All implementations must update simultaneously; old and new formats are mutually incompatible. ([#208](https://github.com/marmot-protocol/mdk/pull/208))
 - **MIP-04**: MLS exporter label for encrypted media changed from `("nostr", "nostr")` to `("marmot", "encrypted-media")`. Encrypted media produced with the old label cannot be decrypted with this version. ([#208](https://github.com/marmot-protocol/mdk/pull/208))
 

--- a/crates/mdk-core/Cargo.toml
+++ b/crates/mdk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdk-core"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 description = "A simplified interface to build secure messaging apps on nostr with MLS."
 authors = ["Jeff Gardner <j@jeffg.me>", "Yuki Kishimoto <yukikishimoto@protonmail.com>", "MDK Developers"]

--- a/crates/mdk-memory-storage/CHANGELOG.md
+++ b/crates/mdk-memory-storage/CHANGELOG.md
@@ -27,6 +27,20 @@
 
 ### Breaking changes
 
+### Changed
+
+### Added
+
+### Fixed
+
+### Removed
+
+### Deprecated
+
+## [0.7.0] - 2026-03-04
+
+### Breaking changes
+
 - `GroupScopedSnapshot` has a new `group_mip04_exporter_secrets` field. Any code constructing this struct directly must be updated. ([#208](https://github.com/marmot-protocol/mdk/pull/208))
 - `MemoryStorageSnapshot` has a new `group_mip04_exporter_secrets` field. Any code constructing this struct directly must be updated. ([#208](https://github.com/marmot-protocol/mdk/pull/208))
 

--- a/crates/mdk-memory-storage/Cargo.toml
+++ b/crates/mdk-memory-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdk-memory-storage"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 description = "In-memory database for MDK that implements the MdkStorageProvider trait"
 authors = ["Jeff Gardner <j@jeffg.me>", "Yuki Kishimoto <yukikishimoto@protonmail.com>", "MDK Developers"]

--- a/crates/mdk-sqlite-storage/CHANGELOG.md
+++ b/crates/mdk-sqlite-storage/CHANGELOG.md
@@ -27,6 +27,20 @@
 
 ### Breaking changes
 
+### Changed
+
+### Added
+
+### Fixed
+
+### Removed
+
+### Deprecated
+
+## [0.7.0] - 2026-03-04
+
+### Breaking changes
+
 - New SQLite migration `V005` adds a `label` column (`'group-event'` or `'encrypted-media'`) to the `group_exporter_secrets` table. Existing rows are migrated to `label = 'group-event'`. The primary key now includes `label`, allowing both MIP-03 and MIP-04 exporter secrets to coexist for the same `(mls_group_id, epoch)` pair. ([#208](https://github.com/marmot-protocol/mdk/pull/208))
 
 ### Added

--- a/crates/mdk-sqlite-storage/Cargo.toml
+++ b/crates/mdk-sqlite-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdk-sqlite-storage"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 description = "SQLite database for MDK that implements the MdkStorageProvider trait"
 authors = ["Jeff Gardner <j@jeffg.me>", "Yuki Kishimoto <yukikishimoto@protonmail.com>", "MDK Developers"]

--- a/crates/mdk-storage-traits/CHANGELOG.md
+++ b/crates/mdk-storage-traits/CHANGELOG.md
@@ -27,6 +27,20 @@
 
 ### Breaking changes
 
+### Changed
+
+### Added
+
+### Fixed
+
+### Removed
+
+### Deprecated
+
+## [0.7.0] - 2026-03-04
+
+### Breaking changes
+
 - Added `get_group_mip04_exporter_secret` and `save_group_mip04_exporter_secret` methods to the `GroupStorage` trait. Implementors must add these methods to store and retrieve MIP-04 `MLS-Exporter("marmot", "encrypted-media", 32)` secrets separately from MIP-03 `group-event` secrets. ([#208](https://github.com/marmot-protocol/mdk/pull/208))
 
 ### Added

--- a/crates/mdk-storage-traits/Cargo.toml
+++ b/crates/mdk-storage-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdk-storage-traits"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 description = "Storage abstraction for MDK that wraps OpenMLS storage backends"
 authors = ["Jeff Gardner <j@jeffg.me>", "Yuki Kishimoto <yukikishimoto@protonmail.com>", "MDK Developers"]
@@ -26,5 +26,4 @@ serde_json = { workspace = true, features = ["std"] }
 postcard = { workspace = true, features = ["alloc"] }
 thiserror.workspace = true
 zeroize = { workspace = true, features = ["zeroize_derive"] }
-
 

--- a/crates/mdk-uniffi/CHANGELOG.md
+++ b/crates/mdk-uniffi/CHANGELOG.md
@@ -29,6 +29,20 @@
 
 ### Changed
 
+### Added
+
+### Fixed
+
+### Removed
+
+### Deprecated
+
+## [0.7.0] - 2026-03-04
+
+### Breaking changes
+
+### Changed
+
 - `MdkConfig` now includes a `max_past_epochs: Option<u32>` field (defaults to `5` when `None`) that controls how many past MLS epoch message secrets are retained for late message decryption. ([#207](https://github.com/marmot-protocol/mdk/pull/207))
 
 ### Added

--- a/crates/mdk-uniffi/Cargo.toml
+++ b/crates/mdk-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdk-uniffi"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 description = "UniFFI bindings for mdk-core with SQLite storage"
 authors = [


### PR DESCRIPTION
## Summary
- bump all MDK workspace crate versions from `0.6.0` to `0.7.0`
- update `Cargo.lock` and README dependency examples to reference `0.7.0`
- cut crate changelogs by moving current `Unreleased` entries into `0.7.0` sections dated 2026-03-04 and reintroduce empty `Unreleased` templates

## Verification
- just precommit
- cargo check --workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR prepares the 0.7.0 release by bumping all workspace crate versions from 0.6.0 to 0.7.0, updating Cargo.lock and README examples, and cutting changelogs by moving "Unreleased" entries into version 0.7.0 sections dated 2026-03-04.

**What changed:**
- All five MDK crates (mdk-core, mdk-memory-storage, mdk-sqlite-storage, mdk-storage-traits, mdk-uniffi) bumped from 0.6.0 to 0.7.0 in their Cargo.toml files
- Cargo.lock updated to reflect new versions
- README.md dependency examples updated to reference 0.7.0 versions
- Changelogs reorganized with empty "Unreleased" sections and populated 0.7.0 sections documenting changes from prior commits (#208, #207, #206, #204, #202)

**API surface:**
- The 0.7.0 release documents breaking changes already implemented in prior commits, including: new `GroupStorage::get_group_mip04_exporter_secret()` and `save_group_mip04_exporter_secret()` trait methods added to mdk-storage-traits; new snapshot struct fields (`group_mip04_exporter_secrets`) added to mdk-memory-storage; SQLite schema migration V005 adding a `label` column to the `group_exporter_secrets` table
- mdk-core adds `get_ratchet_tree_info()` method and `max_past_epochs` field to `MdkConfig`

**Security-sensitive changes:**
- The 0.7.0 changelog documents cryptographic changes from prior commits: MIP-03 group-event encryption switched from NIP-44 to ChaCha20-Poly1305 with `base64(nonce || ciphertext)` encoding using cryptographically random 12-byte nonces; MIP-04 exporter label changed from `("nostr", "nostr")` to `("marmot", "encrypted-media")` and now derives separate epoch secrets stored independently from MIP-03 secrets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->