### PR TITLE
fix(mdk-core): compute group RequiredCapabilities as LCD of invitee capabilities to unblock mixed-version invites (whitenoise-rs#749)

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -39,6 +39,8 @@
 - New groups now use `MIXED_CIPHERTEXT` wire format policy (outgoing: ciphertext, incoming: mixed) instead of the OpenMLS default `PURE_CIPHERTEXT`. Regular messages remain `PrivateMessage`; the mixed incoming policy is required to accept `PublicMessage` SelfRemove proposals from departing members.
 - `leave_group` now sends a SelfRemove proposal (MLS Extensions draft, type `0x000a`) instead of a Remove proposal. Falls back to Remove for legacy groups created with `PURE_CIPHERTEXT`. SelfRemove proposals are auto-committed by any member, removing the requirement for an admin to be online.
 - Non-admin members can now create SelfRemove-only Commits in addition to self-update Commits. These two commit types must not be combined.
+- **`create_group` now computes the group's `RequiredCapabilities` as a least-common-denominator (LCD) intersection of `SUPPORTED_PROPOSALS` with every invitee's advertised proposals**, instead of requiring `SelfRemove` unconditionally. An all-modern invitee set still produces `RequiredCapabilities = [SelfRemove]`; any legacy invitee strips `SelfRemove` from the required set. Empty-invitee (single-member / "message to self") groups stay permissive with `RequiredCapabilities = []` so a later `add_members` call can admit legacy key packages. This unblocks two call patterns that previously failed OpenMLS's admission check with `Error::Group("Proposals are not acceptable")`: `create_group` with at least one legacy invitee, and `add_members` of a legacy invitee into a group that was created mixed (`RequiredCapabilities = []`). Resolves [whitenoise-rs #749](https://github.com/marmot-protocol/whitenoise-rs/issues/749) via [#261](https://github.com/marmot-protocol/mdk/pull/261).
+- `leave_group` now consults the group's `RequiredCapabilities` before emitting a `SelfRemove` proposal. If the group's `RequiredCapabilities` does not include `SelfRemove` (i.e. any mixed/legacy group), the leave falls back to a legacy `Remove` proposal that only admins can commit. Complements the existing `PURE_CIPHERTEXT` wire-format fallback. ([#261](https://github.com/marmot-protocol/mdk/pull/261))
 
 ### Added
 
@@ -52,6 +54,7 @@
 ### Fixed
 
 - Rejected receiver-side commits that would leave a group with no active admins, including admin-authored group-data extension updates that bypass MDK's creating-side guards. ([#256](https://github.com/marmot-protocol/mdk/pull/256))
+- `self_update` now injects `MDK::capabilities()` into the rotated leaf's `LeafNodeParameters` instead of cloning the leaf's existing (possibly stale) capabilities. Previously, a leaf added before MDK's capability set last changed would continue re-advertising stale capabilities across every rotation; with this change, every self-update advances the leaf toward MDK's current set. Changes semantics for callers relying on self-update preserving legacy leaf capabilities; all in-tree `self_update` tests continue to pass. Resolves [whitenoise-rs #749](https://github.com/marmot-protocol/whitenoise-rs/issues/749) via [#261](https://github.com/marmot-protocol/mdk/pull/261).
 - Added ciphertext deduplication to commit race resolution. Epoch snapshots now store a SHA-256 hash of the outer event content; re-wrapped events carrying identical ciphertext are rejected before the MIP-03 timestamp/ID comparison, preventing replay-triggered rollbacks. ([#246](https://github.com/marmot-protocol/mdk/pull/246))
 - Bumped `hpke-rs` from `0.6.0` to `0.6.1`, resolving two high-severity advisories in the transitive `libcrux` chain: [RUSTSEC-2026-0073](https://rustsec.org/advisories/RUSTSEC-2026-0073) (panic in `libcrux-poly1305` standalone MAC operations) and [RUSTSEC-2026-0074](https://rustsec.org/advisories/RUSTSEC-2026-0074) (incorrect SHAKE output in `libcrux-sha3`). `Cargo.lock` only — no `Cargo.toml` changes required. ([#234](https://github.com/marmot-protocol/mdk/pull/234))
 - Bumped `digest` lockfile entry from yanked `0.11.1` to `0.11.2`, resolving the `cargo audit` yanked-crate warning introduced transitively via `openmls_rust_crypto` → `hpke-rs-rust-crypto` → `x-wing` → `sha3`. ([#229](https://github.com/marmot-protocol/mdk/pull/229))
@@ -66,6 +69,8 @@
 - `remove_members` now atomically strips removed members from the group admin list within the same MLS commit ([#225](https://github.com/marmot-protocol/mdk/pull/225))
 
 ### Removed
+
+- Dead constant `GROUP_CONTEXT_REQUIRED_PROPOSALS` and the `MDK::required_capabilities_extension()` helper. Superseded by the per-group LCD intersection inlined at the `create_group` call site. ([#261](https://github.com/marmot-protocol/mdk/pull/261))
 
 ### Deprecated
 

--- a/crates/mdk-core/src/constant.rs
+++ b/crates/mdk-core/src/constant.rs
@@ -69,12 +69,6 @@ pub const SUPPORTED_PROPOSALS: [ProposalType; 1] = [
     ProposalType::SelfRemove, // 0x000A
 ];
 
-/// Proposal types required in the GroupContext RequiredCapabilities.
-/// All group members must support these proposal types.
-pub const GROUP_CONTEXT_REQUIRED_PROPOSALS: [ProposalType; 1] = [
-    ProposalType::SelfRemove, // 0x000A
-];
-
 /// Proposal types advertised in Nostr event tags (mls_proposals tag).
 /// Derived from SUPPORTED_PROPOSALS to guarantee consistency.
 pub const TAG_PROPOSALS: [ProposalType; 1] = SUPPORTED_PROPOSALS;

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -26,6 +26,7 @@ use sha2::{Digest, Sha256};
 
 use super::MDK;
 use super::extension::NostrGroupDataExtension;
+use crate::constant::{GROUP_CONTEXT_REQUIRED_EXTENSIONS, SUPPORTED_PROPOSALS};
 use crate::error::Error;
 use crate::messages::EventTag;
 use crate::messages::crypto::encrypt_message_with_exporter_secret;
@@ -1197,8 +1198,48 @@ where
             None, // image_upload_key - will be set when image is uploaded
         );
 
+        // Parse invitee KeyPackages up front — the LCD intersection below
+        // needs their advertised capabilities to compute the group's
+        // `RequiredCapabilities`.
+        let key_packages_vec: Vec<KeyPackage> = member_key_package_events
+            .iter()
+            .map(|event| self.parse_key_package(event))
+            .collect::<Result<_, _>>()?;
+
+        // LCD: require only proposals every invitee's leaf can satisfy. An
+        // all-modern group keeps [SelfRemove]; any legacy invitee strips it.
+        // MDK itself supports every entry in SUPPORTED_PROPOSALS by
+        // construction, so the creator's own leaf never needs an explicit
+        // intersection term.
+        //
+        // Empty-invitee groups (single-member setup / "message to self") stay
+        // permissive: `Iterator::all` is vacuously true over an empty set, so
+        // a naive intersection would freeze in SUPPORTED_PROPOSALS and close
+        // the group to later legacy `add_members` calls. We don't know the
+        // future composition yet, and `RequiredCapabilities` is immutable
+        // until a `GroupContextExtensions` upgrade ships, so empty stays
+        // empty.
+        let required_proposals: Vec<ProposalType> = if key_packages_vec.is_empty() {
+            Vec::new()
+        } else {
+            SUPPORTED_PROPOSALS
+                .iter()
+                .copied()
+                .filter(|pt| {
+                    key_packages_vec
+                        .iter()
+                        .all(|kp| kp.leaf_node().capabilities().proposals().contains(pt))
+                })
+                .collect()
+        };
+
         let extension = Self::get_unknown_extension_from_group_data(&group_data)?;
-        let required_capabilities_extension = self.required_capabilities_extension();
+        let required_capabilities_extension =
+            Extension::RequiredCapabilities(RequiredCapabilitiesExtension::new(
+                &GROUP_CONTEXT_REQUIRED_EXTENSIONS,
+                &required_proposals,
+                &[],
+            ));
         let extensions = Extensions::from_vec(vec![extension, required_capabilities_extension])?;
 
         // Build the group config
@@ -1219,13 +1260,6 @@ where
 
         let mut mls_group =
             MlsGroup::new(&self.provider, &signer, &group_config, credential.clone())?;
-
-        let mut key_packages_vec: Vec<KeyPackage> = Vec::new();
-        for event in &member_key_package_events {
-            // TODO: Error handling for failure here
-            let key_package: KeyPackage = self.parse_key_package(event)?;
-            key_packages_vec.push(key_package);
-        }
 
         // Handle member addition and welcome message creation
         // For single-member groups (no additional members), we skip adding members
@@ -1372,7 +1406,7 @@ where
 
         let leaf_node_params = LeafNodeParameters::builder()
             .with_credential_with_key(new_credential_with_key)
-            .with_capabilities(own_leaf.capabilities().clone())
+            .with_capabilities(self.capabilities())
             .with_extensions(own_leaf.extensions().clone())
             .build();
 
@@ -1435,19 +1469,28 @@ where
         group: &mut MlsGroup,
         signer: &SignatureKeyPair,
     ) -> Result<MlsMessageOut, Error> {
-        // Legacy groups (PURE_CIPHERTEXT) have AlwaysCiphertext incoming on all peers.
-        // A PublicMessage SelfRemove would be rejected with IncompatibleWireFormat.
-        // Fall back to Remove immediately — don't bother switching config.
-        //
-        // MIXED_CIPHERTEXT groups also have AlwaysCiphertext outgoing but Mixed
-        // incoming — they CAN accept PublicMessage SelfRemove.
-        if matches!(
-            group.configuration().wire_format_policy().incoming(),
-            IncomingWireFormatPolicy::AlwaysCiphertext
-        ) {
+        // RequiredCapabilities gate. RFC 9420 §7.2 guarantees every leaf's
+        // advertised proposals cover RequiredCapabilities, so if SelfRemove
+        // is required, OpenMLS's commit-time validate_proposal_type_support
+        // is guaranteed to accept it on every peer. If SelfRemove is NOT
+        // required, fall back to legacy Remove — a mixed-composition group's
+        // non-admin-committable SelfRemove path would orphan on at least one
+        // peer. This is also our wire-format guarantee: modern groups are
+        // born with `RequiredCapabilities = [SelfRemove]` and
+        // `MIXED_CIPHERTEXT` in lockstep (PR #236), and legacy groups have
+        // neither, so this single check covers both invariants in practice.
+        // Sound but over-conservative for formerly-mixed groups that became
+        // all-modern: `RequiredCapabilities` is frozen at creation and only
+        // a `GroupContextExtensions` commit can mutate it.
+        let self_remove_required = group
+            .extensions()
+            .required_capabilities()
+            .is_some_and(|rc| rc.proposal_types().contains(&ProposalType::SelfRemove));
+
+        if !self_remove_required {
             tracing::debug!(
                 target: "mdk_core::groups::leave_group",
-                "SelfRemove unavailable (legacy group with PURE_CIPHERTEXT), \
+                "SelfRemove not in group's RequiredCapabilities, \
                  falling back to Remove proposal"
             );
             return group
@@ -6287,5 +6330,638 @@ mod tests {
         assert_eq!(leaf_map.get(&1), Some(&bob_keys.public_key()));
         assert_eq!(leaf_map.get(&3), Some(&dave_keys.public_key()));
         assert!(!leaf_map.contains_key(&2));
+    }
+
+    // ============================================================================
+    // LCD admission at create_group.
+    //
+    // These tests pin the observable group-context shape resulting from the
+    // least-common-denominator intersection across invitee KeyPackage
+    // capabilities. All three assertions are against
+    // `MlsGroup::extensions().required_capabilities().proposal_types()` as
+    // read back from persistent storage via `load_mls_group`.
+    // ============================================================================
+
+    /// All-modern invitees: the resulting group's `RequiredCapabilities`
+    /// MUST contain `SelfRemove`. LCD should preserve the #7.2 guarantee
+    /// whenever every invitee can honour it.
+    #[test]
+    fn test_create_group_all_modern_invitees_requires_self_remove() {
+        use openmls::prelude::ProposalType;
+
+        let creator_mdk = create_test_mdk();
+        let alice_mdk = create_test_mdk();
+        let bob_mdk = create_test_mdk();
+        let creator = Keys::generate();
+        let alice = Keys::generate();
+        let bob = Keys::generate();
+        let creator_pk = creator.public_key();
+
+        let alice_kp = create_key_package_event(&alice_mdk, &alice);
+        let bob_kp = create_key_package_event(&bob_mdk, &bob);
+
+        let create_result = creator_mdk
+            .create_group(
+                &creator_pk,
+                vec![alice_kp, bob_kp],
+                create_nostr_group_config_data(vec![creator_pk]),
+            )
+            .expect("all-modern group creation should succeed");
+
+        let group_id = create_result.group.mls_group_id.clone();
+        let mls_group = creator_mdk
+            .load_mls_group(&group_id)
+            .expect("load ok")
+            .expect("group exists");
+
+        let proposal_types: Vec<ProposalType> = mls_group
+            .extensions()
+            .required_capabilities()
+            .map(|rc| rc.proposal_types().to_vec())
+            .unwrap_or_default();
+
+        assert!(
+            proposal_types.contains(&ProposalType::SelfRemove),
+            "all-modern group should require SelfRemove (got {:?})",
+            proposal_types
+        );
+    }
+
+    /// Empty-invitee setup groups (single-member / "message to self") must
+    /// NOT freeze in `RequiredCapabilities = [SelfRemove]`. A naive LCD
+    /// over an empty invitee set is vacuously true, which would pin
+    /// `SUPPORTED_PROPOSALS` and close the group to any later legacy
+    /// `add_members()` call. This test pins the empty-stays-empty
+    /// permissive default and guards against someone "simplifying" the
+    /// `is_empty()` branch out of `create_group`.
+    #[test]
+    fn test_create_group_empty_invitees_yields_empty_required_capabilities() {
+        let creator_mdk = create_test_mdk();
+        let creator = Keys::generate();
+        let creator_pk = creator.public_key();
+
+        let create_result = creator_mdk
+            .create_group(
+                &creator_pk,
+                Vec::new(),
+                create_nostr_group_config_data(vec![creator_pk]),
+            )
+            .expect("single-member group creation should succeed");
+
+        let group_id = create_result.group.mls_group_id.clone();
+        let mls_group = creator_mdk
+            .load_mls_group(&group_id)
+            .expect("load ok")
+            .expect("group exists");
+
+        let proposal_types = mls_group
+            .extensions()
+            .required_capabilities()
+            .map(|rc| rc.proposal_types().to_vec())
+            .unwrap_or_default();
+
+        assert!(
+            proposal_types.is_empty(),
+            "empty-invitee group must stay permissive (got {:?})",
+            proposal_types
+        );
+    }
+
+    /// Admin-leave demotion flow in a mixed group. Admins cannot leave
+    /// directly; they must `self_demote()` first, have the demotion
+    /// committed, then leave. In a mixed group, the subsequent leave must
+    /// follow the legacy-Remove fallback (observable: a non-admin receiver
+    /// sees `PendingProposal`, not `Proposal`).
+    #[test]
+    fn test_admin_in_mixed_group_demotes_then_leaves_legacy() {
+        use crate::messages::MessageProcessingResult;
+
+        // Two admins so self-demote is allowed (not last-admin).
+        // Charlie is a modern non-admin observer; a legacy invitee forces
+        // LCD → RequiredCapabilities = [].
+        let alice_mdk = create_test_mdk(); // admin leaving
+        let bob_mdk = create_test_mdk(); // admin who stays
+        let charlie_mdk = create_test_mdk(); // non-admin modern observer
+        let alice_keys = Keys::generate();
+        let bob_keys = Keys::generate();
+        let charlie_keys = Keys::generate();
+        let legacy_keys = Keys::generate();
+
+        let bob_kp = create_key_package_event(&bob_mdk, &bob_keys);
+        let charlie_kp = create_key_package_event(&charlie_mdk, &charlie_keys);
+        let legacy_kp = create_legacy_key_package_event(&alice_mdk, &legacy_keys);
+
+        let create_result = alice_mdk
+            .create_group(
+                &alice_keys.public_key(),
+                vec![bob_kp, charlie_kp, legacy_kp],
+                create_nostr_group_config_data(vec![
+                    alice_keys.public_key(),
+                    bob_keys.public_key(),
+                ]),
+            )
+            .expect("alice creates mixed group with two admins");
+        let group_id = create_result.group.mls_group_id.clone();
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("alice merges creation");
+
+        let bob_welcome = bob_mdk
+            .process_welcome(
+                &nostr::EventId::all_zeros(),
+                &create_result.welcome_rumors[0],
+            )
+            .expect("bob processes welcome");
+        bob_mdk.accept_welcome(&bob_welcome).expect("bob accepts");
+        let charlie_welcome = charlie_mdk
+            .process_welcome(
+                &nostr::EventId::all_zeros(),
+                &create_result.welcome_rumors[1],
+            )
+            .expect("charlie processes welcome");
+        charlie_mdk
+            .accept_welcome(&charlie_welcome)
+            .expect("charlie accepts");
+
+        // Step 1: Alice (admin) cannot leave directly.
+        let direct_err = alice_mdk
+            .leave_group(&group_id)
+            .expect_err("admin cannot leave without demoting");
+        assert!(
+            direct_err.to_string().contains("self-demote"),
+            "expected demotion-required error substring; got: {direct_err}"
+        );
+
+        // Step 2: Alice self-demotes; the demotion commit must propagate
+        // to Charlie (so his group state reflects Alice's non-admin status
+        // when he later processes her leave).
+        let demote_result = alice_mdk
+            .self_demote(&group_id)
+            .expect("alice self-demotes");
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("alice merges her demotion");
+        charlie_mdk
+            .process_message(&demote_result.evolution_event)
+            .expect("charlie processes demotion commit");
+
+        // Step 3: Alice (now non-admin) leaves. Mixed group → legacy Remove
+        // fallback → non-admin receiver sees PendingProposal.
+        let alice_leave = alice_mdk
+            .leave_group(&group_id)
+            .expect("alice leaves after demotion");
+
+        let result = charlie_mdk
+            .process_message(&alice_leave.evolution_event)
+            .expect("charlie processes alice's leave");
+        assert!(
+            matches!(result, MessageProcessingResult::PendingProposal { .. }),
+            "demoted-admin leave in a mixed group should fall back to legacy Remove \
+             (non-admin receiver sees PendingProposal); got {:?}",
+            result
+        );
+    }
+
+    /// `self_update()` must inject `MDK::capabilities()` into the new leaf,
+    /// not clone the (possibly stale) capabilities already there. A member
+    /// whose leaf currently advertises an empty proposals set must, after a
+    /// self-update, advertise MDK's full set (which includes `SelfRemove`).
+    #[test]
+    fn test_self_update_refreshes_leaf_capabilities() {
+        use openmls::prelude::ProposalType;
+
+        let alice_mdk = create_test_mdk();
+        let charlie_mdk = create_test_mdk();
+        let alice_keys = Keys::generate();
+        let charlie_keys = Keys::generate();
+
+        // Alice invites Charlie using a capability-poor KeyPackage. Charlie's
+        // leaf on entry therefore advertises NO proposals (no SelfRemove).
+        // The group's RequiredCapabilities will also end up empty (LCD).
+        let legacy_kp = create_legacy_key_package_event(&charlie_mdk, &charlie_keys);
+
+        let create_result = alice_mdk
+            .create_group(
+                &alice_keys.public_key(),
+                vec![legacy_kp],
+                create_nostr_group_config_data(vec![alice_keys.public_key()]),
+            )
+            .expect("alice creates mixed group");
+        let group_id = create_result.group.mls_group_id.clone();
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("alice merges");
+
+        let charlie_welcome = charlie_mdk
+            .process_welcome(
+                &nostr::EventId::all_zeros(),
+                &create_result.welcome_rumors[0],
+            )
+            .expect("charlie processes welcome");
+        charlie_mdk
+            .accept_welcome(&charlie_welcome)
+            .expect("charlie accepts");
+
+        // Precondition: Charlie's leaf advertises NO proposals.
+        let pre = charlie_mdk
+            .load_mls_group(&group_id)
+            .expect("load pre")
+            .expect("group pre");
+        let pre_proposals: Vec<ProposalType> = pre
+            .own_leaf()
+            .expect("own leaf pre")
+            .capabilities()
+            .proposals()
+            .to_vec();
+        assert!(
+            pre_proposals.is_empty(),
+            "sanity: capability-poor leaf starts with NO proposals; got {:?}",
+            pre_proposals
+        );
+
+        // Run a self-update and commit.
+        charlie_mdk
+            .self_update(&group_id)
+            .expect("self-update succeeds");
+        charlie_mdk
+            .merge_pending_commit(&group_id)
+            .expect("charlie merges self-update");
+
+        // Postcondition: leaf now advertises MDK's modern proposals set,
+        // which includes SelfRemove. This is the bug fix.
+        let post = charlie_mdk
+            .load_mls_group(&group_id)
+            .expect("load post")
+            .expect("group post");
+        let post_proposals: Vec<ProposalType> = post
+            .own_leaf()
+            .expect("own leaf post")
+            .capabilities()
+            .proposals()
+            .to_vec();
+        assert!(
+            post_proposals.contains(&ProposalType::SelfRemove),
+            "self_update should refresh leaf proposals to current MDK capabilities; \
+             expected SelfRemove, got {:?}",
+            post_proposals
+        );
+    }
+
+    /// Documents accepted over-conservatism. A group created mixed
+    /// (RequiredCapabilities = []) keeps that value forever in MDK's
+    /// stable-0.8.1 world, so any subsequent modern-member leaves fall back
+    /// to legacy `Remove` even after every legacy member has been
+    /// admin-removed. This test pins the accepted wrong behavior so somebody
+    /// doesn't "optimize" the Guard 2 check by reading the tree without also
+    /// shipping a GCE-upgrade path that makes the optimization correct.
+    // TODO(gce-upgrade): delete/invert when GCE-upgrade ships. At that
+    // point the group should regain SelfRemove UX automatically after
+    // legacy members depart, and this assertion becomes wrong.
+    #[test]
+    fn test_mixed_group_stays_legacy_after_legacy_members_leave_over_conservative() {
+        use crate::messages::MessageProcessingResult;
+
+        // Alice (admin), Bob (modern non-admin), plus a legacy invitee.
+        let alice_mdk = create_test_mdk();
+        let bob_mdk = create_test_mdk();
+        let charlie_mdk = create_test_mdk();
+        let alice_keys = Keys::generate();
+        let bob_keys = Keys::generate();
+        let charlie_keys = Keys::generate();
+        let legacy_keys = Keys::generate();
+
+        let bob_kp = create_key_package_event(&bob_mdk, &bob_keys);
+        let charlie_kp = create_key_package_event(&charlie_mdk, &charlie_keys);
+        let legacy_kp = create_legacy_key_package_event(&alice_mdk, &legacy_keys);
+
+        let create_result = alice_mdk
+            .create_group(
+                &alice_keys.public_key(),
+                vec![bob_kp, charlie_kp, legacy_kp],
+                create_nostr_group_config_data(vec![alice_keys.public_key()]),
+            )
+            .expect("mixed group creation");
+        let group_id = create_result.group.mls_group_id.clone();
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("alice merges");
+
+        let bob_welcome = bob_mdk
+            .process_welcome(
+                &nostr::EventId::all_zeros(),
+                &create_result.welcome_rumors[0],
+            )
+            .expect("bob processes welcome");
+        bob_mdk.accept_welcome(&bob_welcome).expect("bob accepts");
+        let charlie_welcome = charlie_mdk
+            .process_welcome(
+                &nostr::EventId::all_zeros(),
+                &create_result.welcome_rumors[1],
+            )
+            .expect("charlie processes welcome");
+        charlie_mdk
+            .accept_welcome(&charlie_welcome)
+            .expect("charlie accepts");
+
+        // Alice admin-removes the legacy member.
+        alice_mdk
+            .remove_members(&group_id, &[legacy_keys.public_key()])
+            .expect("alice removes legacy");
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("alice merges removal");
+
+        // The stored RequiredCapabilities is still [] — MDK does not upgrade
+        // it on its own. Bob (still modern) leaves; Charlie (non-admin
+        // receiver) should still see a legacy Remove => PendingProposal.
+        let bob_leave = bob_mdk
+            .leave_group(&group_id)
+            .expect("bob leaves the now-all-modern group");
+
+        let result = charlie_mdk
+            .process_message(&bob_leave.evolution_event)
+            .expect("charlie processes bob's leave");
+
+        assert!(
+            matches!(result, MessageProcessingResult::PendingProposal { .. }),
+            "formerly-mixed-now-all-modern group should still fall back to legacy Remove \
+             until GCE-upgrade ships; got {:?}",
+            result
+        );
+    }
+
+    /// Leave-path: after a modern SelfRemove send, the group's wire-format
+    /// policy must be back to MIXED_CIPHERTEXT in persistent storage.
+    /// Reloading from storage is load-bearing — in-memory state alone does
+    /// not prove the persist-side restoration worked.
+    #[test]
+    fn test_self_remove_restores_ciphertext_config_on_disk() {
+        use openmls::prelude::{IncomingWireFormatPolicy, OutgoingWireFormatPolicy};
+
+        // All-modern 3-member group so RequiredCapabilities = [SelfRemove].
+        let alice_mdk = create_test_mdk();
+        let bob_mdk = create_test_mdk();
+        let charlie_mdk = create_test_mdk();
+        let alice_keys = Keys::generate();
+        let bob_keys = Keys::generate();
+        let charlie_keys = Keys::generate();
+
+        let bob_kp = create_key_package_event(&bob_mdk, &bob_keys);
+        let charlie_kp = create_key_package_event(&charlie_mdk, &charlie_keys);
+
+        let create_result = alice_mdk
+            .create_group(
+                &alice_keys.public_key(),
+                vec![bob_kp, charlie_kp],
+                create_nostr_group_config_data(vec![alice_keys.public_key()]),
+            )
+            .expect("alice creates group");
+        let group_id = create_result.group.mls_group_id.clone();
+
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("alice merges creation commit");
+
+        let bob_welcome = bob_mdk
+            .process_welcome(
+                &nostr::EventId::all_zeros(),
+                &create_result.welcome_rumors[0],
+            )
+            .expect("bob processes welcome");
+        bob_mdk.accept_welcome(&bob_welcome).expect("bob accepts");
+
+        // Bob sends the SelfRemove. Internally `try_self_remove` flips to
+        // plaintext, sends, then restores ciphertext.
+        bob_mdk
+            .leave_group(&group_id)
+            .expect("bob sends SelfRemove");
+
+        // Reload from storage and assert restoration.
+        let reloaded = bob_mdk
+            .load_mls_group(&group_id)
+            .expect("reload ok")
+            .expect("group still exists for bob");
+        let policy = reloaded.configuration().wire_format_policy();
+        assert_eq!(
+            policy.outgoing(),
+            OutgoingWireFormatPolicy::AlwaysCiphertext,
+            "outgoing policy should be restored to AlwaysCiphertext"
+        );
+        assert_eq!(
+            policy.incoming(),
+            IncomingWireFormatPolicy::Mixed,
+            "incoming policy should be restored to Mixed (MIXED_CIPHERTEXT)"
+        );
+    }
+
+    /// Leave-path: a mixed group (RequiredCapabilities = []) must fall back
+    /// to legacy `Remove` when a modern non-admin member leaves. Observable
+    /// via the receiver — a non-admin receiver sees `PendingProposal`
+    /// (waiting for an admin to commit), NOT `Proposal` (the SelfRemove
+    /// auto-commit signature).
+    #[test]
+    fn test_leave_mixed_group_falls_back_to_legacy_remove() {
+        use crate::messages::MessageProcessingResult;
+
+        let alice_mdk = create_test_mdk(); // admin
+        let bob_mdk = create_test_mdk(); // non-admin, the leaver, modern
+        let charlie_mdk = create_test_mdk(); // non-admin receiver, modern
+        let alice_keys = Keys::generate();
+        let bob_keys = Keys::generate();
+        let charlie_keys = Keys::generate();
+        let legacy_keys = Keys::generate();
+        let admins = vec![alice_keys.public_key()];
+
+        // Mixed group: bob + charlie are modern, one capability-poor invitee
+        // poisons LCD into RequiredCapabilities = [].
+        let bob_kp = create_key_package_event(&bob_mdk, &bob_keys);
+        let charlie_kp = create_key_package_event(&charlie_mdk, &charlie_keys);
+        let legacy_kp = create_legacy_key_package_event(&alice_mdk, &legacy_keys);
+
+        let create_result = alice_mdk
+            .create_group(
+                &alice_keys.public_key(),
+                vec![bob_kp, charlie_kp, legacy_kp],
+                create_nostr_group_config_data(admins),
+            )
+            .expect("mixed group creation should succeed");
+        let group_id = create_result.group.mls_group_id.clone();
+
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("alice merges creation commit");
+
+        // Bob + Charlie join via welcomes (legacy invitee does not participate;
+        // the capability-poor KP fixture bypasses MDK's welcome flow anyway).
+        let bob_welcome = bob_mdk
+            .process_welcome(
+                &nostr::EventId::all_zeros(),
+                &create_result.welcome_rumors[0],
+            )
+            .expect("bob processes welcome");
+        bob_mdk.accept_welcome(&bob_welcome).expect("bob accepts");
+
+        let charlie_welcome = charlie_mdk
+            .process_welcome(
+                &nostr::EventId::all_zeros(),
+                &create_result.welcome_rumors[1],
+            )
+            .expect("charlie processes welcome");
+        charlie_mdk
+            .accept_welcome(&charlie_welcome)
+            .expect("charlie accepts");
+
+        // Bob leaves the mixed group.
+        let bob_leave = bob_mdk.leave_group(&group_id).expect("Bob should leave");
+
+        // Charlie (non-admin) processing a legacy Remove: it goes into the
+        // pending store (needs admin commit). For SelfRemove it would
+        // auto-commit on any member (MessageProcessingResult::Proposal).
+        let result = charlie_mdk
+            .process_message(&bob_leave.evolution_event)
+            .expect("charlie processes bob's leave");
+
+        assert!(
+            matches!(result, MessageProcessingResult::PendingProposal { .. }),
+            "mixed-group leave must fall back to legacy Remove and surface as PendingProposal \
+             for a non-admin receiver; got {:?}",
+            result
+        );
+    }
+
+    /// Admission: after an all-modern group is created, adding a member
+    /// whose KeyPackage omits `SelfRemove` must be rejected. The rejection
+    /// surfaces as `Error::Group(String)` via the flat-string wrapping in
+    /// `add_members` (`.map_err(|e| Error::Group(e.to_string()))`); the
+    /// substring below was
+    /// observed empirically — openmls 0.8.1 wraps the leaf-node validation
+    /// failure into its `ProposalValidationError` whose `Display` is
+    /// "Proposals are not acceptable." This matches the exact error the
+    /// original #749 bug surfaced before the LCD fix, confirming this
+    /// branch is the upstream-enforced proposal-type gate.
+    #[test]
+    fn test_add_members_rejects_legacy_kp_in_all_modern_group() {
+        let creator_mdk = create_test_mdk();
+        let alice_mdk = create_test_mdk();
+        let legacy_mdk = create_test_mdk();
+        let creator = Keys::generate();
+        let alice = Keys::generate();
+        let legacy = Keys::generate();
+        let creator_pk = creator.public_key();
+
+        // All-modern bootstrap — RequiredCapabilities will contain SelfRemove.
+        let alice_kp = create_key_package_event(&alice_mdk, &alice);
+        let create_result = creator_mdk
+            .create_group(
+                &creator_pk,
+                vec![alice_kp],
+                create_nostr_group_config_data(vec![creator_pk]),
+            )
+            .expect("all-modern group creation should succeed");
+        let group_id = create_result.group.mls_group_id.clone();
+        creator_mdk
+            .merge_pending_commit(&group_id)
+            .expect("merge creation commit");
+
+        // Attempting to add a capability-poor invitee must fail.
+        let legacy_kp = create_legacy_key_package_event(&legacy_mdk, &legacy);
+        let err = creator_mdk
+            .add_members(&group_id, &[legacy_kp])
+            .expect_err("adding capability-poor KP to all-modern group must fail");
+
+        // MDK flattens openmls errors into Error::Group(String).
+        // Substring is the literal Display of openmls's ProposalValidationError.
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Proposals are not acceptable"),
+            "expected openmls proposal-rejection substring; got: {msg}"
+        );
+    }
+
+    /// All-legacy invitees: creation still succeeds and the resulting
+    /// group's `RequiredCapabilities` is empty. Degenerate case proving
+    /// that LCD does not blow up when no invitee advertises anything in
+    /// `SUPPORTED_PROPOSALS`.
+    #[test]
+    fn test_create_group_all_legacy_invitees_yields_empty_required_capabilities() {
+        let creator_mdk = create_test_mdk();
+        let creator = Keys::generate();
+        let legacy1 = Keys::generate();
+        let legacy2 = Keys::generate();
+        let creator_pk = creator.public_key();
+
+        let kp1 = create_legacy_key_package_event(&creator_mdk, &legacy1);
+        let kp2 = create_legacy_key_package_event(&creator_mdk, &legacy2);
+
+        let create_result = creator_mdk
+            .create_group(
+                &creator_pk,
+                vec![kp1, kp2],
+                create_nostr_group_config_data(vec![creator_pk]),
+            )
+            .expect("all-legacy group creation should succeed");
+
+        let group_id = create_result.group.mls_group_id.clone();
+        let mls_group = creator_mdk
+            .load_mls_group(&group_id)
+            .expect("load ok")
+            .expect("group exists");
+
+        let proposal_types = mls_group
+            .extensions()
+            .required_capabilities()
+            .map(|rc| rc.proposal_types().to_vec())
+            .unwrap_or_default();
+
+        assert!(
+            proposal_types.is_empty(),
+            "all-legacy group should have empty RequiredCapabilities.proposal_types (got {:?})",
+            proposal_types
+        );
+    }
+
+    /// Tracer for whitenoise-rs#749: creating a group whose invitee set
+    /// contains a capability-poor (legacy) KeyPackage must succeed AND the
+    /// resulting group's `RequiredCapabilities` must NOT advertise
+    /// `SelfRemove`. This is the core #749 regression guard.
+    #[test]
+    fn test_create_group_mixed_invitees_drops_self_remove_requirement() {
+        use openmls::prelude::ProposalType;
+
+        let creator_mdk = create_test_mdk();
+        let modern_mdk = create_test_mdk();
+        let creator = Keys::generate();
+        let modern_member = Keys::generate();
+        let legacy_member = Keys::generate();
+        let creator_pk = creator.public_key();
+
+        let modern_kp = create_key_package_event(&modern_mdk, &modern_member);
+        let legacy_kp = create_legacy_key_package_event(&creator_mdk, &legacy_member);
+
+        let create_result = creator_mdk
+            .create_group(
+                &creator_pk,
+                vec![modern_kp, legacy_kp],
+                create_nostr_group_config_data(vec![creator_pk]),
+            )
+            .expect("mixed-invitee group creation should succeed");
+
+        let group_id = create_result.group.mls_group_id.clone();
+        let mls_group = creator_mdk
+            .load_mls_group(&group_id)
+            .expect("load ok")
+            .expect("group exists");
+
+        let proposal_types: Vec<ProposalType> = mls_group
+            .extensions()
+            .required_capabilities()
+            .map(|rc| rc.proposal_types().to_vec())
+            .unwrap_or_default();
+
+        assert!(
+            !proposal_types.contains(&ProposalType::SelfRemove),
+            "mixed group must not require SelfRemove (got {:?})",
+            proposal_types
+        );
     }
 }

--- a/crates/mdk-core/src/lib.rs
+++ b/crates/mdk-core/src/lib.rs
@@ -40,8 +40,7 @@ pub mod welcomes;
 
 use self::callback::{MdkCallback, RollbackInfo};
 use self::constant::{
-    DEFAULT_CIPHERSUITE, GROUP_CONTEXT_REQUIRED_EXTENSIONS, GROUP_CONTEXT_REQUIRED_PROPOSALS,
-    SUPPORTED_EXTENSIONS, SUPPORTED_PROPOSALS, TAG_PROPOSALS,
+    DEFAULT_CIPHERSUITE, SUPPORTED_EXTENSIONS, SUPPORTED_PROPOSALS, TAG_PROPOSALS,
 };
 use self::epoch_snapshots::EpochSnapshotManager;
 pub use self::error::Error;
@@ -400,16 +399,6 @@ where
             None,
         )
         .with_grease(&self.provider.crypto)
-    }
-
-    /// Get the group's required capabilities extension
-    #[inline]
-    pub(crate) fn required_capabilities_extension(&self) -> Extension {
-        Extension::RequiredCapabilities(RequiredCapabilitiesExtension::new(
-            &GROUP_CONTEXT_REQUIRED_EXTENSIONS,
-            &GROUP_CONTEXT_REQUIRED_PROPOSALS,
-            &[],
-        ))
     }
 
     /// Get the ciphersuite value formatted for Nostr tags (hex with 0x prefix)

--- a/crates/mdk-core/src/test_util.rs
+++ b/crates/mdk-core/src/test_util.rs
@@ -5,11 +5,19 @@
 
 use mdk_storage_traits::GroupId;
 use mdk_storage_traits::MdkStorageProvider;
-use nostr::{Event, EventBuilder, Keys, Kind, PublicKey, RelayUrl};
+use nostr::{Event, EventBuilder, Keys, Kind, PublicKey, RelayUrl, Tag, TagKind};
+use openmls::key_packages::KeyPackage;
+use openmls::prelude::{BasicCredential, Capabilities, CredentialWithKey};
+use openmls_basic_credential::SignatureKeyPair;
+use openmls_traits::OpenMlsProvider;
+use tls_codec::Serialize as TlsSerialize;
 
 use crate::MDK;
-use crate::constant::MLS_KEY_PACKAGE_KIND;
+use crate::constant::{
+    DEFAULT_CIPHERSUITE, MLS_KEY_PACKAGE_KIND, MLS_KEY_PACKAGE_KIND_LEGACY, SUPPORTED_EXTENSIONS,
+};
 use crate::groups::NostrGroupConfigData;
+use crate::util::{ContentEncoding, encode_content};
 
 /// Creates test group members with standard configuration
 ///
@@ -79,6 +87,103 @@ where
         .tags(tags)
         .sign_with_keys(signing_keys)
         .expect("Failed to sign event")
+}
+
+/// Creates a legacy (capability-poor) KeyPackage event for a member.
+///
+/// The produced KeyPackage's `LeafNode.capabilities.proposals` is explicitly
+/// empty (no `SelfRemove`), simulating an older client that predates MIP-03.
+/// This is packaged inside a kind:443 (legacy, pre-May-2026) Nostr event
+/// because the stricter kind:30443 validator requires the `mls_proposals`
+/// tag and an `i` (KeyPackageRef) tag we do not compute here.
+///
+/// `mdk` is only a storage host for the signer; `member_keys` is the signing
+/// identity for the resulting KeyPackage. Tests typically pass a neighbor's
+/// MDK here — the "legacy" party never loads from its own storage.
+///
+/// # Important
+///
+/// This builds the KeyPackage directly via `openmls::KeyPackage::builder()` —
+/// not via `MDK::create_key_package_for_event`, which unconditionally injects
+/// `self.capabilities()` (which advertises `SelfRemove`). Passing `None` for
+/// `Capabilities::new`'s `proposals` argument is also a trap — it falls back
+/// to `Capabilities::default()`, which advertises `SelfRemove`. We pass
+/// `Some(&[])` explicitly.
+pub fn create_legacy_key_package_event<Storage>(mdk: &MDK<Storage>, member_keys: &Keys) -> Event
+where
+    Storage: MdkStorageProvider,
+{
+    let public_key = member_keys.public_key();
+    let public_key_bytes: Vec<u8> = public_key.to_bytes().to_vec();
+
+    // Credential + signer built directly (no capability-injecting helper).
+    let credential = BasicCredential::new(public_key_bytes);
+    let signature_keypair = SignatureKeyPair::new(DEFAULT_CIPHERSUITE.signature_algorithm())
+        .expect("Failed to generate signature keypair");
+    signature_keypair
+        .store(mdk.provider.storage())
+        .expect("Failed to store signature keypair");
+
+    let credential_with_key = CredentialWithKey {
+        credential: credential.into(),
+        signature_key: signature_keypair.public().into(),
+    };
+
+    // Capability-poor leaf: no proposals advertised (no SelfRemove).
+    // Extensions mirror the modern set so the event's mls_extensions tag
+    // remains well-formed and the tag-level validator accepts the event.
+    let capabilities = Capabilities::new(
+        None,
+        Some(&[DEFAULT_CIPHERSUITE]),
+        Some(&SUPPORTED_EXTENSIONS),
+        Some(&[]), // explicit empty: NO SelfRemove
+        None,
+    );
+
+    let key_package_bundle = KeyPackage::builder()
+        .leaf_node_capabilities(capabilities)
+        .mark_as_last_resort()
+        .build(
+            DEFAULT_CIPHERSUITE,
+            &mdk.provider,
+            &signature_keypair,
+            credential_with_key,
+        )
+        .expect("Failed to build legacy key package");
+
+    let serialized = key_package_bundle
+        .key_package()
+        .tls_serialize_detached()
+        .expect("Failed to serialize key package");
+    let content = encode_content(&serialized, ContentEncoding::Base64);
+
+    // Build kind:443 (legacy) event tags. Match the kind:443 shape produced
+    // by MDK's own helper (see `tags_443` in KeyPackageEventData): no `d`,
+    // no `mls_proposals` requirement at parse time.
+    let extensions_hex: Vec<String> = SUPPORTED_EXTENSIONS
+        .iter()
+        .map(|e| format!("0x{:04x}", u16::from(*e)))
+        .collect();
+    let relays = vec![RelayUrl::parse("wss://test.relay").unwrap()];
+    let tags = vec![
+        Tag::custom(TagKind::MlsProtocolVersion, ["1.0"]),
+        Tag::custom(
+            TagKind::MlsCiphersuite,
+            [format!("0x{:04x}", u16::from(DEFAULT_CIPHERSUITE))],
+        ),
+        Tag::custom(TagKind::MlsExtensions, extensions_hex),
+        Tag::relays(relays),
+        Tag::client(format!("legacy-test/{}", env!("CARGO_PKG_VERSION"))),
+        Tag::custom(
+            TagKind::Custom("encoding".into()),
+            [ContentEncoding::Base64.as_tag_value()],
+        ),
+    ];
+
+    EventBuilder::new(MLS_KEY_PACKAGE_KIND_LEGACY, content)
+        .tags(tags)
+        .sign_with_keys(member_keys)
+        .expect("Failed to sign legacy key package event")
 }
 
 /// Creates standard test group configuration data

--- a/crates/mdk-core/src/welcomes.rs
+++ b/crates/mdk-core/src/welcomes.rs
@@ -131,11 +131,8 @@ where
                         has_relays = true;
                     }
                 }
-                kind if kind == TagKind::e() => {
-                    // Check that e tag has non-empty content
-                    if tag.content().is_some() && tag.content() != Some("") {
-                        has_event_ref = true;
-                    }
+                kind if kind == TagKind::e() && tag.content().is_some_and(|c| !c.is_empty()) => {
+                    has_event_ref = true;
                 }
                 TagKind::Client => {
                     // Client tag is optional, but if present its value must be non-empty

--- a/crates/mdk-memory-storage/src/groups.rs
+++ b/crates/mdk-memory-storage/src/groups.rs
@@ -260,9 +260,8 @@ impl GroupStorage for MdkMemoryStorage {
 
         let group_event_keys: Vec<(GroupId, u64)> = inner
             .group_exporter_secrets_cache
-            .iter()
-            .filter_map(|(k, _)| {
-                let (gid, epoch) = k;
+            .keys()
+            .filter_map(|(gid, epoch)| {
                 if gid == group_id && *epoch < min_epoch_to_keep {
                     Some((gid.clone(), *epoch))
                 } else {
@@ -277,9 +276,8 @@ impl GroupStorage for MdkMemoryStorage {
 
         let legacy_group_event_keys: Vec<(GroupId, u64)> = inner
             .group_legacy_exporter_secrets_cache
-            .iter()
-            .filter_map(|(k, _)| {
-                let (gid, epoch) = k;
+            .keys()
+            .filter_map(|(gid, epoch)| {
                 if gid == group_id && *epoch < min_epoch_to_keep {
                     Some((gid.clone(), *epoch))
                 } else {
@@ -294,9 +292,8 @@ impl GroupStorage for MdkMemoryStorage {
 
         let mip04_keys: Vec<(GroupId, u64)> = inner
             .group_mip04_exporter_secrets_cache
-            .iter()
-            .filter_map(|(k, _)| {
-                let (gid, epoch) = k;
+            .keys()
+            .filter_map(|(gid, epoch)| {
                 if gid == group_id && *epoch < min_epoch_to_keep {
                     Some((gid.clone(), *epoch))
                 } else {

--- a/crates/mdk-memory-storage/src/messages.rs
+++ b/crates/mdk-memory-storage/src/messages.rs
@@ -244,8 +244,8 @@ impl MessageStorage for MdkMemoryStorage {
 
         let invalidated: Vec<ProcessedMessage> = inner
             .processed_messages_cache
-            .iter()
-            .filter_map(|(_, pm)| {
+            .values()
+            .filter_map(|pm| {
                 if let Some(ref msg_group_id) = pm.mls_group_id
                     && msg_group_id == group_id
                     && pm.state == ProcessedMessageState::EpochInvalidated

--- a/crates/mdk-memory-storage/src/welcomes.rs
+++ b/crates/mdk-memory-storage/src/welcomes.rs
@@ -43,7 +43,7 @@ impl WelcomeStorage for MdkMemoryStorage {
             .collect();
 
         // Sort by ID (descending) for consistent ordering
-        welcomes.sort_by(|a, b| b.id.cmp(&a.id));
+        welcomes.sort_by_key(|w| std::cmp::Reverse(w.id));
 
         // Apply pagination
         let welcomes: Vec<Welcome> = welcomes.into_iter().skip(offset).take(limit).collect();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR changes how group RequiredCapabilities are computed so invitee capabilities are intersected (LCD) at group creation, unblocking mixed-version invites that were previously forced to require SelfRemove; it also updates leave/self-update behavior to honor per-group capabilities, removes now-unused helpers/constants, refreshes rotated-leaf capability advertising, and adds tests and a legacy KeyPackage test helper to validate mixed/legacy scenarios. These changes focus on capability/extension handling and test utilities rather than cryptographic primitives or storage of secrets.

**What changed**:
- create_group now pre-parses invitee KeyPackages and computes the group's RequiredCapabilities.proposal_types as the least-common-denominator intersection of SUPPORTED_PROPOSALS with each invitee's advertised proposals, embedding that as the RequiredCapabilities extension (crates/mdk-core).  
- leave_group / try_self_remove now consult the group's RequiredCapabilities and fall back to an admin-committable legacy Remove when ProposalType::SelfRemove is not included, preserving the existing PURE_CIPHERTEXT wire-format fallback (crates/mdk-core).  
- self_update now uses MDK::capabilities() for rotated LeafNodeParameters so rotated leaves advertise the MDK capability set rather than cloning the old leaf capabilities (crates/mdk-core).  
- Removed the dead GROUP_CONTEXT_REQUIRED_PROPOSALS constant and the crate-private MDK::required_capabilities_extension() helper, moving responsibility to per-call-site LCD computation (crates/mdk-core).  
- Added create_legacy_key_package_event test helper to emit capability-poor legacy KeyPackage events (kind:443) for tests and expanded unit tests covering LCD-based RequiredCapabilities, leave/self-remove fallback, self_update behavior, ciphertext/exporter-secret persistence, and mixed/legacy regressions (crates/mdk-core).  
- Minor internal iterator/sorting cleanups in mdk-memory-storage (prune/exporter-secret key iteration, processed message iteration, pending-welcomes sort) with no behavioral change (crates/mdk-memory-storage).

**Security impact**:
- No changes to cryptographic primitives, key derivation, AEAD, HKDF contexts, SQLCipher configuration, file permissions, or secret storage semantics.  
- Rotated leaves now advertise the current MDK capabilities (protocol behavior change) but this does not expose secret material or change key management.

**Protocol changes**:
- Group RequiredCapabilities semantics now reflect the LCD of invitee-advertised proposals, affecting MLS admission/extension behavior (notably whether SelfRemove is required) and interacting with OpenMLS admission checks and MIP-03-related compatibility scenarios.  
- Nostr integration: test tooling added to emit legacy kind:443 KeyPackage events to model pre-MIP-03 clients; no production wire-format changes beyond testing helpers.

**API surface**:
- Removed public constant GROUP_CONTEXT_REQUIRED_PROPOSALS from crates/mdk-core/src/constant.rs.  
- Removed crate-private method MDK::required_capabilities_extension() from crates/mdk-core/src/lib.rs.  
- Added public test helper fn create_legacy_key_package_event<Storage>(mdk: &MDK<Storage>, member_keys: &Keys) -> Event in crates/mdk-core/src/test_util.rs.  
- No storage schema, UniFFI/FFI boundary, or other public API breaking changes beyond the above removals/addition.

**Testing**:
- Added and expanded unit tests in crates/mdk-core for RequiredCapabilities computation at group creation, leave/self-remove fallback under capability constraints, self_update capability refresh, ciphertext/exporter-secret persistence checks, and mixed/legacy regression scenarios, and introduced a legacy KeyPackage event test helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->