### PR TITLE
Fix memory storage message payload bounds

### DIFF
--- a/crates/mdk-memory-storage/CHANGELOG.md
+++ b/crates/mdk-memory-storage/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixed
 
+- Fixed `MdkMemoryStorage::save_message` to reject oversized message content, serialized tags JSON, and serialized event JSON before caching messages, matching SQLite backend payload bounds. ([#257](https://github.com/marmot-protocol/mdk/pull/257))
+
 ### Removed
 
 ### Deprecated

--- a/crates/mdk-memory-storage/src/lib.rs
+++ b/crates/mdk-memory-storage/src/lib.rs
@@ -19,7 +19,7 @@
 //! ## Memory Exhaustion Protection
 //!
 //! This implementation includes input validation to prevent memory exhaustion attacks.
-//! The following limits are enforced (with configurable defaults via [`ValidationLimits`]):
+//! The following configurable limits are enforced via [`ValidationLimits`]:
 //!
 //! - [`DEFAULT_MAX_RELAYS_PER_GROUP`]: Maximum number of relays per group
 //! - [`DEFAULT_MAX_MESSAGES_PER_GROUP`]: Maximum messages stored per group in the cache
@@ -29,6 +29,10 @@
 //! - [`DEFAULT_MAX_RELAYS_PER_WELCOME`]: Maximum number of relays in a welcome message
 //! - [`DEFAULT_MAX_ADMINS_PER_WELCOME`]: Maximum number of admin pubkeys in a welcome message
 //! - [`DEFAULT_MAX_RELAY_URL_LENGTH`]: Maximum length of a relay URL in bytes
+//!
+//! Message payloads also enforce the same fixed size limits as the SQLite backend:
+//! 1 MiB for message content, 100 KiB for serialized tags JSON, and 100 KiB for
+//! serialized event JSON.
 //!
 //! ## Customizing Limits
 //!

--- a/crates/mdk-memory-storage/src/messages.rs
+++ b/crates/mdk-memory-storage/src/messages.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use mdk_storage_traits::GroupId;
-use nostr::EventId;
+use nostr::{EventId, JsonUtil};
 #[cfg(test)]
 use nostr::{Kind, Tags, Timestamp, UnsignedEvent};
 
@@ -13,6 +13,60 @@ use mdk_storage_traits::messages::error::MessageError;
 use mdk_storage_traits::messages::types::*;
 
 use crate::MdkMemoryStorage;
+
+/// Maximum size for message content, matching the SQLite backend.
+const MAX_MESSAGE_CONTENT_SIZE: usize = 1024 * 1024;
+
+/// Maximum size for serialized tags JSON, matching the SQLite backend.
+const MAX_TAGS_JSON_SIZE: usize = 100 * 1024;
+
+/// Maximum size for serialized event JSON, matching the SQLite backend.
+const MAX_EVENT_JSON_SIZE: usize = 100 * 1024;
+
+fn validate_size(data: &[u8], max_size: usize, field_name: &str) -> Result<(), MessageError> {
+    if data.len() > max_size {
+        return Err(MessageError::InvalidParameters(format!(
+            "{} exceeds maximum length of {} bytes (got {} bytes)",
+            field_name,
+            max_size,
+            data.len()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_string_length(
+    s: &str,
+    max_length: usize,
+    field_name: &str,
+) -> Result<(), MessageError> {
+    if s.len() > max_length {
+        return Err(MessageError::InvalidParameters(format!(
+            "{} exceeds maximum length of {} bytes (got {} bytes)",
+            field_name,
+            max_length,
+            s.len()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_message_payload(message: &Message) -> Result<(), MessageError> {
+    validate_string_length(
+        &message.content,
+        MAX_MESSAGE_CONTENT_SIZE,
+        "Message content",
+    )?;
+
+    let tags_json = serde_json::to_string(&message.tags)
+        .map_err(|e| MessageError::DatabaseError(format!("Failed to serialize tags: {}", e)))?;
+    validate_size(tags_json.as_bytes(), MAX_TAGS_JSON_SIZE, "Tags JSON")?;
+
+    let event_json = message.event.as_json();
+    validate_size(event_json.as_bytes(), MAX_EVENT_JSON_SIZE, "Event JSON")?;
+
+    Ok(())
+}
 
 impl MessageStorage for MdkMemoryStorage {
     fn save_message(&self, message: Message) -> Result<(), MessageError> {
@@ -33,6 +87,8 @@ impl MessageStorage for MdkMemoryStorage {
                 )));
             }
         }
+
+        validate_message_payload(&message)?;
 
         // Acquire lock on inner storage
         let mut guard = self.inner.write();
@@ -366,6 +422,101 @@ mod tests {
             epoch,
             state: MessageState::Created,
         }
+    }
+
+    fn assert_save_message_invalid_parameters(result: Result<(), MessageError>, expected: &str) {
+        match result {
+            Err(MessageError::InvalidParameters(message)) => {
+                assert!(
+                    message.contains(expected),
+                    "expected error containing '{expected}', got '{message}'"
+                );
+            }
+            Err(err) => panic!("expected InvalidParameters error, got {err:?}"),
+            Ok(()) => panic!("expected save_message to reject invalid payload"),
+        }
+    }
+
+    #[test]
+    fn test_save_message_rejects_oversized_content() {
+        let storage = MdkMemoryStorage::new();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let event_id = EventId::from_slice(&[10u8; 32]).unwrap();
+
+        storage
+            .save_group(create_test_group(group_id.clone()))
+            .unwrap();
+
+        let oversized_content = "a".repeat(MAX_MESSAGE_CONTENT_SIZE + 1);
+        let message = create_test_message(event_id, group_id.clone(), &oversized_content, 1000);
+
+        let result = storage.save_message(message);
+
+        assert_save_message_invalid_parameters(result, "Message content exceeds maximum length");
+        assert!(
+            storage
+                .find_message_by_event_id(&group_id, &event_id)
+                .unwrap()
+                .is_none(),
+            "oversized message content must not be cached"
+        );
+    }
+
+    #[test]
+    fn test_save_message_rejects_oversized_tags_json() {
+        let storage = MdkMemoryStorage::new();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let event_id = EventId::from_slice(&[11u8; 32]).unwrap();
+
+        storage
+            .save_group(create_test_group(group_id.clone()))
+            .unwrap();
+
+        let oversized_tag_value = "a".repeat(MAX_TAGS_JSON_SIZE);
+        let mut message = create_test_message(event_id, group_id.clone(), "content", 1000);
+        message.tags = Tags::parse(vec![vec!["imeta", oversized_tag_value.as_str()]]).unwrap();
+
+        let result = storage.save_message(message);
+
+        assert_save_message_invalid_parameters(result, "Tags JSON exceeds maximum length");
+        assert!(
+            storage
+                .find_message_by_event_id(&group_id, &event_id)
+                .unwrap()
+                .is_none(),
+            "message with oversized tags must not be cached"
+        );
+    }
+
+    #[test]
+    fn test_save_message_rejects_oversized_event_json() {
+        let storage = MdkMemoryStorage::new();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let event_id = EventId::from_slice(&[12u8; 32]).unwrap();
+
+        storage
+            .save_group(create_test_group(group_id.clone()))
+            .unwrap();
+
+        let mut message = create_test_message(event_id, group_id.clone(), "content", 1000);
+        message.event = UnsignedEvent::new(
+            message.pubkey,
+            message.created_at,
+            message.kind,
+            Tags::new(),
+            "a".repeat(MAX_EVENT_JSON_SIZE),
+        );
+
+        let result = storage.save_message(message);
+
+        assert_save_message_invalid_parameters(result, "Event JSON exceeds maximum length");
+        assert!(
+            storage
+                .find_message_by_event_id(&group_id, &event_id)
+                .unwrap()
+                .is_none(),
+            "message with oversized event JSON must not be cached"
+        );
     }
 
     /// Test that saving a message with the same EventId updates the existing message


### PR DESCRIPTION
## Summary
- Enforce SQLite-matching size limits in `mdk-memory-storage` for message content, serialized tags JSON, and serialized event JSON.
- Reject oversized messages before they are inserted into memory caches.
- Document the fixed message payload limits and add regression coverage for each rejected payload type.

## Testing
- `cargo test -p mdk-memory-storage save_message_rejects_oversized -- --nocapture`
- `cargo test -p mdk-memory-storage`
- `cargo clippy -p mdk-memory-storage --all-targets --all-features -- -D warnings`
- `cargo doc -p mdk-memory-storage --no-deps`
- `cargo fmt --check`
- `just check`

Fixes https://github.com/marmot-protocol/marmot-security/issues/10