### PR TITLE
fix: remove redundant builds and revert to release profile in CI

### DIFF
--- a/.github/workflows/package-mdk-bindings.yml
+++ b/.github/workflows/package-mdk-bindings.yml
@@ -49,9 +49,6 @@ jobs:
         just _build-uniffi-ios aarch64-apple-ios
         just _build-uniffi-ios aarch64-apple-ios-sim
 
-    - name: Build host library
-      run: cargo build --release --lib -p mdk-uniffi
-
     - name: Generate Swift bindings
       run: just gen-binding-swift
 
@@ -145,14 +142,8 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Build host library (debug for bindgen)
-      run: cargo build --lib -p mdk-uniffi
-
     - name: Generate Python bindings
       run: just gen-binding "python"
-
-    - name: Build release library
-      run: cargo build --lib -p mdk-uniffi --release
 
     - name: Determine library filename
       id: lib_filename
@@ -356,14 +347,8 @@ jobs:
       with:
         ruby-version: '3.2'
 
-    - name: Build host library (debug for bindgen)
-      run: cargo build --lib -p mdk-uniffi
-
     - name: Generate Ruby bindings
       run: just gen-binding "ruby"
-
-    - name: Build release library
-      run: cargo build --lib -p mdk-uniffi --release
 
     - name: Determine library filename
       id: lib_filename

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ tempfile = "3.20"
 [profile.release-size]
 inherits = "release"
 opt-level = "z"      # Optimize for binary size over speed
-lto = true           # Fat LTO: cross-crate dead-code elimination
+lto = "thin"         # Thin LTO: cross-crate optimization without embedding full IR in .a archives
 codegen-units = 1    # Required for fat LTO to be effective
 panic = "abort"      # No unwinding machinery; safe at UniFFI FFI boundary
 strip = true         # Strip all symbols from the output binary

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,10 +70,9 @@ tracing-subscriber = "0.3"
 # Testing
 tempfile = "3.20"
 
-[profile.release-size]
-inherits = "release"
+[profile.release]
 opt-level = "z"      # Optimize for binary size over speed
 lto = "thin"         # Thin LTO: cross-crate optimization without embedding full IR in .a archives
-codegen-units = 1    # Required for fat LTO to be effective
+codegen-units = 1    # Single codegen unit for maximum optimization
 panic = "abort"      # No unwinding machinery; safe at UniFFI FFI boundary
 strip = true         # Strip all symbols from the output binary

--- a/crates/mdk-uniffi/CHANGELOG.md
+++ b/crates/mdk-uniffi/CHANGELOG.md
@@ -31,9 +31,12 @@
 
 ### Added
 
-- Added `[profile.release-size]` custom profile with `opt-level = "z"`, fat LTO, single codegen unit, `panic = "abort"`, and symbol stripping. Android binding builds now use `--profile release-size` and additionally run `llvm-strip` post-build. Measured ~40% reduction in `.so` size. ([`#221`](https://github.com/marmot-protocol/mdk/pull/221))
+- Moved binary size optimizations (`opt-level = "z"`, thin LTO, single codegen unit, `panic = "abort"`, symbol stripping) into `[profile.release]` directly. Android builds override to fat LTO via `CARGO_PROFILE_RELEASE_LTO=fat` for maximum `.so` reduction; iOS uses thin LTO to avoid `.a` archive bloat. ([`#221`](https://github.com/marmot-protocol/mdk/pull/221), [`#232`](https://github.com/marmot-protocol/mdk/pull/232))
 
 ### Fixed
+
+- Removed redundant `cargo build` steps from Swift, Python, and Ruby binding CI jobs that duplicated work already done by `_build-uniffi`. ([`#232`](https://github.com/marmot-protocol/mdk/pull/232))
+- Fixed stale `release-size` artifact paths in Kotlin and Swift binding generation recipes. ([`#232`](https://github.com/marmot-protocol/mdk/pull/232))
 
 ### Removed
 

--- a/justfile
+++ b/justfile
@@ -167,7 +167,7 @@ _build-uniffi-ios TARGET:
     # the system Clang defaults to the current SDK version (e.g. 18.5), which emits
     # symbols like ___chkstk_darwin that are unavailable at the linker's deployment target,
     # causing "undefined symbol" link errors.
-    IPHONEOS_DEPLOYMENT_TARGET=15.0 cargo build --profile release-size --lib -p mdk-uniffi --target {{TARGET}}
+    IPHONEOS_DEPLOYMENT_TARGET=15.0 cargo build --release --lib -p mdk-uniffi --target {{TARGET}}
 
 _build-uniffi-android TARGET CLANG_PREFIX:
     #!/usr/bin/env bash
@@ -304,7 +304,9 @@ _build-uniffi-android TARGET CLANG_PREFIX:
     # Tell openssl-sys to use static linking
     export OPENSSL_STATIC=1
 
-    cargo build --profile release-size --lib -p mdk-uniffi --target {{TARGET}}
+    # Fat LTO for Android: maximum binary size reduction; .a archive bloat
+    # doesn't matter since Android ships .so files only
+    CARGO_PROFILE_RELEASE_LTO=fat cargo build --release --lib -p mdk-uniffi --target {{TARGET}}
 
 uniffi-bindgen: (gen-binding "python") gen-binding-kotlin gen-binding-ruby
     @if [ "{{os()}}" = "macos" ]; then just gen-binding-swift; fi
@@ -337,12 +339,12 @@ gen-binding-kotlin: (_build-uniffi "true") (gen-binding "kotlin")
     mkdir -p "$PROJECT_DIR/src/main/jniLibs/armeabi-v7a"
     # mkdir -p "$PROJECT_DIR/src/main/jniLibs/x86-64"
 
-    test -f target/aarch64-linux-android/release-size/libmdk_uniffi.so || (echo "Error: aarch64 Android library not found. Did the build succeed?" && exit 1)
-    test -f target/armv7-linux-androideabi/release-size/libmdk_uniffi.so || (echo "Error: armv7 Android library not found. Did the build succeed?" && exit 1)
+    test -f target/aarch64-linux-android/release/libmdk_uniffi.so || (echo "Error: aarch64 Android library not found. Did the build succeed?" && exit 1)
+    test -f target/armv7-linux-androideabi/release/libmdk_uniffi.so || (echo "Error: armv7 Android library not found. Did the build succeed?" && exit 1)
 
-    cp target/aarch64-linux-android/release-size/libmdk_uniffi.so "$PROJECT_DIR/src/main/jniLibs/arm64-v8a/libmdk_uniffi.so"
-    cp target/armv7-linux-androideabi/release-size/libmdk_uniffi.so "$PROJECT_DIR/src/main/jniLibs/armeabi-v7a/libmdk_uniffi.so"
-    # cp target/x86_64-linux-android/release-size/libmdk_uniffi.so "$PROJECT_DIR/src/main/jniLibs/x86-64/libmdk_uniffi.so"
+    cp target/aarch64-linux-android/release/libmdk_uniffi.so "$PROJECT_DIR/src/main/jniLibs/arm64-v8a/libmdk_uniffi.so"
+    cp target/armv7-linux-androideabi/release/libmdk_uniffi.so "$PROJECT_DIR/src/main/jniLibs/armeabi-v7a/libmdk_uniffi.so"
+    # cp target/x86_64-linux-android/release/libmdk_uniffi.so "$PROJECT_DIR/src/main/jniLibs/x86-64/libmdk_uniffi.so"
     rm -f "$BINDINGS_DIR/libmdk_uniffi.so"
     echo "✓ Kotlin bindings generated and moved to Android project"
 
@@ -356,8 +358,8 @@ gen-binding-swift: (_build-uniffi "false" "true") (gen-binding "swift")
     mkdir -p ios-artifacts/headers
     cp crates/mdk-uniffi/bindings/swift/mdk_uniffiFFI.h ios-artifacts/headers/
     xcodebuild -create-xcframework \
-        -library target/aarch64-apple-ios/release-size/libmdk_uniffi.a -headers ios-artifacts/headers \
-        -library target/aarch64-apple-ios-sim/release-size/libmdk_uniffi.a -headers ios-artifacts/headers \
+        -library target/aarch64-apple-ios/release/libmdk_uniffi.a -headers ios-artifacts/headers \
+        -library target/aarch64-apple-ios-sim/release/libmdk_uniffi.a -headers ios-artifacts/headers \
         -output ios-artifacts/mdk_uniffi.xcframework
     @echo "✓ Swift bindings and xcframework ready"
 

--- a/justfile
+++ b/justfile
@@ -133,7 +133,7 @@ _build-uniffi needs_android="false" needs_ios="false":
     #!/usr/bin/env bash
     set -euo pipefail
     echo "Building mdk-uniffi library..."
-    cargo build --profile release-size --lib -p mdk-uniffi
+    cargo build --release --lib -p mdk-uniffi
     if [ "{{needs_android}}" = "true" ]; then
         just _build-uniffi-android aarch64-linux-android aarch64-linux-android21-clang
         just _build-uniffi-android armv7-linux-androideabi armv7a-linux-androideabi21-clang
@@ -322,9 +322,9 @@ gen-binding lang: (_build-uniffi "false" "false")
     @echo "Generating {{lang}} bindings..."
     cd crates/mdk-uniffi && cargo run --bin uniffi-bindgen generate \
         -l {{lang}} \
-        --library ../../target/release-size/{{lib_filename}} \
+        --library ../../target/release/{{lib_filename}} \
         --out-dir bindings/{{lang}}
-    cp target/release-size/{{lib_filename}} crates/mdk-uniffi/bindings/{{lang}}/{{lib_filename}}
+    cp target/release/{{lib_filename}} crates/mdk-uniffi/bindings/{{lang}}/{{lib_filename}}
     @echo "✓ Bindings generated in crates/mdk-uniffi/bindings/{{lang}}/"
 
 gen-binding-kotlin: (_build-uniffi "true") (gen-binding "kotlin")


### PR DESCRIPTION
![marmot](https://blossom.primal.net/f9c6a7aa3b17a1f92b442ac862bb33c8989c31a94b44b7f3a9def5dc8e9de960.jpg)

The packaging workflow had three problems tripping over each other. First, redundant `cargo build` steps ran before binding generation, but `gen-binding` already triggers `_build-uniffi`, so those extra builds were wasted work that sometimes built with the wrong profile.

Second, fat LTO (`lto = true`) embedded full LLVM bitcode in static archives, bloating `.a` files. Thin LTO gets most of the cross-crate optimization without the archive size penalty.

Third, the `release-size` custom profile put artifacts in `target/release-size/` while CI expected them at `target/release/`. Reverting to the standard release profile fixes the path mismatch.

Changes:
- Removed 5 redundant `cargo build` steps from the Swift, Python, and Ruby binding jobs
- Switched from fat LTO to thin LTO in the release-size profile
- Reverted `_build-uniffi` and `gen-binding` to use `--release` instead of `--profile release-size`

Fixes #231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes CI packaging failures by removing redundant cargo builds in binding jobs, switching from fat LTO to thin LTO to avoid large static archives, and reverting build steps to use the standard release profile so artifacts appear in target/release/. Together these changes restore correct binding generation on Linux, prevent Swift .a files from exceeding GitHub limits, and align CI packaging paths with expectations.

**What changed**:
- Removed five redundant `cargo build` steps for the `mdk-uniffi` host library from Swift, Python, and Ruby packaging jobs in .github/workflows/package-mdk-bindings.yml (these builds were already triggered by subsequent gen-binding/_build-uniffi steps).
- Consolidated size optimizations into the standard `[profile.release]` in Cargo.toml and switched LTO from fat (`lto = true`) to thin (`lto = "thin"`) to reduce static archive sizes.
- Reverted build and binding-generation commands in justfile to use `cargo build --release` and updated all artifact paths from `target/release-size/...` to `target/release/...`; Android builds retain an override to use fat LTO when needed.
- Affected crate: mdk-uniffi (no changes to mdk-core, mdk-sqlite-storage, mdk-memory-storage, or mdk-storage-traits).

**Security impact**:
- None related to cryptography, key handling, identity, error-message leakage, SQLCipher, or file permissions.

**Protocol changes**:
- None.

**API surface**:
- No breaking changes, no new public APIs, and no UniFFI/FFI boundary changes.

**Testing**:
- No tests added or modified; changes are CI/build configuration and packaging fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->