### PR TITLE
Materialize own confirmed commits as pre-validated convergence candidates (#706)

### DIFF
--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -213,6 +213,7 @@ struct StoredOpenMlsCanonicalizationWork {
     policy: CanonicalizationPolicy,
     now_ms: u64,
     replay_start_epoch: u64,
+    own_commits: PrevalidatedOwnCommits,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -309,6 +310,107 @@ impl From<StorageError> for OpenMlsProjectionError {
     }
 }
 
+/// Own published-and-confirmed commits usable as pre-validated candidate-path
+/// segments during stored-convergence materialization.
+///
+/// MLS cannot process a device's own commit through `process_message`, so a
+/// candidate path containing one cannot be materialized by replay alone: after
+/// a restart clears the in-memory `committed_from` guard, the own commit's
+/// branch would silently drop out of branch selection and the device could be
+/// reorged onto a losing sibling (or, with two restarted committers, the group
+/// could fork permanently). Instead, an own `Processed` commit whose ordering
+/// stamp was persisted at confirm time is realized by rolling the group
+/// forward to the retained anchor snapshot at its resulting epoch — the exact
+/// post-merge state the commit produced — and synthesizing its
+/// `CommitStaged` observation from the stamp.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PrevalidatedOwnCommits {
+    /// Confirm-stamped own `Processed` commits, keyed by wire-bytes digest.
+    by_digest: BTreeMap<[u8; 32], cgka_traits::message::OwnCommitConvergenceStamp>,
+    /// Digests of every `Processed` commit (own and others') — the canonical
+    /// chain. An own commit is pre-validated only while the replayed path
+    /// prefix stays canonical: it was created from the canonical state at its
+    /// source epoch, so on any diverging prefix it must NOT apply.
+    canonical_digests: BTreeSet<[u8; 32]>,
+}
+
+impl PrevalidatedOwnCommits {
+    fn insert_canonical(&mut self, digest: [u8; 32]) {
+        self.canonical_digests.insert(digest);
+    }
+
+    fn insert_stamped(
+        &mut self,
+        digest: [u8; 32],
+        stamp: cgka_traits::message::OwnCommitConvergenceStamp,
+    ) {
+        self.by_digest.insert(digest, stamp);
+    }
+
+    fn stamp(&self, digest: &[u8; 32]) -> Option<&cgka_traits::message::OwnCommitConvergenceStamp> {
+        self.by_digest.get(digest)
+    }
+
+    fn is_canonical(&self, digest: &[u8; 32]) -> bool {
+        self.canonical_digests.contains(digest)
+    }
+}
+
+/// Build the convergence ordering stamp for a staged local commit, captured
+/// while the staged commit is still attached (confirm time). See
+/// [`cgka_traits::message::OwnCommitConvergenceStamp`].
+pub(crate) fn own_commit_stamp(
+    staged: &openmls::group::StagedCommit,
+    committer: MemberId,
+) -> Result<cgka_traits::message::OwnCommitConvergenceStamp, cgka_traits::error::EngineError> {
+    let priority = crate::app_components::commit_ordering_priority_for_staged(staged);
+    let mut consumed_proposal_refs = staged
+        .queued_proposals()
+        .map(|proposal| tls_hex(proposal.proposal_reference_ref()))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| cgka_traits::error::EngineError::Serialize(format!("{e}")))?;
+    consumed_proposal_refs.sort();
+    consumed_proposal_refs.dedup();
+    Ok(cgka_traits::message::OwnCommitConvergenceStamp {
+        committer,
+        priority,
+        consumed_proposal_refs,
+    })
+}
+
+/// Mark the origin commit record `Processed` and, when a confirm-time stamp is
+/// available, enrich its stored wire payload to `OwnCommitWire` in the same
+/// write, so stored convergence can later rebuild this commit's branch as a
+/// pre-validated candidate.
+pub(crate) fn stamp_processed_own_commit_record<S: StorageProvider>(
+    storage: &S,
+    message_id: &MessageId,
+    stamp: Option<cgka_traits::message::OwnCommitConvergenceStamp>,
+) -> Result<(), cgka_traits::error::EngineError> {
+    let Some(stamp) = stamp else {
+        storage.update_message_state(message_id, MessageState::Processed)?;
+        return Ok(());
+    };
+    let mut record = storage.get_message(message_id)?;
+    let payload = StoredMessagePayload::decode(&record.payload)
+        .map_err(|e| cgka_traits::error::EngineError::Serialize(format!("{e:?}")))?;
+    let payload = match payload {
+        StoredMessagePayload::OpenMlsWire(message)
+        | StoredMessagePayload::OwnCommitWire { message, .. } => {
+            StoredMessagePayload::own_commit_wire(message, stamp)
+        }
+        // Raw-transport rows never enter the OpenMLS candidate graph; a plain
+        // state update preserves their shape.
+        other @ StoredMessagePayload::RawTransport(_) => other,
+    };
+    record.state = MessageState::Processed;
+    record.payload = payload
+        .encode()
+        .map_err(|e| cgka_traits::error::EngineError::Serialize(format!("{e:?}")))?;
+    storage.put_message(&record)?;
+    Ok(())
+}
+
 pub fn project_mls_message(
     bytes: &[u8],
 ) -> Result<OpenMlsMessageProjection, OpenMlsProjectionError> {
@@ -335,16 +437,32 @@ pub fn replay_openmls_messages<S: StorageProvider>(
     group_id: &GroupId,
     messages: &[TransportMessage],
 ) -> Result<Vec<OpenMlsReplayObservation>, OpenMlsProjectionError> {
+    replay_openmls_messages_prevalidated(
+        storage,
+        group_id,
+        messages,
+        &PrevalidatedOwnCommits::default(),
+    )
+}
+
+fn replay_openmls_messages_prevalidated<S: StorageProvider>(
+    storage: &S,
+    group_id: &GroupId,
+    messages: &[TransportMessage],
+    own_commits: &PrevalidatedOwnCommits,
+) -> Result<Vec<OpenMlsReplayObservation>, OpenMlsProjectionError> {
     use crate::snapshot_guard::SnapshotRollbackGuard;
     let snapshot = replay_snapshot_name(group_id, messages);
     // RAII: on any unwind path (panic during replay, early error)
     // Drop rolls back + releases. On the happy path we explicitly
-    // commit at the end.
+    // commit at the end. Pre-validated own-commit rollforwards inside the
+    // replay land within this guard, so they are unwound with everything
+    // else.
     let guard = SnapshotRollbackGuard::create(storage, group_id.clone(), snapshot)
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
 
-    let result =
-        process_openmls_messages_inner(storage, group_id, messages).map(|out| out.observations);
+    let result = process_openmls_messages_inner(storage, group_id, messages, own_commits)
+        .map(|out| out.observations);
     guard
         .commit()
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
@@ -360,6 +478,7 @@ pub fn materialize_openmls_candidate_paths<S: StorageProvider>(
         storage,
         group_id,
         paths,
+        &PrevalidatedOwnCommits::default(),
         &mut ReplayBudget::unlimited(),
     )
 }
@@ -368,6 +487,7 @@ fn materialize_openmls_candidate_paths_budgeted<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
     paths: &[OpenMlsCandidatePath],
+    own_commits: &PrevalidatedOwnCommits,
     budget: &mut ReplayBudget,
 ) -> Result<Vec<OpenMlsMaterializedCandidate>, OpenMlsProjectionError> {
     let mut candidates = Vec::with_capacity(paths.len());
@@ -378,7 +498,8 @@ fn materialize_openmls_candidate_paths_budgeted<S: StorageProvider>(
             ));
         }
         budget.consume()?;
-        let observations = replay_openmls_messages(storage, group_id, &path.messages)?;
+        let observations =
+            replay_openmls_messages_prevalidated(storage, group_id, &path.messages, own_commits)?;
         let mut fork_epoch: Option<u64> = None;
         let mut tip_epoch: Option<u64> = None;
         let mut tip_digest: Option<[u8; 32]> = None;
@@ -445,11 +566,31 @@ pub fn canonicalize_openmls_batch<S: StorageProvider>(
     group_id: &GroupId,
     batch: OpenMlsCanonicalizationBatch,
 ) -> Result<CanonicalizationResult, OpenMlsProjectionError> {
+    canonicalize_openmls_batch_prevalidated(
+        storage,
+        group_id,
+        batch,
+        &PrevalidatedOwnCommits::default(),
+    )
+}
+
+fn canonicalize_openmls_batch_prevalidated<S: StorageProvider>(
+    storage: &S,
+    group_id: &GroupId,
+    batch: OpenMlsCanonicalizationBatch,
+    own_commits: &PrevalidatedOwnCommits,
+) -> Result<CanonicalizationResult, OpenMlsProjectionError> {
     let candidate_paths = candidate_paths_with_pending_replay_messages(
         &batch.candidate_paths,
         &batch.pending_messages,
     )?;
-    let materialized = materialize_openmls_candidate_paths(storage, group_id, &candidate_paths)?;
+    let materialized = materialize_openmls_candidate_paths_budgeted(
+        storage,
+        group_id,
+        &candidate_paths,
+        own_commits,
+        &mut ReplayBudget::unlimited(),
+    )?;
     canonicalize_openmls_batch_with_materialized(group_id, batch, materialized)
 }
 
@@ -512,12 +653,16 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
     let mut commit_messages = Vec::new();
     let mut pending_messages = Vec::new();
     let mut stale_commit_drops = Vec::new();
+    let mut own_commits = PrevalidatedOwnCommits::default();
 
     for record in records {
         if !record_state_can_contribute_to_openmls_graph(record.state) {
             continue;
         }
-        let Some(message) = openmls_wire_message_from_record(&record)? else {
+        let payload = StoredMessagePayload::decode(&record.payload)
+            .map_err(|e| OpenMlsProjectionError::Serialize(format!("{e:?}")))?;
+        let own_commit_stamp = payload.own_commit_stamp().cloned();
+        let Some(message) = payload.as_openmls_wire().cloned() else {
             continue;
         };
         if matches!(message.envelope, TransportEnvelope::Welcome { .. }) {
@@ -539,6 +684,12 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
                         });
                     }
                     continue;
+                }
+                if record.state == MessageState::Processed {
+                    own_commits.insert_canonical(projection.message_digest);
+                    if let Some(stamp) = own_commit_stamp {
+                        own_commits.insert_stamped(projection.message_digest, stamp);
+                    }
                 }
                 commit_messages.push(StoredCommitMessage {
                     message,
@@ -581,6 +732,7 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
                 policy,
                 now_ms,
                 replay_start_epoch,
+                own_commits,
             },
         )?;
         append_dropped_messages(&mut result, stale_commit_drops);
@@ -598,6 +750,7 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
             policy,
             now_ms,
             replay_start_epoch,
+            own_commits,
         },
     )?;
     append_dropped_messages(&mut result, stale_commit_drops);
@@ -667,6 +820,7 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
         &work.pending_messages,
         work.replay_start_epoch,
         work.policy.convergence.max_rewind_commits,
+        &work.own_commits,
     )?;
 
     // Reuse the candidates the BFS already materialized instead of replaying every completed
@@ -691,7 +845,7 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
         materialized.sort_by(|a, b| a.branch_id.cmp(&b.branch_id));
         canonicalize_openmls_batch_with_materialized(group_id, batch, materialized)?
     } else {
-        canonicalize_openmls_batch(storage, group_id, batch)?
+        canonicalize_openmls_batch_prevalidated(storage, group_id, batch, &work.own_commits)?
     };
     append_dropped_messages(&mut result, path_result.invalid_commit_drops);
     Ok(result)
@@ -743,6 +897,9 @@ fn missing_retained_anchor_result(
     }
 }
 
+// The last two arguments carry independent replay context; folding them into a
+// struct would just relocate the same fields.
+#[allow(clippy::too_many_arguments)]
 fn build_stored_openmls_candidate_paths<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
@@ -750,6 +907,7 @@ fn build_stored_openmls_candidate_paths<S: StorageProvider>(
     pending_messages: &[TransportMessage],
     starting_epoch: u64,
     max_rewind_commits: u64,
+    own_commits: &PrevalidatedOwnCommits,
 ) -> Result<StoredOpenMlsCandidatePathResult, OpenMlsProjectionError> {
     commits.sort_by(|a, b| {
         a.source_epoch
@@ -794,6 +952,7 @@ fn build_stored_openmls_candidate_paths<S: StorageProvider>(
                     messages.clone(),
                     &digests,
                     &pending_proposals,
+                    own_commits,
                     &mut budget,
                 )? {
                     CandidatePathProbeResult::Materialized(Some(candidate)) => candidate,
@@ -881,12 +1040,15 @@ fn pending_proposal_messages(
     Ok(proposals)
 }
 
+// See `build_stored_openmls_candidate_paths` — same shared-context argument set.
+#[allow(clippy::too_many_arguments)]
 fn probe_candidate_path<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
     messages: Vec<TransportMessage>,
     digests: &[[u8; 32]],
     pending_proposals: &[TransportMessage],
+    own_commits: &PrevalidatedOwnCommits,
     budget: &mut ReplayBudget,
 ) -> Result<CandidatePathProbeResult, OpenMlsProjectionError> {
     let path = OpenMlsCandidatePath {
@@ -894,7 +1056,13 @@ fn probe_candidate_path<S: StorageProvider>(
         messages,
     };
     let replay_paths = candidate_paths_with_pending_replay_messages(&[path], pending_proposals)?;
-    match materialize_openmls_candidate_paths_budgeted(storage, group_id, &replay_paths, budget) {
+    match materialize_openmls_candidate_paths_budgeted(
+        storage,
+        group_id,
+        &replay_paths,
+        own_commits,
+        budget,
+    ) {
         Ok(mut candidates) => Ok(CandidatePathProbeResult::Materialized(candidates.pop())),
         Err(OpenMlsProjectionError::UnauthorizedCommit { message_id }) => {
             Ok(CandidatePathProbeResult::UnauthorizedCommit { message_id })
@@ -914,12 +1082,20 @@ pub fn apply_openmls_canonicalization_result<S: StorageProvider>(
     result: &CanonicalizationResult,
     max_retained_anchor_rewind: u64,
 ) -> Result<Vec<OpenMlsReplayObservation>, OpenMlsProjectionError> {
-    let replay_messages = replay_messages_for_canonicalization_result(storage, result)?;
     let current_epoch = storage
         .get_group(group_id)
         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?
         .epoch
         .0;
+    // The selected branch's already-applied prefix — leading `Processed`
+    // commits below the live tip — IS the live canonical chain: skip it and
+    // start state reconstruction from the first genuinely new commit. This is
+    // also what lets a branch containing this device's OWN confirmed commit
+    // apply at all (MLS cannot re-process own commits), and it avoids
+    // re-replaying history the live state already reflects.
+    let applied_prefix = already_applied_commit_prefix(storage, result, current_epoch)?;
+    let replay_messages =
+        replay_messages_for_canonicalization_result(storage, result, &applied_prefix)?;
     let live_message_records = storage
         .list_messages(group_id, EpochId(0))
         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
@@ -927,30 +1103,31 @@ pub fn apply_openmls_canonicalization_result<S: StorageProvider>(
         .list_queued_outbound_intents(group_id)
         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
     let apply_start_epoch =
-        apply_start_epoch_for_canonicalization_result(storage, result)?.unwrap_or(current_epoch);
+        apply_start_epoch_for_canonicalization_result(storage, result, &applied_prefix)?
+            .unwrap_or(current_epoch);
+    let has_new_commits = result.accepted_commits.len() > applied_prefix.len();
     let snapshot = apply_snapshot_name(group_id, result);
     storage
         .create_group_snapshot(group_id, &snapshot)
         .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;
 
-    let prepare_result =
-        if !result.accepted_commits.is_empty() && apply_start_epoch == current_epoch {
-            retain_current_group_epoch_snapshot(storage, group_id, max_retained_anchor_rewind)
-        } else if apply_start_epoch < current_epoch {
-            let anchor_snapshot = retained_anchor_snapshot_name(apply_start_epoch);
-            storage
-                .rollback_group_to_snapshot(group_id, &anchor_snapshot)
-                .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))
-                .and_then(|()| {
-                    restore_live_message_and_queue_records(
-                        storage,
-                        &live_message_records,
-                        &live_queued_outbound,
-                    )
-                })
-        } else {
-            Ok(())
-        };
+    let prepare_result = if has_new_commits && apply_start_epoch == current_epoch {
+        retain_current_group_epoch_snapshot(storage, group_id, max_retained_anchor_rewind)
+    } else if apply_start_epoch < current_epoch {
+        let anchor_snapshot = retained_anchor_snapshot_name(apply_start_epoch);
+        storage
+            .rollback_group_to_snapshot(group_id, &anchor_snapshot)
+            .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))
+            .and_then(|()| {
+                restore_live_message_and_queue_records(
+                    storage,
+                    &live_message_records,
+                    &live_queued_outbound,
+                )
+            })
+    } else {
+        Ok(())
+    };
     if let Err(err) = prepare_result {
         rollback_and_release_group_snapshot(storage, group_id, &snapshot)?;
         return Err(err);
@@ -1020,11 +1197,43 @@ pub fn persist_openmls_canonicalization_dispositions<S: StorageProvider>(
     Ok(())
 }
 
+/// The longest leading run of accepted commits already applied on the live
+/// canonical state: `Processed` records whose source epoch sits below the live
+/// tip. `Processed` means "applied on this device's canonical chain" (there is
+/// at most one per epoch), so the prefix needs no re-replay — and an OWN
+/// confirmed commit in it CANNOT be re-replayed (`process_message` refuses own
+/// commits).
+fn already_applied_commit_prefix<S: StorageProvider>(
+    storage: &S,
+    result: &CanonicalizationResult,
+    current_epoch: u64,
+) -> Result<BTreeSet<String>, OpenMlsProjectionError> {
+    let mut prefix = BTreeSet::new();
+    for commit_id in &result.accepted_commits {
+        let message_id = message_id_from_hex(commit_id)?;
+        let record = match storage.get_message(&message_id) {
+            Ok(record) => record,
+            Err(StorageError::NotFound) => break,
+            Err(e) => return Err(OpenMlsProjectionError::Storage(format!("{e:?}"))),
+        };
+        if record.state != MessageState::Processed || record.epoch.0 >= current_epoch {
+            break;
+        }
+        prefix.insert(commit_id.clone());
+    }
+    Ok(prefix)
+}
+
 fn apply_start_epoch_for_canonicalization_result<S: StorageProvider>(
     storage: &S,
     result: &CanonicalizationResult,
+    applied_prefix: &BTreeSet<String>,
 ) -> Result<Option<u64>, OpenMlsProjectionError> {
-    let Some(first_commit_id) = result.accepted_commits.first() else {
+    let Some(first_commit_id) = result
+        .accepted_commits
+        .iter()
+        .find(|commit_id| !applied_prefix.contains(*commit_id))
+    else {
         return Ok(None);
     };
     let message_id = message_id_from_hex(first_commit_id)?;
@@ -1128,7 +1337,16 @@ fn apply_openmls_canonicalization_result_inner<S: StorageProvider>(
     // inside an open one. The snapshot guards in-process error returns; this
     // transaction guards hard crashes mid-merge.
     storage.with_transaction(|storage| {
-        let output = process_openmls_messages_inner(storage, group_id, replay_messages)?;
+        // No pre-validated own commits here: snapshot rollforward cannot nest
+        // inside this transaction, and the already-applied prefix (which is
+        // where own commits can appear on an accepted branch) was excluded
+        // from `replay_messages` before this call.
+        let output = process_openmls_messages_inner(
+            storage,
+            group_id,
+            replay_messages,
+            &PrevalidatedOwnCommits::default(),
+        )?;
         update_group_record_from_replay(storage, group_id, &output)?;
         persist_openmls_canonicalization_dispositions(storage, result)?;
         Ok(output.observations)
@@ -1138,13 +1356,19 @@ fn apply_openmls_canonicalization_result_inner<S: StorageProvider>(
 fn replay_messages_for_canonicalization_result<S: StorageProvider>(
     storage: &S,
     result: &CanonicalizationResult,
+    applied_prefix: &BTreeSet<String>,
 ) -> Result<Vec<TransportMessage>, OpenMlsProjectionError> {
     let mut replay_messages = Vec::new();
     let mut seen = BTreeSet::new();
     for hex_message_id in result
         .accepted_proposals
         .iter()
-        .chain(&result.accepted_commits)
+        .chain(
+            result
+                .accepted_commits
+                .iter()
+                .filter(|commit_id| !applied_prefix.contains(*commit_id)),
+        )
         .chain(&result.accepted_app_messages)
     {
         if !seen.insert(hex_message_id.clone()) {
@@ -1474,6 +1698,7 @@ fn process_openmls_messages_inner<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
     messages: &[TransportMessage],
+    own_commits: &PrevalidatedOwnCommits,
 ) -> Result<OpenMlsReplayOutput, OpenMlsProjectionError> {
     let crypto = RustCrypto::default();
     let provider = EngineOpenMlsProvider::<S>::new(&crypto, storage.mls_storage());
@@ -1483,6 +1708,11 @@ fn process_openmls_messages_inner<S: StorageProvider>(
         .ok_or(OpenMlsProjectionError::MissingGroup)?;
 
     let mut observations = Vec::new();
+    // An own commit is pre-validated only while every commit replayed before
+    // it was canonical (`Processed`): it was created from the canonical state
+    // at its source epoch, so on a diverging prefix its anchor state would
+    // not be the state the commit actually produces there.
+    let mut prefix_canonical = true;
     for message in messages {
         let projection = project_mls_message(&message.payload)?;
         let message_id = hex::encode(message.id.as_slice());
@@ -1499,6 +1729,54 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                 .ok_or(OpenMlsProjectionError::UnsupportedMessageKind(
                     projection.kind,
                 ))?;
+        if projection.kind == OpenMlsContentKind::Commit
+            && prefix_canonical
+            && let Some(stamp) = own_commits.stamp(&projection.message_digest)
+        {
+            // MLS cannot process this device's own commit; realize its
+            // pre-validated result by rolling the group forward to the
+            // retained anchor snapshot the confirm path captured at its
+            // resulting epoch, and synthesize the CommitStaged observation
+            // from the confirm-time stamp. Any failure prunes this branch
+            // (the pre-fix behavior) rather than failing the pass.
+            let group_epoch = mls_group.epoch().as_u64();
+            if group_epoch != source_epoch {
+                return Err(OpenMlsProjectionError::Replay(format!(
+                    "own commit source epoch {source_epoch} does not match replay state {group_epoch}"
+                )));
+            }
+            let resulting_epoch = source_epoch.saturating_add(1);
+            match storage.rollback_group_to_snapshot(
+                group_id,
+                &retained_anchor_snapshot_name(resulting_epoch),
+            ) {
+                Ok(()) => {}
+                Err(StorageError::SnapshotMissing(_)) => {
+                    return Err(OpenMlsProjectionError::Replay(format!(
+                        "own commit anchor snapshot missing at epoch {resulting_epoch}"
+                    )));
+                }
+                Err(e) => return Err(OpenMlsProjectionError::Snapshot(format!("{e:?}"))),
+            }
+            mls_group = MlsGroup::load(provider.storage(), &mls_group_id)
+                .map_err(|e| OpenMlsProjectionError::Replay(format!("anchor reload: {e:?}")))?
+                .ok_or(OpenMlsProjectionError::MissingGroup)?;
+            let anchor_epoch = mls_group.epoch().as_u64();
+            if anchor_epoch != resulting_epoch {
+                return Err(OpenMlsProjectionError::Replay(format!(
+                    "own commit anchor epoch {anchor_epoch} does not match resulting epoch {resulting_epoch}"
+                )));
+            }
+            observations.push(OpenMlsReplayObservation::CommitStaged {
+                message_id,
+                source_epoch,
+                resulting_epoch,
+                priority: stamp.priority,
+                committer: stamp.committer.as_slice().to_vec(),
+                consumed_proposal_refs: stamp.consumed_proposal_refs.clone(),
+            });
+            continue;
+        }
         let processed = match if projection.kind == OpenMlsContentKind::Commit {
             process_commit_with_app_data_updates(&mut mls_group, &provider, protocol)
         } else {
@@ -1629,6 +1907,8 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                     .map_err(|e| {
                         OpenMlsProjectionError::Replay(format!("merge_staged_commit: {e:?}"))
                     })?;
+                prefix_canonical =
+                    prefix_canonical && own_commits.is_canonical(&projection.message_digest);
             }
             ProcessedMessageContent::ApplicationMessage(bytes) => {
                 let payload = bytes.into_bytes();

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -1094,17 +1094,21 @@ pub fn apply_openmls_canonicalization_result<S: StorageProvider>(
     // apply at all (MLS cannot re-process own commits), and it avoids
     // re-replaying history the live state already reflects.
     let applied_prefix = already_applied_commit_prefix(storage, result, current_epoch)?;
-    let replay_messages =
-        replay_messages_for_canonicalization_result(storage, result, &applied_prefix)?;
+    let apply_start_epoch =
+        apply_start_epoch_for_canonicalization_result(storage, result, &applied_prefix)?
+            .unwrap_or(current_epoch);
+    let replay_messages = replay_messages_for_canonicalization_result(
+        storage,
+        result,
+        &applied_prefix,
+        apply_start_epoch,
+    )?;
     let live_message_records = storage
         .list_messages(group_id, EpochId(0))
         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
     let live_queued_outbound = storage
         .list_queued_outbound_intents(group_id)
         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
-    let apply_start_epoch =
-        apply_start_epoch_for_canonicalization_result(storage, result, &applied_prefix)?
-            .unwrap_or(current_epoch);
     let has_new_commits = result.accepted_commits.len() > applied_prefix.len();
     let snapshot = apply_snapshot_name(group_id, result);
     storage
@@ -1357,6 +1361,7 @@ fn replay_messages_for_canonicalization_result<S: StorageProvider>(
     storage: &S,
     result: &CanonicalizationResult,
     applied_prefix: &BTreeSet<String>,
+    apply_start_epoch: u64,
 ) -> Result<Vec<TransportMessage>, OpenMlsProjectionError> {
     let mut replay_messages = Vec::new();
     let mut seen = BTreeSet::new();
@@ -1378,6 +1383,16 @@ fn replay_messages_for_canonicalization_result<S: StorageProvider>(
         let record = storage
             .get_message(&message_id)
             .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+        // An accepted proposal below the apply-start epoch was consumed by a
+        // commit in the skipped already-applied prefix: its effect is inside
+        // the live state, and MLS proposals are epoch-scoped, so replaying it
+        // against the post-prefix state would be rejected (WrongEpoch) and
+        // fail the whole apply. Skip the replay; its `Processed` disposition
+        // still persists so it leaves the convergence input set.
+        if result.accepted_proposals.contains(hex_message_id) && record.epoch.0 < apply_start_epoch
+        {
+            continue;
+        }
         let Some(message) = openmls_wire_message_from_record(&record)? else {
             return Err(OpenMlsProjectionError::Decode(format!(
                 "accepted message {} is not a stored OpenMLS wire payload",

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -95,6 +95,7 @@ impl<S: StorageProvider> Engine<S> {
         // left an unrecoverable `UnknownPending` on retry.
         self.storage
             .with_transaction(|storage| -> Result<(), EngineError> {
+                let mut own_commit_stamp = None;
                 if has_pending_commit {
                     // `staged` borrows `mls_group`; scope it so the subsequent
                     // `merge_pending_commit` can take `&mut mls_group`.
@@ -108,6 +109,15 @@ impl<S: StorageProvider> Engine<S> {
                             staged,
                             self.ciphersuite,
                         )?;
+                        // Capture the convergence ordering stamp while the
+                        // staged commit is still attached: stored convergence
+                        // cannot re-derive priority or consumed proposal refs
+                        // from the wire bytes later (MLS refuses to process
+                        // own commits), so this is the only durable source.
+                        own_commit_stamp = Some(crate::openmls_projection::own_commit_stamp(
+                            staged,
+                            self.identity.self_id().clone(),
+                        )?);
                     }
                     let tx_provider =
                         EngineOpenMlsProvider::<S>::new(&self.crypto, storage.mls_storage());
@@ -138,7 +148,16 @@ impl<S: StorageProvider> Engine<S> {
                     self.ciphersuite,
                 )?;
                 if let Some(message_id) = origin_commit_id.as_ref() {
-                    storage.update_message_state(message_id, MessageState::Processed)?;
+                    // Enrich the stored wire record with the convergence stamp
+                    // (when one was captured above) in the same write that marks
+                    // it `Processed`, so a post-restart stored-convergence pass
+                    // can rebuild this commit's branch as a pre-validated
+                    // candidate instead of silently pruning it.
+                    crate::openmls_projection::stamp_processed_own_commit_record(
+                        storage,
+                        message_id,
+                        own_commit_stamp.take(),
+                    )?;
                 }
                 Ok(())
             })?;

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -778,8 +778,10 @@ async fn welcome_wrapped_pre_merge_lands_recipient_at_post_stage_epoch() {
 // lock there advanced the epoch durably yet made a retry fail with
 // `UnknownPending` — a half-applied, unrecoverable confirm.
 
-/// Shared, arm-able fault switch: while armed, the next `update_message_state`
-/// to `Processed` returns `StorageError::Busy` once, then disarms.
+/// Shared, arm-able fault switch: while armed, the next write that marks a
+/// message `Processed` (`update_message_state`, or the `put_message` the
+/// confirm path uses to stamp own-commit convergence metadata in the same
+/// write) returns `StorageError::Busy` once, then disarms.
 #[derive(Clone, Default)]
 struct ProcessedFault(Arc<AtomicUsize>);
 
@@ -822,6 +824,9 @@ impl GroupStorage for FaultStorage {
 
 impl MessageStorage for FaultStorage {
     fn put_message(&self, record: &MessageRecord) -> StorageResult<()> {
+        if record.state == MessageState::Processed && self.fault.should_fail() {
+            return Err(StorageError::Busy("injected confirm-path lock".into()));
+        }
         self.inner.put_message(record)
     }
     fn get_message(&self, id: &MessageId) -> StorageResult<MessageRecord> {

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -2119,6 +2119,211 @@ async fn mutually_rebuilt_engines_converge_on_same_branch_after_concurrent_renam
     }
 }
 
+/// Restart-winner variant where the winning own commit CONSUMED a by-reference
+/// proposal (a SelfRemove auto-commit) and that proposal is simultaneously a
+/// pending convergence input on the restarted device.
+///
+/// The apply path skips the already-applied own commit (it cannot be
+/// re-processed), so it must also skip replaying the proposal that commit
+/// consumed: MLS proposals are epoch-scoped, and replaying the fork-epoch
+/// proposal against the live tip would be rejected (WrongEpoch) and fail the
+/// whole apply — rolling back the convergence pass on every retry, a
+/// permanent livelock. The proposal's `Processed` disposition must still
+/// persist so it leaves the convergence input set.
+#[tokio::test]
+async fn rebuilt_winner_applies_own_selfremove_commit_without_replaying_consumed_proposal() {
+    use cgka_traits::engine::{CommitOrderingKey, CommitOrderingPriority};
+
+    async fn advance_selfremove_auto_commit(
+        engine: &mut Engine<SqliteAccountStorage>,
+        group_id: &GroupId,
+    ) {
+        tokio::time::sleep(std::time::Duration::from_millis(75)).await;
+        let results = engine.advance_convergence(group_id).await.unwrap();
+        assert!(
+            results.is_empty(),
+            "SelfRemove auto-commit should drain through auto-publish, got {results:?}"
+        );
+    }
+
+    let (mut alice, alice_storage) = build_with_storage(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let mut carol = build(b"carol");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+
+    let (gid, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "mip03-fork".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, mut welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcomes.remove(0)).await.unwrap();
+    carol.join_welcome(welcomes.remove(0)).await.unwrap();
+
+    // A settled rename round first, so every member holds a retained anchor at
+    // the upcoming fork epoch: the committer retains it at confirm, each
+    // recipient when its convergence pass applies the commit. (A welcome-joined
+    // member whose only own commit is the auto-commit would otherwise hold no
+    // anchor at the fork epoch — the auto-commit send path projects the group
+    // record to the post-merge epoch before confirm's retention reads it.)
+    let res = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: gid.clone(),
+            name: Some("settled before fork".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (rename_commit, rename_pending) = match res {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(rename_pending).await.unwrap();
+    bob.ingest(route_to_group(&rename_commit, &gid))
+        .await
+        .unwrap();
+    converge_buffered_commit(&mut bob, &gid);
+    carol
+        .ingest(route_to_group(&rename_commit, &gid))
+        .await
+        .unwrap();
+    converge_buffered_commit(&mut carol, &gid);
+    assert_eq!(alice.epoch(&gid).unwrap().0, 2);
+    assert_eq!(bob.epoch(&gid).unwrap().0, 2);
+
+    // Carol leaves; BOTH remaining members ingest her SelfRemove proposal and
+    // race the SelfRemove-only auto-commit at the same epoch — an ordinary
+    // same-epoch fork whose commits each consume the proposal by reference.
+    let proposal = match carol
+        .send(SendIntent::Leave {
+            group_id: gid.clone(),
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::Proposal { msg } => msg,
+        other => panic!("expected Proposal, got {other:?}"),
+    };
+    alice.ingest(route_to_group(&proposal, &gid)).await.unwrap();
+    bob.ingest(route_to_group(&proposal, &gid)).await.unwrap();
+    advance_selfremove_auto_commit(&mut alice, &gid).await;
+    advance_selfremove_auto_commit(&mut bob, &gid).await;
+    let mut alice_auto = alice.drain_auto_publish();
+    let mut bob_auto = bob.drain_auto_publish();
+    assert_eq!(alice_auto.len(), 1);
+    assert_eq!(bob_auto.len(), 1);
+    let alice_auto = alice_auto.remove(0);
+    let bob_auto = bob_auto.remove(0);
+    alice.confirm_published(alice_auto.pending).await.unwrap();
+    bob.confirm_published(bob_auto.pending).await.unwrap();
+    alice.drain_events();
+    bob.drain_events();
+
+    // Deterministic winner: both auto-commits are SelfRemove-only (Ordinary),
+    // so the authenticated committer id decides.
+    let alice_key = CommitOrderingKey::from_commit_bytes(
+        cgka_traits::EpochId(2),
+        CommitOrderingPriority::Ordinary,
+        alice.self_id(),
+        &alice_auto.msg.payload,
+    );
+    let bob_key = CommitOrderingKey::from_commit_bytes(
+        cgka_traits::EpochId(2),
+        CommitOrderingPriority::Ordinary,
+        bob.self_id(),
+        &bob_auto.msg.payload,
+    );
+    let alice_wins = alice_key < bob_key;
+    let (winner, winner_storage, winner_commit, winner_id, loser_commit) = if alice_wins {
+        (
+            alice,
+            alice_storage,
+            alice_auto.msg,
+            b"alice".as_slice(),
+            bob_auto.msg,
+        )
+    } else {
+        (
+            bob,
+            bob_storage,
+            bob_auto.msg,
+            b"bob".as_slice(),
+            alice_auto.msg,
+        )
+    };
+
+    // The WINNER restarts.
+    drop(winner);
+    let mut winner =
+        build_with_storage_and_peeler(winner_id, winner_storage.clone(), mock_peeler());
+    winner.drain_events();
+
+    // Re-open carol's consumed proposal as a pending convergence input on the
+    // restarted winner — the state left behind when the proposal's disposition
+    // write is lost (crash between the convergence apply and its disposition
+    // persistence, or a restored backup). Its record exists under the content
+    // dedup id from the direct ingest.
+    let proposal_record_id = content_id(&proposal);
+    winner_storage
+        .get_message(&proposal_record_id)
+        .expect("consumed proposal record exists under its content id");
+    winner_storage
+        .update_message_state(&proposal_record_id, MessageState::Created)
+        .expect("re-open consumed proposal as pending");
+
+    // The losing sibling commit arrives through stored convergence.
+    winner
+        .buffer_openmls_convergence_message(&gid, route_to_group(&loser_commit, &gid), 1_000)
+        .expect("losing sibling auto-commit buffered on the restarted winner");
+    let result = winner
+        .converge_stored_openmls_messages(&gid, 1_000_000)
+        .expect("apply must not replay the proposal consumed by the skipped own commit");
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+
+    // Own branch selected and intact: carol removed, epoch unchanged, the
+    // losing sibling dropped against the candidate state.
+    assert_eq!(winner.epoch(&gid).unwrap().0, 3);
+    let members = winner.members(&gid).unwrap();
+    assert_eq!(members.len(), 2, "carol must stay removed; got {members:?}");
+    assert!(
+        result.dropped_messages.iter().any(|dropped| {
+            dropped.message_id == hex::encode(content_id(&loser_commit).as_slice())
+                && dropped.reason == DroppedMessageReason::InvalidAgainstCandidateState
+        }),
+        "losing sibling must be dropped against the selected candidate state, got {:?}",
+        result.dropped_messages
+    );
+
+    // The re-opened proposal was accepted on the selected branch WITHOUT being
+    // replayed: its disposition returns to Processed, closing the retry loop.
+    assert_eq!(
+        winner_storage
+            .get_message(&proposal_record_id)
+            .unwrap()
+            .state,
+        MessageState::Processed,
+        "consumed proposal must settle back to Processed, not stay a pending input"
+    );
+
+    // And no withdrawal names the winner's own canonical commit.
+    let invalidations = state_invalidations(&winner.drain_events());
+    assert!(
+        !invalidations.iter().any(|(id, _)| id == &winner_commit.id),
+        "winner must not withdraw its own canonical auto-commit, got {invalidations:?}"
+    );
+}
+
 /// Sequential control: when the second rename builds on the first commit
 /// (no fork), both notifications are accurate history — two
 /// `GroupStateChanged` events, and no `GroupStateInvalidated` anywhere.

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -1723,6 +1723,402 @@ async fn rebuilt_engine_convergence_withdraws_own_confirmed_rename_by_stamped_or
     }
 }
 
+/// Restart-WINNER variant of the stored-convergence fork: the committer whose
+/// authenticated ordering key WINS branch selection restarts, so the losing
+/// sibling commit routes into stored convergence instead of the direct seam.
+///
+/// The own published-and-confirmed commit cannot be replayed through
+/// `process_message` (MLS refuses own commits), so before the confirm-time
+/// convergence stamp + retained-anchor rollforward existed, the winner's own
+/// branch never materialized as a candidate: the losing sibling was the ONLY
+/// candidate, branch selection picked it, and the restarted device was
+/// reorged OFF the canonical branch its ordering key had won — withdrawing
+/// its own rename and diverging from every peer that resolved the same fork
+/// correctly on the direct seam.
+#[tokio::test]
+async fn rebuilt_engine_convergence_keeps_own_confirmed_rename_when_it_wins_selection() {
+    use cgka_traits::engine::{CommitOrderingKey, CommitOrderingPriority, GroupStateChange};
+    use cgka_traits::ingest::IngestOutcome;
+
+    let (mut alice, alice_storage, mut bob, bob_storage, gid) =
+        create_admin_pair_with_peeler(ephemeral_peeler).await;
+    alice.drain_events();
+    bob.drain_events();
+
+    // Concurrent renames in the same epoch window; both confirmed locally.
+    let alice_res = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: gid.clone(),
+            name: Some("New name from A".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let bob_res = bob
+        .send(SendIntent::UpdateGroupData {
+            group_id: gid.clone(),
+            name: Some("New name from B".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (alice_commit, alice_pending) = match alice_res {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    let (bob_commit, bob_pending) = match bob_res {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(alice_pending).await.unwrap();
+    bob.confirm_published(bob_pending).await.unwrap();
+    let alice_own = attributed_state_changes(&alice.drain_events());
+    let bob_own = attributed_state_changes(&bob.drain_events());
+
+    // Deterministic branch-selection winner (both commits are admin-gated,
+    // so Privileged; the authenticated committer id then decides).
+    let alice_key = CommitOrderingKey::from_commit_bytes(
+        cgka_traits::EpochId(1),
+        CommitOrderingPriority::Privileged,
+        alice.self_id(),
+        &alice_commit.payload,
+    );
+    let bob_key = CommitOrderingKey::from_commit_bytes(
+        cgka_traits::EpochId(1),
+        CommitOrderingPriority::Privileged,
+        bob.self_id(),
+        &bob_commit.payload,
+    );
+    let alice_wins = alice_key < bob_key;
+    #[allow(clippy::type_complexity)]
+    let (
+        winner,
+        winner_storage,
+        winner_commit,
+        winner_name,
+        winner_own,
+        winner_id,
+        mut loser,
+        loser_storage,
+        loser_commit,
+    ): (
+        Engine<SqliteAccountStorage>,
+        SqliteAccountStorage,
+        TransportMessage,
+        &str,
+        Vec<(GroupStateChange, MessageId)>,
+        &[u8],
+        Engine<SqliteAccountStorage>,
+        SqliteAccountStorage,
+        TransportMessage,
+    ) = if alice_wins {
+        (
+            alice,
+            alice_storage,
+            alice_commit,
+            "New name from A",
+            alice_own,
+            b"alice",
+            bob,
+            bob_storage,
+            bob_commit,
+        )
+    } else {
+        (
+            bob,
+            bob_storage,
+            bob_commit,
+            "New name from B",
+            bob_own,
+            b"bob",
+            alice,
+            alice_storage,
+            alice_commit,
+        )
+    };
+    let winner_origin = match winner_own.as_slice() {
+        [(GroupStateChange::GroupRenamed { .. }, origin)] => origin.clone(),
+        other => panic!("expected exactly one attributed rename on the winner, got {other:?}"),
+    };
+
+    // The WINNER restarts: durable state survives, the in-memory
+    // `committed_from` guard does not, so the losing sibling commit routes
+    // into stored convergence. Its own confirmed commit must still compete
+    // there — realized from the confirm-time stamp + retained anchor — and
+    // win by the same authenticated ordering key the direct seam would use.
+    drop(winner);
+    let mut winner =
+        build_with_storage_and_peeler(winner_id, winner_storage.clone(), ephemeral_peeler());
+    winner.drain_events();
+    winner
+        .buffer_openmls_convergence_message(&gid, route_to_group(&loser_commit, &gid), 1_000)
+        .expect("losing sibling commit buffered on the restarted winner");
+    let result = winner
+        .converge_stored_openmls_messages(&gid, 1_000_000)
+        .expect("winner converges over the fork");
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    let winner_after = winner.drain_events();
+
+    // The winner's own branch was selected: canonical name and epoch are
+    // unchanged, and the losing sibling was dropped against the candidate
+    // state rather than applied.
+    assert_eq!(
+        winner_storage.get_group(&gid).unwrap().name,
+        winner_name,
+        "restarted winner must keep its own canonical rename, not be reorged \
+         onto the losing sibling"
+    );
+    assert_eq!(winner.epoch(&gid).unwrap().0, 2);
+    assert!(
+        result.dropped_messages.iter().any(|dropped| {
+            dropped.message_id == hex::encode(content_id(&loser_commit).as_slice())
+                && dropped.reason == DroppedMessageReason::InvalidAgainstCandidateState
+        }),
+        "losing sibling must be dropped against the selected candidate state, \
+         got {:?}",
+        result.dropped_messages
+    );
+
+    // No withdrawal may name the winner's own confirmed commit: its rename is
+    // canonical. (A withdrawal naming the never-applied sibling is fine —
+    // the app-side tombstone is a no-op there.)
+    let winner_invalidations = state_invalidations(&winner_after);
+    assert!(
+        !winner_invalidations
+            .iter()
+            .any(|(id, _)| id == &winner_origin),
+        "winner must not withdraw its own canonical rename, got {winner_invalidations:?} \
+         (own origin {winner_origin:?})"
+    );
+
+    // Resulting view on the winner: exactly its own rename, still attributed
+    // to the confirm-time stamped origin.
+    let mut winner_notifications = winner_own;
+    winner_notifications.extend(attributed_state_changes(&winner_after));
+    let surviving = surviving_state_changes(&winner_notifications, &winner_invalidations);
+    match surviving.as_slice() {
+        [(GroupStateChange::GroupRenamed { name, .. }, origin)] => {
+            assert_eq!(name, winner_name);
+            assert_eq!(origin, &winner_origin);
+        }
+        other => panic!(
+            "resulting view must hold exactly the winner's own rename, got {other:?} \
+             (invalidations {winner_invalidations:?})"
+        ),
+    }
+
+    // The never-restarted loser resolves the same fork on the direct seam and
+    // lands on the same canonical branch — no group-level fork.
+    let loser_outcome = loser
+        .ingest(route_to_group(&winner_commit, &gid))
+        .await
+        .unwrap();
+    assert!(
+        !matches!(loser_outcome, IngestOutcome::Stale { .. }),
+        "loser must apply the winning commit, got {loser_outcome:?}"
+    );
+    assert_eq!(loser_storage.get_group(&gid).unwrap().name, winner_name);
+    assert_eq!(
+        winner_storage.get_group(&gid).unwrap().name,
+        loser_storage.get_group(&gid).unwrap().name,
+        "both devices must converge to the same canonical branch"
+    );
+}
+
+/// Mutual-restart variant: BOTH concurrent committers restart before seeing
+/// each other's commit, so BOTH resolve the same-epoch fork through stored
+/// convergence with no in-memory state at all.
+///
+/// Before own confirmed commits could compete in branch selection, each
+/// device saw exactly one materializable candidate — the OTHER device's
+/// branch — so each deterministically reorged onto the other's commit and the
+/// group forked permanently (A ends on B's rename, B on A's). With the
+/// confirm-time stamp both devices score the same two candidates, pick the
+/// same winner by the authenticated ordering key, and converge.
+#[tokio::test]
+async fn mutually_rebuilt_engines_converge_on_same_branch_after_concurrent_renames() {
+    use cgka_traits::engine::{CommitOrderingKey, CommitOrderingPriority, GroupStateChange};
+
+    let (mut alice, alice_storage, mut bob, bob_storage, gid) =
+        create_admin_pair_with_peeler(ephemeral_peeler).await;
+    alice.drain_events();
+    bob.drain_events();
+
+    // Concurrent renames in the same epoch window; both confirmed locally.
+    let alice_res = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: gid.clone(),
+            name: Some("New name from A".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let bob_res = bob
+        .send(SendIntent::UpdateGroupData {
+            group_id: gid.clone(),
+            name: Some("New name from B".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (alice_commit, alice_pending) = match alice_res {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    let (bob_commit, bob_pending) = match bob_res {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(alice_pending).await.unwrap();
+    bob.confirm_published(bob_pending).await.unwrap();
+    let alice_own = attributed_state_changes(&alice.drain_events());
+    let bob_own = attributed_state_changes(&bob.drain_events());
+    let (alice_origin, bob_origin) = match (alice_own.as_slice(), bob_own.as_slice()) {
+        (
+            [(GroupStateChange::GroupRenamed { .. }, a_origin)],
+            [(GroupStateChange::GroupRenamed { .. }, b_origin)],
+        ) => (a_origin.clone(), b_origin.clone()),
+        other => panic!("expected exactly one attributed rename per committer, got {other:?}"),
+    };
+
+    let alice_key = CommitOrderingKey::from_commit_bytes(
+        cgka_traits::EpochId(1),
+        CommitOrderingPriority::Privileged,
+        alice.self_id(),
+        &alice_commit.payload,
+    );
+    let bob_key = CommitOrderingKey::from_commit_bytes(
+        cgka_traits::EpochId(1),
+        CommitOrderingPriority::Privileged,
+        bob.self_id(),
+        &bob_commit.payload,
+    );
+    let alice_wins = alice_key < bob_key;
+    let winner_name = if alice_wins {
+        "New name from A"
+    } else {
+        "New name from B"
+    };
+
+    // BOTH committers restart, then each learns of the other's commit only
+    // through stored convergence.
+    drop(alice);
+    drop(bob);
+    let mut alice =
+        build_with_storage_and_peeler(b"alice", alice_storage.clone(), ephemeral_peeler());
+    let mut bob = build_with_storage_and_peeler(b"bob", bob_storage.clone(), ephemeral_peeler());
+    alice.drain_events();
+    bob.drain_events();
+    alice
+        .buffer_openmls_convergence_message(&gid, route_to_group(&bob_commit, &gid), 1_000)
+        .expect("bob's sibling commit buffered on restarted alice");
+    bob.buffer_openmls_convergence_message(&gid, route_to_group(&alice_commit, &gid), 1_000)
+        .expect("alice's sibling commit buffered on restarted bob");
+    let alice_result = alice
+        .converge_stored_openmls_messages(&gid, 1_000_000)
+        .expect("alice converges over the fork");
+    let bob_result = bob
+        .converge_stored_openmls_messages(&gid, 1_000_000)
+        .expect("bob converges over the fork");
+    assert_eq!(alice_result.convergence_status, ConvergenceStatus::Settled);
+    assert_eq!(bob_result.convergence_status, ConvergenceStatus::Settled);
+    let alice_after = alice.drain_events();
+    let bob_after = bob.drain_events();
+
+    // The permanent-fork regression core: both devices settle on the SAME
+    // canonical branch — the deterministic ordering-key winner — instead of
+    // each selecting the other's branch.
+    assert_eq!(
+        alice_storage.get_group(&gid).unwrap().name,
+        bob_storage.get_group(&gid).unwrap().name,
+        "mutually restarted committers must converge on one canonical branch, \
+         not swap onto each other's"
+    );
+    assert_eq!(alice_storage.get_group(&gid).unwrap().name, winner_name);
+    assert_eq!(alice.epoch(&gid).unwrap().0, 2);
+    assert_eq!(bob.epoch(&gid).unwrap().0, 2);
+
+    // Exactly the losing committer withdraws its own confirmed rename, by the
+    // id its confirm-time rows were stamped with.
+    let (
+        loser_after,
+        loser_origin,
+        loser_own_notifications,
+        winner_after,
+        winner_origin,
+        winner_own_notifications,
+    ) = if alice_wins {
+        (
+            bob_after,
+            bob_origin,
+            bob_own,
+            alice_after,
+            alice_origin,
+            alice_own,
+        )
+    } else {
+        (
+            alice_after,
+            alice_origin,
+            alice_own,
+            bob_after,
+            bob_origin,
+            bob_own,
+        )
+    };
+    let loser_invalidations = state_invalidations(&loser_after);
+    assert!(
+        loser_invalidations
+            .iter()
+            .any(|(id, epoch)| id == &loser_origin && *epoch == cgka_traits::EpochId(1)),
+        "loser must withdraw its own confirmed commit by its stamped origin id, \
+         got {loser_invalidations:?} (stamped {loser_origin:?})"
+    );
+    let winner_invalidations = state_invalidations(&winner_after);
+    assert!(
+        !winner_invalidations
+            .iter()
+            .any(|(id, _)| id == &winner_origin),
+        "winner must not withdraw its own canonical rename, got {winner_invalidations:?} \
+         (own origin {winner_origin:?})"
+    );
+
+    // Resulting views: the winner keeps exactly its own rename; the loser
+    // ends with exactly the winner's rename (attributed to the winning
+    // commit's content id on the losing device).
+    let mut winner_notifications = winner_own_notifications;
+    winner_notifications.extend(attributed_state_changes(&winner_after));
+    let winner_surviving = surviving_state_changes(&winner_notifications, &winner_invalidations);
+    match winner_surviving.as_slice() {
+        [(GroupStateChange::GroupRenamed { name, .. }, origin)] => {
+            assert_eq!(name, winner_name);
+            assert_eq!(origin, &winner_origin);
+        }
+        other => panic!(
+            "winner's resulting view must hold exactly its own rename, got {other:?} \
+             (invalidations {winner_invalidations:?})"
+        ),
+    }
+    let winning_commit_content_id = if alice_wins {
+        content_id(&alice_commit)
+    } else {
+        content_id(&bob_commit)
+    };
+    let mut loser_notifications = loser_own_notifications;
+    loser_notifications.extend(attributed_state_changes(&loser_after));
+    let loser_surviving = surviving_state_changes(&loser_notifications, &loser_invalidations);
+    match loser_surviving.as_slice() {
+        [(GroupStateChange::GroupRenamed { name, .. }, origin)] => {
+            assert_eq!(name, winner_name);
+            assert_eq!(origin, &winning_commit_content_id);
+        }
+        other => panic!(
+            "loser's resulting view must hold exactly the winner's rename, got {other:?} \
+             (invalidations {loser_invalidations:?})"
+        ),
+    }
+}
+
 /// Sequential control: when the second rename builds on the first commit
 /// (no fork), both notifications are accurate history — two
 /// `GroupStateChanged` events, and no `GroupStateInvalidated` anywhere.

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -77,7 +77,7 @@ pub use error::{EngineError, PeelerError};
 pub use group::{Group, Member};
 pub use group_context::{GroupContext, GroupContextSnapshot, SecretBytes};
 pub use ingest::{IngestOutcome, PeeledContent, PeeledMessage, StaleReason};
-pub use message::{MessageRecord, MessageState, StoredMessagePayload};
+pub use message::{MessageRecord, MessageState, OwnCommitConvergenceStamp, StoredMessagePayload};
 pub use peeler::{GroupMessageMetadata, GroupMessageMetadataError, TransportPeeler};
 pub use storage::{
     CapabilityStorage, GroupStorage, LeaveRequest, LeaveRequestStorage, MessageStorage,

--- a/crates/traits/src/message.rs
+++ b/crates/traits/src/message.rs
@@ -5,9 +5,31 @@
 //! progresses. Kept here (and not inside the engine) so the storage backend
 //! can query "what's retryable?" without cracking engine internals.
 
+use crate::engine::CommitOrderingPriority;
 use crate::transport::TransportMessage;
-use crate::types::{EpochId, GroupId, MessageId};
+use crate::types::{EpochId, GroupId, MemberId, MessageId};
 use serde::{Deserialize, Serialize};
+
+/// Convergence-relevant ordering metadata for a commit this device published
+/// and confirmed, captured at confirm time (while the staged commit is still
+/// attached) and persisted alongside the stored wire bytes.
+///
+/// MLS cannot process a device's own commit through `process_message`, so
+/// after an engine restart the stored wire record is the ONLY source from
+/// which stored convergence can rebuild the own commit's branch-selection
+/// ordering key (priority + authenticated committer; the digest is recomputed
+/// from the stored bytes) and its consumed proposal references.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OwnCommitConvergenceStamp {
+    /// This device's member identity — the authenticated committer of the
+    /// stored commit.
+    pub committer: MemberId,
+    /// Authorization-aware ordering priority derived from the staged commit's
+    /// shape at confirm time.
+    pub priority: CommitOrderingPriority,
+    /// Hex-encoded proposal references the commit consumed, in sorted order.
+    pub consumed_proposal_refs: Vec<String>,
+}
 
 /// Typed envelope for the opaque bytes stored in [`MessageRecord::payload`].
 ///
@@ -18,13 +40,21 @@ use serde::{Deserialize, Serialize};
 /// - `RawTransport`: original transport-wrapped message. Used when peeling is
 ///   deferred or the engine needs to retry with a different epoch context.
 /// - `OpenMlsWire`: transport metadata plus payload replaced with peeled MLS
-///   wire bytes. Only this variant is eligible for OpenMLS projection and
-///   convergence replay.
+///   wire bytes. Only this variant and `OwnCommitWire` are eligible for
+///   OpenMLS projection and convergence replay.
+/// - `OwnCommitWire`: an `OpenMlsWire` commit this device published and
+///   confirmed, enriched with its [`OwnCommitConvergenceStamp`] so stored
+///   convergence can treat it as a pre-validated candidate branch after a
+///   restart.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "message", rename_all = "snake_case")]
 pub enum StoredMessagePayload {
     RawTransport(TransportMessage),
     OpenMlsWire(TransportMessage),
+    OwnCommitWire {
+        message: TransportMessage,
+        stamp: OwnCommitConvergenceStamp,
+    },
 }
 
 impl StoredMessagePayload {
@@ -34,6 +64,10 @@ impl StoredMessagePayload {
 
     pub fn openmls_wire(message: TransportMessage) -> Self {
         Self::OpenMlsWire(message)
+    }
+
+    pub fn own_commit_wire(message: TransportMessage, stamp: OwnCommitConvergenceStamp) -> Self {
+        Self::OwnCommitWire { message, stamp }
     }
 
     pub fn encode(&self) -> Result<Vec<u8>, serde_json::Error> {
@@ -53,20 +87,31 @@ impl StoredMessagePayload {
     pub fn as_raw_transport(&self) -> Option<&TransportMessage> {
         match self {
             Self::RawTransport(message) => Some(message),
-            Self::OpenMlsWire(_) => None,
+            Self::OpenMlsWire(_) | Self::OwnCommitWire { .. } => None,
         }
     }
 
     pub fn as_openmls_wire(&self) -> Option<&TransportMessage> {
         match self {
             Self::RawTransport(_) => None,
-            Self::OpenMlsWire(message) => Some(message),
+            Self::OpenMlsWire(message) | Self::OwnCommitWire { message, .. } => Some(message),
+        }
+    }
+
+    /// The confirm-time convergence stamp, when this payload is an own
+    /// published-and-confirmed commit.
+    pub fn own_commit_stamp(&self) -> Option<&OwnCommitConvergenceStamp> {
+        match self {
+            Self::RawTransport(_) | Self::OpenMlsWire(_) => None,
+            Self::OwnCommitWire { stamp, .. } => Some(stamp),
         }
     }
 
     pub fn into_message(self) -> TransportMessage {
         match self {
-            Self::RawTransport(message) | Self::OpenMlsWire(message) => message,
+            Self::RawTransport(message)
+            | Self::OpenMlsWire(message)
+            | Self::OwnCommitWire { message, .. } => message,
         }
     }
 }

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -268,6 +268,38 @@ fn stored_message_payload_distinguishes_raw_and_openmls_wire() {
 }
 
 #[test]
+fn stored_message_payload_own_commit_wire_round_trips_with_stamp() {
+    use cgka_traits::engine::CommitOrderingPriority;
+    use cgka_traits::message::OwnCommitConvergenceStamp;
+
+    let message = TransportMessage {
+        id: mid(),
+        payload: vec![0xAB, 0xCD],
+        timestamp: Timestamp(1717171717),
+        causal_deps: vec![],
+        source: TransportSource("nostr".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: vec![0xCC; 4],
+        },
+    };
+    let stamp = OwnCommitConvergenceStamp {
+        committer: MemberId::new(vec![0xEE; 32]),
+        priority: CommitOrderingPriority::Privileged,
+        consumed_proposal_refs: vec!["0a0b".into()],
+    };
+    let payload = StoredMessagePayload::own_commit_wire(message.clone(), stamp.clone());
+
+    insta::assert_json_snapshot!("stored_payload_own_commit_wire", payload);
+
+    let decoded = StoredMessagePayload::decode(&payload.encode().unwrap()).unwrap();
+    // Convergence replay reads the same wire message as a plain OpenMlsWire row;
+    // the stamp rides alongside for own-branch materialization.
+    assert_eq!(decoded.as_openmls_wire().unwrap(), &message);
+    assert_eq!(decoded.own_commit_stamp().unwrap(), &stamp);
+    assert!(decoded.as_raw_transport().is_none());
+}
+
+#[test]
 fn stored_message_payload_decodes_legacy_transport_message_as_openmls_wire() {
     let legacy = TransportMessage {
         id: mid(),

--- a/crates/traits/tests/snapshots/snapshots__stored_payload_own_commit_wire.snap
+++ b/crates/traits/tests/snapshots/snapshots__stored_payload_own_commit_wire.snap
@@ -1,0 +1,75 @@
+---
+source: crates/traits/tests/snapshots.rs
+assertion_line: 292
+expression: payload
+---
+{
+  "kind": "own_commit_wire",
+  "message": {
+    "message": {
+      "id": [
+        187,
+        187,
+        187,
+        187
+      ],
+      "payload": [
+        171,
+        205
+      ],
+      "timestamp": 1717171717,
+      "causal_deps": [],
+      "source": "nostr",
+      "envelope": {
+        "GroupMessage": {
+          "transport_group_id": [
+            204,
+            204,
+            204,
+            204
+          ]
+        }
+      }
+    },
+    "stamp": {
+      "committer": [
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238,
+        238
+      ],
+      "priority": "privileged",
+      "consumed_proposal_refs": [
+        "0a0b"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes #706.

A device's own published-and-confirmed commit cannot be replayed through OpenMLS `process_message`, so after an engine restart cleared the in-memory `committed_from` guard, its branch silently dropped out of stored-convergence branch selection: a losing same-epoch sibling was selected even when the own commit's authenticated ordering key should win, and when both concurrent committers restarted, each deterministically reorged onto the other's branch — a permanent group fork.

### What this does

1. **Confirm-time stamp** (`crates/traits/src/message.rs`, `crates/cgka-engine/src/publish.rs`): new `StoredMessagePayload::OwnCommitWire { message, stamp }` variant carrying `OwnCommitConvergenceStamp { committer, priority, consumed_proposal_refs }`. `do_confirm_published` captures it while the staged commit is still attached and enriches the stored wire record in the same durable write that marks it `Processed`. Convergence replay still reads the record as a plain wire row; the stamp rides alongside.
2. **Anchor rollforward during candidate materialization** (`crates/cgka-engine/src/openmls_projection.rs`): when a replayed candidate path reaches a stamped own commit and every commit replayed before it was canonical (`Processed`), the group is rolled forward to the retained anchor snapshot at the commit's resulting epoch — the exact post-merge state the confirm path retains — and its `CommitStaged` observation is synthesized from the stamp. Any failure (missing anchor, epoch mismatch, non-canonical prefix) prunes the branch exactly as before, so the change is strictly additive.
3. **Already-applied prefix skip at apply**: the selected branch's leading run of `Processed` commits below the live tip is the live canonical chain; it is excluded from the apply replay and the apply-start epoch moves past it. An own-branch win applies without re-processing own commits (no-op on group state); an own-branch loss keeps the existing rollback-to-anchor + replay path.

With both branches materialized, selection and withdrawal compose with #702: a losing own branch is dropped `InvalidAgainstCandidateState` and withdrawn via `emit_rolled_back_commits` under the same confirm-time stamped origin id; `emit_superseded_processed_commits` remains the backstop for own commits that never materialized (pre-stamp records).

### Tests

- `rebuilt_engine_convergence_keeps_own_confirmed_rename_when_it_wins_selection` — restart-WINNER variant: without the fix the losing sibling is wrongly selected and the device reorgs off its own canonical branch.
- `mutually_rebuilt_engines_converge_on_same_branch_after_concurrent_renames` — mutual-restart variant: without the fix both devices swap onto each other's branch (verified: disabling the stamp collection reproduces the fork with exactly that failure).
- JSON shape snapshot for the new payload variant; `publish_lifecycle` fault-injection extended to cover the enriched `Processed` write.

`just fast-ci` green; `cgka-engine`, `cgka-traits`, `storage-sqlite`, and `cgka-conformance-simulator` suites pass on this branch rebased onto current master (includes #701/#702/#703/#704).

### Residual edges (documented in #706)

Sent-but-never-confirmed own commits still prune (no stamp, no post-merge anchor); pre-fix records keep the old behavior with #702's backstop; an accepted fork-epoch proposal below a skipped prefix can fail apply-replay cleanly (snapshot rolls back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/723">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stored convergence now preserves metadata for confirmed own commits, improving how restarted devices reconcile their latest changes.
  * Confirmed commits can be replayed more reliably from local storage without being reprocessed incorrectly.

* **Bug Fixes**
  * Fixed branch selection issues after restart so a device is less likely to switch away from its own confirmed commit.
  * Improved handling of persisted message processing to avoid duplicate replay of already-applied commits.
  * Strengthened retry behavior for transient write failures during publish confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->