### PR TITLE
ci: harden Kotlin packaging and coverage workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -103,10 +103,24 @@ jobs:
       - name: Get master branch coverage (for PRs)
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
         id: master_coverage
+        env:
+          BASELINE_INPUT: ${{ github.event.inputs.baseline_coverage }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # Check if manual baseline provided (for testing)
-          if [ -n "${{ github.event.inputs.baseline_coverage }}" ]; then
-            MASTER_COV="${{ github.event.inputs.baseline_coverage }}"
+          # Numeric percentage: integer or decimal, no leading sign. Anything else
+          # is rejected so it can't flow into downstream expression expansions
+          # (Compare coverage / github-script) as a shell or JS payload.
+          NUMERIC_RE='^[0-9]+(\.[0-9]+)?$'
+
+          # Check if manual baseline provided (for testing).
+          # The workflow_dispatch input defaults to "0", which is a sentinel meaning
+          # "not provided" — fall through to the master-artifact path in that case.
+          if [ -n "$BASELINE_INPUT" ] && [ "$BASELINE_INPUT" != "0" ]; then
+            if ! [[ "$BASELINE_INPUT" =~ $NUMERIC_RE ]]; then
+              echo "::error::baseline_coverage must be a numeric percentage (got: $BASELINE_INPUT)"
+              exit 1
+            fi
+            MASTER_COV="$BASELINE_INPUT"
             echo "baseline=$MASTER_COV" >> "$GITHUB_OUTPUT"
             echo "Using manual baseline: $MASTER_COV%"
           else
@@ -138,6 +152,11 @@ jobs:
 
               if [ -f master-coverage/coverage-baseline.txt ]; then
                 MASTER_COV=$(cat master-coverage/coverage-baseline.txt)
+                if ! [[ "$MASTER_COV" =~ $NUMERIC_RE ]]; then
+                  echo "baseline=0" >> "$GITHUB_OUTPUT"
+                  echo "⚠️  Baseline artifact contained non-numeric data, ignoring"
+                  exit 0
+                fi
                 echo "baseline=$MASTER_COV" >> "$GITHUB_OUTPUT"
                 echo "✓ Master branch coverage: $MASTER_COV%"
               else
@@ -149,8 +168,6 @@ jobs:
               echo "⚠️  Failed to download baseline artifact from run $RUN_ID"
             fi
           fi
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Compare coverage
         if: (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && steps.master_coverage.outputs.baseline != '0'

--- a/.github/workflows/package-mdk-bindings.yml
+++ b/.github/workflows/package-mdk-bindings.yml
@@ -675,22 +675,34 @@ jobs:
         fi
 
     - name: Create and push version tag
+      if: startsWith(github.ref, 'refs/tags/v')
       shell: bash
+      env:
+        SOURCE_TAG: ${{ github.ref_name }}
+        VERSION: ${{ steps.cargo_version.outputs.version }}
+        BINDINGS_PACKAGE_PAT: ${{ secrets.BINDINGS_PACKAGE_PAT }}
+        KOTLIN_PACKAGE_REPO: ${{ env.KOTLIN_PACKAGE_REPO }}
       run: |
         cd kotlin-package-repo
-        VERSION="${{ steps.cargo_version.outputs.version }}"
         TAG="$VERSION"
 
-        # Check if tag already exists locally
-        if git rev-parse "$TAG" >/dev/null 2>&1; then
-          echo "Tag $TAG already exists locally, updating it"
-          git tag -d "$TAG" 2>/dev/null || true
+        # Refuse to publish if the trigger tag and Cargo.toml version disagree —
+        # otherwise a forgotten Cargo.toml bump can publish a stale Kotlin
+        # artifact under a fresh release tag.
+        if [ "$SOURCE_TAG" != "v$VERSION" ]; then
+          echo "ERROR: Trigger tag $SOURCE_TAG does not match Cargo.toml version v$VERSION."
+          exit 1
         fi
 
-        # Create or update the tag
-        git tag -a "$TAG" -m "Release version $VERSION"
-        git remote set-url origin https://x-access-token:${{ secrets.BINDINGS_PACKAGE_PAT }}@github.com/${{ env.KOTLIN_PACKAGE_REPO }}.git
+        git remote set-url origin "https://x-access-token:${BINDINGS_PACKAGE_PAT}@github.com/${KOTLIN_PACKAGE_REPO}.git"
 
-        # Force push to update remote tag if it exists
-        git push origin "$TAG" --force
-        echo "Created/updated and pushed tag: $TAG"
+        # Refuse to overwrite an existing remote tag — tags must be immutable for
+        # downstream JitPack consumers (see issue #80).
+        if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "refs/tags/$TAG$"; then
+          echo "ERROR: Tag $TAG already exists on remote. Refusing to overwrite."
+          exit 1
+        fi
+
+        git tag -a "$TAG" -m "Release version $VERSION"
+        git push origin "$TAG"
+        echo "Created and pushed tag: $TAG"

--- a/crates/mdk-uniffi/CHANGELOG.md
+++ b/crates/mdk-uniffi/CHANGELOG.md
@@ -33,6 +33,8 @@
 
 ### Fixed
 
+- Hardened the Kotlin bindings publishing workflow. The version-tag step now runs only on `v*` tag pushes, refuses to overwrite an existing remote tag (no more `git push --force`), and routes secrets through step `env:` blocks instead of inline expression substitution. Downstream JitPack consumers can now trust that a pinned Kotlin version maps to immutable artifact content. ([#292](https://github.com/marmot-protocol/mdk/pull/292))
+
 ### Removed
 
 ### Deprecated


### PR DESCRIPTION
![marmot](https://blossom.primal.net/dee5da90149595c358c28680e6e6549d7a1941891322884d856e4028045d12ff.png)

This PR addresses two CI/CD security issues in marmot-security related to the Kotlin packaging path. A third (#76) was investigated and dropped during rebase.

**marmot-protocol/marmot-security#78**: replaced direct `${{ github.event.inputs.baseline_coverage }}` shell interpolation in `coverage.yml` with an `env: BASELINE_INPUT` pass-through. The shell now reads the value from the environment, so input characters can no longer break out of the script context. The existing `GH_TOKEN: ${{ github.token }}` env was merged into the same block.

**marmot-protocol/marmot-security#80**: made the Kotlin version-tag step honest.
- `if: startsWith(github.ref, 'refs/tags/v')` so the step runs only on `v*` tag pushes, not on every branch push.
- `git ls-remote --tags` precheck that fails the workflow if the tag already exists on the remote.
- Dropped `--force` from `git push`.
- `BINDINGS_PACKAGE_PAT` and `KOTLIN_PACKAGE_REPO` now flow through `env:` blocks. The previous inline expression substitution into shell text is gone.

JitPack consumers can now trust that a pinned Kotlin version maps to immutable artifact content.

**marmot-protocol/marmot-security#76 (not actionable)**: rebasing onto current master showed that #285 deliberately bumped `actions/checkout` to `v6.0.2`, and #279 then SHA-pinned every action across the workflows. The Kotlin-job checkout now reads `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`, identical to every other checkout in the file. The supply-chain concern raised in the issue is already mitigated. Recommending #76 be closed as resolved-upstream.

Note: issue #80 also recommends enabling tag protection rules on the downstream `mdk-kotlin` repo. That's a repo-settings change, out of scope here. Flagging for follow-up.

Closes marmot-protocol/marmot-security#78
Closes marmot-protocol/marmot-security#80


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR hardens GitHub Actions workflows for Kotlin packaging and coverage by removing unsafe shell interpolation of workflow inputs, enforcing tag immutability for Kotlin releases, and consolidating secret handling into step env blocks. These changes close marmot-security issues #78 and #80, reduce command-injection and tag-rewrite supply-chain risks for downstream Kotlin consumers (e.g., JitPack), and mark #76 as resolved upstream after rebase.

What changed:
- Reworked .github/workflows/coverage.yml to stop interpolating github.event.inputs.baseline_coverage into shell commands by passing it as env: BASELINE_INPUT and reading it from the environment; treats the workflow_dispatch default "0" as “not provided” and falls back to the existing master-artifact baseline lookup when appropriate.
- Added numeric validation for manual baseline inputs and for the downloaded coverage-baseline artifact; non-numeric artifact content causes baseline=0 and successful exit, while invalid manual input fails the step with an error.
- Updated .github/workflows/package-mdk-bindings.yml so the Kotlin version-tag step runs only for v* tag pushes (if: startsWith(github.ref, 'refs/tags/v')), derives SOURCE_TAG and VERSION via env:, aborts if they mismatch, checks the remote with git ls-remote and fails if the tag already exists, creates annotated tags, and pushes without --force.
- Moved secrets and repo identifiers (BINDINGS_PACKAGE_PAT, KOTLIN_PACKAGE_REPO) and GH_TOKEN into step-level env: blocks and SHA-pinned the checkout action in the Kotlin workflow to align with other workflows.
- Updated crates/mdk-uniffi/CHANGELOG.md with a note describing the Kotlin bindings publishing hardening.

Security impact:
- Eliminates shell metacharacter injection risk from workflow_dispatch inputs by reading baseline inputs from environment variables instead of interpolating them in shell.
- Prevents tag-rewrite and force-push supply-chain attacks by restricting tag creation to v* tag events, refusing to overwrite existing remote tags, and removing forced pushes.
- Reduces secret-exposure and inline-expression substitution risks by routing PATs, repo identifiers, and GH_TOKEN through env: blocks and pinning actions where appropriate.

Protocol changes:
- None.

API surface:
- None (no changes to public APIs, storage schemas, or UniFFI/FFI boundaries).

Testing:
- Coverage workflow logic was modified to validate manual BASELINE_INPUT and artifact-derived baselines; no unit tests or source code tests were added or changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->