### PR TITLE
fix(ci): verify OpenSSL tarball SHA-256 in Android build script

### DIFF
--- a/crates/mdk-uniffi/CHANGELOG.md
+++ b/crates/mdk-uniffi/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Fixed stale `release-size` artifact paths in Kotlin and Swift binding generation recipes. ([#232](https://github.com/marmot-protocol/mdk/pull/232))
 - Unbroke binding builds on Linux: switched `[profile.release].strip` from `true` to `"debuginfo"` so `uniffi-bindgen --library` can still read `UNIFFI_META_*` symbols from the cdylib's `.symtab` (GNU strip's `--strip-all` was removing them, which silently produced empty Kotlin/Ruby/Python binding output). DWARF debug info is still stripped, so the binary-size cost is small. ([#267](https://github.com/marmot-protocol/mdk/pull/267))
 - Switched iOS bindings to fat LTO (`CARGO_PROFILE_RELEASE_LTO=fat`, mirroring Android) so the static `.a` archives no longer embed per-module thin-LTO bitcode. This shrinks `libmdk_uniffi.a` back below GitHub's 100 MB push limit. The Swift package workflow also configures `git lfs track "*.a"` as a defensive safety net. ([#267](https://github.com/marmot-protocol/mdk/pull/267))
+- **Security**: `scripts/build-openssl-android.sh` now verifies the upstream OpenSSL release tarball against a pinned SHA-256 before extraction, and aborts when no hash is recorded for the requested version. Without this check, a tampered tarball (poisoned CDN, MITM, or compromised GitHub release) would have been linked into the `mdk-uniffi` Android shared library. ([#290](https://github.com/marmot-protocol/mdk/pull/290))
 
 ### Removed
 

--- a/scripts/build-openssl-android.sh
+++ b/scripts/build-openssl-android.sh
@@ -15,6 +15,15 @@ ABI="${1:-}"
 OUTPUT_DIR="${2:-}"
 OPENSSL_VERSION="${OPENSSL_VERSION:-3.3.2}"
 
+# SHA-256 of the upstream openssl-${OPENSSL_VERSION}.tar.gz release tarball.
+# Sourced from the official OpenSSL release (openssl.org) and cross-checked
+# against the GitHub release's published .sha256 sidecar. Update this in
+# lockstep with OPENSSL_VERSION; mismatched values must abort the build.
+declare -A OPENSSL_SHA256_BY_VERSION=(
+    ["3.3.2"]="2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281"
+)
+OPENSSL_SHA256="${OPENSSL_SHA256:-${OPENSSL_SHA256_BY_VERSION[${OPENSSL_VERSION}]:-}}"
+
 if [ -z "$ABI" ] || [ -z "$OUTPUT_DIR" ]; then
     echo "Usage: $0 <ABI> <OUTPUT_DIR>"
     echo "  ABI: arm64-v8a, armeabi-v7a, x86_64, x86"
@@ -24,6 +33,13 @@ fi
 
 if [ -z "${NDK_HOME:-}" ]; then
     echo "Error: NDK_HOME environment variable is not set"
+    exit 1
+fi
+
+if [ -z "${OPENSSL_SHA256}" ]; then
+    echo "Error: no pinned SHA-256 for OpenSSL ${OPENSSL_VERSION}."
+    echo "  Add the verified upstream hash to OPENSSL_SHA256_BY_VERSION,"
+    echo "  or set OPENSSL_SHA256 explicitly in the environment."
     exit 1
 fi
 
@@ -128,6 +144,13 @@ echo "  Output: ${OUTPUT_DIR}"
 cd "${BUILD_DIR}"
 curl -fsSL "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz" \
     -o openssl.tar.gz
+
+# Verify integrity before extraction. A mismatch indicates the tarball was
+# tampered with in transit, on the CDN, or in the GitHub release; in any of
+# those cases continuing the build would link a compromised OpenSSL into the
+# distributed Android library.
+echo "${OPENSSL_SHA256}  openssl.tar.gz" | sha256sum -c -
+
 tar -xzf openssl.tar.gz
 cd "openssl-${OPENSSL_VERSION}"
 

--- a/scripts/build-openssl-android.sh
+++ b/scripts/build-openssl-android.sh
@@ -19,10 +19,18 @@ OPENSSL_VERSION="${OPENSSL_VERSION:-3.3.2}"
 # Sourced from the official OpenSSL release (openssl.org) and cross-checked
 # against the GitHub release's published .sha256 sidecar. Update this in
 # lockstep with OPENSSL_VERSION; mismatched values must abort the build.
-declare -A OPENSSL_SHA256_BY_VERSION=(
-    ["3.3.2"]="2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281"
-)
-OPENSSL_SHA256="${OPENSSL_SHA256:-${OPENSSL_SHA256_BY_VERSION[${OPENSSL_VERSION}]:-}}"
+#
+# A plain `case` is used instead of `declare -A` so the script keeps working
+# on macOS hosts, where the default /bin/bash is 3.2 and lacks associative
+# arrays. The `darwin*` host branch below is part of this script's contract.
+OPENSSL_SHA256="${OPENSSL_SHA256:-}"
+if [ -z "${OPENSSL_SHA256}" ]; then
+    case "${OPENSSL_VERSION}" in
+        3.3.2)
+            OPENSSL_SHA256="2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281"
+            ;;
+    esac
+fi
 
 if [ -z "$ABI" ] || [ -z "$OUTPUT_DIR" ]; then
     echo "Usage: $0 <ABI> <OUTPUT_DIR>"
@@ -38,7 +46,7 @@ fi
 
 if [ -z "${OPENSSL_SHA256}" ]; then
     echo "Error: no pinned SHA-256 for OpenSSL ${OPENSSL_VERSION}."
-    echo "  Add the verified upstream hash to OPENSSL_SHA256_BY_VERSION,"
+    echo "  Add the verified upstream hash to the case statement above,"
     echo "  or set OPENSSL_SHA256 explicitly in the environment."
     exit 1
 fi
@@ -149,7 +157,18 @@ curl -fsSL "https://github.com/openssl/openssl/releases/download/openssl-${OPENS
 # tampered with in transit, on the CDN, or in the GitHub release; in any of
 # those cases continuing the build would link a compromised OpenSSL into the
 # distributed Android library.
-echo "${OPENSSL_SHA256}  openssl.tar.gz" | sha256sum -c -
+#
+# `sha256sum` is GNU coreutils and absent on macOS by default; fall back to
+# `shasum -a 256`, mirroring the `nproc || sysctl -n hw.ncpu` pattern used
+# later in this script.
+if command -v sha256sum >/dev/null 2>&1; then
+    echo "${OPENSSL_SHA256}  openssl.tar.gz" | sha256sum -c -
+elif command -v shasum >/dev/null 2>&1; then
+    echo "${OPENSSL_SHA256}  openssl.tar.gz" | shasum -a 256 -c -
+else
+    echo "Error: neither sha256sum nor shasum is available to verify the OpenSSL tarball" >&2
+    exit 1
+fi
 
 tar -xzf openssl.tar.gz
 cd "openssl-${OPENSSL_VERSION}"


### PR DESCRIPTION
![marmot](https://blossom.primal.net/066e8f5c2725a6d4fedfcca78760d8ab04904d7683d4c3289f76d935ba31a1e3.jpg)

Fixes marmot-protocol/marmot-security#82.

The Android packaging workflow downloaded `openssl-${OPENSSL_VERSION}.tar.gz` from a GitHub release and extracted it without any integrity check. A tampered tarball, whether from a poisoned CDN, MITM, or compromised release, would have linked a backdoored OpenSSL into the `mdk-uniffi` shared library shipped to Android consumers. For a cryptographic library, that is a bad day.

This pins the upstream SHA-256 in a per-version map and verifies the tarball with `sha256sum -c` before extraction. A future version bump without a recorded hash now aborts the build with a clear error. The hash was sourced from openssl.org and cross-checked against the GitHub release's published `.sha256` sidecar.

The marmots are no longer accepting parcels without checking the wax seal.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/290">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
⚠️ Security-sensitive changes

This PR adds SHA-256 integrity verification to the OpenSSL source tarball download used by the Android build script, preventing a tampered upstream release from being extracted and linked into the mdk-uniffi Android library. It pins per-version OpenSSL SHA-256 checksums, verifies the downloaded tarball before extraction, and aborts the build if no recorded hash exists for the requested OpenSSL version.

**What changed**:
- scripts/build-openssl-android.sh now derives OPENSSL_SHA256 from a pinned per-version mapping (with an environment override) and exits if the resulting value is empty.
- The script downloads openssl-${OPENSSL_VERSION}.tar.gz and verifies its SHA-256 before extraction using sha256sum -c with a fallback to shasum -a 256, and errors if neither tool is available.
- A pinned SHA-256 for OpenSSL 3.3.2 was added, sourced from openssl.org and cross-checked against the GitHub release’s .sha256 sidecar.
- crates/mdk-uniffi/CHANGELOG.md was updated with a Security entry documenting the new verification behavior.

**Security impact**:
- Prevents a backdoored OpenSSL tarball (via CDN poisoning, MITM, or a compromised GitHub release) from being silently extracted and linked into the distributed Android mdk-uniffi library.
- Enforces explicit pinning of upstream hashes for any OpenSSL version bump, requiring maintainers to verify and record hashes before builds succeed.
- Causes builds to fail closed when an OpenSSL version lacks a recorded hash, avoiding accidental unverified builds.

**Protocol changes**:
- None.

**API surface**:
- No breaking changes or new public APIs; no UniFFI/FFI boundary changes.

**Testing**:
- No tests were added or modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->