### PR TITLE
Fix crates.io publishing for the 0.8.0 release

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   publish-macros:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     name: Publish mdk-macros
 
@@ -34,6 +35,7 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   publish-storage-traits:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     name: Publish mdk-storage-traits
 
@@ -58,6 +60,7 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   publish-memory-storage:
+    if: startsWith(github.ref, 'refs/tags/')
     needs: publish-storage-traits
     runs-on: ubuntu-latest
     name: Publish mdk-memory-storage
@@ -86,6 +89,7 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   publish-sqlite-storage:
+    if: startsWith(github.ref, 'refs/tags/')
     needs: publish-storage-traits
     runs-on: ubuntu-latest
     name: Publish mdk-sqlite-storage
@@ -114,6 +118,7 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   publish-core:
+    if: startsWith(github.ref, 'refs/tags/')
     needs: [publish-macros, publish-memory-storage, publish-sqlite-storage]
     runs-on: ubuntu-latest
     name: Publish mdk-core

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -3,6 +3,7 @@ name: Publish to crates.io
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -11,6 +12,27 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  publish-macros:
+    runs-on: ubuntu-latest
+    name: Publish mdk-macros
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Rust (stable)
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: publish-macros
+
+    - name: Publish mdk-macros
+      run: cargo publish -p mdk-macros
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   publish-storage-traits:
     runs-on: ubuntu-latest
     name: Publish mdk-storage-traits
@@ -92,7 +114,7 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   publish-core:
-    needs: [publish-memory-storage, publish-sqlite-storage]
+    needs: [publish-macros, publish-memory-storage, publish-sqlite-storage]
     runs-on: ubuntu-latest
     name: Publish mdk-core
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ mdk-macros = { version = "0.8.0", path = "./crates/mdk-macros" }
 # All four crates must move in lockstep on the same rev.
 # Do not move to upstream tip until openmls #1972's MessageSecretsStore
 # shape has a postcard-compatible storage path, or MDK migrates codecs.
-openmls = { git = "https://github.com/openmls/openmls", rev = "04c50d7fb12d52f4f9aee26de5f5234f3df29fa8", default-features = false }
-openmls_traits = { git = "https://github.com/openmls/openmls", rev = "04c50d7fb12d52f4f9aee26de5f5234f3df29fa8", default-features = false }
-openmls_basic_credential = { git = "https://github.com/openmls/openmls", rev = "04c50d7fb12d52f4f9aee26de5f5234f3df29fa8", default-features = false }
-openmls_rust_crypto = { git = "https://github.com/openmls/openmls", rev = "04c50d7fb12d52f4f9aee26de5f5234f3df29fa8", default-features = false }
+openmls = { version = "0.8.1", git = "https://github.com/openmls/openmls", rev = "04c50d7fb12d52f4f9aee26de5f5234f3df29fa8", default-features = false }
+openmls_traits = { version = "0.5.0", git = "https://github.com/openmls/openmls", rev = "04c50d7fb12d52f4f9aee26de5f5234f3df29fa8", default-features = false }
+openmls_basic_credential = { version = "0.5.0", git = "https://github.com/openmls/openmls", rev = "04c50d7fb12d52f4f9aee26de5f5234f3df29fa8", default-features = false }
+openmls_rust_crypto = { version = "0.5.1", git = "https://github.com/openmls/openmls", rev = "04c50d7fb12d52f4f9aee26de5f5234f3df29fa8", default-features = false }
 
 # Nostr
 nostr = { version = "0.44", default-features = false }


### PR DESCRIPTION
## Summary
- Add a `publish-macros` job so `mdk-macros` is published before `mdk-core`.
- Add `workflow_dispatch` support so the publish workflow can be rerun manually.
- Add crates.io version requirements to the OpenMLS git dependencies so published manifests verify cleanly.

## Testing
- `cargo check --workspace --all-features`
- `cargo publish --dry-run` validation for `mdk-macros` and `mdk-storage-traits`
- Verified the publish workflow YAML parses correctly

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/272">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes crates.io publishing for the 0.8.0 release by ensuring mdk-macros is published before mdk-core, restricting publish jobs to tag refs, adding manual dispatch support for the publish workflow, and adding explicit version fields to OpenMLS git dependencies so published manifests validate on crates.io.

**What changed**:
- Added workflow_dispatch trigger to .github/workflows/publish-crates.yml to allow manual reruns of the publish workflow.
- Added a new publish-macros job to publish the mdk-macros crate before other crates.
- Added if: startsWith(github.ref, 'refs/tags/') guards to all publish jobs so they only run for tag refs.
- Updated publish-core job to need: [publish-macros, publish-memory-storage, publish-sqlite-storage] so mdk-core waits for mdk-macros.
- Affected crates: mdk-macros, mdk-core, mdk-memory-storage, mdk-sqlite-storage, mdk-storage-traits.
- Added explicit version constraints to OpenMLS git dependencies in workspace Cargo.toml: openmls = 0.8.1, openmls_traits = 0.5.0, openmls_basic_credential = 0.5.0, openmls_rust_crypto = 0.5.1 (keeps pinned git rev).

**Security impact**:
- No changes to cryptographic algorithms, key handling, credential validation, SQLCipher configuration, or file permissions.

**Protocol changes**:
- None; no MLS, Nostr, or MIP protocol logic changes.

**API surface**:
- No public API, storage schema, or UniFFI/FFI boundary changes.

**Testing**:
- Ran cargo check --workspace --all-features.
- Performed cargo publish --dry-run validation for mdk-macros and mdk-storage-traits.
- Verified the publish workflow YAML parses and job conditions are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->