### PR TITLE
Clear removed marker when branch selection supersedes the local member's removal

### DIFF
--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -632,6 +632,40 @@ impl<S: StorageProvider> Engine<S> {
             );
         }
         if current_ids.contains(self.identity.self_id()) {
+            // The selected canonical branch records our membership, so a
+            // `removed` marker on the record is inconsistent with canonical
+            // state and must clear: a previously applied removal that lost
+            // branch selection "MUST NOT remain visible to the application as
+            // a completed change" (convergence.md, "Applying the selected
+            // branch"), and member-departure.md's "terminal for that group
+            // copy" rule presumes removal evidence on the selected canonical
+            // branch (clarification tracked in marmot-protocol/marmot#220).
+            // A reorg normally already restored the pre-removal
+            // record from the retained anchor before the replay (the anchor
+            // predates the marker write), so this is the explicit
+            // state-derived inverse of `realize_self_eviction`: it reconciles
+            // the pathological copy whose marker survived without canonical
+            // evidence, and keeps the send-gate posture derivable from
+            // canonical state alone. Outbound intents purged at realization
+            // stay purged — the app re-issues sends against the reopened
+            // send gate.
+            let mut group = self
+                .storage
+                .get_group(group_id)
+                .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+            if group.removed {
+                group.removed = false;
+                self.storage
+                    .put_group(&group)
+                    .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+                // Privacy-safe breadcrumb: aggregate signal only, no
+                // group/member ids (observability.md).
+                tracing::info!(
+                    target: "cgka_engine::distributed_convergence",
+                    method = "emit_convergence_events",
+                    "cleared removed marker: selected canonical branch records local membership"
+                );
+            }
             if self
                 .load_leave_request_state(group_id)
                 .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -568,6 +568,10 @@ impl<S: StorageProvider> Engine<S> {
                 );
             }
         }
+        // Captured before `current_group.members` is consumed below: gates the
+        // removed-marker reconciliation so the common (not-removed) path pays
+        // no extra storage read.
+        let group_record_was_removed = current_group.removed;
         let previous_ids: HashSet<MemberId> = previous_members
             .iter()
             .map(|member| member.id.clone())
@@ -648,23 +652,28 @@ impl<S: StorageProvider> Engine<S> {
             // evidence, and keeps the send-gate posture derivable from
             // canonical state alone. Outbound intents purged at realization
             // stay purged — the app re-issues sends against the reopened
-            // send gate.
-            let mut group = self
-                .storage
-                .get_group(group_id)
-                .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
-            if group.removed {
-                group.removed = false;
-                self.storage
-                    .put_group(&group)
+            // send gate. Gated on the record snapshot loaded above so the
+            // common (not-removed) path re-reads nothing; the re-fetch on the
+            // rare marked path re-checks under the fresh record before
+            // writing.
+            if group_record_was_removed {
+                let mut group = self
+                    .storage
+                    .get_group(group_id)
                     .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
-                // Privacy-safe breadcrumb: aggregate signal only, no
-                // group/member ids (observability.md).
-                tracing::info!(
-                    target: "cgka_engine::distributed_convergence",
-                    method = "emit_convergence_events",
-                    "cleared removed marker: selected canonical branch records local membership"
-                );
+                if group.removed {
+                    group.removed = false;
+                    self.storage
+                        .put_group(&group)
+                        .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+                    // Privacy-safe breadcrumb: aggregate signal only, no
+                    // group/member ids (observability.md).
+                    tracing::info!(
+                        target: "cgka_engine::distributed_convergence",
+                        method = "emit_convergence_events",
+                        "cleared removed marker: selected canonical branch records local membership"
+                    );
+                }
             }
             if self
                 .load_leave_request_state(group_id)

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -1,4 +1,25 @@
 //! Engine entry point for stored-message distributed convergence.
+//!
+//! # Removed-marker lifecycle
+//!
+//! `Group.removed` realizes the local member's own removal
+//! (member-departure.md, "Realizing removal"): it is set when an accepted
+//! commit on the selected canonical branch removes our leaf — on the direct
+//! seam, via `realize_self_eviction`, or in `emit_convergence_events` here —
+//! and it clears in exactly two ways: an authenticated re-join
+//! (`do_join_welcome`), or branch selection superseding the removal that set
+//! it. A superseded removal was never canonically applied, so it "MUST NOT
+//! remain visible to the application as a completed change" (convergence.md,
+//! "Applying the selected branch"); member-departure.md's "terminal for that
+//! group copy" rule presumes the removal stays canonical (clarification
+//! tracked in marmot-protocol/marmot#220). A supersession reorg normally
+//! restores the pre-removal record wholesale from the retained anchor (the
+//! anchor predates the marker write); the explicit reconciliation in
+//! `emit_convergence_events` is the state-derived inverse of
+//! `realize_self_eviction` for markers no anchor restore can see, and it
+//! clears only when the canonical roster AND the live MLS state both record
+//! our active membership. Outbound intents purged at realization stay purged
+//! — the app re-issues sends against the reopened send gate.
 
 use std::collections::HashSet;
 
@@ -492,6 +513,38 @@ impl<S: StorageProvider> Engine<S> {
         ))
     }
 
+    /// Whether the live OpenMLS group state records the local member as an
+    /// active member: the group loads, is active, and its own leaf carries
+    /// the engine's identity. Fail-closed (`false`) on any missing or
+    /// unreadable state, so callers gating a safety-relevant transition on
+    /// canonical membership never act on a copy MLS itself would refuse.
+    fn self_leaf_is_active_in_mls(&self, group_id: &GroupId) -> bool {
+        let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
+            &self.crypto,
+            self.storage.mls_storage(),
+        );
+        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+        let Ok(Some(mls_group)) = openmls::group::MlsGroup::load(
+            <crate::provider::EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(
+                &provider,
+            ),
+            &mls_gid,
+        ) else {
+            return false;
+        };
+        if !mls_group.is_active() {
+            return false;
+        }
+        let Some(leaf) = mls_group.own_leaf_node() else {
+            return false;
+        };
+        let Ok(credential) = openmls::prelude::BasicCredential::try_from(leaf.credential().clone())
+        else {
+            return false;
+        };
+        credential.identity() == self.identity.self_id().as_slice()
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn emit_convergence_events(
         &mut self,
@@ -637,26 +690,13 @@ impl<S: StorageProvider> Engine<S> {
         }
         if current_ids.contains(self.identity.self_id()) {
             // The selected canonical branch records our membership, so a
-            // `removed` marker on the record is inconsistent with canonical
-            // state and must clear: a previously applied removal that lost
-            // branch selection "MUST NOT remain visible to the application as
-            // a completed change" (convergence.md, "Applying the selected
-            // branch"), and member-departure.md's "terminal for that group
-            // copy" rule presumes removal evidence on the selected canonical
-            // branch (clarification tracked in marmot-protocol/marmot#220).
-            // A reorg normally already restored the pre-removal
-            // record from the retained anchor before the replay (the anchor
-            // predates the marker write), so this is the explicit
-            // state-derived inverse of `realize_self_eviction`: it reconciles
-            // the pathological copy whose marker survived without canonical
-            // evidence, and keeps the send-gate posture derivable from
-            // canonical state alone. Outbound intents purged at realization
-            // stay purged — the app re-issues sends against the reopened
-            // send gate. Gated on the record snapshot loaded above so the
-            // common (not-removed) path re-reads nothing; the re-fetch on the
-            // rare marked path re-checks under the fresh record before
-            // writing.
-            if group_record_was_removed {
+            // surviving `removed` marker must clear (module docs, "Removed-
+            // marker lifecycle"; marmot-protocol/marmot#220). Gated on the
+            // record snapshot loaded above (no extra read on the common
+            // not-removed path) AND on the live MLS state carrying our
+            // active leaf, so the heal stays derivable from canonical MLS
+            // state even if the record roster were ever stale.
+            if group_record_was_removed && self.self_leaf_is_active_in_mls(group_id) {
                 let mut group = self
                     .storage
                     .get_group(group_id)

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -954,8 +954,11 @@ impl<S: StorageProvider> Engine<S> {
     /// self-eviction; member-departure.md "Realizing removal"). A removed copy
     /// is terminal for outbound work: nothing may be prepared or published for
     /// it. Unknown groups report `false` — callers fail them with their own
-    /// unknown-group handling. The marker clears only through an authenticated
-    /// re-join (`do_join_welcome` rebuilds the record).
+    /// unknown-group handling. The marker clears through an authenticated
+    /// re-join (`do_join_welcome` rebuilds the record) or when branch
+    /// selection supersedes the removal that set it — the convergence reorg
+    /// path re-derives membership from the selected canonical branch
+    /// (`emit_convergence_events`).
     pub(crate) fn group_record_is_removed(&self, group_id: &GroupId) -> Result<bool, EngineError> {
         match self.storage.get_group(group_id) {
             Ok(group) => Ok(group.removed),

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -1937,6 +1937,121 @@ async fn convergence_apply_clears_removed_marker_without_canonical_evidence() {
     send_app(&mut carol, &group_id, b"send after healing".to_vec()).await;
 }
 
+/// Sibling of the test above with the FULL post-`realize_self_eviction`
+/// record shape: `removed = true` AND self stripped from `Group.members`,
+/// while the live MLS state (the canonical evidence) still records our
+/// active leaf. The convergence apply rebuilds the roster from the replayed
+/// MLS state and the reconciliation guard clears the marker, so the heal
+/// works even when the record looked fully evicted before the replay
+/// refreshed it.
+#[tokio::test]
+async fn convergence_apply_heals_fully_evicted_shaped_record() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage) = build_client(b"carol");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-heal-evicted-record".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    carol.drain_events();
+
+    // Pathological copy mirroring the shape `realize_self_eviction` writes
+    // (marker + roster reconciliation in one record), but WITHOUT any
+    // removal in MLS state: the canonical evidence still records our leaf.
+    let mut record = carol_storage.get_group(&group_id).unwrap();
+    record.removed = true;
+    let self_id = carol.self_id();
+    record.members.retain(|member| member.id != self_id);
+    carol_storage.put_group(&record).unwrap();
+    let payload = app_payload_for(&carol, b"blocked by evicted-shaped record");
+    let gate = carol
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload,
+        })
+        .await;
+    assert!(
+        matches!(
+            &gate,
+            Err(cgka_traits::error::EngineError::InvalidTransition(t)) if t.from == "Removed"
+        ),
+        "marked copy must reject sends, got {gate:?}"
+    );
+
+    let rename_res = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("healed from evicted shape".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (rename_commit, rename_pending) = evolution(rename_res);
+    alice.confirm_published(rename_pending).await.unwrap();
+    let rename_commit = route(rename_commit, &group_id);
+    carol
+        .buffer_openmls_convergence_message(&group_id, rename_commit.clone(), 1_000)
+        .expect("rename commit buffered");
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("forward apply converges");
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    assert_eq!(result.accepted_commits, vec![content_hex(&rename_commit)]);
+
+    let group = carol_storage.get_group(&group_id).unwrap();
+    assert!(
+        !group.removed,
+        "convergence apply must clear a marker the canonical MLS state contradicts"
+    );
+    assert_eq!(group.name, "healed from evicted shape");
+    assert!(
+        group.members.iter().any(|m| m.id == carol.self_id()),
+        "replay must rebuild the roster from canonical MLS state"
+    );
+    // The stale record presented us as absent, so the apply re-announces our
+    // membership as a roster-correction row.
+    let events = carol.drain_events();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            GroupEvent::GroupStateChanged {
+                group_id: g,
+                change: cgka_traits::engine::GroupStateChange::MemberAdded { member },
+                ..
+            } if g == &group_id && *member == carol.self_id()
+        )),
+        "expected roster-correction MemberAdded for self, got {events:?}"
+    );
+    send_app(
+        &mut carol,
+        &group_id,
+        b"send after evicted-shape heal".to_vec(),
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn engine_does_not_apply_stored_branch_before_stability_gate() {
     let (mut alice, _alice_storage) = build_client(b"alice");

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -1612,6 +1612,331 @@ async fn convergence_rollback_emits_commit_rolled_back_for_losing_branch() {
     );
 }
 
+/// A commit that removes the LOCAL member's own leaf is applied (realizing
+/// removal: `Group.removed` set, send gate closed, group presented as
+/// removed), then LOSES branch selection to a same-epoch sibling through
+/// stored convergence. The realized removal was never canonically applied,
+/// so it "MUST NOT remain visible to the application as a completed change"
+/// (convergence.md, "Applying the selected branch") — member-departure.md's
+/// terminal-marker rule presumes removal evidence "on the selected canonical
+/// branch". This test pins the whole resulting view of that supersession:
+/// the withdrawal names the superseded removal in the id space the
+/// self-removed notification was stamped with, the copy stops
+/// self-quarantining (marker cleared, membership and the winner's rename
+/// presented), and the send gate reopens.
+#[tokio::test]
+async fn superseded_self_removal_clears_removed_marker_and_restores_send() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage) = build_client(b"carol");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-superseded-self-removal".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    carol.set_convergence_policy(CanonicalizationPolicy {
+        convergence: ConvergencePolicy {
+            max_rewind_commits: 1,
+            ..ConvergencePolicy::default()
+        },
+        ..CanonicalizationPolicy::default()
+    });
+    carol.drain_events();
+
+    // Same-epoch fork by the two admins: one removes Carol, the other renames
+    // the group. Both commit shapes are admin-gated (Privileged), so the
+    // authenticated committer tie-break decides branch selection — give the
+    // rename to the winning committer so the REMOVAL deterministically loses.
+    let (mut renamer, mut remover) =
+        if commit_tiebreak_winner_index(&alice.self_id(), &bob.self_id()) == 0 {
+            (alice, bob)
+        } else {
+            (bob, alice)
+        };
+    let remove_res = remover
+        .send(SendIntent::RemoveMembers {
+            group_id: group_id.clone(),
+            members: vec![carol.self_id()],
+        })
+        .await
+        .unwrap();
+    let (remove_commit, remove_pending) = evolution(remove_res);
+    remover.confirm_published(remove_pending).await.unwrap();
+    let rename_res = renamer
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("name after reorg".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (rename_commit, rename_pending) = evolution(rename_res);
+    renamer.confirm_published(rename_pending).await.unwrap();
+    let remove_commit = route(remove_commit, &group_id);
+    let rename_commit = route(rename_commit, &group_id);
+
+    // Carol's copy applies the removal: the inbound commit is buffered for the
+    // convergence quiescence window, then the convergence apply realizes the
+    // removal (marker + self-removed notification, the seam #703 added at
+    // `emit_convergence_events`).
+    let outcome = carol.ingest(remove_commit.clone()).await.unwrap();
+    assert!(
+        matches!(outcome, IngestOutcome::Buffered { .. }),
+        "removal commit buffers for convergence, got {outcome:?}"
+    );
+    let applied = carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("removal branch applies");
+    assert_eq!(applied.convergence_status, ConvergenceStatus::Settled);
+    assert_eq!(applied.accepted_commits, vec![content_hex(&remove_commit)]);
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(2));
+    let removal_events = carol.drain_events();
+    let self_removed_origin = removal_events
+        .iter()
+        .find_map(|event| match event {
+            GroupEvent::GroupStateChanged {
+                change: cgka_traits::engine::GroupStateChange::MemberRemoved { member },
+                origin_commit_id,
+                ..
+            } if *member == carol.self_id() => origin_commit_id.clone(),
+            _ => None,
+        })
+        .expect("self-removed state notification carries an origin commit");
+    assert_eq!(self_removed_origin, content_id(&remove_commit));
+    assert!(
+        carol_storage.get_group(&group_id).unwrap().removed,
+        "applying the removal marks the local copy removed"
+    );
+    // The removed-copy send gate quarantines outbound work.
+    let payload = app_payload_for(&carol, b"blocked while removed");
+    let gate = carol
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload,
+        })
+        .await;
+    assert!(
+        matches!(
+            &gate,
+            Err(cgka_traits::error::EngineError::InvalidTransition(t)) if t.from == "Removed"
+        ),
+        "removed copy must reject sends, got {gate:?}"
+    );
+
+    // The winning same-epoch sibling arrives through stored convergence: the
+    // direct seam classifies every further input `SelfEvicted` once the copy
+    // is removed, so this is the stored-message path (e.g. a session-layer
+    // replay after restart).
+    carol
+        .buffer_openmls_convergence_message(&group_id, rename_commit.clone(), 1_001_000)
+        .expect("sibling rename commit buffered");
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 3_000_000)
+        .expect("reorg over the superseded removal");
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    assert_eq!(result.accepted_commits, vec![content_hex(&rename_commit)]);
+    assert_message_state(
+        &carol_storage,
+        &remove_commit,
+        MessageState::EpochInvalidated,
+    );
+
+    // Final presented state: the removal never canonically happened. The copy
+    // is a member again, presents the winner's rename, and is NOT removed.
+    let group = carol_storage.get_group(&group_id).unwrap();
+    assert!(
+        !group.removed,
+        "superseded removal must clear the removed marker"
+    );
+    assert_eq!(group.name, "name after reorg");
+    assert_eq!(group.epoch, EpochId(2));
+    assert!(group.members.iter().any(|m| m.id == carol.self_id()));
+    assert!(
+        carol
+            .members(&group_id)
+            .unwrap()
+            .iter()
+            .any(|m| m.id == carol.self_id())
+    );
+
+    let events = carol.drain_events();
+    // The withdrawal names the superseded removal in the SAME id space the
+    // self-removed notification was stamped with, so the app tombstones that
+    // row: the removal is treated as not having happened.
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            GroupEvent::GroupStateInvalidated {
+                group_id: g,
+                epoch,
+                invalidated_commit_id,
+                reason: cgka_traits::engine::GroupStateInvalidationReason::SupersededByBranchSelection,
+            } if g == &group_id && *invalidated_commit_id == self_removed_origin && epoch.0 == 1
+        )),
+        "expected withdrawal naming the superseded removal, got {events:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            GroupEvent::CommitRolledBack { group_id: g, invalidated_commit_id }
+                if g == &group_id && *invalidated_commit_id == content_id(&remove_commit)
+        )),
+        "expected CommitRolledBack for the superseded removal, got {events:?}"
+    );
+    // The winning rename is never withdrawn, and no direct-seam ForkRecovered
+    // fires on the stored-convergence path.
+    assert!(
+        !events.iter().any(|event| matches!(
+            event,
+            GroupEvent::GroupStateInvalidated { invalidated_commit_id, .. }
+                if *invalidated_commit_id == content_id(&rename_commit)
+        )),
+        "the accepted rename must not be withdrawn, got {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, GroupEvent::ForkRecovered { .. })),
+        "stored convergence must not emit ForkRecovered, got {events:?}"
+    );
+    // Roster correction: the reorg diff re-announces our membership relative
+    // to the previously presented (removed) roster, attributed to the
+    // accepted commit that drove the pass.
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            GroupEvent::GroupStateChanged {
+                group_id: g,
+                change: cgka_traits::engine::GroupStateChange::MemberAdded { member },
+                origin_commit_id: Some(origin),
+                ..
+            } if g == &group_id
+                && *member == carol.self_id()
+                && *origin == content_id(&rename_commit)
+        )),
+        "expected roster-correction MemberAdded for self, got {events:?}"
+    );
+
+    // Send eligibility is restored: the intent the removed-copy gate rejected
+    // above now succeeds.
+    send_app(&mut carol, &group_id, b"post-reorg send".to_vec()).await;
+}
+
+/// State-derived inverse of `realize_self_eviction`: a `removed` marker that
+/// survives WITHOUT canonical evidence — the selected canonical branch
+/// records our membership — is reconciled by the next convergence apply. The
+/// marker is forced directly on the record to simulate the pathological
+/// copy: a real supersession reorg already restores the pre-removal record
+/// from the retained anchor (covered by
+/// `superseded_self_removal_clears_removed_marker_and_restores_send`); this
+/// pins the explicit guard for a marker no anchor restore can see.
+#[tokio::test]
+async fn convergence_apply_clears_removed_marker_without_canonical_evidence() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage) = build_client(b"carol");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-heal-removed-marker".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    carol.drain_events();
+
+    // Pathological copy: marker set while canonical state (active MLS group,
+    // roster with our leaf) records membership — no removal was ever applied.
+    let mut record = carol_storage.get_group(&group_id).unwrap();
+    record.removed = true;
+    carol_storage.put_group(&record).unwrap();
+    let payload = app_payload_for(&carol, b"blocked by pathological marker");
+    let gate = carol
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload,
+        })
+        .await;
+    assert!(
+        matches!(
+            &gate,
+            Err(cgka_traits::error::EngineError::InvalidTransition(t)) if t.from == "Removed"
+        ),
+        "marked copy must reject sends, got {gate:?}"
+    );
+
+    // An ordinary accepted commit converges (forward apply, no reorg): the
+    // selected canonical branch still records our membership, so the apply
+    // reconciles the marker.
+    let rename_res = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("healed".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (rename_commit, rename_pending) = evolution(rename_res);
+    alice.confirm_published(rename_pending).await.unwrap();
+    let rename_commit = route(rename_commit, &group_id);
+    carol
+        .buffer_openmls_convergence_message(&group_id, rename_commit.clone(), 1_000)
+        .expect("rename commit buffered");
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("forward apply converges");
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    assert_eq!(result.accepted_commits, vec![content_hex(&rename_commit)]);
+
+    let group = carol_storage.get_group(&group_id).unwrap();
+    assert!(
+        !group.removed,
+        "convergence apply must clear a marker the canonical roster contradicts"
+    );
+    assert_eq!(group.name, "healed");
+    assert!(group.members.iter().any(|m| m.id == carol.self_id()));
+    send_app(&mut carol, &group_id, b"send after healing".to_vec()).await;
+}
+
 #[tokio::test]
 async fn engine_does_not_apply_stored_branch_before_stability_gate() {
     let (mut alice, _alice_storage) = build_client(b"alice");

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -23,6 +23,11 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 - `dmd` now buffers daemon request frames before scanning for the newline delimiter, avoiding one async `read()` call per
   byte for large `Execute` requests while preserving the existing 1 MiB request cap and stalled-client timeout.
+- A group copy that realized your own removal no longer stays self-quarantined when the removing commit later loses
+  branch selection: the convergence apply clears the removed marker whenever the selected canonical branch records your
+  membership, so `message send` works again on that group instead of failing `invalid_transition` ("local group copy is
+  marked removed"). The removal's system rows are withdrawn through the existing invalidation event; rejoining via a new
+  Welcome is only required while the removal remains canonical.
 
 ### Changed
 

--- a/crates/traits/src/group.rs
+++ b/crates/traits/src/group.rs
@@ -27,7 +27,12 @@ pub struct Group {
     /// flag is the idempotence marker for the realization obligation: it is
     /// set together with the self-removed state notification, so later input
     /// classified `SelfEvicted` does not re-emit the notification. Terminal
-    /// for the group on this client. Defaults to `false` for records
+    /// for the group on this client while the removal stays canonical; it
+    /// clears on an authenticated re-join, or when branch selection
+    /// supersedes the removal that set it — the selected canonical branch
+    /// then records the local member's membership, so the removal "is treated
+    /// as not having happened" (spec `protocol-core/convergence.md`,
+    /// "Applying the selected branch"). Defaults to `false` for records
     /// persisted before this field existed.
     #[serde(default)]
     pub removed: bool,


### PR DESCRIPTION
## What

Handles the #702 × #703 interaction left out of scope during the #702 merge: a commit that removes the local member's own leaf is applied (realizing removal — `Group.removed` set, send gate closed, group presented as removed), and that commit later **loses branch selection**. The withdrawal machinery from #702 already retracts the self-removed notification; this PR pins the marker semantics so the device does not stay self-quarantined for a group it canonically still belongs to.

- `distributed_convergence::emit_convergence_events`: when the selected canonical branch records the local member's membership, a surviving `removed` marker is cleared — the explicit, state-derived inverse of `realize_self_eviction`. Outbound intents purged at realization stay purged; the app re-issues sends against the reopened gate.
- Doc updates in `engine.rs` / `traits::Group`: the marker is terminal only while the removal remains canonical; it clears via authenticated re-join **or** supersession of the removal that set it.
- CLI CHANGELOG (Unreleased/Fixed): sends work again on such a group instead of failing `invalid_transition` forever.

## Spec basis

member-departure.md defines removal evidence as "an accepted commit **on the selected canonical branch** … recorded in retained canonical state" and makes realization state-derived; convergence.md ("Applying the selected branch") requires that a change that lost branch selection "MUST NOT remain visible to the application as a completed change". A superseded removal was never canonically applied, so clearing is spec-required, not a violation of the "terminal for that group copy" rule — that rule presumes the removal stays canonical. Since the terminal sentence can be misread as unconditional, a spec clarification is filed as marmot-protocol/marmot#220.

## What a reviewer should know

**The marker could not actually survive a convergence reorg on master.** The reorg apply rolls back to the retained anchor before replaying the winner, and SQLite group snapshots capture the whole group record — so the anchor restore already reset `removed: false` incidentally (see `snapshot_rollback_restores_group_messages_queue_caps_and_openmls_group_state`). The resulting view was spec-correct, but only as an undocumented side effect of snapshot mechanics; a future change narrowing snapshot scope (plausible, if someone deliberately preserves the "terminal" marker across rollbacks) would silently reintroduce the quarantine bug. This PR makes the invariant explicit in code, docs, and tests.

## Tests

- `superseded_self_removal_clears_removed_marker_and_restores_send` — the previously untested scenario end-to-end: Carol applies a peer commit removing her own leaf (marker set, send rejected with the `Removed` invalid-transition, self-removed notification emitted), then the removal loses a same-epoch fork to a rename through stored convergence. Asserts the full resulting view: withdrawal names the superseded removal in the stamped id space, `CommitRolledBack` fires, no `ForkRecovered`, marker cleared, membership + the winner's rename presented, roster-correction `MemberAdded` emitted, and the previously rejected send succeeds. Passes with or without the code change — it pins the behavior against regressions in either mechanism (anchor restore or explicit clear).
- `convergence_apply_clears_removed_marker_without_canonical_evidence` — covers the explicit reconciliation branch directly (marker forced on the record, mirroring the existing pathological-copy tests in `invite_leave.rs`); fails without the fix.

Verified: both new tests, full `cargo test -p cgka-engine`, `cargo test -p cgka-traits`, `just fast-ci`, `cargo fmt --check`.

Related: the open post-restart own-commit branch-selection investigation is how this scenario becomes reachable in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/724">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed groups now clear their “removed” marker when later convergence indicates the device is still an active member.
  * App sending eligibility is restored after convergence reorg/branch selection supersedes a prior self-removal state.
  * Superseded self-removal no longer leaves the group copy incorrectly self-quarantined.
* **Tests**
  * Added regression tests covering removed-marker reconciliation across stored-convergence apply/reorg edge cases.
* **Documentation**
  * Updated the changelog and expanded “removed” marker documentation to clarify all clearing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->