### PR TITLE
Withdraw losing committer's group-state notifications via explicit invalidation event (#363)

### DIFF
--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -14,7 +14,9 @@ use crate::openmls_projection::{
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use cgka_traits::engine::{AppMessageInvalidationReason, GroupEvent, GroupStateChange};
+use cgka_traits::engine::{
+    AppMessageInvalidationReason, GroupEvent, GroupStateChange, GroupStateInvalidationReason,
+};
 use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
 use cgka_traits::storage::{StorageError, StorageProvider};
 use cgka_traits::transport::TransportMessage;
@@ -693,6 +695,13 @@ impl<S: StorageProvider> Engine<S> {
     /// and the app-side tombstone is a no-op when no row carries the commit id,
     /// so emitting here is idempotent and safe even for commits this client
     /// never applied.
+    ///
+    /// Each rolled-back commit also gets a [`GroupEvent::GroupStateInvalidated`]:
+    /// the spec-required explicit withdrawal of every state notification
+    /// attributed to the superseded commit (convergence.md "Applying the
+    /// selected branch"). This covers the client's own published-and-confirmed
+    /// commit when it loses branch selection through the stored-convergence
+    /// seam, mirroring the direct seam's `ForkRecovered` pairing.
     fn emit_rolled_back_commits(
         &mut self,
         group_id: &GroupId,
@@ -707,10 +716,29 @@ impl<S: StorageProvider> Engine<S> {
             {
                 continue;
             }
+            let invalidated_commit_id = message_id_from_hex(&dropped.message_id)?;
+            // The stored record's epoch is the commit's source epoch (the fork
+            // it lost). Best-effort: fall back to the selected branch's fork
+            // epoch when the record is gone — the id-matched withdrawal is what
+            // conformance requires; the epoch is presentation metadata.
+            let epoch = self
+                .storage
+                .get_message(&invalidated_commit_id)
+                .map(|record| record.epoch)
+                .unwrap_or(EpochId(
+                    result.selected_fork_epoch.unwrap_or(result.previous_tip),
+                ));
             self.events_buf.push_back(GroupEvent::CommitRolledBack {
                 group_id: group_id.clone(),
-                invalidated_commit_id: message_id_from_hex(&dropped.message_id)?,
+                invalidated_commit_id: invalidated_commit_id.clone(),
             });
+            self.events_buf
+                .push_back(GroupEvent::GroupStateInvalidated {
+                    group_id: group_id.clone(),
+                    epoch,
+                    invalidated_commit_id,
+                    reason: GroupStateInvalidationReason::SupersededByBranchSelection,
+                });
         }
         Ok(())
     }

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -435,6 +435,7 @@ impl<S: StorageProvider> Engine<S> {
         self.emit_application_replay_events(group_id, &observations);
         self.emit_invalidated_app_events(group_id, &result)?;
         self.emit_rolled_back_commits(group_id, &result)?;
+        self.emit_superseded_processed_commits(group_id, &result)?;
 
         // A selected branch reached the canonical state (Settled): the run is
         // applied/stable. With no selected branch the pass simply settled with
@@ -718,16 +719,18 @@ impl<S: StorageProvider> Engine<S> {
             }
             let invalidated_commit_id = message_id_from_hex(&dropped.message_id)?;
             // The stored record's epoch is the commit's source epoch (the fork
-            // it lost). Best-effort: fall back to the selected branch's fork
-            // epoch when the record is gone — the id-matched withdrawal is what
-            // conformance requires; the epoch is presentation metadata.
-            let epoch = self
-                .storage
-                .get_message(&invalidated_commit_id)
-                .map(|record| record.epoch)
-                .unwrap_or(EpochId(
-                    result.selected_fork_epoch.unwrap_or(result.previous_tip),
-                ));
+            // it lost). A missing record falls back to the selected branch's
+            // fork epoch — the id-matched withdrawal is what conformance
+            // requires; the epoch is presentation metadata. Any other storage
+            // failure propagates: masking a locked/corrupt backend here would
+            // emit a fabricated epoch and hide the failure from the caller.
+            let epoch = match self.storage.get_message(&invalidated_commit_id) {
+                Ok(record) => record.epoch,
+                Err(StorageError::NotFound) => {
+                    EpochId(result.selected_fork_epoch.unwrap_or(result.previous_tip))
+                }
+                Err(e) => return Err(OpenMlsProjectionError::Storage(format!("{e:?}"))),
+            };
             self.events_buf.push_back(GroupEvent::CommitRolledBack {
                 group_id: group_id.clone(),
                 invalidated_commit_id: invalidated_commit_id.clone(),
@@ -737,6 +740,100 @@ impl<S: StorageProvider> Engine<S> {
                     group_id: group_id.clone(),
                     epoch,
                     invalidated_commit_id,
+                    reason: GroupStateInvalidationReason::SupersededByBranchSelection,
+                });
+        }
+        Ok(())
+    }
+
+    /// Withdraw every commit this device PREVIOUSLY APPLIED (stored state
+    /// `Processed`) that a convergence apply left off the selected branch.
+    ///
+    /// The canonicalization drop set only covers commits the candidate BFS
+    /// could materialize. A device's OWN published-and-confirmed commit is not
+    /// replayable through `process_message` (MLS cannot process own messages),
+    /// so when a reorg supersedes it — e.g. after a restart cleared the
+    /// in-memory `committed_from` guard and routed a same-epoch sibling into
+    /// stored convergence — the own commit gets no disposition at all: no
+    /// `CommitRolledBack`, no withdrawal, and the confirm-time
+    /// `GroupStateChanged` rows survive as the issue #363 lie.
+    ///
+    /// Spec (convergence.md "Applying the selected branch"): branch selection
+    /// superseding "a commit the client previously applied — including the
+    /// client's own published and confirmed commit" MUST withdraw the state
+    /// notifications attributed to it. `Processed` is exactly "previously
+    /// applied"; not on the accepted path at or above the selected fork epoch
+    /// is exactly "superseded". Commits the drop set already covered are
+    /// skipped so each supersession is reported once.
+    fn emit_superseded_processed_commits(
+        &mut self,
+        group_id: &GroupId,
+        result: &CanonicalizationResult,
+    ) -> Result<(), OpenMlsProjectionError> {
+        if result.selected_tip.is_none() {
+            return Ok(());
+        }
+        let Some(fork_epoch) = result.selected_fork_epoch else {
+            return Ok(());
+        };
+        let accepted: std::collections::BTreeSet<&str> =
+            result.accepted_commits.iter().map(String::as_str).collect();
+        let records = self
+            .storage
+            .list_messages(group_id, EpochId(0))
+            .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+        for record in records {
+            if record.state != MessageState::Processed || record.epoch.0 < fork_epoch {
+                continue;
+            }
+            let payload = StoredMessagePayload::decode(&record.payload)
+                .map_err(|e| OpenMlsProjectionError::Serialize(format!("{e:?}")))?;
+            let Some(message) = payload.as_openmls_wire() else {
+                continue;
+            };
+            if project_mls_message(&message.payload)?.kind != OpenMlsContentKind::Commit {
+                continue;
+            }
+            let record_id_hex = hex::encode(record.id.as_slice());
+            // The same MLS bytes can be keyed by the wrap-time transport id
+            // (own sent commits) or the content dedup id (inbound commits), so
+            // acceptance is checked under both aliases before declaring the
+            // record superseded.
+            let content_id_hex = hex::encode(
+                crate::message_processor::content_dedup_id(&message.payload).as_slice(),
+            );
+            if accepted.contains(record_id_hex.as_str())
+                || accepted.contains(content_id_hex.as_str())
+            {
+                continue;
+            }
+            if result
+                .dropped_messages
+                .iter()
+                .any(|dropped| dropped.message_id == record_id_hex)
+            {
+                continue;
+            }
+            self.storage
+                .update_message_state(&record.id, MessageState::EpochInvalidated)
+                .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+            self.audit_group(
+                group_id,
+                crate::audit_helpers::message_state_changed_event(
+                    record_id_hex,
+                    MessageState::EpochInvalidated,
+                    "superseded_processed_commit",
+                ),
+            );
+            self.events_buf.push_back(GroupEvent::CommitRolledBack {
+                group_id: group_id.clone(),
+                invalidated_commit_id: record.id.clone(),
+            });
+            self.events_buf
+                .push_back(GroupEvent::GroupStateInvalidated {
+                    group_id: group_id.clone(),
+                    epoch: record.epoch,
+                    invalidated_commit_id: record.id,
                     reason: GroupStateInvalidationReason::SupersededByBranchSelection,
                 });
         }

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -19,6 +19,7 @@ use crate::provider::EngineOpenMlsProvider;
 use crate::snapshot_guard::SnapshotRollbackGuard;
 use cgka_traits::engine::{
     AutoPublish, CommitOrderingKey, CommitOrderingPriority, GroupEvent, GroupStateChange,
+    GroupStateInvalidationReason,
 };
 use cgka_traits::error::{EngineError, PeelerError};
 use cgka_traits::ingest::{IngestOutcome, PeeledContent, StaleReason};
@@ -793,8 +794,21 @@ impl<S: StorageProvider> Engine<S> {
                             recovered_epoch: after,
                             winner,
                             invalidated,
-                            invalidated_commit_id,
+                            invalidated_commit_id: invalidated_commit_id.clone(),
                         });
+                        // Branch selection superseded the previously applied
+                        // commit (including our own published-and-confirmed
+                        // commit), so every state notification attributed to it
+                        // is withdrawn before the winning commit's fresh
+                        // `GroupStateChanged` events are synthesized below
+                        // (convergence.md "Applying the selected branch").
+                        self.events_buf
+                            .push_back(GroupEvent::GroupStateInvalidated {
+                                group_id: group_id.clone(),
+                                epoch: source_epoch,
+                                invalidated_commit_id,
+                                reason: GroupStateInvalidationReason::SupersededByBranchSelection,
+                            });
                     }
                     self.events_buf.push_back(GroupEvent::EpochChanged {
                         group_id: group_id.clone(),

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -900,6 +900,33 @@ async fn convergence_rollback_emits_commit_rolled_back_for_losing_branch() {
         )),
         "expected CommitRolledBack for the losing commit, got {events:?}"
     );
+    // (b') Issue #363 / spec convergence.md "Applying the selected branch": the
+    // stored-convergence seam must also emit the explicit state-notification
+    // withdrawal naming the superseded commit, so every `GroupStateChanged`
+    // attributed to it is treated as not having happened.
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            GroupEvent::GroupStateInvalidated {
+                group_id: g,
+                epoch,
+                invalidated_commit_id,
+                reason: cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection,
+            } if g == &group_id
+                && *invalidated_commit_id == losing_commit_id
+                && epoch.0 == 1
+        )),
+        "expected GroupStateInvalidated for the losing commit, got {events:?}"
+    );
+    // The winning (accepted) commit's notifications are never withdrawn.
+    assert!(
+        !events.iter().any(|event| matches!(
+            event,
+            GroupEvent::GroupStateInvalidated { invalidated_commit_id, .. }
+                if *invalidated_commit_id == winning_commit_id
+        )),
+        "the accepted commit must not be named by a withdrawal, got {events:?}"
+    );
     // No ForkRecovered fires here: this is the convergence path, not the direct
     // staged-commit seam.
     assert!(

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -426,6 +426,113 @@ async fn create_pair() -> (
     (alice, bob, gid)
 }
 
+/// Like [`create_pair`] but with storage handles and BOTH members as group
+/// admins, so either side can publish an admin-gated `UpdateGroupData` /
+/// `UpdateAppComponents` commit (the concurrent-committer fork scenarios).
+async fn create_admin_pair_with_storage() -> (
+    Engine<SqliteAccountStorage>,
+    SqliteAccountStorage,
+    Engine<SqliteAccountStorage>,
+    SqliteAccountStorage,
+    GroupId,
+) {
+    let (mut alice, alice_storage) = build_with_storage(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (gid, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "original".into(),
+            description: "orig description".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        _ => unreachable!(),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    let welcome = welcomes.into_iter().next().unwrap();
+    bob.join_welcome(welcome).await.unwrap();
+    (alice, alice_storage, bob, bob_storage, gid)
+}
+
+fn route_to_group(msg: &TransportMessage, gid: &GroupId) -> TransportMessage {
+    TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: gid.as_slice().to_vec(),
+        },
+        ..msg.clone()
+    }
+}
+
+/// The `(change, origin_commit_id)` of every `GroupStateChanged` in `events`.
+/// Asserts each commit-derived notification carries an attribution — without
+/// it the notification could never be withdrawn by origin commit.
+fn attributed_state_changes(
+    events: &[cgka_traits::engine::GroupEvent],
+) -> Vec<(cgka_traits::engine::GroupStateChange, MessageId)> {
+    events
+        .iter()
+        .filter_map(|event| match event {
+            cgka_traits::engine::GroupEvent::GroupStateChanged {
+                change,
+                origin_commit_id,
+                ..
+            } => Some((
+                change.clone(),
+                origin_commit_id
+                    .clone()
+                    .expect("commit-derived GroupStateChanged must carry origin_commit_id"),
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Every `(invalidated_commit_id, epoch)` named by a `GroupStateInvalidated`
+/// withdrawal in `events`.
+fn state_invalidations(
+    events: &[cgka_traits::engine::GroupEvent],
+) -> Vec<(MessageId, cgka_traits::EpochId)> {
+    events
+        .iter()
+        .filter_map(|event| match event {
+            cgka_traits::engine::GroupEvent::GroupStateInvalidated {
+                invalidated_commit_id,
+                epoch,
+                reason:
+                    cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection,
+                ..
+            } => Some((invalidated_commit_id.clone(), *epoch)),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The state notifications still in effect after applying every withdrawal in
+/// `invalidations` to the accumulated `notifications` — the spec's "resulting
+/// view" (convergence.md "Applying the selected branch"): once convergence is
+/// settled this must equal exactly the notifications derivable from accepted
+/// commits on the selected branch.
+fn surviving_state_changes(
+    notifications: &[(cgka_traits::engine::GroupStateChange, MessageId)],
+    invalidations: &[(MessageId, cgka_traits::EpochId)],
+) -> Vec<(cgka_traits::engine::GroupStateChange, MessageId)> {
+    notifications
+        .iter()
+        .filter(|(_, origin)| {
+            !invalidations
+                .iter()
+                .any(|(invalidated, _)| invalidated == origin)
+        })
+        .cloned()
+        .collect()
+}
+
 // ── Happy path ──────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -1033,6 +1140,417 @@ async fn convergence_emits_attributed_message_retention_change_events() {
         )),
         "convergence apply must emit an attributed MessageRetentionChanged for alice, got: {events:?}",
     );
+}
+
+// ── Concurrent-rename supersession (issue #363) ─────────────────────────────
+
+/// Issue #363 regression: two admins rename concurrently; branch selection
+/// picks one commit. The losing committer previously kept its own
+/// `GroupStateChanged { GroupRenamed }` as a completed change ("B renamed the
+/// group to X" with no retraction) while the canonical name held the winner's
+/// value. Per spec (marmot-protocol/marmot#171, convergence.md "Applying the
+/// selected branch") the engine MUST withdraw every state notification
+/// attributed to the superseded commit via an explicit
+/// `GroupStateInvalidated` naming that commit — including the client's own
+/// published-and-confirmed commit.
+#[tokio::test]
+async fn concurrent_rename_withdraws_losing_committers_state_notification() {
+    use cgka_traits::engine::{GroupStateChange, GroupStateInvalidationReason};
+    use cgka_traits::ingest::{IngestOutcome, StaleReason};
+
+    let (mut alice, alice_storage, mut bob, bob_storage, gid) =
+        create_admin_pair_with_storage().await;
+    alice.drain_events();
+    bob.drain_events();
+
+    // Same epoch window: neither has seen the other's commit yet.
+    let alice_res = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: gid.clone(),
+            name: Some("New name from A".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let bob_res = bob
+        .send(SendIntent::UpdateGroupData {
+            group_id: gid.clone(),
+            name: Some("New name from B".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (alice_commit, alice_pending) = match alice_res {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    let (bob_commit, bob_pending) = match bob_res {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(alice_pending).await.unwrap();
+    bob.confirm_published(bob_pending).await.unwrap();
+
+    // Each committer's own confirmed rename surfaced as an ATTRIBUTED state
+    // notification — the attribution is what makes withdrawal targetable.
+    let alice_own = attributed_state_changes(&alice.drain_events());
+    let bob_own = attributed_state_changes(&bob.drain_events());
+    let (alice_origin, bob_origin) = match (alice_own.as_slice(), bob_own.as_slice()) {
+        (
+            [(GroupStateChange::GroupRenamed { name: a_name, .. }, a_origin)],
+            [(GroupStateChange::GroupRenamed { name: b_name, .. }, b_origin)],
+        ) => {
+            assert_eq!(a_name, "New name from A");
+            assert_eq!(b_name, "New name from B");
+            (a_origin.clone(), b_origin.clone())
+        }
+        other => panic!("expected exactly one attributed rename per committer, got {other:?}"),
+    };
+
+    // Deliver both commits to both members.
+    let alice_outcome = alice
+        .ingest(route_to_group(&bob_commit, &gid))
+        .await
+        .unwrap();
+    let bob_outcome = bob
+        .ingest(route_to_group(&alice_commit, &gid))
+        .await
+        .unwrap();
+    let alice_after = alice.drain_events();
+    let bob_after = bob.drain_events();
+
+    // Convergence settles to one canonical name on both devices.
+    let canonical_name = alice_storage.get_group(&gid).unwrap().name;
+    assert_eq!(
+        canonical_name,
+        bob_storage.get_group(&gid).unwrap().name,
+        "both devices must converge to the same canonical name"
+    );
+    assert_eq!(alice.epoch(&gid).unwrap().0, 2);
+    assert_eq!(bob.epoch(&gid).unwrap().0, 2);
+
+    // Exactly one committer lost. Identify it from the canonical name so the
+    // test does not depend on which authenticated ordering key sorts first.
+    // On the losing device the winner's inbound commit is keyed by its
+    // content-derived id, so the surviving notification's attribution is
+    // `content_id(winning commit)` there (attribution only has to be
+    // deterministic per device across the emit and withdraw paths).
+    let (loser_after, loser_origin, loser_own, loser_outcome, winner_after, winner_outcome) =
+        if canonical_name == "New name from A" {
+            (
+                bob_after,
+                bob_origin,
+                bob_own,
+                bob_outcome,
+                alice_after,
+                alice_outcome,
+            )
+        } else {
+            assert_eq!(canonical_name, "New name from B");
+            (
+                alice_after,
+                alice_origin,
+                alice_own,
+                alice_outcome,
+                bob_after,
+                bob_outcome,
+            )
+        };
+    let winner_commit_id_on_loser = if canonical_name == "New name from A" {
+        content_id(&alice_commit)
+    } else {
+        content_id(&bob_commit)
+    };
+
+    // The losing committer applied the winner's commit over its own.
+    assert!(
+        !matches!(loser_outcome, IngestOutcome::Stale { .. }),
+        "loser must apply the winning commit, got {loser_outcome:?}"
+    );
+    // The winner classifies the losing commit as stale — no rollback, no
+    // withdrawal of its own (canonical) rename.
+    assert!(
+        matches!(
+            winner_outcome,
+            IngestOutcome::Stale {
+                reason: StaleReason::AlreadyAtEpoch { .. }
+            }
+        ),
+        "winner must not roll back to the losing commit, got {winner_outcome:?}"
+    );
+    assert!(
+        state_invalidations(&winner_after).is_empty(),
+        "winner must not withdraw any state notification, got {winner_after:?}"
+    );
+
+    // The losing committer MUST emit the explicit invalidation naming its own
+    // superseded commit, in the same identifier space as the notification's
+    // origin_commit_id (spec: "the client MUST emit a group-state-change
+    // invalidation naming the superseded commit").
+    let loser_invalidations = state_invalidations(&loser_after);
+    assert_eq!(
+        loser_invalidations.len(),
+        1,
+        "expected exactly one withdrawal on the losing committer, got {loser_after:?}"
+    );
+    assert_eq!(
+        loser_invalidations[0].0, loser_origin,
+        "withdrawal must name the superseded commit that produced the rename"
+    );
+    assert_eq!(
+        loser_invalidations[0].1,
+        cgka_traits::EpochId(1),
+        "withdrawal carries the fork's source epoch"
+    );
+    assert!(
+        loser_after.iter().any(|event| matches!(
+            event,
+            cgka_traits::engine::GroupEvent::GroupStateInvalidated {
+                group_id: g,
+                reason: GroupStateInvalidationReason::SupersededByBranchSelection,
+                ..
+            } if g == &gid
+        )),
+        "withdrawal must carry the losing-branch reason, got {loser_after:?}"
+    );
+
+    // Resulting view (the conformance requirement): the notifications still in
+    // effect on the losing device are exactly those derivable from accepted
+    // commits on the selected branch — one rename, the winner's, attributed to
+    // the winner's commit. The loser's own rename is withdrawn.
+    let mut loser_notifications = loser_own;
+    loser_notifications.extend(attributed_state_changes(&loser_after));
+    let surviving = surviving_state_changes(&loser_notifications, &loser_invalidations);
+    match surviving.as_slice() {
+        [(GroupStateChange::GroupRenamed { name, .. }, origin)] => {
+            assert_eq!(
+                name, &canonical_name,
+                "surviving rename must match canonical state"
+            );
+            assert_eq!(
+                origin, &winner_commit_id_on_loser,
+                "surviving rename must be attributed to the winning commit"
+            );
+        }
+        other => panic!(
+            "resulting view must hold exactly the winner's rename, got {other:?} \
+             (invalidations {loser_invalidations:?})"
+        ),
+    }
+}
+
+/// Sequential control: when the second rename builds on the first commit
+/// (no fork), both notifications are accurate history — two
+/// `GroupStateChanged` events, and no `GroupStateInvalidated` anywhere.
+#[tokio::test]
+async fn sequential_renames_emit_two_notifications_without_invalidation() {
+    use cgka_traits::engine::GroupStateChange;
+
+    let (mut alice, alice_storage, mut bob, bob_storage, gid) =
+        create_admin_pair_with_storage().await;
+    alice.drain_events();
+    bob.drain_events();
+
+    // A renames; the commit converges everywhere before B renames.
+    let res = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: gid.clone(),
+            name: Some("first rename".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (alice_commit, alice_pending) = match res {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(alice_pending).await.unwrap();
+    bob.ingest(route_to_group(&alice_commit, &gid))
+        .await
+        .unwrap();
+    converge_buffered_commit(&mut bob, &gid);
+
+    // Now B renames on top of A's accepted commit.
+    let res = bob
+        .send(SendIntent::UpdateGroupData {
+            group_id: gid.clone(),
+            name: Some("second rename".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (bob_commit, bob_pending) = match res {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    bob.confirm_published(bob_pending).await.unwrap();
+    alice
+        .ingest(route_to_group(&bob_commit, &gid))
+        .await
+        .unwrap();
+    converge_buffered_commit(&mut alice, &gid);
+
+    assert_eq!(alice_storage.get_group(&gid).unwrap().name, "second rename");
+    assert_eq!(bob_storage.get_group(&gid).unwrap().name, "second rename");
+
+    for (who, events) in [("alice", alice.drain_events()), ("bob", bob.drain_events())] {
+        assert!(
+            state_invalidations(&events).is_empty(),
+            "{who}: sequential renames must not withdraw anything, got {events:?}"
+        );
+        let renames: Vec<&str> = events
+            .iter()
+            .filter_map(|event| match event {
+                cgka_traits::engine::GroupEvent::GroupStateChanged {
+                    change: GroupStateChange::GroupRenamed { name, .. },
+                    ..
+                } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            renames,
+            vec!["first rename", "second rename"],
+            "{who}: both sequential renames must remain in effect, in order"
+        );
+    }
+}
+
+/// Cross-contamination guard: a concurrent rename racing a DIFFERENT losing
+/// change type (message-retention update) must only withdraw the
+/// notifications attributed to the superseded commit; the winning commit's
+/// notification survives untouched.
+#[tokio::test]
+async fn concurrent_rename_and_retention_change_withdraw_only_superseded_commit() {
+    use cgka_traits::engine::GroupStateChange;
+    use cgka_traits::ingest::IngestOutcome;
+
+    let (mut alice, alice_storage, mut bob, bob_storage, gid) =
+        create_admin_pair_with_storage().await;
+    alice.drain_events();
+    bob.drain_events();
+
+    // Alice renames while Bob concurrently changes message retention.
+    let alice_res = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: gid.clone(),
+            name: Some("renamed while racing".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let bob_res = bob
+        .send(SendIntent::UpdateAppComponents {
+            group_id: gid.clone(),
+            updates: vec![AppComponentData {
+                component_id: GROUP_MESSAGE_RETENTION_COMPONENT_ID,
+                data: 60u64.to_be_bytes().to_vec(),
+            }],
+        })
+        .await
+        .unwrap();
+    let (alice_commit, alice_pending) = match alice_res {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    let (bob_commit, bob_pending) = match bob_res {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(alice_pending).await.unwrap();
+    bob.confirm_published(bob_pending).await.unwrap();
+
+    let alice_own = attributed_state_changes(&alice.drain_events());
+    let bob_own = attributed_state_changes(&bob.drain_events());
+    let alice_origin = match alice_own.as_slice() {
+        [(GroupStateChange::GroupRenamed { .. }, origin)] => origin.clone(),
+        other => panic!("expected alice's attributed rename, got {other:?}"),
+    };
+    let bob_origin = match bob_own.as_slice() {
+        [(GroupStateChange::MessageRetentionChanged { .. }, origin)] => origin.clone(),
+        other => panic!("expected bob's attributed retention change, got {other:?}"),
+    };
+
+    let alice_outcome = alice
+        .ingest(route_to_group(&bob_commit, &gid))
+        .await
+        .unwrap();
+    let bob_outcome = bob
+        .ingest(route_to_group(&alice_commit, &gid))
+        .await
+        .unwrap();
+    let alice_after = alice.drain_events();
+    let bob_after = bob.drain_events();
+
+    // Identify the loser from canonical state: exactly one change took effect.
+    let alice_group = alice_storage.get_group(&gid).unwrap();
+    let bob_group = bob_storage.get_group(&gid).unwrap();
+    assert_eq!(alice_group.name, bob_group.name);
+    let rename_won = alice_group.name == "renamed while racing";
+
+    let (loser_after, loser_origin, loser_own, winner_after, winner_commit_id_on_loser) =
+        if rename_won {
+            assert!(!matches!(bob_outcome, IngestOutcome::Stale { .. }));
+            (
+                bob_after,
+                bob_origin,
+                bob_own,
+                alice_after,
+                content_id(&alice_commit),
+            )
+        } else {
+            assert!(!matches!(alice_outcome, IngestOutcome::Stale { .. }));
+            (
+                alice_after,
+                alice_origin,
+                alice_own,
+                bob_after,
+                content_id(&bob_commit),
+            )
+        };
+
+    // Only the superseded commit's notification is withdrawn.
+    let loser_invalidations = state_invalidations(&loser_after);
+    assert_eq!(
+        loser_invalidations.len(),
+        1,
+        "expected exactly one withdrawal on the losing committer, got {loser_after:?}"
+    );
+    assert_eq!(loser_invalidations[0].0, loser_origin);
+    assert_ne!(
+        loser_invalidations[0].0, winner_commit_id_on_loser,
+        "the winning commit's notifications must not be withdrawn"
+    );
+    assert!(
+        state_invalidations(&winner_after).is_empty(),
+        "winner must not withdraw anything, got {winner_after:?}"
+    );
+
+    // Resulting view on the losing device: exactly the winner's change type,
+    // attributed to the winner's commit.
+    let mut loser_notifications = loser_own;
+    loser_notifications.extend(attributed_state_changes(&loser_after));
+    let surviving = surviving_state_changes(&loser_notifications, &loser_invalidations);
+    assert_eq!(
+        surviving.len(),
+        1,
+        "resulting view must hold exactly the winner's notification, got {surviving:?}"
+    );
+    let (surviving_change, surviving_origin) = &surviving[0];
+    assert_eq!(surviving_origin, &winner_commit_id_on_loser);
+    if rename_won {
+        assert!(
+            matches!(surviving_change, GroupStateChange::GroupRenamed { name, .. } if name == "renamed while racing")
+        );
+    } else {
+        assert!(matches!(
+            surviving_change,
+            GroupStateChange::MessageRetentionChanged {
+                old_seconds: 0,
+                new_seconds: 60,
+            }
+        ));
+    }
 }
 
 // ── State guard ─────────────────────────────────────────────────────────────

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -166,6 +166,103 @@ impl TransportPeeler for MockPeeler {
     }
 }
 
+/// Production-shaped peeler: a pass-through for MLS bytes like [`MockPeeler`],
+/// but every wrap mints a FRESH transport id — as the Nostr adapter does,
+/// where the outer kind-445 event id depends on the ephemeral key and nonce —
+/// so a wrap-time transport id NEVER equals the content dedup id
+/// (`SHA-256(mls_bytes)`). `MockPeeler` hides that split (`hash_id(payload)`
+/// on both sides), so tests built on it cannot catch a cross-id attribution
+/// bug between `confirm_published`-stamped rows and rollback events.
+struct EphemeralIdPeeler(std::sync::atomic::AtomicU64);
+
+impl EphemeralIdPeeler {
+    fn new() -> Self {
+        Self(std::sync::atomic::AtomicU64::new(0))
+    }
+
+    fn fresh_id(&self, payload: &[u8]) -> MessageId {
+        let seq = self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mut hasher = Sha256::new();
+        hasher.update(b"ephemeral-transport-id/v1");
+        hasher.update(seq.to_be_bytes());
+        hasher.update(payload);
+        MessageId::new(hasher.finalize().to_vec())
+    }
+}
+
+#[async_trait]
+impl TransportPeeler for EphemeralIdPeeler {
+    async fn peel_group_message(
+        &self,
+        msg: &TransportMessage,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        Ok(PeeledMessage {
+            id: msg.id.clone(),
+            group_id: None,
+            sender: None,
+            content: PeeledContent::MlsMessage {
+                bytes: msg.payload.clone(),
+            },
+            origin: msg.clone(),
+        })
+    }
+
+    async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        Ok(PeeledMessage {
+            id: msg.id.clone(),
+            group_id: None,
+            sender: None,
+            content: PeeledContent::Welcome {
+                bytes: msg.payload.clone(),
+            },
+            origin: msg.clone(),
+        })
+    }
+
+    async fn wrap_group_message(
+        &self,
+        payload: &EncryptedPayload,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        Ok(TransportMessage {
+            id: self.fresh_id(&payload.ciphertext),
+            payload: payload.ciphertext.clone(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("mock".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: vec![],
+            },
+        })
+    }
+
+    async fn wrap_welcome(
+        &self,
+        payload: &EncryptedPayload,
+        recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        Ok(TransportMessage {
+            id: self.fresh_id(&payload.ciphertext),
+            payload: payload.ciphertext.clone(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("mock".into()),
+            envelope: TransportEnvelope::Welcome {
+                recipient: recipient.clone(),
+            },
+        })
+    }
+}
+
+fn mock_peeler() -> Box<dyn TransportPeeler> {
+    Box::new(MockPeeler)
+}
+
+fn ephemeral_peeler() -> Box<dyn TransportPeeler> {
+    Box::new(EphemeralIdPeeler::new())
+}
+
 fn registry() -> FeatureRegistry {
     let mut r = FeatureRegistry::new();
     r.register(
@@ -426,6 +523,23 @@ async fn create_pair() -> (
     (alice, bob, gid)
 }
 
+/// Build an engine over an EXISTING storage handle (an engine "restart": the
+/// durable state survives, all in-memory engine state — `committed_from`,
+/// fork-recovery incumbents, seen/sent sets — is rebuilt from storage).
+fn build_with_storage_and_peeler(
+    id: &[u8],
+    storage: SqliteAccountStorage,
+    peeler: Box<dyn TransportPeeler>,
+) -> Engine<SqliteAccountStorage> {
+    EngineBuilder::new(storage)
+        .identity(pad32(id))
+        .account_identity_proof_signer(proof_signer(id))
+        .feature_registry(registry())
+        .peeler(peeler)
+        .build()
+        .unwrap()
+}
+
 /// Like [`create_pair`] but with storage handles and BOTH members as group
 /// admins, so either side can publish an admin-gated `UpdateGroupData` /
 /// `UpdateAppComponents` commit (the concurrent-committer fork scenarios).
@@ -436,8 +550,24 @@ async fn create_admin_pair_with_storage() -> (
     SqliteAccountStorage,
     GroupId,
 ) {
-    let (mut alice, alice_storage) = build_with_storage(b"alice");
-    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    create_admin_pair_with_peeler(mock_peeler).await
+}
+
+/// [`create_admin_pair_with_storage`] with an explicit peeler per engine, so
+/// scenarios can run against production-shaped ids ([`EphemeralIdPeeler`]).
+async fn create_admin_pair_with_peeler(
+    make_peeler: fn() -> Box<dyn TransportPeeler>,
+) -> (
+    Engine<SqliteAccountStorage>,
+    SqliteAccountStorage,
+    Engine<SqliteAccountStorage>,
+    SqliteAccountStorage,
+    GroupId,
+) {
+    let alice_storage = SqliteAccountStorage::in_memory().unwrap();
+    let bob_storage = SqliteAccountStorage::in_memory().unwrap();
+    let mut alice = build_with_storage_and_peeler(b"alice", alice_storage.clone(), make_peeler());
+    let mut bob = build_with_storage_and_peeler(b"bob", bob_storage.clone(), make_peeler());
     let bob_kp = bob.fresh_key_package().await.unwrap();
     let (gid, create) = alice
         .create_group(CreateGroupRequest {
@@ -1155,11 +1285,34 @@ async fn convergence_emits_attributed_message_retention_change_events() {
 /// published-and-confirmed commit.
 #[tokio::test]
 async fn concurrent_rename_withdraws_losing_committers_state_notification() {
+    let (alice, alice_storage, bob, bob_storage, gid) = create_admin_pair_with_storage().await;
+    assert_concurrent_rename_withdrawal(alice, alice_storage, bob, bob_storage, gid, false).await;
+}
+
+/// Same scenario with PRODUCTION-shaped ids: every wrap mints a fresh
+/// transport id (`EphemeralIdPeeler`), so the wrap-time transport id the
+/// committer's own rows are stamped with is DISTINCT from the content dedup
+/// id inbound processing rebinds to — exactly the split the Nostr adapter
+/// produces. The withdrawal must still name the id the rows were stamped
+/// with, or the tombstone is a silent no-op.
+#[tokio::test]
+async fn concurrent_rename_withdrawal_survives_distinct_transport_and_content_ids() {
+    let (alice, alice_storage, bob, bob_storage, gid) =
+        create_admin_pair_with_peeler(ephemeral_peeler).await;
+    assert_concurrent_rename_withdrawal(alice, alice_storage, bob, bob_storage, gid, true).await;
+}
+
+async fn assert_concurrent_rename_withdrawal(
+    mut alice: Engine<SqliteAccountStorage>,
+    alice_storage: SqliteAccountStorage,
+    mut bob: Engine<SqliteAccountStorage>,
+    bob_storage: SqliteAccountStorage,
+    gid: GroupId,
+    expect_distinct_transport_ids: bool,
+) {
     use cgka_traits::engine::{GroupStateChange, GroupStateInvalidationReason};
     use cgka_traits::ingest::{IngestOutcome, StaleReason};
 
-    let (mut alice, alice_storage, mut bob, bob_storage, gid) =
-        create_admin_pair_with_storage().await;
     alice.drain_events();
     bob.drain_events();
 
@@ -1206,6 +1359,21 @@ async fn concurrent_rename_withdraws_losing_committers_state_notification() {
         }
         other => panic!("expected exactly one attributed rename per committer, got {other:?}"),
     };
+    if expect_distinct_transport_ids {
+        // Prove the production id split is actually exercised: the stamped
+        // attribution (wrap-time transport id) differs from the content dedup
+        // id inbound peers rebind the same commit to.
+        assert_ne!(
+            alice_origin,
+            content_id(&alice_commit),
+            "ephemeral peeler must split transport id from content id"
+        );
+        assert_ne!(
+            bob_origin,
+            content_id(&bob_commit),
+            "ephemeral peeler must split transport id from content id"
+        );
+    }
 
     // Deliver both commits to both members.
     let alice_outcome = alice
@@ -1331,6 +1499,222 @@ async fn concurrent_rename_withdraws_losing_committers_state_notification() {
                 origin, &winner_commit_id_on_loser,
                 "surviving rename must be attributed to the winning commit"
             );
+        }
+        other => panic!(
+            "resulting view must hold exactly the winner's rename, got {other:?} \
+             (invalidations {loser_invalidations:?})"
+        ),
+    }
+}
+
+/// Stored-convergence variant of the issue #363 scenario, with
+/// PRODUCTION-shaped ids: the losing committer's own published-and-confirmed
+/// rename is superseded by a rewind/replay reorg, not the direct
+/// staged-commit seam. The loser restarts after confirming (an engine rebuild
+/// drops the in-memory `committed_from` set, so the sibling commit routes
+/// into stored convergence — there is no direct-seam `ForkRecovered` on this
+/// path), then converges over the winner's commit.
+///
+/// The correctness core: the withdrawal on the losing device must name the
+/// SAME id its confirm-time rows were stamped with (the wrap-time transport
+/// id of its own commit — preserved by the stored wire record), even though
+/// every inbound commit is keyed by the content dedup id.
+#[tokio::test]
+async fn rebuilt_engine_convergence_withdraws_own_confirmed_rename_by_stamped_origin() {
+    use cgka_traits::engine::{CommitOrderingKey, CommitOrderingPriority, GroupStateChange};
+    use cgka_traits::ingest::{IngestOutcome, StaleReason};
+
+    let (mut alice, alice_storage, mut bob, bob_storage, gid) =
+        create_admin_pair_with_peeler(ephemeral_peeler).await;
+    alice.drain_events();
+    bob.drain_events();
+
+    // Concurrent renames in the same epoch window; both confirmed locally.
+    let alice_res = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: gid.clone(),
+            name: Some("New name from A".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let bob_res = bob
+        .send(SendIntent::UpdateGroupData {
+            group_id: gid.clone(),
+            name: Some("New name from B".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (alice_commit, alice_pending) = match alice_res {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    let (bob_commit, bob_pending) = match bob_res {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(alice_pending).await.unwrap();
+    bob.confirm_published(bob_pending).await.unwrap();
+
+    let alice_own = attributed_state_changes(&alice.drain_events());
+    let bob_own = attributed_state_changes(&bob.drain_events());
+    let (alice_origin, bob_origin) = match (alice_own.as_slice(), bob_own.as_slice()) {
+        (
+            [(GroupStateChange::GroupRenamed { .. }, a_origin)],
+            [(GroupStateChange::GroupRenamed { .. }, b_origin)],
+        ) => (a_origin.clone(), b_origin.clone()),
+        other => panic!("expected exactly one attributed rename per committer, got {other:?}"),
+    };
+    // Production id split in effect on both committers.
+    assert_ne!(alice_origin, content_id(&alice_commit));
+    assert_ne!(bob_origin, content_id(&bob_commit));
+
+    // Determine the deterministic branch-selection loser up front. Both
+    // UpdateGroupData commits are admin-gated (Privileged), so the
+    // authenticated ordering key decides: committer id, then digest.
+    let alice_key = CommitOrderingKey::from_commit_bytes(
+        cgka_traits::EpochId(1),
+        CommitOrderingPriority::Privileged,
+        alice.self_id(),
+        &alice_commit.payload,
+    );
+    let bob_key = CommitOrderingKey::from_commit_bytes(
+        cgka_traits::EpochId(1),
+        CommitOrderingPriority::Privileged,
+        bob.self_id(),
+        &bob_commit.payload,
+    );
+    assert_ne!(alice_key, bob_key);
+    let alice_wins = alice_key < bob_key;
+    #[allow(clippy::type_complexity)]
+    let (
+        mut winner,
+        winner_commit,
+        winner_name,
+        winner_storage,
+        loser_engine,
+        loser_storage,
+        loser_commit,
+        loser_origin,
+        loser_own,
+        loser_id,
+    ): (
+        Engine<SqliteAccountStorage>,
+        TransportMessage,
+        &str,
+        SqliteAccountStorage,
+        Engine<SqliteAccountStorage>,
+        SqliteAccountStorage,
+        TransportMessage,
+        MessageId,
+        Vec<(GroupStateChange, MessageId)>,
+        &[u8],
+    ) = if alice_wins {
+        (
+            alice,
+            alice_commit,
+            "New name from A",
+            alice_storage,
+            bob,
+            bob_storage,
+            bob_commit,
+            bob_origin,
+            bob_own,
+            b"bob",
+        )
+    } else {
+        (
+            bob,
+            bob_commit,
+            "New name from B",
+            bob_storage,
+            alice,
+            alice_storage,
+            alice_commit,
+            alice_origin,
+            alice_own,
+            b"alice",
+        )
+    };
+
+    // The winner never restarts: it classifies the losing commit as stale on
+    // the direct seam (its own confirmed commit stays the incumbent) and
+    // withdraws nothing.
+    let winner_outcome = winner
+        .ingest(route_to_group(&loser_commit, &gid))
+        .await
+        .unwrap();
+    assert!(
+        matches!(
+            winner_outcome,
+            IngestOutcome::Stale {
+                reason: StaleReason::AlreadyAtEpoch { .. }
+            }
+        ),
+        "winner must keep its incumbent commit, got {winner_outcome:?}"
+    );
+    assert!(state_invalidations(&winner.drain_events()).is_empty());
+
+    // The LOSER restarts. Durable state survives; the in-memory
+    // `committed_from` set does not, so the winner's sibling commit is
+    // buffered for stored convergence instead of hitting the direct
+    // fork-recovery seam — the reorg path issue #363's own-commit withdrawal
+    // must also cover.
+    drop(loser_engine);
+    let mut loser =
+        build_with_storage_and_peeler(loser_id, loser_storage.clone(), ephemeral_peeler());
+    loser.drain_events();
+    loser
+        .buffer_openmls_convergence_message(&gid, route_to_group(&winner_commit, &gid), 1_000)
+        .expect("winning sibling commit buffered on the restarted loser");
+    let result = loser
+        .converge_stored_openmls_messages(&gid, 1_000_000)
+        .expect("loser converges over the fork");
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    let loser_after = loser.drain_events();
+
+    // Both devices settle on the winner's canonical name.
+    assert_eq!(loser_storage.get_group(&gid).unwrap().name, winner_name);
+    assert_eq!(winner_storage.get_group(&gid).unwrap().name, winner_name);
+
+    // This is the convergence path: no ForkRecovered fires.
+    assert!(
+        !loser_after
+            .iter()
+            .any(|event| matches!(event, cgka_traits::engine::GroupEvent::ForkRecovered { .. })),
+        "stored convergence must not emit ForkRecovered, got {loser_after:?}"
+    );
+
+    // The correctness core: the withdrawal names the stamped origin of the
+    // loser's OWN confirmed commit (its wrap-time transport id, preserved by
+    // the stored wire record) — not the content dedup id — so the
+    // confirm-time rows are actually tombstoned despite the id split.
+    let loser_invalidations = state_invalidations(&loser_after);
+    assert!(
+        loser_invalidations
+            .iter()
+            .any(|(id, epoch)| id == &loser_origin && *epoch == cgka_traits::EpochId(1)),
+        "loser must withdraw its own confirmed commit by its stamped origin id, \
+         got {loser_invalidations:?} (stamped {loser_origin:?})"
+    );
+    assert!(
+        !loser_invalidations
+            .iter()
+            .any(|(id, _)| id == &content_id(&winner_commit)),
+        "loser must not withdraw the winning commit's notifications"
+    );
+
+    // Resulting view on the losing device: exactly the winner's rename,
+    // attributed to the id the winner's commit carries on THIS device (its
+    // content dedup id).
+    let mut loser_notifications = loser_own;
+    loser_notifications.extend(attributed_state_changes(&loser_after));
+    let surviving = surviving_state_changes(&loser_notifications, &loser_invalidations);
+    match surviving.as_slice() {
+        [(GroupStateChange::GroupRenamed { name, .. }, origin)] => {
+            assert_eq!(name, winner_name);
+            assert_eq!(origin, &content_id(&winner_commit));
         }
         other => panic!(
             "resulting view must hold exactly the winner's rename, got {other:?} \

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -442,69 +442,18 @@ impl AppClient {
                 updated_group.as_ref(),
                 source_message_id_hex,
             );
-            if let cgka_traits::engine::GroupEvent::AppMessageInvalidated {
-                message_id, reason, ..
-            } = event
-                && let Some(projection_update) = self.app.invalidate_timeline_source_message(
-                    &self.state.label,
-                    &hex::encode(message_id.as_slice()),
-                    &format!("{reason:?}"),
-                )?
-            {
-                summary.projection_updates.push(projection_update);
-            }
-            // A rolled-back commit on a losing branch invalidates any kind-1210
-            // group system rows it synthesized (one commit → many rows). The
-            // winning branch's fresh rows are synthesized below from this
-            // current effect's `GroupStateChanged` events, so the timeline
-            // converges to the canonical branch without stale losing-branch rows.
-            if let cgka_traits::engine::GroupEvent::ForkRecovered {
-                invalidated_commit_id,
-                ..
-            } = event
-                && let Some(projection_update) = self.app.invalidate_timeline_origin_commit(
-                    &self.state.label,
-                    &hex::encode(invalidated_commit_id.as_slice()),
-                    "LosingBranch",
-                )?
-            {
-                summary.projection_updates.push(projection_update);
-            }
-            // Convergence-path analog of `ForkRecovered`: a commit first applied
-            // through stored convergence (so its synthesized kind-1210 rows carry
-            // `origin_commit_id`) later lost a same-epoch fork and was rolled
-            // back. `ForkRecovered` only fires on the direct staged-commit seam,
-            // so without this the convergence-born losing rows would survive.
-            // Invalidate every row whose origin commit matches.
-            if let cgka_traits::engine::GroupEvent::CommitRolledBack {
-                invalidated_commit_id,
-                ..
-            } = event
-                && let Some(projection_update) = self.app.invalidate_timeline_origin_commit(
-                    &self.state.label,
-                    &hex::encode(invalidated_commit_id.as_slice()),
-                    "LosingBranch",
-                )?
-            {
-                summary.projection_updates.push(projection_update);
-            }
-            // Explicit state-notification withdrawal (convergence.md "Applying
-            // the selected branch"): branch selection superseded a previously
-            // applied commit — including this account's own published-and-
-            // confirmed commit — so every kind-1210 system row stamped with its
-            // origin commit id is invalidated. Idempotent alongside the
-            // `ForkRecovered` / `CommitRolledBack` handlers above, which fire
-            // for the same commit on their respective seams.
-            if let cgka_traits::engine::GroupEvent::GroupStateInvalidated {
-                invalidated_commit_id,
-                reason,
-                ..
-            } = event
-                && let Some(projection_update) = self.app.invalidate_timeline_origin_commit(
-                    &self.state.label,
-                    &hex::encode(invalidated_commit_id.as_slice()),
-                    &format!("{reason:?}"),
-                )?
+            // Timeline invalidation dispatch: `AppMessageInvalidated` withdraws
+            // the delivered source row; `GroupStateInvalidated` withdraws every
+            // kind-1210 system row stamped with the superseded commit's
+            // `origin_commit_id`. The engine pairs `GroupStateInvalidated` with
+            // both commit-rollback seams (`ForkRecovered` on the direct
+            // staged-commit seam, `CommitRolledBack` on the stored-convergence
+            // seam), so those events no longer trigger tombstoning here — the
+            // explicit withdrawal event is the single authoritative signal and
+            // one rollback produces exactly one projection update.
+            if let Some(projection_update) = self
+                .app
+                .projection_update_for_invalidation_event(&self.state.label, event)?
             {
                 summary.projection_updates.push(projection_update);
             }

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -488,6 +488,26 @@ impl AppClient {
             {
                 summary.projection_updates.push(projection_update);
             }
+            // Explicit state-notification withdrawal (convergence.md "Applying
+            // the selected branch"): branch selection superseded a previously
+            // applied commit — including this account's own published-and-
+            // confirmed commit — so every kind-1210 system row stamped with its
+            // origin commit id is invalidated. Idempotent alongside the
+            // `ForkRecovered` / `CommitRolledBack` handlers above, which fire
+            // for the same commit on their respective seams.
+            if let cgka_traits::engine::GroupEvent::GroupStateInvalidated {
+                invalidated_commit_id,
+                reason,
+                ..
+            } = event
+                && let Some(projection_update) = self.app.invalidate_timeline_origin_commit(
+                    &self.state.label,
+                    &hex::encode(invalidated_commit_id.as_slice()),
+                    &format!("{reason:?}"),
+                )?
+            {
+                summary.projection_updates.push(projection_update);
+            }
             if self.state.groups.len() != before {
                 routes_dirty = true;
             }

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -1014,6 +1014,7 @@ pub(crate) fn event_group_id(event: &GroupEvent) -> Option<&GroupId> {
         | GroupEvent::EpochChanged { group_id, .. }
         | GroupEvent::ForkRecovered { group_id, .. }
         | GroupEvent::CommitRolledBack { group_id, .. }
+        | GroupEvent::GroupStateInvalidated { group_id, .. }
         | GroupEvent::GroupUnrecoverable { group_id, .. }
         | GroupEvent::PendingCommitRecovered { group_id, .. }
         | GroupEvent::GroupHydrationQuarantined { group_id, .. }

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -2633,6 +2633,47 @@ impl MarmotApp {
             .transpose()
     }
 
+    /// Timeline-invalidation dispatch for one engine [`GroupEvent`], shared by
+    /// the sync ingest loop and unit-testable without transport plumbing.
+    ///
+    /// - [`GroupEvent::AppMessageInvalidated`] withdraws the delivered app
+    ///   message row addressed by its source message id.
+    /// - [`GroupEvent::GroupStateInvalidated`] is the spec's explicit
+    ///   state-notification withdrawal (convergence.md "Applying the selected
+    ///   branch"): every kind-1210 system row stamped with the superseded
+    ///   commit's `origin_commit_id` is invalidated — including rows the
+    ///   account's own published-and-confirmed commit synthesized. The engine
+    ///   pairs this event with both commit-rollback seams (`ForkRecovered`,
+    ///   `CommitRolledBack`), so those commit-level events intentionally do
+    ///   NOT dispatch here: one rollback must tombstone once, with one reason.
+    ///
+    /// Every other event carries no timeline invalidation and returns `None`.
+    pub(crate) fn projection_update_for_invalidation_event(
+        &self,
+        label: &str,
+        event: &cgka_traits::engine::GroupEvent,
+    ) -> Result<Option<AppProjectionUpdate>, AppError> {
+        match event {
+            cgka_traits::engine::GroupEvent::AppMessageInvalidated {
+                message_id, reason, ..
+            } => self.invalidate_timeline_source_message(
+                label,
+                &hex::encode(message_id.as_slice()),
+                &format!("{reason:?}"),
+            ),
+            cgka_traits::engine::GroupEvent::GroupStateInvalidated {
+                invalidated_commit_id,
+                reason,
+                ..
+            } => self.invalidate_timeline_origin_commit(
+                label,
+                &hex::encode(invalidated_commit_id.as_slice()),
+                &format!("{reason:?}"),
+            ),
+            _ => Ok(None),
+        }
+    }
+
     fn app_projection_update(
         &self,
         label: &str,

--- a/crates/marmot-app/src/runtime/event_routing.rs
+++ b/crates/marmot-app/src/runtime/event_routing.rs
@@ -120,6 +120,7 @@ pub(crate) fn chat_list_trigger_from_event(event: &MarmotAppEvent) -> ChatListUp
             | GroupEvent::EpochChanged { .. }
             | GroupEvent::ForkRecovered { .. }
             | GroupEvent::CommitRolledBack { .. }
+            | GroupEvent::GroupStateInvalidated { .. }
             | GroupEvent::GroupUnrecoverable { .. }
             | GroupEvent::PendingCommitRecovered { .. }
             | GroupEvent::GroupHydrationQuarantined { .. }
@@ -147,6 +148,7 @@ fn group_id_from_event(event: &GroupEvent) -> &GroupId {
         | GroupEvent::EpochChanged { group_id, .. }
         | GroupEvent::ForkRecovered { group_id, .. }
         | GroupEvent::CommitRolledBack { group_id, .. }
+        | GroupEvent::GroupStateInvalidated { group_id, .. }
         | GroupEvent::GroupUnrecoverable { group_id, .. }
         | GroupEvent::PendingCommitRecovered { group_id, .. }
         | GroupEvent::GroupHydrationQuarantined { group_id, .. }

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -2064,6 +2064,129 @@ fn secure_prune_account_app_events_before_returns_media_hashes_above_storage_lay
     );
 }
 
+/// Issue #363 app-layer regression: a `GroupStateInvalidated` event flowing
+/// through the sync loop's invalidation dispatch must tombstone every
+/// persisted kind-1210 system row stamped with the superseded commit's
+/// `origin_commit_id` — and only those rows. A duplicate withdrawal must be a
+/// projection no-op.
+#[test]
+fn group_state_invalidated_event_tombstones_origin_commit_system_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    let account = home.create_account("alice").unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    app.save_state(&AccountState {
+        label: "alice".to_owned(),
+        seen_events: Vec::new(),
+        last_transport_timestamp: None,
+        groups: vec![AppGroupRecord::new(
+            "aa".to_owned(),
+            AppGroupNostrRoutingComponent::new(
+                NostrRoutingV1::new([0xAA; 32], vec!["wss://relay.example".to_owned()]).unwrap(),
+            )
+            .unwrap(),
+            "alpha".to_owned(),
+            String::new(),
+            AppGroupImageInput::default(),
+            AppGroupAdminPolicyComponent::new(Vec::new()),
+            AppGroupMessageRetentionComponent::disabled(),
+        )],
+    })
+    .unwrap();
+
+    let losing_commit_id = cgka_traits::types::MessageId::new(vec![0xBE; 32]);
+    let system_row =
+        |message_id_hex: &str, origin_commit_id: Option<String>| AppMessageProjection {
+            message_id_hex: message_id_hex.to_owned(),
+            // Synthesized system rows carry no source id (see
+            // build_group_system_projection); origin_commit_id is the 1:N link.
+            source_message_id_hex: None,
+            direction: "system".to_owned(),
+            group_id_hex: "aa".to_owned(),
+            sender: account.account_id_hex.clone(),
+            plaintext: "renamed the group".to_owned(),
+            kind: MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
+            tags: Vec::new(),
+            source_epoch: Some(2),
+            recorded_at: Some(10),
+            origin_commit_id,
+        };
+    // The losing commit synthesized this row (the "B renamed the group" lie).
+    app.record_account_app_event(
+        "alice",
+        &system_row(
+            "losing-rename",
+            Some(hex::encode(losing_commit_id.as_slice())),
+        ),
+    )
+    .unwrap();
+    // A different (winning) commit's row must survive the withdrawal.
+    app.record_account_app_event(
+        "alice",
+        &system_row("winning-rename", Some("cf".repeat(32))),
+    )
+    .unwrap();
+
+    let withdrawal = cgka_traits::engine::GroupEvent::GroupStateInvalidated {
+        group_id: GroupId::new(vec![0xAA]),
+        epoch: cgka_traits::EpochId(1),
+        invalidated_commit_id: losing_commit_id,
+        reason: cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection,
+    };
+    let update = app
+        .projection_update_for_invalidation_event("alice", &withdrawal)
+        .unwrap()
+        .expect("withdrawal must invalidate the stamped system row");
+    assert_eq!(update.group_id_hex, "aa");
+
+    let rows = app
+        .timeline_messages_with_query(
+            "alice",
+            storage_sqlite::TimelineMessageQuery {
+                group_id_hex: Some("aa".to_owned()),
+                ..storage_sqlite::TimelineMessageQuery::default()
+            },
+        )
+        .unwrap()
+        .messages;
+    let status = |id: &str| {
+        rows.iter()
+            .find(|row| row.message_id_hex == id)
+            .map(|row| row.invalidation_status.clone())
+    };
+    assert_eq!(
+        status("losing-rename"),
+        Some(Some("SupersededByBranchSelection".to_owned())),
+        "the superseded commit's row must be tombstoned with the withdrawal reason"
+    );
+    assert_eq!(
+        status("winning-rename"),
+        Some(None),
+        "rows attributed to other commits must stay live"
+    );
+
+    // Duplicate withdrawal (replayed event): projection no-op, reason kept.
+    assert!(
+        app.projection_update_for_invalidation_event("alice", &withdrawal)
+            .unwrap()
+            .is_none(),
+        "a replayed withdrawal must not produce another projection update"
+    );
+    // Events that carry no timeline invalidation dispatch to None.
+    assert!(
+        app.projection_update_for_invalidation_event(
+            "alice",
+            &cgka_traits::engine::GroupEvent::CommitRolledBack {
+                group_id: GroupId::new(vec![0xAA]),
+                invalidated_commit_id: cgka_traits::types::MessageId::new(vec![0xCF; 32]),
+            },
+        )
+        .unwrap()
+        .is_none(),
+        "commit-level rollback events must not tombstone; GroupStateInvalidated is authoritative"
+    );
+}
+
 // Finding 2: an in-place nostr_group_id / relay rotation on an existing group
 // must switch the transport subscription. `add_group` previously early-returned
 // on a duplicate group_id, so a rotated route never took effect; it now replaces

--- a/crates/marmot-uniffi/src/conversions/event.rs
+++ b/crates/marmot-uniffi/src/conversions/event.rs
@@ -1,7 +1,9 @@
 //! Top-level event firehose FFI conversion.
 
 use cgka_traits::GroupId;
-use cgka_traits::engine::{AppMessageInvalidationReason, GroupEvent, GroupStateChange};
+use cgka_traits::engine::{
+    AppMessageInvalidationReason, GroupEvent, GroupStateChange, GroupStateInvalidationReason,
+};
 use marmot_app::{AppGroupHydrationQuarantineReason, MarmotAppEvent};
 
 use super::group::AppGroupHydrationQuarantineReasonFfi;
@@ -20,6 +22,7 @@ fn group_id_from_event(event: &GroupEvent) -> &GroupId {
         | GroupEvent::EpochChanged { group_id, .. }
         | GroupEvent::ForkRecovered { group_id, .. }
         | GroupEvent::CommitRolledBack { group_id, .. }
+        | GroupEvent::GroupStateInvalidated { group_id, .. }
         | GroupEvent::GroupUnrecoverable { group_id, .. }
         | GroupEvent::PendingCommitRecovered { group_id, .. }
         | GroupEvent::GroupHydrationQuarantined { group_id, .. }
@@ -117,6 +120,16 @@ pub enum GroupEventKindFfi {
     CommitRolledBack {
         invalidated_commit_id_hex: String,
     },
+    /// Explicit withdrawal of every `GroupStateChanged` notification whose
+    /// `origin_commit_id_hex` matches `invalidated_commit_id_hex`: branch
+    /// selection superseded that commit, so the changes it announced never
+    /// canonically happened. `reason` is a stable low-cardinality tag
+    /// (`superseded_by_branch_selection`).
+    GroupStateInvalidated {
+        epoch: u64,
+        invalidated_commit_id_hex: String,
+        reason: String,
+    },
     GroupUnrecoverable,
     PendingCommitRecovered {
         recovered_epoch: u64,
@@ -140,6 +153,15 @@ fn group_state_change_tag(change: &GroupStateChange) -> &'static str {
         GroupStateChange::GroupRenamed { .. } => "group_renamed",
         GroupStateChange::GroupAvatarChanged => "group_avatar_changed",
         GroupStateChange::MessageRetentionChanged { .. } => "disappearing_timer_changed",
+    }
+}
+
+/// Stable, low-cardinality tag for a [`GroupStateInvalidationReason`].
+fn group_state_invalidation_reason_tag(reason: &GroupStateInvalidationReason) -> &'static str {
+    match reason {
+        GroupStateInvalidationReason::SupersededByBranchSelection => {
+            "superseded_by_branch_selection"
+        }
     }
 }
 
@@ -219,6 +241,16 @@ impl From<GroupEvent> for GroupEventKindFfi {
                 ..
             } => Self::CommitRolledBack {
                 invalidated_commit_id_hex: hex::encode(invalidated_commit_id.as_slice()),
+            },
+            GroupEvent::GroupStateInvalidated {
+                epoch,
+                invalidated_commit_id,
+                reason,
+                ..
+            } => Self::GroupStateInvalidated {
+                epoch: epoch.0,
+                invalidated_commit_id_hex: hex::encode(invalidated_commit_id.as_slice()),
+                reason: group_state_invalidation_reason_tag(&reason).to_string(),
             },
             GroupEvent::GroupUnrecoverable { .. } => Self::GroupUnrecoverable,
             GroupEvent::PendingCommitRecovered {

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -458,12 +458,15 @@ impl SqliteAccountStorage {
             // Fetch all rows the commit synthesized. They all share one group (a
             // commit belongs to a single group), so one rebuild + change set covers
             // them. `origin_commit_id` is non-unique by design (multi-row-per-commit).
+            // Already-invalidated rows are excluded so a replayed or duplicate
+            // withdrawal event is a no-op: it neither rewrites the recorded
+            // invalidation reason nor produces a redundant projection update.
             let rows: Vec<(String, String, u64, Vec<Vec<String>>)> = {
                 let mut stmt = conn
                     .prepare(
                         "SELECT group_id_hex, message_id_hex, kind, tags_json
                          FROM app_events
-                         WHERE origin_commit_id = ?1",
+                         WHERE origin_commit_id = ?1 AND invalidated = 0",
                     )
                     .storage()?;
                 stmt.query_map(params![origin_commit_id], |row| {
@@ -502,7 +505,7 @@ impl SqliteAccountStorage {
             conn.execute(
                 "UPDATE app_events
                  SET invalidated = 1, invalidation_reason = ?2
-                 WHERE origin_commit_id = ?1",
+                 WHERE origin_commit_id = ?1 AND invalidated = 0",
                 params![origin_commit_id, reason],
             )
             .storage()?;

--- a/crates/storage-sqlite/src/timeline/tests.rs
+++ b/crates/storage-sqlite/src/timeline/tests.rs
@@ -229,6 +229,46 @@ fn invalidate_by_origin_commit_tombstones_all_rows_from_one_commit() {
 }
 
 #[test]
+fn invalidate_by_origin_commit_is_a_noop_for_already_invalidated_rows() {
+    // The engine can name the same superseded commit more than once (e.g. a
+    // replayed withdrawal event). The second invalidation must be a no-op: it
+    // returns no projection update and does not overwrite the recorded reason.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    store
+        .record_app_event(&group_system_from_commit(
+            "losing-added",
+            "member_added",
+            10,
+            "commit-losing",
+        ))
+        .unwrap();
+
+    assert!(
+        store
+            .invalidate_app_events_by_origin_commit("commit-losing", "SupersededByBranchSelection",)
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        store
+            .invalidate_app_events_by_origin_commit("commit-losing", "LosingBranch")
+            .unwrap()
+            .is_none(),
+        "re-invalidating the same commit must be a no-op"
+    );
+    let rows = list(&store);
+    let status = rows
+        .iter()
+        .find(|row| row.message_id_hex == "losing-added")
+        .map(|row| row.invalidation_status.clone());
+    assert_eq!(
+        status,
+        Some(Some("SupersededByBranchSelection".to_owned())),
+        "the first recorded reason must survive a duplicate withdrawal"
+    );
+}
+
+#[test]
 fn invalidate_by_origin_commit_returns_none_when_no_rows_match() {
     let store = SqliteAccountStorage::in_memory().unwrap();
     store

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -195,6 +195,19 @@ pub enum AppMessageInvalidationReason {
     UndecryptableInCanonicalState,
 }
 
+/// Why the state notifications attributed to a commit were withdrawn
+/// (spec `protocol-core/convergence.md` "Applying the selected branch"). The
+/// state-notification counterpart of [`AppMessageInvalidationReason`], carried
+/// by [`GroupEvent::GroupStateInvalidated`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GroupStateInvalidationReason {
+    /// Branch selection superseded a commit this client previously applied —
+    /// including the client's own published and confirmed commit — so every
+    /// state notification derived from that commit describes a change that,
+    /// canonically, never happened.
+    SupersededByBranchSelection,
+}
+
 /// Deterministic, content-derived ordering key used to resolve same-epoch
 /// commit races. Two replicas processing the same commit derive the same key
 /// from authenticated commit metadata and the same MLS wire bytes, independent
@@ -405,6 +418,35 @@ pub enum GroupEvent {
         group_id: GroupId,
         /// Transport-layer `MessageId` of the rolled-back (losing) commit.
         invalidated_commit_id: MessageId,
+    },
+    /// Every state notification attributed to `invalidated_commit_id` is
+    /// withdrawn: the application MUST treat the changes those
+    /// [`GroupEvent::GroupStateChanged`] events announced as not having
+    /// happened (spec `protocol-core/convergence.md` "Applying the selected
+    /// branch" and `protocol-core/inbound-processing.md` "Application-visible
+    /// output"). This is the state-notification counterpart of
+    /// [`GroupEvent::AppMessageInvalidated`], and it covers the client's own
+    /// published-and-confirmed commit when branch selection supersedes it —
+    /// e.g. a losing concurrent rename must not survive as a completed
+    /// "renamed the group" system row.
+    ///
+    /// The engine emits this alongside the commit-level rollback events
+    /// ([`GroupEvent::ForkRecovered`] on the direct staged-commit seam,
+    /// [`GroupEvent::CommitRolledBack`] on the stored-convergence seam), as the
+    /// explicit withdrawal signal for state notifications. `invalidated_commit_id`
+    /// is in the same identifier space as `origin_commit_id` on
+    /// [`GroupEvent::GroupStateChanged`], so withdrawal is an exact match over
+    /// previously synthesized notifications.
+    GroupStateInvalidated {
+        group_id: GroupId,
+        /// Source epoch the superseded commit branched from (the epoch of the
+        /// fork it lost).
+        epoch: EpochId,
+        /// Transport-layer `MessageId` of the superseded commit. Matches the
+        /// `origin_commit_id` stamped on every [`GroupEvent::GroupStateChanged`]
+        /// that commit produced.
+        invalidated_commit_id: MessageId,
+        reason: GroupStateInvalidationReason,
     },
     /// The group entered the `Unrecoverable` state: convergence reported a
     /// `MissingRetainedAnchor` inside the rollback horizon, so the client

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -199,7 +199,7 @@ pub enum AppMessageInvalidationReason {
 /// (spec `protocol-core/convergence.md` "Applying the selected branch"). The
 /// state-notification counterpart of [`AppMessageInvalidationReason`], carried
 /// by [`GroupEvent::GroupStateInvalidated`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GroupStateInvalidationReason {
     /// Branch selection superseded a commit this client previously applied —
     /// including the client's own published and confirmed commit — so every

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -14,8 +14,8 @@ use cgka_traits::capabilities::{
 };
 use cgka_traits::engine::{
     AppMessageInvalidationReason, CommitOrderingKey, CommitOrderingPriority, CreateGroupRequest,
-    GroupEvent, GroupHydrationQuarantineReason, GroupStateChange, KeyPackage, SendIntent,
-    SendResult,
+    GroupEvent, GroupHydrationQuarantineReason, GroupStateChange, GroupStateInvalidationReason,
+    KeyPackage, SendIntent, SendResult,
 };
 use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::group::{Group, Member};
@@ -522,6 +522,15 @@ fn snapshot_group_events() {
         GroupEvent::CommitRolledBack {
             group_id: gid(),
             invalidated_commit_id: mid(),
+        }
+    );
+    insta::assert_json_snapshot!(
+        "event_group_state_invalidated",
+        GroupEvent::GroupStateInvalidated {
+            group_id: gid(),
+            epoch: EpochId(1),
+            invalidated_commit_id: mid(),
+            reason: GroupStateInvalidationReason::SupersededByBranchSelection,
         }
     );
     insta::assert_json_snapshot!(

--- a/crates/traits/tests/snapshots/snapshots__event_group_state_invalidated.snap
+++ b/crates/traits/tests/snapshots/snapshots__event_group_state_invalidated.snap
@@ -1,0 +1,22 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "GroupEvent::GroupStateInvalidated\n{\n    group_id: gid(), epoch: EpochId(1), invalidated_commit_id: mid(), reason:\n    GroupStateInvalidationReason::SupersededByBranchSelection,\n}"
+---
+{
+  "GroupStateInvalidated": {
+    "group_id": [
+      170,
+      170,
+      170,
+      170
+    ],
+    "epoch": 1,
+    "invalidated_commit_id": [
+      187,
+      187,
+      187,
+      187
+    ],
+    "reason": "SupersededByBranchSelection"
+  }
+}


### PR DESCRIPTION
## Problem

Two admins concurrently rename a group; convergence picks A's commit. B's device correctly shows A's name in the header, but B's timeline still shows "B renamed the group to X" as a successful system message: the engine emitted `GroupStateChanged` for B's own commit at `confirm_published` and never retracted it when branch selection superseded that commit.

Spec basis: marmot-protocol/marmot#171 (merged) — `protocol-core/convergence.md` "Applying the selected branch" and `protocol-core/inbound-processing.md` "Application-visible output". When branch selection supersedes a commit the client previously applied — **including the client's own published and confirmed commit** — the client MUST emit a group-state-change invalidation naming the superseded commit, withdrawing every state notification attributed to it. Conformance is the resulting view: settled notifications == exactly those derivable from accepted commits on the selected branch.

## Design

**New event** (`crates/traits/src/engine.rs`):

```rust
GroupEvent::GroupStateInvalidated {
    group_id: GroupId,
    epoch: EpochId,                     // source epoch of the fork the commit lost
    invalidated_commit_id: MessageId,   // same id space as GroupStateChanged.origin_commit_id
    reason: GroupStateInvalidationReason, // SupersededByBranchSelection
}
```

**Attribution: `origin_commit_id` (MessageId), not `commit_digest`.** `GroupStateChanged` already carries `origin_commit_id` as the local attribution key, and both supersession seams already hold the exact id used at emit time:

- Direct staged-commit seam: the fork-recovery incumbent record's `storage_id` is the same id `confirm_published` stamps onto the committer's own `GroupStateChanged` events (both come from the same `CommitRecoveryRecord`), and the same id `ForkRecovered` reports.
- Stored-convergence seam: inbound commits are keyed by the content-derived dedup id on both the emit path (`push_group_state_change(origin_commit_id = msg.id)`) and the drop path (`dropped_messages`).

So the MessageId deterministically identifies the superseded commit across emit and invalidate **per device**, which is all the spec's implementation-defined notification surface requires. No new commit_digest plumbing was needed; the digest already participates via `CommitOrderingKey` for selection, not attribution.

**Emit sites** (both supersession seams):

1. `crates/cgka-engine/src/message_processor/ingest.rs` — alongside `ForkRecovered` when a same-epoch candidate wins over the previously applied incumbent. This is the issue's exact scenario: the losing committer's own published-and-confirmed commit is the incumbent (`we_committed_from` routes the sibling commit to this seam, not convergence).
2. `crates/cgka-engine/src/distributed_convergence.rs::emit_rolled_back_commits` — alongside `CommitRolledBack` for every commit dropped `InvalidAgainstCandidateState`. Idempotent for commits this client never applied (no row carries the id), same argument as the existing `CommitRolledBack` emission.

The commit-level events (`ForkRecovered` / `CommitRolledBack`) are kept unchanged; `GroupStateInvalidated` is the explicit, seam-independent state-notification withdrawal signal.

**Attribution audit (scoping item 3):** every commit-derived `GroupStateChanged` emitter populates `origin_commit_id` — direct seam (`Some(msg.id)`), own-commit confirm (`Some(recovery record id)`), and single-commit convergence passes. The one remaining `None` emitter is a multi-commit convergence pass, where the previous-tip → selected-tip diff is the *combined* effect of several accepted commits and per-commit attribution is inherently ambiguous (pre-existing, documented on the field). Those unattributed rows describe accepted-branch canonical state, not losing-branch claims, so they don't reproduce this bug; making them per-commit attributable would require per-commit replay diffing and is left out per the smallest-design guidance.

**App + FFI:**

- `marmot-app`: event routed like `CommitRolledBack` (`event_routing.rs`, `groups.rs::event_group_id`, reaches the subscriber surface via `observe_event`); `client/sync.rs` invalidates every kind-1210 row whose `origin_commit_id` matches (multi-row, idempotent alongside the existing `ForkRecovered`/`CommitRolledBack` handlers).
- `marmot-uniffi`: `GroupEventKindFfi::GroupStateInvalidated { epoch, invalidated_commit_id_hex, reason }` with the stable low-cardinality tag `superseded_by_branch_selection`. Bindings are derived artifacts regenerated by the platform scripts per `crates/marmot-uniffi/README.md`; only the Rust side is in-repo.

## Deliberately skipped

- **Conformance-simulator oracle**: adding an invalidation `OracleBehavior` fans out into the serialized vector observation schema (`ClientObservation`/`ClientEventCounts`), evidence counting, per-stimulus expectation tables, and stored fixture regeneration. The engine-level tests below are the required coverage; the oracle extension is left for a follow-up. Existing simulator tests pass unchanged (the new event is not extracted into any observation, so fixtures stay valid).
- **Multi-commit convergence-pass attribution** (see audit note above).

## Test plan

- `concurrent_rename_withdraws_losing_committers_state_notification` (crates/cgka-engine/tests/update_group_data.rs) — the issue scenario: both admins rename in the same epoch window, both commits delivered to both. Asserts: canonical name converges; the losing committer emits exactly one `GroupStateInvalidated` whose `invalidated_commit_id` equals the `origin_commit_id` of its earlier `GroupStateChanged { GroupRenamed }`; the winner withdraws nothing and classifies the losing commit stale; and the **resulting view** on the losing device (notifications minus withdrawals) is exactly the winner's rename attributed to the winning commit.
- `sequential_renames_emit_two_notifications_without_invalidation` — sequential control: two ordered renames, both survive, zero invalidations on either device.
- `concurrent_rename_and_retention_change_withdraw_only_superseded_commit` — cross-contamination guard: rename racing a message-retention change; only the superseded commit's notification is withdrawn, the winner's survives with its attribution.
- `convergence_rollback_emits_commit_rolled_back_for_losing_branch` (tests/distributed_convergence.rs) — extended: the stored-convergence seam emits `GroupStateInvalidated` naming the losing commit (and never the accepted commit).
- Traits snapshot for the new event variant.
- Suites: `cargo test -p cgka-traits -p cgka-engine -p marmot-app -p marmot-uniffi -p cgka-conformance-simulator` all green; `just fast-ci` (fmt-check, check incl. OTLP features, clippy) green.

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/702">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit **group-state invalidation** events when an applied branch is superseded, including a standardized reason and the superseded commit reference.
  * Extended event propagation so invalidations update timelines and related app views.
  * Updated the client/FFI event stream to deliver the new invalidation event consistently.

* **Bug Fixes**
  * Improved rollback and fork-recovery behavior so superseded (losing-branch) notifications are withdrawn while winning-branch notifications remain.

* **Tests**
  * Added regression coverage for concurrent admin renames, mixed-change isolation, and durable/convergence replay correctness.
  * Added timeline invalidation no-op behavior for already-invalidated rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->