### PR TITLE
Surface self-eviction instead of swallowing UseAfterEviction (SelfEvicted / realizing removal)

### DIFF
--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -1431,6 +1431,7 @@ fn dummy_group(group_id: GroupId) -> Group {
             credential: vec![1],
         }],
         required_capabilities: GroupCapabilities::default(),
+        removed: false,
     }
 }
 

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -77,6 +77,7 @@ pub(crate) fn stale_reason_str(reason: &StaleReason) -> &'static str {
         StaleReason::UnknownGroup => "unknown_group",
         StaleReason::OwnEcho => "own_echo",
         StaleReason::PeelFailed => "peel_failed",
+        StaleReason::SelfEvicted => "self_evicted",
     }
 }
 

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -597,6 +597,21 @@ impl<S: StorageProvider> Engine<S> {
             if member_id == self.identity.self_id() {
                 self.clear_leave_request_state(group_id)
                     .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+                // The canonical branch removed our own leaf: mark the local
+                // copy removed (member-departure.md, "Realizing removal") in
+                // the same pass that emits the self-removed notification
+                // below, so the marker and the notification stay coupled and
+                // later `SelfEvicted` input does not re-emit it.
+                let mut group = self
+                    .storage
+                    .get_group(group_id)
+                    .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+                if !group.removed {
+                    group.removed = true;
+                    self.storage
+                        .put_group(&group)
+                        .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+                }
             }
             self.push_group_state_change(
                 group_id,

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -612,6 +612,11 @@ impl<S: StorageProvider> Engine<S> {
                         .put_group(&group)
                         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
                 }
+                // The copy just became removed: purge queued outbound intents
+                // so later drains do not re-fail them forever against the
+                // removed-copy send gate.
+                self.discard_queued_outbound_intents_for_removed_group(group_id)
+                    .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
             }
             self.push_group_state_change(
                 group_id,

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -950,6 +950,20 @@ impl<S: StorageProvider> Engine<S> {
         Ok(())
     }
 
+    /// Whether the local copy of `group_id` is marked removed (realized
+    /// self-eviction; member-departure.md "Realizing removal"). A removed copy
+    /// is terminal for outbound work: nothing may be prepared or published for
+    /// it. Unknown groups report `false` — callers fail them with their own
+    /// unknown-group handling. The marker clears only through an authenticated
+    /// re-join (`do_join_welcome` rebuilds the record).
+    pub(crate) fn group_record_is_removed(&self, group_id: &GroupId) -> Result<bool, EngineError> {
+        match self.storage.get_group(group_id) {
+            Ok(group) => Ok(group.removed),
+            Err(StorageError::NotFound) => Ok(false),
+            Err(err) => Err(EngineError::Storage(err)),
+        }
+    }
+
     /// Clear ONLY the live OpenMLS group state for `group_id`, leaving every
     /// retained artifact in place.
     ///

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -221,6 +221,7 @@ impl<S: StorageProvider> Engine<S> {
             epoch: EpochId(mls_group.epoch().as_u64()),
             members: projected_members,
             required_capabilities: required_caps,
+            removed: false,
         };
         self.storage.put_group(&group_record)?;
         // #740: index this group's transport routing id for O(1) inbound
@@ -538,6 +539,7 @@ impl<S: StorageProvider> Engine<S> {
             required_capabilities: crate::capability_manager::required_capabilities_from_group(
                 &mls_group,
             ),
+            removed: false,
         };
         mirror_app_components_into_record(&mls_group, &mut group_record);
         self.storage.put_group(&group_record)?;

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1303,6 +1303,19 @@ impl<S: StorageProvider> Engine<S> {
     /// is kept inactive, never deleted). Callers must only invoke this on
     /// authenticated evidence of eviction (the local MLS group state records
     /// our removal), never on a bare decrypt failure.
+    ///
+    /// Ordering: the notification is enqueued BEFORE the durable marker write,
+    /// so a crash between the two re-runs realization on the next
+    /// `SelfEvicted` input (at worst a duplicate notification, absorbed by the
+    /// app's canonical-row-id upsert) instead of leaving a durable marker that
+    /// suppresses a notification nobody observed. A window this ordering
+    /// cannot close remains: `events_buf` is in-memory, so a process death
+    /// after the marker write but before the caller drains and persists the
+    /// event still loses it. That at-most-once property is shared by every
+    /// `GroupStateChanged` emission in the engine today (the commit-apply seam
+    /// has the same shape for all roster/admin/profile rows); making the event
+    /// channel durable — or reconciling on session open from `Group::removed`
+    /// at the app layer — is a systemic follow-up, not realization-specific.
     pub(crate) fn realize_self_eviction(
         &mut self,
         group_id: &GroupId,
@@ -1316,9 +1329,14 @@ impl<S: StorageProvider> Engine<S> {
         if group.removed {
             return Ok(());
         }
-        group.removed = true;
-        self.storage.put_group(&group)?;
-        self.clear_leave_request_state(group_id)?;
+        // OpenMLS's `Inactive` state does not record WHY our leaf left the
+        // tree. The durable leave request is local, authenticated intent to
+        // leave, so when one is pending the departure being realized is our
+        // own leave: attribute it as `MemberLeft` (actor = self), matching the
+        // direct seam's SelfRemove classification. Without one the removal is
+        // attributed as involuntary with an unknown actor — the accepted
+        // degradation when the removing commit itself was never applied.
+        let had_leave_request = self.load_leave_request_state(group_id)?.is_some();
         // Privacy-safe breadcrumb: aggregate signal only, no group/member ids
         // (observability.md).
         tracing::info!(
@@ -1326,18 +1344,27 @@ impl<S: StorageProvider> Engine<S> {
             method = "realize_self_eviction",
             "realized own removal for a group whose canonical state records eviction"
         );
-        // Actor unknown: the removing commit was not (or could not be)
-        // attributed here — realization derives from retained state, not from
-        // applying the specific removal commit.
-        self.push_group_state_change(
-            group_id,
-            epoch,
-            None,
-            GroupStateChange::MemberRemoved {
-                member: self.identity.self_id().clone(),
-            },
-            None,
-        );
+        let member = self.identity.self_id().clone();
+        let (actor, change) = if had_leave_request {
+            (
+                Some(member.clone()),
+                GroupStateChange::MemberLeft { member },
+            )
+        } else {
+            (None, GroupStateChange::MemberRemoved { member })
+        };
+        self.push_group_state_change(group_id, epoch, actor, change, None);
+        // Marker + roster reconciliation in one durable write: a removed copy
+        // must not keep presenting self as a member, so roster-gated callers
+        // (`members()`, hydrate restore checks, backfill) cannot disagree with
+        // the terminal marker. The seam and convergence paths already write
+        // the post-removal roster; this reconciles the pathological copy whose
+        // roster was never mirrored.
+        group.removed = true;
+        let self_id = self.identity.self_id().clone();
+        group.members.retain(|member| member.id != self_id);
+        self.storage.put_group(&group)?;
+        self.clear_leave_request_state(group_id)?;
         Ok(())
     }
 

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -854,6 +854,10 @@ impl<S: StorageProvider> Engine<S> {
                         .any(|member| member == self.identity.self_id())
                     {
                         self.clear_leave_request_state(&group_id)?;
+                        // The copy just became removed: purge queued outbound
+                        // intents so later drains do not re-fail them forever
+                        // against the removed-copy send gate.
+                        self.discard_queued_outbound_intents_for_removed_group(&group_id)?;
                     } else if after_ids.contains(self.identity.self_id()) {
                         if self.load_leave_request_state(&group_id)?.is_some() {
                             // A SelfRemove proposal is valid only in its
@@ -1364,6 +1368,11 @@ impl<S: StorageProvider> Engine<S> {
         let self_id = self.identity.self_id().clone();
         group.members.retain(|member| member.id != self_id);
         self.storage.put_group(&group)?;
+        // A removed copy must never publish: drop any outbound intents that
+        // were durably queued before the removal was realized, instead of
+        // leaving them to re-fail through the removed-copy send gate on every
+        // later drain.
+        self.discard_queued_outbound_intents_for_removed_group(group_id)?;
         // Deliberately LAST, after the marker write — not before it like the
         // convergence path (which has no attribution read). The notification
         // is already enqueued above, so a failure here cannot lose it; it only

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -127,14 +127,23 @@ impl<S: StorageProvider> Engine<S> {
             // group returns to Stable.
             let current_epoch = EpochId(mls_group.epoch().as_u64());
             if !mls_group.is_active() {
+                // The persisted OpenMLS group state is `Inactive`: retained
+                // canonical state records our own removal. This is
+                // authenticated evidence (a merged commit removed our leaf),
+                // not a decrypt failure, so later input for this group is
+                // `SelfEvicted` and must perform "realizing removal" when not
+                // already done (member-departure.md), instead of classifying
+                // as ordinary stale traffic while the group still presents as
+                // active.
                 self.persist_transport_message(
                     msg,
                     &group_id,
                     current_epoch,
                     MessageState::Failed,
                 )?;
+                self.realize_self_eviction(&group_id, current_epoch)?;
                 return Ok(IngestOutcome::Stale {
-                    reason: StaleReason::PeelFailed,
+                    reason: StaleReason::SelfEvicted,
                 });
             }
             if !self.epoch_manager.can_ingest(&group_id) {
@@ -558,9 +567,19 @@ impl<S: StorageProvider> Engine<S> {
                     });
                 }
                 Err(ProcessMessageError::GroupStateError(MlsGroupStateError::UseAfterEviction)) => {
+                    // OpenMLS states authoritatively that our own leaf was
+                    // removed (the group state records eviction). Surface the
+                    // removal instead of silently dropping the message: this
+                    // is the `SelfEvicted` outcome, and processing it must
+                    // perform "realizing removal" when not already done
+                    // (member-departure.md). Normally the `is_active` gate
+                    // above classifies this first; this arm keeps the
+                    // realization obligation attached to the authenticated
+                    // OpenMLS signal itself.
                     self.update_stored_message_state(&msg.id, MessageState::Failed)?;
+                    self.realize_self_eviction(&group_id, current_epoch)?;
                     return Ok(IngestOutcome::Stale {
-                        reason: StaleReason::PeelFailed,
+                        reason: StaleReason::SelfEvicted,
                     });
                 }
                 Err(e) => {
@@ -766,6 +785,19 @@ impl<S: StorageProvider> Engine<S> {
                         crate::group_lifecycle::mirror_app_components_into_record(
                             &mls_group, &mut g,
                         );
+                        // This commit removed our own leaf: mark the local
+                        // copy removed (member-departure.md, "Realizing
+                        // removal") in the same record write. The departure
+                        // notification for self is emitted with the roster
+                        // diff below, so the marker and the notification stay
+                        // coupled and later `SelfEvicted` input does not
+                        // re-emit it.
+                        if removed
+                            .iter()
+                            .any(|member| member == self.identity.self_id())
+                        {
+                            g.removed = true;
+                        }
                         self.storage.put_group(&g)?;
                     }
                     // #740 rotation: a peer's applied commit may have changed the
@@ -1261,6 +1293,52 @@ impl<S: StorageProvider> Engine<S> {
         });
         pending_commit_guard.disarm();
         Ok(true)
+    }
+
+    /// Realize our own removal from `group_id` (member-departure.md,
+    /// "Realizing removal"): emit the self-removed state notification and mark
+    /// the local group copy removed. State-derived and idempotent — when the
+    /// copy is already marked removed the notification was already surfaced,
+    /// so this is a no-op. The record and its history are retained (the copy
+    /// is kept inactive, never deleted). Callers must only invoke this on
+    /// authenticated evidence of eviction (the local MLS group state records
+    /// our removal), never on a bare decrypt failure.
+    pub(crate) fn realize_self_eviction(
+        &mut self,
+        group_id: &GroupId,
+        epoch: EpochId,
+    ) -> Result<(), EngineError> {
+        let mut group = match self.storage.get_group(group_id) {
+            Ok(group) => group,
+            Err(StorageError::NotFound) => return Ok(()),
+            Err(err) => return Err(EngineError::Storage(err)),
+        };
+        if group.removed {
+            return Ok(());
+        }
+        group.removed = true;
+        self.storage.put_group(&group)?;
+        self.clear_leave_request_state(group_id)?;
+        // Privacy-safe breadcrumb: aggregate signal only, no group/member ids
+        // (observability.md).
+        tracing::info!(
+            target: "cgka_engine::message_processor",
+            method = "realize_self_eviction",
+            "realized own removal for a group whose canonical state records eviction"
+        );
+        // Actor unknown: the removing commit was not (or could not be)
+        // attributed here — realization derives from retained state, not from
+        // applying the specific removal commit.
+        self.push_group_state_change(
+            group_id,
+            epoch,
+            None,
+            GroupStateChange::MemberRemoved {
+                member: self.identity.self_id().clone(),
+            },
+            None,
+        );
+        Ok(())
     }
 
     fn mark_raw_transport_message_failed_if_deferred(

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1364,6 +1364,16 @@ impl<S: StorageProvider> Engine<S> {
         let self_id = self.identity.self_id().clone();
         group.members.retain(|member| member.id != self_id);
         self.storage.put_group(&group)?;
+        // Deliberately LAST, after the marker write — not before it like the
+        // convergence path (which has no attribution read). The notification
+        // is already enqueued above, so a failure here cannot lose it; it only
+        // leaves a stale leave-request row, which the removed-copy send gate
+        // supersedes and re-join cleans up. Clearing BEFORE the marker write
+        // would be worse: a failed marker write would then retry against
+        // already-cleared leave state and emit a differently-attributed
+        // duplicate (`MemberRemoved` after an original `MemberLeft`), i.e. a
+        // second visible row. With this order any retry duplicate is
+        // byte-identical and collapses in the app's canonical-row-id upsert.
         self.clear_leave_request_state(group_id)?;
         Ok(())
     }

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -85,6 +85,19 @@ impl<S: StorageProvider> Engine<S> {
 
     pub(crate) async fn do_send(&mut self, intent: SendIntent) -> Result<SendResult, EngineError> {
         let group_id = send_intent_group_id(&intent).clone();
+        // Terminal gate before queueing: a local copy marked removed (realized
+        // self-eviction) must never accept or queue outbound work. Checked
+        // again in `do_send_ready` so queued-intent drains for a copy removed
+        // after queueing hit the same deterministic error.
+        if self.group_record_is_removed(&group_id)? {
+            return Err(EngineError::InvalidTransition(
+                cgka_traits::engine_state::InvalidTransition {
+                    from: "Removed",
+                    to: crate::audit_helpers::send_intent_kind_str(&intent),
+                    reason: "local group copy is marked removed (self-evicted)",
+                },
+            ));
+        }
         if !matches!(intent, SendIntent::Leave { .. }) && self.has_leave_send_gate(&group_id)? {
             return Err(EngineError::InvalidTransition(
                 cgka_traits::engine_state::InvalidTransition {

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -119,6 +119,16 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         now_ms: u64,
     ) -> Result<Vec<SendResult>, EngineError> {
+        // Terminal: a removed copy must never publish, and the removed-copy
+        // gate in `do_send_ready` would turn every queued record into a
+        // permanent drain error that the app retries forever. Discard the
+        // queue and report nothing to drain. This is the defense-in-depth
+        // side; the marker sites (realization, commit-apply seam, convergence
+        // reorg) also purge at the moment the copy becomes removed.
+        if self.group_record_is_removed(group_id)? {
+            self.discard_queued_outbound_intents_for_removed_group(group_id)?;
+            return Ok(Vec::new());
+        }
         if let Some(state) = self.epoch_manager.state(group_id)
             && !matches!(state, EpochState::Stable { .. })
         {
@@ -399,6 +409,45 @@ impl<S: StorageProvider> Engine<S> {
             }
         }
         Ok(progressed)
+    }
+
+    /// Discard every queued outbound intent for a group whose local copy is
+    /// marked removed. A removed copy must never prepare or publish anything
+    /// (member-departure.md, "Realizing removal"), so a durably queued intent
+    /// — e.g. one accepted mid-convergence just before the removal was
+    /// realized — is terminally unsendable: leaving it queued would make every
+    /// later drain re-fail it through the removed-copy send gate forever. The
+    /// discard is silent toward the app (the self-removed notification already
+    /// carries the user-facing signal); each dropped intent leaves a forensic
+    /// `Rejection` audit row plus an aggregate trace line. Returns the number
+    /// discarded.
+    pub(crate) fn discard_queued_outbound_intents_for_removed_group(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<usize, EngineError> {
+        let queued = self.storage.list_queued_outbound_intents(group_id)?;
+        if queued.is_empty() {
+            return Ok(0);
+        }
+        for record in &queued {
+            self.storage.delete_queued_outbound_intent(&record.id)?;
+            self.audit_group(
+                group_id,
+                marmot_forensics::AuditEventKind::Rejection {
+                    msg_id: hex::encode(record.id.as_slice()),
+                    reason: "queued_outbound_intent_discarded_group_removed".to_string(),
+                },
+            );
+        }
+        // Privacy-safe: aggregate count only, no group ids or intent contents
+        // (observability.md).
+        tracing::info!(
+            target: "cgka_engine::message_processor",
+            method = "discard_queued_outbound_intents_for_removed_group",
+            discarded = queued.len(),
+            "discarded queued outbound intents for a removed group copy"
+        );
+        Ok(queued.len())
     }
 
     fn queue_outbound_intent(

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -25,6 +25,22 @@ impl<S: StorageProvider> Engine<S> {
         &mut self,
         intent: SendIntent,
     ) -> Result<SendResult, EngineError> {
+        // A local copy marked removed is terminal for outbound work: the spec
+        // forbids preparing/publishing anything for it (member-departure.md,
+        // "Realizing removal"), and the underlying OpenMLS state would only
+        // fail with an opaque `UseAfterEviction` backend error anyway. Gate
+        // here (not just `do_send`) so queued-intent drains hit the same
+        // deterministic terminal error. Every intent kind is blocked,
+        // including `Leave` — there is nothing left to leave.
+        if self.group_record_is_removed(super::send_intent_group_id(&intent))? {
+            return Err(EngineError::InvalidTransition(
+                cgka_traits::engine_state::InvalidTransition {
+                    from: "Removed",
+                    to: crate::audit_helpers::send_intent_kind_str(&intent),
+                    reason: "local group copy is marked removed (self-evicted)",
+                },
+            ));
+        }
         match intent {
             SendIntent::AppMessage { group_id, payload } => {
                 self.do_send_app_message(group_id, payload).await

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -176,6 +176,7 @@ fn insert_marmot_group_without_openmls_state(
             members: Vec::new(),
             epoch: EpochId(epoch),
             required_capabilities: GroupCapabilities::default(),
+            removed: false,
         })
         .expect("insert marmot group record without openmls state");
 }

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -14,7 +14,9 @@ use cgka_traits::error::PeelerError;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage, StaleReason};
 use cgka_traits::peeler::TransportPeeler;
-use cgka_traits::storage::{AccountDeviceSignerStorage, GroupStorage, StorageProvider};
+use cgka_traits::storage::{
+    AccountDeviceSignerStorage, GroupStorage, LeaveRequestStorage, StorageProvider,
+};
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
@@ -783,6 +785,116 @@ async fn post_eviction_message_realizes_self_removal_and_returns_self_evicted() 
     assert!(
         record.removed,
         "realization must mark the local group copy removed"
+    );
+    assert!(
+        !record.members.iter().any(|m| m.id == bob.self_id()),
+        "realization must reconcile the roster: a removed copy must not keep \
+         presenting self as a member; got {:?}",
+        record.members
+    );
+}
+
+/// #376 attribution: OpenMLS's Inactive state does not record WHY the local
+/// leaf left the tree, but a durable leave request is authenticated local
+/// intent to leave. When one is pending, realization attributes the departure
+/// as `MemberLeft` (actor = self) — "you left" — instead of an involuntary
+/// `MemberRemoved` with an unknown actor.
+#[tokio::test]
+async fn realization_with_pending_leave_request_attributes_member_left() {
+    let (mut alice, mut bob, bob_storage, group_id, routed_commit) =
+        setup_removed_member(b"evict-left").await;
+
+    let outcome = bob.ingest(routed_commit).await.unwrap();
+    assert!(matches!(outcome, IngestOutcome::Buffered { .. }));
+    converge_buffered_commit(&mut bob, &group_id);
+    bob.drain_events();
+
+    // Silent-eviction copy again, but this time the durable state also holds
+    // a leave request: the member had asked to leave before the eviction was
+    // realized.
+    let mut record = bob_storage.get_group(&group_id).unwrap();
+    record.removed = false;
+    record.members = vec![cgka_traits::group::Member {
+        id: bob.self_id(),
+        credential: bob.self_id().as_slice().to_vec(),
+    }];
+    bob_storage.put_group(&record).unwrap();
+    bob_storage
+        .put_leave_request(&cgka_traits::storage::LeaveRequest {
+            group_id: group_id.clone(),
+            requested_at_ms: 1,
+            last_proposed_epoch: None,
+        })
+        .unwrap();
+
+    let routed_app = post_eviction_app_message(&mut alice, &group_id, b"after-leave").await;
+    let outcome = bob.ingest(routed_app).await.unwrap();
+    assert!(matches!(
+        outcome,
+        IngestOutcome::Stale {
+            reason: StaleReason::SelfEvicted
+        }
+    ));
+    let bob_events = bob.drain_events();
+    let bob_id = bob.self_id();
+    assert!(
+        bob_events.iter().any(|event| matches!(
+            event,
+            cgka_traits::engine::GroupEvent::GroupStateChanged {
+                change: cgka_traits::engine::GroupStateChange::MemberLeft { member },
+                actor: Some(actor),
+                ..
+            } if member == &bob_id && actor == &bob_id
+        )),
+        "a pending leave request must attribute realization as MemberLeft by self; got {bob_events:?}"
+    );
+    assert!(
+        !emits_removed_of(&bob_events, &bob_id),
+        "no involuntary MemberRemoved when the departure was our own leave; got {bob_events:?}"
+    );
+    assert!(bob_storage.get_group(&group_id).unwrap().removed);
+    assert!(
+        bob_storage.leave_request(&group_id).unwrap().is_none(),
+        "realization consumes the leave request"
+    );
+}
+
+/// #376 outbound terminal semantics: a copy marked removed must not prepare
+/// or publish anything (member-departure.md). Sends fail with a deterministic
+/// terminal `InvalidTransition` — not an opaque backend error from OpenMLS's
+/// `UseAfterEviction`.
+#[tokio::test]
+async fn send_after_realized_eviction_is_rejected_terminally() {
+    let (_alice, mut bob, bob_storage, group_id, routed_commit) =
+        setup_removed_member(b"evict-send-gate").await;
+
+    let outcome = bob.ingest(routed_commit).await.unwrap();
+    assert!(matches!(outcome, IngestOutcome::Buffered { .. }));
+    converge_buffered_commit(&mut bob, &group_id);
+    bob.drain_events();
+    assert!(bob_storage.get_group(&group_id).unwrap().removed);
+
+    let payload = app_payload_for(&bob, b"after eviction");
+    let blocked = bob
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload,
+        })
+        .await;
+    assert!(
+        matches!(blocked, Err(EngineError::InvalidTransition(_))),
+        "send on a removed copy must fail terminally, got {blocked:?}"
+    );
+
+    // Leave is equally pointless on a removed copy: same terminal error.
+    let blocked = bob
+        .send(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await;
+    assert!(
+        matches!(blocked, Err(EngineError::InvalidTransition(_))),
+        "leave on a removed copy must fail terminally, got {blocked:?}"
     );
 }
 

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -12,9 +12,9 @@ use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, Requ
 use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, KeyPackage, SendIntent, SendResult};
 use cgka_traits::error::PeelerError;
 use cgka_traits::group_context::GroupContextSnapshot;
-use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage};
+use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage, StaleReason};
 use cgka_traits::peeler::TransportPeeler;
-use cgka_traits::storage::{AccountDeviceSignerStorage, StorageProvider};
+use cgka_traits::storage::{AccountDeviceSignerStorage, GroupStorage, StorageProvider};
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
@@ -612,6 +612,249 @@ async fn admin_remove_members_publishes_commit_and_updates_membership() {
             .iter()
             .any(|member| member.id == bob.self_id()),
         "carol should converge to a group without bob; got {carol_members:?}"
+    );
+}
+
+/// Shared setup for the self-eviction realization tests (#376): alice (admin)
+/// creates a group with bob, bob joins, alice removes bob and confirms the
+/// publish. Returns the engines, bob's storage handle, the group id, and the
+/// removal commit routed for group ingestion (NOT yet delivered to bob).
+async fn setup_removed_member(
+    tag: &[u8],
+) -> (
+    Engine<SqliteAccountStorage>,
+    Engine<SqliteAccountStorage>,
+    SqliteAccountStorage,
+    GroupId,
+    TransportMessage,
+) {
+    let mut alice = build_client(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: String::from_utf8_lossy(tag).into_owned(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let welcome_for_bob = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            welcomes.remove(0)
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcome_for_bob).await.unwrap();
+
+    let remove = alice
+        .send(SendIntent::RemoveMembers {
+            group_id: group_id.clone(),
+            members: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (commit, pending) = match remove {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    alice.drain_events();
+
+    let routed_commit = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..commit
+    };
+    (alice, bob, bob_storage, group_id, routed_commit)
+}
+
+/// Send a post-eviction application message from `alice` and route it for
+/// group ingestion.
+async fn post_eviction_app_message(
+    alice: &mut Engine<SqliteAccountStorage>,
+    group_id: &GroupId,
+    payload: &[u8],
+) -> TransportMessage {
+    let payload = app_payload_for(alice, payload);
+    let sent = alice
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload,
+        })
+        .await
+        .unwrap();
+    let msg = match sent {
+        SendResult::ApplicationMessage { msg } => msg,
+        other => panic!("expected ApplicationMessage, got {other:?}"),
+    };
+    TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..msg
+    }
+}
+
+/// #376 realization marker: when the removed member applies the removal
+/// commit, the local group copy is marked removed alongside the self-removed
+/// notification, so later `SelfEvicted` input does not re-notify.
+#[tokio::test]
+async fn removed_member_applying_removal_commit_marks_local_copy_removed() {
+    let (_alice, mut bob, bob_storage, group_id, routed_commit) =
+        setup_removed_member(b"evict-marks-removed").await;
+
+    let outcome = bob.ingest(routed_commit).await.unwrap();
+    assert!(
+        matches!(outcome, IngestOutcome::Buffered { .. }),
+        "removal commit enters convergence; got {outcome:?}"
+    );
+    converge_buffered_commit(&mut bob, &group_id);
+
+    let bob_events = bob.drain_events();
+    assert!(
+        emits_departure_of(&bob_events, &bob.self_id()),
+        "bob should observe his own removal; got {bob_events:?}"
+    );
+    let record = bob_storage.get_group(&group_id).unwrap();
+    assert!(
+        record.removed,
+        "applying the removal commit must mark the local group copy removed"
+    );
+}
+
+/// #376 regression (silent eviction): later group input for a group whose
+/// retained canonical state records our own removal classifies as
+/// `Stale {{ SelfEvicted }}` and performs "realizing removal"
+/// (member-departure.md) when the local copy is not yet marked removed —
+/// emitting the self-removed notification and marking the copy removed —
+/// instead of failing silently as generic `PeelFailed` stale traffic.
+#[tokio::test]
+async fn post_eviction_message_realizes_self_removal_and_returns_self_evicted() {
+    let (mut alice, mut bob, bob_storage, group_id, routed_commit) =
+        setup_removed_member(b"evict-realize").await;
+
+    // Bob's MLS state records the eviction (the removal commit applied)...
+    let outcome = bob.ingest(routed_commit).await.unwrap();
+    assert!(matches!(outcome, IngestOutcome::Buffered { .. }));
+    converge_buffered_commit(&mut bob, &group_id);
+    bob.drain_events();
+
+    // ...but simulate the silent-eviction client state the issue describes: a
+    // local copy that never realized the removal (no notification observed,
+    // record not marked removed, self still presented as a member). This is
+    // the persisted state of a pre-fix client — or one whose removal
+    // notification was lost — that only ever sees post-eviction traffic.
+    let mut record = bob_storage.get_group(&group_id).unwrap();
+    record.removed = false;
+    record.members = vec![cgka_traits::group::Member {
+        id: bob.self_id(),
+        credential: bob.self_id().as_slice().to_vec(),
+    }];
+    bob_storage.put_group(&record).unwrap();
+
+    // A later post-eviction message must surface the removal, not vanish.
+    let routed_app = post_eviction_app_message(&mut alice, &group_id, b"post-eviction").await;
+    let outcome = bob.ingest(routed_app).await.unwrap();
+    assert!(
+        matches!(
+            outcome,
+            IngestOutcome::Stale {
+                reason: StaleReason::SelfEvicted
+            }
+        ),
+        "post-eviction input must classify SelfEvicted; got {outcome:?}"
+    );
+    let bob_events = bob.drain_events();
+    assert!(
+        emits_removed_of(&bob_events, &bob.self_id()),
+        "realization must emit the self-removed notification; got {bob_events:?}"
+    );
+    let record = bob_storage.get_group(&group_id).unwrap();
+    assert!(
+        record.removed,
+        "realization must mark the local group copy removed"
+    );
+}
+
+/// #376 idempotence: realization is a state-derived obligation. A second
+/// post-eviction message still classifies `SelfEvicted`, but the already-
+/// marked-removed copy suppresses a duplicate self-removed notification.
+#[tokio::test]
+async fn second_post_eviction_message_is_self_evicted_without_duplicate_notification() {
+    let (mut alice, mut bob, bob_storage, group_id, routed_commit) =
+        setup_removed_member(b"evict-idempotent").await;
+
+    let outcome = bob.ingest(routed_commit).await.unwrap();
+    assert!(matches!(outcome, IngestOutcome::Buffered { .. }));
+    converge_buffered_commit(&mut bob, &group_id);
+    bob.drain_events();
+    assert!(
+        bob_storage.get_group(&group_id).unwrap().removed,
+        "precondition: the copy is already marked removed"
+    );
+
+    for round in 0..2u8 {
+        let routed_app =
+            post_eviction_app_message(&mut alice, &group_id, format!("again-{round}").as_bytes())
+                .await;
+        let outcome = bob.ingest(routed_app).await.unwrap();
+        assert!(
+            matches!(
+                outcome,
+                IngestOutcome::Stale {
+                    reason: StaleReason::SelfEvicted
+                }
+            ),
+            "round {round}: post-eviction input stays SelfEvicted; got {outcome:?}"
+        );
+        let bob_events = bob.drain_events();
+        assert!(
+            !emits_departure_of(&bob_events, &bob.self_id()),
+            "round {round}: an already-realized removal must not re-notify; got {bob_events:?}"
+        );
+    }
+}
+
+/// #376 guard: failure to decrypt alone is NOT evidence of removal
+/// (member-departure.md). A member that merely missed the removal commit has
+/// no authenticated evidence, so post-eviction traffic stays a
+/// missing-history/repair condition (buffered) — it must NOT map to
+/// `SelfEvicted` and must NOT fabricate a removal notification.
+#[tokio::test]
+async fn missed_removal_commit_without_evidence_is_not_self_evicted() {
+    let (mut alice, mut bob, bob_storage, group_id, _undelivered_commit) =
+        setup_removed_member(b"evict-no-evidence").await;
+
+    // Bob never sees the removal commit; only later traffic arrives.
+    let routed_app = post_eviction_app_message(&mut alice, &group_id, b"future-epoch").await;
+    let outcome = bob.ingest(routed_app).await.unwrap();
+    assert!(
+        !matches!(
+            outcome,
+            IngestOutcome::Stale {
+                reason: StaleReason::SelfEvicted
+            }
+        ),
+        "undecryptable input without authenticated evidence must not be SelfEvicted; got {outcome:?}"
+    );
+    let bob_events = bob.drain_events();
+    assert!(
+        !emits_departure_of(&bob_events, &bob.self_id()),
+        "no removal notification without authenticated evidence; got {bob_events:?}"
+    );
+    assert!(
+        !bob_storage.get_group(&group_id).unwrap().removed,
+        "the local copy must not be marked removed without authenticated evidence"
     );
 }
 

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -15,7 +15,8 @@ use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage, StaleReason};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
-    AccountDeviceSignerStorage, GroupStorage, LeaveRequestStorage, StorageProvider,
+    AccountDeviceSignerStorage, GroupStorage, LeaveRequestStorage, OutboundIntentStorage,
+    StorageProvider,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -895,6 +896,119 @@ async fn send_after_realized_eviction_is_rejected_terminally() {
     assert!(
         matches!(blocked, Err(EngineError::InvalidTransition(_))),
         "leave on a removed copy must fail terminally, got {blocked:?}"
+    );
+}
+
+/// Durably queue an app-message intent for `group_id`, simulating a send the
+/// engine accepted mid-convergence (`SendResult::Queued`) that has not been
+/// drained yet.
+fn queue_app_message_intent(
+    storage: &SqliteAccountStorage,
+    engine: &Engine<SqliteAccountStorage>,
+    group_id: &GroupId,
+    tag: u8,
+) -> MessageId {
+    let id = MessageId::new(vec![tag; 32]);
+    storage
+        .put_queued_outbound_intent(&cgka_traits::storage::QueuedOutboundIntent {
+            id: id.clone(),
+            group_id: group_id.clone(),
+            intent: SendIntent::AppMessage {
+                group_id: group_id.clone(),
+                payload: app_payload_for(engine, b"queued before removal"),
+            },
+            created_at_ms: 1,
+        })
+        .expect("queue outbound intent");
+    id
+}
+
+/// #376 review follow-up: an outbound intent durably queued before the
+/// removal is applied must be discarded when the copy becomes removed —
+/// applying the removal commit purges the queue, so later drains have nothing
+/// to perpetually re-fail against the removed-copy send gate.
+#[tokio::test]
+async fn applying_removal_commit_purges_queued_outbound_intents() {
+    let (_alice, mut bob, bob_storage, group_id, routed_commit) =
+        setup_removed_member(b"evict-purge-queue").await;
+
+    queue_app_message_intent(&bob_storage, &bob, &group_id, 0x51);
+    assert_eq!(
+        bob_storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .len(),
+        1
+    );
+
+    let outcome = bob.ingest(routed_commit).await.unwrap();
+    assert!(matches!(outcome, IngestOutcome::Buffered { .. }));
+    converge_buffered_commit(&mut bob, &group_id);
+    assert!(bob_storage.get_group(&group_id).unwrap().removed);
+    assert!(
+        bob_storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .is_empty(),
+        "marking the copy removed must discard queued outbound intents"
+    );
+}
+
+/// #376 review follow-up: realization itself purges queued intents, and the
+/// drain path treats a removed copy as terminal — it discards any remaining
+/// queued records and reports nothing to drain instead of returning the
+/// removed-copy send error forever (which the app-layer scheduler would
+/// retry for the lifetime of the account).
+#[tokio::test]
+async fn drain_on_removed_copy_discards_queued_intents_without_error() {
+    let (mut alice, mut bob, bob_storage, group_id, routed_commit) =
+        setup_removed_member(b"evict-drain-queue").await;
+
+    let outcome = bob.ingest(routed_commit).await.unwrap();
+    assert!(matches!(outcome, IngestOutcome::Buffered { .. }));
+    converge_buffered_commit(&mut bob, &group_id);
+    bob.drain_events();
+
+    // Realization-side purge: recreate the silent copy with an undrained
+    // queued intent, then let a post-eviction message trigger realization.
+    let mut record = bob_storage.get_group(&group_id).unwrap();
+    record.removed = false;
+    bob_storage.put_group(&record).unwrap();
+    queue_app_message_intent(&bob_storage, &bob, &group_id, 0x52);
+    let routed_app = post_eviction_app_message(&mut alice, &group_id, b"trigger realize").await;
+    let outcome = bob.ingest(routed_app).await.unwrap();
+    assert!(matches!(
+        outcome,
+        IngestOutcome::Stale {
+            reason: StaleReason::SelfEvicted
+        }
+    ));
+    assert!(
+        bob_storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .is_empty(),
+        "realization must discard queued outbound intents"
+    );
+
+    // Drain-side defense in depth: an intent queued after the copy is already
+    // marked removed (any ordering the marker-site purges missed) is
+    // discarded by the drain itself — no error, nothing drained, queue empty.
+    queue_app_message_intent(&bob_storage, &bob, &group_id, 0x53);
+    let drained = bob
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_000_000)
+        .await
+        .expect("drain on a removed copy must not error");
+    assert!(
+        drained.is_empty(),
+        "nothing may be published for a removed copy; got {drained:?}"
+    );
+    assert!(
+        bob_storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .is_empty(),
+        "drain must discard queued intents for a removed copy"
     );
 }
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -24,6 +24,12 @@ versioning through the workspace version in the root `Cargo.toml`.
 - `dmd` now buffers daemon request frames before scanning for the newline delimiter, avoiding one async `read()` call per
   byte for large `Execute` requests while preserving the existing 1 MiB request cap and stalled-client timeout.
 
+### Changed
+
+- `message send` (and every other group send) on a group whose local copy records your own removal now fails with the
+  deterministic JSON error code `invalid_transition` ("local group copy is marked removed (self-evicted)") instead of an
+  opaque `engine_error`, matching the engine's realized self-eviction semantics (#376).
+
 ## [0.2.0] - 2026-06-21
 
 ### Added

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -5632,7 +5632,16 @@ fn three_user_message_lifecycle_covers_invite_remove_and_later_delivery() {
             "sender",
         ],
     );
-    assert_eq!(bob_send_error["code"], "engine_error");
+    // A copy whose canonical state records our own removal is terminal for
+    // outbound work: the engine rejects the send with a deterministic
+    // InvalidTransition (from: "Removed") instead of an opaque backend error
+    // (#376 realization semantics).
+    assert_eq!(bob_send_error["code"], "invalid_transition");
+    let message = bob_send_error["message"].as_str().expect("error message");
+    assert!(
+        message.contains("marked removed"),
+        "removed-copy send should explain the terminal state; got {message}"
+    );
 }
 
 #[test]

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -1006,6 +1006,7 @@ async fn drain_surfaces_hydration_quarantine_without_inbound_delivery() {
                 members: Vec::new(),
                 epoch: EpochId(9),
                 required_capabilities: GroupCapabilities::default(),
+                removed: false,
             })
             .unwrap();
     }

--- a/crates/storage-sqlite/src/storage/test_support.rs
+++ b/crates/storage-sqlite/src/storage/test_support.rs
@@ -38,6 +38,7 @@ pub(crate) fn sample_group(id: GroupId, epoch: u64, members: usize) -> Group {
             })
             .collect(),
         required_capabilities: GroupCapabilities::default(),
+        removed: false,
     }
 }
 

--- a/crates/traits/src/group.rs
+++ b/crates/traits/src/group.rs
@@ -19,6 +19,18 @@ pub struct Group {
     pub epoch: EpochId,
     pub members: Vec<Member>,
     pub required_capabilities: GroupCapabilities,
+    /// The local copy of this group is marked removed: retained canonical
+    /// state records the local member's own removal (spec
+    /// `protocol-core/member-departure.md`, "Realizing removal"). The record
+    /// is retained inactive — history may be kept, but the group must not be
+    /// presented as active and nothing may be sent or published to it. This
+    /// flag is the idempotence marker for the realization obligation: it is
+    /// set together with the self-removed state notification, so later input
+    /// classified `SelfEvicted` does not re-emit the notification. Terminal
+    /// for the group on this client. Defaults to `false` for records
+    /// persisted before this field existed.
+    #[serde(default)]
+    pub removed: bool,
 }
 
 /// One member of a group, as storage sees it.

--- a/crates/traits/src/ingest.rs
+++ b/crates/traits/src/ingest.rs
@@ -46,6 +46,17 @@ pub enum StaleReason {
     /// retryable depending on whether the engine has evidence that another
     /// epoch context could later peel it.
     PeelFailed,
+    /// The local retained canonical state records our own removal from this
+    /// group, so later group input can never be processed here. Terminal for
+    /// the group on this client. Processing input that classifies as
+    /// `SelfEvicted` also performs "realizing removal" when not already done:
+    /// emit a self-removed state notification and mark the local group copy
+    /// removed (spec `protocol-core/member-departure.md`, registered as the
+    /// `SelfEvicted` outcome in `foundation/errors.md`). Only authenticated
+    /// evidence (the local MLS state records the eviction) maps here — a bare
+    /// decrypt failure is a missing-history/repair condition, never
+    /// `SelfEvicted`.
+    SelfEvicted,
 }
 
 /// Decrypted inbound message ready for engine processing.

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -347,6 +347,12 @@ fn snapshot_ingest_outcomes() {
             reason: StaleReason::PeelFailed
         }
     );
+    insta::assert_json_snapshot!(
+        "stale_self_evicted",
+        IngestOutcome::Stale {
+            reason: StaleReason::SelfEvicted
+        }
+    );
 }
 
 #[test]
@@ -609,6 +615,7 @@ fn snapshot_group_and_member() {
                 credential: vec![],
             }],
             required_capabilities: GroupCapabilities::default(),
+            removed: false,
         }
     );
 }

--- a/crates/traits/tests/snapshots/snapshots__group.snap
+++ b/crates/traits/tests/snapshots/snapshots__group.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/traits/tests/snapshots.rs
-assertion_line: 510
-expression: "Group\n{\n    id: gid(), name: \"ops\".into(), description: \"for ops talk\".into(), epoch:\n    EpochId(3), members: vec![Member { id: mem_id(), credential: vec![], }],\n    required_capabilities: GroupCapabilities::default(),\n}"
+expression: "Group\n{\n    id: gid(), name: \"ops\".into(), description: \"for ops talk\".into(), epoch:\n    EpochId(3), members: vec![Member { id: mem_id(), credential: vec![], }],\n    required_capabilities: GroupCapabilities::default(), removed: false,\n}"
 ---
 {
   "id": [
@@ -31,5 +30,6 @@ expression: "Group\n{\n    id: gid(), name: \"ops\".into(), description: \"for o
     "app_components": {
       "ids": []
     }
-  }
+  },
+  "removed": false
 }

--- a/crates/traits/tests/snapshots/snapshots__stale_self_evicted.snap
+++ b/crates/traits/tests/snapshots/snapshots__stale_self_evicted.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Stale { reason: StaleReason::SelfEvicted }"
+---
+{
+  "Stale": {
+    "reason": "SelfEvicted"
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the silent-eviction gap from #376: when the local retained canonical state records the member's **own removal** — OpenMLS group state `Inactive`, surfaced as `MlsGroupStateError::UseAfterEviction` — the engine classified later group input as generic `Stale { PeelFailed }`, emitted no event, and never marked the group inactive. A cross-device removed member kept seeing the group as fully active forever.

This implements the merged spec behavior from marmot-protocol/marmot#171:

- **`foundation/errors.md` — `SelfEvicted` outcome** (disposition `stale`, category `stale_epoch`): terminal for the group on that client; attaches to later input for a group whose retained canonical state records the local member's own removal.
- **`protocol-core/member-departure.md` — "Realizing removal"**: a state-derived, idempotent obligation. Whenever retained canonical state records the local member's removal and the local copy is not yet marked removed, the client MUST emit a self-removed state notification and mark the copy removed. The removed copy is retained inactive, not deleted. Failure to decrypt alone is NOT evidence of removal.
- **`protocol-core/inbound-processing.md`**: processing such input must surface the removal as a state notification instead of failing silently.

## What changed

- **`crates/traits/src/ingest.rs`** — new `StaleReason::SelfEvicted` variant (unit variant; group scoping travels elsewhere, matching the existing style).
- **`crates/traits/src/group.rs`** — new `Group.removed: bool` (`#[serde(default)]`, so pre-existing serialized records read back as `removed: false`). This is the "local copy is marked removed" realization marker: the record and history are retained, the group is just never presented as active again. No prior inactive/removed representation existed, so this is the smallest coherent one.
- **`crates/cgka-engine/src/message_processor/ingest.rs`** — both authenticated-eviction sites now realize instead of swallowing:
  - the `!mls_group.is_active()` front gate (the persisted OpenMLS `Inactive` state — the site all later input actually hits), and
  - the `UseAfterEviction` arm from `process_message` (kept as the defense-in-depth handler bound to the OpenMLS signal itself).

  Both call the new `realize_self_eviction`: if the copy is not yet marked removed, emit `GroupStateChanged { change: MemberRemoved { member: self }, actor: None }` via the existing `push_group_state_change` machinery, mark the record removed, clear any leave-request state; then return `Stale { SelfEvicted }`. Already-realized copies return `SelfEvicted` without re-emitting.
- **Marker coupling at the paths that already notify** — the direct commit-apply seam (roster diff) and the convergence reorg diff set `removed = true` in the same pass that emits the self-departure notification, so the marker and the notification never diverge and realized removals never double-notify.
- **`crates/cgka-engine/src/audit_helpers.rs`** — `stale_reason_str` maps the new reason to the stable low-cardinality string `"self_evicted"` for forensic audit rows.
- **Consumers** — `cgka-session`, `marmot-account`, and the conformance simulator match only on outcome kind (`Processed`/`Buffered`/`Stale`), so `SelfEvicted` correctly flows as `Stale` and never enters convergence buffering; verified no reason-specific branches exist. `IngestOutcome` is not exposed through `marmot-uniffi` (verified — no FFI change).
- Mechanical `removed: false` additions at `Group` literal construction sites (engine group lifecycle, storage/simulator/account test fixtures) and updated `cgka-traits` insta snapshots.

## Guarded semantics

Only authenticated evidence triggers realization: the OpenMLS group state records the eviction (set exclusively by merging a commit that removed our own leaf). Generic decrypt failures / missed commits keep their existing missing-history behavior (peel-deferred / convergence-buffered) — covered by a dedicated guard test.

## Test plan

New tests in `crates/cgka-engine/tests/invite_leave.rs`:

- `removed_member_applying_removal_commit_marks_local_copy_removed` — applying the removal commit emits the departure and durably marks the copy removed.
- `post_eviction_message_realizes_self_removal_and_returns_self_evicted` — **the #376 regression**: a copy whose canonical state records eviction but which never realized it (silent-eviction state) ingests a later post-eviction message → outcome is `Stale { SelfEvicted }`, a self-removed `GroupStateChanged` is emitted, and the record reads removed.
- `second_post_eviction_message_is_self_evicted_without_duplicate_notification` — idempotence: repeated post-eviction input keeps classifying `SelfEvicted` with no duplicate notification.
- `missed_removal_commit_without_evidence_is_not_self_evicted` — guard: a member that merely missed the removal commit (no authenticated evidence) stays buffered/repair, is not marked removed, and gets no fabricated notification.

Ran locally:

- `just fast-ci` (fmt-check, workspace check incl. OTLP builds, clippy) — clean
- `cargo test -p cgka-traits` (66 + snapshot suites) — pass
- `cargo test -p cgka-engine` (full suite incl. the 4 new tests) — pass
- `cargo test -p cgka-session`, `-p marmot-account`, `-p storage-sqlite`, `-p marmot-app`, `-p cgka-conformance-simulator` — pass

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/703">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persisted “removed” marker to local group records to better represent self-eviction.
  * Ingestion now classifies post-eviction traffic with a dedicated **SelfEvicted** stale outcome.
* **Bug Fixes**
  * Self-eviction realization is now idempotent and reliably reconciles persisted roster/state.
  * Outbound sends and queued intent drains are blocked/cleared for removed groups to prevent repeated failures.
* **Tests**
  * Expanded self-eviction, queue-purge, and snapshot coverage, including updated CLI failure assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->