### PR TITLE
Close out #707: mirror ingest invariants on every seam, enforce quarantine, bound the deferred-peel lifecycle

### DIFF
--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -1432,6 +1432,7 @@ fn dummy_group(group_id: GroupId) -> Group {
         }],
         required_capabilities: GroupCapabilities::default(),
         removed: false,
+        join_epoch: EpochId(0),
     }
 }
 

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -212,8 +212,12 @@ in `tests/`; this section exists so a future contributor can grep for the rule t
 - **Item:** **S3** Unattributable application messages
   - **What changed:** `message_processor::ingest_group_message` no longer emits `MessageReceived` with an empty
     `MemberId` for senders whose leaf credential cannot be resolved. The message is marked `Failed`; a typed sender
-    variant on `GroupEvent` would be a larger API change deferred to v0.2.
-  - **Test:** implicit (no event leak — covered by existing tests)
+    variant on `GroupEvent` would be a larger API change deferred to v0.2. Mirrored on the stored-convergence/replay
+    seam (mdk#383): the replay ApplicationMessage arm pushes `Ignored` for an unresolvable sender, both seams share
+    `app_payload::validate_app_payload_for_sender` (which rejects an empty `MemberId` outright), and
+    `emit_application_replay_events` skips empty-sender observations as a backstop.
+  - **Test:** `app_payload::tests` (empty-sender and pubkey-mismatch rejection);
+    `tests/distributed_convergence.rs::convergence_app_message_with_unresolvable_sender_emits_no_event_and_lands_terminal`
 
 - **Item:** **Sm1** Atomic state-machine transitions
   - **What changed:** `EpochManager::confirm_publish` / `rollback_publish` / `begin_pending` clone the prior
@@ -315,6 +319,19 @@ shapes. Tests: `tests/fork_detection.rs` plus the harness `deliberate_fork_via_h
 
 ## Conventions in this crate
 
+- **Mirror every ingest invariant on every inbound seam.** An inbound MLS message reaches application-visible state
+  through three seams — **direct ingest** (`message_processor/ingest.rs::ingest_group_message`),
+  **stored-convergence/replay** (`openmls_projection.rs::process_openmls_messages_inner`, materialization and apply),
+  and **fork recovery** (the `WrongEpoch` branch in `message_processor/ingest.rs` + `fork_recovery.rs`). Every
+  sender-authentication, admin/identity-proof, app-payload, and component-retention check MUST run identically on all
+  of them, through the *same* shared helper — never a seam-local re-implementation. Shared chokepoints:
+  `identity::member_id_of_sender` (MLS `Sender` → validated `MemberId`) and
+  `app_payload::validate_app_payload_for_sender` (payload + `&MemberId` → validated `MarmotAppEvent`; rejects an empty
+  id). An application message whose sender cannot resolve to a validated member id is never surfaced as
+  `MessageReceived` and never accepted into canonical state on any seam (direct: `Failed`; replay: `Ignored` →
+  terminal disposition). Fork-recovery paths fail closed with typed errors (`EngineError::ForkedEpoch` / `Backend`) —
+  never `unreachable!`/`panic!` — on attacker-influenced input. When you add a guard to one seam, add it to the shared
+  helper (or all seams) and extend the parity tests; a guard that exists on one seam only is a bug (see mdk#707).
 - **Only `EpochManager` may construct non-`Stable` `EpochState` variants.** This is enforced by visibility — the
   variants' fields are private. Don't add a public constructor for `Recovering` etc. somewhere else.
 - **No Nostr library/SDK dependency.** These crates do not depend on any Nostr crate and use no Nostr SDK types. They

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -332,6 +332,16 @@ shapes. Tests: `tests/fork_detection.rs` plus the harness `deliberate_fork_via_h
   terminal disposition). Fork-recovery paths fail closed with typed errors (`EngineError::ForkedEpoch` / `Backend`) —
   never `unreachable!`/`panic!` — on attacker-influenced input. When you add a guard to one seam, add it to the shared
   helper (or all seams) and extend the parity tests; a guard that exists on one seam only is a bug (see mdk#707).
+- **Hydration quarantine is enforced through `Engine::ensure_group_live`.** A quarantined group vanishes from every
+  live surface (mdk#364 / #365): every public accessor that reads durable or MLS group state (`members`,
+  `group_record`, `group_context`, `admin_pubkeys`, `app_component`, `feature_status`, capability queries, the
+  safe-export family, `own_leaf_index`) calls `ensure_group_live` first and returns `UnknownGroup`; `do_send` and
+  `converge_and_drain_queued_outbound_intents` refuse to run; `ingest_group_message` retains inbound input as
+  `PeelDeferred` and classifies it `Stale { reason: Quarantined }`; `converge_stored_openmls_messages` reports a
+  `Blocked` run without touching state; `retry_deferred_peels` skips the group. When you add a new accessor or data
+  path that reads group state, add the gate — a path that bypasses it can silently un-quarantine a group via
+  `set_stable`. Quarantine clears only through `retry_hydrate_quarantined_group` or an authenticated re-join welcome,
+  both of which schedule retained input for replay.
 - **Only `EpochManager` may construct non-`Stable` `EpochState` variants.** This is enforced by visibility — the
   variants' fields are private. Don't add a public constructor for `Recovering` etc. somewhere else.
 - **No Nostr library/SDK dependency.** These crates do not depend on any Nostr crate and use no Nostr SDK types. They

--- a/crates/cgka-engine/src/app_payload.rs
+++ b/crates/cgka-engine/src/app_payload.rs
@@ -1,9 +1,19 @@
 use cgka_traits::{EngineError, MarmotAppEvent, MemberId};
 
+/// Shared application-payload sender validation for every inbound seam
+/// (direct ingest, stored-convergence/replay). An application message is
+/// surfaced only when its inner event's author matches the MLS-authenticated
+/// sender; an empty sender is rejected outright so an unattributable message
+/// can never validate, regardless of what the inner event claims.
 pub(crate) fn validate_app_payload_for_sender(
     payload: &[u8],
     sender: &MemberId,
 ) -> Result<MarmotAppEvent, EngineError> {
+    if sender.as_slice().is_empty() {
+        return Err(EngineError::InvalidAppMessagePayload(
+            "application message has no authenticated member sender".into(),
+        ));
+    }
     let event = MarmotAppEvent::decode(payload)
         .map_err(|err| EngineError::InvalidAppMessagePayload(err.to_string()))?;
     let sender_hex = hex::encode(sender.as_slice());
@@ -13,10 +23,47 @@ pub(crate) fn validate_app_payload_for_sender(
     Ok(event)
 }
 
-pub(crate) fn app_payload_is_valid_for_sender(payload: &[u8], sender: &[u8]) -> bool {
-    let event = match MarmotAppEvent::decode(payload) {
-        Ok(event) => event,
-        Err(_) => return false,
-    };
-    event.validate_sender(&hex::encode(sender)).is_ok()
+#[cfg(test)]
+mod tests {
+    use super::validate_app_payload_for_sender;
+    use cgka_traits::{EngineError, MarmotAppEvent, MemberId};
+
+    fn payload_from(pubkey: &str) -> Vec<u8> {
+        MarmotAppEvent::new(pubkey, 1, 9, vec![], "hello")
+            .encode()
+            .expect("encode app event")
+    }
+
+    #[test]
+    fn empty_sender_is_rejected_even_when_event_pubkey_is_empty() {
+        // Regression for the S3 replay-seam gap (#383): an event whose
+        // `pubkey` is the empty string must not validate against an empty
+        // (unresolvable) MLS sender.
+        let payload = payload_from("");
+        let result = validate_app_payload_for_sender(&payload, &MemberId::new(Vec::new()));
+        assert!(matches!(
+            result,
+            Err(EngineError::InvalidAppMessagePayload(_))
+        ));
+    }
+
+    #[test]
+    fn pubkey_mismatch_is_rejected() {
+        let sender = MemberId::new(vec![0x11; 32]);
+        let payload = payload_from(&hex::encode([0x22; 32]));
+        let result = validate_app_payload_for_sender(&payload, &sender);
+        assert!(matches!(
+            result,
+            Err(EngineError::InvalidAppMessagePayload(_))
+        ));
+    }
+
+    #[test]
+    fn matching_sender_validates() {
+        let sender = MemberId::new(vec![0x11; 32]);
+        let payload = payload_from(&hex::encode([0x11; 32]));
+        let event =
+            validate_app_payload_for_sender(&payload, &sender).expect("matching sender validates");
+        assert_eq!(event.content, "hello");
+    }
 }

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -453,6 +453,8 @@ pub(crate) fn message_state_changed_event(
         new_state: message_state_str(state).to_string(),
         epoch: None,
         reason: reason.to_string(),
+        retry_count: None,
+        sweeps_waited: None,
     }
 }
 
@@ -470,6 +472,31 @@ pub(crate) fn message_state_transition_event(
         new_state: message_state_str(state).to_string(),
         epoch: epoch.map(|epoch| epoch.0),
         reason: reason.to_string(),
+        retry_count: None,
+        sweeps_waited: None,
+    }
+}
+
+/// Terminal transition of a deferred-peel row, carrying the lifecycle's
+/// per-row telemetry: how many re-peel attempts it consumed and how many
+/// retry sweeps it waited between first attempt and this transition
+/// (mdk#339).
+pub(crate) fn deferred_peel_terminal_event(
+    msg_id_hex: MessageRefHex,
+    epoch: Option<EpochId>,
+    reason: &str,
+    retry_count: u64,
+    sweeps_waited: u64,
+) -> AuditEventKind {
+    AuditEventKind::MessageStateChanged {
+        msg_id: msg_id_hex,
+        artifact_kind: None,
+        previous_state: Some(message_state_str(MessageState::PeelDeferred).to_string()),
+        new_state: message_state_str(MessageState::Failed).to_string(),
+        epoch: epoch.map(|epoch| epoch.0),
+        reason: reason.to_string(),
+        retry_count: Some(retry_count),
+        sweeps_waited: Some(sweeps_waited),
     }
 }
 

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -78,6 +78,7 @@ pub(crate) fn stale_reason_str(reason: &StaleReason) -> &'static str {
         StaleReason::OwnEcho => "own_echo",
         StaleReason::PeelFailed => "peel_failed",
         StaleReason::SelfEvicted => "self_evicted",
+        StaleReason::Quarantined => "quarantined",
     }
 }
 

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -254,6 +254,30 @@ impl<S: StorageProvider> Engine<S> {
             return Ok(unrecoverable_result(epoch));
         }
 
+        // A hydration-quarantined group is frozen until explicit repair: no
+        // canonicalization pass may read or mutate its state, and no
+        // set_stable may re-activate it out of band (mdk#364). Report a
+        // blocked run and leave everything untouched; retained inputs replay
+        // once repair clears the quarantine.
+        if self.quarantined_reason(group_id).is_some() {
+            let epoch = self
+                .epoch_manager
+                .epoch(group_id)
+                .map(|e| e.0)
+                .unwrap_or_default();
+            self.audit_group(
+                group_id,
+                marmot_forensics::AuditEventKind::ConvergenceRunState {
+                    phase: ConvergencePhase::Blocked,
+                    current_tip_epoch: Some(epoch),
+                    retained_anchor_horizon: None,
+                    reason: Some("group_quarantined".to_string()),
+                    error_kind: None,
+                },
+            );
+            return Ok(quarantined_result(epoch));
+        }
+
         let previous_group = self
             .storage
             .get_group(group_id)
@@ -1044,6 +1068,31 @@ fn unrecoverable_result(current_tip: u64) -> CanonicalizationResult {
         queued_outbound_intents: Vec::new(),
         publishable_outbound_messages: Vec::new(),
         errors: vec![CanonicalizationError::MissingRetainedAnchor],
+        selection_trace: None,
+    }
+}
+
+/// Blocked no-op result for a hydration-quarantined group: convergence ran
+/// against nothing, selected nothing, and reports no errors — the group is
+/// deliberately frozen, not failing.
+fn quarantined_result(current_tip: u64) -> CanonicalizationResult {
+    CanonicalizationResult {
+        previous_tip: current_tip,
+        selected_tip: None,
+        selected_fork_epoch: None,
+        selected_branch_id: None,
+        candidate_count: 0,
+        eligible_count: 0,
+        convergence_status: ConvergenceStatus::Blocked,
+        accepted_commits: Vec::new(),
+        accepted_proposals: Vec::new(),
+        accepted_app_messages: Vec::new(),
+        invalidated_app_messages: Vec::new(),
+        dropped_messages: Vec::new(),
+        already_seen: Vec::new(),
+        queued_outbound_intents: Vec::new(),
+        publishable_outbound_messages: Vec::new(),
+        errors: Vec::new(),
         selection_trace: None,
     }
 }

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -749,6 +749,18 @@ impl<S: StorageProvider> Engine<S> {
             else {
                 continue;
             };
+            if sender.is_empty() {
+                // Backstop for the mirror-on-all-seams contract (#383): the
+                // replay arm never produces an empty-sender observation, but
+                // an unattributable application message must not surface as
+                // MessageReceived from any seam.
+                tracing::warn!(
+                    target: "cgka_engine::distributed_convergence",
+                    method = "emit_application_replay_events",
+                    "skipping replayed application message with unattributable sender"
+                );
+                continue;
+            }
             self.events_buf.push_back(GroupEvent::MessageReceived {
                 group_id: group_id.clone(),
                 epoch: cgka_traits::EpochId(*source_epoch),

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -60,7 +60,7 @@ fn hydration_quarantine_reason_tag(reason: GroupHydrationQuarantineReason) -> &'
     }
 }
 
-fn hydration_quarantine_group_digest(group_id: &GroupId) -> String {
+pub(crate) fn hydration_quarantine_group_digest(group_id: &GroupId) -> String {
     let mut hasher = Sha256::new();
     hasher.update(b"marmot-hydration-quarantine-group/v1");
     hasher.update(group_id.as_slice());
@@ -730,6 +730,18 @@ impl<S: StorageProvider> Engine<S> {
         .map_err(|_| GroupHydrationQuarantineReason::OpenMlsLoadFailed)?
         .ok_or(GroupHydrationQuarantineReason::OpenMlsGroupMissing)?;
 
+        // Record the transport routing id as soon as the MLS state loads —
+        // before any validation that can quarantine the group — so inbound
+        // messages for a quarantined-but-loadable group still resolve to the
+        // group id and can be retained for post-repair replay instead of
+        // dying as UnknownGroup at routing (mdk#364).
+        if let Ok(transport_group_id) =
+            crate::app_components::transport_group_id_of_group(&mls_group)
+        {
+            self.transport_group_id_index
+                .insert(transport_group_id, group_id.clone());
+        }
+
         // Member-credential + account-identity-proof validation runs one
         // BIP-340 schnorr verification per leaf. All of this state was already
         // validated at join/invite/commit ingress and read back from this
@@ -848,17 +860,9 @@ impl<S: StorageProvider> Engine<S> {
             self.leaving_groups.remove(group_id);
         }
 
-        // #740: record this group's transport routing id so inbound resolution
-        // is an O(1) index hit rather than a pre-auth O(groups) MlsGroup-load
-        // scan. `mls_group` is owned here (not borrowing `self`), and the
-        // `provider` borrow is already released, so this direct field insert is
-        // disjoint from the storage/crypto borrows above.
-        if let Ok(transport_group_id) =
-            crate::app_components::transport_group_id_of_group(&mls_group)
-        {
-            self.transport_group_id_index
-                .insert(transport_group_id, group_id.clone());
-        }
+        // #740: the transport routing id was already indexed right after the
+        // MLS load above (kept pre-validation so quarantined groups resolve
+        // too); nothing on this path changes it.
 
         self.epoch_manager.set_stable(group_id.clone(), group.epoch);
         self.audit_group(
@@ -1116,8 +1120,17 @@ impl<S: StorageProvider> Engine<S> {
     ///
     /// This is the engine-side source of truth for the application's per-group
     /// recovery flow (mdk#426): a quarantined group is not in the live
-    /// roster (`epoch`/`members` return `UnknownGroup`) and otherwise vanishes
-    /// from the account with no explanation. The app reads this list to surface
+    /// roster and otherwise vanishes from the account with no explanation. The
+    /// contract is enforced on every live surface (mdk#364 / #365):
+    /// every accessor that reads durable or MLS group state (`epoch`,
+    /// `members`, `group_record`, `group_context`, `admin_pubkeys`,
+    /// `app_component`, `feature_status`, the safe-export family, …) returns
+    /// `UnknownGroup`; `send` and convergence refuse to run; inbound group
+    /// messages are retained durably (`PeelDeferred`) and classified
+    /// `Stale { reason: Quarantined }` without touching group state. Retained
+    /// input replays automatically after a successful
+    /// [`Self::retry_hydrate_quarantined_group`] or an authenticated re-join
+    /// welcome (both clear the quarantine). The app reads this list to surface
     /// those groups distinctly from healthy/archived ones and to offer
     /// [`Self::retry_hydrate_quarantined_group`].
     ///
@@ -1128,6 +1141,27 @@ impl<S: StorageProvider> Engine<S> {
             .iter()
             .map(|(group_id, reason)| (group_id.clone(), *reason))
             .collect()
+    }
+
+    /// Quarantine lookup for the live data-path gates.
+    pub(crate) fn quarantined_reason(
+        &self,
+        group_id: &GroupId,
+    ) -> Option<GroupHydrationQuarantineReason> {
+        self.quarantined_groups.get(group_id).copied()
+    }
+
+    /// Enforce the documented quarantine contract on a live surface: a
+    /// quarantined group is indistinguishable from an unknown one on every
+    /// accessor and every send/convergence entry point, so validation-rejected
+    /// state can neither leak to the application nor keep evolving out of
+    /// band (mdk#364 / #365). Ingest has its own gate that additionally
+    /// retains the input for post-repair replay.
+    pub(crate) fn ensure_group_live(&self, group_id: &GroupId) -> Result<(), EngineError> {
+        if self.quarantined_groups.contains_key(group_id) {
+            return Err(EngineError::UnknownGroup(group_id.clone()));
+        }
+        Ok(())
     }
 
     /// Re-attempt hydration of a single quarantined group.
@@ -1186,6 +1220,11 @@ impl<S: StorageProvider> Engine<S> {
                         group_id: group_id.clone(),
                         recovered_epoch,
                     });
+                // Inbound messages that arrived while the group was
+                // quarantined were retained as PeelDeferred. Schedule the
+                // group so the application's convergence drain replays them
+                // now that the group is live again.
+                self.schedule_pending_convergence_group(group_id);
                 Ok(true)
             }
             Err(reason) => {
@@ -1400,12 +1439,14 @@ impl<S: StorageProvider> Engine<S> {
     /// App surfaces use this for projections such as group profile components
     /// without reaching into OpenMLS internals.
     pub fn group_record(&self, group_id: &GroupId) -> Result<Group, EngineError> {
+        self.ensure_group_live(group_id)?;
         Ok(self.storage.get_group(group_id)?)
     }
 
     /// Return the current Marmot admin policy keys mirrored from signed MLS
     /// group state.
     pub fn admin_pubkeys(&self, group_id: &GroupId) -> Result<Vec<[u8; 32]>, EngineError> {
+        self.ensure_group_live(group_id)?;
         let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
             &self.crypto,
             self.storage.mls_storage(),
@@ -1428,6 +1469,7 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         component_id: AppComponentId,
     ) -> Result<(EpochId, cgka_traits::SecretBytes), EngineError> {
+        self.ensure_group_live(group_id)?;
         let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
             &self.crypto,
             self.storage.mls_storage(),
@@ -1476,6 +1518,7 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         component_id: AppComponentId,
     ) -> Result<EpochId, EngineError> {
+        self.ensure_group_live(group_id)?;
         let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
             &self.crypto,
             self.storage.mls_storage(),
@@ -1574,6 +1617,7 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
         group_id: &GroupId,
         feature: &Feature,
     ) -> Result<FeatureStatus, EngineError> {
+        self.ensure_group_live(group_id)?;
         self.do_feature_status(group_id, feature)
     }
 
@@ -1588,6 +1632,7 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
         &self,
         group_id: &GroupId,
     ) -> Result<GroupCapabilities, EngineError> {
+        self.ensure_group_live(group_id)?;
         self.do_upgradeable_capabilities(group_id)
     }
 
@@ -1595,11 +1640,15 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
         &mut self,
         group_id: &GroupId,
     ) -> Result<SendResult, EngineError> {
+        self.ensure_group_live(group_id)?;
         self.do_upgrade_group_capabilities(group_id).await
     }
 
     fn group_context(&self, group_id: &GroupId) -> Result<Box<dyn GroupContext + '_>, EngineError> {
         use crate::provider::EngineOpenMlsProvider;
+        // A quarantined group's MLS state may load fine (e.g.
+        // MemberValidationFailed) — never export its secrets.
+        self.ensure_group_live(group_id)?;
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
         let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
         let mls_group = openmls::group::MlsGroup::load(
@@ -1723,6 +1772,7 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
         group_id: &GroupId,
         component_id: AppComponentId,
     ) -> Result<Option<Vec<u8>>, EngineError> {
+        self.ensure_group_live(group_id)?;
         let provider = crate::provider::EngineOpenMlsProvider::<S>::new(
             &self.crypto,
             self.storage.mls_storage(),
@@ -1741,10 +1791,12 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
     }
 
     fn own_leaf_index(&self, group_id: &GroupId) -> Result<u32, EngineError> {
+        self.ensure_group_live(group_id)?;
         self.do_own_leaf_index(group_id)
     }
 
     fn members(&self, group_id: &GroupId) -> Result<Vec<Member>, EngineError> {
+        self.ensure_group_live(group_id)?;
         self.do_members(group_id)
     }
 

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1362,10 +1362,6 @@ impl<S: StorageProvider> Engine<S> {
         self.recorder.set_data_mode(mode, reason)
     }
 
-    /// Replace the installed forensic recorder on a live engine. Dropping the
-    /// prior recorder flushes and closes any file it held. Used to start or
-    /// stop audit logging in place when the audit switch is toggled, without
-    /// rebuilding the engine. Pass [`NoopRecorder`] to stop recording.
     /// Override the deferred-peel retry budget (mdk#339). Rows that
     /// exceed it without ever peeling transition to terminal `Failed`
     /// (`permanently_undecryptable`). Exposed so tests can exhaust the budget
@@ -1374,6 +1370,10 @@ impl<S: StorageProvider> Engine<S> {
         self.deferred_peel_retry_budget = budget.max(1);
     }
 
+    /// Replace the installed forensic recorder on a live engine. Dropping the
+    /// prior recorder flushes and closes any file it held. Used to start or
+    /// stop audit logging in place when the audit switch is toggled, without
+    /// rebuilding the engine. Pass [`NoopRecorder`] to stop recording.
     pub fn set_recorder(&mut self, recorder: Box<dyn ForensicRecorder>) {
         self.recorder = recorder;
     }

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -211,6 +211,19 @@ pub struct Engine<S: StorageProvider> {
     /// previously re-hex-encoded the whole (up to 100k-entry) set every pass;
     /// this rebuilds only when the set actually changed. `None` until first use.
     pub(crate) seen_message_ids_hex_cache: Option<(u64, std::collections::BTreeSet<String>)>,
+
+    /// Per-group deferred-peel retry lifecycle state (mdk#339):
+    /// context-fingerprint sweep gate, per-row attempt/first-seen bookkeeping,
+    /// bounded-sweep cursor, and the cached `PeelDeferred` row count backing
+    /// the per-group flood cap. In-memory by design — a restart costs one free
+    /// re-sweep and a count rescan; terminal decisions are durable via
+    /// `MessageState::Failed`.
+    pub(crate) deferred_peel: HashMap<GroupId, crate::message_processor::DeferredPeelGroupState>,
+
+    /// Retry budget before a `PeelDeferred` row transitions to terminal
+    /// `Failed` (`permanently_undecryptable`). Field (not a const) so tests
+    /// can exhaust it quickly via [`Self::set_deferred_peel_retry_budget`].
+    pub(crate) deferred_peel_retry_budget: u32,
 }
 
 // ── Builder ─────────────────────────────────────────────────────────────────
@@ -351,6 +364,8 @@ impl<S: StorageProvider> EngineBuilder<S> {
             quarantined_groups: HashMap::new(),
             transport_group_id_index: HashMap::new(),
             seen_message_ids_hex_cache: None,
+            deferred_peel: HashMap::new(),
+            deferred_peel_retry_budget: crate::message_processor::MAX_DEFERRED_PEEL_ATTEMPTS,
         })
     }
 }
@@ -1351,6 +1366,14 @@ impl<S: StorageProvider> Engine<S> {
     /// prior recorder flushes and closes any file it held. Used to start or
     /// stop audit logging in place when the audit switch is toggled, without
     /// rebuilding the engine. Pass [`NoopRecorder`] to stop recording.
+    /// Override the deferred-peel retry budget (mdk#339). Rows that
+    /// exceed it without ever peeling transition to terminal `Failed`
+    /// (`permanently_undecryptable`). Exposed so tests can exhaust the budget
+    /// quickly; production uses the default.
+    pub fn set_deferred_peel_retry_budget(&mut self, budget: u32) {
+        self.deferred_peel_retry_budget = budget.max(1);
+    }
+
     pub fn set_recorder(&mut self, recorder: Box<dyn ForensicRecorder>) {
         self.recorder = recorder;
     }

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -28,6 +28,7 @@ use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
 use cgka_traits::storage::StorageProvider;
 use cgka_traits::transport::{EncryptedPayload, TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId};
+use marmot_forensics::AuditEventKind;
 use openmls::group::{MlsGroup, MlsGroupCreateConfig};
 use openmls::prelude::{BasicCredential, Extension, Extensions, MlsMessageBodyIn, MlsMessageIn};
 use openmls::treesync::Node;
@@ -618,6 +619,31 @@ impl<S: StorageProvider> Engine<S> {
                 });
         }
         self.seen_message_ids.insert(welcome_id);
+
+        // An authenticated welcome re-validated every leaf and wrote fresh
+        // group state — strictly stronger evidence of health than
+        // `retry_hydrate_quarantined_group` re-reading stored state. Clear a
+        // hydration quarantine for this id so the map cannot go stale against
+        // the now-live group (and so an unrepairable group can always be
+        // recovered by re-invite). The buffered-message replay below picks up
+        // any input retained while quarantined.
+        if self.quarantined_groups.remove(&group_id).is_some() {
+            let recovered_epoch = EpochId(mls_group.epoch().as_u64());
+            tracing::info!(
+                target: "cgka_engine::hydrate",
+                method = "do_join_welcome",
+                outcome = "recovered_via_rejoin",
+                "authenticated re-join welcome cleared a hydration quarantine"
+            );
+            self.audit(AuditEventKind::GroupHydrationRecovered {
+                group_digest: crate::engine::hydration_quarantine_group_digest(&group_id),
+            });
+            self.events_buf
+                .push_back(cgka_traits::engine::GroupEvent::GroupHydrationRecovered {
+                    group_id: group_id.clone(),
+                    recovered_epoch,
+                });
+        }
 
         self.replay_buffered_messages(&group_id).await?;
         Ok(group_id)

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -223,6 +223,7 @@ impl<S: StorageProvider> Engine<S> {
             members: projected_members,
             required_capabilities: required_caps,
             removed: false,
+            join_epoch: EpochId(mls_group.epoch().as_u64()),
         };
         self.storage.put_group(&group_record)?;
         // #740: index this group's transport routing id for O(1) inbound
@@ -541,6 +542,7 @@ impl<S: StorageProvider> Engine<S> {
                 &mls_group,
             ),
             removed: false,
+            join_epoch: EpochId(mls_group.epoch().as_u64()),
         };
         mirror_app_components_into_record(&mls_group, &mut group_record);
         self.storage.put_group(&group_record)?;

--- a/crates/cgka-engine/src/lib.rs
+++ b/crates/cgka-engine/src/lib.rs
@@ -53,6 +53,7 @@ pub mod group_lifecycle;
 pub mod group_state_changes;
 pub mod identity;
 pub mod key_package;
+pub(crate) mod message_disposition;
 pub mod message_processor;
 pub mod openmls_projection;
 pub mod pending_commit_guard;

--- a/crates/cgka-engine/src/message_disposition.rs
+++ b/crates/cgka-engine/src/message_disposition.rs
@@ -1,0 +1,50 @@
+//! One classification table for why a raw inbound message was not applied
+//! (mdk#339 / #707): both processing seams and the deferred-peel
+//! lifecycle name their dispositions from this enum instead of scattering
+//! ad-hoc reason strings, so forensic audit rows (`MessageStateChanged.reason`
+//! / `Rejection.reason`) stay a closed, greppable vocabulary.
+
+/// Why a raw inbound message was skipped, deferred, or terminally failed
+/// before it could be applied.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MessageDisposition {
+    /// The message's MLS epoch precedes this device's membership
+    /// (`Group::join_epoch`). Permanently undecryptable by design — terminal,
+    /// never retried.
+    PreMembershipEvent,
+    /// The device was (or may have been) a member at the message's epoch, but
+    /// no retained snapshot or past-epoch secret can decrypt it anymore.
+    /// Terminal for this device; content-level redelivery is the recovery
+    /// path.
+    ValidHistorySnapshotMissing,
+    /// The transport bytes failed to peel against the current epoch context
+    /// and every retained snapshot. Retained as `PeelDeferred`; retried only
+    /// when the (epoch, snapshot-set) peel context actually changes.
+    RetryPending,
+    /// A retained `PeelDeferred` row exhausted its retry budget without ever
+    /// peeling. Terminal: indistinguishable from garbage; a legitimate
+    /// message re-delivered under a fresh transport id starts over.
+    PermanentlyUndecryptable,
+    /// The per-group cap on retained `PeelDeferred` rows is reached; the
+    /// message was dropped without being persisted so a flood of
+    /// undecryptable input cannot grow the durable store unboundedly.
+    DeferredCapExceeded,
+    /// The group is under hydration quarantine; input is retained for
+    /// post-repair replay (see `StaleReason::Quarantined`).
+    Quarantined,
+}
+
+impl MessageDisposition {
+    /// Stable snake_case tag recorded in forensic audit rows.
+    pub(crate) fn tag(self) -> &'static str {
+        match self {
+            Self::PreMembershipEvent => "pre_membership_event",
+            Self::ValidHistorySnapshotMissing => "valid_history_snapshot_missing",
+            // Historical audit string, kept for dashboard continuity.
+            Self::RetryPending => "peel_failed_no_snapshot",
+            Self::PermanentlyUndecryptable => "permanently_undecryptable",
+            Self::DeferredCapExceeded => "peel_deferred_cap_exceeded",
+            Self::Quarantined => "quarantined_group_input_deferred",
+        }
+    }
+}

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -88,6 +88,34 @@ impl<S: StorageProvider> Engine<S> {
         transport_group_id: Vec<u8>,
     ) -> Result<IngestOutcome, EngineError> {
         let group_id = self.group_id_for_transport_group_id(&transport_group_id)?;
+
+        // Quarantine gate (mdk#364): a group frozen by hydration
+        // quarantine must not process any input — its OpenMLS state may load
+        // fine (e.g. MemberValidationFailed) and a merged commit would call
+        // set_stable, silently re-activating a group validation rejected.
+        // Retain the raw transport durably instead: PeelDeferred rows are
+        // excluded from settlement math and replay through
+        // retry_deferred_peels once repair clears the quarantine.
+        if self.quarantined_reason(&group_id).is_some() {
+            self.persist_transport_message_for_existing_group(
+                msg,
+                &group_id,
+                EpochId(0),
+                MessageState::PeelDeferred,
+            )?;
+            self.audit_group(
+                &group_id,
+                crate::audit_helpers::message_state_changed_event(
+                    hex::encode(msg.id.as_slice()),
+                    MessageState::PeelDeferred,
+                    "quarantined_group_input_deferred",
+                ),
+            );
+            return Ok(IngestOutcome::Stale {
+                reason: StaleReason::Quarantined,
+            });
+        }
+
         let mut pending_recovery: Option<(
             EpochId,
             CommitOrderingKey,

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -466,36 +466,27 @@ impl<S: StorageProvider> Engine<S> {
                                 mls_bytes.as_slice(),
                             )? {
                                 ForkResolution::MissingSnapshot => {
-                                    let previous_state =
-                                        self.epoch_manager.state(&group_id).map(|state| {
-                                            crate::audit_helpers::epoch_state_name_str(state.name())
-                                                .to_string()
-                                        });
-                                    self.epoch_manager.detect_fork(&group_id, vec![]);
-                                    self.audit_group(
-                                        &group_id,
-                                        crate::audit_helpers::epoch_state_changed_event(
-                                            previous_state.as_deref(),
-                                            "recovering",
-                                            msg_epoch,
-                                            "fork_detected",
-                                            None,
-                                            None,
-                                        ),
-                                    );
-                                    self.update_stored_message_state(
-                                        &msg.id,
-                                        MessageState::EpochInvalidated,
-                                    )?;
-                                    return Err(EngineError::ForkedEpoch {
-                                        group_id: group_id.clone(),
-                                        last_stable: msg_epoch,
-                                        conflicting_epoch: current,
-                                    });
+                                    return Err(self.forked_epoch_fail_closed(
+                                        &group_id, &msg.id, msg_epoch, current,
+                                    ));
                                 }
                                 ForkResolution::IncumbentWins
                                 | ForkResolution::CandidateWins { .. } => {
-                                    unreachable!("missing snapshot cannot resolve a fork candidate")
+                                    // recovery_snapshot_name_for_fork and
+                                    // resolve_fork_candidate read the same
+                                    // incumbents map, so a resolution without
+                                    // a snapshot means that coupling broke.
+                                    // This path is reachable from inbound
+                                    // same-epoch fork commits — fail closed
+                                    // instead of panicking (#394).
+                                    tracing::warn!(
+                                        target: "cgka_engine::message_processor",
+                                        method = "ingest_group_message",
+                                        "fork candidate resolved without a recovery snapshot; failing closed"
+                                    );
+                                    return Err(self.forked_epoch_fail_closed(
+                                        &group_id, &msg.id, msg_epoch, current,
+                                    ));
                                 }
                             }
                         };
@@ -532,32 +523,9 @@ impl<S: StorageProvider> Engine<S> {
                                 });
                             }
                             ForkResolution::MissingSnapshot => {
-                                let previous_state =
-                                    self.epoch_manager.state(&group_id).map(|state| {
-                                        crate::audit_helpers::epoch_state_name_str(state.name())
-                                            .to_string()
-                                    });
-                                self.epoch_manager.detect_fork(&group_id, vec![]);
-                                self.audit_group(
-                                    &group_id,
-                                    crate::audit_helpers::epoch_state_changed_event(
-                                        previous_state.as_deref(),
-                                        "recovering",
-                                        msg_epoch,
-                                        "fork_detected",
-                                        None,
-                                        None,
-                                    ),
-                                );
-                                self.update_stored_message_state(
-                                    &msg.id,
-                                    MessageState::EpochInvalidated,
-                                )?;
-                                return Err(EngineError::ForkedEpoch {
-                                    group_id: group_id.clone(),
-                                    last_stable: msg_epoch,
-                                    conflicting_epoch: current,
-                                });
+                                return Err(self.forked_epoch_fail_closed(
+                                    &group_id, &msg.id, msg_epoch, current,
+                                ));
                             }
                         }
                     }
@@ -1438,6 +1406,46 @@ impl<S: StorageProvider> Engine<S> {
             }
             Ok(_) | Err(StorageError::NotFound) => Ok(()),
             Err(err) => Err(EngineError::Storage(err)),
+        }
+    }
+
+    /// Fail-closed terminal handling for a same-epoch fork commit with no
+    /// replayable winner: mark the group recovering, record the fork in the
+    /// audit log, invalidate the stored message, and hand back the typed
+    /// `ForkedEpoch` error for the caller to return. Every arm of the
+    /// fork-recovery seam that ends without a recovery snapshot goes through
+    /// this — including the invariant-break arm that previously panicked via
+    /// `unreachable!` on attacker-delivered input (#394).
+    fn forked_epoch_fail_closed(
+        &mut self,
+        group_id: &GroupId,
+        msg_id: &MessageId,
+        msg_epoch: EpochId,
+        current: EpochId,
+    ) -> EngineError {
+        let previous_state = self
+            .epoch_manager
+            .state(group_id)
+            .map(|state| crate::audit_helpers::epoch_state_name_str(state.name()).to_string());
+        self.epoch_manager.detect_fork(group_id, vec![]);
+        self.audit_group(
+            group_id,
+            crate::audit_helpers::epoch_state_changed_event(
+                previous_state.as_deref(),
+                "recovering",
+                msg_epoch,
+                "fork_detected",
+                None,
+                None,
+            ),
+        );
+        if let Err(err) = self.update_stored_message_state(msg_id, MessageState::EpochInvalidated) {
+            return err;
+        }
+        EngineError::ForkedEpoch {
+            group_id: group_id.clone(),
+            last_stable: msg_epoch,
+            conflicting_epoch: current,
         }
     }
 

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -116,10 +116,11 @@ impl<S: StorageProvider> Engine<S> {
                         crate::message_disposition::MessageDisposition::Quarantined.tag(),
                     ),
                 );
-            } else {
+            } else if self.should_audit_peel_deferred_cap_rejection(&group_id) {
                 // Same flood cap as the deferral seam (mdk#339): a
                 // quarantined group's replay buffer must not grow unboundedly
-                // either.
+                // either. Audited once per cap-full episode so a flood does
+                // not emit one write per rejected message.
                 self.audit_group(
                     &group_id,
                     marmot_forensics::AuditEventKind::Rejection {
@@ -288,15 +289,17 @@ impl<S: StorageProvider> Engine<S> {
                         );
                         if !already_retained && !self.reserve_peel_deferred_slot(&group_id)? {
                             self.seen_message_ids.insert(msg.id.clone());
-                            self.audit_group(
-                                &group_id,
-                                marmot_forensics::AuditEventKind::Rejection {
-                                    msg_id: msg_id_hex.clone(),
-                                    reason: crate::message_disposition::MessageDisposition::DeferredCapExceeded
-                                        .tag()
-                                        .to_string(),
-                                },
-                            );
+                            if self.should_audit_peel_deferred_cap_rejection(&group_id) {
+                                self.audit_group(
+                                    &group_id,
+                                    marmot_forensics::AuditEventKind::Rejection {
+                                        msg_id: msg_id_hex.clone(),
+                                        reason: crate::message_disposition::MessageDisposition::DeferredCapExceeded
+                                            .tag()
+                                            .to_string(),
+                                    },
+                                );
+                            }
                             tracing::debug!(
                                 target: "cgka_engine::message_processor",
                                 method = "ingest_group_message",
@@ -455,30 +458,29 @@ impl<S: StorageProvider> Engine<S> {
             // never be decrypted here by design — OpenMLS holds no secrets
             // for epochs before the welcome. Classify it terminal before any
             // OpenMLS processing instead of feeding it the retry lifecycle.
-            if msg_content_type == ContentType::Application && msg_epoch < current_epoch {
-                let join_epoch = self.group_join_epoch(&group_id);
-                if join_epoch.0 > 0 && msg_epoch < join_epoch {
-                    let tag =
-                        crate::message_disposition::MessageDisposition::PreMembershipEvent.tag();
-                    self.persist_openmls_wire_message(
-                        &openmls_msg,
-                        &group_id,
-                        current_epoch,
+            if msg_content_type == ContentType::Application
+                && msg_epoch < current_epoch
+                && self.msg_is_pre_membership(&group_id, msg_epoch)
+            {
+                let tag = crate::message_disposition::MessageDisposition::PreMembershipEvent.tag();
+                self.persist_openmls_wire_message(
+                    &openmls_msg,
+                    &group_id,
+                    current_epoch,
+                    MessageState::Failed,
+                )?;
+                self.audit_group(
+                    &group_id,
+                    crate::audit_helpers::message_state_changed_event(
+                        hex::encode(msg.id.as_slice()),
                         MessageState::Failed,
-                    )?;
-                    self.audit_group(
-                        &group_id,
-                        crate::audit_helpers::message_state_changed_event(
-                            hex::encode(msg.id.as_slice()),
-                            MessageState::Failed,
-                            tag,
-                        ),
-                    );
-                    self.mark_raw_transport_message_failed_if_deferred(&raw_msg_id, tag)?;
-                    return Ok(IngestOutcome::Stale {
-                        reason: StaleReason::PeelFailed,
-                    });
-                }
+                        tag,
+                    ),
+                );
+                self.mark_raw_transport_message_failed_if_deferred(&raw_msg_id, tag)?;
+                return Ok(IngestOutcome::Stale {
+                    reason: StaleReason::PeelFailed,
+                });
             }
 
             let commit_should_enter_convergence = if msg_content_type == ContentType::Commit {
@@ -547,8 +549,7 @@ impl<S: StorageProvider> Engine<S> {
                     // before the join epoch the message was never decryptable
                     // here by design; at or after it, this device was a
                     // member but the past-epoch secrets are gone.
-                    let join_epoch = self.group_join_epoch(&group_id);
-                    let tag = if join_epoch.0 > 0 && msg_epoch < join_epoch {
+                    let tag = if self.msg_is_pre_membership(&group_id, msg_epoch) {
                         crate::message_disposition::MessageDisposition::PreMembershipEvent.tag()
                     } else {
                         crate::message_disposition::MessageDisposition::ValidHistorySnapshotMissing
@@ -1526,14 +1527,19 @@ impl<S: StorageProvider> Engine<S> {
         }
     }
 
-    /// Best-effort join-epoch bound for post-peel pre-membership
-    /// classification (mdk#339). `EpochId(0)` (legacy records or a
-    /// missing record) means "unknown — apply no bound".
-    fn group_join_epoch(&self, group_id: &GroupId) -> EpochId {
-        self.storage
+    /// Whether `msg_epoch` predates this device's membership in `group_id`
+    /// (mdk#339): such a message was never decryptable here by design —
+    /// OpenMLS holds no secrets for epochs before the welcome — so it is
+    /// terminal, never retried. Best-effort: a `join_epoch` of `EpochId(0)`
+    /// (legacy records or a missing record) is "unknown", which applies no
+    /// bound and returns `false`.
+    fn msg_is_pre_membership(&self, group_id: &GroupId, msg_epoch: EpochId) -> bool {
+        let join_epoch = self
+            .storage
             .get_group(group_id)
             .map(|group| group.join_epoch)
-            .unwrap_or_default()
+            .unwrap_or_default();
+        join_epoch.0 > 0 && msg_epoch < join_epoch
     }
 
     /// Fail-closed terminal handling for a same-epoch fork commit with no

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -353,6 +353,14 @@ impl<S: StorageProvider> Engine<S> {
                         );
                         recovery.peeled
                     } else {
+                        // Terminal peel failure. Retire the raw deferred row
+                        // (if this came via the retry lifecycle) so it stops
+                        // holding a per-group cap slot (mdk#339); a no-op on
+                        // the direct path where no deferred row exists.
+                        self.mark_raw_transport_message_failed_if_deferred(
+                            &raw_msg_id,
+                            "stale_epoch_no_snapshot",
+                        )?;
                         self.persist_transport_message(
                             msg,
                             &group_id,
@@ -377,13 +385,19 @@ impl<S: StorageProvider> Engine<S> {
             let mls_bytes = match peeled.content {
                 PeeledContent::MlsMessage { bytes } => bytes,
                 PeeledContent::Welcome { .. } => {
+                    // A group-message envelope that peels to a Welcome is
+                    // malformed: terminal. Retire the raw deferred row first
+                    // so its cap slot is released (mdk#339).
+                    self.mark_raw_transport_message_failed_if_deferred(
+                        &raw_msg_id,
+                        "peeled_welcome_in_group_message",
+                    )?;
                     self.persist_transport_message(
                         msg,
                         &group_id,
                         current_epoch,
                         MessageState::Failed,
                     )?;
-                    self.update_stored_message_state(&msg.id, MessageState::Failed)?;
                     return Ok(IngestOutcome::Stale {
                         reason: StaleReason::PeelFailed,
                     });
@@ -443,6 +457,13 @@ impl<S: StorageProvider> Engine<S> {
                         &group_id,
                         current_epoch,
                         MessageState::Failed,
+                    )?;
+                    // Peeled successfully but the MLS body is neither a
+                    // public nor private message: terminal. Retire the raw
+                    // deferred row so it leaves the retry lifecycle (mdk#339).
+                    self.mark_raw_transport_message_failed_if_deferred(
+                        &raw_msg_id,
+                        "non_mls_message_body",
                     )?;
                     return Ok(IngestOutcome::Stale {
                         reason: StaleReason::PeelFailed,
@@ -693,6 +714,13 @@ impl<S: StorageProvider> Engine<S> {
                             "dropping application message with unattributable sender"
                         );
                         self.update_stored_message_state(&msg.id, MessageState::Failed)?;
+                        // Peeled successfully but terminally rejected: retire
+                        // the raw deferred row so it leaves the retry
+                        // lifecycle instead of holding a cap slot (mdk#339).
+                        self.mark_raw_transport_message_failed_if_deferred(
+                            &raw_msg_id,
+                            "unattributable_sender",
+                        )?;
                         return Ok(IngestOutcome::Stale {
                             reason: StaleReason::PeelFailed,
                         });
@@ -707,6 +735,12 @@ impl<S: StorageProvider> Engine<S> {
                             "dropping application message with invalid Marmot app event",
                         );
                         self.update_stored_message_state(&msg.id, MessageState::Failed)?;
+                        // Peeled successfully but terminally rejected: retire
+                        // the raw deferred row (mdk#339).
+                        self.mark_raw_transport_message_failed_if_deferred(
+                            &raw_msg_id,
+                            "invalid_app_payload",
+                        )?;
                         return Ok(IngestOutcome::Stale {
                             reason: StaleReason::PeelFailed,
                         });

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -97,20 +97,39 @@ impl<S: StorageProvider> Engine<S> {
         // excluded from settlement math and replay through
         // retry_deferred_peels once repair clears the quarantine.
         if self.quarantined_reason(&group_id).is_some() {
-            self.persist_transport_message_for_existing_group(
-                msg,
-                &group_id,
-                EpochId(0),
-                MessageState::PeelDeferred,
-            )?;
-            self.audit_group(
-                &group_id,
-                crate::audit_helpers::message_state_changed_event(
-                    hex::encode(msg.id.as_slice()),
-                    MessageState::PeelDeferred,
-                    "quarantined_group_input_deferred",
-                ),
+            let already_retained = matches!(
+                self.storage.get_message(&msg.id),
+                Ok(record) if record.state == MessageState::PeelDeferred
             );
+            if already_retained || self.reserve_peel_deferred_slot(&group_id)? {
+                self.persist_transport_message_for_existing_group(
+                    msg,
+                    &group_id,
+                    EpochId(0),
+                    MessageState::PeelDeferred,
+                )?;
+                self.audit_group(
+                    &group_id,
+                    crate::audit_helpers::message_state_changed_event(
+                        hex::encode(msg.id.as_slice()),
+                        MessageState::PeelDeferred,
+                        crate::message_disposition::MessageDisposition::Quarantined.tag(),
+                    ),
+                );
+            } else {
+                // Same flood cap as the deferral seam (mdk#339): a
+                // quarantined group's replay buffer must not grow unboundedly
+                // either.
+                self.audit_group(
+                    &group_id,
+                    marmot_forensics::AuditEventKind::Rejection {
+                        msg_id: hex::encode(msg.id.as_slice()),
+                        reason: crate::message_disposition::MessageDisposition::DeferredCapExceeded
+                            .tag()
+                            .to_string(),
+                    },
+                );
+            }
             return Ok(IngestOutcome::Stale {
                 reason: StaleReason::Quarantined,
             });
@@ -258,6 +277,35 @@ impl<S: StorageProvider> Engine<S> {
                         );
                         recovery.peeled
                     } else {
+                        // Flood cap (mdk#339): raw transport ids are
+                        // attacker-controllable, so retained rows are capped
+                        // per group; at the cap, new undecryptable input is
+                        // dropped unpersisted and transport redelivery is the
+                        // recovery path once the backlog drains.
+                        let already_retained = matches!(
+                            self.storage.get_message(&msg.id),
+                            Ok(record) if record.state == MessageState::PeelDeferred
+                        );
+                        if !already_retained && !self.reserve_peel_deferred_slot(&group_id)? {
+                            self.seen_message_ids.insert(msg.id.clone());
+                            self.audit_group(
+                                &group_id,
+                                marmot_forensics::AuditEventKind::Rejection {
+                                    msg_id: msg_id_hex.clone(),
+                                    reason: crate::message_disposition::MessageDisposition::DeferredCapExceeded
+                                        .tag()
+                                        .to_string(),
+                                },
+                            );
+                            tracing::debug!(
+                                target: "cgka_engine::message_processor",
+                                method = "ingest_group_message",
+                                "peel-deferred row cap reached; dropping undecryptable input unpersisted"
+                            );
+                            return Ok(IngestOutcome::Stale {
+                                reason: StaleReason::PeelFailed,
+                            });
+                        }
                         self.persist_transport_message(
                             msg,
                             &group_id,
@@ -269,7 +317,7 @@ impl<S: StorageProvider> Engine<S> {
                             crate::audit_helpers::message_state_changed_event(
                                 msg_id_hex.clone(),
                                 MessageState::PeelDeferred,
-                                "peel_failed_no_snapshot",
+                                crate::message_disposition::MessageDisposition::RetryPending.tag(),
                             ),
                         );
                         return Ok(IngestOutcome::Stale {
@@ -401,6 +449,38 @@ impl<S: StorageProvider> Engine<S> {
 
             let msg_epoch = EpochId(proto.epoch().as_u64());
             let msg_content_type = proto.content_type();
+
+            // Pre-membership classification (mdk#339): an application
+            // message whose MLS epoch precedes this device's join epoch can
+            // never be decrypted here by design — OpenMLS holds no secrets
+            // for epochs before the welcome. Classify it terminal before any
+            // OpenMLS processing instead of feeding it the retry lifecycle.
+            if msg_content_type == ContentType::Application && msg_epoch < current_epoch {
+                let join_epoch = self.group_join_epoch(&group_id);
+                if join_epoch.0 > 0 && msg_epoch < join_epoch {
+                    let tag =
+                        crate::message_disposition::MessageDisposition::PreMembershipEvent.tag();
+                    self.persist_openmls_wire_message(
+                        &openmls_msg,
+                        &group_id,
+                        current_epoch,
+                        MessageState::Failed,
+                    )?;
+                    self.audit_group(
+                        &group_id,
+                        crate::audit_helpers::message_state_changed_event(
+                            hex::encode(msg.id.as_slice()),
+                            MessageState::Failed,
+                            tag,
+                        ),
+                    );
+                    self.mark_raw_transport_message_failed_if_deferred(&raw_msg_id, tag)?;
+                    return Ok(IngestOutcome::Stale {
+                        reason: StaleReason::PeelFailed,
+                    });
+                }
+            }
+
             let commit_should_enter_convergence = if msg_content_type == ContentType::Commit {
                 if msg_epoch >= current_epoch {
                     true
@@ -463,11 +543,19 @@ impl<S: StorageProvider> Engine<S> {
             } {
                 Ok(p) => p,
                 Err(e) if process_message_error_is_too_distant_in_the_past(&e) => {
+                    // Refine the historical classification (mdk#339):
+                    // before the join epoch the message was never decryptable
+                    // here by design; at or after it, this device was a
+                    // member but the past-epoch secrets are gone.
+                    let join_epoch = self.group_join_epoch(&group_id);
+                    let tag = if join_epoch.0 > 0 && msg_epoch < join_epoch {
+                        crate::message_disposition::MessageDisposition::PreMembershipEvent.tag()
+                    } else {
+                        crate::message_disposition::MessageDisposition::ValidHistorySnapshotMissing
+                            .tag()
+                    };
                     self.update_stored_message_state(&msg.id, MessageState::Failed)?;
-                    self.mark_raw_transport_message_failed_if_deferred(
-                        &raw_msg_id,
-                        "too_distant_in_the_past",
-                    )?;
+                    self.mark_raw_transport_message_failed_if_deferred(&raw_msg_id, tag)?;
                     return Ok(IngestOutcome::Stale {
                         reason: StaleReason::PeelFailed,
                     });
@@ -1412,7 +1500,7 @@ impl<S: StorageProvider> Engine<S> {
     }
 
     fn mark_raw_transport_message_failed_if_deferred(
-        &self,
+        &mut self,
         raw_msg_id: &MessageId,
         reason: &str,
     ) -> Result<(), EngineError> {
@@ -1430,11 +1518,22 @@ impl<S: StorageProvider> Engine<S> {
                         reason,
                     ),
                 );
+                self.note_peel_deferred_row_retired(&record.group_id, raw_msg_id);
                 Ok(())
             }
             Ok(_) | Err(StorageError::NotFound) => Ok(()),
             Err(err) => Err(EngineError::Storage(err)),
         }
+    }
+
+    /// Best-effort join-epoch bound for post-peel pre-membership
+    /// classification (mdk#339). `EpochId(0)` (legacy records or a
+    /// missing record) means "unknown — apply no bound".
+    fn group_join_epoch(&self, group_id: &GroupId) -> EpochId {
+        self.storage
+            .get_group(group_id)
+            .map(|group| group.join_epoch)
+            .unwrap_or_default()
     }
 
     /// Fail-closed terminal handling for a same-epoch fork commit with no
@@ -1648,7 +1747,7 @@ impl<S: StorageProvider> Engine<S> {
         Ok(false)
     }
 
-    fn available_past_peel_snapshots(
+    pub(crate) fn available_past_peel_snapshots(
         &self,
         group_id: &GroupId,
     ) -> Result<Vec<(EpochId, String)>, EngineError> {

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -31,6 +31,64 @@ const MAX_CONVERGENCE_REPROCESSING_PASSES: usize = 16;
 const SELF_REMOVE_AUTO_COMMIT_JITTER_MIN_MS: u64 = 10;
 const SELF_REMOVE_AUTO_COMMIT_JITTER_SPAN_MS: u64 = 40;
 
+/// Retry budget for a `PeelDeferred` row (mdk#339). Each unit is one
+/// actual re-peel attempt under a *changed* peel context (the fingerprint
+/// gate skips unchanged contexts entirely), so a legitimate future-epoch
+/// message would need to trail the group by this many context changes before
+/// its retained row goes terminal — and content-level redelivery under a
+/// fresh transport id still recovers it afterwards.
+pub const MAX_DEFERRED_PEEL_ATTEMPTS: u32 = 32;
+
+/// Per-group cap on retained `PeelDeferred` rows (mdk#339). Raw
+/// transport ids are attacker-controllable (a fresh wrap yields a fresh id),
+/// so without a cap a peer flooding undecryptable group-routed events grows
+/// the durable store without bound. At the cap, new undecryptable input is
+/// dropped unpersisted (transport redelivery is the recovery path once the
+/// backlog drains).
+pub const MAX_PEEL_DEFERRED_ROWS_PER_GROUP: usize = 256;
+
+/// Upper bound on `PeelDeferred` rows re-attempted per retry sweep
+/// (mdk#339): a large historical backlog is worked through in slices
+/// across passes instead of holding a convergence drain hostage, so current
+/// events are never blocked behind irrelevant history.
+pub(crate) const MAX_DEFERRED_ROWS_PER_SWEEP: usize = 64;
+
+/// Per-group deferred-peel retry lifecycle state (mdk#339). Held on the
+/// engine in `Engine::deferred_peel`; in-memory by design (see the field doc).
+#[derive(Default)]
+pub(crate) struct DeferredPeelGroupState {
+    /// Peel-context fingerprint recorded after a full zero-progress cycle
+    /// over the backlog. While the live context matches, whole sweeps are
+    /// skipped — a deferred row can only become peelable when the group
+    /// epoch advances or the retained-snapshot set changes.
+    gate: Option<[u8; 32]>,
+    /// Monotonic sweep counter; also the clock behind `sweeps_waited`.
+    sweep_count: u64,
+    /// Resume offset into the (stable-ordered) deferred-row list for the
+    /// bounded sweep.
+    cursor: usize,
+    /// Whether any row progressed since the cursor last wrapped to 0. The
+    /// gate is armed only after a full unproductive cycle, so a bounded
+    /// sweep never permanently skips rows it has not attempted.
+    cycle_progressed: bool,
+    /// Cached count of retained `PeelDeferred` rows backing the flood cap.
+    /// Refreshed from storage on every sweep; adjusted at the deferral /
+    /// terminal transition sites in between.
+    deferred_rows: usize,
+    /// Whether `deferred_rows` has been initialized from storage this
+    /// session.
+    counted: bool,
+    /// Per-row attempt count and first-seen sweep, keyed by the raw
+    /// transport message id.
+    attempts: std::collections::HashMap<MessageId, DeferredPeelAttempts>,
+}
+
+#[derive(Clone, Copy, Default)]
+struct DeferredPeelAttempts {
+    attempts: u32,
+    first_seen_sweep: u64,
+}
+
 impl<S: StorageProvider> Engine<S> {
     /// Inbound pipeline. Never panics; every classifiable stale case returns
     /// a typed `StaleReason` inside `Ok(IngestOutcome::Stale { .. })`.
@@ -359,6 +417,19 @@ impl<S: StorageProvider> Engine<S> {
         self.has_unresolved_convergence_inputs(group_id)
     }
 
+    /// Re-attempt retained `PeelDeferred` rows under the deferred-peel
+    /// lifecycle (mdk#339):
+    ///
+    /// - **Event-driven**: a failed peel can only start succeeding when the
+    ///   (epoch, retained-snapshot-set) peel context changes, so after a full
+    ///   unproductive cycle over the backlog the context fingerprint gates
+    ///   whole sweeps until the context actually changes.
+    /// - **Budgeted**: a row that exhausts its retry budget without ever
+    ///   peeling goes terminal `Failed` (`permanently_undecryptable`) instead
+    ///   of retrying forever.
+    /// - **Bounded**: at most [`MAX_DEFERRED_ROWS_PER_SWEEP`] rows are
+    ///   attempted per sweep (cursor resumes next pass) so a large historical
+    ///   backlog never starves current-event processing.
     pub async fn retry_deferred_peels(&mut self, group_id: &GroupId) -> Result<usize, EngineError> {
         // A quarantined group has no epoch_manager entry, so the Stable gate
         // below would fall through and re-ingest its retained rows against
@@ -373,12 +444,89 @@ impl<S: StorageProvider> Engine<S> {
             return Ok(0);
         }
 
-        let records = self.storage.list_messages(group_id, EpochId(0))?;
-        let mut progressed = 0;
-        for record in records {
-            if record.state != MessageState::PeelDeferred {
+        let fingerprint = self.deferred_peel_context_fingerprint(group_id)?;
+        if self
+            .deferred_peel
+            .get(group_id)
+            .is_some_and(|state| state.gate == Some(fingerprint))
+        {
+            // The peel context is unchanged since the last full unproductive
+            // cycle: every retained row would fail exactly as before. New
+            // deferrals don't clear this gate either — a row is only deferred
+            // after failing a live peel against this same context.
+            tracing::debug!(
+                target: "cgka_engine::message_processor",
+                method = "retry_deferred_peels",
+                "skipping deferred-peel sweep: peel context unchanged"
+            );
+            return Ok(0);
+        }
+
+        let sweep_started = std::time::Instant::now();
+        let deferred: Vec<_> = self
+            .storage
+            .list_messages(group_id, EpochId(0))?
+            .into_iter()
+            .filter(|record| record.state == MessageState::PeelDeferred)
+            .collect();
+        let total = deferred.len();
+
+        let (sweep_index, start, retry_budget) = {
+            let budget = self.deferred_peel_retry_budget;
+            let state = self.deferred_peel.entry(group_id.clone()).or_default();
+            // The full row list is in hand: refresh the flood-cap count.
+            state.deferred_rows = total;
+            state.counted = true;
+            state.sweep_count += 1;
+            if state.cursor >= total {
+                state.cursor = 0;
+            }
+            if state.cursor == 0 {
+                state.cycle_progressed = false;
+            }
+            (state.sweep_count, state.cursor, budget)
+        };
+        if total == 0 {
+            return Ok(0);
+        }
+
+        let end = (start + MAX_DEFERRED_ROWS_PER_SWEEP).min(total);
+        let mut progressed = 0usize;
+        let mut terminal = 0usize;
+        for record in &deferred[start..end] {
+            // Budget check first: bump this row's attempt count and go
+            // terminal once it exceeds the budget without ever peeling.
+            let (attempts, first_seen_sweep) = {
+                let state = self.deferred_peel.entry(group_id.clone()).or_default();
+                let entry =
+                    state
+                        .attempts
+                        .entry(record.id.clone())
+                        .or_insert(DeferredPeelAttempts {
+                            attempts: 0,
+                            first_seen_sweep: sweep_index,
+                        });
+                entry.attempts += 1;
+                (entry.attempts, entry.first_seen_sweep)
+            };
+            if attempts > retry_budget {
+                self.update_stored_message_state(&record.id, MessageState::Failed)?;
+                self.audit_group(
+                    group_id,
+                    crate::audit_helpers::deferred_peel_terminal_event(
+                        hex::encode(record.id.as_slice()),
+                        Some(record.epoch),
+                        crate::message_disposition::MessageDisposition::PermanentlyUndecryptable
+                            .tag(),
+                        u64::from(attempts.saturating_sub(1)),
+                        sweep_index.saturating_sub(first_seen_sweep),
+                    ),
+                );
+                self.note_peel_deferred_row_retired(group_id, &record.id);
+                terminal += 1;
                 continue;
             }
+
             let stored_payload = StoredMessagePayload::decode(&record.payload)
                 .map_err(|e| EngineError::Serialize(format!("{e:?}")))?;
             let Some(msg) = stored_payload.as_raw_transport().cloned() else {
@@ -405,33 +553,132 @@ impl<S: StorageProvider> Engine<S> {
                     // retire the raw transport wrapper so it does not keep
                     // re-entering this retry loop as a stale duplicate.
                     self.update_stored_message_state(&record.id, MessageState::Processed)?;
+                    self.note_peel_deferred_row_retired(group_id, &record.id);
                     progressed += 1;
                 }
                 Ok(IngestOutcome::Stale { .. }) => {
                     // Terminal stale classifications are still successful
                     // reclassifications of this raw deferred row.
                     self.update_stored_message_state(&record.id, MessageState::Processed)?;
+                    self.note_peel_deferred_row_retired(group_id, &record.id);
                     progressed += 1;
                 }
                 Err(EngineError::ForkedEpoch {
-                    group_id,
+                    group_id: forked_group_id,
                     last_stable,
                     conflicting_epoch,
                 }) => {
                     self.update_stored_message_state(&record.id, MessageState::EpochInvalidated)?;
+                    self.note_peel_deferred_row_retired(group_id, &record.id);
                     return Err(EngineError::ForkedEpoch {
-                        group_id,
+                        group_id: forked_group_id,
                         last_stable,
                         conflicting_epoch,
                     });
                 }
                 Err(e) => {
                     self.update_stored_message_state(&record.id, MessageState::Retryable)?;
+                    self.note_peel_deferred_row_retired(group_id, &record.id);
                     return Err(e);
                 }
             }
         }
+
+        let queue_depth = {
+            let state = self.deferred_peel.entry(group_id.clone()).or_default();
+            state.cycle_progressed |= progressed > 0;
+            state.cursor = if end >= total { 0 } else { end };
+            // Arm the gate only after a full cycle over the backlog made no
+            // progress — a bounded sweep must never permanently skip rows it
+            // has not attempted under this context.
+            if end >= total && !state.cycle_progressed {
+                state.gate = Some(fingerprint);
+            }
+            state.deferred_rows
+        };
+        tracing::info!(
+            target: "cgka_engine::message_processor",
+            method = "retry_deferred_peels",
+            rows_attempted = (end - start) as u64,
+            backlog = total as u64,
+            progressed = progressed as u64,
+            terminal = terminal as u64,
+            queue_depth = queue_depth as u64,
+            sweep_duration_ms = sweep_started.elapsed().as_millis() as u64,
+            "deferred-peel retry sweep"
+        );
         Ok(progressed)
+    }
+
+    /// Fingerprint of everything that can change a deferred peel's outcome:
+    /// the group's live epoch and the retained peel-snapshot set. While this
+    /// is unchanged, re-peeling a deferred row is guaranteed wasted work.
+    fn deferred_peel_context_fingerprint(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<[u8; 32], EngineError> {
+        let epoch = self.epoch_manager.epoch(group_id).unwrap_or_default();
+        let mut names: Vec<String> = self
+            .available_past_peel_snapshots(group_id)?
+            .into_iter()
+            .map(|(snapshot_epoch, name)| format!("{}:{name}", snapshot_epoch.0))
+            .collect();
+        names.sort();
+        let mut hasher = Sha256::new();
+        hasher.update(b"cgka-engine-deferred-peel-context/v1");
+        hasher.update(epoch.0.to_be_bytes());
+        for name in names {
+            hasher.update((name.len() as u64).to_be_bytes());
+            hasher.update(name.as_bytes());
+        }
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&hasher.finalize());
+        Ok(out)
+    }
+
+    /// Reserve capacity for one new `PeelDeferred` row, lazily counting the
+    /// group's retained rows on first use this session. Returns `false` when
+    /// the per-group flood cap is reached — the caller drops the message
+    /// unpersisted (mdk#339).
+    pub(crate) fn reserve_peel_deferred_slot(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<bool, EngineError> {
+        if !self
+            .deferred_peel
+            .get(group_id)
+            .is_some_and(|state| state.counted)
+        {
+            let count = self
+                .storage
+                .list_messages(group_id, EpochId(0))?
+                .into_iter()
+                .filter(|record| record.state == MessageState::PeelDeferred)
+                .count();
+            let state = self.deferred_peel.entry(group_id.clone()).or_default();
+            state.deferred_rows = count;
+            state.counted = true;
+        }
+        let state = self.deferred_peel.entry(group_id.clone()).or_default();
+        if state.deferred_rows >= MAX_PEEL_DEFERRED_ROWS_PER_GROUP {
+            return Ok(false);
+        }
+        state.deferred_rows += 1;
+        Ok(true)
+    }
+
+    /// Bookkeeping for a row leaving `PeelDeferred` (applied, reclassified,
+    /// invalidated, or terminally failed): release its flood-cap slot and its
+    /// attempt-tracking entry.
+    pub(crate) fn note_peel_deferred_row_retired(
+        &mut self,
+        group_id: &GroupId,
+        msg_id: &MessageId,
+    ) {
+        if let Some(state) = self.deferred_peel.get_mut(group_id) {
+            state.deferred_rows = state.deferred_rows.saturating_sub(1);
+            state.attempts.remove(msg_id);
+        }
     }
 
     /// Discard every queued outbound intent for a group whose local copy is
@@ -554,28 +801,38 @@ impl<S: StorageProvider> Engine<S> {
             let Some(msg) = stored_payload.as_raw_transport().cloned() else {
                 continue;
             };
+            let was_peel_deferred = record.state == MessageState::PeelDeferred;
             match self
                 .ingest_group_message(&msg, group_id.as_slice().to_vec())
                 .await
             {
                 Ok(IngestOutcome::Buffered { .. }) => {
                     self.update_stored_message_state(&record.id, MessageState::Retryable)?;
+                    if was_peel_deferred {
+                        self.note_peel_deferred_row_retired(group_id, &record.id);
+                    }
                 }
                 Ok(_) => {}
                 Err(EngineError::ForkedEpoch {
-                    group_id,
+                    group_id: forked_group_id,
                     last_stable,
                     conflicting_epoch,
                 }) => {
                     self.update_stored_message_state(&record.id, MessageState::EpochInvalidated)?;
+                    if was_peel_deferred {
+                        self.note_peel_deferred_row_retired(group_id, &record.id);
+                    }
                     return Err(EngineError::ForkedEpoch {
-                        group_id,
+                        group_id: forked_group_id,
                         last_stable,
                         conflicting_epoch,
                     });
                 }
                 Err(e) => {
                     self.update_stored_message_state(&record.id, MessageState::Retryable)?;
+                    if was_peel_deferred {
+                        self.note_peel_deferred_row_retired(group_id, &record.id);
+                    }
                     return Err(e);
                 }
             }

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -78,6 +78,12 @@ pub(crate) struct DeferredPeelGroupState {
     /// Whether `deferred_rows` has been initialized from storage this
     /// session.
     counted: bool,
+    /// Whether a cap-exceeded `Rejection` has already been audited for the
+    /// current cap-full episode. Raw transport ids are attacker-controlled,
+    /// so a sustained flood past the cap would otherwise emit one audit write
+    /// per rejected message; this suppresses the repeats until the backlog
+    /// drops back below the cap and re-arms.
+    cap_rejection_audited: bool,
     /// Per-row attempt count and first-seen sweep, keyed by the raw
     /// transport message id.
     attempts: std::collections::HashMap<MessageId, DeferredPeelAttempts>,
@@ -669,7 +675,9 @@ impl<S: StorageProvider> Engine<S> {
 
     /// Bookkeeping for a row leaving `PeelDeferred` (applied, reclassified,
     /// invalidated, or terminally failed): release its flood-cap slot and its
-    /// attempt-tracking entry.
+    /// attempt-tracking entry. Once the backlog drops back below the cap, the
+    /// cap-rejection audit re-arms so a fresh cap-full episode is recorded
+    /// once more.
     pub(crate) fn note_peel_deferred_row_retired(
         &mut self,
         group_id: &GroupId,
@@ -678,7 +686,24 @@ impl<S: StorageProvider> Engine<S> {
         if let Some(state) = self.deferred_peel.get_mut(group_id) {
             state.deferred_rows = state.deferred_rows.saturating_sub(1);
             state.attempts.remove(msg_id);
+            if state.deferred_rows < MAX_PEEL_DEFERRED_ROWS_PER_GROUP {
+                state.cap_rejection_audited = false;
+            }
         }
+    }
+
+    /// Whether a cap-exceeded `Rejection` should be audited now: `true` only
+    /// the first time the cap is hit for the current cap-full episode, so a
+    /// sustained attacker flood past the cap does not emit one audit write
+    /// per rejected message (mdk#339). Re-arms via
+    /// [`Self::note_peel_deferred_row_retired`] once the backlog drains.
+    pub(crate) fn should_audit_peel_deferred_cap_rejection(&mut self, group_id: &GroupId) -> bool {
+        let state = self.deferred_peel.entry(group_id.clone()).or_default();
+        if state.cap_rejection_audited {
+            return false;
+        }
+        state.cap_rejection_audited = true;
+        true
     }
 
     /// Discard every queued outbound intent for a group whose local copy is

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -85,6 +85,10 @@ impl<S: StorageProvider> Engine<S> {
 
     pub(crate) async fn do_send(&mut self, intent: SendIntent) -> Result<SendResult, EngineError> {
         let group_id = send_intent_group_id(&intent).clone();
+        // Quarantine gate: a group frozen by hydration quarantine must not
+        // stage, queue, or publish anything — a confirm would set_stable and
+        // silently un-quarantine it out of band (mdk#364).
+        self.ensure_group_live(&group_id)?;
         // Terminal gate before queueing: a local copy marked removed (realized
         // self-eviction) must never accept or queue outbound work. Checked
         // again in `do_send_ready` so queued-intent drains for a copy removed
@@ -119,6 +123,9 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         now_ms: u64,
     ) -> Result<Vec<SendResult>, EngineError> {
+        // Quarantined groups vanish from every live surface; convergence and
+        // queued-intent drains must not touch their state (mdk#364).
+        self.ensure_group_live(group_id)?;
         // Terminal: a removed copy must never publish, and the removed-copy
         // gate in `do_send_ready` would turn every queued record into a
         // permanent drain error that the app retries forever. Discard the
@@ -353,6 +360,13 @@ impl<S: StorageProvider> Engine<S> {
     }
 
     pub async fn retry_deferred_peels(&mut self, group_id: &GroupId) -> Result<usize, EngineError> {
+        // A quarantined group has no epoch_manager entry, so the Stable gate
+        // below would fall through and re-ingest its retained rows against
+        // the very state validation rejected (mdk#364). The rows replay
+        // once repair clears the quarantine.
+        if self.quarantined_reason(group_id).is_some() {
+            return Ok(0);
+        }
         if let Some(state) = self.epoch_manager.state(group_id)
             && !matches!(state, EpochState::Stable { .. })
         {
@@ -377,6 +391,15 @@ impl<S: StorageProvider> Engine<S> {
                 Ok(IngestOutcome::Stale {
                     reason: StaleReason::PeelFailed,
                 }) => {}
+                Ok(IngestOutcome::Stale {
+                    reason: StaleReason::Quarantined,
+                }) => {
+                    // Defense-in-depth: the gate above should keep this loop
+                    // from running for a quarantined group at all, but if a
+                    // row still classifies Quarantined it must keep its
+                    // PeelDeferred state — the catch-all arm below would
+                    // retire the replay buffer.
+                }
                 Ok(IngestOutcome::Buffered { .. } | IngestOutcome::Processed) => {
                     // The peeled content now has its own content-derived record;
                     // retire the raw transport wrapper so it does not keep

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -832,12 +832,36 @@ impl<S: StorageProvider> Engine<S> {
                 .await
             {
                 Ok(IngestOutcome::Buffered { .. }) => {
-                    self.update_stored_message_state(&record.id, MessageState::Retryable)?;
                     if was_peel_deferred {
+                        // The content-derived row is now the buffered
+                        // convergence witness; retire the raw deferred wrapper
+                        // so it leaves the retry lifecycle and frees its cap
+                        // slot (mdk#339), mirroring `retry_deferred_peels`.
+                        self.update_stored_message_state(&record.id, MessageState::Processed)?;
+                        self.note_peel_deferred_row_retired(group_id, &record.id);
+                    } else {
+                        self.update_stored_message_state(&record.id, MessageState::Retryable)?;
+                    }
+                }
+                Ok(IngestOutcome::Stale {
+                    reason: StaleReason::PeelFailed | StaleReason::Quarantined,
+                }) => {
+                    // Still un-peelable, or the group is quarantined: leave the
+                    // row deferred. A terminal-after-peel `PeelFailed` already
+                    // retired its raw deferred row inside `ingest_group_message`
+                    // via `mark_raw_transport_message_failed_if_deferred`.
+                }
+                Ok(_) => {
+                    // Applied (`Processed`) or terminally reclassified
+                    // (`AlreadySeen`, `SelfEvicted`, ...): retire a raw
+                    // deferred wrapper so it stops holding a cap slot
+                    // (mdk#339). Non-deferred rows keep the pre-existing
+                    // no-op behavior.
+                    if was_peel_deferred {
+                        self.update_stored_message_state(&record.id, MessageState::Processed)?;
                         self.note_peel_deferred_row_retired(group_id, &record.id);
                     }
                 }
-                Ok(_) => {}
                 Err(EngineError::ForkedEpoch {
                     group_id: forked_group_id,
                     last_stable,

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -406,6 +406,7 @@ mod tests {
                 members: vec![],
                 required_capabilities: Default::default(),
                 removed: false,
+                join_epoch: EpochId(0),
             })
             .unwrap();
         let msg = transport_message(b"colliding-id", b"wire-bytes");

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -221,14 +221,22 @@ impl<S: StorageProvider> Engine<S> {
             Err(StorageError::NotFound) => None,
             Err(err) => return Err(EngineError::Storage(err)),
         };
-        if previous.as_ref().is_some_and(|record| {
-            record.group_id == *group_id && record.epoch == epoch && record.state == state
-        }) {
-            return Ok(());
-        }
         let payload = payload
             .encode()
             .map_err(|e| EngineError::Serialize(format!("{e:?}")))?;
+        // Short-circuit only when the stored record is fully identical,
+        // including the encoded payload bytes. A same (group, epoch, state)
+        // row persisted under a different payload variant (e.g. RawTransport
+        // then OpenMlsWire) must be overwritten, not silently kept — a reader
+        // on the other processing path would otherwise skip the record (#369).
+        if previous.as_ref().is_some_and(|record| {
+            record.group_id == *group_id
+                && record.epoch == epoch
+                && record.state == state
+                && record.payload == payload
+        }) {
+            return Ok(());
+        }
         self.storage.put_message(&MessageRecord {
             id,
             group_id: group_id.clone(),
@@ -269,5 +277,159 @@ impl<S: StorageProvider> Engine<S> {
             self.audit(event);
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::account_identity_proof::{AccountIdentityProofRequest, AccountIdentityProofSigner};
+    use crate::engine::EngineBuilder;
+    use async_trait::async_trait;
+    use cgka_traits::error::PeelerError;
+    use cgka_traits::group_context::GroupContextSnapshot;
+    use cgka_traits::ingest::PeeledMessage;
+    use cgka_traits::message::{MessageState, StoredMessagePayload};
+    use cgka_traits::peeler::TransportPeeler;
+    use cgka_traits::storage::{GroupStorage, MessageStorage};
+    use cgka_traits::transport::{
+        EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
+    };
+    use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
+    use k256::schnorr::{SigningKey, signature::hazmat::PrehashSigner};
+    use sha2::{Digest, Sha256};
+    use std::sync::Arc;
+    use storage_sqlite::SqliteAccountStorage;
+
+    struct UnreachablePeeler;
+
+    #[async_trait]
+    impl TransportPeeler for UnreachablePeeler {
+        async fn peel_group_message(
+            &self,
+            _msg: &TransportMessage,
+            _ctx: &GroupContextSnapshot,
+        ) -> Result<PeeledMessage, PeelerError> {
+            Err(PeelerError::DecryptFailed)
+        }
+
+        async fn peel_welcome(
+            &self,
+            _msg: &TransportMessage,
+        ) -> Result<PeeledMessage, PeelerError> {
+            Err(PeelerError::DecryptFailed)
+        }
+
+        async fn wrap_group_message(
+            &self,
+            _payload: &EncryptedPayload,
+            _ctx: &GroupContextSnapshot,
+        ) -> Result<TransportMessage, PeelerError> {
+            Err(PeelerError::DecryptFailed)
+        }
+
+        async fn wrap_welcome(
+            &self,
+            _payload: &EncryptedPayload,
+            _recipient: &MemberId,
+        ) -> Result<TransportMessage, PeelerError> {
+            Err(PeelerError::DecryptFailed)
+        }
+    }
+
+    struct TestProofSigner(SigningKey);
+
+    impl AccountIdentityProofSigner for TestProofSigner {
+        fn sign_account_identity_proof(
+            &self,
+            request: &AccountIdentityProofRequest,
+        ) -> Result<[u8; 64], String> {
+            let signature = self
+                .0
+                .sign_prehash(&request.signing_digest())
+                .map_err(|e| e.to_string())?;
+            Ok(signature.to_bytes())
+        }
+    }
+
+    fn test_signing_key() -> SigningKey {
+        let mut counter = 0u64;
+        loop {
+            let mut material = [0u8; 32];
+            let mut hasher = Sha256::new();
+            hasher.update(b"cgka-engine-store-test-identity-v1");
+            hasher.update(counter.to_be_bytes());
+            material.copy_from_slice(&hasher.finalize());
+            if let Ok(sk) = SigningKey::from_bytes(&material) {
+                return sk;
+            }
+            counter += 1;
+        }
+    }
+
+    fn transport_message(id: &[u8], payload: &[u8]) -> TransportMessage {
+        TransportMessage {
+            id: MessageId::new(id.to_vec()),
+            payload: payload.to_vec(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("store-test".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: vec![],
+            },
+        }
+    }
+
+    /// Regression for mdk#369: the idempotency short-circuit must compare the
+    /// encoded payload, not just (group, epoch, state) — a second persist of
+    /// the same id under a different `StoredMessagePayload` variant must
+    /// overwrite, or a reader on the other processing path silently loses the
+    /// record.
+    #[test]
+    fn same_key_persist_with_different_payload_variant_overwrites() {
+        let storage = SqliteAccountStorage::in_memory().unwrap();
+        let signing_key = test_signing_key();
+        let identity = signing_key.verifying_key().to_bytes().to_vec();
+        let engine = EngineBuilder::new(storage.clone())
+            .identity(identity)
+            .account_identity_proof_signer(Arc::new(TestProofSigner(signing_key)))
+            .peeler(Box::new(UnreachablePeeler))
+            .build()
+            .unwrap();
+
+        let group_id = GroupId::new(vec![7u8; 16]);
+        storage
+            .put_group(&cgka_traits::group::Group {
+                id: group_id.clone(),
+                name: "store-test".into(),
+                description: String::new(),
+                epoch: EpochId(3),
+                members: vec![],
+                required_capabilities: Default::default(),
+                removed: false,
+            })
+            .unwrap();
+        let msg = transport_message(b"colliding-id", b"wire-bytes");
+
+        engine
+            .persist_transport_message(&msg, &group_id, EpochId(3), MessageState::Failed)
+            .unwrap();
+        engine
+            .persist_openmls_wire_message(&msg, &group_id, EpochId(3), MessageState::Failed)
+            .unwrap();
+
+        let record = storage.get_message(&msg.id).unwrap();
+        let stored = StoredMessagePayload::decode(&record.payload).unwrap();
+        assert!(
+            stored.as_openmls_wire().is_some(),
+            "second persist with a different payload variant must overwrite the record"
+        );
+
+        // Fully identical re-persist still short-circuits without error.
+        engine
+            .persist_openmls_wire_message(&msg, &group_id, EpochId(3), MessageState::Failed)
+            .unwrap();
+        let record = storage.get_message(&msg.id).unwrap();
+        let stored = StoredMessagePayload::decode(&record.payload).unwrap();
+        assert!(stored.as_openmls_wire().is_some());
     }
 }

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -21,7 +21,7 @@ use openmls::group::{MlsGroup, ProcessMessageError, ValidationError};
 use openmls::messages::proposals::{AppDataUpdateOperation, Proposal, ProposalOrRef};
 use openmls::prelude::{
     BasicCredential, ContentType, MlsMessageBodyIn, MlsMessageIn, ProcessedMessage,
-    ProcessedMessageContent, ProtocolMessage, ProtocolVersion, Sender,
+    ProcessedMessageContent, ProtocolMessage, ProtocolVersion,
 };
 use openmls_rust_crypto::RustCrypto;
 use openmls_traits::OpenMlsProvider;
@@ -1819,11 +1819,7 @@ fn process_openmls_messages_inner<S: StorageProvider>(
             }
             Err(e) => return Err(replay_error("process_message", e)),
         };
-        let sender_id = sender_member_id(processed.sender(), &mls_group);
-        let sender = sender_id
-            .as_ref()
-            .map(|id| id.as_slice().to_vec())
-            .unwrap_or_default();
+        let sender_id = crate::identity::member_id_of_sender(processed.sender(), &mls_group);
 
         match processed.into_content() {
             ProcessedMessageContent::ProposalMessage(queued) => {
@@ -1881,7 +1877,11 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                     ));
                 }
                 let priority = crate::app_components::commit_ordering_priority_for_staged(&staged);
-                let committer = sender.clone();
+                let committer = sender_id
+                    .as_ref()
+                    .expect("checked above")
+                    .as_slice()
+                    .to_vec();
                 // foundation/identity.md: deferred commits replayed during
                 // convergence are an inbound credential ingress too. Reject
                 // commits that introduce or mutate a member LeafNode whose
@@ -1927,11 +1927,26 @@ fn process_openmls_messages_inner<S: StorageProvider>(
             }
             ProcessedMessageContent::ApplicationMessage(bytes) => {
                 let payload = bytes.into_bytes();
-                if crate::app_payload::app_payload_is_valid_for_sender(&payload, &sender) {
+                // Mirror the direct ingest seam (audit item S3): an
+                // application message whose MLS sender does not resolve to a
+                // validated member leaf is never surfaced, so a blank,
+                // unauthenticated author cannot reach the app through the
+                // replay seam (#383). Pushing `Ignored` keeps the message out
+                // of `app_messages_by_id`; canonicalization then classifies
+                // it undecryptable-in-canonical-state and the disposition
+                // writer marks it terminal once its epoch is at or below the
+                // settled tip. A bad-sender future-epoch message stays
+                // retryable until the tip passes it — indistinguishable from
+                // a legitimate future message at this point, and it converts
+                // to terminal as the tip advances.
+                let validated_sender = sender_id.as_ref().filter(|sender| {
+                    crate::app_payload::validate_app_payload_for_sender(&payload, sender).is_ok()
+                });
+                if let Some(sender) = validated_sender {
                     observations.push(OpenMlsReplayObservation::ApplicationProcessed {
                         message_id,
                         source_epoch,
-                        sender,
+                        sender: sender.as_slice().to_vec(),
                         payload: payload.clone(),
                         decrypted_payload_ref: format!(
                             "sha256:{}",
@@ -2073,14 +2088,6 @@ pub(crate) fn process_commit_with_app_data_updates<S: StorageProvider>(
         unverified,
         updater.changes(),
     )
-}
-
-fn sender_member_id(sender: &Sender, group: &MlsGroup) -> Option<MemberId> {
-    let Sender::Member(leaf_idx) = sender else {
-        return None;
-    };
-    let member = group.member_at(*leaf_idx)?;
-    crate::identity::validated_member_id(&member.credential).ok()
 }
 
 fn message_digest(bytes: &[u8]) -> [u8; 32] {

--- a/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
+++ b/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
@@ -1,0 +1,662 @@
+//! Deferred-peel retry lifecycle (mdk#339): event-driven retries via
+//! the peel-context fingerprint gate, the per-row retry budget, the per-group
+//! flood cap on retained `PeelDeferred` rows, and post-peel pre-membership
+//! classification against `Group::join_epoch`.
+
+use async_trait::async_trait;
+use cgka_engine::canonicalization::CanonicalizationPolicy;
+use cgka_engine::message_processor::MAX_PEEL_DEFERRED_ROWS_PER_GROUP;
+use cgka_engine::openmls_projection::project_mls_message;
+use cgka_engine::{Engine, EngineBuilder};
+use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
+use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult};
+use cgka_traits::error::PeelerError;
+use cgka_traits::group_context::GroupContextSnapshot;
+use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage, StaleReason};
+use cgka_traits::message::MessageState;
+use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::storage::{MessageStorage, StorageError};
+use cgka_traits::transport::{
+    EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
+};
+use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use storage_sqlite::SqliteAccountStorage;
+
+mod support;
+use support::proof_signer;
+
+fn pad32(name: &[u8]) -> Vec<u8> {
+    use k256::schnorr::SigningKey;
+
+    let mut counter = 0u64;
+    loop {
+        let mut material = [0u8; 32];
+        let mut hasher = Sha256::new();
+        hasher.update(b"cgka-engine-test-identity-v1");
+        hasher.update(name);
+        hasher.update(counter.to_be_bytes());
+        material.copy_from_slice(&hasher.finalize());
+        if let Ok(sk) = SigningKey::from_bytes(&material) {
+            return sk.verifying_key().to_bytes().to_vec();
+        }
+        counter += 1;
+    }
+}
+
+fn hash_id(bytes: &[u8]) -> MessageId {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut h = DefaultHasher::new();
+    bytes.hash(&mut h);
+    MessageId::new(h.finish().to_be_bytes().to_vec())
+}
+
+fn content_id(msg: &TransportMessage) -> MessageId {
+    MessageId::new(Sha256::digest(&msg.payload).to_vec())
+}
+
+/// Pass-through peeler that fails `DecryptFailed` for messages wrapped at an
+/// epoch beyond the receiver's context — the same gate as the
+/// `EpochGatePeeler` in `distributed_convergence.rs` — while counting every
+/// peel attempt per raw transport message id, so tests can assert exactly
+/// when the engine re-peels a deferred row.
+#[derive(Clone)]
+struct CountingEpochGatePeeler {
+    peel_attempts: Arc<Mutex<HashMap<MessageId, u64>>>,
+}
+
+impl CountingEpochGatePeeler {
+    fn new() -> Self {
+        Self {
+            peel_attempts: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn attempts_for(&self, id: &MessageId) -> u64 {
+        self.peel_attempts
+            .lock()
+            .unwrap()
+            .get(id)
+            .copied()
+            .unwrap_or(0)
+    }
+}
+
+#[async_trait]
+impl TransportPeeler for CountingEpochGatePeeler {
+    async fn peel_group_message(
+        &self,
+        msg: &TransportMessage,
+        ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        *self
+            .peel_attempts
+            .lock()
+            .unwrap()
+            .entry(msg.id.clone())
+            .or_insert(0) += 1;
+        if let Ok(projection) = project_mls_message(&msg.payload)
+            && let Some(source_epoch) = projection.source_epoch
+            && ctx.epoch().0 < source_epoch
+        {
+            return Err(PeelerError::DecryptFailed);
+        }
+        Ok(PeeledMessage {
+            id: msg.id.clone(),
+            group_id: None,
+            sender: None,
+            content: PeeledContent::MlsMessage {
+                bytes: msg.payload.clone(),
+            },
+            origin: msg.clone(),
+        })
+    }
+
+    async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        Ok(PeeledMessage {
+            id: msg.id.clone(),
+            group_id: None,
+            sender: None,
+            content: PeeledContent::Welcome {
+                bytes: msg.payload.clone(),
+            },
+            origin: msg.clone(),
+        })
+    }
+
+    async fn wrap_group_message(
+        &self,
+        payload: &EncryptedPayload,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        Ok(TransportMessage {
+            id: hash_id(&payload.ciphertext),
+            payload: payload.ciphertext.clone(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("mock".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: vec![],
+            },
+        })
+    }
+
+    async fn wrap_welcome(
+        &self,
+        payload: &EncryptedPayload,
+        recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        Ok(TransportMessage {
+            id: hash_id(&payload.ciphertext),
+            payload: payload.ciphertext.clone(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("mock".into()),
+            envelope: TransportEnvelope::Welcome {
+                recipient: recipient.clone(),
+            },
+        })
+    }
+}
+
+fn build_client(name: &[u8]) -> (Engine<SqliteAccountStorage>, SqliteAccountStorage) {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let engine = EngineBuilder::new(storage.clone())
+        .identity(pad32(name))
+        .account_identity_proof_signer(proof_signer(name))
+        .peeler(Box::new(CountingEpochGatePeeler::new()))
+        .build()
+        .unwrap();
+    (engine, storage)
+}
+
+fn build_counting_client(
+    name: &[u8],
+) -> (
+    Engine<SqliteAccountStorage>,
+    SqliteAccountStorage,
+    CountingEpochGatePeeler,
+) {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let peeler = CountingEpochGatePeeler::new();
+    let mut engine = EngineBuilder::new(storage.clone())
+        .identity(pad32(name))
+        .account_identity_proof_signer(proof_signer(name))
+        .peeler(Box::new(peeler.clone()))
+        .build()
+        .unwrap();
+    engine.set_convergence_policy(CanonicalizationPolicy {
+        settlement_quiescence_ms: 0,
+        ..CanonicalizationPolicy::default()
+    });
+    (engine, storage, peeler)
+}
+
+fn route(msg: TransportMessage, group_id: &GroupId) -> TransportMessage {
+    match msg.envelope {
+        TransportEnvelope::Welcome { .. } => msg,
+        TransportEnvelope::GroupMessage { .. } => TransportMessage {
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: group_id.as_slice().to_vec(),
+            },
+            ..msg
+        },
+    }
+}
+
+fn welcome_for(welcomes: &[TransportMessage], name: &[u8]) -> TransportMessage {
+    let recipient = MemberId::new(pad32(name));
+    welcomes
+        .iter()
+        .find(|welcome| {
+            matches!(&welcome.envelope, TransportEnvelope::Welcome { recipient: r } if *r == recipient)
+        })
+        .cloned()
+        .expect("welcome for recipient")
+}
+
+fn evolution(result: SendResult) -> (TransportMessage, cgka_traits::engine_state::PendingStateRef) {
+    match result {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected group evolution, got {other:?}"),
+    }
+}
+
+fn app_payload_for(engine: &Engine<SqliteAccountStorage>, content: &str) -> Vec<u8> {
+    MarmotAppEvent::new(
+        hex::encode(engine.self_id().as_slice()),
+        1_700_000_000,
+        MARMOT_APP_EVENT_KIND_CHAT,
+        vec![],
+        content,
+    )
+    .encode()
+    .expect("test app event encodes")
+}
+
+async fn send_app(
+    engine: &mut Engine<SqliteAccountStorage>,
+    group_id: &GroupId,
+    content: &str,
+) -> TransportMessage {
+    let result = engine
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(engine, content),
+        })
+        .await
+        .expect("send app");
+    match result {
+        SendResult::ApplicationMessage { msg } => route(msg, group_id),
+        other => panic!("expected app message, got {other:?}"),
+    }
+}
+
+/// Common scaffold: alice owns the group; carol (counting epoch-gate peeler)
+/// joins at epoch 1. Alice then advances to epoch 2 (invite david) and 3
+/// (invite eve) without delivering those commits. Returns the two withheld
+/// commits so tests choose what carol sees.
+async fn carol_behind_two_epochs() -> (
+    Engine<SqliteAccountStorage>,
+    Engine<SqliteAccountStorage>,
+    SqliteAccountStorage,
+    CountingEpochGatePeeler,
+    GroupId,
+    TransportMessage,
+    TransportMessage,
+) {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage, carol_peeler) = build_counting_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+    let (mut eve, _eve_storage) = build_client(b"eve");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "deferred-peel-lifecycle".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![alice.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    carol.drain_events();
+
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let invite_david = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david_kp],
+        })
+        .await
+        .unwrap();
+    let (commit_to_epoch2, pending) = evolution(invite_david);
+    let commit_to_epoch2 = route(commit_to_epoch2, &group_id);
+    alice.confirm_published(pending).await.unwrap();
+
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let invite_eve = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+        })
+        .await
+        .unwrap();
+    let (commit_to_epoch3, pending) = evolution(invite_eve);
+    let commit_to_epoch3 = route(commit_to_epoch3, &group_id);
+    alice.confirm_published(pending).await.unwrap();
+
+    (
+        alice,
+        carol,
+        carol_storage,
+        carol_peeler,
+        group_id,
+        commit_to_epoch2,
+        commit_to_epoch3,
+    )
+}
+
+/// The core #339 fix: a deferred row is not re-peeled while the
+/// (epoch, snapshot-set) peel context is unchanged — after one unproductive
+/// full cycle over the backlog, whole sweeps are skipped.
+#[tokio::test]
+async fn deferred_peel_not_retried_while_context_unchanged() {
+    let (_alice, mut carol, carol_storage, carol_peeler, group_id, _commit2, commit3) =
+        carol_behind_two_epochs().await;
+
+    // The epoch-3 commit does not peel at carol's epoch 1: deferred.
+    assert!(matches!(
+        carol.ingest(commit3.clone()).await.unwrap(),
+        IngestOutcome::Stale {
+            reason: StaleReason::PeelFailed
+        }
+    ));
+    assert_eq!(
+        carol_storage.get_message(&commit3.id).unwrap().state,
+        MessageState::PeelDeferred
+    );
+
+    // First drain performs one sweep (one re-peel attempt), makes no
+    // progress, and arms the context gate.
+    carol
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_000_000)
+        .await
+        .unwrap();
+    let attempts_after_first_sweep = carol_peeler.attempts_for(&commit3.id);
+
+    // Nothing changed: subsequent drains must not re-peel the row at all.
+    carol
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_000_001)
+        .await
+        .unwrap();
+    carol
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_000_002)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        carol_peeler.attempts_for(&commit3.id),
+        attempts_after_first_sweep,
+        "unchanged peel context must skip deferred-peel sweeps entirely"
+    );
+    assert_eq!(
+        carol_storage.get_message(&commit3.id).unwrap().state,
+        MessageState::PeelDeferred,
+        "row stays retained while the context is unchanged"
+    );
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
+}
+
+/// The gate must not block legitimate retries: once the epoch advances, the
+/// deferred row is re-attempted and applies.
+#[tokio::test]
+async fn deferred_peel_retries_after_epoch_advance() {
+    let (_alice, mut carol, carol_storage, carol_peeler, group_id, commit2, commit3) =
+        carol_behind_two_epochs().await;
+
+    carol.ingest(commit3.clone()).await.unwrap();
+    carol
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_000_000)
+        .await
+        .unwrap();
+    let gated_attempts = carol_peeler.attempts_for(&commit3.id);
+
+    // The epoch-2 commit arrives: the peel context changes, the gate opens,
+    // and the deferred epoch-3 commit replays to the tip.
+    carol.ingest(commit2.clone()).await.unwrap();
+    carol
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_000_001)
+        .await
+        .unwrap();
+
+    assert!(
+        carol_peeler.attempts_for(&commit3.id) > gated_attempts,
+        "changed peel context must re-attempt the deferred row"
+    );
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(3));
+    assert_eq!(
+        carol_storage.get_message(&commit3.id).unwrap().state,
+        MessageState::Processed
+    );
+}
+
+/// A row that exhausts its retry budget without ever peeling goes terminal
+/// `Failed` (`permanently_undecryptable`) and is never attempted again.
+#[tokio::test]
+async fn deferred_peel_terminal_after_attempt_budget() {
+    let (mut alice, mut carol, carol_storage, carol_peeler, group_id, commit2, _commit3) =
+        carol_behind_two_epochs().await;
+    carol.set_deferred_peel_retry_budget(1);
+
+    // An application message at epoch 3 can never peel while carol never
+    // sees the epoch-3 commit.
+    let stuck_app = send_app(&mut alice, &group_id, "forever ahead").await;
+    assert!(matches!(
+        carol.ingest(stuck_app.clone()).await.unwrap(),
+        IngestOutcome::Stale {
+            reason: StaleReason::PeelFailed
+        }
+    ));
+
+    // Sweep 1 (context: epoch 1) consumes the single budgeted attempt.
+    carol
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_000_000)
+        .await
+        .unwrap();
+    assert_eq!(
+        carol_storage.get_message(&stuck_app.id).unwrap().state,
+        MessageState::PeelDeferred
+    );
+
+    // The epoch-2 commit changes the context; the next sweep finds the row
+    // over budget and goes terminal without another peel attempt.
+    carol.ingest(commit2.clone()).await.unwrap();
+    carol
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_000_001)
+        .await
+        .unwrap();
+    assert_eq!(
+        carol_storage.get_message(&stuck_app.id).unwrap().state,
+        MessageState::Failed,
+        "budget-exhausted deferred row must go terminal"
+    );
+
+    // Terminal rows are out of the lifecycle: further context changes do not
+    // re-peel them.
+    let attempts_at_terminal = carol_peeler.attempts_for(&stuck_app.id);
+    carol
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_000_002)
+        .await
+        .unwrap();
+    assert_eq!(
+        carol_peeler.attempts_for(&stuck_app.id),
+        attempts_at_terminal
+    );
+}
+
+/// A flood of undecryptable group-routed input (fresh transport id per
+/// re-wrap is attacker-controllable) must not grow the durable store past
+/// the per-group cap; overflow is dropped unpersisted and deduplicated.
+#[tokio::test]
+async fn peel_deferred_rows_capped_per_group_under_flood() {
+    let (mut alice, mut carol, carol_storage, _carol_peeler, group_id, _commit2, _commit3) =
+        carol_behind_two_epochs().await;
+
+    // One real epoch-3 app message, re-wrapped under distinct transport ids —
+    // exactly the re-wrap flood a malicious peer can produce for free.
+    let template = send_app(&mut alice, &group_id, "flood payload").await;
+    let flood = MAX_PEEL_DEFERRED_ROWS_PER_GROUP + 5;
+    let mut overflow_ids = Vec::new();
+    for i in 0..flood {
+        let wrapped = TransportMessage {
+            id: MessageId::new(format!("flood-{i}").into_bytes()),
+            ..template.clone()
+        };
+        let outcome = carol.ingest(wrapped.clone()).await.unwrap();
+        assert!(
+            matches!(
+                outcome,
+                IngestOutcome::Stale {
+                    reason: StaleReason::PeelFailed
+                }
+            ),
+            "flood message {i} classified unexpectedly: {outcome:?}"
+        );
+        if i >= MAX_PEEL_DEFERRED_ROWS_PER_GROUP {
+            overflow_ids.push(wrapped.id.clone());
+        }
+    }
+
+    let retained = carol_storage
+        .list_messages(&group_id, EpochId(0))
+        .unwrap()
+        .into_iter()
+        .filter(|record| record.state == MessageState::PeelDeferred)
+        .count();
+    assert_eq!(
+        retained, MAX_PEEL_DEFERRED_ROWS_PER_GROUP,
+        "durable PeelDeferred rows must be capped per group"
+    );
+    for id in &overflow_ids {
+        assert!(
+            matches!(carol_storage.get_message(id), Err(StorageError::NotFound)),
+            "overflow input must not be persisted"
+        );
+    }
+
+    // Overflow ids were remembered in-process: redelivery dedups cheaply.
+    let overflow_replay = TransportMessage {
+        id: overflow_ids[0].clone(),
+        ..template.clone()
+    };
+    assert!(matches!(
+        carol.ingest(overflow_replay).await.unwrap(),
+        IngestOutcome::Stale {
+            reason: StaleReason::AlreadySeen
+        }
+    ));
+}
+
+/// An application message from before this device joined is terminal on
+/// first classification — no deferral, no retry (mdk#339 acceptance
+/// criterion).
+#[tokio::test]
+async fn pre_membership_application_message_is_terminal_not_deferred() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage, carol_peeler) = build_counting_client(b"carol");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "pre-membership-terminal".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![alice.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, _welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+
+    // History carol can never decrypt: sent before she was invited.
+    let pre_membership_app = send_app(&mut alice, &group_id, "before carol").await;
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![carol_kp],
+        })
+        .await
+        .unwrap();
+    let (welcomes, pending) = match invite {
+        SendResult::GroupEvolution {
+            welcomes, pending, ..
+        } => (welcomes, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    let join_epoch = carol.epoch(&group_id).unwrap();
+    assert_eq!(
+        carol.group_record(&group_id).unwrap().join_epoch,
+        join_epoch,
+        "welcome join must record the join epoch"
+    );
+
+    // The pre-membership message peels (pass-through) but classifies
+    // terminal before any OpenMLS processing or deferral.
+    let outcome = carol.ingest(pre_membership_app.clone()).await.unwrap();
+    assert!(matches!(
+        outcome,
+        IngestOutcome::Stale {
+            reason: StaleReason::PeelFailed
+        }
+    ));
+    let record = carol_storage
+        .get_message(&content_id(&pre_membership_app))
+        .expect("terminal classification persists the content row");
+    assert_eq!(record.state, MessageState::Failed);
+    assert!(
+        matches!(
+            carol_storage.get_message(&pre_membership_app.id),
+            Err(StorageError::NotFound)
+        ),
+        "a peelable pre-membership message must not leave a PeelDeferred row"
+    );
+
+    // Terminal means terminal: convergence drains never re-peel it.
+    let attempts = carol_peeler.attempts_for(&pre_membership_app.id);
+    carol
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_000_000)
+        .await
+        .unwrap();
+    assert_eq!(carol_peeler.attempts_for(&pre_membership_app.id), attempts);
+}
+
+/// `join_epoch` bookkeeping: welcome joins record the join epoch; a group's
+/// creator records `EpochId(0)` — no bound, nothing predates the creator.
+#[tokio::test]
+async fn join_epoch_recorded_on_welcome_join() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut carol, _carol_storage, _peeler) = build_counting_client(b"carol");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "join-epoch-recorded".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![alice.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        carol.group_record(&group_id).unwrap().join_epoch,
+        carol.epoch(&group_id).unwrap(),
+        "welcome join records the post-welcome epoch"
+    );
+    assert_eq!(
+        alice.group_record(&group_id).unwrap().join_epoch,
+        EpochId(0),
+        "creator records no pre-membership bound"
+    );
+}

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -4426,6 +4426,113 @@ async fn send_preflight_retries_deferred_peels_after_convergence_apply() {
     );
 }
 
+/// Regression for mdk#707 review finding 2: a raw `PeelDeferred` row
+/// that becomes peelable but whose content is terminally rejected (here a
+/// forged, unattributable application payload) must be retired from the
+/// deferred queue — marked terminal and released from the retry lifecycle —
+/// not left durably `PeelDeferred` holding a per-group cap slot. Without the
+/// fix, `retry_deferred_peels` treats the post-peel terminal `PeelFailed`
+/// like "still cannot peel" and leaves the raw row deferred forever.
+#[tokio::test]
+async fn deferred_row_terminally_rejected_after_peel_leaves_the_deferred_queue() {
+    let (mut alice, alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage) = build_epoch_gate_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "deferred-terminal-after-peel".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![alice.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    carol.drain_events();
+
+    // Alice advances to epoch 2 and forges an unattributable app message
+    // there (inner `pubkey: ""`), which validation must reject.
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david_kp],
+        })
+        .await
+        .unwrap();
+    let (commit_to_epoch2, pending) = evolution(invite);
+    let commit_to_epoch2 = route(commit_to_epoch2, &group_id);
+    alice.confirm_published(pending).await.unwrap();
+    let forged_payload = MarmotAppEvent::new(
+        "",
+        1_700_000_000,
+        MARMOT_APP_EVENT_KIND_CHAT,
+        vec![],
+        "forged",
+    )
+    .encode()
+    .expect("forged app event encodes");
+    let forged =
+        raw_app_message_with_payload(&alice_storage, &alice.self_id(), &group_id, &forged_payload);
+
+    // Carol is at epoch 1: the epoch-gate peeler cannot peel an epoch-2
+    // message, so it is retained as a PeelDeferred raw row.
+    assert!(matches!(
+        carol.ingest(forged.clone()).await.unwrap(),
+        IngestOutcome::Stale {
+            reason: cgka_traits::ingest::StaleReason::PeelFailed
+        }
+    ));
+    assert_eq!(
+        carol_storage.get_message(&forged.id).unwrap().state,
+        MessageState::PeelDeferred
+    );
+
+    // Deliver the epoch-2 commit and converge: carol catches up, re-peels the
+    // forged message, and terminally rejects it. The raw deferred row must be
+    // retired (terminal `Failed`), not left `PeelDeferred`.
+    carol
+        .ingest(commit_to_epoch2)
+        .await
+        .expect("commit buffered");
+    carol.set_convergence_policy(CanonicalizationPolicy {
+        settlement_quiescence_ms: 0,
+        ..CanonicalizationPolicy::default()
+    });
+    carol
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_000_000)
+        .await
+        .unwrap();
+
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(2));
+    assert_eq!(
+        carol_storage.get_message(&forged.id).unwrap().state,
+        MessageState::Failed,
+        "a deferred row terminally rejected after peel must leave the deferred queue"
+    );
+    for event in carol.drain_events() {
+        if let GroupEvent::MessageReceived {
+            sender, payload, ..
+        } = event
+        {
+            assert!(!sender.as_slice().is_empty());
+            assert_ne!(payload, forged_payload);
+        }
+    }
+}
+
 #[tokio::test]
 async fn send_preflight_terminally_retires_deferred_app_message_outside_past_epoch_window() {
     let (mut alice, _alice_storage) = build_client(b"alice");

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -361,6 +361,51 @@ fn raw_remove_members_commit(
     }
 }
 
+/// Raw OpenMLS application message from `sender`'s current group state whose
+/// inner payload the test controls entirely — the engine `send` path would
+/// refuse a payload whose `MarmotAppEvent.pubkey` differs from the sender's
+/// own id, so forged-attribution payloads must be built at the OpenMLS layer.
+fn raw_app_message_with_payload(
+    storage: &SqliteAccountStorage,
+    sender: &MemberId,
+    group_id: &GroupId,
+    payload: &[u8],
+) -> TransportMessage {
+    let crypto = openmls_rust_crypto::RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mut mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load sender MLS group")
+        .expect("sender joined group");
+    let binding = storage
+        .account_device_signer(sender)
+        .expect("load signer binding")
+        .expect("signer binding exists");
+    let signer = SignatureKeyPair::read(
+        storage.mls_storage(),
+        &binding.mls_signature_public_key,
+        DEFAULT_CIPHERSUITE.signature_algorithm(),
+    )
+    .expect("MLS signer exists");
+    let msg = mls_group
+        .create_message(&provider, &signer, payload)
+        .expect("raw OpenMLS application message");
+    let payload = msg
+        .tls_serialize_detached()
+        .expect("serialize raw app message");
+    TransportMessage {
+        id: hash_id(&payload),
+        payload,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("raw-openmls-app".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    }
+}
+
 /// Raw OpenMLS commit that removes `targets` and ALSO replaces the
 /// GroupContext extensions with a copy that drops the `app_data_dictionary`
 /// entirely, so the resulting epoch carries no admin-policy bytes at all.
@@ -3418,6 +3463,123 @@ async fn engine_ingest_buffers_future_epoch_app_message_as_convergence_witness()
         }),
         "expected accepted app message event after canonical convergence, got {events:?}"
     );
+}
+
+/// Regression for mdk#383 (audit item S3 on the convergence/replay seam): a
+/// replayed application message whose attribution fails validation is never
+/// surfaced as `MessageReceived` and lands in a terminal state, exactly as on
+/// the direct ingest seam.
+///
+/// The exploit payload is a `MarmotAppEvent` whose `pubkey` is the empty
+/// string. Pre-fix, the replay arm validated it against raw sender bytes that
+/// default to empty when the MLS sender leaf does not resolve to a validated
+/// member id — `hex::encode([]) == ""` matched the forged `pubkey` and the
+/// message surfaced with a blank, unauthenticated author. A truly
+/// unresolvable in-tree sender cannot be constructed end-to-end (every
+/// credential ingress validates identities — this fix is defense-in-depth),
+/// so this test drives the forged payload through the real
+/// ingest → stored-convergence → replay path from a resolvable sender and
+/// pins the seam behavior: no `MessageReceived` for the forged payload, no
+/// `MessageReceived` with an empty `MemberId` ever, and a terminal stored
+/// state. The unresolvable-sender half of the guard is pinned by the
+/// `app_payload` unit tests (empty `MemberId` rejected outright) and the
+/// emit-side backstop in `emit_application_replay_events`.
+#[tokio::test]
+async fn convergence_app_message_with_unresolvable_sender_emits_no_event_and_lands_terminal() {
+    let (mut alice, alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-forged-sender-app".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    carol.drain_events();
+
+    // Alice advances the group epoch 1 -> 2, then authors an application
+    // message at epoch 2 whose inner event claims an empty author.
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david_kp],
+        })
+        .await
+        .unwrap();
+    let (commit, pending) = evolution(invite);
+    alice.confirm_published(pending).await.unwrap();
+    let forged_payload = MarmotAppEvent::new(
+        "",
+        1_700_000_000,
+        MARMOT_APP_EVENT_KIND_CHAT,
+        vec![],
+        "forged",
+    )
+    .encode()
+    .expect("forged app event encodes");
+    let forged_msg =
+        raw_app_message_with_payload(&alice_storage, &alice.self_id(), &group_id, &forged_payload);
+
+    // Carol buffers the future-epoch app message as a convergence witness,
+    // then the commit, and converges — the forged message replays through the
+    // stored-convergence seam at epoch 2.
+    let outcome = carol.ingest(forged_msg.clone()).await.unwrap();
+    assert!(matches!(outcome, IngestOutcome::Buffered { .. }));
+    carol
+        .ingest(route(commit, &group_id))
+        .await
+        .expect("commit is buffered by ingest");
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("convergence settles despite forged app message");
+
+    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
+    assert!(
+        !result
+            .accepted_app_messages
+            .contains(&content_hex(&forged_msg)),
+        "forged-attribution app message must not be accepted"
+    );
+    // Message epoch (2) is at the settled tip (2): the failed validation is
+    // terminal, not retryable — the message cannot re-enter convergence.
+    assert_message_state(&carol_storage, &forged_msg, MessageState::EpochInvalidated);
+
+    let events = carol.drain_events();
+    for event in &events {
+        if let GroupEvent::MessageReceived {
+            sender, payload, ..
+        } = event
+        {
+            assert!(
+                !sender.as_slice().is_empty(),
+                "no MessageReceived may carry an empty MemberId, got {events:?}"
+            );
+            assert_ne!(
+                payload, &forged_payload,
+                "forged app message must not surface, got {events:?}"
+            );
+        }
+    }
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(2));
 }
 
 /// Regression for mdk#144: a future-epoch app message that is

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -599,6 +599,385 @@ async fn retry_for_unknown_group_errors() {
     ));
 }
 
+// ── Quarantine enforcement on the live data path (mdk#364 / #365) ──
+
+fn build_named_client(name: &[u8]) -> (Engine<SqliteAccountStorage>, SqliteAccountStorage) {
+    let storage = SqliteAccountStorage::in_memory().expect("storage");
+    let engine = EngineBuilder::new(storage.clone())
+        .identity(pad32(name))
+        .account_identity_proof_signer(proof_signer(name))
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .expect("build client");
+    (engine, storage)
+}
+
+fn route(msg: TransportMessage, group_id: &GroupId) -> TransportMessage {
+    match msg.envelope {
+        TransportEnvelope::Welcome { .. } => msg,
+        TransportEnvelope::GroupMessage { .. } => TransportMessage {
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: group_id.as_slice().to_vec(),
+            },
+            ..msg
+        },
+    }
+}
+
+fn welcome_for(welcomes: &[TransportMessage], name: &[u8]) -> TransportMessage {
+    let recipient = MemberId::new(pad32(name));
+    welcomes
+        .iter()
+        .find(|welcome| {
+            matches!(&welcome.envelope, TransportEnvelope::Welcome { recipient: r } if *r == recipient)
+        })
+        .cloned()
+        .expect("welcome for recipient")
+}
+
+fn evolution(result: SendResult) -> (TransportMessage, cgka_traits::engine_state::PendingStateRef) {
+    match result {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected group evolution, got {other:?}"),
+    }
+}
+
+/// Shared setup: alice (flaky storage) creates a group with bob as
+/// member+admin; bob joins; alice reopens with `get_group` failing so the
+/// group is quarantined (`GroupRecordLoadFailed`) while its OpenMLS state
+/// stays fully intact; then storage is un-failed again. What blocks activity
+/// afterwards is the quarantine gate, not broken storage. Returns
+/// (quarantined alice, alice storage handle, bob, group id).
+async fn quarantined_alice_with_live_bob() -> (
+    Engine<FlakyGroupRecordStorage>,
+    FlakyGroupRecordStorage,
+    Engine<SqliteAccountStorage>,
+    GroupId,
+) {
+    let storage = FlakyGroupRecordStorage::new(SqliteAccountStorage::in_memory().expect("storage"));
+    let mut alice = build_flaky_engine(storage.clone());
+    let (mut bob, _bob_storage) = build_named_client(b"bob-quarantine");
+
+    let bob_kp = bob.fresh_key_package().await.expect("bob key package");
+    let (group_id, send_result) = alice
+        .create_group(CreateGroupRequest {
+            name: "quarantine-enforcement".into(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .expect("create group");
+    let SendResult::GroupCreated { pending, welcomes } = send_result else {
+        panic!("expected group-created send result");
+    };
+    alice.confirm_published(pending).await.expect("confirm");
+    bob.join_welcome(welcome_for(&welcomes, b"bob-quarantine"))
+        .await
+        .expect("bob joins");
+    bob.drain_events();
+    drop(alice);
+
+    storage.set_fail_get_group(true);
+    let mut reopened = build_flaky_engine(storage.clone());
+    reopened
+        .hydrate_stable_groups_from_storage()
+        .expect("hydration quarantines the unreadable group");
+    assert_eq!(
+        reopened.quarantined_groups(),
+        vec![(
+            group_id.clone(),
+            GroupHydrationQuarantineReason::GroupRecordLoadFailed
+        )]
+    );
+    reopened.drain_events();
+    storage.set_fail_get_group(false);
+
+    (reopened, storage, bob, group_id)
+}
+
+/// A valid inbound commit authored by bob (admin) inviting carol; advances
+/// the group from epoch 1 to epoch 2.
+async fn bob_invites_carol(
+    bob: &mut Engine<SqliteAccountStorage>,
+    group_id: &GroupId,
+) -> TransportMessage {
+    let (mut carol, _carol_storage) = build_named_client(b"carol-quarantine");
+    let carol_kp = carol.fresh_key_package().await.expect("carol key package");
+    let invite = bob
+        .send(cgka_traits::engine::SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![carol_kp],
+        })
+        .await
+        .expect("bob invites carol");
+    let (commit, pending) = evolution(invite);
+    bob.confirm_published(pending).await.expect("bob confirms");
+    route(commit, group_id)
+}
+
+/// The #707 acceptance-criterion test: a quarantined group rejects a valid
+/// inbound commit on `ingest`, retains the input durably for post-repair
+/// replay, stays quarantined, and both `epoch()` and `members()` report it
+/// vanished — no `set_stable` resurrection out of band.
+#[tokio::test]
+async fn quarantined_group_rejects_valid_inbound_commit_on_do_ingest() {
+    let (mut alice, storage, mut bob, group_id) = quarantined_alice_with_live_bob().await;
+    let commit = bob_invites_carol(&mut bob, &group_id).await;
+
+    let outcome = alice
+        .ingest(commit.clone())
+        .await
+        .expect("ingest classifies");
+    assert!(
+        matches!(
+            outcome,
+            cgka_traits::ingest::IngestOutcome::Stale {
+                reason: cgka_traits::ingest::StaleReason::Quarantined
+            }
+        ),
+        "expected Stale::Quarantined, got {outcome:?}"
+    );
+
+    // Still quarantined, still vanished on every accessor.
+    assert_eq!(alice.quarantined_groups().len(), 1);
+    assert!(matches!(
+        alice.epoch(&group_id),
+        Err(EngineError::UnknownGroup(id)) if id == group_id
+    ));
+    assert!(matches!(
+        alice.members(&group_id),
+        Err(EngineError::UnknownGroup(id)) if id == group_id
+    ));
+
+    // The commit is retained durably as the post-repair replay buffer.
+    let record = storage.get_message(&commit.id).expect("commit retained");
+    assert_eq!(record.state, MessageState::PeelDeferred);
+
+    // No epoch_manager resurrection happened as a side effect.
+    assert!(matches!(
+        alice.epoch(&group_id),
+        Err(EngineError::UnknownGroup(_))
+    ));
+}
+
+#[tokio::test]
+async fn quarantined_group_blocks_convergence_and_send() {
+    let (mut alice, _storage, _bob, group_id) = quarantined_alice_with_live_bob().await;
+
+    assert!(matches!(
+        alice
+            .converge_and_drain_queued_outbound_intents(&group_id, 1_000_000)
+            .await,
+        Err(EngineError::UnknownGroup(id)) if id == group_id
+    ));
+
+    let result = alice
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("quarantined convergence reports a blocked no-op run");
+    assert_eq!(
+        result.convergence_status,
+        cgka_engine::canonicalization::ConvergenceStatus::Blocked
+    );
+    assert!(result.errors.is_empty());
+    assert!(result.accepted_commits.is_empty());
+
+    assert!(matches!(
+        alice
+            .send(cgka_traits::engine::SendIntent::AppMessage {
+                group_id: group_id.clone(),
+                payload: b"blocked".to_vec(),
+            })
+            .await,
+        Err(EngineError::UnknownGroup(id)) if id == group_id
+    ));
+
+    // Nothing above re-activated the group.
+    assert!(matches!(
+        alice.epoch(&group_id),
+        Err(EngineError::UnknownGroup(_))
+    ));
+    assert_eq!(alice.quarantined_groups().len(), 1);
+}
+
+#[tokio::test]
+async fn quarantined_group_accessors_all_report_unknown_group() {
+    let (mut alice, _storage, _bob, group_id) = quarantined_alice_with_live_bob().await;
+    let component = cgka_traits::app_components::GROUP_ADMIN_POLICY_COMPONENT_ID;
+
+    let unknown = |result: Result<(), EngineError>, name: &str| {
+        assert!(
+            matches!(&result, Err(EngineError::UnknownGroup(id)) if *id == group_id),
+            "{name} must report UnknownGroup for a quarantined group, got {result:?}"
+        );
+    };
+
+    unknown(alice.members(&group_id).map(drop), "members");
+    unknown(alice.epoch(&group_id).map(drop), "epoch");
+    unknown(alice.group_record(&group_id).map(drop), "group_record");
+    unknown(alice.admin_pubkeys(&group_id).map(drop), "admin_pubkeys");
+    unknown(alice.group_context(&group_id).map(drop), "group_context");
+    unknown(
+        alice.app_component(&group_id, component).map(drop),
+        "app_component",
+    );
+    unknown(
+        alice
+            .feature_status(&group_id, &Feature("self-remove"))
+            .map(drop),
+        "feature_status",
+    );
+    unknown(
+        alice.upgradeable_capabilities(&group_id).map(drop),
+        "upgradeable_capabilities",
+    );
+    unknown(
+        alice.upgrade_group_capabilities(&group_id).await.map(drop),
+        "upgrade_group_capabilities",
+    );
+    unknown(alice.own_leaf_index(&group_id).map(drop), "own_leaf_index");
+    unknown(
+        alice
+            .safe_export_secret_with_epoch(&group_id, component)
+            .map(drop),
+        "safe_export_secret_with_epoch",
+    );
+    unknown(
+        alice
+            .current_safe_export_epoch(&group_id, component)
+            .map(drop),
+        "current_safe_export_epoch",
+    );
+    unknown(
+        alice.safe_export_secret(&group_id, component).map(drop),
+        "safe_export_secret",
+    );
+}
+
+/// After repair, input retained while quarantined replays through the
+/// existing deferred-peel machinery and the group catches up to the commit.
+#[tokio::test]
+async fn repair_replays_buffered_commit_and_group_catches_up() {
+    let (mut alice, storage, mut bob, group_id) = quarantined_alice_with_live_bob().await;
+    let commit = bob_invites_carol(&mut bob, &group_id).await;
+
+    let outcome = alice
+        .ingest(commit.clone())
+        .await
+        .expect("ingest classifies");
+    assert!(matches!(
+        outcome,
+        cgka_traits::ingest::IngestOutcome::Stale {
+            reason: cgka_traits::ingest::StaleReason::Quarantined
+        }
+    ));
+
+    let recovered = alice
+        .retry_hydrate_quarantined_group(&group_id)
+        .expect("retry runs");
+    assert!(recovered, "storage is healthy again; retry must recover");
+    assert!(alice.quarantined_groups().is_empty());
+
+    // Repair scheduled the group for the app's convergence drain.
+    let scheduled = alice.drain_pending_convergence_groups();
+    assert!(
+        scheduled.contains(&group_id),
+        "repair must schedule the recovered group for convergence, got {scheduled:?}"
+    );
+
+    alice
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_000_000)
+        .await
+        .expect("post-repair drain replays retained input");
+
+    assert_eq!(alice.epoch(&group_id).unwrap(), EpochId(2));
+    assert_eq!(alice.members(&group_id).unwrap().len(), 3);
+    let record = storage.get_message(&commit.id).expect("replayed row");
+    assert_eq!(record.state, MessageState::Processed);
+}
+
+/// An authenticated re-join welcome for a quarantined id clears the
+/// quarantine: the welcome re-validated every leaf and wrote fresh state —
+/// strictly stronger than `retry_hydrate_quarantined_group`. Blocking it
+/// would permanently strand a group whose stored state is unrecoverable.
+#[tokio::test]
+async fn rejoin_welcome_clears_quarantine() {
+    // Bob owns the real group; alice has a corrupted partial copy (Marmot
+    // record without OpenMLS state) that quarantines as OpenMlsGroupMissing.
+    let (mut bob, _bob_storage) = build_named_client(b"bob-rejoin");
+    let (group_id, send_result) = bob
+        .create_group(CreateGroupRequest {
+            name: "rejoin-clears-quarantine".into(),
+            description: String::new(),
+            members: vec![],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .expect("bob creates group");
+    let SendResult::GroupCreated { pending, .. } = send_result else {
+        panic!("expected group-created send result");
+    };
+    bob.confirm_published(pending).await.expect("bob confirms");
+
+    let alice_storage = SqliteAccountStorage::in_memory().expect("storage");
+    let mut alice = EngineBuilder::new(alice_storage.clone())
+        .identity(pad32(b"alice-rejoin"))
+        .account_identity_proof_signer(proof_signer(b"alice-rejoin"))
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .expect("build alice");
+    insert_marmot_group_without_openmls_state(&alice_storage, &group_id, "corrupted-copy", 1);
+    alice
+        .hydrate_stable_groups_from_storage()
+        .expect("hydration quarantines the corrupted copy");
+    assert_eq!(
+        alice.quarantined_groups(),
+        vec![(
+            group_id.clone(),
+            GroupHydrationQuarantineReason::OpenMlsGroupMissing
+        )]
+    );
+    alice.drain_events();
+
+    // Bob invites alice into the real group; the welcome carries the same id.
+    let alice_kp = alice.fresh_key_package().await.expect("alice key package");
+    let invite = bob
+        .send(cgka_traits::engine::SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![alice_kp],
+        })
+        .await
+        .expect("bob invites alice");
+    let SendResult::GroupEvolution {
+        pending, welcomes, ..
+    } = invite
+    else {
+        panic!("expected group evolution with welcomes");
+    };
+    bob.confirm_published(pending).await.expect("bob confirms");
+    let joined = alice
+        .join_welcome(welcome_for(&welcomes, b"alice-rejoin"))
+        .await
+        .expect("authenticated re-join succeeds for a quarantined id");
+    assert_eq!(joined, group_id);
+
+    assert!(alice.quarantined_groups().is_empty());
+    assert!(alice.epoch(&group_id).is_ok());
+    assert!(alice.members(&group_id).is_ok());
+    let events = alice.drain_events();
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            GroupEvent::GroupHydrationRecovered { group_id: gid, .. } if gid == &group_id
+        )),
+        "re-join must emit GroupHydrationRecovered: {events:?}"
+    );
+}
+
 // mdk#152: session open must not re-verify an unchanged group's
 // account-identity proofs on every open. After a successful hydration the
 // engine persists a content-bound validation marker; reopening an unchanged

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -979,6 +979,104 @@ async fn rejoin_welcome_clears_quarantine() {
     );
 }
 
+/// Regression for mdk#707 review finding 1: input retained while
+/// quarantined and replayed by `do_join_welcome`'s `replay_buffered_messages`
+/// must be retired from the deferred queue on a successful or terminal
+/// outcome — not left durably `PeelDeferred` holding a per-group cap slot.
+#[tokio::test]
+async fn rejoin_welcome_replays_and_retires_quarantine_retained_input() {
+    // Bob owns the real group; alice has a corrupted partial copy that
+    // quarantines as OpenMlsGroupMissing.
+    let (mut bob, _bob_storage) = build_named_client(b"bob-replay");
+    let (group_id, send_result) = bob
+        .create_group(CreateGroupRequest {
+            name: "rejoin-replays-retained".into(),
+            description: String::new(),
+            members: vec![],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .expect("bob creates group");
+    let SendResult::GroupCreated { pending, .. } = send_result else {
+        panic!("expected group-created send result");
+    };
+    bob.confirm_published(pending).await.expect("bob confirms");
+
+    let alice_storage = SqliteAccountStorage::in_memory().expect("storage");
+    let mut alice = EngineBuilder::new(alice_storage.clone())
+        .identity(pad32(b"alice-replay"))
+        .account_identity_proof_signer(proof_signer(b"alice-replay"))
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .expect("build alice");
+    insert_marmot_group_without_openmls_state(&alice_storage, &group_id, "corrupted-copy", 1);
+    alice
+        .hydrate_stable_groups_from_storage()
+        .expect("hydration quarantines the corrupted copy");
+    assert_eq!(alice.quarantined_groups().len(), 1);
+    alice.drain_events();
+
+    // A group message arrives while alice is quarantined: it is retained as a
+    // PeelDeferred replay-buffer row.
+    let retained_commit = bob_invites_carol(&mut bob, &group_id).await;
+    let outcome = alice
+        .ingest(retained_commit.clone())
+        .await
+        .expect("quarantine gate classifies");
+    assert!(matches!(
+        outcome,
+        cgka_traits::ingest::IngestOutcome::Stale {
+            reason: cgka_traits::ingest::StaleReason::Quarantined
+        }
+    ));
+    let deferred_before = alice_storage
+        .list_messages(&group_id, EpochId(0))
+        .unwrap()
+        .into_iter()
+        .filter(|record| record.state == MessageState::PeelDeferred)
+        .count();
+    assert_eq!(
+        deferred_before, 1,
+        "retained input must be a PeelDeferred row"
+    );
+
+    // Bob re-invites alice; the authenticated welcome clears the quarantine
+    // and do_join_welcome replays the retained input.
+    let alice_kp = alice.fresh_key_package().await.expect("alice key package");
+    let invite = bob
+        .send(cgka_traits::engine::SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![alice_kp],
+        })
+        .await
+        .expect("bob invites alice");
+    let SendResult::GroupEvolution {
+        pending, welcomes, ..
+    } = invite
+    else {
+        panic!("expected group evolution with welcomes");
+    };
+    bob.confirm_published(pending).await.expect("bob confirms");
+    alice
+        .join_welcome(welcome_for(&welcomes, b"alice-replay"))
+        .await
+        .expect("re-join succeeds");
+
+    assert!(alice.quarantined_groups().is_empty());
+    let deferred_after = alice_storage
+        .list_messages(&group_id, EpochId(0))
+        .unwrap()
+        .into_iter()
+        .filter(|record| record.state == MessageState::PeelDeferred)
+        .count();
+    assert_eq!(
+        deferred_after, 0,
+        "replay must retire the retained deferred row, not leave it holding a cap slot"
+    );
+}
+
 // mdk#152: session open must not re-verify an unchanged group's
 // account-identity proofs on every open. After a successful hydration the
 // engine persists a content-bound validation marker; reopening an unchanged

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -177,6 +177,7 @@ fn insert_marmot_group_without_openmls_state(
             epoch: EpochId(epoch),
             required_capabilities: GroupCapabilities::default(),
             removed: false,
+            join_epoch: EpochId(0),
         })
         .expect("insert marmot group record without openmls state");
 }

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -1007,6 +1007,7 @@ async fn drain_surfaces_hydration_quarantine_without_inbound_delivery() {
                 epoch: EpochId(9),
                 required_capabilities: GroupCapabilities::default(),
                 removed: false,
+                join_epoch: EpochId(0),
             })
             .unwrap();
     }

--- a/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
+++ b/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
@@ -1558,6 +1558,12 @@
             },
             "reason": {
               "type": "string"
+            },
+            "retry_count": {
+              "$ref": "#/$defs/u64"
+            },
+            "sweeps_waited": {
+              "$ref": "#/$defs/u64"
             }
           }
         },

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -934,6 +934,14 @@ pub enum AuditEventKind {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         epoch: Option<u64>,
         reason: String,
+        /// How many re-peel attempts a deferred row consumed before this
+        /// transition (deferred-peel lifecycle rows only).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        retry_count: Option<u64>,
+        /// How many retry sweeps elapsed between the row's first attempt and
+        /// this transition — the queue-wait clock for deferred rows.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sweeps_waited: Option<u64>,
     },
     /// A message or intent was rejected with a structured reason.
     Rejection {

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -692,6 +692,8 @@ fn sample_audit_event_kinds() -> Vec<AuditEventKind> {
             new_state: "epoch_invalidated".into(),
             epoch: Some(3),
             reason: "fork_loser".into(),
+            retry_count: Some(2),
+            sweeps_waited: Some(5),
         },
         AuditEventKind::Rejection {
             msg_id: "m".into(),

--- a/crates/storage-sqlite/src/storage/test_support.rs
+++ b/crates/storage-sqlite/src/storage/test_support.rs
@@ -39,6 +39,7 @@ pub(crate) fn sample_group(id: GroupId, epoch: u64, members: usize) -> Group {
             .collect(),
         required_capabilities: GroupCapabilities::default(),
         removed: false,
+        join_epoch: EpochId(0),
     }
 }
 

--- a/crates/traits/src/group.rs
+++ b/crates/traits/src/group.rs
@@ -36,6 +36,14 @@ pub struct Group {
     /// persisted before this field existed.
     #[serde(default)]
     pub removed: bool,
+    /// Epoch at which this device's membership began (welcome-join or group
+    /// creation), refreshed on an authenticated re-join. Post-peel
+    /// classification lower bound: an application message whose MLS epoch
+    /// precedes it is pre-membership — permanently undecryptable by design
+    /// and never worth retrying. `EpochId(0)` (the default for records
+    /// persisted before this field existed) means "unknown — no bound".
+    #[serde(default)]
+    pub join_epoch: EpochId,
 }
 
 /// One member of a group, as storage sees it.

--- a/crates/traits/src/ingest.rs
+++ b/crates/traits/src/ingest.rs
@@ -57,6 +57,15 @@ pub enum StaleReason {
     /// decrypt failure is a missing-history/repair condition, never
     /// `SelfEvicted`.
     SelfEvicted,
+    /// The group is under hydration quarantine: it failed session-open
+    /// validation and is frozen until explicit repair. The message was not
+    /// applied and no group state changed, but the raw input is retained
+    /// durably and replays automatically once
+    /// `retry_hydrate_quarantined_group` (or an authenticated re-join
+    /// welcome) clears the quarantine. Terminal for the message until then.
+    /// The application can read the quarantine reason from
+    /// `quarantined_groups()`.
+    Quarantined,
 }
 
 /// Decrypted inbound message ready for engine processing.

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -663,6 +663,7 @@ fn snapshot_group_and_member() {
             }],
             required_capabilities: GroupCapabilities::default(),
             removed: false,
+            join_epoch: EpochId(2),
         }
     );
 }

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -385,6 +385,12 @@ fn snapshot_ingest_outcomes() {
             reason: StaleReason::SelfEvicted
         }
     );
+    insta::assert_json_snapshot!(
+        "stale_quarantined",
+        IngestOutcome::Stale {
+            reason: StaleReason::Quarantined
+        }
+    );
 }
 
 #[test]

--- a/crates/traits/tests/snapshots/snapshots__group.snap
+++ b/crates/traits/tests/snapshots/snapshots__group.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/traits/tests/snapshots.rs
-expression: "Group\n{\n    id: gid(), name: \"ops\".into(), description: \"for ops talk\".into(), epoch:\n    EpochId(3), members: vec![Member { id: mem_id(), credential: vec![], }],\n    required_capabilities: GroupCapabilities::default(), removed: false,\n}"
+expression: "Group\n{\n    id: gid(), name: \"ops\".into(), description: \"for ops talk\".into(), epoch:\n    EpochId(3), members: vec![Member { id: mem_id(), credential: vec![], }],\n    required_capabilities: GroupCapabilities::default(), removed: false,\n    join_epoch: EpochId(2),\n}"
 ---
 {
   "id": [
@@ -31,5 +31,6 @@ expression: "Group\n{\n    id: gid(), name: \"ops\".into(), description: \"for o
       "ids": []
     }
   },
-  "removed": false
+  "removed": false,
+  "join_epoch": 2
 }

--- a/crates/traits/tests/snapshots/snapshots__stale_quarantined.snap
+++ b/crates/traits/tests/snapshots/snapshots__stale_quarantined.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Stale { reason: StaleReason::Quarantined }"
+---
+{
+  "Stale": {
+    "reason": "Quarantined"
+  }
+}


### PR DESCRIPTION
Closes the remaining open children of tracking issue #707 (one convergence contract: every application-visible invariant enforced identically on the direct-ingest, stored-convergence/replay, and fork-recovery seams). Four commits, one per cluster.

Fixes #383
Fixes #394
Fixes #369
Fixes #364
Fixes #365
Fixes #339
Fixes #707

### Commit 1 — seam parity (#383)

The replay seam could emit `MessageReceived` with an empty, unauthenticated sender (S3 regression): the ApplicationMessage arm defaulted an unresolvable MLS sender to empty bytes and validated the inner event against `hex("")`, so a crafted `MarmotAppEvent` with `pubkey: ""` surfaced with a blank author. The per-seam validator pairs are collapsed into the shared chokepoints (`identity::member_id_of_sender`, typed `app_payload::validate_app_payload_for_sender` — which now rejects an empty `MemberId` outright), the replay arm pushes `Ignored` for anything that fails attribution (terminal via existing canonicalization), and `emit_application_replay_events` skips empty senders as a backstop. The mirror-on-all-seams contract is now documented as a hard invariant in `crates/cgka-engine/AGENTS.md`.

### Commit 2 — fail-closed hardening (#394, #369)

- The fork-recovery missing-snapshot branch no longer panics via `unreachable!()` on an invariant break reachable from attacker-delivered same-epoch fork commits; both arms share one fail-closed helper (`detect_fork` + audit + `EpochInvalidated` + typed `ForkedEpoch`).
- `persist_stored_message_payload`'s idempotency short-circuit now compares the encoded payload bytes, so a same-`(group, epoch, state)` persist under a different `StoredMessagePayload` variant overwrites instead of silently keeping the old variant. Verified independent of the #723 `OwnCommitWire` enrichment (which writes via `put_message` directly).

### Commit 3 — quarantine enforcement (#364, #365)

`quarantined_groups` is now enforced on every live surface through one chokepoint (`Engine::ensure_group_live`): all durable/MLS accessors return `UnknownGroup` (matching `epoch()` and the documented "vanish" contract — including `group_context()`, which previously exported a quarantined group's exporter secrets); `send`, convergence, and queued-intent drains refuse to run; inbound input is retained durably (`PeelDeferred`) and classified with the new `StaleReason::Quarantined`; nothing can `set_stable` a quarantined group out of band. Repair via `retry_hydrate_quarantined_group` or an authenticated re-join welcome clears the quarantine and replays the retained input.

### Commit 4 — deferred-peel lifecycle (#339, full scope)

`PeelDeferred` rows were retried forever at O(rows × snapshots) per convergence pass and grew the durable store without bound under a re-wrap flood (raw transport ids are attacker-controllable). The lifecycle is now: context-fingerprint gating (retry only when the (epoch, snapshot-set) peel context actually changes), a per-row retry budget → terminal `permanently_undecryptable`, a per-group cap of 256 retained rows (overflow dropped unpersisted), bounded 64-row sweeps so backlog never starves current events, and post-peel pre-membership classification via the new `Group.join_epoch` (`pre_membership_event` vs `valid_history_snapshot_missing`). One `MessageDisposition` taxonomy supplies the audit reason tags; `MessageStateChanged` gains optional `retry_count`/`sweeps_waited`, and each sweep emits an aggregate privacy-safe tracing line with queue depth and duration.

Note on #339's "identify pre-membership *before* peel" criterion: the transport wrapper carries no epoch, so pre-peel classification is physically impossible; the fix achieves the criterion's intent (no unbounded retries, no cryptographic amplification, terminal classification) via the gate + budget + post-peel classification.

### Verification

`just fast-ci` green; full workspace suite green (1992 tests, 0 failed); clippy clean across the workspace. New coverage: `app_payload` unit tests + `convergence_app_message_with_unresolvable_sender_emits_no_event_and_lands_terminal` (#383), `same_key_persist_with_different_payload_variant_overwrites` (#369), five quarantine-enforcement tests incl. the #707 acceptance-criterion test `quarantined_group_rejects_valid_inbound_commit_on_do_ingest` (#364/#365), and six lifecycle tests in the new `tests/deferred_peel_lifecycle.rs` (#339) with `send_preflight_retries_deferred_peels_after_convergence_apply` unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/726">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hydration-quarantine handling: quarantined groups are blocked until recovered via retry hydration or authenticated re-join, with replay resuming afterward.
  * Enhanced deferred-peel lifecycle for more reliable retry/recovery, including bounded retries and improved convergence behavior.
* **Bug Fixes**
  * Empty or unresolvable senders are now rejected consistently, preventing invalid application events from being accepted or surfaced in group events.
  * Improved message storage idempotency so updated payload variants are preserved correctly.
  * Added more accurate group join-epoch metadata to improve join, replay, and recovery consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->