### PR TITLE
feat: add delete_messages_for_group and delete_group public methods for local chat/group cleanup

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 ### Added
 
+- Added `delete_messages_for_group` and `delete_group` public methods on `MDK` for local "clear chat" and "delete chat" operations. `delete_group` also cleans up `EpochSnapshotManager` in-memory state. Neither operation publishes MLS proposals or Nostr events. ([#250](https://github.com/marmot-protocol/mdk/pull/250))
 - Added ThumbHash preview generation alongside existing BlurHash support. `MediaProcessingOptions` now includes `generate_thumbhash`, `ImageMetadata`, `MediaMetadata`, `EncryptedMediaUpload`, and `GroupImageUpload` expose optional `thumbhash`, and encrypted-media IMETA writing emits `thumbhash` while parsing accepts both `blurhash` and `thumbhash` tags for compatibility. ([#244](https://github.com/marmot-protocol/mdk/pull/244))
 - SelfRemove proposal type (`0x000a`) added to client capabilities, group required capabilities, and KeyPackage `mls_proposals` tag per MIP-03.
 - Admin depletion validation: SelfRemove proposals and commits are rejected if they would leave the group with zero admins.

--- a/crates/mdk-core/src/epoch_snapshots.rs
+++ b/crates/mdk-core/src/epoch_snapshots.rs
@@ -99,6 +99,16 @@ impl EpochSnapshotManager {
         }
     }
 
+    /// Remove all snapshot state for a group.
+    ///
+    /// Clears both the snapshot queue and the hydration tracking for the group.
+    /// Called when a group is deleted from storage.
+    pub fn remove_group(&self, group_id: &GroupId) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.snapshots.remove(group_id);
+        inner.hydrated_groups.remove(group_id);
+    }
+
     /// Ensure a group's snapshots have been loaded from storage.
     ///
     /// For persistent backends (SQLite), this loads existing snapshots into memory
@@ -1182,5 +1192,60 @@ mod tests {
         // parts[1] is the group_id hex, parts[3] is the commit_id hex
         assert_eq!(parts[1].len(), 64, "Group ID hex should be 64 chars");
         assert_eq!(parts[3].len(), 64, "Commit ID hex should be 64 chars");
+    }
+
+    #[test]
+    fn test_remove_group_clears_state() {
+        let manager = EpochSnapshotManager::new(5);
+        let group_id = test_group_id(1);
+
+        // Directly populate the manager's inner state
+        {
+            let mut inner = manager.inner.lock().unwrap();
+            inner
+                .snapshots
+                .entry(group_id.clone())
+                .or_default()
+                .push_back(EpochSnapshot {
+                    group_id: group_id.clone(),
+                    epoch: 5,
+                    applied_commit_id: test_event_id(
+                        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    ),
+                    applied_commit_ts: 999,
+                    applied_commit_content_hash: [0u8; 32],
+                    created_at: std::time::Instant::now(),
+                    snapshot_name: "snap_test".to_string(),
+                });
+            inner.hydrated_groups.insert(group_id.clone());
+        }
+
+        // Verify state exists
+        {
+            let inner = manager.inner.lock().unwrap();
+            assert!(inner.snapshots.contains_key(&group_id));
+            assert!(inner.hydrated_groups.contains(&group_id));
+        }
+
+        manager.remove_group(&group_id);
+
+        // Both maps cleaned
+        {
+            let inner = manager.inner.lock().unwrap();
+            assert!(!inner.snapshots.contains_key(&group_id));
+            assert!(!inner.hydrated_groups.contains(&group_id));
+        }
+    }
+
+    #[test]
+    fn test_remove_group_is_idempotent() {
+        let manager = EpochSnapshotManager::new(5);
+        let group_id = test_group_id(42);
+
+        // Removing a nonexistent group is a no-op
+        manager.remove_group(&group_id);
+
+        let inner = manager.inner.lock().unwrap();
+        assert!(!inner.snapshots.contains_key(&group_id));
     }
 }

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -1595,6 +1595,42 @@ where
         })
     }
 
+    /// Delete all locally stored messages for a group.
+    ///
+    /// Removes decrypted message content from storage. The group remains
+    /// active and can continue to receive new messages. Processing records
+    /// are preserved to prevent re-processing of already-seen events.
+    ///
+    /// Returns the number of messages deleted.
+    ///
+    /// This is a local-only operation — no MLS proposals or Nostr events
+    /// are published.
+    pub fn delete_messages_for_group(&self, group_id: &GroupId) -> Result<usize, Error> {
+        self.storage()
+            .delete_messages_for_group(group_id)
+            .map_err(|e| Error::Group(e.to_string()))
+    }
+
+    /// Delete all local state for a group.
+    ///
+    /// Removes everything MDK stores for this group: messages, processed
+    /// message records, MLS tree state, epoch secrets, key material, relay
+    /// associations, proposals, and snapshots.
+    ///
+    /// After deletion, the group cannot receive or decrypt new messages.
+    /// Call `leave_group()` first if you want to notify other members of
+    /// your departure before cleaning up local state.
+    ///
+    /// Idempotent: deleting a nonexistent group is a no-op.
+    ///
+    /// This is a local-only operation — no MLS proposals or Nostr events
+    /// are published.
+    pub fn delete_group(&self, group_id: &GroupId) -> Result<(), Error> {
+        self.storage().delete_group(group_id)?;
+        self.epoch_snapshots.remove_group(group_id);
+        Ok(())
+    }
+
     /// Clear (rollback) a pending commit without merging it.
     ///
     /// This should be called when the Kind:445 publish fails after creating a commit

--- a/crates/mdk-memory-storage/CHANGELOG.md
+++ b/crates/mdk-memory-storage/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ### Added
 
+- Implemented `delete_messages_for_group` and `delete_group` for local "clear chat" and "delete chat" operations. Added `clear_group` methods to `MlsGroupData` and `MlsEpochKeyPairs` for bulk group-scoped MLS state cleanup. ([#250](https://github.com/marmot-protocol/mdk/pull/250))
 - Implemented legacy exporter-secret compatibility storage for the temporary `0.6.x -> 0.7.x` migration window, including snapshot and restore support for preserved pre-0.7.0 group-event secrets. ([#222](https://github.com/marmot-protocol/mdk/pull/222))
 
 ### Fixed

--- a/crates/mdk-memory-storage/src/lib.rs
+++ b/crates/mdk-memory-storage/src/lib.rs
@@ -958,16 +958,30 @@ impl MdkStorageProvider for MdkMemoryStorage {
             let mut guard = self.inner.write();
             let inner = &mut *guard;
 
-            // Messages (inlined for atomicity — avoids releasing/reacquiring lock)
-            if let Some(group_messages) = inner.messages_by_group_cache.pop(group_id) {
-                for event_id in group_messages.keys() {
-                    inner.messages_cache.pop(event_id);
-                }
+            // Messages — scan messages_cache directly since the two LRU caches
+            // can diverge (per-group entry evicted while individual messages remain)
+            inner.messages_by_group_cache.pop(group_id);
+            let orphaned_msgs: Vec<nostr::EventId> = inner
+                .messages_cache
+                .iter()
+                .filter(|(_, msg)| &msg.mls_group_id == group_id)
+                .map(|(eid, _)| *eid)
+                .collect();
+            for eid in &orphaned_msgs {
+                inner.messages_cache.pop(eid);
             }
 
-            // Group metadata
-            if let Some(group) = inner.groups_cache.pop(group_id) {
-                inner.groups_by_nostr_id_cache.pop(&group.nostr_group_id);
+            // Group metadata — scan nostr index independently since the two
+            // group caches can diverge under LRU eviction
+            inner.groups_cache.pop(group_id);
+            let nostr_ids: Vec<[u8; 32]> = inner
+                .groups_by_nostr_id_cache
+                .iter()
+                .filter(|(_, group)| &group.mls_group_id == group_id)
+                .map(|(nid, _)| *nid)
+                .collect();
+            for nid in &nostr_ids {
+                inner.groups_by_nostr_id_cache.pop(nid);
             }
 
             // Group relays

--- a/crates/mdk-memory-storage/src/lib.rs
+++ b/crates/mdk-memory-storage/src/lib.rs
@@ -952,6 +952,95 @@ impl MdkStorageProvider for MdkMemoryStorage {
         let pruned_count = initial_count - snapshots.len();
         Ok(pruned_count)
     }
+
+    fn delete_group(&self, group_id: &GroupId) -> Result<(), MdkStorageError> {
+        {
+            let mut guard = self.inner.write();
+            let inner = &mut *guard;
+
+            // Messages (inlined for atomicity — avoids releasing/reacquiring lock)
+            if let Some(group_messages) = inner.messages_by_group_cache.pop(group_id) {
+                for event_id in group_messages.keys() {
+                    inner.messages_cache.pop(event_id);
+                }
+            }
+
+            // Group metadata
+            if let Some(group) = inner.groups_cache.pop(group_id) {
+                inner.groups_by_nostr_id_cache.pop(&group.nostr_group_id);
+            }
+
+            // Group relays
+            inner.group_relays_cache.pop(group_id);
+
+            // Exporter secrets (keyed by (GroupId, u64) — must iterate)
+            let secret_keys: Vec<(GroupId, u64)> = inner
+                .group_exporter_secrets_cache
+                .iter()
+                .filter(|((gid, _), _)| gid == group_id)
+                .map(|(k, _)| k.clone())
+                .collect();
+            for key in &secret_keys {
+                inner.group_exporter_secrets_cache.pop(key);
+            }
+
+            let legacy_keys: Vec<(GroupId, u64)> = inner
+                .group_legacy_exporter_secrets_cache
+                .iter()
+                .filter(|((gid, _), _)| gid == group_id)
+                .map(|(k, _)| k.clone())
+                .collect();
+            for key in &legacy_keys {
+                inner.group_legacy_exporter_secrets_cache.pop(key);
+            }
+
+            let mip04_keys: Vec<(GroupId, u64)> = inner
+                .group_mip04_exporter_secrets_cache
+                .iter()
+                .filter(|((gid, _), _)| gid == group_id)
+                .map(|(k, _)| k.clone())
+                .collect();
+            for key in &mip04_keys {
+                inner.group_mip04_exporter_secrets_cache.pop(key);
+            }
+
+            // Processed messages (keyed by EventId — must iterate for group match)
+            let pm_keys: Vec<nostr::EventId> = inner
+                .processed_messages_cache
+                .iter()
+                .filter(|(_, pm)| pm.mls_group_id.as_ref() == Some(group_id))
+                .map(|(k, _)| *k)
+                .collect();
+            for key in &pm_keys {
+                inner.processed_messages_cache.pop(key);
+            }
+
+            // OpenMLS data (typed methods handle key serialization)
+            inner
+                .mls_group_data
+                .clear_group(group_id)
+                .map_err(|e| MdkStorageError::Serialization(e.to_string()))?;
+            inner
+                .mls_own_leaf_nodes
+                .delete(group_id)
+                .map_err(|e| MdkStorageError::Serialization(e.to_string()))?;
+            inner
+                .mls_proposals
+                .clear(group_id)
+                .map_err(|e| MdkStorageError::Serialization(e.to_string()))?;
+            inner
+                .mls_epoch_key_pairs
+                .clear_group(group_id)
+                .map_err(|e| MdkStorageError::Serialization(e.to_string()))?;
+        }
+
+        // Snapshots (separate RwLock on outer struct)
+        self.group_snapshots
+            .write()
+            .retain(|(gid, _), _| gid != group_id);
+
+        Ok(())
+    }
 }
 
 // ============================================================================
@@ -3860,5 +3949,145 @@ mod tests {
              groups.epoch=5 but crypto state is epoch6 means split-brain: \
              MDK thinks epoch 5, MLS engine has epoch 6 keys."
         );
+    }
+
+    mod delete_group_tests {
+        use mdk_storage_traits::MdkStorageProvider;
+        use mdk_storage_traits::groups::GroupStorage;
+        use mdk_storage_traits::groups::types::{Group, GroupState, SelfUpdateState};
+        use mdk_storage_traits::messages::MessageStorage;
+        use mdk_storage_traits::messages::types::{
+            Message, MessageState, ProcessedMessage, ProcessedMessageState,
+        };
+        use nostr::{EventId, Keys, Kind, Tags, Timestamp, UnsignedEvent};
+        use std::collections::BTreeSet;
+
+        use super::*;
+
+        fn create_group(id_bytes: &[u8]) -> Group {
+            let group_id = GroupId::from_slice(id_bytes);
+            let mut nostr_group_id = [0u8; 32];
+            nostr_group_id[..id_bytes.len().min(32)]
+                .copy_from_slice(&id_bytes[..id_bytes.len().min(32)]);
+            Group {
+                mls_group_id: group_id,
+                nostr_group_id,
+                name: "Test".to_string(),
+                description: "".to_string(),
+                admin_pubkeys: BTreeSet::new(),
+                last_message_id: None,
+                last_message_at: None,
+                last_message_processed_at: None,
+                epoch: 1,
+                state: GroupState::Active,
+                image_hash: None,
+                image_key: None,
+                image_nonce: None,
+                self_update_state: SelfUpdateState::Required,
+            }
+        }
+
+        fn create_message(group_id: &GroupId, eid_bytes: &[u8; 32]) -> Message {
+            let pubkey = Keys::generate().public_key();
+            let now = Timestamp::now();
+            Message {
+                id: EventId::from_slice(eid_bytes).unwrap(),
+                pubkey,
+                kind: Kind::from(1u16),
+                mls_group_id: group_id.clone(),
+                created_at: now,
+                processed_at: now,
+                content: "test".to_string(),
+                tags: Tags::new(),
+                event: UnsignedEvent::new(
+                    pubkey,
+                    now,
+                    Kind::from(9u16),
+                    vec![],
+                    "test".to_string(),
+                ),
+                wrapper_event_id: EventId::all_zeros(),
+                epoch: Some(1),
+                state: MessageState::Created,
+            }
+        }
+
+        #[test]
+        fn delete_group_removes_all_state() {
+            let storage = MdkMemoryStorage::default();
+            let group_id = GroupId::from_slice(&[10, 20, 30]);
+            storage.save_group(create_group(&[10, 20, 30])).unwrap();
+            storage
+                .save_message(create_message(&group_id, &[1u8; 32]))
+                .unwrap();
+            let pm = ProcessedMessage {
+                wrapper_event_id: EventId::from_slice(&[0xFFu8; 32]).unwrap(),
+                message_event_id: None,
+                processed_at: Timestamp::now(),
+                epoch: Some(1),
+                mls_group_id: Some(group_id.clone()),
+                state: ProcessedMessageState::Processed,
+                failure_reason: None,
+            };
+            storage.save_processed_message(pm).unwrap();
+
+            storage.delete_group(&group_id).unwrap();
+
+            assert!(
+                storage
+                    .find_group_by_mls_group_id(&group_id)
+                    .unwrap()
+                    .is_none()
+            );
+            // Processed messages cleaned
+            assert!(
+                storage
+                    .find_processed_message_by_event_id(
+                        &EventId::from_slice(&[0xFFu8; 32]).unwrap()
+                    )
+                    .unwrap()
+                    .is_none()
+            );
+        }
+
+        #[test]
+        fn delete_group_is_idempotent() {
+            let storage = MdkMemoryStorage::default();
+            let group_id = GroupId::from_slice(&[99, 99, 99]);
+
+            let result = storage.delete_group(&group_id);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn delete_group_does_not_affect_other_groups() {
+            let storage = MdkMemoryStorage::default();
+            let group_a = GroupId::from_slice(&[1, 1, 1]);
+            let group_b = GroupId::from_slice(&[2, 2, 2]);
+            storage.save_group(create_group(&[1, 1, 1])).unwrap();
+            storage.save_group(create_group(&[2, 2, 2])).unwrap();
+            storage
+                .save_message(create_message(&group_a, &[0xAAu8; 32]))
+                .unwrap();
+            storage
+                .save_message(create_message(&group_b, &[0xBBu8; 32]))
+                .unwrap();
+
+            storage.delete_group(&group_a).unwrap();
+
+            assert!(
+                storage
+                    .find_group_by_mls_group_id(&group_a)
+                    .unwrap()
+                    .is_none()
+            );
+            assert!(
+                storage
+                    .find_group_by_mls_group_id(&group_b)
+                    .unwrap()
+                    .is_some()
+            );
+            assert_eq!(storage.messages(&group_b, None).unwrap().len(), 1);
+        }
     }
 }

--- a/crates/mdk-memory-storage/src/lib.rs
+++ b/crates/mdk-memory-storage/src/lib.rs
@@ -1029,6 +1029,17 @@ impl MdkStorageProvider for MdkMemoryStorage {
                 inner.processed_messages_cache.pop(key);
             }
 
+            // Welcomes (keyed by EventId — must iterate for group match)
+            let welcome_keys: Vec<nostr::EventId> = inner
+                .welcomes_cache
+                .iter()
+                .filter(|(_, w)| &w.mls_group_id == group_id)
+                .map(|(k, _)| *k)
+                .collect();
+            for key in &welcome_keys {
+                inner.welcomes_cache.pop(key);
+            }
+
             // OpenMLS data (typed methods handle key serialization)
             inner
                 .mls_group_data

--- a/crates/mdk-memory-storage/src/messages.rs
+++ b/crates/mdk-memory-storage/src/messages.rs
@@ -271,6 +271,25 @@ impl MessageStorage for MdkMemoryStorage {
 
         Ok(None)
     }
+
+    fn delete_messages_for_group(&self, group_id: &GroupId) -> Result<usize, MessageError> {
+        let mut guard = self.inner.write();
+        let inner = &mut *guard;
+
+        let event_ids: Vec<EventId> = inner
+            .messages_by_group_cache
+            .pop(group_id)
+            .map(|msgs| msgs.into_keys().collect())
+            .unwrap_or_default();
+
+        let count = event_ids.len();
+
+        for event_id in &event_ids {
+            inner.messages_cache.pop(event_id);
+        }
+
+        Ok(count)
+    }
 }
 
 #[cfg(test)]
@@ -998,5 +1017,73 @@ mod tests {
             .unwrap();
 
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn delete_messages_removes_all_messages_for_group() {
+        let storage = MdkMemoryStorage::default();
+        let group_id = GroupId::from_slice(&[10, 20, 30]);
+        storage
+            .save_group(create_test_group(group_id.clone()))
+            .unwrap();
+        let eid1 = EventId::from_slice(&[1u8; 32]).unwrap();
+        let eid2 = EventId::from_slice(&[2u8; 32]).unwrap();
+        storage
+            .save_message(create_test_message(eid1, group_id.clone(), "msg1", 100))
+            .unwrap();
+        storage
+            .save_message(create_test_message(eid2, group_id.clone(), "msg2", 101))
+            .unwrap();
+
+        let deleted = storage.delete_messages_for_group(&group_id).unwrap();
+
+        assert_eq!(deleted, 2);
+        assert!(storage.messages(&group_id, None).unwrap().is_empty());
+        // Group still exists
+        assert!(
+            storage
+                .find_group_by_mls_group_id(&group_id)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn delete_messages_is_idempotent_on_empty_group() {
+        let storage = MdkMemoryStorage::default();
+        let group_id = GroupId::from_slice(&[11, 22, 33]);
+        storage
+            .save_group(create_test_group(group_id.clone()))
+            .unwrap();
+
+        let deleted = storage.delete_messages_for_group(&group_id).unwrap();
+
+        assert_eq!(deleted, 0);
+    }
+
+    #[test]
+    fn delete_messages_does_not_affect_other_groups() {
+        let storage = MdkMemoryStorage::default();
+        let group_a = GroupId::from_slice(&[1, 1, 1]);
+        let group_b = GroupId::from_slice(&[2, 2, 2]);
+        storage
+            .save_group(create_test_group(group_a.clone()))
+            .unwrap();
+        storage
+            .save_group(create_test_group(group_b.clone()))
+            .unwrap();
+        let eid_a = EventId::from_slice(&[0xAAu8; 32]).unwrap();
+        let eid_b = EventId::from_slice(&[0xBBu8; 32]).unwrap();
+        storage
+            .save_message(create_test_message(eid_a, group_a.clone(), "a", 100))
+            .unwrap();
+        storage
+            .save_message(create_test_message(eid_b, group_b.clone(), "b", 100))
+            .unwrap();
+
+        storage.delete_messages_for_group(&group_a).unwrap();
+
+        assert!(storage.messages(&group_a, None).unwrap().is_empty());
+        assert_eq!(storage.messages(&group_b, None).unwrap().len(), 1);
     }
 }

--- a/crates/mdk-memory-storage/src/messages.rs
+++ b/crates/mdk-memory-storage/src/messages.rs
@@ -276,15 +276,20 @@ impl MessageStorage for MdkMemoryStorage {
         let mut guard = self.inner.write();
         let inner = &mut *guard;
 
-        let event_ids: Vec<EventId> = inner
-            .messages_by_group_cache
-            .pop(group_id)
-            .map(|msgs| msgs.into_keys().collect())
-            .unwrap_or_default();
+        // Remove the per-group index entry
+        inner.messages_by_group_cache.pop(group_id);
 
-        let count = event_ids.len();
+        // Scan messages_cache directly — the two LRU caches can diverge if the
+        // per-group entry was evicted while individual messages remain.
+        let orphaned: Vec<EventId> = inner
+            .messages_cache
+            .iter()
+            .filter(|(_, msg)| &msg.mls_group_id == group_id)
+            .map(|(eid, _)| *eid)
+            .collect();
 
-        for event_id in &event_ids {
+        let count = orphaned.len();
+        for event_id in &orphaned {
             inner.messages_cache.pop(event_id);
         }
 
@@ -1085,5 +1090,39 @@ mod tests {
 
         assert!(storage.messages(&group_a, None).unwrap().is_empty());
         assert_eq!(storage.messages(&group_b, None).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn delete_messages_handles_lru_divergence() {
+        // Directly manipulate the inner caches to simulate LRU divergence:
+        // messages_cache has an entry for group_a, but messages_by_group_cache
+        // does not (simulating eviction of the per-group index).
+        let storage = MdkMemoryStorage::default();
+        let group_id = GroupId::from_slice(&[1, 1, 1]);
+        storage
+            .save_group(create_test_group(group_id.clone()))
+            .unwrap();
+
+        let eid = EventId::from_slice(&[0xAAu8; 32]).unwrap();
+        storage
+            .save_message(create_test_message(eid, group_id.clone(), "orphan", 100))
+            .unwrap();
+
+        // Simulate LRU eviction: remove the per-group index but leave the
+        // individual message in messages_cache
+        {
+            let mut guard = storage.inner.write();
+            guard.messages_by_group_cache.pop(&group_id);
+        }
+
+        // delete_messages_for_group must still find and remove the orphaned message
+        let deleted = storage.delete_messages_for_group(&group_id).unwrap();
+        assert_eq!(deleted, 1);
+        assert!(
+            storage
+                .find_message_by_event_id(&group_id, &eid)
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/crates/mdk-memory-storage/src/mls_storage/mod.rs
+++ b/crates/mdk-memory-storage/src/mls_storage/mod.rs
@@ -162,6 +162,16 @@ impl MlsGroupData {
         self.data.remove(&(group_id_bytes, data_type));
         Ok(())
     }
+
+    /// Clear all data for a group.
+    pub fn clear_group<GroupId>(&mut self, group_id: &GroupId) -> Result<(), MdkStorageError>
+    where
+        GroupId: Serialize,
+    {
+        let group_id_bytes = serialize_key(group_id)?;
+        self.data.retain(|(gid, _), _| *gid != group_id_bytes);
+        Ok(())
+    }
 }
 
 mls_store_base!(
@@ -380,6 +390,16 @@ impl MlsEpochKeyPairs {
         let group_id_bytes = serialize_key(group_id)?;
         let epoch_bytes = serialize_key(epoch)?;
         self.data.remove(&(group_id_bytes, epoch_bytes, leaf_index));
+        Ok(())
+    }
+
+    /// Clear all epoch key pairs for a group.
+    pub fn clear_group<GroupId>(&mut self, group_id: &GroupId) -> Result<(), MdkStorageError>
+    where
+        GroupId: Serialize,
+    {
+        let group_id_bytes = serialize_key(group_id)?;
+        self.data.retain(|(gid, _, _), _| *gid != group_id_bytes);
         Ok(())
     }
 }

--- a/crates/mdk-sqlite-storage/CHANGELOG.md
+++ b/crates/mdk-sqlite-storage/CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ### Added
 
+- Implemented `delete_messages_for_group` and `delete_group` for local "clear chat" and "delete chat" operations. `delete_group` runs all deletes in a single `BEGIN IMMEDIATE` transaction covering OpenMLS tables, MDK tables, and `processed_messages`. ([#250](https://github.com/marmot-protocol/mdk/pull/250))
 - Implemented legacy exporter-secret compatibility storage for the temporary `0.6.x -> 0.7.x` migration window, including read/write support for preserved pre-0.7.0 group-event secrets and snapshot rollback restoration into the legacy compatibility label. ([#222](https://github.com/marmot-protocol/mdk/pull/222))
 
 ### Fixed

--- a/crates/mdk-sqlite-storage/src/lib.rs
+++ b/crates/mdk-sqlite-storage/src/lib.rs
@@ -1334,6 +1334,13 @@ impl MdkStorageProvider for MdkSqliteStorage {
             )
             .map_err(|e| MdkStorageError::Database(e.to_string()))?;
 
+            // welcomes has no FK to groups — needs explicit delete
+            conn.execute(
+                "DELETE FROM welcomes WHERE mls_group_id = ?",
+                [group_id_bytes],
+            )
+            .map_err(|e| MdkStorageError::Database(e.to_string()))?;
+
             // groups last — CASCADE handles messages and snapshots as safety net
             conn.execute(
                 "DELETE FROM groups WHERE mls_group_id = ?",
@@ -4632,6 +4639,8 @@ mod tests {
         use mdk_storage_traits::messages::types::{
             Message, MessageState, ProcessedMessage, ProcessedMessageState,
         };
+        use mdk_storage_traits::welcomes::WelcomeStorage;
+        use mdk_storage_traits::welcomes::types::{Welcome, WelcomeState};
         use nostr::{EventId, Kind, PublicKey, Tags, Timestamp, UnsignedEvent};
         use rusqlite::params;
 
@@ -4720,6 +4729,36 @@ mod tests {
             };
             storage.save_group_exporter_secret(secret).unwrap();
 
+            // Add a welcome
+            let mut welcome_bytes = [0xEEu8; 32];
+            welcome_bytes[..id_bytes.len().min(32)]
+                .copy_from_slice(&id_bytes[..id_bytes.len().min(32)]);
+            let welcome_eid = EventId::from_slice(&welcome_bytes).unwrap();
+            let welcome = Welcome {
+                id: welcome_eid,
+                event: UnsignedEvent::new(
+                    pubkey,
+                    now,
+                    Kind::from(444u16),
+                    vec![],
+                    "welcome".to_string(),
+                ),
+                mls_group_id: group_id.clone(),
+                nostr_group_id,
+                group_name: "Test".to_string(),
+                group_description: "".to_string(),
+                group_image_hash: None,
+                group_image_key: None,
+                group_image_nonce: None,
+                group_admin_pubkeys: BTreeSet::new(),
+                group_relays: BTreeSet::new(),
+                welcomer: pubkey,
+                member_count: 2,
+                state: WelcomeState::Pending,
+                wrapper_event_id: EventId::all_zeros(),
+            };
+            storage.save_welcome(welcome).unwrap();
+
             (group_id, wrapper_eid)
         }
 
@@ -4763,6 +4802,15 @@ mod tests {
                     )
                     .unwrap();
                 assert_eq!(count, 0, "exporter secrets should be deleted");
+
+                let count: i64 = conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM welcomes WHERE mls_group_id = ?",
+                        params![group_id.as_slice()],
+                        |row| row.get(0),
+                    )
+                    .unwrap();
+                assert_eq!(count, 0, "welcomes should be deleted");
             });
         }
 

--- a/crates/mdk-sqlite-storage/src/lib.rs
+++ b/crates/mdk-sqlite-storage/src/lib.rs
@@ -1278,6 +1278,84 @@ impl MdkStorageProvider for MdkSqliteStorage {
             .map_err(|e| MdkStorageError::Database(e.to_string()))?;
         Ok(deleted)
     }
+
+    fn delete_group(&self, group_id: &GroupId) -> Result<(), MdkStorageError> {
+        let conn = self.connection.lock().unwrap();
+        let group_id_bytes = group_id.as_slice();
+        let mls_group_id_bytes = mls_storage::MlsCodec::serialize(group_id)
+            .map_err(|e| MdkStorageError::Serialization(e.to_string()))?;
+
+        conn.execute("BEGIN IMMEDIATE", [])
+            .map_err(|e| MdkStorageError::Database(e.to_string()))?;
+
+        let result = (|| -> Result<(), MdkStorageError> {
+            // OpenMLS tables (MlsCodec-serialized group_id)
+            conn.execute(
+                "DELETE FROM openmls_group_data WHERE group_id = ?",
+                [&mls_group_id_bytes],
+            )
+            .map_err(|e| MdkStorageError::Database(e.to_string()))?;
+
+            conn.execute(
+                "DELETE FROM openmls_proposals WHERE group_id = ?",
+                [&mls_group_id_bytes],
+            )
+            .map_err(|e| MdkStorageError::Database(e.to_string()))?;
+
+            conn.execute(
+                "DELETE FROM openmls_own_leaf_nodes WHERE group_id = ?",
+                [&mls_group_id_bytes],
+            )
+            .map_err(|e| MdkStorageError::Database(e.to_string()))?;
+
+            conn.execute(
+                "DELETE FROM openmls_epoch_key_pairs WHERE group_id = ?",
+                [&mls_group_id_bytes],
+            )
+            .map_err(|e| MdkStorageError::Database(e.to_string()))?;
+
+            // MDK tables (raw group_id bytes) — explicit deletes before groups
+            conn.execute(
+                "DELETE FROM group_exporter_secrets WHERE mls_group_id = ?",
+                [group_id_bytes],
+            )
+            .map_err(|e| MdkStorageError::Database(e.to_string()))?;
+
+            conn.execute(
+                "DELETE FROM group_relays WHERE mls_group_id = ?",
+                [group_id_bytes],
+            )
+            .map_err(|e| MdkStorageError::Database(e.to_string()))?;
+
+            // processed_messages has no FK to groups — needs explicit delete
+            conn.execute(
+                "DELETE FROM processed_messages WHERE mls_group_id = ?",
+                [group_id_bytes],
+            )
+            .map_err(|e| MdkStorageError::Database(e.to_string()))?;
+
+            // groups last — CASCADE handles messages and snapshots as safety net
+            conn.execute(
+                "DELETE FROM groups WHERE mls_group_id = ?",
+                [group_id_bytes],
+            )
+            .map_err(|e| MdkStorageError::Database(e.to_string()))?;
+
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => {
+                conn.execute("COMMIT", [])
+                    .map_err(|e| MdkStorageError::Database(e.to_string()))?;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", []);
+                Err(e)
+            }
+        }
+    }
 }
 
 // ============================================================================
@@ -4544,6 +4622,188 @@ mod tests {
                  row. More than 1 means the DELETE used the wrong key format and \
                  failed to remove the stale OpenMLS row before re-inserting from \
                  snapshot."
+            );
+        }
+    }
+
+    mod delete_group_tests {
+        use mdk_storage_traits::MdkStorageProvider;
+        use mdk_storage_traits::messages::MessageStorage;
+        use mdk_storage_traits::messages::types::{
+            Message, MessageState, ProcessedMessage, ProcessedMessageState,
+        };
+        use nostr::{EventId, Kind, PublicKey, Tags, Timestamp, UnsignedEvent};
+        use rusqlite::params;
+
+        use super::*;
+
+        /// Returns (group_id, wrapper_event_id) for verification after deletion.
+        fn setup_group_with_data(
+            storage: &MdkSqliteStorage,
+            id_bytes: &[u8],
+        ) -> (GroupId, EventId) {
+            let group_id = GroupId::from_slice(id_bytes);
+            let mut nostr_group_id = [0u8; 32];
+            nostr_group_id[..id_bytes.len().min(32)]
+                .copy_from_slice(&id_bytes[..id_bytes.len().min(32)]);
+            let group = Group {
+                mls_group_id: group_id.clone(),
+                nostr_group_id,
+                name: "Test Group".to_string(),
+                description: "".to_string(),
+                admin_pubkeys: BTreeSet::new(),
+                last_message_id: None,
+                last_message_at: None,
+                last_message_processed_at: None,
+                epoch: 1,
+                state: GroupState::Active,
+                image_hash: None,
+                image_key: None,
+                image_nonce: None,
+                self_update_state: SelfUpdateState::Required,
+            };
+            storage.save_group(group).unwrap();
+
+            // Add a message
+            let pubkey = PublicKey::parse(
+                "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+            )
+            .unwrap();
+            let now = Timestamp::now();
+            let mut event_bytes = [0u8; 32];
+            event_bytes[..id_bytes.len().min(32)]
+                .copy_from_slice(&id_bytes[..id_bytes.len().min(32)]);
+            let event_id = EventId::from_slice(&event_bytes).unwrap();
+            let message = Message {
+                id: event_id,
+                pubkey,
+                kind: Kind::from(1u16),
+                mls_group_id: group_id.clone(),
+                created_at: now,
+                processed_at: now,
+                content: "test".to_string(),
+                tags: Tags::new(),
+                event: UnsignedEvent::new(
+                    pubkey,
+                    now,
+                    Kind::from(9u16),
+                    vec![],
+                    "test".to_string(),
+                ),
+                wrapper_event_id: EventId::all_zeros(),
+                epoch: Some(1),
+                state: MessageState::Created,
+            };
+            storage.save_message(message).unwrap();
+
+            // Add a processed message
+            let mut wrapper_bytes = [0xFFu8; 32];
+            wrapper_bytes[..id_bytes.len().min(32)]
+                .copy_from_slice(&id_bytes[..id_bytes.len().min(32)]);
+            let wrapper_eid = EventId::from_slice(&wrapper_bytes).unwrap();
+            let pm = ProcessedMessage {
+                wrapper_event_id: wrapper_eid,
+                message_event_id: Some(event_id),
+                processed_at: now,
+                epoch: Some(1),
+                mls_group_id: Some(group_id.clone()),
+                state: ProcessedMessageState::Processed,
+                failure_reason: None,
+            };
+            storage.save_processed_message(pm).unwrap();
+
+            // Add an exporter secret
+            let secret = GroupExporterSecret {
+                mls_group_id: group_id.clone(),
+                epoch: 1,
+                secret: Secret::new([42u8; 32]),
+            };
+            storage.save_group_exporter_secret(secret).unwrap();
+
+            (group_id, wrapper_eid)
+        }
+
+        #[test]
+        fn delete_group_removes_all_state() {
+            let storage = MdkSqliteStorage::new_in_memory().unwrap();
+            let (group_id, wrapper_eid) = setup_group_with_data(&storage, &[10, 20, 30, 40]);
+
+            storage.delete_group(&group_id).unwrap();
+
+            // Group gone
+            assert!(
+                storage
+                    .find_group_by_mls_group_id(&group_id)
+                    .unwrap()
+                    .is_none()
+            );
+            // Processed messages gone (no FK to groups, explicitly deleted)
+            assert!(
+                storage
+                    .find_processed_message_by_event_id(&wrapper_eid)
+                    .unwrap()
+                    .is_none()
+            );
+            // Verify no orphaned rows via direct SQL
+            storage.with_connection(|conn| {
+                let count: i64 = conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM messages WHERE mls_group_id = ?",
+                        params![group_id.as_slice()],
+                        |row| row.get(0),
+                    )
+                    .unwrap();
+                assert_eq!(count, 0, "messages should be deleted");
+
+                let count: i64 = conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM group_exporter_secrets WHERE mls_group_id = ?",
+                        params![group_id.as_slice()],
+                        |row| row.get(0),
+                    )
+                    .unwrap();
+                assert_eq!(count, 0, "exporter secrets should be deleted");
+            });
+        }
+
+        #[test]
+        fn delete_group_is_idempotent() {
+            let storage = MdkSqliteStorage::new_in_memory().unwrap();
+            let group_id = GroupId::from_slice(&[99, 99, 99]);
+
+            // Deleting a nonexistent group is a no-op
+            let result = storage.delete_group(&group_id);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn delete_group_does_not_affect_other_groups() {
+            let storage = MdkSqliteStorage::new_in_memory().unwrap();
+            let (group_a, _) = setup_group_with_data(&storage, &[1, 1, 1, 1]);
+            let (group_b, _) = setup_group_with_data(&storage, &[2, 2, 2, 2]);
+
+            storage.delete_group(&group_a).unwrap();
+
+            // Group A gone
+            assert!(
+                storage
+                    .find_group_by_mls_group_id(&group_a)
+                    .unwrap()
+                    .is_none()
+            );
+            // Group B intact
+            assert!(
+                storage
+                    .find_group_by_mls_group_id(&group_b)
+                    .unwrap()
+                    .is_some()
+            );
+            assert_eq!(storage.messages(&group_b, None).unwrap().len(), 1);
+            assert!(
+                storage
+                    .get_group_exporter_secret(&group_b, 1)
+                    .unwrap()
+                    .is_some()
             );
         }
     }

--- a/crates/mdk-sqlite-storage/src/messages.rs
+++ b/crates/mdk-sqlite-storage/src/messages.rs
@@ -338,6 +338,19 @@ impl MessageStorage for MdkSqliteStorage {
             .map_err(into_message_err)
         })
     }
+
+    fn delete_messages_for_group(
+        &self,
+        group_id: &mdk_storage_traits::GroupId,
+    ) -> Result<usize, MessageError> {
+        self.with_connection(|conn| {
+            conn.execute(
+                "DELETE FROM messages WHERE mls_group_id = ?",
+                params![group_id.as_slice()],
+            )
+            .map_err(into_message_err)
+        })
+    }
 }
 
 #[cfg(test)]
@@ -843,5 +856,162 @@ mod tests {
             result, None,
             "\\ must be treated as a literal, not an escape"
         );
+    }
+
+    /// Create a test group and save it to storage, returning its GroupId.
+    fn create_test_group(storage: &MdkSqliteStorage, id_bytes: &[u8]) -> GroupId {
+        let group_id = GroupId::from_slice(id_bytes);
+        let mut nostr_group_id = [0u8; 32];
+        nostr_group_id[..id_bytes.len().min(32)]
+            .copy_from_slice(&id_bytes[..id_bytes.len().min(32)]);
+        let group = Group {
+            mls_group_id: group_id.clone(),
+            nostr_group_id,
+            name: "Test Group".to_string(),
+            description: "".to_string(),
+            admin_pubkeys: BTreeSet::new(),
+            last_message_id: None,
+            last_message_at: None,
+            last_message_processed_at: None,
+            epoch: 0,
+            state: GroupState::Active,
+            image_hash: None,
+            image_key: None,
+            image_nonce: None,
+            self_update_state: SelfUpdateState::Required,
+        };
+        storage.save_group(group).unwrap();
+        group_id
+    }
+
+    /// Create and save a test message for the given group, returning its EventId.
+    fn create_test_message(
+        storage: &MdkSqliteStorage,
+        group_id: &GroupId,
+        event_id_hex: &str,
+    ) -> EventId {
+        let event_id = EventId::parse(event_id_hex).unwrap();
+        let pubkey =
+            PublicKey::parse("79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
+                .unwrap();
+        let wrapper_event_id = EventId::all_zeros();
+        let now = Timestamp::now();
+        let message = Message {
+            id: event_id,
+            pubkey,
+            kind: Kind::from(1u16),
+            mls_group_id: group_id.clone(),
+            created_at: now,
+            processed_at: now,
+            content: "test".to_string(),
+            tags: Tags::new(),
+            event: UnsignedEvent::new(pubkey, now, Kind::from(9u16), vec![], "test".to_string()),
+            wrapper_event_id,
+            epoch: Some(1),
+            state: MessageState::Created,
+        };
+        storage.save_message(message).unwrap();
+        event_id
+    }
+
+    #[test]
+    fn delete_messages_removes_all_messages_for_group() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+        let group_id = create_test_group(&storage, &[10, 20, 30]);
+        create_test_message(
+            &storage,
+            &group_id,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        );
+        create_test_message(
+            &storage,
+            &group_id,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        );
+        create_test_message(
+            &storage,
+            &group_id,
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        );
+
+        let deleted = storage.delete_messages_for_group(&group_id).unwrap();
+
+        assert_eq!(deleted, 3);
+        let messages = storage.messages(&group_id, None).unwrap();
+        assert!(messages.is_empty());
+        // Group itself still exists
+        assert!(
+            storage
+                .find_group_by_mls_group_id(&group_id)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn delete_messages_is_idempotent_on_empty_group() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+        let group_id = create_test_group(&storage, &[11, 22, 33]);
+
+        let deleted = storage.delete_messages_for_group(&group_id).unwrap();
+
+        assert_eq!(deleted, 0);
+    }
+
+    #[test]
+    fn delete_messages_preserves_processed_messages() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+        let group_id = create_test_group(&storage, &[44, 55, 66]);
+        create_test_message(
+            &storage,
+            &group_id,
+            "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        );
+
+        let wrapper_eid =
+            EventId::parse("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
+                .unwrap();
+        let pm = mdk_storage_traits::messages::types::ProcessedMessage {
+            wrapper_event_id: wrapper_eid,
+            message_event_id: None,
+            processed_at: Timestamp::now(),
+            epoch: Some(1),
+            mls_group_id: Some(group_id.clone()),
+            state: ProcessedMessageState::Processed,
+            failure_reason: None,
+        };
+        storage.save_processed_message(pm).unwrap();
+
+        storage.delete_messages_for_group(&group_id).unwrap();
+
+        // Processed message still exists
+        assert!(
+            storage
+                .find_processed_message_by_event_id(&wrapper_eid)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn delete_messages_does_not_affect_other_groups() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+        let group_a = create_test_group(&storage, &[1, 1, 1]);
+        let group_b = create_test_group(&storage, &[2, 2, 2]);
+        create_test_message(
+            &storage,
+            &group_a,
+            "1111111111111111111111111111111111111111111111111111111111111111",
+        );
+        create_test_message(
+            &storage,
+            &group_b,
+            "2222222222222222222222222222222222222222222222222222222222222222",
+        );
+
+        storage.delete_messages_for_group(&group_a).unwrap();
+
+        assert!(storage.messages(&group_a, None).unwrap().is_empty());
+        assert_eq!(storage.messages(&group_b, None).unwrap().len(), 1);
     }
 }

--- a/crates/mdk-storage-traits/CHANGELOG.md
+++ b/crates/mdk-storage-traits/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Breaking changes
 
+- Added `MessageStorage::delete_messages_for_group` and `MdkStorageProvider::delete_group` for local "clear chat" and "delete chat" operations. Storage implementations must add these methods. ([#250](https://github.com/marmot-protocol/mdk/pull/250))
 - Added `GroupStorage::get_group_legacy_exporter_secret` and `GroupStorage::save_group_legacy_exporter_secret` so storage backends can preserve pre-0.7.0 exporter-secret bytes separately during the temporary migration-compatibility window. Storage implementations must add these methods. ([#222](https://github.com/marmot-protocol/mdk/pull/222))
 
 ### Changed

--- a/crates/mdk-storage-traits/src/lib.rs
+++ b/crates/mdk-storage-traits/src/lib.rs
@@ -351,6 +351,19 @@ pub trait MdkStorageProvider:
     ///
     /// The number of snapshots deleted, or an error.
     fn prune_expired_snapshots(&self, min_timestamp: u64) -> Result<usize, MdkStorageError>;
+
+    /// Delete all local state for a group.
+    ///
+    /// Removes the group, its messages, processed message records, MLS tree state,
+    /// epoch secrets, key material, proposals, and snapshots from local storage.
+    ///
+    /// This is irreversible. After deletion, the group cannot receive or decrypt
+    /// new messages. Call `leave_group()` before this method to notify other members.
+    ///
+    /// Idempotent: deleting a nonexistent group returns `Ok(())`.
+    ///
+    /// This is a local-only operation with no protocol-level side effects.
+    fn delete_group(&self, group_id: &GroupId) -> Result<(), MdkStorageError>;
 }
 
 #[cfg(test)]

--- a/crates/mdk-storage-traits/src/messages/mod.rs
+++ b/crates/mdk-storage-traits/src/messages/mod.rs
@@ -110,4 +110,13 @@ pub trait MessageStorage {
         group_id: &GroupId,
         content_substring: &str,
     ) -> Result<Option<u64>, MessageError>;
+
+    /// Delete all stored messages for a group.
+    ///
+    /// Removes decrypted message content from local storage. Does not affect
+    /// processed message records, the group's MLS state, or epoch secrets.
+    ///
+    /// Returns the number of messages deleted. Deleting messages for a group
+    /// with no messages returns `Ok(0)`.
+    fn delete_messages_for_group(&self, group_id: &GroupId) -> Result<usize, MessageError>;
 }

--- a/crates/mdk-uniffi/CHANGELOG.md
+++ b/crates/mdk-uniffi/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 ### Added
 
+- Added UniFFI bindings for `delete_messages_for_group` and `delete_group` for local "clear chat" and "delete chat" operations. ([#250](https://github.com/marmot-protocol/mdk/pull/250))
 - Added UniFFI bindings for 10 previously unbound methods: `delete_key_package_from_storage`, `delete_key_package_from_storage_by_hash_ref`, `get_ratchet_tree_info`, `group_leaf_map`, `own_leaf_index`, `pending_added_members_pubkeys`, `pending_member_changes`, `pending_removed_members_pubkeys`, `prepare_group_image_for_upload_with_options`, and `process_message_with_context`. ([#249](https://github.com/marmot-protocol/mdk/pull/249))
 - Added optional `thumbhash` fields alongside the existing `blurhash` UniFFI records for group-image and encrypted-media uploads, plus a `generate_thumbhash` option in `MediaProcessingOptionsInput`. ([#244](https://github.com/marmot-protocol/mdk/pull/244))
 - Moved binary size optimizations (`opt-level = "z"`, thin LTO, single codegen unit, `panic = "abort"`, symbol stripping) into `[profile.release]` directly. Android builds override to fat LTO via `CARGO_PROFILE_RELEASE_LTO=fat` for maximum `.so` reduction; iOS uses thin LTO to avoid `.a` archive bloat. ([`#221`](https://github.com/marmot-protocol/mdk/pull/221), [`#232`](https://github.com/marmot-protocol/mdk/pull/232))

--- a/crates/mdk-uniffi/src/lib.rs
+++ b/crates/mdk-uniffi/src/lib.rs
@@ -920,6 +920,22 @@ impl Mdk {
         update_group_result_to_uniffi(result)
     }
 
+    /// Delete all locally stored messages for a group.
+    pub fn delete_messages_for_group(&self, mls_group_id: String) -> Result<u32, MdkUniffiError> {
+        let group_id = parse_group_id(&mls_group_id)?;
+        let mdk = self.lock()?;
+        let count = mdk.delete_messages_for_group(&group_id)?;
+        Ok(count as u32)
+    }
+
+    /// Delete all local state for a group.
+    pub fn delete_group(&self, mls_group_id: String) -> Result<(), MdkUniffiError> {
+        let group_id = parse_group_id(&mls_group_id)?;
+        let mdk = self.lock()?;
+        mdk.delete_group(&group_id)?;
+        Ok(())
+    }
+
     /// Self-demote from admin status before leaving a group.
     ///
     /// Per MIP-03, admins must call this before leave_group(). If the caller is


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
⚠️ Security-sensitive changes

This PR adds local "clear chat" and "delete chat" functionality across core, storage, and UniFFI layers to let callers remove decrypted messages or erase all locally persisted group state without emitting protocol proposals or Nostr events, and it ensures in-memory epoch snapshot and MLS in-memory state are cleaned when a group is deleted.

What changed:
- Added storage trait methods MessageStorage::delete_messages_for_group and MdkStorageProvider::delete_group in mdk-storage-traits to define the required local-only deletion contract.
- Added public MDK APIs delete_messages_for_group and delete_group in mdk-core that delegate to storage and call EpochSnapshotManager::remove_group when deleting a group.
- Implemented EpochSnapshotManager::remove_group in mdk-core to evict in-memory snapshot queues and hydrated-group tracking for a group.
- Implemented delete_messages_for_group and delete_group in mdk-memory-storage with coordinated LRU/cache evictions, processed-message removals, and OpenMLS in-memory cleanup, including new MlsGroupData::clear_group and MlsEpochKeyPairs::clear_group helpers.
- Implemented delete_messages_for_group and transactional delete_group in mdk-sqlite-storage with ordered DELETE statements across OpenMLS and MDK tables inside an IMMEDIATE transaction.
- Added UniFFI bindings in mdk-uniffi exposing delete_messages_for_group and delete_group for FFI consumers.
- Updated changelogs in affected crates documenting the new local cleanup APIs.

Security impact:
- Key material handling is affected only by local cleanup: epoch key pairs, exporter secrets, and other in-memory MLS state are cleared or deleted, but no changes to cryptographic algorithms, key derivation, nonces, or HKDF contexts were introduced.
- The operations are explicitly local-only and do not publish MLS proposals or Nostr events, minimizing protocol-level side effects.
- No changes to identity binding, credential validation, error messages that leak identifiers, SQLCipher configuration, or filesystem permissions were made.

Protocol changes:
- None; MLS protocol behavior is unchanged and no MLS proposals or Nostr events are produced by these APIs.

API surface:
- New required storage trait methods: fn delete_group(&self, group_id: &GroupId) -> Result<(), MdkStorageError> and fn delete_messages_for_group(&self, group_id: &GroupId) -> Result<usize, MessageError>.
- New public core APIs: MDK::delete_messages_for_group(&self, group_id: &GroupId) -> Result<usize, Error> and MDK::delete_group(&self, group_id: &GroupId) -> Result<(), Error>.
- New UniFFI exports: delete_messages_for_group(String) -> Result<u32, MdkUniffiError> and delete_group(String) -> Result<(), MdkUniffiError>.
- Storage implementations updated: mdk-memory-storage and mdk-sqlite-storage implement the new trait methods with no schema migrations beyond DELETE usage.

Testing:
- Added unit tests across mdk-memory-storage and mdk-sqlite-storage (and epoch snapshots) verifying deletion semantics, idempotency, cross-group isolation, and that epoch snapshots and MLS in-memory state are cleared where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->