### PR TITLE
feat(mdk-core): expose test_util module behind a test-utils Cargo feature

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 ### Added
 
+- Added `test-utils` Cargo feature on `mdk-core` exposing the existing `test_util` module (notably `create_legacy_key_package_event`) so downstream crates can build legacy-LeafNode fixtures without a `cfg(test)` workaround. ([#269](https://github.com/marmot-protocol/mdk/pull/269))
 - **GroupContextExtensions upgrade path.** Three new public methods on `MDK` let client UX prompt an admin to upgrade a mixed group that has since become all-modern:
   - `group_member_capabilities(&GroupId) -> Result<Vec<MemberCapabilities>, Error>` — per-member advertised proposal types, extension types, ciphersuites, and admin flag. Proposal and extension capabilities are returned as `BTreeSet`s. Any member may call it.
   - `group_capability_upgrade_status(&GroupId) -> Result<CapabilityUpgradeStatus, Error>` — per-proposal upgrade readiness. Each entry in `SUPPORTED_PROPOSALS` is reported as `AlreadyRequired`, `Available`, or `Blocked { blockers: Vec<PublicKey> }`. Any member may call it.

--- a/crates/mdk-core/Cargo.toml
+++ b/crates/mdk-core/Cargo.toml
@@ -17,6 +17,7 @@ default = []
 mip04 = []
 mip05 = ["nostr/nip59"]
 debug-examples = []
+test-utils = ["mdk-storage-traits/test-utils"]
 
 [dependencies]
 mdk-macros.workspace = true

--- a/crates/mdk-core/src/lib.rs
+++ b/crates/mdk-core/src/lib.rs
@@ -33,7 +33,8 @@ pub mod messages;
 pub mod mip05;
 pub mod prelude;
 mod state_validation;
-#[cfg(test)]
+#[cfg(any(test, feature = "test-utils"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-utils")))]
 pub mod test_util;
 mod util;
 pub mod welcomes;


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/269">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a feature-gated export of the existing test_util module in mdk-core so downstream crates can use test helpers (e.g., create_legacy_key_package_event) without relying on cfg(test) workarounds. It does this by introducing a new Cargo feature "test-utils" and gating the test_util module on either test builds or that feature, with docs.rs metadata for the feature.

**What changed**:
- Added a new "test-utils" feature to crates/mdk-core/Cargo.toml that enables mdk-storage-traits/test-utils.
- Changed crates/mdk-core/src/lib.rs to compile and publicly expose pub mod test_util under #[cfg(any(test, feature = "test-utils"))] and added #[cfg_attr(docsrs, doc(cfg(feature = "test-utils")))].
- Updated crates/mdk-core/CHANGELOG.md with an entry documenting the new feature.
- Dev-dependencies already include storage crates with test-utils enabled (mdk-storage-traits, mdk-memory-storage, mdk-sqlite-storage) so downstream test usage is supported.

**Security impact**:
- None: no cryptographic, key handling, file-permission, or SQLCipher changes.

**Protocol changes**:
- None: no MLS, Nostr, or MIP protocol semantics were modified.

**API surface**:
- New optional public API surface when the feature is enabled: the previously test-only test_util module (exposes helpers like create_legacy_key_package_event) is now accessible to downstream crates via the "test-utils" feature; this is additive and feature-gated (no breaking changes).

**Testing**:
- No tests added in this PR, but dev-dependencies for storage test features are present and the change enables downstream crates to reuse mdk-core test helpers in their test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->