### PR TITLE
[codex] Pin GitHub Actions to immutable SHAs [skip-changelog]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[skip-changelog]"

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -13,13 +13,13 @@ jobs:
       issues: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Get PR information
         id: pr_info
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -73,8 +73,8 @@ jobs:
           echo "Reason: PR has skip label or title contains [skip-changelog]"
 
       - name: Comment on PR if changelog is missing
-        if: steps.check_changelog.outputs.changed == 'false' && steps.pr_info.outputs.skip != 'true'
-        uses: actions/github-script@v7
+        if: always() && steps.check_changelog.outputs.changed == 'false' && steps.pr_info.outputs.skip != 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const comment = `## ❌ Changelog Check Failed
@@ -91,10 +91,9 @@ jobs:
 
             To skip this check, add the \`skip-changelog\` label or include \`[skip-changelog]\` in the PR title.`;
 
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: comment
             });
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
       ci: ${{ steps.filter.outputs.ci }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 2
 
       - name: Detect changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           filters: |
             rust:
@@ -46,6 +46,21 @@ jobs:
               - 'scripts/**'
             ci:
               - '.github/workflows/**'
+              - 'scripts/check-github-actions-pinned.sh'
+
+  # ── GitHub Actions supply-chain guard ───────────────────────────────
+  actions-pinned:
+    runs-on: ubuntu-latest
+    name: GitHub Actions Pins
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.ci == 'true'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+    - name: Check GitHub Actions pins
+      run: bash scripts/check-github-actions-pinned.sh
 
   # ── Quick checks that fail fast ─────────────────────────────────────
   format:
@@ -56,11 +71,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Setup Rust (stable)
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
       with:
+        toolchain: stable
         components: rustfmt
 
     - name: Check formatting
@@ -88,16 +104,16 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Setup Rust (${{ matrix.rust }})
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
       with:
         toolchain: ${{ matrix.rust }}
         components: clippy
 
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         key: ${{ matrix.rust }}-${{ matrix.features.name }}
 
@@ -122,15 +138,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Setup Rust (${{ matrix.rust }})
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
       with:
         toolchain: ${{ matrix.rust }}
 
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         key: ${{ matrix.rust }}-docs
 
@@ -163,18 +179,22 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Setup Rust (stable)
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
+      with:
+        toolchain: stable
 
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         key: test-${{ matrix.features.name }}
 
     - name: Install cargo-nextest
-      uses: taiki-e/install-action@cargo-nextest
+      uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
+      with:
+        tool: cargo-nextest
 
     - name: Install system dependencies
       run: sudo apt-get update && sudo apt-get install -y pkg-config
@@ -195,10 +215,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Install cargo-audit
-      uses: taiki-e/install-action@cargo-audit
+      uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
+      with:
+        tool: cargo-audit
 
     - name: Run cargo audit
       run: cargo audit

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,11 +30,11 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Detect changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           filters: |
             rust:
@@ -53,13 +53,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
+        with:
+          toolchain: stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: coverage
 
@@ -67,7 +69,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y pkg-config
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
+        with:
+          tool: cargo-llvm-cov
 
       - name: Generate coverage
         run: |
@@ -172,7 +176,7 @@ jobs:
 
       - name: Comment PR with coverage change
         if: always() && github.event_name == 'pull_request' && steps.master_coverage.outputs.baseline != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const current = parseFloat('${{ steps.coverage.outputs.percentage }}');
@@ -180,9 +184,10 @@ jobs:
             const diff = (current - baseline).toFixed(2);
 
             let emoji = current > baseline ? '✅' : current < baseline ? '❌' : '⚠️';
+            const commentMarker = '<!-- coverage-comment -->';
 
             // Build the message (with markdown header for comments, without for logs)
-            const commentBody = `## ${emoji} Coverage: ${baseline}% → ${current}% (${diff > 0 ? '+' : ''}${diff}%)`;
+            const commentBody = `${commentMarker}\n## ${emoji} Coverage: ${baseline}% → ${current}% (${diff > 0 ? '+' : ''}${diff}%)`;
             const logMessage = `${emoji} Coverage: ${baseline}% → ${current}% (${diff > 0 ? '+' : ''}${diff}%)`;
 
             // Skip commenting on PRs from forks (they don't have write permissions)
@@ -194,12 +199,31 @@ jobs:
             }
 
             try {
-              await github.rest.issues.createComment({
+              const { data: comments } = await github.rest.issues.listComments({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: commentBody
+                repo: context.repo.repo
               });
+
+              const existing = comments.find(c =>
+                c.body.includes(commentMarker) && c.user.type === 'Bot'
+              );
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  comment_id: existing.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: commentBody
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: commentBody
+                });
+              }
             } catch (error) {
               // Gracefully handle permission errors (e.g., from forks)
               if (error.status === 403) {
@@ -219,28 +243,28 @@ jobs:
 
       - name: Upload coverage baseline (master only)
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-baseline
           path: coverage-baseline/coverage-baseline.txt
           retention-days: 90
 
       - name: Upload HTML coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report-html
           path: coverage/html/
           retention-days: 90
 
       - name: Upload lcov coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report-lcov
           path: coverage/lcov.info
           retention-days: 90
 
       - name: Upload coverage summary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-summary
           path: coverage/summary.txt

--- a/.github/workflows/package-mdk-bindings.yml
+++ b/.github/workflows/package-mdk-bindings.yml
@@ -30,18 +30,20 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
 
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
+      with:
+        toolchain: stable
 
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
     - name: Install just
-      uses: extractions/setup-just@v2
+      uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
 
     - name: Build iOS targets
       run: |
@@ -66,7 +68,7 @@ jobs:
         echo "✓ Swift package assembled"
 
     - name: Checkout Swift package repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         repository: ${{ env.SWIFT_PACKAGE_REPO }}
         path: swift-package-repo
@@ -116,12 +118,14 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
 
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
+      with:
+        toolchain: stable
 
     - name: Add aarch64-apple-ios target if matrix.os is macos-latest
       if: matrix.os == 'macos-latest'
@@ -140,13 +144,13 @@ jobs:
         echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
 
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
     - name: Install just
-      uses: extractions/setup-just@v2
+      uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
 
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.11'
 
@@ -179,7 +183,7 @@ jobs:
         echo "✓ Python artifacts prepared for ${{ runner.os }}"
 
     - name: Upload Python artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: python-artifacts-${{ matrix.os }}
         path: python-artifacts/
@@ -196,12 +200,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
 
     - name: Download all Python artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         path: python-artifacts-all
         pattern: python-artifacts-*
@@ -247,7 +251,7 @@ jobs:
         ls -la python-package/mdk/
 
     - name: Checkout Python package repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         repository: ${{ env.PYTHON_PACKAGE_REPO }}
         path: python-package-repo
@@ -280,7 +284,7 @@ jobs:
 
     - name: Setup Python for package publishing
       if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_test_pypi == true
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.11'
 
@@ -300,14 +304,14 @@ jobs:
 
     - name: Publish to TestPyPI
       if: inputs.publish_test_pypi == true
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         packages-dir: python-package/dist/
         repository-url: https://test.pypi.org/legacy/
 
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         packages-dir: python-package/dist/
 
@@ -321,12 +325,14 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
 
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
+      with:
+        toolchain: stable
 
     - name: Add aarch64-apple-ios target if matrix.os is macos-latest
       if: matrix.os == 'macos-latest'
@@ -345,13 +351,13 @@ jobs:
         echo "OPENSSL_STATIC=1" >> $env:GITHUB_ENV
 
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
     - name: Install just
-      uses: extractions/setup-just@v2
+      uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
 
     - name: Setup Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
       with:
         ruby-version: '3.2'
 
@@ -381,7 +387,7 @@ jobs:
         echo "✓ Ruby artifacts prepared for ${{ runner.os }}"
 
     - name: Upload Ruby artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ruby-artifacts-${{ matrix.os }}
         path: ruby-artifacts/
@@ -398,12 +404,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
 
     - name: Download all Ruby artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         path: ruby-artifacts-all
         pattern: ruby-artifacts-*
@@ -436,7 +442,7 @@ jobs:
         echo "✓ Complete Ruby gem assembled with all platform libraries"
 
     - name: Checkout Ruby package repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         repository: ${{ env.RUBY_PACKAGE_REPO }}
         path: ruby-package-repo
@@ -469,13 +475,13 @@ jobs:
 
     - name: Setup Ruby for gem publishing
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
       with:
         ruby-version: '3.2'
 
     - name: Configure RubyGems Trusted Publishing credentials
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: rubygems/configure-rubygems-credentials@v1.0.0
+      uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0
 
     - name: Build and publish gem to RubyGems.org
       if: startsWith(github.ref, 'refs/tags/v')
@@ -490,7 +496,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
 
@@ -499,26 +505,28 @@ jobs:
         rm -rf /opt/hostedtoolcache
 
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
+      with:
+        toolchain: stable
 
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
     - name: Install just
-      uses: extractions/setup-just@v2
+      uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
 
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         distribution: 'temurin'
         java-version: '17'
 
     - name: Setup Android SDK
-      uses: android-actions/setup-android@v3
+      uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
 
     - name: Setup Android NDK
       id: setup-ndk
-      uses: nttld/setup-ndk@v1
+      uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779 # v1.6.0
       with:
         ndk-version: r27d
         add-to-path: false
@@ -598,7 +606,7 @@ jobs:
         echo "Updated gradle.properties with version: $VERSION"
 
     - name: Checkout Kotlin package repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ env.KOTLIN_PACKAGE_REPO }}
         path: kotlin-package-repo
@@ -686,4 +694,3 @@ jobs:
         # Force push to update remote tag if it exists
         git push origin "$TAG" --force
         echo "Created/updated and pushed tag: $TAG"
-

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -19,13 +19,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Setup Rust (stable)
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
+      with:
+        toolchain: stable
 
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         key: publish-macros
 
@@ -41,13 +43,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Setup Rust (stable)
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
+      with:
+        toolchain: stable
 
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         key: publish-storage-traits
 
@@ -67,13 +71,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Setup Rust (stable)
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
+      with:
+        toolchain: stable
 
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         key: publish-memory-storage
 
@@ -96,13 +102,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Setup Rust (stable)
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
+      with:
+        toolchain: stable
 
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         key: publish-sqlite-storage
 
@@ -125,13 +133,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Setup Rust (stable)
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
+      with:
+        toolchain: stable
 
     - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         key: publish-core
 

--- a/.github/workflows/uniffi-bindings-check.yml
+++ b/.github/workflows/uniffi-bindings-check.yml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  UNIFFI_RUSTDOC_TOOLCHAIN: nightly-2025-09-30
 
 jobs:
   # ── Change Detection ────────────────────────────────────────────────
@@ -25,13 +26,13 @@ jobs:
     outputs:
       should_run: ${{ steps.filter.outputs.rust }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 2
 
       - name: Detect changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           filters: |
             rust:
@@ -53,28 +54,30 @@ jobs:
       issues: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@nightly
+      - name: Install Rust nightly for rustdoc JSON
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # pinned from master
+        with:
+          toolchain: ${{ env.UNIFFI_RUSTDOC_TOOLCHAIN }}
 
       - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Cache cargo registry and build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: uniffi-check
 
       - name: Generate rustdoc JSON for mdk-core
         run: |
           RUSTDOCFLAGS='-Z unstable-options --output-format json' \
-            cargo +nightly doc -p mdk-core --no-deps --all-features
+            cargo +"${UNIFFI_RUSTDOC_TOOLCHAIN}" doc -p mdk-core --no-deps --all-features
 
       - name: Generate rustdoc JSON for mdk-uniffi
         run: |
           RUSTDOCFLAGS='-Z unstable-options --output-format json' \
-            cargo +nightly doc -p mdk-uniffi --no-deps --all-features
+            cargo +"${UNIFFI_RUSTDOC_TOOLCHAIN}" doc -p mdk-uniffi --no-deps --all-features
 
       - name: Check UniFFI binding coverage
         id: check
@@ -82,7 +85,7 @@ jobs:
 
       - name: Comment on PR
         if: steps.check.outcome == 'success' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const fs = require('fs');

--- a/justfile
+++ b/justfile
@@ -61,6 +61,10 @@ fmt:
 docs:
     @bash scripts/check-docs.sh
 
+# Check that GitHub Actions references are SHA-pinned
+actions-pinned:
+    @bash scripts/check-github-actions-pinned.sh
+
 # ==============================================================================
 # PRE-COMMIT CHECKS
 # ==============================================================================
@@ -68,6 +72,7 @@ docs:
 # Pre-commit checks: quiet mode with minimal output (recommended for agents/CI)
 precommit:
     @just _run-quiet "fmt"               "fmt (stable)"
+    @just _run-quiet "actions-pinned"    "actions pinned"
     @just _run-quiet "docs"              "docs (stable)"
     @just _run-quiet "lint"              "clippy (stable)"
     @just _run-quiet "_fmt-msrv"         "fmt (msrv)"
@@ -84,6 +89,9 @@ precommit-verbose:
     @echo "=========================================="
     @echo "Running pre-commit checks (stable + MSRV)"
     @echo "=========================================="
+    @echo ""
+    @echo "→ Checking GitHub Actions pins..."
+    @just actions-pinned
     @echo ""
     @echo "→ Checking with stable Rust..."
     @bash scripts/check-all.sh stable
@@ -461,4 +469,3 @@ _run-quiet recipe label:
         cat "$TMPFILE"
         exit 1
     fi
-

--- a/scripts/check-github-actions-pinned.sh
+++ b/scripts/check-github-actions-pinned.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+failed=0
+
+normalize_action() {
+    local value="$1"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+
+    if [[ "${#value}" -ge 2 ]]; then
+        local first="${value:0:1}"
+        local last="${value: -1}"
+
+        if [[ ( "$first" == '"' && "$last" == '"' ) || ( "$first" == "'" && "$last" == "'" ) ]]; then
+            value="${value:1:${#value}-2}"
+        fi
+    fi
+
+    printf '%s' "$value"
+}
+
+while IFS= read -r -d '' file; do
+    line_number=0
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        ((line_number += 1))
+
+        if [[ ! "$line" =~ ^[[:space:]-]*uses:[[:space:]]*([^[:space:]#]+)([[:space:]]*#(.*))? ]]; then
+            continue
+        fi
+
+        action="$(normalize_action "${BASH_REMATCH[1]}")"
+        comment="${BASH_REMATCH[3]:-}"
+
+        case "$action" in
+            ./*|docker://*)
+                continue
+                ;;
+        esac
+
+        if [[ "$action" != *@* ]]; then
+            echo "$file:$line_number: action is missing an explicit ref: $action" >&2
+            failed=1
+            continue
+        fi
+
+        ref="${action##*@}"
+        if [[ ! "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "$file:$line_number: action ref is not pinned to a full commit SHA: $action" >&2
+            failed=1
+            continue
+        fi
+
+        if [[ -z "${comment//[[:space:]]/}" ]]; then
+            echo "$file:$line_number: pinned action is missing a version comment: $action" >&2
+            failed=1
+        fi
+    done < "$file"
+done < <(find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) -print0)
+
+if [[ "$failed" -ne 0 ]]; then
+    exit 1
+fi
+
+echo "All GitHub Actions are pinned to full commit SHAs."


### PR DESCRIPTION
## Summary

- Pin external GitHub Actions in all workflows to full commit SHAs with version comments.
- Add a CI and precommit guard that rejects mutable GitHub Actions refs.
- Add weekly Dependabot updates for GitHub Actions so pinned SHAs can rotate.

## Validation

- `bash scripts/check-github-actions-pinned.sh`
- Temporary negative check confirmed mutable refs are rejected.
- Ruby YAML parsing for all workflows and Dependabot config
- `actionlint`
- `just precommit`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/279">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->