### PR TITLE
[codex] Verify unsigned rumor IDs

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 
+- Verified unsigned application-message rumor IDs before accepting or sending them, preventing caller-supplied IDs from being trusted when they do not match the canonical event hash. ([#287](https://github.com/marmot-protocol/mdk/pull/287))
 - Fixed `mdk-core` crates.io package verification against OpenMLS 0.8.1 by using a temporary exported-ratchet-tree compatibility shim until crates.io OpenMLS exposes the upstream full-leaf iterator. ([#273](https://github.com/marmot-protocol/mdk/pull/273))
 
 ### Removed

--- a/crates/mdk-core/src/messages/application.rs
+++ b/crates/mdk-core/src/messages/application.rs
@@ -50,6 +50,7 @@ where
         let bytes = application_message.into_bytes();
         let mut rumor: UnsignedEvent = UnsignedEvent::from_json(bytes)?;
 
+        rumor.verify_id()?;
         self.verify_rumor_author(&rumor.pubkey, sender_credential)?;
 
         let rumor_id: EventId = rumor.id();
@@ -102,7 +103,8 @@ where
 mod tests {
     use mdk_storage_traits::messages::MessageStorage;
     use mdk_storage_traits::messages::types as message_types;
-    use nostr::{Keys, Kind};
+    use nostr::{EventId, JsonUtil, Keys, Kind};
+    use tls_codec::Serialize as TlsSerialize;
 
     use crate::messages::MessageProcessingResult;
     use crate::test_util::*;
@@ -175,6 +177,55 @@ mod tests {
         // For this test, we verify the state tracking works
         assert_eq!(message.content, "Test message");
         assert_eq!(message.pubkey, creator.public_key());
+    }
+
+    #[test]
+    fn test_process_message_rejects_mismatched_rumor_id() {
+        let (alice_mdk, bob_mdk, alice_keys, _bob_keys, group_id) = setup_two_member_group();
+        let mut rumor = create_test_rumor(&alice_keys, "Forged rumor ID");
+        let canonical_id = rumor.id();
+        let forged_id = EventId::all_zeros();
+        assert_ne!(canonical_id, forged_id);
+
+        rumor.id = Some(forged_id);
+
+        let mut alice_group = alice_mdk
+            .load_mls_group(&group_id)
+            .expect("Alice should load MLS group")
+            .expect("Alice MLS group should exist");
+        let signer = alice_mdk
+            .load_mls_signer(&alice_group)
+            .expect("Alice should load MLS signer");
+        let json = rumor.as_json();
+        let message_out = alice_group
+            .create_message(&alice_mdk.provider, &signer, json.as_bytes())
+            .expect("Alice should create MLS message");
+        let serialized_message = message_out
+            .tls_serialize_detached()
+            .expect("MLS message should serialize");
+        let event = alice_mdk
+            .build_message_event(&group_id, serialized_message, None)
+            .expect("Alice should build wrapper event");
+
+        let result = bob_mdk.process_message(&event);
+
+        assert!(matches!(
+            result,
+            Ok(MessageProcessingResult::Unprocessable { mls_group_id })
+                if mls_group_id == group_id
+        ));
+        assert!(
+            bob_mdk
+                .get_message(&group_id, &forged_id)
+                .expect("Storage lookup should succeed")
+                .is_none()
+        );
+        assert!(
+            bob_mdk
+                .get_message(&group_id, &canonical_id)
+                .expect("Storage lookup should succeed")
+                .is_none()
+        );
     }
 
     /// Test message from non-member

--- a/crates/mdk-core/src/messages/create.rs
+++ b/crates/mdk-core/src/messages/create.rs
@@ -76,6 +76,7 @@ where
 
         // Ensure rumor ID
         rumor.ensure_id();
+        rumor.verify_id()?;
 
         // Serialize as JSON
         let json: String = rumor.as_json();
@@ -178,7 +179,8 @@ where
 mod tests {
     use mdk_storage_traits::GroupId;
     use mdk_storage_traits::messages::types as message_types;
-    use nostr::{Keys, Kind, TagKind, Timestamp};
+    use nostr::event::Error as NostrEventError;
+    use nostr::{EventId, Keys, Kind, TagKind, Timestamp};
 
     use crate::error::Error;
     use crate::messages::EventTag;
@@ -223,6 +225,36 @@ mod tests {
         let result = mdk.create_message(&non_existent_group_id, rumor, None);
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), Error::GroupNotFound));
+    }
+
+    #[test]
+    fn test_create_message_rejects_mismatched_rumor_id() {
+        let mdk = create_test_mdk();
+        let (creator, members, admins) = create_test_group_members();
+        let group_id = create_test_group(&mdk, &creator, &members, &admins);
+        let mut rumor = create_test_rumor(&creator, "Forged local rumor ID");
+        let canonical_id = rumor.id();
+        let forged_id = EventId::all_zeros();
+        assert_ne!(canonical_id, forged_id);
+
+        rumor.id = Some(forged_id);
+
+        let result = mdk.create_message(&group_id, rumor, None);
+
+        assert!(matches!(
+            result,
+            Err(Error::Event(NostrEventError::InvalidId))
+        ));
+        assert!(
+            mdk.get_message(&group_id, &forged_id)
+                .expect("Storage lookup should succeed")
+                .is_none()
+        );
+        assert!(
+            mdk.get_message(&group_id, &canonical_id)
+                .expect("Storage lookup should succeed")
+                .is_none()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- verify parsed unsigned application-message rumor IDs before accepting them
- reject caller-supplied malformed rumor IDs on the send path
- add regression coverage for receive-side and send-side mismatch cases
- document the security fix in the `mdk-core` changelog

## Root cause
`UnsignedEvent::ensure_id()` preserves an existing `id`, so MDK could trust a caller-supplied ID that did not match the canonical unsigned event hash.

## Validation
- `cargo test -p mdk-core mismatched_rumor_id`
- `cargo fmt --check`
- `just precommit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

⚠️ **Security-sensitive changes**

This PR fixes a vulnerability where unsigned rumor IDs supplied by callers could be accepted without verifying they match the canonical event hash. The fix adds explicit verification of rumor IDs on both the send and receive paths, rejecting any malformed or mismatched IDs before further processing.

**What changed**:
- Added `rumor.verify_id()?` validation after deserializing unsigned application messages in `process_application_message` (mdk-core receive path)
- Added `rumor.verify_id()?` validation in `create_mls_message_payload` after ensuring the rumor has an ID (mdk-core send path)
- Documented the security fix in mdk-core's CHANGELOG under **Unreleased → Fixed**

**Security impact**:
- Prevents caller-supplied unsigned rumor IDs from being trusted when they do not match the canonical unsigned event hash, closing a trust model violation
- Rejects malformed rumor IDs on both send and receive paths before they reach encryption, storage, or author-binding verification stages

**Testing**:
- Added regression test `test_process_message_rejects_mismatched_rumor_id` for the receive path that verifies forged rumors are rejected as `Unprocessable` and neither version is stored
- Added regression test `test_create_message_rejects_mismatched_rumor_id` for the send path that verifies `create_message` returns `Error::Event(NostrEventError::InvalidId)` and no message record is stored for either ID variant

<!-- end of auto-generated comment: release notes by coderabbit.ai -->