### PR TITLE
Add optional audio display metadata to MIP-04 media tags

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Breaking changes
 
+- **MIP-04 media upload/reference structs now include optional audio display metadata.** `EncryptedMediaUpload` and `MediaReference` both add `duration_ms: Option<u64>` and `waveform: Option<Vec<u8>>`; callers constructing these structs directly must provide the new fields. The IMETA parser reads optional NIP-A0 `duration` and `waveform` entries on a best-effort basis, and the tag builder emits them when provided. ([#300](https://github.com/marmot-protocol/mdk/pull/300))
 - **Extension version bumped from 2 to 3**: `NostrGroupDataExtension::CURRENT_VERSION` is now `3`. The new version adds a `disappearing_message_secs` field to the TLS-serialized group data extension. Existing v1/v2 groups are forward-compatible (the field deserializes as `None`). `NostrGroupConfigData::new` now takes an additional `disappearing_message_secs: Option<u64>` parameter. ([#253](https://github.com/marmot-protocol/mdk/pull/253))
 - **`NostrGroupDataExtension::migrate_to_v2` removed from public API.** The 0.8.0 method was used only to construct test fixtures; production code never migrates extensions in-place (deserialization upgrades v1/v2 → v3 through `into_v3`, and new groups author v3 directly). Mirrors the existing convention for `migrate_group_image_v1_to_v2`, which was already documented as internal-only. ([#253](https://github.com/marmot-protocol/mdk/pull/253))
 

--- a/crates/mdk-core/src/encrypted_media/manager.rs
+++ b/crates/mdk-core/src/encrypted_media/manager.rs
@@ -27,6 +27,11 @@ use mdk_storage_traits::{MdkStorageProvider, Secret};
 /// temporarily without leaving the legacy fallback open-ended.
 const LEGACY_MEDIA_MIGRATION_DEADLINE: u64 = 1_778_803_200;
 
+/// Generous abuse-resistance bound for display-only waveform metadata.
+/// NIP-A0 suggests compact sample counts, but MDK does not enforce product
+/// duration or UI limits for audio attachments.
+const MAX_WAVEFORM_SAMPLES: usize = 16_384;
+
 /// Manager for encrypted media operations
 pub struct EncryptedMediaManager<'a, Storage>
 where
@@ -42,6 +47,104 @@ where
 {
     fn allow_legacy_media_fallback_at(current_time: u64) -> bool {
         current_time <= LEGACY_MEDIA_MIGRATION_DEADLINE
+    }
+
+    fn parse_duration_ms(value: &str) -> Option<u64> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() || trimmed.starts_with('-') || trimmed.starts_with('+') {
+            return None;
+        }
+
+        let (seconds_part, fractional_part) = match trimmed.split_once('.') {
+            Some((seconds, fractional)) => (seconds, Some(fractional)),
+            None => (trimmed, None),
+        };
+
+        if seconds_part.is_empty() || !seconds_part.chars().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+
+        let seconds = seconds_part.parse::<u64>().ok()?;
+        let seconds_ms = seconds.checked_mul(1000)?;
+        let fractional_ms = match fractional_part {
+            Some(fractional) => {
+                if fractional.is_empty()
+                    || fractional.len() > 3
+                    || !fractional.chars().all(|c| c.is_ascii_digit())
+                {
+                    return None;
+                }
+
+                let mut padded = fractional.to_string();
+                while padded.len() < 3 {
+                    padded.push('0');
+                }
+                padded.parse::<u64>().ok()?
+            }
+            None => 0,
+        };
+
+        let duration_ms = seconds_ms.checked_add(fractional_ms)?;
+        match duration_ms {
+            0 => None,
+            _ => Some(duration_ms),
+        }
+    }
+
+    fn format_duration_seconds(duration_ms: u64) -> Option<String> {
+        match duration_ms {
+            0 => None,
+            _ => {
+                let seconds = duration_ms / 1000;
+                let millis = duration_ms % 1000;
+                match millis {
+                    0 => Some(seconds.to_string()),
+                    _ => {
+                        let fractional = format!("{:03}", millis).trim_end_matches('0').to_string();
+                        Some(format!("{}.{}", seconds, fractional))
+                    }
+                }
+            }
+        }
+    }
+
+    fn parse_waveform(value: &str) -> Option<Vec<u8>> {
+        let mut samples = Vec::new();
+
+        for sample in value.split_whitespace() {
+            if samples.len() == MAX_WAVEFORM_SAMPLES {
+                return None;
+            }
+
+            let sample = sample.parse::<u8>().ok()?;
+            if sample > 100 {
+                return None;
+            }
+
+            samples.push(sample);
+        }
+
+        match samples.is_empty() {
+            true => None,
+            false => Some(samples),
+        }
+    }
+
+    fn format_waveform(waveform: &[u8]) -> Option<String> {
+        if waveform.is_empty()
+            || waveform.len() > MAX_WAVEFORM_SAMPLES
+            || waveform.iter().any(|sample| *sample > 100)
+        {
+            return None;
+        }
+
+        Some(
+            waveform
+                .iter()
+                .map(u8::to_string)
+                .collect::<Vec<_>>()
+                .join(" "),
+        )
     }
 
     /// Try to decrypt with a single exporter secret, falling back to the legacy
@@ -208,6 +311,8 @@ where
             dimensions: metadata.dimensions,
             blurhash: metadata.blurhash,
             thumbhash: metadata.thumbhash,
+            duration_ms: None,
+            waveform: None,
             nonce: *nonce,
         })
     }
@@ -412,6 +517,12 @@ where
         if let Some(ref thumbhash) = upload.thumbhash {
             tag_values.push(format!("thumbhash {}", thumbhash));
         }
+        if let Some(duration) = upload.duration_ms.and_then(Self::format_duration_seconds) {
+            tag_values.push(format!("duration {}", duration));
+        }
+        if let Some(waveform) = upload.waveform.as_deref().and_then(Self::format_waveform) {
+            tag_values.push(format!("waveform {}", waveform));
+        }
 
         // x field contains SHA256 hash of original file content (hex-encoded)
         tag_values.push(format!("x {}", hex::encode(upload.original_hash)));
@@ -437,6 +548,8 @@ where
             mime_type: upload.mime_type.clone(),
             filename: upload.filename.clone(),
             dimensions: upload.dimensions,
+            duration_ms: upload.duration_ms,
+            waveform: upload.waveform.clone(),
             scheme_version: DEFAULT_SCHEME_VERSION.to_string(),
             nonce: upload.nonce,
         }
@@ -473,6 +586,8 @@ where
         let mut original_hash: Option<[u8; 32]> = None;
         let mut nonce: Option<[u8; 12]> = None;
         let mut dimensions: Option<(u32, u32)> = None;
+        let mut duration_ms: Option<u64> = None;
+        let mut waveform: Option<Vec<u8>> = None;
         let mut version: Option<String> = None;
 
         // Parse key-value pairs from IMETA tag
@@ -536,6 +651,8 @@ where
                         dimensions = Some((width, height));
                     }
                 }
+                "duration" => duration_ms = Self::parse_duration_ms(parts[1]),
+                "waveform" => waveform = Self::parse_waveform(parts[1]),
                 "filename" => match validation::validate_filename(parts[1]) {
                     Ok(_) => filename = Some(parts[1].to_string()),
                     Err(_) => {
@@ -591,6 +708,8 @@ where
             mime_type,
             filename,
             dimensions,
+            duration_ms,
+            waveform,
             scheme_version,
             nonce,
         })
@@ -716,6 +835,22 @@ mod tests {
         LEGACY_MEDIA_MIGRATION_DEADLINE.saturating_add(1)
     }
 
+    fn valid_audio_imeta_tag(extra_fields: Vec<String>) -> NostrTag {
+        let mut tag_values = vec![
+            "url https://example.com/encrypted.ogg".to_string(),
+            "m audio/ogg".to_string(),
+            "filename voice.ogg".to_string(),
+        ];
+        tag_values.extend(extra_fields);
+        tag_values.extend([
+            format!("x {}", hex::encode([0x42; 32])),
+            format!("n {}", hex::encode([0xBE; 12])),
+            "v mip04-v2".to_string(),
+        ]);
+
+        NostrTag::custom(TagKind::Custom("imeta".into()), tag_values)
+    }
+
     #[test]
     fn test_create_imeta_tag() {
         let mdk = create_test_mdk();
@@ -733,6 +868,8 @@ mod tests {
             dimensions: Some((1920, 1080)),
             blurhash: Some("LKO2?U%2Tw=w]~RBVZRi};RPxuwH".to_string()),
             thumbhash: Some("}U#WoBrZy#_/qQ8PC,N]q7m}6X".to_string()),
+            duration_ms: None,
+            waveform: None,
             nonce: [0xAA; 12],
         };
 
@@ -791,6 +928,8 @@ mod tests {
             dimensions: Some((1920, 1080)),
             blurhash: Some("LKO2?U%2Tw=w]~RBVZRi};RPxuwH".to_string()),
             thumbhash: None,
+            duration_ms: None,
+            waveform: None,
             nonce: [0xAA; 12],
         };
 
@@ -822,6 +961,8 @@ mod tests {
             dimensions: Some((1920, 1080)),
             blurhash: None,
             thumbhash: Some("}U#WoBrZy#_/qQ8PC,N]q7m}6X".to_string()),
+            duration_ms: None,
+            waveform: None,
             nonce: [0xAA; 12],
         };
 
@@ -834,6 +975,41 @@ mod tests {
                 .iter()
                 .any(|v| v.starts_with("thumbhash }U#WoBrZy#_/qQ8PC,N]q7m}6X"))
         );
+    }
+
+    #[test]
+    fn test_create_imeta_tag_emits_audio_display_metadata() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        let upload = EncryptedMediaUpload {
+            encrypted_data: vec![1, 2, 3, 4],
+            original_hash: [0x42; 32],
+            encrypted_hash: [0x43; 32],
+            mime_type: "audio/ogg".to_string(),
+            filename: "voice.ogg".to_string(),
+            original_size: 1000,
+            encrypted_size: 1004,
+            dimensions: None,
+            blurhash: None,
+            thumbhash: None,
+            duration_ms: Some(1_500),
+            waveform: Some(vec![0, 25, 50, 75, 100]),
+            nonce: [0xAA; 12],
+        };
+
+        let tag = manager.create_imeta_tag(&upload, "https://example.com/voice.ogg");
+        let values = tag.clone().to_vec();
+
+        assert!(values.iter().any(|v| v == "duration 1.5"));
+        assert!(values.iter().any(|v| v == "waveform 0 25 50 75 100"));
+
+        let parsed = manager
+            .parse_imeta_tag(&tag)
+            .expect("builder output should round-trip through parser");
+        assert_eq!(parsed.duration_ms, Some(1_500));
+        assert_eq!(parsed.waveform, Some(vec![0, 25, 50, 75, 100]));
     }
 
     #[test]
@@ -868,6 +1044,105 @@ mod tests {
         assert_eq!(media_ref.dimensions, Some((1920, 1080)));
         assert_eq!(media_ref.scheme_version, "mip04-v2");
         assert_eq!(media_ref.nonce, test_nonce);
+    }
+
+    #[test]
+    fn test_parse_imeta_tag_audio_display_metadata() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        let imeta_tag = valid_audio_imeta_tag(vec![
+            "duration 42".to_string(),
+            "waveform 0 25 50 75 100".to_string(),
+        ]);
+        let media_ref = manager
+            .parse_imeta_tag(&imeta_tag)
+            .expect("valid audio display metadata should parse");
+
+        assert_eq!(media_ref.mime_type, "audio/ogg");
+        assert_eq!(media_ref.duration_ms, Some(42_000));
+        assert_eq!(media_ref.waveform, Some(vec![0, 25, 50, 75, 100]));
+    }
+
+    #[test]
+    fn test_parse_imeta_tag_accepts_audio_without_display_metadata() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        let imeta_tag = valid_audio_imeta_tag(vec![]);
+        let media_ref = manager
+            .parse_imeta_tag(&imeta_tag)
+            .expect("audio media without display metadata should parse");
+
+        assert_eq!(media_ref.mime_type, "audio/ogg");
+        assert_eq!(media_ref.duration_ms, None);
+        assert_eq!(media_ref.waveform, None);
+    }
+
+    #[test]
+    fn test_parse_imeta_tag_malformed_duration_is_best_effort() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        for duration in ["not-a-number", "0", "-1", "1.2345"] {
+            let imeta_tag = valid_audio_imeta_tag(vec![
+                format!("duration {}", duration),
+                "waveform 0 50 100".to_string(),
+            ]);
+            let media_ref = manager
+                .parse_imeta_tag(&imeta_tag)
+                .expect("bad duration should not fail a valid media tag");
+
+            assert_eq!(media_ref.duration_ms, None);
+            assert_eq!(media_ref.waveform, Some(vec![0, 50, 100]));
+        }
+    }
+
+    #[test]
+    fn test_parse_imeta_tag_malformed_waveform_is_best_effort() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        for waveform in ["", "0 101 100", "0 nope 100", "-1 50 100"] {
+            let imeta_tag = valid_audio_imeta_tag(vec![
+                "duration 2".to_string(),
+                format!("waveform {}", waveform),
+            ]);
+            let media_ref = manager
+                .parse_imeta_tag(&imeta_tag)
+                .expect("bad waveform should not fail a valid media tag");
+
+            assert_eq!(media_ref.duration_ms, Some(2_000));
+            assert_eq!(media_ref.waveform, None);
+        }
+    }
+
+    #[test]
+    fn test_parse_imeta_tag_audio_metadata_does_not_replace_required_fields() {
+        let mdk = create_test_mdk();
+        let group_id = GroupId::from_slice(&[1, 2, 3, 4]);
+        let manager = mdk.media_manager(group_id);
+
+        let tag_values = vec![
+            "url https://example.com/encrypted.ogg".to_string(),
+            "m audio/ogg".to_string(),
+            "filename voice.ogg".to_string(),
+            "duration 2".to_string(),
+            "waveform 0 50 100".to_string(),
+            format!("x {}", hex::encode([0x42; 32])),
+            "v mip04-v2".to_string(),
+        ];
+        let tag = NostrTag::custom(TagKind::Custom("imeta".into()), tag_values);
+        let result = manager.parse_imeta_tag(&tag);
+
+        assert!(matches!(
+            result,
+            Err(EncryptedMediaError::InvalidImetaTag { .. })
+        ));
     }
 
     #[test]
@@ -979,6 +1254,8 @@ mod tests {
             dimensions: Some((800, 600)),
             blurhash: None,
             thumbhash: None,
+            duration_ms: None,
+            waveform: None,
             nonce: test_nonce,
         };
 
@@ -1823,6 +2100,8 @@ mod tests {
             mime_type: "text/plain".to_string(),
             filename: "legacy-current.txt".to_string(),
             dimensions: None,
+            duration_ms: None,
+            waveform: None,
             scheme_version: DEFAULT_SCHEME_VERSION.to_string(),
             nonce: *nonce,
         };
@@ -1963,6 +2242,8 @@ mod tests {
             dimensions: None,
             blurhash: None,
             thumbhash: None,
+            duration_ms: None,
+            waveform: None,
             nonce: *nonce,
         };
         let media_ref = mdk
@@ -2208,6 +2489,8 @@ mod tests {
             mime_type: "text/plain".to_string(),
             filename: "legacy.txt".to_string(),
             dimensions: None,
+            duration_ms: None,
+            waveform: None,
             scheme_version: DEFAULT_SCHEME_VERSION.to_string(),
             nonce: *nonce,
         };
@@ -2227,6 +2510,8 @@ mod tests {
                 dimensions: None,
                 blurhash: None,
                 thumbhash: None,
+                duration_ms: None,
+                waveform: None,
                 nonce: *nonce,
             },
             alice_keys.public_key(),
@@ -2282,6 +2567,8 @@ mod tests {
             mime_type: "text/plain".to_string(),
             filename: "legacy-post.txt".to_string(),
             dimensions: None,
+            duration_ms: None,
+            waveform: None,
             scheme_version: DEFAULT_SCHEME_VERSION.to_string(),
             nonce: *nonce,
         };
@@ -2301,6 +2588,8 @@ mod tests {
                 dimensions: None,
                 blurhash: None,
                 thumbhash: None,
+                duration_ms: None,
+                waveform: None,
                 nonce: *nonce,
             },
             alice_keys.public_key(),

--- a/crates/mdk-core/src/encrypted_media/types.rs
+++ b/crates/mdk-core/src/encrypted_media/types.rs
@@ -46,6 +46,10 @@ pub struct EncryptedMediaUpload {
     pub blurhash: Option<String>,
     /// Thumbhash for images
     pub thumbhash: Option<String>,
+    /// Optional audio duration in milliseconds for display purposes
+    pub duration_ms: Option<u64>,
+    /// Optional audio waveform samples in the inclusive range 0..=100
+    pub waveform: Option<Vec<u8>>,
     /// Encryption nonce (96 bits, 12 bytes) - randomly generated per encryption
     pub nonce: [u8; 12],
 }
@@ -63,6 +67,10 @@ pub struct MediaReference {
     pub filename: String,
     /// Dimensions if applicable
     pub dimensions: Option<(u32, u32)>,
+    /// Optional audio duration in milliseconds for display purposes
+    pub duration_ms: Option<u64>,
+    /// Optional audio waveform samples in the inclusive range 0..=100
+    pub waveform: Option<Vec<u8>>,
     /// Encryption scheme version (e.g., "mip04-v2")
     pub scheme_version: String,
     /// Encryption nonce (96 bits, 12 bytes) - required for decryption
@@ -162,6 +170,8 @@ mod tests {
             dimensions: Some((1024, 768)),
             blurhash: Some("L6PZfSi_.AyE_3t7t7R**0o#DgR4".to_string()),
             thumbhash: Some("}U#WoBrZy#_/qQ8PC,N]q7m}6X".to_string()), // dummy base91 thumbhash
+            duration_ms: None,
+            waveform: None,
             nonce: [0x03; 12],
         };
 
@@ -176,6 +186,8 @@ mod tests {
         assert_eq!(upload.dimensions, Some((1024, 768)));
         assert!(upload.blurhash.is_some());
         assert!(upload.thumbhash.is_some());
+        assert_eq!(upload.duration_ms, None);
+        assert_eq!(upload.waveform, None);
         assert_eq!(upload.nonce, [0x03; 12]);
     }
 
@@ -187,6 +199,8 @@ mod tests {
             mime_type: "video/mp4".to_string(),
             filename: "test.mp4".to_string(),
             dimensions: Some((1920, 1080)),
+            duration_ms: Some(3_500),
+            waveform: Some(vec![0, 20, 80, 100]),
             scheme_version: "mip04-v2".to_string(),
             nonce: [0xAA; 12],
         };
@@ -197,6 +211,8 @@ mod tests {
         assert_eq!(media_ref.mime_type, "video/mp4");
         assert_eq!(media_ref.filename, "test.mp4");
         assert_eq!(media_ref.dimensions, Some((1920, 1080)));
+        assert_eq!(media_ref.duration_ms, Some(3_500));
+        assert_eq!(media_ref.waveform, Some(vec![0, 20, 80, 100]));
         assert_eq!(media_ref.scheme_version, "mip04-v2");
         assert_eq!(media_ref.nonce, [0xAA; 12]);
     }

--- a/crates/mdk-uniffi/CHANGELOG.md
+++ b/crates/mdk-uniffi/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Breaking changes
 
+- **MIP-04 media records now include optional audio display metadata.** `EncryptedMediaUploadResult` and `MediaReferenceRecord` both add `duration_ms: Option<u64>` and `waveform: Option<Vec<u8>>`, allowing binding consumers to pass and receive typed audio duration and waveform metadata through IMETA tag creation/parsing. Callers constructing these records directly must provide the new fields. ([#300](https://github.com/marmot-protocol/mdk/pull/300))
+
 ### Changed
 
 ### Added

--- a/crates/mdk-uniffi/src/lib.rs
+++ b/crates/mdk-uniffi/src/lib.rs
@@ -2021,6 +2021,10 @@ pub struct EncryptedMediaUploadResult {
     pub blurhash: Option<String>,
     /// Thumbhash preview string if generated, otherwise `None`
     pub thumbhash: Option<String>,
+    /// Optional audio duration in milliseconds for display purposes
+    pub duration_ms: Option<u64>,
+    /// Optional audio waveform samples in the inclusive range 0..=100
+    pub waveform: Option<Vec<u8>>,
     /// 12-byte ChaCha20-Poly1305 nonce used for encryption
     pub nonce: Vec<u8>,
 }
@@ -2040,6 +2044,8 @@ impl TryFrom<EncryptedMediaUpload> for EncryptedMediaUploadResult {
             dimensions: u.dimensions.map(|(w, h)| vec![w, h]),
             blurhash: u.blurhash,
             thumbhash: u.thumbhash,
+            duration_ms: u.duration_ms,
+            waveform: u.waveform,
             nonce: u.nonce.to_vec(),
         })
     }
@@ -2061,6 +2067,10 @@ pub struct MediaReferenceRecord {
     pub filename: String,
     /// Image dimensions `[width, height]` if the media is an image, otherwise `None`
     pub dimensions: Option<Vec<u32>>,
+    /// Optional audio duration in milliseconds for display purposes
+    pub duration_ms: Option<u64>,
+    /// Optional audio waveform samples in the inclusive range 0..=100
+    pub waveform: Option<Vec<u8>>,
     /// Encryption scheme version (e.g. `"mip04-v2"`)
     pub scheme_version: String,
     /// 12-byte ChaCha20-Poly1305 nonce — 12 bytes
@@ -2096,6 +2106,8 @@ impl TryFrom<MediaReferenceRecord> for MediaReference {
             mime_type: r.mime_type,
             filename: r.filename,
             dimensions,
+            duration_ms: r.duration_ms,
+            waveform: r.waveform,
             scheme_version: r.scheme_version,
             nonce,
         })
@@ -2110,6 +2122,8 @@ impl From<MediaReference> for MediaReferenceRecord {
             mime_type: r.mime_type,
             filename: r.filename,
             dimensions: r.dimensions.map(|(w, h)| vec![w, h]),
+            duration_ms: r.duration_ms,
+            waveform: r.waveform,
             scheme_version: r.scheme_version,
             nonce: r.nonce.to_vec(),
         }
@@ -2317,6 +2331,8 @@ impl TryFrom<EncryptedMediaUploadResult> for EncryptedMediaUpload {
             dimensions,
             blurhash: r.blurhash,
             thumbhash: r.thumbhash,
+            duration_ms: r.duration_ms,
+            waveform: r.waveform,
             nonce,
         })
     }
@@ -4047,6 +4063,8 @@ mod tests {
                 mime_type: "image/jpeg".to_string(),
                 filename: "test.jpg".to_string(),
                 dimensions: None,
+                duration_ms: None,
+                waveform: None,
                 scheme_version: "mip04-v2".to_string(),
                 nonce: vec![0u8; 8], // wrong length — should be 12
             };
@@ -4085,7 +4103,7 @@ mod tests {
             let mdk = create_test_mdk();
             let group_id = create_test_group(&mdk);
 
-            let upload = mdk
+            let mut upload = mdk
                 .encrypt_media_for_upload(
                     group_id.clone(),
                     TEST_PAYLOAD.to_vec(),
@@ -4093,6 +4111,8 @@ mod tests {
                     "payload.bin".to_string(),
                 )
                 .unwrap();
+            upload.duration_ms = Some(1_500);
+            upload.waveform = Some(vec![0, 25, 50, 75, 100]);
 
             // Build a MediaReferenceRecord directly from the upload result
             let reference = MediaReferenceRecord {
@@ -4101,6 +4121,8 @@ mod tests {
                 mime_type: upload.mime_type.clone(),
                 filename: upload.filename.clone(),
                 dimensions: upload.dimensions.clone(),
+                duration_ms: upload.duration_ms,
+                waveform: upload.waveform.clone(),
                 scheme_version: "mip04-v2".to_string(),
                 nonce: upload.nonce.clone(),
             };
@@ -4120,7 +4142,7 @@ mod tests {
             let mdk = create_test_mdk();
             let group_id = create_test_group(&mdk);
 
-            let upload = mdk
+            let mut upload = mdk
                 .encrypt_media_for_upload(
                     group_id.clone(),
                     TEST_PAYLOAD.to_vec(),
@@ -4128,6 +4150,8 @@ mod tests {
                     "payload.bin".to_string(),
                 )
                 .unwrap();
+            upload.duration_ms = Some(1_500);
+            upload.waveform = Some(vec![0, 25, 50, 75, 100]);
 
             let uploaded_url = "https://blossom.example.com/abc123.bin".to_string();
             let imeta_tag = mdk
@@ -4149,6 +4173,8 @@ mod tests {
             assert_eq!(reference.original_hash, upload.original_hash);
             assert_eq!(reference.nonce, upload.nonce);
             assert_eq!(reference.scheme_version, "mip04-v2");
+            assert_eq!(reference.duration_ms, Some(1_500));
+            assert_eq!(reference.waveform, Some(vec![0, 25, 50, 75, 100]));
         }
 
         #[test]


### PR DESCRIPTION
## Summary
- Added optional `duration_ms` and `waveform` fields to MDK media references and uploads so audio attachments can carry typed display metadata.
- Updated IMETA parsing to accept best-effort `duration` and `waveform` fields without breaking required MIP-04 decryption inputs.
- Updated IMETA building and UniFFI bindings so downstream apps can round-trip the new metadata.
- Kept existing image/video/file IMETA behavior intact and left audio decoding/UI policy out of MDK.

## Testing
- Added unit coverage for valid audio metadata, missing optional metadata, malformed duration, malformed waveform, required-field failures, and builder round-trips.
- Ran `cargo test -p mdk-core encrypted_media --features mip04`.
- Ran `cargo test -p mdk-uniffi test_create_and_parse_imeta_tag_round_trip --all-features`.
- Ran `cargo check --all-features` and `just check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds optional audio display metadata to MIP-04 IMETA tags so audio attachments can carry typed presentation information (duration and a lightweight waveform) while preserving existing decryption inputs and backward compatibility. It updates core parsing/formatting and UniFFI bindings so downstream apps can round-trip the new metadata without changing required MIP-04 fields.

**What changed**:
- Added optional fields `duration_ms: Option<u64>` and `waveform: Option<Vec<u8>>` to EncryptedMediaUpload and MediaReference in mdk-core.
- Extended EncryptedMediaManager parsing and tag-building to accept/emit `duration` (seconds with optional fractional part) and `waveform` (whitespace-separated 0..=100 samples) as best-effort display metadata, enforcing a maximum sample count and sample-range/format validation.
- Updated mdk-uniffi records (EncryptedMediaUploadResult and MediaReferenceRecord) and conversion code to carry `duration_ms` and `waveform` across the FFI boundary.
- IMETA generation conditionally emits the new fields when present; existing image/video/file IMETA behavior unchanged and audio decoding/UI policy remains out of MDK.

**Protocol changes**:
- MIP-04 IMETA tags now optionally support NIP-A0 `duration` and `waveform` entries as display-only metadata; required encryption/decryption fields are unchanged and still enforced.

**API surface**:
- Public struct fields added: EncryptedMediaUpload::duration_ms, EncryptedMediaUpload::waveform, MediaReference::duration_ms, MediaReference::waveform (mdk-core).
- UniFFI/FFI record fields added: EncryptedMediaUploadResult::duration_ms, EncryptedMediaUploadResult::waveform, MediaReferenceRecord::duration_ms, MediaReferenceRecord::waveform (mdk-uniffi).
- No breaking changes: all new fields are optional and default to None.

**Testing**:
- Added/updated unit tests covering valid audio metadata, missing optional metadata, malformed duration, malformed waveform, required-field enforcement, and builder/round-trip behavior.
- Verified with: cargo test -p mdk-core encrypted_media --features mip04; cargo test -p mdk-uniffi test_create_and_parse_imeta_tag_round_trip --all-features; and cargo check --all-features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/mdk/pull/300)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->