### PR TITLE
fix(ci): build Swift package on macos-26-arm64 for iOS 26 SDK

### DIFF
--- a/.github/workflows/package-mdk-bindings.yml
+++ b/.github/workflows/package-mdk-bindings.yml
@@ -25,7 +25,14 @@ env:
 
 jobs:
   package-swift:
-    runs-on: macos-latest
+    # Pin to macos-26 so the iOS SDK we build against matches what
+    # downstream consumers on Xcode 26 expect. macos-latest currently resolves
+    # to macos-15-arm64 whose default Xcode is 16.x (iPhoneSimulator 18.5 SDK),
+    # and the resulting sim slice — while structurally a valid iossimulator
+    # build — mixes sdk=18.5 and sdk=26.x objects, which Xcode 26's stricter
+    # linker rejects with the platform-mismatch error reported in
+    # marmot-protocol/mdk-swift#1.
+    runs-on: macos-26
     name: Build and Package Swift Bindings
 
     steps:

--- a/crates/mdk-uniffi/CHANGELOG.md
+++ b/crates/mdk-uniffi/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### Fixed
 
+- Swift bindings now build on `macos-26` (Xcode 26) so the published xcframework's iOS Simulator slice is compiled against the iOS 26 SDK end-to-end. Previously the runner defaulted to `macos-15-arm64` + Xcode 16.4 (iPhoneSimulator 18.5 SDK), and the resulting archive mixed `sdk=18.5` and `sdk=26.x` objects — which Xcode 26's stricter linker rejected with a misleading "iOS Simulator-arm64 but ... iOS-arm64" platform-mismatch error when consumers built for an iOS 26 simulator target. ([`#312`](https://github.com/marmot-protocol/mdk/pull/312))
 - Hardened the Kotlin bindings publishing workflow. The version-tag step now runs only on `v*` tag pushes, refuses to overwrite an existing remote tag (no more `git push --force`), and routes secrets through step `env:` blocks instead of inline expression substitution. Downstream JitPack consumers can now trust that a pinned Kotlin version maps to immutable artifact content. ([#292](https://github.com/marmot-protocol/mdk/pull/292))
 
 ### Removed


### PR DESCRIPTION
![marmot](https://blossom.primal.net/858b7a6a289e82149f7ba930f5b1f07222e1451f454264b894d866630c874038.png)

A downstream marmot on Xcode 26 hit this when consuming `mdk-swift` for an iOS 26 simulator target:

```
ld: building for iOS Simulator-arm64 but attempting to link with file built for iOS-arm64
```

Reported in marmot-protocol/mdk-swift#1.

## Root cause

The simulator slice is fine. I pulled it from LFS, extracted all 619 object files, and every one carries `LC_BUILD_VERSION platform=iossimulator`. Info.plist also checks out.

What's broken is the SDK mix inside the archive:

| count | platform     | minos | sdk       |
|------:|--------------|-------|-----------|
|   340 | iossimulator | 14.0  | n/a       |
|   230 | iossimulator | 15.0  | n/a       |
|    44 | iossimulator | 14.0  | **26.2**  |
|     5 | iossimulator | 15.0  | **18.5**  |

Rust objects leave `sdk` blank (normal). But the `cc`-driven C deps (`sqlite3`, `lax_der_parsing`, secp256k1 asm) split: some end up `sdk=18.5`, others `sdk=26.2`. Cause: `macos-latest` resolves to `macos-15-arm64`, whose default Xcode is **16.4 (iPhoneSimulator 18.5 SDK)**, while the image also carries Xcode 26.x in `/Applications/`, and individual `cc` build scripts reach `xcrun` inconsistently.

Xcode 26's stricter linker refuses that mixed-SDK archive and surfaces the generic "iOS Simulator-arm64 but ... iOS-arm64" message even though no object is actually platform=`ios`.

## Fix

Pin `package-swift` to `macos-26-arm64` (GA since Feb 2026, default Xcode 26.2). Every C dep then compiles against the iOS 26 SDK, the archive ends up consistent, and Xcode 26 marmots link cleanly.

We don't need the iOS 26 simulator *runtime* (see [actions/runner-images#13853](https://github.com/actions/runner-images/issues/13853)): CI compiles, it never runs a simulator.

`IPHONEOS_DEPLOYMENT_TARGET=15.0` and `Package.swift`'s `platforms: [.iOS(.v15)]` stay put, so existing iOS 15+ marmots keep working.

## Scope

- Swift package (`package-swift` job): pinned to `macos-26-arm64`
- Python / Ruby: skipped; their `macos-latest` matrix entry only builds a macOS `.dylib`, no iOS SDK in play
- Kotlin: skipped; Linux runner, unrelated

## Verification

- `just workflow-policy` passes
- YAML parses cleanly
- On merge, `package-mdk-bindings.yml` republishes `mdk-swift@main` automatically with the corrected slice

Relates to marmot-protocol/mdk-swift#1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes a CI issue where downstream Xcode 26 consumers encountered linker errors when building for iOS 26 simulator targets. The fix pins the Swift package build job to `macos-26-arm64` to ensure consistent iOS SDK tagging (SDK 26.x) in the published xcframework's simulator slice, resolving the mixed SDK problem that occurred when using `macos-latest` runners with multiple installed Xcode versions.

**What changed**:
- CI workflow (`.github/workflows/package-mdk-bindings.yml`): The `package-swift` job runner changed from `macos-latest` to `macos-26-arm64`, with added inline comments explaining the iOS SDK simulator platform-mismatch issue being avoided
- Changelog (`crates/mdk-uniffi/CHANGELOG.md`): Added entry documenting the Swift bindings build fix that ensures consistent iOS 26 SDK compilation for the xcframework

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/mdk/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->