### PR TITLE
Fix mdk-core crates.io publish compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ mdk-macros = { version = "0.8.0", path = "./crates/mdk-macros" }
 
 # OpenMLS family — pinned to a post-#1959 rev for public
 # `MlsGroup::treesync().full_leaves()` (merged upstream 2026-02-16).
+# Published crates currently verify against OpenMLS 0.8.1 from crates.io, so
+# mdk-core carries a temporary exported-ratchet-tree compatibility shim until
+# crates.io OpenMLS includes that public full-leaf API.
 # All four crates must move in lockstep on the same rev.
 # Do not move to upstream tip until openmls #1972's MessageSecretsStore
 # shape has a postcard-compatible storage path, or MDK migrates codecs.

--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -31,6 +31,8 @@
 
 ### Fixed
 
+- Fixed `mdk-core` crates.io package verification against OpenMLS 0.8.1 by using a temporary exported-ratchet-tree compatibility shim until crates.io OpenMLS exposes the upstream full-leaf iterator. ([#273](https://github.com/marmot-protocol/mdk/pull/273))
+
 ### Removed
 
 ### Deprecated

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -628,12 +628,9 @@ where
             .members()
             .map(|member| {
                 let public_key = self.pubkey_for_member(&member)?;
-                let capabilities = capabilities_by_leaf.get(&member.index).ok_or_else(|| {
-                    Error::Group(format!(
-                        "missing capabilities for leaf index {}",
-                        member.index.u32()
-                    ))
-                })?;
+                let capabilities = capabilities_by_leaf
+                    .get(&member.index)
+                    .ok_or_else(|| missing_leaf_capabilities_error(member.index.u32()))?;
                 Ok(MemberCapabilities {
                     is_admin: group_data.admins.contains(&public_key),
                     member: public_key,
@@ -653,11 +650,17 @@ where
         let capabilities_by_leaf = exported_leaf_capabilities(group)?;
         group
             .members()
-            .filter_map(|member| match capabilities_by_leaf.get(&member.index) {
-                Some(capabilities) if capabilities.proposals().contains(&proposal) => None,
-                _ => Some(self.pubkey_for_member(&member)),
+            .try_fold(Vec::new(), |mut blockers, member| {
+                let capabilities = capabilities_by_leaf
+                    .get(&member.index)
+                    .ok_or_else(|| missing_leaf_capabilities_error(member.index.u32()))?;
+
+                if !capabilities.proposals().contains(&proposal) {
+                    blockers.push(self.pubkey_for_member(&member)?);
+                }
+
+                Ok(blockers)
             })
-            .collect()
     }
 
     /// Returns per-proposal upgrade readiness for the group's
@@ -2429,6 +2432,10 @@ where
 
         Ok(welcome_rumors)
     }
+}
+
+fn missing_leaf_capabilities_error(leaf_index: u32) -> Error {
+    Error::Group(format!("missing capabilities for leaf index {leaf_index}"))
 }
 
 #[cfg(test)]

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -25,6 +25,9 @@ use tls_codec::Serialize as TlsSerialize;
 
 use sha2::{Digest, Sha256};
 
+mod openmls_compat;
+
+use self::openmls_compat::exported_leaf_capabilities;
 use super::MDK;
 use super::extension::NostrGroupDataExtension;
 use crate::constant::{GROUP_CONTEXT_REQUIRED_EXTENSIONS, SUPPORTED_PROPOSALS};
@@ -620,15 +623,20 @@ where
     ) -> Result<Vec<MemberCapabilities>, Error> {
         let group = self.load_mls_group(group_id)?.ok_or(Error::GroupNotFound)?;
         let group_data = NostrGroupDataExtension::from_group(&group)?;
+        let capabilities_by_leaf = exported_leaf_capabilities(&group)?;
         group
-            .treesync()
-            .full_leaves()
-            .map(|(_, leaf)| {
-                let member = self.pubkey_for_leaf_node(leaf)?;
-                let capabilities = leaf.capabilities();
+            .members()
+            .map(|member| {
+                let public_key = self.pubkey_for_member(&member)?;
+                let capabilities = capabilities_by_leaf.get(&member.index).ok_or_else(|| {
+                    Error::Group(format!(
+                        "missing capabilities for leaf index {}",
+                        member.index.u32()
+                    ))
+                })?;
                 Ok(MemberCapabilities {
-                    is_admin: group_data.admins.contains(&member),
-                    member,
+                    is_admin: group_data.admins.contains(&public_key),
+                    member: public_key,
                     proposals: capabilities.proposals().iter().copied().collect(),
                     extensions: capabilities.extensions().iter().copied().collect(),
                     ciphersuites: capabilities.ciphersuites().to_vec(),
@@ -642,11 +650,13 @@ where
         group: &MlsGroup,
         proposal: ProposalType,
     ) -> Result<Vec<PublicKey>, Error> {
+        let capabilities_by_leaf = exported_leaf_capabilities(group)?;
         group
-            .treesync()
-            .full_leaves()
-            .filter(|(_, leaf)| !leaf.capabilities().proposals().contains(&proposal))
-            .map(|(_, leaf)| self.pubkey_for_leaf_node(leaf))
+            .members()
+            .filter_map(|member| match capabilities_by_leaf.get(&member.index) {
+                Some(capabilities) if capabilities.proposals().contains(&proposal) => None,
+                _ => Some(self.pubkey_for_member(&member)),
+            })
             .collect()
     }
 

--- a/crates/mdk-core/src/groups/openmls_compat.rs
+++ b/crates/mdk-core/src/groups/openmls_compat.rs
@@ -1,0 +1,122 @@
+//! Temporary OpenMLS compatibility helpers.
+//!
+//! MDK's workspace pins OpenMLS to an upstream git revision that exposes
+//! `MlsGroup::treesync().full_leaves()`, but crates.io packages verify against
+//! registry dependencies. The OpenMLS 0.8.1 release needed for MDK 0.8.0
+//! verification does not have that public API. Delete this module and use the
+//! upstream full-leaf iterator directly once a crates.io OpenMLS release
+//! includes it.
+
+use std::collections::BTreeMap;
+
+use openmls::prelude::Signature as MlsSignature;
+use openmls::prelude::*;
+use openmls::treesync::EncryptionKey;
+use tls_codec::{
+    DeserializeBytes as TlsDeserializeBytes, Serialize as TlsSerialize, Size as TlsSize, VLBytes,
+};
+
+const RATCHET_TREE_NODE_TYPE_LEAF: u8 = 1;
+const RATCHET_TREE_NODE_TYPE_PARENT: u8 = 2;
+const LEAF_NODE_SOURCE_KEY_PACKAGE: u8 = 1;
+const LEAF_NODE_SOURCE_UPDATE: u8 = 2;
+const LEAF_NODE_SOURCE_COMMIT: u8 = 3;
+
+#[derive(Debug)]
+enum ExportedRatchetTreeNode {
+    Leaf {
+        capabilities: Capabilities,
+        serialized_len: usize,
+    },
+    Parent {
+        serialized_len: usize,
+    },
+}
+
+impl TlsSize for ExportedRatchetTreeNode {
+    fn tls_serialized_len(&self) -> usize {
+        match self {
+            Self::Leaf { serialized_len, .. } | Self::Parent { serialized_len } => *serialized_len,
+        }
+    }
+}
+
+impl TlsDeserializeBytes for ExportedRatchetTreeNode {
+    fn tls_deserialize_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), tls_codec::Error> {
+        let original_len = bytes.len();
+        let (node_type, remainder) = u8::tls_deserialize_bytes(bytes)?;
+
+        match node_type {
+            RATCHET_TREE_NODE_TYPE_LEAF => {
+                let remainder = skip_tls_value::<EncryptionKey>(remainder)?;
+                let remainder = skip_tls_value::<SignaturePublicKey>(remainder)?;
+                let remainder = skip_tls_value::<Credential>(remainder)?;
+                let (capabilities, remainder) = Capabilities::tls_deserialize_bytes(remainder)?;
+                let (leaf_node_source, remainder) = u8::tls_deserialize_bytes(remainder)?;
+                let remainder = match leaf_node_source {
+                    LEAF_NODE_SOURCE_KEY_PACKAGE => skip_tls_value::<Lifetime>(remainder)?,
+                    LEAF_NODE_SOURCE_UPDATE => remainder,
+                    LEAF_NODE_SOURCE_COMMIT => skip_tls_value::<VLBytes>(remainder)?,
+                    unknown => {
+                        return Err(tls_codec::Error::DecodingError(format!(
+                            "unknown leaf node source {unknown}"
+                        )));
+                    }
+                };
+                let remainder = skip_tls_value::<Extensions<LeafNode>>(remainder)?;
+                let remainder = skip_tls_value::<MlsSignature>(remainder)?;
+
+                Ok((
+                    Self::Leaf {
+                        capabilities,
+                        serialized_len: original_len - remainder.len(),
+                    },
+                    remainder,
+                ))
+            }
+            RATCHET_TREE_NODE_TYPE_PARENT => {
+                let remainder = skip_tls_value::<ParentNode>(remainder)?;
+                Ok((
+                    Self::Parent {
+                        serialized_len: original_len - remainder.len(),
+                    },
+                    remainder,
+                ))
+            }
+            unknown => Err(tls_codec::Error::DecodingError(format!(
+                "unknown ratchet tree node type {unknown}"
+            ))),
+        }
+    }
+}
+
+pub(super) fn exported_leaf_capabilities(
+    group: &MlsGroup,
+) -> Result<BTreeMap<LeafNodeIndex, Capabilities>, tls_codec::Error> {
+    let serialized_tree = group.export_ratchet_tree().tls_serialize_detached()?;
+    let (nodes, remainder): (Vec<Option<ExportedRatchetTreeNode>>, _) =
+        Vec::tls_deserialize_bytes(&serialized_tree)?;
+
+    if !remainder.is_empty() {
+        return Err(tls_codec::Error::TrailingData);
+    }
+
+    Ok(nodes
+        .into_iter()
+        .enumerate()
+        .filter_map(|(node_index, node)| match node {
+            Some(ExportedRatchetTreeNode::Leaf { capabilities, .. }) => {
+                Some((LeafNodeIndex::new((node_index / 2) as u32), capabilities))
+            }
+            Some(ExportedRatchetTreeNode::Parent { .. }) | None => None,
+        })
+        .collect())
+}
+
+fn skip_tls_value<T>(bytes: &[u8]) -> Result<&[u8], tls_codec::Error>
+where
+    T: TlsDeserializeBytes,
+{
+    let (_, remainder) = T::tls_deserialize_bytes(bytes)?;
+    Ok(remainder)
+}


### PR DESCRIPTION
## Summary

This adds a temporary OpenMLS compatibility shim so `mdk-core` 0.8.0 can verify during `cargo publish` against crates.io dependencies.

The workspace currently pins OpenMLS to a git revision that includes `MlsGroup::treesync().full_leaves()`, but crates.io package verification resolves OpenMLS 0.8.1 from the registry. OpenMLS 0.8.1 does not expose that API, which caused `mdk-core` publishing to fail even though the workspace build passed.

## What changed

- Replaced the two `treesync().full_leaves()` call sites with public `group.members()` plus a private exported-ratchet-tree capability parser.
- Isolated the parser in `groups/openmls_compat.rs` with an explicit removal note for the next crates.io OpenMLS release that exposes the upstream full-leaf iterator.
- Documented the temporary workaround next to the OpenMLS workspace dependency pin.

## Verification

- `just precommit`
- `cargo publish --dry-run --allow-dirty -p mdk-core`
- `cargo publish --dry-run --allow-dirty -p mdk-core --all-features`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/273">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR introduces a temporary OpenMLS compatibility shim so the mdk-core crate can successfully verify against crates.io OpenMLS during cargo publish; it replaces uses of the upstream-only MlsGroup::treesync().full_leaves() with logic that derives per-leaf capabilities from the group's exported ratchet tree. The change is explicitly marked for removal once a crates.io OpenMLS release exposes the full-leaf iterator API.

**What changed**:
- Replaced two call sites that used treesync().full_leaves() with iteration over group.members() plus capability lookups keyed by leaf index (crates/mdk-core/src/groups.rs).
- Added a new internal compatibility module crates/mdk-core/src/groups/openmls_compat.rs which parses an exported ratchet tree to re-derive leaf Capabilities and exposes pub(super) fn exported_leaf_capabilities(...) for use within mdk-core.
- Documented the temporary workspace OpenMLS pin and the rationale in Cargo.toml and added an Unreleased CHANGELOG entry noting the verification fix (mdk-core affected).

**Security impact**:
- None: no cryptographic primitives, key handling, storage permissions, or error messages exposing sensitive identifiers were changed.

**Protocol changes**:
- None to MLS protocol semantics; this is a compatibility/workaround for a crates.io API mismatch and does not alter MLS wire formats or protocol behavior.

**API surface**:
- No breaking changes to public APIs; the new function is pub(super) and intended as an internal compatibility shim to be removed once upstream exposes the needed API.

**Testing / verification**:
- Verified by running the project's precommit and cargo publish dry-run checks: just precommit; cargo publish --dry-run --allow-dirty -p mdk-core; and cargo publish --dry-run --allow-dirty -p mdk-core --all-features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->