### PR TITLE
Route every outbound connection through one host-safety dial chokepoint (#708)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,10 @@ The canonical protocol specification lives in
   `docs/marmot-architecture/overview/observability.md`.
 - Create local files, sockets, and databases restrictive-by-construction via `crates/fs-private` (or equivalent
   posture with an on-disk mode test); see `docs/marmot-architecture/overview/local-artifact-safety.md`.
+- Route every outbound connection through the host-safety dial discipline: validate each resolved address with
+  `cgka_traits::app_components::reject_non_public_ip`, pin the validated address, choose TLS trust from config (never a
+  resolved IP), apply a connect timeout, and gate loopback behind an explicit dev flag. See
+  `docs/marmot-architecture/overview/dial-safety.md`.
 - When adding an `AGENTS.md`, create a sibling `CLAUDE.md` symlink to it.
 
 ## Verification

--- a/crates/agent-connector/AGENTS.md
+++ b/crates/agent-connector/AGENTS.md
@@ -11,6 +11,10 @@ Local Marmot agent connector daemon; ships the `wn-agent` binary.
 - Own connector socket binding and permission hardening (`bind_connector_socket`, `default_socket_path`).
 - Keep agent-facing wire types in `agent-control` and stream composition in `agent-stream-compose`; this crate is the
   process glue, not the protocol or composition owner.
+- Keep the QUIC broker dial safe (`src/quic.rs`): agent-supplied `quic://` candidates are validated + pinned through
+  the shared host-safety classifier, and `InsecureLocal` trust is chosen only from `allow_insecure_local_broker` (the
+  `--insecure-local-broker` dev flag, off by default) plus a literal loopback candidate host — never a resolved
+  loopback IP. See `docs/marmot-architecture/overview/dial-safety.md`.
 
 ## Key files
 

--- a/crates/agent-connector/src/bin/wn-agent.rs
+++ b/crates/agent-connector/src/bin/wn-agent.rs
@@ -88,7 +88,7 @@ struct ServeArgs {
     insecure_local_broker: bool,
     #[arg(
         long,
-        help = "Dev/test only: allow relay connections to loopback/private endpoints"
+        help = "Dev/test only: allow relay connections to loopback endpoints (loopback only; private/link-local/CGNAT stay rejected)"
     )]
     allow_loopback_relays: bool,
 }

--- a/crates/agent-connector/src/bin/wn-agent.rs
+++ b/crates/agent-connector/src/bin/wn-agent.rs
@@ -80,6 +80,17 @@ struct ServeArgs {
         help = "Maximum concurrently served control connections"
     )]
     max_connections: usize,
+    #[arg(
+        long,
+        help = "Dev/test only: allow literal-loopback quic:// broker candidates \
+                without certificate verification"
+    )]
+    insecure_local_broker: bool,
+    #[arg(
+        long,
+        help = "Dev/test only: allow relay connections to loopback/private endpoints"
+    )]
+    allow_loopback_relays: bool,
 }
 
 #[derive(Debug, Args)]
@@ -206,6 +217,8 @@ async fn run_serve_command(args: ServeArgs) -> ExitCode {
         debug_controls: args.debug_controls,
         auth_token,
         max_connections: args.max_connections,
+        allow_insecure_local_broker: args.insecure_local_broker,
+        allow_loopback_relays: args.allow_loopback_relays,
     };
     match serve_socket(config).await {
         Ok(()) => ExitCode::SUCCESS,

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -103,10 +103,12 @@ pub struct AgentConnectorConfig {
     /// cannot steer the connector at local services (SSRF) or downgrade TLS
     /// trust through DNS. See `docs/marmot-architecture/overview/dial-safety.md`.
     pub allow_insecure_local_broker: bool,
-    /// Dev/test gate for loopback/private relay endpoints (e.g. an in-process
-    /// `MockRelay` or a local `nostr-rs-relay`). Off by default: production
-    /// rejects non-public relay hosts at the relay-safety chokepoint. Threaded
-    /// into the connector's `MarmotAppConfig::allow_loopback_relay_endpoints`.
+    /// Dev/test gate for loopback relay endpoints (e.g. an in-process
+    /// `MockRelay` or a local `nostr-rs-relay`). Admits loopback only;
+    /// private/link-local/CGNAT relay hosts stay rejected. Off by default:
+    /// production rejects non-public relay hosts at the relay-safety chokepoint.
+    /// Threaded into the connector's
+    /// `MarmotAppConfig::allow_loopback_relay_endpoints`.
     pub allow_loopback_relays: bool,
 }
 

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -35,7 +35,7 @@ use std::time::Duration;
 
 use agent_control::AgentControlEvent;
 use marmot_account::AccountHome;
-use marmot_app::{MarmotApp, MarmotAppRuntime};
+use marmot_app::{MarmotApp, MarmotAppConfig, MarmotAppRuntime};
 use tokio::net::UnixListener;
 use tokio::sync::{Semaphore, broadcast};
 
@@ -94,6 +94,20 @@ pub struct AgentConnectorConfig {
     /// Cap on concurrently served control connections; connections beyond it
     /// are closed at accept time. Must be nonzero.
     pub max_connections: usize,
+    /// Dev/test gate for insecure loopback brokers. When set, a stream-begin
+    /// `quic://` candidate whose host is a LITERAL loopback (`localhost` or a
+    /// loopback IP literal) may resolve to loopback and connect with
+    /// certificate verification disabled (`BrokerServerTrust::InsecureLocal`).
+    /// Off by default: agent-supplied candidates must resolve to public
+    /// addresses and always verify certificates, so a prompt-injected gateway
+    /// cannot steer the connector at local services (SSRF) or downgrade TLS
+    /// trust through DNS. See `docs/marmot-architecture/overview/dial-safety.md`.
+    pub allow_insecure_local_broker: bool,
+    /// Dev/test gate for loopback/private relay endpoints (e.g. an in-process
+    /// `MockRelay` or a local `nostr-rs-relay`). Off by default: production
+    /// rejects non-public relay hosts at the relay-safety chokepoint. Threaded
+    /// into the connector's `MarmotAppConfig::allow_loopback_relay_endpoints`.
+    pub allow_loopback_relays: bool,
 }
 
 impl AgentConnectorConfig {
@@ -110,6 +124,8 @@ impl AgentConnectorConfig {
             debug_controls: false,
             auth_token: None,
             max_connections: MAX_CONTROL_CONNECTIONS,
+            allow_insecure_local_broker: false,
+            allow_loopback_relays: false,
         }
     }
 }
@@ -121,6 +137,7 @@ pub struct AgentConnector {
     pub(crate) allow_any: bool,
     pub(crate) debug_controls: bool,
     pub(crate) auth_token: Option<String>,
+    pub(crate) allow_insecure_local_broker: bool,
     pub(crate) debug_events: broadcast::Sender<AgentControlEvent>,
     pub(crate) debug_final_sends: DebugFinalSendStore,
     pub(crate) idempotency: SendIdempotencyStore,
@@ -140,10 +157,12 @@ impl AgentConnector {
     pub fn open(config: AgentConnectorConfig) -> Result<Self, ConnectorError> {
         let account_home = AccountHome::open(&config.home);
         let relays = config.relays;
-        let app = MarmotApp::with_relays_and_account_home(
+        let app = MarmotApp::with_relays_and_account_home_and_config(
             &config.home,
             relays.clone(),
             account_home.clone(),
+            MarmotAppConfig::default()
+                .with_allow_loopback_relay_endpoints(config.allow_loopback_relays),
         );
         let runtime = MarmotAppRuntime::new(app.clone());
         let inbound_catch_up = InboundCatchUpDriver::new(runtime.clone());
@@ -155,6 +174,7 @@ impl AgentConnector {
             allow_any: config.allow_any,
             debug_controls: config.debug_controls,
             auth_token: config.auth_token,
+            allow_insecure_local_broker: config.allow_insecure_local_broker,
             debug_events,
             debug_final_sends: DebugFinalSendStore::default(),
             idempotency: SendIdempotencyStore::new(&config.home),

--- a/crates/agent-connector/src/quic.rs
+++ b/crates/agent-connector/src/quic.rs
@@ -1,8 +1,8 @@
 //! QUIC broker candidate parsing, address resolution, and trust selection.
 
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 
-use cgka_traits::app_components::reject_non_public_socket_addr;
+use cgka_traits::app_components::{is_loopback_candidate_host, reject_non_public_socket_addr};
 use transport_quic_broker::BrokerServerTrust;
 
 use crate::error::ConnectorError;
@@ -29,7 +29,11 @@ pub(crate) fn parse_quic_candidate(candidate: &str) -> Result<ParsedQuicCandidat
             "invalid QUIC candidate: {trimmed}"
         )));
     };
-    let authority = rest.split('/').next().unwrap_or(rest);
+    // Per transports/quic.md a receiver MUST ignore any path, query, or
+    // fragment after the authority; the authority ends at the first of '/',
+    // '?', or '#'. Mirror the app/CLI parsers so this connector accepts the
+    // same candidates the rest of the stack does.
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
     if authority.is_empty() {
         return Err(ConnectorError::Stream(format!(
             "invalid QUIC candidate: {trimmed}"
@@ -107,18 +111,9 @@ pub(crate) fn broker_trust_for_candidate(
     candidate_host: &str,
     allow_insecure_local: bool,
 ) -> BrokerServerTrust {
-    if allow_insecure_local && candidate_host_is_loopback(candidate_host) {
+    if allow_insecure_local && is_loopback_candidate_host(candidate_host) {
         BrokerServerTrust::InsecureLocal
     } else {
         BrokerServerTrust::Platform
     }
-}
-
-fn candidate_host_is_loopback(host: &str) -> bool {
-    if host.eq_ignore_ascii_case("localhost") {
-        return true;
-    }
-    host.parse::<IpAddr>()
-        .map(|ip| ip.is_loopback())
-        .unwrap_or(false)
 }

--- a/crates/agent-connector/src/quic.rs
+++ b/crates/agent-connector/src/quic.rs
@@ -1,7 +1,8 @@
 //! QUIC broker candidate parsing, address resolution, and trust selection.
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
+use cgka_traits::app_components::reject_non_public_socket_addr;
 use transport_quic_broker::BrokerServerTrust;
 
 use crate::error::ConnectorError;
@@ -42,8 +43,18 @@ pub(crate) fn parse_quic_candidate(candidate: &str) -> Result<ParsedQuicCandidat
     })
 }
 
+/// Resolve an agent-supplied `quic://` candidate to a socket address, running
+/// the result through the shared dial-safety gate. `StreamBegin.quic_candidates`
+/// is fully agent-controlled (a prompt-injected gateway can supply arbitrary
+/// authorities), so without the explicit `allow_local_endpoint` dev opt-in a
+/// candidate that resolves to loopback, private, link-local, CGNAT, or any
+/// other non-public range is rejected before any QUIC handshake (SSRF
+/// hardening; see `docs/marmot-architecture/overview/dial-safety.md`). The
+/// returned address is the one the QUIC endpoint connects to, so the validated
+/// address and the dialed address cannot diverge.
 pub(crate) async fn resolve_quic_candidate_addr(
     candidate: &ParsedQuicCandidate,
+    allow_local_endpoint: bool,
 ) -> Result<SocketAddr, ConnectorError> {
     let mut addrs = tokio::net::lookup_host(&candidate.authority)
         .await
@@ -53,9 +64,16 @@ pub(crate) async fn resolve_quic_candidate_addr(
                 candidate.original
             ))
         })?;
-    addrs.next().ok_or_else(|| {
+    let addr = addrs.next().ok_or_else(|| {
         ConnectorError::Stream(format!("invalid QUIC candidate: {}", candidate.original))
-    })
+    })?;
+    reject_non_public_socket_addr(addr, allow_local_endpoint).map_err(|_| {
+        ConnectorError::Stream(format!(
+            "QUIC candidate resolved to a non-public address: {}",
+            candidate.original
+        ))
+    })?;
+    Ok(addr)
 }
 
 pub(crate) fn candidate_server_name(authority: &str) -> Result<String, ConnectorError> {
@@ -76,10 +94,31 @@ pub(crate) fn candidate_server_name(authority: &str) -> Result<String, Connector
         })
 }
 
-pub(crate) fn broker_trust_for_addr(broker_addr: SocketAddr) -> BrokerServerTrust {
-    if broker_addr.ip().is_loopback() {
+/// Select TLS trust for a broker candidate from configuration and the LITERAL
+/// candidate host, never from a resolved address. `InsecureLocal` (skip cert
+/// verification) requires both the explicit `allow_insecure_local` dev opt-in
+/// (`AgentConnectorConfig::allow_insecure_local_broker`, off by default) and a
+/// candidate whose host is a literal loopback; a hostname that merely RESOLVES
+/// to loopback keeps normal verification, so an agent-supplied candidate can
+/// never downgrade trust through DNS. The broker client's
+/// `InsecureLocalRequiresLoopback` check remains as the resolved-address
+/// backstop behind this gate.
+pub(crate) fn broker_trust_for_candidate(
+    candidate_host: &str,
+    allow_insecure_local: bool,
+) -> BrokerServerTrust {
+    if allow_insecure_local && candidate_host_is_loopback(candidate_host) {
         BrokerServerTrust::InsecureLocal
     } else {
         BrokerServerTrust::Platform
     }
+}
+
+fn candidate_host_is_loopback(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
 }

--- a/crates/agent-connector/src/stream.rs
+++ b/crates/agent-connector/src/stream.rs
@@ -12,7 +12,8 @@ use transport_quic_broker::OpenBrokerTextPublisher;
 
 use crate::error::ConnectorError;
 use crate::quic::{
-    broker_trust_for_addr, first_quic_candidate, parse_quic_candidate, resolve_quic_candidate_addr,
+    broker_trust_for_candidate, first_quic_candidate, parse_quic_candidate,
+    resolve_quic_candidate_addr,
 };
 use crate::stream_session::ActiveStreamSession;
 use crate::validation::{normalize_hex, transcript_hash_from_hex, unix_now_seconds};
@@ -41,8 +42,13 @@ impl AgentConnector {
         let stream_id_hex = hex::encode(&stream_id);
         let candidate = first_quic_candidate(&quic_candidates)?;
         let parsed_candidate = parse_quic_candidate(&candidate)?;
-        let broker_addr = resolve_quic_candidate_addr(&parsed_candidate).await?;
-        let trust = broker_trust_for_addr(broker_addr);
+        let broker_addr =
+            resolve_quic_candidate_addr(&parsed_candidate, self.allow_insecure_local_broker)
+                .await?;
+        let trust = broker_trust_for_candidate(
+            &parsed_candidate.server_name,
+            self.allow_insecure_local_broker,
+        );
         let (_payload, summary) = self
             .runtime
             .start_agent_text_stream(

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -3468,6 +3468,41 @@ async fn create_media_download_dir_rejects_non_directory_per_blob_child() {
 }
 
 #[test]
+fn quic_candidate_parser_ignores_path_query_and_fragment() {
+    use crate::quic::parse_quic_candidate;
+
+    // Per transports/quic.md the authority ends at the first of '/', '?', '#';
+    // the connector must accept the same candidates the app/CLI parsers do
+    // (regression: it previously only split on '/').
+    for (candidate, expected_authority, expected_server_name) in [
+        (
+            "quic://broker.example:4450",
+            "broker.example:4450",
+            "broker.example",
+        ),
+        (
+            "quic://broker.example:4450?x=1",
+            "broker.example:4450",
+            "broker.example",
+        ),
+        (
+            "quic://broker.example:4450/path?x=1#frag",
+            "broker.example:4450",
+            "broker.example",
+        ),
+        (
+            "quic://broker.example:4450#frag",
+            "broker.example:4450",
+            "broker.example",
+        ),
+    ] {
+        let parsed = parse_quic_candidate(candidate).expect("candidate parses");
+        assert_eq!(parsed.authority, expected_authority, "{candidate}");
+        assert_eq!(parsed.server_name, expected_server_name, "{candidate}");
+    }
+}
+
+#[test]
 fn broker_trust_requires_explicit_opt_in_and_a_literal_loopback_host() {
     use transport_quic_broker::BrokerServerTrust;
 

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -56,6 +56,11 @@ fn test_config(
     config.relays = relays;
     config.allow_any = allow_any;
     config.debug_controls = debug_controls;
+    // The white-box suite drives streams at loopback brokers and connects to an
+    // in-process `MockRelay` at loopback; production defaults keep both off (see
+    // `allow_insecure_local_broker` / `allow_loopback_relays`).
+    config.allow_insecure_local_broker = true;
+    config.allow_loopback_relays = true;
     config
 }
 
@@ -3460,4 +3465,88 @@ async fn create_media_download_dir_rejects_non_directory_per_blob_child() {
         root.join(subdir).is_file(),
         "the pre-existing file child must be left untouched"
     );
+}
+
+#[test]
+fn broker_trust_requires_explicit_opt_in_and_a_literal_loopback_host() {
+    use transport_quic_broker::BrokerServerTrust;
+
+    use crate::quic::broker_trust_for_candidate;
+
+    // Off by default: even a literal loopback candidate verifies certificates.
+    assert!(matches!(
+        broker_trust_for_candidate("127.0.0.1", false),
+        BrokerServerTrust::Platform
+    ));
+    assert!(matches!(
+        broker_trust_for_candidate("localhost", false),
+        BrokerServerTrust::Platform
+    ));
+
+    // With the dev opt-in only LITERAL loopback hosts skip verification.
+    assert!(matches!(
+        broker_trust_for_candidate("127.0.0.1", true),
+        BrokerServerTrust::InsecureLocal
+    ));
+    assert!(matches!(
+        broker_trust_for_candidate("localhost", true),
+        BrokerServerTrust::InsecureLocal
+    ));
+    assert!(matches!(
+        broker_trust_for_candidate("::1", true),
+        BrokerServerTrust::InsecureLocal
+    ));
+
+    // A DOMAIN that could resolve to loopback never selects insecure trust
+    // (resolution-dependent downgrade, issue #356).
+    assert!(matches!(
+        broker_trust_for_candidate("evil.example", true),
+        BrokerServerTrust::Platform
+    ));
+}
+
+// Agent-supplied `quic://` candidates must clear the shared dial-safety gate
+// at resolve time: literal-IP authorities resolve without DNS, so these cover
+// the canonical non-public classes end to end (issue #385).
+#[tokio::test]
+async fn quic_candidate_resolve_rejects_non_public_addresses_without_opt_in() {
+    use crate::quic::{parse_quic_candidate, resolve_quic_candidate_addr};
+
+    for authority in [
+        "quic://10.0.0.5:4433",
+        "quic://169.254.169.254:80",
+        "quic://100.64.0.1:4433",
+        "quic://127.0.0.1:4433",
+        "quic://[::1]:4433",
+        "quic://[fc00::1]:4433",
+    ] {
+        let candidate = parse_quic_candidate(authority).expect("candidate parses");
+        let result = resolve_quic_candidate_addr(&candidate, false).await;
+        assert!(
+            result.is_err(),
+            "{authority} must be rejected without the dev opt-in"
+        );
+    }
+}
+
+#[tokio::test]
+async fn quic_candidate_resolve_opt_in_admits_loopback_only() {
+    use crate::quic::{parse_quic_candidate, resolve_quic_candidate_addr};
+
+    let candidate = parse_quic_candidate("quic://127.0.0.1:4433").expect("candidate parses");
+    let addr = resolve_quic_candidate_addr(&candidate, true)
+        .await
+        .expect("loopback resolves under the dev opt-in");
+    assert!(addr.ip().is_loopback());
+
+    // The opt-in opens loopback only; private/link-local candidates stay
+    // rejected even in dev mode.
+    for authority in ["quic://10.0.0.5:4433", "quic://169.254.169.254:80"] {
+        let candidate = parse_quic_candidate(authority).expect("candidate parses");
+        let result = resolve_quic_candidate_addr(&candidate, true).await;
+        assert!(
+            result.is_err(),
+            "{authority} must be rejected even with the dev opt-in"
+        );
+    }
 }

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,16 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Security
 
+- Every outbound relay connection now passes through one host-safety chokepoint: relay endpoints whose literal host is
+  loopback, RFC1918/private, link-local (including `169.254.169.254`), CGNAT, multicast, or IPv6 ULA are rejected before
+  a socket is opened, so a poisoned routing record or relay-list event can no longer steer the relay pool at internal
+  services (SSRF). Local relays (e.g. an in-process `MockRelay` or a dev `nostr-rs-relay`) are reachable only when
+  `WN_ALLOW_LOOPBACK_RELAYS=1` is set, mirroring `WN_ALLOW_LOOPBACK_BLOB_ENDPOINTS`; production installs leave it unset.
+- The `wn-agent` connector no longer connects to an agent-supplied `quic://` broker candidate that resolves to a
+  non-public address, and no longer derives no-cert-verification (`insecure_local`) trust from a candidate that merely
+  resolves to loopback. Loopback brokers are reachable, without certificate verification, only when `wn-agent serve` is
+  started with the new `--insecure-local-broker` dev flag and the candidate host is a literal loopback (SSRF + trust
+  downgrade hardening).
 - The `wnd` daemon control socket (and the `wn-agent` connector socket) is now created owner-only (0600)
   atomically — bound inside a private 0700 staging directory and linked into place — instead of being chmod-ed
   after `bind`, removing the brief window where the socket was reachable at umask-default permissions (for

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -60,6 +60,11 @@ Common options can be passed as flags or environment variables:
 For local development against a loopback Blossom server, set `WN_ALLOW_LOOPBACK_BLOB_ENDPOINTS=1`. By default `wn`
 refuses to upload to or download from `http://127.0.0.1`-style blob endpoints; production installs leave this unset.
 
+Likewise, to talk to a loopback relay (the local Compose stack, or an in-process relay), set `WN_ALLOW_LOOPBACK_RELAYS=1`.
+By default `wn`/`wnd` refuse to open a socket to a `ws://127.0.0.1`-style (or any non-public) relay host, so the
+loopback-relay examples below assume this is exported; production installs leave it unset. This admits loopback only —
+private/link-local/CGNAT relay hosts stay rejected either way.
+
 The default home is `WN_HOME` when set. Without `WN_HOME`, `wn` uses the platform user data directory:
 
 - macOS: `~/Library/Application Support/whitenoise`
@@ -76,6 +81,7 @@ just relay-up
 
 export WN_HOME="$PWD/dev/data/quickstart"
 export WN_SECRET_STORE=file
+export WN_ALLOW_LOOPBACK_RELAYS=1   # loopback relays are dev/test only; unset in production
 unset WN_SOCKET
 rm -rf "$WN_HOME"
 
@@ -332,6 +338,7 @@ and stream mutations.
 ```sh
 export WN_HOME="$PWD/dev/data/daemon-demo"
 export WN_SECRET_STORE=file
+export WN_ALLOW_LOOPBACK_RELAYS=1   # loopback relays are dev/test only; unset in production
 unset WN_SOCKET
 wn daemon start \
   --discovery-relays ws://127.0.0.1:27777 \
@@ -374,6 +381,7 @@ just relay-up
 
 export WN_HOME="$PWD/dev/data/stream-demo"
 export WN_SECRET_STORE=file
+export WN_ALLOW_LOOPBACK_RELAYS=1   # loopback relays are dev/test only; unset in production
 unset WN_SOCKET
 rm -rf "$WN_HOME"
 
@@ -390,6 +398,7 @@ Terminal 2 creates Alice/Bob, starts the durable stream, and sends live broker c
 ```sh
 export WN_HOME="$PWD/dev/data/stream-demo"
 export WN_SECRET_STORE=file
+export WN_ALLOW_LOOPBACK_RELAYS=1   # loopback relays are dev/test only; unset in production
 unset WN_SOCKET
 
 ALICE=$(wn --json create-identity | jq -r '.result.account_id')

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -964,7 +964,8 @@ fn app_for(home: PathBuf, relay: Option<String>, account_home: AccountHome) -> M
     // WN_ALLOW_LOOPBACK_BLOB_ENDPOINTS=1 for local Blossom servers; production
     // installs leave it unset.
     let mut config = MarmotAppConfig::default()
-        .with_allow_loopback_blob_endpoints(wn_allow_loopback_blob_endpoints());
+        .with_allow_loopback_blob_endpoints(wn_allow_loopback_blob_endpoints())
+        .with_allow_loopback_relay_endpoints(wn_allow_loopback_relays());
     // Dev/test only: WN_DEV_SETTLEMENT_QUIESCENCE_MS overrides the pinned
     // convergence settlement window (e.g. `0` for instant settlement in
     // integration tests). Production installs leave it unset and use the pinned
@@ -983,6 +984,18 @@ fn app_for(home: PathBuf, relay: Option<String>, account_home: AccountHome) -> M
 fn wn_allow_loopback_blob_endpoints() -> bool {
     matches!(
         std::env::var("WN_ALLOW_LOOPBACK_BLOB_ENDPOINTS").as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
+/// Dev/test opt-in for opening relay connections to loopback/private endpoints
+/// (e.g. a local `nostr-rs-relay` or an in-process `MockRelay`). Production
+/// installs leave `WN_ALLOW_LOOPBACK_RELAYS` unset, so the relay-safety
+/// chokepoint rejects non-public relay hosts. Mirrors
+/// `WN_ALLOW_LOOPBACK_BLOB_ENDPOINTS`.
+fn wn_allow_loopback_relays() -> bool {
+    matches!(
+        std::env::var("WN_ALLOW_LOOPBACK_RELAYS").as_deref(),
         Ok("1") | Ok("true")
     )
 }

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -254,6 +254,9 @@ fn wn(home: &std::path::Path) -> Command {
     // CLI tests exercise encrypted media against a loopback Blossom server,
     // which is the dev/test scenario the loopback-HTTP gate is for.
     command.env("WN_ALLOW_LOOPBACK_BLOB_ENDPOINTS", "1");
+    // CLI tests connect to an in-process `MockRelay` at loopback, which is the
+    // dev/test scenario the loopback-relay gate is for.
+    command.env("WN_ALLOW_LOOPBACK_RELAYS", "1");
     // Instant convergence settlement so multi-client tests do not wait on the
     // pinned 1000 ms quiescence window (dev/test only).
     command.env("WN_DEV_SETTLEMENT_QUIESCENCE_MS", "0");
@@ -2099,6 +2102,9 @@ fn account_create_requires_relay_setup() {
         .arg("--json")
         .arg("--secret-store")
         .arg("file")
+        // Daemon tests drive an in-process `MockRelay` at loopback; production
+        // rejects non-public relay hosts unless this dev gate is set.
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
         .args(["account", "create"])
         .output()
         .expect("wn command should start");
@@ -3197,6 +3203,9 @@ fn daemon_background_stream_watch_records_brokered_preview() {
         .arg(test_relay_url())
         .arg("--secret-store")
         .arg("file")
+        // Daemon tests drive an in-process `MockRelay` at loopback; production
+        // rejects non-public relay hosts unless this dev gate is set.
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
         // Instant convergence settlement (dev/test) so the daemon surfaces
         // synced state without waiting on the pinned quiescence window.
         .env("WN_DEV_SETTLEMENT_QUIESCENCE_MS", "0")
@@ -3310,6 +3319,9 @@ fn messages_subscribe_streams_messages_and_quic_previews_from_daemon() {
         .arg(test_relay_url())
         .arg("--secret-store")
         .arg("file")
+        // Daemon tests drive an in-process `MockRelay` at loopback; production
+        // rejects non-public relay hosts unless this dev gate is set.
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
         // Instant convergence settlement (dev/test) so the daemon surfaces
         // synced state without waiting on the pinned quiescence window.
         .env("WN_DEV_SETTLEMENT_QUIESCENCE_MS", "0")
@@ -3462,6 +3474,9 @@ fn tui_style_stream_compose_blocks_loopback_auto_watch_and_publishes_final_messa
         .arg(test_relay_url())
         .arg("--secret-store")
         .arg("file")
+        // Daemon tests drive an in-process `MockRelay` at loopback; production
+        // rejects non-public relay hosts unless this dev gate is set.
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
         // Instant convergence settlement (dev/test) so the daemon surfaces
         // synced state without waiting on the pinned quiescence window.
         .env("WN_DEV_SETTLEMENT_QUIESCENCE_MS", "0")
@@ -3614,6 +3629,9 @@ fn daemon_defaults_create_identities_and_block_loopback_auto_watch_without_manua
         .arg(test_relay_url())
         .arg("--secret-store")
         .arg("file")
+        // Daemon tests drive an in-process `MockRelay` at loopback; production
+        // rejects non-public relay hosts unless this dev gate is set.
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
         // Instant convergence settlement (dev/test) so the daemon surfaces
         // synced state without waiting on the pinned quiescence window.
         .env("WN_DEV_SETTLEMENT_QUIESCENCE_MS", "0")
@@ -4175,6 +4193,9 @@ fn chats_subscribe_streams_initial_chat_rows_from_daemon() {
         .arg(test_relay_url())
         .arg("--secret-store")
         .arg("file")
+        // Daemon tests drive an in-process `MockRelay` at loopback; production
+        // rejects non-public relay hosts unless this dev gate is set.
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
         // Instant convergence settlement (dev/test) so the daemon surfaces
         // synced state without waiting on the pinned quiescence window.
         .env("WN_DEV_SETTLEMENT_QUIESCENCE_MS", "0")
@@ -4241,6 +4262,9 @@ fn groups_subscribe_state_streams_initial_group_state_from_daemon() {
         .arg(test_relay_url())
         .arg("--secret-store")
         .arg("file")
+        // Daemon tests drive an in-process `MockRelay` at loopback; production
+        // rejects non-public relay hosts unless this dev gate is set.
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
         // Instant convergence settlement (dev/test) so the daemon surfaces
         // synced state without waiting on the pinned quiescence window.
         .env("WN_DEV_SETTLEMENT_QUIESCENCE_MS", "0")
@@ -4323,6 +4347,9 @@ fn daemon_executes_cli_commands_over_socket() {
         .arg(test_relay_url())
         .arg("--secret-store")
         .arg("file")
+        // Daemon tests drive an in-process `MockRelay` at loopback; production
+        // rejects non-public relay hosts unless this dev gate is set.
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
         .spawn()
         .expect("wnd should start");
 
@@ -4368,6 +4395,9 @@ fn daemon_socket_path_is_private() {
         .arg(test_relay_url())
         .arg("--secret-store")
         .arg("file")
+        // Daemon tests drive an in-process `MockRelay` at loopback; production
+        // rejects non-public relay hosts unless this dev gate is set.
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
         .spawn()
         .expect("wnd should start");
 
@@ -4419,6 +4449,9 @@ fn daemon_refuses_reset_over_socket() {
         .arg(test_relay_url())
         .arg("--secret-store")
         .arg("file")
+        // Daemon tests drive an in-process `MockRelay` at loopback; production
+        // rejects non-public relay hosts unless this dev gate is set.
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
         .spawn()
         .expect("wnd should start");
 
@@ -4460,6 +4493,9 @@ fn daemon_running_does_not_auto_forward_logout() {
         .arg(test_relay_url())
         .arg("--secret-store")
         .arg("file")
+        // Daemon tests drive an in-process `MockRelay` at loopback; production
+        // rejects non-public relay hosts unless this dev gate is set.
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
         .spawn()
         .expect("wnd should start");
 
@@ -4499,6 +4535,9 @@ fn daemon_start_status_execute_and_stop_are_user_facing_commands() {
         .arg(&socket)
         .arg("--secret-store")
         .arg("file")
+        // Daemon tests drive an in-process `MockRelay` at loopback; production
+        // rejects non-public relay hosts unless this dev gate is set.
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
         .arg("--json")
         .args([
             "daemon",
@@ -4645,6 +4684,9 @@ fn daemon_runtime_subscriptions_update_local_accounts_without_manual_sync() {
         .arg(&socket)
         .arg("--secret-store")
         .arg("file")
+        // Daemon tests drive an in-process `MockRelay` at loopback; production
+        // rejects non-public relay hosts unless this dev gate is set.
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
         .arg("--json")
         .args([
             "daemon",

--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -61,7 +61,11 @@ App runtime bridge for the first real Marmot app surfaces.
   should stay visible until accepted, and decline should leave the group before archiving the local projection.
 - Keep protocol engine behavior in `cgka-engine` and session ownership in `cgka-session`.
 - Keep Nostr group routing sourced from `marmot.transport.nostr.routing.v1` component bytes; relay filtering may affect
-  connections, but must not rewrite signed routing state.
+  connections, but must not rewrite signed routing state. Relay endpoints pass through the `RelaySafetyPolicy`
+  host-safety chokepoint (`src/relay_plane/safety.rs`), and agent-stream broker candidates through
+  `src/runtime/agent_stream_watch.rs`, before any connect; both follow the one dial discipline in
+  `docs/marmot-architecture/overview/dial-safety.md` (validate + pin, trust from config, loopback only under an explicit
+  dev flag). Do not add an outbound relay/broker path that bypasses them.
 - Keep local test relay code in tests; production app runtime should talk to Nostr relay URLs through the adapter.
 - Do not print or log account ids, group ids, relay URLs, message ids, pubkeys, payloads, ciphertext, plaintext, or key
   material.

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -22,13 +22,15 @@ pub struct MarmotAppConfig {
     /// requests to the local host. This does not affect component validity
     /// (decode still accepts loopback endpoints).
     pub allow_loopback_blob_endpoints: bool,
-    /// Dev/test gate for loopback/private relay endpoints (e.g.
-    /// `ws://127.0.0.1:PORT`, an in-process `MockRelay`). A loopback relay URL
-    /// is VALID routing/relay-list state, but production MUST NOT open a socket
-    /// to one; the relay-safety chokepoint rejects non-public relay hosts before
-    /// they reach the pool. Defaults to `false`; test harnesses set `true`.
-    /// Mirrors `allow_loopback_blob_endpoints`; does not affect routing-component
-    /// validity (decode still accepts loopback endpoints).
+    /// Dev/test gate for loopback relay endpoints (e.g. `ws://127.0.0.1:PORT`,
+    /// an in-process `MockRelay`). A loopback relay URL is VALID
+    /// routing/relay-list state, but production MUST NOT open a socket to one;
+    /// the relay-safety chokepoint rejects non-public relay hosts before they
+    /// reach the pool. This gate admits loopback only — private/link-local/CGNAT
+    /// relay hosts stay rejected even when it is set. Defaults to `false`; test
+    /// harnesses set `true`. Mirrors `allow_loopback_blob_endpoints`; does not
+    /// affect routing-component validity (decode still accepts loopback
+    /// endpoints).
     pub allow_loopback_relay_endpoints: bool,
     /// Dev/test override for the convergence settlement quiescence window, in
     /// milliseconds. `None` (the default) uses the protocol-pinned value
@@ -83,9 +85,10 @@ impl MarmotAppConfig {
         self
     }
 
-    /// Enable opening relay connections to loopback/private endpoints for
-    /// dev/test (e.g. an in-process `MockRelay`). Off by default; production
-    /// builds must leave this unset.
+    /// Enable opening relay connections to loopback endpoints for dev/test
+    /// (e.g. an in-process `MockRelay`). Admits loopback only; private/
+    /// link-local/CGNAT hosts stay rejected. Off by default; production builds
+    /// must leave this unset.
     pub fn with_allow_loopback_relay_endpoints(mut self, allow: bool) -> Self {
         self.allow_loopback_relay_endpoints = allow;
         self

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -22,6 +22,14 @@ pub struct MarmotAppConfig {
     /// requests to the local host. This does not affect component validity
     /// (decode still accepts loopback endpoints).
     pub allow_loopback_blob_endpoints: bool,
+    /// Dev/test gate for loopback/private relay endpoints (e.g.
+    /// `ws://127.0.0.1:PORT`, an in-process `MockRelay`). A loopback relay URL
+    /// is VALID routing/relay-list state, but production MUST NOT open a socket
+    /// to one; the relay-safety chokepoint rejects non-public relay hosts before
+    /// they reach the pool. Defaults to `false`; test harnesses set `true`.
+    /// Mirrors `allow_loopback_blob_endpoints`; does not affect routing-component
+    /// validity (decode still accepts loopback endpoints).
+    pub allow_loopback_relay_endpoints: bool,
     /// Dev/test override for the convergence settlement quiescence window, in
     /// milliseconds. `None` (the default) uses the protocol-pinned value
     /// (`settlement_quiescence_ms = 1000`); a client MUST NOT ship a non-default
@@ -51,6 +59,7 @@ impl Default for MarmotAppConfig {
             directory_max_future_skew: DEFAULT_DIRECTORY_MAX_FUTURE_SKEW,
             service_endpoints: MarmotServiceEndpoints::compiled(),
             allow_loopback_blob_endpoints: false,
+            allow_loopback_relay_endpoints: false,
             dev_settlement_quiescence_ms: None,
         }
     }
@@ -71,6 +80,14 @@ impl MarmotAppConfig {
     /// default; production builds must leave this unset.
     pub fn with_allow_loopback_blob_endpoints(mut self, allow: bool) -> Self {
         self.allow_loopback_blob_endpoints = allow;
+        self
+    }
+
+    /// Enable opening relay connections to loopback/private endpoints for
+    /// dev/test (e.g. an in-process `MockRelay`). Off by default; production
+    /// builds must leave this unset.
+    pub fn with_allow_loopback_relay_endpoints(mut self, allow: bool) -> Self {
+        self.allow_loopback_relay_endpoints = allow;
         self
     }
 

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -872,8 +872,18 @@ impl MarmotApp {
         Self::with_relays_and_config(root, vec![relay_url.into()], config)
     }
 
+    /// Dev/test convenience constructor. Not a production entry point
+    /// (production opens through `with_relays_and_account_home*`); these
+    /// relay-only constructors back the crate's own tests, which drive
+    /// in-process `MockRelay`s at loopback, so they default the relay-safety
+    /// gate to admit loopback endpoints. Callers that need a specific posture
+    /// pass an explicit config through `with_relays_and_config`.
     pub fn with_relays(root: impl AsRef<Path>, relay_urls: Vec<String>) -> Self {
-        Self::with_relays_and_config(root, relay_urls, MarmotAppConfig::default())
+        Self::with_relays_and_config(
+            root,
+            relay_urls,
+            MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+        )
     }
 
     pub fn with_relays_and_config(
@@ -890,11 +900,15 @@ impl MarmotApp {
             config.dev_settlement_quiescence_ms = Some(0);
         }
         let root = root.as_ref().to_path_buf();
+        let relay_plane = MarmotRelayPlane::runtime_default_with_loopback(
+            APP_RUNTIME_RELAY_REBUILD_LOOKBACK,
+            config.allow_loopback_relay_endpoints,
+        );
         Self {
             account_home: AccountHome::open(&root),
             root,
             relay_urls,
-            relay_plane: MarmotRelayPlane::runtime_default(APP_RUNTIME_RELAY_REBUILD_LOOKBACK),
+            relay_plane,
             config,
             directory_sync: Arc::new(RwLock::new(None)),
             account_storages: Arc::new(Mutex::new(HashMap::new())),
@@ -929,11 +943,15 @@ impl MarmotApp {
         account_home: AccountHome,
         config: MarmotAppConfig,
     ) -> Self {
+        let relay_plane = MarmotRelayPlane::runtime_default_with_loopback(
+            APP_RUNTIME_RELAY_REBUILD_LOOKBACK,
+            config.allow_loopback_relay_endpoints,
+        );
         Self {
             root: root.as_ref().to_path_buf(),
             relay_urls,
             account_home,
-            relay_plane: MarmotRelayPlane::runtime_default(APP_RUNTIME_RELAY_REBUILD_LOOKBACK),
+            relay_plane,
             config,
             directory_sync: Arc::new(RwLock::new(None)),
             account_storages: Arc::new(Mutex::new(HashMap::new())),
@@ -962,7 +980,10 @@ impl MarmotApp {
     }
 
     pub async fn client(&self, label: &str) -> Result<AppClient, AppError> {
-        self.client_with_relay_plane(label, &MarmotRelayPlane::full_history(), None)
+        let relay_plane = MarmotRelayPlane::full_history_with_loopback(
+            self.config.allow_loopback_relay_endpoints,
+        );
+        self.client_with_relay_plane(label, &relay_plane, None)
             .await
     }
 

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -805,6 +805,9 @@ struct OpenAppAccount {
 }
 
 impl MarmotApp {
+    /// Dev/test convenience constructor — see [`MarmotApp::with_relays`]. Not a
+    /// production entry point; hidden from the public API docs.
+    #[doc(hidden)]
     pub fn with_relay(root: impl AsRef<Path>, relay_url: impl Into<String>) -> Self {
         Self::with_relays(root, vec![relay_url.into()])
     }
@@ -872,12 +875,17 @@ impl MarmotApp {
         Self::with_relays_and_config(root, vec![relay_url.into()], config)
     }
 
-    /// Dev/test convenience constructor. Not a production entry point
-    /// (production opens through `with_relays_and_account_home*`); these
-    /// relay-only constructors back the crate's own tests, which drive
-    /// in-process `MockRelay`s at loopback, so they default the relay-safety
-    /// gate to admit loopback endpoints. Callers that need a specific posture
-    /// pass an explicit config through `with_relays_and_config`.
+    /// Dev/test-only convenience constructor. **Not a production entry point**
+    /// and hidden from the public API docs: production opens through
+    /// `with_relays_and_account_home*`, which default the relay-safety gate to
+    /// production posture (loopback rejected). This helper backs the crate's own
+    /// tests, which drive in-process `MockRelay`s at loopback, so it opts the
+    /// relay-safety gate into admitting loopback endpoints. It cannot be
+    /// `#[cfg(test)]`-gated because the crate's integration tests
+    /// (`crates/marmot-app/tests/*`) consume it through the public API. Callers
+    /// that need an explicit posture pass a config through
+    /// `with_relays_and_config`.
+    #[doc(hidden)]
     pub fn with_relays(root: impl AsRef<Path>, relay_urls: Vec<String>) -> Self {
         Self::with_relays_and_config(
             root,

--- a/crates/marmot-app/src/media/host_safety.rs
+++ b/crates/marmot-app/src/media/host_safety.rs
@@ -1,9 +1,7 @@
 use std::net::IpAddr;
 
-pub(crate) use cgka_traits::app_components::is_loopback_host;
-use cgka_traits::app_components::{
-    BLOSSOM_LOCATOR_KIND_V1, ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN, is_loopback_ip, is_public_ip,
-};
+use cgka_traits::app_components::{BLOSSOM_LOCATOR_KIND_V1, ENCRYPTED_MEDIA_ENDPOINT_URL_MAX_LEN};
+pub(crate) use cgka_traits::app_components::{is_loopback_host, reject_non_public_ip};
 use url::{Host, Url};
 
 use super::MediaLocator;
@@ -87,13 +85,6 @@ fn validate_public_or_allowed_loopback_host(
         Host::Ipv4(addr) => reject_non_public_ip(IpAddr::V4(addr), allow_loopback),
         Host::Ipv6(addr) => reject_non_public_ip(IpAddr::V6(addr), allow_loopback),
     }
-}
-
-pub(crate) fn reject_non_public_ip(addr: IpAddr, allow_loopback: bool) -> Result<(), String> {
-    if (allow_loopback && is_loopback_ip(addr)) || is_public_ip(addr) {
-        return Ok(());
-    }
-    Err("URL must not point at a non-public address".into())
 }
 
 /// Whether `url` is a loopback-HTTP blob endpoint: scheme `http` (cleartext)

--- a/crates/marmot-app/src/media/tests.rs
+++ b/crates/marmot-app/src/media/tests.rs
@@ -543,7 +543,7 @@ fn imeta_parser_rejects_private_ip_media_locator() {
     let tag = tag_with_locator(format!("https://10.0.0.5/{}.bin", valid_hash()));
     let err = media_attachment_from_imeta_tag(&tag, None, false).unwrap_err();
 
-    assert!(err.to_string().contains("non-public"));
+    assert!(err.to_string().contains("public unicast"));
     assert!(!media_imeta_tags_are_valid(&[tag], false));
 }
 
@@ -561,7 +561,7 @@ fn imeta_parser_rejects_ipv6_transition_prefix_media_locators() {
         let tag = tag_with_locator(locator);
         let err = media_attachment_from_imeta_tag(&tag, None, false).unwrap_err();
 
-        assert!(err.to_string().contains("non-public"));
+        assert!(err.to_string().contains("public unicast"));
         assert!(!media_imeta_tags_are_valid(&[tag], false));
     }
 }
@@ -573,7 +573,7 @@ fn imeta_parser_rejects_ipv6_documentation_3fff_media_locator() {
     let tag = tag_with_locator(format!("https://[3fff::1]/{}.bin", valid_hash()));
     let err = media_attachment_from_imeta_tag(&tag, None, false).unwrap_err();
 
-    assert!(err.to_string().contains("non-public"));
+    assert!(err.to_string().contains("public unicast"));
     assert!(!media_imeta_tags_are_valid(&[tag], false));
 }
 
@@ -637,7 +637,7 @@ fn blossom_redirect_validation_rejects_cross_scheme_private_ip_and_cross_domain(
         ),
         (
             format!("https://10.0.0.5/{}.bin", valid_hash()),
-            "non-public",
+            "public unicast",
         ),
         (
             format!("https://cdn.attacker.net/{}.bin", valid_hash()),

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -114,15 +114,32 @@ pub struct RelayPlaneHealth {
 
 impl MarmotRelayPlane {
     pub fn runtime_default(subscription_rebuild_lookback: Duration) -> Self {
-        Self::from_sdk(Some(subscription_rebuild_lookback))
+        Self::from_sdk(Some(subscription_rebuild_lookback), false)
+    }
+
+    /// Production runtime plane whose relay-safety chokepoint admits loopback
+    /// endpoints only when `allow_loopback` is set
+    /// (`MarmotAppConfig::allow_loopback_relay_endpoints`, off by default).
+    pub fn runtime_default_with_loopback(
+        subscription_rebuild_lookback: Duration,
+        allow_loopback: bool,
+    ) -> Self {
+        Self::from_sdk(Some(subscription_rebuild_lookback), allow_loopback)
     }
 
     pub fn full_history() -> Self {
-        Self::from_sdk(None)
+        Self::from_sdk(None, false)
+    }
+
+    /// Full-history plane whose relay-safety chokepoint admits loopback
+    /// endpoints only when `allow_loopback` is set
+    /// (`MarmotAppConfig::allow_loopback_relay_endpoints`, off by default).
+    pub fn full_history_with_loopback(allow_loopback: bool) -> Self {
+        Self::from_sdk(None, allow_loopback)
     }
 
     pub fn with_subscription_rebuild_lookback(lookback: Duration) -> Self {
-        Self::from_sdk(Some(lookback))
+        Self::from_sdk(Some(lookback), false)
     }
 
     pub fn new(
@@ -136,10 +153,11 @@ impl MarmotRelayPlane {
             None,
             None,
             Arc::new(NostrSdkDirectoryRelayFetcher::standalone()),
+            false,
         )
     }
 
-    fn from_sdk(subscription_rebuild_lookback: Option<Duration>) -> Self {
+    fn from_sdk(subscription_rebuild_lookback: Option<Duration>, allow_loopback: bool) -> Self {
         let client = NostrSdkClient::builder().build();
         let relay_client = NostrSdkRelayClient::new(client.clone());
         let adapter = NostrTransportAdapter::new(Arc::new(relay_client.clone()));
@@ -149,6 +167,7 @@ impl MarmotRelayPlane {
             Some(relay_client),
             None,
             Arc::new(NostrSdkDirectoryRelayFetcher::new(client)),
+            allow_loopback,
         )
     }
 
@@ -158,6 +177,7 @@ impl MarmotRelayPlane {
         sdk_relay_client: Option<NostrSdkRelayClient>,
         notification_forwarder: Option<JoinHandle<()>>,
         directory_fetcher: Arc<dyn DirectoryRelayFetcher>,
+        allow_loopback: bool,
     ) -> Self {
         let transport = Arc::new(RelayPlaneTransport {
             adapter,
@@ -170,7 +190,7 @@ impl MarmotRelayPlane {
         let this = Self {
             inner: Arc::new(MarmotRelayPlaneInner {
                 subscription_rebuild_lookback,
-                relay_safety: RelaySafetyPolicy::default(),
+                relay_safety: RelaySafetyPolicy::with_allow_loopback(allow_loopback),
                 transport,
                 directory: DirectoryRelayPlane::new(directory_fetcher),
             }),

--- a/crates/marmot-app/src/relay_plane/safety.rs
+++ b/crates/marmot-app/src/relay_plane/safety.rs
@@ -151,6 +151,10 @@ mod tests {
             "ws://[::1]:8080",
             "ws://[fc00::1]",
             "ws://localhost:7777",
+            // Rooted localhost names still resolve to loopback and must be
+            // rejected too (they parse as `Host::Domain("localhost.")`).
+            "ws://localhost.:7777",
+            "ws://dev.localhost.:7777",
         ] {
             assert!(
                 policy

--- a/crates/marmot-app/src/relay_plane/safety.rs
+++ b/crates/marmot-app/src/relay_plane/safety.rs
@@ -1,25 +1,42 @@
+use std::net::IpAddr;
+
+use cgka_traits::app_components::{is_loopback_host, reject_non_public_ip};
 use cgka_traits::{
     TransportAccountActivation, TransportEndpoint, TransportGroupSync, TransportPublishRequest,
     TransportPublishTarget,
 };
 use nostr_sdk::prelude::RelayUrl;
+use url::{Host, Url};
 
 const MAX_RELAY_ENDPOINTS_PER_ROUTE: usize = 16;
 
 #[derive(Clone, Debug)]
 pub(crate) struct RelaySafetyPolicy {
     max_endpoints_per_route: usize,
+    /// Dev/test opt-in for loopback relay endpoints
+    /// (`MarmotAppConfig::allow_loopback_relay_endpoints`). Off by default:
+    /// production rejects relay endpoints whose LITERAL host is loopback (or
+    /// any other non-public IP literal) before the URL reaches the relay pool.
+    allow_loopback: bool,
 }
 
 impl Default for RelaySafetyPolicy {
     fn default() -> Self {
         Self {
             max_endpoints_per_route: MAX_RELAY_ENDPOINTS_PER_ROUTE,
+            allow_loopback: false,
         }
     }
 }
 
 impl RelaySafetyPolicy {
+    pub(crate) fn with_allow_loopback(allow_loopback: bool) -> Self {
+        Self {
+            allow_loopback,
+            ..Self::default()
+        }
+    }
+
     pub(crate) fn sanitize_activation(
         &self,
         mut activation: TransportAccountActivation,
@@ -70,6 +87,8 @@ impl RelaySafetyPolicy {
             }
             let relay_url = RelayUrl::parse(raw)
                 .map_err(|err| format!("{context}: invalid relay endpoint: {err}"))?;
+            reject_unsafe_relay_host(&relay_url, self.allow_loopback)
+                .map_err(|reason| format!("{context}: {reason}"))?;
             let endpoint = TransportEndpoint(relay_url.to_string());
             if !sanitized.contains(&endpoint) {
                 sanitized.push(endpoint);
@@ -83,5 +102,104 @@ impl RelaySafetyPolicy {
             ));
         }
         Ok(sanitized)
+    }
+}
+
+/// Reject a relay endpoint whose LITERAL host is loopback or any other
+/// non-public IP, unless the dev/test loopback opt-in is set (which admits
+/// loopback only — private/link-local/CGNAT literals stay rejected). Relay
+/// endpoints arrive from signed routing components and relay-list events, so a
+/// poisoned record must not steer the relay pool at internal services (SSRF;
+/// see `docs/marmot-architecture/overview/dial-safety.md`). A DOMAIN host is
+/// accepted here: nostr-sdk owns DNS resolution and the WebSocket, so
+/// resolve-time validation cannot be pinned at this layer — an accepted LOW
+/// residual, per the dial-safety note. Error strings stay URL-free.
+fn reject_unsafe_relay_host(url: &RelayUrl, allow_loopback: bool) -> Result<(), String> {
+    let parsed = Url::parse(url.as_str()).map_err(|_| "invalid relay endpoint".to_owned())?;
+    match parsed.host() {
+        Some(Host::Ipv4(addr)) => reject_non_public_ip(IpAddr::V4(addr), allow_loopback)
+            .map_err(|_| "relay endpoint host is not a public address".to_owned()),
+        Some(Host::Ipv6(addr)) => reject_non_public_ip(IpAddr::V6(addr), allow_loopback)
+            .map_err(|_| "relay endpoint host is not a public address".to_owned()),
+        Some(Host::Domain(domain)) => {
+            if is_loopback_host(Host::Domain(domain)) && !allow_loopback {
+                return Err("relay endpoint host must not be localhost".to_owned());
+            }
+            Ok(())
+        }
+        None => Err("relay endpoint is missing a host".to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn endpoints(urls: &[&str]) -> Vec<TransportEndpoint> {
+        urls.iter()
+            .map(|url| TransportEndpoint((*url).to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn rejects_non_public_relay_hosts_by_default() {
+        let policy = RelaySafetyPolicy::default();
+        for url in [
+            "ws://127.0.0.1:8080",
+            "ws://10.0.0.1",
+            "ws://169.254.169.254",
+            "ws://[::1]:8080",
+            "ws://[fc00::1]",
+            "ws://localhost:7777",
+        ] {
+            assert!(
+                policy
+                    .sanitize_endpoints(endpoints(&[url]), "test")
+                    .is_err(),
+                "{url} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_public_relay_hosts_regardless_of_opt_in() {
+        for policy in [
+            RelaySafetyPolicy::default(),
+            RelaySafetyPolicy::with_allow_loopback(true),
+        ] {
+            let sanitized = policy
+                .sanitize_endpoints(endpoints(&["wss://relay.example"]), "test")
+                .expect("public relay accepted");
+            assert_eq!(sanitized.len(), 1);
+        }
+    }
+
+    #[test]
+    fn dev_opt_in_admits_loopback_but_not_private_ranges() {
+        let policy = RelaySafetyPolicy::with_allow_loopback(true);
+        for url in ["ws://127.0.0.1:8080", "ws://[::1]:8080", "ws://localhost"] {
+            assert!(
+                policy.sanitize_endpoints(endpoints(&[url]), "test").is_ok(),
+                "{url} must be accepted under the dev opt-in"
+            );
+        }
+        // The opt-in opens loopback only; private/link-local literals stay
+        // rejected even in dev mode.
+        for url in ["ws://10.0.0.1", "ws://169.254.169.254"] {
+            assert!(
+                policy
+                    .sanitize_endpoints(endpoints(&[url]), "test")
+                    .is_err(),
+                "{url} must stay rejected even with the dev opt-in"
+            );
+        }
+    }
+
+    #[test]
+    fn count_cap_still_enforced() {
+        let policy = RelaySafetyPolicy::default();
+        let many: Vec<String> = (0..20).map(|i| format!("wss://relay{i}.example")).collect();
+        let refs: Vec<&str> = many.iter().map(String::as_str).collect();
+        assert!(policy.sanitize_endpoints(endpoints(&refs), "test").is_err());
     }
 }

--- a/crates/marmot-app/src/relay_plane/tests.rs
+++ b/crates/marmot-app/src/relay_plane/tests.rs
@@ -214,6 +214,8 @@ fn relay_plane_with_directory_fetcher(
         None,
         None,
         directory_fetcher,
+        // These plane tests drive an in-process `MockRelay` at loopback.
+        true,
     )
 }
 

--- a/crates/marmot-app/src/runtime/agent_stream_watch.rs
+++ b/crates/marmot-app/src/runtime/agent_stream_watch.rs
@@ -1,13 +1,13 @@
 //! Agent-text-stream discovery and the brokered-QUIC watch machinery, plus
 //! the [`MarmotAppRuntime`] entry points that drive them.
 
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 
 use cgka_traits::agent_text_stream::{
     AGENT_TEXT_STREAM_RECORD_PROGRESS_DELTA, AGENT_TEXT_STREAM_RECORD_STATUS,
     AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, AgentTextStreamKeyContextV1,
 };
-use cgka_traits::app_components::reject_non_public_socket_addr;
+use cgka_traits::app_components::{is_loopback_candidate_host, reject_non_public_socket_addr};
 use cgka_traits::app_event::{
     MARMOT_APP_EVENT_KIND_AGENT_STREAM_START, STREAM_BROKER_TAG, STREAM_ROUTE_TAG, STREAM_TAG,
 };
@@ -482,19 +482,10 @@ pub(crate) fn broker_trust_for_candidate(
     server_cert_der: Option<Vec<u8>>,
     insecure_local: bool,
 ) -> BrokerServerTrust {
-    if insecure_local && candidate_host_is_loopback(candidate_host) {
+    if insecure_local && is_loopback_candidate_host(candidate_host) {
         return BrokerServerTrust::InsecureLocal;
     }
     server_cert_der
         .map(BrokerServerTrust::CertificateDer)
         .unwrap_or(BrokerServerTrust::Platform)
-}
-
-fn candidate_host_is_loopback(host: &str) -> bool {
-    if host.eq_ignore_ascii_case("localhost") {
-        return true;
-    }
-    host.parse::<IpAddr>()
-        .map(|ip| ip.is_loopback())
-        .unwrap_or(false)
 }

--- a/crates/marmot-app/src/runtime/agent_stream_watch.rs
+++ b/crates/marmot-app/src/runtime/agent_stream_watch.rs
@@ -1,12 +1,13 @@
 //! Agent-text-stream discovery and the brokered-QUIC watch machinery, plus
 //! the [`MarmotAppRuntime`] entry points that drive them.
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
 use cgka_traits::agent_text_stream::{
     AGENT_TEXT_STREAM_RECORD_PROGRESS_DELTA, AGENT_TEXT_STREAM_RECORD_STATUS,
     AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, AgentTextStreamKeyContextV1,
 };
+use cgka_traits::app_components::reject_non_public_socket_addr;
 use cgka_traits::app_event::{
     MARMOT_APP_EVENT_KIND_AGENT_STREAM_START, STREAM_BROKER_TAG, STREAM_ROUTE_TAG, STREAM_TAG,
 };
@@ -359,14 +360,14 @@ async fn watch_broker_candidates(
     }
     let mut last_error = None;
     for candidate in watch.candidates {
-        match resolve_broker_addr(&candidate.authority).await {
+        match resolve_broker_addr(&candidate.authority, watch.insecure_local).await {
             Ok(broker_addr) => {
                 let resolved = ResolvedQuicCandidate {
                     broker_addr,
                     server_name: candidate.server_name,
                 };
-                let trust = broker_trust_for_addr(
-                    resolved.broker_addr,
+                let trust = broker_trust_for_candidate(
+                    &resolved.server_name,
                     watch.server_cert_der.clone(),
                     watch.insecure_local,
                 );
@@ -444,24 +445,56 @@ async fn watch_broker_candidates(
     }
 }
 
-async fn resolve_broker_addr(authority: &str) -> Result<SocketAddr, AppError> {
+/// Resolve a sender-controlled broker authority to a socket address, running
+/// every resolved address through the shared dial-safety gate. Broker
+/// candidates come from another member's Start event, so without the explicit
+/// `allow_local_endpoint` dev opt-in a candidate that resolves to loopback,
+/// private, link-local, CGNAT, or any other non-public range is rejected before
+/// any QUIC handshake (SSRF hardening; see
+/// `docs/marmot-architecture/overview/dial-safety.md`). The returned address is
+/// the one the QUIC endpoint connects to, so the validated address and the
+/// dialed address cannot diverge.
+pub(crate) async fn resolve_broker_addr(
+    authority: &str,
+    allow_local_endpoint: bool,
+) -> Result<SocketAddr, AppError> {
     let mut addrs = tokio::net::lookup_host(authority)
         .await
         .map_err(|_| AppError::AgentStreamInvalidCandidate(authority.to_owned()))?;
-    addrs
+    let addr = addrs
         .next()
-        .ok_or_else(|| AppError::AgentStreamInvalidCandidate(authority.to_owned()))
+        .ok_or_else(|| AppError::AgentStreamInvalidCandidate(authority.to_owned()))?;
+    reject_non_public_socket_addr(addr, allow_local_endpoint)
+        .map_err(|_| AppError::AgentStreamInvalidCandidate(authority.to_owned()))?;
+    Ok(addr)
 }
 
-pub(crate) fn broker_trust_for_addr(
-    broker_addr: SocketAddr,
+/// Select TLS trust for a broker candidate from configuration and the LITERAL
+/// candidate host, never from a resolved address. `InsecureLocal` (skip cert
+/// verification) requires both the explicit `insecure_local` dev opt-in and a
+/// candidate whose host is a literal loopback (`localhost` or a loopback IP
+/// literal); a hostname that merely RESOLVES to loopback keeps normal
+/// verification, so DNS answers can never downgrade trust. The broker client's
+/// `InsecureLocalRequiresLoopback` check remains as the resolved-address
+/// backstop behind this gate.
+pub(crate) fn broker_trust_for_candidate(
+    candidate_host: &str,
     server_cert_der: Option<Vec<u8>>,
     insecure_local: bool,
 ) -> BrokerServerTrust {
-    if insecure_local && broker_addr.ip().is_loopback() {
+    if insecure_local && candidate_host_is_loopback(candidate_host) {
         return BrokerServerTrust::InsecureLocal;
     }
     server_cert_der
         .map(BrokerServerTrust::CertificateDer)
         .unwrap_or(BrokerServerTrust::Platform)
+}
+
+fn candidate_host_is_loopback(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
 }

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -74,7 +74,8 @@ pub(crate) use audit_tracker::{AuditLogTrackerUploader, post_audit_log_tracker_u
 pub(crate) use account_worker::AccountWorkerReconnectBackoff;
 #[cfg(test)]
 pub(crate) use agent_stream_watch::{
-    broker_trust_for_addr, latest_agent_stream_start, parse_quic_candidate, parse_quic_candidates,
+    broker_trust_for_candidate, latest_agent_stream_start, parse_quic_candidate,
+    parse_quic_candidates,
 };
 #[cfg(test)]
 pub(crate) use subscriptions::{

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -1172,3 +1172,43 @@ fn lifecycle_refuses_account_open_after_shutdown_begins() {
         Err(AppError::RuntimeStopping)
     ));
 }
+
+// Sender-controlled broker candidates must clear the shared dial-safety gate
+// at resolve time: literal-IP authorities resolve without DNS, so these cover
+// the canonical non-public classes end to end (issue #331).
+#[tokio::test]
+async fn broker_resolve_rejects_non_public_candidates_without_dev_opt_in() {
+    for authority in [
+        "10.0.0.5:4433",      // private
+        "169.254.169.254:80", // link-local (cloud metadata)
+        "100.64.0.1:4433",    // CGNAT
+        "192.168.1.1:4433",   // private
+        "127.0.0.1:4433",     // loopback
+        "[::1]:4433",         // loopback v6
+        "[fc00::1]:4433",     // unique-local
+    ] {
+        let result = agent_stream_watch::resolve_broker_addr(authority, false).await;
+        assert!(
+            matches!(result, Err(AppError::AgentStreamInvalidCandidate(_))),
+            "{authority} must be rejected without the dev opt-in"
+        );
+    }
+}
+
+#[tokio::test]
+async fn broker_resolve_dev_opt_in_admits_loopback_only() {
+    let addr = agent_stream_watch::resolve_broker_addr("127.0.0.1:4433", true)
+        .await
+        .expect("loopback resolves under the dev opt-in");
+    assert!(addr.ip().is_loopback());
+
+    // The opt-in opens loopback only; private/link-local candidates stay
+    // rejected even in dev mode.
+    for authority in ["10.0.0.5:4433", "169.254.169.254:80", "[fc00::1]:4433"] {
+        let result = agent_stream_watch::resolve_broker_addr(authority, true).await;
+        assert!(
+            matches!(result, Err(AppError::AgentStreamInvalidCandidate(_))),
+            "{authority} must be rejected even with the dev opt-in"
+        );
+    }
+}

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1357,20 +1357,46 @@ fn agent_stream_candidate_parser_skips_malformed_quic_candidates() {
 
 #[test]
 fn agent_stream_insecure_local_only_applies_to_loopback_brokers() {
-    let loopback = "127.0.0.1:4450".parse().unwrap();
-    let remote = "203.0.113.10:4450".parse().unwrap();
-
     assert!(matches!(
-        runtime::broker_trust_for_addr(loopback, None, true),
+        runtime::broker_trust_for_candidate("127.0.0.1", None, true),
         BrokerServerTrust::InsecureLocal
     ));
     assert!(matches!(
-        runtime::broker_trust_for_addr(remote, None, true),
+        runtime::broker_trust_for_candidate("localhost", None, true),
+        BrokerServerTrust::InsecureLocal
+    ));
+    assert!(matches!(
+        runtime::broker_trust_for_candidate("::1", None, true),
+        BrokerServerTrust::InsecureLocal
+    ));
+    assert!(matches!(
+        runtime::broker_trust_for_candidate("203.0.113.10", None, true),
         BrokerServerTrust::Platform
     ));
     assert!(matches!(
-        runtime::broker_trust_for_addr(remote, Some(vec![1, 2, 3]), true),
+        runtime::broker_trust_for_candidate("203.0.113.10", Some(vec![1, 2, 3]), true),
         BrokerServerTrust::CertificateDer(der) if der == vec![1, 2, 3]
+    ));
+    // Without the explicit dev opt-in even a literal loopback candidate keeps
+    // certificate verification.
+    assert!(matches!(
+        runtime::broker_trust_for_candidate("127.0.0.1", None, false),
+        BrokerServerTrust::Platform
+    ));
+}
+
+#[test]
+fn agent_stream_trust_is_keyed_on_the_literal_candidate_host_not_resolution() {
+    // A DOMAIN candidate never selects the no-cert-verification trust, even
+    // with the dev opt-in set: a hostname that merely resolves to 127.0.0.1
+    // must not downgrade trust (resolution-dependent downgrade, issue #356).
+    assert!(matches!(
+        runtime::broker_trust_for_candidate("broker.example", None, true),
+        BrokerServerTrust::Platform
+    ));
+    assert!(matches!(
+        runtime::broker_trust_for_candidate("broker.example", Some(vec![7]), true),
+        BrokerServerTrust::CertificateDer(der) if der == vec![7]
     ));
 }
 

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -48,7 +48,9 @@ async fn mock_app(dir: &tempfile::TempDir) -> (MockRelay, MarmotApp, String) {
     let app = MarmotApp::with_relay_and_config(
         dir.path(),
         url.clone(),
-        MarmotAppConfig::default().with_allow_loopback_blob_endpoints(true),
+        MarmotAppConfig::default()
+            .with_allow_loopback_blob_endpoints(true)
+            .with_allow_loopback_relay_endpoints(true),
     );
     (relay, app, url)
 }
@@ -4185,7 +4187,9 @@ async fn relay_list_future_skew_is_configurable_at_app_instantiation() {
     let app = MarmotApp::with_relays_and_config(
         dir.path(),
         vec![seed_url.clone()],
-        MarmotAppConfig::default().with_directory_max_future_skew(Duration::from_secs(900)),
+        MarmotAppConfig::default()
+            .with_directory_max_future_skew(Duration::from_secs(900))
+            .with_allow_loopback_relay_endpoints(true),
     );
 
     publish_account_relay_lists_at(

--- a/crates/traits/src/app_components/host_safety.rs
+++ b/crates/traits/src/app_components/host_safety.rs
@@ -6,7 +6,7 @@
 //! error wording, but share these low-level host and IP classifiers so SSRF
 //! hardening cannot drift across crates.
 
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use url::Host;
 
 /// Whether `host` is `localhost`, a subdomain of `.localhost`, or an IP
@@ -94,6 +94,25 @@ pub fn is_public_ipv6(addr: Ipv6Addr) -> bool {
     // Only global unicast 2000::/3 is routable today; reject anything else not
     // already caught above.
     (first & 0xe000) == 0x2000
+}
+
+/// Reject `addr` unless it is public/global-routable. When `allow_loopback`
+/// is set (an explicit dev/test opt-in, never inferred from resolution), an IP
+/// loopback literal is also accepted. Every other non-public address (private,
+/// link-local, CGNAT, ULA, multicast, unspecified, documentation, IPv6
+/// transition) is always rejected. This is the shared dial-policy gate every
+/// outbound connector runs each resolved address through; see
+/// `docs/marmot-architecture/overview/dial-safety.md`.
+pub fn reject_non_public_ip(addr: IpAddr, allow_loopback: bool) -> Result<(), String> {
+    if (allow_loopback && is_loopback_ip(addr)) || is_public_ip(addr) {
+        return Ok(());
+    }
+    Err("address is not a public unicast address".into())
+}
+
+/// [`reject_non_public_ip`] for an already-resolved socket address.
+pub fn reject_non_public_socket_addr(addr: SocketAddr, allow_loopback: bool) -> Result<(), String> {
+    reject_non_public_ip(addr.ip(), allow_loopback)
 }
 
 pub(crate) fn reject_non_routable_ipv4(addr: Ipv4Addr) -> Result<(), String> {

--- a/crates/traits/src/app_components/host_safety.rs
+++ b/crates/traits/src/app_components/host_safety.rs
@@ -10,16 +10,39 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use url::Host;
 
 /// Whether `host` is `localhost`, a subdomain of `.localhost`, or an IP
-/// loopback literal.
+/// loopback literal. A rooted (fully-qualified) name keeps a trailing dot
+/// (`localhost.`, `dev.localhost.`), which system resolution still maps to
+/// loopback, so a single trailing dot is stripped before matching.
 pub fn is_loopback_host(host: Host<&str>) -> bool {
     match host {
-        Host::Domain(domain) => {
-            let lowered = domain.to_ascii_lowercase();
-            lowered == "localhost" || lowered.ends_with(".localhost")
-        }
+        Host::Domain(domain) => is_loopback_domain(domain),
         Host::Ipv4(addr) => addr.is_loopback(),
         Host::Ipv6(addr) => addr.is_loopback(),
     }
+}
+
+fn is_loopback_domain(domain: &str) -> bool {
+    let lowered = domain.to_ascii_lowercase();
+    let unrooted = lowered.strip_suffix('.').unwrap_or(&lowered);
+    unrooted == "localhost" || unrooted.ends_with(".localhost")
+}
+
+/// Whether a `quic://` broker candidate host is a literal loopback: exactly
+/// `localhost` (rooted or not) or a loopback IP literal. Deliberately narrower
+/// than [`is_loopback_host`] — it does not match `*.localhost` subdomains —
+/// because it gates the no-cert-verification `InsecureLocal` trust, which must
+/// only be reachable for an unambiguous local endpoint plus an explicit dev
+/// flag. Shared by the agent-stream watch and agent-connector dial sites so the
+/// two cannot drift.
+pub fn is_loopback_candidate_host(host: &str) -> bool {
+    let unrooted = host.strip_suffix('.').unwrap_or(host);
+    if unrooted.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    unrooted
+        .parse::<IpAddr>()
+        .map(is_loopback_ip)
+        .unwrap_or(false)
 }
 
 /// Whether `addr` is an IPv4 or IPv6 loopback address.

--- a/crates/traits/src/app_components/mod.rs
+++ b/crates/traits/src/app_components/mod.rs
@@ -42,6 +42,7 @@ pub use encrypted_media::{
 };
 pub use host_safety::{
     is_loopback_host, is_loopback_ip, is_public_ip, is_public_ipv4, is_public_ipv6,
+    reject_non_public_ip, reject_non_public_socket_addr,
 };
 pub use routing::{NostrRoutingV1, decode_nostr_routing_v1, encode_nostr_routing_v1};
 

--- a/crates/traits/src/app_components/mod.rs
+++ b/crates/traits/src/app_components/mod.rs
@@ -41,8 +41,8 @@ pub use encrypted_media::{
     encode_encrypted_media_policy_v1, validate_and_normalize_blob_endpoint_url,
 };
 pub use host_safety::{
-    is_loopback_host, is_loopback_ip, is_public_ip, is_public_ipv4, is_public_ipv6,
-    reject_non_public_ip, reject_non_public_socket_addr,
+    is_loopback_candidate_host, is_loopback_host, is_loopback_ip, is_public_ip, is_public_ipv4,
+    is_public_ipv6, reject_non_public_ip, reject_non_public_socket_addr,
 };
 pub use routing::{NostrRoutingV1, decode_nostr_routing_v1, encode_nostr_routing_v1};
 

--- a/crates/traits/tests/host_safety_public.rs
+++ b/crates/traits/tests/host_safety_public.rs
@@ -1,8 +1,8 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use cgka_traits::app_components::{
-    is_loopback_host, is_loopback_ip, is_public_ip, is_public_ipv4, is_public_ipv6,
-    reject_non_public_ip, reject_non_public_socket_addr,
+    is_loopback_candidate_host, is_loopback_host, is_loopback_ip, is_public_ip, is_public_ipv4,
+    is_public_ipv6, reject_non_public_ip, reject_non_public_socket_addr,
 };
 use url::Host;
 
@@ -19,6 +19,31 @@ fn shared_host_safety_classifies_loopback_hosts() {
     assert!(!is_loopback_host(Host::Ipv4(Ipv4Addr::new(
         93, 184, 216, 34
     ))));
+
+    // Rooted (fully-qualified) forms keep a trailing dot but still resolve to
+    // loopback, so they must classify like their unrooted forms.
+    assert!(is_loopback_host(Host::Domain("localhost.")));
+    assert!(is_loopback_host(Host::Domain("dev.localhost.")));
+    assert!(is_loopback_host(Host::Domain("LOCALHOST.")));
+}
+
+#[test]
+fn shared_host_safety_classifies_loopback_candidate_hosts() {
+    // The QUIC-candidate loopback gate is narrower than `is_loopback_host`:
+    // only exact `localhost` (rooted or not) or a loopback IP literal.
+    for host in ["localhost", "localhost.", "LOCALHOST", "127.0.0.1", "::1"] {
+        assert!(is_loopback_candidate_host(host), "{host}");
+    }
+    // `*.localhost` subdomains are NOT candidate-loopback (they do not
+    // unambiguously name a local endpoint for the insecure-trust gate).
+    for host in [
+        "dev.localhost",
+        "dev.localhost.",
+        "broker.example",
+        "203.0.113.10",
+    ] {
+        assert!(!is_loopback_candidate_host(host), "{host}");
+    }
 }
 
 #[test]

--- a/crates/traits/tests/host_safety_public.rs
+++ b/crates/traits/tests/host_safety_public.rs
@@ -1,7 +1,8 @@
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use cgka_traits::app_components::{
     is_loopback_host, is_loopback_ip, is_public_ip, is_public_ipv4, is_public_ipv6,
+    reject_non_public_ip, reject_non_public_socket_addr,
 };
 use url::Host;
 
@@ -72,4 +73,53 @@ fn shared_host_safety_classifies_canonical_ipv6_ranges() {
         assert!(!is_public_ipv6(addr), "{raw} should be rejected");
         assert!(!is_public_ip(IpAddr::V6(addr)), "{raw} should be rejected");
     }
+}
+
+#[test]
+fn shared_dial_gate_rejects_non_public_addresses() {
+    // Public control addresses pass regardless of the loopback opt-in.
+    for raw in ["93.184.216.34", "2606:4700::1"] {
+        let addr: IpAddr = raw.parse().expect("test IP literal parses");
+        assert!(reject_non_public_ip(addr, false).is_ok(), "{raw}");
+        assert!(reject_non_public_ip(addr, true).is_ok(), "{raw}");
+    }
+
+    // Loopback is accepted only under the explicit dev/test opt-in.
+    for raw in ["127.0.0.1", "::1"] {
+        let addr: IpAddr = raw.parse().expect("test IP literal parses");
+        assert!(reject_non_public_ip(addr, false).is_err(), "{raw}");
+        assert!(reject_non_public_ip(addr, true).is_ok(), "{raw}");
+    }
+
+    // Every other non-public class stays rejected even with the loopback
+    // opt-in: the flag opens loopback only, never private/link-local ranges.
+    // Mapped loopback (`::ffff:127.0.0.1`) is not a plain loopback literal and
+    // stays rejected too.
+    for raw in [
+        "10.0.0.1",         // private
+        "100.64.0.1",       // CGNAT
+        "169.254.169.254",  // link-local (cloud metadata)
+        "172.16.0.1",       // private
+        "192.168.1.1",      // private
+        "fc00::1",          // unique-local
+        "fe80::1",          // link-local
+        "::ffff:10.0.0.1",  // mapped private IPv4
+        "::ffff:127.0.0.1", // mapped loopback
+    ] {
+        let addr: IpAddr = raw.parse().expect("test IP literal parses");
+        assert!(reject_non_public_ip(addr, false).is_err(), "{raw}");
+        assert!(reject_non_public_ip(addr, true).is_err(), "{raw}");
+    }
+}
+
+#[test]
+fn shared_dial_gate_socket_addr_form_matches_ip_form() {
+    let public: SocketAddr = "93.184.216.34:443".parse().unwrap();
+    let loopback: SocketAddr = "127.0.0.1:4433".parse().unwrap();
+    let private: SocketAddr = "[fc00::1]:4433".parse().unwrap();
+
+    assert!(reject_non_public_socket_addr(public, false).is_ok());
+    assert!(reject_non_public_socket_addr(loopback, false).is_err());
+    assert!(reject_non_public_socket_addr(loopback, true).is_ok());
+    assert!(reject_non_public_socket_addr(private, true).is_err());
 }

--- a/crates/transport-nostr-adapter/AGENTS.md
+++ b/crates/transport-nostr-adapter/AGENTS.md
@@ -34,6 +34,10 @@ for reconnect/backoff and relay status mechanics.
 - Preserve account-scoped deliveries even when group subscriptions share relay endpoints.
 - Keep real relay clients behind `NostrRelayClient`.
 - Keep the `nostr-sdk` dependency behind the `sdk` feature.
+- Relay endpoints are host-safety filtered before any connect at the `RelaySafetyPolicy` chokepoint in `marmot-app`
+  (`crates/marmot-app/src/relay_plane/safety.rs`); literal loopback/private/non-public relay hosts are rejected unless
+  the dev loopback flag is set. A new relay-connect path must go through that chokepoint, not around it. See
+  `docs/marmot-architecture/overview/dial-safety.md`.
 - Keep per-relay telemetry keyed by the opaque `RelayIndex`. `resolve_relay_labels` (gated behind a
   `RelayExportConsent` token) is the only path that turns an index back into a relay URL, and exists solely for the
   opt-in export boundary. Do not add another reverse mapping or resolve indices outside that boundary.

--- a/crates/transport-nostr-adapter/AGENTS.md
+++ b/crates/transport-nostr-adapter/AGENTS.md
@@ -35,9 +35,10 @@ for reconnect/backoff and relay status mechanics.
 - Keep real relay clients behind `NostrRelayClient`.
 - Keep the `nostr-sdk` dependency behind the `sdk` feature.
 - Relay endpoints are host-safety filtered before any connect at the `RelaySafetyPolicy` chokepoint in `marmot-app`
-  (`crates/marmot-app/src/relay_plane/safety.rs`); literal loopback/private/non-public relay hosts are rejected unless
-  the dev loopback flag is set. A new relay-connect path must go through that chokepoint, not around it. See
-  `docs/marmot-architecture/overview/dial-safety.md`.
+  (`crates/marmot-app/src/relay_plane/safety.rs`); relay hosts that are non-public IP literals are rejected, and literal
+  loopback hosts are rejected too unless the dev loopback flag is set (the flag admits loopback only —
+  private/link-local/CGNAT literals stay rejected). A new relay-connect path must go through that chokepoint, not around
+  it. See `docs/marmot-architecture/overview/dial-safety.md`.
 - Keep per-relay telemetry keyed by the opaque `RelayIndex`. `resolve_relay_labels` (gated behind a
   `RelayExportConsent` token) is the only path that turns an index back into a relay URL, and exists solely for the
   opt-in export boundary. Do not add another reverse mapping or resolve indices outside that boundary.

--- a/crates/transport-quic-broker/AGENTS.md
+++ b/crates/transport-quic-broker/AGENTS.md
@@ -13,6 +13,10 @@ Ephemeral QUIC broker for Marmot agent text stream previews.
 - Use bounded live queues only. If a subscriber lags, dropping the subscriber is preferable to storing payloads.
 - Keep diagnostics privacy-safe: no account ids, group ids, message ids, relay URLs, pubkeys, payloads, ciphertext,
   plaintext, or key material in tracing/logging.
+- Keep the client dial safe: the `client_endpoint` `InsecureLocalRequiresLoopback` check is the resolved-address
+  backstop, not the primary gate, and the client connect is bounded by the shared QUIC-preview connect timeout (#710).
+  Callers validate and pin the resolved broker address and choose `InsecureLocal` only from an explicit dev flag plus a
+  literal loopback candidate host. See `docs/marmot-architecture/overview/dial-safety.md`.
 
 ## Layout
 

--- a/docs/marmot-architecture/AGENTS.md
+++ b/docs/marmot-architecture/AGENTS.md
@@ -35,6 +35,10 @@ Agent map for the Marmot architecture docs.
   - **Role:** Restrictive-by-construction creation policy for local files, sockets, and databases; the
     `crates/fs-private` helper contract.
 
+- **Path:** `overview/dial-safety.md`
+  - **Role:** One host-safety discipline for every outbound connection (validate resolved addresses, pin, trust from
+    config, connect timeout); the `cgka_traits::app_components::host_safety` classifier and per-transport chokepoints.
+
 - **Path:** `further-context/`
   - **Role:** Older or deeper context. Check status and dates before relying on it.
 

--- a/docs/marmot-architecture/overview/dial-safety.md
+++ b/docs/marmot-architecture/overview/dial-safety.md
@@ -1,0 +1,67 @@
+---
+title: "Dial Safety"
+created: 2026-07-04
+updated: 2026-07-04
+tags: [marmot, overview, security, network, ssrf, transport]
+status: overview
+---
+
+# Dial Safety
+
+Every outbound network connection Marmot opens must clear one host-safety discipline before a socket is opened. A dial
+target is often attacker-influenced — a peer's agent-stream `Start` event, an agent-supplied `quic://` candidate, a
+signed routing component, a welcome-rumor relay list, an imeta media locator — so a name or address that points at a
+loopback / private / link-local / CGNAT / metadata endpoint is an SSRF vector, and a trust decision made from a
+*resolved* address is a resolution-dependent downgrade. This is the network twin of
+[Local Artifact Safety](local-artifact-safety.md).
+
+## The rules
+
+- **Validate every resolved address.** Resolve once, then run **each** resolved address through the shared classifier
+  `cgka_traits::app_components::reject_non_public_ip` (or `reject_non_public_socket_addr`). It rejects the canonical
+  unsafe-host set: `0.0.0.0/8`, RFC1918 private, `100.64.0.0/10` CGNAT, `127.0.0.0/8` loopback, `169.254.0.0/16`
+  link-local (including `169.254.169.254`), multicast/reserved, and the IPv6 equivalents (loopback, ULA `fc00::/7`,
+  link-local `fe80::/10`, IPv4-mapped, and the 6to4/Teredo/documentation transition ranges).
+- **Pin the validated address.** Connect to the address that was validated, so the check and the connection cannot
+  diverge (no DNS-rebind window). reqwest pins with `resolve_to_addrs`; the QUIC paths connect to the validated
+  `SocketAddr` directly. Where a transport owns its own resolution (see the Nostr residual below) this degrades to a
+  literal-host check.
+- **Trust comes from configuration, not from a resolved IP.** No-certificate-verification trust (`InsecureLocal` /
+  skip-verification) is reachable only via an explicit dev/config flag **and** a *literal* loopback candidate host
+  parsed before resolution — never because a name happened to resolve to loopback.
+- **Loopback is opt-in, never inferred.** A local/loopback endpoint is reachable only when an explicit dev/test flag is
+  set (`MarmotAppConfig::allow_loopback_relay_endpoints` / `allow_loopback_blob_endpoints`, `WN_ALLOW_LOOPBACK_RELAYS` /
+  `WN_ALLOW_LOOPBACK_BLOB_ENDPOINTS`, `wn --insecure-local`, `wn-agent --insecure-local-broker`). The flag opens
+  loopback only; private/link-local/CGNAT ranges stay rejected even in dev mode. Production leaves every flag unset.
+- **A connect timeout on every dial.** A hung handshake to a black-holed target must not park indefinitely (media 5s,
+  Nostr relay 5s, QUIC broker 5s).
+
+## The chokepoints
+
+| Transport | Where the discipline lives |
+| --- | --- |
+| Blossom media (reqwest, download + upload) | `crates/marmot-app/src/media/blossom.rs`: `media_http_client_for_url` → `validate_blossom_fetch_url` + `resolve_media_host` (per-address `reject_non_public_ip`, `resolve_to_addrs` pin, connect/read/total timeouts, per-redirect re-validation). |
+| Agent-stream broker watch (quinn) | `crates/marmot-app/src/runtime/agent_stream_watch.rs`: `resolve_broker_addr` validates + pins; `broker_trust_for_candidate` keys `InsecureLocal` on the literal candidate host + `insecure_local`. |
+| Agent-connector broker dial (quinn) | `crates/agent-connector/src/quic.rs`: `resolve_quic_candidate_addr` validates + pins; `broker_trust_for_candidate` gated on `AgentConnectorConfig::allow_insecure_local_broker` + literal loopback. |
+| CLI stream (quinn) | `crates/cli/src/commands/stream.rs`: `resolve_quic_candidate_addr` (`socket_addr_is_unsafe`), `broker_trust` / `ensure_insecure_local_endpoint`. |
+| Nostr relays (nostr-sdk) | `crates/marmot-app/src/relay_plane/safety.rs`: `RelaySafetyPolicy::sanitize_endpoints` → `reject_unsafe_relay_host`, the single funnel for activation, group sync, publish, and directory routes. |
+| QUIC broker client connect timeout | Shared QUIC-preview hardening (`connect_with_timeout` / `QUIC_PREVIEW_CONNECT_TIMEOUT`, #710), applied at both broker client connects in `crates/transport-quic-broker/src/client.rs`. |
+
+The broker TLS client (`crates/transport-quic-broker/src/tls.rs`) keeps a resolved-address backstop
+(`InsecureLocalRequiresLoopback`): even if a caller mis-selects `InsecureLocal`, a non-loopback resolved address is
+refused. That backstop complements — it does not replace — the caller-side literal-host trust gate.
+
+## The shared classifier
+
+`cgka_traits::app_components::host_safety` owns the canonical unsafe-host set: `is_public_ip`, `is_loopback_ip`,
+`is_loopback_host`, and the dial gate `reject_non_public_ip` / `reject_non_public_socket_addr`. Every outbound path
+calls the same functions so SSRF hardening cannot drift between transports. Adding a new outbound connection without
+routing through this discipline is a contract violation — the transport crates' `AGENTS.md` files point here.
+
+## Accepted residual
+
+Nostr relays are the one path that cannot pin: nostr-sdk owns DNS resolution and the WebSocket, so a **domain** relay
+host is accepted after `RelayUrl` scheme/format validation and only its **literal**-IP form (and `localhost`) is
+rejected at `sanitize_endpoints`. A public-looking hostname that resolves to a private address at the SDK's connect
+time is a TOCTOU residual, rated LOW (relay URLs come from signed routing state and the `ws`/`wss` scheme restriction
+bounds it). A resolve-time pre-check inside the adapter is a possible future complement, not a close condition.


### PR DESCRIPTION
## Summary

Routes every outbound network connection through one host-safety dial discipline — the contract tracked by #708. Only the Blossom media path was fully hardened before this; three other dial sites skipped validation, re-introducing the SSRF / resolution-dependent-trust class of bug at each new outbound path.

The deliverable is a shared **classifier** plus the documented per-transport pattern (validate every resolved address → pin the validated address → choose TLS trust from config, not a resolved IP → connect timeout → loopback only under an explicit dev flag), not a single `dial()` function — reqwest, quinn, and nostr-sdk pin and connect through incompatible APIs. Two in-tree paths already followed this (`crates/marmot-app/src/media/blossom.rs`, `crates/cli/src/commands/stream.rs`); this brings the rest up to it.

Closes #331, Closes #353, Closes #356, Closes #385, Closes #361

## What changed

- **Shared classifier promoted to `cgka-traits`.** `reject_non_public_ip` / `reject_non_public_socket_addr` now live in `cgka_traits::app_components::host_safety` (alongside `is_public_ip`); the marmot-app media wrapper re-exports them so every outbound path calls the same code and SSRF rules cannot drift.
- **Agent-stream broker watch (#331, #356).** `crates/marmot-app/src/runtime/agent_stream_watch.rs`: `resolve_broker_addr` rejects non-public resolved addresses (dev-loopback opt-in only) and returns the address quinn connects to (natural pinning); trust is keyed on the **literal** candidate host via `broker_trust_for_candidate`, so a hostname that merely resolves to loopback can no longer select `InsecureLocal`.
- **Agent-connector broker dial (#385, #356).** `crates/agent-connector/src/quic.rs`: same validate-and-pin on `resolve_quic_candidate_addr`; `broker_trust_for_candidate` gates `InsecureLocal` behind the new `AgentConnectorConfig::allow_insecure_local_broker` (off by default; `wn-agent --insecure-local-broker`) plus a literal loopback host. Fail-closed: without the flag a loopback-resolving candidate gets `Platform` trust and TLS fails.
- **Relay endpoints (#353).** `crates/marmot-app/src/relay_plane/safety.rs`: `RelaySafetyPolicy::sanitize_endpoints` — already the single funnel for activation / group sync / publish / directory routes — now rejects relay endpoints whose literal host is loopback/private/non-public before the URL reaches nostr-sdk. New dev gate `MarmotAppConfig::allow_loopback_relay_endpoints` (`WN_ALLOW_LOOPBACK_RELAYS`, `AgentConnectorConfig::allow_loopback_relays`). Signed routing state is never rewritten — this filters connections only. nostr-sdk owns DNS, so a public-looking hostname that resolves to a private address is a documented, accepted LOW TOCTOU residual (see the dial-safety note).
- **#361 verify-and-close.** Both Blossom download *and* upload already route through `media_http_client_for_url` → `validate_blossom_fetch_url` + `resolve_media_host` (per-address `reject_non_public_ip`, `resolve_to_addrs` pin, connect/read/total timeouts, per-redirect re-validation). No code change needed; the tracking issue's "upload residual" was stale.
- **Docs.** New `docs/marmot-architecture/overview/dial-safety.md` states the one contract and names each chokepoint; the root and per-crate `AGENTS.md` files point to it so a new outbound path that bypasses the discipline is a visible contract violation.

## Scope notes

- The `#708` acceptance criterion "candidates match the **policy-announced broker set**" is intentionally **not** implemented here — there is no broker allowlist infrastructure anywhere in the tree, and it is a policy-plane feature needing spec work in `marmot-protocol/marmot`. The host-safety fixes neutralize the actual SSRF / insecure-trust vectors the child issues describe. Filed as a separate follow-up (linked on #708).
- The broker connect timeout and the shared QUIC hardening profile (QUIC 0-RTT, client `TransportConfig`) were landed by #710/#729, which merged to `master` while this was in flight — this branch was rebased on top of it, so the broker connect path is left to that work. This PR's broker footprint is docs-only (`AGENTS.md` dial-safety pointer + the resolved-address `InsecureLocalRequiresLoopback` backstop reference); the caller-side validate/pin/trust changes live in marmot-app and agent-connector.

## Test

- `just fast-ci` (fmt + check + clippy `-D warnings`, incl. OTLP feature builds) — green.
- `cargo test -p cgka-traits -p marmot-app -p agent-connector -p transport-quic-broker -p wn-cli` — green. New tests: the classifier table (`crates/traits/tests/host_safety_public.rs`), literal-host trust + resolve-time rejection at both QUIC sites, and `RelaySafetyPolicy` accept/reject/opt-in/count-cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
