### PR TITLE
[skip-changelog]: Combine low-risk Dependabot action updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
         key: test-${{ matrix.features.name }}
 
     - name: Install cargo-nextest
-      uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
+      uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
       with:
         tool: cargo-nextest
 
@@ -219,9 +219,9 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install cargo-audit
-      uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
+      uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
       with:
         tool: cargo-audit
 
     - name: Run cargo audit
-      run: cargo audit
+      run: cargo audit --ignore RUSTSEC-2026-0124

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -69,7 +69,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y pkg-config
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
         with:
           tool: cargo-llvm-cov
 

--- a/.github/workflows/package-mdk-bindings.yml
+++ b/.github/workflows/package-mdk-bindings.yml
@@ -43,7 +43,7 @@ jobs:
       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
     - name: Install just
-      uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
     - name: Build iOS targets
       run: |
@@ -147,7 +147,7 @@ jobs:
       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
     - name: Install just
-      uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
     - name: Setup Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -354,7 +354,7 @@ jobs:
       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
     - name: Install just
-      uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
@@ -481,7 +481,7 @@ jobs:
 
     - name: Configure RubyGems Trusted Publishing credentials
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0
+      uses: rubygems/configure-rubygems-credentials@762a4b77c3300434bb57c7ce80b20e36231927aa # v2.0.0
 
     - name: Build and publish gem to RubyGems.org
       if: startsWith(github.ref, 'refs/tags/v')
@@ -513,7 +513,7 @@ jobs:
       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
     - name: Install just
-      uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
+      uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
     - name: Setup Java
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/justfile
+++ b/justfile
@@ -35,7 +35,7 @@ test-all:
 
 # Run cargo audit to check for known vulnerabilities and advisories
 audit:
-    cargo audit
+    cargo audit --ignore RUSTSEC-2026-0124
 
 # ==============================================================================
 # LINTING & FORMATTING


### PR DESCRIPTION
## Summary
- Combine the three lower-risk Dependabot workflow updates from #296, #297, and #298.
- Keep #294 and #295 separate for now while the upstream GitHub action dependency posture settles.
- Add the intended `cargo audit --ignore RUSTSEC-2026-0124` wiring to local precommit and the CI audit job; current `master` did not already contain that ignore.

## Security review
- `taiki-e/install-action` moves from `v2.77.1` to `v2.77.7`, pinned to `3235f8901fd37ffed0052b276cec25a362fb82e9`.
- `extractions/setup-just` moves from `v2.0.0` to `v4.0.0`, pinned to `53165ef7e734c5c07cb06b3c8e7b647c5aa16db3`.
- `rubygems/configure-rubygems-credentials` moves from `v1.0.0` to `v2.0.0`, pinned to `762a4b77c3300434bb57c7ce80b20e36231927aa`.
- The libcrux advisory remains tracked explicitly as an audit ignore rather than being hidden by a passing workflow.

## Validation
- `bash scripts/check-github-actions-pinned.sh`
- `actionlint .github/workflows/*.yml`
- `just precommit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR combines three lower-risk Dependabot workflow updates that bump GitHub Action dependencies to newer pinned versions and adds explicit audit ignore configuration for a known advisory. The changes modernize the CI/CD infrastructure while maintaining security pin integrity across the build and packaging workflows.

**What changed**:
- Updated `taiki-e/install-action` from v2.77.1 to v2.77.7 (pinned to commit 3235f8901fd37ffed0052b276cec25a362fb82e9) in the `test` and `audit` jobs in ci.yml and the coverage job in coverage.yml.
- Upgraded `extractions/setup-just` from v2.0.0 to v4.0.0 (pinned to commit 53165ef7e734c5c07cb06b3c8e7b647c5aa16db3) across the Swift, Python, Ruby, and Kotlin packaging jobs in package-mdk-bindings.yml.
- Upgraded `rubygems/configure-rubygems-credentials` from v1.0.0 to v2.0.0 (pinned to commit 762a4b77c3300434bb57c7ce80b20e36231927aa) in the Ruby publishing job in package-mdk-bindings.yml.
- Added explicit audit ignore flag `--ignore RUSTSEC-2026-0124` to the cargo audit invocations in both ci.yml and justfile.

**Security impact**:
- The RUSTSEC-2026-0124 advisory is now explicitly tracked as an audit ignore rather than being masked by passing workflows, improving visibility of known issues.
- All GitHub Action dependencies were updated to newer versions with verified commit pins maintained throughout the workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/mdk/pull/299)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->