### PR TITLE
Couple admin-policy updates to member removals on send and validate paths

### DIFF
--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -251,6 +251,15 @@ pub(crate) fn validate_admin_leaf_coupling_for_staged_commit(
         Some(admin_bytes) => decode_admin_policy(admin_bytes)?,
         None => admins_of_group(mls_group)?,
     };
+    // An empty carried-forward set means the current epoch has no admin-policy
+    // state at all (component bytes cannot encode an empty list), so there is
+    // no admin key to orphan and the check is vacuously satisfied. This is not
+    // a bypass for admin-less groups: every commit shape that can remove
+    // ANOTHER member's leaf requires an authenticated admin sender
+    // (`require_admin_for_staged_commit`, enforced before this check on the
+    // send, ingest, and convergence-replay paths), which fail-closes when the
+    // admin set is empty; the only leaf-removing shape a non-admin may commit
+    // is SelfRemove-only, which cannot de-leaf a member of an empty admin set.
     if resulting_admins.is_empty() {
         return Ok(());
     }

--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -237,14 +237,20 @@ pub(crate) fn validate_admin_leaf_coupling_for_staged_commit(
     staged: &StagedCommit,
 ) -> Result<(), EngineError> {
     // Resulting admins come from the staged (provisional) app_data_dictionary, so
-    // an admin-policy update in this same commit is already reflected.
-    let Some(dict) = staged.group_context().extensions().app_data_dictionary() else {
-        return Ok(());
+    // an admin-policy update in this same commit is already reflected. When the
+    // staged GroupContext carries no admin-policy bytes, the resulting epoch's
+    // admin set is the prior epoch's set carried forward
+    // (admin-policy-v1.md "Validation"), so evaluate against the current
+    // group's admin set instead of skipping the check.
+    let staged_admin_bytes = staged
+        .group_context()
+        .extensions()
+        .app_data_dictionary()
+        .and_then(|dict| dict.dictionary().get(&GROUP_ADMIN_POLICY_COMPONENT_ID));
+    let resulting_admins = match staged_admin_bytes {
+        Some(admin_bytes) => decode_admin_policy(admin_bytes)?,
+        None => admins_of_group(mls_group)?,
     };
-    let Some(admin_bytes) = dict.dictionary().get(&GROUP_ADMIN_POLICY_COMPONENT_ID) else {
-        return Ok(());
-    };
-    let resulting_admins = decode_admin_policy(admin_bytes)?;
     if resulting_admins.is_empty() {
         return Ok(());
     }

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -8,6 +8,7 @@ use crate::engine::Engine;
 use crate::group_lifecycle::{self};
 use crate::pending_commit_guard::PendingCommitCleanupGuard;
 use crate::provider::EngineOpenMlsProvider;
+use cgka_traits::app_components::GROUP_ADMIN_POLICY_COMPONENT_ID;
 use cgka_traits::engine::{CommitOrderingKey, GroupStateChange, SendIntent, SendResult};
 use cgka_traits::engine_state::EpochState;
 use cgka_traits::error::EngineError;
@@ -15,7 +16,9 @@ use cgka_traits::peeler::GroupMessageMetadata;
 use cgka_traits::storage::{LeaveRequest, StorageError, StorageProvider};
 use cgka_traits::transport::{EncryptedPayload, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId};
+use openmls::component::ComponentData;
 use openmls::group::MlsGroup;
+use openmls::messages::proposals::{AppDataUpdateOperation, AppDataUpdateProposal, Proposal};
 use openmls::prelude::{BasicCredential, MlsMessageOut};
 use std::collections::HashSet;
 use tls_codec::Serialize as _;
@@ -383,9 +386,66 @@ impl<S: StorageProvider> Engine<S> {
         let pre_commit_ctx =
             crate::group_lifecycle::build_group_context_snapshot(&mls_group, &provider)?;
 
-        let (commit_out, _welcome_opt, _gi) = mls_group
-            .remove_members(&provider, &self.identity.signer, &leaf_indices)
-            .map_err(|e| EngineError::Backend(format!("remove_members: {e:?}")))?;
+        // Admin/leaf coupling (admin-policy-v1.md "Validation"): if any removed
+        // account is currently listed in `admins`, the same commit must also
+        // drop those keys from the admin-policy component — otherwise the
+        // resulting epoch lists an admin with no member leaf and is invalid.
+        let resulting_admins: Vec<[u8; 32]> = admins
+            .iter()
+            .filter(|admin| !target_admins.iter().any(|target| target == *admin))
+            .copied()
+            .collect();
+        let commit_out = if resulting_admins.len() == admins.len() {
+            // No removed member is an admin: a plain Remove commit carries the
+            // admin set forward unchanged.
+            let (commit_out, _welcome_opt, _gi) = mls_group
+                .remove_members(&provider, &self.identity.signer, &leaf_indices)
+                .map_err(|e| EngineError::Backend(format!("remove_members: {e:?}")))?;
+            commit_out
+        } else {
+            // The AdminDepletion guard above ensures resulting_admins is
+            // non-empty here.
+            let admin_update = Proposal::AppDataUpdate(Box::new(AppDataUpdateProposal::update(
+                GROUP_ADMIN_POLICY_COMPONENT_ID,
+                crate::app_components::encode_admin_policy(&resulting_admins)?,
+            )));
+            let mut builder = mls_group
+                .commit_builder()
+                .propose_removals(leaf_indices)
+                .add_proposal(admin_update)
+                .load_psks(
+                    <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(
+                        &provider,
+                    ),
+                )
+                .map_err(|e| EngineError::Backend(format!("load_psks: {e:?}")))?;
+            let mut app_data = builder.app_data_dictionary_updater();
+            for proposal in builder.app_data_update_proposals() {
+                if let AppDataUpdateOperation::Update(data) = proposal.operation() {
+                    app_data.set(ComponentData::from_parts(
+                        proposal.component_id(),
+                        data.clone(),
+                    ));
+                }
+            }
+            builder.with_app_data_dictionary_updates(app_data.changes());
+            let commit_bundle = builder
+                .build(
+                    <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::rand(
+                        &provider,
+                    ),
+                    <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::crypto(
+                        &provider,
+                    ),
+                    &self.identity.signer,
+                    |_| true,
+                )
+                .map_err(|e| EngineError::Backend(format!("remove_members build: {e:?}")))?
+                .stage_commit(&provider)
+                .map_err(|e| EngineError::Backend(format!("remove_members stage: {e:?}")))?;
+            let (commit_out, _welcome_opt, _gi) = commit_bundle.into_contents();
+            commit_out
+        };
 
         let staged_commit = mls_group
             .pending_commit()

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -16,9 +16,8 @@ use cgka_traits::peeler::GroupMessageMetadata;
 use cgka_traits::storage::{LeaveRequest, StorageError, StorageProvider};
 use cgka_traits::transport::{EncryptedPayload, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId};
-use openmls::component::ComponentData;
 use openmls::group::MlsGroup;
-use openmls::messages::proposals::{AppDataUpdateOperation, AppDataUpdateProposal, Proposal};
+use openmls::messages::proposals::{AppDataUpdateProposal, Proposal};
 use openmls::prelude::{BasicCredential, MlsMessageOut};
 use std::collections::HashSet;
 use tls_codec::Serialize as _;
@@ -386,65 +385,52 @@ impl<S: StorageProvider> Engine<S> {
         let pre_commit_ctx =
             crate::group_lifecycle::build_group_context_snapshot(&mls_group, &provider)?;
 
-        // Admin/leaf coupling (admin-policy-v1.md "Validation"): if any removed
-        // account is currently listed in `admins`, the same commit must also
-        // drop those keys from the admin-policy component — otherwise the
-        // resulting epoch lists an admin with no member leaf and is invalid.
+        // Admin/leaf coupling (admin-policy-v1.md "Validation"): the resulting
+        // epoch must not list an admin key without a member leaf. Derive the
+        // resulting admin set from the same membership delta the validator
+        // (`validate_admin_leaf_coupling_for_staged_commit`) uses — current
+        // leaves minus the leaves this commit removes — so an admin key is
+        // dropped exactly when none of its account's leaves survives,
+        // independent of how targets were expanded to leaf indices above.
+        let removed_leaves: HashSet<u32> = leaf_indices.iter().map(|idx| idx.u32()).collect();
+        let mut surviving_accounts: HashSet<[u8; 32]> = HashSet::new();
+        for member in mls_group.members() {
+            if removed_leaves.contains(&member.index.u32()) {
+                continue;
+            }
+            if let Ok(basic) = BasicCredential::try_from(member.credential)
+                && let Ok(pk) = <[u8; 32]>::try_from(basic.identity())
+            {
+                surviving_accounts.insert(pk);
+            }
+        }
         let resulting_admins: Vec<[u8; 32]> = admins
             .iter()
-            .filter(|admin| !target_admins.iter().any(|target| target == *admin))
+            .filter(|admin| surviving_accounts.contains(*admin))
             .copied()
             .collect();
         let commit_out = if resulting_admins.len() == admins.len() {
-            // No removed member is an admin: a plain Remove commit carries the
-            // admin set forward unchanged.
+            // No admin loses their last leaf: a plain Remove commit carries
+            // the admin set forward unchanged.
             let (commit_out, _welcome_opt, _gi) = mls_group
                 .remove_members(&provider, &self.identity.signer, &leaf_indices)
                 .map_err(|e| EngineError::Backend(format!("remove_members: {e:?}")))?;
             commit_out
         } else {
-            // The AdminDepletion guard above ensures resulting_admins is
-            // non-empty here.
+            // Couple an admin-policy update dropping the de-leafed admin keys
+            // into the same commit. The AdminDepletion guard above ensures
+            // `resulting_admins` is non-empty here.
             let admin_update = Proposal::AppDataUpdate(Box::new(AppDataUpdateProposal::update(
                 GROUP_ADMIN_POLICY_COMPONENT_ID,
                 crate::app_components::encode_admin_policy(&resulting_admins)?,
             )));
-            let mut builder = mls_group
-                .commit_builder()
-                .propose_removals(leaf_indices)
-                .add_proposal(admin_update)
-                .load_psks(
-                    <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(
-                        &provider,
-                    ),
-                )
-                .map_err(|e| EngineError::Backend(format!("load_psks: {e:?}")))?;
-            let mut app_data = builder.app_data_dictionary_updater();
-            for proposal in builder.app_data_update_proposals() {
-                if let AppDataUpdateOperation::Update(data) = proposal.operation() {
-                    app_data.set(ComponentData::from_parts(
-                        proposal.component_id(),
-                        data.clone(),
-                    ));
-                }
-            }
-            builder.with_app_data_dictionary_updates(app_data.changes());
-            let commit_bundle = builder
-                .build(
-                    <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::rand(
-                        &provider,
-                    ),
-                    <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::crypto(
-                        &provider,
-                    ),
-                    &self.identity.signer,
-                    |_| true,
-                )
-                .map_err(|e| EngineError::Backend(format!("remove_members build: {e:?}")))?
-                .stage_commit(&provider)
-                .map_err(|e| EngineError::Backend(format!("remove_members stage: {e:?}")))?;
-            let (commit_out, _welcome_opt, _gi) = commit_bundle.into_contents();
-            commit_out
+            self.stage_commit_with_app_data_updates(
+                &mut mls_group,
+                &provider,
+                leaf_indices,
+                vec![admin_update],
+                "remove_members",
+            )?
         };
 
         let staged_commit = mls_group
@@ -528,7 +514,7 @@ impl<S: StorageProvider> Engine<S> {
             ),
             recovery_snapshot,
         );
-        let removed_changes = unique_targets
+        let mut removed_changes: Vec<crate::engine::PendingGroupStateChange> = unique_targets
             .iter()
             .cloned()
             .map(|member| crate::engine::PendingGroupStateChange {
@@ -536,6 +522,16 @@ impl<S: StorageProvider> Engine<S> {
                 change: GroupStateChange::MemberRemoved { member },
             })
             .collect();
+        // Mirror what receivers derive from their before/after admin snapshot:
+        // the coupled admin-policy update also revokes admin status, so the
+        // author's confirm-published events must carry the same AdminRemoved
+        // rows (attributed to self, as UpdateAppComponents does).
+        for change in crate::group_state_changes::admin_changes(&admins, &resulting_admins) {
+            removed_changes.push(crate::engine::PendingGroupStateChange {
+                actor: Some(self.identity.self_id().clone()),
+                change,
+            });
+        }
         self.pending_state_changes
             .insert(pending_ref, removed_changes);
         pending_commit_guard.disarm();

--- a/crates/cgka-engine/src/update_group_data.rs
+++ b/crates/cgka-engine/src/update_group_data.rs
@@ -336,9 +336,9 @@ impl<S: StorageProvider> Engine<S> {
 
     /// Stage (don't merge) a commit that carries `AppDataUpdate` proposals,
     /// optionally alongside member removals, through the OpenMLS commit
-    /// builder. Every `Update` proposal is mirrored into the resulting
-    /// `app_data_dictionary` via the builder's dictionary updater, matching
-    /// what recipients compute in
+    /// builder. Every `Update` and `Remove` proposal is mirrored into the
+    /// resulting `app_data_dictionary` via the builder's dictionary updater,
+    /// matching what recipients compute in
     /// [`crate::openmls_projection::process_commit_with_app_data_updates`].
     /// Shared by the `UpdateAppComponents` path and the coupled admin-policy
     /// removal path in `do_send_remove_members`. `context` prefixes error
@@ -351,6 +351,22 @@ impl<S: StorageProvider> Engine<S> {
         proposals: Vec<Proposal>,
         context: &str,
     ) -> Result<MlsMessageOut, EngineError> {
+        // Mirror the receiver-side guard: a Remove of the negotiation
+        // component or a group-required component must fail at staging, not
+        // surface as a recipient-side rejection. Checked before the builder
+        // takes its mutable borrow of `mls_group`. No current caller produces
+        // a Remove (all send intents carry Update bytes); this keeps the
+        // shared helper in parity with the projection for future callers.
+        for proposal in &proposals {
+            if let Proposal::AppDataUpdate(update) = proposal
+                && matches!(update.operation(), AppDataUpdateOperation::Remove)
+            {
+                crate::app_components::validate_app_component_remove(
+                    mls_group,
+                    update.component_id(),
+                )?;
+            }
+        }
         let mut builder = mls_group
             .commit_builder()
             .propose_removals(removals)
@@ -363,11 +379,16 @@ impl<S: StorageProvider> Engine<S> {
             .map_err(|e| EngineError::Backend(format!("{context} load_psks: {e:?}")))?;
         let mut app_data = builder.app_data_dictionary_updater();
         for proposal in builder.app_data_update_proposals() {
-            if let AppDataUpdateOperation::Update(data) = proposal.operation() {
-                app_data.set(ComponentData::from_parts(
-                    proposal.component_id(),
-                    data.clone(),
-                ));
+            match proposal.operation() {
+                AppDataUpdateOperation::Update(data) => {
+                    app_data.set(ComponentData::from_parts(
+                        proposal.component_id(),
+                        data.clone(),
+                    ));
+                }
+                AppDataUpdateOperation::Remove => {
+                    app_data.remove(&proposal.component_id());
+                }
             }
         }
         builder.with_app_data_dictionary_updates(app_data.changes());

--- a/crates/cgka-engine/src/update_group_data.rs
+++ b/crates/cgka-engine/src/update_group_data.rs
@@ -18,6 +18,7 @@ use cgka_traits::types::{EpochId, GroupId};
 use openmls::component::ComponentData;
 use openmls::group::MlsGroup;
 use openmls::messages::proposals::{AppDataUpdateOperation, AppDataUpdateProposal, Proposal};
+use openmls::prelude::{LeafNodeIndex, MlsMessageOut};
 use std::collections::BTreeSet;
 use tls_codec::Serialize as _;
 
@@ -224,38 +225,13 @@ impl<S: StorageProvider> Engine<S> {
                 )))
             })
             .collect::<Vec<_>>();
-        let mut builder = mls_group
-            .commit_builder()
-            .add_proposals(proposals)
-            .load_psks(
-                <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(
-                    &provider,
-                ),
-            )
-            .map_err(|e| EngineError::Backend(format!("load_psks: {e:?}")))?;
-        let mut app_data = builder.app_data_dictionary_updater();
-        for proposal in builder.app_data_update_proposals() {
-            if let AppDataUpdateOperation::Update(data) = proposal.operation() {
-                app_data.set(ComponentData::from_parts(
-                    proposal.component_id(),
-                    data.clone(),
-                ));
-            }
-        }
-        builder.with_app_data_dictionary_updates(app_data.changes());
-        let commit_bundle = builder
-            .build(
-                <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::rand(&provider),
-                <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::crypto(
-                    &provider,
-                ),
-                &self.identity.signer,
-                |_| true,
-            )
-            .map_err(|e| EngineError::Backend(format!("app_data_update build: {e:?}")))?
-            .stage_commit(&provider)
-            .map_err(|e| EngineError::Backend(format!("app_data_update stage: {e:?}")))?;
-        let (commit_out, _welcome_opt, _gi) = commit_bundle.into_contents();
+        let commit_out = self.stage_commit_with_app_data_updates(
+            &mut mls_group,
+            &provider,
+            Vec::new(),
+            proposals,
+            "app_data_update",
+        )?;
         let commit_bytes = commit_out
             .tls_serialize_detached()
             .map_err(|e| EngineError::Serialize(format!("{e:?}")))?;
@@ -356,5 +332,56 @@ impl<S: StorageProvider> Engine<S> {
             welcomes: vec![],
             pending: pending_ref,
         })
+    }
+
+    /// Stage (don't merge) a commit that carries `AppDataUpdate` proposals,
+    /// optionally alongside member removals, through the OpenMLS commit
+    /// builder. Every `Update` proposal is mirrored into the resulting
+    /// `app_data_dictionary` via the builder's dictionary updater, matching
+    /// what recipients compute in
+    /// [`crate::openmls_projection::process_commit_with_app_data_updates`].
+    /// Shared by the `UpdateAppComponents` path and the coupled admin-policy
+    /// removal path in `do_send_remove_members`. `context` prefixes error
+    /// messages so failures stay attributable to the calling intent.
+    pub(crate) fn stage_commit_with_app_data_updates(
+        &self,
+        mls_group: &mut MlsGroup,
+        provider: &EngineOpenMlsProvider<'_, S>,
+        removals: Vec<LeafNodeIndex>,
+        proposals: Vec<Proposal>,
+        context: &str,
+    ) -> Result<MlsMessageOut, EngineError> {
+        let mut builder = mls_group
+            .commit_builder()
+            .propose_removals(removals)
+            .add_proposals(proposals)
+            .load_psks(
+                <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(
+                    provider,
+                ),
+            )
+            .map_err(|e| EngineError::Backend(format!("{context} load_psks: {e:?}")))?;
+        let mut app_data = builder.app_data_dictionary_updater();
+        for proposal in builder.app_data_update_proposals() {
+            if let AppDataUpdateOperation::Update(data) = proposal.operation() {
+                app_data.set(ComponentData::from_parts(
+                    proposal.component_id(),
+                    data.clone(),
+                ));
+            }
+        }
+        builder.with_app_data_dictionary_updates(app_data.changes());
+        let commit_bundle = builder
+            .build(
+                <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::rand(provider),
+                <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::crypto(provider),
+                &self.identity.signer,
+                |_| true,
+            )
+            .map_err(|e| EngineError::Backend(format!("{context} build: {e:?}")))?
+            .stage_commit(provider)
+            .map_err(|e| EngineError::Backend(format!("{context} stage: {e:?}")))?;
+        let (commit_out, _welcome_opt, _gi) = commit_bundle.into_contents();
+        Ok(commit_out)
     }
 }

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -856,6 +856,96 @@ async fn convergence_rejects_remove_whose_context_carries_no_admin_policy_bytes(
 }
 
 #[tokio::test]
+async fn live_ingest_rejects_remove_whose_context_carries_no_admin_policy_bytes() {
+    // Sibling of the stored-convergence test above, pushed through the live
+    // `ingest` entry point instead of pre-buffering — pinning the hot path a
+    // relay-delivered commit takes. The invalid remove must never be applied:
+    // the outcome is terminal, and Carol's epoch, membership, and admin view
+    // stay untouched.
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let bob_id = bob.self_id();
+    let alice_id = alice.self_id();
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "live-ingest-carried-forward-admins".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob_id.clone()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    let invalid_remove = route(
+        raw_remove_members_commit_dropping_app_data_dictionary(
+            &bob_storage,
+            &bob.self_id(),
+            &group_id,
+            std::slice::from_ref(&alice_id),
+        ),
+        &group_id,
+    );
+
+    let outcome = carol.ingest(invalid_remove.clone()).await.unwrap();
+    assert!(
+        !matches!(outcome, IngestOutcome::Processed),
+        "invalid remove must not be applied via live ingest, got {outcome:?}"
+    );
+    // Drive convergence to quiescence in case the inline pass left the commit
+    // pending; the commit must still never be accepted.
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, u64::MAX)
+        .expect("stored OpenMLS messages converge");
+    assert!(
+        result.accepted_commits.is_empty(),
+        "invalid remove must not be accepted after quiescence: {result:?}"
+    );
+
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
+    let stored_group = carol_storage.get_group(&group_id).expect("group stored");
+    assert_eq!(stored_group.epoch, EpochId(1));
+    assert_eq!(stored_group.members.len(), 3);
+    let projected_members = carol.members(&group_id).expect("members projected");
+    assert_eq!(projected_members.len(), 3);
+    assert!(
+        projected_members.iter().any(|member| member.id == alice_id),
+        "alice must remain a member on carol's view: {projected_members:?}"
+    );
+    let alice_admin: [u8; 32] = alice_id.as_slice().try_into().unwrap();
+    let bob_admin: [u8; 32] = bob_id.as_slice().try_into().unwrap();
+    let mut expected_admins = vec![alice_admin, bob_admin];
+    expected_admins.sort();
+    assert_eq!(
+        carol.admin_pubkeys(&group_id).unwrap(),
+        expected_admins,
+        "carol's admin view must be unchanged"
+    );
+    assert_message_state(
+        &carol_storage,
+        &invalid_remove,
+        MessageState::EpochInvalidated,
+    );
+}
+
+#[tokio::test]
 async fn convergence_accepts_remove_when_admin_policy_drops_removed_admin() {
     // Positive control for the same invariant: a commit may remove an admin's
     // last member leaf if the same resulting epoch's signed admin-policy drops

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -360,6 +360,83 @@ fn raw_remove_members_commit(
     }
 }
 
+/// Raw OpenMLS commit that removes `targets` and ALSO replaces the
+/// GroupContext extensions with a copy that drops the `app_data_dictionary`
+/// entirely, so the resulting epoch carries no admin-policy bytes at all.
+/// OpenMLS accepts this shape (its draft-08 dictionary guard only applies to
+/// commits that carry AppDataUpdate proposals), so the Marmot engine must
+/// evaluate the admin/leaf coupling against the carried-forward admin set
+/// (admin-policy-v1.md "Validation") instead of skipping the check.
+fn raw_remove_members_commit_dropping_app_data_dictionary(
+    storage: &SqliteAccountStorage,
+    sender: &MemberId,
+    group_id: &GroupId,
+    targets: &[MemberId],
+) -> TransportMessage {
+    let crypto = openmls_rust_crypto::RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mut mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load sender MLS group")
+        .expect("sender joined group");
+    let binding = storage
+        .account_device_signer(sender)
+        .expect("load signer binding")
+        .expect("signer binding exists");
+    let signer = SignatureKeyPair::read(
+        storage.mls_storage(),
+        &binding.mls_signature_public_key,
+        DEFAULT_CIPHERSUITE.signature_algorithm(),
+    )
+    .expect("MLS signer exists");
+
+    let mut leaf_indices = Vec::new();
+    for member in mls_group.members() {
+        let credential =
+            BasicCredential::try_from(member.credential).expect("member uses BasicCredential");
+        if targets
+            .iter()
+            .any(|target| target.as_slice() == credential.identity())
+        {
+            leaf_indices.push(member.index);
+        }
+    }
+    assert_eq!(
+        leaf_indices.len(),
+        targets.len(),
+        "raw test commit must find every removal target"
+    );
+
+    let mut stripped_extensions = mls_group.extensions().clone();
+    stripped_extensions.remove(openmls::extensions::ExtensionType::AppDataDictionary);
+    let commit_bundle = mls_group
+        .commit_builder()
+        .propose_removals(leaf_indices)
+        .propose_group_context_extensions(stripped_extensions)
+        .expect("propose GCE without app_data_dictionary")
+        .load_psks(provider.storage())
+        .expect("load PSKs")
+        .build(provider.rand(), provider.crypto(), &signer, |_| true)
+        .expect("build raw remove+GCE commit")
+        .stage_commit(&provider)
+        .expect("stage raw remove+GCE commit");
+    let (commit, _welcome, _group_info) = commit_bundle.into_contents();
+    let payload = commit
+        .tls_serialize_detached()
+        .expect("serialize raw remove+GCE commit");
+    TransportMessage {
+        id: hash_id(&payload),
+        payload,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("raw-openmls-remove-drop-dict".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    }
+}
+
 fn raw_remove_members_commit_with_admin_policy(
     storage: &SqliteAccountStorage,
     sender: &MemberId,
@@ -636,6 +713,109 @@ async fn convergence_rejects_remove_that_leaves_orphan_admin_key() {
     assert!(
         result.accepted_commits.is_empty(),
         "orphan-admin remove must not be accepted: {result:?}"
+    );
+    assert!(
+        result.dropped_messages.iter().any(|dropped| {
+            dropped.kind == MessageKind::Commit
+                && dropped.reason == DroppedMessageReason::InvalidAgainstCandidateState
+                && dropped.message_id == content_hex(&invalid_remove)
+        }),
+        "expected invalid remove dropped as InvalidAgainstCandidateState, got {:?}",
+        result.dropped_messages
+    );
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
+    let stored_group = carol_storage.get_group(&group_id).expect("group stored");
+    assert_eq!(stored_group.epoch, EpochId(1));
+    assert_eq!(
+        stored_group.members.len(),
+        3,
+        "invalid convergence commit must not change stored member count"
+    );
+    let projected_members = carol.members(&group_id).expect("members projected");
+    assert_eq!(
+        projected_members.len(),
+        3,
+        "invalid convergence commit must not change projected member count"
+    );
+    for expected in [&alice_id, &bob_id, &carol_id] {
+        assert!(
+            projected_members
+                .iter()
+                .any(|member| member.id == *expected),
+            "projected members should still contain {expected:?}: {projected_members:?}"
+        );
+    }
+    assert_message_state(
+        &carol_storage,
+        &invalid_remove,
+        MessageState::EpochInvalidated,
+    );
+}
+
+#[tokio::test]
+async fn convergence_rejects_remove_whose_context_carries_no_admin_policy_bytes() {
+    // darkmatter#393 / admin-policy-v1.md "Validation": the cross-component
+    // check runs on every commit that changes the member leaf set, whether or
+    // not the commit carries admin-policy bytes. Bob's raw commit removes
+    // Alice's last member leaf and swaps in GroupContext extensions with no
+    // app_data_dictionary, so the staged context has no admin-policy entry to
+    // read. The resulting epoch's admin set is the prior set carried forward
+    // ({Alice, Bob}), so the commit must be rejected instead of skipping the
+    // check on the missing bytes.
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let bob_id = bob.self_id();
+    let alice_id = alice.self_id();
+    let carol_id = carol.self_id();
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "convergence-carried-forward-admins".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob_id.clone()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    let invalid_remove = route(
+        raw_remove_members_commit_dropping_app_data_dictionary(
+            &bob_storage,
+            &bob.self_id(),
+            &group_id,
+            std::slice::from_ref(&alice_id),
+        ),
+        &group_id,
+    );
+    carol
+        .buffer_openmls_convergence_message(&group_id, invalid_remove.clone(), 1_000)
+        .expect("invalid remove commit buffered");
+
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("stored OpenMLS messages converge");
+
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    assert!(
+        result.accepted_commits.is_empty(),
+        "remove with no admin-policy bytes must not be accepted: {result:?}"
     );
     assert!(
         result.dropped_messages.iter().any(|dropped| {

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -616,15 +616,17 @@ async fn admin_remove_members_publishes_commit_and_updates_membership() {
 }
 
 #[tokio::test]
-async fn remove_co_admin_without_admin_policy_update_is_rejected() {
+async fn remove_co_admin_couples_admin_policy_update_in_same_commit() {
     // admin-policy-v1.md: a commit that removes an account's last member leaf
     // MUST also remove that account's key from `admins` in the same resulting
-    // epoch. The public RemoveMembers path cannot currently carry that
-    // admin-policy rewrite, so removing a listed co-admin must be rejected
-    // before staging a local commit.
+    // epoch. The public RemoveMembers path builds that coupled
+    // Remove + AppDataUpdate commit itself, so removing a listed co-admin
+    // succeeds, the commit publishes, and the resulting admin set no longer
+    // lists the removed account — locally and for a member ingesting it.
     let mut alice = build_client(b"alice");
     let mut bob = build_client(b"bob");
     let mut carol = build_client(b"carol");
+    let alice_id = alice.self_id();
     let bob_id = bob.self_id();
     let bob_kp = bob.fresh_key_package().await.unwrap();
     let carol_kp = carol.fresh_key_package().await.unwrap();
@@ -640,37 +642,80 @@ async fn remove_co_admin_without_admin_policy_update_is_rejected() {
         })
         .await
         .unwrap();
-    match create {
-        SendResult::GroupCreated { pending, .. } => {
+    let (welcome_for_bob, welcome_for_carol) = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
             alice.confirm_published(pending).await.unwrap();
+            (welcomes.remove(0), welcomes.remove(0))
         }
         other => panic!("expected GroupCreated, got {other:?}"),
-    }
+    };
+    bob.join_welcome(welcome_for_bob).await.unwrap();
+    carol.join_welcome(welcome_for_carol).await.unwrap();
 
-    let result = alice
+    let alice_admin: [u8; 32] = alice_id.as_slice().try_into().unwrap();
+    let bob_admin: [u8; 32] = bob_id.as_slice().try_into().unwrap();
+    let mut initial_admins = vec![alice_admin, bob_admin];
+    initial_admins.sort();
+    assert_eq!(alice.admin_pubkeys(&group_id).unwrap(), initial_admins);
+
+    let remove = alice
         .send(SendIntent::RemoveMembers {
             group_id: group_id.clone(),
             members: vec![bob_id.clone()],
         })
-        .await;
+        .await
+        .expect("removing a co-admin stages a coupled Remove+AppDataUpdate commit");
+    let (commit, pending) = match remove {
+        SendResult::GroupEvolution {
+            msg,
+            welcomes,
+            pending,
+        } => {
+            assert!(welcomes.is_empty());
+            (msg, pending)
+        }
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
 
-    match result {
-        Err(EngineError::Other(message)) => assert!(
-            message.contains("admin key has no member leaf"),
-            "unexpected error text: {message}"
-        ),
-        Err(other) => panic!("expected admin/leaf coupling error, got {other:?}"),
-        Ok(_) => panic!("removing a listed co-admin without updating admin policy must fail"),
-    }
-
-    assert_eq!(alice.epoch(&group_id).unwrap().0, 1);
+    assert_eq!(alice.epoch(&group_id).unwrap().0, 2);
+    let alice_members = alice.members(&group_id).unwrap();
+    assert_eq!(alice_members.len(), 2);
     assert!(
-        alice
-            .members(&group_id)
-            .unwrap()
-            .iter()
-            .any(|member| member.id == bob_id),
-        "failed remove must leave bob in the local member projection"
+        !alice_members.iter().any(|member| member.id == bob_id),
+        "bob must be removed from alice's membership; got {alice_members:?}"
+    );
+    assert_eq!(
+        alice.admin_pubkeys(&group_id).unwrap(),
+        vec![alice_admin],
+        "the same commit must drop bob from the admin set"
+    );
+
+    // A second member ingesting the commit accepts it and sees the same
+    // membership and admin-set change.
+    let routed_commit = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..commit
+    };
+    let outcome = carol.ingest(routed_commit).await.unwrap();
+    assert!(matches!(outcome, IngestOutcome::Buffered { .. }));
+    converge_buffered_commit(&mut carol, &group_id);
+    assert_eq!(carol.epoch(&group_id).unwrap().0, 2);
+    let carol_members = carol.members(&group_id).unwrap();
+    assert_eq!(carol_members.len(), 2);
+    assert!(
+        !carol_members.iter().any(|member| member.id == bob_id),
+        "carol must converge to a group without bob; got {carol_members:?}"
+    );
+    assert_eq!(
+        carol.admin_pubkeys(&group_id).unwrap(),
+        vec![alice_admin],
+        "carol's admin view must drop bob after ingesting the commit"
     );
 }
 

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -681,6 +681,25 @@ async fn remove_co_admin_couples_admin_policy_update_in_same_commit() {
     };
     alice.confirm_published(pending).await.unwrap();
 
+    // The author's confirm-published events must carry BOTH the membership
+    // change and the coupled admin revocation, matching what receivers derive
+    // from their before/after admin snapshot.
+    let alice_events = alice.drain_events();
+    assert!(
+        emits_removed_of(&alice_events, &bob_id),
+        "alice should emit MemberRemoved for bob after confirm; got {alice_events:?}"
+    );
+    assert!(
+        alice_events.iter().any(|event| matches!(
+            event,
+            cgka_traits::engine::GroupEvent::GroupStateChanged {
+                change: cgka_traits::engine::GroupStateChange::AdminRemoved { member },
+                ..
+            } if member == &bob_id
+        )),
+        "alice should emit AdminRemoved for bob after confirm; got {alice_events:?}"
+    );
+
     assert_eq!(alice.epoch(&group_id).unwrap().0, 2);
     let alice_members = alice.members(&group_id).unwrap();
     assert_eq!(alice_members.len(), 2);


### PR DESCRIPTION
## Summary

Fixes both sides of the admin/leaf coupling invariant that marmot-protocol/marmot#171 made normative in `app-components/admin-policy-v1.md` ("Validation"):

> The cross-component check is a property of the resulting epoch, not of the commits that carry admin-policy bytes. It runs on every commit that changes the member leaf set or this component's state. When a commit carries no admin-policy update, the resulting epoch's admin set is the prior epoch's admin set carried forward, and the check is evaluated against that carried-forward set. A commit that removes a listed account's last member leaf without also updating this component is therefore invalid whether or not the commit re-serializes this component's bytes.

### Validating side — Closes #393

`validate_admin_leaf_coupling_for_staged_commit` (`crates/cgka-engine/src/app_components.rs`) previously early-returned `Ok(())` when the staged commit's GroupContext carried no `app_data_dictionary` extension or no admin-policy entry. It now falls back to the current group's admin set (`admins_of_group`) — the carried-forward set per the spec — and runs the same coupling validation against it, skipping only when the computed set is empty. All three callers (outbound send, live ingest, convergence replay) benefit automatically, so a commit whose resulting state fails the check cannot create a candidate edge (`protocol-core/convergence.md`, "Candidate branches").

Concretely, this closes the hole where a raw commit carrying a `GroupContextExtensions` proposal that drops the `app_data_dictionary` (OpenMLS only guards the dictionary against GCE rewrites for commits that also carry `AppDataUpdate` proposals) could remove an admin's last member leaf and be accepted.

### Producing side — Closes #362

`do_send_remove_members` (`crates/cgka-engine/src/message_processor/send.rs`) previously called `mls_group.remove_members(...)` unconditionally, so removing an admin produced a commit whose resulting epoch still listed them — correctly rejected by the coupling check, leaving the remove-an-admin flow broken. It now detects removal targets that are listed admins and builds the commit through the OpenMLS commit builder with a coupled `AppDataUpdate` that drops the removed keys from the admin-policy component in the same commit (same pattern as `do_send_update_app_components`). Removing non-admin members keeps the plain `remove_members` path; the existing `AdminDepletion` guard still rejects removing the last admin(s), which also guarantees the coupled admin set is never empty.

## Test plan

- `remove_co_admin_couples_admin_policy_update_in_same_commit` (`tests/invite_leave.rs`, replaces `remove_co_admin_without_admin_policy_update_is_rejected`, which documented the now-fixed broken behavior of the public send path): removing a co-admin via `SendIntent::RemoveMembers` publishes, drops the member, drops them from the admin set, and a second member ingesting the commit accepts it and sees the updated membership and admin view.
- `convergence_rejects_remove_whose_context_carries_no_admin_policy_bytes` (`tests/distributed_convergence.rs`): a raw Remove+GCE commit whose resulting GroupContext carries no admin-policy bytes while removing an admin's last leaf is rejected via the carried-forward fallback (`InvalidAgainstCandidateState`, epoch and membership unchanged). Verified this test fails without the validation fix (the commit was accepted) and passes with it.
- Existing negative/positive controls still pass: `convergence_rejects_remove_that_leaves_orphan_admin_key`, `convergence_accepts_remove_when_admin_policy_drops_removed_admin`.
- Full crate suite: `cargo test -p cgka-engine` — 214 passed, 0 failed.
- `just fast-ci` (fmt-check, check incl. OTLP features, clippy `-D warnings`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/701">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removing members with admin roles now succeeds while maintaining admin/leaf coupling by applying the required admin-policy adjustments in the same commit.
  * Improved invariant validation when staged admin-policy data is missing by evaluating against the current group’s admin set.

* **Tests**
  * Added regression coverage for distributed convergence and live ingest to ensure invalid commits are rejected/invalidated and state remains unchanged.
  * Updated invite/leave tests to confirm successful coupled removal behavior and correct event/state propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->