### PR TITLE
Prep 0.8.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "mdk-core"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "base64",
  "blurhash",
@@ -1907,11 +1907,11 @@ dependencies = [
 
 [[package]]
 name = "mdk-macros"
-version = "0.7.1"
+version = "0.8.0"
 
 [[package]]
 name = "mdk-memory-storage"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "lru",
  "mdk-storage-traits",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "mdk-sqlite-storage"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "base64",
  "getrandom 0.4.2",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "mdk-storage-traits"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "nostr",
  "openmls",
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "mdk-uniffi"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ rust-version = "1.90.0"
 
 [workspace.dependencies]
 # Internal crates
-mdk-memory-storage = { version = "0.7.1", path = "./crates/mdk-memory-storage", default-features = false }
-mdk-sqlite-storage = { version = "0.7.1", path = "./crates/mdk-sqlite-storage", default-features = false }
-mdk-storage-traits = { version = "0.7.1", path = "./crates/mdk-storage-traits", default-features = false }
-mdk-core = { version = "0.7.1", path = "./crates/mdk-core", default-features = false }
-mdk-macros = { version = "0.7.1", path = "./crates/mdk-macros" }
+mdk-memory-storage = { version = "0.8.0", path = "./crates/mdk-memory-storage", default-features = false }
+mdk-sqlite-storage = { version = "0.8.0", path = "./crates/mdk-sqlite-storage", default-features = false }
+mdk-storage-traits = { version = "0.8.0", path = "./crates/mdk-storage-traits", default-features = false }
+mdk-core = { version = "0.8.0", path = "./crates/mdk-core", default-features = false }
+mdk-macros = { version = "0.8.0", path = "./crates/mdk-macros" }
 
 # OpenMLS family — pinned to a post-#1959 rev for public
 # `MlsGroup::treesync().full_leaves()` (merged upstream 2026-02-16).

--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -15,9 +15,6 @@
 
 ### Added
 
-- Added feature-gated `mip05` protocol primitives in `mdk-core`, including typed token payloads, strict token encryption/decryption helpers, and rumor build/parse helpers for MIP-05 `kind:447`, `kind:448`, and `kind:449`. ([#235](https://github.com/marmot-protocol/mdk/pull/235))
-- Added public MLS leaf-index helpers via `process_message_with_context`, `own_leaf_index`, and `group_leaf_map` so clients can access sender, local, and active group leaf positions without ratchet-tree workarounds. ([#235](https://github.com/marmot-protocol/mdk/pull/235))
-
 ### Fixed
 
 ### Removed
@@ -28,18 +25,32 @@
 
 ### Breaking changes
 
-- **MIP-05 push token wire format enlarged and validation relaxed**: `TOKEN_PLAINTEXT_LEN` increased from 220 to 1024 bytes (`ENCRYPTED_TOKEN_LEN` from 280 to 1084) to accommodate real-world FCM tokens (observed up to ~312 bytes) and future UnifiedPush endpoints (spec max 1000 bytes). Device tokens are now treated as opaque variable-length bytes with no per-platform length constraints — only non-empty and within wire-format capacity. `InvalidApnsTokenLength` and `InvalidFcmTokenLength` error variants replaced by a single `InvalidDeviceTokenLength`. `MAX_NOTIFICATION_REQUEST_TOKENS` reduced from 100 to 25 to stay within the NIP-44 plaintext limit at the larger token size.
-- **MIP-00 KeyPackage event kind migrated from `kind:443` to `kind:30443`**: KeyPackage events are now addressable (NIP-33) instead of regular events. A `d` tag with a random 32-byte hex identifier is included in every KeyPackage event, enabling relay-side replacement for rotation without explicit NIP-09 deletion. `create_key_package_for_event` and `create_key_package_for_event_with_options` now return a `KeyPackageEventData` struct instead of a tuple. This struct contains both `tags_30443` (for current spec) and `tags_443` (for legacy clients) to facilitate dual-publishing during the migration period. Callers must update destructuring. Callers MUST dual-publish both `kind:30443` (using `tags_30443`) and `kind:443` (using `tags_443`) until May 1, 2026 so that legacy clients can still discover new key packages. `parse_key_package` accepts both `kind:30443` (new) and `kind:443` (legacy) during the migration period. ([#233](https://github.com/marmot-protocol/mdk/pull/233))
+### Changed
+
+### Added
+
+### Fixed
+
+### Removed
+
+### Deprecated
+
+## [0.8.0] - 2026-05-04
+
+### Breaking changes
+
+- **MIP-05 push token wire format enlarged and validation relaxed**: `TOKEN_PLAINTEXT_LEN` increased from 220 to 1024 bytes (`ENCRYPTED_TOKEN_LEN` from 280 to 1084) to accommodate real-world FCM tokens (observed up to ~312 bytes) and future UnifiedPush endpoints (spec max 1000 bytes). Device tokens are now treated as opaque variable-length bytes with no per-platform length constraints — only non-empty and within wire-format capacity. `InvalidApnsTokenLength` and `InvalidFcmTokenLength` error variants replaced by a single `InvalidDeviceTokenLength`. `MAX_NOTIFICATION_REQUEST_TOKENS` reduced from 100 to 25 to stay within the NIP-44 plaintext limit at the larger token size. ([#254](https://github.com/marmot-protocol/mdk/pull/254))
+- **MIP-00 KeyPackage event kind migrated from `kind:443` to `kind:30443`**: KeyPackage events are now addressable (NIP-33) instead of regular events. A `d` tag with a random 32-byte hex identifier is included in every KeyPackage event, enabling relay-side replacement for rotation without explicit NIP-09 deletion. `create_key_package_for_event` and `create_key_package_for_event_with_options` now return a `KeyPackageEventData` struct instead of a tuple. This struct contains both `tags_30443` (for current spec) and `tags_443` (for legacy clients) to facilitate dual-publishing during the migration period. Callers must update destructuring. Callers MUST dual-publish both `kind:30443` (using `tags_30443`) and `kind:443` (using `tags_443`) through May 31, 2026 so that legacy clients can still discover new key packages. `parse_key_package` accepts both `kind:30443` (new) and `kind:443` (legacy) during the migration period. ([#233](https://github.com/marmot-protocol/mdk/pull/233))
 
 ### Changed
 
-- `add_members`, `remove_members`, `update_group_data`, and `self_demote` now return typed `Error::NotAdmin` for local caller authorization failures instead of stringly `Error::Group` values.
+- `add_members`, `remove_members`, `update_group_data`, and `self_demote` now return typed `Error::NotAdmin` for local caller authorization failures instead of stringly `Error::Group` values. ([#266](https://github.com/marmot-protocol/mdk/pull/266))
 - Admin updates now prune non-member public keys instead of rejecting the entire update. Only errors if no valid admins remain after pruning. ([#223](https://github.com/marmot-protocol/mdk/pull/223))
-- Replaced ~15 identical `From<...> for Error` impls with `impl_from_display_error!` and `impl_from_generic_display_error!` macros. ([`#239`](https://github.com/marmot-protocol/mdk/pull/239))
-- Consolidated duplicate test wiring between memory and sqlite storage test binaries into a `storage_backend_tests!` macro. ([`#239`](https://github.com/marmot-protocol/mdk/pull/239))
-- New groups now use `MIXED_CIPHERTEXT` wire format policy (outgoing: ciphertext, incoming: mixed) instead of the OpenMLS default `PURE_CIPHERTEXT`. Regular messages remain `PrivateMessage`; the mixed incoming policy is required to accept `PublicMessage` SelfRemove proposals from departing members.
-- `leave_group` now sends a SelfRemove proposal (MLS Extensions draft, type `0x000a`) instead of a Remove proposal. Falls back to Remove for legacy groups created with `PURE_CIPHERTEXT`. SelfRemove proposals are auto-committed by any member, removing the requirement for an admin to be online.
-- Non-admin members can now create SelfRemove-only Commits in addition to self-update Commits. These two commit types must not be combined.
+- Replaced ~15 identical `From<...> for Error` impls with `impl_from_display_error!` and `impl_from_generic_display_error!` macros. ([#239](https://github.com/marmot-protocol/mdk/pull/239))
+- Consolidated duplicate test wiring between memory and sqlite storage test binaries into a `storage_backend_tests!` macro. ([#239](https://github.com/marmot-protocol/mdk/pull/239))
+- New groups now use `MIXED_CIPHERTEXT` wire format policy (outgoing: ciphertext, incoming: mixed) instead of the OpenMLS default `PURE_CIPHERTEXT`. Regular messages remain `PrivateMessage`; the mixed incoming policy is required to accept `PublicMessage` SelfRemove proposals from departing members. ([#236](https://github.com/marmot-protocol/mdk/pull/236))
+- `leave_group` now sends a SelfRemove proposal (MLS Extensions draft, type `0x000a`) instead of a Remove proposal. Falls back to Remove for legacy groups created with `PURE_CIPHERTEXT`. SelfRemove proposals are auto-committed by any member, removing the requirement for an admin to be online. ([#236](https://github.com/marmot-protocol/mdk/pull/236))
+- Non-admin members can now create SelfRemove-only Commits in addition to self-update Commits. These two commit types must not be combined. ([#236](https://github.com/marmot-protocol/mdk/pull/236))
 - **`create_group` now computes the group's `RequiredCapabilities` as a least-common-denominator (LCD) intersection of `SUPPORTED_PROPOSALS` with every invitee's advertised proposals**, instead of requiring `SelfRemove` unconditionally. An all-modern invitee set still produces `RequiredCapabilities = [SelfRemove]`; any legacy invitee strips `SelfRemove` from the required set. Empty-invitee (single-member / "message to self") groups stay permissive with `RequiredCapabilities = []` so a later `add_members` call can admit legacy key packages. This unblocks two call patterns that previously failed OpenMLS's admission check with `Error::Group("Proposals are not acceptable")`: `create_group` with at least one legacy invitee, and `add_members` of a legacy invitee into a group that was created mixed (`RequiredCapabilities = []`). Resolves [whitenoise-rs #749](https://github.com/marmot-protocol/whitenoise-rs/issues/749) via [#261](https://github.com/marmot-protocol/mdk/pull/261).
 - `leave_group` now consults the group's `RequiredCapabilities` before emitting a `SelfRemove` proposal. If the group's `RequiredCapabilities` does not include `SelfRemove` (i.e. any mixed/legacy group), the leave falls back to a legacy `Remove` proposal that only admins can commit. Complements the existing `PURE_CIPHERTEXT` wire-format fallback. ([#261](https://github.com/marmot-protocol/mdk/pull/261))
 - `add_members` now returns the typed `Error::InviteeMissingRequiredProposal` when OpenMLS rejects a KeyPackage whose `LeafNode.capabilities.proposals` does not cover the group's `RequiredCapabilities`, instead of flat-stringing the OpenMLS error through `Error::Group`. Callers can distinguish legacy-joiner rejection from other `add_members` failures without substring-matching OpenMLS's `Display` output. **New `Error` variant**: exhaustive matchers on `Error` need an additional arm. Follow-up to [#261](https://github.com/marmot-protocol/mdk/pull/261). ([#263](https://github.com/marmot-protocol/mdk/pull/263))
@@ -48,6 +59,8 @@
 ### Added
 
 - Added `test-utils` Cargo feature on `mdk-core` exposing the existing `test_util` module (notably `create_legacy_key_package_event`) so downstream crates can build legacy-LeafNode fixtures without a `cfg(test)` workaround. ([#269](https://github.com/marmot-protocol/mdk/pull/269))
+- Added feature-gated `mip05` protocol primitives in `mdk-core`, including typed token payloads, strict token encryption/decryption helpers, and rumor build/parse helpers for MIP-05 `kind:447`, `kind:448`, and `kind:449`. ([#235](https://github.com/marmot-protocol/mdk/pull/235))
+- Added public MLS leaf-index helpers via `process_message_with_context`, `own_leaf_index`, and `group_leaf_map` so clients can access sender, local, and active group leaf positions without ratchet-tree workarounds. ([#235](https://github.com/marmot-protocol/mdk/pull/235))
 - **GroupContextExtensions upgrade path.** Three new public methods on `MDK` let client UX prompt an admin to upgrade a mixed group that has since become all-modern:
   - `group_member_capabilities(&GroupId) -> Result<Vec<MemberCapabilities>, Error>` — per-member advertised proposal types, extension types, ciphersuites, and admin flag. Proposal and extension capabilities are returned as `BTreeSet`s. Any member may call it.
   - `group_capability_upgrade_status(&GroupId) -> Result<CapabilityUpgradeStatus, Error>` — per-proposal upgrade readiness. Each entry in `SUPPORTED_PROPOSALS` is reported as `AlreadyRequired`, `Available`, or `Blocked { blockers: Vec<PublicKey> }`. Any member may call it.
@@ -56,8 +69,8 @@
 - Re-exported `openmls::prelude::ProposalType` through `mdk_core::prelude` so consumers can name the return type of `group_required_proposals` without adding a direct `openmls` dependency. Prelude module doc comment updated to reflect the actual policy: dependency types that appear in MDK's public API surface are re-exported (as was already true for `GroupId`). ([#265](https://github.com/marmot-protocol/mdk/pull/265))
 - Added `delete_messages_for_group` and `delete_group` public methods on `MDK` for local "clear chat" and "delete chat" operations. `delete_group` also cleans up `EpochSnapshotManager` in-memory state. Neither operation publishes MLS proposals or Nostr events. ([#250](https://github.com/marmot-protocol/mdk/pull/250))
 - Added ThumbHash preview generation alongside existing BlurHash support. `MediaProcessingOptions` now includes `generate_thumbhash`, `ImageMetadata`, `MediaMetadata`, `EncryptedMediaUpload`, and `GroupImageUpload` expose optional `thumbhash`, and encrypted-media IMETA writing emits `thumbhash` while parsing accepts both `blurhash` and `thumbhash` tags for compatibility. ([#244](https://github.com/marmot-protocol/mdk/pull/244))
-- SelfRemove proposal type (`0x000a`) added to client capabilities, group required capabilities, and KeyPackage `mls_proposals` tag per MIP-03.
-- Admin depletion validation: SelfRemove proposals and commits are rejected if they would leave the group with zero admins.
+- SelfRemove proposal type (`0x000a`) added to client capabilities, group required capabilities, and KeyPackage `mls_proposals` tag per MIP-03. ([#236](https://github.com/marmot-protocol/mdk/pull/236))
+- Admin depletion validation: SelfRemove proposals and commits are rejected if they would leave the group with zero admins. ([#236](https://github.com/marmot-protocol/mdk/pull/236))
 - Added feature-gated MIP-05 notification request builders that group token tags by notification server, preserve relay hints, chunk requests at 100 tokens per server, and return ready-to-publish gift-wrapped notification batches for `kind:446` delivery. ([#238](https://github.com/marmot-protocol/mdk/pull/238))
 - `create_message` now accepts an optional `tags` parameter of type `Vec<EventTag>` for appending allow-listed tags (e.g. NIP-40 `expiration`) to the outer kind:445 wrapper event. The `EventTag` enum enforces at compile time which tags are permitted. ([#248](https://github.com/marmot-protocol/mdk/pull/248))
 
@@ -75,7 +88,7 @@
 - `decrypt_from_download` now delegates to `decrypt_from_download_at` (pub(crate)) for deterministic testing of the migration deadline. ([#222](https://github.com/marmot-protocol/mdk/pull/222))
 - Improved diagnostic logging: AEAD decryption failures in `decrypt_message_with_any_supported_format` are now traced before the NIP-44 fallback is attempted, making post-migration forensics easier. ([#222](https://github.com/marmot-protocol/mdk/pull/222))
 - `setup_two_member_group` test helper deduplicated from `messages::decryption` into `crate::test_util`. ([#222](https://github.com/marmot-protocol/mdk/pull/222))
-- **0.6.x/0.7.x migration compatibility**: Current-epoch MIP-03 exporter secrets now self-heal from live MLS state while preserving mismatched pre-0.7.0 bytes for temporary read compatibility. Message decryption temporarily accepts transition-era AEAD wrappers encrypted with old secrets, preserved late-epoch legacy secrets during upgrade, and untagged legacy NIP-44 wrappers only until June 4, 2026. ([#222](https://github.com/marmot-protocol/mdk/pull/222))
+- **0.6.x/0.7.x migration compatibility**: Current-epoch MIP-03 exporter secrets now self-heal from live MLS state while preserving mismatched pre-0.7.0 bytes for temporary read compatibility. Message decryption temporarily accepts transition-era AEAD wrappers encrypted with old secrets, preserved late-epoch legacy secrets during upgrade, and untagged legacy NIP-44 wrappers only until May 15, 2026 00:00:00 UTC. ([#222](https://github.com/marmot-protocol/mdk/pull/222))
 - **Legacy media read compatibility**: MIP-04 download decryption now temporarily falls back across preserved legacy exporter secrets and the pre-0.7.1 HKDF derivation so more `0.6.x -> 0.7.x` media remains readable during migration. ([#222](https://github.com/marmot-protocol/mdk/pull/222))
 - `remove_members` now atomically strips removed members from the group admin list within the same MLS commit ([#225](https://github.com/marmot-protocol/mdk/pull/225))
 
@@ -190,7 +203,7 @@
 - **MIP-04 Epoch Fallback for Media Decryption**: `decrypt_from_download` now resolves the correct decryption key via an O(1) epoch hint lookup instead of only using the current epoch's exporter secret. Added `NoExporterSecretForEpoch` variant to `EncryptedMediaError` for programmatic error matching. ([#167](https://github.com/marmot-protocol/mdk/pull/167))
 - **`PreviouslyFailed` Result Variant**: Added `MessageProcessingResult::PreviouslyFailed` variant to handle cases where a previously failed message arrives again but the MLS group ID cannot be extracted. This prevents crashes in client applications by returning a result instead of throwing an error. ([#165](https://github.com/marmot-protocol/mdk/pull/165), fixes [#154](https://github.com/marmot-protocol/mdk/issues/154), [#159](https://github.com/marmot-protocol/mdk/issues/159))
 - **Message Retry Support**: Implemented better handling for retryable message states. When a message fails processing, it now preserves the `message_event_id` and other context. Added logic to allow reprocessing of messages marked as `Retryable`, with automatic state recovery to `Processed` upon success. ([#161](https://github.com/marmot-protocol/mdk/pull/161))
-- Configurable `out_of_order_tolerance` and `maximum_forward_distance` in `MdkConfig` for MLS sender ratchet settings. Default `out_of_order_tolerance` increased from 5 to 100 for better handling of out-of-order message delivery on Nostr relays. ([`#155`](https://github.com/marmot-protocol/mdk/pull/155))
+- Configurable `out_of_order_tolerance` and `maximum_forward_distance` in `MdkConfig` for MLS sender ratchet settings. Default `out_of_order_tolerance` increased from 5 to 100 for better handling of out-of-order message delivery on Nostr relays. ([#155](https://github.com/marmot-protocol/mdk/pull/155))
 - **Epoch Snapshots & Rollback**: Added `EpochSnapshotManager` to maintain historical epoch states for rollback. ([#152](https://github.com/marmot-protocol/mdk/pull/152))
 - **Configuration**: Added `epoch_snapshot_retention` to `MdkConfig` (default: 5) to control how many past epochs are retained for rollback support. ([#152](https://github.com/marmot-protocol/mdk/pull/152))
 - **Rollback Callback**: Added `MdkCallback` trait and `MdkBuilder::with_callback()` to allow applications to react to rollback events (e.g., to refresh UI). ([#152](https://github.com/marmot-protocol/mdk/pull/152))

--- a/crates/mdk-core/Cargo.toml
+++ b/crates/mdk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdk-core"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 description = "A simplified interface to build secure messaging apps on nostr with MLS."
 authors = ["Jeff Gardner <j@jeffg.me>", "Yuki Kishimoto <yukikishimoto@protonmail.com>", "MDK Developers"]

--- a/crates/mdk-core/src/constant.rs
+++ b/crates/mdk-core/src/constant.rs
@@ -15,7 +15,7 @@ pub const MLS_KEY_PACKAGE_KIND: Kind = Kind::Custom(30443);
 /// Legacy Nostr event kind for MLS KeyPackage events (regular, non-replaceable).
 ///
 /// Earlier versions of the Marmot spec used kind 443. Clients SHOULD accept this kind
-/// during the migration period (until May 1, 2026) but MUST publish using kind 30443.
+/// during the migration period (through May 31, 2026) but MUST publish using kind 30443.
 pub const MLS_KEY_PACKAGE_KIND_LEGACY: Kind = Kind::Custom(443);
 
 /// Nostr Group Data extension type

--- a/crates/mdk-core/src/key_packages.rs
+++ b/crates/mdk-core/src/key_packages.rs
@@ -32,7 +32,7 @@ pub struct KeyPackageEventData {
 
     /// Tags for the legacy kind:443 event.
     /// Same as `tags_30443` but with the `d` tag removed.
-    /// Use with `Kind::Custom(443)` during the transition period (until May 1, 2026).
+    /// Use with `Kind::Custom(443)` during the transition period (through May 31, 2026).
     pub tags_443: Vec<Tag>,
 
     /// Serialized `KeyPackageRef` bytes for lifecycle tracking.
@@ -328,8 +328,8 @@ where
     /// # }
     /// ```
     pub fn parse_key_package(&self, event: &Event) -> Result<KeyPackage, Error> {
-        // Accept both kind:30443 (current spec) and kind:443 (legacy, pre-May 2026).
-        // TODO: Remove MLS_KEY_PACKAGE_KIND_LEGACY acceptance after May 1, 2026
+        // Accept both kind:30443 (current spec) and kind:443 (legacy, through May 31, 2026).
+        // TODO: Remove MLS_KEY_PACKAGE_KIND_LEGACY acceptance after May 31, 2026
         if event.kind != MLS_KEY_PACKAGE_KIND && event.kind != MLS_KEY_PACKAGE_KIND_LEGACY {
             return Err(Error::UnexpectedEvent {
                 expected: MLS_KEY_PACKAGE_KIND,
@@ -3037,9 +3037,9 @@ mod tests {
         );
     }
 
-    /// Regression: parse_key_package accepts kind:443 (legacy) events until May 2026
+    /// Regression: parse_key_package accepts kind:443 (legacy) events through May 31, 2026
     ///
-    /// TODO: Remove this test together with MLS_KEY_PACKAGE_KIND_LEGACY acceptance after May 1, 2026
+    /// TODO: Remove this test together with MLS_KEY_PACKAGE_KIND_LEGACY acceptance after May 31, 2026
     #[test]
     fn test_parse_key_package_accepts_legacy_kind_443() {
         let mdk = create_test_mdk();
@@ -3066,7 +3066,7 @@ mod tests {
         let result = mdk.parse_key_package(&event);
         assert!(
             result.is_ok(),
-            "Should accept legacy kind:443 KeyPackage event until May 2026, got: {:?}",
+            "Should accept legacy kind:443 KeyPackage event through May 31, 2026, got: {:?}",
             result
         );
     }

--- a/crates/mdk-core/src/test_util.rs
+++ b/crates/mdk-core/src/test_util.rs
@@ -93,7 +93,7 @@ where
 ///
 /// The produced KeyPackage's `LeafNode.capabilities.proposals` is explicitly
 /// empty (no `SelfRemove`), simulating an older client that predates MIP-03.
-/// This is packaged inside a kind:443 (legacy, pre-May-2026) Nostr event
+/// This is packaged inside a kind:443 (legacy through May 31, 2026) Nostr event
 /// because the stricter kind:30443 validator requires the `mls_proposals`
 /// tag and an `i` (KeyPackageRef) tag we do not compute here.
 ///

--- a/crates/mdk-macros/Cargo.toml
+++ b/crates/mdk-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdk-macros"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 description = "Shared declarative macros for the MDK workspace"
 authors.workspace = true

--- a/crates/mdk-memory-storage/CHANGELOG.md
+++ b/crates/mdk-memory-storage/CHANGELOG.md
@@ -17,8 +17,6 @@
 
 ### Fixed
 
-- Fixed `MdkMemoryStorage::save_message` to reject oversized message content, serialized tags JSON, and serialized event JSON before caching messages, matching SQLite backend payload bounds. ([#257](https://github.com/marmot-protocol/mdk/pull/257))
-
 ### Removed
 
 ### Deprecated
@@ -31,8 +29,22 @@
 
 ### Changed
 
-- Replaced 6 identical MLS storage struct definitions and their `Debug`/`new`/`clone_data`/`restore_data` impls with `mls_store_base!` and `mls_single_key_ops!` macros, reducing `mls_storage/mod.rs` by ~400 lines. ([`#239`](https://github.com/marmot-protocol/mdk/pull/239))
-- Migrated group and welcome storage to use shared validation functions from `mdk-storage-traits`. ([`#239`](https://github.com/marmot-protocol/mdk/pull/239))
+### Added
+
+### Fixed
+
+### Removed
+
+### Deprecated
+
+## [0.8.0] - 2026-05-04
+
+### Breaking changes
+
+### Changed
+
+- Replaced 6 identical MLS storage struct definitions and their `Debug`/`new`/`clone_data`/`restore_data` impls with `mls_store_base!` and `mls_single_key_ops!` macros, reducing `mls_storage/mod.rs` by ~400 lines. ([#239](https://github.com/marmot-protocol/mdk/pull/239))
+- Migrated group and welcome storage to use shared validation functions from `mdk-storage-traits`. ([#239](https://github.com/marmot-protocol/mdk/pull/239))
 
 ### Added
 
@@ -43,6 +55,7 @@
 
 ### Fixed
 
+- Fixed `MdkMemoryStorage::save_message` to reject oversized message content, serialized tags JSON, and serialized event JSON before caching messages, matching SQLite backend payload bounds. ([#257](https://github.com/marmot-protocol/mdk/pull/257))
 - Converted `processed_messages_cache`, `processed_welcomes_cache`, and all three `group_*_exporter_secrets_cache` fields from `LruCache` to `HashMap` to prevent silent eviction of security-critical deduplication records and decryption keys under cache pressure (fixes [marmot-security#12](https://github.com/marmot-protocol/marmot-security/issues/12)) ([#259](https://github.com/marmot-protocol/mdk/pull/259)).
 
 ### Removed

--- a/crates/mdk-memory-storage/Cargo.toml
+++ b/crates/mdk-memory-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdk-memory-storage"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 description = "In-memory database for MDK that implements the MdkStorageProvider trait"
 authors = ["Jeff Gardner <j@jeffg.me>", "Yuki Kishimoto <yukikishimoto@protonmail.com>", "MDK Developers"]

--- a/crates/mdk-sqlite-storage/CHANGELOG.md
+++ b/crates/mdk-sqlite-storage/CHANGELOG.md
@@ -27,12 +27,26 @@
 
 ### Breaking changes
 
+### Changed
+
+### Added
+
+### Fixed
+
+### Removed
+
+### Deprecated
+
+## [0.8.0] - 2026-05-04
+
+### Breaking changes
+
 - `new_unencrypted()` and `new_in_memory()` are now gated behind the `test-utils` feature flag. Downstream crates that call these methods must add `features = ["test-utils"]` to their `mdk-sqlite-storage` dependency. ([#245](https://github.com/marmot-protocol/mdk/pull/245))
 
 ### Changed
 
-- Extracted row-parsing helpers (`blob_to_group_id`, `blob_to_event_id`, `blob_to_pubkey`, `text_to_state`, `text_to_json`, `text_to_parsed`) to replace repetitive inline column extraction across `row_to_group`, `row_to_group_relay`, `row_to_group_exporter_secret`, `row_to_message`, and `row_to_welcome`. ([`#239`](https://github.com/marmot-protocol/mdk/pull/239))
-- Migrated group and welcome storage to use shared validation functions from `mdk-storage-traits`. ([`#239`](https://github.com/marmot-protocol/mdk/pull/239))
+- Extracted row-parsing helpers (`blob_to_group_id`, `blob_to_event_id`, `blob_to_pubkey`, `text_to_state`, `text_to_json`, `text_to_parsed`) to replace repetitive inline column extraction across `row_to_group`, `row_to_group_relay`, `row_to_group_exporter_secret`, `row_to_message`, and `row_to_welcome`. ([#239](https://github.com/marmot-protocol/mdk/pull/239))
+- Migrated group and welcome storage to use shared validation functions from `mdk-storage-traits`. ([#239](https://github.com/marmot-protocol/mdk/pull/239))
 
 ### Added
 

--- a/crates/mdk-sqlite-storage/Cargo.toml
+++ b/crates/mdk-sqlite-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdk-sqlite-storage"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 description = "SQLite database for MDK that implements the MdkStorageProvider trait"
 authors = ["Jeff Gardner <j@jeffg.me>", "Yuki Kishimoto <yukikishimoto@protonmail.com>", "MDK Developers"]

--- a/crates/mdk-storage-traits/CHANGELOG.md
+++ b/crates/mdk-storage-traits/CHANGELOG.md
@@ -27,16 +27,30 @@
 
 ### Breaking changes
 
+### Changed
+
+### Added
+
+### Fixed
+
+### Removed
+
+### Deprecated
+
+## [0.8.0] - 2026-05-04
+
+### Breaking changes
+
 - Added `MessageStorage::delete_messages_for_group` and `MdkStorageProvider::delete_group` for local "clear chat" and "delete chat" operations. Storage implementations must add these methods. ([#250](https://github.com/marmot-protocol/mdk/pull/250))
 - Added `GroupStorage::get_group_legacy_exporter_secret` and `GroupStorage::save_group_legacy_exporter_secret` so storage backends can preserve pre-0.7.0 exporter-secret bytes separately during the temporary migration-compatibility window. Storage implementations must add these methods. ([#222](https://github.com/marmot-protocol/mdk/pull/222))
 
 ### Changed
 
-- Replaced hand-written `Display`, `FromStr`, `Serialize`, and `Deserialize` impls on `GroupState`, `MessageState`, `WelcomeState`, `ProcessedMessageState`, and `ProcessedWelcomeState` with a declarative `string_enum!` macro. ([`#239`](https://github.com/marmot-protocol/mdk/pull/239))
-- Replaced hand-written `Pagination` structs and limit-validation functions in groups, messages, and welcomes modules with a `bounded_pagination!` macro. ([`#239`](https://github.com/marmot-protocol/mdk/pull/239))
-- Replaced manual `Error` + `Display` impls on `GroupError`, `MessageError`, and `WelcomeError` with a `storage_error!` macro backed by `thiserror`. ([`#239`](https://github.com/marmot-protocol/mdk/pull/239))
-- Extracted shared group and welcome validation logic into `groups::validation` and `welcomes::validation` modules. ([`#239`](https://github.com/marmot-protocol/mdk/pull/239))
-- Removed ~700 lines of duplicated test functions from `test_utils::cross_storage` that had already been migrated to `mdk-core/tests/shared/`. ([`#239`](https://github.com/marmot-protocol/mdk/pull/239))
+- Replaced hand-written `Display`, `FromStr`, `Serialize`, and `Deserialize` impls on `GroupState`, `MessageState`, `WelcomeState`, `ProcessedMessageState`, and `ProcessedWelcomeState` with a declarative `string_enum!` macro. ([#239](https://github.com/marmot-protocol/mdk/pull/239))
+- Replaced hand-written `Pagination` structs and limit-validation functions in groups, messages, and welcomes modules with a `bounded_pagination!` macro. ([#239](https://github.com/marmot-protocol/mdk/pull/239))
+- Replaced manual `Error` + `Display` impls on `GroupError`, `MessageError`, and `WelcomeError` with a `storage_error!` macro backed by `thiserror`. ([#239](https://github.com/marmot-protocol/mdk/pull/239))
+- Extracted shared group and welcome validation logic into `groups::validation` and `welcomes::validation` modules. ([#239](https://github.com/marmot-protocol/mdk/pull/239))
+- Removed ~700 lines of duplicated test functions from `test_utils::cross_storage` that had already been migrated to `mdk-core/tests/shared/`. ([#239](https://github.com/marmot-protocol/mdk/pull/239))
 
 ### Added
 

--- a/crates/mdk-storage-traits/Cargo.toml
+++ b/crates/mdk-storage-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdk-storage-traits"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 description = "Storage abstraction for MDK that wraps OpenMLS storage backends"
 authors = ["Jeff Gardner <j@jeffg.me>", "Yuki Kishimoto <yukikishimoto@protonmail.com>", "MDK Developers"]

--- a/crates/mdk-uniffi/CHANGELOG.md
+++ b/crates/mdk-uniffi/CHANGELOG.md
@@ -27,14 +27,28 @@
 
 ### Breaking changes
 
-- **`KeyPackageResult` now includes `d_tag` and `tags_legacy`**: The `KeyPackageResult` struct returned by `create_key_package_for_event` and `create_key_package_for_event_with_options` now includes a `d_tag: String` field containing the 32-byte hex identifier for the KeyPackage slot. This enables callers to reuse the same `d` value when rotating KeyPackages so that relays automatically replace the old event. It also includes `tags_legacy`, which provides the tags without the `d` tag. Callers MUST dual-publish both `kind:30443` (using `tags`) and `kind:443` (using `tags_legacy`) until May 1, 2026 so that legacy clients can still discover new key packages. All test event builders updated to use `kind:30443`. ([#233](https://github.com/marmot-protocol/mdk/pull/233))
+### Changed
+
+### Added
+
+### Fixed
+
+### Removed
+
+### Deprecated
+
+## [0.8.0] - 2026-05-04
+
+### Breaking changes
+
+- **`KeyPackageResult` now includes `d_tag` and `tags_legacy`**: The `KeyPackageResult` struct returned by `create_key_package_for_event` and `create_key_package_for_event_with_options` now includes a `d_tag: String` field containing the 32-byte hex identifier for the KeyPackage slot. This enables callers to reuse the same `d` value when rotating KeyPackages so that relays automatically replace the old event. It also includes `tags_legacy`, which provides the tags without the `d` tag. Callers MUST dual-publish both `kind:30443` (using `tags`) and `kind:443` (using `tags_legacy`) through May 31, 2026 so that legacy clients can still discover new key packages. All test event builders updated to use `kind:30443`. ([#233](https://github.com/marmot-protocol/mdk/pull/233))
 - `new_mdk_unencrypted()` is now gated behind the `test-utils` feature flag. Downstream consumers must enable the `test-utils` feature to access this function. ([#245](https://github.com/marmot-protocol/mdk/pull/245))
 - `create_message` now takes an additional `event_tags` parameter (`Option<Vec<Vec<String>>>`) for appending allow-listed tags (e.g. NIP-40 `expiration`) to the outer kind:445 wrapper event. Pass `None` to preserve existing behavior. ([#248](https://github.com/marmot-protocol/mdk/pull/248))
 
 ### Changed
 
-- Extracted `update_group_result_to_uniffi()` and `mdk_from_storage()` helpers to eliminate duplicated serialization and constructor logic across multiple exported functions. ([`#239`](https://github.com/marmot-protocol/mdk/pull/239))
-- Simplified iterator collection patterns to use `.collect::<Result<_, _>>()` instead of two-step collect-then-unwrap. ([`#239`](https://github.com/marmot-protocol/mdk/pull/239))
+- Extracted `update_group_result_to_uniffi()` and `mdk_from_storage()` helpers to eliminate duplicated serialization and constructor logic across multiple exported functions. ([#239](https://github.com/marmot-protocol/mdk/pull/239))
+- Simplified iterator collection patterns to use `.collect::<Result<_, _>>()` instead of two-step collect-then-unwrap. ([#239](https://github.com/marmot-protocol/mdk/pull/239))
 
 ### Added
 
@@ -44,16 +58,16 @@
 - Added UniFFI bindings for `delete_messages_for_group` and `delete_group` for local "clear chat" and "delete chat" operations. ([#250](https://github.com/marmot-protocol/mdk/pull/250))
 - Added UniFFI bindings for 10 previously unbound methods: `delete_key_package_from_storage`, `delete_key_package_from_storage_by_hash_ref`, `get_ratchet_tree_info`, `group_leaf_map`, `own_leaf_index`, `pending_added_members_pubkeys`, `pending_member_changes`, `pending_removed_members_pubkeys`, `prepare_group_image_for_upload_with_options`, and `process_message_with_context`. ([#249](https://github.com/marmot-protocol/mdk/pull/249))
 - Added optional `thumbhash` fields alongside the existing `blurhash` UniFFI records for group-image and encrypted-media uploads, plus a `generate_thumbhash` option in `MediaProcessingOptionsInput`. ([#244](https://github.com/marmot-protocol/mdk/pull/244))
-- Moved binary size optimizations (`opt-level = "z"`, thin LTO, single codegen unit, `panic = "abort"`, symbol stripping) into `[profile.release]` directly. Android builds override to fat LTO via `CARGO_PROFILE_RELEASE_LTO=fat` for maximum `.so` reduction; iOS uses thin LTO to avoid `.a` archive bloat. ([`#221`](https://github.com/marmot-protocol/mdk/pull/221), [`#232`](https://github.com/marmot-protocol/mdk/pull/232))
+- Moved binary size optimizations (`opt-level = "z"`, thin LTO, single codegen unit, `panic = "abort"`, symbol stripping) into `[profile.release]` directly. Android builds override to fat LTO via `CARGO_PROFILE_RELEASE_LTO=fat` for maximum `.so` reduction; iOS uses thin LTO to avoid `.a` archive bloat. ([#221](https://github.com/marmot-protocol/mdk/pull/221), [#232](https://github.com/marmot-protocol/mdk/pull/232))
 
 ### Fixed
 
 - Allowed failed platform keyring auto-initialization attempts to be retried, so a transient keyring failure does not permanently block `new_mdk()` in the current process. ([#252](https://github.com/marmot-protocol/mdk/pull/252))
 - Removed the Swift package's explicit system `sqlite3` link and linked the native frameworks required by the bundled SQLCipher provider instead. ([#252](https://github.com/marmot-protocol/mdk/pull/252))
-- Removed redundant `cargo build` steps from Swift, Python, and Ruby binding CI jobs that duplicated work already done by `_build-uniffi`. ([`#232`](https://github.com/marmot-protocol/mdk/pull/232))
-- Fixed stale `release-size` artifact paths in Kotlin and Swift binding generation recipes. ([`#232`](https://github.com/marmot-protocol/mdk/pull/232))
-- Unbroke binding builds on Linux: switched `[profile.release].strip` from `true` to `"debuginfo"` so `uniffi-bindgen --library` can still read `UNIFFI_META_*` symbols from the cdylib's `.symtab` (GNU strip's `--strip-all` was removing them, which silently produced empty Kotlin/Ruby/Python binding output). DWARF debug info is still stripped, so the binary-size cost is small. ([`#267`](https://github.com/marmot-protocol/mdk/pull/267))
-- Switched iOS bindings to fat LTO (`CARGO_PROFILE_RELEASE_LTO=fat`, mirroring Android) so the static `.a` archives no longer embed per-module thin-LTO bitcode. This shrinks `libmdk_uniffi.a` back below GitHub's 100 MB push limit. The Swift package workflow also configures `git lfs track "*.a"` as a defensive safety net. ([`#267`](https://github.com/marmot-protocol/mdk/pull/267))
+- Removed redundant `cargo build` steps from Swift, Python, and Ruby binding CI jobs that duplicated work already done by `_build-uniffi`. ([#232](https://github.com/marmot-protocol/mdk/pull/232))
+- Fixed stale `release-size` artifact paths in Kotlin and Swift binding generation recipes. ([#232](https://github.com/marmot-protocol/mdk/pull/232))
+- Unbroke binding builds on Linux: switched `[profile.release].strip` from `true` to `"debuginfo"` so `uniffi-bindgen --library` can still read `UNIFFI_META_*` symbols from the cdylib's `.symtab` (GNU strip's `--strip-all` was removing them, which silently produced empty Kotlin/Ruby/Python binding output). DWARF debug info is still stripped, so the binary-size cost is small. ([#267](https://github.com/marmot-protocol/mdk/pull/267))
+- Switched iOS bindings to fat LTO (`CARGO_PROFILE_RELEASE_LTO=fat`, mirroring Android) so the static `.a` archives no longer embed per-module thin-LTO bitcode. This shrinks `libmdk_uniffi.a` back below GitHub's 100 MB push limit. The Swift package workflow also configures `git lfs track "*.a"` as a defensive safety net. ([#267](https://github.com/marmot-protocol/mdk/pull/267))
 
 ### Removed
 
@@ -88,14 +102,14 @@
 - **`KeyPackageResult` now includes `hash_ref`**: The `KeyPackageResult` struct returned by `create_key_package_for_event` and `create_key_package_for_event_with_options` now includes a `hash_ref: Vec<u8>` field containing the serialized hash reference of the key package. This enables callers to track key packages for lifecycle management without re-parsing. ([#178](https://github.com/marmot-protocol/mdk/pull/178))
 - **`create_key_package_for_event` No Longer Adds Protected Tag**: The `create_key_package_for_event()` function no longer adds the NIP-70 protected tag by default. This is a behavioral change - existing code that relied on the protected tag being present will now produce key packages without it. Key packages can now be republished by third parties to any relay. For users who need the protected tag, use the new `create_key_package_for_event_with_options()` function with `protected: true`. ([#173](https://github.com/marmot-protocol/mdk/pull/173), related: [#168](https://github.com/marmot-protocol/mdk/issues/168))
 - **Security (Audit Issue M)**: Changed `get_message()` to require both `mls_group_id` and `event_id` parameters. This prevents messages from different groups from overwriting each other by scoping lookups to a specific group. ([#124](https://github.com/marmot-protocol/mdk/pull/124))
-- Renamed `Message.processed_at` to `Message.created_at` for semantic accuracy. The field represents when a message was created, not when it was processed by the system. ([`#163`](https://github.com/marmot-protocol/mdk/pull/163))
+- Renamed `Message.processed_at` to `Message.created_at` for semantic accuracy. The field represents when a message was created, not when it was processed by the system. ([#163](https://github.com/marmot-protocol/mdk/pull/163))
 
 ### Changed
 
 - Upgraded `nostr` dependency from 0.43 to 0.44, replacing deprecated `Timestamp::as_u64()` calls with `Timestamp::as_secs()` ([#162](https://github.com/marmot-protocol/mdk/pull/162))
 - Changed `get_messages()` to accept optional `limit` and `offset` parameters for pagination control. Existing calls must be updated to pass `None, None` for default behavior (limit: 1000, offset: 0), or specify values for custom pagination. ([#111](https://github.com/marmot-protocol/mdk/pull/111))
 - Changed `get_pending_welcomes()` to accept optional `limit` and `offset` parameters for pagination control. Existing calls must be updated to pass `None, None` for default behavior (limit: 1000, offset: 0), or specify values for custom pagination. ([#119](https://github.com/marmot-protocol/mdk/pull/119))
-- Changed `new_mdk()`, `new_mdk_with_key()`, and `new_mdk_unencrypted()` to accept an optional `MdkConfig` parameter for customizing MDK behavior. Existing calls must be updated to pass `None` for default behavior. ([`#155`](https://github.com/marmot-protocol/mdk/pull/155))
+- Changed `new_mdk()`, `new_mdk_with_key()`, and `new_mdk_unencrypted()` to accept an optional `MdkConfig` parameter for customizing MDK behavior. Existing calls must be updated to pass `None` for default behavior. ([#155](https://github.com/marmot-protocol/mdk/pull/155))
 
 ### Added
 
@@ -107,7 +121,7 @@
 - **Group `last_message_processed_at` Field**: The `Group` record now includes an optional `last_message_processed_at: u64` field (Unix timestamp) indicating when the last message was received/processed by this client. This complements `last_message_at` (sender's timestamp) and ensures `last_message_id` is consistent with the first message returned by `get_messages()`. ([#166](https://github.com/marmot-protocol/mdk/pull/166))
 - **Message `processed_at` Field**: The `Message` record now includes a `processed_at: u64` field (Unix timestamp) indicating when this client received/processed the message. This complements the existing `created_at` field (sender's timestamp) and helps clients handle clock skew between devices - messages can now be displayed in reception order if desired. ([#166](https://github.com/marmot-protocol/mdk/pull/166))
 - **`PreviouslyFailed` Result Variant**: Added `ProcessMessageResult.PreviouslyFailed` enum variant to handle cases where a previously failed message arrives again but the MLS group ID cannot be extracted. This prevents crashes in client applications (fixes [#153](https://github.com/marmot-protocol/mdk/issues/153)) by returning a result instead of throwing an exception. ([#165](https://github.com/marmot-protocol/mdk/pull/165), fixes [#154](https://github.com/marmot-protocol/mdk/issues/154), [#159](https://github.com/marmot-protocol/mdk/issues/159))
-- Added `MdkConfig` record for configuring MDK behavior, including `out_of_order_tolerance` and `maximum_forward_distance` settings for MLS sender ratchet configuration. All fields are optional and default to sensible values. ([`#155`](https://github.com/marmot-protocol/mdk/pull/155))
+- Added `MdkConfig` record for configuring MDK behavior, including `out_of_order_tolerance` and `maximum_forward_distance` settings for MLS sender ratchet configuration. All fields are optional and default to sensible values. ([#155](https://github.com/marmot-protocol/mdk/pull/155))
 - Exposed pagination control for `get_messages()` to foreign language bindings via optional `limit` and `offset` parameters. ([#111](https://github.com/marmot-protocol/mdk/pull/111))
 - Exposed pagination control for `get_pending_welcomes()` to foreign language bindings via optional `limit` and `offset` parameters. ([#119](https://github.com/marmot-protocol/mdk/pull/119))
 

--- a/crates/mdk-uniffi/Cargo.toml
+++ b/crates/mdk-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdk-uniffi"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 description = "UniFFI bindings for mdk-core with SQLite storage"
 authors = [


### PR DESCRIPTION
## Summary
- Prepared the MDK workspace for the `0.8.0` release after the post-`0.7.1` breaking/API/protocol changes.
- Extended the MIP-00 KeyPackage legacy `kind:443` acceptance and dual-publish documentation through May 31, 2026, while keeping `kind:30443` as the required publishing target.
- Bumped all MDK crate package versions, workspace internal dependency versions, and `Cargo.lock` entries from `0.7.1` to `0.8.0`.
- Converted each affected crate changelog from `Unreleased` release notes into `## [0.8.0] - 2026-05-04`, then added a fresh empty `## Unreleased` section above it for future changes.

## Changelog cleanup
- Added missing PR links to `mdk-core` release entries and normalized PR reference formatting across changelogs.
- Moved existing changelog entries that were accidentally left in template comments into the real `0.8.0` sections.
- Added missing obvious entries for the MIP-05 primitives / leaf-index helpers and memory storage payload-bounds fix.
- Corrected stale migration compatibility text so the legacy exporter/media fallback deadline consistently says May 15, 2026 00:00:00 UTC.

## Review findings addressed
- Resolved the expired KeyPackage cutoff finding by extending the documented legacy window through May 31, 2026.
- Resolved the workspace version finding with a coordinated `0.8.0` bump.
- Resolved the changelog PR-link finding and kept fresh top-level `Unreleased` sections for follow-up work.

## Testing
- Verified changelog heading order with a parser that ignores template comments.
- Verified all `0.8.0` changelog entries include PR links.
- Ran `git diff --check`.
- Ran `cargo check --all-targets --all-features`.
- Ran `cargo test -p mdk-core key_packages --all-features`.
- Ran `just precommit` successfully.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/271">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
