### PR TITLE
fix(security): sanitize welcome failure reasons and cap stored length

### DIFF
--- a/crates/mdk-core/CHANGELOG.md
+++ b/crates/mdk-core/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Verified unsigned application-message rumor IDs before accepting or sending them, preventing caller-supplied IDs from being trusted when they do not match the canonical event hash. ([#287](https://github.com/marmot-protocol/mdk/pull/287))
 - Fixed `mdk-core` crates.io package verification against OpenMLS 0.8.1 by using a temporary exported-ratchet-tree compatibility shim until crates.io OpenMLS exposes the upstream full-leaf iterator. ([#273](https://github.com/marmot-protocol/mdk/pull/273))
 - Updated `MDK::delete_group` docstring to list welcome and processed welcome records, matching the storage backends now that processed-welcome scrubbing is wired into both backends. Closes [marmot-protocol/marmot-security#68](https://github.com/marmot-protocol/marmot-security/issues/68). ([#293](https://github.com/marmot-protocol/mdk/pull/293))
+- Replaced raw `{:?}`-formatted debug strings on the welcome path with stable, sanitized category strings (`missing_encoding_tag`, `welcome_decode_failed`, `welcome_parse_failed`) so persistent failure records and logs no longer leak internal state or privacy-sensitive identifiers derived from untrusted welcome content. Matches the sanitized-category pattern already used on the message path. Closes [marmot-protocol/marmot-security#6](https://github.com/marmot-protocol/marmot-security/issues/6). ([#307](https://github.com/marmot-protocol/mdk/pull/307))
 
 ### Removed
 

--- a/crates/mdk-core/src/welcomes.rs
+++ b/crates/mdk-core/src/welcomes.rs
@@ -14,6 +14,22 @@ use crate::error::Error;
 use crate::extension::NostrGroupDataExtension;
 use crate::util::{ContentEncoding, decode_content};
 
+/// Stable, sanitized failure categories used when recording a failed welcome.
+///
+/// These strings are persisted to storage and surfaced in logs and in
+/// [`Error::WelcomePreviouslyFailed`]. They intentionally do not include the
+/// underlying error (which is derived from untrusted welcome content) so that
+/// internal state and privacy-sensitive identifiers cannot leak through
+/// failure records.
+mod welcome_failure {
+    /// The welcome event was missing its required `encoding` tag.
+    pub const MISSING_ENCODING_TAG: &str = "missing_encoding_tag";
+    /// The welcome event content could not be decoded with the declared encoding.
+    pub const DECODE_FAILED: &str = "welcome_decode_failed";
+    /// The decoded welcome could not be parsed as a valid MLS staged welcome.
+    pub const PARSE_FAILED: &str = "welcome_parse_failed";
+}
+
 /// Welcome preview
 #[derive(Debug)]
 pub struct WelcomePreview {
@@ -450,26 +466,11 @@ where
         let encoding = match ContentEncoding::from_tags(welcome_event.tags.iter()) {
             Some(enc) => enc,
             None => {
-                let error_string = "Missing required encoding tag".to_string();
-                let processed_welcome = welcome_types::ProcessedWelcome {
-                    wrapper_event_id: *wrapper_event_id,
-                    welcome_event_id: welcome_event.id,
-                    processed_at: Timestamp::now(),
-                    state: welcome_types::ProcessedWelcomeState::Failed,
-                    failure_reason: Some(error_string.clone()),
-                };
-
-                self.storage()
-                    .save_processed_welcome(processed_welcome)
-                    .map_err(|e| Error::Welcome(e.to_string()))?;
-
-                tracing::error!(
-                    target: "mdk_core::welcomes::process_welcome",
-                    "Error processing welcome: {}",
-                    error_string
-                );
-
-                return Err(Error::Welcome(error_string));
+                return Err(self.record_welcome_failure(
+                    wrapper_event_id,
+                    welcome_event.id,
+                    welcome_failure::MISSING_ENCODING_TAG,
+                )?);
             }
         };
 
@@ -481,27 +482,12 @@ where
                 );
                 content
             }
-            Err(e) => {
-                let error_string = format!(
-                    "Error decoding welcome event content ({}): {:?}",
-                    encoding.as_tag_value(),
-                    e
-                );
-                let processed_welcome = welcome_types::ProcessedWelcome {
-                    wrapper_event_id: *wrapper_event_id,
-                    welcome_event_id: welcome_event.id,
-                    processed_at: Timestamp::now(),
-                    state: welcome_types::ProcessedWelcomeState::Failed,
-                    failure_reason: Some(error_string.clone()),
-                };
-
-                self.storage()
-                    .save_processed_welcome(processed_welcome)
-                    .map_err(|e| Error::Welcome(e.to_string()))?;
-
-                tracing::error!(target: "mdk_core::welcomes::process_welcome", "Error processing welcome: {}", error_string);
-
-                return Err(Error::Welcome(error_string));
+            Err(_e) => {
+                return Err(self.record_welcome_failure(
+                    wrapper_event_id,
+                    welcome_event.id,
+                    welcome_failure::DECODE_FAILED,
+                )?);
             }
         };
 
@@ -510,27 +496,54 @@ where
                 staged_welcome,
                 nostr_group_data,
             },
-            Err(e) => {
-                let error_string = format!("Error previewing welcome: {:?}", e);
-                let processed_welcome = welcome_types::ProcessedWelcome {
-                    wrapper_event_id: *wrapper_event_id,
-                    welcome_event_id: welcome_event.id,
-                    processed_at: Timestamp::now(),
-                    state: welcome_types::ProcessedWelcomeState::Failed,
-                    failure_reason: Some(error_string.clone()),
-                };
-
-                self.storage()
-                    .save_processed_welcome(processed_welcome)
-                    .map_err(|e| Error::Welcome(e.to_string()))?;
-
-                tracing::error!(target: "mdk_core::welcomes::process_welcome", "Error processing welcome: {}", error_string);
-
-                return Err(Error::Welcome(error_string));
+            Err(_e) => {
+                return Err(self.record_welcome_failure(
+                    wrapper_event_id,
+                    welcome_event.id,
+                    welcome_failure::PARSE_FAILED,
+                )?);
             }
         };
 
         Ok(welcome_preview)
+    }
+
+    /// Persist a failed-welcome record with a stable, sanitized category and
+    /// return the corresponding [`Error::Welcome`].
+    ///
+    /// Only the category is stored and logged — the underlying error (which is
+    /// derived from untrusted welcome content) is intentionally dropped so it
+    /// cannot leak through persistent failure records or logs.
+    ///
+    /// Returns `Err(_)` only if persisting the failed-welcome record itself
+    /// fails; in that case the storage error is returned and the original
+    /// welcome failure is logged but not persisted.
+    fn record_welcome_failure(
+        &self,
+        wrapper_event_id: &EventId,
+        welcome_event_id: Option<EventId>,
+        category: &'static str,
+    ) -> Result<Error, Error> {
+        let processed_welcome = welcome_types::ProcessedWelcome {
+            wrapper_event_id: *wrapper_event_id,
+            welcome_event_id,
+            processed_at: Timestamp::now(),
+            state: welcome_types::ProcessedWelcomeState::Failed,
+            failure_reason: Some(category.to_string()),
+        };
+
+        self.storage()
+            .save_processed_welcome(processed_welcome)
+            .map_err(|e| Error::Welcome(e.to_string()))?;
+
+        tracing::error!(
+            target: "mdk_core::welcomes::process_welcome",
+            wrapper_event_id = %wrapper_event_id,
+            "Welcome processing failed: {}",
+            category
+        );
+
+        Ok(Error::Welcome(category.to_string()))
     }
 }
 
@@ -1221,17 +1234,20 @@ mod tests {
         let welcome = &group_result.welcome_rumors[0];
 
         // Step 3: Test missing signing key scenario
-        // Bob Device B tries to process the welcome but doesn't have the signing key
+        // Bob Device B tries to process the welcome but doesn't have the signing key.
+        // The welcome parses but cannot be constructed into a StagedWelcome without
+        // the key material; this surfaces as the sanitized `welcome_parse_failed`
+        // category (no raw debug content is leaked).
         let result = bob_device_b.process_welcome(&nostr::EventId::all_zeros(), welcome);
 
-        // Verify the error message is informative
-        let error_msg = result
-            .expect_err("Processing welcome without signing key should fail")
-            .to_string();
+        let error = result.expect_err("Processing welcome without signing key should fail");
         assert!(
-            error_msg.contains("key") || error_msg.contains("Key") || error_msg.contains("storage"),
-            "Error message should mention key/storage issue: {}",
-            error_msg
+            matches!(
+                error,
+                Error::Welcome(ref msg) if msg == welcome_failure::PARSE_FAILED
+            ),
+            "Error should be the sanitized parse-failed category, got: {:?}",
+            error
         );
 
         // Step 4: Test unknown KeyPackage scenario
@@ -1646,34 +1662,95 @@ mod tests {
             content: "not_valid_base64!!!".to_string(),
         };
 
-        // First attempt should fail with a decoding error
+        // First attempt should fail with the sanitized decode-failed category
         let first_result = mdk.process_welcome(&wrapper_event_id, &invalid_welcome);
         assert!(first_result.is_err(), "First attempt should fail");
         let first_error = first_result.unwrap_err();
-        // The error should be a Welcome error about decoding
         assert!(
-            matches!(first_error, Error::Welcome(ref msg) if msg.contains("decoding")),
-            "First error should be about decoding, got: {:?}",
+            matches!(
+                first_error,
+                Error::Welcome(ref msg) if msg == welcome_failure::DECODE_FAILED
+            ),
+            "First error should be the sanitized decode-failed category, got: {:?}",
             first_error
         );
 
-        // Second attempt (retry) should return WelcomePreviouslyFailed with the original reason
+        // Second attempt (retry) should return WelcomePreviouslyFailed carrying
+        // the stored category (also sanitized).
         let second_result = mdk.process_welcome(&wrapper_event_id, &invalid_welcome);
         assert!(second_result.is_err(), "Second attempt should also fail");
         let second_error = second_result.unwrap_err();
 
-        // Verify we get the new error type with the original failure reason
         match second_error {
             Error::WelcomePreviouslyFailed(reason) => {
-                assert!(
-                    reason.contains("decoding"),
-                    "Failure reason should contain original error about decoding, got: {}",
-                    reason
+                assert_eq!(
+                    reason,
+                    welcome_failure::DECODE_FAILED,
+                    "Stored failure reason should be the sanitized category"
                 );
             }
             other => {
                 panic!("Expected WelcomePreviouslyFailed error, got: {:?}", other);
             }
         }
+    }
+
+    /// Test that welcome failures are stored as sanitized category strings, not
+    /// raw debug-formatted error messages (security issue: leaking debug
+    /// content into persistent failure records).
+    #[test]
+    fn test_welcome_failure_reason_is_sanitized_category() {
+        use mdk_storage_traits::welcomes::WelcomeStorage;
+        use nostr::RelayUrl;
+
+        let mdk = create_test_mdk();
+        let wrapper_event_id = EventId::from_slice(&[7u8; 32]).unwrap();
+
+        // Valid structure, invalid base64 content -> decode failure path.
+        let mut tags = nostr::Tags::new();
+        tags.push(nostr::Tag::relays(vec![
+            RelayUrl::parse("wss://relay.example.com").unwrap(),
+        ]));
+        tags.push(nostr::Tag::event(EventId::all_zeros()));
+        tags.push(nostr::Tag::custom(
+            nostr::TagKind::Custom("encoding".into()),
+            ["base64"],
+        ));
+
+        let invalid_welcome = UnsignedEvent {
+            id: Some(EventId::from_slice(&[8u8; 32]).unwrap()),
+            pubkey: Keys::generate().public_key(),
+            created_at: Timestamp::now(),
+            kind: Kind::MlsWelcome,
+            tags,
+            content: "not_valid_base64!!!".to_string(),
+        };
+
+        let result = mdk.process_welcome(&wrapper_event_id, &invalid_welcome);
+        assert!(result.is_err(), "Expected decode failure");
+
+        let processed = mdk
+            .storage()
+            .find_processed_welcome_by_event_id(&wrapper_event_id)
+            .expect("storage lookup")
+            .expect("processed welcome record");
+
+        assert_eq!(
+            processed.state,
+            welcome_types::ProcessedWelcomeState::Failed
+        );
+
+        let reason = processed
+            .failure_reason
+            .expect("failure_reason should be set");
+
+        // The reason must be exactly the stable category — not a debug-formatted
+        // error string carrying untrusted content.
+        assert_eq!(reason, welcome_failure::DECODE_FAILED);
+
+        // Defense-in-depth: must not contain debug tokens or wrapped error fragments.
+        assert!(!reason.contains("Error"));
+        assert!(!reason.contains("{"));
+        assert!(!reason.contains(':'));
     }
 }

--- a/crates/mdk-memory-storage/CHANGELOG.md
+++ b/crates/mdk-memory-storage/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 - Fixed `MdkMemoryStorage::save_welcome` to reject oversized welcome group metadata and serialized event JSON before caching welcomes, matching SQLite backend payload bounds. ([#276](https://github.com/marmot-protocol/mdk/pull/276))
 - `delete_group` now scrubs `processed_welcomes_cache` entries for the group by consulting a non-evicting `wrapper_event_id -> mls_group_id` index (populated by `save_processed_welcome` from the just-cached welcome). Previously these entries survived deletion, leaking group-linkable metadata and tripping the welcome dedup path on re-processing. The index closes the eviction window where an LRU-evicted welcome would otherwise strand its processed-welcome entry; bounded at the same rate as `processed_welcomes_cache` itself. Closes [marmot-protocol/marmot-security#68](https://github.com/marmot-protocol/marmot-security/issues/68). ([#293](https://github.com/marmot-protocol/mdk/pull/293))
+- Bounded `failure_reason` length in `save_processed_message` and `save_processed_welcome` via `truncate_failure_reason` from `mdk-storage-traits`, removing an unbounded storage-exhaustion sink for attacker-influenced diagnostic strings. Closes [marmot-protocol/marmot-security#19](https://github.com/marmot-protocol/marmot-security/issues/19). ([#307](https://github.com/marmot-protocol/mdk/pull/307))
 
 ### Removed
 

--- a/crates/mdk-memory-storage/src/messages.rs
+++ b/crates/mdk-memory-storage/src/messages.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use mdk_storage_traits::GroupId;
+use mdk_storage_traits::{GroupId, truncate_failure_reason};
 use nostr::{EventId, JsonUtil};
 #[cfg(test)]
 use nostr::{Kind, Tags, Timestamp, UnsignedEvent};
@@ -155,8 +155,11 @@ impl MessageStorage for MdkMemoryStorage {
 
     fn save_processed_message(
         &self,
-        processed_message: ProcessedMessage,
+        mut processed_message: ProcessedMessage,
     ) -> Result<(), MessageError> {
+        processed_message.failure_reason =
+            truncate_failure_reason(processed_message.failure_reason);
+
         let mut inner = self.inner.write();
         inner
             .processed_messages_cache

--- a/crates/mdk-memory-storage/src/welcomes.rs
+++ b/crates/mdk-memory-storage/src/welcomes.rs
@@ -1,5 +1,6 @@
 //! Memory-based storage implementation of the MdkStorageProvider trait for MDK welcomes
 
+use mdk_storage_traits::truncate_failure_reason;
 use mdk_storage_traits::welcomes::error::WelcomeError;
 use mdk_storage_traits::welcomes::types::*;
 use mdk_storage_traits::welcomes::validation::validate_welcome_fields;
@@ -124,8 +125,11 @@ impl WelcomeStorage for MdkMemoryStorage {
 
     fn save_processed_welcome(
         &self,
-        processed_welcome: ProcessedWelcome,
+        mut processed_welcome: ProcessedWelcome,
     ) -> Result<(), WelcomeError> {
+        processed_welcome.failure_reason =
+            truncate_failure_reason(processed_welcome.failure_reason);
+
         let mut inner = self.inner.write();
         // Capture the wrapper -> group association from the just-saved welcome
         // so delete_group can still scrub this processed_welcomes entry after

--- a/crates/mdk-sqlite-storage/CHANGELOG.md
+++ b/crates/mdk-sqlite-storage/CHANGELOG.md
@@ -36,6 +36,7 @@
 ### Fixed
 
 - `delete_group` now scrubs `processed_welcomes` rows for the group via a join through `welcomes` on `wrapper_event_id`, ordered before the existing `welcomes` delete. Previously these rows survived deletion, leaking `wrapper_event_id`, `welcome_event_id`, `processed_at`, `state`, and unsanitized `failure_reason` linkable to the deleted group, and tripping the welcome dedup path on re-processing. Closes [marmot-protocol/marmot-security#68](https://github.com/marmot-protocol/marmot-security/issues/68). ([#293](https://github.com/marmot-protocol/mdk/pull/293))
+- Bounded `failure_reason` length in `save_processed_message` and `save_processed_welcome` via `truncate_failure_reason` from `mdk-storage-traits`, removing an unbounded storage-exhaustion sink for attacker-influenced diagnostic strings. Closes [marmot-protocol/marmot-security#19](https://github.com/marmot-protocol/marmot-security/issues/19). ([#307](https://github.com/marmot-protocol/mdk/pull/307))
 
 ### Removed
 

--- a/crates/mdk-sqlite-storage/src/messages.rs
+++ b/crates/mdk-sqlite-storage/src/messages.rs
@@ -3,6 +3,7 @@
 use mdk_storage_traits::messages::MessageStorage;
 use mdk_storage_traits::messages::error::MessageError;
 use mdk_storage_traits::messages::types::{Message, ProcessedMessage};
+use mdk_storage_traits::truncate_failure_reason;
 use nostr::{EventId, JsonUtil};
 use rusqlite::{OptionalExtension, params};
 
@@ -97,8 +98,11 @@ impl MessageStorage for MdkSqliteStorage {
 
     fn save_processed_message(
         &self,
-        processed_message: ProcessedMessage,
+        mut processed_message: ProcessedMessage,
     ) -> Result<(), MessageError> {
+        processed_message.failure_reason =
+            truncate_failure_reason(processed_message.failure_reason);
+
         // Convert message_event_id to bytes if it exists
         let message_event_id = processed_message
             .message_event_id

--- a/crates/mdk-sqlite-storage/src/welcomes.rs
+++ b/crates/mdk-sqlite-storage/src/welcomes.rs
@@ -1,5 +1,6 @@
 //! Implementation of WelcomeStorage trait for SQLite storage.
 
+use mdk_storage_traits::truncate_failure_reason;
 use mdk_storage_traits::welcomes::error::WelcomeError;
 use mdk_storage_traits::welcomes::types::{ProcessedWelcome, Welcome};
 use mdk_storage_traits::welcomes::{Pagination, WelcomeStorage, validate_pending_welcomes_limit};
@@ -143,8 +144,11 @@ impl WelcomeStorage for MdkSqliteStorage {
 
     fn save_processed_welcome(
         &self,
-        processed_welcome: ProcessedWelcome,
+        mut processed_welcome: ProcessedWelcome,
     ) -> Result<(), WelcomeError> {
+        processed_welcome.failure_reason =
+            truncate_failure_reason(processed_welcome.failure_reason);
+
         // Convert welcome_event_id to string if it exists
         let welcome_event_id: Option<&[u8; 32]> = processed_welcome
             .welcome_event_id

--- a/crates/mdk-storage-traits/CHANGELOG.md
+++ b/crates/mdk-storage-traits/CHANGELOG.md
@@ -34,6 +34,8 @@
 
 ### Added
 
+- Added `MAX_FAILURE_REASON_LEN` (256 bytes) and `truncate_failure_reason(Option<String>) -> Option<String>` so storage backends can defensively cap the length of `failure_reason` values before persistence, with UTF-8-safe truncation that walks back to a valid char boundary. Closes [marmot-protocol/marmot-security#19](https://github.com/marmot-protocol/marmot-security/issues/19). ([#307](https://github.com/marmot-protocol/mdk/pull/307))
+
 ### Fixed
 
 - Redacted sensitive MLS/Nostr group identifiers and private payload fields from storage-domain `Debug` output. ([#277](https://github.com/marmot-protocol/mdk/pull/277))

--- a/crates/mdk-storage-traits/src/lib.rs
+++ b/crates/mdk-storage-traits/src/lib.rs
@@ -248,6 +248,31 @@ pub use error::MdkStorageError;
 pub use group_id::GroupId;
 pub use secret::{PlaintextSecret, Secret, Zeroize};
 
+/// Maximum number of bytes accepted for a persisted `failure_reason` string.
+///
+/// Failure reasons are expected to be short, stable category identifiers
+/// (e.g. `"welcome_decode_failed"`) produced by the caller. This bound is a
+/// defense-in-depth cap so that even an unsanitized caller cannot use the
+/// `failure_reason` field as an unbounded storage-exhaustion vector.
+pub const MAX_FAILURE_REASON_LEN: usize = 256;
+
+/// Truncate a `failure_reason` string to at most [`MAX_FAILURE_REASON_LEN`] bytes.
+///
+/// Truncation respects UTF-8 character boundaries, so the returned string is
+/// always valid UTF-8 even when the limit falls inside a multi-byte sequence.
+pub fn truncate_failure_reason(reason: Option<String>) -> Option<String> {
+    reason.map(|mut s| {
+        if s.len() > MAX_FAILURE_REASON_LEN {
+            let mut idx = MAX_FAILURE_REASON_LEN;
+            while idx > 0 && !s.is_char_boundary(idx) {
+                idx -= 1;
+            }
+            s.truncate(idx);
+        }
+        s
+    })
+}
+
 use self::groups::GroupStorage;
 use self::messages::MessageStorage;
 use self::welcomes::WelcomeStorage;
@@ -374,5 +399,37 @@ mod tests {
     fn test_backend_is_persistent() {
         assert!(!Backend::Memory.is_persistent());
         assert!(Backend::SQLite.is_persistent());
+    }
+
+    #[test]
+    fn truncate_failure_reason_passes_short_strings_unchanged() {
+        let short = "welcome_decode_failed".to_string();
+        let result = truncate_failure_reason(Some(short.clone()));
+        assert_eq!(result, Some(short));
+    }
+
+    #[test]
+    fn truncate_failure_reason_preserves_none() {
+        assert_eq!(truncate_failure_reason(None), None);
+    }
+
+    #[test]
+    fn truncate_failure_reason_caps_long_strings() {
+        let long = "a".repeat(MAX_FAILURE_REASON_LEN * 4);
+        let result = truncate_failure_reason(Some(long)).unwrap();
+        assert_eq!(result.len(), MAX_FAILURE_REASON_LEN);
+    }
+
+    #[test]
+    fn truncate_failure_reason_respects_utf8_boundaries() {
+        // "é" is two bytes (0xC3 0xA9). Construct a string where the cap
+        // would otherwise fall in the middle of a multi-byte character.
+        let mut s = "a".repeat(MAX_FAILURE_REASON_LEN - 1);
+        s.push('é');
+        let result = truncate_failure_reason(Some(s)).unwrap();
+        // The 2-byte 'é' starts at index MAX_FAILURE_REASON_LEN - 1, so we
+        // must truncate back to that boundary rather than split it.
+        assert_eq!(result.len(), MAX_FAILURE_REASON_LEN - 1);
+        assert!(result.chars().all(|c| c == 'a'));
     }
 }


### PR DESCRIPTION
![marmot](https://blossom.primal.net/3bdcf1a4312b39d4c9da3e8c8b20cad03a664982a8e66f8f805447d779944585.jpg)

Closes marmot-protocol/marmot-security#6.
Closes marmot-protocol/marmot-security#19.

When a welcome arrives malformed, the colony was scribbling raw `{:?}`-formatted error strings into `ProcessedWelcome::failure_reason` and re-emitting them through `Error::Welcome` and the `tracing` log. Two problems followed:

- **Leakage.** The strings come from untrusted welcome content and can carry internal state or privacy-sensitive identifiers (`mls_group_id`, `nostr_group_id`) into persistent records and logs. The message-processing path already forbids this via `mdk_core::messages::error_handling::sanitize_error_reason`; the welcome path was an inconsistent gap.
- **Unbounded storage.** Both backends accepted `Option<String>` with no length cap, so an attacker who can influence the value gets a durable, unbounded sink in the marmot's own pantry.

The fix sanitizes at the source so we only ever write stable category strings, and caps at the storage layer so a future sloppy caller still can't blow up the pantry.

`crates/mdk-core/src/welcomes.rs::preview_welcome` had three sites that built `format!("...{:?}", e)` strings. Each one now runs through a single `record_welcome_failure` helper that stores, logs, and returns exactly one of three stable categories (`missing_encoding_tag`, `welcome_decode_failed`, `welcome_parse_failed`), defined together in a `welcome_failure` module so future failure sites have a single place to add to.

The storage-layer cap is defense in depth. `mdk-storage-traits` now exposes `MAX_FAILURE_REASON_LEN = 256` and `truncate_failure_reason`, which walks back to a valid UTF-8 char boundary so the stored value stays valid UTF-8 even if the cap lands inside a multi-byte codepoint. Both backends apply it at every `save_processed_message` / `save_processed_welcome` entry point.

## Changes

- `crates/mdk-storage-traits/src/lib.rs`: adds `MAX_FAILURE_REASON_LEN` (256 bytes), `truncate_failure_reason(Option<String>) -> Option<String>` with UTF-8-safe truncation, and unit tests including a multi-byte boundary case.
- `crates/mdk-core/src/welcomes.rs`: introduces the `welcome_failure` module with three category constants, replaces the three `format!("...{:?}", e)` failure sites in `preview_welcome` with a new `record_welcome_failure` helper that does persistence, logging, and the error return in one place. Existing welcome tests that checked the old raw strings now check the categories; a new `test_welcome_failure_reason_is_sanitized_category` test asserts the persisted reason carries no debug-format fragments.
- `crates/mdk-memory-storage/src/messages.rs`, `crates/mdk-memory-storage/src/welcomes.rs`, `crates/mdk-sqlite-storage/src/messages.rs`, `crates/mdk-sqlite-storage/src/welcomes.rs`: each `save_processed_*` runs the value through `truncate_failure_reason` before persisting.

## Verification

- `cargo test -p mdk-storage-traits --lib`: 78 passed (includes four new truncation tests).
- `cargo test -p mdk-core --lib welcomes`: 19 passed (includes the new sanitization test).
- `cargo test -p mdk-storage-traits -p mdk-memory-storage -p mdk-sqlite-storage --all-features`: all green.
- `cargo fmt --all -- --check`: clean.
- The two `encrypted_media::manager::*legacy_media_compat` failures in `cargo test -p mdk-core --all-features` reproduce on `master` and are unrelated to this PR.

## Notes

The SQL schema is unchanged. The application-layer truncation runs before every insert; a `CHECK(length(failure_reason) <= 256)` constraint would need a new migration without changing real behavior, so it is left out.

`Error::WelcomePreviouslyFailed(reason)` now carries the sanitized category through to retry callers, so the previously leaky `welcome previously failed to process: <raw debug>` Display string also resolves to a stable category.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR prevents leaking internal identifiers and storing unbounded attacker-controlled strings by replacing raw debug-formatted welcome error details with stable sanitized categories and by capping persisted failure_reason values with UTF-8-safe truncation. It centralizes welcome-failure recording (logging + persistence) and applies a 256-byte application-layer limit to all persisted failure reasons in memory and SQLite backends.

**What changed**:
- Introduces a private welcome_failure module in mdk-core with three stable failure categories and a record_welcome_failure helper to persist and log only sanitized categories.
- Replaces debug-formatted error strings in welcome handling so ProcessedWelcome.failure_reason stores a stable category instead of untrusted debug output.
- Adds MAX_FAILURE_REASON_LEN = 256 and truncate_failure_reason(Option<String>) -> Option<String> in mdk-storage-traits to UTF-8-safely truncate overlong failure reasons.
- Applies truncate_failure_reason at save_processed_message and save_processed_welcome entry points in mdk-memory-storage and mdk-sqlite-storage (parameters made mutable to allow in-place truncation).
- Updated tests and changelogs across affected crates.

Affected crates: mdk-core, mdk-storage-traits, mdk-memory-storage, mdk-sqlite-storage

**Security impact**:
- Eliminates leakage of internal/state identifiers (e.g., mls_group_id, nostr_group_id) by removing debug-formatted untrusted error details from logs and persistent records.
- Mitigates storage-exhaustion and durable exfiltration by bounding persisted failure_reason to 256 bytes with UTF-8-safe truncation.
- Logging and persisted failure_reason now contain only stable, sanitized category identifiers.

**API surface**:
- No public types or trait signatures changed; only internal welcome-handling behavior and storage helpers added.
- New public constant: MAX_FAILURE_REASON_LEN = 256.
- New public helper: truncate_failure_reason(Option<String>) -> Option<String>.
- Minor method signature changes for mutability in storage implementations to allow truncation (no semantic API break).

**Testing**:
- Existing tests updated to expect sanitized category strings instead of debug output.
- New unit tests for truncate_failure_reason cover short strings, None passthrough, byte-length capping, and multi-byte UTF-8 boundary handling.
- New test confirms persisted welcome.failure_reason equals a sanitized category exactly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/mdk/pull/307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->