### PR TITLE
[codex] Prevent default plaintext Secret serialization

### DIFF
--- a/crates/mdk-storage-traits/CHANGELOG.md
+++ b/crates/mdk-storage-traits/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 ### Breaking changes
 
+- Changed default serde serialization for `Secret<T>` to fail instead of emitting wrapped secret values. Use `Secret::expose_for_serialization()` for deliberate plaintext exports. ([#280](https://github.com/marmot-protocol/mdk/pull/280))
+
 ### Changed
 
 ### Added
@@ -34,6 +36,7 @@
 ### Fixed
 
 - Redacted sensitive MLS/Nostr group identifiers and private payload fields from storage-domain `Debug` output. ([#277](https://github.com/marmot-protocol/mdk/pull/277))
+- Prevented serde-based exports of storage-domain structs from leaking image keys, nonces, and exporter secrets in plaintext. ([#280](https://github.com/marmot-protocol/mdk/pull/280))
 
 ### Removed
 

--- a/crates/mdk-storage-traits/src/groups/types.rs
+++ b/crates/mdk-storage-traits/src/groups/types.rs
@@ -381,6 +381,34 @@ mod tests {
     }
 
     #[test]
+    fn test_group_serialization_with_secret_is_rejected() {
+        let group = Group {
+            mls_group_id: GroupId::from_slice(&[1, 2, 3]),
+            nostr_group_id: [0u8; 32],
+            name: "Test Group".to_string(),
+            description: "Test Description".to_string(),
+            image_hash: Some([8u8; 32]),
+            image_key: Some(Secret::new([7u8; 32])),
+            image_nonce: Some(Secret::new([6u8; 12])),
+            admin_pubkeys: BTreeSet::new(),
+            last_message_id: None,
+            last_message_at: None,
+            last_message_processed_at: None,
+            epoch: 0,
+            state: GroupState::Active,
+            self_update_state: SelfUpdateState::Required,
+        };
+
+        let err = serde_json::to_value(&group)
+            .expect_err("Group serialization should fail when secrets are present");
+        let err = err.to_string();
+
+        assert!(err.contains("Secret values cannot be serialized"));
+        assert!(!err.contains("[7"));
+        assert!(!err.contains("[6"));
+    }
+
+    #[test]
     fn test_group_debug_redacts_sensitive_values() {
         let group = Group {
             mls_group_id: GroupId::from_slice(&[222, 173, 190, 239]),
@@ -412,25 +440,36 @@ mod tests {
     }
 
     #[test]
-    fn test_group_exporter_secret_serialization() {
+    fn test_group_exporter_secret_serialization_is_rejected() {
         let secret = GroupExporterSecret {
             mls_group_id: GroupId::from_slice(&[1, 2, 3]),
             epoch: 42,
             secret: Secret::new([0u8; 32]),
         };
 
-        let serialized = serde_json::to_value(&secret).unwrap();
-        assert_eq!(serialized["mls_group_id"]["value"]["vec"], json!([1, 2, 3]));
-        assert_eq!(serialized["epoch"], json!(42));
-        assert_eq!(
-            serialized["secret"],
-            json!([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0
-            ])
-        );
+        let err = serde_json::to_value(&secret)
+            .expect_err("Group exporter secret serialization should not expose plaintext");
+        let err = err.to_string();
 
-        // Test deserialization
+        assert!(err.contains("Secret values cannot be serialized"));
+        assert!(!err.contains("[0"));
+    }
+
+    #[test]
+    fn test_group_exporter_secret_deserialization() {
+        let serialized = json!({
+            "mls_group_id": {
+                "value": {
+                    "vec": [1, 2, 3]
+                }
+            },
+            "epoch": 42,
+            "secret": [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0
+            ]
+        });
+
         let deserialized: GroupExporterSecret = serde_json::from_value(serialized).unwrap();
         assert_eq!(deserialized.epoch, 42);
         assert_eq!(*deserialized.secret, [0u8; 32]);

--- a/crates/mdk-storage-traits/src/groups/types.rs
+++ b/crates/mdk-storage-traits/src/groups/types.rs
@@ -444,7 +444,7 @@ mod tests {
         let secret = GroupExporterSecret {
             mls_group_id: GroupId::from_slice(&[1, 2, 3]),
             epoch: 42,
-            secret: Secret::new([0u8; 32]),
+            secret: Secret::new([0xABu8; 32]),
         };
 
         let err = serde_json::to_value(&secret)
@@ -452,7 +452,7 @@ mod tests {
         let err = err.to_string();
 
         assert!(err.contains("Secret values cannot be serialized"));
-        assert!(!err.contains("[0"));
+        assert!(!err.contains("171"));
     }
 
     #[test]

--- a/crates/mdk-storage-traits/src/lib.rs
+++ b/crates/mdk-storage-traits/src/lib.rs
@@ -246,7 +246,7 @@ pub mod welcomes;
 // Re-export GroupId for convenience
 pub use error::MdkStorageError;
 pub use group_id::GroupId;
-pub use secret::{Secret, Zeroize};
+pub use secret::{PlaintextSecret, Secret, Zeroize};
 
 use self::groups::GroupStorage;
 use self::messages::MessageStorage;

--- a/crates/mdk-storage-traits/src/secret.rs
+++ b/crates/mdk-storage-traits/src/secret.rs
@@ -92,7 +92,7 @@ where
         S: serde::Serializer,
     {
         Err(serde::ser::Error::custom(
-            "Secret values cannot be serialized",
+            "Secret values cannot be serialized; use Secret::expose_for_serialization() for deliberate plaintext export",
         ))
     }
 }
@@ -162,6 +162,7 @@ mod tests {
         let err = err.to_string();
 
         assert!(err.contains("Secret values cannot be serialized"));
+        assert!(err.contains("Secret::expose_for_serialization()"));
         assert!(!err.contains("222"));
         assert!(!err.contains("173"));
         assert!(!err.contains("190"));

--- a/crates/mdk-storage-traits/src/secret.rs
+++ b/crates/mdk-storage-traits/src/secret.rs
@@ -21,6 +21,7 @@ where
     ///
     /// This is intentionally opt-in so accidental serde exports of `Secret<T>`
     /// fail instead of leaking wrapped key material.
+    #[must_use = "PlaintextSecret is only useful when passed to a serializer"]
     pub fn expose_for_serialization(&self) -> PlaintextSecret<'_, T> {
         PlaintextSecret(&self.0)
     }
@@ -75,6 +76,12 @@ where
 
 /// Explicit opt-in wrapper for serializing the plaintext value inside a [`Secret`].
 pub struct PlaintextSecret<'a, T>(&'a T);
+
+impl<T> fmt::Debug for PlaintextSecret<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PlaintextSecret(***)")
+    }
+}
 
 impl<T> Serialize for Secret<T>
 where
@@ -168,5 +175,35 @@ mod tests {
         let serialized = serde_json::to_value(secret.expose_for_serialization()).unwrap();
 
         assert_eq!(serialized, serde_json::json!([222, 173, 190, 239]));
+    }
+
+    #[test]
+    fn test_optional_plaintext_secret_serialization_is_explicit() {
+        let secret = Some(Secret::new([222u8, 173, 190, 239]));
+        let missing_secret: Option<Secret<[u8; 4]>> = None;
+
+        let serialized =
+            serde_json::to_value(secret.as_ref().map(Secret::expose_for_serialization)).unwrap();
+        let serialized_missing = serde_json::to_value(
+            missing_secret
+                .as_ref()
+                .map(Secret::expose_for_serialization),
+        )
+        .unwrap();
+
+        assert_eq!(serialized, serde_json::json!([222, 173, 190, 239]));
+        assert_eq!(serialized_missing, serde_json::Value::Null);
+    }
+
+    #[test]
+    fn test_plaintext_secret_debug_redacts_value() {
+        let secret = Secret::new([222u8, 173, 190, 239]);
+        let debug_str = format!("{:?}", secret.expose_for_serialization());
+
+        assert_eq!(debug_str, "PlaintextSecret(***)");
+        assert!(!debug_str.contains("222"));
+        assert!(!debug_str.contains("173"));
+        assert!(!debug_str.contains("190"));
+        assert!(!debug_str.contains("239"));
     }
 }

--- a/crates/mdk-storage-traits/src/secret.rs
+++ b/crates/mdk-storage-traits/src/secret.rs
@@ -16,6 +16,14 @@ where
     pub fn new(value: T) -> Self {
         Self(value)
     }
+
+    /// Return an explicit plaintext serialization wrapper for this secret.
+    ///
+    /// This is intentionally opt-in so accidental serde exports of `Secret<T>`
+    /// fail instead of leaking wrapped key material.
+    pub fn expose_for_serialization(&self) -> PlaintextSecret<'_, T> {
+        PlaintextSecret(&self.0)
+    }
 }
 
 impl<T> AsMut<T> for Secret<T>
@@ -65,10 +73,26 @@ where
     }
 }
 
-// Serialization support
+/// Explicit opt-in wrapper for serializing the plaintext value inside a [`Secret`].
+pub struct PlaintextSecret<'a, T>(&'a T);
+
 impl<T> Serialize for Secret<T>
 where
-    T: zeroize::Zeroize + Serialize,
+    T: zeroize::Zeroize,
+{
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Err(serde::ser::Error::custom(
+            "Secret values cannot be serialized",
+        ))
+    }
+}
+
+impl<T> Serialize for PlaintextSecret<'_, T>
+where
+    T: Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -120,5 +144,29 @@ mod tests {
         assert!(!debug_str.contains("173"));
         assert!(!debug_str.contains("190"));
         assert!(!debug_str.contains("239"));
+    }
+
+    #[test]
+    fn test_secret_serialization_is_rejected() {
+        let secret = Secret::new([222u8, 173, 190, 239]);
+
+        let err = serde_json::to_value(&secret)
+            .expect_err("Secret serialization should not expose plaintext");
+        let err = err.to_string();
+
+        assert!(err.contains("Secret values cannot be serialized"));
+        assert!(!err.contains("222"));
+        assert!(!err.contains("173"));
+        assert!(!err.contains("190"));
+        assert!(!err.contains("239"));
+    }
+
+    #[test]
+    fn test_plaintext_secret_serialization_is_explicit() {
+        let secret = Secret::new([222u8, 173, 190, 239]);
+
+        let serialized = serde_json::to_value(secret.expose_for_serialization()).unwrap();
+
+        assert_eq!(serialized, serde_json::json!([222, 173, 190, 239]));
     }
 }

--- a/crates/mdk-storage-traits/src/welcomes/types.rs
+++ b/crates/mdk-storage-traits/src/welcomes/types.rs
@@ -158,6 +158,65 @@ mod tests {
     }
 
     #[test]
+    fn test_welcome_deserialization_with_secret_fields_is_accepted() {
+        let pubkey =
+            PublicKey::from_hex("8a9de562cbbed225b6ea0118dd3997a02df92c0bffd2224f71081a7450c3e549")
+                .unwrap();
+        let now = Timestamp::from_secs(1_677_721_600);
+        let event = UnsignedEvent::new(
+            pubkey,
+            now,
+            nostr::Kind::MlsWelcome,
+            nostr::Tags::new(),
+            "private welcome event body".to_string(),
+        );
+        let mls_group_id = GroupId::from_slice(&[1, 2, 3]);
+        let nostr_group_id = [0u8; 32];
+        let image_hash = [8u8; 32];
+        let image_key = [7u8; 32];
+        let image_nonce = [6u8; 12];
+        let mut group_admin_pubkeys = BTreeSet::new();
+        group_admin_pubkeys.insert(pubkey);
+        let mut group_relays = BTreeSet::new();
+        group_relays.insert(RelayUrl::from_str("wss://relay.example.com").unwrap());
+
+        let serialized = json!({
+            "id": EventId::all_zeros(),
+            "event": event,
+            "mls_group_id": mls_group_id,
+            "nostr_group_id": nostr_group_id,
+            "group_name": "Private Group",
+            "group_description": "Private Description",
+            "group_image_hash": image_hash,
+            "group_image_key": image_key,
+            "group_image_nonce": image_nonce,
+            "group_admin_pubkeys": group_admin_pubkeys,
+            "group_relays": group_relays,
+            "welcomer": pubkey,
+            "member_count": 3,
+            "state": "pending",
+            "wrapper_event_id": EventId::all_zeros(),
+        });
+
+        let welcome: Welcome = serde_json::from_value(serialized).unwrap();
+
+        assert_eq!(
+            welcome
+                .group_image_key
+                .as_ref()
+                .map(|secret| secret.as_ref()),
+            Some(&image_key)
+        );
+        assert_eq!(
+            welcome
+                .group_image_nonce
+                .as_ref()
+                .map(|secret| secret.as_ref()),
+            Some(&image_nonce)
+        );
+    }
+
+    #[test]
     fn test_processed_welcome_debug_redacts_sensitive_values() {
         let processed_welcome = ProcessedWelcome {
             wrapper_event_id: EventId::all_zeros(),

--- a/crates/mdk-storage-traits/src/welcomes/types.rs
+++ b/crates/mdk-storage-traits/src/welcomes/types.rs
@@ -119,6 +119,45 @@ mod tests {
     }
 
     #[test]
+    fn test_welcome_serialization_with_secret_is_rejected() {
+        let pubkey =
+            PublicKey::from_hex("8a9de562cbbed225b6ea0118dd3997a02df92c0bffd2224f71081a7450c3e549")
+                .unwrap();
+        let now = Timestamp::now();
+        let welcome = Welcome {
+            id: EventId::all_zeros(),
+            event: UnsignedEvent::new(
+                pubkey,
+                now,
+                nostr::Kind::MlsWelcome,
+                nostr::Tags::new(),
+                "private welcome event body".to_string(),
+            ),
+            mls_group_id: GroupId::from_slice(&[1, 2, 3]),
+            nostr_group_id: [0u8; 32],
+            group_name: "Private Group".to_string(),
+            group_description: "Private Description".to_string(),
+            group_image_hash: Some([8u8; 32]),
+            group_image_key: Some(Secret::new([7u8; 32])),
+            group_image_nonce: Some(Secret::new([6u8; 12])),
+            group_admin_pubkeys: BTreeSet::new(),
+            group_relays: BTreeSet::new(),
+            welcomer: pubkey,
+            member_count: 3,
+            state: WelcomeState::Pending,
+            wrapper_event_id: EventId::all_zeros(),
+        };
+
+        let err = serde_json::to_value(&welcome)
+            .expect_err("Welcome serialization should fail when secrets are present");
+        let err = err.to_string();
+
+        assert!(err.contains("Secret values cannot be serialized"));
+        assert!(!err.contains("[7"));
+        assert!(!err.contains("[6"));
+    }
+
+    #[test]
     fn test_processed_welcome_debug_redacts_sensitive_values() {
         let processed_welcome = ProcessedWelcome {
             wrapper_event_id: EventId::all_zeros(),


### PR DESCRIPTION
## Summary

- make default `Secret<T>` serde serialization fail with a generic error instead of delegating to the wrapped value
- add `PlaintextSecret` and `Secret::expose_for_serialization()` for explicit plaintext export boundaries
- add regression coverage for direct secrets, group image secrets, welcome image secrets, and exporter secrets

## Validation

- `cargo test -p mdk-storage-traits`
- `cargo check --workspace --all-features`
- `just precommit`

## Security note

This prevents accidental serde-based plaintext export of storage-domain secret material while preserving deserialization for existing storage/import paths.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/280">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

⚠️ Security-sensitive changes

This PR prevents accidental plaintext serialization of `Secret<T>` by making default serde serialization fail with a clear error. It introduces `PlaintextSecret` wrapper and an explicit `Secret::expose_for_serialization()` method to provide intentional plaintext export boundaries while preserving deserialization support for existing storage/import paths.

**What changed**:
- `Secret<T>` serialization now fails with error "Secret values cannot be serialized" instead of delegating to the wrapped value (mdk-storage-traits)
- Added `PlaintextSecret<'a, T>` wrapper type that explicitly allows serialization of plaintext secret values when needed (mdk-storage-traits)
- Added `Secret<T>::expose_for_serialization()` method to obtain the `PlaintextSecret` wrapper for deliberate plaintext exports (mdk-storage-traits)
- Re-exported `PlaintextSecret` alongside `Secret` and `Zeroize` in the public API (mdk-storage-traits)

**Security impact**:
- Prevents accidental serde-based exports of storage-domain secret material including image keys, nonces, and exporter secrets in plaintext
- Requires explicit opt-in via `expose_for_serialization()` for any plaintext export of secrets
- Complements existing Debug output redaction to block multiple leakage vectors

**API surface**:
- Breaking change: `Secret<T>` serialization fails by default; code relying on implicit plaintext serialization must migrate to `secret.expose_for_serialization()` before serializing
- New public type: `PlaintextSecret<'a, T>`
- New public method: `Secret<T>::expose_for_serialization(&self) -> PlaintextSecret<'_, T>`
- Updated public re-exports in lib.rs to include `PlaintextSecret`

**Testing**:
- Added regression tests covering direct secrets, group image secrets, group exporter secrets, and welcome image secrets
- Tests validate that secret serialization is rejected and that plaintext values are not leaked in error messages
- Tests confirm deserialization continues to work for existing storage/import paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->