### PR TITLE
security(mdk-uniffi): forbid unsafe_code at FFI boundary

### DIFF
--- a/crates/mdk-uniffi/src/lib.rs
+++ b/crates/mdk-uniffi/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate provides foreign language bindings for mdk-core using UniFFI.
 //! It wraps the MDK core functionality with SQLite storage backend.
 
+#![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
 use std::collections::BTreeSet;


### PR DESCRIPTION
![marmot](https://blossom.primal.net/b847f10d8852ffcdb8953651dc54b84efd2402138b88a35ce4f387a2a7e6988a.jpg)

Closes marmot-protocol/marmot-security#85.

The `mdk-uniffi` crate ships as `.so`/`.dylib`/`.dll` to mobile and desktop consumers. It's the highest-risk surface in the colony, yet it was the only MDK crate without `#![forbid(unsafe_code)]`.

Every other crate already enforces the policy: `mdk-core`, `mdk-sqlite-storage`, `mdk-memory-storage`, and `mdk-macros` use `forbid`; `mdk-storage-traits` uses `deny`. This PR brings the FFI burrow into line with the rest of the colony.

UniFFI 0.31's macros (`setup_scaffolding!`, `#[uniffi::export]`, the various derives) keep their unsafe scaffolding inside the `uniffi` library crate, so the consuming crate stays clean. `cargo check`, `cargo build`, and `cargo test --no-run` all pass under `--all-features`.

The diff is one line.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/291">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds `#![forbid(unsafe_code)]` to the `mdk-uniffi` crate's library manifest, enforcing a no-unsafe-code policy at the FFI boundary that serves Swift, Kotlin, Python, and Ruby consumers. This aligns with other MDK crates (`mdk-core`, `mdk-sqlite-storage`, `mdk-memory-storage`, `mdk-macros`) that already enforce `forbid`, and `mdk-storage-traits` which uses `deny`. Since UniFFI 0.31 maintains unsafe scaffolding in its own crate, `mdk-uniffi` can safely enforce this restriction.

**What changed**:
- Adds `#![forbid(unsafe_code)]` to `crates/mdk-uniffi/src/lib.rs` to prevent unsafe code blocks at the FFI boundary.

**Security impact**:
- Prevents introduction of unsafe code at the FFI boundary, reducing risk of memory safety issues (buffer overflows, use-after-free) that could affect downstream language bindings.

**Testing**:
- `cargo check`, `cargo build`, and `cargo test --no-run` all pass under `--all-features`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->