### PR TITLE
Rotate stale keyring entries when creating a new SQLite database

### DIFF
--- a/crates/mdk-sqlite-storage/CHANGELOG.md
+++ b/crates/mdk-sqlite-storage/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixed
 
+- Rotated stale keyring entries when creating a fresh encrypted SQLite database, so app reinstall or data-wipe flows do not reuse a key from a previous database lifecycle. ([#275](https://github.com/marmot-protocol/mdk/pull/275))
+
 ### Removed
 
 ### Deprecated

--- a/crates/mdk-sqlite-storage/src/keyring.rs
+++ b/crates/mdk-sqlite-storage/src/keyring.rs
@@ -188,6 +188,54 @@ pub fn get_or_create_db_key(service_id: &str, db_key_id: &str) -> Result<Encrypt
     Ok(config)
 }
 
+pub(crate) fn create_fresh_db_key(
+    service_id: &str,
+    db_key_id: &str,
+) -> Result<EncryptionConfig, Error> {
+    let lock = KEY_GENERATION_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock
+        .lock()
+        .map_err(|e| Error::Keyring(format!("Failed to acquire key generation lock: {}", e)))?;
+
+    let entry = Entry::new(service_id, db_key_id).map_err(|e| {
+        Error::Keyring(format!(
+            "Failed to create keyring entry for service='{}', key='{}': {}",
+            service_id, db_key_id, e
+        ))
+    })?;
+
+    match entry.delete_credential() {
+        Ok(()) => {
+            tracing::info!(
+                service_id = service_id,
+                db_key_id = db_key_id,
+                "Deleted stale database encryption key from keyring before fresh database creation"
+            );
+        }
+        Err(KeyringError::NoEntry) => {}
+        Err(KeyringError::NoStorageAccess(err)) => {
+            return Err(Error::KeyringNotInitialized(err.to_string()));
+        }
+        Err(e) => {
+            return Err(Error::Keyring(format!(
+                "Failed to delete stale encryption key from keyring: {}",
+                e
+            )));
+        }
+    }
+
+    tracing::info!(
+        service_id = service_id,
+        db_key_id = db_key_id,
+        "Generating new database encryption key"
+    );
+
+    let config = EncryptionConfig::generate()?;
+    save_db_key(&entry, &config)?;
+
+    Ok(config)
+}
+
 /// Gets an existing database encryption key from the keyring.
 ///
 /// Unlike [`get_or_create_db_key`], this function does NOT generate a new key if one

--- a/crates/mdk-sqlite-storage/src/keyring.rs
+++ b/crates/mdk-sqlite-storage/src/keyring.rs
@@ -188,6 +188,21 @@ pub fn get_or_create_db_key(service_id: &str, db_key_id: &str) -> Result<Encrypt
     Ok(config)
 }
 
+/// Creates a fresh database encryption key, replacing any existing keyring entry.
+///
+/// This is used only after the caller has created a new database file and is
+/// starting a new database lifecycle. If this function returns an error, callers
+/// should remove any precreated empty database file before returning so a retry
+/// can attempt fresh creation again rather than treating the orphan file as an
+/// existing database.
+///
+/// # Thread Safety
+///
+/// This function uses the same in-process mutex as [`get_or_create_db_key`] to
+/// coordinate key creation with other threads in this process. Cross-process
+/// coordination is not provided, and keyring replacement is delete-then-save
+/// rather than an atomic keyring operation. A process crash between those
+/// operations can leave no key in the keyring.
 pub(crate) fn create_fresh_db_key(
     service_id: &str,
     db_key_id: &str,

--- a/crates/mdk-sqlite-storage/src/lib.rs
+++ b/crates/mdk-sqlite-storage/src/lib.rs
@@ -258,6 +258,20 @@ pub struct MdkSqliteStorage {
     connection: Arc<Mutex<Connection>>,
 }
 
+fn remove_precreated_database_file(file_path: &Path) {
+    match std::fs::remove_file(file_path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            tracing::warn!(
+                db_path = %file_path.display(),
+                error = %e,
+                "Failed to remove precreated database file after keyring rotation failure"
+            );
+        }
+    }
+}
+
 macro_rules! snapshot_helper {
     (
             $fn_name:ident,
@@ -362,9 +376,15 @@ impl MdkSqliteStorage {
     ///
     /// # Key Management
     ///
-    /// - If no key exists for the given identifiers, a new 32-byte key is generated using
-    ///   cryptographically secure randomness and stored in the keyring.
-    /// - On subsequent calls with the same identifiers, the existing key is retrieved.
+    /// - If the database file is newly created, any pre-existing keyring entry for
+    ///   the given identifiers is replaced before database initialization. This
+    ///   ensures app reinstall or data-wipe flows start with a fresh key and do
+    ///   not reuse key material from a previous database lifecycle.
+    /// - If no key exists for a new database file or special SQLite path, a new
+    ///   32-byte key is generated using cryptographically secure randomness and
+    ///   stored in the keyring.
+    /// - On subsequent calls for an existing database, the existing key is
+    ///   retrieved. A missing key for an existing encrypted database is an error.
     ///
     /// # Errors
     ///
@@ -405,7 +425,13 @@ impl MdkSqliteStorage {
                 // We created the file, so this is a new database lifecycle.
                 // Replace any stale keyring value left behind by an app reinstall
                 // or host-level data wipe before writing the new encrypted database.
-                keyring::create_fresh_db_key(service_id, db_key_id)?
+                match keyring::create_fresh_db_key(service_id, db_key_id) {
+                    Ok(config) => config,
+                    Err(e) => {
+                        remove_precreated_database_file(file_path);
+                        return Err(e);
+                    }
+                }
             }
             FileCreationOutcome::Skipped => {
                 // Special paths like :memory: do not have a file lifecycle to compare
@@ -2125,6 +2151,7 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
         use std::thread;
 
+        use keyring_core::{Entry, Error as KeyringError};
         use mdk_storage_traits::Secret;
         use mdk_storage_traits::groups::GroupStorage;
         use mdk_storage_traits::groups::types::{Group, GroupExporterSecret, GroupState};
@@ -2137,6 +2164,17 @@ mod tests {
 
         use super::*;
         use crate::test_utils::ensure_mock_store;
+
+        struct KeyringCleanup<'a> {
+            service_id: &'a str,
+            db_key_id: &'a str,
+        }
+
+        impl Drop for KeyringCleanup<'_> {
+            fn drop(&mut self) {
+                let _ = keyring::delete_db_key(self.service_id, self.db_key_id);
+            }
+        }
 
         #[test]
         fn test_encrypted_storage_creation() {
@@ -2925,6 +2963,10 @@ mod tests {
 
             let service_id = "test.mdk.storage.stalekey";
             let db_key_id = "test.key.stalekeytest";
+            let _cleanup = KeyringCleanup {
+                service_id,
+                db_key_id,
+            };
 
             let _ = keyring::delete_db_key(service_id, db_key_id);
 
@@ -2964,8 +3006,45 @@ mod tests {
                 encryption::is_database_encrypted(&db_path).unwrap(),
                 "Database should be encrypted"
             );
+        }
 
-            keyring::delete_db_key(service_id, db_key_id).unwrap();
+        /// Test that a keyring rotation failure does not strand an empty database file.
+        #[test]
+        fn test_new_db_removes_precreated_file_when_key_rotation_fails() {
+            ensure_mock_store();
+
+            let temp_dir = tempdir().unwrap();
+            let db_path = temp_dir.path().join("new_db_keyring_failure.db");
+
+            let service_id = "test.mdk.storage.rotationfailure";
+            let db_key_id = "test.key.rotationfailuretest";
+            let _cleanup = KeyringCleanup {
+                service_id,
+                db_key_id,
+            };
+
+            let _ = keyring::delete_db_key(service_id, db_key_id);
+            keyring::get_or_create_db_key(service_id, db_key_id).unwrap();
+
+            let entry = Entry::new(service_id, db_key_id).unwrap();
+            let credential = entry
+                .as_any()
+                .downcast_ref::<keyring_core::mock::Cred>()
+                .expect("Mock keyring store should provide mock credentials");
+            credential.set_error(KeyringError::NoStorageAccess(Box::new(
+                std::io::Error::new(std::io::ErrorKind::PermissionDenied, "delete denied"),
+            )));
+
+            let result = MdkSqliteStorage::new(&db_path, service_id, db_key_id);
+            assert!(
+                matches!(result, Err(error::Error::KeyringNotInitialized(_))),
+                "Keyring rotation failure should be returned"
+            );
+
+            assert!(
+                !db_path.exists(),
+                "Precreated database file should be removed after key rotation failure"
+            );
         }
 
         /// Test that reopening a database with keyring works when the key is present.

--- a/crates/mdk-sqlite-storage/src/lib.rs
+++ b/crates/mdk-sqlite-storage/src/lib.rs
@@ -2935,6 +2935,7 @@ mod tests {
 
             let storage = MdkSqliteStorage::new(&db_path, service_id, db_key_id);
             assert!(storage.is_ok(), "Should create database successfully");
+            drop(storage);
 
             let current_config = keyring::get_db_key(service_id, db_key_id)
                 .unwrap()
@@ -2945,12 +2946,25 @@ mod tests {
                 "Fresh database creation should replace stale keyring entries"
             );
 
+            let stale_result =
+                MdkSqliteStorage::new_with_key(&db_path, EncryptionConfig::new(stale_key));
+            assert!(
+                matches!(stale_result, Err(error::Error::WrongEncryptionKey)),
+                "Stale key should not decrypt the fresh database"
+            );
+
+            let current_result = MdkSqliteStorage::new_with_key(&db_path, current_config);
+            assert!(
+                current_result.is_ok(),
+                "Current keyring key should decrypt the fresh database"
+            );
+            drop(current_result);
+
             assert!(
                 encryption::is_database_encrypted(&db_path).unwrap(),
                 "Database should be encrypted"
             );
 
-            drop(storage);
             keyring::delete_db_key(service_id, db_key_id).unwrap();
         }
 

--- a/crates/mdk-sqlite-storage/src/lib.rs
+++ b/crates/mdk-sqlite-storage/src/lib.rs
@@ -401,9 +401,15 @@ impl MdkSqliteStorage {
         let creation_outcome = precreate_secure_database_file(file_path)?;
 
         let config = match creation_outcome {
-            FileCreationOutcome::Created | FileCreationOutcome::Skipped => {
-                // We created the file (or it's a special path like :memory:).
-                // Safe to generate a new key since we own this database.
+            FileCreationOutcome::Created => {
+                // We created the file, so this is a new database lifecycle.
+                // Replace any stale keyring value left behind by an app reinstall
+                // or host-level data wipe before writing the new encrypted database.
+                keyring::create_fresh_db_key(service_id, db_key_id)?
+            }
+            FileCreationOutcome::Skipped => {
+                // Special paths like :memory: do not have a file lifecycle to compare
+                // against the keyring entry, so preserve the existing get-or-create behavior.
                 keyring::get_or_create_db_key(service_id, db_key_id)?
             }
             FileCreationOutcome::AlreadyExisted => {
@@ -2905,6 +2911,45 @@ mod tests {
             );
 
             // Clean up
+            drop(storage);
+            keyring::delete_db_key(service_id, db_key_id).unwrap();
+        }
+
+        /// Test that a stale keyring entry is not reused for a new database lifecycle.
+        #[test]
+        fn test_new_db_replaces_stale_keyring_entry() {
+            ensure_mock_store();
+
+            let temp_dir = tempdir().unwrap();
+            let db_path = temp_dir.path().join("new_db_stale_keyring.db");
+
+            let service_id = "test.mdk.storage.stalekey";
+            let db_key_id = "test.key.stalekeytest";
+
+            let _ = keyring::delete_db_key(service_id, db_key_id);
+
+            let stale_config = keyring::get_or_create_db_key(service_id, db_key_id).unwrap();
+            let stale_key = *stale_config.key();
+
+            assert!(!db_path.exists(), "Database should not exist yet");
+
+            let storage = MdkSqliteStorage::new(&db_path, service_id, db_key_id);
+            assert!(storage.is_ok(), "Should create database successfully");
+
+            let current_config = keyring::get_db_key(service_id, db_key_id)
+                .unwrap()
+                .expect("Key should be stored in keyring");
+            assert_ne!(
+                current_config.key(),
+                &stale_key,
+                "Fresh database creation should replace stale keyring entries"
+            );
+
+            assert!(
+                encryption::is_database_encrypted(&db_path).unwrap(),
+                "Database should be encrypted"
+            );
+
             drop(storage);
             keyring::delete_db_key(service_id, db_key_id).unwrap();
         }


### PR DESCRIPTION
## Summary
- Treat fresh database creation as a new key lifecycle and replace any stale keyring entry before writing the encrypted database.
- Keep the existing get-or-create behavior for special paths like `:memory:`.
- Add regression coverage to ensure a newly created database does not reuse an old stored key.

## Testing
- Added a unit regression test for stale key replacement on fresh database creation.
- Ran the `mdk-sqlite-storage` test suite, formatting, and clippy checks locally; all passed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/275">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
⚠️ Security-sensitive changes

This PR treats fresh SQLite database creation as a new key lifecycle event and rotates any stale keyring entry before writing an encrypted database to avoid reusing keys from prior installs or data wipes; it preserves existing get-or-create behavior for existing databases and special paths (e.g., :memory:). It also ensures that if key generation/rotation fails during fresh DB creation, the precreated database file is removed to avoid leaving an invalid/empty file on disk.

**What changed**:
- Added a crate-visible helper `pub(crate) fn create_fresh_db_key(service_id: &str, db_key_id: &str) -> Result<EncryptionConfig, Error>` in mdk-sqlite-storage that deletes any existing keyring entry for the given identifiers, generates a fresh `EncryptionConfig`, persists it, and returns the stored config.
- Modified `MdkSqliteStorage::new()` in mdk-sqlite-storage to call `create_fresh_db_key` when `precreate_secure_database_file` reports the file was Created, while preserving `get_or_create_db_key` behavior for Skipped outcomes and special paths like `:memory:`.
- Added a `remove_precreated_database_file` helper and updated error handling so a failed key rotation during fresh DB creation removes the precreated DB file before returning the error.
- Introduced `KeyringCleanup`, an RAII test helper that deletes keyring entries on drop to keep tests isolated.
- Updated crates/mdk-sqlite-storage/CHANGELOG.md to document the fix; affected crate: mdk-sqlite-storage (no changes to mdk-core, mdk-memory-storage, mdk-storage-traits, or mdk-uniffi).

**Security impact**:
- Rotates stale/orphaned encryption keys on fresh database creation to avoid reusing keys from previous application lifecycles.
- Key generation remains serialized by the in-process KEY_GENERATION_LOCK and continues to use secure randomness for new key material.
- Key deletion treats `KeyringError::NoEntry` as non-fatal, maps `NoStorageAccess` to `KeyringNotInitialized`, and surfaces other delete failures to avoid ambiguous state.
- Key material is persisted via the same platform-native keyring storage mechanism as before.

**API surface**:
- No breaking public API changes; the new helper is crate-visible (`pub(crate)`) and no public types or methods were removed or altered.

**Testing**:
- Added unit regression test `test_new_db_replaces_stale_keyring_entry` verifying that a stale keyring entry is deleted and the newly created database uses a fresh key.
- Added test `test_new_db_removes_precreated_file_when_key_rotation_fails` verifying that a failed key rotation does not leave the precreated database file behind.
- Author reports running the mdk-sqlite-storage test suite, formatting, and clippy locally with all checks passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->