### PR TITLE
Fix legacy self-remove auto-commit

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -31,11 +31,8 @@
 
 ### Fixed
 
-<<<<<<< codex/fix-marmot-security-98
 - Fixed admin auto-commit of legacy `Remove(self)` leaves in mixed/legacy groups so departing members are actually removed instead of silently remaining in the MLS group. ([#288](https://github.com/marmot-protocol/mdk/pull/288))
-=======
 - Recorded rollback snapshots for locally merged admin-list updates so clients can converge on the MIP-03 winner when competing admins concurrently mutate `admin_pubkeys`. ([#289](https://github.com/marmot-protocol/mdk/pull/289))
->>>>>>> master
 - Verified unsigned application-message rumor IDs before accepting or sending them, preventing caller-supplied IDs from being trusted when they do not match the canonical event hash. ([#287](https://github.com/marmot-protocol/mdk/pull/287))
 - Fixed `mdk-core` crates.io package verification against OpenMLS 0.8.1 by using a temporary exported-ratchet-tree compatibility shim until crates.io OpenMLS exposes the upstream full-leaf iterator. ([#273](https://github.com/marmot-protocol/mdk/pull/273))
 

--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 
+- Fixed admin auto-commit of legacy `Remove(self)` leaves in mixed/legacy groups so departing members are actually removed instead of silently remaining in the MLS group. ([#288](https://github.com/marmot-protocol/mdk/pull/288))
 - Verified unsigned application-message rumor IDs before accepting or sending them, preventing caller-supplied IDs from being trusted when they do not match the canonical event hash. ([#287](https://github.com/marmot-protocol/mdk/pull/287))
 - Fixed `mdk-core` crates.io package verification against OpenMLS 0.8.1 by using a temporary exported-ratchet-tree compatibility shim until crates.io OpenMLS exposes the upstream full-leaf iterator. ([#273](https://github.com/marmot-protocol/mdk/pull/273))
 

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -8291,6 +8291,14 @@ mod tests {
             .accept_welcome(&charlie_welcome)
             .expect("charlie accepts");
 
+        let required_proposals = bob_mdk
+            .group_required_proposals(&group_id)
+            .expect("bob reads required proposals");
+        assert!(
+            !required_proposals.contains(&ProposalType::SelfRemove),
+            "mixed group must not require SelfRemove before Bob's legacy fallback leave"
+        );
+
         // Bob leaves the mixed group.
         let bob_leave = bob_mdk.leave_group(&group_id).expect("Bob should leave");
 
@@ -8360,6 +8368,14 @@ mod tests {
                 .count(),
             3,
             "alice starts with alice, bob, and charlie"
+        );
+
+        let required_proposals = charlie_mdk
+            .group_required_proposals(&group_id)
+            .expect("charlie reads required proposals");
+        assert!(
+            !required_proposals.contains(&ProposalType::SelfRemove),
+            "mixed group must not require SelfRemove before Charlie's legacy fallback leave"
         );
 
         let charlie_leave = charlie_mdk

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -8365,21 +8365,21 @@ mod tests {
     #[test]
     fn test_admin_auto_commit_legacy_remove_self_removes_member() {
         let alice_mdk = create_test_mdk(); // admin
-        let bob_mdk = create_test_mdk(); // capability-poor legacy fixture
+        let legacy_mdk = create_test_mdk(); // capability-poor legacy fixture
         let charlie_mdk = create_test_mdk(); // modern non-admin, the leaver
         let alice_keys = Keys::generate();
-        let bob_keys = Keys::generate();
+        let legacy_keys = Keys::generate();
         let charlie_keys = Keys::generate();
 
-        // Bob's legacy KeyPackage forces RequiredCapabilities = [], so
+        // The legacy KeyPackage forces RequiredCapabilities = [], so
         // Charlie's leave falls back to legacy Remove(self).
-        let bob_kp = create_legacy_key_package_event(&bob_mdk, &bob_keys);
+        let legacy_kp = create_legacy_key_package_event(&legacy_mdk, &legacy_keys);
         let charlie_kp = create_key_package_event(&charlie_mdk, &charlie_keys);
 
         let create_result = alice_mdk
             .create_group(
                 &alice_keys.public_key(),
-                vec![bob_kp, charlie_kp],
+                vec![legacy_kp, charlie_kp],
                 create_nostr_group_config_data(vec![alice_keys.public_key()]),
             )
             .expect("alice creates mixed group");
@@ -8389,8 +8389,9 @@ mod tests {
             .merge_pending_commit(&group_id)
             .expect("alice merges creation commit");
 
-        // Charlie joins. Bob is only a legacy fixture and does not need to
-        // process a welcome for Alice to hold a mixed-group state.
+        // create_group returns welcomes in invitee order. Charlie's KeyPackage
+        // is second; the first invitee is only a legacy capability fixture and
+        // does not need to process a welcome for Alice to hold mixed state.
         let charlie_welcome = charlie_mdk
             .process_welcome(
                 &nostr::EventId::all_zeros(),
@@ -8409,7 +8410,7 @@ mod tests {
                 .members()
                 .count(),
             3,
-            "alice starts with alice, bob, and charlie"
+            "alice starts with alice, the legacy invitee, and charlie"
         );
 
         let required_proposals = charlie_mdk

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -8309,6 +8309,85 @@ mod tests {
         );
     }
 
+    /// Leave-path: when an admin receives a legacy `Remove(self)` leave from
+    /// a mixed group, the auto-commit must actually remove the departing
+    /// member rather than producing an empty self-update commit.
+    #[test]
+    fn test_admin_auto_commit_legacy_remove_self_removes_member() {
+        let alice_mdk = create_test_mdk(); // admin
+        let bob_mdk = create_test_mdk(); // capability-poor legacy fixture
+        let charlie_mdk = create_test_mdk(); // modern non-admin, the leaver
+        let alice_keys = Keys::generate();
+        let bob_keys = Keys::generate();
+        let charlie_keys = Keys::generate();
+
+        // Bob's legacy KeyPackage forces RequiredCapabilities = [], so
+        // Charlie's leave falls back to legacy Remove(self).
+        let bob_kp = create_legacy_key_package_event(&bob_mdk, &bob_keys);
+        let charlie_kp = create_key_package_event(&charlie_mdk, &charlie_keys);
+
+        let create_result = alice_mdk
+            .create_group(
+                &alice_keys.public_key(),
+                vec![bob_kp, charlie_kp],
+                create_nostr_group_config_data(vec![alice_keys.public_key()]),
+            )
+            .expect("alice creates mixed group");
+        let group_id = create_result.group.mls_group_id.clone();
+
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("alice merges creation commit");
+
+        // Charlie joins. Bob is only a legacy fixture and does not need to
+        // process a welcome for Alice to hold a mixed-group state.
+        let charlie_welcome = charlie_mdk
+            .process_welcome(
+                &nostr::EventId::all_zeros(),
+                &create_result.welcome_rumors[1],
+            )
+            .expect("charlie processes welcome");
+        charlie_mdk
+            .accept_welcome(&charlie_welcome)
+            .expect("charlie accepts welcome");
+
+        assert_eq!(
+            alice_mdk
+                .load_mls_group(&group_id)
+                .expect("alice loads group")
+                .expect("alice has group")
+                .members()
+                .count(),
+            3,
+            "alice starts with alice, bob, and charlie"
+        );
+
+        let charlie_leave = charlie_mdk
+            .leave_group(&group_id)
+            .expect("charlie leaves mixed group");
+
+        let result = alice_mdk
+            .process_message(&charlie_leave.evolution_event)
+            .expect("alice processes charlie's leave");
+        assert!(
+            matches!(result, MessageProcessingResult::Proposal(_)),
+            "admin should auto-commit legacy Remove(self), got {:?}",
+            result
+        );
+
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("alice merges auto-commit");
+
+        let members = alice_mdk
+            .get_members(&group_id)
+            .expect("alice reads members after leave");
+        assert!(
+            !members.contains(&charlie_keys.public_key()),
+            "legacy Remove(self) auto-commit must remove the departing member"
+        );
+    }
+
     /// Admission: after an all-modern group is created, adding a member
     /// whose KeyPackage omits `SelfRemove` must be rejected and surface as
     /// the typed `Error::InviteeMissingRequiredProposal`. The underlying

--- a/crates/mdk-core/src/messages/proposal.rs
+++ b/crates/mdk-core/src/messages/proposal.rs
@@ -95,9 +95,11 @@ where
                                         return Ok(result);
                                     }
 
-                                    // Legacy Remove(self) proposal + admin receiver:
-                                    // auto-commit an admin-authored removal for the
-                                    // departing leaf.
+                                    // OpenMLS returns a QueuedProposal here, but it only enters
+                                    // the proposal store when store_pending_proposal is called.
+                                    // The admin path intentionally drops the queued legacy
+                                    // proposal and builds an equivalent admin-authored removal,
+                                    // avoiding the SelfRemove-only pending-store filter.
                                     self.auto_commit_legacy_self_remove(
                                         mls_group,
                                         event,
@@ -298,6 +300,9 @@ where
             }));
         }
 
+        // Check the current admin set against live members after this sender's
+        // leaf departs. If no active admin would remain, the leave is invalid
+        // and should not be stored for a later commit.
         if let Err(e) = self.validate_admin_depletion(mls_group, &[sender_leaf_index]) {
             tracing::warn!(
                 target: "mdk_core::messages::process_proposal",
@@ -359,6 +364,8 @@ where
 
         let commit_event = self.build_message_event(group_id, serialized_commit_message, None)?;
 
+        // Record the epoch after staging the generated commit. Rollback
+        // invalidation treats this proposal as part of the staged epoch branch.
         self.mark_processed(event, group_id, mls_group.epoch().as_u64())?;
 
         tracing::debug!(
@@ -411,6 +418,8 @@ where
 
         let commit_event = self.build_message_event(group_id, serialized_commit_message, None)?;
 
+        // Record the epoch after staging the generated commit. Rollback
+        // invalidation treats this proposal as part of the staged epoch branch.
         self.mark_processed(event, group_id, mls_group.epoch().as_u64())?;
 
         tracing::debug!(
@@ -659,6 +668,7 @@ mod tests {
             .merge_pending_commit(&group_id)
             .expect("Alice should merge commit");
 
+        // create_group returns welcomes in invitee order; Bob's KeyPackage was first.
         let bob_preview = bob_mdk
             .process_welcome(
                 &nostr::EventId::all_zeros(),

--- a/crates/mdk-core/src/messages/proposal.rs
+++ b/crates/mdk-core/src/messages/proposal.rs
@@ -5,7 +5,9 @@
 use mdk_storage_traits::messages::types as message_types;
 use mdk_storage_traits::{GroupId, MdkStorageProvider};
 use nostr::Event;
-use openmls::prelude::{BasicCredential, MlsGroup, Proposal, QueuedProposal, Sender};
+use openmls::prelude::{
+    BasicCredential, LeafNodeIndex, MlsGroup, Proposal, QueuedProposal, Sender,
+};
 use openmls_traits::OpenMlsProvider;
 use tls_codec::Serialize as TlsSerialize;
 
@@ -83,11 +85,13 @@ where
                                 let is_self_remove = *sender_leaf_index == removed_leaf_index;
 
                                 if is_self_remove && receiver_is_admin {
-                                    // Self-remove proposal + admin receiver: auto-commit
-                                    self.auto_commit_proposal(
+                                    // Legacy Remove(self) proposal + admin receiver:
+                                    // auto-commit an admin-authored removal for the
+                                    // departing leaf.
+                                    self.auto_commit_legacy_self_remove(
                                         mls_group,
                                         event,
-                                        staged_proposal,
+                                        removed_leaf_index,
                                         &group_id,
                                     )
                                 } else {
@@ -198,7 +202,7 @@ where
                                     });
                                 }
 
-                                self.auto_commit_proposal(
+                                self.auto_commit_self_remove_proposal(
                                     mls_group,
                                     event,
                                     staged_proposal,
@@ -292,13 +296,13 @@ where
         self.save_processed_message_record(processed_message)
     }
 
-    /// Stores a proposal and immediately auto-commits it.
+    /// Stores a `SelfRemove` proposal and immediately auto-commits it.
     ///
     /// Uses the commit builder with a SelfRemove-only filter to ensure no other
     /// pending proposals (Add, Remove, etc.) are accidentally included in the
     /// commit. This prevents non-admin committers from creating commits that
     /// violate MIP-03 authorization rules.
-    pub(super) fn auto_commit_proposal(
+    pub(super) fn auto_commit_self_remove_proposal(
         &self,
         mls_group: &mut MlsGroup,
         event: &Event,
@@ -341,6 +345,58 @@ where
         tracing::debug!(
             target: "mdk_core::messages::process_proposal",
             "Auto-committed self-remove proposal"
+        );
+
+        Ok(MessageProcessingResult::Proposal(UpdateGroupResult {
+            evolution_event: commit_event,
+            welcome_rumors: None,
+            mls_group_id: group_id.clone(),
+        }))
+    }
+
+    /// Auto-commits a legacy `Remove(self)` leave proposal received by an admin.
+    ///
+    /// The original proposal is already validated before this method is called.
+    /// Unlike `SelfRemove`, legacy `Remove` is not committable by arbitrary
+    /// non-admin receivers, so the admin commits an equivalent removal directly
+    /// instead of routing it through the SelfRemove-only proposal-store filter.
+    pub(super) fn auto_commit_legacy_self_remove(
+        &self,
+        mls_group: &mut MlsGroup,
+        event: &Event,
+        removed_leaf_index: LeafNodeIndex,
+        group_id: &GroupId,
+    ) -> Result<MessageProcessingResult> {
+        let mls_signer = self.load_mls_signer(mls_group)?;
+
+        let (commit_message, _welcomes, _group_info) = mls_group
+            .commit_builder()
+            .consume_proposal_store(false)
+            .propose_removals([removed_leaf_index])
+            .load_psks(self.provider.storage())
+            .map_err(|e| Error::Group(e.to_string()))?
+            .build(
+                self.provider.rand(),
+                self.provider.crypto(),
+                &mls_signer,
+                |_| true,
+            )
+            .map_err(|e| Error::Group(e.to_string()))?
+            .stage_commit(&self.provider)
+            .map_err(|e| Error::Group(e.to_string()))?
+            .into_contents();
+
+        let serialized_commit_message = commit_message
+            .tls_serialize_detached()
+            .map_err(|_e| Error::Group("Failed to serialize commit message".to_string()))?;
+
+        let commit_event = self.build_message_event(group_id, serialized_commit_message, None)?;
+
+        self.mark_processed(event, group_id, mls_group.epoch().as_u64())?;
+
+        tracing::debug!(
+            target: "mdk_core::messages::process_proposal",
+            "Auto-committed legacy self-remove proposal"
         );
 
         Ok(MessageProcessingResult::Proposal(UpdateGroupResult {

--- a/crates/mdk-core/src/messages/proposal.rs
+++ b/crates/mdk-core/src/messages/proposal.rs
@@ -85,6 +85,16 @@ where
                                 let is_self_remove = *sender_leaf_index == removed_leaf_index;
 
                                 if is_self_remove && receiver_is_admin {
+                                    if let Some(result) = self.validate_self_remove_allowed(
+                                        mls_group,
+                                        event,
+                                        &group_id,
+                                        *sender_leaf_index,
+                                        "legacy Remove(self)",
+                                    )? {
+                                        return Ok(result);
+                                    }
+
                                     // Legacy Remove(self) proposal + admin receiver:
                                     // auto-commit an admin-authored removal for the
                                     // departing leaf.
@@ -152,56 +162,17 @@ where
                                 })
                             }
                             Proposal::SelfRemove => {
-                                // Per MIP-03, admins MUST NOT send SelfRemove.
-                                // Reject proposals from admin senders.
-                                let sender_member = mls_group
-                                    .member_at(*sender_leaf_index)
-                                    .ok_or(Error::MessageFromNonMember)?;
-                                let sender_cred =
-                                    BasicCredential::try_from(sender_member.credential)?;
-                                let sender_pubkey =
-                                    self.parse_credential_identity(sender_cred.identity())?;
-                                let group_data =
-                                    crate::extension::NostrGroupDataExtension::from_group(
-                                        mls_group,
-                                    )?;
-
-                                if group_data.admins.contains(&sender_pubkey) {
-                                    tracing::warn!(
-                                        target: "mdk_core::messages::process_proposal",
-                                        "Rejecting SelfRemove from admin — must self-demote first"
-                                    );
-                                    self.mark_processed(
-                                        event,
-                                        &group_id,
-                                        mls_group.epoch().as_u64(),
-                                    )?;
-                                    return Ok(MessageProcessingResult::IgnoredProposal {
-                                        mls_group_id: group_id,
-                                        reason: "SelfRemove rejected: sender is an admin"
-                                            .to_string(),
-                                    });
+                                if let Some(result) = self.validate_self_remove_allowed(
+                                    mls_group,
+                                    event,
+                                    &group_id,
+                                    *sender_leaf_index,
+                                    "SelfRemove",
+                                )? {
+                                    return Ok(result);
                                 }
 
                                 // Non-admin SelfRemove: any member can commit, so auto-commit.
-                                if let Err(e) =
-                                    self.validate_admin_depletion(mls_group, &[*sender_leaf_index])
-                                {
-                                    tracing::warn!(
-                                        target: "mdk_core::messages::process_proposal",
-                                        "Rejecting SelfRemove: {}", e
-                                    );
-                                    self.mark_processed(
-                                        event,
-                                        &group_id,
-                                        mls_group.epoch().as_u64(),
-                                    )?;
-                                    return Ok(MessageProcessingResult::IgnoredProposal {
-                                        mls_group_id: group_id,
-                                        reason: format!("SelfRemove rejected: {}", e),
-                                    });
-                                }
-
                                 self.auto_commit_self_remove_proposal(
                                     mls_group,
                                     event,
@@ -294,6 +265,54 @@ where
         );
 
         self.save_processed_message_record(processed_message)
+    }
+
+    /// Validates shared MIP-03 self-remove constraints before auto-commit.
+    fn validate_self_remove_allowed(
+        &self,
+        mls_group: &MlsGroup,
+        event: &Event,
+        group_id: &GroupId,
+        sender_leaf_index: LeafNodeIndex,
+        proposal_label: &str,
+    ) -> Result<Option<MessageProcessingResult>> {
+        // Per MIP-03, admins MUST NOT leave via SelfRemove-style proposals.
+        // They must self-demote first so the admin set changes explicitly.
+        let sender_member = mls_group
+            .member_at(sender_leaf_index)
+            .ok_or(Error::MessageFromNonMember)?;
+        let sender_cred = BasicCredential::try_from(sender_member.credential)?;
+        let sender_pubkey = self.parse_credential_identity(sender_cred.identity())?;
+        let group_data = crate::extension::NostrGroupDataExtension::from_group(mls_group)?;
+
+        if group_data.admins.contains(&sender_pubkey) {
+            tracing::warn!(
+                target: "mdk_core::messages::process_proposal",
+                "Rejecting {} from admin — must self-demote first",
+                proposal_label
+            );
+            self.mark_processed(event, group_id, mls_group.epoch().as_u64())?;
+            return Ok(Some(MessageProcessingResult::IgnoredProposal {
+                mls_group_id: group_id.clone(),
+                reason: format!("{proposal_label} rejected: sender is an admin"),
+            }));
+        }
+
+        if let Err(e) = self.validate_admin_depletion(mls_group, &[sender_leaf_index]) {
+            tracing::warn!(
+                target: "mdk_core::messages::process_proposal",
+                "Rejecting {}: {}",
+                proposal_label,
+                e
+            );
+            self.mark_processed(event, group_id, mls_group.epoch().as_u64())?;
+            return Ok(Some(MessageProcessingResult::IgnoredProposal {
+                mls_group_id: group_id.clone(),
+                reason: format!("{proposal_label} rejected: {e}"),
+            }));
+        }
+
+        Ok(None)
     }
 
     /// Stores a `SelfRemove` proposal and immediately auto-commits it.
@@ -410,9 +429,16 @@ where
 #[cfg(test)]
 mod tests {
     use nostr::Keys;
+    use openmls::prelude::{
+        MIXED_CIPHERTEXT_WIRE_FORMAT_POLICY, MIXED_PLAINTEXT_WIRE_FORMAT_POLICY,
+        MlsGroupJoinConfig, ProposalType, SenderRatchetConfiguration,
+    };
+    use tls_codec::Serialize as TlsSerialize;
 
     use crate::messages::MessageProcessingResult;
-    use crate::test_util::{create_key_package_event, create_nostr_group_config_data};
+    use crate::test_util::{
+        create_key_package_event, create_legacy_key_package_event, create_nostr_group_config_data,
+    };
     use crate::tests::create_test_mdk;
 
     /// Tests that self-leave proposals are auto-committed when processed by an admin.
@@ -609,12 +635,6 @@ mod tests {
     /// is in admin_pubkeys and rejects the proposal per MIP-03.
     #[test]
     fn test_receiving_side_rejects_admin_self_remove() {
-        use openmls::prelude::{
-            MIXED_CIPHERTEXT_WIRE_FORMAT_POLICY, MIXED_PLAINTEXT_WIRE_FORMAT_POLICY,
-            MlsGroupJoinConfig, SenderRatchetConfiguration,
-        };
-        use tls_codec::Serialize as TlsSerialize;
-
         let alice_keys = Keys::generate();
         let bob_keys = Keys::generate();
 
@@ -700,6 +720,87 @@ mod tests {
                 if reason.contains("sender is an admin")
             ),
             "Receiver should reject SelfRemove from admin, got: {:?}",
+            result
+        );
+    }
+
+    /// Tests that the receiving side rejects legacy Remove(self) from an
+    /// admin sender even when another admin receives the proposal.
+    #[test]
+    fn test_receiving_side_rejects_admin_legacy_remove_self() {
+        let alice_keys = Keys::generate();
+        let bob_keys = Keys::generate();
+        let legacy_keys = Keys::generate();
+
+        let alice_mdk = create_test_mdk();
+        let bob_mdk = create_test_mdk();
+        let legacy_mdk = create_test_mdk();
+
+        // Alice and Bob are admins. The legacy invitee forces the group to
+        // omit SelfRemove from RequiredCapabilities so this exercises the
+        // legacy Remove(self) path.
+        let admins = vec![alice_keys.public_key(), bob_keys.public_key()];
+        let bob_key_package = create_key_package_event(&bob_mdk, &bob_keys);
+        let legacy_key_package = create_legacy_key_package_event(&legacy_mdk, &legacy_keys);
+
+        let create_result = alice_mdk
+            .create_group(
+                &alice_keys.public_key(),
+                vec![bob_key_package, legacy_key_package],
+                create_nostr_group_config_data(admins),
+            )
+            .expect("Alice should create mixed group");
+        let group_id = create_result.group.mls_group_id.clone();
+
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("Alice should merge commit");
+
+        let bob_preview = bob_mdk
+            .process_welcome(
+                &nostr::EventId::all_zeros(),
+                &create_result.welcome_rumors[0],
+            )
+            .expect("Bob should process welcome");
+        bob_mdk
+            .accept_welcome(&bob_preview)
+            .expect("Bob should accept welcome");
+
+        let required_proposals = bob_mdk
+            .group_required_proposals(&group_id)
+            .expect("Bob reads required proposals");
+        assert!(
+            !required_proposals.contains(&ProposalType::SelfRemove),
+            "mixed group must not require SelfRemove before legacy Remove(self)"
+        );
+
+        // Simulate non-compliant client: Alice (admin) sends legacy
+        // Remove(self) by bypassing leave_group's admin check and using
+        // OpenMLS directly.
+        let mut mls_group = alice_mdk
+            .load_mls_group(&group_id)
+            .expect("load group")
+            .expect("group exists");
+        let signer = alice_mdk.load_mls_signer(&mls_group).expect("load signer");
+        let leave_msg = mls_group
+            .leave_group(&alice_mdk.provider, &signer)
+            .expect("legacy Remove(self) should succeed at MLS level");
+        let serialized = leave_msg.tls_serialize_detached().expect("serialize");
+        let event = alice_mdk
+            .build_message_event(&group_id, serialized, None)
+            .expect("build event");
+
+        let result = bob_mdk
+            .process_message(&event)
+            .expect("Bob should process without panic");
+
+        assert!(
+            matches!(
+                &result,
+                MessageProcessingResult::IgnoredProposal { reason, .. }
+                if reason.contains("sender is an admin")
+            ),
+            "Receiver should reject legacy Remove(self) from admin, got: {:?}",
             result
         );
     }


### PR DESCRIPTION
## Summary

- Fix admin handling of legacy `Remove(self)` leave proposals in mixed/legacy groups so the auto-commit actually removes the departing member.
- Keep the modern `SelfRemove` path on the SelfRemove-only proposal-store filter.
- Add a regression test covering an admin receiver of a legacy `Remove(self)` leave.

Closes marmot-protocol/marmot-security#98

## Tests

- `cargo test -p mdk-core --lib --features test-utils test_admin_auto_commit_legacy_remove_self_removes_member`
- `cargo test -p mdk-core --lib --features test-utils legacy_remove`
- `cargo test -p mdk-core --lib --features test-utils self_remove_proposal_auto_committed`
- `cargo test -p mdk-core --lib --features test-utils self_leave_proposal_auto_committed_by_admin`
- `cargo fmt --check`
- `just precommit`

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/288">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a bug where admin receivers in mixed/legacy groups could consume-and-drop legacy Proposal::Remove(self) leave proposals without producing a commit, leaving the departing member in the MLS group; it splits the admin-receiver path so legacy Remove(self) receipts are explicitly committed by admins and the member is actually removed, while preserving the SelfRemove-only auto-commit semantics for modern SelfRemove proposals. A regression test was added to prevent this from regressing and the mdk-core changelog was updated.

What changed:
- process_proposal now distinguishes legacy Proposal::Remove(self) when the receiver is an admin and routes it to a dedicated admin legacy-path commit builder instead of the SelfRemove-only auto-commit path (crates/mdk-core/src/messages/proposal.rs).
- Added auto_commit_legacy_self_remove(...) which builds and stages an admin commit to remove the departing leaf without using the SelfRemove-only pending-proposal filter (crates/mdk-core/src/messages/proposal.rs).
- Renamed the previous auto_commit_proposal(...) helper to auto_commit_self_remove_proposal(...) to preserve the SelfRemove-only filter behavior for modern SelfRemove proposals (crates/mdk-core/src/messages/proposal.rs).
- Introduced validate_self_remove_allowed(...) to centralize MIP-03-style checks (reject admin senders and admin-depletion) used by both paths (crates/mdk-core/src/messages/proposal.rs).
- Added regression test test_admin_auto_commit_legacy_remove_self_removes_member and strengthened related mixed-group leave tests to assert legacy-fallback preconditions (crates/mdk-core/src/groups.rs and tests).
- Updated crates/mdk-core/CHANGELOG.md to record the fix.

Crates affected:
- mdk-core only (no changes to mdk-sqlite-storage, mdk-memory-storage, mdk-storage-traits, or mdk-uniffi).

Security impact:
- No cryptographic primitive, key derivation, key handling/storage, identity-binding, error-message leakage, SQLCipher, or file-permission changes; this is a behavioral fix to commit-routing and group-state correctness.

Protocol changes:
- Runtime handling of legacy Remove(self) in mixed/legacy groups now ensures admins include and commit legacy self-remove proposals so group-state evolution conforms to MIP-03 semantics; there are no wire-format or cryptographic protocol changes.

API surface:
- Internal rename: pub(super) fn auto_commit_proposal(...) → pub(super) fn auto_commit_self_remove_proposal(...) (internal API only).
- New internal API: pub(super) fn auto_commit_legacy_self_remove(...) added to handle admin-received legacy Remove(self) commits.
- No public crate-level API breaks, storage schema changes, or UniFFI/FFI boundary changes.

Testing:
- Added regression test test_admin_auto_commit_legacy_remove_self_removes_member verifying an admin-handled legacy Remove(self) is actually committed and the departing member is removed.
- Existing mixed-group leave tests were strengthened to assert the group's RequiredCapabilities do not include SelfRemove before exercising legacy fallback.
- Tests referenced in the PR: cargo test -p mdk-core --lib --features test-utils test_admin_auto_commit_legacy_remove_self_removes_member, legacy_remove, self_remove_proposal_auto_committed, self_leave_proposal_auto_committed_by_admin; plus cargo fmt --check and just precommit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->