### PR TITLE
Enforce strict tag extraction and post-verification id trust at the Nostr ingest boundary

### DIFF
--- a/crates/marmot-app/src/relay_plane/tests.rs
+++ b/crates/marmot-app/src/relay_plane/tests.rs
@@ -888,15 +888,20 @@ async fn directory_live_event_rejected_after_subscription_removed() {
 }
 
 fn group_event(id_prefix: &str, transport_group_id: &[u8]) -> NostrTransportEvent {
-    NostrTransportEvent {
-        id: id_prefix.repeat(32),
+    // `to_transport_message` verifies the id against the event hash (#351), so
+    // the distinguishing prefix lives in the content and the id is computed
+    // from it — distinct `id_prefix` values still yield distinct event ids.
+    let mut event = NostrTransportEvent {
+        id: String::new(),
         pubkey: "22".repeat(32),
         created_at: 1_700_000_000,
         kind: KIND_MARMOT_GROUP_MESSAGE,
         tags: vec![vec!["h".into(), hex::encode(transport_group_id)]],
-        content: "encrypted".into(),
+        content: format!("encrypted {id_prefix}"),
         sig: None,
-    }
+    };
+    event.id = event.computed_id();
+    event
 }
 
 #[test]

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -81,7 +81,7 @@ fn relay_delivery(marker: &str, pubkey: String) -> cgka_traits::TransportDeliver
         pubkey,
         created_at: 1,
         kind: transport_nostr_peeler::KIND_MARMOT_GROUP_MESSAGE,
-        tags: vec![vec!["h".to_owned(), "aa".to_owned()]],
+        tags: vec![vec!["h".to_owned(), "aa".repeat(32)]],
         content: format!("ciphertext {marker}"),
         sig: None,
     };

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -73,16 +73,19 @@ fn assert_profile_word_list(name: &str, words: &[&str]) {
     }
 }
 
-fn relay_delivery(event_id: String, pubkey: String) -> cgka_traits::TransportDelivery {
-    let event = NostrTransportEvent {
-        id: event_id,
+fn relay_delivery(marker: &str, pubkey: String) -> cgka_traits::TransportDelivery {
+    // `to_transport_message` verifies the id against the event hash (#351), so
+    // the distinguishing marker lives in the content and the id is computed.
+    let mut event = NostrTransportEvent {
+        id: String::new(),
         pubkey,
         created_at: 1,
         kind: transport_nostr_peeler::KIND_MARMOT_GROUP_MESSAGE,
         tags: vec![vec!["h".to_owned(), "aa".to_owned()]],
-        content: "ciphertext".to_owned(),
+        content: format!("ciphertext {marker}"),
         sig: None,
     };
+    event.id = event.computed_id();
     cgka_traits::TransportDelivery {
         account_id: MemberId::new(vec![0; 32]),
         group_id_hint: None,
@@ -1228,25 +1231,28 @@ fn ingest_applies_owner_signed_transitive_448_and_drops_spoof() {
 #[test]
 fn own_relay_echo_requires_known_event_id_not_just_pubkey() {
     let local_pubkey = "11".repeat(32);
-    let known_event_id = "22".repeat(32);
-    let new_cross_device_event_id = "33".repeat(32);
-    let known_event_ids = HashSet::from([known_event_id.clone()]);
 
-    let known_local_delivery = relay_delivery(known_event_id.clone(), local_pubkey.clone());
+    let known_local_delivery = relay_delivery("known", local_pubkey.clone());
+    let known_event_ids = HashSet::from([hex::encode(known_local_delivery.message.id.as_slice())]);
     assert!(client::is_own_relay_echo(
         &known_local_delivery,
         &local_pubkey,
         &known_event_ids
     ));
 
-    let same_pubkey_new_event = relay_delivery(new_cross_device_event_id, local_pubkey.clone());
+    let same_pubkey_new_event = relay_delivery("new-cross-device", local_pubkey.clone());
     assert!(!client::is_own_relay_echo(
         &same_pubkey_new_event,
         &local_pubkey,
         &known_event_ids
     ));
 
-    let known_other_pubkey_delivery = relay_delivery(known_event_id, "44".repeat(32));
+    // A delivery claiming a known id under another pubkey can no longer come
+    // out of the transport boundary (the id is verified against the event
+    // hash, #351); forge one directly to prove the echo check independently
+    // requires the local pubkey.
+    let mut known_other_pubkey_delivery = relay_delivery("known", "44".repeat(32));
+    known_other_pubkey_delivery.message.id = known_local_delivery.message.id.clone();
     assert!(!client::is_own_relay_echo(
         &known_other_pubkey_delivery,
         &local_pubkey,

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -450,6 +450,58 @@ async fn deduplicated_delivery_path_does_not_record_spread() {
 }
 
 #[tokio::test]
+async fn forged_event_id_fails_closed_on_delivery_and_telemetry_paths() {
+    // #351 — a subscribed, otherwise well-formed event whose self-reported id
+    // does not match the event hash must neither be routed (no `wire_id`
+    // poisoning) nor key per-relay telemetry on `observe_relay_event`.
+    let relay = Arc::new(FakeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay);
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let group_id = cgka_traits::GroupId::new(vec![0xB2; 32]);
+    let transport_group_id = vec![0xC3; 32];
+    let endpoint = TransportEndpoint("wss://group.example".into());
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![TransportGroupSubscription {
+                group_id,
+                transport_group_id: transport_group_id.clone(),
+                endpoints: vec![endpoint.clone()],
+            }],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+
+    let mut forged = group_event("11", &transport_group_id);
+    forged.id = "77".repeat(32);
+
+    adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: endpoint.clone(),
+            subscription_id: Some("group-sub".into()),
+            event: forged.clone(),
+        })
+        .await
+        .expect_err("forged id must not map to a delivery");
+
+    adapter
+        .observe_relay_event(NostrRelayEvent {
+            endpoint,
+            subscription_id: Some("group-sub".into()),
+            event: forged,
+        })
+        .await;
+
+    let spread = adapter.delivery_spread().await;
+    assert_eq!(spread.observed, 0, "forged id must not enter telemetry");
+    assert_eq!(spread.spread.sample_count(), 0);
+    assert_eq!(spread.per_relay.len(), 0);
+}
+
+#[tokio::test]
 async fn initial_sync_gate_closes_only_after_every_endpoint_eoses() {
     let relay = Arc::new(FakeRelayClient::default());
     let adapter = NostrTransportAdapter::new(relay.clone());
@@ -1143,13 +1195,18 @@ async fn sync_telemetry_tracks_only_live_subscriptions_across_churn() {
 }
 
 fn group_event(id_byte: &str, transport_group_id: &[u8]) -> NostrTransportEvent {
-    NostrTransportEvent {
-        id: id_byte.repeat(32),
+    // `to_transport_message` verifies the id against the event hash (#351), so
+    // the distinguishing byte lives in the content and the id is computed from
+    // it — distinct `id_byte` values still yield distinct event ids.
+    let mut event = NostrTransportEvent {
+        id: String::new(),
         pubkey: "22".repeat(32),
         created_at: 1_700_000_010,
         kind: KIND_MARMOT_GROUP_MESSAGE,
         tags: vec![vec!["h".into(), hex::encode(transport_group_id)]],
-        content: "outer encrypted body".into(),
+        content: format!("outer encrypted body {id_byte}"),
         sig: None,
-    }
+    };
+    event.id = event.computed_id();
+    event
 }

--- a/crates/transport-nostr-peeler/AGENTS.md
+++ b/crates/transport-nostr-peeler/AGENTS.md
@@ -25,6 +25,25 @@ storage. Keep those in adapters or the app layer above this crate.
 | `src/peeler.rs` | `TransportPeeler` implementation for Nostr/MLS group messages. |
 | `src/error.rs` | Nostr boundary error vocabulary. |
 
+## Boundary validation contract
+
+Default contract for every field read off an ingest path (#709). A new tag or identifier that uses a loose helper or
+skips content validation is a contract violation, not a style choice.
+
+- **Routing-significant tags are strict single-tag.** The kind `445` `h` tag, the kind `1059` `p` tag, and the kind
+  `444` rumor `e` and `relays` tags are extracted with exactly-one-tag enforcement (`single_tag_value` on the outer
+  event, `rumor_single_tag_*` on the rumor). Missing and duplicate tags are both rejected — never first-matched. Any
+  future routing-significant tag gets the same treatment.
+- **Content-validate at extraction.** Tag values are validated before they surface: ids are hex/length-checked
+  (`decode_hex_exact`), and `relays` values are count-bounded (`MAX_WELCOME_RELAYS`), length-bounded
+  (`MAX_WELCOME_RELAY_URL_LEN`), and ws/wss-scheme-validated (`RelayUrl::parse`) on both wrap and peel.
+- **No self-reported identifier is trusted before verification.** `to_transport_message` verifies the event `id`
+  against the recomputed NIP-01 event hash before it becomes `TransportMessage.id` (which keys routing metrics,
+  telemetry, and the forensic `wire_id`); a mismatch fails closed on every ingest path, including telemetry-only
+  observation. Signature verification still happens at peel time.
+- **Loose first-match helpers (`tag_value`, `tag_values`) are for non-routing, genuinely multi-valued fields only**,
+  and any such field must carry explicit count/length bounds. Do not reach for them when wiring up a new tag.
+
 ## Current limits
 
 - Group messages are wrapped and peeled. Each outbound kind `445` event is signed by a fresh ephemeral Nostr key

--- a/crates/transport-nostr-peeler/src/event.rs
+++ b/crates/transport-nostr-peeler/src/event.rs
@@ -30,6 +30,15 @@ pub struct NostrTransportEvent {
 impl NostrTransportEvent {
     /// Convert a Nostr event into the raw transport message the engine ingests.
     pub fn to_transport_message(&self) -> Result<TransportMessage, NostrPeelerError> {
+        // #709/#351 — the resulting `TransportMessage.id` keys routing metrics,
+        // telemetry, and the forensic `wire_id`, so bind it to the event hash
+        // here rather than trusting the self-reported id. Signature
+        // verification still happens at peel time.
+        if !self.id.eq_ignore_ascii_case(&self.computed_id()) {
+            return Err(NostrPeelerError::Malformed(
+                "event id does not match event hash".into(),
+            ));
+        }
         let id = MessageId::new(decode_hex_exact("event id", &self.id, 32)?);
         let envelope = match self.kind {
             KIND_MARMOT_GROUP_MESSAGE => {
@@ -39,9 +48,7 @@ impl NostrTransportEvent {
                 }
             }
             KIND_NIP59_GIFT_WRAP => {
-                let recipient = self
-                    .tag_value(RECIPIENT_TAG)
-                    .ok_or_else(|| NostrPeelerError::MissingTag(RECIPIENT_TAG.into()))?;
+                let recipient = self.single_tag_value(RECIPIENT_TAG)?;
                 TransportEnvelope::Welcome {
                     recipient: MemberId::new(decode_hex_exact("recipient p tag", recipient, 32)?),
                 }
@@ -135,6 +142,19 @@ impl NostrTransportEvent {
         }
     }
 
+    /// NIP-01 event id (lowercase hex sha256 of the canonical serialization)
+    /// computed from this event's own fields, independent of the self-reported
+    /// `id` field.
+    pub fn computed_id(&self) -> String {
+        pre_signing_id(
+            &self.pubkey,
+            self.created_at,
+            self.kind,
+            &self.tags,
+            &self.content,
+        )
+    }
+
     /// Build an unsigned local Nostr DTO and precompute the event id for the
     /// supplied unsigned event core.
     pub fn new_unsigned(
@@ -212,8 +232,8 @@ mod tests {
 
     #[test]
     fn kind_445_event_maps_to_group_transport_message() {
-        let event = NostrTransportEvent {
-            id: "11".repeat(32),
+        let mut event = NostrTransportEvent {
+            id: String::new(),
             pubkey: "22".repeat(32),
             created_at: 1_700_000_000,
             kind: KIND_MARMOT_GROUP_MESSAGE,
@@ -221,10 +241,14 @@ mod tests {
             content: "encrypted body".into(),
             sig: None,
         };
+        event.id = event.computed_id();
 
         let msg = event.to_transport_message().expect("event maps");
 
-        assert_eq!(msg.id.as_slice(), vec![0x11; 32].as_slice());
+        assert_eq!(
+            msg.id.as_slice(),
+            hex::decode(&event.id).unwrap().as_slice()
+        );
         assert_eq!(msg.timestamp.0, 1_700_000_000);
         assert_eq!(msg.source.0, NOSTR_SOURCE);
         // The peeler does not extract `e` causal-dependency tags (kind 445 carries
@@ -273,8 +297,8 @@ mod tests {
 
     #[test]
     fn kind_1059_route_mapping_defers_signature_verification_to_peeling() {
-        let event = NostrTransportEvent {
-            id: "33".repeat(32),
+        let mut event = NostrTransportEvent {
+            id: String::new(),
             pubkey: "44".repeat(32),
             created_at: 1_700_000_001,
             kind: KIND_NIP59_GIFT_WRAP,
@@ -282,6 +306,7 @@ mod tests {
             content: "gift wrap body".into(),
             sig: None,
         };
+        event.id = event.computed_id();
 
         let msg = event
             .to_transport_message()
@@ -293,5 +318,73 @@ mod tests {
                 recipient: MemberId::new(vec![0x55; 32]),
             }
         );
+    }
+
+    #[test]
+    fn route_mapping_rejects_forged_event_id() {
+        // #351 — `TransportMessage.id` keys routing/telemetry/forensics, so a
+        // self-reported id that does not match the event hash fails closed.
+        let event = NostrTransportEvent {
+            id: "33".repeat(32),
+            pubkey: "22".repeat(32),
+            created_at: 1_700_000_000,
+            kind: KIND_MARMOT_GROUP_MESSAGE,
+            tags: vec![vec!["h".into(), "aa55".into()]],
+            content: "encrypted body".into(),
+            sig: None,
+        };
+        assert_ne!(event.id, event.computed_id());
+
+        assert!(matches!(
+            event.to_transport_message(),
+            Err(NostrPeelerError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn route_mapping_rejects_duplicate_recipient_tags() {
+        // #336 — gift-wrap `p` extraction is strict single-tag, matching the
+        // kind-445 `h` path; a multi-`p` wrap is rejected, not first-matched.
+        let mut event = NostrTransportEvent {
+            id: String::new(),
+            pubkey: "44".repeat(32),
+            created_at: 1_700_000_001,
+            kind: KIND_NIP59_GIFT_WRAP,
+            tags: vec![
+                vec!["p".into(), "55".repeat(32)],
+                vec!["p".into(), "66".repeat(32)],
+            ],
+            content: "gift wrap body".into(),
+            sig: None,
+        };
+        event.id = event.computed_id();
+
+        assert!(matches!(
+            event.to_transport_message(),
+            Err(NostrPeelerError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn computed_id_matches_sdk_signed_event_id() {
+        // `to_transport_message` verifies self-reported ids against
+        // `computed_id`, so the local NIP-01 id computation must agree with the
+        // Nostr SDK's — including for content that needs JSON escaping.
+        let content = "line\nbreak \"quote\" back\\slash tab\t unicode ✨ control \u{1}";
+        let signed = nostr::EventBuilder::new(
+            nostr::Kind::Custom(KIND_MARMOT_GROUP_MESSAGE as u16),
+            content,
+        )
+        .tags([nostr::Tag::custom(
+            nostr::TagKind::custom("h"),
+            [hex::encode([0x99; 32])],
+        )])
+        .sign_with_keys(&nostr::Keys::generate())
+        .expect("sign kind-445");
+
+        let dto = NostrTransportEvent::from_nostr_event(&signed).unwrap();
+
+        assert_eq!(dto.id, dto.computed_id());
+        assert!(dto.to_transport_message().is_ok());
     }
 }

--- a/crates/transport-nostr-peeler/src/event.rs
+++ b/crates/transport-nostr-peeler/src/event.rs
@@ -44,7 +44,10 @@ impl NostrTransportEvent {
             KIND_MARMOT_GROUP_MESSAGE => {
                 let group_id = self.single_tag_value(GROUP_TAG)?;
                 TransportEnvelope::GroupMessage {
-                    transport_group_id: decode_hex("group h tag", group_id)?,
+                    // The `h` tag is the hex of the 32-byte nostr_group_id
+                    // (spec/transports/nostr.md); shorter/longer route ids are
+                    // rejected, not passed through.
+                    transport_group_id: decode_hex_exact("group h tag", group_id, 32)?,
                 }
             }
             KIND_NIP59_GIFT_WRAP => {
@@ -130,16 +133,27 @@ impl NostrTransportEvent {
             .collect()
     }
 
-    /// Return exactly one value for a Nostr tag name.
+    /// Return the value of exactly one Nostr tag.
+    ///
+    /// Counts tag *occurrences* (any tag whose name matches), not extracted
+    /// values, so a valueless duplicate like `["p"]` next to `["p", <value>]`
+    /// is still rejected instead of collapsing to a single first-match value.
     pub fn single_tag_value(&self, name: &str) -> Result<&str, NostrPeelerError> {
-        let values = self.tag_values(name);
-        match values.as_slice() {
-            [] => Err(NostrPeelerError::MissingTag(name.into())),
-            [value] => Ok(value),
-            _ => Err(NostrPeelerError::Malformed(format!(
+        let mut matches = self
+            .tags
+            .iter()
+            .filter(|tag| tag.first().is_some_and(|tag_name| tag_name == name));
+        let first = matches
+            .next()
+            .ok_or_else(|| NostrPeelerError::MissingTag(name.into()))?;
+        if matches.next().is_some() {
+            return Err(NostrPeelerError::Malformed(format!(
                 "Nostr event must contain exactly one {name} tag"
-            ))),
+            )));
         }
+        first.get(1).map(String::as_str).ok_or_else(|| {
+            NostrPeelerError::Malformed(format!("Nostr event {name} tag has no value"))
+        })
     }
 
     /// NIP-01 event id (lowercase hex sha256 of the canonical serialization)
@@ -237,7 +251,7 @@ mod tests {
             pubkey: "22".repeat(32),
             created_at: 1_700_000_000,
             kind: KIND_MARMOT_GROUP_MESSAGE,
-            tags: vec![vec!["h".into(), "aa55".into()]],
+            tags: vec![vec!["h".into(), "aa".repeat(32)]],
             content: "encrypted body".into(),
             sig: None,
         };
@@ -257,7 +271,7 @@ mod tests {
         assert_eq!(
             msg.envelope,
             TransportEnvelope::GroupMessage {
-                transport_group_id: vec![0xaa, 0x55],
+                transport_group_id: vec![0xaa; 32],
             }
         );
         assert_eq!(
@@ -329,7 +343,7 @@ mod tests {
             pubkey: "22".repeat(32),
             created_at: 1_700_000_000,
             kind: KIND_MARMOT_GROUP_MESSAGE,
-            tags: vec![vec!["h".into(), "aa55".into()]],
+            tags: vec![vec!["h".into(), "aa".repeat(32)]],
             content: "encrypted body".into(),
             sig: None,
         };
@@ -361,6 +375,80 @@ mod tests {
 
         assert!(matches!(
             event.to_transport_message(),
+            Err(NostrPeelerError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn route_mapping_rejects_non_32_byte_group_route_id() {
+        // The `h` tag is the hex of the 32-byte nostr_group_id
+        // (spec/transports/nostr.md); a short route id must be rejected at the
+        // boundary, not passed through into the transport envelope.
+        let mut event = NostrTransportEvent {
+            id: String::new(),
+            pubkey: "22".repeat(32),
+            created_at: 1_700_000_000,
+            kind: KIND_MARMOT_GROUP_MESSAGE,
+            tags: vec![vec!["h".into(), "aa55".into()]],
+            content: "encrypted body".into(),
+            sig: None,
+        };
+        event.id = event.computed_id();
+
+        assert!(matches!(
+            event.to_transport_message(),
+            Err(NostrPeelerError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn single_tag_enforcement_counts_valueless_duplicate_tags() {
+        // A valueless `["p"]` next to `["p", <valid>]` must not collapse into
+        // "exactly one value" — duplicate occurrences are rejected regardless
+        // of whether each carries a value. Same contract for `h`.
+        let mut gift_wrap = NostrTransportEvent {
+            id: String::new(),
+            pubkey: "44".repeat(32),
+            created_at: 1_700_000_001,
+            kind: KIND_NIP59_GIFT_WRAP,
+            tags: vec![vec!["p".into()], vec!["p".into(), "55".repeat(32)]],
+            content: "gift wrap body".into(),
+            sig: None,
+        };
+        gift_wrap.id = gift_wrap.computed_id();
+        assert!(matches!(
+            gift_wrap.to_transport_message(),
+            Err(NostrPeelerError::Malformed(_))
+        ));
+
+        let mut group = NostrTransportEvent {
+            id: String::new(),
+            pubkey: "22".repeat(32),
+            created_at: 1_700_000_000,
+            kind: KIND_MARMOT_GROUP_MESSAGE,
+            tags: vec![vec!["h".into()], vec!["h".into(), "aa".repeat(32)]],
+            content: "encrypted body".into(),
+            sig: None,
+        };
+        group.id = group.computed_id();
+        assert!(matches!(
+            group.to_transport_message(),
+            Err(NostrPeelerError::Malformed(_))
+        ));
+
+        // A single matching tag with no value is malformed, not missing.
+        let mut valueless = NostrTransportEvent {
+            id: String::new(),
+            pubkey: "44".repeat(32),
+            created_at: 1_700_000_001,
+            kind: KIND_NIP59_GIFT_WRAP,
+            tags: vec![vec!["p".into()]],
+            content: "gift wrap body".into(),
+            sig: None,
+        };
+        valueless.id = valueless.computed_id();
+        assert!(matches!(
+            valueless.to_transport_message(),
             Err(NostrPeelerError::Malformed(_))
         ));
     }

--- a/crates/transport-nostr-peeler/src/peeler.rs
+++ b/crates/transport-nostr-peeler/src/peeler.rs
@@ -1,5 +1,5 @@
 use crate::error::to_peeler_error;
-use crate::event::{decode_hex, decode_hex_exact};
+use crate::event::decode_hex_exact;
 use crate::{
     DEFAULT_EXPORTER_LABEL, GROUP_TAG, KIND_MARMOT_GROUP_MESSAGE, KIND_MARMOT_WELCOME_RUMOR,
     KIND_NIP59_GIFT_WRAP, NOSTR_GROUP_CONTENT_MIN_LEN, NOSTR_GROUP_KEY_LEN, NostrTransportEvent,
@@ -464,7 +464,7 @@ fn ensure_group_routing_matches(
     let event_group_id = event
         .single_tag_value(GROUP_TAG)
         .map_err(to_peeler_error)
-        .and_then(|h| decode_hex("group h tag", h).map_err(to_peeler_error))?;
+        .and_then(|h| decode_hex_exact("group h tag", h, 32).map_err(to_peeler_error))?;
     match &msg.envelope {
         TransportEnvelope::GroupMessage { transport_group_id }
             if *transport_group_id == event_group_id =>

--- a/crates/transport-nostr-peeler/src/peeler.rs
+++ b/crates/transport-nostr-peeler/src/peeler.rs
@@ -17,7 +17,7 @@ use chacha20poly1305::aead::{Aead, KeyInit, Payload};
 use chacha20poly1305::{ChaCha20Poly1305, Nonce};
 use nostr::base64::Engine as _;
 use nostr::base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use nostr::{EventBuilder, Keys, Kind, NostrSigner, PublicKey, Tag, UnsignedEvent};
+use nostr::{EventBuilder, Keys, Kind, NostrSigner, PublicKey, RelayUrl, Tag, UnsignedEvent};
 use rand::RngCore;
 use std::sync::Arc;
 
@@ -26,6 +26,11 @@ const WELCOME_SIGNER_CONTEXT: &str = "nostr_welcome_signer";
 const KEY_PACKAGE_EVENT_TAG: &str = "e";
 const EXPIRATION_TAG: &str = "expiration";
 const WELCOME_RELAYS_TAG: &str = "relays";
+/// Bound on the welcome rumor `relays` tag value count (#392). Parity with
+/// `MAX_RELAY_ENDPOINTS_PER_ROUTE` in `marmot-app`'s relay safety policy.
+const MAX_WELCOME_RELAYS: usize = 16;
+/// Bound on each welcome rumor relay URL length in bytes (#392).
+const MAX_WELCOME_RELAY_URL_LEN: usize = 512;
 
 /// Empty AAD for the outer kind-445 ChaCha20-Poly1305 sealing
 /// (`spec/transports/nostr.md`: `aad = ""`).
@@ -260,17 +265,13 @@ impl TransportPeeler for NostrMlsPeeler {
 
         // spec/transports/nostr.md — the kind-444 welcome rumor links to the
         // KeyPackage event consumed for this welcome and carries the group
-        // relay list the new member should use next.
-        let key_package_event_id = rumor_tag_value(&unwrapped.rumor, KEY_PACKAGE_EVENT_TAG)
-            .ok_or_else(|| PeelerError::Malformed("welcome rumor is missing e tag".into()))?;
+        // relay list the new member should use next. Both tags are
+        // routing-significant, so duplicates are rejected and the relay values
+        // are content-validated before anything downstream sees them (#709).
+        let key_package_event_id = rumor_single_tag_value(&unwrapped.rumor, KEY_PACKAGE_EVENT_TAG)?;
         decode_hex_exact("welcome e tag", key_package_event_id, 32).map_err(to_peeler_error)?;
-        let relays = rumor_tag_values(&unwrapped.rumor, WELCOME_RELAYS_TAG)
-            .ok_or_else(|| PeelerError::Malformed("welcome rumor is missing relays tag".into()))?;
-        if relays.is_empty() || relays.iter().any(|relay| relay.is_empty()) {
-            return Err(PeelerError::Malformed(
-                "welcome rumor relays tag must contain at least one non-empty relay".into(),
-            ));
-        }
+        let relays = rumor_single_tag_values(&unwrapped.rumor, WELCOME_RELAYS_TAG)?;
+        validate_welcome_relays(&relays).map_err(PeelerError::Malformed)?;
 
         let welcome_bytes = BASE64_STANDARD
             .decode(unwrapped.rumor.content.as_bytes())
@@ -344,11 +345,10 @@ impl TransportPeeler for NostrMlsPeeler {
             .await
             .map_err(|e| PeelerError::WrapFailed(format!("signer public key: {e}")))?;
         let recipient_pubkey = Self::recipient_pubkey(recipient)?;
-        if metadata.relays.is_empty() {
-            return Err(PeelerError::WrapFailed(
-                "Nostr welcome relays tag must not be empty".into(),
-            ));
-        }
+        // Outbound parity with `peel_welcome`: never emit a relays tag this
+        // peeler would reject on ingest (#392).
+        let relay_strs: Vec<&str> = metadata.relays.iter().map(|relay| relay.as_str()).collect();
+        validate_welcome_relays(&relay_strs).map_err(PeelerError::WrapFailed)?;
         let rumor: UnsignedEvent = EventBuilder::new(
             Kind::Custom(KIND_MARMOT_WELCOME_RUMOR),
             BASE64_STANDARD.encode(&payload.ciphertext),
@@ -372,28 +372,80 @@ impl TransportPeeler for NostrMlsPeeler {
     }
 }
 
-/// First value of a tag on an unwrapped NIP-59 rumor (`tag[0] == name` →
-/// `tag[1]`).
-fn rumor_tag_value<'a>(rumor: &'a UnsignedEvent, name: &str) -> Option<&'a str> {
-    rumor.tags.iter().find_map(|tag| {
-        let slice = tag.as_slice();
-        match (slice.first(), slice.get(1)) {
-            (Some(tag_name), Some(value)) if tag_name == name => Some(value.as_str()),
-            _ => None,
-        }
-    })
-}
-
-fn rumor_tag_values<'a>(rumor: &'a UnsignedEvent, name: &str) -> Option<Vec<&'a str>> {
-    rumor.tags.iter().find_map(|tag| {
+/// Exactly one `[name, ...]` tag on an unwrapped NIP-59 rumor.
+///
+/// Boundary validation contract (#709): routing-significant rumor tags are
+/// single-valued, so a missing tag and a duplicate tag are both rejected
+/// instead of first-matched, mirroring `single_tag_value` on the outer event.
+fn rumor_single_tag<'a>(rumor: &'a UnsignedEvent, name: &str) -> Result<&'a [String], PeelerError> {
+    let mut matches = rumor.tags.iter().filter_map(|tag| {
         let slice = tag.as_slice();
         match slice.first() {
-            Some(tag_name) if tag_name == name => {
-                Some(slice.iter().skip(1).map(String::as_str).collect())
-            }
+            Some(tag_name) if tag_name == name => Some(slice),
             _ => None,
         }
-    })
+    });
+    let first = matches
+        .next()
+        .ok_or_else(|| PeelerError::Malformed(format!("welcome rumor is missing {name} tag")))?;
+    if matches.next().is_some() {
+        return Err(PeelerError::Malformed(format!(
+            "welcome rumor must contain exactly one {name} tag"
+        )));
+    }
+    Ok(first)
+}
+
+/// Value of the single `[name, value]` tag on an unwrapped NIP-59 rumor.
+fn rumor_single_tag_value<'a>(
+    rumor: &'a UnsignedEvent,
+    name: &str,
+) -> Result<&'a str, PeelerError> {
+    rumor_single_tag(rumor, name)?
+        .get(1)
+        .map(String::as_str)
+        .ok_or_else(|| PeelerError::Malformed(format!("welcome rumor {name} tag has no value")))
+}
+
+/// All values of the single `[name, value, ...]` tag on an unwrapped NIP-59
+/// rumor. The tag itself must appear exactly once; its values stay multi.
+fn rumor_single_tag_values<'a>(
+    rumor: &'a UnsignedEvent,
+    name: &str,
+) -> Result<Vec<&'a str>, PeelerError> {
+    Ok(rumor_single_tag(rumor, name)?
+        .iter()
+        .skip(1)
+        .map(String::as_str)
+        .collect())
+}
+
+/// Content-validate welcome `relays` values on both wrap and peel (#392):
+/// bounded count, bounded per-entry length, and well-formed ws/wss relay URLs
+/// via [`RelayUrl::parse`]. The relay strings are attacker-controlled on
+/// ingest, so error messages carry only aggregate values, never the URL.
+fn validate_welcome_relays(relays: &[&str]) -> Result<(), String> {
+    if relays.is_empty() {
+        return Err("welcome relays tag must contain at least one relay".into());
+    }
+    if relays.len() > MAX_WELCOME_RELAYS {
+        return Err(format!(
+            "welcome relays tag lists {} relays, limit is {MAX_WELCOME_RELAYS}",
+            relays.len()
+        ));
+    }
+    for relay in relays {
+        if relay.len() > MAX_WELCOME_RELAY_URL_LEN {
+            return Err(format!(
+                "welcome relay URL is {} bytes, limit is {MAX_WELCOME_RELAY_URL_LEN}",
+                relay.len()
+            ));
+        }
+        if RelayUrl::parse(relay).is_err() {
+            return Err("welcome relay is not a valid ws/wss relay URL".into());
+        }
+    }
+    Ok(())
 }
 
 fn transport_group_id(msg: &TransportMessage) -> Option<GroupId> {
@@ -433,8 +485,8 @@ fn ensure_welcome_routing_matches(
     msg: &TransportMessage,
 ) -> Result<(), PeelerError> {
     let event_recipient = event
-        .tag_value(RECIPIENT_TAG)
-        .ok_or_else(|| PeelerError::Malformed("missing p tag".into()))
+        .single_tag_value(RECIPIENT_TAG)
+        .map_err(to_peeler_error)
         .and_then(|p| decode_hex_exact("recipient p tag", p, 32).map_err(to_peeler_error))?;
     match &msg.envelope {
         TransportEnvelope::Welcome { recipient } if recipient.as_slice() == event_recipient => {
@@ -927,19 +979,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn welcome_peel_rejects_duplicate_recipient_tags() {
+        // #336 — `ensure_welcome_routing_matches` runs before gift-wrap
+        // signature verification, so a multi-`p` payload is rejected at the
+        // routing boundary even when the envelope names a valid recipient.
+        let sender = sender_keys();
+        let receiver = receiver_keys();
+        let recipient = MemberId::new(receiver.public_key().to_bytes().to_vec());
+        let mut wrapped = NostrMlsPeeler::new()
+            .with_welcome_signer(sender)
+            .wrap_welcome_with_metadata(
+                &EncryptedPayload {
+                    ciphertext: b"mls welcome bytes".to_vec(),
+                    aad: vec![],
+                },
+                &recipient,
+                &sample_welcome_metadata(),
+            )
+            .await
+            .expect("wrap succeeds");
+        let mut event = NostrTransportEvent::from_transport_message(&wrapped).unwrap();
+        event.tags.push(vec!["p".into(), "66".repeat(32)]);
+        event.id = event.computed_id();
+        wrapped.payload = serde_json::to_vec(&event).unwrap();
+
+        let err = NostrMlsPeeler::new()
+            .with_welcome_signer(receiver)
+            .peel_welcome(&wrapped)
+            .await
+            .expect_err("duplicate p tags should not peel");
+
+        assert!(matches!(err, PeelerError::Malformed(_)));
+    }
+
+    #[tokio::test]
     async fn welcome_peel_rejects_unsigned_gift_wrap_after_route_mapping() {
         let receiver = receiver_keys();
-        let unsigned = NostrTransportEvent {
-            id: "33".repeat(32),
+        let mut event = NostrTransportEvent {
+            id: String::new(),
             pubkey: "44".repeat(32),
             created_at: 1_700_000_001,
             kind: KIND_NIP59_GIFT_WRAP,
             tags: vec![vec!["p".into(), receiver.public_key().to_hex()]],
             content: "gift wrap body".into(),
             sig: None,
-        }
-        .to_transport_message()
-        .expect("route mapping accepts unverified gift-wrap envelope");
+        };
+        event.id = event.computed_id();
+        let unsigned = event
+            .to_transport_message()
+            .expect("route mapping accepts unverified gift-wrap envelope");
 
         let err = NostrMlsPeeler::new()
             .with_welcome_signer(receiver)
@@ -998,14 +1086,14 @@ mod tests {
             .await
             .expect("unwrap");
         assert_eq!(
-            rumor_tag_value(&unwrapped.rumor, KEY_PACKAGE_EVENT_TAG),
-            Some(hex::encode(metadata.key_package_event_id.as_slice()).as_str())
+            rumor_single_tag_value(&unwrapped.rumor, KEY_PACKAGE_EVENT_TAG).unwrap(),
+            hex::encode(metadata.key_package_event_id.as_slice()).as_str()
         );
         assert_eq!(
-            rumor_tag_values(&unwrapped.rumor, WELCOME_RELAYS_TAG),
-            Some(vec!["wss://group-a.example", "wss://group-b.example"])
+            rumor_single_tag_values(&unwrapped.rumor, WELCOME_RELAYS_TAG).unwrap(),
+            vec!["wss://group-a.example", "wss://group-b.example"]
         );
-        assert_eq!(rumor_tag_value(&unwrapped.rumor, "encoding"), None);
+        assert!(rumor_single_tag_value(&unwrapped.rumor, "encoding").is_err());
         // Content is base64 of the welcome bytes.
         assert_eq!(
             BASE64_STANDARD
@@ -1021,33 +1109,134 @@ mod tests {
         let receiver = receiver_keys();
         let receiver_peeler = NostrMlsPeeler::new().with_welcome_signer(receiver.clone());
 
-        let missing_key_package = welcome_rumor_gift_wrap(&sender, &receiver, false, true).await;
+        let missing_key_package =
+            welcome_rumor_gift_wrap(&sender, &receiver, 0, &[&["wss://group-a.example"]]).await;
         assert!(matches!(
             receiver_peeler.peel_welcome(&missing_key_package).await,
             Err(PeelerError::Malformed(_))
         ));
 
-        let missing_relays = welcome_rumor_gift_wrap(&sender, &receiver, true, false).await;
+        let missing_relays = welcome_rumor_gift_wrap(&sender, &receiver, 1, &[]).await;
         assert!(matches!(
             receiver_peeler.peel_welcome(&missing_relays).await,
             Err(PeelerError::Malformed(_))
         ));
     }
 
-    /// Build a kind-444 welcome rumor gift wrap with optional required tags,
-    /// used to exercise receiver-side metadata validation.
+    #[tokio::test]
+    async fn welcome_peel_rejects_duplicate_key_package_or_relays_tags() {
+        // #350 — the rumor `e` and `relays` tags are strict single-tag, matching
+        // the kind-445 `h` path; duplicates are rejected, not first-matched.
+        let sender = sender_keys();
+        let receiver = receiver_keys();
+        let receiver_peeler = NostrMlsPeeler::new().with_welcome_signer(receiver.clone());
+
+        let duplicate_key_package =
+            welcome_rumor_gift_wrap(&sender, &receiver, 2, &[&["wss://group-a.example"]]).await;
+        assert!(matches!(
+            receiver_peeler.peel_welcome(&duplicate_key_package).await,
+            Err(PeelerError::Malformed(_))
+        ));
+
+        let duplicate_relays = welcome_rumor_gift_wrap(
+            &sender,
+            &receiver,
+            1,
+            &[&["wss://group-a.example"], &["wss://group-b.example"]],
+        )
+        .await;
+        assert!(matches!(
+            receiver_peeler.peel_welcome(&duplicate_relays).await,
+            Err(PeelerError::Malformed(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn welcome_peel_rejects_unvalidated_relay_values() {
+        // #392 — the relay strings are attacker-controlled: bound the count,
+        // bound each entry's length, and require well-formed ws/wss URLs.
+        let sender = sender_keys();
+        let receiver = receiver_keys();
+        let receiver_peeler = NostrMlsPeeler::new().with_welcome_signer(receiver.clone());
+
+        let too_many: Vec<String> = (0..MAX_WELCOME_RELAYS + 1)
+            .map(|i| format!("wss://relay-{i}.example"))
+            .collect();
+        let oversized_entry = format!("wss://{}.example", "a".repeat(MAX_WELCOME_RELAY_URL_LEN));
+        let cases: Vec<Vec<&str>> = vec![
+            too_many.iter().map(String::as_str).collect(),
+            vec![oversized_entry.as_str()],
+            vec!["https://relay.example"],
+            vec!["not a relay url"],
+            vec![],
+        ];
+
+        for relays in cases {
+            let relay_tag: Vec<&[&str]> = vec![&relays[..]];
+            let msg = welcome_rumor_gift_wrap(&sender, &receiver, 1, &relay_tag).await;
+            assert!(
+                matches!(
+                    receiver_peeler.peel_welcome(&msg).await,
+                    Err(PeelerError::Malformed(_))
+                ),
+                "relay list {:?}... (len {}) should be rejected",
+                relays.first(),
+                relays.len()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn welcome_wrap_rejects_relay_metadata_it_would_not_peel() {
+        // Outbound parity for #392: the wrap path applies the same relay
+        // validation, so a misconfigured local relay list fails closed.
+        let sender = sender_keys();
+        let receiver = receiver_keys();
+        let recipient = MemberId::new(receiver.public_key().to_bytes().to_vec());
+        let peeler = NostrMlsPeeler::new().with_welcome_signer(sender);
+
+        let too_many: Vec<TransportEndpoint> = (0..MAX_WELCOME_RELAYS + 1)
+            .map(|i| TransportEndpoint(format!("wss://relay-{i}.example")))
+            .collect();
+        for relays in [
+            vec![],
+            vec![TransportEndpoint("https://relay.example".into())],
+            too_many,
+        ] {
+            let metadata = WelcomeMetadata {
+                key_package_event_id: MessageId::new(vec![0x44; 32]),
+                relays,
+            };
+            let err = peeler
+                .wrap_welcome_with_metadata(
+                    &EncryptedPayload {
+                        ciphertext: b"mls welcome bytes".to_vec(),
+                        aad: vec![],
+                    },
+                    &recipient,
+                    &metadata,
+                )
+                .await
+                .expect_err("invalid relay metadata should not wrap");
+            assert!(matches!(err, PeelerError::WrapFailed(_)));
+        }
+    }
+
+    /// Build a kind-444 welcome rumor gift wrap with `key_package_tags` copies
+    /// of the `e` tag and one `relays` tag per entry of `relays_tags`, used to
+    /// exercise receiver-side metadata validation.
     async fn welcome_rumor_gift_wrap(
         sender: &nostr::Keys,
         receiver: &nostr::Keys,
-        include_key_package: bool,
-        include_relays: bool,
+        key_package_tags: usize,
+        relays_tags: &[&[&str]],
     ) -> TransportMessage {
         let mut builder = EventBuilder::new(
             Kind::Custom(KIND_MARMOT_WELCOME_RUMOR),
             BASE64_STANDARD.encode(b"mls welcome bytes"),
         );
         let mut tags = Vec::new();
-        if include_key_package {
+        for _ in 0..key_package_tags {
             tags.push(Tag::custom(
                 nostr::TagKind::custom(KEY_PACKAGE_EVENT_TAG),
                 [hex::encode(
@@ -1055,10 +1244,10 @@ mod tests {
                 )],
             ));
         }
-        if include_relays {
+        for relays in relays_tags {
             tags.push(Tag::custom(
                 nostr::TagKind::custom(WELCOME_RELAYS_TAG),
-                ["wss://group-a.example"],
+                relays.iter().copied(),
             ));
         }
         if !tags.is_empty() {


### PR DESCRIPTION
## Summary

Lands the unified boundary contract from #709: **every routing-significant tag on a Nostr ingest path is extracted with single-tag enforcement and content-validated, and no self-reported identifier is trusted before verification.** The strict helper already guarded the kind-445 `h` tag; this brings the `p`, `e`, and `relays` tags and the event id up to the same contract instead of closing the gaps one tag at a time.

## Changes

**Strict single-tag extraction (#336, #350)**
- The kind-1059 gift-wrap recipient `p` tag now uses `single_tag_value` at route mapping (`event.rs to_transport_message`) and at peel (`peeler.rs ensure_welcome_routing_matches`); a multi-`p` wrap is rejected, not routed by an arbitrary first tag.
- The welcome rumor `e` (KeyPackage id) and `relays` tags are extracted with new `rumor_single_tag_*` helpers that reject duplicate tags; the loose first-match `rumor_tag_value`/`rumor_tag_values` helpers are gone.

**Welcome `relays` content validation (#392)**
- `validate_welcome_relays` bounds the count (`MAX_WELCOME_RELAYS = 16`, parity with `marmot-app`'s `MAX_RELAY_ENDPOINTS_PER_ROUTE`), bounds each entry (`MAX_WELCOME_RELAY_URL_LEN = 512`), and requires well-formed ws/wss URLs via `RelayUrl::parse`.
- Applied on peel (attacker-controlled input fails closed as `Malformed`) and on wrap (`WrapFailed` — the peeler never emits a rumor it would reject on ingest).

**Post-verification id trust (#351)**
- `to_transport_message` recomputes the NIP-01 event id from the event's own fields (new `computed_id()`, reusing the existing `pre_signing_id`) and rejects a mismatched self-reported id before it becomes `TransportMessage.id`.
- Both adapter ingest paths go through this conversion, so a forged id can no longer reach routing, cross-relay telemetry keying, or the forensic `wire_id` — including the `observe_relay_event` telemetry-only path, which previously never verified at all. Signature verification stays at peel time.

**Contract documentation**
- `crates/transport-nostr-peeler/AGENTS.md` gains a "Boundary validation contract" section so a future tag wired up with a loose helper is a visible contract violation.

## Tests

- Multi-`p` gift wraps rejected at route mapping and at peel (routing check runs before signature verification, so a tampered wrap dies at the boundary).
- Duplicate `e` / duplicate `relays` rumor tags rejected.
- Oversized relay lists (17+), over-long entries, `https://` scheme, garbage URLs, and empty lists rejected at peel; same violations rejected at wrap.
- Forged-id events: rejected at route mapping; `handle_relay_event` fails closed with no delivery; `observe_relay_event` records zero telemetry state.
- `computed_id` parity with SDK-signed event ids locked by a test including JSON-escaped content; all existing wrap→peel round trips exercise it implicitly.
- Fabricated-id test fixtures across `transport-nostr-adapter`, `marmot-app`, and the peeler now compute real ids (distinguishing markers moved into content so ids stay distinct).

## Verification

- `cargo test -p transport-nostr-peeler` (28), `-p transport-nostr-adapter` (+ `--features sdk`), `-p marmot-app` (305+), `-p cgka-session` — all green.
- `just fast-ci` passes.

Closes #336
Closes #350
Closes #392
Closes #351
Closes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/727">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for inbound Nostr events and welcome messages, rejecting forged event IDs, duplicate or missing required tags, and invalid relay data.
  * Improved routing checks so message IDs are verified against recomputed event hashes before being accepted.
  * Tightened recipient handling for gift-wrapped messages to prevent ambiguous tag parsing.
* **Tests**
  * Added and updated regression coverage for forged IDs, duplicate tags, relay validation, and hash computation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->