### PR TITLE
Unify sensitive-material handling: zeroize secrets, redact Debug/FFI, enforce redaction at log/audit sinks (#379)

### DIFF
--- a/crates/agent-connector/src/stream_session.rs
+++ b/crates/agent-connector/src/stream_session.rs
@@ -170,7 +170,7 @@ impl SendIdempotencyStore {
                 target: "agent_connector",
                 method = "send_idempotency_persist",
                 error_code = "persist_failed",
-                error = %err,
+                error_kind = err.code(),
                 "failed to persist send idempotency record"
             );
         }
@@ -186,7 +186,7 @@ impl SendIdempotencyStore {
                     target: "agent_connector",
                     method = "send_idempotency_load",
                     error_code = "read_failed",
-                    error = %err,
+                    error_kind = %err.kind(),
                     "failed to read send idempotency file; starting empty"
                 );
                 return;

--- a/crates/cgka-conformance-simulator/tests/tracing_audit.rs
+++ b/crates/cgka-conformance-simulator/tests/tracing_audit.rs
@@ -16,6 +16,23 @@ const TRACING_MACROS: &[&str] = &[
 
 const DIRECT_OUTPUT_MACROS: &[&str] = &["println!(", "eprintln!(", "dbg!("];
 
+/// Verbatim error interpolation in tracing calls. Error `Display` output can
+/// carry relay URLs (transport errors), file paths (io/sqlite errors), or
+/// attacker-controlled event content, so tracing must log a stable
+/// privacy-safe kind (`error_kind = err.privacy_safe_kind()`,
+/// `error_kind = %err.kind()`, an error-code enum) instead of the raw error
+/// value (darkmatter#340, darkmatter#399).
+const FORBIDDEN_ERROR_INTERPOLATIONS: &[&str] = &[
+    "error = %",
+    "error = ?",
+    "{err}",
+    "{err:",
+    "{e}",
+    "{e:",
+    "{error}",
+    "{error:",
+];
+
 const FORBIDDEN_TRACE_TOKENS: &[&str] = &[
     "account_id",
     "member_id",
@@ -75,6 +92,37 @@ fn production_tracing_calls_are_structured_and_privacy_safe() {
     assert!(
         failures.is_empty(),
         "tracing audit failed:\n{}",
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn production_tracing_calls_do_not_interpolate_raw_errors() {
+    let repo = workspace_root();
+    let mut failures = Vec::new();
+
+    for file in rust_source_files(&repo.join("crates")) {
+        let Ok(contents) = fs::read_to_string(&file) else {
+            continue;
+        };
+
+        for invocation in tracing_invocations(&contents) {
+            for token in FORBIDDEN_ERROR_INTERPOLATIONS {
+                if invocation.body.contains(token) {
+                    failures.push(format!(
+                        "{}:{} tracing call interpolates a raw error via `{token}`; \
+                         log a privacy-safe error kind instead",
+                        file.display(),
+                        invocation.line
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "raw-error tracing audit failed:\n{}",
         failures.join("\n")
     );
 }

--- a/crates/cgka-conformance-simulator/tests/tracing_audit.rs
+++ b/crates/cgka-conformance-simulator/tests/tracing_audit.rs
@@ -22,9 +22,32 @@ const DIRECT_OUTPUT_MACROS: &[&str] = &["println!(", "eprintln!(", "dbg!("];
 /// privacy-safe kind (`error_kind = err.privacy_safe_kind()`,
 /// `error_kind = %err.kind()`, an error-code enum) instead of the raw error
 /// value (darkmatter#340, darkmatter#399).
+/// Matching is keyed to the interpolated *value* (`%err`, `?e`, ...) as well
+/// as the conventional `error` field name, so renaming the field (`cause =
+/// %err`, `reason = %e`) does not bypass the audit. Tokens are terminated by
+/// `,`, `)`, or end-of-line so projections of the error to a safe value
+/// (`error_kind = %err.kind()`) stay allowed.
 const FORBIDDEN_ERROR_INTERPOLATIONS: &[&str] = &[
     "error = %",
     "error = ?",
+    "%err,",
+    "%err)",
+    "%err\n",
+    "?err,",
+    "?err)",
+    "?err\n",
+    "%e,",
+    "%e)",
+    "%e\n",
+    "?e,",
+    "?e)",
+    "?e\n",
+    "%error,",
+    "%error)",
+    "%error\n",
+    "?error,",
+    "?error)",
+    "?error\n",
     "{err}",
     "{err:",
     "{e}",

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -230,7 +230,11 @@ where
                 tracing::warn!(
                     target: TRACE_TARGET,
                     method = "publish_fresh_key_package",
-                    error = %cleanup_err,
+                    error_kind = if cleanup_err.is_transient() {
+                        "engine_transient"
+                    } else {
+                        "engine"
+                    },
                     "failed to delete orphaned key package bundle after publish failure"
                 );
             }

--- a/crates/marmot-app/src/audit_log.rs
+++ b/crates/marmot-app/src/audit_log.rs
@@ -408,7 +408,7 @@ impl MarmotApp {
                 tracing::warn!(
                     target: "marmot_app",
                     method = "open_audit_recorder",
-                    error = %e,
+                    error_kind = e.privacy_safe_kind(),
                     "failed to prepare forensic audit identity; continuing without it"
                 );
                 return None;
@@ -463,7 +463,7 @@ impl MarmotApp {
                 tracing::warn!(
                     target: "marmot_app",
                     method = "open_audit_recorder",
-                    error = %e,
+                    error_kind = %e.kind(),
                     "failed to open forensic audit log; continuing without it"
                 );
                 None
@@ -491,7 +491,7 @@ impl MarmotApp {
                 tracing::warn!(
                     target: "marmot_app",
                     method = "build_audit_recorder",
-                    error = %e,
+                    error_kind = e.privacy_safe_kind(),
                     "failed to resolve account identity for audit logging; continuing without it"
                 );
                 return Box::new(marmot_forensics::NoopRecorder);

--- a/crates/marmot-app/src/client/audit.rs
+++ b/crates/marmot-app/src/client/audit.rs
@@ -150,7 +150,7 @@ impl AppClient {
             tracing::warn!(
                 target: "marmot_app",
                 method = "set_audit_data_mode",
-                error = %e,
+                error_kind = %e.kind(),
                 "failed to switch audit data mode on live session; continuing"
             );
         }

--- a/crates/marmot-app/src/client/push.rs
+++ b/crates/marmot-app/src/client/push.rs
@@ -47,7 +47,8 @@ impl AppClient {
                     tracing::warn!(
                         target: "marmot_app::notifications",
                         method = "share_push_registration",
-                        "push token gossip publish failed: {err}",
+                        error_kind = err.privacy_safe_kind(),
+                        "push token gossip publish failed",
                     );
                 }
             }
@@ -94,7 +95,8 @@ impl AppClient {
                     tracing::warn!(
                         target: "marmot_app::notifications",
                         method = "remove_push_registration",
-                        "push token removal gossip publish failed: {err}",
+                        error_kind = err.privacy_safe_kind(),
+                        "push token removal gossip publish failed",
                     );
                 }
             }
@@ -119,7 +121,8 @@ impl AppClient {
             tracing::warn!(
                 target: "marmot_app::notifications",
                 method = "publish_notification_trigger_best_effort",
-                "notification trigger publish failed: {err}",
+                error_kind = err.privacy_safe_kind(),
+                "notification trigger publish failed",
             );
         }
     }

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -390,7 +390,8 @@ impl AppClient {
                         tracing::warn!(
                             target: "marmot_app::notifications",
                             method = "ingest_delivery",
-                            "ignoring malformed push token gossip: {err}",
+                            error_kind = err.privacy_safe_kind(),
+                            "ignoring malformed push token gossip",
                         );
                     }
                     gossip_message_ids.insert(message.message_id_hex.clone());

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -154,7 +154,7 @@ impl std::fmt::Debug for RelayTelemetryRuntimeConfig {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AuditLogUploadSource {
     pub device_label: Option<String>,
     pub platform: Option<String>,

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -129,11 +129,29 @@ pub struct RelayTelemetryResource {
     pub device_model_identifier: Option<String>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Hand-written `Debug` below redacts `authorization_bearer_token` (the OTLP
+/// push credential) so a `{:?}` never prints it.
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct RelayTelemetryRuntimeConfig {
     pub otlp_endpoint: Option<String>,
     pub authorization_bearer_token: Option<String>,
     pub resource: Option<RelayTelemetryResource>,
+}
+
+impl std::fmt::Debug for RelayTelemetryRuntimeConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RelayTelemetryRuntimeConfig")
+            .field("otlp_endpoint", &self.otlp_endpoint)
+            .field(
+                "authorization_bearer_token",
+                &self
+                    .authorization_bearer_token
+                    .as_ref()
+                    .map(|_| "<redacted>"),
+            )
+            .field("resource", &self.resource)
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -143,11 +161,29 @@ pub struct AuditLogUploadSource {
     pub app_version: Option<String>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// Hand-written `Debug` below redacts `authorization_bearer_token` (the audit
+/// upload credential) so a `{:?}` never prints it.
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct AuditLogTrackerConfig {
     pub endpoint: Option<String>,
     pub authorization_bearer_token: Option<String>,
     pub source: AuditLogUploadSource,
+}
+
+impl std::fmt::Debug for AuditLogTrackerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuditLogTrackerConfig")
+            .field("endpoint", &self.endpoint)
+            .field(
+                "authorization_bearer_token",
+                &self
+                    .authorization_bearer_token
+                    .as_ref()
+                    .map(|_| "<redacted>"),
+            )
+            .field("source", &self.source)
+            .finish()
+    }
 }
 
 impl RelayTelemetryResource {

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -179,7 +179,11 @@ pub struct AppGroupProfileComponent {
     pub data_hex: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+/// `image_key_hex`/`image_upload_key_hex` are key material that travels
+/// in-band inside the MLS-protected component (`data_hex` carries the same
+/// bytes). Serialization is the component's design; the hand-written `Debug`
+/// impl below redacts the key fields so a `{:?}` never prints key material.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AppGroupImageComponent {
     pub component_id: u16,
     pub component: String,
@@ -190,6 +194,22 @@ pub struct AppGroupImageComponent {
     pub image_upload_key_hex: String,
     pub media_type: Option<String>,
     pub data_hex: String,
+}
+
+impl std::fmt::Debug for AppGroupImageComponent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppGroupImageComponent")
+            .field("component_id", &self.component_id)
+            .field("component", &self.component)
+            .field("present", &self.present)
+            .field("image_hash_hex", &self.image_hash_hex)
+            .field("image_key_hex", &"<redacted>")
+            .field("image_nonce_hex", &self.image_nonce_hex)
+            .field("image_upload_key_hex", &"<redacted>")
+            .field("media_type", &self.media_type)
+            .field("data_hex", &"<redacted>")
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -721,13 +741,27 @@ impl AppGroupEncryptedMediaComponent {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// `image_key_hex`/`image_upload_key_hex` are key material; the hand-written
+/// `Debug` impl below redacts them.
+#[derive(Clone, Default, PartialEq, Eq)]
 pub(crate) struct AppGroupImageInput {
     pub(crate) image_hash_hex: String,
     pub(crate) image_key_hex: String,
     pub(crate) image_nonce_hex: String,
     pub(crate) image_upload_key_hex: String,
     pub(crate) media_type: Option<String>,
+}
+
+impl std::fmt::Debug for AppGroupImageInput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppGroupImageInput")
+            .field("image_hash_hex", &self.image_hash_hex)
+            .field("image_key_hex", &"<redacted>")
+            .field("image_nonce_hex", &self.image_nonce_hex)
+            .field("image_upload_key_hex", &"<redacted>")
+            .field("media_type", &self.media_type)
+            .finish()
+    }
 }
 
 impl AppGroupImageInput {

--- a/crates/marmot-app/src/key_package_records.rs
+++ b/crates/marmot-app/src/key_package_records.rs
@@ -412,8 +412,10 @@ pub(crate) fn require_key_package_tag(
     reject_duplicate_key_package_tag(event, name)?;
     match event.tag_value(name) {
         Some(value) if predicate(value) => Ok(()),
-        Some(value) => Err(AppError::InvalidKeyPackageEvent(format!(
-            "invalid {name} tag: {value}"
+        // Never echo the tag value: it is attacker-controlled kind:30443 event
+        // content, and this error's Display reaches tracing at upper layers.
+        Some(_) => Err(AppError::InvalidKeyPackageEvent(format!(
+            "invalid {name} tag"
         ))),
         None => Err(AppError::InvalidKeyPackageEvent(format!(
             "missing {name} tag"

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1872,7 +1872,7 @@ impl MarmotApp {
                 tracing::warn!(
                     target: "marmot_app",
                     method = "open_account",
-                    error = %e,
+                    error_kind = e.privacy_safe_kind(),
                     "failed to read forensic audit log settings; continuing without audit logging"
                 );
                 false
@@ -2033,7 +2033,7 @@ impl MarmotApp {
                         tracing::warn!(
                             target: "marmot_app::key_packages",
                             method = "account_key_package_records",
-                            error = %err,
+                            error_kind = err.privacy_safe_kind(),
                             "skipping invalid key package event while listing account packages"
                         );
                     }

--- a/crates/marmot-app/src/media/group_image.rs
+++ b/crates/marmot-app/src/media/group_image.rs
@@ -111,7 +111,7 @@ pub(crate) async fn fetch_group_image(
             .as_slice()
             .try_into()
             .map_err(|_| {
-                AppError::InvalidEncryptedMedia("group image key must be 32 bytes".into())
+                AppError::InvalidEncryptedMedia("group image key must be 32 bytes".to_owned())
             })?,
     );
     let nonce: [u8; 12] = hex::decode(image_nonce_hex)?.try_into().map_err(|_| {

--- a/crates/marmot-app/src/media/group_image.rs
+++ b/crates/marmot-app/src/media/group_image.rs
@@ -3,6 +3,7 @@ use chacha20poly1305::{ChaCha20Poly1305, KeyInit, Nonce};
 use rand::RngCore;
 use rand::rngs::OsRng;
 use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
 
 use super::DEFAULT_BLOSSOM_SERVER_URL;
 use super::blossom::{blossom_blob_url, fetch_blossom_blob, upload_blossom_blob};
@@ -16,6 +17,13 @@ const GROUP_IMAGE_VERSION: &str = "marmot-group-image-v1";
 /// content key travels in-band inside the (MLS-protected) component, so the
 /// image is self-contained and content-addressed by `image_hash_hex` — no URL
 /// or file name is stored.
+///
+/// `image_key_hex` (avatar decryption key) and `image_upload_key_hex` (Blossom
+/// upload secret) are key material. They deliberately flow onward into the
+/// MLS-protected component bytes and the SQLCipher-protected projections, but
+/// must never be logged or `Debug`-rendered — do not add a `Debug` derive
+/// here, and keep the raw key buffers in `upload_group_image`/
+/// `fetch_group_image` wrapped in `Zeroizing`.
 pub(crate) struct GroupImageUpload {
     pub(crate) image_hash_hex: String,
     pub(crate) image_key_hex: String,
@@ -52,12 +60,12 @@ pub(crate) async fn upload_group_image(
             "group image media type must be at most 128 bytes".into(),
         ));
     }
-    let mut content_key = [0_u8; 32];
-    OsRng.fill_bytes(&mut content_key);
+    let mut content_key = Zeroizing::new([0_u8; 32]);
+    OsRng.fill_bytes(content_key.as_mut());
     let mut nonce = [0_u8; 12];
     OsRng.fill_bytes(&mut nonce);
     let aad = group_image_aad(&media_type);
-    let cipher = ChaCha20Poly1305::new_from_slice(&content_key)
+    let cipher = ChaCha20Poly1305::new_from_slice(content_key.as_ref())
         .map_err(|_| AppError::InvalidEncryptedMedia("invalid group image key length".into()))?;
     let encrypted = cipher
         .encrypt(
@@ -77,9 +85,13 @@ pub(crate) async fn upload_group_image(
     upload_blossom_blob(server, &encrypted, &encrypted_hash_hex, &upload_keys, false).await?;
     Ok(GroupImageUpload {
         image_hash_hex: encrypted_hash_hex,
-        image_key_hex: hex::encode(content_key),
+        image_key_hex: hex::encode(&content_key),
         image_nonce_hex: hex::encode(nonce),
-        image_upload_key_hex: hex::encode(upload_keys.secret_key().to_secret_bytes()),
+        // Wipe the copied upload-secret bytes on drop; the hex string moves
+        // into the (MLS-protected, in-band) component fields.
+        image_upload_key_hex: hex::encode(Zeroizing::new(
+            upload_keys.secret_key().to_secret_bytes(),
+        )),
         media_type,
     })
 }
@@ -94,9 +106,14 @@ pub(crate) async fn fetch_group_image(
     server: Option<&str>,
 ) -> Result<Vec<u8>, AppError> {
     let media_type = canonical_media_type(media_type)?;
-    let content_key: [u8; 32] = hex::decode(image_key_hex)?
-        .try_into()
-        .map_err(|_| AppError::InvalidEncryptedMedia("group image key must be 32 bytes".into()))?;
+    let content_key: Zeroizing<[u8; 32]> = Zeroizing::new(
+        Zeroizing::new(hex::decode(image_key_hex)?)
+            .as_slice()
+            .try_into()
+            .map_err(|_| {
+                AppError::InvalidEncryptedMedia("group image key must be 32 bytes".into())
+            })?,
+    );
     let nonce: [u8; 12] = hex::decode(image_nonce_hex)?.try_into().map_err(|_| {
         AppError::InvalidEncryptedMedia("group image nonce must be 12 bytes".into())
     })?;
@@ -113,7 +130,7 @@ pub(crate) async fn fetch_group_image(
         ));
     }
     let aad = group_image_aad(&media_type);
-    let cipher = ChaCha20Poly1305::new_from_slice(&content_key)
+    let cipher = ChaCha20Poly1305::new_from_slice(content_key.as_ref())
         .map_err(|_| AppError::InvalidEncryptedMedia("invalid group image key length".into()))?;
     cipher
         .decrypt(

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -57,7 +57,7 @@ impl ManagedAccountWorker {
                     tracing::debug!(
                         target: "marmot_app::runtime",
                         method = "shutdown",
-                        error = %err,
+                        error_kind = if err.is_panic() { "panic" } else { "cancelled" },
                         "managed account worker exited during shutdown",
                     );
                 }

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -326,7 +326,7 @@ async fn run_app_runtime_account_worker(
     } {
         Ok(client) => client,
         Err(err) => {
-            let message = format!("runtime startup failed: {err}");
+            let message = account_error_message("runtime startup failed", &err);
             publish_app_runtime_account_error(
                 &events,
                 &account_id_hex,
@@ -365,7 +365,7 @@ async fn run_app_runtime_account_worker(
                 &events,
                 &account_id_hex,
                 &account_label,
-                format!("runtime startup snapshot capture failed: {err}"),
+                account_error_message("runtime startup snapshot capture failed", &err),
             );
             None
         }
@@ -450,7 +450,7 @@ async fn run_app_runtime_account_worker(
         Err(err) => {
             // A failed initial catch-up surfaces as an account error but must not
             // fail worker readiness — readiness was already signalled above.
-            let message = format!("runtime startup receive failed: {err}");
+            let message = account_error_message("runtime startup receive failed", &err);
             publish_app_runtime_account_error(
                 &events,
                 &account_id_hex,
@@ -527,7 +527,7 @@ async fn run_app_runtime_account_worker(
                                         &events,
                                         &account_id_hex,
                                         &account_label,
-                                        format!("scheduled convergence failed: {err}"),
+                                        account_error_message("scheduled convergence failed", &err),
                                     );
                                 }
                             }
@@ -539,7 +539,7 @@ async fn run_app_runtime_account_worker(
                             &events,
                             &account_id_hex,
                             &account_label,
-                            format!("scheduled convergence sync failed: {err}"),
+                            account_error_message("scheduled convergence sync failed", &err),
                         );
                     }
                 }
@@ -576,7 +576,7 @@ async fn run_app_runtime_account_worker(
                             &events,
                             &account_id_hex,
                             &account_label,
-                            format!("runtime receive failed: {err}"),
+                            account_error_message("runtime receive failed", &err),
                         );
                         tokio::select! {
                             _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
@@ -602,7 +602,7 @@ async fn run_app_runtime_account_worker(
                                     &events,
                                     &account_id_hex,
                                     &account_label,
-                                    format!("runtime restart failed: {setup_err}"),
+                                    account_error_message("runtime restart failed", &setup_err),
                                 );
                                 tokio::select! {
                                     _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
@@ -646,7 +646,7 @@ async fn handle_account_worker_command(
                     Ok(())
                 }
                 Err(err) => {
-                    let message = format!("runtime catch-up failed: {err}");
+                    let message = account_error_message("runtime catch-up failed", &err);
                     publish_app_runtime_account_error(
                         events,
                         account_id_hex,
@@ -722,7 +722,7 @@ async fn handle_account_worker_command(
                         events,
                         account_id_hex,
                         account_label,
-                        format!("retry recovery drain failed: {err}"),
+                        account_error_message("retry recovery drain failed", &err),
                     ),
                 }
                 publish_app_runtime_group_state_updated(
@@ -1489,6 +1489,15 @@ fn agent_stream_runtime_event(
     ))
 }
 
+/// Build a [`RuntimeAccountError`] message from a static prefix and the
+/// error's privacy-safe kind. These messages leave the runtime: the CLI daemon
+/// persists them into `dm daemon status --json` and the TUI, and host apps may
+/// log them. Never interpolate the raw error — `AppError::Transport` Display
+/// can embed relay URLs, which the privacy invariant forbids surfacing.
+fn account_error_message(prefix: &str, err: &AppError) -> String {
+    format!("{prefix}: {}", err.privacy_safe_kind())
+}
+
 fn publish_app_runtime_account_error(
     events: &broadcast::Sender<MarmotAppEvent>,
     account_id_hex: &str,
@@ -1508,6 +1517,20 @@ mod tests {
 
     fn test_group_id(byte: u8) -> GroupId {
         GroupId::new(vec![byte])
+    }
+
+    #[test]
+    fn account_error_message_never_carries_transport_error_detail() {
+        // Transport errors commonly embed relay URLs (nostr-sdk error strings,
+        // per-endpoint failure reasons). RuntimeAccountError messages are
+        // persisted into `dm daemon status --json` and host surfaces, so only
+        // the stable privacy-safe kind may appear.
+        let err = AppError::Transport(cgka_traits::TransportAdapterError::Publish(
+            "connect relay: wss://private-relay.example".to_owned(),
+        ));
+        let message = account_error_message("runtime receive failed", &err);
+        assert_eq!(message, "runtime receive failed: transport");
+        assert!(!message.contains("private-relay.example"), "{message}");
     }
 
     #[test]

--- a/crates/marmot-app/src/runtime/audit_tracker.rs
+++ b/crates/marmot-app/src/runtime/audit_tracker.rs
@@ -92,7 +92,7 @@ impl AuditLogTrackerUploader {
                     tracing::debug!(
                         target: "marmot_app::audit_log",
                         method = "shutdown",
-                        error = %err,
+                        error_kind = if err.is_panic() { "panic" } else { "cancelled" },
                         "audit log tracker uploader exited during shutdown"
                     );
                 }

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -146,7 +146,7 @@ impl AccountManager {
                 tracing::warn!(
                     target: "marmot_app::runtime",
                     method = "retry_hydrate_quarantined_group",
-                    error = %error,
+                    error_kind = error.privacy_safe_kind(),
                     "group recovered from quarantine but post-recovery catch-up failed; \
                      group is live and will sync on the next cycle"
                 );

--- a/crates/marmot-app/src/sqlcipher.rs
+++ b/crates/marmot-app/src/sqlcipher.rs
@@ -273,7 +273,7 @@ fn derive_sqlcipher_key_material(
     encode_hkdf_part(&mut info, keys.public_key().to_bytes().as_slice());
     let mut output = Zeroizing::new([0_u8; SQLCIPHER_KEY_LEN]);
     hkdf.expand(&info, output.as_mut())
-        .map_err(|_| AppError::SqlcipherKeyDerivation("HKDF output length rejected".into()))?;
+        .map_err(|_| AppError::SqlcipherKeyDerivation("HKDF output length rejected".to_owned()))?;
     Ok(hex::encode(&output))
 }
 

--- a/crates/marmot-app/src/sqlcipher.rs
+++ b/crates/marmot-app/src/sqlcipher.rs
@@ -16,6 +16,7 @@ use rand::rngs::OsRng;
 use rusqlite::Connection;
 use sha2::{Digest, Sha256};
 use storage_sqlite::{SqlCipherHardening, SqlCipherKey, open_hardened_sqlcipher};
+use zeroize::Zeroizing;
 
 use crate::{AppError, MarmotApp};
 
@@ -260,17 +261,20 @@ fn derive_sqlcipher_key_material(
     salt: &[u8; SQLCIPHER_SALT_LEN],
     kind: SqlcipherDatabaseKind,
 ) -> Result<String, AppError> {
-    let secret = keys.secret_key().to_secret_bytes();
-    let hkdf = Hkdf::<Sha256>::new(Some(salt), &secret);
+    // The account-secret copy and the raw derived key are wiped on drop; the
+    // returned hex string is moved straight into `SqlCipherKey`, which
+    // zeroizes it.
+    let secret = Zeroizing::new(keys.secret_key().to_secret_bytes());
+    let hkdf = Hkdf::<Sha256>::new(Some(salt), secret.as_ref());
     let mut info = Vec::new();
     encode_hkdf_part(&mut info, b"marmot-app-sqlcipher-key");
     encode_hkdf_part(&mut info, kind.hkdf_info_label());
     encode_hkdf_part(&mut info, label.as_bytes());
     encode_hkdf_part(&mut info, keys.public_key().to_bytes().as_slice());
-    let mut output = [0_u8; SQLCIPHER_KEY_LEN];
-    hkdf.expand(&info, &mut output)
+    let mut output = Zeroizing::new([0_u8; SQLCIPHER_KEY_LEN]);
+    hkdf.expand(&info, output.as_mut())
         .map_err(|_| AppError::SqlcipherKeyDerivation("HKDF output length rejected".into()))?;
-    Ok(hex::encode(output))
+    Ok(hex::encode(&output))
 }
 
 fn legacy_sqlcipher_key_material(
@@ -278,12 +282,16 @@ fn legacy_sqlcipher_key_material(
     keys: &nostr::Keys,
     kind: SqlcipherDatabaseKind,
 ) -> String {
+    // Wipe the account-secret copy and the raw digest (the legacy DB key) on
+    // drop; the returned hex string is moved straight into `SqlCipherKey`,
+    // which zeroizes it.
     let mut hasher = Sha256::new();
     hasher.update(kind.legacy_hash_label());
     hasher.update(label.as_bytes());
     hasher.update(keys.public_key().to_bytes());
-    hasher.update(keys.secret_key().to_secret_bytes());
-    hex::encode(hasher.finalize())
+    hasher.update(Zeroizing::new(keys.secret_key().to_secret_bytes()));
+    let digest: Zeroizing<[u8; 32]> = Zeroizing::new(hasher.finalize().into());
+    hex::encode(&digest)
 }
 
 fn encode_hkdf_part(out: &mut Vec<u8>, bytes: &[u8]) {

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -34,6 +34,12 @@
 //! A recorder stamps its configured mode onto every event. Switching modes
 //! ([`ForensicRecorder::set_data_mode`]) rotates the backing store so each
 //! file has a single, unambiguous mode boundary.
+//!
+//! The obfuscated-mode contract is enforced at the sink, not just by producer
+//! convention: [`JsonlRecorder`]'s `record()` scrubs full-data-only fields
+//! (decoded payloads, full pubkeys/npubs) before serializing when the mode is
+//! [`AuditDataMode::ObfuscatedSensitiveData`], so a single producer bug cannot
+//! write them into a log that is expected to be safe to share.
 
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Write};
@@ -1199,6 +1205,86 @@ fn stamp_system_human_action(
     Some(context)
 }
 
+/// Enforce the obfuscated-mode redaction contract at the sink.
+///
+/// `record()` is the single chokepoint every producer writes through, so
+/// scrubbing here means one producer bug (or a future caller unaware of the
+/// contract) cannot write full-data-only material — decrypted content, full
+/// author/subject pubkeys, npubs — into an obfuscated-mode audit log that is
+/// expected to be safe to share. Obfuscated-safe siblings (salted member refs,
+/// digests, lengths, counts) are kept, so a scrubbed row stays useful and the
+/// producer bug stays visible to analyzers.
+fn scrub_full_data_fields(kind: &mut AuditEventKind, context: &mut Option<AuditEventContext>) {
+    if let Some(context) = context.as_mut()
+        && let Some(source) = context.source.as_mut()
+    {
+        scrub_source_context(source);
+    }
+    match kind {
+        AuditEventKind::SourceContext { source } => scrub_source_context(source),
+        AuditEventKind::MessageContentDecoded {
+            author,
+            decoded_payload,
+            decoded_app_event,
+            ..
+        } => {
+            author.member_pubkey_hex = None;
+            author.account_pubkey_hex = None;
+            author.npub = None;
+            decoded_payload.text = None;
+            decoded_payload.json = None;
+            decoded_payload.bytes_b64 = None;
+            *decoded_app_event = None;
+        }
+        AuditEventKind::RecipientExpectation { expectation, .. } => {
+            expectation.expected_pubkeys_hex.clear();
+        }
+        AuditEventKind::SendOutcome {
+            outbound_messages, ..
+        }
+        | AuditEventKind::CreateGroupOutcome {
+            outbound_messages, ..
+        } => {
+            for message in outbound_messages {
+                if let Some(expectation) = message.recipient_expectation.as_mut() {
+                    expectation.expected_pubkeys_hex.clear();
+                }
+            }
+        }
+        AuditEventKind::GroupStateChanged {
+            actor_pubkey_hex,
+            subject_pubkey_hex,
+            value,
+            ..
+        } => {
+            *actor_pubkey_hex = None;
+            *subject_pubkey_hex = None;
+            if let Some(value) = value.as_mut() {
+                value.text = None;
+                value.json = None;
+                value.pubkeys_hex.clear();
+            }
+        }
+        AuditEventKind::ConvergenceDecision { candidates, .. } => {
+            for candidate in candidates {
+                candidate.tip_committer_pubkey_hex = None;
+                if let Some(score) = candidate.score.as_mut() {
+                    score.tip_committer_pubkey_hex = None;
+                }
+                for witness in &mut candidate.app_witnesses {
+                    witness.sender_pubkey_hex = None;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn scrub_source_context(source: &mut AuditSourceContext) {
+    source.account_pubkey_hex = None;
+    source.account_npub = None;
+}
+
 impl ForensicRecorder for JsonlRecorder {
     fn record(&self, record: AuditRecord) {
         // Poisoning means a prior `record()` panicked while holding the lock.
@@ -1214,7 +1300,11 @@ impl ForensicRecorder for JsonlRecorder {
         };
         let seq = inner.seq;
         inner.seq = seq.wrapping_add(1);
-        let context = stamp_system_human_action(record.context, &record.kind);
+        let mut kind = record.kind;
+        let mut context = stamp_system_human_action(record.context, &kind);
+        if inner.data_mode == AuditDataMode::ObfuscatedSensitiveData {
+            scrub_full_data_fields(&mut kind, &mut context);
+        }
         let event = AuditEvent {
             schema_version: AUDIT_LOG_SCHEMA_VERSION.to_string(),
             seq,
@@ -1228,7 +1318,7 @@ impl ForensicRecorder for JsonlRecorder {
             engine_id: inner.engine_id.clone(),
             group_ref: record.group_ref,
             context,
-            kind: record.kind,
+            kind,
         };
         if let Ok(line) = serde_json::to_string(&event) {
             if writeln!(inner.writer, "{line}").is_err() {

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -1019,3 +1019,214 @@ fn sample_events_serialize_within_schema_property_names() {
     let value = serde_json::to_value(&event).unwrap();
     assert_keys_within_schema(&value, &schema, &defs, "event");
 }
+
+fn full_data_message_content_decoded() -> AuditEventKind {
+    AuditEventKind::MessageContentDecoded {
+        msg_id: "msg-1".into(),
+        artifact_kind: Some(MessageArtifactKind::ApplicationMessage),
+        author: MessageAuthor {
+            member_ref: Some("member-ref-1".into()),
+            member_pubkey_hex: Some("aa".repeat(32)),
+            account_pubkey_hex: Some("bb".repeat(32)),
+            npub: Some("npub1exampleexample".into()),
+        },
+        decoded_payload: DecodedPayload {
+            content_type: "text".into(),
+            text: Some("secret plaintext".into()),
+            json: Some(serde_json::json!({"content": "secret plaintext"})),
+            bytes_b64: Some("c2VjcmV0".into()),
+        },
+        decoded_app_event: Some(DecodedApplicationEvent {
+            format: "nostr".into(),
+            content: Some("secret plaintext".into()),
+            pubkey_hex: Some("cc".repeat(32)),
+            ..DecodedApplicationEvent::default()
+        }),
+    }
+}
+
+#[test]
+fn obfuscated_mode_recorder_scrubs_full_data_only_fields_at_the_sink() {
+    let dir = TempDir::new().unwrap();
+    let path = default_jsonl_path(dir.path(), "engine-abc");
+    // Default mode is ObfuscatedSensitiveData.
+    let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+
+    // A buggy producer submits full-data-only material in obfuscated mode.
+    recorder.record(AuditRecord::new(
+        Some("group-1".into()),
+        full_data_message_content_decoded(),
+    ));
+    recorder.record(AuditRecord::new(
+        Some("group-1".into()),
+        AuditEventKind::RecipientExpectation {
+            msg_id: "msg-2".into(),
+            expectation: RecipientExpectation {
+                artifact_kind: MessageArtifactKind::ApplicationMessage,
+                recipient_scope: RecipientScope::AllOtherCurrentGroupMembers,
+                membership_epoch: Some(3),
+                basis_commit_id: None,
+                expected_member_refs: vec!["member-ref-1".into()],
+                expected_pubkeys_hex: vec!["dd".repeat(32)],
+                expected_count: Some(1),
+            },
+        },
+    ));
+    recorder.record(AuditRecord::new(
+        Some("group-1".into()),
+        AuditEventKind::GroupStateChanged {
+            epoch: 4,
+            change_kind: "profile_changed".into(),
+            membership_change_source: None,
+            actor_member_ref: Some("member-ref-1".into()),
+            actor_pubkey_hex: Some("ee".repeat(32)),
+            subject_member_ref: None,
+            subject_pubkey_hex: Some("ff".repeat(32)),
+            origin_commit_id: None,
+            fields: vec!["name".into()],
+            component_ids: Vec::new(),
+            value: Some(GroupStateValue {
+                digest: Some("ab".repeat(32)),
+                len: Some(11),
+                text: Some("secret group name".into()),
+                json: None,
+                pubkeys_hex: vec!["dd".repeat(32)],
+            }),
+        },
+    ));
+    recorder.record(
+        AuditRecord::new(
+            None,
+            AuditEventKind::SourceContext {
+                source: AuditSourceContext {
+                    account_label: Some("alice".into()),
+                    account_pubkey_hex: Some("aa".repeat(32)),
+                    account_npub: Some("npub1exampleexample".into()),
+                    ..AuditSourceContext::default()
+                },
+            },
+        )
+        .with_context(AuditEventContext {
+            source: Some(AuditSourceContext {
+                account_pubkey_hex: Some("aa".repeat(32)),
+                ..AuditSourceContext::default()
+            }),
+            ..AuditEventContext::default()
+        }),
+    );
+    drop(recorder);
+
+    let contents = fs::read_to_string(&path).unwrap();
+    for secret in [
+        "secret plaintext",
+        "secret group name",
+        "c2VjcmV0",
+        "npub1exampleexample",
+        &"aa".repeat(32),
+        &"bb".repeat(32),
+        &"cc".repeat(32),
+        &"dd".repeat(32),
+        &"ee".repeat(32),
+        &"ff".repeat(32),
+    ] {
+        assert!(
+            !contents.contains(secret),
+            "obfuscated-mode log leaked {secret:?}: {contents}"
+        );
+    }
+
+    // Obfuscated-safe siblings survive the scrub.
+    assert!(contents.contains("member-ref-1"), "{contents}");
+    assert!(contents.contains(&"ab".repeat(32)), "{contents}");
+    assert!(contents.contains("alice"), "{contents}");
+}
+
+#[test]
+fn full_data_mode_recorder_keeps_full_data_fields() {
+    let dir = TempDir::new().unwrap();
+    let path = default_jsonl_path(dir.path(), "engine-abc");
+    let recorder = JsonlRecorder::open_with_data_mode(
+        &path,
+        "engine-abc".to_string(),
+        None,
+        AuditDataMode::FullData,
+    )
+    .unwrap();
+    recorder.record(AuditRecord::new(
+        Some("group-1".into()),
+        full_data_message_content_decoded(),
+    ));
+    drop(recorder);
+
+    let contents = fs::read_to_string(&path).unwrap();
+    assert!(contents.contains("secret plaintext"), "{contents}");
+    assert!(contents.contains(&"aa".repeat(32)), "{contents}");
+}
+
+#[test]
+fn obfuscated_mode_scrubs_outbound_and_convergence_pubkeys() {
+    let dir = TempDir::new().unwrap();
+    let path = default_jsonl_path(dir.path(), "engine-abc");
+    let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+    recorder.record(AuditRecord::new(
+        Some("group-1".into()),
+        AuditEventKind::SendOutcome {
+            intent_kind: "app_message".into(),
+            result_kind: "published".into(),
+            outbound_messages: vec![OutboundMessage {
+                msg_id: "msg-3".into(),
+                artifact_kind: MessageArtifactKind::ApplicationMessage,
+                transport: None,
+                recipient_expectation: Some(RecipientExpectation {
+                    artifact_kind: MessageArtifactKind::ApplicationMessage,
+                    recipient_scope: RecipientScope::AllOtherCurrentGroupMembers,
+                    membership_epoch: None,
+                    basis_commit_id: None,
+                    expected_member_refs: vec!["member-ref-1".into()],
+                    expected_pubkeys_hex: vec!["dd".repeat(32)],
+                    expected_count: Some(1),
+                }),
+            }],
+        },
+    ));
+    recorder.record(AuditRecord::new(
+        Some("group-1".into()),
+        AuditEventKind::ConvergenceDecision {
+            current_tip_epoch: 7,
+            max_rewind_commits: 5,
+            candidates: vec![ConvergenceCandidate {
+                branch_id: "branch-1".into(),
+                fork_epoch: 6,
+                tip_epoch: 7,
+                tip_committer_pubkey_hex: Some("ee".repeat(32)),
+                score: Some(ConvergenceScore {
+                    tip_committer_pubkey_hex: Some("ee".repeat(32)),
+                    ..ConvergenceScore::default()
+                }),
+                app_witnesses: vec![ConvergenceAppWitness {
+                    epoch: 7,
+                    sender_ref: Some("member-ref-1".into()),
+                    sender_pubkey_hex: Some("ff".repeat(32)),
+                }],
+                ..ConvergenceCandidate::default()
+            }],
+            rule_trace: Vec::new(),
+            selected_branch_id: Some("branch-1".into()),
+            selected_fork_epoch: None,
+            selected_tip_epoch: None,
+            losing_branch_ids: Vec::new(),
+            error_kinds: Vec::new(),
+        },
+    ));
+    drop(recorder);
+
+    let contents = fs::read_to_string(&path).unwrap();
+    for secret in [&"dd".repeat(32), &"ee".repeat(32), &"ff".repeat(32)] {
+        assert!(
+            !contents.contains(secret),
+            "obfuscated-mode log leaked {secret:?}: {contents}"
+        );
+    }
+    assert!(contents.contains("member-ref-1"), "{contents}");
+    assert!(contents.contains("branch-1"), "{contents}");
+}

--- a/crates/marmot-uniffi/src/commands/audit.rs
+++ b/crates/marmot-uniffi/src/commands/audit.rs
@@ -35,14 +35,16 @@ impl Marmot {
     /// Supply non-persisted audit tracker upload metadata: optional Goggles
     /// upload URL override, bearer token from the host app, and optional human
     /// source labels.
+    ///
+    /// The returned config confirms what was stored but never echoes the
+    /// bearer token back across FFI: secrets flow in, not out.
     pub fn set_audit_log_tracker_config(
         &self,
         config: AuditLogTrackerConfigFfi,
     ) -> Result<AuditLogTrackerConfigFfi, MarmotKitError> {
-        Ok(self
-            .runtime
-            .set_audit_log_tracker_config(config.into())?
-            .into())
+        Ok(AuditLogTrackerConfigFfi::redacted(
+            self.runtime.set_audit_log_tracker_config(config.into())?,
+        ))
     }
 
     /// Local JSONL audit logs available for explicit forensic upload.

--- a/crates/marmot-uniffi/src/conversions/audit.rs
+++ b/crates/marmot-uniffi/src/conversions/audit.rs
@@ -154,11 +154,31 @@ impl From<AuditLogUploadSource> for AuditLogUploadSourceFfi {
     }
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+/// Tracker upload config supplied by the host app. Write-only across FFI:
+/// `authorization_bearer_token` is accepted here but never returned back to
+/// the host — [`redacted`](Self::redacted) strips it — and the hand-written
+/// `Debug` impl below never prints it.
+#[derive(Clone, uniffi::Record)]
 pub struct AuditLogTrackerConfigFfi {
     pub endpoint: Option<String>,
     pub authorization_bearer_token: Option<String>,
     pub source: AuditLogUploadSourceFfi,
+}
+
+impl std::fmt::Debug for AuditLogTrackerConfigFfi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuditLogTrackerConfigFfi")
+            .field("endpoint", &self.endpoint)
+            .field(
+                "authorization_bearer_token",
+                &self
+                    .authorization_bearer_token
+                    .as_ref()
+                    .map(|_| "<redacted>"),
+            )
+            .field("source", &self.source)
+            .finish()
+    }
 }
 
 impl From<AuditLogTrackerConfigFfi> for AuditLogTrackerConfig {
@@ -171,12 +191,53 @@ impl From<AuditLogTrackerConfigFfi> for AuditLogTrackerConfig {
     }
 }
 
-impl From<AuditLogTrackerConfig> for AuditLogTrackerConfigFfi {
-    fn from(value: AuditLogTrackerConfig) -> Self {
+impl AuditLogTrackerConfigFfi {
+    /// The stored config with the bearer token stripped, for returning across
+    /// FFI: secrets flow in through setters but are never handed back out.
+    pub(crate) fn redacted(value: AuditLogTrackerConfig) -> Self {
         Self {
             endpoint: value.endpoint,
-            authorization_bearer_token: value.authorization_bearer_token,
+            authorization_bearer_token: None,
             source: value.source.into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TOKEN: &str = "super-secret-bearer-token";
+
+    fn config_with_token() -> AuditLogTrackerConfigFfi {
+        AuditLogTrackerConfigFfi {
+            endpoint: Some("https://goggles.example/upload".to_owned()),
+            authorization_bearer_token: Some(TOKEN.to_owned()),
+            source: AuditLogUploadSourceFfi {
+                device_label: Some("test-device".to_owned()),
+                platform: None,
+                app_version: None,
+            },
+        }
+    }
+
+    #[test]
+    fn audit_tracker_config_debug_redacts_bearer_token() {
+        let rendered = format!("{:?}", config_with_token());
+        assert!(!rendered.contains(TOKEN), "{rendered}");
+        assert!(rendered.contains("<redacted>"), "{rendered}");
+        // Non-secret fields stay visible for diagnostics.
+        assert!(rendered.contains("goggles.example"), "{rendered}");
+    }
+
+    #[test]
+    fn audit_tracker_config_redacted_strips_bearer_token() {
+        let stored: AuditLogTrackerConfig = config_with_token().into();
+        let returned = AuditLogTrackerConfigFfi::redacted(stored);
+        assert_eq!(returned.authorization_bearer_token, None);
+        assert_eq!(
+            returned.endpoint.as_deref(),
+            Some("https://goggles.example/upload")
+        );
     }
 }

--- a/crates/marmot-uniffi/src/conversions/chat_list.rs
+++ b/crates/marmot-uniffi/src/conversions/chat_list.rs
@@ -7,8 +7,13 @@ use crate::markdown::MarkdownDocumentFfi;
 
 /// Group avatar reference. `image_key_hex` is the symmetric key that decrypts
 /// the avatar blob and `image_upload_key_hex` is the Blossom upload secret;
-/// the hand-written `Debug` impl below redacts both so a `{:?}` (or a host's
-/// generated `description`/`toString`) never prints key material.
+/// the hand-written `Debug` impl below redacts both so a Rust-side `{:?}`
+/// never prints key material.
+///
+/// Host-language stringification is NOT covered: uniffi 0.28 generates plain
+/// record types (e.g. Kotlin data classes) whose default `toString` prints
+/// all fields, and `#[uniffi::export(Debug)]` on records requires uniffi
+/// >= 0.29. Host apps must not log this record until that upgrade lands.
 #[derive(Clone, uniffi::Record)]
 pub struct ChatListAvatarFfi {
     pub image_hash_hex: String,

--- a/crates/marmot-uniffi/src/conversions/chat_list.rs
+++ b/crates/marmot-uniffi/src/conversions/chat_list.rs
@@ -5,13 +5,29 @@ use marmot_app::{ChatListAvatar, ChatListMessagePreview, ChatListRow, RuntimeCha
 use super::common::{SelfMembershipFfi, markdown_content_tokens};
 use crate::markdown::MarkdownDocumentFfi;
 
-#[derive(Clone, Debug, uniffi::Record)]
+/// Group avatar reference. `image_key_hex` is the symmetric key that decrypts
+/// the avatar blob and `image_upload_key_hex` is the Blossom upload secret;
+/// the hand-written `Debug` impl below redacts both so a `{:?}` (or a host's
+/// generated `description`/`toString`) never prints key material.
+#[derive(Clone, uniffi::Record)]
 pub struct ChatListAvatarFfi {
     pub image_hash_hex: String,
     pub image_key_hex: String,
     pub image_nonce_hex: String,
     pub image_upload_key_hex: String,
     pub media_type: Option<String>,
+}
+
+impl std::fmt::Debug for ChatListAvatarFfi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChatListAvatarFfi")
+            .field("image_hash_hex", &self.image_hash_hex)
+            .field("image_key_hex", &"<redacted>")
+            .field("image_nonce_hex", &self.image_nonce_hex)
+            .field("image_upload_key_hex", &"<redacted>")
+            .field("media_type", &self.media_type)
+            .finish()
+    }
 }
 
 impl From<ChatListAvatar> for ChatListAvatarFfi {
@@ -160,5 +176,29 @@ impl From<marmot_app::ChatListUpdateTrigger> for ChatListUpdateTriggerFfi {
             marmot_app::ChatListUpdateTrigger::SnapshotRefresh => Self::SnapshotRefresh,
             marmot_app::ChatListUpdateTrigger::Removed => Self::Removed,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chat_list_avatar_debug_redacts_key_material() {
+        let key_hex = "aa".repeat(32);
+        let upload_key_hex = "bb".repeat(32);
+        let avatar = ChatListAvatarFfi {
+            image_hash_hex: "cc".repeat(32),
+            image_key_hex: key_hex.clone(),
+            image_nonce_hex: "dd".repeat(12),
+            image_upload_key_hex: upload_key_hex.clone(),
+            media_type: Some("image/png".to_owned()),
+        };
+        let rendered = format!("{avatar:?}");
+        assert!(!rendered.contains(&key_hex), "{rendered}");
+        assert!(!rendered.contains(&upload_key_hex), "{rendered}");
+        assert!(rendered.contains("<redacted>"), "{rendered}");
+        // Non-secret fields stay visible for diagnostics.
+        assert!(rendered.contains(&"cc".repeat(32)), "{rendered}");
     }
 }

--- a/crates/marmot-uniffi/src/conversions/relay.rs
+++ b/crates/marmot-uniffi/src/conversions/relay.rs
@@ -54,11 +54,30 @@ impl From<RelayTelemetryResourceFfi> for RelayTelemetryResource {
     }
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+/// Relay-telemetry runtime config supplied by the host app. The hand-written
+/// `Debug` impl below redacts `authorization_bearer_token` (the OTLP push
+/// credential) so a `{:?}` never prints it.
+#[derive(Clone, uniffi::Record)]
 pub struct RelayTelemetryRuntimeConfigFfi {
     pub otlp_endpoint: Option<String>,
     pub authorization_bearer_token: Option<String>,
     pub resource: Option<RelayTelemetryResourceFfi>,
+}
+
+impl std::fmt::Debug for RelayTelemetryRuntimeConfigFfi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RelayTelemetryRuntimeConfigFfi")
+            .field("otlp_endpoint", &self.otlp_endpoint)
+            .field(
+                "authorization_bearer_token",
+                &self
+                    .authorization_bearer_token
+                    .as_ref()
+                    .map(|_| "<redacted>"),
+            )
+            .field("resource", &self.resource)
+            .finish()
+    }
 }
 
 impl From<RelayTelemetryRuntimeConfigFfi> for RelayTelemetryRuntimeConfig {
@@ -161,5 +180,23 @@ impl From<RelayPlaneHealth> for RelayHealthFfi {
             connection_attempts: value.connection_attempts as u32,
             connection_successes: value.connection_successes as u32,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relay_telemetry_config_debug_redacts_bearer_token() {
+        let config = RelayTelemetryRuntimeConfigFfi {
+            otlp_endpoint: Some("https://otlp.example/v1/metrics".to_owned()),
+            authorization_bearer_token: Some("super-secret-otlp-token".to_owned()),
+            resource: None,
+        };
+        let rendered = format!("{config:?}");
+        assert!(!rendered.contains("super-secret-otlp-token"), "{rendered}");
+        assert!(rendered.contains("<redacted>"), "{rendered}");
+        assert!(rendered.contains("otlp.example"), "{rendered}");
     }
 }

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -659,11 +659,20 @@ impl SqliteAccountStorage {
         if outcome.pruned_messages > 0 {
             let conn = self.lock()?;
             if let Err(error) = checkpoint_wal_truncate_after_secure_prune(&conn) {
+                // Log only the stable variant kind: storage error Display can
+                // embed SQL text or file paths.
                 tracing::warn!(
                     target: "storage_sqlite::retention",
                     method = "secure_prune_app_events_before",
                     pruned_messages = outcome.pruned_messages,
-                    error = %error,
+                    error_kind = match &error {
+                        StorageError::NotFound => "not_found",
+                        StorageError::AlreadyExists => "already_exists",
+                        StorageError::SnapshotMissing(_) => "snapshot_missing",
+                        StorageError::Busy(_) => "busy",
+                        StorageError::Backend(_) => "backend",
+                        StorageError::Serialization(_) => "serialization",
+                    },
                     "retention secure-delete WAL checkpoint failed after committed prune"
                 );
             }

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -37,13 +37,29 @@ impl AccountUnreadTotal {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+/// `image_key_hex`/`image_upload_key_hex` are key material. They are
+/// intentionally serialized into the SQLCipher-protected projection, but the
+/// hand-written `Debug` impl below redacts them so a `{:?}` never prints key
+/// material into logs.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatListAvatar {
     pub image_hash_hex: String,
     pub image_key_hex: String,
     pub image_nonce_hex: String,
     pub image_upload_key_hex: String,
     pub media_type: Option<String>,
+}
+
+impl std::fmt::Debug for ChatListAvatar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChatListAvatar")
+            .field("image_hash_hex", &self.image_hash_hex)
+            .field("image_key_hex", &"<redacted>")
+            .field("image_nonce_hex", &self.image_nonce_hex)
+            .field("image_upload_key_hex", &"<redacted>")
+            .field("media_type", &self.media_type)
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/traits/tests/error_display.rs
+++ b/crates/traits/tests/error_display.rs
@@ -47,6 +47,20 @@ fn engine_error_display_does_not_expose_group_or_member_ids() {
 }
 
 #[test]
+fn transport_adapter_error_display_passes_reasons_through_verbatim() {
+    // Reason strings appear verbatim in Display, and Display reaches upper
+    // layers that log or persist errors. Constructors must therefore never
+    // embed relay URLs or endpoint values in reasons; the Nostr adapter
+    // builds operation-only reasons (asserted in transport-nostr-adapter's
+    // sdk_client tests). This test pins the passthrough behavior that
+    // contract rests on.
+    let err = TransportAdapterError::Publish("connect relay failed".to_owned());
+    assert_eq!(err.to_string(), "publish failed: connect relay failed");
+    let err = TransportAdapterError::Subscription("add relay failed".to_owned());
+    assert_eq!(err.to_string(), "subscription failed: add relay failed");
+}
+
+#[test]
 fn transport_and_app_event_error_display_do_not_expose_pubkeys() {
     let pubkey = "cc".repeat(32);
 

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -297,10 +297,15 @@ impl NostrSdkRelayClient {
         .await
         {
             Ok(Ok(())) => {}
-            Ok(Err(e)) => {
+            // Failure reasons never embed the nostr-sdk error Display: it
+            // commonly carries the relay URL, and these reasons flow into
+            // `TransportAdapterError::Publish` Display (see
+            // `finish_publish_outcome`), which upper layers may log. The
+            // endpoint stays available on the structured failure record.
+            Ok(Err(_)) => {
                 return Err(TransportEndpointFailure {
                     endpoint: transport_endpoint,
-                    reason: format!("connect relay: {e}"),
+                    reason: "connect relay failed".to_owned(),
                 });
             }
             Err(_) => {
@@ -332,8 +337,10 @@ impl NostrSdkRelayClient {
                         .cloned()
                         .unwrap_or_else(|| "relay did not acknowledge event".to_owned());
                 }
-                Ok(Err(e)) => {
-                    last_error = format!("send event: {e}");
+                Ok(Err(_)) => {
+                    // No sdk error Display here either — it can carry the
+                    // relay URL.
+                    last_error = "send event failed".to_owned();
                 }
                 Err(_) => {
                     last_error = "send event timed out".to_owned();
@@ -358,7 +365,9 @@ impl NostrSdkRelayClient {
         self.client
             .add_relay(endpoint)
             .await
-            .map_err(|e| TransportAdapterError::Subscription(format!("add relay: {e}")))?;
+            // The sdk error Display can carry the relay URL; keep the error
+            // operation-only so `TransportAdapterError` Display stays URL-free.
+            .map_err(|_| TransportAdapterError::Subscription("add relay failed".to_owned()))?;
         Ok(())
     }
 
@@ -387,9 +396,9 @@ impl NostrSdkRelayClient {
                 Ok(true)
             }
             Ok(false) => Ok(false),
-            Err(e) => Err(TransportEndpointFailure {
+            Err(_) => Err(TransportEndpointFailure {
                 endpoint: transport_endpoint,
-                reason: format!("add publish relay: {e}"),
+                reason: "add publish relay failed".to_owned(),
             }),
         }
     }
@@ -504,7 +513,7 @@ impl NostrRelayClient for NostrSdkRelayClient {
                 None,
             )
             .await
-            .map_err(|e| TransportAdapterError::Subscription(format!("subscribe: {e}")))?;
+            .map_err(|_| TransportAdapterError::Subscription("subscribe failed".to_owned()))?;
 
         if output.success.is_empty() {
             return Err(TransportAdapterError::Subscription(format!(
@@ -723,10 +732,10 @@ fn parse_endpoints(
     endpoints
         .iter()
         .map(|endpoint| {
-            RelayUrl::parse(endpoint.as_str()).map_err(|e| {
-                TransportAdapterError::Subscription(format!(
-                    "{context}: invalid endpoint {endpoint}: {e}"
-                ))
+            // Neither the endpoint nor the parse error (which echoes its
+            // input) may appear here: this Display reaches upper-layer logs.
+            RelayUrl::parse(endpoint.as_str()).map_err(|_| {
+                TransportAdapterError::Subscription(format!("{context}: invalid relay endpoint"))
             })
         })
         .collect()
@@ -793,6 +802,30 @@ mod tests {
             .sign_with_keys(&ephemeral)
             .expect("sign ephemeral 445");
         NostrTransportEvent::from_nostr_event(&signed).expect("dto from signed event")
+    }
+
+    #[test]
+    fn publish_failure_error_display_carries_no_relay_url() {
+        // Per-endpoint failure reasons are joined into
+        // `TransportAdapterError::Publish` Display, which upper layers may
+        // log; the privacy invariant forbids relay URLs there. The endpoint
+        // stays available on the structured failure record only.
+        let endpoint = TransportEndpoint("wss://private-relay.example".into());
+        let err = NostrSdkRelayClient::finish_publish_outcome(
+            cgka_traits::MessageId::new(vec![0xD4; 32]),
+            Vec::new(),
+            vec![TransportEndpointFailure {
+                endpoint: endpoint.clone(),
+                reason: "connect relay failed".to_owned(),
+            }],
+            1,
+            false,
+        )
+        .unwrap_err();
+
+        let rendered = err.to_string();
+        assert!(!rendered.contains("private-relay.example"), "{rendered}");
+        assert!(rendered.contains("connect relay failed"), "{rendered}");
     }
 
     #[test]
@@ -1146,7 +1179,11 @@ mod tests {
         })
         .unwrap_err();
 
-        assert!(err.to_string().contains("invalid endpoint"));
+        let rendered = err.to_string();
+        assert!(rendered.contains("invalid relay endpoint"), "{rendered}");
+        // The privacy invariant forbids relay URLs in error Display: the bad
+        // endpoint itself must not be echoed back.
+        assert!(!rendered.contains("not a relay url"), "{rendered}");
     }
 
     async fn silent_relay_url() -> String {

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -331,11 +331,17 @@ impl NostrSdkRelayClient {
                     });
                 }
                 Ok(Ok(output)) => {
-                    last_error = output
-                        .failed
-                        .get(&endpoint)
-                        .cloned()
-                        .unwrap_or_else(|| "relay did not acknowledge event".to_owned());
+                    // The relay's rejection text is remote-controlled and can
+                    // embed the relay URL, event ids, or arbitrary content, so
+                    // it must not reach the display-bearing publish error
+                    // (`finish_publish_outcome` joins these reasons into
+                    // `TransportAdapterError::Publish`). Map to a stable
+                    // reason instead of echoing it.
+                    last_error = if output.failed.contains_key(&endpoint) {
+                        "relay rejected event".to_owned()
+                    } else {
+                        "relay did not acknowledge event".to_owned()
+                    };
                 }
                 Ok(Err(_)) => {
                     // No sdk error Display here either — it can carry the

--- a/docs/marmot-architecture/overview/observability.md
+++ b/docs/marmot-architecture/overview/observability.md
@@ -1,7 +1,7 @@
 ---
 title: "Observability & Privacy"
 created: 2026-05-09
-updated: 2026-06-06
+updated: 2026-07-02
 tags: [marmot, overview, observability, tracing, privacy]
 status: overview
 ---
@@ -42,13 +42,34 @@ tracing::debug!(
 Keep field names neutral. Prefer `endpoint_count` over a field or local name that contains a concrete relay URL. Prefer
 `delivered` over a message id.
 
+## Sensitive-value classification
+
+A sensitive value can escape through more than one exit. Each value class below lists the required posture per escape
+route, so "does not leak" holds by construction rather than by author vigilance at every call site (tracked in
+darkmatter#379).
+
+| Value class | Memory | `Debug`/`Display` | FFI | Tracing/logs | Forensic audit |
+| --- | --- | --- | --- | --- | --- |
+| Key material (account secret, SQLCipher keys, media/avatar keys, exporter secrets) | `Zeroizing` for raw buffers and copies | Redacted (hand-written `Debug`, never derive on the holding struct) | Setters accept, accessors never return | Never | Never, either mode |
+| Bearer/upload tokens (OTLP, audit tracker) | Short-lived; avoid long-lived copies | Redacted | Write-only: setters in, no read-back | Never | Never, either mode |
+| Plaintext / decoded content | n/a | Only on message DTOs that never reach tracing | Allowed (it is the product) | Never | Full-data mode only; scrubbed at the sink in obfuscated mode |
+| Full pubkeys / npubs | n/a | Allowed on DTOs | Allowed | Never | Full-data mode only; scrubbed at the sink; salted member refs are the obfuscated form |
+| Relay URLs / endpoints | n/a | Structured fields only (never inside error `reason` strings) | Allowed | Never — log `endpoint_count` or a privacy-safe error kind | Allowed (audit is local-only, explicit opt-in) |
+| Account/group/message ids | n/a | Allowed on DTOs | Allowed | Never | Allowed (hashed/truncated forms preferred) |
+| Errors wrapping any of the above | n/a | Constructors keep `Display` free of URLs/ids/values | n/a | Log `error_kind = privacy_safe_kind()` (or `io::ErrorKind`, variant names) — never `{err}`/`error = %err` | `error_kind` strings only |
+
 ## Current enforcement
 
 `crates/cgka-conformance-simulator/tests/tracing_audit.rs` scans production Rust source for qualified and imported
-tracing calls. It requires explicit `target` and `method` fields and rejects known-sensitive token names inside tracing
-macro bodies.
+tracing calls. It requires explicit `target` and `method` fields, rejects known-sensitive token names inside tracing
+macro bodies, and rejects raw-error interpolation (`error = %err`, `{err}`-style message formatting) so error `Display`
+values — which may carry relay URLs, paths, or attacker-controlled content — never reach logs verbatim.
 
 The same audit rejects direct `println!`, `eprintln!`, and `dbg!` output from production library source.
+
+Sink-side enforcement backs up the producer rules: the forensic recorder scrubs full-data-only fields in obfuscated
+mode (`marmot-forensics`), the Nostr adapter constructs operation-only error reasons, and `traits`/adapter tests pin
+that `TransportAdapterError` `Display` carries no relay URL.
 
 CLI output generators such as the conformance report writer and Tamarin policy-case generator may use `println!` /
 `eprintln!` for their explicit artifact output. That output is not runtime application logging.


### PR DESCRIPTION
Closes the #379 tracking issue's child issues, one commit per issue so regressions can be bisected:

| Commit | Issue | Fix |
| --- | --- | --- |
| `ba73dbb` | Closes #373 | `Zeroizing` for the copied account secret, raw HKDF-derived SQLCipher key, and legacy digest in `marmot-app/src/sqlcipher.rs`. The derived hex strings were already moved straight into `SqlCipherKey`, which zeroizes them. |
| `72f0d60` | Closes #360 | Hand-written redacting `Debug` for `AuditLogTrackerConfigFfi`; the FFI setter returns the stored config with the bearer token stripped, so there is no read-back path. Tests assert both. |
| `a8af979` | Closes #359 | `JsonlRecorder::record()` scrubs full-data-only fields (decoded payloads/app events, author/actor/subject pubkeys and npubs, group-state cleartext, expected-recipient and convergence pubkeys) before serializing in obfuscated mode — redaction enforced at the sink, so a single producer bug cannot defeat it. Obfuscated-safe siblings (salted refs, digests, lengths) are kept. |
| `975b41a` | Closes #340 | Relay URLs out of transport error surfaces at every layer: the Nostr adapter builds operation-only failure reasons instead of embedding nostr-sdk error Display (which carries the relay URL); marmot-app log sites use `error_kind = privacy_safe_kind()`; all `RuntimeAccountError` messages (persisted into `dm daemon status --json`/TUI) are built by one helper that only appends the privacy-safe kind. Guard tests at adapter, traits, and app layers. |
| `8adb772` | Closes #397 | Redacting `Debug` for `ChatListAvatarFfi` (avatar decryption key + Blossom upload secret) and `RelayTelemetryRuntimeConfigFfi` (OTLP bearer token). |
| `b4a5ff7` | Closes #400 | `Zeroizing` for the avatar content-key buffers (encrypt + decrypt paths) and the copied upload-secret bytes; `GroupImageUpload` documents that the hex keys intentionally continue into the MLS-protected component and forbids adding a `Debug` derive. |
| `d86ea0c` | Closes #399 | Drops the attacker-controlled kind:30443 tag value from the `InvalidKeyPackageEvent` message and converts the remaining `error = %err` tracing sites to stable kinds (`privacy_safe_kind()`, `io::ErrorKind`, panic/cancelled). |
| `3e4deab` | #379 sweep | Repo scan for lingering same-category issues: redacting `Debug` for the marmot-app bearer-token configs, `ChatListAvatar` (storage-sqlite), and `AppGroupImageComponent`/`AppGroupImageInput`; remaining verbatim-error tracing sites in storage-sqlite, marmot-account, and agent-connector. The repo-wide tracing audit now **rejects raw-error interpolation** (`error = %...`, `{err}`-style formatting) in production tracing calls, locking the discipline in for future call sites. |
| `008e95f` | #379 docs | Sensitive-value classification table in `docs/marmot-architecture/overview/observability.md`: each value class × required posture across memory / Debug / FFI / logs / audit, plus the new enforcement notes. |

## Reviewer notes

- **FFI behavior change (intentional):** `set_audit_log_tracker_config` keeps its signature but the returned config now carries `authorization_bearer_token: None`. Hosts should never read the token back; this makes that structural.
- **Error messages are terser by design:** transport failures surface as e.g. `runtime receive failed: transport` instead of embedding the nostr-sdk error. Per-endpoint detail remains on the structured publish report, and the (local-only, opt-in) forensic audit log is the intended home for relay-level diagnosis — it may carry relay URLs by contract.
- **No new `Secret` wrapper type:** the workspace already has zeroizing/redacting newtypes where they fit (`SqlCipherKey`, `StoredSecretKeyHex`), and uniffi records cannot hold custom wrappers, so the acceptance criteria are met with per-site `Zeroizing` + hand-written `Debug` + the repo-wide audit test instead of a cross-crate refactor.

## Verification

- `just fast-ci` (fmt, check, clippy incl. OTLP feature builds) — clean
- Full test suites of every touched crate: marmot-app (370), storage-sqlite (182), marmot-forensics (19, incl. 3 new sink-redaction tests), transport-nostr-adapter (default + `--features sdk`), cgka-traits, marmot-uniffi (50, incl. 4 new redaction tests), marmot-account, agent-connector, darkmatter-cli — all passing
- Extended repo-wide `tracing_audit.rs` passes across all crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/699">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger privacy protections for logs, debug output, and exported data so sensitive tokens, keys, and raw errors are no longer exposed.
  * Audit data can now be automatically scrubbed in privacy-preserving mode while still keeping useful non-sensitive details.
* **Bug Fixes**
  * Reduced accidental disclosure in error messages and warning logs across account, sync, push, audit, and storage flows.
  * Improved relay and endpoint error text so it no longer echoes raw URLs or invalid input values.
* **Tests**
  * Added coverage to verify sensitive values stay hidden and redaction behavior works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->