### PR TITLE
Add a default CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewers for all files
+* @erskingardner @dannym-arx @mubarakcoded @jgmontoya


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` with a default `*` rule
- Set the default reviewers to `@erskingardner`, `@dannym-arx`, `@mubarakcoded`, and `@jgmontoya`

## Testing
- Not run (not requested)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/286">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds a `.github/CODEOWNERS` file to the repository to establish default code ownership and review requirements. The file designates four GitHub users (`@erskingardner`, `@dannym-arx`, `@mubarakcoded`, `@jgmontoya`) as default reviewers for all repository files.

**What changed**:
- Added `.github/CODEOWNERS` file with a default `*` ownership rule assigning all files to four designated maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->