### PR TITLE
fix(memory-storage): prevent eviction of security-critical state

### DIFF
--- a/crates/mdk-memory-storage/CHANGELOG.md
+++ b/crates/mdk-memory-storage/CHANGELOG.md
@@ -41,6 +41,8 @@
 
 ### Fixed
 
+- Converted `processed_messages_cache`, `processed_welcomes_cache`, and all three `group_*_exporter_secrets_cache` fields from `LruCache` to `HashMap` to prevent silent eviction of security-critical deduplication records and decryption keys under cache pressure (fixes [marmot-security#12](https://github.com/marmot-protocol/marmot-security/issues/12)).
+
 ### Removed
 
 ### Deprecated

--- a/crates/mdk-memory-storage/CHANGELOG.md
+++ b/crates/mdk-memory-storage/CHANGELOG.md
@@ -41,7 +41,7 @@
 
 ### Fixed
 
-- Converted `processed_messages_cache`, `processed_welcomes_cache`, and all three `group_*_exporter_secrets_cache` fields from `LruCache` to `HashMap` to prevent silent eviction of security-critical deduplication records and decryption keys under cache pressure (fixes [marmot-security#12](https://github.com/marmot-protocol/marmot-security/issues/12)).
+- Converted `processed_messages_cache`, `processed_welcomes_cache`, and all three `group_*_exporter_secrets_cache` fields from `LruCache` to `HashMap` to prevent silent eviction of security-critical deduplication records and decryption keys under cache pressure (fixes [marmot-security#12](https://github.com/marmot-protocol/marmot-security/issues/12)) ([#259](https://github.com/marmot-protocol/mdk/pull/259)).
 
 ### Removed
 

--- a/crates/mdk-memory-storage/src/groups.rs
+++ b/crates/mdk-memory-storage/src/groups.rs
@@ -12,7 +12,7 @@ macro_rules! group_exporter_secret_get {
         if inner.groups_cache.peek($mls_group_id).is_none() {
             return Err(group_not_found());
         }
-        Ok(inner.$cache.peek(&($mls_group_id.clone(), $epoch)).cloned())
+        Ok(inner.$cache.get(&($mls_group_id.clone(), $epoch)).cloned())
     }};
 }
 
@@ -27,7 +27,7 @@ macro_rules! group_exporter_secret_save {
             return Err(group_not_found());
         }
         let key = ($secret.mls_group_id.clone(), $secret.epoch);
-        inner.$cache.put(key, $secret);
+        inner.$cache.insert(key, $secret);
         Ok(())
     }};
 }
@@ -272,7 +272,7 @@ impl GroupStorage for MdkMemoryStorage {
             .collect();
 
         for key in group_event_keys {
-            inner.group_exporter_secrets_cache.pop(&key);
+            inner.group_exporter_secrets_cache.remove(&key);
         }
 
         let legacy_group_event_keys: Vec<(GroupId, u64)> = inner
@@ -289,7 +289,7 @@ impl GroupStorage for MdkMemoryStorage {
             .collect();
 
         for key in legacy_group_event_keys {
-            inner.group_legacy_exporter_secrets_cache.pop(&key);
+            inner.group_legacy_exporter_secrets_cache.remove(&key);
         }
 
         let mip04_keys: Vec<(GroupId, u64)> = inner
@@ -306,7 +306,7 @@ impl GroupStorage for MdkMemoryStorage {
             .collect();
 
         for key in mip04_keys {
-            inner.group_mip04_exporter_secrets_cache.pop(&key);
+            inner.group_mip04_exporter_secrets_cache.remove(&key);
         }
 
         Ok(())
@@ -318,6 +318,7 @@ mod tests {
     use mdk_storage_traits::groups::types::GroupState;
     use mdk_storage_traits::messages::MessageStorage;
     use mdk_storage_traits::messages::types::{Message, MessageState};
+    use mdk_storage_traits::secret::Secret;
     use nostr::{EventId, Keys, Kind, Tags, Timestamp, UnsignedEvent};
 
     use super::*;
@@ -919,5 +920,51 @@ mod tests {
             .unwrap();
         assert_eq!(found.name, "Updated Group Name");
         assert_eq!(found.epoch, 1);
+    }
+
+    /// Regression test for marmot-security#12:
+    /// exporter secrets must not be evicted by cache pressure.
+    ///
+    /// Exporter secrets are used for decryption of historical messages. If they
+    /// are evicted from an LRU cache by traffic volume, historical messages
+    /// become permanently undecryptable. Using HashMap instead of LruCache
+    /// prevents this.
+    #[test]
+    fn test_exporter_secrets_not_evicted_under_cache_pressure() {
+        // Small cache size to trigger pressure quickly
+        let limits = crate::ValidationLimits::default().with_cache_size(5);
+        let storage = MdkMemoryStorage::with_limits(limits);
+
+        let group_id = GroupId::from_slice(&[99u8; 4]);
+        let nostr_group_id = [99u8; 32];
+        let group = create_test_group(group_id.clone(), nostr_group_id);
+        storage.save_group(group).unwrap();
+
+        // Save an exporter secret at epoch 0
+        let early_secret = GroupExporterSecret {
+            mls_group_id: group_id.clone(),
+            epoch: 0,
+            secret: Secret::new([0xABu8; 32]),
+        };
+        storage.save_group_exporter_secret(early_secret).unwrap();
+
+        // Flood with many more epoch secrets on the same group to exceed cache_size many times over.
+        // Using the same group avoids evicting it from groups_cache (which is still LRU-bounded)
+        // and focuses the pressure on the exporter secrets cache itself.
+        for epoch in 1u64..=50 {
+            let secret = GroupExporterSecret {
+                mls_group_id: group_id.clone(),
+                epoch,
+                secret: Secret::new([epoch as u8; 32]),
+            };
+            storage.save_group_exporter_secret(secret).unwrap();
+        }
+
+        // The early secret at epoch 0 must still be present
+        let found = storage.get_group_exporter_secret(&group_id, 0).unwrap();
+        assert!(
+            found.is_some(),
+            "exporter secret was evicted under cache pressure — historical decryption broken"
+        );
     }
 }

--- a/crates/mdk-memory-storage/src/lib.rs
+++ b/crates/mdk-memory-storage/src/lib.rs
@@ -407,13 +407,16 @@ struct MdkMemoryStorageInner {
     groups_by_nostr_id_cache: LruCache<[u8; 32], Group>,
     group_relays_cache: LruCache<GroupId, BTreeSet<GroupRelay>>,
     welcomes_cache: LruCache<EventId, Welcome>,
-    processed_welcomes_cache: LruCache<EventId, ProcessedWelcome>,
+    // Security-critical: must not be evicted — use HashMap instead of LruCache
+    processed_welcomes_cache: HashMap<EventId, ProcessedWelcome>,
     messages_cache: LruCache<EventId, Message>,
     messages_by_group_cache: LruCache<GroupId, HashMap<EventId, Message>>,
-    processed_messages_cache: LruCache<EventId, ProcessedMessage>,
-    group_exporter_secrets_cache: LruCache<(GroupId, u64), GroupExporterSecret>,
-    group_legacy_exporter_secrets_cache: LruCache<(GroupId, u64), GroupExporterSecret>,
-    group_mip04_exporter_secrets_cache: LruCache<(GroupId, u64), GroupExporterSecret>,
+    // Security-critical: must not be evicted — use HashMap instead of LruCache
+    processed_messages_cache: HashMap<EventId, ProcessedMessage>,
+    // Security-critical: must not be evicted — use HashMap instead of LruCache
+    group_exporter_secrets_cache: HashMap<(GroupId, u64), GroupExporterSecret>,
+    group_legacy_exporter_secrets_cache: HashMap<(GroupId, u64), GroupExporterSecret>,
+    group_mip04_exporter_secrets_cache: HashMap<(GroupId, u64), GroupExporterSecret>,
 }
 
 impl fmt::Debug for MdkMemoryStorage {
@@ -487,13 +490,13 @@ impl MdkMemoryStorage {
             groups_by_nostr_id_cache: LruCache::new(cache_size),
             group_relays_cache: LruCache::new(cache_size),
             welcomes_cache: LruCache::new(cache_size),
-            processed_welcomes_cache: LruCache::new(cache_size),
+            processed_welcomes_cache: HashMap::new(),
             messages_cache: LruCache::new(cache_size),
             messages_by_group_cache: LruCache::new(cache_size),
-            processed_messages_cache: LruCache::new(cache_size),
-            group_exporter_secrets_cache: LruCache::new(cache_size),
-            group_legacy_exporter_secrets_cache: LruCache::new(cache_size),
-            group_mip04_exporter_secrets_cache: LruCache::new(cache_size),
+            processed_messages_cache: HashMap::new(),
+            group_exporter_secrets_cache: HashMap::new(),
+            group_legacy_exporter_secrets_cache: HashMap::new(),
+            group_mip04_exporter_secrets_cache: HashMap::new(),
         };
 
         MdkMemoryStorage {
@@ -535,18 +538,14 @@ impl MdkMemoryStorage {
             groups: inner.groups_cache.clone_to_hashmap(),
             groups_by_nostr_id: inner.groups_by_nostr_id_cache.clone_to_hashmap(),
             group_relays: inner.group_relays_cache.clone_to_hashmap(),
-            group_exporter_secrets: inner.group_exporter_secrets_cache.clone_to_hashmap(),
-            group_legacy_exporter_secrets: inner
-                .group_legacy_exporter_secrets_cache
-                .clone_to_hashmap(),
-            group_mip04_exporter_secrets: inner
-                .group_mip04_exporter_secrets_cache
-                .clone_to_hashmap(),
+            group_exporter_secrets: inner.group_exporter_secrets_cache.clone(),
+            group_legacy_exporter_secrets: inner.group_legacy_exporter_secrets_cache.clone(),
+            group_mip04_exporter_secrets: inner.group_mip04_exporter_secrets_cache.clone(),
             welcomes: inner.welcomes_cache.clone_to_hashmap(),
-            processed_welcomes: inner.processed_welcomes_cache.clone_to_hashmap(),
+            processed_welcomes: inner.processed_welcomes_cache.clone(),
             messages: inner.messages_cache.clone_to_hashmap(),
             messages_by_group: inner.messages_by_group_cache.clone_to_hashmap(),
-            processed_messages: inner.processed_messages_cache.clone_to_hashmap(),
+            processed_messages: inner.processed_messages_cache.clone(),
         }
     }
 
@@ -593,26 +592,16 @@ impl MdkMemoryStorage {
         snapshot
             .group_relays
             .restore_to_lru(&mut inner.group_relays_cache);
-        snapshot
-            .group_exporter_secrets
-            .restore_to_lru(&mut inner.group_exporter_secrets_cache);
-        snapshot
-            .group_legacy_exporter_secrets
-            .restore_to_lru(&mut inner.group_legacy_exporter_secrets_cache);
-        snapshot
-            .group_mip04_exporter_secrets
-            .restore_to_lru(&mut inner.group_mip04_exporter_secrets_cache);
+        inner.group_exporter_secrets_cache = snapshot.group_exporter_secrets;
+        inner.group_legacy_exporter_secrets_cache = snapshot.group_legacy_exporter_secrets;
+        inner.group_mip04_exporter_secrets_cache = snapshot.group_mip04_exporter_secrets;
         snapshot.welcomes.restore_to_lru(&mut inner.welcomes_cache);
-        snapshot
-            .processed_welcomes
-            .restore_to_lru(&mut inner.processed_welcomes_cache);
+        inner.processed_welcomes_cache = snapshot.processed_welcomes;
         snapshot.messages.restore_to_lru(&mut inner.messages_cache);
         snapshot
             .messages_by_group
             .restore_to_lru(&mut inner.messages_by_group_cache);
-        snapshot
-            .processed_messages
-            .restore_to_lru(&mut inner.processed_messages_cache);
+        inner.processed_messages_cache = snapshot.processed_messages;
     }
 
     // ========================================================================
@@ -787,36 +776,18 @@ impl MdkMemoryStorage {
         inner.group_relays_cache.pop(group_id);
 
         // Remove all MIP-03 exporter secrets for this group
-        let keys_to_remove: Vec<_> = inner
+        inner
             .group_exporter_secrets_cache
-            .iter()
-            .filter(|((gid, _), _)| gid == group_id)
-            .map(|(k, _)| k.clone())
-            .collect();
-        for key in keys_to_remove {
-            inner.group_exporter_secrets_cache.pop(&key);
-        }
+            .retain(|(gid, _), _| gid != group_id);
 
-        let legacy_keys_to_remove: Vec<_> = inner
+        inner
             .group_legacy_exporter_secrets_cache
-            .iter()
-            .filter(|((gid, _), _)| gid == group_id)
-            .map(|(k, _)| k.clone())
-            .collect();
-        for key in legacy_keys_to_remove {
-            inner.group_legacy_exporter_secrets_cache.pop(&key);
-        }
+            .retain(|(gid, _), _| gid != group_id);
 
         // Remove all MIP-04 exporter secrets for this group
-        let mip04_keys_to_remove: Vec<_> = inner
+        inner
             .group_mip04_exporter_secrets_cache
-            .iter()
-            .filter(|((gid, _), _)| gid == group_id)
-            .map(|(k, _)| k.clone())
-            .collect();
-        for key in mip04_keys_to_remove {
-            inner.group_mip04_exporter_secrets_cache.pop(&key);
-        }
+            .retain(|(gid, _), _| gid != group_id);
 
         // 2. Restore from snapshot
 
@@ -865,19 +836,19 @@ impl MdkMemoryStorage {
         for (epoch, secret) in snapshot.group_exporter_secrets {
             inner
                 .group_exporter_secrets_cache
-                .put((group_id.clone(), epoch), secret);
+                .insert((group_id.clone(), epoch), secret);
         }
 
         for (epoch, secret) in snapshot.group_legacy_exporter_secrets {
             inner
                 .group_legacy_exporter_secrets_cache
-                .put((group_id.clone(), epoch), secret);
+                .insert((group_id.clone(), epoch), secret);
         }
 
         for (epoch, secret) in snapshot.group_mip04_exporter_secrets {
             inner
                 .group_mip04_exporter_secrets_cache
-                .put((group_id.clone(), epoch), secret);
+                .insert((group_id.clone(), epoch), secret);
         }
     }
 
@@ -992,46 +963,22 @@ impl MdkStorageProvider for MdkMemoryStorage {
             inner.group_relays_cache.pop(group_id);
 
             // Exporter secrets (keyed by (GroupId, u64) — must iterate)
-            let secret_keys: Vec<(GroupId, u64)> = inner
+            inner
                 .group_exporter_secrets_cache
-                .iter()
-                .filter(|((gid, _), _)| gid == group_id)
-                .map(|(k, _)| k.clone())
-                .collect();
-            for key in &secret_keys {
-                inner.group_exporter_secrets_cache.pop(key);
-            }
+                .retain(|(gid, _), _| gid != group_id);
 
-            let legacy_keys: Vec<(GroupId, u64)> = inner
+            inner
                 .group_legacy_exporter_secrets_cache
-                .iter()
-                .filter(|((gid, _), _)| gid == group_id)
-                .map(|(k, _)| k.clone())
-                .collect();
-            for key in &legacy_keys {
-                inner.group_legacy_exporter_secrets_cache.pop(key);
-            }
+                .retain(|(gid, _), _| gid != group_id);
 
-            let mip04_keys: Vec<(GroupId, u64)> = inner
+            inner
                 .group_mip04_exporter_secrets_cache
-                .iter()
-                .filter(|((gid, _), _)| gid == group_id)
-                .map(|(k, _)| k.clone())
-                .collect();
-            for key in &mip04_keys {
-                inner.group_mip04_exporter_secrets_cache.pop(key);
-            }
+                .retain(|(gid, _), _| gid != group_id);
 
             // Processed messages (keyed by EventId — must iterate for group match)
-            let pm_keys: Vec<nostr::EventId> = inner
+            inner
                 .processed_messages_cache
-                .iter()
-                .filter(|(_, pm)| pm.mls_group_id.as_ref() == Some(group_id))
-                .map(|(k, _)| *k)
-                .collect();
-            for key in &pm_keys {
-                inner.processed_messages_cache.pop(key);
-            }
+                .retain(|_, pm| pm.mls_group_id.as_ref() != Some(group_id));
 
             // Welcomes (keyed by EventId — must iterate for group match)
             let welcome_keys: Vec<nostr::EventId> = inner
@@ -1677,9 +1624,9 @@ mod tests {
         {
             let inner = nostr_storage.inner.read();
             let cache = &inner.group_exporter_secrets_cache;
-            assert!(cache.contains(&(mls_group_id.clone(), 0)));
-            assert!(cache.contains(&(mls_group_id.clone(), 1)));
-            assert!(!cache.contains(&(mls_group_id.clone(), 999)));
+            assert!(cache.contains_key(&(mls_group_id.clone(), 0)));
+            assert!(cache.contains_key(&(mls_group_id.clone(), 1)));
+            assert!(!cache.contains_key(&(mls_group_id.clone(), 999)));
         }
     }
 
@@ -1765,7 +1712,7 @@ mod tests {
         {
             let inner = nostr_storage.inner.read();
             let cache = &inner.processed_welcomes_cache;
-            assert!(cache.contains(&wrapper_id));
+            assert!(cache.contains_key(&wrapper_id));
         }
     }
 
@@ -1867,7 +1814,7 @@ mod tests {
         {
             let inner = nostr_storage.inner.read();
             let cache = &inner.processed_messages_cache;
-            assert!(cache.contains(&wrapper_id));
+            assert!(cache.contains_key(&wrapper_id));
         }
     }
 

--- a/crates/mdk-memory-storage/src/messages.rs
+++ b/crates/mdk-memory-storage/src/messages.rs
@@ -150,7 +150,7 @@ impl MessageStorage for MdkMemoryStorage {
         event_id: &EventId,
     ) -> Result<Option<ProcessedMessage>, MessageError> {
         let inner = self.inner.read();
-        Ok(inner.processed_messages_cache.peek(event_id).cloned())
+        Ok(inner.processed_messages_cache.get(event_id).cloned())
     }
 
     fn save_processed_message(
@@ -160,7 +160,7 @@ impl MessageStorage for MdkMemoryStorage {
         let mut inner = self.inner.write();
         inner
             .processed_messages_cache
-            .put(processed_message.wrapper_event_id, processed_message);
+            .insert(processed_message.wrapper_event_id, processed_message);
 
         Ok(())
     }
@@ -359,6 +359,7 @@ mod tests {
 
     use mdk_storage_traits::groups::GroupStorage;
     use mdk_storage_traits::groups::types::{Group, GroupState, SelfUpdateState};
+    use mdk_storage_traits::messages::types::{ProcessedMessage, ProcessedMessageState};
     use nostr::Keys;
 
     use super::*;
@@ -1274,6 +1275,60 @@ mod tests {
                 .find_message_by_event_id(&group_id, &eid)
                 .unwrap()
                 .is_none()
+        );
+    }
+
+    /// Regression test for marmot-security#12:
+    /// processed_messages must not be evicted by cache pressure.
+    ///
+    /// An attacker flooding with unique event IDs fills the LRU cache so that
+    /// earlier deduplication records are evicted, allowing replays of already-
+    /// processed messages. Using a HashMap instead of LruCache prevents this.
+    #[test]
+    fn test_processed_messages_not_evicted_under_cache_pressure() {
+        // Create storage with a very small cache so pressure is easy to trigger
+        let limits = crate::ValidationLimits::default().with_cache_size(5);
+        let storage = MdkMemoryStorage::with_limits(limits);
+
+        let group_id = GroupId::from_slice(&[42u8; 4]);
+        let group = create_test_group(group_id.clone());
+        storage.save_group(group).unwrap();
+
+        // Save one processed message that should survive cache pressure
+        let early_wrapper_id = EventId::from_slice(&[1u8; 32]).unwrap();
+        let pm = ProcessedMessage {
+            wrapper_event_id: early_wrapper_id,
+            message_event_id: None,
+            processed_at: Timestamp::from(1000u64),
+            epoch: Some(0),
+            mls_group_id: Some(group_id.clone()),
+            state: ProcessedMessageState::Processed,
+            failure_reason: None,
+        };
+        storage.save_processed_message(pm).unwrap();
+
+        // Flood with many more processed messages to exceed cache_size (5) many times over
+        for i in 2u8..=50 {
+            let wrapper_id = EventId::from_slice(&[i; 32]).unwrap();
+            let pm = ProcessedMessage {
+                wrapper_event_id: wrapper_id,
+                message_event_id: None,
+                processed_at: Timestamp::from(1000u64 + u64::from(i)),
+                epoch: Some(u64::from(i)),
+                mls_group_id: Some(group_id.clone()),
+                state: ProcessedMessageState::Processed,
+                failure_reason: None,
+            };
+            storage.save_processed_message(pm).unwrap();
+        }
+
+        // The early record must still be present — it must not have been evicted
+        let found = storage
+            .find_processed_message_by_event_id(&early_wrapper_id)
+            .unwrap();
+        assert!(
+            found.is_some(),
+            "processed message was evicted under cache pressure — replay dedup broken"
         );
     }
 }

--- a/crates/mdk-memory-storage/src/snapshot.rs
+++ b/crates/mdk-memory-storage/src/snapshot.rs
@@ -126,7 +126,7 @@ pub struct MemoryStorageSnapshot {
     pub(crate) mls_encryption_keys: HashMap<Vec<u8>, Vec<u8>>,
     pub(crate) mls_epoch_key_pairs: HashMap<(Vec<u8>, Vec<u8>, u32), Vec<u8>>,
 
-    // MDK data - cloned from LRU caches
+    // MDK data - hot caches (LruCache) and security-critical maps (HashMap)
     pub(crate) groups: HashMap<GroupId, Group>,
     pub(crate) groups_by_nostr_id: HashMap<[u8; 32], Group>,
     pub(crate) group_relays: HashMap<GroupId, BTreeSet<GroupRelay>>,

--- a/crates/mdk-memory-storage/src/welcomes.rs
+++ b/crates/mdk-memory-storage/src/welcomes.rs
@@ -66,7 +66,7 @@ impl WelcomeStorage for MdkMemoryStorage {
         let mut inner = self.inner.write();
         inner
             .processed_welcomes_cache
-            .put(processed_welcome.wrapper_event_id, processed_welcome);
+            .insert(processed_welcome.wrapper_event_id, processed_welcome);
 
         Ok(())
     }
@@ -76,7 +76,7 @@ impl WelcomeStorage for MdkMemoryStorage {
         event_id: &EventId,
     ) -> Result<Option<ProcessedWelcome>, WelcomeError> {
         let inner = self.inner.read();
-        Ok(inner.processed_welcomes_cache.peek(event_id).cloned())
+        Ok(inner.processed_welcomes_cache.get(event_id).cloned())
     }
 }
 
@@ -86,11 +86,12 @@ mod tests {
 
     use mdk_storage_traits::GroupId;
     use mdk_storage_traits::test_utils::cross_storage::create_test_welcome;
+    use mdk_storage_traits::welcomes::types::{ProcessedWelcome, ProcessedWelcomeState};
     use nostr::{EventId, Keys, Kind, PublicKey, RelayUrl, Tags, Timestamp, UnsignedEvent};
 
     use super::*;
     use crate::{
-        DEFAULT_MAX_ADMINS_PER_WELCOME, DEFAULT_MAX_RELAY_URL_LENGTH,
+        ValidationLimits, DEFAULT_MAX_ADMINS_PER_WELCOME, DEFAULT_MAX_RELAY_URL_LENGTH,
         DEFAULT_MAX_RELAYS_PER_WELCOME,
     };
 
@@ -365,11 +366,55 @@ mod tests {
         assert_eq!(empty.len(), 0);
     }
 
+    /// Regression test for marmot-security#12:
+    /// processed_welcomes must not be evicted by cache pressure.
+    ///
+    /// Processed welcome records serve as deduplication guards. If evicted from
+    /// an LRU cache, the same welcome event could be re-processed, potentially
+    /// allowing a user to be added to a group twice or bypassing replay protections.
+    #[test]
+    fn test_processed_welcomes_not_evicted_under_cache_pressure() {
+        // Small cache size so pressure is easy to trigger
+        let limits = crate::ValidationLimits::default().with_cache_size(5);
+        let storage = MdkMemoryStorage::with_limits(limits);
+
+        // Save one processed welcome that must survive cache pressure
+        let early_wrapper_id = EventId::from_slice(&[1u8; 32]).unwrap();
+        let pw = ProcessedWelcome {
+            wrapper_event_id: early_wrapper_id,
+            welcome_event_id: None,
+            processed_at: nostr::Timestamp::from(1000u64),
+            state: ProcessedWelcomeState::Processed,
+            failure_reason: None,
+        };
+        storage.save_processed_welcome(pw).unwrap();
+
+        // Flood with many more processed welcomes to exceed cache_size (5) many times over
+        for i in 2u8..=50 {
+            let wrapper_id = EventId::from_slice(&[i; 32]).unwrap();
+            let pw = ProcessedWelcome {
+                wrapper_event_id: wrapper_id,
+                welcome_event_id: None,
+                processed_at: nostr::Timestamp::from(1000u64 + u64::from(i)),
+                state: ProcessedWelcomeState::Processed,
+                failure_reason: None,
+            };
+            storage.save_processed_welcome(pw).unwrap();
+        }
+
+        // The early record must still be present — it must not have been evicted
+        let found = storage
+            .find_processed_welcome_by_event_id(&early_wrapper_id)
+            .unwrap();
+        assert!(
+            found.is_some(),
+            "processed welcome was evicted under cache pressure — replay dedup broken"
+        );
+    }
+
     /// Test that custom validation limits work correctly for welcomes
     #[test]
     fn test_custom_welcome_limits() {
-        use crate::ValidationLimits;
-
         // Create storage with custom smaller limits
         let limits = ValidationLimits::default()
             .with_max_relays_per_welcome(2)

--- a/crates/mdk-memory-storage/src/welcomes.rs
+++ b/crates/mdk-memory-storage/src/welcomes.rs
@@ -91,8 +91,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        ValidationLimits, DEFAULT_MAX_ADMINS_PER_WELCOME, DEFAULT_MAX_RELAY_URL_LENGTH,
-        DEFAULT_MAX_RELAYS_PER_WELCOME,
+        DEFAULT_MAX_ADMINS_PER_WELCOME, DEFAULT_MAX_RELAY_URL_LENGTH,
+        DEFAULT_MAX_RELAYS_PER_WELCOME, ValidationLimits,
     };
 
     fn create_welcome_with_relays(


### PR DESCRIPTION
## Summary

- Converts `processed_messages_cache`, `processed_welcomes_cache`, and all three `group_*_exporter_secrets_cache` fields from `LruCache` to `HashMap` in `MdkMemoryStorageInner`
- LRU eviction of these fields breaks security invariants: dedup records lost → replay attacks enabled; exporter secrets lost → historical decryption broken
- Adds regression tests for each converted field verifying entries survive cache pressure (cache size 5 + 50 flood entries)

Fixes [marmot-security#12](https://github.com/marmot-protocol/marmot-security/issues/12)

## Test plan

- [x] `cargo fmt --check -p mdk-memory-storage` — clean
- [x] `cargo clippy -p mdk-memory-storage --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test -p mdk-memory-storage --all-features` — 117/117 pass
- [x] `cargo test -p mdk-memory-storage --no-default-features` — 117/117 pass
- [x] Regression tests: `test_processed_messages_not_evicted_under_cache_pressure`, `test_processed_welcomes_not_evicted_under_cache_pressure`, `test_exporter_secrets_not_evicted_under_cache_pressure`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

⚠️ Security-sensitive changes

This PR converts several security-critical caches in mdk-memory-storage from LRU eviction-based caches to non-evicting HashMaps to prevent silent data loss under cache pressure. The changes address critical security invariants: losing processed message/welcome deduplication records could enable replay attacks, and losing exporter secrets would prevent historical message decryption for past epochs. Regression tests verify that security-critical entries survive cache pressure scenarios.

**What changed**:
- Converted `processed_messages_cache`, `processed_welcomes_cache`, and three `group_*_exporter_secrets_cache` fields from `LruCache` to `HashMap` in `MdkMemoryStorageInner` to eliminate unbounded eviction
- Updated all cache access patterns from `peek()`/`put()`/`pop()` LRU semantics to `get()`/`insert()`/`remove()` HashMap semantics in `messages.rs`, `welcomes.rs`, and `groups.rs`
- Modified snapshot cloning and restoration logic in `lib.rs` to directly work with `HashMap` values instead of converting between LRU and HashMap formats
- Simplified group deletion logic in `lib.rs` to use `HashMap::retain` filters instead of iterating and popping entries
- Changes are isolated to mdk-memory-storage crate; other non-critical caches (groups, welcomes, messages) remain as LruCache

**Security impact**:
- Prevents silent eviction of processed message/welcome deduplication records that protect against replay attacks under high-frequency message traffic
- Prevents eviction of group exporter secrets required for decrypting historical messages across epochs, maintaining the ability to decrypt past communications
- Eliminates bounded memory pressure that could trigger unintended loss of security-critical key material

**Testing**:
- Added three regression tests (`test_processed_messages_not_evicted_under_cache_pressure`, `test_processed_welcomes_not_evicted_under_cache_pressure`, `test_exporter_secrets_not_evicted_under_cache_pressure`) that create cache pressure by storing small initial entries then inserting 50 additional entries against a cache size of 5, verifying early entries remain retrievable
- All 117 tests pass with and without default features; cargo fmt and clippy checks pass

<!-- end of auto-generated comment: release notes by coderabbit.ai -->