### PR TITLE
[skip-changelog]: Bump artifact and setup-python GitHub Actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -260,28 +260,28 @@ jobs:
 
       - name: Upload coverage baseline (master only)
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-baseline
           path: coverage-baseline/coverage-baseline.txt
           retention-days: 90
 
       - name: Upload HTML coverage report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report-html
           path: coverage/html/
           retention-days: 90
 
       - name: Upload lcov coverage report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report-lcov
           path: coverage/lcov.info
           retention-days: 90
 
       - name: Upload coverage summary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-summary
           path: coverage/summary.txt

--- a/.github/workflows/package-mdk-bindings.yml
+++ b/.github/workflows/package-mdk-bindings.yml
@@ -150,7 +150,7 @@ jobs:
       uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
 
     - name: Setup Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
 
@@ -183,7 +183,7 @@ jobs:
         echo "✓ Python artifacts prepared for ${{ runner.os }}"
 
     - name: Upload Python artifacts
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: python-artifacts-${{ matrix.os }}
         path: python-artifacts/
@@ -284,7 +284,7 @@ jobs:
 
     - name: Setup Python for package publishing
       if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_test_pypi == true
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
 
@@ -387,7 +387,7 @@ jobs:
         echo "✓ Ruby artifacts prepared for ${{ runner.os }}"
 
     - name: Upload Ruby artifacts
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ruby-artifacts-${{ matrix.os }}
         path: ruby-artifacts/


### PR DESCRIPTION
## Summary
- replace Dependabot PR #294 by bumping actions/upload-artifact from v4.6.2 to v7.0.1 in coverage and bindings packaging workflows
- replace Dependabot PR #295 by bumping actions/setup-python from v5.6.0 to v6.2.0 in bindings packaging workflows
- carry only the workflow pin updates onto current master, avoiding the stale-base reverse diff in the bot branches

## Safety review
- verified both new pinned SHAs resolve to official action tags: actions/upload-artifact@v7.0.1 and actions/setup-python@v6.2.0
- reviewed upstream release notes: both major updates are Node 24 compatible; runner requirement is 2.327.1+ for Node 24 actions
- checked this repo's affected workflows use GitHub-hosted runners, not self-hosted runners
- confirmed PR #294's failing Security Audit was from the stale bot merge ref running cargo audit without the current RUSTSEC-2026-0124 ignore; fresh branch passes the current audit gate

## Validation
- actionlint .github/workflows/coverage.yml .github/workflows/package-mdk-bindings.yml
- git diff --check
- just audit
- just precommit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR updates GitHub Actions versions across CI workflows to address maintenance and compatibility updates. The changes bump `actions/upload-artifact` from v4.6.2 to v7.0.1 and `actions/setup-python` from v5.6.0 to v6.2.0, with safety review confirming Node 24 compatibility and runner requirements are met for GitHub-hosted runners.

**What changed**:
- Updated `actions/upload-artifact` to v7.0.1 across coverage and bindings packaging workflows.
- Updated `actions/setup-python` to v6.2.0 in bindings packaging workflows (both `package-python` and `publish-python` jobs).
- Applied workflow pin updates to current master to consolidate Dependabot PRs #294 and #295 and avoid stale-base reverse diff issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/mdk/pull/305)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->