### PR TITLE
fix(uniffi-kotlin): suppress java.awt warnings in consumer ProGuard rules

### DIFF
--- a/crates/mdk-uniffi/CHANGELOG.md
+++ b/crates/mdk-uniffi/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### Fixed
 
+- Suppressed R8 minify warnings about missing `java.awt.*` classes referenced by JNA's `Native$AWT` helper. Added `-dontwarn java.awt.**` to the Kotlin consumer ProGuard rules so downstream Android apps with minification enabled no longer fail with `Missing class java.awt.Component` errors. ([#313](https://github.com/marmot-protocol/mdk/pull/313))
 - Swift bindings now build on `macos-26` (Xcode 26) so the published xcframework's iOS Simulator slice is compiled against the iOS 26 SDK end-to-end. Previously the runner defaulted to `macos-15-arm64` + Xcode 16.4 (iPhoneSimulator 18.5 SDK), and the resulting archive mixed `sdk=18.5` and `sdk=26.x` objects — which Xcode 26's stricter linker rejected with a misleading "iOS Simulator-arm64 but ... iOS-arm64" platform-mismatch error when consumers built for an iOS 26 simulator target. ([`#312`](https://github.com/marmot-protocol/mdk/pull/312))
 - Hardened the Kotlin bindings publishing workflow. The version-tag step now runs only on `v*` tag pushes, refuses to overwrite an existing remote tag (no more `git push --force`), and routes secrets through step `env:` blocks instead of inline expression substitution. Downstream JitPack consumers can now trust that a pinned Kotlin version maps to immutable artifact content. ([#292](https://github.com/marmot-protocol/mdk/pull/292))
 

--- a/crates/mdk-uniffi/src/kotlin/consumer-rules.pro
+++ b/crates/mdk-uniffi/src/kotlin/consumer-rules.pro
@@ -6,3 +6,7 @@
 -keep class com.sun.jna.** { *; }
 -keep class * extends com.sun.jna.** { *; }
 -keep class build.marmot.mdk.** { *; }
+
+# JNA's Native$AWT references java.awt.* which doesn't exist on Android.
+# Without this, R8 fails consumer builds with "Missing class java.awt.Component" etc.
+-dontwarn java.awt.**


### PR DESCRIPTION
![marmot](https://blossom.primal.net/dba31b5865ba7003314c616cdfc3b144e6aeede050b2f7f2f8f91f723ad97aff.jpg)

Fixes downstream Android apps that enable R8 minification against the published mdk-kotlin AAR. JNA's `Native$AWT` helper references `java.awt.Component`, `java.awt.GraphicsEnvironment`, `java.awt.HeadlessException`, and `java.awt.Window`. None of those classes exist on Android, so R8 walks the references during the consumer's build and fails with `Missing class java.awt.*` errors.

The fix adds `-dontwarn java.awt.**` to `consumer-rules.pro`. The rule lives in a consumer ProGuard file, so it ships embedded in the AAR and applies to every downstream app with no manual setup.

`crates/mdk-uniffi/src/kotlin/` is the source of truth. The release workflow (`package-mdk-bindings.yml`) rsyncs the directory to `marmot-protocol/mdk-kotlin` on every cut, so this rule lands in the next published version.

Reported by SubatomicPlanets in marmot-protocol/mdk-kotlin#2. One less pile of dust for the marmot colony to track through the burrow.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/313">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR embeds a ProGuard/R8 suppression rule into the Kotlin UniFFI bindings so downstream Android apps that enable R8 minification no longer fail due to JNA's Native$AWT referencing java.awt classes (which are absent on Android). The consumer rule is added to the AAR source so the suppression will ship with the next published mdk-kotlin release and automatically apply to consumers.

**What changed**:
- Added a ProGuard/R8 suppression rule `-dontwarn java.awt.**` with explanatory comments to crates/mdk-uniffi/src/kotlin/consumer-rules.pro to silence warnings about JNA's references to java.awt on Android.
- Updated crates/mdk-uniffi/CHANGELOG.md with an entry describing the R8 fix.
- Affected crate: mdk-uniffi (Kotlin/UniFFI bindings).

**Security impact**:
- No cryptographic, key-handling, credential, SQLCipher, or file-permission changes were made.

**Protocol changes**:
- None.

**API surface**:
- No breaking changes, new public APIs, storage schema changes, or UniFFI/FFI boundary changes.

**Testing**:
- No tests were added or modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/mdk/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->