### PR TITLE
Fix receiver-side admin depletion validation

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -51,6 +51,7 @@
 
 ### Fixed
 
+- Rejected receiver-side commits that would leave a group with no active admins, including admin-authored group-data extension updates that bypass MDK's creating-side guards. ([#256](https://github.com/marmot-protocol/mdk/pull/256))
 - Added ciphertext deduplication to commit race resolution. Epoch snapshots now store a SHA-256 hash of the outer event content; re-wrapped events carrying identical ciphertext are rejected before the MIP-03 timestamp/ID comparison, preventing replay-triggered rollbacks. ([#246](https://github.com/marmot-protocol/mdk/pull/246))
 - Bumped `hpke-rs` from `0.6.0` to `0.6.1`, resolving two high-severity advisories in the transitive `libcrux` chain: [RUSTSEC-2026-0073](https://rustsec.org/advisories/RUSTSEC-2026-0073) (panic in `libcrux-poly1305` standalone MAC operations) and [RUSTSEC-2026-0074](https://rustsec.org/advisories/RUSTSEC-2026-0074) (incorrect SHAKE output in `libcrux-sha3`). `Cargo.lock` only — no `Cargo.toml` changes required. ([#234](https://github.com/marmot-protocol/mdk/pull/234))
 - Bumped `digest` lockfile entry from yanked `0.11.1` to `0.11.2`, resolving the `cargo audit` yanked-crate warning introduced transitively via `openmls_rust_crypto` → `hpke-rs-rust-crypto` → `x-wing` → `sha3`. ([#229](https://github.com/marmot-protocol/mdk/pull/229))

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -199,7 +199,10 @@ where
     Storage: MdkStorageProvider,
 {
     /// Extracts a public key from an MLS credential.
-    fn pubkey_from_credential(&self, credential: &Credential) -> Result<PublicKey, Error> {
+    pub(crate) fn pubkey_from_credential(
+        &self,
+        credential: &Credential,
+    ) -> Result<PublicKey, Error> {
         let basic = BasicCredential::try_from(credential.clone())?;
         self.parse_credential_identity(basic.identity())
     }
@@ -501,16 +504,7 @@ where
     /// * `Err(Error)` - If the group is not found or there is an error accessing member data
     pub fn get_members(&self, group_id: &GroupId) -> Result<BTreeSet<PublicKey>, Error> {
         let group = self.load_mls_group(group_id)?.ok_or(Error::GroupNotFound)?;
-
-        // Store members in a variable to extend its lifetime
-        let mut members = group.members();
-        members.try_fold(BTreeSet::new(), |mut acc, m| {
-            let credentials: BasicCredential = BasicCredential::try_from(m.credential)?;
-            let identity_bytes: &[u8] = credentials.identity();
-            let public_key = self.parse_credential_identity(identity_bytes)?;
-            acc.insert(public_key);
-            Ok(acc)
-        })
+        self.member_pubkeys(&group)
     }
 
     /// Returns the local member's current MLS leaf index for a group.

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -1777,8 +1777,9 @@ where
         let mls_group = self.load_mls_group(group_id)?.ok_or(Error::GroupNotFound)?;
         let mut stored_group = self.get_group(group_id)?.ok_or(Error::GroupNotFound)?;
 
-        // Validate the mandatory group-data extension FIRST before making any state changes
-        // This ensures we don't update stored_group if the extension is missing, invalid, or unsupported
+        // Validate the mandatory group-data extension FIRST before making any state changes.
+        // Receiver-side commits are checked before merge; this guard covers local merge
+        // and storage-sync paths so invalid MLS metadata is not copied into storage.
         let group_data = NostrGroupDataExtension::from_group(&mls_group)?;
         self.validate_active_admins_in_group(&mls_group, &group_data.admins)?;
         // Only after successful validation, update epoch and metadata from MLS group
@@ -3590,6 +3591,8 @@ mod tests {
             .merge_pending_commit(&creator_mdk.provider)
             .expect("OpenMLS should merge the adminless extension update");
 
+        // This guard does not roll back the mutated MLS group. It prevents the
+        // invalid extension from being copied into stored group metadata.
         let result = creator_mdk.sync_group_metadata_from_mls(&group_id);
 
         assert!(

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -1786,6 +1786,7 @@ where
         // Validate the mandatory group-data extension FIRST before making any state changes
         // This ensures we don't update stored_group if the extension is missing, invalid, or unsupported
         let group_data = NostrGroupDataExtension::from_group(&mls_group)?;
+        self.validate_active_admins_in_group(&mls_group, &group_data.admins)?;
         // Only after successful validation, update epoch and metadata from MLS group
         stored_group.epoch = mls_group.epoch().as_u64();
 
@@ -3556,6 +3557,61 @@ mod tests {
             initial_stored_group.last_message_at
         );
         assert_eq!(synced_stored_group.state, initial_stored_group.state);
+    }
+
+    #[test]
+    fn test_sync_group_metadata_rejects_adminless_group_data() {
+        let creator_mdk = create_test_mdk();
+        let (creator, initial_members, admins) = create_test_group_members();
+        let group_id = create_test_group(&creator_mdk, &creator, &initial_members, &admins);
+
+        let initial_stored_group = creator_mdk
+            .get_group(&group_id)
+            .expect("Failed to get initial stored group")
+            .expect("Stored group should exist");
+
+        let mut mls_group = creator_mdk
+            .load_mls_group(&group_id)
+            .expect("Failed to load MLS group")
+            .expect("MLS group should exist");
+        let mut group_data =
+            NostrGroupDataExtension::from_group(&mls_group).expect("Group data should parse");
+        group_data.admins.clear();
+
+        let extension =
+            super::MDK::<MdkMemoryStorage>::get_unknown_extension_from_group_data(&group_data)
+                .expect("Failed to build adminless group-data extension");
+        let mut extensions = mls_group.extensions().clone();
+        extensions
+            .add_or_replace(extension)
+            .expect("Failed to replace group-data extension");
+
+        let signature_keypair = creator_mdk
+            .load_mls_signer(&mls_group)
+            .expect("Failed to load signer");
+        let (_message_out, _, _) = mls_group
+            .update_group_context_extensions(&creator_mdk.provider, extensions, &signature_keypair)
+            .expect("OpenMLS should allow the adminless extension update");
+        mls_group
+            .merge_pending_commit(&creator_mdk.provider)
+            .expect("OpenMLS should merge the adminless extension update");
+
+        let result = creator_mdk.sync_group_metadata_from_mls(&group_id);
+
+        assert!(
+            matches!(result, Err(crate::Error::Group(ref msg)) if msg.contains("no admins")),
+            "sync should reject adminless group data, got: {:?}",
+            result
+        );
+
+        let stored_group = creator_mdk
+            .get_group(&group_id)
+            .expect("Failed to reload stored group")
+            .expect("Stored group should still exist");
+        assert_eq!(
+            stored_group.admin_pubkeys, initial_stored_group.admin_pubkeys,
+            "Rejected sync should not alter stored admins"
+        );
     }
 
     #[test]

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -492,7 +492,7 @@ where
             .map_err(|e| Error::Group(e.to_string()))
     }
 
-    /// Gets the public keys of all members in an MLS group
+    /// Gets the Nostr identities represented by all live members in an MLS group
     ///
     /// # Arguments
     ///
@@ -500,11 +500,11 @@ where
     ///
     /// # Returns
     ///
-    /// * `Ok(BTreeSet<PublicKey>)` - Set of member public keys
+    /// * `Ok(BTreeSet<PublicKey>)` - Set of represented member identities
     /// * `Err(Error)` - If the group is not found or there is an error accessing member data
     pub fn get_members(&self, group_id: &GroupId) -> Result<BTreeSet<PublicKey>, Error> {
         let group = self.load_mls_group(group_id)?.ok_or(Error::GroupNotFound)?;
-        self.member_pubkeys(&group)
+        self.live_member_identities(&group)
     }
 
     /// Returns the local member's current MLS leaf index for a group.

--- a/crates/mdk-core/src/lib.rs
+++ b/crates/mdk-core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod messages;
 #[cfg_attr(docsrs, doc(cfg(feature = "mip05")))]
 pub mod mip05;
 pub mod prelude;
+mod state_validation;
 #[cfg(test)]
 pub mod test_util;
 mod util;

--- a/crates/mdk-core/src/messages/commit.rs
+++ b/crates/mdk-core/src/messages/commit.rs
@@ -190,7 +190,10 @@ mod tests {
     use mdk_storage_traits::groups::GroupStorage;
     use mdk_storage_traits::groups::types as group_types;
     use nostr::{EventBuilder, EventId, Keys, Kind};
+    use openmls::prelude::{Extension, UnknownExtension};
+    use tls_codec::Serialize as TlsSerialize;
 
+    use crate::extension::NostrGroupDataExtension;
     use crate::messages::MessageProcessingResult;
     use crate::test_util::*;
     use crate::tests::create_test_mdk;
@@ -793,6 +796,99 @@ mod tests {
         assert_eq!(
             group_state.name, "Updated Group Name",
             "Group name should be updated"
+        );
+    }
+
+    /// Test that an admin-authored commit cannot empty the admin set.
+    ///
+    /// This bypasses MDK's creating-side group-data guard and uses OpenMLS
+    /// directly to create the receiver-side shape reported in issue #29.
+    #[test]
+    fn test_admin_extension_update_cannot_deplete_all_admins() {
+        let alice_keys = Keys::generate();
+        let bob_keys = Keys::generate();
+
+        let alice_mdk = create_test_mdk();
+        let bob_mdk = create_test_mdk();
+
+        let admins = vec![alice_keys.public_key()];
+        let bob_key_package = create_key_package_event(&bob_mdk, &bob_keys);
+
+        let create_result = alice_mdk
+            .create_group(
+                &alice_keys.public_key(),
+                vec![bob_key_package],
+                create_nostr_group_config_data(admins.clone()),
+            )
+            .expect("Failed to create group");
+
+        let group_id = create_result.group.mls_group_id.clone();
+
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("Failed to merge pending commit");
+
+        let bob_welcome_rumor = &create_result.welcome_rumors[0];
+        let bob_welcome = bob_mdk
+            .process_welcome(&EventId::all_zeros(), bob_welcome_rumor)
+            .expect("Bob should process welcome");
+        bob_mdk
+            .accept_welcome(&bob_welcome)
+            .expect("Bob should accept welcome");
+
+        let mut alice_mls_group = alice_mdk
+            .load_mls_group(&group_id)
+            .expect("Failed to load Alice MLS group")
+            .expect("Alice MLS group should exist");
+        let mut group_data = NostrGroupDataExtension::from_group(&alice_mls_group)
+            .expect("Alice MLS group should have group data");
+        group_data.admins.clear();
+
+        let serialized_group_data = group_data
+            .as_raw()
+            .tls_serialize_detached()
+            .expect("Failed to serialize group-data extension");
+        let extension = Extension::Unknown(
+            group_data.extension_type(),
+            UnknownExtension(serialized_group_data),
+        );
+        let mut extensions = alice_mls_group.extensions().clone();
+        extensions
+            .add_or_replace(extension)
+            .expect("Failed to replace group-data extension");
+
+        let signature_keypair = alice_mdk
+            .load_mls_signer(&alice_mls_group)
+            .expect("Failed to load Alice signer");
+        let (message_out, _, _) = alice_mls_group
+            .update_group_context_extensions(&alice_mdk.provider, extensions, &signature_keypair)
+            .expect("OpenMLS should create the extension update commit");
+        let malicious_commit_event = alice_mdk
+            .build_message_event(
+                &group_id,
+                message_out
+                    .tls_serialize_detached()
+                    .expect("Failed to serialize malicious commit"),
+                None,
+            )
+            .expect("Failed to build malicious commit event");
+
+        let result = bob_mdk.process_message(&malicious_commit_event);
+
+        assert!(
+            matches!(result, Ok(MessageProcessingResult::Unprocessable { .. })),
+            "Admin-depleting commit should be rejected as unprocessable, got: {:?}",
+            result
+        );
+
+        let bob_group = bob_mdk
+            .get_group(&group_id)
+            .expect("Failed to get Bob's group")
+            .expect("Bob's group should exist");
+        assert_eq!(
+            bob_group.admin_pubkeys,
+            admins.into_iter().collect(),
+            "Rejected commit should not alter Bob's stored admin set"
         );
     }
 

--- a/crates/mdk-core/src/messages/commit.rs
+++ b/crates/mdk-core/src/messages/commit.rs
@@ -877,8 +877,7 @@ mod tests {
 
         assert!(
             matches!(result, Ok(MessageProcessingResult::Unprocessable { .. })),
-            "Admin-depleting commit should be rejected as unprocessable, got: {:?}",
-            result
+            "Admin-depleting commit should be rejected as unprocessable"
         );
 
         let bob_group = bob_mdk

--- a/crates/mdk-core/src/messages/commit.rs
+++ b/crates/mdk-core/src/messages/commit.rs
@@ -802,7 +802,7 @@ mod tests {
     /// Test that an admin-authored commit cannot empty the admin set.
     ///
     /// This bypasses MDK's creating-side group-data guard and uses OpenMLS
-    /// directly to create the receiver-side shape reported in issue #29.
+    /// directly to create the receiver-side shape reported in marmot-security#29.
     #[test]
     fn test_admin_extension_update_cannot_deplete_all_admins() {
         let alice_keys = Keys::generate();
@@ -835,6 +835,11 @@ mod tests {
         bob_mdk
             .accept_welcome(&bob_welcome)
             .expect("Bob should accept welcome");
+        let bob_epoch_before = bob_mdk
+            .get_group(&group_id)
+            .expect("Failed to get Bob's group before malicious commit")
+            .expect("Bob's group should exist before malicious commit")
+            .epoch;
 
         let mut alice_mls_group = alice_mdk
             .load_mls_group(&group_id)
@@ -884,6 +889,10 @@ mod tests {
             .get_group(&group_id)
             .expect("Failed to get Bob's group")
             .expect("Bob's group should exist");
+        assert_eq!(
+            bob_group.epoch, bob_epoch_before,
+            "Rejected commit should not advance Bob's stored epoch"
+        );
         assert_eq!(
             bob_group.admin_pubkeys,
             admins.into_iter().collect(),

--- a/crates/mdk-core/src/messages/validation.rs
+++ b/crates/mdk-core/src/messages/validation.rs
@@ -333,6 +333,9 @@ where
                         leaf_index
                     );
 
+                    // The staged invariant uses the post-commit group context,
+                    // so extension changes and all SelfRemove effects are
+                    // checked together before merge.
                     self.validate_admin_invariant_after_commit(mls_group, staged_commit)?;
 
                     return Ok(());

--- a/crates/mdk-core/src/messages/validation.rs
+++ b/crates/mdk-core/src/messages/validation.rs
@@ -2,12 +2,15 @@
 //!
 //! This module handles validation of Nostr events and MLS identity verification.
 
+use std::collections::BTreeSet;
+
 use mdk_storage_traits::MdkStorageProvider;
-use nostr::{Event, Kind, TagKind, Timestamp};
+use nostr::{Event, Kind, PublicKey, TagKind, Timestamp};
 use openmls::prelude::{BasicCredential, LeafNodeIndex, MlsGroup, Proposal, Sender, StagedCommit};
 
 use crate::MDK;
 use crate::error::Error;
+use crate::extension::NostrGroupDataExtension;
 
 use super::Result;
 
@@ -270,6 +273,87 @@ where
         Ok(())
     }
 
+    /// Validates that the current MLS group contains at least one active admin.
+    ///
+    /// The admin set is checked against live MLS members so stale admin entries
+    /// do not satisfy the invariant.
+    pub(crate) fn validate_active_admins_in_group(
+        &self,
+        mls_group: &MlsGroup,
+        admins: &BTreeSet<PublicKey>,
+    ) -> Result<()> {
+        for member in mls_group.members() {
+            let basic_cred = BasicCredential::try_from(member.credential)?;
+            let pubkey = self.parse_credential_identity(basic_cred.identity())?;
+            if admins.contains(&pubkey) {
+                return Ok(());
+            }
+        }
+
+        Err(Error::Group("Would leave group with no admins".to_string()))
+    }
+
+    /// Validates that a staged commit leaves at least one active admin.
+    ///
+    /// This checks the post-commit group-data extension from the staged commit
+    /// together with the post-commit membership implied by Remove, SelfRemove,
+    /// and Add proposals.
+    pub(super) fn validate_post_commit_admin_invariant(
+        &self,
+        mls_group: &MlsGroup,
+        staged_commit: &StagedCommit,
+    ) -> Result<()> {
+        let staged_group_data =
+            NostrGroupDataExtension::from_group_context(staged_commit.group_context())?;
+        let departing_leaf_indices = Self::departing_leaf_indices(staged_commit);
+
+        for member in mls_group.members() {
+            if departing_leaf_indices.contains(&member.index) {
+                continue;
+            }
+
+            let basic_cred = BasicCredential::try_from(member.credential)?;
+            let pubkey = self.parse_credential_identity(basic_cred.identity())?;
+            if staged_group_data.admins.contains(&pubkey) {
+                return Ok(());
+            }
+        }
+
+        for add_proposal in staged_commit.add_proposals() {
+            let credential = add_proposal
+                .add_proposal()
+                .key_package()
+                .leaf_node()
+                .credential()
+                .clone();
+            let basic_cred = BasicCredential::try_from(credential)?;
+            let pubkey = self.parse_credential_identity(basic_cred.identity())?;
+            if staged_group_data.admins.contains(&pubkey) {
+                return Ok(());
+            }
+        }
+
+        Err(Error::Group("Would leave group with no admins".to_string()))
+    }
+
+    fn departing_leaf_indices(staged_commit: &StagedCommit) -> Vec<LeafNodeIndex> {
+        let mut departing_leaf_indices = Vec::new();
+
+        for queued in staged_commit.queued_proposals() {
+            match queued.proposal() {
+                Proposal::Remove(remove) => departing_leaf_indices.push(remove.removed()),
+                Proposal::SelfRemove => {
+                    if let Sender::Member(leaf_index) = queued.sender() {
+                        departing_leaf_indices.push(*leaf_index);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        departing_leaf_indices
+    }
+
     /// Validates that a staged commit does not attempt to change any member's identity
     ///
     /// This function checks all Update proposals within a staged commit to ensure
@@ -357,6 +441,7 @@ where
                 let sender_is_admin = group_data.admins.contains(&sender_pubkey);
 
                 if sender_is_admin {
+                    self.validate_post_commit_admin_invariant(mls_group, staged_commit)?;
                     return Ok(());
                 }
 
@@ -389,6 +474,7 @@ where
                         .collect();
 
                     self.validate_admin_depletion(mls_group, &departing_leaves)?;
+                    self.validate_post_commit_admin_invariant(mls_group, staged_commit)?;
 
                     return Ok(());
                 }

--- a/crates/mdk-core/src/messages/validation.rs
+++ b/crates/mdk-core/src/messages/validation.rs
@@ -2,15 +2,12 @@
 //!
 //! This module handles validation of Nostr events and MLS identity verification.
 
-use std::collections::BTreeSet;
-
 use mdk_storage_traits::MdkStorageProvider;
-use nostr::{Event, Kind, PublicKey, TagKind, Timestamp};
-use openmls::prelude::{BasicCredential, LeafNodeIndex, MlsGroup, Proposal, Sender, StagedCommit};
+use nostr::{Event, Kind, TagKind, Timestamp};
+use openmls::prelude::{BasicCredential, MlsGroup, Proposal, Sender, StagedCommit};
 
 use crate::MDK;
 use crate::error::Error;
-use crate::extension::NostrGroupDataExtension;
 
 use super::Result;
 
@@ -227,133 +224,6 @@ where
         has_self_remove
     }
 
-    /// Validates that removing the specified members would not deplete all admins.
-    ///
-    /// Per MIP-03, a Commit containing SelfRemove proposals MUST be rejected
-    /// if the resulting admin_pubkeys set would be empty. This checks the
-    /// cumulative effect of all departures, not each one individually.
-    ///
-    /// Admin count is cross-referenced against actual group membership to ignore
-    /// stale entries in `admin_pubkeys` (e.g., from admins who departed without
-    /// a corresponding GroupContextExtensions update).
-    pub(super) fn validate_admin_depletion(
-        &self,
-        mls_group: &MlsGroup,
-        departing_leaf_indices: &[LeafNodeIndex],
-    ) -> Result<()> {
-        let group_data = crate::extension::NostrGroupDataExtension::from_group(mls_group)?;
-
-        // Count only admins who are actual group members (ignores stale entries)
-        let active_admin_count = mls_group
-            .members()
-            .filter_map(|member| {
-                let basic_cred = BasicCredential::try_from(member.credential).ok()?;
-                let pubkey = self.parse_credential_identity(basic_cred.identity()).ok()?;
-                group_data.admins.contains(&pubkey).then_some(pubkey)
-            })
-            .count();
-
-        let mut departing_admin_count = 0usize;
-        for &leaf_index in departing_leaf_indices {
-            let member = mls_group
-                .member_at(leaf_index)
-                .ok_or(Error::MessageFromNonMember)?;
-            let basic_cred = BasicCredential::try_from(member.credential.clone())?;
-            let pubkey = self.parse_credential_identity(basic_cred.identity())?;
-
-            if group_data.admins.contains(&pubkey) {
-                departing_admin_count += 1;
-            }
-        }
-
-        if departing_admin_count >= active_admin_count {
-            return Err(Error::Group("Would leave group with no admins".to_string()));
-        }
-
-        Ok(())
-    }
-
-    /// Validates that the current MLS group contains at least one active admin.
-    ///
-    /// The admin set is checked against live MLS members so stale admin entries
-    /// do not satisfy the invariant.
-    pub(crate) fn validate_active_admins_in_group(
-        &self,
-        mls_group: &MlsGroup,
-        admins: &BTreeSet<PublicKey>,
-    ) -> Result<()> {
-        for member in mls_group.members() {
-            let basic_cred = BasicCredential::try_from(member.credential)?;
-            let pubkey = self.parse_credential_identity(basic_cred.identity())?;
-            if admins.contains(&pubkey) {
-                return Ok(());
-            }
-        }
-
-        Err(Error::Group("Would leave group with no admins".to_string()))
-    }
-
-    /// Validates that a staged commit leaves at least one active admin.
-    ///
-    /// This checks the post-commit group-data extension from the staged commit
-    /// together with the post-commit membership implied by Remove, SelfRemove,
-    /// and Add proposals.
-    pub(super) fn validate_post_commit_admin_invariant(
-        &self,
-        mls_group: &MlsGroup,
-        staged_commit: &StagedCommit,
-    ) -> Result<()> {
-        let staged_group_data =
-            NostrGroupDataExtension::from_group_context(staged_commit.group_context())?;
-        let departing_leaf_indices = Self::departing_leaf_indices(staged_commit);
-
-        for member in mls_group.members() {
-            if departing_leaf_indices.contains(&member.index) {
-                continue;
-            }
-
-            let basic_cred = BasicCredential::try_from(member.credential)?;
-            let pubkey = self.parse_credential_identity(basic_cred.identity())?;
-            if staged_group_data.admins.contains(&pubkey) {
-                return Ok(());
-            }
-        }
-
-        for add_proposal in staged_commit.add_proposals() {
-            let credential = add_proposal
-                .add_proposal()
-                .key_package()
-                .leaf_node()
-                .credential()
-                .clone();
-            let basic_cred = BasicCredential::try_from(credential)?;
-            let pubkey = self.parse_credential_identity(basic_cred.identity())?;
-            if staged_group_data.admins.contains(&pubkey) {
-                return Ok(());
-            }
-        }
-
-        Err(Error::Group("Would leave group with no admins".to_string()))
-    }
-
-    fn departing_leaf_indices(staged_commit: &StagedCommit) -> Vec<LeafNodeIndex> {
-        let mut departing_leaf_indices = Vec::new();
-
-        for queued in staged_commit.queued_proposals() {
-            match queued.proposal() {
-                Proposal::Remove(remove) => departing_leaf_indices.push(remove.removed()),
-                Proposal::SelfRemove => {
-                    if let Sender::Member(leaf_index) = queued.sender() {
-                        departing_leaf_indices.push(*leaf_index);
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        departing_leaf_indices
-    }
-
     /// Validates that a staged commit does not attempt to change any member's identity
     ///
     /// This function checks all Update proposals within a staged commit to ensure
@@ -441,7 +311,7 @@ where
                 let sender_is_admin = group_data.admins.contains(&sender_pubkey);
 
                 if sender_is_admin {
-                    self.validate_post_commit_admin_invariant(mls_group, staged_commit)?;
+                    self.validate_admin_invariant_after_commit(mls_group, staged_commit)?;
                     return Ok(());
                 }
 
@@ -463,18 +333,7 @@ where
                         leaf_index
                     );
 
-                    // Admin depletion check: the cumulative effect of all SelfRemove
-                    // proposals must not leave the group with zero admins.
-                    let departing_leaves: Vec<LeafNodeIndex> = staged_commit
-                        .queued_proposals()
-                        .filter_map(|queued| match queued.sender() {
-                            Sender::Member(leaf) => Some(*leaf),
-                            _ => None,
-                        })
-                        .collect();
-
-                    self.validate_admin_depletion(mls_group, &departing_leaves)?;
-                    self.validate_post_commit_admin_invariant(mls_group, staged_commit)?;
+                    self.validate_admin_invariant_after_commit(mls_group, staged_commit)?;
 
                     return Ok(());
                 }

--- a/crates/mdk-core/src/state_validation.rs
+++ b/crates/mdk-core/src/state_validation.rs
@@ -23,7 +23,11 @@ where
     Storage: MdkStorageProvider,
 {
     /// Returns the Nostr identities represented by live members of an MLS group.
-    pub(crate) fn member_pubkeys(
+    ///
+    /// This is the in-memory `MlsGroup` variant used by state validation. Public
+    /// callers that only have a `GroupId` should use `get_members`, which loads
+    /// the group and delegates here.
+    pub(crate) fn live_member_identities(
         &self,
         mls_group: &MlsGroup,
     ) -> Result<BTreeSet<PublicKey>, Error> {
@@ -34,14 +38,14 @@ where
     }
 
     /// Returns the Nostr identities represented after applying a staged commit.
-    pub(crate) fn post_commit_member_pubkeys(
+    pub(crate) fn post_commit_member_identities(
         &self,
         mls_group: &MlsGroup,
         staged_commit: &StagedCommit,
     ) -> Result<BTreeSet<PublicKey>, Error> {
         let departing_leaf_indices = Self::departing_leaf_indices(staged_commit);
-        let mut member_pubkeys =
-            self.member_pubkeys_after_departures(mls_group, &departing_leaf_indices)?;
+        let mut member_identities =
+            self.live_member_identities_after_departures(mls_group, &departing_leaf_indices)?;
 
         for add_proposal in staged_commit.add_proposals() {
             let credential = add_proposal
@@ -49,10 +53,10 @@ where
                 .key_package()
                 .leaf_node()
                 .credential();
-            member_pubkeys.insert(self.pubkey_from_credential(credential)?);
+            member_identities.insert(self.pubkey_from_credential(credential)?);
         }
 
-        Ok(member_pubkeys)
+        Ok(member_identities)
     }
 
     /// Validates that removing the specified members would not deplete all admins.
@@ -70,17 +74,17 @@ where
     ) -> Result<(), Error> {
         let group_data = NostrGroupDataExtension::from_group(mls_group)?;
         let departing_leaf_indices = departing_leaf_indices.iter().copied().collect();
-        let member_pubkeys =
-            self.member_pubkeys_after_departures(mls_group, &departing_leaf_indices)?;
-        Self::validate_active_admins(&group_data.admins, &member_pubkeys)
+        let member_identities =
+            self.live_member_identities_after_departures(mls_group, &departing_leaf_indices)?;
+        Self::validate_active_admins(&group_data.admins, &member_identities)
     }
 
     /// Validates that at least one admin identity is represented by a live member.
     pub(crate) fn validate_active_admins(
         admins: &BTreeSet<PublicKey>,
-        member_pubkeys: &BTreeSet<PublicKey>,
+        member_identities: &BTreeSet<PublicKey>,
     ) -> Result<(), Error> {
-        if admins.is_disjoint(member_pubkeys) {
+        if admins.is_disjoint(member_identities) {
             return Err(Error::Group("Would leave group with no admins".to_string()));
         }
 
@@ -93,8 +97,8 @@ where
         mls_group: &MlsGroup,
         admins: &BTreeSet<PublicKey>,
     ) -> Result<(), Error> {
-        let member_pubkeys = self.member_pubkeys(mls_group)?;
-        Self::validate_active_admins(admins, &member_pubkeys)
+        let member_identities = self.live_member_identities(mls_group)?;
+        Self::validate_active_admins(admins, &member_identities)
     }
 
     /// Validates that a staged commit leaves at least one active admin identity.
@@ -105,11 +109,11 @@ where
     ) -> Result<(), Error> {
         let group_data =
             NostrGroupDataExtension::from_group_context(staged_commit.group_context())?;
-        let member_pubkeys = self.post_commit_member_pubkeys(mls_group, staged_commit)?;
-        Self::validate_active_admins(&group_data.admins, &member_pubkeys)
+        let member_identities = self.post_commit_member_identities(mls_group, staged_commit)?;
+        Self::validate_active_admins(&group_data.admins, &member_identities)
     }
 
-    fn member_pubkeys_after_departures(
+    fn live_member_identities_after_departures(
         &self,
         mls_group: &MlsGroup,
         departing_leaf_indices: &BTreeSet<LeafNodeIndex>,

--- a/crates/mdk-core/src/state_validation.rs
+++ b/crates/mdk-core/src/state_validation.rs
@@ -3,6 +3,10 @@
 //! Keep state-transition checks here when they compare current MLS state with
 //! staged post-commit state. Broader proposal and group evolution validation can
 //! move here incrementally as follow-up work.
+//!
+//! These helpers model membership by Nostr identity, not by MLS leaf count.
+//! Multiple MLS leaves may legitimately carry the same Nostr identity, so the
+//! `BTreeSet<PublicKey>` return values intentionally deduplicate identities.
 
 use std::collections::BTreeSet;
 
@@ -18,7 +22,7 @@ impl<Storage> MDK<Storage>
 where
     Storage: MdkStorageProvider,
 {
-    /// Returns the Nostr public keys for the live members of an MLS group.
+    /// Returns the Nostr identities represented by live members of an MLS group.
     pub(crate) fn member_pubkeys(
         &self,
         mls_group: &MlsGroup,
@@ -29,7 +33,7 @@ where
             .collect()
     }
 
-    /// Returns the Nostr public keys for members after applying a staged commit.
+    /// Returns the Nostr identities represented after applying a staged commit.
     pub(crate) fn post_commit_member_pubkeys(
         &self,
         mls_group: &MlsGroup,
@@ -53,6 +57,10 @@ where
 
     /// Validates that removing the specified members would not deplete all admins.
     ///
+    /// This is for proposal-time checks where no staged commit exists yet, so it
+    /// reads the admin set from the current MLS group extension. Commit-time
+    /// validation should use `validate_admin_invariant_after_commit` instead.
+    ///
     /// The admin set is checked against post-departure live MLS members so stale
     /// admin entries do not satisfy the invariant.
     pub(crate) fn validate_admin_depletion(
@@ -67,7 +75,7 @@ where
         Self::validate_active_admins(&group_data.admins, &member_pubkeys)
     }
 
-    /// Validates that an admin set contains at least one live member.
+    /// Validates that at least one admin identity is represented by a live member.
     pub(crate) fn validate_active_admins(
         admins: &BTreeSet<PublicKey>,
         member_pubkeys: &BTreeSet<PublicKey>,
@@ -79,7 +87,7 @@ where
         Ok(())
     }
 
-    /// Validates that the current MLS group contains at least one active admin.
+    /// Validates that the current MLS group contains at least one active admin identity.
     pub(crate) fn validate_active_admins_in_group(
         &self,
         mls_group: &MlsGroup,
@@ -89,7 +97,7 @@ where
         Self::validate_active_admins(admins, &member_pubkeys)
     }
 
-    /// Validates that a staged commit leaves at least one active admin.
+    /// Validates that a staged commit leaves at least one active admin identity.
     pub(crate) fn validate_admin_invariant_after_commit(
         &self,
         mls_group: &MlsGroup,

--- a/crates/mdk-core/src/state_validation.rs
+++ b/crates/mdk-core/src/state_validation.rs
@@ -1,0 +1,135 @@
+//! Shared validation helpers for MLS group state.
+//!
+//! Keep state-transition checks here when they compare current MLS state with
+//! staged post-commit state. Broader proposal and group evolution validation can
+//! move here incrementally as follow-up work.
+
+use std::collections::BTreeSet;
+
+use mdk_storage_traits::MdkStorageProvider;
+use nostr::PublicKey;
+use openmls::prelude::{LeafNodeIndex, MlsGroup, Proposal, Sender, StagedCommit};
+
+use crate::MDK;
+use crate::error::Error;
+use crate::extension::NostrGroupDataExtension;
+
+impl<Storage> MDK<Storage>
+where
+    Storage: MdkStorageProvider,
+{
+    /// Returns the Nostr public keys for the live members of an MLS group.
+    pub(crate) fn member_pubkeys(
+        &self,
+        mls_group: &MlsGroup,
+    ) -> Result<BTreeSet<PublicKey>, Error> {
+        mls_group
+            .members()
+            .map(|member| self.pubkey_from_credential(&member.credential))
+            .collect()
+    }
+
+    /// Returns the Nostr public keys for members after applying a staged commit.
+    pub(crate) fn post_commit_member_pubkeys(
+        &self,
+        mls_group: &MlsGroup,
+        staged_commit: &StagedCommit,
+    ) -> Result<BTreeSet<PublicKey>, Error> {
+        let departing_leaf_indices = Self::departing_leaf_indices(staged_commit);
+        let mut member_pubkeys =
+            self.member_pubkeys_after_departures(mls_group, &departing_leaf_indices)?;
+
+        for add_proposal in staged_commit.add_proposals() {
+            let credential = add_proposal
+                .add_proposal()
+                .key_package()
+                .leaf_node()
+                .credential();
+            member_pubkeys.insert(self.pubkey_from_credential(credential)?);
+        }
+
+        Ok(member_pubkeys)
+    }
+
+    /// Validates that removing the specified members would not deplete all admins.
+    ///
+    /// The admin set is checked against post-departure live MLS members so stale
+    /// admin entries do not satisfy the invariant.
+    pub(crate) fn validate_admin_depletion(
+        &self,
+        mls_group: &MlsGroup,
+        departing_leaf_indices: &[LeafNodeIndex],
+    ) -> Result<(), Error> {
+        let group_data = NostrGroupDataExtension::from_group(mls_group)?;
+        let departing_leaf_indices = departing_leaf_indices.iter().copied().collect();
+        let member_pubkeys =
+            self.member_pubkeys_after_departures(mls_group, &departing_leaf_indices)?;
+        Self::validate_active_admins(&group_data.admins, &member_pubkeys)
+    }
+
+    /// Validates that an admin set contains at least one live member.
+    pub(crate) fn validate_active_admins(
+        admins: &BTreeSet<PublicKey>,
+        member_pubkeys: &BTreeSet<PublicKey>,
+    ) -> Result<(), Error> {
+        if admins.is_disjoint(member_pubkeys) {
+            return Err(Error::Group("Would leave group with no admins".to_string()));
+        }
+
+        Ok(())
+    }
+
+    /// Validates that the current MLS group contains at least one active admin.
+    pub(crate) fn validate_active_admins_in_group(
+        &self,
+        mls_group: &MlsGroup,
+        admins: &BTreeSet<PublicKey>,
+    ) -> Result<(), Error> {
+        let member_pubkeys = self.member_pubkeys(mls_group)?;
+        Self::validate_active_admins(admins, &member_pubkeys)
+    }
+
+    /// Validates that a staged commit leaves at least one active admin.
+    pub(crate) fn validate_admin_invariant_after_commit(
+        &self,
+        mls_group: &MlsGroup,
+        staged_commit: &StagedCommit,
+    ) -> Result<(), Error> {
+        let group_data =
+            NostrGroupDataExtension::from_group_context(staged_commit.group_context())?;
+        let member_pubkeys = self.post_commit_member_pubkeys(mls_group, staged_commit)?;
+        Self::validate_active_admins(&group_data.admins, &member_pubkeys)
+    }
+
+    fn member_pubkeys_after_departures(
+        &self,
+        mls_group: &MlsGroup,
+        departing_leaf_indices: &BTreeSet<LeafNodeIndex>,
+    ) -> Result<BTreeSet<PublicKey>, Error> {
+        for leaf_index in departing_leaf_indices {
+            mls_group
+                .member_at(*leaf_index)
+                .ok_or(Error::MessageFromNonMember)?;
+        }
+
+        mls_group
+            .members()
+            .filter(|member| !departing_leaf_indices.contains(&member.index))
+            .map(|member| self.pubkey_from_credential(&member.credential))
+            .collect()
+    }
+
+    fn departing_leaf_indices(staged_commit: &StagedCommit) -> BTreeSet<LeafNodeIndex> {
+        staged_commit
+            .queued_proposals()
+            .filter_map(|queued| match queued.proposal() {
+                Proposal::Remove(remove) => Some(remove.removed()),
+                Proposal::SelfRemove => match queued.sender() {
+                    Sender::Member(leaf_index) => Some(*leaf_index),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect()
+    }
+}


### PR DESCRIPTION
## Summary
- Add pre-merge validation that receiver-processed commits leave at least one active admin.
- Validate the staged post-commit group-data extension against effective membership, including removals, self-removals, and additions.
- Add a defensive storage-sync guard to prevent persisting adminless MLS group metadata.
- Add regressions for malicious admin-authored extension updates and adminless metadata sync.

## Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p mdk-core`
- `cargo clippy -p mdk-core --all-targets -- -D warnings`
- `cargo test -p mdk-core --no-default-features test_admin_extension_update_cannot_deplete_all_admins -- --nocapture`

Fixes https://github.com/marmot-protocol/marmot-security/issues/29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR prevents receiver-side acceptance or storage of MLS group state that would leave a group with no active admins by validating the post-commit effective admin set (including extension-only updates) and adding a defensive storage-sync guard. It adds a small state_validation module with utilities that compute live and post-commit member identities and enforces an "at least one active admin" invariant during commit processing and metadata sync, plus regression tests covering both extension-based and removal-based attack vectors.

What changed:
- Added a new internal module crates/mdk-core/src/state_validation.rs providing post-commit and post-departure member-identity derivation and admin-invariant checks (member_pubkeys, post_commit_member_pubkeys, validate_admin_depletion, validate_active_admins(_in_group), validate_admin_invariant_after_commit).
- Update validate_commit_authorization to call validate_admin_invariant_after_commit for admin senders and for SelfRemove cases, moving from removal-count heuristics to post-commit admin-set validation.
- Added a defensive guard in sync_group_metadata_from_mls to refuse persisting group metadata when the effective admin set is empty.
- Introduced regression tests: test_admin_extension_update_cannot_deplete_all_admins and test_sync_group_metadata_rejects_adminless_group_data that assert malicious admin-authored extension updates and adminless metadata sync are rejected.
- Minor visibility change: pubkey_from_credential widened to pub(crate) to permit use by the new module.
- Updated CHANGELOG with an Unreleased → Fixed entry documenting rejection of adminless group states.

Security impact:
- ⚠️ Security-sensitive changes: strengthens identity-binding/credential validation by enforcing that at least one admin identity is still represented by live members after commits and before persisting metadata.
- No cryptographic algorithm, key derivation, nonce, or HKDF context changes were introduced.
- No changes to SQLCipher, file permissions, or storage encryption configuration are present.
- Error messages are generic for the admin-depletion case ("Would leave group with no admins") and do not leak member identities.

Protocol changes:
- MLS handling: commit/merge-time validation now checks the staged post-commit admin set (including admins from group-data extensions and add/remove proposals) to ensure the group is not orphaned, tightening receiver-side validation to complement creating-side guards.
- Nostr integration: admin identity determination remains based on Nostr PublicKey extracted from member credentials; the PR ensures admin_pubkeys extension and member identities are reconciled post-commit.

API surface:
- No breaking public API changes to exported crates; changes are internal to mdk-core (new pub(crate) methods and a module).
- Storage schema, UniFFI/FFI boundaries, and public types remain unchanged.

Testing:
- Added focused regression tests covering admin-extension-only depletion and adminless metadata sync rejection, and included test commands used by the author (cargo fmt/check, cargo test -p mdk-core, cargo clippy -p mdk-core, targeted cargo test invocation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->