### PR TITLE
fix(ios): set IPHONEOS_DEPLOYMENT_TARGET=15.0 to fix ___chkstk_darwin link error

### DIFF
--- a/justfile
+++ b/justfile
@@ -150,7 +150,12 @@ _build-uniffi-ios TARGET:
         exit 1
     fi
 
-    cargo build --release --lib -p mdk-uniffi --target {{TARGET}}
+    # Set the deployment target so C dependencies (sqlite3-sys, secp256k1-sys) compile
+    # against the same iOS version as the Swift package minimum (iOS 15). Without this,
+    # the system Clang defaults to the current SDK version (e.g. 18.5), which emits
+    # symbols like ___chkstk_darwin that are unavailable at the linker's deployment target,
+    # causing "undefined symbol" link errors.
+    IPHONEOS_DEPLOYMENT_TARGET=15.0 cargo build --release --lib -p mdk-uniffi --target {{TARGET}}
 
 _build-uniffi-android TARGET CLANG_PREFIX:
     #!/usr/bin/env bash


### PR DESCRIPTION
![marmot](https://blossom.primal.net/e29f7e54c772ca3ddf4fc8b842e353b0f1c1d2a44fb0fd72405db7b9184c87c6.png)

This marmot fixed the iOS build by aligning C dependency compilation with the declared Swift package minimum. Without an explicit `IPHONEOS_DEPLOYMENT_TARGET`, `libsqlite3-sys` and `secp256k1-sys` compiled against the system SDK (iOS 18.5), emitting `___chkstk_darwin` — a symbol unavailable below iOS 13 — while the linker targeted iOS 10.0, causing the build to explode at link time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes an iOS build link error by setting IPHONEOS_DEPLOYMENT_TARGET=15.0 in the build configuration, ensuring C dependencies (libsqlite3-sys and secp256k1-sys) are compiled with the correct iOS deployment target and preventing the emission of unavailable symbols like ___chkstk_darwin.

**What changed**:
- The justfile's `_build-uniffi-ios` recipe now prefixes the cargo build command with `IPHONEOS_DEPLOYMENT_TARGET=15.0` to align C dependency compilation with the Swift package's minimum deployment target, replacing the bare cargo build invocation.
- Added explanatory comments documenting why the deployment target is set and how it prevents link errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->