### PR TITLE
Reject commits whose resulting GroupContext strips required app components

### DIFF
--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -16,9 +16,9 @@ use cgka_traits::error::EngineError;
 use cgka_traits::types::{GroupId, MemberId};
 use openmls::extensions::{AppDataDictionary, AppDataDictionaryExtension, Extension};
 use openmls::group::{MlsGroup, StagedCommit};
-use openmls::messages::proposals::Proposal;
+use openmls::messages::proposals::{AppDataUpdateOperation, Proposal};
 use openmls::prelude::{BasicCredential, LeafNode, Sender};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct InitialComponentState {
@@ -297,48 +297,91 @@ pub(crate) fn validate_admin_leaf_coupling_for_staged_commit(
     Ok(())
 }
 
-/// Reject (pre-merge) a commit whose resulting GroupContext strips Marmot
-/// component state the group requires: the `app_data_dictionary` extension
-/// itself, its `app_components` entry, or the state of any component listed in
-/// the group's required `app_components`.
+/// Reject (pre-merge) a commit whose resulting GroupContext strips or rewrites
+/// Marmot component state outside the validated `AppDataUpdate` channel.
 ///
-/// OpenMLS's draft-08 guard only validates the dictionary against a commit's
-/// `AppDataUpdate` proposals, and [`validate_app_component_remove`] only sees
-/// `AppDataUpdate::Remove` operations — so a `GroupContextExtensions`-only
-/// commit could otherwise replace the extensions with a set that omits
-/// required Marmot state. Such a strip cannot orphan an admin key (an absent
-/// admin-policy component is the empty admin set, handled in
-/// [`validate_admin_leaf_coupling_for_staged_commit`]), but it silently makes
-/// the group admin-less and freezes every admin-gated operation — a
-/// denial-of-service / consistency break that must be rejected pre-merge.
-pub(crate) fn validate_required_component_retention_for_staged_commit(
+/// OpenMLS's draft-08 guard only validates the resulting dictionary against a
+/// commit's `AppDataUpdate` proposals and returns early when there are none,
+/// and the engine's component validators ([`validate_app_component_update`] /
+/// [`validate_app_component_remove`]) likewise only run for `AppDataUpdate`
+/// operations — so a `GroupContextExtensions`-only commit could otherwise
+/// replace the extensions with a set that drops the `app_data_dictionary`
+/// (making the group admin-less and freezing every admin-gated operation), or
+/// keep every entry present while rewriting its bytes (swapping the admin set,
+/// or corrupting profile/routing/retention state with bytes that never passed
+/// the component validators).
+///
+/// Enforced rules, in order:
+/// 1. the `app_data_dictionary` extension itself may never be dropped;
+/// 2. the engine-owned `app_components` entry and the state entry of every
+///    component in the current epoch's required set may never be dropped
+///    (mirrors [`validate_app_component_remove`]: a component becomes
+///    droppable only after a prior commit removes it from the required list);
+/// 3. every dictionary entry that changes relative to the current epoch —
+///    added, rewritten, or removed — must match one of this commit's own
+///    `AppDataUpdate` operations, whose payloads passed the component
+///    validators before the commit was staged.
+pub(crate) fn validate_app_component_integrity_for_staged_commit(
     mls_group: &MlsGroup,
     group_id: &GroupId,
     staged: &StagedCommit,
 ) -> Result<(), EngineError> {
-    let Some(current) = mls_group.extensions().app_data_dictionary() else {
-        // The group never carried Marmot component state; nothing to retain.
-        return Ok(());
-    };
-    let current = current.dictionary();
-    let Some(resulting) = staged.group_context().extensions().app_data_dictionary() else {
+    let current = mls_group.extensions().app_data_dictionary();
+    let resulting = staged.group_context().extensions().app_data_dictionary();
+    if current.is_some() && resulting.is_none() {
         return Err(EngineError::Other(format!(
             "commit is invalid: resulting GroupContext drops the app_data_dictionary (group {group_id:?})"
         )));
-    };
-    let resulting = resulting.dictionary();
-    // The negotiated required-component list is engine-owned and can never be
-    // dropped (mirrors `validate_app_component_remove`); required components
-    // must keep whatever state entry the current epoch carries. A component
-    // becomes droppable only after a prior commit removes it from the required
-    // list via an `AppDataUpdate` to `app_components`.
+    }
+    let current = current.map(|ext| ext.dictionary());
+    let resulting = resulting.map(|ext| ext.dictionary());
+
     let mut protected = required_app_components_of_group(mls_group)?.ids;
     protected.insert(APP_COMPONENTS_COMPONENT_ID);
-    for component_id in protected {
-        if current.get(&component_id).is_some() && resulting.get(&component_id).is_none() {
+    for component_id in &protected {
+        let currently_present = current.is_some_and(|dict| dict.contains(component_id));
+        let still_present = resulting.is_some_and(|dict| dict.contains(component_id));
+        if currently_present && !still_present {
             return Err(EngineError::Other(format!(
                 "commit is invalid: resulting GroupContext drops required app component \
                  {component_id:#06x} (group {group_id:?})"
+            )));
+        }
+    }
+
+    // This commit's AppDataUpdate operations by component id: the exact set of
+    // resulting values a changed entry is allowed to take. `None` is a Remove.
+    let mut update_ops: BTreeMap<AppComponentId, Vec<Option<&[u8]>>> = BTreeMap::new();
+    for queued in staged.queued_proposals() {
+        if let Proposal::AppDataUpdate(update) = queued.proposal() {
+            let op = match update.operation() {
+                AppDataUpdateOperation::Update(data) => Some(data.as_slice()),
+                AppDataUpdateOperation::Remove => None,
+            };
+            update_ops
+                .entry(update.component_id())
+                .or_default()
+                .push(op);
+        }
+    }
+    let component_ids: BTreeSet<AppComponentId> = current
+        .into_iter()
+        .chain(resulting)
+        .flat_map(|dict| dict.entries().map(|entry| entry.id()))
+        .collect();
+    for component_id in component_ids {
+        let before = current.and_then(|dict| dict.get(&component_id));
+        let after = resulting.and_then(|dict| dict.get(&component_id));
+        if before == after {
+            continue;
+        }
+        let update_backed = update_ops
+            .get(&component_id)
+            .is_some_and(|ops| ops.contains(&after));
+        if !update_backed {
+            return Err(EngineError::Other(format!(
+                "commit is invalid: resulting GroupContext changes app component \
+                 {component_id:#06x} outside an AppDataUpdate proposal (group {group_id:?})"
             )));
         }
     }

--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -297,6 +297,54 @@ pub(crate) fn validate_admin_leaf_coupling_for_staged_commit(
     Ok(())
 }
 
+/// Reject (pre-merge) a commit whose resulting GroupContext strips Marmot
+/// component state the group requires: the `app_data_dictionary` extension
+/// itself, its `app_components` entry, or the state of any component listed in
+/// the group's required `app_components`.
+///
+/// OpenMLS's draft-08 guard only validates the dictionary against a commit's
+/// `AppDataUpdate` proposals, and [`validate_app_component_remove`] only sees
+/// `AppDataUpdate::Remove` operations — so a `GroupContextExtensions`-only
+/// commit could otherwise replace the extensions with a set that omits
+/// required Marmot state. Such a strip cannot orphan an admin key (an absent
+/// admin-policy component is the empty admin set, handled in
+/// [`validate_admin_leaf_coupling_for_staged_commit`]), but it silently makes
+/// the group admin-less and freezes every admin-gated operation — a
+/// denial-of-service / consistency break that must be rejected pre-merge.
+pub(crate) fn validate_required_component_retention_for_staged_commit(
+    mls_group: &MlsGroup,
+    group_id: &GroupId,
+    staged: &StagedCommit,
+) -> Result<(), EngineError> {
+    let Some(current) = mls_group.extensions().app_data_dictionary() else {
+        // The group never carried Marmot component state; nothing to retain.
+        return Ok(());
+    };
+    let current = current.dictionary();
+    let Some(resulting) = staged.group_context().extensions().app_data_dictionary() else {
+        return Err(EngineError::Other(format!(
+            "commit is invalid: resulting GroupContext drops the app_data_dictionary (group {group_id:?})"
+        )));
+    };
+    let resulting = resulting.dictionary();
+    // The negotiated required-component list is engine-owned and can never be
+    // dropped (mirrors `validate_app_component_remove`); required components
+    // must keep whatever state entry the current epoch carries. A component
+    // becomes droppable only after a prior commit removes it from the required
+    // list via an `AppDataUpdate` to `app_components`.
+    let mut protected = required_app_components_of_group(mls_group)?.ids;
+    protected.insert(APP_COMPONENTS_COMPONENT_ID);
+    for component_id in protected {
+        if current.get(&component_id).is_some() && resulting.get(&component_id).is_none() {
+            return Err(EngineError::Other(format!(
+                "commit is invalid: resulting GroupContext drops required app component \
+                 {component_id:#06x} (group {group_id:?})"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Reject an admin set that lists an admin with no member leaf in the CURRENT
 /// epoch (admin-policy-v1.md). Used on the outbound `UpdateAppComponents` path,
 /// where the commit changes only component bytes and not membership, so the

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -654,11 +654,13 @@ impl<S: StorageProvider> Engine<S> {
                         return Err(err);
                     }
                     // Reject (pre-merge) a commit whose resulting GroupContext
-                    // strips the app_data_dictionary or a required component's
-                    // state — e.g. a GroupContextExtensions-only commit that
-                    // replaces the extensions without the dictionary.
+                    // strips or rewrites app-component state outside the
+                    // validated AppDataUpdate channel — e.g. a
+                    // GroupContextExtensions-only commit that replaces the
+                    // extensions without the dictionary, or with tampered
+                    // component bytes.
                     if let Err(err) =
-                        crate::app_components::validate_required_component_retention_for_staged_commit(
+                        crate::app_components::validate_app_component_integrity_for_staged_commit(
                             &mls_group, &group_id, &staged,
                         )
                     {

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -653,6 +653,18 @@ impl<S: StorageProvider> Engine<S> {
                         self.update_stored_message_state(&msg.id, MessageState::Failed)?;
                         return Err(err);
                     }
+                    // Reject (pre-merge) a commit whose resulting GroupContext
+                    // strips the app_data_dictionary or a required component's
+                    // state — e.g. a GroupContextExtensions-only commit that
+                    // replaces the extensions without the dictionary.
+                    if let Err(err) =
+                        crate::app_components::validate_required_component_retention_for_staged_commit(
+                            &mls_group, &group_id, &staged,
+                        )
+                    {
+                        self.update_stored_message_state(&msg.id, MessageState::Failed)?;
+                        return Err(err);
+                    }
                     let Some(commit_committer) = sender_id.clone() else {
                         self.update_stored_message_state(&msg.id, MessageState::Failed)?;
                         return Err(EngineError::Backend(

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -395,7 +395,7 @@ impl<S: StorageProvider> Engine<S> {
             &group_id,
             staged_commit,
         )?;
-        crate::app_components::validate_required_component_retention_for_staged_commit(
+        crate::app_components::validate_app_component_integrity_for_staged_commit(
             &mls_group,
             &group_id,
             staged_commit,

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -395,6 +395,11 @@ impl<S: StorageProvider> Engine<S> {
             &group_id,
             staged_commit,
         )?;
+        crate::app_components::validate_required_component_retention_for_staged_commit(
+            &mls_group,
+            &group_id,
+            staged_commit,
+        )?;
         let commit_priority =
             crate::app_components::commit_ordering_priority_for_staged(staged_commit);
         self.epoch_manager

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -1572,6 +1572,16 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                         reason: format!("admin leaf coupling: {err}"),
                     });
                 }
+                if let Err(err) =
+                    crate::app_components::validate_required_component_retention_for_staged_commit(
+                        &mls_group, group_id, &staged,
+                    )
+                {
+                    return Err(OpenMlsProjectionError::InvalidCommit {
+                        message_id,
+                        reason: format!("required component retention: {err}"),
+                    });
+                }
                 if sender_id.is_none() {
                     return Err(OpenMlsProjectionError::Replay(
                         "commit has no authenticated member sender".into(),

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -1573,13 +1573,13 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                     });
                 }
                 if let Err(err) =
-                    crate::app_components::validate_required_component_retention_for_staged_commit(
+                    crate::app_components::validate_app_component_integrity_for_staged_commit(
                         &mls_group, group_id, &staged,
                     )
                 {
                     return Err(OpenMlsProjectionError::InvalidCommit {
                         message_id,
-                        reason: format!("required component retention: {err}"),
+                        reason: format!("app component integrity: {err}"),
                     });
                 }
                 if sender_id.is_none() {

--- a/crates/cgka-engine/src/upgrade.rs
+++ b/crates/cgka-engine/src/upgrade.rs
@@ -207,14 +207,14 @@ impl<S: StorageProvider> Engine<S> {
             .map_err(|e| EngineError::Backend(format!("upgrade stage: {e:?}")))?;
         let (commit_out, _welcome_opt, _gi) = commit_bundle.into_contents();
         // Self-check the staged GroupContextExtensions commit against the same
-        // retention rule inbound processing enforces: the resulting
-        // GroupContext must keep the app_data_dictionary and every required
-        // component's state.
+        // integrity rule inbound processing enforces: the resulting
+        // GroupContext must keep the app_data_dictionary and may only change
+        // component state through this commit's AppDataUpdate proposals.
         {
             let staged_commit = mls_group
                 .pending_commit()
                 .ok_or_else(|| EngineError::Backend("upgrade produced no pending commit".into()))?;
-            crate::app_components::validate_required_component_retention_for_staged_commit(
+            crate::app_components::validate_app_component_integrity_for_staged_commit(
                 &mls_group,
                 group_id,
                 staged_commit,

--- a/crates/cgka-engine/src/upgrade.rs
+++ b/crates/cgka-engine/src/upgrade.rs
@@ -206,6 +206,20 @@ impl<S: StorageProvider> Engine<S> {
             .stage_commit(&provider)
             .map_err(|e| EngineError::Backend(format!("upgrade stage: {e:?}")))?;
         let (commit_out, _welcome_opt, _gi) = commit_bundle.into_contents();
+        // Self-check the staged GroupContextExtensions commit against the same
+        // retention rule inbound processing enforces: the resulting
+        // GroupContext must keep the app_data_dictionary and every required
+        // component's state.
+        {
+            let staged_commit = mls_group
+                .pending_commit()
+                .ok_or_else(|| EngineError::Backend("upgrade produced no pending commit".into()))?;
+            crate::app_components::validate_required_component_retention_for_staged_commit(
+                &mls_group,
+                group_id,
+                staged_commit,
+            )?;
+        }
         let commit_bytes = commit_out
             .tls_serialize_detached()
             .map_err(|e| EngineError::Serialize(format!("{e:?}")))?;

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -10,7 +10,7 @@ use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::openmls_projection::{OpenMlsProjectionError, project_mls_message};
 use cgka_engine::provider::EngineOpenMlsProvider;
 use cgka_engine::{DEFAULT_CIPHERSUITE, Engine, EngineBuilder};
-use cgka_traits::app_components::GROUP_ADMIN_POLICY_COMPONENT_ID;
+use cgka_traits::app_components::{AppComponentId, GROUP_ADMIN_POLICY_COMPONENT_ID};
 use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{
@@ -444,18 +444,28 @@ fn raw_remove_members_commit_with_admin_policy(
     }
 }
 
+/// How a raw GroupContextExtensions commit tampers with the group's
+/// `app_data_dictionary` (see [`raw_group_context_extensions_tamper_commit`]).
+enum GceDictionaryTamper {
+    /// Replace the extensions with a set omitting the dictionary entirely.
+    StripDictionary,
+    /// Keep the dictionary but omit one component's entry.
+    DropEntry(AppComponentId),
+    /// Keep the dictionary and every entry present, but rewrite one
+    /// component's bytes — no `AppDataUpdate` proposal carries the change.
+    ReplaceEntry(AppComponentId, Vec<u8>),
+}
+
 /// Build a raw OpenMLS GroupContextExtensions-only commit (no member changes)
-/// whose resulting GroupContext strips Marmot component state: either the
-/// whole `app_data_dictionary` extension (`strip_whole_dictionary`) or just
-/// the required admin-policy entry inside it. OpenMLS's draft-08 dictionary
-/// guard only runs when a commit carries `AppDataUpdate` proposals, so this
-/// commit builds and stages cleanly — only the engine's required-component
-/// retention check can reject it.
-fn raw_group_context_extensions_strip_commit(
+/// that tampers with the Marmot component state in the resulting GroupContext.
+/// OpenMLS's draft-08 dictionary guard only runs when a commit carries
+/// `AppDataUpdate` proposals, so every tamper here builds and stages cleanly —
+/// only the engine's app-component integrity check can reject it.
+fn raw_group_context_extensions_tamper_commit(
     storage: &SqliteAccountStorage,
     sender: &MemberId,
     group_id: &GroupId,
-    strip_whole_dictionary: bool,
+    tamper: GceDictionaryTamper,
 ) -> TransportMessage {
     let crypto = openmls_rust_crypto::RustCrypto::default();
     let provider =
@@ -481,35 +491,42 @@ fn raw_group_context_extensions_strip_commit(
         .filter(|ext| !matches!(ext, Extension::AppDataDictionary(_)))
         .cloned()
         .collect();
-    if !strip_whole_dictionary {
-        let current = mls_group
-            .extensions()
-            .app_data_dictionary()
-            .expect("group carries app_data_dictionary");
-        let mut dict = AppDataDictionary::new();
-        for entry in current.dictionary().entries() {
-            if entry.id() != GROUP_ADMIN_POLICY_COMPONENT_ID {
+    match &tamper {
+        GceDictionaryTamper::StripDictionary => {}
+        GceDictionaryTamper::DropEntry(target) | GceDictionaryTamper::ReplaceEntry(target, _) => {
+            let current = mls_group
+                .extensions()
+                .app_data_dictionary()
+                .expect("group carries app_data_dictionary");
+            let mut dict = AppDataDictionary::new();
+            for entry in current.dictionary().entries() {
+                if entry.id() == *target {
+                    if let GceDictionaryTamper::ReplaceEntry(_, data) = &tamper {
+                        dict.insert(entry.id(), data.clone());
+                    }
+                    continue;
+                }
                 dict.insert(entry.id(), entry.data().to_vec());
             }
+            new_extensions.push(Extension::AppDataDictionary(
+                AppDataDictionaryExtension::new(dict),
+            ));
         }
-        new_extensions.push(Extension::AppDataDictionary(
-            AppDataDictionaryExtension::new(dict),
-        ));
     }
-    let new_extensions = Extensions::from_vec(new_extensions).expect("stripped extensions build");
+    let new_extensions = Extensions::from_vec(new_extensions).expect("tampered extensions build");
 
     let (commit, _welcome, _group_info) = mls_group
         .update_group_context_extensions(&provider, new_extensions, &signer)
-        .expect("raw OpenMLS GroupContextExtensions strip commit");
+        .expect("raw OpenMLS GroupContextExtensions tamper commit");
     let payload = commit
         .tls_serialize_detached()
-        .expect("serialize raw GCE strip commit");
+        .expect("serialize raw GCE tamper commit");
     TransportMessage {
         id: hash_id(&payload),
         payload,
         timestamp: Timestamp(0),
         causal_deps: vec![],
-        source: TransportSource("raw-openmls-gce-strip".to_string()),
+        source: TransportSource("raw-openmls-gce-tamper".to_string()),
         envelope: TransportEnvelope::GroupMessage {
             transport_group_id: group_id.as_slice().to_vec(),
         },
@@ -872,7 +889,12 @@ async fn ingest_rejects_group_context_commit_stripping_app_data_dictionary() {
         .unwrap();
 
     let strip = route(
-        raw_group_context_extensions_strip_commit(&alice_storage, &alice_id, &group_id, true),
+        raw_group_context_extensions_tamper_commit(
+            &alice_storage,
+            &alice_id,
+            &group_id,
+            GceDictionaryTamper::StripDictionary,
+        ),
         &group_id,
     );
     let outcome = bob.ingest(strip.clone()).await.expect("ingest completes");
@@ -928,7 +950,12 @@ async fn ingest_rejects_group_context_commit_dropping_required_component_entry()
         .unwrap();
 
     let strip = route(
-        raw_group_context_extensions_strip_commit(&alice_storage, &alice_id, &group_id, false),
+        raw_group_context_extensions_tamper_commit(
+            &alice_storage,
+            &alice_id,
+            &group_id,
+            GceDictionaryTamper::DropEntry(GROUP_ADMIN_POLICY_COMPONENT_ID),
+        ),
         &group_id,
     );
     let outcome = bob.ingest(strip.clone()).await.expect("ingest completes");
@@ -982,7 +1009,12 @@ async fn convergence_rejects_group_context_commit_stripping_app_data_dictionary(
         .unwrap();
 
     let strip = route(
-        raw_group_context_extensions_strip_commit(&alice_storage, &alice_id, &group_id, true),
+        raw_group_context_extensions_tamper_commit(
+            &alice_storage,
+            &alice_id,
+            &group_id,
+            GceDictionaryTamper::StripDictionary,
+        ),
         &group_id,
     );
     carol
@@ -1021,6 +1053,156 @@ async fn convergence_rejects_group_context_commit_stripping_app_data_dictionary(
         .expect("test identities are 32-byte account keys");
     assert_eq!(carol.admin_pubkeys(&group_id).unwrap(), vec![alice_admin]);
     assert_message_state(&carol_storage, &strip, MessageState::EpochInvalidated);
+}
+
+#[tokio::test]
+async fn ingest_rejects_group_context_commit_rewriting_admin_policy_bytes() {
+    // Content-integrity variant: the GroupContextExtensions commit keeps the
+    // app_data_dictionary and every required entry PRESENT, but rewrites the
+    // admin-policy bytes to a different (well-formed) admin set — with no
+    // AppDataUpdate proposal carrying the change. The rewritten set names a
+    // member with a leaf, so the admin-leaf coupling check passes, and the
+    // presence-only retention rule passes too; only the AppDataUpdate
+    // attribution rule can reject it. Without it, an admin could rewrite any
+    // required component's bytes (admin set, profile, routing, retention)
+    // bypassing the component validators entirely.
+    let (mut alice, alice_storage) = build_client(b"alice");
+    let (mut bob, bob_storage) = build_client(b"bob");
+    let alice_id = alice.self_id();
+    let bob_id = bob.self_id();
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "ingest-gce-admin-policy-rewrite".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+
+    let rewrite = route(
+        raw_group_context_extensions_tamper_commit(
+            &alice_storage,
+            &alice_id,
+            &group_id,
+            GceDictionaryTamper::ReplaceEntry(
+                GROUP_ADMIN_POLICY_COMPONENT_ID,
+                encode_admin_policy_for_test(std::slice::from_ref(&bob_id)),
+            ),
+        ),
+        &group_id,
+    );
+    let outcome = bob.ingest(rewrite.clone()).await.expect("ingest completes");
+    assert!(
+        matches!(outcome, IngestOutcome::Stale { .. }),
+        "GCE commit rewriting admin-policy bytes must not be processed: {outcome:?}"
+    );
+    assert_eq!(bob.epoch(&group_id).unwrap(), EpochId(1));
+    let alice_admin: [u8; 32] = alice_id
+        .as_slice()
+        .try_into()
+        .expect("test identities are 32-byte account keys");
+    assert_eq!(
+        bob.admin_pubkeys(&group_id).unwrap(),
+        vec![alice_admin],
+        "the GCE-rewritten admin set must not take effect"
+    );
+    // Same input-window caveat as the dictionary-strip ingest test above.
+    let record = bob_storage
+        .get_message(&content_id(&rewrite))
+        .expect("rewrite commit remains stored");
+    assert_ne!(record.state, MessageState::Processed);
+}
+
+#[tokio::test]
+async fn convergence_rejects_group_context_commit_rewriting_admin_policy_bytes() {
+    // The same admin-policy byte rewrite through STORED CONVERGENCE with a
+    // closed input window: the commit must be classified invalid, not
+    // materialize an epoch whose admin set was swapped outside AppDataUpdate.
+    let (mut alice, alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let alice_id = alice.self_id();
+    let carol_id = carol.self_id();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "convergence-gce-admin-policy-rewrite".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    let rewrite = route(
+        raw_group_context_extensions_tamper_commit(
+            &alice_storage,
+            &alice_id,
+            &group_id,
+            GceDictionaryTamper::ReplaceEntry(
+                GROUP_ADMIN_POLICY_COMPONENT_ID,
+                encode_admin_policy_for_test(std::slice::from_ref(&carol_id)),
+            ),
+        ),
+        &group_id,
+    );
+    carol
+        .buffer_openmls_convergence_message(&group_id, rewrite.clone(), 1_000)
+        .expect("GCE rewrite commit buffered");
+
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("stored OpenMLS messages converge");
+
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    assert!(
+        result.accepted_commits.is_empty(),
+        "GCE admin-policy rewrite commit must not be accepted: {result:?}"
+    );
+    assert!(
+        result.dropped_messages.iter().any(|dropped| {
+            dropped.kind == MessageKind::Commit
+                && dropped.reason == DroppedMessageReason::InvalidAgainstCandidateState
+                && dropped.message_id == content_hex(&rewrite)
+        }),
+        "expected GCE rewrite commit dropped as InvalidAgainstCandidateState, got {:?}",
+        result.dropped_messages
+    );
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
+    let alice_admin: [u8; 32] = alice_id
+        .as_slice()
+        .try_into()
+        .expect("test identities are 32-byte account keys");
+    assert_eq!(
+        carol.admin_pubkeys(&group_id).unwrap(),
+        vec![alice_admin],
+        "the GCE-rewritten admin set must not take effect"
+    );
+    assert_message_state(&carol_storage, &rewrite, MessageState::EpochInvalidated);
 }
 
 /// darkmatter#286: a commit applied through STORED CONVERGENCE that later loses

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -852,27 +852,20 @@ async fn convergence_accepts_remove_when_admin_policy_drops_removed_admin() {
     assert_message_state(&carol_storage, &valid_remove, MessageState::Processed);
 }
 
-#[tokio::test]
-async fn ingest_rejects_group_context_commit_stripping_app_data_dictionary() {
-    // Regression: OpenMLS's draft-08 dictionary guard only validates the
-    // GroupContext against a commit's AppDataUpdate proposals, so an
-    // admin-authored GroupContextExtensions-only commit could replace the
-    // extensions with a set that omits the app_data_dictionary entirely.
-    // Merging it cannot orphan an admin key (the absent component is the empty
-    // admin set), but it silently makes the group admin-less and freezes every
-    // admin-gated operation. Inbound same-epoch commits route through
-    // convergence, so `ingest` must classify the strip commit invalid instead
-    // of materializing the admin-less epoch.
-    let (mut alice, alice_storage) = build_client(b"alice");
-    let (mut bob, bob_storage) = build_client(b"bob");
-    let alice_id = alice.self_id();
-    let bob_kp = bob.fresh_key_package().await.unwrap();
-
-    let (group_id, create) = alice
+/// Two-member bootstrap for the GCE tamper regressions: `creator` creates the
+/// group (sole admin), confirms, and `joiner` joins via welcome.
+async fn bootstrap_gce_tamper_group(
+    creator: &mut Engine<SqliteAccountStorage>,
+    joiner: &mut Engine<SqliteAccountStorage>,
+    joiner_name: &[u8],
+    group_name: &str,
+) -> GroupId {
+    let joiner_kp = joiner.fresh_key_package().await.unwrap();
+    let (group_id, create) = creator
         .create_group(CreateGroupRequest {
-            name: "ingest-gce-dictionary-strip".into(),
+            name: group_name.into(),
             description: "".into(),
-            members: vec![bob_kp],
+            members: vec![joiner_kp],
             required_features: vec![],
             app_components: vec![],
             initial_admins: vec![],
@@ -883,10 +876,118 @@ async fn ingest_rejects_group_context_commit_stripping_app_data_dictionary() {
         SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
         other => panic!("expected GroupCreated, got {other:?}"),
     };
-    alice.confirm_published(pending).await.unwrap();
-    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+    creator.confirm_published(pending).await.unwrap();
+    joiner
+        .join_welcome(welcome_for(&welcomes, joiner_name))
         .await
         .unwrap();
+    group_id
+}
+
+fn admin_key(member: &MemberId) -> [u8; 32] {
+    member
+        .as_slice()
+        .try_into()
+        .expect("test identities are 32-byte account keys")
+}
+
+/// Ingest `tampered` on `recipient` and assert the GCE tamper commit is
+/// rejected: outcome `Stale`, epoch and sole admin unchanged, and the stored
+/// message never `Processed`. Inbound same-epoch commits route through
+/// convergence, and the ingest-driven pass runs inside the input window, so
+/// the terminal disposition may not be persisted yet — the pinned invariant is
+/// that the tamper commit is never applied.
+async fn assert_gce_tamper_rejected_by_ingest(
+    recipient: &mut Engine<SqliteAccountStorage>,
+    recipient_storage: &SqliteAccountStorage,
+    group_id: &GroupId,
+    tampered: &TransportMessage,
+    expected_admin: &MemberId,
+) {
+    let outcome = recipient
+        .ingest(tampered.clone())
+        .await
+        .expect("ingest completes");
+    assert!(
+        matches!(outcome, IngestOutcome::Stale { .. }),
+        "GCE tamper commit must not be processed: {outcome:?}"
+    );
+    assert_eq!(recipient.epoch(group_id).unwrap(), EpochId(1));
+    assert_eq!(
+        recipient.admin_pubkeys(group_id).unwrap(),
+        vec![admin_key(expected_admin)],
+        "the tampered component state must not take effect"
+    );
+    let record = recipient_storage
+        .get_message(&content_id(tampered))
+        .expect("tamper commit remains stored");
+    assert_ne!(record.state, MessageState::Processed);
+}
+
+/// Buffer `tampered` into STORED CONVERGENCE on `recipient` and converge with
+/// a closed input window; assert the pass settles with the commit dropped as
+/// `InvalidAgainstCandidateState`, epoch and sole admin unchanged, and the
+/// message `EpochInvalidated`.
+fn assert_gce_tamper_rejected_by_convergence(
+    recipient: &mut Engine<SqliteAccountStorage>,
+    recipient_storage: &SqliteAccountStorage,
+    group_id: &GroupId,
+    tampered: &TransportMessage,
+    expected_admin: &MemberId,
+) {
+    recipient
+        .buffer_openmls_convergence_message(group_id, tampered.clone(), 1_000)
+        .expect("GCE tamper commit buffered");
+    let result = recipient
+        .converge_stored_openmls_messages(group_id, 1_000_000)
+        .expect("stored OpenMLS messages converge");
+
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    assert!(
+        result.accepted_commits.is_empty(),
+        "GCE tamper commit must not be accepted: {result:?}"
+    );
+    assert!(
+        result.dropped_messages.iter().any(|dropped| {
+            dropped.kind == MessageKind::Commit
+                && dropped.reason == DroppedMessageReason::InvalidAgainstCandidateState
+                && dropped.message_id == content_hex(tampered)
+        }),
+        "expected GCE tamper commit dropped as InvalidAgainstCandidateState, got {:?}",
+        result.dropped_messages
+    );
+    assert_eq!(recipient.epoch(group_id).unwrap(), EpochId(1));
+    assert_eq!(
+        recipient_storage
+            .get_group(group_id)
+            .expect("group stored")
+            .epoch,
+        EpochId(1)
+    );
+    assert_eq!(
+        recipient.admin_pubkeys(group_id).unwrap(),
+        vec![admin_key(expected_admin)],
+        "the tampered component state must not take effect"
+    );
+    assert_message_state(recipient_storage, tampered, MessageState::EpochInvalidated);
+}
+
+#[tokio::test]
+async fn ingest_rejects_group_context_commit_stripping_app_data_dictionary() {
+    // Regression: OpenMLS's draft-08 dictionary guard only validates the
+    // GroupContext against a commit's AppDataUpdate proposals, so an
+    // admin-authored GroupContextExtensions-only commit could replace the
+    // extensions with a set that omits the app_data_dictionary entirely.
+    // Merging it cannot orphan an admin key (the absent component is the empty
+    // admin set), but it silently makes the group admin-less and freezes every
+    // admin-gated operation. `ingest` must classify the strip commit invalid
+    // instead of materializing the admin-less epoch.
+    let (mut alice, alice_storage) = build_client(b"alice");
+    let (mut bob, bob_storage) = build_client(b"bob");
+    let alice_id = alice.self_id();
+    let group_id =
+        bootstrap_gce_tamper_group(&mut alice, &mut bob, b"bob", "ingest-gce-dictionary-strip")
+            .await;
 
     let strip = route(
         raw_group_context_extensions_tamper_commit(
@@ -897,24 +998,8 @@ async fn ingest_rejects_group_context_commit_stripping_app_data_dictionary() {
         ),
         &group_id,
     );
-    let outcome = bob.ingest(strip.clone()).await.expect("ingest completes");
-    assert!(
-        matches!(outcome, IngestOutcome::Stale { .. }),
-        "GCE commit stripping the app_data_dictionary must not be processed: {outcome:?}"
-    );
-    assert_eq!(bob.epoch(&group_id).unwrap(), EpochId(1));
-    let alice_admin: [u8; 32] = alice_id
-        .as_slice()
-        .try_into()
-        .expect("test identities are 32-byte account keys");
-    assert_eq!(bob.admin_pubkeys(&group_id).unwrap(), vec![alice_admin]);
-    // The ingest-driven convergence pass runs inside the input window, so the
-    // terminal disposition may not be persisted yet — the pinned invariant is
-    // that the strip commit is never applied.
-    let record = bob_storage
-        .get_message(&content_id(&strip))
-        .expect("strip commit remains stored");
-    assert_ne!(record.state, MessageState::Processed);
+    assert_gce_tamper_rejected_by_ingest(&mut bob, &bob_storage, &group_id, &strip, &alice_id)
+        .await;
 }
 
 #[tokio::test]
@@ -923,31 +1008,17 @@ async fn ingest_rejects_group_context_commit_dropping_required_component_entry()
     // commit keeps the app_data_dictionary but replaces it with one that omits
     // the required admin-policy component's state. validate_app_component_remove
     // only sees AppDataUpdate::Remove operations, so without the staged-commit
-    // retention check this strip would also merge.
+    // integrity check this strip would also merge.
     let (mut alice, alice_storage) = build_client(b"alice");
     let (mut bob, bob_storage) = build_client(b"bob");
     let alice_id = alice.self_id();
-    let bob_kp = bob.fresh_key_package().await.unwrap();
-
-    let (group_id, create) = alice
-        .create_group(CreateGroupRequest {
-            name: "ingest-gce-admin-policy-strip".into(),
-            description: "".into(),
-            members: vec![bob_kp],
-            required_features: vec![],
-            app_components: vec![],
-            initial_admins: vec![],
-        })
-        .await
-        .unwrap();
-    let (pending, welcomes) = match create {
-        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
-        other => panic!("expected GroupCreated, got {other:?}"),
-    };
-    alice.confirm_published(pending).await.unwrap();
-    bob.join_welcome(welcome_for(&welcomes, b"bob"))
-        .await
-        .unwrap();
+    let group_id = bootstrap_gce_tamper_group(
+        &mut alice,
+        &mut bob,
+        b"bob",
+        "ingest-gce-admin-policy-strip",
+    )
+    .await;
 
     let strip = route(
         raw_group_context_extensions_tamper_commit(
@@ -958,55 +1029,26 @@ async fn ingest_rejects_group_context_commit_dropping_required_component_entry()
         ),
         &group_id,
     );
-    let outcome = bob.ingest(strip.clone()).await.expect("ingest completes");
-    assert!(
-        matches!(outcome, IngestOutcome::Stale { .. }),
-        "GCE commit dropping the required admin-policy entry must not be processed: {outcome:?}"
-    );
-    assert_eq!(bob.epoch(&group_id).unwrap(), EpochId(1));
-    let alice_admin: [u8; 32] = alice_id
-        .as_slice()
-        .try_into()
-        .expect("test identities are 32-byte account keys");
-    assert_eq!(bob.admin_pubkeys(&group_id).unwrap(), vec![alice_admin]);
-    // Same input-window caveat as the dictionary-strip ingest test above.
-    let record = bob_storage
-        .get_message(&content_id(&strip))
-        .expect("strip commit remains stored");
-    assert_ne!(record.state, MessageState::Processed);
+    assert_gce_tamper_rejected_by_ingest(&mut bob, &bob_storage, &group_id, &strip, &alice_id)
+        .await;
 }
 
 #[tokio::test]
 async fn convergence_rejects_group_context_commit_stripping_app_data_dictionary() {
     // The same dictionary-strip commit through STORED CONVERGENCE. Before the
-    // required-component retention check, a GCE-only strip commit with no
-    // member removals was ACCEPTED here — convergence materialized the
-    // admin-less epoch. It must classify the commit as invalid instead.
+    // integrity check, a GCE-only strip commit with no member removals was
+    // ACCEPTED here — convergence materialized the admin-less epoch. It must
+    // classify the commit as invalid instead.
     let (mut alice, alice_storage) = build_client(b"alice");
     let (mut carol, carol_storage) = build_client(b"carol");
     let alice_id = alice.self_id();
-    let carol_kp = carol.fresh_key_package().await.unwrap();
-
-    let (group_id, create) = alice
-        .create_group(CreateGroupRequest {
-            name: "convergence-gce-dictionary-strip".into(),
-            description: "".into(),
-            members: vec![carol_kp],
-            required_features: vec![],
-            app_components: vec![],
-            initial_admins: vec![],
-        })
-        .await
-        .unwrap();
-    let (pending, welcomes) = match create {
-        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
-        other => panic!("expected GroupCreated, got {other:?}"),
-    };
-    alice.confirm_published(pending).await.unwrap();
-    carol
-        .join_welcome(welcome_for(&welcomes, b"carol"))
-        .await
-        .unwrap();
+    let group_id = bootstrap_gce_tamper_group(
+        &mut alice,
+        &mut carol,
+        b"carol",
+        "convergence-gce-dictionary-strip",
+    )
+    .await;
 
     let strip = route(
         raw_group_context_extensions_tamper_commit(
@@ -1017,42 +1059,13 @@ async fn convergence_rejects_group_context_commit_stripping_app_data_dictionary(
         ),
         &group_id,
     );
-    carol
-        .buffer_openmls_convergence_message(&group_id, strip.clone(), 1_000)
-        .expect("GCE strip commit buffered");
-
-    let result = carol
-        .converge_stored_openmls_messages(&group_id, 1_000_000)
-        .expect("stored OpenMLS messages converge");
-
-    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
-    assert!(
-        result.accepted_commits.is_empty(),
-        "GCE dictionary-strip commit must not be accepted: {result:?}"
+    assert_gce_tamper_rejected_by_convergence(
+        &mut carol,
+        &carol_storage,
+        &group_id,
+        &strip,
+        &alice_id,
     );
-    assert!(
-        result.dropped_messages.iter().any(|dropped| {
-            dropped.kind == MessageKind::Commit
-                && dropped.reason == DroppedMessageReason::InvalidAgainstCandidateState
-                && dropped.message_id == content_hex(&strip)
-        }),
-        "expected GCE strip commit dropped as InvalidAgainstCandidateState, got {:?}",
-        result.dropped_messages
-    );
-    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
-    assert_eq!(
-        carol_storage
-            .get_group(&group_id)
-            .expect("group stored")
-            .epoch,
-        EpochId(1)
-    );
-    let alice_admin: [u8; 32] = alice_id
-        .as_slice()
-        .try_into()
-        .expect("test identities are 32-byte account keys");
-    assert_eq!(carol.admin_pubkeys(&group_id).unwrap(), vec![alice_admin]);
-    assert_message_state(&carol_storage, &strip, MessageState::EpochInvalidated);
 }
 
 #[tokio::test]
@@ -1062,35 +1075,21 @@ async fn ingest_rejects_group_context_commit_rewriting_admin_policy_bytes() {
     // admin-policy bytes to a different (well-formed) admin set — with no
     // AppDataUpdate proposal carrying the change. The rewritten set names a
     // member with a leaf, so the admin-leaf coupling check passes, and the
-    // presence-only retention rule passes too; only the AppDataUpdate
-    // attribution rule can reject it. Without it, an admin could rewrite any
-    // required component's bytes (admin set, profile, routing, retention)
-    // bypassing the component validators entirely.
+    // presence rules pass too; only the AppDataUpdate attribution rule can
+    // reject it. Without it, an admin could rewrite any required component's
+    // bytes (admin set, profile, routing, retention) bypassing the component
+    // validators entirely.
     let (mut alice, alice_storage) = build_client(b"alice");
     let (mut bob, bob_storage) = build_client(b"bob");
     let alice_id = alice.self_id();
     let bob_id = bob.self_id();
-    let bob_kp = bob.fresh_key_package().await.unwrap();
-
-    let (group_id, create) = alice
-        .create_group(CreateGroupRequest {
-            name: "ingest-gce-admin-policy-rewrite".into(),
-            description: "".into(),
-            members: vec![bob_kp],
-            required_features: vec![],
-            app_components: vec![],
-            initial_admins: vec![],
-        })
-        .await
-        .unwrap();
-    let (pending, welcomes) = match create {
-        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
-        other => panic!("expected GroupCreated, got {other:?}"),
-    };
-    alice.confirm_published(pending).await.unwrap();
-    bob.join_welcome(welcome_for(&welcomes, b"bob"))
-        .await
-        .unwrap();
+    let group_id = bootstrap_gce_tamper_group(
+        &mut alice,
+        &mut bob,
+        b"bob",
+        "ingest-gce-admin-policy-rewrite",
+    )
+    .await;
 
     let rewrite = route(
         raw_group_context_extensions_tamper_commit(
@@ -1104,26 +1103,8 @@ async fn ingest_rejects_group_context_commit_rewriting_admin_policy_bytes() {
         ),
         &group_id,
     );
-    let outcome = bob.ingest(rewrite.clone()).await.expect("ingest completes");
-    assert!(
-        matches!(outcome, IngestOutcome::Stale { .. }),
-        "GCE commit rewriting admin-policy bytes must not be processed: {outcome:?}"
-    );
-    assert_eq!(bob.epoch(&group_id).unwrap(), EpochId(1));
-    let alice_admin: [u8; 32] = alice_id
-        .as_slice()
-        .try_into()
-        .expect("test identities are 32-byte account keys");
-    assert_eq!(
-        bob.admin_pubkeys(&group_id).unwrap(),
-        vec![alice_admin],
-        "the GCE-rewritten admin set must not take effect"
-    );
-    // Same input-window caveat as the dictionary-strip ingest test above.
-    let record = bob_storage
-        .get_message(&content_id(&rewrite))
-        .expect("rewrite commit remains stored");
-    assert_ne!(record.state, MessageState::Processed);
+    assert_gce_tamper_rejected_by_ingest(&mut bob, &bob_storage, &group_id, &rewrite, &alice_id)
+        .await;
 }
 
 #[tokio::test]
@@ -1135,28 +1116,13 @@ async fn convergence_rejects_group_context_commit_rewriting_admin_policy_bytes()
     let (mut carol, carol_storage) = build_client(b"carol");
     let alice_id = alice.self_id();
     let carol_id = carol.self_id();
-    let carol_kp = carol.fresh_key_package().await.unwrap();
-
-    let (group_id, create) = alice
-        .create_group(CreateGroupRequest {
-            name: "convergence-gce-admin-policy-rewrite".into(),
-            description: "".into(),
-            members: vec![carol_kp],
-            required_features: vec![],
-            app_components: vec![],
-            initial_admins: vec![],
-        })
-        .await
-        .unwrap();
-    let (pending, welcomes) = match create {
-        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
-        other => panic!("expected GroupCreated, got {other:?}"),
-    };
-    alice.confirm_published(pending).await.unwrap();
-    carol
-        .join_welcome(welcome_for(&welcomes, b"carol"))
-        .await
-        .unwrap();
+    let group_id = bootstrap_gce_tamper_group(
+        &mut alice,
+        &mut carol,
+        b"carol",
+        "convergence-gce-admin-policy-rewrite",
+    )
+    .await;
 
     let rewrite = route(
         raw_group_context_extensions_tamper_commit(
@@ -1170,39 +1136,13 @@ async fn convergence_rejects_group_context_commit_rewriting_admin_policy_bytes()
         ),
         &group_id,
     );
-    carol
-        .buffer_openmls_convergence_message(&group_id, rewrite.clone(), 1_000)
-        .expect("GCE rewrite commit buffered");
-
-    let result = carol
-        .converge_stored_openmls_messages(&group_id, 1_000_000)
-        .expect("stored OpenMLS messages converge");
-
-    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
-    assert!(
-        result.accepted_commits.is_empty(),
-        "GCE admin-policy rewrite commit must not be accepted: {result:?}"
+    assert_gce_tamper_rejected_by_convergence(
+        &mut carol,
+        &carol_storage,
+        &group_id,
+        &rewrite,
+        &alice_id,
     );
-    assert!(
-        result.dropped_messages.iter().any(|dropped| {
-            dropped.kind == MessageKind::Commit
-                && dropped.reason == DroppedMessageReason::InvalidAgainstCandidateState
-                && dropped.message_id == content_hex(&rewrite)
-        }),
-        "expected GCE rewrite commit dropped as InvalidAgainstCandidateState, got {:?}",
-        result.dropped_messages
-    );
-    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
-    let alice_admin: [u8; 32] = alice_id
-        .as_slice()
-        .try_into()
-        .expect("test identities are 32-byte account keys");
-    assert_eq!(
-        carol.admin_pubkeys(&group_id).unwrap(),
-        vec![alice_admin],
-        "the GCE-rewritten admin set must not take effect"
-    );
-    assert_message_state(&carol_storage, &rewrite, MessageState::EpochInvalidated);
 }
 
 /// darkmatter#286: a commit applied through STORED CONVERGENCE that later loses

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -509,7 +509,7 @@ fn raw_group_context_extensions_strip_commit(
         payload,
         timestamp: Timestamp(0),
         causal_deps: vec![],
-        source: TransportSource("raw-openmls-gce-strip".into()),
+        source: TransportSource("raw-openmls-gce-strip".to_string()),
         envelope: TransportEnvelope::GroupMessage {
             transport_group_id: group_id.as_slice().to_vec(),
         },

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -31,6 +31,7 @@ use cgka_traits::transport::{
 };
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use openmls::component::ComponentData;
+use openmls::extensions::{AppDataDictionary, AppDataDictionaryExtension, Extension, Extensions};
 use openmls::group::MlsGroup;
 use openmls::messages::proposals::{AppDataUpdateOperation, AppDataUpdateProposal, Proposal};
 use openmls::prelude::BasicCredential;
@@ -443,6 +444,78 @@ fn raw_remove_members_commit_with_admin_policy(
     }
 }
 
+/// Build a raw OpenMLS GroupContextExtensions-only commit (no member changes)
+/// whose resulting GroupContext strips Marmot component state: either the
+/// whole `app_data_dictionary` extension (`strip_whole_dictionary`) or just
+/// the required admin-policy entry inside it. OpenMLS's draft-08 dictionary
+/// guard only runs when a commit carries `AppDataUpdate` proposals, so this
+/// commit builds and stages cleanly — only the engine's required-component
+/// retention check can reject it.
+fn raw_group_context_extensions_strip_commit(
+    storage: &SqliteAccountStorage,
+    sender: &MemberId,
+    group_id: &GroupId,
+    strip_whole_dictionary: bool,
+) -> TransportMessage {
+    let crypto = openmls_rust_crypto::RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mut mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load sender MLS group")
+        .expect("sender joined group");
+    let binding = storage
+        .account_device_signer(sender)
+        .expect("load signer binding")
+        .expect("signer binding exists");
+    let signer = SignatureKeyPair::read(
+        storage.mls_storage(),
+        &binding.mls_signature_public_key,
+        DEFAULT_CIPHERSUITE.signature_algorithm(),
+    )
+    .expect("MLS signer exists");
+
+    let mut new_extensions: Vec<Extension> = mls_group
+        .extensions()
+        .iter()
+        .filter(|ext| !matches!(ext, Extension::AppDataDictionary(_)))
+        .cloned()
+        .collect();
+    if !strip_whole_dictionary {
+        let current = mls_group
+            .extensions()
+            .app_data_dictionary()
+            .expect("group carries app_data_dictionary");
+        let mut dict = AppDataDictionary::new();
+        for entry in current.dictionary().entries() {
+            if entry.id() != GROUP_ADMIN_POLICY_COMPONENT_ID {
+                dict.insert(entry.id(), entry.data().to_vec());
+            }
+        }
+        new_extensions.push(Extension::AppDataDictionary(
+            AppDataDictionaryExtension::new(dict),
+        ));
+    }
+    let new_extensions = Extensions::from_vec(new_extensions).expect("stripped extensions build");
+
+    let (commit, _welcome, _group_info) = mls_group
+        .update_group_context_extensions(&provider, new_extensions, &signer)
+        .expect("raw OpenMLS GroupContextExtensions strip commit");
+    let payload = commit
+        .tls_serialize_detached()
+        .expect("serialize raw GCE strip commit");
+    TransportMessage {
+        id: hash_id(&payload),
+        payload,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("raw-openmls-gce-strip".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    }
+}
+
 #[tokio::test]
 async fn engine_converges_stored_openmls_messages_to_selected_branch() {
     let (mut alice, _alice_storage) = build_client(b"alice");
@@ -760,6 +833,194 @@ async fn convergence_accepts_remove_when_admin_policy_drops_removed_admin() {
         .expect("test identities are 32-byte account keys");
     assert_eq!(carol.admin_pubkeys(&group_id).unwrap(), vec![bob_admin]);
     assert_message_state(&carol_storage, &valid_remove, MessageState::Processed);
+}
+
+#[tokio::test]
+async fn ingest_rejects_group_context_commit_stripping_app_data_dictionary() {
+    // Regression: OpenMLS's draft-08 dictionary guard only validates the
+    // GroupContext against a commit's AppDataUpdate proposals, so an
+    // admin-authored GroupContextExtensions-only commit could replace the
+    // extensions with a set that omits the app_data_dictionary entirely.
+    // Merging it cannot orphan an admin key (the absent component is the empty
+    // admin set), but it silently makes the group admin-less and freezes every
+    // admin-gated operation. Inbound same-epoch commits route through
+    // convergence, so `ingest` must classify the strip commit invalid instead
+    // of materializing the admin-less epoch.
+    let (mut alice, alice_storage) = build_client(b"alice");
+    let (mut bob, bob_storage) = build_client(b"bob");
+    let alice_id = alice.self_id();
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "ingest-gce-dictionary-strip".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+
+    let strip = route(
+        raw_group_context_extensions_strip_commit(&alice_storage, &alice_id, &group_id, true),
+        &group_id,
+    );
+    let outcome = bob.ingest(strip.clone()).await.expect("ingest completes");
+    assert!(
+        matches!(outcome, IngestOutcome::Stale { .. }),
+        "GCE commit stripping the app_data_dictionary must not be processed: {outcome:?}"
+    );
+    assert_eq!(bob.epoch(&group_id).unwrap(), EpochId(1));
+    let alice_admin: [u8; 32] = alice_id
+        .as_slice()
+        .try_into()
+        .expect("test identities are 32-byte account keys");
+    assert_eq!(bob.admin_pubkeys(&group_id).unwrap(), vec![alice_admin]);
+    // The ingest-driven convergence pass runs inside the input window, so the
+    // terminal disposition may not be persisted yet — the pinned invariant is
+    // that the strip commit is never applied.
+    let record = bob_storage
+        .get_message(&content_id(&strip))
+        .expect("strip commit remains stored");
+    assert_ne!(record.state, MessageState::Processed);
+}
+
+#[tokio::test]
+async fn ingest_rejects_group_context_commit_dropping_required_component_entry() {
+    // Entry-level variant of the dictionary strip: the GroupContextExtensions
+    // commit keeps the app_data_dictionary but replaces it with one that omits
+    // the required admin-policy component's state. validate_app_component_remove
+    // only sees AppDataUpdate::Remove operations, so without the staged-commit
+    // retention check this strip would also merge.
+    let (mut alice, alice_storage) = build_client(b"alice");
+    let (mut bob, bob_storage) = build_client(b"bob");
+    let alice_id = alice.self_id();
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "ingest-gce-admin-policy-strip".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+
+    let strip = route(
+        raw_group_context_extensions_strip_commit(&alice_storage, &alice_id, &group_id, false),
+        &group_id,
+    );
+    let outcome = bob.ingest(strip.clone()).await.expect("ingest completes");
+    assert!(
+        matches!(outcome, IngestOutcome::Stale { .. }),
+        "GCE commit dropping the required admin-policy entry must not be processed: {outcome:?}"
+    );
+    assert_eq!(bob.epoch(&group_id).unwrap(), EpochId(1));
+    let alice_admin: [u8; 32] = alice_id
+        .as_slice()
+        .try_into()
+        .expect("test identities are 32-byte account keys");
+    assert_eq!(bob.admin_pubkeys(&group_id).unwrap(), vec![alice_admin]);
+    // Same input-window caveat as the dictionary-strip ingest test above.
+    let record = bob_storage
+        .get_message(&content_id(&strip))
+        .expect("strip commit remains stored");
+    assert_ne!(record.state, MessageState::Processed);
+}
+
+#[tokio::test]
+async fn convergence_rejects_group_context_commit_stripping_app_data_dictionary() {
+    // The same dictionary-strip commit through STORED CONVERGENCE. Before the
+    // required-component retention check, a GCE-only strip commit with no
+    // member removals was ACCEPTED here — convergence materialized the
+    // admin-less epoch. It must classify the commit as invalid instead.
+    let (mut alice, alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let alice_id = alice.self_id();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "convergence-gce-dictionary-strip".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    let strip = route(
+        raw_group_context_extensions_strip_commit(&alice_storage, &alice_id, &group_id, true),
+        &group_id,
+    );
+    carol
+        .buffer_openmls_convergence_message(&group_id, strip.clone(), 1_000)
+        .expect("GCE strip commit buffered");
+
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("stored OpenMLS messages converge");
+
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    assert!(
+        result.accepted_commits.is_empty(),
+        "GCE dictionary-strip commit must not be accepted: {result:?}"
+    );
+    assert!(
+        result.dropped_messages.iter().any(|dropped| {
+            dropped.kind == MessageKind::Commit
+                && dropped.reason == DroppedMessageReason::InvalidAgainstCandidateState
+                && dropped.message_id == content_hex(&strip)
+        }),
+        "expected GCE strip commit dropped as InvalidAgainstCandidateState, got {:?}",
+        result.dropped_messages
+    );
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
+    assert_eq!(
+        carol_storage
+            .get_group(&group_id)
+            .expect("group stored")
+            .epoch,
+        EpochId(1)
+    );
+    let alice_admin: [u8; 32] = alice_id
+        .as_slice()
+        .try_into()
+        .expect("test identities are 32-byte account keys");
+    assert_eq!(carol.admin_pubkeys(&group_id).unwrap(), vec![alice_admin]);
+    assert_message_state(&carol_storage, &strip, MessageState::EpochInvalidated);
 }
 
 /// darkmatter#286: a commit applied through STORED CONVERGENCE that later loses


### PR DESCRIPTION
## What

Adds a staged-commit validation, `validate_required_component_retention_for_staged_commit` (`crates/cgka-engine/src/app_components.rs`), that rejects — pre-merge — any commit whose resulting GroupContext:

- drops the `app_data_dictionary` extension entirely,
- drops the engine-owned `app_components` entry, or
- drops the state entry of any component in the group's current required set.

## Why

OpenMLS's draft-08 guard (`validate_app_data_update_proposals_and_group_context`) only validates the dictionary when the commit **also** carries `AppDataUpdate` proposals, and the engine's `validate_app_component_remove` only runs for `AppDataUpdate::Remove` operations. So an admin-authored **GroupContextExtensions-only** commit could replace the extensions with a set that omits the `app_data_dictionary` (or individual required entries) and merge cleanly.

The strip cannot orphan an admin key (an absent admin-policy component is the empty admin set — see the empty-set handling in `validate_admin_leaf_coupling_for_staged_commit` and the #701 review discussion), but after merging, the group becomes admin-less and frozen for every admin-required operation: a denial-of-service / consistency gap rather than a coupling bypass.

The rule uses the **current** epoch's required set, mirroring `validate_app_component_remove`: a component only becomes droppable after a prior commit removes it from the required list via an `AppDataUpdate` to `app_components`.

## Enforcement points

- `message_processor/ingest.rs` — direct staged-commit seam, alongside the admin-leaf-coupling check.
- `openmls_projection.rs` (`process_openmls_messages_inner`) — the convergence/replay path, returning `InvalidCommit`. This is the path that actually handles inbound same-epoch commits, since `ingest` routes commits with `msg_epoch >= current_epoch` through convergence.
- `message_processor/send.rs` — outbound remove-members path (defense-in-depth, same placement as the coupling check).
- `upgrade.rs` — the one outbound path that authors GCE commits, self-checked after staging.

## Tests

Three tests in `crates/cgka-engine/tests/distributed_convergence.rs`, built on a new `raw_group_context_extensions_strip_commit` helper (a raw OpenMLS `update_group_context_extensions` commit with no member changes):

- `ingest_rejects_group_context_commit_stripping_app_data_dictionary`
- `ingest_rejects_group_context_commit_dropping_required_component_entry` (dictionary kept, required admin-policy entry omitted)
- `convergence_rejects_group_context_commit_stripping_app_data_dictionary` — the pinned regression: via stored convergence the strip commit is dropped as `InvalidAgainstCandidateState`, epoch and admin set unchanged, message state `EpochInvalidated`.

Verified the tests pin the regression by temporarily disabling the projection-site check: all three then fail with the strip commit **accepted** (the pre-fix behavior).

## Notes for reviewers

- The ingest-path tests assert `IngestOutcome::Stale` + unchanged epoch/admins rather than `Err`: same-epoch commits route through convergence inside the input window, so the terminal disposition isn't persisted until the window closes. The pinned invariant is that the strip commit is never `Processed`.
- `cargo test -p cgka-engine` (18 test binaries) and `just fast-ci` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/704">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an app-component integrity check to reject staged commits that try to remove or tamper required app-component state (including the app data dictionary and mandatory entries) unless the changes are made through the allowed app data update operations.
  * Applied the validation across ingest, stored convergence/replay, send/remove-members flows, and upgrade staging to ensure failures don’t advance the epoch.

* **Tests**
  * Extended distributed convergence tests with GroupContextExtensions tampering scenarios (dictionary strip, required entry removal, and prohibited byte rewrites), verifying consistent rejection/invalidations and unchanged epoch/admin keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->