### PR TITLE
Add search_messages to GroupStorage trait

### DIFF
--- a/crates/mdk-core/src/messages/mod.rs
+++ b/crates/mdk-core/src/messages/mod.rs
@@ -228,6 +228,27 @@ where
             .map_err(|_e| Error::Message("Storage error while getting messages".to_string()))
     }
 
+    /// Search messages using full-text search with prefix matching.
+    ///
+    /// Each word in the query is matched as a prefix against the FTS index.
+    /// Only chat messages (`kind = 1`) in `Processed` state are searched.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - Search string (each token is prefix-matched)
+    /// * `mls_group_id` - If `Some`, restrict to one group; if `None`, search all groups
+    /// * `limit` - Maximum results to return
+    pub fn search_messages(
+        &self,
+        query: &str,
+        mls_group_id: Option<&GroupId>,
+        limit: usize,
+    ) -> Result<Vec<message_types::Message>> {
+        self.storage()
+            .search_messages(query, mls_group_id, limit)
+            .map_err(|_e| Error::Message("Storage error while searching messages".to_string()))
+    }
+
     /// Returns the most recent message in a group according to the given sort order.
     ///
     /// This is useful for clients that use [`MessageSortOrder::ProcessedAtFirst`] and

--- a/crates/mdk-memory-storage/src/groups.rs
+++ b/crates/mdk-memory-storage/src/groups.rs
@@ -379,6 +379,65 @@ impl GroupStorage for MdkMemoryStorage {
 
         Ok(())
     }
+
+    fn search_messages(
+        &self,
+        query: &str,
+        group_id: Option<&GroupId>,
+        limit: usize,
+    ) -> Result<Vec<Message>, GroupError> {
+        // Tokenize query the same way the SQLite FTS5 impl does:
+        // split on whitespace, lowercase each token, require every token to
+        // prefix-match at least one word in the message content.
+        let tokens: Vec<String> = query
+            .split_whitespace()
+            .filter(|t| !t.is_empty())
+            .map(|t| t.to_lowercase())
+            .collect();
+
+        if tokens.is_empty() || limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let limit = limit.min(MAX_MESSAGE_LIMIT);
+        let inner = self.inner.read();
+
+        let mut results = Vec::new();
+
+        let group_ids: Vec<GroupId> = match group_id {
+            Some(gid) => vec![gid.clone()],
+            None => inner
+                .messages_by_group_cache
+                .iter()
+                .map(|(k, _)| k.clone())
+                .collect(),
+        };
+
+        for gid in &group_ids {
+            if let Some(messages_map) = inner.messages_by_group_cache.peek(gid) {
+                for msg in messages_map.values() {
+                    if msg.kind == nostr::Kind::ChatMessage
+                        && msg.state == mdk_storage_traits::messages::types::MessageState::Processed
+                        && {
+                            let content_lower = msg.content.to_lowercase();
+                            let words: Vec<&str> = content_lower.split_whitespace().collect();
+                            tokens.iter().all(|token| {
+                                words.iter().any(|w| w.starts_with(token.as_str()))
+                            })
+                        }
+                    {
+                        results.push(msg.clone());
+                    }
+                }
+            }
+        }
+
+        // Sort by created_at DESC
+        results.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        results.truncate(limit);
+
+        Ok(results)
+    }
 }
 
 #[cfg(test)]
@@ -988,4 +1047,214 @@ mod tests {
         assert_eq!(found.name, "Updated Group Name");
         assert_eq!(found.epoch, 1);
     }
+
+    /// Helper: save a processed chat message with the given content and timestamp.
+    fn save_chat_msg(storage: &MdkMemoryStorage, group_id: &GroupId, index: u8, content: &str, ts: u64) {
+        let pubkey = nostr::PublicKey::from_slice(&[1u8; 32]).unwrap();
+        let mut id_bytes = [0u8; 32];
+        id_bytes[0] = index;
+        let event_id = EventId::from_slice(&id_bytes).unwrap();
+        let mut wrapper_bytes = [0u8; 32];
+        wrapper_bytes[0] = 200u8.wrapping_add(index);
+        let wrapper_event_id = EventId::from_slice(&wrapper_bytes).unwrap();
+        let timestamp = Timestamp::from(ts);
+
+        let message = Message {
+            id: event_id,
+            pubkey,
+            kind: Kind::ChatMessage,
+            mls_group_id: group_id.clone(),
+            created_at: timestamp,
+            processed_at: timestamp,
+            content: content.to_string(),
+            tags: Tags::new(),
+            event: UnsignedEvent::new(pubkey, timestamp, Kind::from(9u16), vec![], content.to_string()),
+            wrapper_event_id,
+            state: MessageState::Processed,
+            epoch: Some(1),
+        };
+
+        storage.save_message(message).unwrap();
+    }
+
+    fn create_and_save_search_group(storage: &MdkMemoryStorage, id_bytes: &[u8], nostr_bytes: [u8; 32]) -> GroupId {
+        let mls_group_id = GroupId::from_slice(id_bytes);
+        let group = create_test_group(mls_group_id.clone(), nostr_bytes);
+        storage.save_group(group).unwrap();
+        mls_group_id
+    }
+
+    #[test]
+    fn test_search_messages_per_group() {
+        let storage = MdkMemoryStorage::new();
+        let gid = create_and_save_search_group(&storage, &[1, 2, 3, 4], [1u8; 32]);
+
+        save_chat_msg(&storage, &gid, 1, "hello world", 1000);
+        save_chat_msg(&storage, &gid, 2, "goodbye world", 1001);
+        save_chat_msg(&storage, &gid, 3, "hello again", 1002);
+        save_chat_msg(&storage, &gid, 4, "unrelated", 1003);
+
+        let results = storage.search_messages("hello", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].content, "hello again");
+        assert_eq!(results[1].content, "hello world");
+    }
+
+    #[test]
+    fn test_search_messages_global() {
+        let storage = MdkMemoryStorage::new();
+        let g1 = create_and_save_search_group(&storage, &[1, 2, 3, 4], [1u8; 32]);
+        let g2 = create_and_save_search_group(&storage, &[5, 6, 7, 8], [2u8; 32]);
+
+        save_chat_msg(&storage, &g1, 1, "alpha hello", 1000);
+        save_chat_msg(&storage, &g2, 2, "beta hello", 1001);
+        save_chat_msg(&storage, &g1, 3, "no match", 1002);
+
+        let results = storage.search_messages("hello", None, 100).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].content, "beta hello");
+        assert_eq!(results[1].content, "alpha hello");
+    }
+
+    #[test]
+    fn test_search_messages_case_insensitive() {
+        let storage = MdkMemoryStorage::new();
+        let gid = create_and_save_search_group(&storage, &[1, 2, 3, 4], [1u8; 32]);
+
+        save_chat_msg(&storage, &gid, 1, "Hello World", 1000);
+        save_chat_msg(&storage, &gid, 2, "HELLO WORLD", 1001);
+        save_chat_msg(&storage, &gid, 3, "hello world", 1002);
+
+        let results = storage.search_messages("hello", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn test_search_messages_prefix_matching() {
+        let storage = MdkMemoryStorage::new();
+        let gid = create_and_save_search_group(&storage, &[1, 2, 3, 4], [1u8; 32]);
+
+        save_chat_msg(&storage, &gid, 1, "hello world", 1000);
+        save_chat_msg(&storage, &gid, 2, "help me", 1001);
+        save_chat_msg(&storage, &gid, 3, "unrelated", 1002);
+
+        // Prefix "hel" should match both "hello" and "help"
+        let results = storage.search_messages("hel", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_search_messages_multi_word_query() {
+        let storage = MdkMemoryStorage::new();
+        let gid = create_and_save_search_group(&storage, &[1, 2, 3, 4], [1u8; 32]);
+
+        save_chat_msg(&storage, &gid, 1, "hello world", 1000);
+        save_chat_msg(&storage, &gid, 2, "hello there", 1001);
+        save_chat_msg(&storage, &gid, 3, "world peace", 1002);
+
+        // Both tokens must match
+        let results = storage.search_messages("hello world", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].content, "hello world");
+    }
+
+    #[test]
+    fn test_search_messages_empty_query() {
+        let storage = MdkMemoryStorage::new();
+        let gid = create_and_save_search_group(&storage, &[1, 2, 3, 4], [1u8; 32]);
+        save_chat_msg(&storage, &gid, 1, "hello", 1000);
+
+        let results = storage.search_messages("", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn test_search_messages_whitespace_only_query() {
+        let storage = MdkMemoryStorage::new();
+        let gid = create_and_save_search_group(&storage, &[1, 2, 3, 4], [1u8; 32]);
+        save_chat_msg(&storage, &gid, 1, "hello", 1000);
+
+        let results = storage.search_messages("   ", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn test_search_messages_no_matches() {
+        let storage = MdkMemoryStorage::new();
+        let gid = create_and_save_search_group(&storage, &[1, 2, 3, 4], [1u8; 32]);
+        save_chat_msg(&storage, &gid, 1, "hello world", 1000);
+
+        let results = storage.search_messages("zzzzz", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn test_search_messages_limit() {
+        let storage = MdkMemoryStorage::new();
+        let gid = create_and_save_search_group(&storage, &[1, 2, 3, 4], [1u8; 32]);
+
+        for i in 0..10 {
+            save_chat_msg(&storage, &gid, i, &format!("hello {}", i), 1000 + i as u64);
+        }
+
+        let results = storage.search_messages("hello", Some(&gid), 3).unwrap();
+        assert_eq!(results.len(), 3);
+        // Newest first
+        assert_eq!(results[0].content, "hello 9");
+    }
+
+    #[test]
+    fn test_search_messages_skips_non_chat_and_non_processed() {
+        let storage = MdkMemoryStorage::new();
+        let gid = create_and_save_search_group(&storage, &[1, 2, 3, 4], [1u8; 32]);
+
+        // Save a processed chat message (should match)
+        save_chat_msg(&storage, &gid, 1, "hello processed", 1000);
+
+        // Save a non-processed message (state = Created, should not match)
+        let pubkey = nostr::PublicKey::from_slice(&[1u8; 32]).unwrap();
+        let event_id = EventId::from_slice(&[2u8; 32]).unwrap();
+        let wrapper_id = EventId::from_slice(&[202u8; 32]).unwrap();
+        let ts = Timestamp::from(1001u64);
+        let msg = Message {
+            id: event_id,
+            pubkey,
+            kind: Kind::ChatMessage,
+            mls_group_id: gid.clone(),
+            created_at: ts,
+            processed_at: ts,
+            content: "hello created".to_string(),
+            tags: Tags::new(),
+            event: UnsignedEvent::new(pubkey, ts, Kind::from(9u16), vec![], "hello created"),
+            wrapper_event_id: wrapper_id,
+            state: MessageState::Created,
+            epoch: Some(1),
+        };
+        storage.save_message(msg).unwrap();
+
+        // Save a reaction (kind 7, should not match)
+        let event_id = EventId::from_slice(&[3u8; 32]).unwrap();
+        let wrapper_id = EventId::from_slice(&[203u8; 32]).unwrap();
+        let ts = Timestamp::from(1002u64);
+        let msg = Message {
+            id: event_id,
+            pubkey,
+            kind: Kind::from(7u16),
+            mls_group_id: gid.clone(),
+            created_at: ts,
+            processed_at: ts,
+            content: "hello reaction".to_string(),
+            tags: Tags::new(),
+            event: UnsignedEvent::new(pubkey, ts, Kind::from(9u16), vec![], "hello reaction"),
+            wrapper_event_id: wrapper_id,
+            state: MessageState::Processed,
+            epoch: Some(1),
+        };
+        storage.save_message(msg).unwrap();
+
+        let results = storage.search_messages("hello", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].content, "hello processed");
+    }
+
 }

--- a/crates/mdk-sqlite-storage/migrations/V006__add_fts5_search_index.sql
+++ b/crates/mdk-sqlite-storage/migrations/V006__add_fts5_search_index.sql
@@ -1,0 +1,29 @@
+-- FTS5 full-text search index for message content.
+-- Uses external-content mode so the index stays in sync with the messages table
+-- via triggers, without duplicating the content column.
+
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+    content,
+    content='messages',
+    content_rowid='rowid'
+);
+
+-- Keep FTS index in sync on INSERT.
+CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
+    INSERT INTO messages_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+
+-- Keep FTS index in sync on DELETE.
+CREATE TRIGGER messages_fts_delete AFTER DELETE ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
+END;
+
+-- Keep FTS index in sync on UPDATE.
+CREATE TRIGGER messages_fts_update AFTER UPDATE ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
+    INSERT INTO messages_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+
+-- Backfill existing messages into the FTS index.
+INSERT INTO messages_fts(rowid, content)
+    SELECT rowid, content FROM messages;

--- a/crates/mdk-sqlite-storage/src/groups.rs
+++ b/crates/mdk-sqlite-storage/src/groups.rs
@@ -453,6 +453,84 @@ impl GroupStorage for MdkSqliteStorage {
             Ok(())
         })
     }
+
+    fn search_messages(
+        &self,
+        query: &str,
+        group_id: Option<&GroupId>,
+        limit: usize,
+    ) -> Result<Vec<Message>, GroupError> {
+        if query.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let limit = limit.min(MAX_MESSAGE_LIMIT);
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        // Build an FTS5 query: quote each token and append * for prefix matching.
+        // Quoting with double-quotes escapes special FTS5 characters.
+        let fts_query: String = query
+            .split_whitespace()
+            .filter(|t| !t.is_empty())
+            .map(|token| {
+                let escaped = token.replace('"', "\"\"");
+                format!("\"{escaped}\"*")
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        if fts_query.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        self.with_connection(|conn| {
+            let (sql, boxed_params): (String, Vec<Box<dyn rusqlite::types::ToSql>>) = match group_id
+            {
+                Some(gid) => (
+                    "SELECT m.* FROM messages m \
+                         JOIN messages_fts fts ON m.rowid = fts.rowid \
+                         WHERE messages_fts MATCH ?1 \
+                           AND m.mls_group_id = ?2 \
+                           AND m.kind = 1 \
+                           AND m.state = 'processed' \
+                         ORDER BY m.created_at DESC \
+                         LIMIT ?3"
+                        .to_string(),
+                    vec![
+                        Box::new(fts_query),
+                        Box::new(gid.as_slice().to_vec()),
+                        Box::new(limit as i64),
+                    ],
+                ),
+                None => (
+                    "SELECT m.* FROM messages m \
+                         JOIN messages_fts fts ON m.rowid = fts.rowid \
+                         WHERE messages_fts MATCH ?1 \
+                           AND m.kind = 1 \
+                           AND m.state = 'processed' \
+                         ORDER BY m.created_at DESC \
+                         LIMIT ?2"
+                        .to_string(),
+                    vec![Box::new(fts_query), Box::new(limit as i64)],
+                ),
+            };
+
+            let mut stmt = conn.prepare(&sql).map_err(into_group_err)?;
+            let params_refs: Vec<&dyn rusqlite::types::ToSql> =
+                boxed_params.iter().map(|b| b.as_ref()).collect();
+            let rows = stmt
+                .query_map(params_refs.as_slice(), db::row_to_message)
+                .map_err(into_group_err)?;
+
+            let mut messages = Vec::new();
+            for row in rows {
+                messages.push(row.map_err(into_group_err)?);
+            }
+            Ok(messages)
+        })
+    }
 }
 
 #[cfg(test)]
@@ -808,6 +886,287 @@ mod tests {
 
         assert_eq!(*retrieved_secret1.secret, [0u8; 32]);
         assert_eq!(*retrieved_secret2.secret, [0u8; 32]);
+    }
+
+    /// Helper: create a processed chat message in a group.
+    fn save_chat_msg(
+        storage: &MdkSqliteStorage,
+        group_id: &GroupId,
+        index: u8,
+        content: &str,
+        ts: u64,
+    ) {
+        let pubkey = PublicKey::from_slice(&[1u8; 32]).unwrap();
+        let mut id_bytes = [0u8; 32];
+        id_bytes[0] = index;
+        let event_id = EventId::from_slice(&id_bytes).unwrap();
+        let mut wrapper_bytes = [0u8; 32];
+        wrapper_bytes[0] = 200u8.wrapping_add(index);
+        let wrapper_event_id = EventId::from_slice(&wrapper_bytes).unwrap();
+        let timestamp = Timestamp::from(ts);
+
+        let message = Message {
+            id: event_id,
+            pubkey,
+            kind: Kind::from(1u16),
+            mls_group_id: group_id.clone(),
+            created_at: timestamp,
+            processed_at: timestamp,
+            content: content.to_string(),
+            tags: Tags::new(),
+            event: UnsignedEvent::new(
+                pubkey,
+                timestamp,
+                Kind::from(9u16),
+                vec![],
+                content.to_string(),
+            ),
+            wrapper_event_id,
+            state: MessageState::Processed,
+            epoch: Some(1),
+        };
+
+        storage.save_message(message).unwrap();
+    }
+
+    /// Helper: create a test group and save it.
+    fn create_and_save_group(
+        storage: &MdkSqliteStorage,
+        id_bytes: &[u8],
+        nostr_bytes: [u8; 32],
+        name: &str,
+    ) -> GroupId {
+        let mls_group_id = GroupId::from_slice(id_bytes);
+        let group = Group {
+            mls_group_id: mls_group_id.clone(),
+            nostr_group_id: nostr_bytes,
+            name: name.to_string(),
+            description: "".to_string(),
+            admin_pubkeys: BTreeSet::new(),
+            last_message_id: None,
+            last_message_at: None,
+            last_message_processed_at: None,
+            epoch: 0,
+            state: GroupState::Active,
+            image_hash: None,
+            image_key: None,
+            image_nonce: None,
+            self_update_state: SelfUpdateState::Required,
+        };
+        storage.save_group(group).unwrap();
+        mls_group_id
+    }
+
+    #[test]
+    fn test_search_messages_per_group() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+        let gid = create_and_save_group(&storage, &[1, 2, 3, 4], [1u8; 32], "G1");
+
+        save_chat_msg(&storage, &gid, 1, "hello world", 1000);
+        save_chat_msg(&storage, &gid, 2, "goodbye world", 1001);
+        save_chat_msg(&storage, &gid, 3, "hello again", 1002);
+        save_chat_msg(&storage, &gid, 4, "unrelated", 1003);
+
+        let results = storage.search_messages("hello", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 2);
+        // Newest first
+        assert_eq!(results[0].content, "hello again");
+        assert_eq!(results[1].content, "hello world");
+    }
+
+    #[test]
+    fn test_search_messages_global() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+        let g1 = create_and_save_group(&storage, &[1, 2, 3, 4], [1u8; 32], "G1");
+        let g2 = create_and_save_group(&storage, &[5, 6, 7, 8], [2u8; 32], "G2");
+
+        save_chat_msg(&storage, &g1, 1, "alpha hello", 1000);
+        save_chat_msg(&storage, &g2, 2, "beta hello", 1001);
+        save_chat_msg(&storage, &g1, 3, "no match", 1002);
+
+        let results = storage.search_messages("hello", None, 100).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].content, "beta hello");
+        assert_eq!(results[1].content, "alpha hello");
+    }
+
+    #[test]
+    fn test_search_messages_case_insensitive() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+        let gid = create_and_save_group(&storage, &[1, 2, 3, 4], [1u8; 32], "G1");
+
+        save_chat_msg(&storage, &gid, 1, "Hello World", 1000);
+        save_chat_msg(&storage, &gid, 2, "HELLO WORLD", 1001);
+        save_chat_msg(&storage, &gid, 3, "hello world", 1002);
+
+        let results = storage.search_messages("hello", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn test_search_messages_prefix_matching() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+        let gid = create_and_save_group(&storage, &[1, 2, 3, 4], [1u8; 32], "G1");
+
+        save_chat_msg(&storage, &gid, 1, "hello world", 1000);
+        save_chat_msg(&storage, &gid, 2, "help me", 1001);
+        save_chat_msg(&storage, &gid, 3, "unrelated", 1002);
+
+        // Prefix "hel" should match both "hello" and "help"
+        let results = storage.search_messages("hel", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_search_messages_multi_word_query() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+        let gid = create_and_save_group(&storage, &[1, 2, 3, 4], [1u8; 32], "G1");
+
+        save_chat_msg(&storage, &gid, 1, "hello world", 1000);
+        save_chat_msg(&storage, &gid, 2, "hello there", 1001);
+        save_chat_msg(&storage, &gid, 3, "world peace", 1002);
+
+        // Both tokens must match
+        let results = storage
+            .search_messages("hello world", Some(&gid), 100)
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].content, "hello world");
+    }
+
+    #[test]
+    fn test_search_messages_empty_query() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+        let gid = create_and_save_group(&storage, &[1, 2, 3, 4], [1u8; 32], "G1");
+        save_chat_msg(&storage, &gid, 1, "hello", 1000);
+
+        let results = storage.search_messages("", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn test_search_messages_no_matches() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+        let gid = create_and_save_group(&storage, &[1, 2, 3, 4], [1u8; 32], "G1");
+        save_chat_msg(&storage, &gid, 1, "hello world", 1000);
+
+        let results = storage.search_messages("zzzzz", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn test_search_messages_limit() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+        let gid = create_and_save_group(&storage, &[1, 2, 3, 4], [1u8; 32], "G1");
+
+        for i in 0..10 {
+            save_chat_msg(&storage, &gid, i, &format!("hello {}", i), 1000 + i as u64);
+        }
+
+        let results = storage.search_messages("hello", Some(&gid), 3).unwrap();
+        assert_eq!(results.len(), 3);
+        // Newest first
+        assert_eq!(results[0].content, "hello 9");
+    }
+
+    #[test]
+    fn test_search_messages_skips_non_chat_and_non_processed() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+        let gid = create_and_save_group(&storage, &[1, 2, 3, 4], [1u8; 32], "G1");
+
+        // Save a processed chat message (should match)
+        save_chat_msg(&storage, &gid, 1, "hello processed", 1000);
+
+        // Save a non-processed message (state = Created, should not match)
+        let pubkey = PublicKey::from_slice(&[1u8; 32]).unwrap();
+        let event_id = EventId::from_slice(&[2u8; 32]).unwrap();
+        let wrapper_id = EventId::from_slice(&[202u8; 32]).unwrap();
+        let ts = Timestamp::from(1001u64);
+        let msg = Message {
+            id: event_id,
+            pubkey,
+            kind: Kind::from(1u16),
+            mls_group_id: gid.clone(),
+            created_at: ts,
+            processed_at: ts,
+            content: "hello created".to_string(),
+            tags: Tags::new(),
+            event: UnsignedEvent::new(pubkey, ts, Kind::from(9u16), vec![], "hello created"),
+            wrapper_event_id: wrapper_id,
+            state: MessageState::Created,
+            epoch: Some(1),
+        };
+        storage.save_message(msg).unwrap();
+
+        // Save a reaction (kind 7, should not match)
+        let event_id = EventId::from_slice(&[3u8; 32]).unwrap();
+        let wrapper_id = EventId::from_slice(&[203u8; 32]).unwrap();
+        let ts = Timestamp::from(1002u64);
+        let msg = Message {
+            id: event_id,
+            pubkey,
+            kind: Kind::from(7u16),
+            mls_group_id: gid.clone(),
+            created_at: ts,
+            processed_at: ts,
+            content: "hello reaction".to_string(),
+            tags: Tags::new(),
+            event: UnsignedEvent::new(pubkey, ts, Kind::from(9u16), vec![], "hello reaction"),
+            wrapper_event_id: wrapper_id,
+            state: MessageState::Processed,
+            epoch: Some(1),
+        };
+        storage.save_message(msg).unwrap();
+
+        let results = storage.search_messages("hello", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].content, "hello processed");
+    }
+
+    #[test]
+    fn test_search_messages_fts_stays_in_sync() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+        let gid = create_and_save_group(&storage, &[1, 2, 3, 4], [1u8; 32], "G1");
+
+        // Insert a message and verify it's searchable.
+        save_chat_msg(&storage, &gid, 1, "hello world", 1000);
+        let results = storage.search_messages("hello", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 1);
+
+        // Update the message by re-saving with different content (ON CONFLICT DO UPDATE).
+        // The FTS index should reflect the new content.
+        let pubkey = PublicKey::from_slice(&[1u8; 32]).unwrap();
+        let mut id_bytes = [0u8; 32];
+        id_bytes[0] = 1; // same id as above
+        let event_id = EventId::from_slice(&id_bytes).unwrap();
+        let mut wrapper_bytes = [0u8; 32];
+        wrapper_bytes[0] = 201;
+        let wrapper_event_id = EventId::from_slice(&wrapper_bytes).unwrap();
+        let ts = Timestamp::from(1000u64);
+        let msg = Message {
+            id: event_id,
+            pubkey,
+            kind: Kind::from(1u16),
+            mls_group_id: gid.clone(),
+            created_at: ts,
+            processed_at: ts,
+            content: "goodbye planet".to_string(),
+            tags: Tags::new(),
+            event: UnsignedEvent::new(pubkey, ts, Kind::from(9u16), vec![], "goodbye planet"),
+            wrapper_event_id,
+            state: MessageState::Processed,
+            epoch: Some(1),
+        };
+        storage.save_message(msg).unwrap();
+
+        // Old content should no longer match.
+        let results = storage.search_messages("hello", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 0);
+
+        // New content should match.
+        let results = storage.search_messages("goodbye", Some(&gid), 100).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].content, "goodbye planet");
     }
 
     #[test]

--- a/crates/mdk-storage-traits/src/groups/mod.rs
+++ b/crates/mdk-storage-traits/src/groups/mod.rs
@@ -262,6 +262,32 @@ pub trait GroupStorage {
         min_epoch_to_keep: u64,
     ) -> Result<(), GroupError>;
 
+    /// Search messages using full-text search with prefix matching.
+    ///
+    /// Uses FTS5 to find messages whose content matches the query tokens.
+    /// Each word in the query is treated as a prefix, so searching "hel"
+    /// matches "hello". Multiple words are AND-ed together.
+    /// Only messages with `kind = 1` (ChatMessage) and `state = 'processed'`
+    /// are included.
+    ///
+    /// # Arguments
+    /// * `query` - The search string. Each whitespace-separated token is
+    ///   matched as a prefix against the FTS index.
+    /// * `group_id` - If `Some`, restrict the search to a single group.
+    ///   If `None`, search across all groups.
+    /// * `limit` - Maximum number of results to return. Values exceeding
+    ///   [`MAX_MESSAGE_LIMIT`] are silently clamped.
+    ///
+    /// # Returns
+    ///
+    /// Matching messages ordered by `created_at DESC`.
+    fn search_messages(
+        &self,
+        query: &str,
+        group_id: Option<&GroupId>,
+        limit: usize,
+    ) -> Result<Vec<Message>, GroupError>;
+
     /// Returns active groups that need a self-update: either because
     /// `self_update_state` is [`SelfUpdateState::Required`] (post-join
     /// requirement per MIP-02) or because the last self-update is older than


### PR DESCRIPTION
Adds full-text search for messages using SQLite FTS5 with prefix matching. Supports global search (all groups) and per-group search with a configurable limit. Only searches chat messages (kind=1) in processed state.

## Changes

- **V006 migration**: Creates `messages_fts` FTS5 virtual table (external-content mode backed by `messages` table) with INSERT/UPDATE/DELETE triggers to keep the index in sync
- **`GroupStorage::search_messages`**: Uses FTS5 `MATCH` with prefix queries — each token is quoted and appended with `*` so "hel" matches "hello"
- **In-memory storage**: Substring matching via `.contains()` for the test/memory backend
- **Tests**: Covers per-group/global search, case-insensitivity, prefix matching, multi-word queries, empty queries, limits, kind/state filtering, and FTS index sync on updates

## Test plan
- [x] `cargo test -p mdk-sqlite-storage -- search_messages` (10 tests pass)
- [x] Verify FTS5 index stays in sync after message updates (`test_search_messages_fts_stays_in_sync`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds full-text search for chat messages across MDK storage backends, using SQLite FTS5 with prefix matching in the SQLite backend and a substring fallback in the in-memory backend, scoped to processed chat messages and limited per-group. It introduces a migration to create and maintain an FTS5 index and expands the GroupStorage trait and MDK public API to expose search functionality.

**What changed**:
- Added GroupStorage::search_messages(query, group_id, limit) and implementations in mdk-sqlite-storage and mdk-memory-storage, plus a delegating public MDK::search_messages in mdk-core.
- mdk-sqlite-storage: implements FTS5-based search using MATCH with tokenized prefix queries, filters to kind = 1 (ChatMessage) and processed state, supports per-group and global search, and enforces MAX_MESSAGE_LIMIT.
- mdk-memory-storage: implements a test-friendly fallback using case-insensitive substring .contains() with the same scoping and limit behavior.
- Added V006 migration (crates/mdk-sqlite-storage/migrations) that creates messages_fts (FTS5 external-content) and INSERT/UPDATE/DELETE triggers plus a backfill to keep the index synchronized.
- Tests and test helpers added/expanded in mdk-sqlite-storage to cover per-group/global search, case-insensitivity, prefix and multi-word queries, empty queries, limits, kind/state filtering, and FTS index sync on updates.

**Security impact**:
- No cryptographic, key-handling, identity-binding, SQLCipher, or file-permission changes are introduced by this PR.

**Protocol changes**:
- No changes to MLS protocol behavior, Nostr integration, or MIP implementations.

**API surface**:
- New public trait method: fn search_messages(&self, query: &str, group_id: Option<&GroupId>, limit: usize) -> Result<Vec<Message>, GroupError> added to GroupStorage (mdk-storage-traits).
- New public MDK API: pub fn search_messages(&self, query: &str, mls_group_id: Option<&GroupId>, limit: usize) -> Result<Vec<message_types::Message>> in mdk-core.
- Storage schema change: new FTS5 virtual table messages_fts with synchronization triggers and backfill migration (V006).
- No UniFFI/FFI boundary changes were made.

**Testing**:
- Added comprehensive tests (10 passing tests reported) exercising per-group/global search, case-insensitivity, prefix matching, multi-word queries, empty queries, limits, filtering by kind/state, and FTS index synchronization after message updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->