### PR TITLE
Fix admin update rollback for local commits

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 
+- Recorded rollback snapshots for locally merged admin-list updates so clients can converge on the MIP-03 winner when competing admins concurrently mutate `admin_pubkeys`. ([#289](https://github.com/marmot-protocol/mdk/pull/289))
 - Verified unsigned application-message rumor IDs before accepting or sending them, preventing caller-supplied IDs from being trusted when they do not match the canonical event hash. ([#287](https://github.com/marmot-protocol/mdk/pull/287))
 - Fixed `mdk-core` crates.io package verification against OpenMLS 0.8.1 by using a temporary exported-ratchet-tree compatibility shim until crates.io OpenMLS exposes the upstream full-leaf iterator. ([#273](https://github.com/marmot-protocol/mdk/pull/273))
 

--- a/crates/mdk-core/src/epoch_snapshots.rs
+++ b/crates/mdk-core/src/epoch_snapshots.rs
@@ -19,6 +19,8 @@ use nostr::EventId;
 
 use crate::Error;
 
+const PENDING_SNAPSHOT_PREFIX: &str = "pending_";
+
 /// Metadata about a snapshot taken before applying a commit
 #[derive(Clone)]
 pub struct EpochSnapshot {
@@ -53,9 +55,16 @@ impl fmt::Debug for EpochSnapshot {
     }
 }
 
+struct PendingEpochSnapshot {
+    snapshot: EpochSnapshot,
+    marker_snapshot_name: String,
+}
+
 struct EpochSnapshotManagerInner {
     /// Snapshots per group, ordered by epoch (oldest first)
     snapshots: HashMap<GroupId, VecDeque<EpochSnapshot>>,
+    /// Pre-merge snapshots for locally created pending commits.
+    pending_snapshots: HashMap<GroupId, PendingEpochSnapshot>,
     /// Groups that have been hydrated from storage (only relevant for persistent backends)
     hydrated_groups: HashSet<GroupId>,
 }
@@ -65,9 +74,10 @@ impl fmt::Debug for EpochSnapshotManagerInner {
         let total_snapshots: usize = self.snapshots.values().map(|q| q.len()).sum();
         write!(
             f,
-            "EpochSnapshotManagerInner {{ groups: {}, total_snapshots: {} }}",
+            "EpochSnapshotManagerInner {{ groups: {}, total_snapshots: {}, pending_snapshots: {} }}",
             self.snapshots.len(),
-            total_snapshots
+            total_snapshots,
+            self.pending_snapshots.len()
         )
     }
 }
@@ -93,6 +103,7 @@ impl EpochSnapshotManager {
         Self {
             inner: Mutex::new(EpochSnapshotManagerInner {
                 snapshots: HashMap::new(),
+                pending_snapshots: HashMap::new(),
                 hydrated_groups: HashSet::new(),
             }),
             retention_count,
@@ -106,6 +117,7 @@ impl EpochSnapshotManager {
     pub fn remove_group(&self, group_id: &GroupId) {
         let mut inner = self.inner.lock().unwrap();
         inner.snapshots.remove(group_id);
+        inner.pending_snapshots.remove(group_id);
         inner.hydrated_groups.remove(group_id);
     }
 
@@ -141,28 +153,33 @@ impl EpochSnapshotManager {
             }
         };
 
-        // Parse snapshot names and populate the queue
-        // Format: "snap_{group_id_hex}_{epoch}_{commit_id_hex}"
-        let queue = inner.snapshots.entry(group_id.clone()).or_default();
+        let pending_snapshot_names: HashSet<String> = stored_snapshots
+            .iter()
+            .filter_map(|(snapshot_name, _)| Self::snapshot_name_from_pending_marker(snapshot_name))
+            .collect();
 
         for (snapshot_name, created_at_unix) in stored_snapshots {
+            if pending_snapshot_names.contains(&snapshot_name)
+                || Self::snapshot_name_from_pending_marker(&snapshot_name).is_some()
+            {
+                continue;
+            }
+
             if let Some(snapshot) =
                 Self::parse_snapshot_name(&snapshot_name, group_id, created_at_unix)
             {
+                let queue = inner.snapshots.entry(group_id.clone()).or_default();
                 queue.push_back(snapshot);
             } else {
                 tracing::warn!(
-                    "Failed to parse snapshot name during hydration: {}",
-                    snapshot_name
+                    "Failed to parse snapshot name during hydration; snapshot name redacted"
                 );
             }
         }
 
         // Enforce retention limit after hydration
-        while queue.len() > self.retention_count {
-            if let Some(old_snap) = queue.pop_front() {
-                let _ = storage.release_group_snapshot(&old_snap.group_id, &old_snap.snapshot_name);
-            }
+        if let Some(queue) = inner.snapshots.get_mut(group_id) {
+            Self::prune_queue(storage, queue, self.retention_count);
         }
 
         inner.hydrated_groups.insert(group_id.clone());
@@ -200,7 +217,92 @@ impl EpochSnapshotManager {
         })
     }
 
-    /// Create a snapshot before applying a commit
+    fn build_snapshot_name(group_id: &GroupId, current_epoch: u64, commit_id: &EventId) -> String {
+        format!(
+            "snap_{}_{}_{}",
+            hex::encode(group_id.as_slice()),
+            current_epoch,
+            commit_id.to_hex()
+        )
+    }
+
+    fn pending_marker_snapshot_name(snapshot_name: &str) -> String {
+        format!("{PENDING_SNAPSHOT_PREFIX}{snapshot_name}")
+    }
+
+    fn snapshot_name_from_pending_marker(snapshot_name: &str) -> Option<String> {
+        snapshot_name
+            .strip_prefix(PENDING_SNAPSHOT_PREFIX)
+            .map(str::to_string)
+    }
+
+    fn build_snapshot<S: MdkStorageProvider>(
+        storage: &S,
+        group_id: &GroupId,
+        current_epoch: u64,
+        commit_id: &EventId,
+        commit_ts: u64,
+        content_hash: &[u8; 32],
+    ) -> Result<EpochSnapshot, Error> {
+        // Generate a unique snapshot name
+        let snapshot_name = Self::build_snapshot_name(group_id, current_epoch, commit_id);
+
+        // Create the snapshot in storage
+        storage
+            .create_group_snapshot(group_id, &snapshot_name)
+            .map_err(Error::Storage)?;
+
+        Ok(EpochSnapshot {
+            group_id: group_id.clone(),
+            epoch: current_epoch,
+            applied_commit_id: *commit_id,
+            applied_commit_ts: commit_ts,
+            applied_commit_content_hash: *content_hash,
+            created_at: Instant::now(),
+            snapshot_name,
+        })
+    }
+
+    fn release_pending_snapshot_record<S: MdkStorageProvider>(
+        storage: &S,
+        pending: PendingEpochSnapshot,
+    ) -> Result<(), Error> {
+        let group_id = &pending.snapshot.group_id;
+        let mut release_error = None;
+
+        for snapshot_name in [
+            &pending.snapshot.snapshot_name,
+            &pending.marker_snapshot_name,
+        ] {
+            if let Err(e) = storage.release_group_snapshot(group_id, snapshot_name)
+                && release_error.is_none()
+            {
+                release_error = Some(e);
+            }
+        }
+
+        match release_error {
+            Some(e) => Err(Error::Storage(e)),
+            None => Ok(()),
+        }
+    }
+
+    fn prune_queue<S: MdkStorageProvider>(
+        storage: &S,
+        queue: &mut VecDeque<EpochSnapshot>,
+        retention_count: usize,
+    ) {
+        // We prune strictly greater than retention count.
+        // If retention is 5, we keep 5 snapshots.
+        while queue.len() > retention_count {
+            if let Some(old_snap) = queue.pop_front() {
+                // Best effort release
+                let _ = storage.release_group_snapshot(&old_snap.group_id, &old_snap.snapshot_name);
+            }
+        }
+    }
+
+    /// Create a snapshot before applying a received commit.
     pub fn create_snapshot<S: MdkStorageProvider>(
         &self,
         storage: &S,
@@ -213,45 +315,219 @@ impl EpochSnapshotManager {
         // Ensure we have loaded any existing snapshots from storage
         self.ensure_hydrated(storage, group_id);
 
-        // Generate a unique snapshot name
-        let snapshot_name = format!(
-            "snap_{}_{}_{}",
-            hex::encode(group_id.as_slice()),
+        let snapshot = Self::build_snapshot(
+            storage,
+            group_id,
             current_epoch,
-            commit_id.to_hex()
-        );
+            commit_id,
+            commit_ts,
+            content_hash,
+        )?;
+        let snapshot_name = snapshot.snapshot_name.clone();
 
-        // Create the snapshot in storage
-        storage
-            .create_group_snapshot(group_id, &snapshot_name)
-            .map_err(Error::Storage)?;
+        let mut inner = self.inner.lock().unwrap();
+        let queue = inner.snapshots.entry(group_id.clone()).or_default();
+        queue.push_back(snapshot);
+        Self::prune_queue(storage, queue, self.retention_count);
 
-        // Record metadata
-        let snapshot = EpochSnapshot {
-            group_id: group_id.clone(),
-            epoch: current_epoch,
-            applied_commit_id: *commit_id,
-            applied_commit_ts: commit_ts,
-            applied_commit_content_hash: *content_hash,
-            created_at: Instant::now(),
-            snapshot_name: snapshot_name.clone(),
+        Ok(snapshot_name)
+    }
+
+    /// Create a dormant snapshot for a locally created pending commit.
+    ///
+    /// The snapshot is not considered for race resolution until
+    /// [`Self::activate_pending_snapshot`] is called after the pending commit is
+    /// merged. This avoids treating unpublished or cleared local commits as the
+    /// incumbent branch while still preserving the pre-merge state needed if a
+    /// better same-epoch commit arrives later.
+    pub fn create_pending_snapshot<S: MdkStorageProvider>(
+        &self,
+        storage: &S,
+        group_id: &GroupId,
+        current_epoch: u64,
+        commit_id: &EventId,
+        commit_ts: u64,
+        content_hash: &[u8; 32],
+    ) -> Result<String, Error> {
+        self.ensure_hydrated(storage, group_id);
+
+        let snapshot = Self::build_snapshot(
+            storage,
+            group_id,
+            current_epoch,
+            commit_id,
+            commit_ts,
+            content_hash,
+        )?;
+        let marker_snapshot_name = Self::pending_marker_snapshot_name(&snapshot.snapshot_name);
+
+        if let Err(e) = storage.create_group_snapshot(group_id, &marker_snapshot_name) {
+            let _ = storage.release_group_snapshot(group_id, &snapshot.snapshot_name);
+            return Err(Error::Storage(e));
+        }
+
+        let snapshot_name = snapshot.snapshot_name.clone();
+
+        let previous = {
+            let mut inner = self.inner.lock().unwrap();
+            inner.pending_snapshots.insert(
+                group_id.clone(),
+                PendingEpochSnapshot {
+                    snapshot,
+                    marker_snapshot_name,
+                },
+            )
+        };
+
+        if let Some(old_snap) = previous {
+            let _ = Self::release_pending_snapshot_record(storage, old_snap);
+        }
+
+        Ok(snapshot_name)
+    }
+
+    /// Check whether a pending snapshot exists for a locally staged commit.
+    pub fn has_pending_snapshot<S: MdkStorageProvider>(
+        &self,
+        storage: &S,
+        group_id: &GroupId,
+        current_epoch: u64,
+        commit_id: &EventId,
+    ) -> bool {
+        self.ensure_hydrated(storage, group_id);
+
+        {
+            let inner = self.inner.lock().unwrap();
+            if let Some(pending) = inner.pending_snapshots.get(group_id)
+                && pending.snapshot.epoch == current_epoch
+                && pending.snapshot.applied_commit_id == *commit_id
+            {
+                return true;
+            }
+        }
+
+        let snapshot_name = Self::build_snapshot_name(group_id, current_epoch, commit_id);
+        let marker_snapshot_name = Self::pending_marker_snapshot_name(&snapshot_name);
+        match storage.list_group_snapshots(group_id) {
+            Ok(snapshots) => snapshots
+                .iter()
+                .any(|(stored_name, _)| stored_name == &marker_snapshot_name),
+            Err(_) => false,
+        }
+    }
+
+    /// Promote a locally created pending-commit snapshot after the commit merges.
+    pub fn activate_pending_snapshot<S: MdkStorageProvider>(
+        &self,
+        storage: &S,
+        group_id: &GroupId,
+    ) -> bool {
+        self.ensure_hydrated(storage, group_id);
+
+        let mut inner = self.inner.lock().unwrap();
+        let Some(pending) = inner.pending_snapshots.remove(group_id) else {
+            return false;
+        };
+        let _ = storage.release_group_snapshot(group_id, &pending.marker_snapshot_name);
+
+        let queue = inner.snapshots.entry(group_id.clone()).or_default();
+        queue.push_back(pending.snapshot);
+        Self::prune_queue(storage, queue, self.retention_count);
+
+        true
+    }
+
+    /// Promote a pending snapshot for a specific local commit after the commit merges.
+    pub fn activate_pending_snapshot_for_commit<S: MdkStorageProvider>(
+        &self,
+        storage: &S,
+        group_id: &GroupId,
+        current_epoch: u64,
+        commit_id: &EventId,
+        commit_ts: u64,
+        content_hash: &[u8; 32],
+    ) -> bool {
+        self.ensure_hydrated(storage, group_id);
+
+        let snapshot_name = Self::build_snapshot_name(group_id, current_epoch, commit_id);
+        let marker_snapshot_name = Self::pending_marker_snapshot_name(&snapshot_name);
+        let snapshot = {
+            let mut inner = self.inner.lock().unwrap();
+            let pending_matches = inner
+                .pending_snapshots
+                .get(group_id)
+                .map(|pending| pending.snapshot.snapshot_name == snapshot_name);
+
+            match pending_matches {
+                Some(true) => {
+                    let pending = inner
+                        .pending_snapshots
+                        .remove(group_id)
+                        .expect("matching pending snapshot must exist");
+                    drop(inner);
+
+                    let _ = storage.release_group_snapshot(group_id, &pending.marker_snapshot_name);
+                    pending.snapshot
+                }
+                Some(false) => return false,
+                None => {
+                    drop(inner);
+
+                    let marker_exists = storage
+                        .list_group_snapshots(group_id)
+                        .map(|snapshots| {
+                            snapshots
+                                .iter()
+                                .any(|(stored_name, _)| stored_name == &marker_snapshot_name)
+                        })
+                        .unwrap_or(false);
+
+                    if !marker_exists {
+                        return false;
+                    }
+
+                    let _ = storage.release_group_snapshot(group_id, &marker_snapshot_name);
+                    EpochSnapshot {
+                        group_id: group_id.clone(),
+                        epoch: current_epoch,
+                        applied_commit_id: *commit_id,
+                        applied_commit_ts: commit_ts,
+                        applied_commit_content_hash: *content_hash,
+                        created_at: Instant::now(),
+                        snapshot_name,
+                    }
+                }
+            }
         };
 
         let mut inner = self.inner.lock().unwrap();
         let queue = inner.snapshots.entry(group_id.clone()).or_default();
         queue.push_back(snapshot);
+        Self::prune_queue(storage, queue, self.retention_count);
 
-        // Prune if needed (deferred slightly, or do it now)
-        // We prune strictly greater than retention count.
-        // If retention is 5, we keep 5 snapshots.
-        while queue.len() > self.retention_count {
-            if let Some(old_snap) = queue.pop_front() {
-                // Best effort release
-                let _ = storage.release_group_snapshot(&old_snap.group_id, &old_snap.snapshot_name);
+        true
+    }
+
+    /// Release a dormant snapshot when the local pending commit is cleared.
+    pub fn release_pending_snapshot<S: MdkStorageProvider>(
+        &self,
+        storage: &S,
+        group_id: &GroupId,
+    ) -> Result<bool, Error> {
+        self.ensure_hydrated(storage, group_id);
+
+        let snapshot = {
+            let mut inner = self.inner.lock().unwrap();
+            inner.pending_snapshots.remove(group_id)
+        };
+
+        match snapshot {
+            Some(snapshot) => {
+                Self::release_pending_snapshot_record(storage, snapshot)?;
+                Ok(true)
             }
+            None => Ok(false),
         }
-
-        Ok(snapshot_name)
     }
 
     /// Check if a candidate commit is "better" than the one we applied for this epoch.
@@ -391,6 +667,35 @@ mod tests {
     /// Helper to create a test event ID from a hex string
     fn test_event_id(hex: &str) -> EventId {
         EventId::from_str(hex).unwrap()
+    }
+
+    fn test_group(group_id: GroupId) -> Group {
+        let admin_pk = PublicKey::from_slice(&[2u8; 32]).unwrap();
+        let mut admin_pubkeys = BTreeSet::new();
+        admin_pubkeys.insert(admin_pk);
+        Group {
+            mls_group_id: group_id,
+            nostr_group_id: [0u8; 32],
+            name: "Test Group".to_string(),
+            description: "Test".to_string(),
+            admin_pubkeys,
+            epoch: 0,
+            last_message_at: None,
+            last_message_processed_at: None,
+            last_message_id: None,
+            image_hash: None,
+            image_key: None,
+            image_nonce: None,
+            state: GroupState::Active,
+            self_update_state: SelfUpdateState::Required,
+        }
+    }
+
+    fn save_test_group<S>(storage: &S, group_id: &GroupId)
+    where
+        S: GroupStorage,
+    {
+        storage.save_group(test_group(group_id.clone())).unwrap();
     }
 
     // ========================================
@@ -1192,6 +1497,222 @@ mod tests {
         // parts[1] is the group_id hex, parts[3] is the commit_id hex
         assert_eq!(parts[1].len(), 64, "Group ID hex should be 64 chars");
         assert_eq!(parts[3].len(), 64, "Commit ID hex should be 64 chars");
+    }
+
+    #[test]
+    fn test_pending_snapshot_marker_excludes_snapshot_from_hydration() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("pending_snapshot.db");
+        let storage = mdk_sqlite_storage::MdkSqliteStorage::new_unencrypted(&db_path).unwrap();
+        let manager = EpochSnapshotManager::new(5);
+        let group_id = test_group_id(7);
+        let admin_pk = PublicKey::from_slice(&[2u8; 32]).unwrap();
+        let mut admin_pubkeys = BTreeSet::new();
+        admin_pubkeys.insert(admin_pk);
+        let group = Group {
+            mls_group_id: group_id.clone(),
+            nostr_group_id: [0u8; 32],
+            name: "Test Group".to_string(),
+            description: "Test".to_string(),
+            admin_pubkeys,
+            epoch: 5,
+            last_message_at: None,
+            last_message_processed_at: None,
+            last_message_id: None,
+            image_hash: None,
+            image_key: None,
+            image_nonce: None,
+            state: GroupState::Active,
+            self_update_state: SelfUpdateState::Required,
+        };
+        storage.save_group(group).unwrap();
+
+        let commit_id =
+            test_event_id("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
+        let snapshot_name = manager
+            .create_pending_snapshot(&storage, &group_id, 5, &commit_id, 1000, &[1u8; 32])
+            .unwrap();
+        let marker_name = EpochSnapshotManager::pending_marker_snapshot_name(&snapshot_name);
+        let stored_names: BTreeSet<String> = storage
+            .list_group_snapshots(&group_id)
+            .unwrap()
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        assert!(stored_names.contains(&snapshot_name));
+        assert!(stored_names.contains(&marker_name));
+
+        let hydrated_manager = EpochSnapshotManager::new(5);
+        let candidate_id =
+            test_event_id("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        assert!(!hydrated_manager.is_better_candidate(
+            &storage,
+            &group_id,
+            5,
+            999,
+            &candidate_id,
+            &[2u8; 32]
+        ));
+        assert!(hydrated_manager.has_pending_snapshot(&storage, &group_id, 5, &commit_id));
+
+        let inner = hydrated_manager.inner.lock().unwrap();
+        assert!(
+            !inner.snapshots.contains_key(&group_id)
+                || inner.snapshots.get(&group_id).unwrap().is_empty(),
+            "Pending snapshots should not hydrate as active rollback snapshots"
+        );
+    }
+
+    #[test]
+    fn test_pending_snapshot_lifecycle_activates_snapshot() {
+        let manager = EpochSnapshotManager::new(5);
+        let storage = mdk_memory_storage::MdkMemoryStorage::default();
+        let group_id = test_group_id(8);
+        save_test_group(&storage, &group_id);
+        let commit_id =
+            test_event_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let better_id =
+            test_event_id("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+        manager
+            .create_pending_snapshot(&storage, &group_id, 3, &commit_id, 1000, &[1u8; 32])
+            .unwrap();
+        assert!(manager.has_pending_snapshot(&storage, &group_id, 3, &commit_id));
+        assert!(!manager.is_better_candidate(&storage, &group_id, 3, 999, &better_id, &[2u8; 32]));
+
+        assert!(manager.activate_pending_snapshot(&storage, &group_id));
+        assert!(!manager.has_pending_snapshot(&storage, &group_id, 3, &commit_id));
+        assert!(manager.is_better_candidate(&storage, &group_id, 3, 999, &better_id, &[2u8; 32]));
+    }
+
+    #[test]
+    fn test_release_pending_snapshot_removes_pending_state() {
+        let manager = EpochSnapshotManager::new(5);
+        let storage = mdk_memory_storage::MdkMemoryStorage::default();
+        let group_id = test_group_id(9);
+        save_test_group(&storage, &group_id);
+        let commit_id =
+            test_event_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let snapshot_name = manager
+            .create_pending_snapshot(&storage, &group_id, 3, &commit_id, 1000, &[1u8; 32])
+            .unwrap();
+        let marker_name = EpochSnapshotManager::pending_marker_snapshot_name(&snapshot_name);
+
+        assert!(
+            manager
+                .release_pending_snapshot(&storage, &group_id)
+                .unwrap()
+        );
+        assert!(
+            !manager
+                .release_pending_snapshot(&storage, &group_id)
+                .unwrap()
+        );
+        assert!(!manager.has_pending_snapshot(&storage, &group_id, 3, &commit_id));
+        let stored_names: BTreeSet<String> = storage
+            .list_group_snapshots(&group_id)
+            .unwrap()
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        assert!(!stored_names.contains(&snapshot_name));
+        assert!(!stored_names.contains(&marker_name));
+    }
+
+    #[test]
+    fn test_pending_snapshot_replacement_releases_previous_snapshot() {
+        let manager = EpochSnapshotManager::new(5);
+        let storage = mdk_memory_storage::MdkMemoryStorage::default();
+        let group_id = test_group_id(10);
+        save_test_group(&storage, &group_id);
+        let first_commit_id =
+            test_event_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let second_commit_id =
+            test_event_id("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let first_snapshot_name = manager
+            .create_pending_snapshot(&storage, &group_id, 3, &first_commit_id, 1000, &[1u8; 32])
+            .unwrap();
+        let first_marker_name =
+            EpochSnapshotManager::pending_marker_snapshot_name(&first_snapshot_name);
+        let second_snapshot_name = manager
+            .create_pending_snapshot(&storage, &group_id, 3, &second_commit_id, 1001, &[2u8; 32])
+            .unwrap();
+        let second_marker_name =
+            EpochSnapshotManager::pending_marker_snapshot_name(&second_snapshot_name);
+
+        let stored_names: BTreeSet<String> = storage
+            .list_group_snapshots(&group_id)
+            .unwrap()
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        assert!(!stored_names.contains(&first_snapshot_name));
+        assert!(!stored_names.contains(&first_marker_name));
+        assert!(stored_names.contains(&second_snapshot_name));
+        assert!(stored_names.contains(&second_marker_name));
+        assert!(!manager.has_pending_snapshot(&storage, &group_id, 3, &first_commit_id));
+        assert!(manager.has_pending_snapshot(&storage, &group_id, 3, &second_commit_id));
+    }
+
+    #[test]
+    fn test_activate_pending_snapshot_for_commit_uses_persisted_marker() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("pending_snapshot_activate.db");
+        let storage = mdk_sqlite_storage::MdkSqliteStorage::new_unencrypted(&db_path).unwrap();
+        let manager = EpochSnapshotManager::new(5);
+        let group_id = test_group_id(11);
+        save_test_group(&storage, &group_id);
+        let commit_id =
+            test_event_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let better_id =
+            test_event_id("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let snapshot_name = manager
+            .create_pending_snapshot(&storage, &group_id, 4, &commit_id, 1000, &[1u8; 32])
+            .unwrap();
+        let marker_name = EpochSnapshotManager::pending_marker_snapshot_name(&snapshot_name);
+
+        let restarted_manager = EpochSnapshotManager::new(5);
+        assert!(restarted_manager.has_pending_snapshot(&storage, &group_id, 4, &commit_id));
+        assert!(restarted_manager.activate_pending_snapshot_for_commit(
+            &storage, &group_id, 4, &commit_id, 1000, &[1u8; 32]
+        ));
+        assert!(
+            restarted_manager
+                .is_better_candidate(&storage, &group_id, 4, 999, &better_id, &[2u8; 32])
+        );
+        let stored_names: BTreeSet<String> = storage
+            .list_group_snapshots(&group_id)
+            .unwrap()
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        assert!(stored_names.contains(&snapshot_name));
+        assert!(!stored_names.contains(&marker_name));
+    }
+
+    #[test]
+    fn test_activate_pending_snapshot_for_commit_keeps_unmatched_pending_snapshot() {
+        let manager = EpochSnapshotManager::new(5);
+        let storage = mdk_memory_storage::MdkMemoryStorage::default();
+        let group_id = test_group_id(12);
+        save_test_group(&storage, &group_id);
+        let pending_commit_id =
+            test_event_id("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let other_commit_id =
+            test_event_id("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+        manager
+            .create_pending_snapshot(&storage, &group_id, 4, &pending_commit_id, 1000, &[1u8; 32])
+            .unwrap();
+        assert!(!manager.activate_pending_snapshot_for_commit(
+            &storage,
+            &group_id,
+            4,
+            &other_commit_id,
+            999,
+            &[2u8; 32]
+        ));
+        assert!(manager.has_pending_snapshot(&storage, &group_id, 4, &pending_commit_id));
     }
 
     #[test]

--- a/crates/mdk-core/src/groups.rs
+++ b/crates/mdk-core/src/groups.rs
@@ -1101,12 +1101,6 @@ where
             None,
         )?;
 
-        self.track_processed_message(
-            commit_event.id,
-            &mls_group,
-            message_types::ProcessedMessageState::ProcessedCommit,
-        )?;
-
         let serialized_welcome_message = welcome_message
             .tls_serialize_detached()
             .map_err(|e| Error::Group(e.to_string()))?;
@@ -1122,6 +1116,12 @@ where
             serialized_welcome_message,
             key_package_events.to_vec(),
             &group_relays,
+        )?;
+
+        self.track_processed_message(
+            commit_event.id,
+            &mls_group,
+            message_types::ProcessedMessageState::ProcessedCommit,
         )?;
 
         // let serialized_group_info = group_info
@@ -1271,18 +1271,18 @@ where
             None,
         )?;
 
-        self.track_processed_message(
-            commit_event.id,
-            &mls_group,
-            message_types::ProcessedMessageState::ProcessedCommit,
-        )?;
-
         // For now, if we find welcomes, throw an error.
         if welcome_option.is_some() {
             return Err(Error::Group(
                 "Found welcomes when removing users".to_string(),
             ));
         }
+
+        self.track_processed_message(
+            commit_event.id,
+            &mls_group,
+            message_types::ProcessedMessageState::ProcessedCommit,
+        )?;
         // let serialized_welcome_message = welcome_option
         //     .map(|w| {
         //         w.tls_serialize_detached()
@@ -1309,6 +1309,7 @@ where
         mls_group: &mut MlsGroup,
         group_id: &GroupId,
         group_data: &NostrGroupDataExtension,
+        track_pending_snapshot: bool,
     ) -> Result<UpdateGroupResult, Error> {
         let own_leaf = mls_group.own_leaf().ok_or(Error::OwnLeafNotFound)?;
         if !self.is_leaf_node_admin(group_id, own_leaf)? {
@@ -1331,11 +1332,15 @@ where
             None,
         )?;
 
-        self.track_processed_message(
-            commit_event.id,
-            mls_group,
-            message_types::ProcessedMessageState::ProcessedCommit,
-        )?;
+        if track_pending_snapshot {
+            self.track_pending_commit_message(mls_group, &commit_event)?;
+        } else {
+            self.track_processed_message(
+                commit_event.id,
+                mls_group,
+                message_types::ProcessedMessageState::ProcessedCommit,
+            )?;
+        }
 
         Ok(UpdateGroupResult {
             evolution_event: commit_event,
@@ -1390,6 +1395,7 @@ where
         let mut mls_group = self.load_mls_group(group_id)?.ok_or(Error::GroupNotFound)?;
 
         let mut group_data = NostrGroupDataExtension::from_group(&mls_group)?;
+        let updates_admins = update.admins.is_some();
 
         // Apply updates only for fields that are specified
         if let Some(name) = update.name {
@@ -1435,7 +1441,7 @@ where
             group_data.nostr_group_id = nostr_group_id;
         }
 
-        self.update_group_data_extension(&mut mls_group, group_id, &group_data)
+        self.update_group_data_extension(&mut mls_group, group_id, &group_data, updates_admins)
     }
 
     /// Retrieves the set of relay URLs associated with an MLS group
@@ -1769,12 +1775,6 @@ where
             None,
         )?;
 
-        self.track_processed_message(
-            commit_event.id,
-            &mls_group,
-            message_types::ProcessedMessageState::ProcessedCommit,
-        )?;
-
         let serialized_welcome_message = commit_message_bundle
             .welcome()
             .map(|w| {
@@ -1789,6 +1789,12 @@ where
                 "Found welcomes when performing a self update".to_string(),
             ));
         }
+
+        self.track_processed_message(
+            commit_event.id,
+            &mls_group,
+            message_types::ProcessedMessageState::ProcessedCommit,
+        )?;
 
         Ok(UpdateGroupResult {
             evolution_event: commit_event,
@@ -2124,6 +2130,9 @@ where
             .clear_pending_commit(self.provider.storage())
             .map_err(|e| Error::Provider(e.to_string()))?;
 
+        self.epoch_snapshots
+            .release_pending_snapshot(self.storage(), group_id)?;
+
         // If this was a self-update, delete the orphaned new signature keypair.
         // OpenMLS reverts to the old signer after clear_pending_commit; the new
         // keypair was stored eagerly in self_update() and is now unreachable.
@@ -2169,6 +2178,8 @@ where
         });
 
         mls_group.merge_pending_commit(&self.provider)?;
+        self.epoch_snapshots
+            .activate_pending_snapshot(self.storage(), group_id);
 
         // Save MIP-03 and MIP-04 exporter secrets for the new epoch
         self.exporter_secret(group_id)?;
@@ -2324,6 +2335,37 @@ where
         }
 
         Ok(valid_admins)
+    }
+
+    /// Records rollback metadata for a locally created commit before it is merged.
+    fn track_pending_commit_message(
+        &self,
+        mls_group: &MlsGroup,
+        commit_event: &Event,
+    ) -> Result<(), Error> {
+        let group_id: GroupId = mls_group.group_id().into();
+        let content_hash = crate::messages::content_hash(&commit_event.content);
+        self.epoch_snapshots.create_pending_snapshot(
+            self.storage(),
+            &group_id,
+            mls_group.epoch().as_u64(),
+            &commit_event.id,
+            commit_event.created_at.as_secs(),
+            &content_hash,
+        )?;
+
+        if let Err(e) = self.track_processed_message(
+            commit_event.id,
+            mls_group,
+            message_types::ProcessedMessageState::ProcessedCommit,
+        ) {
+            let _ = self
+                .epoch_snapshots
+                .release_pending_snapshot(self.storage(), &group_id);
+            return Err(e);
+        }
+
+        Ok(())
     }
 
     /// Records a processed message so the client can track message state.

--- a/crates/mdk-core/src/messages/commit.rs
+++ b/crates/mdk-core/src/messages/commit.rs
@@ -1699,6 +1699,93 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_own_admin_update_can_roll_back_to_better_competing_admin_update() {
+        let alice_keys = Keys::generate();
+        let bob_keys = Keys::generate();
+        let callback = std::sync::Arc::new(TestCallback::new());
+
+        let alice_mdk = crate::MDK::builder(mdk_memory_storage::MdkMemoryStorage::default())
+            .with_callback(callback.clone())
+            .build();
+        let bob_mdk = crate::MDK::builder(mdk_memory_storage::MdkMemoryStorage::default())
+            .with_callback(callback.clone())
+            .build();
+
+        let admins = vec![alice_keys.public_key(), bob_keys.public_key()];
+        let bob_key_package = create_key_package_event(&bob_mdk, &bob_keys);
+        let create_result = alice_mdk
+            .create_group(
+                &alice_keys.public_key(),
+                vec![bob_key_package],
+                create_nostr_group_config_data(admins),
+            )
+            .expect("Alice should create group");
+        let group_id = create_result.group.mls_group_id.clone();
+
+        alice_mdk
+            .merge_pending_commit(&group_id)
+            .expect("Alice should merge creation");
+        let bob_welcome = bob_mdk
+            .process_welcome(&EventId::all_zeros(), &create_result.welcome_rumors[0])
+            .expect("Bob should process welcome");
+        bob_mdk
+            .accept_welcome(&bob_welcome)
+            .expect("Bob should accept welcome");
+
+        let alice_update = alice_mdk
+            .update_group_data(
+                &group_id,
+                crate::groups::NostrGroupDataUpdate::new().admins(vec![alice_keys.public_key()]),
+            )
+            .expect("Alice should create admin update");
+        let bob_update = bob_mdk
+            .update_group_data(
+                &group_id,
+                crate::groups::NostrGroupDataUpdate::new().admins(vec![bob_keys.public_key()]),
+            )
+            .expect("Bob should create admin update");
+
+        let (better_event, worse_event) =
+            order_events_by_mip03(&alice_update.evolution_event, &bob_update.evolution_event);
+
+        let (partitioned_mdk, expected_admin) = if worse_event.id == alice_update.evolution_event.id
+        {
+            (&alice_mdk, bob_keys.public_key())
+        } else {
+            (&bob_mdk, alice_keys.public_key())
+        };
+
+        let own_result = partitioned_mdk.process_message(worse_event);
+        assert!(
+            matches!(own_result, Ok(MessageProcessingResult::Commit { .. })),
+            "Relay echo of own pending admin update should merge the pending commit, got: {:?}",
+            own_result
+        );
+
+        let result = partitioned_mdk.process_message(better_event);
+        assert!(
+            matches!(result, Ok(MessageProcessingResult::Commit { .. })),
+            "Better competing admin update should be applied after rollback, got: {:?}",
+            result
+        );
+
+        assert!(
+            callback.rollback_count() > 0,
+            "Processing the better competing admin update should trigger rollback"
+        );
+
+        let group = partitioned_mdk
+            .get_group(&group_id)
+            .expect("Group lookup should succeed")
+            .expect("Group should exist");
+        assert_eq!(
+            group.admin_pubkeys,
+            [expected_admin].into_iter().collect(),
+            "Partitioned client should converge on the better commit's admin set"
+        );
+    }
+
     /// Test that epoch snapshots are properly pruned based on retention count
     #[test]
     fn test_epoch_snapshot_retention_pruning() {

--- a/crates/mdk-core/src/messages/process.rs
+++ b/crates/mdk-core/src/messages/process.rs
@@ -189,19 +189,28 @@ where
                     "Merging pending own commit after rollback/reprocess"
                 );
 
-                // Snapshot current state before applying commit (for rollback support)
                 let content_hash = super::content_hash(&event.content);
-                if self
-                    .epoch_snapshots
-                    .create_snapshot(
-                        self.storage(),
-                        &group.mls_group_id,
-                        mls_group.epoch().as_u64(),
-                        &event.id,
-                        event.created_at.as_secs(),
-                        &content_hash,
-                    )
-                    .is_err()
+                let current_epoch = mls_group.epoch().as_u64();
+                let has_pending_snapshot = self.epoch_snapshots.has_pending_snapshot(
+                    self.storage(),
+                    &group.mls_group_id,
+                    current_epoch,
+                    &event.id,
+                );
+
+                // Snapshot current state before applying commit (for rollback support)
+                if !has_pending_snapshot
+                    && self
+                        .epoch_snapshots
+                        .create_snapshot(
+                            self.storage(),
+                            &group.mls_group_id,
+                            current_epoch,
+                            &event.id,
+                            event.created_at.as_secs(),
+                            &content_hash,
+                        )
+                        .is_err()
                 {
                     tracing::warn!(
                         target: "mdk_core::messages::dispatch_by_content_type",
@@ -225,6 +234,16 @@ where
                 mls_group
                     .merge_pending_commit(&self.provider)
                     .map_err(|_e| Error::Message("Failed to merge pending commit".to_string()))?;
+                if has_pending_snapshot {
+                    self.epoch_snapshots.activate_pending_snapshot_for_commit(
+                        self.storage(),
+                        &group.mls_group_id,
+                        current_epoch,
+                        &event.id,
+                        event.created_at.as_secs(),
+                        &content_hash,
+                    );
+                }
 
                 // Handle post-commit operations
 


### PR DESCRIPTION
## Summary
- records dormant rollback snapshots for locally-created admin-list updates
- activates those snapshots when the pending commit is merged or processed from relay
- adds a regression for competing admin-list commits converging to the MIP-03 winner

Closes marmot-protocol/marmot-security#40

## Tests
- cargo test -p mdk-core messages::commit::tests::test_own_admin_update_can_roll_back_to_better_competing_admin_update
- cargo test -p mdk-core --no-default-features groups::tests::test_operation_from_removed_member
- just precommit

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/289">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR addresses a state divergence vulnerability in the Marmot protocol where concurrent admin-list mutations could cause clients to converge to different admin sets when observing commits in different orders. It introduces a "pending snapshot" mechanism that records dormant rollback snapshots for locally-created admin-list updates, then activates those snapshots when the pending commit is merged or processed from a relay, enabling clients to converge on the MIP-03 winner.

**What changed**:
- `EpochSnapshotManager` now supports pending snapshots for locally staged admin-list commits, with persisted markers that prevent pending snapshots from becoming active after restart until explicitly activated
- Snapshot lifecycle management was refactored to centralize naming, construction, and retention via a shared prune queue
- Group update operations now detect admin-list changes and conditionally track pending snapshots before recording processed-message state
- Commit rollback handling was extended to release pending snapshots, and merge handling activates pending snapshots after successful merges
- The `OwnCommitPending` recovery path in message processing now conditionally creates/activates rollback snapshots to avoid duplicates when a pending snapshot already exists
- All changes are in the `mdk-core` crate

**Protocol changes**:
- Implements MIP-03 (Group Messages) ordering convergence for competing admin-list updates by binding admin changes to prior commit state via pending snapshots with content hashing

**API surface**:
- Added five public methods to `EpochSnapshotManager`: `create_pending_snapshot`, `has_pending_snapshot`, `activate_pending_snapshot`, `activate_pending_snapshot_for_commit`, and `release_pending_snapshot`
- All other changes are internal; no exported types or trait definitions were modified

**Testing**:
- Added regression test `test_own_admin_update_can_roll_back_to_better_competing_admin_update` verifying that a worse local admin update rolls back when a better competing admin update arrives
- Extended pending snapshot lifecycle tests covering activation on merge, release, replacement behavior, and persisted marker reconstruction across restart
- Added SQLite hydration regression test ensuring pending markers prevent premature activation of rollback snapshots
- Existing test `test_operation_from_removed_member` verifies that pending snapshots are excluded from `remove_members` operations to preserve security invariants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->