### PR TITLE
[codex] Encode SQLite keys for keyring storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
 name = "mdk-sqlite-storage"
 version = "0.7.1"
 dependencies = [
+ "base64",
  "getrandom 0.4.2",
  "hex",
  "keyring-core",

--- a/crates/mdk-sqlite-storage/CHANGELOG.md
+++ b/crates/mdk-sqlite-storage/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 ### Fixed
 
+- Stored new SQLite database keyring payloads as prefixed base64 while continuing to read and migrate legacy raw 32-byte keyring entries. ([#270](https://github.com/marmot-protocol/mdk/pull/270))
 - Added runtime SQLCipher verification and a post-migration file header check so encrypted storage fails closed if linked against a SQLite provider without active SQLCipher support. ([#252](https://github.com/marmot-protocol/mdk/pull/252))
 - Treated only `:memory:` and empty paths as special SQLite paths, so colon-prefixed filenames still receive secure permissions and encrypted database verification. ([#252](https://github.com/marmot-protocol/mdk/pull/252))
 

--- a/crates/mdk-sqlite-storage/Cargo.toml
+++ b/crates/mdk-sqlite-storage/Cargo.toml
@@ -17,6 +17,7 @@ default = []
 test-utils = []
 
 [dependencies]
+base64.workspace = true
 getrandom.workspace = true
 hex = { workspace = true, features = ["std"] }
 keyring-core.workspace = true

--- a/crates/mdk-sqlite-storage/src/keyring.rs
+++ b/crates/mdk-sqlite-storage/src/keyring.rs
@@ -48,6 +48,7 @@ use crate::error::Error;
 /// simultaneously, only one will generate and store it.
 static KEY_GENERATION_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
+// v1 stores the raw 32-byte SQLCipher key as RFC 4648 base64.
 const DB_KEY_KEYRING_PREFIX: &str = "mdk-sqlite-key-v1:";
 
 enum DecodedDbKey {
@@ -59,6 +60,8 @@ fn encode_db_key_for_keyring(config: &EncryptionConfig) -> Vec<u8> {
     format!("{DB_KEY_KEYRING_PREFIX}{}", BASE64.encode(config.key())).into_bytes()
 }
 
+/// Decode current prefixed payloads first; non-UTF-8 payloads and UTF-8 payloads
+/// without the prefix are both handled by the legacy raw-key path.
 fn decode_db_key_from_keyring(secret: &[u8]) -> Result<DecodedDbKey, Error> {
     match std::str::from_utf8(secret) {
         Ok(secret_text) => match secret_text.strip_prefix(DB_KEY_KEYRING_PREFIX) {
@@ -96,7 +99,7 @@ fn decode_legacy_db_key(secret: &[u8]) -> Result<DecodedDbKey, Error> {
     }
 }
 
-fn store_db_key(entry: &Entry, config: &EncryptionConfig) -> Result<(), Error> {
+fn save_db_key(entry: &Entry, config: &EncryptionConfig) -> Result<(), Error> {
     let payload = encode_db_key_for_keyring(config);
     entry.set_secret(&payload).map_err(|e| match e {
         KeyringError::NoStorageAccess(err) => Error::KeyringNotInitialized(err.to_string()),
@@ -180,7 +183,7 @@ pub fn get_or_create_db_key(service_id: &str, db_key_id: &str) -> Result<Encrypt
         ))
     })?;
 
-    store_db_key(&entry, &config)?;
+    save_db_key(&entry, &config)?;
 
     Ok(config)
 }
@@ -214,7 +217,7 @@ pub fn get_db_key(service_id: &str, db_key_id: &str) -> Result<Option<Encryption
             let config = match decode_db_key_from_keyring(&secret)? {
                 DecodedDbKey::Current(config) => config,
                 DecodedDbKey::LegacyRaw(config) => {
-                    if let Err(e) = store_db_key(&entry, &config) {
+                    if let Err(e) = save_db_key(&entry, &config) {
                         tracing::warn!(
                             error = %e,
                             "Failed to migrate legacy database encryption key to encoded keyring payload"
@@ -370,6 +373,10 @@ mod tests {
         let stored_payload_text = str::from_utf8(&stored_payload).unwrap();
         assert_ne!(stored_payload.as_slice(), &legacy_key);
         assert!(stored_payload_text.starts_with(DB_KEY_KEYRING_PREFIX));
+
+        let migrated = get_db_key(service_id, db_key_id).unwrap().unwrap();
+        assert_eq!(migrated.key(), &legacy_key);
+        assert_eq!(entry.get_secret().unwrap(), stored_payload);
 
         delete_db_key(service_id, db_key_id).unwrap();
     }
@@ -592,7 +599,7 @@ mod tests {
         // Clean up any existing key
         let _ = delete_db_key(service_id, db_key_id);
 
-        // Manually store an invalid key (wrong length) in the keyring
+        // Manually store an invalid legacy payload with no prefix and the wrong length.
         let entry = Entry::new(service_id, db_key_id).unwrap();
         entry.set_secret(b"short_key").unwrap(); // Only 9 bytes, not 32
 
@@ -609,7 +616,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_db_key_with_invalid_key_in_keyring_returns_error() {
+    fn test_get_db_key_with_invalid_legacy_key_length_returns_error() {
         ensure_mock_store();
 
         let service_id = "test.mdk.storage.invalidget";
@@ -618,11 +625,9 @@ mod tests {
         // Clean up any existing key
         let _ = delete_db_key(service_id, db_key_id);
 
-        // Manually store an invalid key (wrong length) in the keyring
+        // Manually store an invalid legacy payload with no prefix and the wrong length.
         let entry = Entry::new(service_id, db_key_id).unwrap();
-        entry
-            .set_secret(b"this_is_too_long_a_key_for_our_32_byte_requirement")
-            .unwrap();
+        entry.set_secret(&[0x42u8; 33]).unwrap();
 
         // get_db_key should fail because the stored key is invalid
         let result = get_db_key(service_id, db_key_id);

--- a/crates/mdk-sqlite-storage/src/keyring.rs
+++ b/crates/mdk-sqlite-storage/src/keyring.rs
@@ -35,6 +35,8 @@
 
 use std::sync::{Mutex, OnceLock};
 
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use keyring_core::{Entry, Error as KeyringError};
 
 use crate::encryption::EncryptionConfig;
@@ -46,10 +48,73 @@ use crate::error::Error;
 /// simultaneously, only one will generate and store it.
 static KEY_GENERATION_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
+const DB_KEY_KEYRING_PREFIX: &str = "mdk-sqlite-key-v1:";
+
+enum DecodedDbKey {
+    Current(EncryptionConfig),
+    LegacyRaw(EncryptionConfig),
+}
+
+fn encode_db_key_for_keyring(config: &EncryptionConfig) -> Vec<u8> {
+    format!("{DB_KEY_KEYRING_PREFIX}{}", BASE64.encode(config.key())).into_bytes()
+}
+
+fn decode_db_key_from_keyring(secret: &[u8]) -> Result<DecodedDbKey, Error> {
+    match std::str::from_utf8(secret) {
+        Ok(secret_text) => match secret_text.strip_prefix(DB_KEY_KEYRING_PREFIX) {
+            Some(encoded_key) => decode_current_db_key(encoded_key),
+            None => decode_legacy_db_key(secret),
+        },
+        Err(_) => decode_legacy_db_key(secret),
+    }
+}
+
+fn decode_current_db_key(encoded_key: &str) -> Result<DecodedDbKey, Error> {
+    let key = BASE64.decode(encoded_key).map_err(|_| {
+        Error::Keyring("Stored key has invalid encoded keyring payload".to_string())
+    })?;
+    let config = EncryptionConfig::from_slice(&key).map_err(|e| {
+        Error::Keyring(format!(
+            "Stored key has invalid length after decoding encoded keyring payload: {}",
+            e
+        ))
+    })?;
+    Ok(DecodedDbKey::Current(config))
+}
+
+fn decode_legacy_db_key(secret: &[u8]) -> Result<DecodedDbKey, Error> {
+    match secret.len() {
+        32 => {
+            let config = EncryptionConfig::from_slice(secret)
+                .map_err(|e| Error::Keyring(format!("Stored key has invalid length: {}", e)))?;
+            Ok(DecodedDbKey::LegacyRaw(config))
+        }
+        len => Err(Error::Keyring(format!(
+            "Stored key has invalid length (expected encoded keyring payload or 32-byte legacy key, got {} bytes)",
+            len
+        ))),
+    }
+}
+
+fn store_db_key(entry: &Entry, config: &EncryptionConfig) -> Result<(), Error> {
+    let payload = encode_db_key_for_keyring(config);
+    entry.set_secret(&payload).map_err(|e| match e {
+        KeyringError::NoStorageAccess(err) => Error::KeyringNotInitialized(err.to_string()),
+        other => Error::Keyring(format!(
+            "Failed to store encryption key in keyring: {}",
+            other
+        )),
+    })
+}
+
 /// Gets an existing database encryption key or generates and stores a new one.
 ///
 /// This function uses the `keyring-core` API to securely store encryption keys
 /// in the platform's native credential store (Keychain, Keystore, etc.).
+/// New keys are stored as UTF-8-safe, version-prefixed base64 payloads. Existing
+/// raw 32-byte keyring payloads are still accepted and migrated after a successful
+/// read. If that legacy rewrite fails, the existing key is returned and the
+/// migration failure is logged so callers are not locked out of readable databases.
 ///
 /// # Arguments
 ///
@@ -115,13 +180,7 @@ pub fn get_or_create_db_key(service_id: &str, db_key_id: &str) -> Result<Encrypt
         ))
     })?;
 
-    entry.set_secret(config.key()).map_err(|e| match e {
-        KeyringError::NoStorageAccess(err) => Error::KeyringNotInitialized(err.to_string()),
-        other => Error::Keyring(format!(
-            "Failed to store encryption key in keyring: {}",
-            other
-        )),
-    })?;
+    store_db_key(&entry, &config)?;
 
     Ok(config)
 }
@@ -152,12 +211,18 @@ pub fn get_db_key(service_id: &str, db_key_id: &str) -> Result<Option<Encryption
     match entry.get_secret() {
         Ok(secret) => {
             // Key exists, validate and return it
-            let config = EncryptionConfig::from_slice(&secret).map_err(|e| {
-                Error::Keyring(format!(
-                    "Stored key has invalid length (expected 32 bytes): {}",
-                    e
-                ))
-            })?;
+            let config = match decode_db_key_from_keyring(&secret)? {
+                DecodedDbKey::Current(config) => config,
+                DecodedDbKey::LegacyRaw(config) => {
+                    if let Err(e) = store_db_key(&entry, &config) {
+                        tracing::warn!(
+                            error = %e,
+                            "Failed to migrate legacy database encryption key to encoded keyring payload"
+                        );
+                    }
+                    config
+                }
+            };
             Ok(Some(config))
         }
         Err(KeyringError::NoEntry) => Ok(None),
@@ -221,10 +286,17 @@ pub fn delete_db_key(service_id: &str, db_key_id: &str) -> Result<(), Error> {
 
 #[cfg(test)]
 mod tests {
-    use std::thread;
+    use std::{str, thread};
+
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64;
 
     use super::*;
     use crate::test_utils::ensure_mock_store;
+
+    fn encoded_payload_for_key(key: &[u8; 32]) -> Vec<u8> {
+        format!("{DB_KEY_KEYRING_PREFIX}{}", BASE64.encode(key)).into_bytes()
+    }
 
     #[test]
     fn test_get_or_create_generates_key_if_missing() {
@@ -240,12 +312,113 @@ mod tests {
         let config1 = get_or_create_db_key(service_id, db_key_id).unwrap();
         assert_eq!(config1.key().len(), 32);
 
+        let stored_payload = Entry::new(service_id, db_key_id)
+            .unwrap()
+            .get_secret()
+            .unwrap();
+        let stored_payload_text = str::from_utf8(&stored_payload).unwrap();
+        assert_ne!(stored_payload.as_slice(), config1.key());
+        assert_ne!(stored_payload.len(), 32);
+        assert!(stored_payload_text.starts_with(DB_KEY_KEYRING_PREFIX));
+
         // Calling again should return the same key
         let config2 = get_or_create_db_key(service_id, db_key_id).unwrap();
         assert_eq!(config1.key(), config2.key());
 
         // Clean up
         delete_db_key(service_id, db_key_id).unwrap();
+    }
+
+    #[test]
+    fn test_get_db_key_reads_encoded_keyring_payload() {
+        ensure_mock_store();
+
+        let service_id = "test.mdk.storage.encoded";
+        let db_key_id = "test.key.encoded";
+        let config = EncryptionConfig::new([0x42u8; 32]);
+
+        let _ = delete_db_key(service_id, db_key_id);
+
+        let entry = Entry::new(service_id, db_key_id).unwrap();
+        entry
+            .set_secret(&encoded_payload_for_key(config.key()))
+            .unwrap();
+
+        let retrieved = get_db_key(service_id, db_key_id).unwrap().unwrap();
+        assert_eq!(retrieved.key(), config.key());
+
+        delete_db_key(service_id, db_key_id).unwrap();
+    }
+
+    #[test]
+    fn test_get_db_key_migrates_legacy_raw_keyring_payload() {
+        ensure_mock_store();
+
+        let service_id = "test.mdk.storage.legacy";
+        let db_key_id = "test.key.legacy";
+        let legacy_key = [0x7bu8; 32];
+
+        let _ = delete_db_key(service_id, db_key_id);
+
+        let entry = Entry::new(service_id, db_key_id).unwrap();
+        entry.set_secret(&legacy_key).unwrap();
+
+        let retrieved = get_db_key(service_id, db_key_id).unwrap().unwrap();
+        assert_eq!(retrieved.key(), &legacy_key);
+
+        let stored_payload = entry.get_secret().unwrap();
+        let stored_payload_text = str::from_utf8(&stored_payload).unwrap();
+        assert_ne!(stored_payload.as_slice(), &legacy_key);
+        assert!(stored_payload_text.starts_with(DB_KEY_KEYRING_PREFIX));
+
+        delete_db_key(service_id, db_key_id).unwrap();
+    }
+
+    #[test]
+    fn test_get_or_create_with_invalid_encoded_payload_returns_error_without_replacement() {
+        ensure_mock_store();
+
+        let service_id = "test.mdk.storage.invalidencoded";
+        let db_key_id = "test.key.invalidencoded";
+        let invalid_payload = b"mdk-sqlite-key-v1:not-valid-base64!!!";
+
+        let _ = delete_db_key(service_id, db_key_id);
+
+        let entry = Entry::new(service_id, db_key_id).unwrap();
+        entry.set_secret(invalid_payload).unwrap();
+
+        let result = get_or_create_db_key(service_id, db_key_id);
+        assert!(
+            result.is_err(),
+            "Should fail when keyring contains invalid encoded key"
+        );
+        assert!(result.unwrap_err().to_string().contains("encoded"));
+        assert_eq!(entry.get_secret().unwrap(), invalid_payload);
+
+        let _ = delete_db_key(service_id, db_key_id);
+    }
+
+    #[test]
+    fn test_get_db_key_with_invalid_encoded_key_length_returns_error() {
+        ensure_mock_store();
+
+        let service_id = "test.mdk.storage.invalidencodedlength";
+        let db_key_id = "test.key.invalidencodedlength";
+        let invalid_payload = format!("{DB_KEY_KEYRING_PREFIX}{}", BASE64.encode([0x9au8; 31]));
+
+        let _ = delete_db_key(service_id, db_key_id);
+
+        let entry = Entry::new(service_id, db_key_id).unwrap();
+        entry.set_secret(invalid_payload.as_bytes()).unwrap();
+
+        let result = get_db_key(service_id, db_key_id);
+        assert!(
+            result.is_err(),
+            "Should fail when encoded keyring payload decodes to wrong length"
+        );
+        assert!(result.unwrap_err().to_string().contains("invalid length"));
+
+        let _ = delete_db_key(service_id, db_key_id);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Store new `mdk-sqlite-storage` database keyring payloads as UTF-8-safe `mdk-sqlite-key-v1:<base64>` values instead of raw 32-byte keys.
- Read the encoded format first, while preserving legacy raw 32-byte payload compatibility.
- Migrate legacy raw keyring entries to the encoded format after successful reads, without generating replacement keys for invalid existing payloads.
- Add the `mdk-sqlite-storage` changelog entry for this compatibility fix.

Fixes #268.

## Validation

- `cargo fmt`
- `cargo test -p mdk-sqlite-storage keyring --no-default-features`
- `just precommit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
⚠️ Security-sensitive changes

This PR changes how SQLite database encryption keys are stored in the keyring: raw 32-byte binary keys are replaced by a versioned, UTF-8-safe prefixed base64 encoding to ensure compatibility with string-only keyring backends, while preserving compatibility with and migrating legacy raw entries. The implementation prefers the new prefixed format when reading, falls back to legacy 32-byte payloads, and rewrites successful legacy reads into the encoded format without regenerating keys for unrecognized/invalid payloads.

**What changed**:
- Database encryption keys stored in the keyring are now encoded as prefixed base64 strings ("mdk-sqlite-key-v1:<base64>") instead of raw 32-byte secrets in the mdk-sqlite-storage crate.
- Added helper functions to encode/decode the DB key payload and a save_db_key helper that writes the encoded payload via keyring-core.
- get_db_key now attempts to decode the prefixed encoded payload first, falls back to legacy raw 32-byte payloads, and migrates legacy entries by re-saving them in the encoded format after successful reads.
- get_or_create_db_key uses the new save helper when generating and storing new keys (with an in-process lock to avoid races).
- Added base64 dependency to crates/mdk-sqlite-storage/Cargo.toml and updated CHANGELOG.md documenting the fix.

**Security impact**:
- Key storage format changed from binary to a versioned, prefixed base64 encoding to ensure UTF-8 safety across keyring backends, reducing platform compatibility issues that could prevent secure storage.
- Legacy 32-byte raw keys are accepted and automatically migrated to the encoded format after successful reads, reducing persistence of raw binary key material in keyrings.
- Invalid or unrecognized payloads (e.g., malformed base64, wrong lengths) return clear keyring errors and do not trigger key regeneration, preventing accidental replacement of keys that could render encrypted databases unreadable.
- No changes to cryptographic algorithms, key derivation, SQLCipher configuration, or file permission logic.

**API surface**:
- No breaking changes to public function signatures or exported types; changes are internal to mdk-sqlite-storage's keyring integration.
- No UniFFI/FFI or storage schema changes.

**Testing**:
- Tests added/updated in mdk-sqlite-storage to cover: new encoded payload storage, reading encoded payloads, migration of legacy raw 32-byte entries to encoded form, failure behavior for invalid encoded payloads (no replacement), and other legacy-length handling; tests use the crate's mock keyring store for deterministic assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->