### PR TITLE
Create local files, sockets, and on-disk artifacts restrictive-by-construction (#378)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ The canonical protocol specification lives in
 | App runtime bridge | `crates/marmot-app/AGENTS.md` |
 | App message Markdown display parsing | `crates/marmot-markdown/AGENTS.md` |
 | Storage traits and shared types | `crates/traits/AGENTS.md` |
+| Private file/dir/socket creation helpers | `crates/fs-private/AGENTS.md` |
 | SQLite storage | `crates/storage-sqlite/AGENTS.md` |
 | Nostr transport adapter | `crates/transport-nostr-adapter/AGENTS.md` |
 | Nostr transport peeler | `crates/transport-nostr-peeler/AGENTS.md` |
@@ -63,6 +64,8 @@ The canonical protocol specification lives in
 - Keep tracing/logging privacy-safe: explicit crate/module `target` and `method` fields, aggregate values only, and no
   account ids, group ids, message ids, relay URLs, pubkeys, payloads, ciphertext, plaintext, or key material. See
   `docs/marmot-architecture/overview/observability.md`.
+- Create local files, sockets, and databases restrictive-by-construction via `crates/fs-private` (or equivalent
+  posture with an on-disk mode test); see `docs/marmot-architecture/overview/local-artifact-safety.md`.
 - When adding an `AGENTS.md`, create a sibling `CLAUDE.md` symlink to it.
 
 ## Verification

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,6 +1088,7 @@ dependencies = [
  "cgka-traits",
  "clap",
  "crossterm",
+ "fs-private",
  "hex",
  "libc",
  "marmot-account",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,6 +2635,7 @@ dependencies = [
 name = "marmot-forensics"
 version = "0.2.0"
 dependencies = [
+ "fs-private",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "agent-stream-compose",
  "cgka-traits",
  "clap",
+ "fs-private",
  "hex",
  "libc",
  "marmot-account",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,6 +1431,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-private"
+version = "0.2.0"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,6 +2600,7 @@ dependencies = [
  "cgka-session",
  "cgka-traits",
  "chacha20poly1305",
+ "fs-private",
  "hex",
  "hkdf",
  "marmot-account",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4415,6 +4415,7 @@ name = "storage-sqlite"
 version = "0.2.0"
 dependencies = [
  "cgka-traits",
+ "fs-private",
  "hex",
  "openmls",
  "openmls_traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "3"
 members = [
+    "crates/fs-private",
     "crates/traits",
     "crates/cgka-engine",
     "crates/cgka-session",
@@ -93,6 +94,7 @@ insta = { version = "1", features = ["json"] }
 test-log = { version = "0.2", features = ["trace"] }
 
 # workspace-internal
+fs-private = { path = "crates/fs-private" }
 cgka-traits = { path = "crates/traits" }
 cgka-engine = { path = "crates/cgka-engine" }
 cgka-session = { path = "crates/cgka-session" }

--- a/crates/agent-connector/Cargo.toml
+++ b/crates/agent-connector/Cargo.toml
@@ -14,6 +14,7 @@ agent-control.workspace = true
 agent-stream-compose.workspace = true
 cgka-traits.workspace = true
 clap.workspace = true
+fs-private.workspace = true
 hex.workspace = true
 sha2.workspace = true
 libc.workspace = true

--- a/crates/agent-connector/src/bin/dm-agent.rs
+++ b/crates/agent-connector/src/bin/dm-agent.rs
@@ -164,14 +164,14 @@ async fn run_serve_command(args: ServeArgs) -> ExitCode {
         return ExitCode::FAILURE;
     };
     let socket = args.socket.unwrap_or_else(|| default_socket_path(&home));
-    let socket_dir_mode = match parse_octal_mode(&args.socket_dir_mode) {
+    let socket_dir_mode = match fs_private::parse_octal_mode(&args.socket_dir_mode) {
         Ok(mode) => mode,
         Err(message) => {
             eprintln!("dm-agent: startup failed code=invalid_socket_mode detail={message}");
             return ExitCode::FAILURE;
         }
     };
-    let socket_mode = match parse_octal_mode(&args.socket_mode) {
+    let socket_mode = match fs_private::parse_octal_mode(&args.socket_mode) {
         Ok(mode) => mode,
         Err(message) => {
             eprintln!("dm-agent: startup failed code=invalid_socket_mode detail={message}");
@@ -313,16 +313,6 @@ fn which_qrencode() -> Option<String> {
 
 fn safe_error_message(err: &ConnectorError) -> String {
     format!("startup failed code={}", err.privacy_safe_code())
-}
-
-fn parse_octal_mode(value: &str) -> Result<u32, String> {
-    let value = value.trim();
-    let value = value.strip_prefix("0o").unwrap_or(value);
-    let value = value.strip_prefix('0').unwrap_or(value);
-    if value.is_empty() || value.len() > 3 || !value.chars().all(|ch| ('0'..='7').contains(&ch)) {
-        return Err(format!("expected three octal digits, got {value:?}"));
-    }
-    u32::from_str_radix(value, 8).map_err(|err| err.to_string())
 }
 
 fn read_auth_token(path: Option<&PathBuf>) -> Result<Option<String>, String> {

--- a/crates/agent-connector/src/messaging.rs
+++ b/crates/agent-connector/src/messaging.rs
@@ -40,6 +40,20 @@ pub(crate) fn send_final_fingerprint(
     hex::encode(Sha256::digest(bytes))
 }
 
+/// Per-blob temp subdir name for a downloaded media attachment: the SHA-256 of
+/// the decrypted bytes the connector actually holds. Computing it locally (as
+/// opposed to trusting the sender-supplied `ciphertext_sha256` field) makes the
+/// directory layout attacker-independent — two references can only share a
+/// subdir when their plaintext is byte-identical, in which case the overwrite
+/// is a no-op — while keeping repeat downloads of the same content stable. The
+/// runtime independently verifies `ciphertext_sha256` against the fetched blob;
+/// this just keeps that cross-crate invariant out of the filesystem layout.
+pub(crate) fn media_download_subdir(plaintext: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+
+    hex::encode(Sha256::digest(plaintext))
+}
+
 /// Map a control-plane media reference (the non-secret mirror) back into the
 /// app-runtime `MediaAttachmentReference`. Field-for-field; the content key is
 /// never part of either type, so this is a pure structural reshape.
@@ -412,14 +426,16 @@ impl AgentConnector {
         let account = self.local_account_for_account_id(account_id_hex)?;
         let group_id = GroupId::new(hex::decode(group_id_hex)?);
         let reference = media_ref_to_reference(media);
-        // Derive a unique, stable-per-blob subdir from the ciphertext hash so
-        // repeat downloads land in the same place and distinct blobs do not
-        // collide. The hash is opaque ciphertext metadata, not an id we log.
-        let subdir = normalize_hex(&reference.ciphertext_sha256)?;
         let result = self
             .runtime
             .download_media(&account.label, &group_id, reference)
             .await?;
+        // Derive a unique, stable-per-blob subdir from the connector-computed
+        // hash of the decrypted bytes (never the sender-supplied
+        // `ciphertext_sha256` field) so repeat downloads land in the same place
+        // and distinct blobs cannot be steered into colliding/overwriting each
+        // other. The hash is an opaque dir name, not an id we log.
+        let subdir = media_download_subdir(&result.plaintext);
         let dir = crate::media_temp::create_media_download_dir(&subdir).await?;
         // The file name comes from the (decrypted) sender-controlled media
         // reference, so write under a sanitized basename: a crafted value like

--- a/crates/agent-connector/src/socket.rs
+++ b/crates/agent-connector/src/socket.rs
@@ -26,16 +26,23 @@ pub fn bind_connector_socket_with_mode(
     if let Some(parent) = socket.parent() {
         prepare_socket_dir(parent, socket_dir_mode)?;
     }
-    let listener = match UnixListener::bind(socket) {
+    let listener = match bind_private(socket, socket_mode) {
         Ok(listener) => listener,
         Err(error) if error.kind() == ErrorKind::AddrInUse => {
             remove_stale_socket(socket, &error)?;
-            UnixListener::bind(socket)?
+            bind_private(socket, socket_mode)?
         }
         Err(error) => return Err(error.into()),
     };
-    harden_socket_permissions(socket, socket_mode)?;
     Ok(listener)
+}
+
+/// Bind through a 0700 staging dir so the socket never exists at
+/// umask-default permissions, even when `socket_dir_mode` is group-accessible.
+fn bind_private(socket: &Path, socket_mode: u32) -> std::io::Result<UnixListener> {
+    let listener = fs_private::bind_unix_listener_private(socket, socket_mode)?;
+    listener.set_nonblocking(true)?;
+    UnixListener::from_std(listener)
 }
 
 fn remove_stale_socket(socket: &Path, bind_error: &std::io::Error) -> std::io::Result<()> {
@@ -74,10 +81,6 @@ fn remove_stale_socket(socket: &Path, bind_error: &std::io::Error) -> std::io::R
 fn prepare_socket_dir(parent: &Path, mode: u32) -> std::io::Result<()> {
     std::fs::create_dir_all(parent)?;
     std::fs::set_permissions(parent, std::fs::Permissions::from_mode(mode))
-}
-
-fn harden_socket_permissions(socket: &Path, mode: u32) -> std::io::Result<()> {
-    std::fs::set_permissions(socket, std::fs::Permissions::from_mode(mode))
 }
 
 pub(crate) fn current_effective_uid() -> libc::uid_t {

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -461,12 +461,8 @@ async fn connector_socket_bind_applies_configured_group_modes() {
         socket.metadata().unwrap().permissions().mode() & 0o777,
         0o660
     );
-    let staging = socket
-        .parent()
-        .unwrap()
-        .join(format!(".sock.{}", std::process::id()));
     assert!(
-        !staging.exists(),
+        !fs_private::socket_staging_dir(&socket).exists(),
         "staging dir should be removed after bind"
     );
 }

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -2585,6 +2585,22 @@ fn inbound_message_event_detects_p_tag_mention_without_inline_text() {
 }
 
 #[test]
+fn media_download_subdir_is_stable_and_content_derived() {
+    use crate::messaging::media_download_subdir;
+
+    let a = media_download_subdir(b"plaintext-a");
+    let b = media_download_subdir(b"plaintext-b");
+    assert_eq!(a, media_download_subdir(b"plaintext-a"), "stable per blob");
+    assert_ne!(a, b, "distinct content must not share a subdir");
+    // Lowercase hex: always a single safe path component.
+    assert_eq!(a.len(), 64);
+    assert!(
+        a.bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    );
+}
+
+#[test]
 fn safe_media_filename_strips_path_traversal() {
     use crate::messaging::safe_media_filename;
     assert_eq!(safe_media_filename("a.png"), "a.png");

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -461,6 +461,14 @@ async fn connector_socket_bind_applies_configured_group_modes() {
         socket.metadata().unwrap().permissions().mode() & 0o777,
         0o660
     );
+    let staging = socket
+        .parent()
+        .unwrap()
+        .join(format!(".sock.{}", std::process::id()));
+    assert!(
+        !staging.exists(),
+        "staging dir should be removed after bind"
+    );
 }
 
 #[tokio::test]

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,10 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Security
 
+- The `dmd` daemon control socket (and the `dm-agent` connector socket) is now created owner-only (0600)
+  atomically — bound inside a private 0700 staging directory and linked into place — instead of being chmod-ed
+  after `bind`, removing the brief window where the socket was reachable at umask-default permissions (for
+  example under a caller-supplied `--socket` in a pre-existing shared directory).
 - Daemon auto-watch of inbound agent stream starts (kind:1200) no longer derives no-cert-verification
   (`insecure_local`) trust from the sender-controlled `quic://` candidate, and QUIC candidate resolution now rejects
   sender-provided candidates that resolve to loopback, RFC1918/private, link-local (including `169.254.169.254`),

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,6 +23,7 @@ cgka-traits.workspace = true
 cgka-session.workspace = true
 clap.workspace = true
 crossterm.workspace = true
+fs-private.workspace = true
 hex.workspace = true
 libc.workspace = true
 marmot-account.workspace = true

--- a/crates/cli/src/daemon/lifecycle.rs
+++ b/crates/cli/src/daemon/lifecycle.rs
@@ -138,10 +138,6 @@ pub(crate) fn is_daemon_owned_socket_dir(parent: &Path, home: &Path) -> bool {
     parent == dev_dir || parent.starts_with(dev_dir)
 }
 
-pub(crate) fn harden_socket_permissions(socket: &Path) -> std::io::Result<()> {
-    std::fs::set_permissions(socket, std::fs::Permissions::from_mode(DAEMON_SOCKET_MODE))
-}
-
 pub(crate) fn authorize_daemon_peer(stream: &UnixStream) -> std::io::Result<()> {
     let peer_uid = stream.peer_cred()?.uid();
     let server_uid = current_effective_uid();

--- a/crates/cli/src/daemon/mod.rs
+++ b/crates/cli/src/daemon/mod.rs
@@ -123,8 +123,12 @@ async fn run_server(args: DaemonArgs) -> Result<(), Box<dyn std::error::Error + 
     remove_stale_socket(&socket).await?;
     remove_stale_pid(&pid_path).await?;
 
-    let listener = UnixListener::bind(&socket)?;
-    harden_socket_permissions(&socket)?;
+    // Bind via a 0700 staging dir so the socket is never reachable at
+    // umask-default permissions, even under a caller-supplied `--socket`
+    // whose parent dir the daemon does not own.
+    let listener = fs_private::bind_unix_listener_private(&socket, DAEMON_SOCKET_MODE)?;
+    listener.set_nonblocking(true)?;
+    let listener = UnixListener::from_std(listener)?;
     write_pid_file(&pid_path)?;
     let hidden_relay = crate::resolve_relay(args.relay)?;
     let mut discovery_relays = normalize_relay_list(args.discovery_relays)?;

--- a/crates/cli/src/daemon/tests.rs
+++ b/crates/cli/src/daemon/tests.rs
@@ -97,12 +97,8 @@ async fn daemon_socket_is_owner_only_after_bind() {
             & 0o777,
         0o600
     );
-    let staging = socket
-        .parent()
-        .expect("socket parent")
-        .join(format!(".sock.{}", std::process::id()));
     assert!(
-        !staging.exists(),
+        !fs_private::socket_staging_dir(&socket).exists(),
         "staging dir should be removed after bind"
     );
 

--- a/crates/cli/src/daemon/tests.rs
+++ b/crates/cli/src/daemon/tests.rs
@@ -61,6 +61,67 @@ fn daemon_pid_and_log_writers_create_private_files() {
     );
 }
 
+#[tokio::test]
+#[cfg(unix)]
+async fn daemon_socket_is_owner_only_after_bind() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let socket = home.path().join("dev").join("dmd.sock");
+    let relay = MockRelay::run().await.expect("start mock relay");
+    let relay_url = relay.url().await.to_string();
+    let args = DaemonArgs {
+        home: Some(home.path().to_path_buf()),
+        data_dir: None,
+        logs_dir: None,
+        socket: Some(socket.clone()),
+        relay: Some(relay_url),
+        discovery_relays: Vec::new(),
+        default_account_relays: Vec::new(),
+        secret_store: Some(crate::SecretStoreKind::File),
+        keychain_service: Some("dm-test-keychain".to_owned()),
+    };
+    let server = tokio::spawn(run_server(args));
+    for _ in 0..50 {
+        if socket.try_exists().expect("socket existence check") {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(socket.try_exists().expect("socket existence check"));
+
+    assert_eq!(
+        socket
+            .metadata()
+            .expect("socket metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+    let staging = socket
+        .parent()
+        .expect("socket parent")
+        .join(format!(".sock.{}", std::process::id()));
+    assert!(
+        !staging.exists(),
+        "staging dir should be removed after bind"
+    );
+
+    let shutdown_output = tokio::time::timeout(
+        Duration::from_secs(5),
+        send_request(&socket, &DaemonRequest::Shutdown),
+    )
+    .await
+    .expect("shutdown request should not time out")
+    .expect("shutdown request should succeed");
+    assert_eq!(shutdown_output.code, 0);
+
+    tokio::time::timeout(Duration::from_secs(5), server)
+        .await
+        .expect("server task should not time out")
+        .expect("server task should not panic")
+        .expect("server should shut down cleanly");
+}
+
 #[test]
 fn apply_defaults_overwrites_forwarded_cli_relay_with_daemon_relay() {
     let defaults = DaemonDefaults {

--- a/crates/fs-private/AGENTS.md
+++ b/crates/fs-private/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md - fs-private
+
+Restrictive-by-construction creation of local files, directories, and Unix sockets.
+
+## Scope
+
+- Own the shared "secure local artifact" helpers: files and directories are created already at their target
+  owner-only mode (`O_CREAT` + mode, atomic 0700 `DirBuilder`), never chmod-ed after they are reachable; Unix
+  sockets are bound inside a fresh 0700 staging directory and hard-linked into place at their final mode.
+- Own the workspace's one octal permission-mode parser (`parse_octal_mode`). No call site re-derives leading-zero
+  stripping or radix handling; policy on which parsed modes are acceptable stays with callers.
+- Stay std-only with zero dependencies so lightweight crates (e.g. `marmot-forensics`) can depend on this crate
+  without weight concerns. Mode application is `#[cfg(unix)]`; helpers still create artifacts on other platforms.
+- Keep policy out: this crate knows how to create artifacts privately, not which artifacts an application needs or
+  what modes a feature should accept. See `docs/marmot-architecture/overview/local-artifact-safety.md` for the
+  workspace policy that mandates these helpers.
+
+## Verification
+
+```sh
+cargo test -p fs-private
+```

--- a/crates/fs-private/CLAUDE.md
+++ b/crates/fs-private/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/fs-private/Cargo.toml
+++ b/crates/fs-private/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fs-private"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/fs-private/src/lib.rs
+++ b/crates/fs-private/src/lib.rs
@@ -1,0 +1,344 @@
+//! Restrictive-by-construction creation of local files, directories, and Unix
+//! sockets.
+//!
+//! Every helper creates the artifact already at its target mode (`O_CREAT` +
+//! mode, or a staging directory for sockets) so there is no window where it is
+//! reachable at the process umask's default permissions. Post-create
+//! tightening is only used belt-and-braces for artifacts that already existed.
+//!
+//! Mode application is Unix-only; on other platforms the helpers still create
+//! the artifacts and the mode calls are no-ops.
+
+use std::fs::OpenOptions;
+use std::io;
+use std::path::Path;
+
+/// Owner-only mode for files holding private data.
+pub const PRIVATE_FILE_MODE: u32 = 0o600;
+/// Owner-only mode for directories holding private artifacts.
+pub const PRIVATE_DIR_MODE: u32 = 0o700;
+
+/// Highest meaningful permission value (`suid|sgid|sticky` + `rwxrwxrwx`).
+const MAX_MODE: u32 = 0o7777;
+
+/// Configure `options` to create files owner-only (0600). No-op off Unix.
+pub fn set_private_file_mode(options: &mut OpenOptions) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(PRIVATE_FILE_MODE);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = options;
+    }
+}
+
+/// Create `path` and any missing ancestors as 0700 directories; tighten the
+/// leaf to 0700 if it already existed.
+pub fn create_dir_all_private(path: &Path) -> io::Result<()> {
+    let mut builder = std::fs::DirBuilder::new();
+    builder.recursive(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        builder.mode(PRIVATE_DIR_MODE);
+    }
+    builder.create(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(PRIVATE_DIR_MODE))?;
+    }
+    Ok(())
+}
+
+/// Write `bytes` to `path`, creating the file 0600; tightens a pre-existing
+/// file to 0600 before writing.
+pub fn write_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    use std::io::Write;
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    set_private_file_mode(&mut options);
+    let mut file = options.open(path)?;
+    set_handle_private(&file)?;
+    file.write_all(bytes)?;
+    file.sync_all()
+}
+
+/// Open `path` for appending, creating it 0600; tightens a pre-existing file
+/// to 0600.
+pub fn open_private_append(path: &Path) -> io::Result<std::fs::File> {
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    set_private_file_mode(&mut options);
+    let file = options.open(path)?;
+    set_handle_private(&file)?;
+    Ok(file)
+}
+
+/// Create `path` 0600, failing with `AlreadyExists` if it exists.
+pub fn create_new_private(path: &Path) -> io::Result<std::fs::File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    set_private_file_mode(&mut options);
+    options.open(path)
+}
+
+/// Ensure a file exists at `path` with mode 0600: created atomically at 0600
+/// if missing, tightened to 0600 if pre-existing. Contents are untouched.
+pub fn ensure_private_file(path: &Path) -> io::Result<()> {
+    let mut options = OpenOptions::new();
+    options.write(true).create(true);
+    set_private_file_mode(&mut options);
+    let file = options.open(path)?;
+    set_handle_private(&file)
+}
+
+/// Tighten an existing file at `path` to 0600; `Ok(())` when it does not
+/// exist (for optional sidecars such as `-wal`/`-shm`).
+pub fn tighten_existing_private_file(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        match std::fs::set_permissions(path, std::fs::Permissions::from_mode(PRIVATE_FILE_MODE)) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
+fn set_handle_private(file: &std::fs::File) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(PRIVATE_FILE_MODE))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = file;
+        Ok(())
+    }
+}
+
+/// The workspace's one octal permission-mode parser.
+///
+/// Accepts an optional `0o` prefix followed by octal digits, parsed
+/// whole-string in radix 8 (so `0600`, `00600`, `600`, and `0o600` all yield
+/// `0o600`, and `0` yields mode 0 — rejecting useless-but-valid modes is the
+/// caller's policy). Values above `0o7777`, empty input, and non-octal digits
+/// are errors.
+pub fn parse_octal_mode(value: &str) -> Result<u32, String> {
+    let trimmed = value.trim();
+    let digits = trimmed.strip_prefix("0o").unwrap_or(trimmed);
+    if digits.is_empty()
+        || !digits
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() && byte < b'8')
+    {
+        return Err(format!(
+            "expected octal digits (e.g. 0600), got {trimmed:?}"
+        ));
+    }
+    let mode = u32::from_str_radix(digits, 8)
+        .map_err(|_| format!("octal mode out of range, got {trimmed:?}"))?;
+    if mode > MAX_MODE {
+        return Err(format!("octal mode out of range, got {trimmed:?}"));
+    }
+    Ok(mode)
+}
+
+/// Bind a Unix listener so the socket is never reachable at default
+/// permissions: bind inside a fresh 0700 staging directory next to
+/// `final_path`, chmod the socket to `mode`, then hard-link it into place
+/// (failing with `AddrInUse` if `final_path` already exists, matching plain
+/// `bind` semantics so callers keep their stale-socket recovery).
+///
+/// The staging directory name stays short (`.sock.<pid>`) to respect
+/// `sun_path` length limits.
+#[cfg(unix)]
+pub fn bind_unix_listener_private(
+    final_path: &Path,
+    mode: u32,
+) -> io::Result<std::os::unix::net::UnixListener> {
+    use std::os::unix::fs::DirBuilderExt;
+    use std::os::unix::fs::PermissionsExt;
+
+    let name = final_path.file_name().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "socket path has no file name")
+    })?;
+    let parent = match final_path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => Path::new("."),
+    };
+    let staging_dir = parent.join(format!(".sock.{}", std::process::id()));
+    // A leftover staging dir can only be ours (pid-suffixed, 0700) from a
+    // crashed previous run; clear it so the atomic 0700 create succeeds.
+    if staging_dir.symlink_metadata().is_ok() {
+        std::fs::remove_dir_all(&staging_dir)?;
+    }
+    let mut builder = std::fs::DirBuilder::new();
+    builder.mode(PRIVATE_DIR_MODE);
+    builder.create(&staging_dir)?;
+
+    let staged_socket = staging_dir.join(name);
+    let outcome = (|| {
+        let listener = std::os::unix::net::UnixListener::bind(&staged_socket)?;
+        std::fs::set_permissions(&staged_socket, std::fs::Permissions::from_mode(mode))?;
+        // link(2) fails if the target exists, unlike rename: preserves bind's
+        // AddrInUse contract instead of silently replacing a live socket.
+        std::fs::hard_link(&staged_socket, final_path).map_err(|err| {
+            if err.kind() == io::ErrorKind::AlreadyExists {
+                io::Error::new(
+                    io::ErrorKind::AddrInUse,
+                    format!("{} already exists", final_path.display()),
+                )
+            } else {
+                err
+            }
+        })?;
+        Ok(listener)
+    })();
+    let _ = std::fs::remove_file(&staged_socket);
+    let _ = std::fs::remove_dir(&staging_dir);
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_octal_mode_accepts_0600_00600_600_and_0o600() {
+        for input in ["0600", "00600", "600", "0o600", " 0600 "] {
+            assert_eq!(parse_octal_mode(input), Ok(0o600), "input {input:?}");
+        }
+        assert_eq!(parse_octal_mode("0700"), Ok(0o700));
+        assert_eq!(parse_octal_mode("7777"), Ok(0o7777));
+    }
+
+    #[test]
+    fn parse_octal_mode_parses_bare_zero_to_mode_zero() {
+        assert_eq!(parse_octal_mode("0"), Ok(0));
+        assert_eq!(parse_octal_mode("00"), Ok(0));
+    }
+
+    #[test]
+    fn parse_octal_mode_rejects_empty_non_octal_and_overlong() {
+        for input in ["", "8", "abc", "077777", "0o", "6 00", "-600", "0x600"] {
+            assert!(parse_octal_mode(input).is_err(), "input {input:?}");
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod unix_tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn mode_of(path: &Path) -> u32 {
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o7777
+    }
+
+    #[test]
+    fn write_private_creates_file_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.txt");
+        write_private(&path, b"secret").unwrap();
+        assert_eq!(mode_of(&path), 0o600);
+        assert_eq!(std::fs::read(&path).unwrap(), b"secret");
+    }
+
+    #[test]
+    fn open_private_append_creates_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+        drop(open_private_append(&path).unwrap());
+        assert_eq!(mode_of(&path), 0o600);
+    }
+
+    #[test]
+    fn create_new_private_creates_owner_only_and_rejects_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("id");
+        drop(create_new_private(&path).unwrap());
+        assert_eq!(mode_of(&path), 0o600);
+        let err = create_new_private(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    fn ensure_private_file_tightens_existing_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db.sqlite");
+        std::fs::write(&path, b"data").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        ensure_private_file(&path).unwrap();
+        assert_eq!(mode_of(&path), 0o600);
+        assert_eq!(std::fs::read(&path).unwrap(), b"data", "contents untouched");
+        let missing = dir.path().join("fresh.sqlite");
+        ensure_private_file(&missing).unwrap();
+        assert_eq!(mode_of(&missing), 0o600);
+    }
+
+    #[test]
+    fn tighten_existing_private_file_ignores_missing_sidecars() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db.sqlite-wal");
+        tighten_existing_private_file(&path).unwrap();
+        std::fs::write(&path, b"wal").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        tighten_existing_private_file(&path).unwrap();
+        assert_eq!(mode_of(&path), 0o600);
+    }
+
+    #[test]
+    fn create_dir_all_private_sets_0700() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("a").join("b");
+        create_dir_all_private(&path).unwrap();
+        assert_eq!(mode_of(&path), 0o700);
+        assert_eq!(mode_of(&dir.path().join("a")), 0o700);
+    }
+
+    #[test]
+    fn bind_unix_listener_private_yields_0600_socket_and_no_staging_leftover() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("test.sock");
+        let listener = bind_unix_listener_private(&socket, 0o600).unwrap();
+        assert_eq!(mode_of(&socket), 0o600);
+        let staging = dir.path().join(format!(".sock.{}", std::process::id()));
+        assert!(!staging.exists(), "staging dir should be cleaned up");
+        // The listener must still accept connections at the final path.
+        let client = std::os::unix::net::UnixStream::connect(&socket).unwrap();
+        let (_server, _addr) = listener.accept().unwrap();
+        drop(client);
+    }
+
+    #[test]
+    fn bind_unix_listener_private_errors_addr_in_use_when_target_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("test.sock");
+        std::fs::write(&socket, b"").unwrap();
+        let err = bind_unix_listener_private(&socket, 0o600).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::AddrInUse);
+    }
+
+    #[test]
+    fn bind_unix_listener_private_recovers_from_stale_staging_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let staging = dir.path().join(format!(".sock.{}", std::process::id()));
+        std::fs::create_dir(&staging).unwrap();
+        std::fs::write(staging.join("leftover"), b"x").unwrap();
+        let socket = dir.path().join("test.sock");
+        drop(bind_unix_listener_private(&socket, 0o600).unwrap());
+        assert_eq!(mode_of(&socket), 0o600);
+        assert!(!staging.exists());
+    }
+}

--- a/crates/fs-private/src/lib.rs
+++ b/crates/fs-private/src/lib.rs
@@ -154,13 +154,32 @@ pub fn parse_octal_mode(value: &str) -> Result<u32, String> {
     Ok(mode)
 }
 
+/// The staging directory `bind_unix_listener_private` binds through for
+/// `final_path`. Exposed so callers and tests can assert staging cleanup
+/// without re-deriving the (otherwise private) naming scheme.
+#[cfg(unix)]
+pub fn socket_staging_dir(final_path: &Path) -> std::path::PathBuf {
+    let parent = match final_path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => Path::new("."),
+    };
+    let name = final_path.file_name().unwrap_or_default();
+    // Keyed by pid for crash recovery and by target name so concurrent binds
+    // of different sockets in the same parent never share staging state.
+    parent.join(format!(
+        ".sock.{}.{}",
+        std::process::id(),
+        name.to_string_lossy()
+    ))
+}
+
 /// Bind a Unix listener so the socket is never reachable at default
 /// permissions: bind inside a fresh 0700 staging directory next to
 /// `final_path`, chmod the socket to `mode`, then hard-link it into place
 /// (failing with `AddrInUse` if `final_path` already exists, matching plain
 /// `bind` semantics so callers keep their stale-socket recovery).
 ///
-/// The staging directory name stays short (`.sock.<pid>`) to respect
+/// The staging directory name stays short (`.sock.<pid>.<name>`) to respect
 /// `sun_path` length limits.
 #[cfg(unix)]
 pub fn bind_unix_listener_private(
@@ -173,11 +192,7 @@ pub fn bind_unix_listener_private(
     let name = final_path.file_name().ok_or_else(|| {
         io::Error::new(io::ErrorKind::InvalidInput, "socket path has no file name")
     })?;
-    let parent = match final_path.parent() {
-        Some(parent) if !parent.as_os_str().is_empty() => parent,
-        _ => Path::new("."),
-    };
-    let staging_dir = parent.join(format!(".sock.{}", std::process::id()));
+    let staging_dir = socket_staging_dir(final_path);
     // A leftover staging dir can only be ours (pid-suffixed, 0700) from a
     // crashed previous run; clear it so the atomic 0700 create succeeds.
     if staging_dir.symlink_metadata().is_ok() {
@@ -313,8 +328,10 @@ mod unix_tests {
         let socket = dir.path().join("test.sock");
         let listener = bind_unix_listener_private(&socket, 0o600).unwrap();
         assert_eq!(mode_of(&socket), 0o600);
-        let staging = dir.path().join(format!(".sock.{}", std::process::id()));
-        assert!(!staging.exists(), "staging dir should be cleaned up");
+        assert!(
+            !socket_staging_dir(&socket).exists(),
+            "staging dir should be cleaned up"
+        );
         // The listener must still accept connections at the final path.
         let client = std::os::unix::net::UnixStream::connect(&socket).unwrap();
         let (_server, _addr) = listener.accept().unwrap();
@@ -333,12 +350,25 @@ mod unix_tests {
     #[test]
     fn bind_unix_listener_private_recovers_from_stale_staging_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let staging = dir.path().join(format!(".sock.{}", std::process::id()));
+        let socket = dir.path().join("test.sock");
+        let staging = socket_staging_dir(&socket);
         std::fs::create_dir(&staging).unwrap();
         std::fs::write(staging.join("leftover"), b"x").unwrap();
-        let socket = dir.path().join("test.sock");
         drop(bind_unix_listener_private(&socket, 0o600).unwrap());
         assert_eq!(mode_of(&socket), 0o600);
         assert!(!staging.exists());
+    }
+
+    #[test]
+    fn concurrent_binds_in_same_parent_use_distinct_staging_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first.sock");
+        let second = dir.path().join("second.sock");
+        assert_ne!(socket_staging_dir(&first), socket_staging_dir(&second));
+        let first_listener = bind_unix_listener_private(&first, 0o600).unwrap();
+        let second_listener = bind_unix_listener_private(&second, 0o600).unwrap();
+        assert_eq!(mode_of(&first), 0o600);
+        assert_eq!(mode_of(&second), 0o600);
+        drop((first_listener, second_listener));
     }
 }

--- a/crates/fs-private/src/lib.rs
+++ b/crates/fs-private/src/lib.rs
@@ -114,6 +114,21 @@ pub fn tighten_existing_private_file(path: &Path) -> io::Result<()> {
     }
 }
 
+/// Make a SQLite database owner-only before SQLite can create it at the
+/// process umask: pre-create the main file 0600 (SQLite then copies its mode
+/// onto the `-wal`/`-shm`/journal sidecars it creates) and tighten any
+/// sidecars left behind by earlier permissive builds — SQLite does not
+/// rewrite pre-existing sidecar modes when the main file's mode changes.
+pub fn ensure_private_db_files(path: &Path) -> io::Result<()> {
+    ensure_private_file(path)?;
+    for suffix in ["-wal", "-shm", "-journal"] {
+        let mut sidecar = path.as_os_str().to_owned();
+        sidecar.push(suffix);
+        tighten_existing_private_file(Path::new(&sidecar))?;
+    }
+    Ok(())
+}
+
 fn set_handle_private(file: &std::fs::File) -> io::Result<()> {
     #[cfg(unix)]
     {
@@ -311,6 +326,26 @@ mod unix_tests {
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
         tighten_existing_private_file(&path).unwrap();
         assert_eq!(mode_of(&path), 0o600);
+    }
+
+    #[test]
+    fn ensure_private_db_files_tightens_main_db_and_stale_sidecars() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("cache.sqlite");
+        for suffix in ["", "-wal", "-shm", "-journal"] {
+            let path = dir.path().join(format!("cache.sqlite{suffix}"));
+            std::fs::write(&path, b"x").unwrap();
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+        ensure_private_db_files(&db).unwrap();
+        for suffix in ["", "-wal", "-shm", "-journal"] {
+            let path = dir.path().join(format!("cache.sqlite{suffix}"));
+            assert_eq!(mode_of(&path), 0o600, "suffix {suffix:?}");
+        }
+        // Missing sidecars are fine.
+        let fresh = dir.path().join("fresh.sqlite");
+        ensure_private_db_files(&fresh).unwrap();
+        assert_eq!(mode_of(&fresh), 0o600);
     }
 
     #[test]

--- a/crates/marmot-app/Cargo.toml
+++ b/crates/marmot-app/Cargo.toml
@@ -18,6 +18,7 @@ cgka-engine.workspace = true
 cgka-session.workspace = true
 cgka-traits.workspace = true
 chacha20poly1305.workspace = true
+fs-private.workspace = true
 hex.workspace = true
 hkdf.workspace = true
 marmot-account.workspace = true

--- a/crates/marmot-app/src/audit_log.rs
+++ b/crates/marmot-app/src/audit_log.rs
@@ -146,7 +146,12 @@ fn generate_audit_device_id_hex() -> String {
 fn audit_device_id_hex(account_dir: &Path) -> Result<String, AppError> {
     let path = account_dir.join(AUDIT_DEVICE_ID_FILE);
     match fs::read_to_string(&path) {
-        Ok(value) => return parse_audit_device_id_hex(&value),
+        Ok(value) => {
+            // Remediate ids written by older builds at umask-default modes;
+            // new ids below are created 0600 from the start.
+            fs_private::tighten_existing_private_file(&path)?;
+            return parse_audit_device_id_hex(&value);
+        }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
         Err(err) => return Err(err.into()),
     }
@@ -1037,6 +1042,25 @@ mod tests {
         );
         // Re-read path returns the same id.
         assert_eq!(audit_device_id_hex(dir.path()).unwrap(), device_id);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn pre_existing_permissive_audit_device_id_is_tightened_on_read() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(AUDIT_DEVICE_ID_FILE);
+        let existing_id = generate_audit_device_id_hex();
+        std::fs::write(&path, format!("{existing_id}\n")).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert_eq!(audit_device_id_hex(dir.path()).unwrap(), existing_id);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "ids from permissive builds must be tightened on read"
+        );
     }
 
     #[test]

--- a/crates/marmot-app/src/audit_log.rs
+++ b/crates/marmot-app/src/audit_log.rs
@@ -7,7 +7,7 @@
 //! client, and the `MarmotApp` methods that drive recording, enumeration,
 //! validation, and upload.
 
-use std::fs::{self, OpenOptions};
+use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -152,7 +152,7 @@ fn audit_device_id_hex(account_dir: &Path) -> Result<String, AppError> {
     }
 
     let device_id = generate_audit_device_id_hex();
-    match OpenOptions::new().write(true).create_new(true).open(&path) {
+    match fs_private::create_new_private(&path) {
         Ok(mut file) => {
             file.write_all(device_id.as_bytes())?;
             file.write_all(b"\n")?;
@@ -666,7 +666,7 @@ impl MarmotApp {
         let path = self.account_dir(&account.label).join(KEY_REVEAL_AUDIT_FILE);
         let mut bytes = serde_json::to_vec(&entry)?;
         bytes.push(b'\n');
-        let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let mut file = fs_private::open_private_append(&path)?;
         file.write_all(&bytes)?;
         Ok(())
     }
@@ -1012,6 +1012,31 @@ mod tests {
         assert!(contents.contains("\"caller_context\":\"test::reveal_caller\""));
         assert!(!contents.contains(revealed.as_str()));
         assert!(!contents.contains(&account.account_id_hex));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&audit_path).unwrap().permissions().mode() & 0o777,
+                0o600,
+                "key-reveal audit file must be owner-only"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn audit_device_id_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let device_id = audit_device_id_hex(dir.path()).unwrap();
+        let path = dir.path().join(AUDIT_DEVICE_ID_FILE);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        // Re-read path returns the same id.
+        assert_eq!(audit_device_id_hex(dir.path()).unwrap(), device_id);
     }
 
     #[test]

--- a/crates/marmot-app/src/directory/cache.rs
+++ b/crates/marmot-app/src/directory/cache.rs
@@ -25,6 +25,9 @@ impl DirectoryCache {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
+        // Pre-create 0600 so SQLite's -wal/-shm sidecars (which copy the main
+        // file's mode) never appear at umask-default permissions.
+        fs_private::ensure_private_file(&path)?;
         let conn = Connection::open(path)?;
         // Mirror storage-sqlite's hardened open: pin cipher_compatibility and
         // enable cipher_memory_security before keying, and scrub deleted rows /
@@ -719,6 +722,22 @@ mod tests {
             relay_lists: AccountRelayListStatus::empty(),
             key_package: None,
         }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn directory_cache_db_is_owner_only_on_disk() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let key = SqlCipherKey::new("test-key").unwrap();
+        let path = dir.path().join("directory.sqlite3");
+        let _cache = DirectoryCache::open(path.clone(), &key).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 
     #[test]

--- a/crates/marmot-app/src/directory/cache.rs
+++ b/crates/marmot-app/src/directory/cache.rs
@@ -26,8 +26,9 @@ impl DirectoryCache {
             fs::create_dir_all(parent)?;
         }
         // Pre-create 0600 so SQLite's -wal/-shm sidecars (which copy the main
-        // file's mode) never appear at umask-default permissions.
-        fs_private::ensure_private_file(&path)?;
+        // file's mode) never appear at umask-default permissions, and tighten
+        // sidecars left behind by earlier permissive builds.
+        fs_private::ensure_private_db_files(&path)?;
         let conn = Connection::open(path)?;
         // Mirror storage-sqlite's hardened open: pin cipher_compatibility and
         // enable cipher_memory_security before keying, and scrub deleted rows /
@@ -41,6 +42,9 @@ impl DirectoryCache {
             return Ok(None);
         }
         record_directory_cache_open();
+        // Legacy plaintext caches (and their sidecars) predate the owner-only
+        // creation policy; tighten them before reading.
+        fs_private::ensure_private_db_files(&path)?;
         let conn = Connection::open(path)?;
         let _: i64 = conn.query_row("SELECT count(*) FROM sqlite_master", [], |row| row.get(0))?;
         Self::from_connection(conn).map(Some)
@@ -738,6 +742,40 @@ mod tests {
             std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
             0o600
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn stale_permissive_cache_db_and_sidecars_are_tightened_on_open() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let key = SqlCipherKey::new("test-key").unwrap();
+        let path = dir.path().join("directory.sqlite3");
+        drop(DirectoryCache::open(path.clone(), &key).unwrap());
+
+        // Simulate artifacts from a permissive build: loosen the main DB and
+        // plant loose-mode sidecars. SQLite does not rewrite pre-existing
+        // sidecar modes just because the main file is tightened.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        for suffix in ["-wal", "-shm", "-journal"] {
+            let sidecar = dir.path().join(format!("directory.sqlite3{suffix}"));
+            std::fs::write(&sidecar, b"stale").unwrap();
+            std::fs::set_permissions(&sidecar, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        drop(DirectoryCache::open(path.clone(), &key).unwrap());
+
+        for suffix in ["", "-wal", "-shm", "-journal"] {
+            let file = dir.path().join(format!("directory.sqlite3{suffix}"));
+            if let Ok(metadata) = std::fs::metadata(&file) {
+                assert_eq!(
+                    metadata.permissions().mode() & 0o777,
+                    0o600,
+                    "suffix {suffix:?} must be owner-only after reopen"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -1133,7 +1133,7 @@ impl MarmotApp {
         for account in accounts {
             remove_sqlite_file_set(&self.directory_cache_path(&account.label))?;
         }
-        fs::write(marker_path, b"done\n")?;
+        fs_private::write_private(&marker_path, b"done\n")?;
         Ok(())
     }
 

--- a/crates/marmot-app/src/projection.rs
+++ b/crates/marmot-app/src/projection.rs
@@ -40,8 +40,9 @@ impl LegacyAccountProjectionDb {
             fs::create_dir_all(parent)?;
         }
         // Pre-create 0600 so SQLite's -wal/-shm sidecars (which copy the main
-        // file's mode) never appear at umask-default permissions.
-        fs_private::ensure_private_file(&path)?;
+        // file's mode) never appear at umask-default permissions, and tighten
+        // sidecars left behind by earlier permissive builds.
+        fs_private::ensure_private_db_files(&path)?;
         let conn = Connection::open(path)?;
         // Harden this legacy migration source the same way as storage-sqlite:
         // pin cipher_compatibility and enable cipher_memory_security before

--- a/crates/marmot-app/src/projection.rs
+++ b/crates/marmot-app/src/projection.rs
@@ -39,6 +39,9 @@ impl LegacyAccountProjectionDb {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
+        // Pre-create 0600 so SQLite's -wal/-shm sidecars (which copy the main
+        // file's mode) never appear at umask-default permissions.
+        fs_private::ensure_private_file(&path)?;
         let conn = Connection::open(path)?;
         // Harden this legacy migration source the same way as storage-sqlite:
         // pin cipher_compatibility and enable cipher_memory_security before

--- a/crates/marmot-app/src/projection/tests.rs
+++ b/crates/marmot-app/src/projection/tests.rs
@@ -1,6 +1,22 @@
 use super::*;
 
 #[test]
+#[cfg(unix)]
+fn legacy_projection_db_is_owner_only_on_disk() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("test-key").unwrap();
+    let path = dir.path().join("app.sqlite3");
+    let _db = LegacyAccountProjectionDb::open(path.clone(), &key).unwrap();
+
+    assert_eq!(
+        std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+}
+
+#[test]
 fn save_state_rolls_back_all_tables_when_component_write_fails() {
     let dir = tempfile::tempdir().unwrap();
     let key = SqlCipherKey::new("test-key").unwrap();

--- a/crates/marmot-app/src/sqlcipher.rs
+++ b/crates/marmot-app/src/sqlcipher.rs
@@ -185,11 +185,12 @@ fn atomic_write(path: &Path, contents: &[u8]) -> Result<(), AppError> {
     };
 
     {
-        let mut tmp = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&tmp_path)?;
+        // Owner-only from creation: the salt is key-derivation material and
+        // the rename target inherits the temp file's mode.
+        let mut options = OpenOptions::new();
+        options.write(true).create(true).truncate(true);
+        fs_private::set_private_file_mode(&mut options);
+        let mut tmp = options.open(&tmp_path)?;
         tmp.write_all(contents)?;
         tmp.sync_all()?;
     }
@@ -370,6 +371,22 @@ mod tests {
         assert_ne!(session_key.as_secret_str(), projection_key.as_secret_str());
         assert!(sqlcipher_salt_path(&session_path).exists());
         assert!(sqlcipher_salt_path(&projection_path).exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn sqlcipher_salt_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let salt_path = dir.path().join("session.sqlite.salt");
+        write_sqlcipher_salt(&salt_path, &[0x5a; SQLCIPHER_SALT_LEN]).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&salt_path).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "salt is key-derivation material and must be owner-only"
+        );
     }
 
     #[test]

--- a/crates/marmot-app/src/sqlcipher.rs
+++ b/crates/marmot-app/src/sqlcipher.rs
@@ -6,8 +6,7 @@
 //! crash-safe salt-write/rekey sequence, and recovery for interrupted or
 //! pre-fix bricked migrations.
 
-use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 
 use hkdf::Hkdf;
@@ -184,16 +183,11 @@ fn atomic_write(path: &Path, contents: &[u8]) -> Result<(), AppError> {
         path.with_file_name(tmp_name)
     };
 
-    {
-        // Owner-only from creation: the salt is key-derivation material and
-        // the rename target inherits the temp file's mode.
-        let mut options = OpenOptions::new();
-        options.write(true).create(true).truncate(true);
-        fs_private::set_private_file_mode(&mut options);
-        let mut tmp = options.open(&tmp_path)?;
-        tmp.write_all(contents)?;
-        tmp.sync_all()?;
-    }
+    // Owner-only from creation: the salt is key-derivation material and the
+    // rename target inherits the temp file's mode. write_private also
+    // tightens the inode before writing, so a leftover permissive temp file
+    // from an older build (or pid reuse) cannot smuggle its mode into place.
+    fs_private::write_private(&tmp_path, contents)?;
 
     if let Err(err) = fs::rename(&tmp_path, path) {
         let _ = fs::remove_file(&tmp_path);
@@ -386,6 +380,31 @@ mod tests {
             std::fs::metadata(&salt_path).unwrap().permissions().mode() & 0o777,
             0o600,
             "salt is key-derivation material and must be owner-only"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn leftover_permissive_salt_temp_file_does_not_leak_its_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let salt_path = dir.path().join("session.sqlite.salt");
+        // A crashed older build (or pid reuse) left the temp file behind at
+        // umask-default permissions; the rewrite must not rename that mode
+        // into the final salt path.
+        let tmp_path = dir
+            .path()
+            .join(format!("session.sqlite.salt.tmp.{}", std::process::id()));
+        std::fs::write(&tmp_path, b"stale").unwrap();
+        std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_sqlcipher_salt(&salt_path, &[0x5a; SQLCIPHER_SALT_LEN]).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&salt_path).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "final salt must be owner-only even when the temp inode pre-existed"
         );
     }
 

--- a/crates/marmot-forensics/Cargo.toml
+++ b/crates/marmot-forensics/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
+fs-private.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -35,7 +35,7 @@
 //! ([`ForensicRecorder::set_data_mode`]) rotates the backing store so each
 //! file has a single, unambiguous mode boundary.
 
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -1131,7 +1131,11 @@ impl JsonlRecorder {
             validate_account_ref_hex(account_ref)?;
         }
         let path = path.as_ref().to_path_buf();
-        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        // Owner-only from creation: in FullData mode this file carries
+        // decrypted content and full identifiers, so it must never exist at
+        // umask-default permissions. Pre-existing permissive files are
+        // tightened by the helper.
+        let file = fs_private::open_private_append(&path)?;
         let recorder_session_id = generate_recorder_session_id();
         let recorder = Self {
             path,
@@ -1333,13 +1337,10 @@ impl JsonlRecorder {
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
             Err(err) => return Err(err),
         }
-        // Open a brand-new file at the same path and swap it in. Assigning to
-        // `inner.writer` drops the old `BufWriter`, closing the stale (unlinked)
-        // fd.
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)?;
+        // Open a brand-new owner-only file at the same path and swap it in.
+        // Assigning to `inner.writer` drops the old `BufWriter`, closing the
+        // stale (unlinked) fd.
+        let file = fs_private::open_private_append(&self.path)?;
         inner.writer = BufWriter::new(file);
         inner.seq = 0;
         inner.recorder_session_id = generate_recorder_session_id();

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -59,6 +59,42 @@ fn jsonl_recorder_appends_events_with_monotonic_seq() {
 }
 
 #[test]
+#[cfg(unix)]
+fn audit_file_is_owner_only_on_open_and_rotation() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    let path = default_jsonl_path(dir.path(), "engine-abc");
+    let mode = |p: &Path| fs::metadata(p).unwrap().permissions().mode() & 0o777;
+
+    let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+    assert_eq!(mode(&path), 0o600);
+
+    // Rotation unlinks and recreates the file; the fresh file must be
+    // owner-only too.
+    recorder.rotate().unwrap();
+    assert_eq!(mode(&path), 0o600);
+}
+
+#[test]
+#[cfg(unix)]
+fn pre_existing_permissive_audit_file_is_tightened_on_open() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    let path = default_jsonl_path(dir.path(), "engine-abc");
+    fs::write(&path, b"").unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+    let _recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+
+    assert_eq!(
+        fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+}
+
+#[test]
 fn jsonl_recorder_rotate_discards_old_lines_and_keeps_recording() {
     let dir = TempDir::new().unwrap();
     let path = default_jsonl_path(dir.path(), "engine-abc");

--- a/crates/storage-sqlite/Cargo.toml
+++ b/crates/storage-sqlite/Cargo.toml
@@ -8,6 +8,7 @@ description = "SQLite storage backend for the CGKA engine with Marmot and OpenML
 
 [dependencies]
 cgka-traits.workspace = true
+fs-private.workspace = true
 hex.workspace = true
 openmls.workspace = true
 openmls_traits.workspace = true

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -648,14 +648,37 @@ impl SqliteAccountStorage {
         group_id_hex: &str,
         cutoff_recorded_at: u64,
     ) -> StorageResult<crate::timeline::SecurePruneAppEventsResult> {
-        let outcome = self.connection.with_transaction(|| {
+        // `secure_delete` must be ON *before* the prune transaction begins:
+        // SQLite does not guarantee zero-on-free for pages freed in the same
+        // transaction that toggles the pragma, so setting it inside the
+        // transaction (the previous shape) silently weakened the prune on
+        // connections opened with `secure_delete: false`.
+        let original_secure_delete = {
+            let conn = self.lock()?;
+            let original = conn
+                .query_row("PRAGMA secure_delete", [], |row| row.get::<_, i64>(0))
+                .storage()?;
+            conn.execute_batch("PRAGMA secure_delete = ON;").storage()?;
+            original
+        };
+        let prune_outcome = self.connection.with_transaction(|| {
             let conn = self.lock()?;
             crate::timeline::secure_prune_app_events_before_tx(
                 &conn,
                 group_id_hex,
                 cutoff_recorded_at,
             )
-        })?;
+        });
+        let restore = self.lock().and_then(|conn| {
+            conn.execute_batch(&format!("PRAGMA secure_delete = {original_secure_delete};"))
+                .storage()
+        });
+        let outcome = match (prune_outcome, restore) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Err(err), Ok(())) => Err(err),
+            (Ok(_), Err(err)) => Err(err),
+            (Err(err), Err(_)) => Err(err),
+        }?;
         if outcome.pruned_messages > 0 {
             let conn = self.lock()?;
             if let Err(error) = checkpoint_wal_truncate_after_secure_prune(&conn) {

--- a/crates/storage-sqlite/src/connection.rs
+++ b/crates/storage-sqlite/src/connection.rs
@@ -433,6 +433,8 @@ impl SqliteAccountStorage {
         key: &SqlCipherKey,
         options: SqliteStorageOptions,
     ) -> StorageResult<Self> {
+        let path = path.as_ref();
+        ensure_private_db_files(path)?;
         let connection = rusqlite::Connection::open(path).storage()?;
         Self::from_unkeyed_encrypted_connection_with_options(connection, key, options)
     }
@@ -464,6 +466,21 @@ impl SqliteAccountStorage {
     pub(crate) fn lock(&self) -> StorageResult<std::sync::MutexGuard<'_, rusqlite::Connection>> {
         self.connection.lock()
     }
+}
+
+/// Make a database file owner-only before SQLite can create it at the process
+/// umask: pre-create the main file 0600 (SQLite then copies its mode onto
+/// `-wal`/`-shm`/journal sidecars it creates) and tighten any sidecars left
+/// behind by earlier builds.
+pub(crate) fn ensure_private_db_files(path: &Path) -> StorageResult<()> {
+    fs_private::ensure_private_file(path).map_err(|err| StorageError::Backend(err.to_string()))?;
+    for suffix in ["-wal", "-shm", "-journal"] {
+        let mut sidecar = path.as_os_str().to_owned();
+        sidecar.push(suffix);
+        fs_private::tighten_existing_private_file(Path::new(&sidecar))
+            .map_err(|err| StorageError::Backend(err.to_string()))?;
+    }
+    Ok(())
 }
 
 fn apply_sqlcipher_key(connection: &rusqlite::Connection, key: &SqlCipherKey) -> StorageResult<()> {
@@ -839,6 +856,60 @@ mod tests {
         assert_eq!(pragma_i64(&conn, "trusted_schema"), 0);
         assert_eq!(pragma_i64(&conn, "synchronous"), 2);
         assert_eq!(pragma_string(&conn, "journal_mode"), "wal");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn account_db_and_sidecars_are_owner_only_on_disk() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("marmot.sqlite");
+        let key = SqlCipherKey::new("on-disk mode key").unwrap();
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        // Force a WAL write so the -wal/-shm sidecars exist.
+        store
+            .lock()
+            .unwrap()
+            .execute_batch(
+                "CREATE TABLE mode_probe (id INTEGER); INSERT INTO mode_probe VALUES (1);",
+            )
+            .unwrap();
+
+        let mode = |p: &Path| std::fs::metadata(p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode(&path), 0o600);
+        for suffix in ["-wal", "-shm"] {
+            let sidecar = std::path::PathBuf::from(format!("{}{suffix}", path.display()));
+            assert!(sidecar.exists(), "expected {suffix} sidecar to exist");
+            assert_eq!(mode(&sidecar), 0o600, "sidecar {suffix} should be 0600");
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn pre_existing_db_and_sidecar_modes_are_tightened_on_open() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("marmot.sqlite");
+        let key = SqlCipherKey::new("tighten mode key").unwrap();
+        drop(SqliteAccountStorage::open_encrypted(&path, &key).unwrap());
+        let wal = std::path::PathBuf::from(format!("{}-wal", path.display()));
+        // Simulate files left behind by builds that created them at the umask.
+        for p in [&path, &wal] {
+            if !p.exists() {
+                std::fs::write(p, b"").unwrap();
+            }
+            std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        // Assert while the store is open: the -wal sidecar is checkpointed
+        // away on clean close.
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        let mode = |p: &Path| std::fs::metadata(p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode(&path), 0o600);
+        assert_eq!(mode(&wal), 0o600);
+        drop(store);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/connection.rs
+++ b/crates/storage-sqlite/src/connection.rs
@@ -469,18 +469,9 @@ impl SqliteAccountStorage {
 }
 
 /// Make a database file owner-only before SQLite can create it at the process
-/// umask: pre-create the main file 0600 (SQLite then copies its mode onto
-/// `-wal`/`-shm`/journal sidecars it creates) and tighten any sidecars left
-/// behind by earlier builds.
+/// umask; see `fs_private::ensure_private_db_files` for the sidecar rules.
 pub(crate) fn ensure_private_db_files(path: &Path) -> StorageResult<()> {
-    fs_private::ensure_private_file(path).map_err(|err| StorageError::Backend(err.to_string()))?;
-    for suffix in ["-wal", "-shm", "-journal"] {
-        let mut sidecar = path.as_os_str().to_owned();
-        sidecar.push(suffix);
-        fs_private::tighten_existing_private_file(Path::new(&sidecar))
-            .map_err(|err| StorageError::Backend(err.to_string()))?;
-    }
-    Ok(())
+    fs_private::ensure_private_db_files(path).map_err(|err| StorageError::Backend(err.to_string()))
 }
 
 fn apply_sqlcipher_key(connection: &rusqlite::Connection, key: &SqlCipherKey) -> StorageResult<()> {

--- a/crates/storage-sqlite/src/shared.rs
+++ b/crates/storage-sqlite/src/shared.rs
@@ -65,6 +65,9 @@ impl SqliteSharedStorage {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).map_err(|err| StorageError::Backend(err.to_string()))?;
         }
+        // The shared cache is unencrypted, so file-level 0600 (including
+        // sidecars) is the only thing keeping it from other local users.
+        crate::connection::ensure_private_db_files(path)?;
         let conn = rusqlite::Connection::open(path).storage()?;
         Self::from_connection(conn)
     }
@@ -587,6 +590,24 @@ mod tests {
         assert!(!user_columns.contains(&"local_account_json".to_owned()));
         assert!(!user_columns.contains(&"private_discovery_reason".to_owned()));
         assert!(!user_columns.contains(&"local_fetch_timestamp".to_owned()));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn shared_cache_db_is_owner_only_on_disk() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shared").join("directory.sqlite");
+        drop(SqliteSharedStorage::open(&path).unwrap());
+        let mode = |p: &Path| std::fs::metadata(p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode(&path), 0o600);
+
+        // A pre-existing permissive cache (from builds that created it at the
+        // umask) is tightened on reopen.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        drop(SqliteSharedStorage::open(&path).unwrap());
+        assert_eq!(mode(&path), 0o600);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -710,83 +710,63 @@ pub(crate) fn rebuild_message_timeline_for_group_tx(
     Ok(())
 }
 
+/// Prune body. The caller must have set `PRAGMA secure_delete = ON` on the
+/// connection *before* opening this transaction: SQLite does not guarantee
+/// zero-on-free for pages freed in the same transaction that toggles the
+/// pragma, so an in-transaction toggle would silently degrade the prune's
+/// guarantee on connections configured with `secure_delete: false`.
 pub(crate) fn secure_prune_app_events_before_tx(
     tx: &Connection,
     group_id_hex: &str,
     cutoff_recorded_at: u64,
 ) -> StorageResult<SecurePruneAppEventsResult> {
-    with_secure_delete_enabled_tx(tx, || {
-        let pruned_events = app_events_before_cutoff_tx(tx, group_id_hex, cutoff_recorded_at)?;
-        if pruned_events.is_empty() {
-            return Ok(SecurePruneAppEventsResult::default());
-        }
-
-        let mut pruned_message_ids = BTreeSet::new();
-        let mut affected_message_ids = BTreeSet::new();
-        let mut media_ciphertext_sha256 = BTreeSet::new();
-        for event in &pruned_events {
-            pruned_message_ids.insert(event.message_id_hex.clone());
-            collect_media_ciphertext_hashes(&event.tags, &mut media_ciphertext_sha256);
-            affected_message_ids.extend(affected_timeline_message_ids_for_pruned_event_tx(
-                tx,
-                group_id_hex,
-                &event.message_id_hex,
-                event.kind,
-                &event.tags,
-            )?);
-        }
-
-        scrub_app_events_before_cutoff_tx(tx, group_id_hex, cutoff_recorded_at)?;
-        // `message_timeline.plaintext` is indexed for search; overwriting it
-        // under `secure_delete` before DELETE also rewrites the old index key.
-        scrub_timeline_projection_rows_by_ids_tx(tx, group_id_hex, &pruned_message_ids)?;
-
-        // Deleting the owning app_events rows cascades to message_modifier_edges
-        // via its ON DELETE CASCADE foreign key.
-        let pruned = tx
-            .execute(
-                "DELETE FROM app_events
-                 WHERE group_id_hex = ?1
-                   AND recorded_at < ?2",
-                params![group_id_hex, u64_to_i64(cutoff_recorded_at)?],
-            )
-            .storage()?;
-
-        delete_timeline_projection_rows_by_ids_tx(tx, group_id_hex, &pruned_message_ids)?;
-        affected_message_ids.retain(|message_id| !pruned_message_ids.contains(message_id));
-        for message_id in affected_message_ids {
-            upsert_message_timeline_projection_for_message_tx(tx, group_id_hex, &message_id)?;
-        }
-        refresh_chat_list_last_message_after_secure_prune_tx(tx, group_id_hex)?;
-
-        Ok(SecurePruneAppEventsResult {
-            pruned_messages: pruned,
-            media_ciphertext_sha256: media_ciphertext_sha256.into_iter().collect(),
-        })
-    })
-}
-
-fn with_secure_delete_enabled_tx<T>(
-    tx: &Connection,
-    op: impl FnOnce() -> StorageResult<T>,
-) -> StorageResult<T> {
-    let original_secure_delete = tx
-        .query_row("PRAGMA secure_delete", [], |row| row.get::<_, i64>(0))
-        .storage()?;
-    tx.execute_batch("PRAGMA secure_delete = ON;").storage()?;
-    let outcome = op();
-    let restore = set_secure_delete_tx(tx, original_secure_delete);
-    match (outcome, restore) {
-        (Ok(value), Ok(())) => Ok(value),
-        (Err(err), Ok(())) => Err(err),
-        (Ok(_), Err(err)) => Err(err),
-        (Err(err), Err(_)) => Err(err),
+    let pruned_events = app_events_before_cutoff_tx(tx, group_id_hex, cutoff_recorded_at)?;
+    if pruned_events.is_empty() {
+        return Ok(SecurePruneAppEventsResult::default());
     }
-}
 
-fn set_secure_delete_tx(tx: &Connection, value: i64) -> StorageResult<()> {
-    tx.execute_batch(&format!("PRAGMA secure_delete = {value};"))
-        .storage()
+    let mut pruned_message_ids = BTreeSet::new();
+    let mut affected_message_ids = BTreeSet::new();
+    let mut media_ciphertext_sha256 = BTreeSet::new();
+    for event in &pruned_events {
+        pruned_message_ids.insert(event.message_id_hex.clone());
+        collect_media_ciphertext_hashes(&event.tags, &mut media_ciphertext_sha256);
+        affected_message_ids.extend(affected_timeline_message_ids_for_pruned_event_tx(
+            tx,
+            group_id_hex,
+            &event.message_id_hex,
+            event.kind,
+            &event.tags,
+        )?);
+    }
+
+    scrub_app_events_before_cutoff_tx(tx, group_id_hex, cutoff_recorded_at)?;
+    // `message_timeline.plaintext` is indexed for search; overwriting it
+    // under `secure_delete` before DELETE also rewrites the old index key.
+    scrub_timeline_projection_rows_by_ids_tx(tx, group_id_hex, &pruned_message_ids)?;
+
+    // Deleting the owning app_events rows cascades to message_modifier_edges
+    // via its ON DELETE CASCADE foreign key.
+    let pruned = tx
+        .execute(
+            "DELETE FROM app_events
+             WHERE group_id_hex = ?1
+               AND recorded_at < ?2",
+            params![group_id_hex, u64_to_i64(cutoff_recorded_at)?],
+        )
+        .storage()?;
+
+    delete_timeline_projection_rows_by_ids_tx(tx, group_id_hex, &pruned_message_ids)?;
+    affected_message_ids.retain(|message_id| !pruned_message_ids.contains(message_id));
+    for message_id in affected_message_ids {
+        upsert_message_timeline_projection_for_message_tx(tx, group_id_hex, &message_id)?;
+    }
+    refresh_chat_list_last_message_after_secure_prune_tx(tx, group_id_hex)?;
+
+    Ok(SecurePruneAppEventsResult {
+        pruned_messages: pruned,
+        media_ciphertext_sha256: media_ciphertext_sha256.into_iter().collect(),
+    })
 }
 
 fn refresh_chat_list_last_message_after_secure_prune_tx(

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -720,6 +720,12 @@ pub(crate) fn secure_prune_app_events_before_tx(
     group_id_hex: &str,
     cutoff_recorded_at: u64,
 ) -> StorageResult<SecurePruneAppEventsResult> {
+    debug_assert_eq!(
+        tx.query_row("PRAGMA secure_delete", [], |row| row.get::<_, i64>(0))
+            .unwrap_or(0),
+        1,
+        "secure_delete must be ON before the prune transaction is opened"
+    );
     let pruned_events = app_events_before_cutoff_tx(tx, group_id_hex, cutoff_recorded_at)?;
     if pruned_events.is_empty() {
         return Ok(SecurePruneAppEventsResult::default());

--- a/docs/marmot-architecture/AGENTS.md
+++ b/docs/marmot-architecture/AGENTS.md
@@ -31,6 +31,10 @@ Agent map for the Marmot architecture docs.
 - **Path:** `overview/whitenoise-integration-map.md`
   - **Role:** Current shim map and engine API friction list for whitenoise-rs integration.
 
+- **Path:** `overview/local-artifact-safety.md`
+  - **Role:** Restrictive-by-construction creation policy for local files, sockets, and databases; the
+    `crates/fs-private` helper contract.
+
 - **Path:** `further-context/`
   - **Role:** Older or deeper context. Check status and dates before relying on it.
 

--- a/docs/marmot-architecture/index.md
+++ b/docs/marmot-architecture/index.md
@@ -76,6 +76,10 @@ Written to be readable in 5 minutes each, shareable as a package.
 - **Doc:** [`overview/observability.md`](./overview/observability.md)
   - **What it covers:** Privacy-safe tracing/logging rules and the repo-wide tracing audit guardrail.
 
+- **Doc:** [`overview/local-artifact-safety.md`](./overview/local-artifact-safety.md)
+  - **What it covers:** Restrictive-by-construction creation of local files, sockets, and databases: the
+    `fs-private` helpers, the one octal-mode parser, and the DB sidecar/PRAGMA-at-open rules.
+
 - **Doc:** [`overview/current-state.md`](./overview/current-state.md)
   - **What it covers:** Implementations, merged MIPs, the current CGKA engine workspace, and known gaps.
 

--- a/docs/marmot-architecture/overview/local-artifact-safety.md
+++ b/docs/marmot-architecture/overview/local-artifact-safety.md
@@ -1,0 +1,61 @@
+---
+title: "Local Artifact Safety"
+created: 2026-07-02
+updated: 2026-07-02
+tags: [marmot, overview, security, filesystem, permissions]
+status: overview
+---
+
+# Local Artifact Safety
+
+Every local file, directory, socket, or database Marmot creates must be restrictive **by construction**: the artifact
+is created already at its target owner-only mode, never chmod-ed after it is reachable or holds data. This is the
+local-resource twin of the network endpoint-safety policy (mdk#378; the pattern behind mdk#345, mdk#346, mdk#347,
+mdk#357, mdk#367, mdk#396).
+
+## The rules
+
+- **No post-hoc chmod window.** Files are opened with `O_CREAT` + mode 0600 (directories: atomic 0700 `DirBuilder`).
+  A `set_permissions` call after creation is only allowed belt-and-braces on top of a mode-at-create open, or to
+  tighten artifacts left behind by older builds.
+- **Sockets bind in staging.** Unix listeners are bound inside a fresh 0700 staging directory, chmod-ed there, and
+  hard-linked onto the final path, so the socket never exists at umask-default permissions — even under a
+  caller-supplied `--socket` in a directory the daemon does not own.
+- **One mode parser.** `fs_private::parse_octal_mode` is the workspace's only octal permission-mode parser. Policy on
+  acceptable modes (e.g. rejecting world bits on control sockets) stays with callers.
+- **Databases are pre-created 0600.** The DB file is created 0600 *before* the path is handed to
+  rusqlite/SQLCipher; SQLite then copies that mode onto the `-wal`/`-shm`/journal sidecars it creates. Sidecars from
+  older builds are tightened on open. This applies to encrypted databases too: sidecars and the unencrypted shared
+  cache have no cipher protecting them.
+- **Must-precede-data PRAGMAs are applied before data.** Durability/privacy PRAGMAs that only affect subsequent
+  writes (`secure_delete`, cipher settings) are applied at connection open — or, when toggled around an operation,
+  set on the connection *before* `BEGIN` and restored after commit/rollback. SQLite does not guarantee zero-on-free
+  for pages freed in the same transaction that toggles `secure_delete`.
+
+## The helpers
+
+`crates/fs-private` owns the shared implementations: `write_private`, `open_private_append`, `create_new_private`,
+`ensure_private_file`, `tighten_existing_private_file`, `create_dir_all_private`, `set_private_file_mode`,
+`parse_octal_mode`, and `bind_unix_listener_private`.
+
+**Coverage rule:** new code that creates a local file, socket, or database calls these helpers (or proves equivalent
+restrictive-by-construction posture with an on-disk mode test) instead of re-deriving umask/chmod/PRAGMA ordering.
+`crates/marmot-account/src/io.rs` (`write_file_atomically` with `FileMode::Private`) is a compliant-equivalent
+implementation that predates the shared crate.
+
+## Deliberate exception
+
+The application root directory's mode is left as-is when it already exists: retroactively chmod-ing the root of
+existing installs is a behavior change outside this policy's scope. File-level 0600 inside it is the guarantee.
+
+## Scope
+
+This policy covers *creation-time* posture (permissions, creation ordering, mode parsing, PRAGMA-at-open). Handling
+of secret contents in memory, logs, and FFI is tracked separately under the sensitive-material discipline; tracing
+rules live in [`observability.md`](./observability.md).
+
+## Current enforcement
+
+On-disk mode tests accompany each artifact path: `fs-private` unit tests, the daemon/connector socket tests, the
+`storage-sqlite` DB/sidecar mode tests, the `marmot-forensics` audit-file tests, and the `marmot-app`
+device-id/key-reveal/salt/cache tests. All assert `mode & 0o777` on the real files.


### PR DESCRIPTION
## Summary

Implements the full local-artifact safety tracking issue #378: every file, socket, and database this workspace creates is now at its target owner-only mode **before** it is reachable or holds data, built on one shared helper crate instead of per-call-site umask/chmod logic.

Each child issue is fixed in its own commit for easy bisecting:

| Commit | Issue | Change |
| --- | --- | --- |
| `eadf59e` | #378 | New std-only `crates/fs-private`: 0600/0700 creation helpers (`O_CREAT`+mode, atomic `DirBuilder`), the workspace's one octal-mode parser, and a staging-dir Unix socket bind. |
| `7d2173d` | Closes #357 | `dm-agent` uses `fs_private::parse_octal_mode` (whole-string radix-8: `0600`/`00600`/`600`/`0o600` all parse); buggy single-zero-strip parser deleted. |
| `c729f7a` | Closes #345 | `dmd` and `dm-agent` sockets bind inside a fresh 0700 staging dir and are hard-linked into place at 0600 — no bind→chmod window, `AddrInUse` semantics preserved for stale-socket recovery. |
| `710d78c` | Closes #347 | SQLCipher account DB and the unencrypted shared cache are pre-created 0600 before `rusqlite` opens them; SQLite propagates that mode to `-wal`/`-shm` (proven by on-disk tests), old permissive sidecars tightened on open. |
| `cd7611e` | Closes #346 | `PRAGMA secure_delete` is set on the connection **before** the prune transaction and restored after, so pages freed by the prune's DELETEs are zeroed even on `secure_delete: false` connections. Raw-file scan test proves plaintext absent from db+wal bytes. |
| `c08f103` | Closes #367 | Forensic JSONL audit file created 0600 on initial open and every rotation; pre-existing permissive logs tightened. |
| `eb85a30` | Closes #396 | Media temp subdir derived from the connector-computed SHA-256 of the downloaded plaintext, never the sender-supplied `ciphertext_sha256`. |
| `76850c4` | #378 sweep | Same-category gaps found by a full-repo sweep, all in `marmot-app`: key-reveal audit JSONL, `audit-device-id`, SQLCipher-salt temp file (atomic_write), legacy projection DB, directory cache DB, cleanup marker — all owner-only now. |
| `2160432` | #378 | Policy doc `docs/marmot-architecture/overview/local-artifact-safety.md` (creation ordering, one parser, DB/sidecar + PRAGMA-at-open rules, coverage rule), linked from the architecture index and a new root `AGENTS.md` invariant. |

## Notes for review

- **Socket bind mechanics**: umask manipulation was rejected (process-global, and `dmd` binds inside a live multi-thread tokio runtime). The staging-dir approach uses `link(2)` rather than `rename(2)` for final placement so an existing path still fails `AddrInUse` instead of being silently replaced. Proven by a bind→link→connect test.
- **`parse_octal_mode("0")` returns `Ok(0)`** by design (whole-string octal parse); rejecting useless-but-valid modes remains caller policy (`validate_control_plane_mode` still rejects world bits).
- **One deliberate exception**: pre-existing app-root directory modes in `marmot-app` are left untouched (tightening existing installs' roots is a behavior change); documented in the policy doc.
- **#346 severity note**: production defaults already had `secure_delete=ON` and the prune zeroblob-scrubs cells before DELETE, so this mainly makes the guarantee real for opt-out connections.
- `marmot-account/src/io.rs` was audited and is already restrictive-by-construction; listed as compliant-equivalent in the policy doc rather than converted.

## Testing

- `just fast-ci` (fmt-check, check, clippy incl. OTLP builds) passes.
- Full suites pass for every touched crate: `fs-private` (12), `agent-connector` (85), `darkmatter-cli` (134 lib + 73 integration), `storage-sqlite` (185), `marmot-forensics` (18), `marmot-app` (309).
- New on-disk-mode tests inspect actual `stat` modes for sockets, DBs + WAL/SHM sidecars, audit logs, salt files, and staging-dir cleanup; the #346 test scans raw database bytes for a plaintext marker after pruning with `secure_delete: false`.

Closes #345, closes #346, closes #347, closes #357, closes #367, closes #396. Tracking: #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/698">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared approach for creating local files, directories, sockets, and SQLite databases with owner-only permissions.
  * Improved socket setup so services are created more safely during startup.

* **Bug Fixes**
  * Reduced exposure windows for daemon and connector sockets.
  * Ensured SQLite database files and sidecar files are tightened to private permissions.
  * Made audit and cleanup files consistently private when created or reopened.

* **Documentation**
  * Added and updated security guidance for local artifact creation and permission handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->