### PR TITLE
fix(ci): unbreak binding builds on Linux and Swift package push

### DIFF
--- a/.github/workflows/package-mdk-bindings.yml
+++ b/.github/workflows/package-mdk-bindings.yml
@@ -85,6 +85,14 @@ jobs:
         # Copy package contents
         cp -R swift/MDKPackage/* swift-package-repo/
         cd swift-package-repo
+
+        # Track .a archives via Git LFS — iOS static archives can exceed GitHub's
+        # 100 MB hard push limit even with fat LTO + strip. Configure LFS before
+        # adding files so they're staged through LFS, not as raw blobs.
+        git lfs install
+        git lfs track "*.a"
+        git add .gitattributes
+
         git add -A
 
     - name: Commit and push

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,4 +82,4 @@ opt-level = "z"      # Optimize for binary size over speed
 lto = "thin"         # Thin LTO: cross-crate optimization without embedding full IR in .a archives
 codegen-units = 1    # Single codegen unit for maximum optimization
 panic = "abort"      # No unwinding machinery; safe at UniFFI FFI boundary
-strip = true         # Strip all symbols from the output binary
+strip = "debuginfo"  # Strip DWARF debug info but keep .symtab — uniffi-bindgen --library reads UNIFFI_META_* symbols from it on Linux

--- a/crates/mdk-uniffi/CHANGELOG.md
+++ b/crates/mdk-uniffi/CHANGELOG.md
@@ -52,6 +52,8 @@
 - Removed the Swift package's explicit system `sqlite3` link and linked the native frameworks required by the bundled SQLCipher provider instead. ([#252](https://github.com/marmot-protocol/mdk/pull/252))
 - Removed redundant `cargo build` steps from Swift, Python, and Ruby binding CI jobs that duplicated work already done by `_build-uniffi`. ([`#232`](https://github.com/marmot-protocol/mdk/pull/232))
 - Fixed stale `release-size` artifact paths in Kotlin and Swift binding generation recipes. ([`#232`](https://github.com/marmot-protocol/mdk/pull/232))
+- Unbroke binding builds on Linux: switched `[profile.release].strip` from `true` to `"debuginfo"` so `uniffi-bindgen --library` can still read `UNIFFI_META_*` symbols from the cdylib's `.symtab` (GNU strip's `--strip-all` was removing them, which silently produced empty Kotlin/Ruby/Python binding output). DWARF debug info is still stripped, so the binary-size cost is small. ([`#267`](https://github.com/marmot-protocol/mdk/pull/267))
+- Switched iOS bindings to fat LTO (`CARGO_PROFILE_RELEASE_LTO=fat`, mirroring Android) so the static `.a` archives no longer embed per-module thin-LTO bitcode. This shrinks `libmdk_uniffi.a` back below GitHub's 100 MB push limit. The Swift package workflow also configures `git lfs track "*.a"` as a defensive safety net. ([`#267`](https://github.com/marmot-protocol/mdk/pull/267))
 
 ### Removed
 

--- a/justfile
+++ b/justfile
@@ -167,7 +167,10 @@ _build-uniffi-ios TARGET:
     # the system Clang defaults to the current SDK version (e.g. 18.5), which emits
     # symbols like ___chkstk_darwin that are unavailable at the linker's deployment target,
     # causing "undefined symbol" link errors.
-    IPHONEOS_DEPLOYMENT_TARGET=15.0 cargo build --release --lib -p mdk-uniffi --target {{TARGET}}
+    #
+    # Fat LTO for iOS: avoids embedding per-module bitcode in the static .a archive,
+    # which would otherwise push it past GitHub's 100 MB push limit. Mirrors Android.
+    IPHONEOS_DEPLOYMENT_TARGET=15.0 CARGO_PROFILE_RELEASE_LTO=fat cargo build --release --lib -p mdk-uniffi --target {{TARGET}}
 
 _build-uniffi-android TARGET CLANG_PREFIX:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

The `Package MDK Bindings` workflow has been fully red since [#221](https://github.com/marmot-protocol/mdk/pull/221) (March 20). Most recent failing run: [actions/runs/25085175919](https://github.com/marmot-protocol/mdk/actions/runs/25085175919). This PR fixes all four failing job classes.

## Root causes & fixes

### 1. Kotlin / Ruby (ubuntu) / Python (ubuntu) — `cp: ... mdk_uniffi.{kt,rb,py}: No such file or directory`

`[profile.release].strip = true` tells cargo to invoke `--strip-all` on the cdylib. On Linux ELF, that wipes `.symtab` — which is where the `UNIFFI_META_*` symbols live. `uniffi-bindgen --library` reads those symbols to discover the namespace, so when they're gone it silently writes nothing and exits 0. The next step (`cp .../mdk_uniffi.py ...`) then fails because the file was never produced.

Apple's Mach-O `strip` is conservative and keeps these symbols, which is why every macOS job passed and only Linux failed.

**Fix:** `strip = "debuginfo"` in `Cargo.toml`. Strips DWARF (the bulk of the size win) while preserving the static symtab so bindgen can still find namespaces.

Verified locally: re-ran `just gen-binding python` and `just gen-binding-ruby` — both now emit the binding source files.

### 2. Swift — `File libmdk_uniffi.a is 109 MB; this exceeds GitHub's file size limit of 100 MB`

`lto = "thin"` embeds per-module LLVM bitcode in static archives so downstream consumers can do thin LTO. That bitcode pushes the iOS `.a` from ~30 MB to ~109 MB, past GitHub's hard 100 MB push limit. The Swift workflow had no LFS configured, so the push was rejected.

**Fixes:**
- `CARGO_PROFILE_RELEASE_LTO=fat` for iOS builds in the justfile (mirrors what Android already does). Cross-crate LTO happens at link time, so the archive doesn't carry bitcode.
- `git lfs track \"*.a\"` in the swift-package-repo before staging, as a safety net. The Kotlin job already does the equivalent for `*.so`.

## Files changed

- `Cargo.toml` — `strip = true` → `strip = \"debuginfo\"`
- `justfile` — fat LTO env var on iOS cargo invocation
- `.github/workflows/package-mdk-bindings.yml` — `git lfs install` + `git lfs track \"*.a\"` before commit in the Swift job

## Test plan

- [ ] CI run of `Package MDK Bindings` passes end-to-end on this branch
- [ ] Inspect the published `mdk-swift` and `mdk-kotlin` repos after merge to confirm package contents are correct
- [ ] Spot-check artifact sizes: iOS `.a` should drop substantially from 109 MB; Linux `.so` will grow modestly (debug-info-only strip preserves the symtab)

## Notes for reviewers

- The size cost of dropping symbol stripping is small in absolute terms (~2 MB on macOS dylib in local testing) — DWARF stripping accounts for nearly all of the savings.
- Fat LTO + opt-level=z is what we already use for Android. iOS now matches.
- The LFS step is defensive: with fat LTO the `.a` should fit under 100 MB, but if it ever creeps back up the push won't fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/267">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes failing jobs in the "Package MDK Bindings" CI workflow by addressing two build issues: a Linux bindgen failure caused by over-aggressive symbol stripping, and an iOS Swift package push failure caused by thin-LTO bitcode inflating static archives above GitHub's 100 MB limit. Changes preserve UniFFI metadata in Linux artifacts and prevent oversized iOS archives, with an added Git LFS safety net for .a files.

**What changed**:
- Cargo.toml: release profile changed from `strip = true` to `strip = "debuginfo"` so ELF .symtab (containing UNIFFI_META_* symbols) is preserved for uniffi-bindgen on Linux (affects crates/mdk-uniffi).
- justfile: iOS uniffi build recipe sets `CARGO_PROFILE_RELEASE_LTO=fat` for the iOS static library build to avoid embedding per-module thin-LTO bitcode in `.a` archives (affects mdk-uniffi build invocation).
- .github/workflows/package-mdk-bindings.yml: Swift package job now runs `git lfs install` and `git lfs track "*.a"` before committing the copied Swift package so iOS `.a` files are tracked via Git LFS.
- crates/mdk-uniffi/CHANGELOG.md: added entries documenting these binding-build fixes.

**Security impact**:
- None of the changes touch cryptography, key handling, identity, error messages leaking secrets, or file-permission/SQLCipher configuration.

**Protocol changes**:
- None.

**API surface**:
- No public API, FFI, or storage schema changes; only build configuration changes to mdk-uniffi artifacts.

**Testing**:
- CI "Package MDK Bindings" should be run end-to-end on this branch; local verification reported with `just gen-binding python` and `just gen-binding-ruby`; reviewers should spot-check artifact sizes (iOS `.a` expected to shrink, Linux `.so` may grow slightly).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->