### PR TITLE
[skip-changelog] Harden bindings packaging workflow trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,20 @@ jobs:
             ci:
               - '.github/workflows/**'
 
+  # ── Workflow policy ─────────────────────────────────────────────────
+  workflow-policy:
+    runs-on: ubuntu-latest
+    name: Workflow Policy
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Check GitHub workflow policy
+      run: bash scripts/check-workflow-policy.sh
+
   # ── Quick checks that fail fast ─────────────────────────────────────
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
               - 'scripts/**'
             ci:
               - '.github/workflows/**'
+              - 'scripts/check-workflow-policy.sh'
 
   # ── Workflow policy ─────────────────────────────────────────────────
   workflow-policy:

--- a/.github/workflows/package-mdk-bindings.yml
+++ b/.github/workflows/package-mdk-bindings.yml
@@ -2,7 +2,7 @@ name: Package MDK Bindings
 
 on:
   push:
-    branches: [ master, uniffi-bindings ]
+    branches: [ master ]
     tags:
       - 'v*'
   workflow_dispatch:
@@ -686,4 +686,3 @@ jobs:
         # Force push to update remote tag if it exists
         git push origin "$TAG" --force
         echo "Created/updated and pushed tag: $TAG"
-

--- a/justfile
+++ b/justfile
@@ -93,11 +93,11 @@ precommit-verbose:
     @echo "→ Checking with stable Rust..."
     @bash scripts/check-all.sh stable
     @echo ""
-    @echo "→ Checking GitHub workflow policy..."
-    @just workflow-policy
-    @echo ""
     @echo "→ Checking with MSRV (1.90.0)..."
     @bash scripts/check-msrv.sh
+    @echo ""
+    @echo "→ Checking GitHub workflow policy..."
+    @just workflow-policy
     @echo ""
     @echo "→ Running tests..."
     @just test-all

--- a/justfile
+++ b/justfile
@@ -61,6 +61,10 @@ fmt:
 docs:
     @bash scripts/check-docs.sh
 
+# Check GitHub workflow policy
+workflow-policy:
+    @bash scripts/check-workflow-policy.sh
+
 # ==============================================================================
 # PRE-COMMIT CHECKS
 # ==============================================================================
@@ -68,6 +72,7 @@ docs:
 # Pre-commit checks: quiet mode with minimal output (recommended for agents/CI)
 precommit:
     @just _run-quiet "fmt"               "fmt (stable)"
+    @just _run-quiet "workflow-policy"   "workflow policy"
     @just _run-quiet "docs"              "docs (stable)"
     @just _run-quiet "lint"              "clippy (stable)"
     @just _run-quiet "_fmt-msrv"         "fmt (msrv)"
@@ -88,6 +93,9 @@ precommit-verbose:
     @echo "→ Checking with stable Rust..."
     @bash scripts/check-all.sh stable
     @echo ""
+    @echo "→ Checking GitHub workflow policy..."
+    @just workflow-policy
+    @echo ""
     @echo "→ Checking with MSRV (1.90.0)..."
     @bash scripts/check-msrv.sh
     @echo ""
@@ -104,6 +112,7 @@ precommit-verbose:
 # Quick check with stable (fast for local development)
 check:
     @bash scripts/check-all.sh
+    @just workflow-policy
     @just test-all
 
 # Full comprehensive check including all feature combinations (same as check for now)
@@ -461,4 +470,3 @@ _run-quiet recipe label:
         cat "$TMPFILE"
         exit 1
     fi
-

--- a/scripts/check-workflow-policy.sh
+++ b/scripts/check-workflow-policy.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ruby <<'RUBY'
+require "yaml"
+
+workflow_path = ".github/workflows/package-mdk-bindings.yml"
+workflow = YAML.load_file(workflow_path, aliases: true)
+trigger = workflow.fetch("on") { workflow.fetch(true) { abort "#{workflow_path}: missing on trigger" } }
+push = trigger.fetch("push") { abort "#{workflow_path}: missing push trigger" }
+
+allowed_branches = ["master"]
+branches = Array(push.fetch("branches") { abort "#{workflow_path}: missing push.branches trigger" }).map(&:to_s)
+unless branches == allowed_branches
+  abort "#{workflow_path}: push.branches must be #{allowed_branches.inspect}, got #{branches.inspect}"
+end
+
+tags = Array(push.fetch("tags") { abort "#{workflow_path}: missing push.tags trigger" }).map(&:to_s)
+unless tags == ["v*"]
+  abort "#{workflow_path}: push.tags must stay limited to [\"v*\"], got #{tags.inspect}"
+end
+
+expected_jobs = [
+  "package-swift",
+  "package-python",
+  "publish-python",
+  "package-ruby",
+  "publish-ruby",
+  "package-kotlin",
+]
+jobs = workflow.fetch("jobs") { abort "#{workflow_path}: missing jobs" }
+expected_jobs.each do |job|
+  abort "#{workflow_path}: missing expected job #{job.inspect}" unless jobs.key?(job)
+end
+
+puts "Package workflow policy OK"
+RUBY

--- a/scripts/check-workflow-policy.sh
+++ b/scripts/check-workflow-policy.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ! command -v ruby >/dev/null 2>&1; then
+  echo "Error: Ruby is required to parse GitHub workflow YAML for policy checks." >&2
+  exit 1
+fi
+
 ruby <<'RUBY'
 require "yaml"
 
@@ -18,19 +23,6 @@ end
 tags = Array(push.fetch("tags") { abort "#{workflow_path}: missing push.tags trigger" }).map(&:to_s)
 unless tags == ["v*"]
   abort "#{workflow_path}: push.tags must stay limited to [\"v*\"], got #{tags.inspect}"
-end
-
-expected_jobs = [
-  "package-swift",
-  "package-python",
-  "publish-python",
-  "package-ruby",
-  "publish-ruby",
-  "package-kotlin",
-]
-jobs = workflow.fetch("jobs") { abort "#{workflow_path}: missing jobs" }
-expected_jobs.each do |job|
-  abort "#{workflow_path}: missing expected job #{job.inspect}" unless jobs.key?(job)
 end
 
 puts "Package workflow policy OK"


### PR DESCRIPTION
## Summary

- restrict `package-mdk-bindings.yml` push triggers to `master` plus existing `v*` tags
- add a workflow-policy check that fails if the package workflow reintroduces non-master branch triggers
- wire the policy check into CI and local `just precommit`

## Verification

- verified `uniffi-bindings` is present in the current workflow push trigger and GitHub reports that branch as unprotected
- confirmed the new policy script fails against the previous `branches: [ master, uniffi-bindings ]` trigger
- `just workflow-policy`
- `ruby -r yaml -e 'ARGV.each { |path| YAML.load_file(path, aliases: true); puts "#{path} OK" }' .github/workflows/ci.yml .github/workflows/package-mdk-bindings.yml`
- `just precommit`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/278">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR hardens the packaging workflow by restricting its push triggers to only the master branch and v* tags, while adding automated validation to prevent accidental reintroduction of unprotected branch triggers. A new workflow policy check script validates that the package workflow maintains its restricted trigger configuration, and this check is integrated into both CI and local development workflows.

**What changed**:
- Restricted `.github/workflows/package-mdk-bindings.yml` push triggers from `[master, uniffi-bindings]` to `master` only.
- Added a new "Workflow Policy" job to `.github/workflows/ci.yml` that runs the policy validation script.
- Created `scripts/check-workflow-policy.sh`, a Ruby-based validator that ensures the package workflow only triggers on master and v* tags, failing with descriptive errors if the policy is violated.
- Integrated the workflow-policy check into the `justfile` precommit task and the main check target to catch policy violations during local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->