### PR TITLE
Bound and reclaim long-lived daemon/broker runtime state (#381)

### DIFF
--- a/crates/agent-connector/src/bin/dm-agent.rs
+++ b/crates/agent-connector/src/bin/dm-agent.rs
@@ -4,9 +4,9 @@ use std::time::Duration;
 
 use agent_connector::{
     AgentConnectorConfig, BootstrapOptions, BootstrapResult, ConnectorError,
-    DEFAULT_BOOTSTRAP_LABEL, default_socket_path, read_bootstrap_auth_token,
-    resolve_bootstrap_home, resolve_bootstrap_quic_candidates, resolve_bootstrap_relays,
-    resolve_bootstrap_socket, run_bootstrap, serve_socket,
+    DEFAULT_BOOTSTRAP_LABEL, MAX_CONTROL_CONNECTIONS, default_socket_path,
+    read_bootstrap_auth_token, resolve_bootstrap_home, resolve_bootstrap_quic_candidates,
+    resolve_bootstrap_relays, resolve_bootstrap_socket, run_bootstrap, serve_socket,
 };
 use clap::{Args, Parser, Subcommand};
 
@@ -69,6 +69,13 @@ struct ServeArgs {
     socket_mode: String,
     #[arg(long, hide = true, help = "Enable debug-only local control requests")]
     debug_controls: bool,
+    #[arg(
+        long,
+        value_name = "COUNT",
+        default_value_t = MAX_CONTROL_CONNECTIONS,
+        help = "Maximum concurrently served control connections"
+    )]
+    max_connections: usize,
 }
 
 #[derive(Debug, Args)]
@@ -194,6 +201,7 @@ async fn run_serve_command(args: ServeArgs) -> ExitCode {
         allow_any: args.allow_any,
         debug_controls: args.debug_controls,
         auth_token,
+        max_connections: args.max_connections,
     };
     match serve_socket(config).await {
         Ok(()) => ExitCode::SUCCESS,

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -130,6 +130,10 @@ pub struct AgentConnector {
     pub(crate) inbound_catch_up: InboundCatchUpDriver,
     relays: Vec<String>,
     connection_errors: Arc<AtomicU64>,
+    /// Connections closed at accept time because the concurrency cap was hit.
+    /// Kept separate from `connection_errors` so expected backpressure does
+    /// not muddy fault-rate diagnostics.
+    connections_refused: Arc<AtomicU64>,
 }
 
 impl AgentConnector {
@@ -160,6 +164,7 @@ impl AgentConnector {
             inbound_catch_up,
             relays,
             connection_errors: Arc::new(AtomicU64::new(0)),
+            connections_refused: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -256,11 +261,14 @@ pub async fn serve_socket(config: AgentConnectorConfig) -> Result<(), ConnectorE
         // cursors they hold), mirroring the broker's connection limiter:
         // beyond the cap the connection is closed instead of served.
         let Ok(permit) = Arc::clone(&connection_limiter).try_acquire_owned() else {
-            let connection_error = connector.connection_errors.fetch_add(1, Ordering::Relaxed) + 1;
+            let connections_refused = connector
+                .connections_refused
+                .fetch_add(1, Ordering::Relaxed)
+                + 1;
             tracing::warn!(
                 target: "agent_connector",
                 method = "serve_socket",
-                connection_error,
+                connections_refused,
                 error_code = "connection_limit_exceeded",
                 "refusing control connection beyond the concurrency cap"
             );

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -37,7 +37,7 @@ use agent_control::AgentControlEvent;
 use marmot_account::AccountHome;
 use marmot_app::{MarmotApp, MarmotAppRuntime};
 use tokio::net::UnixListener;
-use tokio::sync::broadcast;
+use tokio::sync::{Semaphore, broadcast};
 
 // Re-exported at the crate root so `crate::AppMessageQuery` resolves for the white-box tests in
 // `src/tests.rs`; the crate's own modules import it from `marmot_app` directly.
@@ -74,6 +74,12 @@ pub(crate) const MEDIA_TEMP_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
 /// (1024) so every message that could be re-queried after a single overflow is still tracked.
 pub(crate) const DELIVERED_INBOUND_CURSOR_CAPACITY: usize = 4096;
 pub(crate) const MAX_PROFILE_NAME_CHARS: usize = 80;
+/// Default maximum concurrently served control-socket connections. The
+/// control plane is local and authenticated, but the threat model includes a
+/// prompt-injected/compromised gateway; each connection holds a spawned task
+/// plus, for `SubscribeInbound`, runtime/debug subscriptions and a delivered
+/// cursor, so beyond the cap new connections are closed instead of accepted.
+pub const MAX_CONTROL_CONNECTIONS: usize = 64;
 
 #[derive(Clone, Debug)]
 pub struct AgentConnectorConfig {
@@ -85,6 +91,9 @@ pub struct AgentConnectorConfig {
     pub allow_any: bool,
     pub debug_controls: bool,
     pub auth_token: Option<String>,
+    /// Cap on concurrently served control connections; connections beyond it
+    /// are closed at accept time. Must be nonzero.
+    pub max_connections: usize,
 }
 
 impl AgentConnectorConfig {
@@ -100,6 +109,7 @@ impl AgentConnectorConfig {
             allow_any: false,
             debug_controls: false,
             auth_token: None,
+            max_connections: MAX_CONTROL_CONNECTIONS,
         }
     }
 }
@@ -220,8 +230,10 @@ pub async fn serve_socket(config: AgentConnectorConfig) -> Result<(), ConnectorE
         config.socket_dir_mode,
         config.socket_mode,
     )?;
+    let max_connections = config.max_connections;
     let connector = AgentConnector::open(config)?;
     connector.start().await?;
+    let connection_limiter = Arc::new(Semaphore::new(max_connections));
     loop {
         let (stream, _peer_addr) = match listener.accept().await {
             Ok(accepted) => accepted,
@@ -240,8 +252,24 @@ pub async fn serve_socket(config: AgentConnectorConfig) -> Result<(), ConnectorE
                 continue;
             }
         };
+        // Bound concurrent per-connection tasks (and the subscriptions and
+        // cursors they hold), mirroring the broker's connection limiter:
+        // beyond the cap the connection is closed instead of served.
+        let Ok(permit) = Arc::clone(&connection_limiter).try_acquire_owned() else {
+            let connection_error = connector.connection_errors.fetch_add(1, Ordering::Relaxed) + 1;
+            tracing::warn!(
+                target: "agent_connector",
+                method = "serve_socket",
+                connection_error,
+                error_code = "connection_limit_exceeded",
+                "refusing control connection beyond the concurrency cap"
+            );
+            drop(stream);
+            continue;
+        };
         let connector = connector.clone();
         tokio::spawn(async move {
+            let _permit = permit;
             if let Err(err) = connector.handle_connection(stream).await {
                 let connection_error =
                     connector.connection_errors.fetch_add(1, Ordering::Relaxed) + 1;

--- a/crates/agent-connector/src/media_temp.rs
+++ b/crates/agent-connector/src/media_temp.rs
@@ -227,10 +227,12 @@ async fn newest_media_use_time(dir: &Path) -> Option<SystemTime> {
     loop {
         match entries.next_entry().await {
             Ok(Some(entry)) => {
-                if let Ok(metadata) = entry.metadata().await
-                    && let Ok(modified) = metadata.modified()
-                    && modified > newest
-                {
+                // A child whose metadata cannot be read is an incomplete
+                // inspection, same as a read_dir failure: its mtime might be
+                // the newest (a just-re-downloaded file), so skip the dir this
+                // sweep rather than under-report and delete in-use media.
+                let modified = entry.metadata().await.ok()?.modified().ok()?;
+                if modified > newest {
                     newest = modified;
                 }
             }

--- a/crates/agent-connector/src/media_temp.rs
+++ b/crates/agent-connector/src/media_temp.rs
@@ -195,13 +195,48 @@ pub(crate) async fn sweep_media_dirs_modified_before(
         if !is_dir {
             continue;
         }
-        let modified = match entry.metadata().await {
-            Ok(metadata) => metadata.modified().unwrap_or(SystemTime::now()),
-            Err(_) => continue,
+        let last_used = match newest_media_use_time(&entry.path()).await {
+            Some(last_used) => last_used,
+            None => continue,
         };
-        if modified < cutoff && tokio::fs::remove_dir_all(entry.path()).await.is_ok() {
+        if last_used < cutoff && tokio::fs::remove_dir_all(entry.path()).await.is_ok() {
             swept += 1;
         }
     }
     Ok(swept)
+}
+
+/// Newest modification time observed on a per-blob dir or any entry directly
+/// inside it.
+///
+/// A repeat download of the same blob overwrites the existing file in place
+/// (`download_media_response` opens with `truncate(true)`), which updates the
+/// file's mtime but not the parent dir's, so the dir mtime alone
+/// under-reports how recently the blob was used and the sweeper would delete
+/// media the connector just handed the agent a path to. Files are written
+/// directly into the per-blob dir, so one level of children is sufficient.
+/// Returns `None` when the dir cannot be fully inspected; the caller skips
+/// such dirs rather than risk sweeping something still in use.
+async fn newest_media_use_time(dir: &Path) -> Option<SystemTime> {
+    let mut newest = tokio::fs::symlink_metadata(dir)
+        .await
+        .ok()?
+        .modified()
+        .ok()?;
+    let mut entries = tokio::fs::read_dir(dir).await.ok()?;
+    loop {
+        match entries.next_entry().await {
+            Ok(Some(entry)) => {
+                if let Ok(metadata) = entry.metadata().await
+                    && let Ok(modified) = metadata.modified()
+                    && modified > newest
+                {
+                    newest = modified;
+                }
+            }
+            Ok(None) => break,
+            Err(_) => return None,
+        }
+    }
+    Some(newest)
 }

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -3098,6 +3098,59 @@ async fn media_temp_sweeper_removes_directories_older_than_cutoff() {
 }
 
 #[tokio::test]
+async fn media_temp_sweeper_spares_dirs_with_recently_rewritten_files() {
+    use std::time::{Duration, SystemTime};
+
+    use crate::media_temp::sweep_media_dirs_modified_before;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let blob_dir = tmp.path().join("blob");
+    tokio::fs::create_dir_all(&blob_dir).await.unwrap();
+    let file_path = blob_dir.join("media.bin");
+    tokio::fs::write(&file_path, b"first download")
+        .await
+        .unwrap();
+
+    // Pick a cutoff after the dir was created, then mimic a re-download of
+    // the same blob: an in-place truncating overwrite updates the file mtime
+    // but not the parent dir mtime.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let cutoff = SystemTime::now();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(&file_path)
+        .await
+        .unwrap();
+    use tokio::io::AsyncWriteExt as _;
+    file.write_all(b"second download").await.unwrap();
+    drop(file);
+
+    let swept = sweep_media_dirs_modified_before(tmp.path(), cutoff)
+        .await
+        .unwrap();
+    assert_eq!(
+        swept, 0,
+        "a dir whose file was re-downloaded after the cutoff must not be swept"
+    );
+    assert!(
+        file_path.exists(),
+        "recently re-downloaded media must survive the sweep"
+    );
+
+    // Once nothing inside the dir is newer than the cutoff, it is reclaimed.
+    let late_cutoff = SystemTime::now() + Duration::from_secs(3600);
+    let swept = sweep_media_dirs_modified_before(tmp.path(), late_cutoff)
+        .await
+        .unwrap();
+    assert_eq!(swept, 1, "fully stale dirs are still reclaimed");
+    assert!(!blob_dir.exists());
+}
+
+#[tokio::test]
 async fn create_media_download_dir_hardens_root_and_blob_dir_to_0700() {
     use std::os::unix::fs::PermissionsExt as _;
 

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -545,6 +545,101 @@ async fn connector_socket_serves_account_list() {
 }
 
 #[tokio::test]
+async fn connector_socket_caps_concurrent_connections() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("dev").join("dm-agent.sock");
+    let mut config = test_config(dir.path(), socket.clone(), Vec::new(), false, false);
+    config.max_connections = 1;
+    let server = tokio::spawn(serve_socket(config));
+
+    // A long-lived subscription holds the only permit for its whole session;
+    // the ack proves it is accepted and served before the second connection.
+    let held = connect_with_retry(&socket).await;
+    let (held_read, mut held_write) = tokio::io::split(held);
+    let mut held_read = BufReader::new(held_read);
+    let request = AgentControlEnvelope::request(
+        Some("req-held".to_owned()),
+        AgentControlRequest::SubscribeInbound {
+            account_id_hex: None,
+            group_id_hex: None,
+        },
+    );
+    write_frame(&mut held_write, &request).await.unwrap();
+    let response: AgentControlEnvelope<AgentControlResponse> =
+        timeout(CONTROL_RESPONSE_TIMEOUT, read_envelope(&mut held_read))
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+    assert_eq!(response.id.as_deref(), Some("req-held"));
+    assert_eq!(response.payload, AgentControlResponse::Ack);
+
+    // A second concurrent connection is over the cap: the connector closes
+    // it at accept time without serving a response.
+    let refused = UnixStream::connect(&socket).await.unwrap();
+    let (refused_read, mut refused_write) = tokio::io::split(refused);
+    let mut refused_read = BufReader::new(refused_read);
+    let request = AgentControlEnvelope::request(
+        Some("req-refused".to_owned()),
+        AgentControlRequest::AccountList,
+    );
+    // The write may race the server-side close; only the read matters.
+    let _ = write_frame(&mut refused_write, &request).await;
+    let refused_result: Result<Option<AgentControlEnvelope<AgentControlResponse>>, _> =
+        timeout(CONTROL_RESPONSE_TIMEOUT, read_envelope(&mut refused_read))
+            .await
+            .unwrap();
+    assert!(
+        matches!(refused_result, Ok(None) | Err(_)),
+        "over-cap connection must be closed without a response"
+    );
+
+    // Dropping the held connection frees the permit for a new connection.
+    drop(held_read);
+    drop(held_write);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let client = connect_with_retry(&socket).await;
+        let (client_read, mut client_write) = tokio::io::split(client);
+        let mut client_read = BufReader::new(client_read);
+        let request = AgentControlEnvelope::request(
+            Some("req-after-release".to_owned()),
+            AgentControlRequest::AccountList,
+        );
+        if write_frame(&mut client_write, &request).await.is_ok()
+            && let Ok(Ok(Some(response))) = timeout(
+                Duration::from_secs(2),
+                read_envelope::<_, AgentControlResponse>(&mut client_read),
+            )
+            .await
+        {
+            assert_eq!(response.id.as_deref(), Some("req-after-release"));
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "released permit must allow a new connection to be served"
+        );
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
+async fn connector_control_plane_rejects_zero_connection_cap() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("dev").join("dm-agent.sock");
+    let mut config = test_config(dir.path(), socket, Vec::new(), false, false);
+    config.max_connections = 0;
+
+    let error = serve_socket(config).await.unwrap_err();
+
+    assert_eq!(error.code(), "unsafe_control_plane_config");
+}
+
+#[tokio::test]
 async fn connector_socket_requires_configured_auth_token() {
     let dir = tempfile::tempdir().unwrap();
     let account_home = AccountHome::open(dir.path());

--- a/crates/agent-connector/src/validation.rs
+++ b/crates/agent-connector/src/validation.rs
@@ -140,6 +140,12 @@ pub(crate) fn validate_control_plane_config(
         ));
     }
 
+    if config.max_connections == 0 {
+        return Err(ConnectorError::UnsafeControlPlaneConfig(
+            "max connections must be nonzero",
+        ));
+    }
+
     if config.auth_token.is_none()
         && (config.socket_dir_mode != AGENT_SOCKET_DIR_MODE
             || config.socket_mode != AGENT_SOCKET_MODE)

--- a/crates/cli/src/daemon/mod.rs
+++ b/crates/cli/src/daemon/mod.rs
@@ -194,12 +194,11 @@ async fn run_server(args: DaemonArgs) -> Result<(), Box<dyn std::error::Error + 
                 // broker accept loops: beyond the cap the connection is closed
                 // instead of served.
                 let Ok(permit) = Arc::clone(&connection_limiter).try_acquire_owned() else {
-                    // dmd's stdout/stderr are redirected to its log file, so
-                    // this lands where `dm daemon status` points operators.
-                    eprintln!(
-                        "dmd: refusing connection beyond the concurrency cap \
-                         ({MAX_DAEMON_CONNECTIONS})"
-                    );
+                    // Dropped without a log line: the repo-wide direct-output
+                    // audit forbids println!/eprintln! in library sources and
+                    // the daemon library is intentionally log-free at runtime.
+                    // The refused client observes its connection close without
+                    // a response.
                     drop(stream);
                     continue;
                 };

--- a/crates/cli/src/daemon/mod.rs
+++ b/crates/cli/src/daemon/mod.rs
@@ -194,6 +194,12 @@ async fn run_server(args: DaemonArgs) -> Result<(), Box<dyn std::error::Error + 
                 // broker accept loops: beyond the cap the connection is closed
                 // instead of served.
                 let Ok(permit) = Arc::clone(&connection_limiter).try_acquire_owned() else {
+                    // dmd's stdout/stderr are redirected to its log file, so
+                    // this lands where `dm daemon status` points operators.
+                    eprintln!(
+                        "dmd: refusing connection beyond the concurrency cap \
+                         ({MAX_DAEMON_CONNECTIONS})"
+                    );
                     drop(stream);
                     continue;
                 };

--- a/crates/cli/src/daemon/mod.rs
+++ b/crates/cli/src/daemon/mod.rs
@@ -61,6 +61,13 @@ const MAX_DAEMON_REQUEST_BYTES: usize = 1024 * 1024;
 const DAEMON_REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(30);
 const DAEMON_SOCKET_DIR_MODE: u32 = 0o700;
 const DAEMON_SOCKET_MODE: u32 = 0o600;
+/// Cap on concurrently served daemon connections. The socket is same-UID
+/// local control, but a runaway or looping client must not be able to grow
+/// the per-connection task set (and the subscriptions those tasks hold)
+/// without bound; over-cap connections are closed at accept time. Generous
+/// relative to real CLI/TUI use (a handful of subscriptions plus one-shot
+/// commands).
+const MAX_DAEMON_CONNECTIONS: usize = 256;
 
 type SharedDaemonWorkers = Arc<AsyncMutex<DaemonWorkers>>;
 
@@ -176,18 +183,27 @@ async fn run_server(args: DaemonArgs) -> Result<(), Box<dyn std::error::Error + 
         .await;
     }
     let mut worker_tasks: Vec<JoinHandle<()>> = Vec::new();
+    let connection_limiter = Arc::new(tokio::sync::Semaphore::new(MAX_DAEMON_CONNECTIONS));
     let (shutdown_tx, mut shutdown_rx) = mpsc::unbounded_channel::<()>();
     let shutdown_result = loop {
         worker_tasks.retain(|task| !task.is_finished());
         tokio::select! {
             accepted = listener.accept() => {
                 let (stream, _) = accepted?;
+                // Bound concurrent per-connection tasks like the connector and
+                // broker accept loops: beyond the cap the connection is closed
+                // instead of served.
+                let Ok(permit) = Arc::clone(&connection_limiter).try_acquire_owned() else {
+                    drop(stream);
+                    continue;
+                };
                 let defaults = defaults.clone();
                 let state = state.clone();
                 let events = events.clone();
                 let workers = workers.clone();
                 let shutdown_tx = shutdown_tx.clone();
                 worker_tasks.push(tokio::spawn(async move {
+                    let _permit = permit;
                     handle_daemon_connection(stream, defaults, state, events, workers, shutdown_tx).await;
                 }));
             }

--- a/crates/marmot-app/src/agent_streams.rs
+++ b/crates/marmot-app/src/agent_streams.rs
@@ -120,6 +120,10 @@ impl AgentStreamWatchManager {
         if let Ok(mut watches) = self.inner.watches.lock() {
             watches.insert(report.watch_id.clone(), report.clone());
         }
+        // Enforce the cap on start too: repeated start-without-finish (broker
+        // hang, dropped watch handle, crashed compose session) must not grow
+        // the map unbounded on the promise of a finish that never arrives.
+        self.prune_watch_reports();
         self.publish_update(AgentStreamUpdate::WatchUpdated(report.clone()));
         report
     }
@@ -144,7 +148,7 @@ impl AgentStreamWatchManager {
             report.result = completion.result;
             report.clone()
         };
-        self.prune_finished_reports();
+        self.prune_watch_reports();
         self.publish_update(AgentStreamUpdate::WatchUpdated(finished.clone()));
         Some(finished)
     }
@@ -220,31 +224,40 @@ impl AgentStreamWatchManager {
         let _ = self.inner.updates.send(update);
     }
 
-    fn prune_finished_reports(&self) {
+    /// Enforce the hard retained-watch cap. Finished watches are evicted
+    /// oldest-first before any running watch; when running watches alone
+    /// exceed the cap, the oldest running ones are evicted too so the map
+    /// stays bounded even if their finish never arrives.
+    fn prune_watch_reports(&self) {
         let Ok(mut watches) = self.inner.watches.lock() else {
             return;
         };
-        if watches.len() <= AGENT_STREAM_WATCH_RETAIN_LIMIT {
+        let excess = watches
+            .len()
+            .saturating_sub(AGENT_STREAM_WATCH_RETAIN_LIMIT);
+        if excess == 0 {
             return;
         }
 
-        let running_count = watches
+        let mut candidates = watches
             .values()
-            .filter(|watch| watch.status == "running")
-            .count();
-        let finished_retain_limit = AGENT_STREAM_WATCH_RETAIN_LIMIT.saturating_sub(running_count);
-        let mut finished = watches
-            .values()
-            .filter(|watch| watch.status != "running")
-            .map(|watch| (watch.started_at, watch.watch_id.clone()))
+            .map(|watch| {
+                (
+                    watch.status == "running",
+                    watch.started_at,
+                    watch.watch_id.clone(),
+                )
+            })
             .collect::<Vec<_>>();
-        if finished.len() <= finished_retain_limit {
-            return;
-        }
-
-        finished.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
-        let remove_count = finished.len() - finished_retain_limit;
-        for (_, watch_id) in finished.into_iter().take(remove_count) {
+        // Finished (`false`) sorts before running, each cohort oldest-first,
+        // so a running watch is evicted only once no finished watch remains.
+        candidates.sort_by(|left, right| {
+            left.0
+                .cmp(&right.0)
+                .then_with(|| left.1.cmp(&right.1))
+                .then_with(|| left.2.cmp(&right.2))
+        });
+        for (_, _, watch_id) in candidates.into_iter().take(excess) {
             watches.remove(&watch_id);
         }
     }
@@ -384,6 +397,92 @@ mod tests {
         assert_eq!(
             reports.last().and_then(|report| report.text.as_deref()),
             Some(expected_last.as_str())
+        );
+    }
+
+    #[test]
+    fn stream_watch_manager_bounds_running_watches_that_never_finish() {
+        let manager = AgentStreamWatchManager::default();
+        let group_id = "aa".repeat(32);
+
+        for index in 0..(AGENT_STREAM_WATCH_RETAIN_LIMIT * 2) {
+            manager.start_watch(AgentStreamWatchStart {
+                account: Some("alice".to_owned()),
+                group_id: group_id.clone(),
+                stream_id: Some(format!("{index:064x}")),
+                started_at: 1_700_000_000 + index as u64,
+                started_at_millis: 1_700_000_000_000 + index as u128,
+            });
+        }
+
+        let reports = manager.reports();
+        assert_eq!(reports.len(), AGENT_STREAM_WATCH_RETAIN_LIMIT);
+        // Oldest running watches were evicted; the newest survive.
+        assert_eq!(
+            reports.first().map(|report| report.started_at),
+            Some(1_700_000_000 + AGENT_STREAM_WATCH_RETAIN_LIMIT as u64)
+        );
+    }
+
+    #[test]
+    fn stream_watch_manager_evicts_finished_watches_before_running_ones() {
+        let manager = AgentStreamWatchManager::default();
+        let group_id = "aa".repeat(32);
+
+        // Fill the map to the cap with finished watches, oldest-first.
+        for index in 0..AGENT_STREAM_WATCH_RETAIN_LIMIT {
+            let started = manager.start_watch(AgentStreamWatchStart {
+                account: Some("alice".to_owned()),
+                group_id: group_id.clone(),
+                stream_id: Some(format!("{index:064x}")),
+                started_at: 1_700_000_000 + index as u64,
+                started_at_millis: 1_700_000_000_000 + index as u128,
+            });
+            manager
+                .finish_watch(
+                    &started.watch_id,
+                    AgentStreamWatchCompletion {
+                        finished_at: 1_700_000_100 + index as u64,
+                        status: "completed".to_owned(),
+                        stream_id: started.stream_id,
+                        text: None,
+                        transcript_hash: None,
+                        chunk_count: Some(1),
+                        error: None,
+                        result: None,
+                    },
+                )
+                .expect("watch finishes");
+        }
+
+        // A newer running watch displaces the oldest finished watch, even
+        // though every finished watch started before it.
+        let running = manager.start_watch(AgentStreamWatchStart {
+            account: Some("alice".to_owned()),
+            group_id: group_id.clone(),
+            stream_id: Some("ff".repeat(32)),
+            started_at: 1_700_009_999,
+            started_at_millis: 1_700_009_999_000,
+        });
+
+        let reports = manager.reports();
+        assert_eq!(reports.len(), AGENT_STREAM_WATCH_RETAIN_LIMIT);
+        assert!(
+            reports
+                .iter()
+                .any(|report| report.watch_id == running.watch_id)
+        );
+        assert_eq!(
+            reports
+                .iter()
+                .filter(|report| report.status == "running")
+                .count(),
+            1
+        );
+        // The evicted entry is the oldest finished watch.
+        assert_eq!(
+            reports.first().map(|report| report.started_at),
+            Some(1_700_000_001)
         );
     }
 }

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -510,6 +510,10 @@ impl TransportAdapter for NostrTransportAdapter {
 
         let now_ms = self.now_ms();
         let mut state = self.state.write().await;
+        // Reactivation replaces the account's routes; evict telemetry for the
+        // old subscription ids first (before recording the new starts, since
+        // unchanged endpoint sets reuse the same ids).
+        state.forget_account_subscription_starts(&account_id);
         state.record_subscription_starts(&issued, now_ms);
         state.activate(activation, replaced_count);
         Ok(())
@@ -563,6 +567,7 @@ impl TransportAdapter for NostrTransportAdapter {
         );
         let now_ms = self.now_ms();
         let mut state = self.state.write().await;
+        state.forget_subscription_starts(&to_remove);
         state.record_subscription_starts(&to_add, now_ms);
         state.sync_groups(sync, to_add.len(), to_remove.len());
         Ok(())
@@ -585,6 +590,7 @@ impl TransportAdapter for NostrTransportAdapter {
         );
         self.relay_client.unsubscribe_account(account_id).await?;
         let mut state = self.state.write().await;
+        state.forget_account_subscription_starts(account_id);
         state.deactivate(account_id, removed_count);
         Ok(())
     }
@@ -868,6 +874,45 @@ impl AdapterState {
                 .collect();
             self.sync
                 .record_subscription_start(&subscription.subscription_id(), &relays, now_ms);
+        }
+    }
+
+    /// Evict sync-telemetry progress for subscriptions being removed, so the
+    /// telemetry map tracks live subscriptions rather than historical churn.
+    fn forget_subscription_starts(&mut self, subscriptions: &[NostrSubscription]) {
+        for subscription in subscriptions {
+            self.sync
+                .forget_subscription(&subscription.subscription_id());
+        }
+    }
+
+    /// Evict sync-telemetry progress for every subscription implied by an
+    /// account's stored routes (its inbox plus each group). Called before the
+    /// routes are replaced (reactivate) or removed (deactivate); subscription
+    /// ids are derived from account/group/endpoint state, never `since`, so
+    /// the reconstructed ids match the ones recorded at subscribe time.
+    fn forget_account_subscription_starts(&mut self, account_id: &MemberId) {
+        let Some(routes) = self.accounts.get(account_id) else {
+            return;
+        };
+        let mut ids = Vec::with_capacity(1 + routes.groups.len());
+        ids.push(
+            NostrSubscription::AccountInbox {
+                account_id: account_id.clone(),
+                endpoints: routes
+                    .inbox_endpoints
+                    .iter()
+                    .map(|endpoint| endpoint.verbatim.clone())
+                    .collect(),
+                since: None,
+            }
+            .subscription_id(),
+        );
+        for group in &routes.groups {
+            ids.push(group_subscription(account_id, group, None).subscription_id());
+        }
+        for id in ids {
+            self.sync.forget_subscription(&id);
         }
     }
 

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -492,11 +492,11 @@ impl TransportAdapter for NostrTransportAdapter {
         }
 
         let mut issued = Vec::with_capacity(1 + activation.group_subscriptions.len());
-        issued.push(NostrSubscription::AccountInbox {
-            account_id: account_id.clone(),
-            endpoints: activation.inbox_endpoints.clone(),
-            since: inbox_since(activation.since),
-        });
+        issued.push(account_inbox_subscription(
+            &account_id,
+            activation.inbox_endpoints.clone(),
+            inbox_since(activation.since),
+        ));
         for group in &activation.group_subscriptions {
             issued.push(group_subscription(&account_id, group, activation.since));
         }
@@ -897,15 +897,15 @@ impl AdapterState {
         };
         let mut ids = Vec::with_capacity(1 + routes.groups.len());
         ids.push(
-            NostrSubscription::AccountInbox {
-                account_id: account_id.clone(),
-                endpoints: routes
+            account_inbox_subscription(
+                account_id,
+                routes
                     .inbox_endpoints
                     .iter()
                     .map(|endpoint| endpoint.verbatim.clone())
                     .collect(),
-                since: None,
-            }
+                None,
+            )
             .subscription_id(),
         );
         for group in &routes.groups {
@@ -1014,6 +1014,21 @@ pub const NIP59_TIMESTAMP_TWEAK_SECS: u64 = 172_800;
 
 fn inbox_since(since: Option<Timestamp>) -> Option<Timestamp> {
     since.map(|since| Timestamp(since.0.saturating_sub(NIP59_TIMESTAMP_TWEAK_SECS)))
+}
+
+/// Single construction point for the account-inbox subscription, shared by
+/// activation issuance and telemetry-eviction id reconstruction so the two
+/// can never derive different subscription ids.
+fn account_inbox_subscription(
+    account_id: &MemberId,
+    endpoints: Vec<TransportEndpoint>,
+    since: Option<Timestamp>,
+) -> NostrSubscription {
+    NostrSubscription::AccountInbox {
+        account_id: account_id.clone(),
+        endpoints,
+        since,
+    }
 }
 
 fn group_subscription(

--- a/crates/transport-nostr-adapter/src/telemetry.rs
+++ b/crates/transport-nostr-adapter/src/telemetry.rs
@@ -525,6 +525,17 @@ impl RelaySyncTelemetry {
         }
     }
 
+    /// Forget the progress entry for `subscription_id`.
+    ///
+    /// Called when the subscription is unsubscribed, replaced by a rotation
+    /// (which mints a new id), or its account deactivates, so the map tracks
+    /// only live subscriptions instead of growing with historical churn. The
+    /// per-relay first-event/EOSE histograms are aggregates bounded by the
+    /// relay count and are intentionally retained.
+    pub fn forget_subscription(&mut self, subscription_id: &str) {
+        self.subscriptions.remove(subscription_id);
+    }
+
     /// Whether every relay of `subscription_id` has reached EOSE.
     ///
     /// Returns `None` for an unknown subscription, `Some(false)` while any

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -1071,6 +1071,77 @@ async fn welcome_event_routes_despite_trailing_slash_mismatch() {
     assert_eq!(delivery.source.endpoint, Some(inbound_inbox));
 }
 
+#[tokio::test]
+async fn sync_telemetry_tracks_only_live_subscriptions_across_churn() {
+    let relay = Arc::new(FakeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay);
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let group_for = |index: u8| TransportGroupSubscription {
+        group_id: cgka_traits::GroupId::new(vec![index; 32]),
+        transport_group_id: vec![index; 32],
+        endpoints: vec![TransportEndpoint(format!("wss://relay-{index}.example"))],
+    };
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![group_for(1)],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    assert_eq!(adapter.relay_sync().await.tracked_subscriptions, 2);
+
+    // Group churn: every sync replaces the previous group with a new one
+    // (join/leave, endpoint rotation). The telemetry map must track only the
+    // live subscriptions, not one entry per historical subscription id.
+    for index in 2..30 {
+        adapter
+            .sync_account_groups(TransportGroupSync {
+                account_id: account_id.clone(),
+                group_subscriptions: vec![group_for(index)],
+                since: None,
+            })
+            .await
+            .expect("group sync succeeds");
+        assert_eq!(
+            adapter.relay_sync().await.tracked_subscriptions,
+            2,
+            "churned-away group subscriptions must be evicted"
+        );
+    }
+    let stale_group_id = NostrSubscription::Group {
+        account_id: account_id.clone(),
+        group_id: cgka_traits::GroupId::new(vec![1; 32]),
+        transport_group_id: vec![1; 32],
+        endpoints: vec![TransportEndpoint("wss://relay-1.example".into())],
+        since: None,
+    }
+    .subscription_id();
+    assert_eq!(adapter.subscription_synced(&stale_group_id).await, None);
+
+    // Reactivation with a rotated inbox endpoint set mints new subscription
+    // ids; the previous ids must not linger.
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox-rotated.example".into())],
+            group_subscriptions: vec![group_for(30)],
+            since: None,
+        })
+        .await
+        .expect("reactivation succeeds");
+    assert_eq!(adapter.relay_sync().await.tracked_subscriptions, 2);
+
+    // Deactivation drops the account's remaining subscriptions.
+    adapter
+        .deactivate_account(&account_id)
+        .await
+        .expect("deactivation succeeds");
+    assert_eq!(adapter.relay_sync().await.tracked_subscriptions, 0);
+}
+
 fn group_event(id_byte: &str, transport_group_id: &[u8]) -> NostrTransportEvent {
     NostrTransportEvent {
         id: id_byte.repeat(32),

--- a/crates/transport-quic-broker/src/state.rs
+++ b/crates/transport-quic-broker/src/state.rs
@@ -258,13 +258,23 @@ impl BrokerState {
                         });
                     }
                     let room = inner.rooms.entry(key.clone()).or_default();
+                    // A publisher reusing a finished room resets it in place,
+                    // discarding its retained backlog without going through
+                    // `remove_room`; free those bytes from the global budget
+                    // so `total_backlog_bytes` cannot drift above the real
+                    // retained total.
+                    let mut freed = 0;
                     if room.finished_at.is_some() {
+                        freed = room.backlog_bytes;
                         *room = BrokerRoom::default();
                     }
-                    if !room.subscribers.is_empty() {
+                    let has_subscribers = !room.subscribers.is_empty();
+                    let notify = room.subscriber_notify.clone();
+                    inner.total_backlog_bytes = inner.total_backlog_bytes.saturating_sub(freed);
+                    if has_subscribers {
                         return Ok(());
                     }
-                    room.subscriber_notify.clone()
+                    notify
                 };
                 notify.notified().await;
             }

--- a/crates/transport-quic-broker/src/tests.rs
+++ b/crates/transport-quic-broker/src/tests.rs
@@ -808,6 +808,33 @@ async fn broker_retains_finished_rooms_and_closes_live_subscribers() {
 }
 
 #[tokio::test]
+async fn broker_frees_backlog_accounting_when_publisher_reuses_finished_room() {
+    let state = Arc::new(test_state(DEFAULT_BROKER_BACKLOG_DEPTH));
+    let key = BrokerStreamKey::new(vec![0xaa; 32], MessageId::new(vec![0x11; 32]));
+    let record = AgentTextStreamRecordV1::text_delta(vec![0xaa; 32], 1, b"hello".to_vec());
+
+    state.publish(&key, record).await.unwrap();
+    state.finish_room(&key).await;
+    assert!(state.backlog_bytes_for_test().await > 0);
+
+    // A new publisher reusing the finished key resets the room in place,
+    // discarding its retained backlog; the discarded bytes must leave the
+    // global accounting with it instead of lingering as phantom budget until
+    // the next state-touching op happens to recompute the total.
+    let waiter = {
+        let state = Arc::clone(&state);
+        let key = key.clone();
+        tokio::spawn(async move { state.wait_for_subscriber(&key).await })
+    };
+    sleep(Duration::from_millis(100)).await;
+    assert_eq!(state.backlog_bytes_for_test().await, 0);
+
+    let (_subscriber_id, _backlog, _rx) = state.subscribe(key).await.unwrap();
+    waiter.await.unwrap().unwrap();
+    assert_eq!(state.backlog_bytes_for_test().await, 0);
+}
+
+#[tokio::test]
 async fn broker_drops_finished_rooms_after_ttl() {
     let state = Arc::new(test_state(DEFAULT_BROKER_BACKLOG_DEPTH));
     let key = BrokerStreamKey::new(vec![0xaa; 32], MessageId::new(vec![0x11; 32]));

--- a/crates/transport-quic-broker/src/tests.rs
+++ b/crates/transport-quic-broker/src/tests.rs
@@ -826,8 +826,23 @@ async fn broker_frees_backlog_accounting_when_publisher_reuses_finished_room() {
         let key = key.clone();
         tokio::spawn(async move { state.wait_for_subscriber(&key).await })
     };
-    sleep(Duration::from_millis(100)).await;
-    assert_eq!(state.backlog_bytes_for_test().await, 0);
+    // The waiter's first lock iteration performs the reset; poll (bounded, and
+    // well under the publish grace period) rather than assume a fixed delay is
+    // enough under CI contention. The counter must drop to zero from the reset
+    // itself — `backlog_bytes_for_test` only reads, and no other
+    // state-touching op runs that could recompute the total.
+    let mut reset_freed_accounting = false;
+    for _ in 0..200 {
+        if state.backlog_bytes_for_test().await == 0 {
+            reset_freed_accounting = true;
+            break;
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        reset_freed_accounting,
+        "finished-room reset must free the discarded backlog accounting"
+    );
 
     let (_subscriber_id, _backlog, _rx) = state.subscribe(key).await.unwrap();
     waiter.await.unwrap().unwrap();

--- a/docs/marmot-architecture/AGENTS.md
+++ b/docs/marmot-architecture/AGENTS.md
@@ -55,6 +55,9 @@ Agent map for the Marmot architecture docs.
 - **Path:** `audit-logging.md`
   - **Role:** Current implementation inventory for opt-in forensic JSONL logs: file identity, event kinds/metadata, and upload/tracker behavior.
 
+- **Path:** `runtime-state-bounds.md`
+  - **Role:** Inventory of long-lived daemon/broker runtime structures with their bounds and eviction/reclamation rules; the tracked-resource discipline for new long-lived state.
+
 - **Path:** `hermes-agent-production-runbook.md`
   - **Role:** Draft operational runbook for the Hermes agent deployment. Check status and dates before relying on it.
 

--- a/docs/marmot-architecture/index.md
+++ b/docs/marmot-architecture/index.md
@@ -121,6 +121,11 @@ These are longer working documents. Go here when you need depth, not orientation
   - **What it covers:** Current implementation inventory for opt-in forensic JSONL logs, file identity, every event
     kind and metadata field, upload/tracker behavior, and downstream tooling guidance.
 
+- **Doc:** [`runtime-state-bounds.md`](./runtime-state-bounds.md)
+  - **What it covers:** Inventory of long-lived daemon/broker runtime structures (maps, counters, handle sets, temp
+    artifacts) with their bounds and eviction/reclamation rules, plus the tracked-resource discipline for adding new
+    ones.
+
 - **Doc:** [marmot-protocol/marmot](https://github.com/marmot-protocol/marmot)
   - **What it covers:** Marmot v2 protocol draft by stable protocol surface and app component.
 

--- a/docs/marmot-architecture/runtime-state-bounds.md
+++ b/docs/marmot-architecture/runtime-state-bounds.md
@@ -1,0 +1,81 @@
+---
+title: "Long-lived runtime state — bounds and reclamation"
+created: 2026-07-02
+updated: 2026-07-02
+tags: [marmot, architecture, runtime, daemon, broker, memory]
+---
+
+# Long-lived runtime state — bounds and reclamation
+
+The daemon (`dm-agent`), the QUIC preview broker, and the app runtime are long-lived processes. Every long-lived
+collection, handle set, counter, and temp artifact they hold must have a defined lifecycle: creation, accounting,
+eviction/expiry, and reclamation, with an enforced bound. Unbounded growth is a contract violation, not a latent leak.
+Tracking issue: marmot-protocol/mdk#381.
+
+## The discipline
+
+- **Every insert has a defined remove**, tied to the originating lifecycle event (unsubscribe, deactivate, rotation,
+  disconnect), not just one terminal transition (a clean "finish" that may never arrive).
+- **Counters cannot drift.** Running totals are adjusted symmetrically with the state they measure on every mutation
+  path, including reset/teardown, or are recomputed wholesale from the tracked set.
+- **Temp artifacts are reclaimed on actual liveness** (per-artifact last-use), never on a heuristic that races with
+  active use.
+- **Each structure documents its bound** (max size, TTL, or eviction policy) below and enforces it in code.
+
+## Inventory
+
+### `transport-quic-broker` (`src/state.rs`, `src/server.rs`)
+
+| Structure | Bound | Reclamation |
+| --- | --- | --- |
+| `BrokerStateInner.rooms` | `max_rooms` (default 512) | Removed when the last subscriber leaves an empty unfinished room; finished rooms drop after a 60 s TTL; stale unfinished rooms are purged activity-driven on every state-touching op. A publisher reusing a finished key resets the room in place. |
+| Per-room `backlog` | `max_backlog` records (default 1024) per room, `max_backlog_bytes` (default 64 MiB) global, `replay_ttl` (default 0 = retain nothing) | Expired entries purged on subscribe/publish/purge; oldest dropped when over depth or byte budget. |
+| `total_backlog_bytes` | Derived from room backlogs | Adjusted symmetrically on every backlog mutation, including the finished-room in-place reset (mdk#372); recomputed wholesale by `purge_expired_rooms`. |
+| Per-subscriber queue | `per_subscriber_queue` records (default 32) | A lagging subscriber is dropped rather than buffered. |
+| Connections | `max_connections` semaphore (default 256), `max_streams_per_connection` (default 64) | Over-cap connections are refused at accept; permits release on disconnect. |
+
+### `agent-connector` / `dm-agent` (`src/lib.rs` and modules)
+
+| Structure | Bound | Reclamation |
+| --- | --- | --- |
+| Control-socket connections | `max_connections` semaphore (default `MAX_CONTROL_CONNECTIONS` = 64, `--max-connections`) | Over-cap connections are closed at accept time (mdk#390); each served connection holds one permit for its whole session, released on disconnect. A zero cap is rejected as unsafe config. |
+| `DeliveredInboundCursor` (per `SubscribeInbound` session) | 4096 ids (`DELIVERED_INBOUND_CURSOR_CAPACITY`) | FIFO eviction of oldest ids; dropped with the session. |
+| `SendIdempotencyStore` | 1024 entries, persisted | FIFO eviction on insert. |
+| Stream compose sessions | Idle timeout 300 s (`STREAM_SESSION_IDLE_TIMEOUT`) | Background sweeper aborts idle sessions every 30 s. |
+| Decrypted-media temp dirs (`$TMPDIR/marmot-media/<hash>/`) | TTL 1 h (`MEDIA_TEMP_MAX_AGE`) | Swept every 60 s, keyed on the newest mtime within the per-blob dir so an in-place re-download refreshes liveness (mdk#374); un-inspectable dirs are skipped, never swept blind. |
+
+### `marmot-app` runtime (`src/agent_streams.rs`)
+
+| Structure | Bound | Reclamation |
+| --- | --- | --- |
+| `AgentStreamWatchManager.watches` | 256 (`AGENT_STREAM_WATCH_RETAIN_LIMIT`), including `running` watches | Enforced on both start and finish. Finished watches evict oldest-first; when running watches alone exceed the cap (a finish that never arrives), the oldest running watches evict too (mdk#343). |
+| `recent_updates` replay ring | 256 (`AGENT_STREAM_UPDATE_REPLAY_LIMIT`) | Oldest popped on publish. |
+
+### `darkmatter-cli` daemon / `dmd` (`src/daemon/`)
+
+| Structure | Bound | Reclamation |
+| --- | --- | --- |
+| Daemon connections | `MAX_DAEMON_CONNECTIONS` semaphore (256) | Over-cap connections are closed at accept time; permits release on disconnect. Finished per-connection task handles are reaped every accept iteration. |
+| `DaemonEventHub.recent_messages` replay ring | 256 (`DAEMON_EVENT_REPLAY_LIMIT`) | Oldest popped on publish. |
+| Per-subscription dedup ids | 256 (`MESSAGE_SUBSCRIPTION_DEDUP_LIMIT`) | FIFO eviction; dropped with the subscription. |
+| `StreamWatchWorkers.handles` | Live watches + finished-since-last-start | Finished handles reaped on every watch start and on status; all aborted at shutdown. |
+
+### `transport-nostr-adapter` (`src/lib.rs`, `src/telemetry.rs`)
+
+| Structure | Bound | Reclamation |
+| --- | --- | --- |
+| `AdapterState.accounts` + `by_transport_group` index | Live accounts × their group subscriptions | Removed on deactivate; index rebuilt wholesale from `accounts` on every mutation so it cannot drift. |
+| `RelaySyncTelemetry.subscriptions` | Live subscription count | Evicted on the `sync_account_groups` remove diff, on deactivate, and on reactivate before the replacement routes are recorded (mdk#342). Subscription ids hash account/group/endpoint-set, so rotations mint new ids and the old ones are forgotten. |
+| `RelaySyncTelemetry.first_event` / `eose`, `RelayIndexRegistry` | Distinct relay endpoints ever configured | Aggregate per-relay histograms; intentionally retained (bounded by configuration, not by traffic). |
+| `RelayDeliveryTelemetry.pending` | 60 s tracking window (`DEFAULT_TRACKING_WINDOW_MS`) | Entries older than the window are pruned inline on every sighting. |
+
+## Adding a new long-lived structure
+
+When adding a map, task set, counter, or temp artifact to a long-lived process:
+
+1. Name the lifecycle event that removes each entry, and wire the removal to every path that retires the entry — not
+   only the clean-completion path.
+2. Prefer deriving counters from the tracked set; if a running total is unavoidable, adjust it in the same critical
+   section as every mutation, including resets.
+3. Give the structure an explicit bound (cap, TTL, or budget) and a test that drives churn and asserts the bound holds.
+4. Add a row to the inventory above.


### PR DESCRIPTION
## Summary

Closes out tracking issue #381 by fixing every child issue, one commit per issue for easy bisecting, each paired with a regression test verified to fail before the fix:

- **#372** — `transport-quic-broker`: `wait_for_subscriber` reset a finished room without decrementing `total_backlog_bytes`, the only reset path that bypassed `remove_room`'s symmetric adjustment. Now the discarded backlog leaves the global budget at the reset site; the test observes the counter in the window before the next op recomputes it.
- **#343** — `marmot-app`: `AgentStreamWatchManager` pruned only on finish and preserved every `running` entry. The 256-watch cap is now enforced on `start_watch` too, and pruning evicts the oldest running watches once no finished watch remains (finished still evict first).
- **#374** — `agent-connector`: the media temp sweeper checked the *dir* mtime while a re-download overwrites the file in place, updating only the *file* mtime — actively re-used media was swept at the 1 h mark. The sweep now keys on the newest mtime within the per-blob dir and skips dirs it cannot fully inspect.
- **#390** — `agent-connector`: the control-socket accept loop spawned unbounded per-connection tasks. It is now gated on a connection semaphore mirroring the broker's limiter (default 64, `--max-connections` on `dm-agent`; zero cap rejected as unsafe config).
- **#342** — `transport-nostr-adapter`: `RelaySyncTelemetry.subscriptions` grew with historical churn (every join/leave, rotation, and reactivate minted a permanent entry). Entries are now evicted from every path that retires a subscription: the group-sync remove diff, deactivation, and reactivation. Ids never include `since`, so ids reconstructed from stored routes match the recorded ones.

A repo-wide sweep for the same category found one additional gap, also fixed:

- `darkmatter-cli`: the `dmd` accept loop had the same unbounded per-connection spawn as #390; now capped at 256.

And per #381's acceptance criteria, `docs/marmot-architecture/runtime-state-bounds.md` inventories every long-lived daemon/broker structure with its cap/TTL/eviction rule and states the tracked-resource discipline for new state.

## Notes for reviewers

- Sweep candidates that were checked and intentionally **not** changed: the daemon's `display_names_by_sender` map (lives only for the bounded snapshot drain), `StreamWatchWorkers.handles` (reaped on every start and on status), and the adapter's per-relay first-event/EOSE histograms (bounded by configured relay count; documented rather than evicted).
- Each fix commit's test was verified to fail with the fix reverted.
- Merging auto-closes #342, #343, #372, #374, #390; #381 can then be closed manually (the dmd-cap and docs commits reference it).

## Verification

- `just fast-ci` (fmt, check, clippy incl. OTLP feature builds) passes.
- Full suites pass for all touched crates: `transport-quic-broker`, `transport-nostr-adapter` (incl. `--features sdk`), `marmot-app`, `agent-connector`, `darkmatter-cli` (750+ tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/700">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added limits on how many control connections can be served at once, with configurable caps in the daemon and agent connector.
  * Added a new architecture guide covering long-lived runtime state limits and cleanup rules.

* **Bug Fixes**
  * Improved cleanup of stale media folders so recently updated files are preserved.
  * Fixed watch retention so old entries are bounded even when watches never finish.
  * Improved telemetry and backlog accounting to avoid stale or inflated counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->