### PR TITLE
feat: extension v3 wire format + disappearing_message_secs schema (1/3)

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -25,12 +25,18 @@
 
 ### Breaking changes
 
+- **Extension version bumped from 2 to 3**: `NostrGroupDataExtension::CURRENT_VERSION` is now `3`. The new version adds a `disappearing_message_secs` field to the TLS-serialized group data extension. Existing v1/v2 groups are forward-compatible (the field deserializes as `None`). `NostrGroupConfigData::new` now takes an additional `disappearing_message_secs: Option<u64>` parameter. ([#253](https://github.com/marmot-protocol/mdk/pull/253))
+- **`NostrGroupDataExtension::migrate_to_v2` removed from public API.** The 0.8.0 method was used only to construct test fixtures; production code never migrates extensions in-place (deserialization upgrades v1/v2 → v3 through `into_v3`, and new groups author v3 directly). Mirrors the existing convention for `migrate_group_image_v1_to_v2`, which was already documented as internal-only. ([#253](https://github.com/marmot-protocol/mdk/pull/253))
+
 ### Changed
 
 ### Added
 
+- Added `disappearing_message_secs: Option<u64>` field to `NostrGroupDataExtension`, `NostrGroupConfigData`, and `NostrGroupDataUpdate` for configuring disappearing messages on groups. `None` means messages persist forever; `Some(n)` means messages expire `n` seconds after creation. The field is propagated through group creation, group updates, and welcome processing. ([#253](https://github.com/marmot-protocol/mdk/pull/253))
+
 ### Fixed
 
+- Accepted `NostrGroupDataExtension` payloads from future versions with unknown trailing fields, per MIP-01's forward-compatibility requirement. Previously, any v(N+1) extension on the wire was rejected by `deserialize_bytes`, which would have bricked every group operation (commit/proposal/welcome/admin checks) the moment any peer authored a newer-version extension. ([#88](https://github.com/marmot-protocol/marmot-security/issues/88))
 - Recorded rollback snapshots for locally merged admin-list updates so clients can converge on the MIP-03 winner when competing admins concurrently mutate `admin_pubkeys`. ([#289](https://github.com/marmot-protocol/mdk/pull/289))
 - Verified unsigned application-message rumor IDs before accepting or sending them, preventing caller-supplied IDs from being trusted when they do not match the canonical event hash. ([#287](https://github.com/marmot-protocol/mdk/pull/287))
 - Fixed `mdk-core` crates.io package verification against OpenMLS 0.8.1 by using a temporary exported-ratchet-tree compatibility shim until crates.io OpenMLS exposes the upstream full-leaf iterator. ([#273](https://github.com/marmot-protocol/mdk/pull/273))

--- a/crates/mdk-core/examples/group_inspection.rs
+++ b/crates/mdk-core/examples/group_inspection.rs
@@ -125,6 +125,7 @@ async fn main() -> Result<(), Error> {
         image_nonce: None,
         relays: vec![relay_url.clone()],
         admins: vec![creator_keys.public_key()], // Creator is admin
+        disappearing_message_secs: None,
     };
 
     let group_result = mdk.create_group(

--- a/crates/mdk-core/examples/mls_memory.rs
+++ b/crates/mdk-core/examples/mls_memory.rs
@@ -74,6 +74,7 @@ async fn main() -> Result<(), Error> {
         Some(image_nonce),
         vec![relay_url.clone()],
         vec![alice_keys.public_key(), bob_keys.public_key()],
+        None, // disappearing_message_secs
     );
 
     let group_create_result = alice_mdk.create_group(

--- a/crates/mdk-core/examples/mls_sqlite.rs
+++ b/crates/mdk-core/examples/mls_sqlite.rs
@@ -86,6 +86,7 @@ async fn main() -> Result<(), Error> {
         Some(image_nonce),
         vec![relay_url.clone()],
         vec![alice_keys.public_key(), bob_keys.public_key()],
+        None, // disappearing_message_secs
     );
 
     // Alice creates the group, adding Bob.

--- a/crates/mdk-core/src/epoch_snapshots.rs
+++ b/crates/mdk-core/src/epoch_snapshots.rs
@@ -688,6 +688,7 @@ mod tests {
             image_nonce: None,
             state: GroupState::Active,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         }
     }
 
@@ -1167,6 +1168,7 @@ mod tests {
             image_nonce: None,
             state: GroupState::Active,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -1216,6 +1218,7 @@ mod tests {
             image_nonce: None,
             state: GroupState::Active,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -1375,6 +1378,7 @@ mod tests {
             image_nonce: None,
             state: GroupState::Active,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -1478,6 +1482,7 @@ mod tests {
             image_nonce: None,
             state: GroupState::Active,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -1524,6 +1529,7 @@ mod tests {
             image_nonce: None,
             state: GroupState::Active,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 

--- a/crates/mdk-core/src/extension/types.rs
+++ b/crates/mdk-core/src/extension/types.rs
@@ -10,13 +10,14 @@ use nostr::{PublicKey, RelayUrl};
 use openmls::extensions::{Extension, ExtensionType};
 use openmls::group::{GroupContext, MlsGroup};
 use tls_codec::{
-    DeserializeBytes, TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSerializeBytes, TlsSize,
+    DeserializeBytes, Serialize as TlsSerializeTrait, TlsDeserialize, TlsDeserializeBytes,
+    TlsSerialize, TlsSerializeBytes, TlsSize,
 };
 
 use crate::constant::NOSTR_GROUP_DATA_EXTENSION_TYPE;
 use crate::error::Error;
 
-/// TLS-serializable representation of Nostr Group Data Extension.
+/// TLS-serializable representation of Nostr Group Data Extension (v3+).
 ///
 /// This struct is used exclusively for TLS codec serialization/deserialization
 /// when the extension is transmitted over the MLS protocol. It uses `Vec<u8>`
@@ -47,13 +48,62 @@ pub(crate) struct TlsNostrGroupDataExtension {
     pub image_key: Vec<u8>,        // Use Vec<u8> to allow empty for None
     pub image_nonce: Vec<u8>,      // Use Vec<u8> to allow empty for None
     pub image_upload_key: Vec<u8>, // Use Vec<u8> to allow empty for None (v2 only)
+    pub disappearing_message_secs: Vec<u8>, // Use Vec<u8>: empty for None, 8 bytes for Some(u64) (v3 only)
+}
+
+/// TLS-serializable representation for v1/v2 payloads (before disappearing messages).
+///
+/// Legacy groups serialized without the `disappearing_message_secs` field
+/// use this struct for deserialization. The missing field is synthesized as an empty
+/// Vec (mapping to `None`) when converting to `TlsNostrGroupDataExtension`.
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    TlsSerialize,
+    TlsDeserialize,
+    TlsSerializeBytes,
+    TlsDeserializeBytes,
+    TlsSize,
+)]
+struct TlsNostrGroupDataExtensionV1V2 {
+    pub version: u16,
+    pub nostr_group_id: [u8; 32],
+    pub name: Vec<u8>,
+    pub description: Vec<u8>,
+    pub admin_pubkeys: Vec<[u8; 32]>,
+    pub relays: Vec<Vec<u8>>,
+    pub image_hash: Vec<u8>,
+    pub image_key: Vec<u8>,
+    pub image_nonce: Vec<u8>,
+    pub image_upload_key: Vec<u8>,
+}
+
+impl TlsNostrGroupDataExtensionV1V2 {
+    /// Promote to the v3 struct with the missing field defaulted to empty.
+    fn into_v3(self) -> TlsNostrGroupDataExtension {
+        TlsNostrGroupDataExtension {
+            version: self.version,
+            nostr_group_id: self.nostr_group_id,
+            name: self.name,
+            description: self.description,
+            admin_pubkeys: self.admin_pubkeys,
+            relays: self.relays,
+            image_hash: self.image_hash,
+            image_key: self.image_key,
+            image_nonce: self.image_nonce,
+            image_upload_key: self.image_upload_key,
+            disappearing_message_secs: Vec::new(),
+        }
+    }
 }
 
 /// This is an MLS Group Context extension used to store the group's name,
 /// description, ID, admin identities, image URL, and image encryption key.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NostrGroupDataExtension {
-    /// Extension format version (current: 2)
+    /// Extension format version (current: 3)
+    /// Version 3: Adds disappearing_message_secs field
     /// Version 2: image_key field contains image_seed, image_upload_key contains upload_seed
     /// Version 1: image_key field contains encryption key directly (deprecated)
     pub version: u16,
@@ -84,6 +134,11 @@ pub struct NostrGroupDataExtension {
     /// In v2, the upload keypair is derived from this seed (cryptographically independent from image_key).
     /// In v1, the upload keypair was derived from image_key (now deprecated).
     pub image_upload_key: Option<[u8; 32]>,
+    /// Disappearing message duration in seconds (v3 only)
+    ///
+    /// - `None`: Messages persist forever (disabled)
+    /// - `Some(n)`: Messages expire `n` seconds after creation (`n > 0`)
+    pub disappearing_message_secs: Option<u64>,
 }
 
 impl NostrGroupDataExtension {
@@ -91,9 +146,10 @@ impl NostrGroupDataExtension {
     pub const EXTENSION_TYPE: u16 = NOSTR_GROUP_DATA_EXTENSION_TYPE;
 
     /// Current extension format version (MIP-01)
+    /// Version 3: Adds disappearing_message_secs field
     /// Version 2: Uses image_seed (stored in image_key field) with HKDF derivation
     /// Version 1: Uses image_key directly as encryption key (deprecated)
-    pub const CURRENT_VERSION: u16 = 2;
+    pub const CURRENT_VERSION: u16 = 3;
 
     /// Creates a new NostrGroupDataExtension with the given parameters.
     ///
@@ -119,6 +175,7 @@ impl NostrGroupDataExtension {
         image_key: Option<[u8; 32]>,
         image_nonce: Option<[u8; 12]>,
         image_upload_key: Option<[u8; 32]>,
+        disappearing_message_secs: Option<u64>,
     ) -> Self
     where
         T1: Into<String>,
@@ -131,8 +188,22 @@ impl NostrGroupDataExtension {
         let mut random_bytes = [0u8; 32];
         rng.fill(&mut random_bytes);
 
+        // Normalize Some(0) to None — zero means "no expiration" and from_raw()
+        // rejects it on the read path, so the write path must not produce it.
+        let disappearing_message_secs = disappearing_message_secs.filter(|&d| d != 0);
+
+        // Version tracks protocol capabilities: v3 when disappearing messages
+        // are active, v2 otherwise. The wire format in to_tls_bytes() uses this
+        // to decide whether to emit the v3 struct (with the extra field) or the
+        // v1/v2 struct (backward-compatible with older clients).
+        let version = if disappearing_message_secs.is_some() {
+            Self::CURRENT_VERSION
+        } else {
+            2
+        };
+
         Self {
-            version: Self::CURRENT_VERSION,
+            version,
             nostr_group_id: random_bytes,
             name: name.into(),
             description: description.into(),
@@ -142,6 +213,7 @@ impl NostrGroupDataExtension {
             image_key,
             image_nonce,
             image_upload_key,
+            disappearing_message_secs,
         }
     }
 
@@ -156,17 +228,41 @@ impl NostrGroupDataExtension {
     /// * `Ok(NostrGroupDataExtension)` - Successfully deserialized extension
     /// * `Err(Error)` - Failed to deserialize
     fn deserialize_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let (deserialized, remainder) = TlsNostrGroupDataExtension::tls_deserialize_bytes(bytes)?;
-        if !remainder.is_empty() {
+        // Dispatch on the version field (first 2 bytes, big-endian u16) so that
+        // a corrupt v3 payload can never silently fall through to the v1/v2 parser.
+        if bytes.len() < 2 {
             return Err(Error::ExtensionFormatError(
-                "Trailing bytes in NostrGroupDataExtension".to_string(),
+                "Extension payload too short to contain a version".to_string(),
             ));
         }
-        Self::from_raw(deserialized)
+        let version = u16::from_be_bytes([bytes[0], bytes[1]]);
+
+        let raw = if version >= 3 {
+            let (deserialized, remainder) =
+                TlsNostrGroupDataExtension::tls_deserialize_bytes(bytes)?;
+            // MIP-01 §Version Field is append-only: implementations MUST parse known
+            // fields and SHOULD ignore unknown trailing fields from future versions.
+            // For known versions (<= CURRENT_VERSION) trailing bytes are still malformed.
+            if !remainder.is_empty() && deserialized.version <= Self::CURRENT_VERSION {
+                return Err(Error::ExtensionFormatError(
+                    "Trailing bytes in NostrGroupDataExtension".to_string(),
+                ));
+            }
+            deserialized
+        } else {
+            let (v1v2, remainder) = TlsNostrGroupDataExtensionV1V2::tls_deserialize_bytes(bytes)?;
+            if !remainder.is_empty() {
+                return Err(Error::ExtensionFormatError(
+                    "Trailing bytes in NostrGroupDataExtension".to_string(),
+                ));
+            }
+            v1v2.into_v3()
+        };
+        Self::from_raw(raw)
     }
 
     pub(crate) fn from_raw(raw: TlsNostrGroupDataExtension) -> Result<Self, Error> {
-        // Validate version - we support versions 1 and 2
+        // Validate version - we support versions 1, 2, and 3
         // Future versions should be handled with forward compatibility
         if raw.version == 0 {
             return Err(Error::InvalidExtensionVersion(raw.version));
@@ -236,6 +332,24 @@ impl NostrGroupDataExtension {
             )
         };
 
+        // Backward compatibility: v1/v2 groups don't have this field, so empty Vec maps to None
+        let disappearing_message_secs = if raw.disappearing_message_secs.is_empty() {
+            None
+        } else {
+            let bytes: [u8; 8] = raw.disappearing_message_secs.try_into().map_err(|_| {
+                Error::ExtensionFormatError(
+                    "Invalid disappearing_message_secs length (expected 8 bytes)".to_string(),
+                )
+            })?;
+            let duration = u64::from_be_bytes(bytes);
+            if duration == 0 {
+                return Err(Error::ExtensionFormatError(
+                    "disappearing_message_secs cannot be zero".to_string(),
+                ));
+            }
+            Some(duration)
+        };
+
         Ok(Self {
             version: raw.version,
             nostr_group_id: raw.nostr_group_id,
@@ -247,6 +361,7 @@ impl NostrGroupDataExtension {
             image_key,
             image_nonce,
             image_upload_key,
+            disappearing_message_secs,
         })
     }
 
@@ -359,79 +474,23 @@ impl NostrGroupDataExtension {
         image_nonce: [u8; 12];
     }
 
-    /// Migrate extension to version 2 format
-    ///
-    /// Updates the extension version to 2. This should be called after migrating
-    /// the group image from v1 to v2 format using `migrate_group_image_v1_to_v2`.
-    ///
-    /// # Arguments
-    ///
-    /// * `new_image_hash` - The new image hash (SHA256 of v2 encrypted image)
-    /// * `new_image_seed` - The new image seed (32 bytes, stored in image_key field for v2)
-    ///   **REQUIRED** when migrating from v1 to v2, as v1 image_key is a direct encryption key,
-    ///   not a seed. Optional when updating an already-v2 extension.
-    /// * `new_image_nonce` - The new image nonce (12 bytes)
-    ///
-    /// # Warning
-    ///
-    /// Migrating from v1 to v2 without providing `new_image_seed` creates a semantic mismatch:
-    /// the version will be set to 2 (expecting seed-based derivation), but the existing
-    /// `image_key` is in v1 format (direct encryption key). This pattern should only be used
-    /// when updating image data for an already-v2 extension.
-    ///
-    /// # Example
-    /// ```ignore
-    /// // Migrate image from v1 to v2
-    /// let v2_prepared = migrate_group_image_v1_to_v2(
-    ///     &encrypted_v1_data,
-    ///     &v1_extension.image_key.unwrap(),
-    ///     &v1_extension.image_nonce.unwrap(),
-    ///     "image/jpeg"
-    /// )?;
-    ///
-    /// // Upload to Blossom
-    /// let new_hash = blossom_client.upload(
-    ///     &v2_prepared.encrypted_data,
-    ///     &v2_prepared.upload_keypair
-    /// ).await?;
-    ///
-    /// // Migrate extension to v2 (MUST provide new seed when migrating from v1)
-    /// extension.migrate_to_v2(
-    ///     Some(new_hash),
-    ///     Some(v2_prepared.image_key), // This is the seed in v2
-    ///     Some(v2_prepared.image_nonce)
-    /// );
-    /// ```
-    pub fn migrate_to_v2(
+    // Test-only helper: synthesize a v2 extension from a v1 by writing the
+    // post-migration image fields directly. Production code never migrates
+    // extensions in-place; new groups author v3 directly via `to_tls_bytes`,
+    // and v1/v2 deserialization upgrades through `into_v3`.
+    #[cfg(test)]
+    fn migrate_v1_to_v2(
         &mut self,
-        new_image_hash: Option<[u8; 32]>,
-        new_image_seed: Option<[u8; 32]>,
-        new_image_nonce: Option<[u8; 12]>,
-        new_image_upload_seed: Option<[u8; 32]>,
+        new_image_hash: [u8; 32],
+        new_image_seed: [u8; 32],
+        new_image_nonce: [u8; 12],
+        new_image_upload_seed: [u8; 32],
     ) {
-        // Warn if migrating from v1 without providing new seeds
-        if self.version == 1
-            && (new_image_seed.is_none() || new_image_upload_seed.is_none())
-            && self.image_key.is_some()
-        {
-            tracing::warn!(
-                target: "mdk_core::extension::types",
-                "Migrating from v1 to v2 without new image_seed and image_upload_seed - existing image_key will be treated as seed, which may cause issues since v1 image_key is a direct encryption key, not a seed"
-            );
-        }
-        self.version = Self::CURRENT_VERSION; // Set to version 2
-        if let Some(hash) = new_image_hash {
-            self.image_hash = Some(hash);
-        }
-        if let Some(seed) = new_image_seed {
-            self.image_key = Some(seed);
-        }
-        if let Some(nonce) = new_image_nonce {
-            self.image_nonce = Some(nonce);
-        }
-        if let Some(upload_seed) = new_image_upload_seed {
-            self.image_upload_key = Some(upload_seed);
-        }
+        self.version = 2;
+        self.image_hash = Some(new_image_hash);
+        self.image_key = Some(new_image_seed);
+        self.image_nonce = Some(new_image_nonce);
+        self.image_upload_key = Some(new_image_upload_seed);
     }
 
     /// Get group image encryption data if all required fields are set
@@ -494,6 +553,47 @@ impl NostrGroupDataExtension {
             image_upload_key: self
                 .image_upload_key
                 .map_or_else(Vec::new, |key| key.to_vec()),
+            // Zero normalization is enforced by new() and from_raw(); no re-check here.
+            disappearing_message_secs: self
+                .disappearing_message_secs
+                .map_or_else(Vec::new, |d| d.to_be_bytes().to_vec()),
+        }
+    }
+
+    /// Serialize the extension to TLS wire bytes with version gating.
+    ///
+    /// When `disappearing_message_secs` is active the v3 wire format is used
+    /// (includes the extra field). Otherwise the v1/v2 struct is emitted so
+    /// that older clients can still parse the extension.
+    pub(crate) fn to_tls_bytes(&self) -> Result<Vec<u8>, tls_codec::Error> {
+        if self.disappearing_message_secs.is_some() {
+            // v3 wire format — includes disappearing_message_secs
+            let mut raw = self.as_raw();
+            raw.version = 3;
+            raw.tls_serialize_detached()
+        } else {
+            // v1/v2 wire format — omits disappearing_message_secs for backward compat
+            let raw = TlsNostrGroupDataExtensionV1V2 {
+                version: self.version.min(2),
+                nostr_group_id: self.nostr_group_id,
+                name: self.name.as_bytes().to_vec(),
+                description: self.description.as_bytes().to_vec(),
+                admin_pubkeys: self.admins.iter().map(|pk| *pk.as_bytes()).collect(),
+                relays: self
+                    .relays
+                    .iter()
+                    .map(|url| url.to_string().into_bytes())
+                    .collect(),
+                image_hash: self.image_hash.map_or_else(Vec::new, |hash| hash.to_vec()),
+                image_key: self.image_key.map_or_else(Vec::new, |key| key.to_vec()),
+                image_nonce: self
+                    .image_nonce
+                    .map_or_else(Vec::new, |nonce| nonce.to_vec()),
+                image_upload_key: self
+                    .image_upload_key
+                    .map_or_else(Vec::new, |key| key.to_vec()),
+            };
+            raw.tls_serialize_detached()
         }
     }
 }
@@ -501,6 +601,7 @@ impl NostrGroupDataExtension {
 #[cfg(test)]
 mod tests {
     use mdk_storage_traits::test_utils::crypto_utils::generate_random_bytes;
+    use tls_codec::Serialize as TlsSerialize;
 
     use super::*;
 
@@ -529,6 +630,7 @@ mod tests {
             Some(image_key),
             Some(image_nonce),
             Some(generate_random_bytes(32).try_into().unwrap()), // image_upload_key for v2
+            None,                                                // disappearing_message_secs
         )
     }
 
@@ -701,6 +803,7 @@ mod tests {
             Some(test_key),
             Some(test_nonce),
             Some([4u8; 32]), // image_upload_key
+            None,            // disappearing_message_secs
         );
 
         // Create extension with None values
@@ -713,6 +816,7 @@ mod tests {
             None,
             None,
             None, // image_upload_key
+            None, // disappearing_message_secs
         );
 
         // Serialize both to measure size
@@ -746,9 +850,8 @@ mod tests {
     /// Test that version field is properly serialized at the beginning of the structure (MIP-01)
     #[test]
     fn test_version_field_serialization() {
-        use tls_codec::Serialize as TlsSerialize;
-
-        let extension = NostrGroupDataExtension::new(
+        // Without disappearing messages → version 2
+        let ext_v2 = NostrGroupDataExtension::new(
             "Test Group",
             "Test Description",
             [PublicKey::parse(ADMIN_1).unwrap()],
@@ -757,31 +860,37 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
+        assert_eq!(ext_v2.version, 2);
 
-        // Verify version is set to current version
+        let bytes_v2 = ext_v2.to_tls_bytes().unwrap();
+        assert!(bytes_v2.len() >= 2);
+        let wire_version_v2 = u16::from_be_bytes([bytes_v2[0], bytes_v2[1]]);
         assert_eq!(
-            extension.version,
-            NostrGroupDataExtension::CURRENT_VERSION,
-            "Version should be set to CURRENT_VERSION (1)"
+            wire_version_v2, 2,
+            "Wire version should be 2 when no disappearing messages"
         );
 
-        // Serialize and verify version field is at the beginning
-        let raw = extension.as_raw();
-        let serialized = raw.tls_serialize_detached().unwrap();
-
-        // The first 2 bytes should be the version field (u16 in big-endian)
-        assert!(
-            serialized.len() >= 2,
-            "Serialized data should be at least 2 bytes"
+        // With disappearing messages → version 3
+        let ext_v3 = NostrGroupDataExtension::new(
+            "Test Group",
+            "Test Description",
+            [PublicKey::parse(ADMIN_1).unwrap()],
+            [RelayUrl::parse(RELAY_1).unwrap()],
+            None,
+            None,
+            None,
+            None,
+            Some(3600),
         );
-        let version_bytes = &serialized[0..2];
-        let version_from_bytes = u16::from_be_bytes([version_bytes[0], version_bytes[1]]);
+        assert_eq!(ext_v3.version, NostrGroupDataExtension::CURRENT_VERSION);
 
+        let bytes_v3 = ext_v3.to_tls_bytes().unwrap();
+        let wire_version_v3 = u16::from_be_bytes([bytes_v3[0], bytes_v3[1]]);
         assert_eq!(
-            version_from_bytes,
-            NostrGroupDataExtension::CURRENT_VERSION,
-            "First 2 bytes of serialized data should contain version field"
+            wire_version_v3, 3,
+            "Wire version should be 3 when disappearing messages set"
         );
     }
 
@@ -803,6 +912,7 @@ mod tests {
             image_key: Vec::new(),
             image_nonce: Vec::new(),
             image_upload_key: Vec::new(),
+            disappearing_message_secs: Vec::new(),
         };
 
         let result = NostrGroupDataExtension::from_raw(raw_v0);
@@ -823,6 +933,7 @@ mod tests {
             image_key: Vec::new(),
             image_nonce: Vec::new(),
             image_upload_key: Vec::new(),
+            disappearing_message_secs: Vec::new(),
         };
 
         let result = NostrGroupDataExtension::from_raw(raw_v1);
@@ -841,6 +952,7 @@ mod tests {
             image_key: Vec::new(),
             image_nonce: Vec::new(),
             image_upload_key: Vec::new(),
+            disappearing_message_secs: Vec::new(),
         };
 
         let result = NostrGroupDataExtension::from_raw(raw_v99);
@@ -855,35 +967,30 @@ mod tests {
         );
     }
 
-    /// Test that version field is preserved through serialization round-trip
+    /// Test that version field is preserved through as_raw/from_raw round-trip
     #[test]
     fn test_version_field_roundtrip() {
         let extension = create_test_extension();
 
-        // Verify initial version
-        assert_eq!(extension.version, NostrGroupDataExtension::CURRENT_VERSION);
+        // create_test_extension() has no disappearing messages → version 2
+        assert_eq!(extension.version, 2);
 
-        // Serialize and deserialize
+        // as_raw/from_raw preserves version
         let raw = extension.as_raw();
         let reconstructed = NostrGroupDataExtension::from_raw(raw).unwrap();
-
-        // Verify version is preserved
         assert_eq!(
             reconstructed.version, extension.version,
-            "Version should be preserved through serialization round-trip"
+            "Version should be preserved through as_raw/from_raw round-trip"
         );
     }
 
     /// Test that deserialize_bytes correctly deserializes TLS-encoded extension data
     #[test]
     fn test_deserialize_bytes() {
-        use tls_codec::Serialize as TlsSerialize;
-
         let extension = create_test_extension();
 
-        // Serialize to bytes
-        let raw = extension.as_raw();
-        let serialized_bytes = raw.tls_serialize_detached().unwrap();
+        // Serialize using to_tls_bytes (version-gated wire format)
+        let serialized_bytes = extension.to_tls_bytes().unwrap();
 
         // Deserialize using deserialize_bytes
         let deserialized = NostrGroupDataExtension::deserialize_bytes(&serialized_bytes).unwrap();
@@ -899,6 +1006,10 @@ mod tests {
         assert_eq!(deserialized.image_key, extension.image_key);
         assert_eq!(deserialized.image_nonce, extension.image_nonce);
         assert_eq!(deserialized.image_upload_key, extension.image_upload_key);
+        assert_eq!(
+            deserialized.disappearing_message_secs,
+            extension.disappearing_message_secs
+        );
     }
 
     /// Test that deserialize_bytes returns an error for invalid data
@@ -917,16 +1028,16 @@ mod tests {
         assert!(result.is_err(), "Truncated data should fail to deserialize");
     }
 
-    /// Test that deserialize_bytes rejects data with trailing bytes
+    /// Test that deserialize_bytes rejects trailing bytes for known (<= CURRENT_VERSION)
+    /// payloads. Trailing bytes at a known version indicate corruption, not a
+    /// future-version field, and must still fail. Forward-compat for unknown
+    /// versions is covered by `test_deserialize_bytes_accepts_trailing_bytes_for_future_version`.
     #[test]
-    fn test_deserialize_bytes_rejects_trailing_bytes() {
-        use tls_codec::Serialize as TlsSerialize;
-
+    fn test_deserialize_bytes_rejects_trailing_bytes_for_known_version() {
         let extension = create_test_extension();
 
-        // Serialize to bytes
-        let raw = extension.as_raw();
-        let mut serialized_bytes = raw.tls_serialize_detached().unwrap();
+        // Serialize using to_tls_bytes (version-gated wire format)
+        let mut serialized_bytes = extension.to_tls_bytes().unwrap();
 
         // Append trailing garbage bytes
         serialized_bytes.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
@@ -943,27 +1054,48 @@ mod tests {
         );
     }
 
-    /// Test migration to version 2
+    /// MIP-01 §Version Field: payloads from a future version with trailing
+    /// fields beyond what we recognize MUST parse successfully, exposing the
+    /// known fields. Without this, a single admin commit advancing the group
+    /// to a newer extension version bricks every older MDK peer (issue #88).
     #[test]
-    fn test_migrate_to_v2() {
+    fn test_deserialize_bytes_accepts_trailing_bytes_for_future_version() {
+        let extension = create_test_extension();
+        let mut raw = extension.as_raw();
+        raw.version = NostrGroupDataExtension::CURRENT_VERSION + 1;
+
+        let mut serialized_bytes = raw.tls_serialize_detached().unwrap();
+        serialized_bytes.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+
+        let parsed = NostrGroupDataExtension::deserialize_bytes(&serialized_bytes)
+            .expect("future-version payload with trailing fields must parse");
+
+        assert_eq!(parsed.version, NostrGroupDataExtension::CURRENT_VERSION + 1);
+        assert_eq!(parsed.name, extension.name);
+        assert_eq!(parsed.description, extension.description);
+        assert_eq!(parsed.nostr_group_id, extension.nostr_group_id);
+        assert_eq!(parsed.admins, extension.admins);
+        assert_eq!(parsed.relays, extension.relays);
+    }
+
+    /// Test v1→v2 image semantic migration
+    #[test]
+    fn test_migrate_v1_to_v2() {
         let pk1 = PublicKey::parse(ADMIN_1).unwrap();
         let relay1 = RelayUrl::parse(RELAY_1).unwrap();
 
-        // Create a version 1 extension with image data
+        // Create a v1 extension with image data
         let mut extension = NostrGroupDataExtension::new(
             "Test Group",
             "Test Description",
             [pk1],
-            [relay1.clone()],
+            [relay1],
             Some([1u8; 32]),
             Some([2u8; 32]),
             Some([3u8; 12]),
             None, // v1 doesn't use image_upload_key
+            None,
         );
-
-        assert_eq!(extension.version, NostrGroupDataExtension::CURRENT_VERSION);
-
-        // Manually set to version 1 for testing
         extension.version = 1;
         assert_eq!(extension.version, 1);
 
@@ -973,106 +1105,224 @@ mod tests {
         let new_nonce = [30u8; 12];
         let new_upload_seed = [40u8; 32];
 
-        extension.migrate_to_v2(
-            Some(new_hash),
-            Some(new_seed),
-            Some(new_nonce),
-            Some(new_upload_seed),
-        );
+        extension.migrate_v1_to_v2(new_hash, new_seed, new_nonce, new_upload_seed);
 
-        // Verify version is now 2
-        assert_eq!(extension.version, NostrGroupDataExtension::CURRENT_VERSION);
+        // Version should be 2, all image fields updated
+        assert_eq!(extension.version, 2);
         assert_eq!(extension.image_hash, Some(new_hash));
         assert_eq!(extension.image_key, Some(new_seed));
         assert_eq!(extension.image_nonce, Some(new_nonce));
+        assert_eq!(extension.image_upload_key, Some(new_upload_seed));
+    }
 
-        // Test partial migration (only updating some fields)
-        let mut extension2 = NostrGroupDataExtension::new(
-            "Test Group 2",
-            "Test Description 2",
+    /// Test that to_tls_bytes gates the version: v2 wire format when no
+    /// disappearing messages, v3 when disappearing messages are set.
+    #[test]
+    fn test_to_tls_bytes_version_gating() {
+        let pk1 = PublicKey::parse(ADMIN_1).unwrap();
+        let relay1 = RelayUrl::parse(RELAY_1).unwrap();
+
+        // Without disappearing messages → v2 wire format
+        let ext_no_dm = NostrGroupDataExtension::new(
+            "Test",
+            "Desc",
+            [pk1],
+            [relay1.clone()],
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        let bytes = ext_no_dm.to_tls_bytes().unwrap();
+        let wire_version = u16::from_be_bytes([bytes[0], bytes[1]]);
+        assert_eq!(wire_version, 2, "No disappearing messages → v2 wire format");
+
+        // Round-trip should work through v1v2 parser
+        let rt = NostrGroupDataExtension::deserialize_bytes(&bytes).unwrap();
+        assert_eq!(rt.version, 2);
+        assert_eq!(rt.disappearing_message_secs, None);
+
+        // With disappearing messages → v3 wire format
+        let ext_dm = NostrGroupDataExtension::new(
+            "Test",
+            "Desc",
+            [pk1],
+            [relay1],
+            None,
+            None,
+            None,
+            None,
+            Some(3600),
+        );
+        let bytes = ext_dm.to_tls_bytes().unwrap();
+        let wire_version = u16::from_be_bytes([bytes[0], bytes[1]]);
+        assert_eq!(
+            wire_version, 3,
+            "Disappearing messages set → v3 wire format"
+        );
+
+        // Round-trip should work through v3 parser
+        let rt = NostrGroupDataExtension::deserialize_bytes(&bytes).unwrap();
+        assert_eq!(rt.version, 3);
+        assert_eq!(rt.disappearing_message_secs, Some(3600));
+    }
+
+    /// Test that a v1 group without disappearing messages preserves v1 on the wire
+    #[test]
+    fn test_to_tls_bytes_preserves_v1_for_legacy_groups() {
+        let pk1 = PublicKey::parse(ADMIN_1).unwrap();
+        let relay1 = RelayUrl::parse(RELAY_1).unwrap();
+
+        let mut extension = NostrGroupDataExtension::new(
+            "Test Group",
+            "Test Description",
             [pk1],
             [relay1],
             Some([1u8; 32]),
             Some([2u8; 32]),
             Some([3u8; 12]),
             None,
-        );
-        extension2.version = 1;
-
-        extension2.migrate_to_v2(Some(new_hash), None, None, None);
-
-        // Version should be updated, but only hash should change
-        assert_eq!(extension2.version, NostrGroupDataExtension::CURRENT_VERSION);
-        assert_eq!(extension2.image_hash, Some(new_hash));
-        assert_eq!(extension2.image_key, Some([2u8; 32])); // Unchanged
-        assert_eq!(extension2.image_nonce, Some([3u8; 12])); // Unchanged
-    }
-
-    /// Test that migrating an already-v2 extension updates fields correctly
-    #[test]
-    fn test_migrate_to_v2_already_v2() {
-        let pk1 = PublicKey::parse(ADMIN_1).unwrap();
-        let relay1 = RelayUrl::parse(RELAY_1).unwrap();
-
-        // Create v2 extension
-        let mut extension = NostrGroupDataExtension::new(
-            "Test Group",
-            "Test Description",
-            [pk1],
-            [relay1.clone()],
-            Some([1u8; 32]),
-            Some([2u8; 32]),
-            Some([3u8; 12]),
-            Some([4u8; 32]), // image_upload_key for v2
-        );
-
-        assert_eq!(extension.version, NostrGroupDataExtension::CURRENT_VERSION);
-
-        // Migrate to v2 again (should still work, just update fields)
-        let new_hash = [10u8; 32];
-        let new_seed = [20u8; 32];
-        let new_nonce = [30u8; 12];
-        let new_upload_seed = [40u8; 32];
-
-        extension.migrate_to_v2(
-            Some(new_hash),
-            Some(new_seed),
-            Some(new_nonce),
-            Some(new_upload_seed),
-        );
-
-        // Version should remain 2, fields should be updated
-        assert_eq!(extension.version, NostrGroupDataExtension::CURRENT_VERSION);
-        assert_eq!(extension.image_hash, Some(new_hash));
-        assert_eq!(extension.image_key, Some(new_seed));
-        assert_eq!(extension.image_nonce, Some(new_nonce));
-    }
-
-    /// Test migration with all None values (just version bump)
-    #[test]
-    fn test_migrate_to_v2_all_none() {
-        let pk1 = PublicKey::parse(ADMIN_1).unwrap();
-        let relay1 = RelayUrl::parse(RELAY_1).unwrap();
-
-        let mut extension = NostrGroupDataExtension::new(
-            "Test Group",
-            "Test Description",
-            [pk1],
-            [relay1],
-            Some([1u8; 32]),
-            Some([2u8; 32]),
-            Some([3u8; 12]),
             None,
         );
         extension.version = 1;
 
-        // Migrate with all None (just version bump)
-        extension.migrate_to_v2(None, None, None, None);
+        let bytes = extension.to_tls_bytes().unwrap();
+        let wire_version = u16::from_be_bytes([bytes[0], bytes[1]]);
+        assert_eq!(
+            wire_version, 1,
+            "v1 group without disappearing messages should stay v1 on wire"
+        );
 
-        // Version should be updated, but fields unchanged
-        assert_eq!(extension.version, NostrGroupDataExtension::CURRENT_VERSION);
-        assert_eq!(extension.image_hash, Some([1u8; 32]));
-        assert_eq!(extension.image_key, Some([2u8; 32]));
-        assert_eq!(extension.image_nonce, Some([3u8; 12]));
+        let rt = NostrGroupDataExtension::deserialize_bytes(&bytes).unwrap();
+        assert_eq!(rt.version, 1);
+        assert_eq!(rt.image_hash, Some([1u8; 32]));
+    }
+
+    /// Test that legacy v1/v2 TLS payloads (without disappearing_message_secs)
+    /// deserialize successfully with the field defaulting to None.
+    #[test]
+    fn test_deserialize_legacy_v1v2_payload_without_disappearing_field() {
+        let pk1 = PublicKey::parse(ADMIN_1).unwrap();
+        let relay1 = RelayUrl::parse(RELAY_1).unwrap();
+
+        // Serialize a v1/v2 payload directly — no disappearing_message_secs field.
+        let v2_raw = TlsNostrGroupDataExtensionV1V2 {
+            version: 2,
+            nostr_group_id: [42u8; 32],
+            name: b"Legacy Group".to_vec(),
+            description: b"A v2 group".to_vec(),
+            admin_pubkeys: vec![*pk1.as_bytes()],
+            relays: vec![relay1.to_string().into_bytes()],
+            image_hash: Vec::new(),
+            image_key: Vec::new(),
+            image_nonce: Vec::new(),
+            image_upload_key: Vec::new(),
+        };
+
+        let v2_bytes = v2_raw.tls_serialize_detached().unwrap();
+
+        // Now deserialize — this should succeed via the v1/v2 fallback path.
+        let extension = NostrGroupDataExtension::deserialize_bytes(&v2_bytes).unwrap();
+
+        assert_eq!(extension.version, 2);
+        assert_eq!(extension.name, "Legacy Group");
+        assert_eq!(extension.description, "A v2 group");
+        assert!(extension.admins.contains(&pk1));
+        assert!(extension.relays.contains(&relay1));
+        assert_eq!(
+            extension.disappearing_message_secs, None,
+            "Legacy v2 payload should default to None"
+        );
+    }
+
+    /// Test that v3 payloads with disappearing_message_secs round-trip correctly.
+    #[test]
+    fn test_deserialize_v3_payload_with_disappearing_duration() {
+        let pk1 = PublicKey::parse(ADMIN_1).unwrap();
+        let relay1 = RelayUrl::parse(RELAY_1).unwrap();
+
+        let extension = NostrGroupDataExtension::new(
+            "v3 Group",
+            "Has disappearing messages",
+            [pk1],
+            [relay1],
+            None,
+            None,
+            None,
+            None,
+            Some(3600),
+        );
+
+        let bytes = extension.to_tls_bytes().unwrap();
+
+        let deserialized = NostrGroupDataExtension::deserialize_bytes(&bytes).unwrap();
+        assert_eq!(
+            deserialized.version,
+            NostrGroupDataExtension::CURRENT_VERSION
+        );
+        assert_eq!(deserialized.disappearing_message_secs, Some(3600));
+    }
+
+    /// Test that a zero-valued disappearing_message_secs is rejected during parsing.
+    #[test]
+    fn test_from_raw_rejects_zero_disappearing_duration() {
+        let pk1 = PublicKey::parse(ADMIN_1).unwrap();
+        let relay1 = RelayUrl::parse(RELAY_1).unwrap();
+
+        let raw = TlsNostrGroupDataExtension {
+            version: 3,
+            nostr_group_id: [0u8; 32],
+            name: b"Test".to_vec(),
+            description: b"Desc".to_vec(),
+            admin_pubkeys: vec![*pk1.as_bytes()],
+            relays: vec![relay1.to_string().into_bytes()],
+            image_hash: Vec::new(),
+            image_key: Vec::new(),
+            image_nonce: Vec::new(),
+            image_upload_key: Vec::new(),
+            disappearing_message_secs: 0u64.to_be_bytes().to_vec(),
+        };
+
+        let result = NostrGroupDataExtension::from_raw(raw);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("cannot be zero"),
+            "Expected zero-duration rejection, got: {err}"
+        );
+    }
+
+    /// Test that a v3 header with a v1/v2 body (missing the disappearing_message_secs
+    /// field) is rejected rather than silently falling back to the v1/v2 parser.
+    #[test]
+    fn test_deserialize_rejects_v3_header_with_v1v2_body() {
+        let pk1 = PublicKey::parse(ADMIN_1).unwrap();
+        let relay1 = RelayUrl::parse(RELAY_1).unwrap();
+
+        // Serialize a v1/v2 payload (no disappearing_message_secs field)
+        // but with version = 3 — this is corrupt.
+        let corrupt = TlsNostrGroupDataExtensionV1V2 {
+            version: 3,
+            nostr_group_id: [42u8; 32],
+            name: b"Corrupt Group".to_vec(),
+            description: b"v3 header but v1v2 body".to_vec(),
+            admin_pubkeys: vec![*pk1.as_bytes()],
+            relays: vec![relay1.to_string().into_bytes()],
+            image_hash: Vec::new(),
+            image_key: Vec::new(),
+            image_nonce: Vec::new(),
+            image_upload_key: Vec::new(),
+        };
+
+        let bytes = corrupt.tls_serialize_detached().unwrap();
+
+        // With version-based dispatch, this should be routed to the v3 parser
+        // which will fail because the payload is too short (missing field).
+        let result = NostrGroupDataExtension::deserialize_bytes(&bytes);
+        assert!(
+            result.is_err(),
+            "Corrupt v3-header + v1v2-body should fail, not silently parse"
+        );
     }
 }

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -129,6 +129,8 @@ pub struct NostrGroupConfigData {
     pub relays: Vec<RelayUrl>,
     /// Group admins
     pub admins: Vec<PublicKey>,
+    /// Disappearing message duration in seconds (None = disabled, Some(n) = n seconds)
+    pub disappearing_message_secs: Option<u64>,
 }
 
 /// Configuration for updating group data with optional fields
@@ -152,6 +154,8 @@ pub struct NostrGroupDataUpdate {
     pub admins: Option<Vec<PublicKey>>,
     /// Nostr group ID for message routing (optional, for rotation per MIP-01)
     pub nostr_group_id: Option<[u8; 32]>,
+    /// Disappearing message duration in seconds (optional, use Some(None) to disable)
+    pub disappearing_message_secs: Option<Option<u64>>,
 }
 
 /// Pending member changes from proposals that need admin approval
@@ -206,6 +210,7 @@ pub struct RatchetTreeInfo {
 
 impl NostrGroupConfigData {
     /// Creates NostrGroupConfigData
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: String,
         description: String,
@@ -214,6 +219,7 @@ impl NostrGroupConfigData {
         image_nonce: Option<[u8; 12]>,
         relays: Vec<RelayUrl>,
         admins: Vec<PublicKey>,
+        disappearing_message_secs: Option<u64>,
     ) -> Self {
         Self {
             name,
@@ -223,6 +229,7 @@ impl NostrGroupConfigData {
             image_nonce,
             relays,
             admins,
+            disappearing_message_secs,
         }
     }
 }
@@ -252,6 +259,8 @@ impl NostrGroupDataUpdate {
         admins: Vec<PublicKey>;
         /// Sets the nostr_group_id to be updated (for ID rotation per MIP-01)
         nostr_group_id: [u8; 32];
+        /// Sets the disappearing message duration (use None to disable)
+        disappearing_message_secs: Option<u64>;
     }
 }
 
@@ -1441,6 +1450,10 @@ where
             group_data.nostr_group_id = nostr_group_id;
         }
 
+        if let Some(duration) = update.disappearing_message_secs {
+            group_data.disappearing_message_secs = duration;
+        }
+
         self.update_group_data_extension(&mut mls_group, group_id, &group_data, updates_admins)
     }
 
@@ -1465,7 +1478,7 @@ where
     fn get_unknown_extension_from_group_data(
         group_data: &NostrGroupDataExtension,
     ) -> Result<Extension, Error> {
-        let serialized_group_data = group_data.as_raw().tls_serialize_detached()?;
+        let serialized_group_data = group_data.to_tls_bytes()?;
 
         Ok(Extension::Unknown(
             group_data.extension_type(),
@@ -1535,6 +1548,7 @@ where
             config.image_key,
             config.image_nonce,
             None, // image_upload_key - will be set when image is uploaded
+            config.disappearing_message_secs,
         );
 
         // Parse invitee KeyPackages up front — the LCD intersection below
@@ -1676,6 +1690,7 @@ where
             image_key: config.image_key.map(mdk_storage_traits::Secret::new),
             image_nonce: config.image_nonce.map(mdk_storage_traits::Secret::new),
             self_update_state: group_types::SelfUpdateState::CompletedAt(Timestamp::now()),
+            disappearing_message_secs: group_data.disappearing_message_secs,
         };
 
         self.storage().save_group(group.clone()).map_err(
@@ -2250,6 +2265,7 @@ where
         stored_group.image_nonce = group_data.image_nonce.map(mdk_storage_traits::Secret::new);
         stored_group.admin_pubkeys = group_data.admins;
         stored_group.nostr_group_id = group_data.nostr_group_id;
+        stored_group.disappearing_message_secs = group_data.disappearing_message_secs;
 
         // Sync relays atomically - replace entire relay set with current extension data
         self.storage()

--- a/crates/mdk-core/src/test_util.rs
+++ b/crates/mdk-core/src/test_util.rs
@@ -210,6 +210,7 @@ pub fn create_nostr_group_config_data(admins: Vec<PublicKey>) -> NostrGroupConfi
         Some(image_nonce),
         relays,
         admins,
+        None, // disappearing_message_secs
     )
 }
 

--- a/crates/mdk-core/src/welcomes.rs
+++ b/crates/mdk-core/src/welcomes.rs
@@ -241,6 +241,7 @@ where
                 .as_u64(),
             state: group_types::GroupState::Pending,
             self_update_state: group_types::SelfUpdateState::Required,
+            disappearing_message_secs: welcome_preview.nostr_group_data.disappearing_message_secs,
         };
 
         let mls_group_id = group.mls_group_id.clone();

--- a/crates/mdk-core/tests/storage_traits_cross.rs
+++ b/crates/mdk-core/tests/storage_traits_cross.rs
@@ -128,6 +128,7 @@ fn create_test_group_for_cross_storage(mls_group_id: &GroupId, nostr_group_id: [
         image_key: None,
         image_nonce: None,
         self_update_state: SelfUpdateState::Required,
+        disappearing_message_secs: None,
     }
 }
 

--- a/crates/mdk-memory-storage/CHANGELOG.md
+++ b/crates/mdk-memory-storage/CHANGELOG.md
@@ -52,6 +52,7 @@
 
 - Added a `test-utils` feature, matching the convention in `mdk-storage-traits` and `mdk-sqlite-storage`, to gate test-only introspection helpers behind an explicit opt-in. ([#262](https://github.com/marmot-protocol/mdk/pull/262))
 - Added `MdkMemoryStorage::signature_key_count` under the `test-utils` feature. Cardinality probe over the signer store for invariant tests that need to observe store growth when the fresh signer's public key is generated internally and therefore cannot be rediscovered via `SignatureKeyPair::read`. ([#262](https://github.com/marmot-protocol/mdk/pull/262))
+- Propagated `disappearing_message_secs` field through all `Group` construction sites for the new disappearing messages feature. ([#258](https://github.com/marmot-protocol/mdk/pull/258))
 - Implemented `delete_messages_for_group` and `delete_group` for local "clear chat" and "delete chat" operations. Added `clear_group` methods to `MlsGroupData` and `MlsEpochKeyPairs` for bulk group-scoped MLS state cleanup. ([#250](https://github.com/marmot-protocol/mdk/pull/250))
 - Implemented legacy exporter-secret compatibility storage for the temporary `0.6.x -> 0.7.x` migration window, including snapshot and restore support for preserved pre-0.7.0 group-event secrets. ([#222](https://github.com/marmot-protocol/mdk/pull/222))
 

--- a/crates/mdk-memory-storage/src/groups.rs
+++ b/crates/mdk-memory-storage/src/groups.rs
@@ -258,6 +258,7 @@ impl GroupStorage for MdkMemoryStorage {
             return Err(group_not_found());
         }
 
+        #[allow(clippy::iter_kv_map)]
         let group_event_keys: Vec<(GroupId, u64)> = inner
             .group_exporter_secrets_cache
             .keys()
@@ -274,6 +275,7 @@ impl GroupStorage for MdkMemoryStorage {
             inner.group_exporter_secrets_cache.remove(&key);
         }
 
+        #[allow(clippy::iter_kv_map)]
         let legacy_group_event_keys: Vec<(GroupId, u64)> = inner
             .group_legacy_exporter_secrets_cache
             .keys()
@@ -290,6 +292,7 @@ impl GroupStorage for MdkMemoryStorage {
             inner.group_legacy_exporter_secrets_cache.remove(&key);
         }
 
+        #[allow(clippy::iter_kv_map)]
         let mip04_keys: Vec<(GroupId, u64)> = inner
             .group_mip04_exporter_secrets_cache
             .keys()
@@ -340,6 +343,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         }
     }
 
@@ -500,6 +504,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         storage.save_group(group).unwrap();
@@ -626,6 +631,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(empty_group).unwrap();
 
@@ -743,6 +749,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         storage.save_group(group1).unwrap();
@@ -765,6 +772,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         // This should fail because nostr_group_id is already used by a different group
@@ -810,6 +818,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         storage.save_group(group).unwrap();
@@ -838,6 +847,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         storage.save_group(updated_group).unwrap();
@@ -884,6 +894,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         storage.save_group(group).unwrap();
@@ -904,6 +915,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         // This should succeed - updating the same group

--- a/crates/mdk-memory-storage/src/lib.rs
+++ b/crates/mdk-memory-storage/src/lib.rs
@@ -1560,6 +1560,7 @@ mod tests {
             image_key,
             image_nonce,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         nostr_storage.save_group(group.clone()).unwrap();
         let found_group = nostr_storage
@@ -1605,6 +1606,7 @@ mod tests {
             image_key,
             image_nonce,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         nostr_storage.save_group(group.clone()).unwrap();
         let relay_url1 = RelayUrl::parse("wss://relay1.example.com").unwrap();
@@ -1652,6 +1654,7 @@ mod tests {
             image_key,
             image_nonce,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         nostr_storage.save_group(group.clone()).unwrap();
         let group_exporter_secret_0 = GroupExporterSecret {
@@ -1804,6 +1807,7 @@ mod tests {
             image_key,
             image_nonce,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         nostr_storage.save_group(group.clone()).unwrap();
         let event_id = EventId::all_zeros();
@@ -1952,6 +1956,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         nostr_storage.save_group(group).unwrap();
 
@@ -2049,6 +2054,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         nostr_storage.save_group(group).unwrap();
 
@@ -2169,6 +2175,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         nostr_storage.save_group(group).unwrap();
 
@@ -2249,6 +2256,7 @@ mod tests {
             image_key,
             image_nonce,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         // Save the group
@@ -2287,6 +2295,7 @@ mod tests {
             image_key,
             image_nonce,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         // Save the group
@@ -2321,6 +2330,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group.clone()).unwrap();
 
@@ -2377,6 +2387,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -2485,6 +2496,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -2522,6 +2534,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group.clone()).unwrap();
 
@@ -2593,6 +2606,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -2645,6 +2659,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -2762,6 +2777,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group1).unwrap();
 
@@ -2787,6 +2803,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group2).unwrap();
 
@@ -2836,6 +2853,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(modified_group1).unwrap();
 
@@ -2891,6 +2909,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group.clone()).unwrap();
 
@@ -2977,6 +2996,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         let group2 = Group {
@@ -2994,6 +3014,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         storage.save_group(group1.clone()).unwrap();
@@ -3087,6 +3108,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         let group2 = Group {
@@ -3104,6 +3126,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         storage.save_group(group1).unwrap();
@@ -3212,6 +3235,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         let group2 = Group {
@@ -3229,6 +3253,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         storage.save_group(group1).unwrap();
@@ -3338,6 +3363,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         storage.save_group(group).unwrap();
@@ -3394,6 +3420,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -3651,6 +3678,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -3763,6 +3791,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -3836,6 +3865,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -3921,6 +3951,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -4025,6 +4056,7 @@ mod tests {
                 image_key: None,
                 image_nonce: None,
                 self_update_state: SelfUpdateState::Required,
+                disappearing_message_secs: None,
             }
         }
 

--- a/crates/mdk-memory-storage/src/messages.rs
+++ b/crates/mdk-memory-storage/src/messages.rs
@@ -242,6 +242,7 @@ impl MessageStorage for MdkMemoryStorage {
     ) -> Result<Vec<ProcessedMessage>, MessageError> {
         let inner = self.inner.read();
 
+        #[allow(clippy::iter_kv_map)]
         let invalidated: Vec<ProcessedMessage> = inner
             .processed_messages_cache
             .values()
@@ -386,6 +387,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         }
     }
 

--- a/crates/mdk-memory-storage/src/welcomes.rs
+++ b/crates/mdk-memory-storage/src/welcomes.rs
@@ -97,6 +97,7 @@ impl WelcomeStorage for MdkMemoryStorage {
         validate_pending_welcomes_limit(limit)?;
 
         let inner = self.inner.read();
+        #[allow(clippy::iter_kv_map)]
         let mut welcomes: Vec<Welcome> = inner
             .welcomes_cache
             .iter()

--- a/crates/mdk-sqlite-storage/CHANGELOG.md
+++ b/crates/mdk-sqlite-storage/CHANGELOG.md
@@ -52,6 +52,7 @@
 
 ### Added
 
+- Added V006 migration adding `disappearing_message_secs INTEGER` column to the `groups` table for disappearing message support. `NULL` means disabled; a positive integer means messages expire after that many seconds. `row_to_group` updated to read the new column. ([#258](https://github.com/marmot-protocol/mdk/pull/258))
 - Implemented `delete_messages_for_group` and `delete_group` for local "clear chat" and "delete chat" operations. `delete_group` runs all deletes in a single `BEGIN IMMEDIATE` transaction covering OpenMLS tables, MDK tables, and `processed_messages`. ([#250](https://github.com/marmot-protocol/mdk/pull/250))
 - Implemented legacy exporter-secret compatibility storage for the temporary `0.6.x -> 0.7.x` migration window, including read/write support for preserved pre-0.7.0 group-event secrets and snapshot rollback restoration into the legacy compatibility label. ([#222](https://github.com/marmot-protocol/mdk/pull/222))
 

--- a/crates/mdk-sqlite-storage/migrations/V006__add_disappearing_message_duration.sql
+++ b/crates/mdk-sqlite-storage/migrations/V006__add_disappearing_message_duration.sql
@@ -1,0 +1,4 @@
+-- Add disappearing message duration to groups table.
+-- NULL means disabled (messages persist forever).
+-- Non-null positive integer means messages expire after that many seconds.
+ALTER TABLE groups ADD COLUMN disappearing_message_secs INTEGER;

--- a/crates/mdk-sqlite-storage/src/db.rs
+++ b/crates/mdk-sqlite-storage/src/db.rs
@@ -177,6 +177,7 @@ pub fn row_to_group(row: &Row) -> SqliteResult<Group> {
         0 => SelfUpdateState::Required,
         ts => SelfUpdateState::CompletedAt(Timestamp::from_secs(ts)),
     };
+    let disappearing_message_secs: Option<u64> = row.get("disappearing_message_secs")?;
 
     Ok(Group {
         mls_group_id,
@@ -193,6 +194,7 @@ pub fn row_to_group(row: &Row) -> SqliteResult<Group> {
         image_key,
         image_nonce,
         self_update_state,
+        disappearing_message_secs,
     })
 }
 
@@ -356,7 +358,8 @@ mod tests {
                 last_message_processed_at INTEGER,
                 epoch INTEGER NOT NULL,
                 state TEXT NOT NULL,
-                last_self_update_at INTEGER NOT NULL DEFAULT 0
+                last_self_update_at INTEGER NOT NULL DEFAULT 0,
+                disappearing_message_secs INTEGER
             )",
         )
         .unwrap();
@@ -371,7 +374,7 @@ mod tests {
         let valid_event_id = [0xabu8; 32];
 
         conn.execute(
-            "INSERT INTO groups VALUES (?, ?, ?, ?, NULL, NULL, NULL, ?, ?, NULL, NULL, ?, ?, 0)",
+            "INSERT INTO groups VALUES (?, ?, ?, ?, NULL, NULL, NULL, ?, ?, NULL, NULL, ?, ?, 0, NULL)",
             rusqlite::params![
                 &[1u8, 2, 3, 4][..], // mls_group_id
                 &[0u8; 32][..],      // nostr_group_id
@@ -398,7 +401,7 @@ mod tests {
         let conn = create_test_db();
 
         conn.execute(
-            "INSERT INTO groups VALUES (?, ?, ?, ?, NULL, NULL, NULL, ?, NULL, NULL, NULL, ?, ?, 0)",
+            "INSERT INTO groups VALUES (?, ?, ?, ?, NULL, NULL, NULL, ?, NULL, NULL, NULL, ?, ?, 0, NULL)",
             rusqlite::params![
                 &[1u8, 2, 3, 4][..], // mls_group_id
                 &[0u8; 32][..],      // nostr_group_id
@@ -427,7 +430,7 @@ mod tests {
         let invalid_event_id = [0xabu8; 16];
 
         conn.execute(
-            "INSERT INTO groups VALUES (?, ?, ?, ?, NULL, NULL, NULL, ?, ?, NULL, NULL, ?, ?, 0)",
+            "INSERT INTO groups VALUES (?, ?, ?, ?, NULL, NULL, NULL, ?, ?, NULL, NULL, ?, ?, 0, NULL)",
             rusqlite::params![
                 &[1u8, 2, 3, 4][..],   // mls_group_id
                 &[0u8; 32][..],        // nostr_group_id
@@ -462,7 +465,7 @@ mod tests {
         let empty_blob: [u8; 0] = [];
 
         conn.execute(
-            "INSERT INTO groups VALUES (?, ?, ?, ?, NULL, NULL, NULL, ?, ?, NULL, NULL, ?, ?, 0)",
+            "INSERT INTO groups VALUES (?, ?, ?, ?, NULL, NULL, NULL, ?, ?, NULL, NULL, ?, ?, 0, NULL)",
             rusqlite::params![
                 &[1u8, 2, 3, 4][..], // mls_group_id
                 &[0u8; 32][..],      // nostr_group_id
@@ -487,5 +490,30 @@ mod tests {
             "Expected error message to contain 'Invalid last message ID', got: {}",
             err
         );
+    }
+
+    #[test]
+    fn test_row_to_group_with_non_null_disappearing_message_secs() {
+        let conn = create_test_db();
+
+        conn.execute(
+            "INSERT INTO groups VALUES (?, ?, ?, ?, NULL, NULL, NULL, ?, NULL, NULL, NULL, ?, ?, 0, ?)",
+            rusqlite::params![
+                &[1u8, 2, 3, 4][..], // mls_group_id
+                &[0u8; 32][..],      // nostr_group_id
+                "Ephemeral Group",   // name
+                "Description",       // description
+                "[]",                // admin_pubkeys
+                0i64,                // epoch
+                "active",            // state
+                3600i64,             // disappearing_message_secs = 1 hour
+            ],
+        )
+        .unwrap();
+
+        let mut stmt = conn.prepare("SELECT * FROM groups").unwrap();
+        let group = stmt.query_row([], row_to_group).unwrap();
+
+        assert_eq!(group.disappearing_message_secs, Some(3600));
     }
 }

--- a/crates/mdk-sqlite-storage/src/groups.rs
+++ b/crates/mdk-sqlite-storage/src/groups.rs
@@ -219,8 +219,8 @@ impl GroupStorage for MdkSqliteStorage {
             conn.execute(
                 "INSERT INTO groups
              (mls_group_id, nostr_group_id, name, description, image_hash, image_key, image_nonce, admin_pubkeys, last_message_id,
-              last_message_at, last_message_processed_at, epoch, state, last_self_update_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              last_message_at, last_message_processed_at, epoch, state, last_self_update_at, disappearing_message_secs)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(mls_group_id) DO UPDATE SET
                 nostr_group_id = excluded.nostr_group_id,
                 name = excluded.name,
@@ -234,7 +234,8 @@ impl GroupStorage for MdkSqliteStorage {
                 last_message_processed_at = excluded.last_message_processed_at,
                 epoch = excluded.epoch,
                 state = excluded.state,
-                last_self_update_at = excluded.last_self_update_at",
+                last_self_update_at = excluded.last_self_update_at,
+                disappearing_message_secs = excluded.disappearing_message_secs",
                 params![
                     &group.mls_group_id.as_slice(),
                     &group.nostr_group_id,
@@ -249,7 +250,8 @@ impl GroupStorage for MdkSqliteStorage {
                     &last_message_processed_at,
                     &(group.epoch as i64),
                     group.state.as_str(),
-                    &last_self_update_at
+                    &last_self_update_at,
+                    &group.disappearing_message_secs.and_then(|d| i64::try_from(d).ok())
                 ],
             )
             .map_err(into_group_err)?;
@@ -452,6 +454,7 @@ mod tests {
             image_key,
             image_nonce,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         // Save the group
@@ -478,6 +481,62 @@ mod tests {
     }
 
     #[test]
+    fn test_group_roundtrip_with_disappearing_message_secs() {
+        let storage = MdkSqliteStorage::new_in_memory().unwrap();
+
+        let mls_group_id = GroupId::from_slice(&[10, 20, 30, 40]);
+        let nostr_group_id = generate_random_bytes(32).try_into().unwrap();
+
+        let group = Group {
+            mls_group_id: mls_group_id.clone(),
+            nostr_group_id,
+            name: "Ephemeral Group".to_string(),
+            description: "Messages vanish".to_string(),
+            admin_pubkeys: BTreeSet::new(),
+            last_message_id: None,
+            last_message_at: None,
+            last_message_processed_at: None,
+            epoch: 0,
+            state: GroupState::Active,
+            image_hash: None,
+            image_key: None,
+            image_nonce: None,
+            self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: Some(3600),
+        };
+
+        storage.save_group(group).unwrap();
+
+        let loaded = storage
+            .find_group_by_mls_group_id(&mls_group_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.disappearing_message_secs, Some(3600));
+
+        // Update to a different value via upsert
+        let mut updated = loaded;
+        updated.disappearing_message_secs = Some(86400);
+        storage.save_group(updated).unwrap();
+
+        let reloaded = storage
+            .find_group_by_mls_group_id(&mls_group_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(reloaded.disappearing_message_secs, Some(86400));
+
+        // Clear back to None
+        let mut cleared = reloaded;
+        cleared.disappearing_message_secs = None;
+        storage.save_group(cleared).unwrap();
+
+        let final_group = storage
+            .find_group_by_mls_group_id(&mls_group_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(final_group.disappearing_message_secs, None);
+    }
+
+    #[test]
     fn test_group_name_length_validation() {
         let storage = MdkSqliteStorage::new_in_memory().unwrap();
 
@@ -500,6 +559,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         // Should fail due to name length
@@ -536,6 +596,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         // Should fail due to description length
@@ -575,6 +636,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         storage.save_group(group).unwrap();
@@ -706,6 +768,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         // Save the group
@@ -793,6 +856,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group1).unwrap();
 
@@ -813,6 +877,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group2).unwrap();
 

--- a/crates/mdk-sqlite-storage/src/lib.rs
+++ b/crates/mdk-sqlite-storage/src/lib.rs
@@ -1913,6 +1913,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         // Save the group
@@ -2043,6 +2044,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -2295,6 +2297,7 @@ mod tests {
                     image_key: None,
                     image_nonce: None,
                     self_update_state: SelfUpdateState::Required,
+                    disappearing_message_secs: None,
                 };
 
                 storage.save_group(group).unwrap();
@@ -2463,6 +2466,7 @@ mod tests {
                     image_key: None,
                     image_nonce: None,
                     self_update_state: SelfUpdateState::Required,
+                    disappearing_message_secs: None,
                 };
                 storage.save_group(group).unwrap();
 
@@ -3432,6 +3436,7 @@ mod tests {
                 image_key: None,
                 image_nonce: None,
                 self_update_state: SelfUpdateState::Required,
+                disappearing_message_secs: None,
             }
         }
 
@@ -3910,6 +3915,7 @@ mod tests {
                 image_key: None,
                 image_nonce: None,
                 self_update_state: SelfUpdateState::Required,
+                disappearing_message_secs: None,
             };
             storage.save_group(group).unwrap();
 
@@ -3965,6 +3971,7 @@ mod tests {
                 image_key: None,
                 image_nonce: None,
                 self_update_state: SelfUpdateState::Required,
+                disappearing_message_secs: None,
             };
             let g2 = Group {
                 mls_group_id: group2.clone(),
@@ -4014,6 +4021,7 @@ mod tests {
                 image_key: None,
                 image_nonce: None,
                 self_update_state: SelfUpdateState::Required,
+                disappearing_message_secs: None,
             };
             storage.save_group(group).unwrap();
 
@@ -4060,6 +4068,7 @@ mod tests {
                 image_key: None,
                 image_nonce: None,
                 self_update_state: SelfUpdateState::Required,
+                disappearing_message_secs: None,
             };
             storage.save_group(group).unwrap();
 
@@ -4104,6 +4113,7 @@ mod tests {
                 image_key: None,
                 image_nonce: None,
                 self_update_state: SelfUpdateState::Required,
+                disappearing_message_secs: None,
             };
             storage.save_group(group).unwrap();
 
@@ -4169,6 +4179,7 @@ mod tests {
                 image_key: None,
                 image_nonce: None,
                 self_update_state: SelfUpdateState::Required,
+                disappearing_message_secs: None,
             }
         }
 
@@ -4812,6 +4823,7 @@ mod tests {
                 image_key: None,
                 image_nonce: None,
                 self_update_state: SelfUpdateState::Required,
+                disappearing_message_secs: None,
             };
             storage.save_group(group).unwrap();
 

--- a/crates/mdk-sqlite-storage/src/messages.rs
+++ b/crates/mdk-sqlite-storage/src/messages.rs
@@ -389,6 +389,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         // Save the group
@@ -502,6 +503,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -565,6 +567,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         let group_2 = Group {
@@ -582,6 +585,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         storage.save_group(group_1).unwrap();
@@ -791,6 +795,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
 
@@ -879,6 +884,7 @@ mod tests {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
         storage.save_group(group).unwrap();
         group_id

--- a/crates/mdk-storage-traits/CHANGELOG.md
+++ b/crates/mdk-storage-traits/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### Breaking changes
 
 - Changed default serde serialization for `Secret<T>` to fail instead of emitting wrapped secret values. Use `Secret::expose_for_serialization()` for deliberate plaintext exports. ([#280](https://github.com/marmot-protocol/mdk/pull/280))
+- Added `disappearing_message_secs: Option<u64>` field to the `Group` struct. All code that constructs `Group` structs must now provide this field. `None` means messages persist forever; `Some(n)` means messages expire after `n` seconds. ([#253](https://github.com/marmot-protocol/mdk/pull/253))
 
 ### Changed
 

--- a/crates/mdk-storage-traits/src/groups/types.rs
+++ b/crates/mdk-storage-traits/src/groups/types.rs
@@ -106,6 +106,11 @@ pub struct Group {
     ///
     /// See [`SelfUpdateState`] for the possible values and their meanings.
     pub self_update_state: SelfUpdateState,
+    /// Disappearing message duration in seconds
+    ///
+    /// - `None`: Messages persist forever (disabled)
+    /// - `Some(n)`: Messages expire `n` seconds after creation (`n > 0`)
+    pub disappearing_message_secs: Option<u64>,
 }
 
 impl fmt::Debug for Group {
@@ -217,6 +222,7 @@ mod tests {
             epoch: 0,
             state: GroupState::Active,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         }
     }
 
@@ -364,6 +370,7 @@ mod tests {
             epoch: 0,
             state: GroupState::Active,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         let serialized = serde_json::to_value(&group).unwrap();
@@ -397,6 +404,7 @@ mod tests {
             epoch: 0,
             state: GroupState::Active,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         let err = serde_json::to_value(&group)
@@ -425,6 +433,7 @@ mod tests {
             epoch: 3,
             state: GroupState::Active,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         };
 
         let debug_str = format!("{:?}", group);

--- a/crates/mdk-storage-traits/src/test_utils.rs
+++ b/crates/mdk-storage-traits/src/test_utils.rs
@@ -48,6 +48,7 @@ pub mod cross_storage {
             image_key: None,
             image_nonce: None,
             self_update_state: SelfUpdateState::Required,
+            disappearing_message_secs: None,
         }
     }
 

--- a/crates/mdk-uniffi/src/lib.rs
+++ b/crates/mdk-uniffi/src/lib.rs
@@ -1003,6 +1003,7 @@ impl Mdk {
             None, // image_nonce
             relay_urls,
             admin_pubkeys,
+            None, // disappearing_message_secs
         );
 
         let mdk = self.lock()?;


### PR DESCRIPTION
![marmot](https://blossom.primal.net/36337ee82e5aa1acaf0f2e895334c35ebf55c2962ca2ad4ccfd4bcdfda3d3afe.jpg)

## Step 1 of 3: splitting #253

This PR lays the wire-format and storage groundwork for disappearing messages without adding any business logic. A marmot architect drafting blueprints before the builders arrive.

### What changed

**Extension v3 wire format.** `NostrGroupDataExtension` gains a `disappearing_message_secs` field serialized as a variable-length `Vec<u8>` (empty = `None`, 8 bytes = `Some(u64)`). The version header bumps from 2 to 3. Deserialization dispatches on the first two bytes: v1/v2 payloads decode through `TlsNostrGroupDataExtensionV1V2` and promote to v3 with the field defaulting to `None`. A dedicated test covers the adversarial case where a v3 header wraps a v1/v2-sized body.

**Storage schema.** V006 migration adds a nullable `disappearing_message_secs INTEGER` column to the `groups` table, and `row_to_group` / `save_group` read and write it. `Group` in `mdk-storage-traits` carries the new field.

**Config structs.** `NostrGroupConfigData` and `NostrGroupDataUpdate` both gain the field. `NostrGroupDataUpdate` uses `Option<Option<u64>>` where the outer option means "was it specified?" and the inner means "enabled or disabled?". The value flows through `create_group`, `update_group_data`, `sync_group_metadata`, and welcome processing.

**Boilerplate.** Every existing `Group` construction site across tests, examples, and storage crates adds `disappearing_message_secs: None`.

### What this PR does NOT add

- No validation (zero-duration rejection comes in PR 2)
- No NIP-40 expiration tag logic (PR 2)
- No message deletion methods (PR 3)
- No `PRAGMA secure_delete` (PR 3)
- No UniFFI binding changes beyond the `create_group` call site fix

### Files touched (24)

| Area | Files | Lines |
|------|-------|-------|
| Extension v3 | `extension/types.rs` | +327 |
| Storage traits | `groups/types.rs`, `test_utils.rs` | +8 |
| SQLite | `V006` migration, `db.rs`, `groups.rs` | +35 |
| Core structs | `groups.rs` | +16 |
| Boilerplate None | 14 files across crates | +33 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR implements groundwork for disappearing messages by introducing a v3 NostrGroupDataExtension wire format (bumping the extension version 2→3), adding persistent storage for an optional disappearing_message_secs duration, and threading the new field through group creation, updates, syncing, and welcome processing; it deliberately does not implement expiration enforcement, message deletion, or broader UniFFI API surface changes. TLS serialization/deserialization is updated to accept v3 payloads while promoting legacy v1/v2 payloads to v3 with disappearing_message_secs = None and to robustly reject malformed inputs.

**What changed**:
- Added disappearing_message_secs: Option<u64> to NostrGroupDataExtension, NostrGroupConfigData, NostrGroupDataUpdate, and the public Group struct (affects mdk-core, mdk-storage-traits).
- Bumped NostrGroupDataExtension::CURRENT_VERSION from 2 → 3 and extended the v3 TLS representation to encode disappearing_message_secs as empty Vec (None) or an 8-byte big-endian u64 (mdk-core).
- Reworked TLS deserialization to read a big-endian u16 version from the first two bytes, dispatch to the v3 parser for version ≥3, or parse legacy v1/v2 payloads and promote them to v3 with disappearing_message_secs = None (mdk-core).
- Added validation that non-empty disappearing_message_secs bytes must be exactly 8 bytes and that zero-valued durations are rejected as invalid during parsing (mdk-core).
- Introduced SQLite migration V006 adding a nullable disappearing_message_secs INTEGER column to groups and updated row_to_group, save_group, and upsert logic to read/write the new column (mdk-sqlite-storage).
- Propagated the new field through create_group, update_group_data, sync_group_metadata, welcome processing, and updated all Group construction sites in tests and examples to include disappearing_message_secs: None (mdk-core, mdk-memory-storage, mdk-sqlite-storage, mdk-storage-traits, mdk-uniffi).

**Security impact**:
- No cryptographic algorithm, key derivation, nonce/HKDF context, identity-binding, key handling/storage, error-message leakage, SQLCipher configuration, PRAGMA secure_delete, or file-permission changes are introduced by this PR.

**Protocol changes**:
- Nostr group-data extension wire format advanced to v3 to carry disappearing_message_secs, deserialization now rejects malformed v3 headers lacking a proper v3 body, and legacy v1/v2 payloads are still supported via promotion (Nostr extension behavior change).

**API surface**:
- Breaking changes: NostrGroupDataExtension::CURRENT_VERSION changed to 3 and NostrGroupConfigData::new(...) now requires an additional disappearing_message_secs: Option<u64> argument (mdk-core).
- Public storage-traits change: Group now includes disappearing_message_secs: Option<u64>, requiring all Group constructors to supply the field (mdk-storage-traits).
- Storage schema change: V006 migration adds groups.disappearing_message_secs INTEGER (nullable) to SQLite (mdk-sqlite-storage).
- UniFFI: create_group call-site updated to pass disappearing_message_secs: None; no other UniFFI surface changes.

**Testing**:
- Added unit tests covering v3 round-trip serialization/deserialization, legacy v1/v2 promotion, rejection of zero-valued durations, and rejection of a v3 header paired with a v1/v2-shaped body (mdk-core).
- Updated numerous tests and examples to set disappearing_message_secs: None in Group literals and added SQLite tests verifying persistence, upsert updates, and clearing of the new column (mdk-sqlite-storage, mdk-memory-storage, mdk-core).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->