### PR TITLE
Docs refresh and workspace version bump to 0.9.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ The canonical protocol specification lives in
 | Agent stream composition | `crates/agent-stream-compose/AGENTS.md` |
 | `wn-agent` connector daemon | `crates/agent-connector/AGENTS.md` |
 | Forensic audit schema | `crates/marmot-forensics/AGENTS.md` |
-| App runtime UniFFI bindings | `crates/marmot-uniffi/README.md` |
+| App runtime UniFFI bindings | `crates/marmot-uniffi/AGENTS.md` |
 | CLI / daemon / TUI surface | `crates/cli/AGENTS.md` |
 | Multi-client harness / vectors | `crates/cgka-conformance-simulator/AGENTS.md` |
 | Architecture docs | `docs/AGENTS.md` and `docs/marmot-architecture/AGENTS.md` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -712,7 +712,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "hex",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "tempfile",
 ]
@@ -2538,7 +2538,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "marmot-account"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -2565,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "fs-private",
  "serde",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -4386,7 +4386,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.2.0"
+version = "0.9.0"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.2.0"
+version = "0.9.0"
 license = "MIT"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Primary implementation areas:
 - `crates/cgka-engine` - OpenMLS-backed CGKA engine and local group state machine.
 - `crates/cgka-conformance-simulator` - multi-client scenarios, generated chaos, reports, property tests, and vectors.
 - `crates/traits` - shared traits and cross-boundary types.
+- `crates/fs-private` - restrictive-by-construction local file, directory, and socket creation helpers.
 - `crates/storage-sqlite` - SQLCipher-backed persistence for session, engine integration, tests, and simulator runs.
 - `crates/transport-nostr-peeler` - Nostr event to engine-message boundary and MLS envelope peeling.
 - `crates/transport-nostr-adapter` - Nostr transport adapter core behind an injectable relay-client boundary.
@@ -73,7 +74,10 @@ cargo test -p cgka-conformance-simulator
 # Wider simulator property-test run.
 cargo test -p cgka-conformance-simulator --features conformance-slow
 
-# Workspace checks.
+# Fast pre-push gate (formatting, naming, compile checks, clippy; skips tests).
+just fast-ci
+
+# Full workspace checks.
 just fmt-check
 just check
 just clippy

--- a/crates/agent-connector/README.md
+++ b/crates/agent-connector/README.md
@@ -17,7 +17,7 @@ connector.
 - `wn-agent` is the installed binary.
 - "WN Agent" is the release track used for binary and adapter-install releases.
 
-The WN Agent release tag has its own prefix, for example `wn-agent-v0.1.0`, but the numeric version is the root
+The WN Agent release tag has its own prefix, for example `wn-agent-v0.9.0`, but the numeric version is the root
 workspace version from `Cargo.toml`. That keeps the agent binary, agent-control protocol, app runtime, and generated
 bindings in one compatibility cohort while still letting us publish only the WN Agent artifacts when that is all that
 changed.
@@ -78,14 +78,14 @@ Versioned WN Agent builds publish the `wn-agent` binary, the Hermes Marmot plugi
 Releases under `wn-agent-v*` tags. Hermes itself must already be installed.
 
 ```sh
-WN_AGENT_VERSION=0.2.0
+WN_AGENT_VERSION=0.9.0
 curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-hermes-marmot.sh" | bash
 ```
 
 To install and immediately run `wn-agent bootstrap --qr`:
 
 ```sh
-WN_AGENT_VERSION=0.2.0
+WN_AGENT_VERSION=0.9.0
 curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-hermes-marmot.sh" | bash -s -- --bootstrap
 ```
 
@@ -100,13 +100,13 @@ Hermes-specific setup, development helpers, and phone-test commands live in
 After the release commit is merged to `master`, cut a WN Agent release tag with:
 
 ```sh
-just release-wn-agent 0.1.0
+just release-wn-agent 0.9.0
 ```
 
 For a dry run:
 
 ```sh
-just release-wn-agent-dry-run 0.1.0
+just release-wn-agent-dry-run 0.9.0
 ```
 
 The helper checks that:

--- a/crates/agent-control/README.md
+++ b/crates/agent-control/README.md
@@ -1,0 +1,26 @@
+# agent-control
+
+Local control-protocol DTOs and newline-delimited JSON framing for Marmot agent integrations.
+
+This crate defines the `marmot.agent-control.v1` request/response/event types and the frame codec used over the
+`wn-agent` Unix socket. Hermes and OpenClaw plugins are thin clients of this protocol.
+
+## What this crate does
+
+- Owns `AgentControlEnvelope` and the typed control DTOs (bootstrap, send, subscribe, stream compose, allowlists, etc.).
+- Provides newline-delimited JSON framing with a 1 MiB per-frame cap.
+- Stays dependency-light: `serde` and Tokio IO only.
+
+## What it does not do
+
+- No engine, storage, account, or transport logic.
+- No socket daemon or process lifecycle (see `agent-connector`).
+- No QUIC preview composition (see `agent-stream-compose`).
+
+## Run the tests
+
+```sh
+cargo test -p agent-control
+```
+
+See [`AGENTS.md`](AGENTS.md) for scope and invariants.

--- a/crates/agent-stream-compose/README.md
+++ b/crates/agent-stream-compose/README.md
@@ -1,0 +1,26 @@
+# agent-stream-compose
+
+Reusable live-preview stream composition over the QUIC broker publisher.
+
+This crate drives a single agent text-stream preview session: connect to the memory-only broker, publish length-delimited
+preview records, and report completion. Record framing and limits come from `cgka-traits`.
+
+## What this crate does
+
+- Exposes `run_stream_compose_session` and the `StreamComposeCommand` / `StreamComposeReport` surface.
+- Reuses canonical record tags, plaintext frame caps, and progress/delta semantics from `cgka_traits::agent_text_stream`.
+- Keeps transport-aware QUIC + broker wiring in one place for `wn-agent` and tests.
+
+## What it does not do
+
+- No account home, MLS engine, or Nostr adapter orchestration.
+- No agent control socket or NDJSON protocol (see `agent-control` / `agent-connector`).
+- No broker process itself (see `transport-quic-broker`).
+
+## Run the tests
+
+```sh
+cargo test -p agent-stream-compose
+```
+
+See [`AGENTS.md`](AGENTS.md) for scope and invariants.

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.2.0",
+  "conformance_version": "0.9.0",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.2.0",
+  "conformance_version": "0.9.0",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.2.0",
+  "conformance_version": "0.9.0",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.2.0",
+  "conformance_version": "0.9.0",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.2.0",
+  "conformance_version": "0.9.0",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.2.0",
+  "conformance_version": "0.9.0",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.2.0",
+  "conformance_version": "0.9.0",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.2.0",
+  "conformance_version": "0.9.0",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.2.0",
+  "conformance_version": "0.9.0",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.2.0",
+  "conformance_version": "0.9.0",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.2.0",
+  "conformance_version": "0.9.0",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.2.0",
+  "conformance_version": "0.9.0",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.2.0",
+  "conformance_version": "0.9.0",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cgka-engine/README.md
+++ b/crates/cgka-engine/README.md
@@ -69,5 +69,5 @@ For the Marmot app-component model now used by new groups, see
 
 ## Status
 
-`0.1.0`, single internal consumer, not semver-stable. For current readiness and open production work, start with
+`0.9.0`, single internal consumer, not semver-stable. For current readiness and open production work, start with
 [`../../docs/marmot-architecture/overview/current-state.md`](../../docs/marmot-architecture/overview/current-state.md).

--- a/crates/cgka-session/README.md
+++ b/crates/cgka-session/README.md
@@ -59,3 +59,5 @@ Run:
 ```sh
 cargo test -p cgka-session
 ```
+
+See [`AGENTS.md`](AGENTS.md) and [`tests/AGENTS.md`](tests/AGENTS.md) for scope and test placement rules.

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -377,6 +377,5 @@ Initial release of the `dm` command-line app, the `dmd` background daemon, and t
 - Homebrew release checklist and namespaced tap packaging path for `marmot-protocol/tap/darkmatter`.
 
 [Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.0...HEAD
-[0.9.0]: https://github.com/marmot-protocol/mdk/releases/tag/v0.9.0
 [0.2.0]: https://github.com/marmot-protocol/mdk/releases/tag/v0.2.0
 [0.1.0]: https://github.com/marmot-protocol/mdk/releases/tag/v0.1.0

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,12 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Changed
+
+- Workspace version unified at `0.9.0` across all crates (successor to MDK `0.8.0`).
+- Documentation refresh: current-state inventory, missing crate READMEs, agent integration agent maps, and release
+  doc alignment.
+
 ### Security
 
 - The `wnd` daemon control socket (and the `wn-agent` connector socket) is now created owner-only (0600)
@@ -370,6 +376,7 @@ Initial release of the `dm` command-line app, the `dmd` background daemon, and t
 - Local installation docs for `cargo install --path crates/cli --locked --bins`.
 - Homebrew release checklist and namespaced tap packaging path for `marmot-protocol/tap/darkmatter`.
 
-[Unreleased]: https://github.com/marmot-protocol/darkmatter/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/marmot-protocol/darkmatter/releases/tag/v0.2.0
-[0.1.0]: https://github.com/marmot-protocol/darkmatter/releases/tag/v0.1.0
+[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/marmot-protocol/mdk/releases/tag/v0.9.0
+[0.2.0]: https://github.com/marmot-protocol/mdk/releases/tag/v0.2.0
+[0.1.0]: https://github.com/marmot-protocol/mdk/releases/tag/v0.1.0

--- a/crates/fs-private/README.md
+++ b/crates/fs-private/README.md
@@ -1,0 +1,30 @@
+# fs-private
+
+Restrictive-by-construction helpers for local files, directories, and Unix domain sockets.
+
+This crate owns the shared "secure local artifact" creation path: files and directories are created already at their
+target owner-only mode, and Unix sockets are bound inside a fresh private staging directory and hard-linked into place.
+Callers supply policy (which paths, which modes); this crate supplies the mechanics.
+
+## What this crate does
+
+- Creates files with `O_CREAT` at the target mode (no post-create chmod on reachable paths).
+- Creates directories atomically at mode `0700` via `DirBuilder`.
+- Binds Unix sockets through a private staging directory and hard-links them into the final path.
+- Exposes the workspace's single octal permission-mode parser (`parse_octal_mode`).
+
+## What it does not do
+
+- No application policy (which artifacts to create, acceptable mode ranges).
+- No dependencies beyond the Rust standard library.
+
+See [`docs/marmot-architecture/overview/local-artifact-safety.md`](../../docs/marmot-architecture/overview/local-artifact-safety.md)
+for the workspace policy that mandates these helpers.
+
+## Run the tests
+
+```sh
+cargo test -p fs-private
+```
+
+See [`AGENTS.md`](AGENTS.md) for scope and invariants.

--- a/crates/marmot-account/README.md
+++ b/crates/marmot-account/README.md
@@ -67,3 +67,5 @@ relay-plane format, or a future non-Nostr transport.
 ```sh
 cargo test -p marmot-account
 ```
+
+See [`AGENTS.md`](AGENTS.md) for scope and invariants.

--- a/crates/marmot-app/README.md
+++ b/crates/marmot-app/README.md
@@ -54,3 +54,12 @@ The crate root now keeps app construction, shared state, storage/projector wirin
 list helpers, and public re-exports. Runtime orchestration lives in the `src/runtime/` module, app-client commands and queries
 live in the `src/client/` module, group DTOs/component projection helpers live in `src/groups.rs`, and encrypted-media
 DTOs plus Blossom upload/download helpers live in the `src/media/` module.
+
+## Run the tests
+
+```sh
+cargo test -p marmot-app
+cargo test -p marmot-app --features otlp-export
+```
+
+See [`AGENTS.md`](AGENTS.md) for the module map and privacy-safe telemetry rules.

--- a/crates/marmot-forensics/README.md
+++ b/crates/marmot-forensics/README.md
@@ -1,0 +1,28 @@
+# marmot-forensics
+
+Shared JSONL forensic audit schema for Marmot incident capture.
+
+This crate defines the append-only audit event model, the `ForensicRecorder` trait, and opt-in recorder
+implementations used by the engine and app runtime when operators enable forensic logging.
+
+## What this crate does
+
+- Owns the versioned JSONL schema (`schema/audit-log-event.v2.schema.json`) and the Rust event kind catalog.
+- Provides `JsonlRecorder` and `NoopRecorder` with an explicit `AuditDataMode` (`obfuscated_sensitive_data` default).
+- Stays independent of engine, storage, transport, and simulator crates.
+
+## What it does not do
+
+- No log upload, tracker, or analysis tooling (external consumers read JSONL files).
+- No always-on logging — forensic capture is opt-in because events can include sensitive operational identifiers.
+
+See [`docs/marmot-architecture/audit-logging.md`](../../docs/marmot-architecture/audit-logging.md) for the full
+implementation inventory.
+
+## Run the tests
+
+```sh
+cargo test -p marmot-forensics
+```
+
+See [`AGENTS.md`](AGENTS.md) for schema/kind lockstep rules.

--- a/crates/marmot-markdown/README.md
+++ b/crates/marmot-markdown/README.md
@@ -1,0 +1,27 @@
+# marmot-markdown
+
+CommonMark and Nostr-aware display parser for Marmot app messages.
+
+This crate turns plaintext message content into a display-oriented AST for CLI, TUI, and mobile renderers. It does not
+define wire format, persistence, or CGKA engine behavior.
+
+## What this crate does
+
+- Parses Markdown into a typed, serde-friendly AST suitable for rendering.
+- Handles Nostr-aware inline entities and rejects ergonomic rendering for private-key material.
+- Keeps dependencies minimal (`serde` only in normal builds).
+
+## What it does not do
+
+- No CGKA engine, storage, transport, or runtime state.
+- No UniFFI surface of its own (bindings expose parsed output through `marmot-app` / `marmot-uniffi` as needed).
+
+Golden fixtures under `tests/golden/` lock parser output for regression coverage.
+
+## Run the tests
+
+```sh
+cargo test -p marmot-markdown
+```
+
+See [`AGENTS.md`](AGENTS.md) for scope and invariants.

--- a/crates/marmot-uniffi/AGENTS.md
+++ b/crates/marmot-uniffi/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md - marmot-uniffi
+
+UniFFI bindings for the Marmot app runtime. Read `README.md` first for build scripts and platform setup.
+
+## Scope
+
+- Own the UniFFI export surface over `marmot-app` for Swift (iOS) and Kotlin (Android) consumers.
+- Own build/packaging scripts: `xcframework.sh` (Swift + XCFramework) and `kotlin-bindings.sh` (Android JNI libs +
+  generated Kotlin).
+- Own `marmotkit-endpoints.env` build-time defaults for audit-log tracker and relay-telemetry OTLP route URLs.
+- Keep generated bindings out of git; host apps vendor artifacts from `output/` after running the scripts.
+
+## Invariants
+
+- The Rust API in `src/` is the source of truth for both Swift and Kotlin — scripts package, they do not fork types.
+- Android consumers must call `MarmotAndroid.initialize(context)` before constructing `Marmot` (Keystore JNI via
+  `ndk-context`).
+- Endpoint env vars set route URLs only; bearer tokens and runtime secrets stay with the host app.
+- Keep binding changes in lockstep with `marmot-app` public API changes; bump the workspace version when UniFFI records,
+  enums, object methods, or error variants change.
+
+## Verification
+
+Regenerate and smoke-test bindings after API changes:
+
+```sh
+./crates/marmot-uniffi/xcframework.sh
+./crates/marmot-uniffi/kotlin-bindings.sh
+cargo test -p marmot-uniffi
+cargo test -p marmot-app
+```
+
+OTLP export builds:
+
+```sh
+cargo check -p marmot-uniffi --features otlp-export
+```
+
+See [`README.md`](README.md) for Android NDK prerequisites and initialization requirements.

--- a/crates/marmot-uniffi/CLAUDE.md
+++ b/crates/marmot-uniffi/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/marmot-uniffi/README.md
+++ b/crates/marmot-uniffi/README.md
@@ -79,3 +79,5 @@ framework already initialized `ndk-context`, do not call `initialize` again.
 
 The output directories are ignored because generated bindings and packaged native libraries are derived artifacts.
 Regenerate them from this crate before vendoring into an app repository.
+
+See [`AGENTS.md`](AGENTS.md) for scope, invariants, and verification commands.

--- a/crates/storage-sqlite/README.md
+++ b/crates/storage-sqlite/README.md
@@ -80,3 +80,5 @@ Run:
 ```sh
 cargo test -p storage-sqlite
 ```
+
+See [`AGENTS.md`](AGENTS.md) for module layout and migration rules.

--- a/crates/traits/README.md
+++ b/crates/traits/README.md
@@ -48,8 +48,10 @@ cargo insta review
 
 ## Stability
 
-`0.1.0`, no public consumers outside this workspace. Snapshot tests will catch accidental drift; deliberate drift is a
+`0.9.0`, no public consumers outside this workspace. Snapshot tests will catch accidental drift; deliberate drift is a
 normal trait-evolution change for now.
 
 For the responsibility breakdown of each trait method (which states are legal, which errors fire, what ordering
 guarantees apply), see the rustdoc on each trait in `src/`.
+
+See [`AGENTS.md`](AGENTS.md) for scope and invariants.

--- a/crates/transport-nostr-adapter/README.md
+++ b/crates/transport-nostr-adapter/README.md
@@ -73,3 +73,5 @@ KeyPackage event kind; do not substitute deprecated NIP-104 key package kinds fo
 cargo test -p transport-nostr-adapter
 cargo test -p transport-nostr-adapter --features sdk
 ```
+
+See [`AGENTS.md`](AGENTS.md) for scope, the `sdk` feature, and privacy-safe telemetry rules.

--- a/crates/transport-nostr-peeler/AGENTS.md
+++ b/crates/transport-nostr-peeler/AGENTS.md
@@ -47,7 +47,8 @@ skips content validation is a contract violation, not a style choice.
 ## Current limits
 
 - Group messages are wrapped and peeled. Each outbound kind `445` event is signed by a fresh ephemeral Nostr key
-  generated per event (`spec/transports/nostr.md:64-65`); the account identity never appears as the outer event pubkey.
+  generated per event (see Nostr transport spec in
+  [marmot-protocol/marmot](https://github.com/marmot-protocol/marmot)); the account identity never appears as the outer event pubkey.
 - Kind `445` content is `base64(nonce || ciphertext)` of a single ChaCha20-Poly1305 sealing under the empty AAD. There
   is no source-epoch hint: an undecryptable message returns `DecryptFailed`, and the engine falls back to retained-epoch
   snapshots / deferred-peel retry rather than a transport-carried epoch.

--- a/crates/transport-nostr-peeler/README.md
+++ b/crates/transport-nostr-peeler/README.md
@@ -60,3 +60,6 @@ local signer.
 ```sh
 cargo test -p transport-nostr-peeler
 ```
+
+See [`AGENTS.md`](AGENTS.md) for strict tag validation rules and the external Nostr transport spec in
+[marmot-protocol/marmot](https://github.com/marmot-protocol/marmot).

--- a/crates/transport-quic-stream/README.md
+++ b/crates/transport-quic-stream/README.md
@@ -1,0 +1,30 @@
+# transport-quic-stream
+
+Raw QUIC transport binding for transient Marmot agent text stream previews.
+
+This crate owns QUIC endpoint setup and reliable stream framing for live preview records. Shared record semantics,
+transcript hashing, and protocol constants live in `cgka-traits`; durable MLS start/final payloads and account
+orchestration stay in higher layers.
+
+## What this crate does
+
+- Sets up QUIC client/server endpoints with ALPN pinning and shared hardening defaults (connect deadline, frame caps,
+  early-data policy) also consumed by `transport-quic-broker`.
+- Seals and opens length-delimited preview records with HKDF-derived keys and AAD.
+- Sends and receives text-stream preview chunks over ordered QUIC streams.
+
+## What it does not do
+
+- No Nostr relay transport, account runtime, or MLS group history.
+- No broker pub/sub fan-out (see `transport-quic-broker`).
+- No UI or agent control protocol (see `agent-control` / `agent-connector`).
+
+Live preview chunks are provisional; the final MLS app payload remains authoritative.
+
+## Run the tests
+
+```sh
+cargo test -p transport-quic-stream
+```
+
+See [`AGENTS.md`](AGENTS.md) for the module map and privacy-safe logging rules.

--- a/docs/marmot-architecture/AGENTS.md
+++ b/docs/marmot-architecture/AGENTS.md
@@ -68,6 +68,9 @@ Agent map for the Marmot architecture docs.
 - **Path:** `hermes-openclaw-agent-integration-plan.md`
   - **Role:** Working plan for the Hermes/OpenClaw agent integration. Check status and dates before relying on it.
 
+- **Path:** `../integrations/hermes/marmot/AGENTS.md` and `../integrations/openclaw/marmot/AGENTS.md`
+  - **Role:** Agent plugin scope, key files, and verification for the control-plane-only Hermes/OpenClaw integrations.
+
 - **Repo:** `github.com/marmot-protocol/marmot`
   - **Role:** Marmot protocol specification by stable surface and app component.
 

--- a/docs/marmot-architecture/AGENTS.md
+++ b/docs/marmot-architecture/AGENTS.md
@@ -68,7 +68,7 @@ Agent map for the Marmot architecture docs.
 - **Path:** `hermes-openclaw-agent-integration-plan.md`
   - **Role:** Working plan for the Hermes/OpenClaw agent integration. Check status and dates before relying on it.
 
-- **Path:** `../integrations/hermes/marmot/AGENTS.md` and `../integrations/openclaw/marmot/AGENTS.md`
+- **Path:** `../../integrations/hermes/marmot/AGENTS.md` and `../../integrations/openclaw/marmot/AGENTS.md`
   - **Role:** Agent plugin scope, key files, and verification for the control-plane-only Hermes/OpenClaw integrations.
 
 - **Repo:** `github.com/marmot-protocol/marmot`

--- a/docs/marmot-architecture/further-context/codebase-survey.md
+++ b/docs/marmot-architecture/further-context/codebase-survey.md
@@ -1,5 +1,10 @@
 # Codebase Survey
 
+> **Deprecated reference (2026-07-04).** This page describes the pre-`0.9.0` MDK layout (`mdk-core`,
+> `mdk-sqlite-storage`, and related crates) and whitenoise-rs metrics from before the current `crates/*` workspace
+> refactor. For current crate boundaries and status, read [`../overview/current-state.md`](../overview/current-state.md)
+> and the per-crate `README.md` / `AGENTS.md` files. Keep this page only for historical archaeology.
+
 > **Reference doc.** Raw data only — skip this unless you need to understand the current size, shape, or dependency
 > structure of the repos. For architectural direction, read [[target-architecture]] instead.
 

--- a/docs/marmot-architecture/further-context/codebase-survey.md
+++ b/docs/marmot-architecture/further-context/codebase-survey.md
@@ -4,7 +4,6 @@
 > `mdk-sqlite-storage`, and related crates) and whitenoise-rs metrics from before the current `crates/*` workspace
 > refactor. For current crate boundaries and status, read [`../overview/current-state.md`](../overview/current-state.md)
 > and the per-crate `README.md` / `AGENTS.md` files. Keep this page only for historical archaeology.
-
 > **Reference doc.** Raw data only — skip this unless you need to understand the current size, shape, or dependency
 > structure of the repos. For architectural direction, read [[target-architecture]] instead.
 

--- a/docs/marmot-architecture/index.md
+++ b/docs/marmot-architecture/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Marmot Architecture — Index"
 created: 2026-04-15
-updated: 2026-06-10
+updated: 2026-07-04
 tags: [marmot, architecture, index]
 ---
 

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -1,7 +1,7 @@
 ---
 title: "Current State — Implementations & Spec"
 created: 2026-04-19
-updated: 2026-06-06
+updated: 2026-07-04
 tags: [marmot, overview, current-state, implementations]
 status: overview
 ---
@@ -19,9 +19,9 @@ status: overview
 
 # Current State — Implementations & Spec
 
-Where Marmot is today: the merged MIPs define the deployed protocol shape, MDK and Marmot-TS give us independent
-implementations, and this repository now contains the candidate CGKA engine/convergence workspace that is being shaped
-into spec text.
+Where Marmot is today: the merged MIPs define the deployed protocol shape, this workspace is MDK at `0.9.0` (the
+unifying bump above the previous `0.8.0` release), Marmot-TS gives us an independent TypeScript implementation, and the
+CGKA engine/convergence workspace here is being shaped into spec text.
 
 ## The spec
 
@@ -49,11 +49,12 @@ deliver unordered, duplicated, delayed input. The engine contract is where that 
 
 ## Protocol implementations
 
-### MDK (Rust)
+### MDK (this repository)
 
-MDK is the deployed Rust protocol implementation. It still carries Nostr-aware API surface in places, but it remains the
-main source of production experience: persistent storage, OpenMLS integration, group operations, and current MIP
-coverage.
+This workspace is the Marmot Development Kit (MDK). Release `0.9.0` unifies every workspace crate under one version
+cohort above the previous `0.8.0` MDK layout (`mdk-core`, `mdk-sqlite-storage`, and related crates). The current
+crate tree under `crates/` is the production-shaped replacement: OpenMLS-backed engine, SQLCipher storage, Nostr
+transports, multi-account app runtime, CLI/daemon/TUI, agent connector stack, UniFFI bindings, and conformance tooling.
 
 ### Marmot-TS (TypeScript)
 
@@ -75,6 +76,7 @@ event-processing complexity. Those are separate from the CGKA engine convergence
 
 This repository now has the main engine candidate:
 
+- `crates/fs-private` — restrictive-by-construction helpers for local files, directories, and Unix sockets.
 - `crates/traits` — cross-boundary value types and traits, including the account-aware `TransportAdapter` boundary.
 - `crates/cgka-engine` — OpenMLS-backed engine implementation.
 - `crates/cgka-session` — production-shaped account-device session wrapper over `Engine<SqliteAccountStorage>`.
@@ -99,9 +101,18 @@ This repository now has the main engine candidate:
 - `crates/transport-quic-broker` — memory-only QUIC pub/sub broker for forwarding live preview records by
   `stream_id + start_event_id` without account state, relay integration, or payload persistence.
 - `crates/cgka-conformance-simulator` — multi-client simulator, vectors, generated scenarios, and property tests.
+- `crates/marmot-markdown` — CommonMark and Nostr-aware display parser for app message rendering.
+- `crates/marmot-forensics` — opt-in JSONL forensic audit schema and recorder traits.
+- `crates/marmot-uniffi` — UniFFI bindings and build scripts for Swift/Kotlin app runtimes.
+- `crates/agent-control` — `marmot.agent-control.v1` DTOs and newline-delimited JSON framing for agent integrations.
+- `crates/agent-stream-compose` — reusable live-preview stream composition over the QUIC broker publisher.
+- `crates/agent-connector` — local `wn-agent` connector daemon bridging agent control, account runtime, and stream
+  composition; Hermes and OpenClaw plugins talk to it over a Unix socket.
+- `integrations/hermes/marmot` and `integrations/openclaw/marmot` — thin control-plane-only agent plugins.
 - `formal/tamarin` — formal models for the convergence selector, delivery-order robustness, lifecycle cases, and
   proof/test mapping.
-- `spec` — Marmot v2 protocol draft by stable surface, including protocol principles and app components.
+- [marmot-protocol/marmot](https://github.com/marmot-protocol/marmot) — canonical Marmot v2 protocol draft by stable
+  surface, including protocol principles and app components (external to this repo).
 
 The current workspace can exercise the peeler-ingest boundary through in-memory clients, reopen encrypted
 SQLCipher-backed account-device sessions, preserve MLS signing identity across those reopens, drive a real

--- a/docs/marmot-architecture/overview/executive-summary.md
+++ b/docs/marmot-architecture/overview/executive-summary.md
@@ -3,7 +3,7 @@ title: "Marmot — Executive Summary"
 created: 2026-04-19
 tags: [marmot, overview, executive-summary]
 status: overview
-updated: 2026-05-13
+updated: 2026-07-04
 ---
 
 # Marmot — Executive Summary

--- a/docs/release/wn-homebrew.md
+++ b/docs/release/wn-homebrew.md
@@ -72,7 +72,8 @@ Use `Formula/` for CLI/source-built packages, `Casks/` for app bundles, and `cmd
 
 ## Before Tagging
 
-1. Confirm the CLI version in the workspace root `Cargo.toml`. The first release is `0.1.0`, tagged as `v0.1.0`.
+1. Confirm the CLI version in the workspace root `Cargo.toml`. The current workspace release is `0.9.0`, tagged as
+   `v0.9.0` (the unifying bump above the previous MDK `0.8.0` release).
 2. Confirm `Cargo.lock` is committed and current.
 3. Run the focused CLI checks:
 
@@ -113,8 +114,8 @@ Use `Formula/` for CLI/source-built packages, `Casks/` for app bundles, and `cmd
 1. Create an annotated tag from the commit whose `Cargo.toml` version matches the tag:
 
    ```sh
-   git tag -a v0.1.0 -m "mdk v0.1.0"
-   git push origin v0.1.0
+   git tag -a v0.9.0 -m "mdk v0.9.0"
+   git push origin v0.9.0
    ```
 
 2. For the current private source repo, update `Formula/wn.rb` in `marmot-protocol/homebrew-tap` to use the
@@ -122,7 +123,7 @@ Use `Formula/` for CLI/source-built packages, `Casks/` for app bundles, and `cmd
 
    ```ruby
    url "ssh://git@github.com/marmot-protocol/mdk.git",
-       tag:      "v0.1.0",
+       tag:      "v0.9.0",
        revision: "<tagged-commit-sha>"
    ```
 
@@ -131,14 +132,14 @@ Use `Formula/` for CLI/source-built packages, `Casks/` for app bundles, and `cmd
 3. If the source repo is public, prefer the GitHub source archive plus `sha256`:
 
    ```sh
-   curl -L -o mdk-v0.1.0.tar.gz \
-     https://github.com/marmot-protocol/mdk/archive/refs/tags/v0.1.0.tar.gz
-   shasum -a 256 mdk-v0.1.0.tar.gz
+   curl -L -o mdk-v0.9.0.tar.gz \
+     https://github.com/marmot-protocol/mdk/archive/refs/tags/v0.9.0.tar.gz
+   shasum -a 256 mdk-v0.9.0.tar.gz
    ```
 
    Then set:
 
-   - `url "https://github.com/marmot-protocol/mdk/archive/refs/tags/v0.1.0.tar.gz"`
+   - `url "https://github.com/marmot-protocol/mdk/archive/refs/tags/v0.9.0.tar.gz"`
    - `sha256 "<archive-sha256>"`
    - Omit `revision 0` for the first formula update.
 

--- a/integrations/hermes/marmot/AGENTS.md
+++ b/integrations/hermes/marmot/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md - integrations/hermes/marmot
+
+Hermes platform plugin for Marmot through the local `wn-agent` control socket.
+The Hermes counterpart of `integrations/openclaw/marmot`. Read `README.md` first.
+
+## Scope
+
+- A thin, **control-plane-only** Hermes platform plugin. `wn-agent` owns the Marmot account, MLS state, Nostr
+  transport, and QUIC previews; this plugin only speaks `marmot.agent-control.v1` (NDJSON over a Unix socket).
+- Keep transcript hashing and stream chunking byte-for-byte with the authoritative Rust
+  `AgentTextStreamTranscriptV1` (`crates/traits/src/agent_text_stream.rs`).
+- No QUIC, crypto, relay, or MLS logic here.
+- Privacy-safe logging only: no account ids, group ids, message ids, pubkeys, relay URLs, payloads, ciphertext,
+  plaintext, or key material.
+
+## Key files
+
+- `plugin.yaml` — Hermes platform plugin manifest.
+- `__init__.py` — plugin entry registration.
+- `adapter.py` — agent-control client, inbound/outbound bridging, and live-preview state machine.
+- `tests/` — unit tests and dev-script smoke coverage.
+
+## Rules
+
+- Regenerate OpenClaw transcript parity vectors in `integrations/openclaw/marmot/test/vectors/` from Rust if transcript
+  hashing changes; keep Hermes chunking aligned with the same Rust source.
+- Treat release installs (`install-hermes-marmot.sh`) and dev harness scripts (`just hermes-dev-*`) as the operational
+  verification path for end-to-end behavior.
+
+## Verification
+
+```sh
+python3 -m unittest discover -s integrations/hermes/marmot/tests
+integrations/hermes/marmot/tests/test_dev_scripts.sh
+# or from the repo root:
+just hermes-dev-script-test
+just hermes-dev-smoke
+```

--- a/integrations/hermes/marmot/CLAUDE.md
+++ b/integrations/hermes/marmot/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -29,14 +29,14 @@ Prerequisites:
 One-line install:
 
 ```sh
-WN_AGENT_VERSION=0.2.0
+WN_AGENT_VERSION=0.9.0
 curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-hermes-marmot.sh" | bash
 ```
 
 Install and bootstrap in one step:
 
 ```sh
-WN_AGENT_VERSION=0.2.0
+WN_AGENT_VERSION=0.9.0
 curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-hermes-marmot.sh" | bash -s -- --bootstrap
 ```
 

--- a/integrations/hermes/marmot/plugin.yaml
+++ b/integrations/hermes/marmot/plugin.yaml
@@ -1,7 +1,7 @@
 name: marmot
 label: Marmot
 kind: platform
-version: 0.2.0
+version: 0.9.0
 description: Hermes platform adapter for Marmot through the local wn-agent control socket
 author: Marmot Protocol
 requires_env: []

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -26,7 +26,7 @@ Prerequisites:
 - Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
 
 ```sh
-WN_AGENT_VERSION=0.2.0
+WN_AGENT_VERSION=0.9.0
 curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-openclaw-marmot.sh" | bash
 # or install + bootstrap the agent account in one step:
 curl -fsSL ".../install-openclaw-marmot.sh" | bash -s -- --bootstrap

--- a/integrations/openclaw/marmot/package.json
+++ b/integrations/openclaw/marmot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marmot-protocol/openclaw-marmot",
-  "version": "0.2.0",
+  "version": "0.9.0",
   "description": "OpenClaw channel plugin for Marmot through the local wn-agent control socket",
   "type": "module",
   "private": true,

--- a/release.md
+++ b/release.md
@@ -11,23 +11,24 @@ artifact that changed.
 
 Current tracks:
 
-- Whole-workspace releases use tags like `v0.1.0`. These identify a versioned source snapshot of the protocol draft,
-  Rust workspace, CLI, daemon, TUI, app runtime, storage, transports, agent crates, and binding source crate.
-- WN Agent releases use tags like `wn-agent-v0.2.0`. These publish the `wn-agent` connector binary plus adapter
+- Whole-workspace releases use tags like `v0.9.0`. These identify a versioned source snapshot of the protocol draft,
+  Rust workspace, CLI, daemon, TUI, app runtime, storage, transports, agent crates, and binding source crate. MDK
+  `0.9.0` is the unifying workspace bump above the previous `0.8.0` release.
+- WN Agent releases use tags like `wn-agent-v0.9.0`. These publish the `wn-agent` connector binary plus adapter
   install assets, starting with the Hermes Marmot plugin and installer.
-- MarmotKit binding releases use tags like `marmotkit-v0.1.0`. These build generated app-consumable binding bundles
+- MarmotKit binding releases use tags like `marmotkit-v0.9.0`. These build generated app-consumable binding bundles
   from `crates/marmot-uniffi` and attach them to a GitHub Release.
 
-Future binary or package tracks should follow the same shape, for example `quic-broker-v0.1.0` or `wn-cli-v0.1.0`, only
+Future binary or package tracks should follow the same shape, for example `quic-broker-v0.9.0` or `wn-cli-v0.9.0`, only
 when those artifacts become independently consumed release surfaces.
 
 When multiple tracks correspond to the same source snapshot, create the tags on the same commit:
 
 ```sh
-git tag -a v0.2.0 -m "mdk v0.2.0"
-git tag -a wn-agent-v0.2.0 -m "WN Agent v0.2.0"
-git tag -a marmotkit-v0.2.0 -m "MarmotKit v0.2.0"
-git push origin v0.2.0 wn-agent-v0.2.0 marmotkit-v0.2.0
+git tag -a v0.9.0 -m "mdk v0.9.0"
+git tag -a wn-agent-v0.9.0 -m "WN Agent v0.9.0"
+git tag -a marmotkit-v0.9.0 -m "MarmotKit v0.9.0"
+git push origin v0.9.0 wn-agent-v0.9.0 marmotkit-v0.9.0
 ```
 
 The workspace is not published to crates.io today. The root `Cargo.toml` has `publish = false`, and the crates depend
@@ -40,7 +41,7 @@ app runtime, and generated bindings:
 
 ```toml
 [workspace.package]
-version = "0.2.0"
+version = "0.9.0"
 ```
 
 Use the same version number in:
@@ -131,11 +132,11 @@ Use this for a versioned MDK source/library release.
 5. Create an annotated tag:
 
    ```sh
-   git tag -a v0.2.0 -m "mdk v0.2.0"
-   git push origin v0.2.0
+   git tag -a v0.9.0 -m "mdk v0.9.0"
+   git push origin v0.9.0
    ```
 
-6. Create or update the GitHub Release for `v0.2.0` on the MDK repo releases page.
+6. Create or update the GitHub Release for `v0.9.0` on the MDK repo releases page.
 7. Include release notes that name the source commit, major user-visible changes, and any migration notes.
 
 Until a dedicated whole-workspace release workflow exists, the whole-workspace GitHub Release is a source release. The
@@ -154,7 +155,7 @@ The workflow lives at:
 ```
 
 Pull requests, master pushes, and manual workflow runs build validation artifacts only. Publishing happens only when a
-tag matching `wn-agent-v*` is pushed. The workflow validates version-like tags such as `wn-agent-v0.2.0` and requires
+tag matching `wn-agent-v*` is pushed. The workflow validates version-like tags such as `wn-agent-v0.9.0` and requires
 the tag version to match the root workspace version in `Cargo.toml`.
 
 Before a WN Agent release, run the normal preflight plus:
@@ -168,13 +169,13 @@ bash scripts/install-openclaw-marmot.sh --dry-run
 Cut the release tag from the current `origin/master` commit:
 
 ```sh
-just release-wn-agent 0.2.0
+just release-wn-agent 0.9.0
 ```
 
 For a dry run:
 
 ```sh
-just release-wn-agent-dry-run 0.2.0
+just release-wn-agent-dry-run 0.9.0
 ```
 
 The helper checks that the workspace version matches, the working tree is clean, `HEAD` matches `origin/master`, and the
@@ -205,9 +206,9 @@ The installer assets are generated during the release and default to their own `
 
 ```sh
 # Hermes gateway
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.2.0/install-hermes-marmot.sh | bash
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.0/install-hermes-marmot.sh | bash
 # OpenClaw gateway
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.2.0/install-openclaw-marmot.sh | bash
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.0/install-openclaw-marmot.sh | bash
 ```
 
 ## MarmotKit Binding Release
@@ -221,13 +222,13 @@ The workflow lives at:
 ```
 
 It runs only when a tag matching `marmotkit-v*` is pushed. The workflow validates version-like tags such as
-`marmotkit-v0.2.0`, builds both binding bundles, and creates or updates the matching GitHub Release.
+`marmotkit-v0.9.0`, builds both binding bundles, and creates or updates the matching GitHub Release.
 
 Create the tag:
 
 ```sh
-git tag -a marmotkit-v0.2.0 -m "MarmotKit v0.2.0"
-git push origin marmotkit-v0.2.0
+git tag -a marmotkit-v0.9.0 -m "MarmotKit v0.9.0"
+git push origin marmotkit-v0.9.0
 ```
 
 The release job creates these assets:
@@ -312,10 +313,10 @@ If a tag points at the wrong commit and nobody should consume it, delete and rec
 testers pin it:
 
 ```sh
-git tag -d wn-agent-v0.2.0
-git push origin :refs/tags/wn-agent-v0.2.0
-git tag -a wn-agent-v0.2.0 -m "WN Agent v0.2.0"
-git push origin wn-agent-v0.2.0
+git tag -d wn-agent-v0.9.0
+git push origin :refs/tags/wn-agent-v0.9.0
+git tag -a wn-agent-v0.9.0 -m "WN Agent v0.9.0"
+git push origin wn-agent-v0.9.0
 ```
 
 If a release has already been consumed, create a new patch version instead.

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -50,7 +50,7 @@ Environment:
   MARMOT_RELAYS         Relay CSV used when --bootstrap starts wn-agent
 
 Example:
-  curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.2.0/install-hermes-marmot.sh | bash
+  curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.0/install-hermes-marmot.sh | bash
 
   curl -fsSL .../install-hermes-marmot.sh | bash -s -- --bootstrap
 USAGE


### PR DESCRIPTION
## Summary
- Bump the workspace compatibility cohort to **0.9.0** (above the previous MDK 0.8.0 release), including conformance vector `conformance_version` fields, release docs, and integration install examples.
- Fix architecture doc drift: refresh `current-state.md` with the full crate inventory, remove the non-existent local `spec/` reference, and deprecate the pre-refactor `codebase-survey.md`.
- Fill documentation gaps: add READMEs for six crates that lacked them, add `AGENTS.md` for `marmot-uniffi` and Hermes, and standardize README → AGENTS cross-links across the workspace.

## Test plan
- [x] `just fast-ci`
- [x] `cargo test -p cgka-conformance-simulator --test canonical_scenarios` (vector version alignment)
- [ ] Review `docs/marmot-architecture/overview/current-state.md` for completeness
- [ ] Spot-check new crate READMEs against each crate's `AGENTS.md`


Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/731">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new crate and integration documentation pages, plus clearer scope, test, and verification guidance across the workspace.
  * Introduced a fast pre-push check in the main README for quicker validation before full checks.

* **Documentation**
  * Updated release and install instructions throughout the repo to align with version **0.9.0**.
  * Refreshed architecture and status docs to reflect the current workspace layout and mark older survey content as deprecated.

* **Bug Fixes**
  * Corrected several repository links and references so documentation points to the current locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->