### PR TITLE
Validate-before-mutate discipline: close the #711 torn-write bundle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,9 @@ The canonical protocol specification lives in
   `cgka_traits::app_components::reject_non_public_ip`, pin the validated address, choose TLS trust from config (never a
   resolved IP), apply a connect timeout, and gate loopback behind an explicit dev flag. See
   `docs/marmot-architecture/overview/dial-safety.md`.
+- Keep multi-step state changes torn-write-free: validate before mutating, compensate every applied step on the error
+  path, record intent before external side effects, and never confirm work that reached no one. See
+  `docs/marmot-architecture/overview/multi-step-state-changes.md`.
 - When adding an `AGENTS.md`, create a sibling `CLAUDE.md` symlink to it.
 
 ## Verification

--- a/crates/agent-connector/src/stream.rs
+++ b/crates/agent-connector/src/stream.rs
@@ -17,7 +17,7 @@ use crate::quic::{
     broker_trust_for_candidate, first_quic_candidate, parse_quic_candidate,
     resolve_quic_candidate_addr,
 };
-use crate::stream_session::ActiveStreamSession;
+use crate::stream_session::{ActiveStreamSession, FinalizedStream};
 use crate::validation::{normalize_hex, transcript_hash_from_hex, unix_now_seconds};
 use crate::{
     AgentConnector, STREAM_COMPOSE_CHANNEL_DEPTH, STREAM_COMPOSE_CHUNK_BYTES,
@@ -120,6 +120,7 @@ impl AgentConnector {
                 cancel_tx,
                 abort: handle.abort_handle(),
                 last_activity: Instant::now(),
+                finalized: None,
             },
         );
         Ok(AgentControlResponse::StreamBegun {
@@ -204,6 +205,32 @@ impl AgentConnector {
         // its teardown. On mismatch the session stays registered and the
         // compose task keeps running, so finalize is retryable (#366).
         let session = self.streams.get(&stream_id_hex)?;
+
+        // Retry fast-path: a prior finalize already validated the transcript and
+        // the compose task exited, but the durable finish below failed. The
+        // compose task is gone, so re-attempt the durable finish directly from
+        // the retained transcript, rejecting a retry that disagrees with what
+        // was frozen (a finalize cannot change after the transcript is sealed).
+        if let Some(finalized) = &session.finalized {
+            if finalized.final_text != final_text
+                || finalized.transcript_hash != transcript_hash
+                || finalized.chunk_count != chunk_count
+            {
+                return Err(ConnectorError::Stream(
+                    "stream finalize does not match the already-finalized transcript".into(),
+                ));
+            }
+            return self
+                .finish_finalized_stream(
+                    &stream_id_hex,
+                    &session,
+                    final_text,
+                    transcript_hash,
+                    chunk_count,
+                )
+                .await;
+        }
+
         let (respond, response) = oneshot::channel();
         if session
             .tx
@@ -241,18 +268,49 @@ impl AgentConnector {
         // running and the session stays registered, so do nothing else here
         // and the agent can append again and/or retry the finalize.
         report.map_err(ConnectorError::Stream)?;
-        let _ = self.streams.remove_if_same(&stream_id_hex, &session);
-        // If the runtime finish below fails, the compose task has already
-        // exited and the durable final remains unretryable — pre-existing
-        // gap, out of scope for #366.
+        // Validation passed and the compose task has now exited. Freeze the
+        // transcript on the still-registered session so a durable-finish
+        // failure below leaves a retryable finalize (the compose task can no
+        // longer be consulted).
+        self.streams.mark_finalized(
+            &stream_id_hex,
+            &session,
+            FinalizedStream {
+                final_text: final_text.clone(),
+                transcript_hash,
+                chunk_count,
+            },
+        );
+        self.finish_finalized_stream(
+            &stream_id_hex,
+            &session,
+            final_text,
+            transcript_hash,
+            chunk_count,
+        )
+        .await
+    }
+
+    /// Publish the durable stream final for an already-validated finalize, and
+    /// remove the session only once that publish succeeds. On failure the
+    /// session stays registered with its frozen transcript so a re-issued
+    /// `StreamFinalize` retries this step (#366).
+    async fn finish_finalized_stream(
+        &self,
+        stream_id_hex: &str,
+        session: &ActiveStreamSession,
+        final_text: String,
+        transcript_hash: [u8; 32],
+        chunk_count: u64,
+    ) -> Result<AgentControlResponse, ConnectorError> {
         let (_payload, summary) = self
             .runtime
             .finish_agent_text_stream(
                 &session.account_label,
                 &session.group_id,
                 AgentTextStreamFinishRequest {
-                    stream_id: session.stream_id,
-                    start_event_id: session.start_message_id_hex,
+                    stream_id: session.stream_id.clone(),
+                    start_event_id: session.start_message_id_hex.clone(),
                     final_text_or_reference: final_text,
                     transcript_hash,
                     chunk_count,
@@ -260,8 +318,10 @@ impl AgentConnector {
                 },
             )
             .await?;
+        // Durable final published: it is now safe to drop the session.
+        let _ = self.streams.remove_if_same(stream_id_hex, session);
         Ok(AgentControlResponse::StreamFinalized {
-            stream_id_hex,
+            stream_id_hex: stream_id_hex.to_owned(),
             message_ids_hex: summary.message_ids,
         })
     }

--- a/crates/agent-connector/src/stream.rs
+++ b/crates/agent-connector/src/stream.rs
@@ -3,7 +3,9 @@
 use std::time::Instant;
 
 use agent_control::AgentControlResponse;
-use agent_stream_compose::{StreamComposeCommand, StreamComposeReport, run_stream_compose_session};
+use agent_stream_compose::{
+    StreamComposeCommand, StreamComposeReport, StreamFinishExpectation, run_stream_compose_session,
+};
 use cgka_traits::{GroupId, MessageId};
 use marmot_app::AgentTextStreamFinishRequest;
 use tokio::sync::mpsc::error::TrySendError;
@@ -196,45 +198,53 @@ impl AgentConnector {
         chunk_count: u64,
     ) -> Result<AgentControlResponse, ConnectorError> {
         let stream_id_hex = normalize_hex(stream_id_hex)?;
-        let session = self.streams.remove(&stream_id_hex)?;
+        let transcript_hash = transcript_hash_from_hex(transcript_hash_hex)?;
+        // Clone (not remove) the session: the final text/hash/chunk-count
+        // expectation is validated inside the compose task, atomically with
+        // its teardown. On mismatch the session stays registered and the
+        // compose task keeps running, so finalize is retryable (#366).
+        let session = self.streams.get(&stream_id_hex)?;
         let (respond, response) = oneshot::channel();
         if session
             .tx
-            .send(StreamComposeCommand::Finish { respond })
+            .send(StreamComposeCommand::Finish {
+                expected: Some(StreamFinishExpectation {
+                    final_text: final_text.clone(),
+                    transcript_hash_hex: hex::encode(transcript_hash),
+                    chunk_count,
+                }),
+                respond,
+            })
             .await
             .is_err()
         {
+            // The compose task is gone: drop the dead registration (only if
+            // it is still this session) and reclaim the task, preserving the
+            // previous remove-then-abort cleanup semantics.
+            let _ = self.streams.remove_if_same(&stream_id_hex, &session);
             session.abort.abort();
             return Err(ConnectorError::Stream(
                 "stream compose session is closed".into(),
             ));
         }
-        let report = response
-            .await
-            .map_err(|err| ConnectorError::Stream(err.to_string()))?
-            .map_err(ConnectorError::Stream)?;
-        if report.text != final_text {
-            return Err(ConnectorError::Stream(
-                "stream final text does not match appended transcript".into(),
-            ));
-        }
-        let transcript_hash = transcript_hash_from_hex(transcript_hash_hex)?;
-        let expected_transcript_hash_hex = hex::encode(transcript_hash);
-        let actual_transcript_hash_hex = report
-            .transcript_hash
-            .as_deref()
-            .map(normalize_hex)
-            .transpose()?;
-        if actual_transcript_hash_hex.as_deref() != Some(expected_transcript_hash_hex.as_str()) {
-            return Err(ConnectorError::Stream(
-                "stream final transcript hash does not match appended transcript".into(),
-            ));
-        }
-        if report.chunk_count != chunk_count {
-            return Err(ConnectorError::Stream(
-                "stream final chunk count does not match appended transcript".into(),
-            ));
-        }
+        let report = match response.await {
+            Ok(report) => report,
+            Err(err) => {
+                // The compose task died mid-command: same cleanup as the
+                // send failure above.
+                let _ = self.streams.remove_if_same(&stream_id_hex, &session);
+                session.abort.abort();
+                return Err(ConnectorError::Stream(err.to_string()));
+            }
+        };
+        // An `Err` report is a validation mismatch: the compose task is still
+        // running and the session stays registered, so do nothing else here
+        // and the agent can append again and/or retry the finalize.
+        report.map_err(ConnectorError::Stream)?;
+        let _ = self.streams.remove_if_same(&stream_id_hex, &session);
+        // If the runtime finish below fails, the compose task has already
+        // exited and the durable final remains unretryable — pre-existing
+        // gap, out of scope for #366.
         let (_payload, summary) = self
             .runtime
             .finish_agent_text_stream(

--- a/crates/agent-connector/src/stream.rs
+++ b/crates/agent-connector/src/stream.rs
@@ -271,8 +271,12 @@ impl AgentConnector {
         // Validation passed and the compose task has now exited. Freeze the
         // transcript on the still-registered session so a durable-finish
         // failure below leaves a retryable finalize (the compose task can no
-        // longer be consulted).
-        self.streams.mark_finalized(
+        // longer be consulted). If the freeze does not land — the session was
+        // superseded by a same-stream-id replacement between our `get` and now
+        // — this clone is stale: proceeding would publish under a lost retry
+        // handle, so bail and let the agent re-finalize against the live
+        // session instead.
+        if !self.streams.mark_finalized(
             &stream_id_hex,
             &session,
             FinalizedStream {
@@ -280,7 +284,11 @@ impl AgentConnector {
                 transcript_hash,
                 chunk_count,
             },
-        );
+        ) {
+            return Err(ConnectorError::Stream(
+                "stream session was superseded during finalize".into(),
+            ));
+        }
         self.finish_finalized_stream(
             &stream_id_hex,
             &session,

--- a/crates/agent-connector/src/stream_session.rs
+++ b/crates/agent-connector/src/stream_session.rs
@@ -322,6 +322,23 @@ pub(crate) struct ActiveStreamSession {
     pub(crate) cancel_tx: mpsc::Sender<()>,
     pub(crate) abort: tokio::task::AbortHandle,
     pub(crate) last_activity: Instant,
+    /// Set once the compose task has validated the finalize expectation and
+    /// exited. The compose task is then gone, but the durable
+    /// `finish_agent_text_stream` publish that follows can still fail; the
+    /// retained transcript lets a re-issued `StreamFinalize` retry that publish
+    /// without the (dead) compose task, so a transient error never strands the
+    /// stream with a live preview and no durable final (#366).
+    pub(crate) finalized: Option<FinalizedStream>,
+}
+
+/// Frozen finalize inputs retained after the compose task exits, so the durable
+/// finish step is retryable and a retry that disagrees with the frozen
+/// transcript is rejected.
+#[derive(Clone)]
+pub(crate) struct FinalizedStream {
+    pub(crate) final_text: String,
+    pub(crate) transcript_hash: [u8; 32],
+    pub(crate) chunk_count: u64,
 }
 
 impl StreamSessionStore {
@@ -371,6 +388,25 @@ impl StreamSessionStore {
         match sessions.get(stream_id_hex) {
             Some(entry) if entry.tx.same_channel(&session.tx) => sessions.remove(stream_id_hex),
             _ => None,
+        }
+    }
+
+    /// Freeze the finalize inputs on the stored entry (only when it is still the
+    /// same session) so a durable-finish failure can be retried without the
+    /// compose task, which has exited by this point. Also refreshes activity so
+    /// the idle sweep does not reclaim a session mid-finalize.
+    pub(crate) fn mark_finalized(
+        &self,
+        stream_id_hex: &str,
+        session: &ActiveStreamSession,
+        finalized: FinalizedStream,
+    ) {
+        let mut sessions = self.sessions.lock().expect("stream session lock poisoned");
+        if let Some(entry) = sessions.get_mut(stream_id_hex)
+            && entry.tx.same_channel(&session.tx)
+        {
+            entry.finalized = Some(finalized);
+            entry.last_activity = Instant::now();
         }
     }
 

--- a/crates/agent-connector/src/stream_session.rs
+++ b/crates/agent-connector/src/stream_session.rs
@@ -355,6 +355,25 @@ impl StreamSessionStore {
         Ok(session.clone())
     }
 
+    /// Remove the entry for `stream_id_hex` only when it is still the same
+    /// session as `session` (identified by command-channel identity).
+    ///
+    /// With a get-first finalize flow, an unconditional removal could tear
+    /// down a same-stream-id replacement session inserted concurrently
+    /// between the `get` and the removal; the channel-identity check makes
+    /// the removal a no-op in that case.
+    pub(crate) fn remove_if_same(
+        &self,
+        stream_id_hex: &str,
+        session: &ActiveStreamSession,
+    ) -> Option<ActiveStreamSession> {
+        let mut sessions = self.sessions.lock().expect("stream session lock poisoned");
+        match sessions.get(stream_id_hex) {
+            Some(entry) if entry.tx.same_channel(&session.tx) => sessions.remove(stream_id_hex),
+            _ => None,
+        }
+    }
+
     pub(crate) fn remove(
         &self,
         stream_id_hex: &str,

--- a/crates/agent-connector/src/stream_session.rs
+++ b/crates/agent-connector/src/stream_session.rs
@@ -391,22 +391,30 @@ impl StreamSessionStore {
         }
     }
 
-    /// Freeze the finalize inputs on the stored entry (only when it is still the
-    /// same session) so a durable-finish failure can be retried without the
-    /// compose task, which has exited by this point. Also refreshes activity so
-    /// the idle sweep does not reclaim a session mid-finalize.
+    /// Freeze the finalize inputs on the stored entry so a durable-finish failure
+    /// can be retried without the compose task, which has exited by this point.
+    ///
+    /// Returns `true` only when the freeze landed on the still-current session
+    /// (matched by command-channel identity). It returns `false` when the entry
+    /// was removed or replaced by a same-stream-id session between the caller's
+    /// `get` and this call: in that case the caller's session is stale and must
+    /// NOT proceed to the durable publish, or a failure there would leave no
+    /// retry handle (`finalized` unset) and strand the stream (#366).
+    #[must_use]
     pub(crate) fn mark_finalized(
         &self,
         stream_id_hex: &str,
         session: &ActiveStreamSession,
         finalized: FinalizedStream,
-    ) {
+    ) -> bool {
         let mut sessions = self.sessions.lock().expect("stream session lock poisoned");
-        if let Some(entry) = sessions.get_mut(stream_id_hex)
-            && entry.tx.same_channel(&session.tx)
-        {
-            entry.finalized = Some(finalized);
-            entry.last_activity = Instant::now();
+        match sessions.get_mut(stream_id_hex) {
+            Some(entry) if entry.tx.same_channel(&session.tx) => {
+                entry.finalized = Some(finalized);
+                entry.last_activity = Instant::now();
+                true
+            }
+            _ => false,
         }
     }
 
@@ -431,12 +439,21 @@ impl StreamSessionStore {
     /// session otherwise keeps the compose task, its `mpsc::Sender`, the accumulated
     /// transcript, and (when broker connect succeeded) a dedicated quinn `Endpoint`
     /// UDP socket plus a live keep-alive'd QUIC connection alive forever.
+    ///
+    /// A session whose transcript has been finalized is NEVER swept: its compose
+    /// task has already exited and the frozen transcript is the only handle for
+    /// retrying a durable finish that failed. Sweeping it would recreate the
+    /// exact #366 failure mode (a published live preview with no durable final
+    /// and no way to retry), so a finalized session lives until its durable
+    /// finish succeeds or the connector restarts.
     pub(crate) fn sweep_idle(&self, max_idle: Duration) -> usize {
         let now = Instant::now();
         let mut sessions = self.sessions.lock().expect("stream session lock poisoned");
         let stale: Vec<String> = sessions
             .iter()
-            .filter(|(_, session)| now.duration_since(session.last_activity) >= max_idle)
+            .filter(|(_, session)| {
+                session.finalized.is_none() && now.duration_since(session.last_activity) >= max_idle
+            })
             .map(|(stream_id_hex, _)| stream_id_hex.clone())
             .collect();
         for stream_id_hex in &stale {

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -1949,6 +1949,157 @@ async fn connector_socket_composes_and_finalizes_stream() {
     assert!(!message_ids_hex[0].is_empty());
 }
 
+/// Regression for #366: a finalize whose expectation does not match the
+/// composed transcript must not tear down the stream session. The compose
+/// task keeps running, further appends succeed, and a corrected finalize
+/// completes the stream.
+#[tokio::test]
+async fn connector_socket_finalize_mismatch_keeps_stream_session_retryable() {
+    let dir = tempfile::tempdir().unwrap();
+    let relay = MockRelay::run().await.unwrap();
+    let relay_url = relay.url().await.to_string();
+    let app = MarmotApp::with_relay(dir.path(), relay_url.clone());
+    let setup_runtime = MarmotAppRuntime::new(app);
+    let setup = AccountSetupRequest {
+        default_relays: vec![crate::validation::endpoint(&relay_url)],
+        bootstrap_relays: vec![crate::validation::endpoint(&relay_url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let agent = setup_runtime.create_identity(setup.clone()).await.unwrap();
+    let human = setup_runtime.create_identity(setup).await.unwrap();
+    let group_id = setup_runtime
+        .create_group(
+            &agent.account.account_id_hex,
+            "agent retryable finalize",
+            std::slice::from_ref(&human.account.account_id_hex),
+            None,
+        )
+        .await
+        .unwrap();
+    setup_runtime.shutdown().await;
+
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let stream_id_hex = hex::encode([0x99; 32]);
+    let socket = dir.path().join("dev").join("wn-agent.sock");
+    let connector = AgentConnector::open(test_config(
+        dir.path(),
+        socket.clone(),
+        vec![relay_url],
+        false,
+        false,
+    ))
+    .unwrap();
+    let listener = bind_connector_socket(&socket).unwrap();
+
+    let begun = serve_control_request_once(
+        &connector,
+        &listener,
+        &socket,
+        "req-retry-begin",
+        AgentControlRequest::StreamBegin {
+            account_id_hex: agent.account.account_id_hex.clone(),
+            group_id_hex: group_id_hex.clone(),
+            stream_id_hex: Some(stream_id_hex.clone()),
+            quic_candidates: vec!["quic://127.0.0.1:9".to_owned()],
+        },
+    )
+    .await;
+    let AgentControlResponse::StreamBegun {
+        start_message_id_hex,
+        ..
+    } = begun.payload
+    else {
+        panic!("expected stream begun response");
+    };
+
+    let appended = serve_control_request_once(
+        &connector,
+        &listener,
+        &socket,
+        "req-retry-append",
+        AgentControlRequest::StreamAppend {
+            stream_id_hex: stream_id_hex.clone(),
+            append_text: "hello stream".to_owned(),
+        },
+    )
+    .await;
+    assert_eq!(appended.payload, AgentControlResponse::Ack);
+
+    // Correct text and hash, wrong chunk count: the finalize must fail
+    // without tearing down the compose session.
+    let first_hash = expected_stream_transcript_hash(
+        &stream_id_hex,
+        &start_message_id_hex,
+        &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, "hello stream")],
+    );
+    let mismatched = serve_control_request_once(
+        &connector,
+        &listener,
+        &socket,
+        "req-retry-finalize-mismatch",
+        AgentControlRequest::StreamFinalize {
+            stream_id_hex: stream_id_hex.clone(),
+            final_text: "hello stream".to_owned(),
+            transcript_hash_hex: first_hash,
+            chunk_count: 7,
+        },
+    )
+    .await;
+    let AgentControlResponse::Error { code, .. } = mismatched.payload else {
+        panic!("expected finalize mismatch error");
+    };
+    assert_eq!(code, "stream_error");
+
+    // The compose session must have survived the mismatch: a further append
+    // still succeeds.
+    let appended_again = serve_control_request_once(
+        &connector,
+        &listener,
+        &socket,
+        "req-retry-append-again",
+        AgentControlRequest::StreamAppend {
+            stream_id_hex: stream_id_hex.clone(),
+            append_text: " again".to_owned(),
+        },
+    )
+    .await;
+    assert_eq!(appended_again.payload, AgentControlResponse::Ack);
+
+    // A corrected finalize over the full transcript succeeds.
+    let corrected_hash = expected_stream_transcript_hash(
+        &stream_id_hex,
+        &start_message_id_hex,
+        &[
+            (AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, "hello stream"),
+            (AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, " again"),
+        ],
+    );
+    let finalized = serve_control_request_once(
+        &connector,
+        &listener,
+        &socket,
+        "req-retry-finalize",
+        AgentControlRequest::StreamFinalize {
+            stream_id_hex: stream_id_hex.clone(),
+            final_text: "hello stream again".to_owned(),
+            transcript_hash_hex: corrected_hash,
+            chunk_count: 2,
+        },
+    )
+    .await;
+    let AgentControlResponse::StreamFinalized {
+        stream_id_hex: finalized_stream_id_hex,
+        message_ids_hex,
+    } = finalized.payload
+    else {
+        panic!("expected stream finalized response");
+    };
+    assert_eq!(finalized_stream_id_hex, stream_id_hex);
+    assert_eq!(message_ids_hex.len(), 1);
+    assert!(!message_ids_hex[0].is_empty());
+}
+
 #[tokio::test]
 async fn connector_socket_cancels_stream_session() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -372,6 +372,7 @@ async fn stream_session_sweeper_aborts_idle_session_and_keeps_active_one() {
             cancel_tx: idle_cancel_tx,
             abort: idle_handle.abort_handle(),
             last_activity: Instant::now() - Duration::from_secs(3600),
+            finalized: None,
         },
     );
 
@@ -390,6 +391,7 @@ async fn stream_session_sweeper_aborts_idle_session_and_keeps_active_one() {
             cancel_tx: active_cancel_tx,
             abort: active_handle.abort_handle(),
             last_activity: Instant::now(),
+            finalized: None,
         },
     );
 
@@ -1215,6 +1217,7 @@ async fn stream_session_store_resolves_non_canonical_stream_id() {
             cancel_tx,
             abort: handle.abort_handle(),
             last_activity: Instant::now(),
+            finalized: None,
         },
     );
 
@@ -1269,6 +1272,7 @@ async fn stream_session_sweep_does_not_force_abort_when_cancel_already_queued() 
             cancel_tx,
             abort,
             last_activity: Instant::now() - Duration::from_secs(3600),
+            finalized: None,
         },
     );
 
@@ -2098,6 +2102,137 @@ async fn connector_socket_finalize_mismatch_keeps_stream_session_retryable() {
     assert_eq!(finalized_stream_id_hex, stream_id_hex);
     assert_eq!(message_ids_hex.len(), 1);
     assert!(!message_ids_hex[0].is_empty());
+}
+
+/// Regression for #366 (review follow-up): once the compose task has validated
+/// and exited, the durable `finish_agent_text_stream` publish can still fail.
+/// The frozen transcript on the still-registered session must let a re-issued
+/// finalize complete that publish WITHOUT the (now-dead) compose task, and a
+/// retry that disagrees with the frozen transcript must be rejected.
+#[tokio::test]
+async fn connector_finalize_retries_durable_finish_without_compose_task() {
+    use crate::error::ConnectorError;
+    use crate::stream_session::FinalizedStream;
+    use crate::validation::normalize_hex;
+
+    let dir = tempfile::tempdir().unwrap();
+    let relay = MockRelay::run().await.unwrap();
+    let relay_url = relay.url().await.to_string();
+    let app = MarmotApp::with_relay(dir.path(), relay_url.clone());
+    let setup_runtime = MarmotAppRuntime::new(app);
+    let setup = AccountSetupRequest {
+        default_relays: vec![crate::validation::endpoint(&relay_url)],
+        bootstrap_relays: vec![crate::validation::endpoint(&relay_url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let agent = setup_runtime.create_identity(setup.clone()).await.unwrap();
+    let human = setup_runtime.create_identity(setup).await.unwrap();
+    let group_id = setup_runtime
+        .create_group(
+            &agent.account.account_id_hex,
+            "agent durable finalize retry",
+            std::slice::from_ref(&human.account.account_id_hex),
+            None,
+        )
+        .await
+        .unwrap();
+    setup_runtime.shutdown().await;
+
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let stream_id_hex = hex::encode([0x5a; 32]);
+    let socket = dir.path().join("dev").join("wn-agent.sock");
+    let connector = AgentConnector::open(test_config(
+        dir.path(),
+        socket.clone(),
+        vec![relay_url],
+        false,
+        false,
+    ))
+    .unwrap();
+    let listener = bind_connector_socket(&socket).unwrap();
+
+    // Begin (and start the runtime) so the durable finish below has a real
+    // account, group, and stream-start event to reference.
+    let begun = serve_control_request_once(
+        &connector,
+        &listener,
+        &socket,
+        "req-durable-begin",
+        AgentControlRequest::StreamBegin {
+            account_id_hex: agent.account.account_id_hex.clone(),
+            group_id_hex,
+            stream_id_hex: Some(stream_id_hex.clone()),
+            quic_candidates: vec!["quic://127.0.0.1:9".to_owned()],
+        },
+    )
+    .await;
+    assert!(matches!(
+        begun.payload,
+        AgentControlResponse::StreamBegun { .. }
+    ));
+
+    // Reconstruct the exact state left after a validated finalize whose durable
+    // publish then failed: the compose task has exited (abort it here to prove
+    // the retry never talks to it) and the transcript is frozen on the still
+    // registered session.
+    let stream_id_norm = normalize_hex(&stream_id_hex).unwrap();
+    let session = connector.streams.get(&stream_id_norm).unwrap();
+    session.abort.abort();
+    let transcript_hash = [0x11u8; 32];
+    connector.streams.mark_finalized(
+        &stream_id_norm,
+        &session,
+        FinalizedStream {
+            final_text: "frozen final".to_owned(),
+            transcript_hash,
+            chunk_count: 1,
+        },
+    );
+
+    // A retry that disagrees with the frozen transcript is rejected and leaves
+    // the session registered.
+    let mismatch = connector
+        .stream_finalize_response(
+            &stream_id_hex,
+            "different final".to_owned(),
+            &hex::encode(transcript_hash),
+            1,
+        )
+        .await;
+    assert!(
+        matches!(mismatch, Err(ConnectorError::Stream(_))),
+        "a retry disagreeing with the frozen transcript must be rejected"
+    );
+    assert!(
+        connector.streams.get(&stream_id_norm).is_ok(),
+        "a rejected retry must not drop the session"
+    );
+
+    // A matching retry completes the durable publish from the frozen transcript
+    // — the compose task was aborted above, so this proves it is not consulted —
+    // and only then removes the session.
+    let finalized = connector
+        .stream_finalize_response(
+            &stream_id_hex,
+            "frozen final".to_owned(),
+            &hex::encode(transcript_hash),
+            1,
+        )
+        .await
+        .expect("frozen-transcript retry finalizes without the compose task");
+    let AgentControlResponse::StreamFinalized {
+        message_ids_hex, ..
+    } = finalized
+    else {
+        panic!("expected stream finalized response");
+    };
+    assert_eq!(message_ids_hex.len(), 1);
+    assert!(!message_ids_hex[0].is_empty());
+    assert!(
+        connector.streams.get(&stream_id_norm).is_err(),
+        "a successful durable finish must remove the session"
+    );
 }
 
 #[tokio::test]

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -414,6 +414,54 @@ async fn stream_session_sweeper_aborts_idle_session_and_keeps_active_one() {
     active_handle.abort();
 }
 
+/// A finalized-but-unpublished session must survive the idle sweep even when
+/// its last activity is well past the timeout: its compose task has exited and
+/// the frozen transcript is the only handle for retrying a failed durable
+/// finish. Sweeping it would recreate the #366 failure mode.
+#[tokio::test]
+async fn stream_session_sweep_spares_finalized_session_despite_idle() {
+    use crate::stream_session::{ActiveStreamSession, FinalizedStream, StreamSessionStore};
+    use agent_stream_compose::StreamComposeCommand;
+    use cgka_traits::GroupId;
+    use std::time::{Duration, Instant};
+
+    let store = StreamSessionStore::default();
+
+    // The compose task has already exited after a validated Finish; model that
+    // with an immediately-finished task so its Sender is closed like the real
+    // post-finalize session.
+    let (tx, rx) = tokio::sync::mpsc::channel::<StreamComposeCommand>(4);
+    drop(rx);
+    let (cancel_tx, _cancel_rx) = tokio::sync::mpsc::channel::<()>(1);
+    let handle = tokio::spawn(async {});
+    store.insert(
+        "aa".to_owned(),
+        ActiveStreamSession {
+            account_label: "agent".to_owned(),
+            group_id: GroupId::new(vec![1]),
+            stream_id: vec![0xaa],
+            start_message_id_hex: "00".to_owned(),
+            tx,
+            cancel_tx,
+            abort: handle.abort_handle(),
+            // Idle far beyond the timeout, but finalized: must be spared.
+            last_activity: Instant::now() - Duration::from_secs(3600),
+            finalized: Some(FinalizedStream {
+                final_text: "frozen".to_owned(),
+                transcript_hash: [0x22; 32],
+                chunk_count: 1,
+            }),
+        },
+    );
+
+    let swept = store.sweep_idle(Duration::from_secs(300));
+    assert_eq!(swept, 0, "a finalized session must never be swept");
+    assert!(
+        store.get("aa").is_ok(),
+        "the finalized session (and its retry handle) must survive the sweep"
+    );
+}
+
 #[tokio::test]
 async fn connector_socket_bind_removes_stale_socket() {
     let dir = tempfile::tempdir().unwrap();
@@ -2180,14 +2228,17 @@ async fn connector_finalize_retries_durable_finish_without_compose_task() {
     let session = connector.streams.get(&stream_id_norm).unwrap();
     session.abort.abort();
     let transcript_hash = [0x11u8; 32];
-    connector.streams.mark_finalized(
-        &stream_id_norm,
-        &session,
-        FinalizedStream {
-            final_text: "frozen final".to_owned(),
-            transcript_hash,
-            chunk_count: 1,
-        },
+    assert!(
+        connector.streams.mark_finalized(
+            &stream_id_norm,
+            &session,
+            FinalizedStream {
+                final_text: "frozen final".to_owned(),
+                transcript_hash,
+                chunk_count: 1,
+            },
+        ),
+        "freeze must land on the still-current session"
     );
 
     // A retry that disagrees with the frozen transcript is rejected and leaves

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -106,6 +106,12 @@ pub enum AgentControlRequest {
         stream_id_hex: String,
         text: String,
     },
+    /// Finalize an active preview stream into the durable final message.
+    ///
+    /// If `final_text`, `transcript_hash_hex`, or `chunk_count` do not match
+    /// the transcript composed from the preceding appends, the request fails
+    /// WITHOUT tearing down the stream session: the agent may append again
+    /// and/or re-issue `StreamFinalize`, or cancel the stream.
     StreamFinalize {
         stream_id_hex: String,
         final_text: String,

--- a/crates/agent-stream-compose/src/lib.rs
+++ b/crates/agent-stream-compose/src/lib.rs
@@ -45,6 +45,17 @@ pub struct StreamComposeReport {
     pub error: Option<String>,
 }
 
+/// Caller-supplied final-transcript expectation, validated atomically inside
+/// the compose task before any teardown. On mismatch the session responds
+/// `Err` and keeps running, so finalize is retryable.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StreamFinishExpectation {
+    pub final_text: String,
+    /// Lowercase hex of the expected transcript hash.
+    pub transcript_hash_hex: String,
+    pub chunk_count: u64,
+}
+
 pub enum StreamComposeCommand {
     Append {
         text: String,
@@ -59,6 +70,13 @@ pub enum StreamComposeCommand {
         respond: oneshot::Sender<Result<StreamComposeReport, String>>,
     },
     Finish {
+        /// Optional final-transcript expectation. When set, it is validated
+        /// inside the compose task before any teardown: an `Err` response
+        /// means the expectation did not match and the session is STILL
+        /// RUNNING (further appends and a retried finish remain possible);
+        /// `Ok` means the session finished and the task has exited. With
+        /// `None`, the session finishes unconditionally.
+        expected: Option<StreamFinishExpectation>,
         respond: oneshot::Sender<Result<StreamComposeReport, String>>,
     },
 }
@@ -285,7 +303,19 @@ async fn run_stream_compose_session_with_connector<P, C, E>(
                 .await;
                 let _ = respond.send(result);
             }
-            StreamComposeCommand::Finish { respond } => {
+            StreamComposeCommand::Finish { expected, respond } => {
+                // Validate the caller-supplied expectation BEFORE any teardown
+                // (connect-task abort, publisher consumption, report mutation).
+                // The command loop is strictly sequential, so this check is
+                // atomic with the finish: on mismatch the session keeps
+                // running with no side effects and finalize stays retryable.
+                if let Some(expected) = &expected
+                    && let Err(mismatch) =
+                        validate_finish_expectation(&report, &transcript, expected)
+                {
+                    let _ = respond.send(Err(mismatch));
+                    continue;
+                }
                 if let Some(task) = connect_task.take() {
                     task.abort();
                 }
@@ -539,6 +569,28 @@ async fn append_live_record<P: LiveBrokerPublisher>(
             *live.live_error = Some(err);
         }
     }
+}
+
+/// Validate a caller-supplied [`StreamFinishExpectation`] against the local
+/// transcript. Hash and chunk count are compared against the transcript's own
+/// accessors (not the report fields) so an empty-transcript finalize is
+/// validated against the empty-transcript hash rather than the report's
+/// `None` hash.
+fn validate_finish_expectation(
+    report: &StreamComposeReport,
+    transcript: &LocalComposeTranscript,
+    expected: &StreamFinishExpectation,
+) -> Result<(), String> {
+    if report.text != expected.final_text {
+        return Err("stream final text does not match appended transcript".to_owned());
+    }
+    if transcript.transcript_hash() != expected.transcript_hash_hex {
+        return Err("stream final transcript hash does not match appended transcript".to_owned());
+    }
+    if transcript.chunk_count() != expected.chunk_count {
+        return Err("stream final chunk count does not match appended transcript".to_owned());
+    }
+    Ok(())
 }
 
 async fn finish_stream_compose_report<P: LiveBrokerPublisher>(

--- a/crates/agent-stream-compose/src/tests.rs
+++ b/crates/agent-stream-compose/src/tests.rs
@@ -108,9 +108,12 @@ async fn compose_session_finalizes_local_transcript_when_broker_connect_is_pendi
     assert_eq!(appended.chunk_count, 1);
 
     let (finish_tx, finish_rx) = oneshot::channel();
-    tx.send(StreamComposeCommand::Finish { respond: finish_tx })
-        .await
-        .unwrap();
+    tx.send(StreamComposeCommand::Finish {
+        expected: None,
+        respond: finish_tx,
+    })
+    .await
+    .unwrap();
     let finished = tokio::time::timeout(Duration::from_millis(250), finish_rx)
         .await
         .expect("finish should use local transcript fallback")
@@ -176,9 +179,12 @@ async fn compose_session_clamps_local_transcript_to_group_policy_cap() {
     );
 
     let (finish_tx, finish_rx) = oneshot::channel();
-    tx.send(StreamComposeCommand::Finish { respond: finish_tx })
-        .await
-        .unwrap();
+    tx.send(StreamComposeCommand::Finish {
+        expected: None,
+        respond: finish_tx,
+    })
+    .await
+    .unwrap();
     let finished = tokio::time::timeout(Duration::from_millis(250), finish_rx)
         .await
         .expect("finish should use policy-clamped local transcript")
@@ -215,9 +221,12 @@ async fn compose_session_final_report_contains_full_transcript_text() {
     }
 
     let (respond, response) = oneshot::channel();
-    tx.send(StreamComposeCommand::Finish { respond })
-        .await
-        .unwrap();
+    tx.send(StreamComposeCommand::Finish {
+        expected: None,
+        respond,
+    })
+    .await
+    .unwrap();
     let finished = tokio::time::timeout(Duration::from_millis(250), response)
         .await
         .expect("finish should complete")
@@ -297,6 +306,7 @@ async fn compose_session_status_updates_transcript_without_changing_text() {
 
     let (finish_respond, finish_response) = oneshot::channel();
     tx.send(StreamComposeCommand::Finish {
+        expected: None,
         respond: finish_respond,
     })
     .await
@@ -372,6 +382,7 @@ async fn compose_session_progress_updates_transcript_without_changing_text() {
 
     let (finish_respond, finish_response) = oneshot::channel();
     tx.send(StreamComposeCommand::Finish {
+        expected: None,
         respond: finish_respond,
     })
     .await
@@ -645,6 +656,7 @@ async fn compose_session_drops_late_connect_after_pending_overflow_disables_live
 
     let (finish_respond, finish_response) = oneshot::channel();
     tx.send(StreamComposeCommand::Finish {
+        expected: None,
         respond: finish_respond,
     })
     .await
@@ -799,9 +811,12 @@ async fn compose_session_times_out_stalled_live_flush_and_still_finishes() {
         .unwrap();
 
     let (finish_tx, finish_rx) = oneshot::channel();
-    tx.send(StreamComposeCommand::Finish { respond: finish_tx })
-        .await
-        .unwrap();
+    tx.send(StreamComposeCommand::Finish {
+        expected: None,
+        respond: finish_tx,
+    })
+    .await
+    .unwrap();
     let finished = tokio::time::timeout(Duration::from_millis(250), finish_rx)
         .await
         .expect("finish should not wait indefinitely behind the stalled live flush")
@@ -896,9 +911,12 @@ async fn compose_session_times_out_pending_broker_connect_and_disables_live_prev
     );
 
     let (finish_tx, finish_rx) = oneshot::channel();
-    tx.send(StreamComposeCommand::Finish { respond: finish_tx })
-        .await
-        .unwrap();
+    tx.send(StreamComposeCommand::Finish {
+        expected: None,
+        respond: finish_tx,
+    })
+    .await
+    .unwrap();
     let finished = tokio::time::timeout(Duration::from_millis(250), finish_rx)
         .await
         .expect("finish should complete after broker connect timeout")
@@ -1060,6 +1078,247 @@ async fn compose_session_cancel_completes_when_broker_unreachable() {
         .await
         .expect("cancel must not hang when the broker is unreachable")
         .unwrap();
+}
+
+#[tokio::test]
+async fn finish_with_matching_expectation_finishes_session() {
+    let stream_id = vec![0x7a; 32];
+    let start_event_id = MessageId::new(vec![0x7b; 32]);
+    let open = test_stream_compose_open(stream_id.clone(), start_event_id.clone());
+    let report = test_stream_compose_report(&stream_id);
+    let (tx, rx) = mpsc::channel(4);
+    let (_cancel_tx, cancel_rx) = mpsc::channel(1);
+    let session = tokio::spawn(run_stream_compose_session(open, 8, rx, cancel_rx, report));
+
+    let (append_tx, append_rx) = oneshot::channel();
+    tx.send(StreamComposeCommand::Append {
+        text: "hello ".to_owned(),
+        respond: append_tx,
+    })
+    .await
+    .unwrap();
+    tokio::time::timeout(Duration::from_millis(250), append_rx)
+        .await
+        .expect("append should complete")
+        .unwrap()
+        .unwrap();
+
+    let expected_hash =
+        expected_stream_transcript_hash_for_appends(&stream_id, &start_event_id, &["hello "], 8);
+    let (finish_tx, finish_rx) = oneshot::channel();
+    tx.send(StreamComposeCommand::Finish {
+        expected: Some(StreamFinishExpectation {
+            final_text: "hello ".to_owned(),
+            transcript_hash_hex: expected_hash.clone(),
+            chunk_count: 1,
+        }),
+        respond: finish_tx,
+    })
+    .await
+    .unwrap();
+    let finished = tokio::time::timeout(Duration::from_millis(250), finish_rx)
+        .await
+        .expect("finish with a matching expectation should complete")
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(finished.status, "finished");
+    assert_eq!(finished.text, "hello ");
+    assert_eq!(finished.chunk_count, 1);
+    assert_eq!(
+        finished.transcript_hash.as_deref(),
+        Some(expected_hash.as_str())
+    );
+
+    session.await.unwrap();
+}
+
+/// Regression for #366: a finish whose expectation does not match the composed
+/// transcript must not tear the session down. The session responds `Err`,
+/// keeps running, still accepts appends, and a corrected finish succeeds.
+#[tokio::test]
+async fn finish_with_mismatched_expectation_keeps_session_alive_and_retryable() {
+    let stream_id = vec![0x8a; 32];
+    let start_event_id = MessageId::new(vec![0x8b; 32]);
+    let open = test_stream_compose_open(stream_id.clone(), start_event_id.clone());
+    let report = test_stream_compose_report(&stream_id);
+    let (tx, rx) = mpsc::channel(4);
+    let (_cancel_tx, cancel_rx) = mpsc::channel(1);
+    let session = tokio::spawn(run_stream_compose_session(open, 8, rx, cancel_rx, report));
+
+    let (append_tx, append_rx) = oneshot::channel();
+    tx.send(StreamComposeCommand::Append {
+        text: "hello ".to_owned(),
+        respond: append_tx,
+    })
+    .await
+    .unwrap();
+    tokio::time::timeout(Duration::from_millis(250), append_rx)
+        .await
+        .expect("append should complete")
+        .unwrap()
+        .unwrap();
+
+    let first_hash =
+        expected_stream_transcript_hash_for_appends(&stream_id, &start_event_id, &["hello "], 8);
+
+    // Wrong chunk count (text and hash correct).
+    let (finish_tx, finish_rx) = oneshot::channel();
+    tx.send(StreamComposeCommand::Finish {
+        expected: Some(StreamFinishExpectation {
+            final_text: "hello ".to_owned(),
+            transcript_hash_hex: first_hash.clone(),
+            chunk_count: 7,
+        }),
+        respond: finish_tx,
+    })
+    .await
+    .unwrap();
+    let mismatch = tokio::time::timeout(Duration::from_millis(250), finish_rx)
+        .await
+        .expect("mismatched finish should respond promptly")
+        .unwrap()
+        .unwrap_err();
+    assert!(
+        mismatch.contains("chunk count"),
+        "expected chunk count mismatch: {mismatch}"
+    );
+
+    // Wrong transcript hash (text and count correct).
+    let (finish_tx, finish_rx) = oneshot::channel();
+    tx.send(StreamComposeCommand::Finish {
+        expected: Some(StreamFinishExpectation {
+            final_text: "hello ".to_owned(),
+            transcript_hash_hex: hex::encode([0u8; 32]),
+            chunk_count: 1,
+        }),
+        respond: finish_tx,
+    })
+    .await
+    .unwrap();
+    let mismatch = tokio::time::timeout(Duration::from_millis(250), finish_rx)
+        .await
+        .expect("mismatched finish should respond promptly")
+        .unwrap()
+        .unwrap_err();
+    assert!(
+        mismatch.contains("transcript hash"),
+        "expected transcript hash mismatch: {mismatch}"
+    );
+
+    // Wrong final text (hash and count correct).
+    let (finish_tx, finish_rx) = oneshot::channel();
+    tx.send(StreamComposeCommand::Finish {
+        expected: Some(StreamFinishExpectation {
+            final_text: "goodbye".to_owned(),
+            transcript_hash_hex: first_hash,
+            chunk_count: 1,
+        }),
+        respond: finish_tx,
+    })
+    .await
+    .unwrap();
+    let mismatch = tokio::time::timeout(Duration::from_millis(250), finish_rx)
+        .await
+        .expect("mismatched finish should respond promptly")
+        .unwrap()
+        .unwrap_err();
+    assert!(
+        mismatch.contains("final text"),
+        "expected final text mismatch: {mismatch}"
+    );
+
+    // The session must still accept appends after the mismatches.
+    let (append_tx, append_rx) = oneshot::channel();
+    tx.send(StreamComposeCommand::Append {
+        text: "world".to_owned(),
+        respond: append_tx,
+    })
+    .await
+    .unwrap();
+    let appended = tokio::time::timeout(Duration::from_millis(250), append_rx)
+        .await
+        .expect("append after mismatched finish should complete")
+        .unwrap()
+        .unwrap();
+    assert_eq!(appended.text, "hello world");
+    assert_eq!(appended.chunk_count, 2);
+
+    // A corrected finish over the full transcript succeeds.
+    let corrected_hash = expected_stream_transcript_hash_for_appends(
+        &stream_id,
+        &start_event_id,
+        &["hello ", "world"],
+        8,
+    );
+    let (finish_tx, finish_rx) = oneshot::channel();
+    tx.send(StreamComposeCommand::Finish {
+        expected: Some(StreamFinishExpectation {
+            final_text: "hello world".to_owned(),
+            transcript_hash_hex: corrected_hash.clone(),
+            chunk_count: 2,
+        }),
+        respond: finish_tx,
+    })
+    .await
+    .unwrap();
+    let finished = tokio::time::timeout(Duration::from_millis(250), finish_rx)
+        .await
+        .expect("corrected finish should complete")
+        .unwrap()
+        .unwrap();
+    assert_eq!(finished.status, "finished");
+    assert_eq!(finished.text, "hello world");
+    assert_eq!(finished.chunk_count, 2);
+    assert_eq!(
+        finished.transcript_hash.as_deref(),
+        Some(corrected_hash.as_str())
+    );
+
+    session.await.unwrap();
+}
+
+/// An empty-transcript finalize must validate against the empty transcript's
+/// actual hash (the report's `transcript_hash` is still `None` before the
+/// first append, so validation has to use the transcript accessors).
+#[tokio::test]
+async fn finish_with_expectation_on_empty_transcript_validates_empty_hash() {
+    let stream_id = vec![0x9c; 32];
+    let start_event_id = MessageId::new(vec![0x9d; 32]);
+    let open = test_stream_compose_open(stream_id.clone(), start_event_id.clone());
+    let report = test_stream_compose_report(&stream_id);
+    let (tx, rx) = mpsc::channel(4);
+    let (_cancel_tx, cancel_rx) = mpsc::channel(1);
+    let session = tokio::spawn(run_stream_compose_session(open, 8, rx, cancel_rx, report));
+
+    let empty_hash =
+        expected_stream_transcript_hash_for_appends(&stream_id, &start_event_id, &[], 8);
+    let (finish_tx, finish_rx) = oneshot::channel();
+    tx.send(StreamComposeCommand::Finish {
+        expected: Some(StreamFinishExpectation {
+            final_text: String::new(),
+            transcript_hash_hex: empty_hash.clone(),
+            chunk_count: 0,
+        }),
+        respond: finish_tx,
+    })
+    .await
+    .unwrap();
+    let finished = tokio::time::timeout(Duration::from_millis(250), finish_rx)
+        .await
+        .expect("empty-transcript finish should complete")
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(finished.status, "finished");
+    assert_eq!(finished.text, "");
+    assert_eq!(finished.chunk_count, 0);
+    assert_eq!(
+        finished.transcript_hash.as_deref(),
+        Some(empty_hash.as_str())
+    );
+
+    session.await.unwrap();
 }
 
 /// Regression for the cancel-starvation bug: a full command queue must not

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -26,7 +26,7 @@ use cgka_traits::ingest::IngestOutcome;
 use cgka_traits::message::{MessageState, StoredMessagePayload};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{LeaveRequest, StorageError, StorageProvider};
-use cgka_traits::transport::TransportMessage;
+use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::MessageId;
 use cgka_traits::types::{EpochId, GroupId, MemberId};
 use marmot_forensics::{
@@ -1464,6 +1464,36 @@ impl<S: StorageProvider> Engine<S> {
     pub fn group_record(&self, group_id: &GroupId) -> Result<Group, EngineError> {
         self.ensure_group_live(group_id)?;
         Ok(self.storage.get_group(group_id)?)
+    }
+
+    /// Return the stored outbound welcome for `id` along with its group.
+    ///
+    /// Wrapped welcomes are persisted at wrap time as `Sent` raw-transport
+    /// records, so a welcome whose publish failed after the commit was already
+    /// confirmed can be re-delivered from storage without re-committing
+    /// (mdk#352). Errors if the id does not resolve to a sent raw-transport
+    /// welcome record.
+    pub fn stored_sent_welcome(
+        &self,
+        id: &MessageId,
+    ) -> Result<(GroupId, TransportMessage), EngineError> {
+        let record = self.storage.get_message(id)?;
+        if record.state != MessageState::Sent {
+            return Err(EngineError::Backend(
+                "stored message is not an outbound sent record".into(),
+            ));
+        }
+        let payload = StoredMessagePayload::decode(&record.payload)
+            .map_err(|e| EngineError::Backend(format!("stored payload decode: {e}")))?;
+        let message = payload.as_raw_transport().ok_or_else(|| {
+            EngineError::Backend("stored message is not a raw transport record".into())
+        })?;
+        if !matches!(message.envelope, TransportEnvelope::Welcome { .. }) {
+            return Err(EngineError::Backend(
+                "stored message is not a welcome".into(),
+            ));
+        }
+        Ok((record.group_id.clone(), message.clone()))
     }
 
     /// Return the current Marmot admin policy keys mirrored from signed MLS

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1332,6 +1332,7 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
+        let stored_proposal_ref = queued.proposal_reference_ref().clone();
         mls_group
             .store_pending_proposal(
                 <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(
@@ -1344,6 +1345,7 @@ impl<S: StorageProvider> Engine<S> {
         let pre_commit_epoch = EpochId(mls_group.epoch().as_u64());
         let mut pending_commit_guard =
             PendingCommitCleanupGuard::arm(&self.storage, &provider, group_id.clone());
+        pending_commit_guard.set_stored_proposal_ref(stored_proposal_ref);
         let recovery_snapshot =
             self.fork_recovery
                 .create_snapshot(&self.storage, group_id, pre_commit_epoch)?;
@@ -1381,13 +1383,6 @@ impl<S: StorageProvider> Engine<S> {
         )?;
 
         let new_epoch = EpochId(pre_commit_epoch.0.saturating_add(1));
-        if let Ok(mut g) = self.storage.get_group(group_id) {
-            g.epoch = new_epoch;
-            g.members
-                .retain(|member| !auto_removed.iter().any(|id| id == &member.id));
-            self.storage.put_group(&g)?;
-        }
-
         let commit_priority = mls_group
             .pending_commit()
             .map(crate::app_components::commit_ordering_priority_for_staged)
@@ -1404,6 +1399,44 @@ impl<S: StorageProvider> Engine<S> {
             crate::epoch_manager::PendingKind::GroupEvolution,
             self.current_audit_context.clone(),
         )?;
+
+        // Project the post-merge record only after every other fallible
+        // staging step has succeeded: a torn record (epoch N+1 with members
+        // dropped while MLS and the state machine stay at N) permanently
+        // strands auto-commit replay, which bails on any epoch mismatch
+        // (mdk#333).
+        if let Ok(mut g) = self.storage.get_group(group_id) {
+            g.epoch = new_epoch;
+            g.members
+                .retain(|member| !auto_removed.iter().any(|id| id == &member.id));
+            if let Err(err) = self.storage.put_group(&g) {
+                // The pending slot was never handed off to a caller, so
+                // `publish_failed` can never reach it — rewind the state
+                // machine here (in-memory, so the storage pressure that
+                // failed the write cannot also defeat the compensation); the
+                // still-armed guard clears the staged OpenMLS commit on the
+                // early return.
+                if self.epoch_manager.rollback_publish(pending_ref).is_err() {
+                    tracing::warn!(
+                        target: "cgka_engine::message_processor",
+                        method = "stage_auto_commit_for_queued_proposal",
+                        "state-machine rollback failed after group record write failure"
+                    );
+                }
+                self.audit_group(
+                    group_id,
+                    crate::audit_helpers::epoch_state_changed_event(
+                        Some("pending_publish"),
+                        "stable",
+                        pre_commit_epoch,
+                        "auto_commit_stage_failed",
+                        Some(pending_ref),
+                        Some("group_evolution"),
+                    ),
+                );
+                return Err(err.into());
+            }
+        }
         self.track_pending_commit_for_recovery(
             pending_ref,
             group_id.clone(),

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1405,37 +1405,42 @@ impl<S: StorageProvider> Engine<S> {
         // dropped while MLS and the state machine stay at N) permanently
         // strands auto-commit replay, which bails on any epoch mismatch
         // (mdk#333).
-        if let Ok(mut g) = self.storage.get_group(group_id) {
+        // Read-then-project as one fallible unit: a failed read is no more
+        // recoverable than a failed write here (both leave the state machine
+        // pending at N+1 with no matching durable record), so both funnel
+        // through the same compensation.
+        let projection = self.storage.get_group(group_id).and_then(|mut g| {
             g.epoch = new_epoch;
             g.members
                 .retain(|member| !auto_removed.iter().any(|id| id == &member.id));
-            if let Err(err) = self.storage.put_group(&g) {
-                // The pending slot was never handed off to a caller, so
-                // `publish_failed` can never reach it — rewind the state
-                // machine here (in-memory, so the storage pressure that
-                // failed the write cannot also defeat the compensation); the
-                // still-armed guard clears the staged OpenMLS commit on the
-                // early return.
-                if self.epoch_manager.rollback_publish(pending_ref).is_err() {
-                    tracing::warn!(
-                        target: "cgka_engine::message_processor",
-                        method = "stage_auto_commit_for_queued_proposal",
-                        "state-machine rollback failed after group record write failure"
-                    );
-                }
-                self.audit_group(
-                    group_id,
-                    crate::audit_helpers::epoch_state_changed_event(
-                        Some("pending_publish"),
-                        "stable",
-                        pre_commit_epoch,
-                        "auto_commit_stage_failed",
-                        Some(pending_ref),
-                        Some("group_evolution"),
-                    ),
+            self.storage.put_group(&g)
+        });
+        if let Err(err) = projection {
+            // The pending slot was never handed off to a caller, so
+            // `publish_failed` can never reach it — rewind the state
+            // machine here (in-memory, so the storage pressure that
+            // failed the read/write cannot also defeat the compensation);
+            // the still-armed guard clears the staged OpenMLS commit on the
+            // early return.
+            if self.epoch_manager.rollback_publish(pending_ref).is_err() {
+                tracing::warn!(
+                    target: "cgka_engine::message_processor",
+                    method = "stage_auto_commit_for_queued_proposal",
+                    "state-machine rollback failed after group record projection failure"
                 );
-                return Err(err.into());
             }
+            self.audit_group(
+                group_id,
+                crate::audit_helpers::epoch_state_changed_event(
+                    Some("pending_publish"),
+                    "stable",
+                    pre_commit_epoch,
+                    "auto_commit_stage_failed",
+                    Some(pending_ref),
+                    Some("group_evolution"),
+                ),
+            );
+            return Err(err.into());
         }
         self.track_pending_commit_for_recovery(
             pending_ref,

--- a/crates/cgka-engine/src/pending_commit_guard.rs
+++ b/crates/cgka-engine/src/pending_commit_guard.rs
@@ -30,7 +30,8 @@
 use crate::provider::EngineOpenMlsProvider;
 use cgka_traits::storage::{StorageError, StorageProvider};
 use cgka_traits::types::GroupId;
-use openmls::group::MlsGroup;
+use openmls::ciphersuite::hash_ref::ProposalRef;
+use openmls::group::{MlsGroup, RemoveProposalError};
 use openmls_traits::OpenMlsProvider as _;
 
 const TRACE_TARGET: &str = "cgka_engine::pending_commit_guard";
@@ -53,6 +54,10 @@ pub(crate) struct PendingCommitCleanupGuard<S: StorageProvider> {
     // caller created one. `None` for paths that stage a commit without a
     // snapshot (e.g. group creation).
     snapshot_name: Option<String>,
+    // Proposal this staging attempt stored via `store_pending_proposal`, to
+    // remove from the OpenMLS proposal store on Drop. `None` for the send
+    // paths, which commit proposals they did not store themselves.
+    stored_proposal_ref: Option<ProposalRef>,
     armed: bool,
 }
 
@@ -72,6 +77,7 @@ impl<S: StorageProvider> PendingCommitCleanupGuard<S> {
             mls_storage: provider.storage() as *const S::Mls,
             group_id,
             snapshot_name: None,
+            stored_proposal_ref: None,
             armed: true,
         }
     }
@@ -81,6 +87,15 @@ impl<S: StorageProvider> PendingCommitCleanupGuard<S> {
     /// immediately after `ForkRecoveryManager::create_snapshot` succeeds.
     pub(crate) fn set_snapshot(&mut self, snapshot_name: String) {
         self.snapshot_name = Some(snapshot_name);
+    }
+
+    /// Attach the reference of a proposal the guarded path stored via
+    /// `store_pending_proposal`, so `Drop` restores the proposal store to its
+    /// pre-attempt state. A stale stored proposal is not benign residue:
+    /// OpenMLS 0.8.1 panics when a later `remove_members` commit filters a
+    /// leftover SelfRemove proposal against a Remove for the same leaf.
+    pub(crate) fn set_stored_proposal_ref(&mut self, proposal_ref: ProposalRef) {
+        self.stored_proposal_ref = Some(proposal_ref);
     }
 
     /// The staged commit (and its snapshot) is now tracked by `EpochManager`
@@ -111,8 +126,30 @@ impl<S: StorageProvider> Drop for PendingCommitCleanupGuard<S> {
         // is still orphaned would strand that commit with no recovery path —
         // strictly worse than the bounded leak this guard exists to prevent.
         let mls_gid = openmls::group::GroupId::from_slice(self.group_id.as_slice());
-        let pending_commit_cleared = match MlsGroup::load(mls_storage, &mls_gid) {
-            Ok(Some(mut mls_group)) => {
+        let mut loaded_group = match MlsGroup::load(mls_storage, &mls_gid) {
+            Ok(Some(mls_group)) => Some(mls_group),
+            Ok(None) => {
+                // No group to clear a pending commit from. We cannot confirm
+                // the staged commit is gone, so treat cleanup as unconfirmed
+                // and retain the snapshot.
+                tracing::warn!(
+                    target: TRACE_TARGET,
+                    method = "drop",
+                    "pending commit guard found no group for cleanup"
+                );
+                None
+            }
+            Err(_e) => {
+                tracing::warn!(
+                    target: TRACE_TARGET,
+                    method = "drop",
+                    "pending commit guard could not load group for cleanup"
+                );
+                None
+            }
+        };
+        let pending_commit_cleared = match loaded_group.as_mut() {
+            Some(mls_group) => {
                 if mls_group.pending_commit().is_none() {
                     true
                 } else {
@@ -135,26 +172,28 @@ impl<S: StorageProvider> Drop for PendingCommitCleanupGuard<S> {
                     }
                 }
             }
-            Ok(None) => {
-                // No group to clear a pending commit from. We cannot confirm
-                // the staged commit is gone, so treat cleanup as unconfirmed
-                // and retain the snapshot.
-                tracing::warn!(
-                    target: TRACE_TARGET,
-                    method = "drop",
-                    "pending commit guard found no group for cleanup"
-                );
-                false
-            }
-            Err(_e) => {
-                tracing::warn!(
-                    target: TRACE_TARGET,
-                    method = "drop",
-                    "pending commit guard could not load group for cleanup"
-                );
-                false
-            }
+            None => false,
         };
+
+        // Restore the proposal store to its pre-attempt state when this path
+        // stored the proposal itself. Best-effort and independent of the
+        // snapshot decision below: a proposal that is already gone is benign
+        // (`clear_pending_commit` does not remove stored proposals, but a
+        // concurrent merge would have consumed it).
+        if let (Some(mls_group), Some(proposal_ref)) =
+            (loaded_group.as_mut(), self.stored_proposal_ref.as_ref())
+        {
+            match mls_group.remove_pending_proposal(mls_storage, proposal_ref) {
+                Ok(()) | Err(RemoveProposalError::ProposalNotFound) => {}
+                Err(_e) => {
+                    tracing::warn!(
+                        target: TRACE_TARGET,
+                        method = "drop",
+                        "pending commit guard could not remove stored proposal"
+                    );
+                }
+            }
+        }
 
         // Release the pre-commit fork-recovery snapshot only after confirming
         // the staged pending commit is gone, mirroring

--- a/crates/cgka-engine/tests/AGENTS.md
+++ b/crates/cgka-engine/tests/AGENTS.md
@@ -61,6 +61,10 @@ backend on the same rail.
   - **Owns:** Crash-during-publish recovery at session open — `hydrate_stable_groups_from_storage` detects a surviving
     `PendingCommit`, clears it, and surfaces `GroupEvent::PendingCommitRecovered` (mdk#150)
 
+- **File:** `auto_commit_atomicity.rs`
+  - **Owns:** Auto-commit staging atomicity (mdk#333) — an injected `put_group` failure during staging leaves no torn
+    group record, no orphaned pending publish, no leaked snapshot, and no stale stored proposal; the group stays usable
+
 - **File:** `hydration_quarantine.rs`
   - **Owns:** Group hydration-quarantine path — `GroupHydrationQuarantineReason` classification on session open
 

--- a/crates/cgka-engine/tests/auto_commit_atomicity.rs
+++ b/crates/cgka-engine/tests/auto_commit_atomicity.rs
@@ -1,0 +1,496 @@
+//! Auto-commit staging atomicity (mdk#333).
+//!
+//! `stage_auto_commit_for_queued_proposal` projects the post-merge group
+//! record (epoch N+1, leaver dropped) as part of staging. If any fallible
+//! staging step fails after durable state has advanced, the record must not
+//! be left torn — epoch/membership disagreeing with the MLS group and the
+//! epoch state machine strands auto-commit replay (which bails on any epoch
+//! mismatch) and forks the rendered member list from reality.
+//!
+//! The staging path orders the record write after `begin_pending` and
+//! compensates a failed `put_group` by rewinding the state machine, with the
+//! armed `PendingCommitCleanupGuard` clearing the staged OpenMLS commit on
+//! the early return. This test injects a one-shot `put_group` failure at
+//! exactly that point and asserts nothing is torn and the group stays usable.
+
+use async_trait::async_trait;
+use cgka_engine::EngineBuilder;
+use cgka_engine::feature_registry::FeatureRegistry;
+use cgka_traits::capabilities::{
+    Capability, CapabilityRequirement, Feature, GroupCapabilities, RequirementLevel,
+};
+use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult};
+use cgka_traits::error::PeelerError;
+use cgka_traits::group::{Group, Member};
+use cgka_traits::group_context::GroupContextSnapshot;
+use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage};
+use cgka_traits::message::{MessageRecord, MessageState};
+use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::storage::{
+    AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
+    ConvergencePolicyStorage, GroupStorage, LeaveRequest, LeaveRequestStorage,
+    MemberValidationCacheStorage, MessageStorage, OutboundIntentStorage, QueuedOutboundIntent,
+    StorageError, StorageProvider, StorageResult, WelcomeStorage,
+};
+use cgka_traits::transport::{
+    EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
+};
+use cgka_traits::types::{Backend, EpochId, GroupId, MemberId, MessageId};
+use cgka_traits::welcome::PendingWelcome;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use storage_sqlite::SqliteAccountStorage;
+
+mod support;
+use support::proof_signer;
+
+fn pad32(name: &[u8]) -> Vec<u8> {
+    use k256::schnorr::SigningKey;
+    use sha2::{Digest, Sha256};
+    let mut counter = 0u64;
+    loop {
+        let mut material = [0u8; 32];
+        let mut hasher = Sha256::new();
+        hasher.update(b"cgka-engine-test-identity-v1");
+        hasher.update(name);
+        hasher.update(counter.to_be_bytes());
+        material.copy_from_slice(&hasher.finalize());
+        if let Ok(sk) = SigningKey::from_bytes(&material) {
+            return sk.verifying_key().to_bytes().to_vec();
+        }
+        counter += 1;
+    }
+}
+
+fn hash_id(bytes: &[u8]) -> MessageId {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    bytes.hash(&mut h);
+    MessageId::new(h.finish().to_be_bytes().to_vec())
+}
+
+struct MockPeeler;
+
+#[async_trait]
+impl TransportPeeler for MockPeeler {
+    async fn peel_group_message(
+        &self,
+        msg: &TransportMessage,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        Ok(PeeledMessage {
+            id: msg.id.clone(),
+            group_id: None,
+            sender: None,
+            content: PeeledContent::MlsMessage {
+                bytes: msg.payload.clone(),
+            },
+            origin: msg.clone(),
+        })
+    }
+
+    async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        Ok(PeeledMessage {
+            id: msg.id.clone(),
+            group_id: None,
+            sender: None,
+            content: PeeledContent::Welcome {
+                bytes: msg.payload.clone(),
+            },
+            origin: msg.clone(),
+        })
+    }
+
+    async fn wrap_group_message(
+        &self,
+        payload: &EncryptedPayload,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        Ok(TransportMessage {
+            id: hash_id(&payload.ciphertext),
+            payload: payload.ciphertext.clone(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("auto-commit-atomicity".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: vec![],
+            },
+        })
+    }
+
+    async fn wrap_welcome(
+        &self,
+        payload: &EncryptedPayload,
+        recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        Ok(TransportMessage {
+            id: hash_id(&payload.ciphertext),
+            payload: payload.ciphertext.clone(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("auto-commit-atomicity".into()),
+            envelope: TransportEnvelope::Welcome {
+                recipient: recipient.clone(),
+            },
+        })
+    }
+}
+
+/// Feature registry advertising MIP-03 SelfRemove so the auto-committer fires
+/// on a peer's leave proposal.
+fn selfremove_registry() -> FeatureRegistry {
+    let mut r = FeatureRegistry::new();
+    r.register(
+        Feature("self-remove"),
+        CapabilityRequirement {
+            requires: Capability::Proposal(10),
+            level: RequirementLevel::Required,
+            description: "MIP-03",
+        },
+    );
+    r
+}
+
+/// Shared, arm-able fault switch: while armed, the next `put_group` fails
+/// with `StorageError::Busy` once per armed count, then disarms.
+#[derive(Clone, Default)]
+struct PutGroupFault(Arc<AtomicUsize>);
+
+impl PutGroupFault {
+    fn arm(&self, times: usize) {
+        self.0.store(times, Ordering::SeqCst);
+    }
+
+    /// True (consuming one armed count) if this call should fail.
+    fn should_fail(&self) -> bool {
+        self.0
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+    }
+}
+
+/// `SqliteAccountStorage` wrapper that injects a transient `Busy` on
+/// `put_group`. Every other call delegates unchanged.
+struct FaultStorage {
+    inner: SqliteAccountStorage,
+    fault: PutGroupFault,
+}
+
+impl GroupStorage for FaultStorage {
+    fn put_group(&self, group: &Group) -> StorageResult<()> {
+        if self.fault.should_fail() {
+            return Err(StorageError::Busy("injected put_group failure".into()));
+        }
+        self.inner.put_group(group)
+    }
+    fn get_group(&self, id: &GroupId) -> StorageResult<Group> {
+        self.inner.get_group(id)
+    }
+    fn delete_group(&self, id: &GroupId) -> StorageResult<()> {
+        self.inner.delete_group(id)
+    }
+    fn list_groups(&self) -> StorageResult<Vec<GroupId>> {
+        self.inner.list_groups()
+    }
+}
+
+impl MessageStorage for FaultStorage {
+    fn put_message(&self, record: &MessageRecord) -> StorageResult<()> {
+        self.inner.put_message(record)
+    }
+    fn get_message(&self, id: &MessageId) -> StorageResult<MessageRecord> {
+        self.inner.get_message(id)
+    }
+    fn update_message_state(&self, id: &MessageId, new_state: MessageState) -> StorageResult<()> {
+        self.inner.update_message_state(id, new_state)
+    }
+    fn list_messages(
+        &self,
+        group_id: &GroupId,
+        at_or_after_epoch: EpochId,
+    ) -> StorageResult<Vec<MessageRecord>> {
+        self.inner.list_messages(group_id, at_or_after_epoch)
+    }
+    fn create_group_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()> {
+        self.inner.create_group_snapshot(group_id, name)
+    }
+    fn list_group_snapshots(&self, group_id: &GroupId) -> StorageResult<Vec<String>> {
+        self.inner.list_group_snapshots(group_id)
+    }
+    fn rollback_group_to_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()> {
+        self.inner.rollback_group_to_snapshot(group_id, name)
+    }
+    fn release_group_snapshot(&self, group_id: &GroupId, name: &str) -> StorageResult<()> {
+        self.inner.release_group_snapshot(group_id, name)
+    }
+}
+
+impl OutboundIntentStorage for FaultStorage {
+    fn put_queued_outbound_intent(&self, record: &QueuedOutboundIntent) -> StorageResult<()> {
+        self.inner.put_queued_outbound_intent(record)
+    }
+    fn list_queued_outbound_intents(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Vec<QueuedOutboundIntent>> {
+        self.inner.list_queued_outbound_intents(group_id)
+    }
+    fn delete_queued_outbound_intent(&self, id: &MessageId) -> StorageResult<()> {
+        self.inner.delete_queued_outbound_intent(id)
+    }
+}
+
+impl LeaveRequestStorage for FaultStorage {
+    fn put_leave_request(&self, request: &LeaveRequest) -> StorageResult<()> {
+        self.inner.put_leave_request(request)
+    }
+    fn leave_request(&self, group_id: &GroupId) -> StorageResult<Option<LeaveRequest>> {
+        self.inner.leave_request(group_id)
+    }
+    fn clear_leave_request(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.inner.clear_leave_request(group_id)
+    }
+}
+
+impl WelcomeStorage for FaultStorage {
+    fn put_welcome(&self, welcome: &PendingWelcome) -> StorageResult<()> {
+        self.inner.put_welcome(welcome)
+    }
+    fn take_welcome(&self, id: &MessageId) -> StorageResult<PendingWelcome> {
+        self.inner.take_welcome(id)
+    }
+    fn list_welcomes(&self) -> StorageResult<Vec<PendingWelcome>> {
+        self.inner.list_welcomes()
+    }
+}
+
+impl CapabilityStorage for FaultStorage {
+    fn register_feature(&self, feature: Feature, req: CapabilityRequirement) -> StorageResult<()> {
+        self.inner.register_feature(feature, req)
+    }
+    fn feature_requirement(
+        &self,
+        feature: &Feature,
+    ) -> StorageResult<Option<CapabilityRequirement>> {
+        self.inner.feature_requirement(feature)
+    }
+    fn save_member_capabilities(
+        &self,
+        group_id: &GroupId,
+        member: &Member,
+        capabilities: GroupCapabilities,
+    ) -> StorageResult<()> {
+        self.inner
+            .save_member_capabilities(group_id, member, capabilities)
+    }
+    fn member_capabilities(
+        &self,
+        group_id: &GroupId,
+        member_id: &MemberId,
+    ) -> StorageResult<Option<GroupCapabilities>> {
+        self.inner.member_capabilities(group_id, member_id)
+    }
+}
+
+impl ConvergencePolicyStorage for FaultStorage {
+    fn put_convergence_policy(&self, group_id: &GroupId, policy: &[u8]) -> StorageResult<()> {
+        self.inner.put_convergence_policy(group_id, policy)
+    }
+    fn convergence_policy(&self, group_id: &GroupId) -> StorageResult<Option<Vec<u8>>> {
+        self.inner.convergence_policy(group_id)
+    }
+}
+
+impl MemberValidationCacheStorage for FaultStorage {
+    fn put_validated_tree_marker(&self, group_id: &GroupId, marker: &[u8]) -> StorageResult<()> {
+        self.inner.put_validated_tree_marker(group_id, marker)
+    }
+    fn validated_tree_marker(&self, group_id: &GroupId) -> StorageResult<Option<Vec<u8>>> {
+        self.inner.validated_tree_marker(group_id)
+    }
+}
+
+impl AccountDeviceSignerStorage for FaultStorage {
+    fn put_account_device_signer(&self, binding: &AccountDeviceSignerBinding) -> StorageResult<()> {
+        self.inner.put_account_device_signer(binding)
+    }
+    fn account_device_signer(
+        &self,
+        marmot_identity: &MemberId,
+    ) -> StorageResult<Option<AccountDeviceSignerBinding>> {
+        self.inner.account_device_signer(marmot_identity)
+    }
+}
+
+impl StorageProvider for FaultStorage {
+    type Mls = <SqliteAccountStorage as StorageProvider>::Mls;
+
+    fn mls_storage(&self) -> &Self::Mls {
+        self.inner.mls_storage()
+    }
+
+    fn with_transaction<T, E, F>(&self, f: F) -> Result<T, E>
+    where
+        Self: Sized,
+        E: From<StorageError>,
+        F: FnOnce(&Self) -> Result<T, E>,
+    {
+        // Drive the real SQLite BEGIN/COMMIT on the inner connection, but run
+        // the closure against the wrapper so its (delegating, fault-injecting)
+        // writes join the same transaction and roll back together.
+        self.inner.with_transaction(|_inner| f(self))
+    }
+
+    fn backend(&self) -> Backend {
+        self.inner.backend()
+    }
+}
+
+/// Returns the engine plus a storage handle sharing the same underlying
+/// connection, so the test can read durable state out-of-band.
+fn build_fault_selfremove_client(
+    id: &[u8],
+    fault: PutGroupFault,
+) -> (cgka_engine::Engine<FaultStorage>, SqliteAccountStorage) {
+    let inner = SqliteAccountStorage::in_memory().unwrap();
+    let handle = inner.clone();
+    let engine = EngineBuilder::new(FaultStorage { inner, fault })
+        .identity(pad32(id))
+        .account_identity_proof_signer(proof_signer(id))
+        .feature_registry(selfremove_registry())
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .unwrap();
+    (engine, handle)
+}
+
+fn build_selfremove_client(identity: &[u8]) -> cgka_engine::Engine<SqliteAccountStorage> {
+    EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
+        .identity(pad32(identity))
+        .account_identity_proof_signer(proof_signer(identity))
+        .feature_registry(selfremove_registry())
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .expect("build engine")
+}
+
+/// A `put_group` failure during auto-commit staging must leave no torn group
+/// record (mdk#333): the record stays at the pre-stage epoch with all members,
+/// no orphaned pending publish or leaked snapshot survives, and the group
+/// remains usable for a fresh commit.
+#[tokio::test]
+async fn auto_commit_record_write_failure_leaves_no_torn_group_record() {
+    let fault = PutGroupFault::default();
+    let (mut alice, handle) = build_fault_selfremove_client(b"alice-aca", fault.clone());
+    let mut bob = build_selfremove_client(b"bob-aca");
+    let mut carol = build_selfremove_client(b"carol-aca");
+    let bob_member_id = bob.self_id();
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "aca".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let welcome_for_bob = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            welcomes.remove(0)
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcome_for_bob).await.unwrap();
+    assert_eq!(alice.epoch(&group_id).unwrap(), EpochId(1));
+    assert_eq!(alice.members(&group_id).unwrap().len(), 3);
+
+    // Bob (non-admin) leaves → SelfRemove proposal; alice (remaining
+    // non-target member) schedules the delayed auto-commit on ingest.
+    let proposal = match bob
+        .send(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::Proposal { msg } => msg,
+        other => panic!("expected Proposal, got {other:?}"),
+    };
+    let routed = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..proposal
+    };
+    let outcome = alice.ingest(routed).await.unwrap();
+    assert!(matches!(outcome, IngestOutcome::Processed));
+    assert!(alice.drain_auto_publish().is_empty());
+    tokio::time::sleep(std::time::Duration::from_millis(75)).await;
+
+    let snapshot_baseline = handle.list_group_snapshots(&group_id).unwrap().len();
+
+    // The due auto-commit stages on the convergence tick; fail exactly the
+    // record projection's `put_group` (every staging step before it has
+    // succeeded by then, including `begin_pending`).
+    fault.arm(1);
+    let staged = alice.advance_convergence(&group_id).await;
+    assert!(
+        staged.is_err(),
+        "injected put_group failure must surface, got {staged:?}"
+    );
+
+    // No torn record: epoch and membership are unchanged...
+    let record = handle.get_group(&group_id).unwrap();
+    assert_eq!(record.epoch, EpochId(1), "record epoch must not advance");
+    assert_eq!(record.members.len(), 3, "no member may be dropped");
+    assert!(
+        record.members.iter().any(|m| m.id == bob_member_id),
+        "bob must survive the failed staging"
+    );
+
+    // ...no orphaned pending publish escaped, and the cleanup guard released
+    // the pre-commit recovery snapshot (fault is one-shot, so the guard's own
+    // cleanup writes succeed).
+    assert!(alice.drain_auto_publish().is_empty());
+    assert_eq!(
+        handle.list_group_snapshots(&group_id).unwrap().len(),
+        snapshot_baseline,
+        "recovery snapshot must be released on the failed staging"
+    );
+
+    // The group stays fully usable: the state machine rewound to Stable, the
+    // staged OpenMLS commit was cleared, AND the stored SelfRemove proposal
+    // was removed from the proposal store (left behind, OpenMLS 0.8.1 panics
+    // when this remove_members filters it against the Remove for bob's
+    // leaf). A fresh commit stages, confirms, and lands. (The failed attempt
+    // consumed bob's scheduled auto-commit — schedule removal precedes
+    // replay by design — so the admin completes the removal explicitly.)
+    let evolution = alice
+        .send(SendIntent::RemoveMembers {
+            group_id: group_id.clone(),
+            members: vec![bob_member_id.clone()],
+        })
+        .await
+        .unwrap();
+    let pending = match evolution {
+        SendResult::GroupEvolution { pending, .. } => pending,
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    let record = handle.get_group(&group_id).unwrap();
+    assert_eq!(record.epoch, EpochId(2));
+    assert_eq!(record.members.len(), 2);
+    assert!(!record.members.iter().any(|m| m.id == bob_member_id));
+}

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -270,6 +270,16 @@ impl AccountDeviceSession {
         Ok(self.engine.group_record(group_id)?)
     }
 
+    /// The stored outbound welcome for `id` along with its group, for
+    /// re-delivering a welcome whose publish failed after the commit was
+    /// already confirmed (mdk#352).
+    pub fn stored_sent_welcome(
+        &self,
+        id: &MessageId,
+    ) -> SessionResult<(GroupId, TransportMessage)> {
+        Ok(self.engine.stored_sent_welcome(id)?)
+    }
+
     /// Stored groups that failed session-open hydration and were skipped
     /// (mdk#151 / #417), paired with their coarse quarantine reason.
     /// Backs the application's per-group recovery surface (mdk#426).

--- a/crates/cli/src/daemon/runtime_host.rs
+++ b/crates/cli/src/daemon/runtime_host.rs
@@ -660,6 +660,10 @@ pub(crate) async fn handle_app_runtime_event(
         marmot_app::MarmotAppEvent::AccountError(error) => {
             record_runtime_activity_error(&state, account_error_activity_message(&error));
         }
+        // A confirmed create/invite queued a welcome for re-delivery (mdk#352).
+        // The durable record + `redeliver_welcome` handle the repair; this
+        // daemon activity path has no runtime-summary shape to record for it.
+        marmot_app::MarmotAppEvent::WelcomeDeliveryPending { .. } => {}
     }
 }
 

--- a/crates/cli/src/daemon/stream_workers.rs
+++ b/crates/cli/src/daemon/stream_workers.rs
@@ -625,6 +625,14 @@ pub(crate) async fn finish_stream_compose(
             format!("no active stream compose session for {stream_id}"),
         );
     };
+    // `expected: None` deliberately skips the transcript cross-check the
+    // connector performs. The connector validates because a remote agent
+    // supplies its own final_text/hash/chunk over the control protocol, which
+    // can disagree with the compose task's accumulated transcript. The daemon
+    // has no such independent claim: `finish_stream_compose` derives the final
+    // marker entirely from the compose task's own report below, so there is
+    // nothing to validate it against — the compose task is the single source of
+    // truth for the transcript here.
     let (respond, response) = oneshot::channel();
     if tx
         .send(StreamComposeCommand::Finish {

--- a/crates/cli/src/daemon/stream_workers.rs
+++ b/crates/cli/src/daemon/stream_workers.rs
@@ -81,6 +81,12 @@ pub(crate) struct StreamComposeSession {
     pub(crate) tx: mpsc::Sender<StreamComposeCommand>,
     pub(crate) cancel_tx: mpsc::Sender<()>,
     pub(crate) handle: JoinHandle<()>,
+    /// Set once the compose task has produced its final report and exited via
+    /// `Finish`. The compose task is then gone, but the durable finish-marker
+    /// publish that follows can still fail; the retained report lets a re-issued
+    /// `stream finish` retry that publish without the (dead) compose task, so a
+    /// transient error never strands the transcript (#366).
+    pub(crate) finalized: Option<StreamComposeReport>,
 }
 
 pub(crate) async fn start_stream_watch(
@@ -522,6 +528,7 @@ pub(crate) async fn open_stream_compose(
             tx,
             cancel_tx,
             handle,
+            finalized: None,
         },
     );
     daemon_output(
@@ -589,9 +596,28 @@ pub(crate) async fn finish_stream_compose(
         Err(err) => return daemon_error(cli.json, "stream_compose_failed", err.to_string()),
     };
     let key = stream_compose_key(cli.account.as_deref(), &stream_id);
-    // Keep the session in the workers map until the MLS finish marker is durably
-    // published below. Borrow only the command sender (clonable) so the session
-    // entry stays intact and the transcript stays retryable if the marker fails.
+
+    // Retry fast-path: a prior finish already produced and froze the final
+    // report, but the durable marker publish below failed. The compose task has
+    // exited, so re-run the marker publish directly from the retained report
+    // instead of sending `Finish` to a closed channel.
+    if let Some(report) = workers
+        .get(&key)
+        .and_then(|session| session.finalized.clone())
+    {
+        return finish_stream_marker_from_report(
+            cli,
+            defaults,
+            state,
+            events,
+            runtime_host,
+            workers,
+            &key,
+            report,
+        )
+        .await;
+    }
+
     let Some(tx) = workers.get(&key).map(|session| session.tx.clone()) else {
         return daemon_error(
             cli.json,
@@ -626,6 +652,48 @@ pub(crate) async fn finish_stream_compose(
             "stream compose text is empty".to_owned(),
         );
     }
+    if report.transcript_hash.is_none() {
+        return daemon_error(
+            cli.json,
+            "stream_compose_failed",
+            "stream compose did not return a transcript hash".to_owned(),
+        );
+    }
+
+    // The compose task has now exited. Freeze the final report on the still
+    // registered session so a marker-publish failure below leaves a retryable
+    // finish that no longer needs the (dead) compose task.
+    if let Some(session) = workers.sessions.get_mut(&key) {
+        session.finalized = Some(report.clone());
+    }
+    finish_stream_marker_from_report(
+        cli,
+        defaults,
+        state,
+        events,
+        runtime_host,
+        workers,
+        &key,
+        report,
+    )
+    .await
+}
+
+/// Publish the durable MLS finish marker for an already-composed final report,
+/// and drop the session only once that publish succeeds. On failure the session
+/// stays in the map with its frozen report so a re-issued `stream finish`
+/// retries this step without the exited compose task (#366).
+#[allow(clippy::too_many_arguments)]
+async fn finish_stream_marker_from_report(
+    cli: &Cli,
+    defaults: &DaemonDefaults,
+    state: Arc<Mutex<DaemonState>>,
+    events: DaemonEventHub,
+    runtime_host: &mut AppRuntimeHost,
+    workers: &mut StreamComposeWorkers,
+    key: &str,
+    report: StreamComposeReport,
+) -> CliOutput {
     let Some(transcript_hash) = report.transcript_hash.clone() else {
         return daemon_error(
             cli.json,
@@ -649,12 +717,12 @@ pub(crate) async fn finish_stream_compose(
     if let Err(err) =
         run_hosted_stream_marker_cli_json(&finish_cli, defaults, state, events, runtime_host).await
     {
-        // The finish marker did not publish: leave the session in the workers
-        // map so the transcript can be retried instead of being lost.
+        // The finish marker did not publish: leave the (now finalized) session
+        // in the workers map so the transcript can be retried instead of lost.
         return daemon_error(cli.json, "stream_compose_failed", err);
     }
     // Marker published: now it is safe to drop the session.
-    workers.remove(&key);
+    workers.remove(key);
     daemon_output(
         cli.json,
         &format!("finished stream {}", short_id(&report.stream_id)),

--- a/crates/cli/src/daemon/stream_workers.rs
+++ b/crates/cli/src/daemon/stream_workers.rs
@@ -601,7 +601,10 @@ pub(crate) async fn finish_stream_compose(
     };
     let (respond, response) = oneshot::channel();
     if tx
-        .send(StreamComposeCommand::Finish { respond })
+        .send(StreamComposeCommand::Finish {
+            expected: None,
+            respond,
+        })
         .await
         .is_err()
     {

--- a/crates/cli/src/daemon/tests.rs
+++ b/crates/cli/src/daemon/tests.rs
@@ -317,9 +317,12 @@ async fn stream_compose_returns_local_transcript_when_broker_connect_is_pending(
     assert_eq!(appended.chunk_count, 1);
 
     let (finish_tx, finish_rx) = oneshot::channel();
-    tx.send(StreamComposeCommand::Finish { respond: finish_tx })
-        .await
-        .unwrap();
+    tx.send(StreamComposeCommand::Finish {
+        expected: None,
+        respond: finish_tx,
+    })
+    .await
+    .unwrap();
     let finished = tokio::time::timeout(Duration::from_millis(250), finish_rx)
         .await
         .expect("finish should use local transcript fallback")
@@ -363,9 +366,12 @@ async fn stream_compose_final_report_contains_full_transcript_text() {
     }
 
     let (respond, response) = oneshot::channel();
-    tx.send(StreamComposeCommand::Finish { respond })
-        .await
-        .unwrap();
+    tx.send(StreamComposeCommand::Finish {
+        expected: None,
+        respond,
+    })
+    .await
+    .unwrap();
     let finished = tokio::time::timeout(Duration::from_millis(250), response)
         .await
         .expect("finish should complete")
@@ -865,7 +871,7 @@ fn stub_compose_session(stream_id: &str) -> StreamComposeSession {
         // Minimal stand-in for the compose worker: answer a single Finish with a
         // completed report, then exit like the real session does.
         while let Some(command) = rx.recv().await {
-            if let StreamComposeCommand::Finish { respond } = command {
+            if let StreamComposeCommand::Finish { respond, .. } = command {
                 let _ = respond.send(Ok(report.clone()));
                 return;
             }

--- a/crates/cli/src/daemon/tests.rs
+++ b/crates/cli/src/daemon/tests.rs
@@ -881,6 +881,7 @@ fn stub_compose_session(stream_id: &str) -> StreamComposeSession {
         tx,
         cancel_tx,
         handle,
+        finalized: None,
     }
 }
 
@@ -919,8 +920,8 @@ async fn finish_stream_compose_keeps_session_when_marker_publish_fails() {
     let output = finish_stream_compose(
         &cli,
         &defaults,
-        state,
-        events,
+        state.clone(),
+        events.clone(),
         &mut runtime_host,
         &mut workers,
         stream_id,
@@ -934,6 +935,44 @@ async fn finish_stream_compose_keeps_session_when_marker_publish_fails() {
     assert!(
         workers.get(&key).is_some(),
         "the compose session must be retained so the transcript stays retryable"
+    );
+    // The final report must be frozen on the session so a retry no longer needs
+    // the compose task (which exits after answering `Finish`).
+    assert!(
+        workers
+            .get(&key)
+            .and_then(|session| session.finalized.as_ref())
+            .is_some(),
+        "the finalized report must be retained for a marker retry"
+    );
+
+    // Retry `stream finish`: the compose task has exited, so the previous code
+    // would send `Finish` to a closed channel and fail with
+    // "stream compose session is closed". With the frozen report, the retry
+    // re-runs the marker publish directly — it still fails here (no runtime),
+    // but with the marker error, proving the dead compose task was not touched.
+    let retry = finish_stream_compose(
+        &cli,
+        &defaults,
+        state,
+        events,
+        &mut runtime_host,
+        &mut workers,
+        stream_id,
+    )
+    .await;
+    assert_ne!(
+        retry.code, 0,
+        "the marker still cannot publish without a runtime"
+    );
+    assert!(
+        !retry.stdout.contains("stream compose session is closed"),
+        "the retry must use the frozen report, not the exited compose task: {}",
+        retry.stdout
+    );
+    assert!(
+        workers.get(&key).is_some(),
+        "a failed marker retry must keep the session for a further retry"
     );
 }
 

--- a/crates/marmot-account/src/lib.rs
+++ b/crates/marmot-account/src/lib.rs
@@ -22,6 +22,6 @@ pub use key_package::{
 pub use routing::{StaticTransportRouting, TransportRoutingError, TransportRoutingPolicy};
 pub use runtime::{
     AccountDeviceEffects, AccountDeviceRuntime, AccountIngestEffects, PendingResolution,
-    PublishFailure,
+    PublishFailure, WelcomeDeliveryFailure,
 };
 pub use secret_store::{AccountSecretStore, KeychainSecretStore, LocalFileSecretStore};

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -16,8 +16,8 @@ use cgka_traits::group::{Group, Member};
 use cgka_traits::ingest::IngestOutcome;
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::{
-    EpochId, GroupId, Timestamp, TransportAccountActivation, TransportAdapter, TransportDelivery,
-    TransportGroupSync, TransportPublishReport, TransportPublishRequest,
+    EpochId, GroupId, MemberId, Timestamp, TransportAccountActivation, TransportAdapter,
+    TransportDelivery, TransportGroupSync, TransportPublishReport, TransportPublishRequest,
 };
 use marmot_forensics::{
     AuditEventContext, AuditEventKind, AuditTransportWire, MessageArtifactKind, PublishRelayFailure,
@@ -477,10 +477,22 @@ where
     ) -> AccountResult<()> {
         let mut all_published = true;
         let mut any_welcome_exposed = false;
+        let mut welcome_failures = Vec::new();
         for welcome in welcomes {
+            let recipient = welcome_recipient(&welcome);
+            let welcome_id = welcome.id.clone();
+            let failures_before = output.failures.len();
             let status = self.publish_one(welcome, output, context.clone()).await?;
             any_welcome_exposed |= status.accepted_by_any_endpoint;
             if !status.met_required_acks {
+                if let Some(recipient) = recipient {
+                    welcome_failures.push(self.welcome_delivery_failure(
+                        welcome_id,
+                        recipient,
+                        output,
+                        failures_before,
+                    ));
+                }
                 all_published = false;
                 if !any_welcome_exposed {
                     break;
@@ -494,6 +506,10 @@ where
                 .pending
                 .push(PendingResolution::Confirmed { pending });
             output.absorb_session_effects(effects, queue);
+            // Only a confirmed create leaves welcomes worth re-delivering; a
+            // rolled-back create discards the whole evolution, welcomes
+            // included.
+            output.welcome_failures.extend(welcome_failures);
         } else {
             let effects = self.session.publish_failed(pending).await?;
             output
@@ -526,7 +542,23 @@ where
             output.absorb_session_effects(effects, queue);
 
             for welcome in welcomes {
-                self.publish_one(welcome, output, context.clone()).await?;
+                let recipient = welcome_recipient(&welcome);
+                let welcome_id = welcome.id.clone();
+                let failures_before = output.failures.len();
+                let status = self.publish_one(welcome, output, context.clone()).await?;
+                if !status.met_required_acks {
+                    // The commit is already confirmed, so this member's join
+                    // hinges on re-delivering exactly this welcome.
+                    if let Some(recipient) = recipient {
+                        let failure = self.welcome_delivery_failure(
+                            welcome_id,
+                            recipient,
+                            output,
+                            failures_before,
+                        );
+                        output.welcome_failures.push(failure);
+                    }
+                }
             }
         } else {
             let effects = self.session.publish_failed(pending).await?;
@@ -536,6 +568,71 @@ where
             output.absorb_session_effects(effects, queue);
         }
         Ok(())
+    }
+
+    /// Re-publish a stored welcome whose original delivery failed after its
+    /// commit was already confirmed (mdk#352).
+    ///
+    /// The wrapped welcome is loaded from the engine's sent-message store, so
+    /// no re-commit happens and no pending confirm/rollback lifecycle is
+    /// involved — the group evolution this welcome belongs to was confirmed
+    /// when the failure was recorded. A re-delivery that again misses the ack
+    /// threshold records a fresh [`WelcomeDeliveryFailure`] on the returned
+    /// effects, so the caller can keep retrying from the same handle.
+    pub async fn redeliver_welcome(
+        &mut self,
+        message_id: &cgka_traits::MessageId,
+    ) -> AccountResult<AccountDeviceEffects> {
+        let (group_id, message) = self.session.stored_sent_welcome(message_id)?;
+        // `stored_sent_welcome` only returns welcome envelopes.
+        let recipient = welcome_recipient(&message);
+        let mut output = AccountDeviceEffects::default();
+        let failures_before = output.failures.len();
+        let status = self.publish_one(message, &mut output, None).await?;
+        if !status.met_required_acks
+            && let Some(recipient) = recipient
+        {
+            let mut failure = self.welcome_delivery_failure(
+                message_id.clone(),
+                recipient,
+                &output,
+                failures_before,
+            );
+            failure.group_id = Some(group_id);
+            output.welcome_failures.push(failure);
+        }
+        Ok(output)
+    }
+
+    /// Build the structured re-delivery record for a welcome that just failed
+    /// to publish, pairing the recipient with the reason `publish_one` pushed.
+    fn welcome_delivery_failure(
+        &self,
+        message_id: cgka_traits::MessageId,
+        recipient: MemberId,
+        output: &AccountDeviceEffects,
+        failures_before: usize,
+    ) -> WelcomeDeliveryFailure {
+        // `publish_one` pushes exactly one `PublishFailure` on each failing
+        // path (routing, adapter, required_acks); the defensive fallback only
+        // guards against that contract changing.
+        let reason = output
+            .failures
+            .get(failures_before..)
+            .and_then(<[PublishFailure]>::last)
+            .map(|failure| failure.reason.clone())
+            .unwrap_or_else(|| "welcome publish failed".into());
+        let group_id = self
+            .session
+            .stored_sent_welcome(&message_id)
+            .ok()
+            .map(|(group_id, _)| group_id);
+        WelcomeDeliveryFailure {
+            message_id,
+            recipient,
+            group_id,
+            reason,
+        }
     }
 
     async fn publish_one(
@@ -696,6 +793,15 @@ where
     }
 }
 
+/// The welcome recipient carried in the message's transport envelope, if the
+/// message is a welcome.
+fn welcome_recipient(message: &TransportMessage) -> Option<MemberId> {
+    match &message.envelope {
+        TransportEnvelope::Welcome { recipient } => Some(recipient.clone()),
+        TransportEnvelope::GroupMessage { .. } => None,
+    }
+}
+
 /// Build the outbound transport wire envelope for a publish, from the message's
 /// transport source and (for group messages) the transport-visible group id.
 /// Transport-generic: the post-wrap relay event id and ephemeral pubkey are
@@ -722,6 +828,11 @@ pub struct AccountDeviceEffects {
     pub pending_convergence: Vec<GroupId>,
     pub reports: Vec<TransportPublishReport>,
     pub failures: Vec<PublishFailure>,
+    /// Welcomes whose publish failed after their commit/create was already
+    /// confirmed. Unlike `failures`, each entry carries the recipient and
+    /// group so the caller can re-deliver the stored welcome via
+    /// [`AccountDeviceRuntime::redeliver_welcome`] without re-committing.
+    pub welcome_failures: Vec<WelcomeDeliveryFailure>,
     pub pending: Vec<PendingResolution>,
 }
 
@@ -747,6 +858,21 @@ pub struct AccountIngestEffects {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PublishFailure {
     pub message_id: cgka_traits::MessageId,
+    pub reason: String,
+}
+
+/// A welcome left undelivered by a confirmed group create/evolution (mdk#352).
+///
+/// The added member cannot join until the welcome reaches them, and the commit
+/// cannot be rolled back (it is already confirmed and externally visible), so
+/// re-delivery is the only repair. The wrapped welcome stays available in the
+/// engine's sent-message store under `message_id`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WelcomeDeliveryFailure {
+    pub message_id: cgka_traits::MessageId,
+    pub recipient: MemberId,
+    /// From the stored sent-welcome record; best-effort.
+    pub group_id: Option<GroupId>,
     pub reason: String,
 }
 

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -792,7 +792,7 @@ async fn create_group_confirms_pending_when_welcome_was_partially_exposed() {
         StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())])
             .required_acks(2)
             .with_inbox_route(
-                bob_id,
+                bob_id.clone(),
                 vec![
                     TransportEndpoint("wss://bob-inbox-a.example".into()),
                     TransportEndpoint("wss://bob-inbox-b.example".into()),
@@ -826,6 +826,16 @@ async fn create_group_confirms_pending_when_welcome_was_partially_exposed() {
     assert_eq!(effects.reports.len(), 1);
     assert_eq!(effects.reports[0].accepted_count(), 1);
     assert!(!effects.reports[0].met_required_acks());
+    // The confirmed create left bob's welcome under-acked: the structured
+    // record pairs the failure with its recipient and group for re-delivery
+    // (mdk#352).
+    assert_eq!(effects.welcome_failures.len(), 1);
+    assert_eq!(effects.welcome_failures[0].recipient, bob_id);
+    assert_eq!(
+        effects.welcome_failures[0].message_id,
+        effects.failures[0].message_id
+    );
+    assert_eq!(effects.welcome_failures[0].group_id, Some(group_id.clone()));
     assert_eq!(runtime.session().epoch(&group_id).unwrap().0, 1);
     assert_eq!(runtime.session().members(&group_id).unwrap().len(), 2);
 
@@ -879,7 +889,7 @@ async fn group_evolution_confirms_commit_when_welcome_publish_fails() {
                 vec![TransportEndpoint("wss://group.example".into())],
             )
             .with_inbox_route(
-                carol_id,
+                carol_id.clone(),
                 vec![TransportEndpoint("wss://carol-inbox.example".into())],
             );
     let mut runtime = AccountDeviceRuntime::new(
@@ -903,6 +913,19 @@ async fn group_evolution_confirms_commit_when_welcome_publish_fails() {
         PendingResolution::Confirmed { .. }
     ));
     assert_eq!(effects.failures.len(), 1);
+    // The commit is confirmed, so carol's undelivered welcome surfaces as a
+    // structured re-delivery handle rather than only a flat failure string
+    // (mdk#352).
+    assert_eq!(effects.welcome_failures.len(), 1);
+    assert_eq!(effects.welcome_failures[0].recipient, carol_id);
+    assert_eq!(
+        effects.welcome_failures[0].message_id,
+        effects.failures[0].message_id
+    );
+    assert_eq!(
+        effects.welcome_failures[0].group_id,
+        Some(created.group_id.clone())
+    );
     assert_eq!(runtime.session().epoch(&created.group_id).unwrap().0, 2);
     assert_eq!(
         runtime.session().members(&created.group_id).unwrap().len(),
@@ -920,6 +943,33 @@ async fn group_evolution_confirms_commit_when_welcome_publish_fails() {
         TransportEnvelope::Welcome { .. }
     ));
 
+    // Re-delivery repairs carol's join from the stored welcome: the adapter
+    // (now accepting) receives the same welcome id again and the epoch does
+    // not advance — no re-commit.
+    let redelivered = runtime
+        .redeliver_welcome(&effects.welcome_failures[0].message_id)
+        .await
+        .unwrap();
+    assert_eq!(redelivered.reports.len(), 1);
+    assert!(redelivered.reports[0].met_required_acks());
+    assert!(redelivered.failures.is_empty());
+    assert!(redelivered.welcome_failures.is_empty());
+    let publishes = adapter.publishes();
+    assert_eq!(publishes.len(), 3);
+    assert!(matches!(
+        publishes[2].message.envelope,
+        TransportEnvelope::Welcome { .. }
+    ));
+    assert_eq!(
+        publishes[2].message.id,
+        effects.welcome_failures[0].message_id
+    );
+    assert_eq!(runtime.session().epoch(&created.group_id).unwrap().0, 2);
+
+    // A non-welcome message id is rejected without publishing anything.
+    let commit_id = publishes[0].message.id.clone();
+    assert!(runtime.redeliver_welcome(&commit_id).await.is_err());
+    assert_eq!(adapter.publishes().len(), 3);
 }
 
 // mdk#499 regression: an explicit group-evolution commit that a relay
@@ -1005,6 +1055,10 @@ async fn group_evolution_confirms_pending_when_commit_was_partially_exposed() {
     assert!(!effects.reports[0].met_required_acks());
     assert_eq!(effects.reports[1].accepted_count(), 2);
     assert!(effects.reports[1].met_required_acks());
+    // The under-acked message here is the commit, not the welcome — the
+    // commit's ack-miss must not be misclassified as a welcome-delivery
+    // failure.
+    assert!(effects.welcome_failures.is_empty());
     assert_eq!(runtime.session().epoch(&created.group_id).unwrap().0, 2);
     assert_eq!(
         runtime.session().members(&created.group_id).unwrap().len(),

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -671,6 +671,58 @@ async fn create_group_rolls_back_pending_when_publish_acks_are_insufficient() {
     assert_eq!(runtime.session().members(&group_id).unwrap().len(), 1);
 }
 
+// A "best effort" routing policy (`required_acks == 0`) must still fail a
+// publish that no endpoint accepted: confirming it would advance the local
+// epoch/membership past a welcome that reached no relay (#375).
+#[tokio::test]
+async fn create_group_with_best_effort_acks_rolls_back_when_nothing_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot best effort key").unwrap();
+    let mut bob_session = session(dir.path().join("bob.sqlite"), &key, b"bob");
+    let bob_kp = bob_session.fresh_key_package().await.unwrap();
+    let bob_id = bob_session.self_id();
+    let session = session(dir.path().join("alice.sqlite"), &key, b"alice");
+    let adapter = RecordingAdapter::default();
+    adapter.accept_only_next(0);
+    let policy =
+        StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())])
+            .required_acks(0)
+            .with_inbox_route(
+                bob_id,
+                vec![TransportEndpoint("wss://bob-inbox.example".into())],
+            );
+    let mut runtime = AccountDeviceRuntime::new(
+        session,
+        adapter.clone(),
+        policy,
+        RecordingKeyPackages::default(),
+    );
+
+    let (group_id, effects) = runtime
+        .create_group(CreateGroupRequest {
+            name: "runtime best effort".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(effects.pending.len(), 1);
+    assert!(matches!(
+        effects.pending[0],
+        PendingResolution::RolledBack { .. }
+    ));
+    assert_eq!(effects.failures.len(), 1);
+    assert_eq!(effects.reports.len(), 1);
+    assert_eq!(effects.reports[0].accepted_count(), 0);
+    assert!(!effects.reports[0].met_required_acks());
+    assert_eq!(runtime.session().epoch(&group_id).unwrap().0, 0);
+    assert_eq!(runtime.session().members(&group_id).unwrap().len(), 1);
+}
+
 #[tokio::test]
 async fn create_group_stops_welcome_publish_after_unexposed_failure() {
     let dir = tempfile::tempdir().unwrap();
@@ -867,6 +919,7 @@ async fn group_evolution_confirms_commit_when_welcome_publish_fails() {
         publishes[1].message.envelope,
         TransportEnvelope::Welcome { .. }
     ));
+
 }
 
 // mdk#499 regression: an explicit group-evolution commit that a relay

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -66,6 +66,11 @@ pub struct AppClient {
     /// broadcasts `ProjectionUpdated` so live timeline subscriptions refresh.
     pub(crate) pending_projection_updates: Vec<crate::AppProjectionUpdate>,
     pub(crate) pending_convergence_groups: HashSet<GroupId>,
+    /// Welcomes queued for re-delivery during the most recent create/invite.
+    /// The runtime account worker drains this after the command and broadcasts a
+    /// `WelcomeDeliveryPending` event so callers learn a member is unjoinable
+    /// without polling (mdk#352).
+    pub(crate) pending_welcome_delivery_events: Vec<PendingWelcomeDelivery>,
 }
 
 /// A point-in-time copy of the live session's read-only group projections
@@ -1994,7 +1999,7 @@ impl AppClient {
     /// is already confirmed and externally visible, so the added member stays in
     /// the roster but cannot join until the welcome is re-delivered.
     fn record_welcome_delivery_failures(
-        &self,
+        &mut self,
         group_id_hex: &str,
         effects: &marmot_account::AccountDeviceEffects,
     ) -> Result<(), AppError> {
@@ -2004,14 +2009,32 @@ impl AppClient {
         let storage = self.app.account_storage(&self.state.label)?;
         let recorded_at = unix_now_seconds();
         for failure in &effects.welcome_failures {
+            let message_id_hex = hex::encode(failure.message_id.as_slice());
+            let recipient_hex = hex::encode(failure.recipient.as_slice());
             storage.record_pending_welcome_delivery(
-                &hex::encode(failure.message_id.as_slice()),
+                &message_id_hex,
                 group_id_hex,
-                &hex::encode(failure.recipient.as_slice()),
+                &recipient_hex,
                 recorded_at,
             )?;
+            // Queue a runtime event so subscribers (UI/CLI/UniFFI) learn the
+            // member is unjoinable without polling the durable queue.
+            self.pending_welcome_delivery_events
+                .push(PendingWelcomeDelivery {
+                    group_id_hex: group_id_hex.to_owned(),
+                    message_id_hex,
+                    recipient_hex,
+                    recorded_at,
+                });
         }
         Ok(())
+    }
+
+    /// Drain the welcomes queued for re-delivery during the last create/invite,
+    /// for the runtime worker to broadcast as `WelcomeDeliveryPending` events
+    /// (mdk#352).
+    pub(crate) fn take_pending_welcome_delivery_events(&mut self) -> Vec<PendingWelcomeDelivery> {
+        std::mem::take(&mut self.pending_welcome_delivery_events)
     }
 
     /// Welcomes still awaiting re-delivery for this account (mdk#352), oldest
@@ -2042,9 +2065,24 @@ impl AppClient {
     ) -> Result<SendSummary, AppError> {
         let message_id = cgka_traits::MessageId::new(hex::decode(message_id_hex)?);
         let effects = self.runtime.redeliver_welcome(&message_id).await?;
-        if !effects.failures.is_empty() {
-            // Still undelivered: keep the pending record so it can be retried.
-            return Err(publish_failure_error(&effects.failures));
+        // Only clear the durable pending record once every "still undelivered"
+        // signal agrees the welcome landed: no PublishFailure, no structured
+        // WelcomeDeliveryFailure, and a report that met its ack threshold.
+        // These are kept in lockstep by `publish_one` today, but asserting all
+        // three means a future refactor cannot drift one signal and clear the
+        // queue while the welcome is still unreachable (the #375 class of bug).
+        let delivered = effects.failures.is_empty()
+            && effects.welcome_failures.is_empty()
+            && effects
+                .reports
+                .last()
+                .is_some_and(|report| report.met_required_acks());
+        if !delivered {
+            return Err(if effects.failures.is_empty() {
+                AppError::Publish("welcome re-delivery did not reach the recipient".into())
+            } else {
+                publish_failure_error(&effects.failures)
+            });
         }
         self.app
             .account_storage(&self.state.label)?

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -23,7 +23,7 @@ use marmot_forensics::AuditEventContext;
 use crate::app_telemetry::AppPerformanceOperation;
 use crate::groups::{
     EventGroupProjection, GroupConfirmationProjection, add_group, fail_if_publish_failed,
-    send_summary_from_effects, validate_group_profile,
+    publish_failure_error, send_summary_from_effects, validate_group_profile,
 };
 use crate::ids::{admin_pubkey_from_account_id_hex, admin_pubkey_from_member_id};
 use crate::media::{
@@ -40,7 +40,7 @@ use crate::{
     AppMessageQuery, AppPerformanceTelemetry, AppQuarantinedGroup, AppRuntime, AppTransportRouting,
     GroupInviteDeclineResult, MarmotApp, MarmotRelayPlane, MarmotRelayPlaneAccountAdapter,
     MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest, MediaUploadResult,
-    SelfMembership, SendSummary, remember_seen_event, unix_now_seconds,
+    PendingWelcomeDelivery, SelfMembership, SendSummary, remember_seen_event, unix_now_seconds,
 };
 
 mod audit;
@@ -261,6 +261,7 @@ impl AppClient {
             )
             .await?;
         fail_if_publish_failed(&effects)?;
+        self.record_welcome_delivery_failures(&hex::encode(group_id.as_slice()), &effects)?;
         self.record_human_action_succeeded(&group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         self.add_group(&group_id)?;
@@ -539,6 +540,7 @@ impl AppClient {
 
         let local_refresh_started_at = Instant::now();
         let local_refresh = (|| {
+            self.record_welcome_delivery_failures(&hex::encode(group_id.as_slice()), &effects)?;
             self.record_human_action_succeeded(group_id, &audit_context, &effects);
             self.remember_published_reports(&effects);
             self.refresh_group(group_id);
@@ -1985,6 +1987,69 @@ impl AppClient {
             let event_id = hex::encode(report.message_id.as_slice());
             remember_seen_event(&mut seen, &mut self.state, event_id);
         }
+    }
+
+    /// Durably record welcomes a confirmed create/invite could not deliver, so
+    /// the repair handle is not lost when the call returns (mdk#352). The commit
+    /// is already confirmed and externally visible, so the added member stays in
+    /// the roster but cannot join until the welcome is re-delivered.
+    fn record_welcome_delivery_failures(
+        &self,
+        group_id_hex: &str,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) -> Result<(), AppError> {
+        if effects.welcome_failures.is_empty() {
+            return Ok(());
+        }
+        let storage = self.app.account_storage(&self.state.label)?;
+        let recorded_at = unix_now_seconds();
+        for failure in &effects.welcome_failures {
+            storage.record_pending_welcome_delivery(
+                &hex::encode(failure.message_id.as_slice()),
+                group_id_hex,
+                &hex::encode(failure.recipient.as_slice()),
+                recorded_at,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Welcomes still awaiting re-delivery for this account (mdk#352), oldest
+    /// first. Each entry's `message_id_hex` is the handle for
+    /// [`AppClient::redeliver_welcome`].
+    pub fn pending_welcome_deliveries(&self) -> Result<Vec<PendingWelcomeDelivery>, AppError> {
+        Ok(self
+            .app
+            .account_storage(&self.state.label)?
+            .list_pending_welcome_deliveries()?
+            .into_iter()
+            .map(|record| PendingWelcomeDelivery {
+                group_id_hex: record.group_id_hex,
+                message_id_hex: record.message_id_hex,
+                recipient_hex: record.recipient_hex,
+                recorded_at: record.recorded_at,
+            })
+            .collect())
+    }
+
+    /// Re-publish a welcome that a confirmed create/invite failed to deliver,
+    /// from the copy the engine stored at wrap time — no re-commit (mdk#352).
+    /// Clears the pending record only once the welcome is accepted; a repeated
+    /// failure leaves it queued for a later retry.
+    pub async fn redeliver_welcome(
+        &mut self,
+        message_id_hex: &str,
+    ) -> Result<SendSummary, AppError> {
+        let message_id = cgka_traits::MessageId::new(hex::decode(message_id_hex)?);
+        let effects = self.runtime.redeliver_welcome(&message_id).await?;
+        if !effects.failures.is_empty() {
+            // Still undelivered: keep the pending record so it can be retried.
+            return Err(publish_failure_error(&effects.failures));
+        }
+        self.app
+            .account_storage(&self.state.label)?
+            .clear_pending_welcome_delivery(message_id_hex)?;
+        Ok(send_summary_from_effects(&effects))
     }
 }
 

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1109,6 +1109,7 @@ impl AppClient {
                 &event,
                 None,
                 source_epoch,
+                false,
             )?;
             on_local_projection(update);
         }
@@ -1137,6 +1138,8 @@ impl AppClient {
             Ok(effects) => effects,
             Err(err) => {
                 if should_project_locally {
+                    // No read-marker rollback needed: the marker only advances
+                    // in the post-publish success projection below.
                     match self.app.invalidate_timeline_app_event(
                         &self.state.label,
                         &group_id_hex,
@@ -1173,6 +1176,7 @@ impl AppClient {
                 &event,
                 source_message_id_hex,
                 source_epoch,
+                true,
             )?;
             on_local_projection(update);
             self.prune_plaintext_retention_for_group(group_id)?;

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -17,6 +17,10 @@ use crate::{
 use super::AppClient;
 
 impl AppClient {
+    /// `advance_read_marker`: pre-publish projections must pass `false` so a
+    /// failed publish never leaves the group read marker advanced past inbound
+    /// unreads or pointing at an invalidated own message (#338); only the
+    /// post-publish success projection advances it.
     pub(crate) fn record_local_app_event_projection(
         &self,
         group_id_hex: &str,
@@ -24,6 +28,7 @@ impl AppClient {
         event: &MarmotInnerEvent,
         source_message_id_hex: Option<String>,
         source_epoch: Option<u64>,
+        advance_read_marker: bool,
     ) -> Result<crate::AppProjectionUpdate, AppError> {
         let message_projection = AppMessageProjection {
             message_id_hex: event.id.clone(),
@@ -43,7 +48,7 @@ impl AppClient {
         let update = self
             .app
             .record_account_app_event(&self.state.label, &message_projection)?;
-        if event.kind == MARMOT_APP_EVENT_KIND_CHAT {
+        if advance_read_marker && event.kind == MARMOT_APP_EVENT_KIND_CHAT {
             let read_marker =
                 self.app
                     .mark_timeline_message_read(&self.state.label, group_id_hex, &event.id);

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -1109,7 +1109,7 @@ pub(crate) fn fail_if_publish_failed(
     Err(publish_failure_error(&effects.failures))
 }
 
-fn publish_failure_error(failures: &[marmot_account::PublishFailure]) -> AppError {
+pub(crate) fn publish_failure_error(failures: &[marmot_account::PublishFailure]) -> AppError {
     AppError::Publish(
         failures
             .iter()

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1065,6 +1065,7 @@ impl MarmotApp {
             state: open.state,
             pending_projection_updates: Vec::new(),
             pending_convergence_groups: std::collections::HashSet::new(),
+            pending_welcome_delivery_events: Vec::new(),
         };
         // One-time upgrade backfill: derive `self_membership` for pre-0018 rows
         // from current engine state so groups the local account already left /

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -661,6 +661,20 @@ pub struct SendSummary {
     pub message_ids: Vec<String>,
 }
 
+/// A welcome that a confirmed group create/invite could not deliver to its
+/// recipient (mdk#352). The commit is already durable, so the member is added
+/// but unjoinable until the welcome reaches them. Persisted so the repair
+/// handle survives the call return and a restart; re-deliver it with
+/// [`AppClient::redeliver_welcome`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingWelcomeDelivery {
+    pub group_id_hex: String,
+    /// The stored welcome's MLS message id — the key for re-delivery.
+    pub message_id_hex: String,
+    pub recipient_hex: String,
+    pub recorded_at: u64,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SecureDeleteExpiredResult {
     /// Number of expired raw app-event rows securely scrubbed and pruned.

--- a/crates/marmot-app/src/notifications.rs
+++ b/crates/marmot-app/src/notifications.rs
@@ -1010,6 +1010,7 @@ pub(crate) fn notification_update_from_event_cached(
         | MarmotAppEvent::ProjectionUpdated(_)
         | MarmotAppEvent::AgentStreamStarted(_)
         | MarmotAppEvent::GroupEvent(_)
+        | MarmotAppEvent::WelcomeDeliveryPending { .. }
         | MarmotAppEvent::AccountError(_) => Ok(None),
     }
 }

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -26,8 +26,8 @@ use crate::{
     AgentTextStreamFinishRequest, AppBlobEndpoint, AppClient, AppError, AppGroupMemberRecord,
     AppGroupMlsState, AppGroupRecord, AppProjectionUpdate, AppQuarantinedGroup,
     GroupInviteDeclineResult, MarmotApp, MarmotRelayPlane, MediaAttachmentReference,
-    MediaDownloadResult, MediaUploadRequest, MediaUploadResult, PushRegistration, ReceivedMessage,
-    SecureDeleteExpiredResult, SendSummary, SyncSummary,
+    MediaDownloadResult, MediaUploadRequest, MediaUploadResult, PendingWelcomeDelivery,
+    PushRegistration, ReceivedMessage, SecureDeleteExpiredResult, SendSummary, SyncSummary,
 };
 use cgka_traits::app_event::MarmotAppEvent as MarmotInnerEvent;
 
@@ -236,6 +236,13 @@ pub(crate) enum AccountWorkerCommand {
     },
     RetryGroupConvergence {
         group_id: GroupId,
+        respond: oneshot::Sender<Result<SendSummary, AppError>>,
+    },
+    PendingWelcomeDeliveries {
+        respond: oneshot::Sender<Result<Vec<PendingWelcomeDelivery>, AppError>>,
+    },
+    RedeliverWelcome {
+        message_id_hex: String,
         respond: oneshot::Sender<Result<SendSummary, AppError>>,
     },
     PublishKeyPackage {
@@ -1158,6 +1165,17 @@ async fn handle_account_worker_command(
         }
         AccountWorkerCommand::RetryGroupConvergence { group_id, respond } => {
             let result = client.retry_group_convergence(&group_id).await;
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::PendingWelcomeDeliveries { respond } => {
+            let result = client.pending_welcome_deliveries();
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::RedeliverWelcome {
+            message_id_hex,
+            respond,
+        } => {
+            let result = client.redeliver_welcome(&message_id_hex).await;
             let _ = respond.send(result);
         }
         AccountWorkerCommand::PublishKeyPackage { respond } => {

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -695,6 +695,7 @@ async fn handle_account_worker_command(
                     group_id,
                 );
             }
+            publish_pending_welcome_delivery_events(events, account_id_hex, account_label, client);
             let _ = respond.send(result);
         }
         AccountWorkerCommand::Members { group_id, respond } => {
@@ -843,6 +844,7 @@ async fn handle_account_worker_command(
                     &group_id,
                 );
             }
+            publish_pending_welcome_delivery_events(events, account_id_hex, account_label, client);
             let _ = respond.send(result);
         }
         AccountWorkerCommand::RemoveMembers {
@@ -1486,6 +1488,29 @@ pub(crate) fn publish_app_runtime_group_state_updated(
         account_label: account_label.to_owned(),
         group_id: group_id.clone(),
     });
+}
+
+/// Broadcast a `WelcomeDeliveryPending` event for each welcome a just-completed
+/// create/invite queued for re-delivery (mdk#352), so subscribers learn a member
+/// is unjoinable without polling the durable queue.
+fn publish_pending_welcome_delivery_events(
+    events: &broadcast::Sender<MarmotAppEvent>,
+    account_id_hex: &str,
+    account_label: &str,
+    client: &mut AppClient,
+) {
+    for pending in client.take_pending_welcome_delivery_events() {
+        let Ok(group_id_bytes) = hex::decode(&pending.group_id_hex) else {
+            continue;
+        };
+        let _ = events.send(MarmotAppEvent::WelcomeDeliveryPending {
+            account_id_hex: account_id_hex.to_owned(),
+            account_label: account_label.to_owned(),
+            group_id: GroupId::new(group_id_bytes),
+            message_id_hex: pending.message_id_hex,
+            recipient_hex: pending.recipient_hex,
+        });
+    }
 }
 
 /// Emit a runtime `AgentStreamStarted` for a kind-1200 start event. Kind-9

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -20,8 +20,8 @@ use crate::{
     AgentOperationEventRequest, AgentTextStreamFinishRequest, AppBlobEndpoint, AppError,
     AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppQuarantinedGroup,
     GroupInviteDeclineResult, GroupPushDebugInfo, MediaAttachmentReference, MediaDownloadResult,
-    MediaUploadRequest, MediaUploadResult, PushRegistration, SecureDeleteExpiredResult,
-    SendSummary,
+    MediaUploadRequest, MediaUploadResult, PendingWelcomeDelivery, PushRegistration,
+    SecureDeleteExpiredResult, SendSummary,
 };
 
 impl AccountManager {
@@ -934,6 +934,38 @@ impl AccountManager {
         let summary = account_worker_response(response).await?;
         self.catch_up_accounts().await?;
         self.schedule_audit_log_tracker_update("retry_group_convergence");
+        Ok(summary)
+    }
+
+    pub async fn pending_welcome_deliveries(
+        &self,
+        account_ref: &str,
+    ) -> Result<Vec<PendingWelcomeDelivery>, AppError> {
+        let command = self.worker_commands(account_ref).await?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::PendingWelcomeDeliveries { respond })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        account_worker_response(response).await
+    }
+
+    pub async fn redeliver_welcome(
+        &self,
+        account_ref: &str,
+        message_id_hex: &str,
+    ) -> Result<SendSummary, AppError> {
+        let command = self.worker_commands(account_ref).await?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::RedeliverWelcome {
+                message_id_hex: message_id_hex.to_owned(),
+                respond,
+            })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        let summary = account_worker_response(response).await?;
+        self.schedule_audit_log_tracker_update("redeliver_welcome");
         Ok(summary)
     }
 

--- a/crates/marmot-app/src/runtime/event_routing.rs
+++ b/crates/marmot-app/src/runtime/event_routing.rs
@@ -22,6 +22,7 @@ pub(crate) fn runtime_message_update_from_event(
         | MarmotAppEvent::GroupStateUpdated { .. }
         | MarmotAppEvent::ProjectionUpdated(_)
         | MarmotAppEvent::GroupEvent(_)
+        | MarmotAppEvent::WelcomeDeliveryPending { .. }
         | MarmotAppEvent::AccountError(_) => None,
     }
 }
@@ -36,6 +37,7 @@ pub(crate) fn projection_update_from_event(
         | MarmotAppEvent::MessageReceived(_)
         | MarmotAppEvent::AgentStreamStarted(_)
         | MarmotAppEvent::GroupEvent(_)
+        | MarmotAppEvent::WelcomeDeliveryPending { .. }
         | MarmotAppEvent::AccountError(_) => None,
     }
 }
@@ -81,6 +83,7 @@ pub(crate) fn runtime_group_event_route(event: &MarmotAppEvent) -> Option<(&str,
         MarmotAppEvent::ProjectionUpdated(_)
         | MarmotAppEvent::MessageReceived(_)
         | MarmotAppEvent::AgentStreamStarted(_)
+        | MarmotAppEvent::WelcomeDeliveryPending { .. }
         | MarmotAppEvent::AccountError(_) => None,
     }
 }
@@ -104,6 +107,7 @@ pub(crate) fn chat_list_event_route(event: &MarmotAppEvent) -> Option<(&str, &Gr
         MarmotAppEvent::ProjectionUpdated(_)
         | MarmotAppEvent::MessageReceived(_)
         | MarmotAppEvent::AgentStreamStarted(_)
+        | MarmotAppEvent::WelcomeDeliveryPending { .. }
         | MarmotAppEvent::AccountError(_) => None,
     }
 }
@@ -134,6 +138,7 @@ pub(crate) fn chat_list_trigger_from_event(event: &MarmotAppEvent) -> ChatListUp
         MarmotAppEvent::ProjectionUpdated(update) => update.update.chat_list_trigger,
         MarmotAppEvent::MessageReceived(_)
         | MarmotAppEvent::AgentStreamStarted(_)
+        | MarmotAppEvent::WelcomeDeliveryPending { .. }
         | MarmotAppEvent::AccountError(_) => ChatListUpdateTrigger::SnapshotRefresh,
     }
 }

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -771,6 +771,18 @@ pub enum MarmotAppEvent {
     ProjectionUpdated(RuntimeProjectionUpdate),
     GroupEvent(RuntimeGroupEvent),
     AccountError(RuntimeAccountError),
+    /// A confirmed create/invite could not deliver a welcome to `recipient_hex`;
+    /// the member is in the group but unjoinable until the welcome is
+    /// re-delivered (mdk#352). Emitted so a UI/CLI/UniFFI subscriber learns a
+    /// member needs repair without polling `pending_welcome_deliveries`. The
+    /// durable record backs a later `redeliver_welcome(message_id_hex)`.
+    WelcomeDeliveryPending {
+        account_id_hex: String,
+        account_label: String,
+        group_id: GroupId,
+        message_id_hex: String,
+        recipient_hex: String,
+    },
 }
 
 impl MarmotAppRuntime {

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -35,10 +35,10 @@ use crate::{
     MAX_SEEN_EVENT_IDS, MarmotApp, MarmotRelayPlane, MarmotServiceEndpoints,
     MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest, MediaUploadResult,
     NotificationCollectionStatus, NotificationSettings, NotificationUpdate, NotificationWakeSource,
-    PushPlatform, PushRegistration, ReceivedMessage, RelayTelemetryExportConfig,
-    RelayTelemetryRuntimeConfig, RelayTelemetrySettings, SecureDeleteExpiredResult, SendSummary,
-    TimelineMessageQuery, TimelinePage, UserDirectoryRefresh, UserProfileMetadata,
-    default_profile_pseudonym, unix_now_seconds,
+    PendingWelcomeDelivery, PushPlatform, PushRegistration, ReceivedMessage,
+    RelayTelemetryExportConfig, RelayTelemetryRuntimeConfig, RelayTelemetrySettings,
+    SecureDeleteExpiredResult, SendSummary, TimelineMessageQuery, TimelinePage,
+    UserDirectoryRefresh, UserProfileMetadata, default_profile_pseudonym, unix_now_seconds,
 };
 
 mod account_worker;
@@ -1733,6 +1733,28 @@ impl MarmotAppRuntime {
     ) -> Result<SendSummary, AppError> {
         self.accounts
             .retry_group_convergence(account_ref, group_id)
+            .await
+    }
+
+    /// Welcomes a confirmed create/invite could not deliver and that still await
+    /// re-delivery for `account_ref` (mdk#352), oldest first.
+    pub async fn pending_welcome_deliveries(
+        &self,
+        account_ref: &str,
+    ) -> Result<Vec<PendingWelcomeDelivery>, AppError> {
+        self.accounts.pending_welcome_deliveries(account_ref).await
+    }
+
+    /// Re-publish a previously undelivered welcome (identified by its stored MLS
+    /// message id) without re-committing (mdk#352). Clears the pending record on
+    /// success; a repeated failure leaves it queued.
+    pub async fn redeliver_welcome(
+        &self,
+        account_ref: &str,
+        message_id_hex: &str,
+    ) -> Result<SendSummary, AppError> {
+        self.accounts
+            .redeliver_welcome(account_ref, message_id_hex)
             .await
     }
 

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -5165,3 +5165,56 @@ async fn runtime_data_mode_toggle_rotates_live_recorder_with_boundary() {
 
     runtime.shutdown().await;
 }
+
+/// mdk#352 review follow-up: the welcome re-delivery surface is reachable end
+/// to end through the runtime worker. A create whose welcome delivered leaves
+/// nothing pending, and re-delivering an unknown welcome id is a clean error
+/// (the failure-record + successful-redeliver paths are covered by the
+/// storage-sqlite round-trip and marmot-account runtime tests).
+#[tokio::test]
+async fn app_runtime_exposes_welcome_redelivery_surface() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let bob = runtime.create_identity(setup).await.unwrap();
+
+    let _group = runtime
+        .create_group(
+            &alice.account.account_id_hex,
+            "welcome redelivery surface",
+            std::slice::from_ref(&bob.account.account_id_hex),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // The welcome delivered over the live relay, so nothing is queued.
+    assert!(
+        runtime
+            .pending_welcome_deliveries(&alice.account.account_id_hex)
+            .await
+            .unwrap()
+            .is_empty(),
+        "a delivered welcome must not queue a pending re-delivery"
+    );
+
+    // No welcome is stored under this id, so re-delivery is a clean error routed
+    // through the worker command (not a panic or a lost request).
+    let unknown_welcome_id = "ab".repeat(32);
+    assert!(
+        runtime
+            .redeliver_welcome(&alice.account.account_id_hex, &unknown_welcome_id)
+            .await
+            .is_err(),
+        "re-delivering an unknown welcome id must error cleanly"
+    );
+
+    runtime.shutdown().await;
+}

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -5185,6 +5185,7 @@ async fn app_runtime_exposes_welcome_redelivery_surface() {
     let alice = runtime.create_identity(setup.clone()).await.unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
 
+    let mut events = runtime.subscribe();
     let _group = runtime
         .create_group(
             &alice.account.account_id_hex,
@@ -5195,7 +5196,7 @@ async fn app_runtime_exposes_welcome_redelivery_surface() {
         .await
         .unwrap();
 
-    // The welcome delivered over the live relay, so nothing is queued.
+    // The welcome delivered over the live relay, so nothing is queued...
     assert!(
         runtime
             .pending_welcome_deliveries(&alice.account.account_id_hex)
@@ -5204,6 +5205,14 @@ async fn app_runtime_exposes_welcome_redelivery_surface() {
             .is_empty(),
         "a delivered welcome must not queue a pending re-delivery"
     );
+    // ...and no WelcomeDeliveryPending event is emitted on the happy path (the
+    // worker still drained the empty queue without spuriously signaling).
+    while let Ok(event) = events.try_recv() {
+        assert!(
+            !matches!(event, MarmotAppEvent::WelcomeDeliveryPending { .. }),
+            "a delivered welcome must not emit WelcomeDeliveryPending"
+        );
+    }
 
     // No welcome is stored under this id, so re-delivery is a clean error routed
     // through the worker command (not a panic or a lost request).

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -3102,6 +3102,135 @@ async fn open_backfill_preserves_unread_for_still_member_account() {
 }
 
 #[tokio::test]
+async fn failed_send_keeps_read_marker_and_inbound_unread() {
+    // mdk#338: the local-send projection recorded BEFORE publish must not
+    // advance the per-group read marker. If it did, a hard publish failure
+    // would leave the marker pointing at the invalidated own message and
+    // silently mark older inbound unreads as read. Only the post-publish
+    // success projection may advance the marker.
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    home.create_account("alice").unwrap();
+    let bob_account = home.create_account("bob").unwrap();
+
+    let (relay, app, _url) = mock_app(&dir).await;
+    let mut bob = app.client("bob").await.unwrap();
+    bob.publish_key_package().await.unwrap();
+
+    let mut alice = app.client("alice").await.unwrap();
+    let group_id = alice.create_group("markers", &["bob"]).await.unwrap();
+    bob.sync().await.unwrap();
+
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let bob_row = || {
+        app.chat_list_row("bob", &group_id_hex)
+            .unwrap()
+            .expect("bob's chat-list row exists after joining")
+    };
+
+    // Phase 1: a SUCCESSFUL own send must still advance bob's read marker to
+    // his own event id — the marker advance is deferred to the post-publish
+    // projection, so this guards that it still fires on success.
+    let bob_success_id = bob
+        .send(&group_id, b"bob success")
+        .await
+        .unwrap()
+        .message_ids[0]
+        .clone();
+    assert_eq!(
+        bob_row().last_read_message_id_hex.as_deref(),
+        Some(bob_success_id.as_str()),
+        "a successful own send must advance the sender's read marker to his own event"
+    );
+
+    // `timeline_at` is second-granular and the unread window is strictly after
+    // the marker tuple, so each subsequent message must land in a strictly
+    // later second to register past the previous watermark.
+    sleep(Duration::from_millis(1100)).await;
+    let read_baseline_id = alice
+        .send(&group_id, b"baseline")
+        .await
+        .unwrap()
+        .message_ids[0]
+        .clone();
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        bob.sync().await.unwrap();
+        if bob_row().unread_count == 1 {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for bob to register alice's baseline as unread"
+        );
+        sleep(Duration::from_millis(50)).await;
+    }
+    app.mark_timeline_message_read("bob", &group_id_hex, &read_baseline_id)
+        .unwrap();
+    let row = bob_row();
+    assert_eq!(
+        row.last_read_message_id_hex.as_deref(),
+        Some(read_baseline_id.as_str())
+    );
+    assert_eq!(row.unread_count, 0);
+
+    sleep(Duration::from_millis(1100)).await;
+    let inbound_unread_id = alice
+        .send(&group_id, b"inbound unread")
+        .await
+        .unwrap()
+        .message_ids[0]
+        .clone();
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        bob.sync().await.unwrap();
+        if bob_row().unread_count == 1 {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for bob to register the inbound unread"
+        );
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    // Hard publish failure: no relay left to accept bob's message. The failed
+    // attempt can take up to the adapter's ~20s publish overall-wait
+    // (SDK_RELAY_PUBLISH_OVERALL_WAIT) before it reports the failure.
+    relay.shutdown();
+    bob.send(&group_id, b"bob failure")
+        .await
+        .expect_err("send must fail once the relay is gone");
+
+    let row = bob_row();
+    assert_eq!(
+        row.unread_count, 1,
+        "a failed send must not mark inbound unreads as read"
+    );
+    assert_eq!(
+        row.last_read_message_id_hex.as_deref(),
+        Some(read_baseline_id.as_str()),
+        "a failed send must leave the read marker untouched, never at the failed event"
+    );
+    assert_eq!(
+        row.first_unread_message_id_hex.as_deref(),
+        Some(inbound_unread_id.as_str()),
+        "the first unread must still be alice's inbound message"
+    );
+    let account_unread = app
+        .account_unread_summary()
+        .unwrap()
+        .into_iter()
+        .find(|summary| summary.account_id_hex == bob_account.account_id_hex)
+        .map(|summary| summary.unread_count)
+        .unwrap_or(0);
+    assert_eq!(
+        account_unread, 1,
+        "the account-level unread aggregate must survive the failed send"
+    );
+}
+
+#[tokio::test]
 async fn relay_app_runtime_publishes_member_leave() {
     let dir = tempfile::tempdir().unwrap();
     let home = AccountHome::open(dir.path());

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -1444,7 +1444,12 @@ impl JsonlRecorder {
         let file = fs_private::create_new_private(&staged)?;
         // Atomic replace: the live path always names either the old complete
         // file or the fresh empty one, and rename preserves the staged 0600
-        // mode. Recorder state advances only after the rename succeeds.
+        // mode. Recorder state advances only after the rename succeeds. This
+        // relies on POSIX rename replacing an existing destination in place;
+        // the crate targets Unix only (like `fs_private`'s owner-only file
+        // model), so the Windows "rename fails if the destination exists"
+        // behavior does not apply — and a delete-then-rename fallback would
+        // reintroduce exactly the non-atomic window this swap removes.
         if let Err(err) = std::fs::rename(&staged, &self.path) {
             let _ = std::fs::remove_file(&staged);
             return Err(err);

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -1392,11 +1392,13 @@ impl ForensicRecorder for JsonlRecorder {
             if previous_mode == new_mode {
                 return Ok(());
             }
-            // Apply the mode before swapping so the fresh file is stamped
-            // entirely with `new_mode`, then rotate so the old mode's lines
-            // never share a file with the new mode's.
-            inner.data_mode = new_mode;
+            // Swap before applying the mode: a failed swap must leave the
+            // recorder in its previous mode, still appending to the original
+            // file, so no records are lost and the call is retryable. The
+            // fresh file is still stamped entirely with `new_mode` because
+            // both steps happen under the lock, before any row lands on it.
             self.swap_to_fresh_file(&mut inner)?;
+            inner.data_mode = new_mode;
             previous_mode
         };
         // Boundary rows on the fresh file: the `recorder_started` marker
@@ -1416,35 +1418,55 @@ impl ForensicRecorder for JsonlRecorder {
 }
 
 impl JsonlRecorder {
-    /// Discard the current backing file and reopen an empty one at the same
+    /// Atomically replace the backing file with a fresh empty one at the same
     /// path, resetting the sequence, recorder session id, and health counters.
-    /// The caller must hold the inner lock; the data mode is left untouched so
-    /// both [`rotate`](ForensicRecorder::rotate) and
+    /// The fresh file is staged as an owner-only sibling and renamed over the
+    /// live path, so any failure leaves the original file, writer fd, seq,
+    /// session id, and data mode untouched and still recording. The caller
+    /// must hold the inner lock; the data mode is left untouched so both
+    /// [`rotate`](ForensicRecorder::rotate) and
     /// [`set_data_mode`](ForensicRecorder::set_data_mode) can reuse it.
     fn swap_to_fresh_file(&self, inner: &mut JsonlInner) -> std::io::Result<()> {
         // Best-effort flush of whatever is buffered into the file we are about
         // to discard.
         let _ = inner.writer.flush();
-        // Unlink the current file. The fd still held by `inner.writer` keeps
-        // pointing at the now-unlinked inode until it is replaced below; on
-        // Unix that is harmless and the writer is discarded immediately. A
-        // missing file is fine — the goal state is "no old file, fresh file
-        // recording".
-        match std::fs::remove_file(&self.path) {
+        // Stage the fresh file as a 0600 sibling. `create_new` refuses to
+        // adopt a leftover staged file (whose contents would leak into the
+        // fresh log), so clear one from an interrupted earlier swap first.
+        let staged = staged_swap_path(&self.path);
+        match std::fs::remove_file(&staged) {
             Ok(()) => {}
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
             Err(err) => return Err(err),
         }
-        // Open a brand-new owner-only file at the same path and swap it in.
+        // The handle is write-only rather than append — equivalent for a
+        // brand-new empty file with a single `BufWriter`.
+        let file = fs_private::create_new_private(&staged)?;
+        // Atomic replace: the live path always names either the old complete
+        // file or the fresh empty one, and rename preserves the staged 0600
+        // mode. Recorder state advances only after the rename succeeds.
+        if let Err(err) = std::fs::rename(&staged, &self.path) {
+            let _ = std::fs::remove_file(&staged);
+            return Err(err);
+        }
         // Assigning to `inner.writer` drops the old `BufWriter`, closing the
-        // stale (unlinked) fd.
-        let file = fs_private::open_private_append(&self.path)?;
+        // fd of the replaced (now unlinked) file.
         inner.writer = BufWriter::new(file);
         inner.seq = 0;
         inner.recorder_session_id = generate_recorder_session_id();
         inner.health = AuditRecorderHealthSnapshot::default();
         Ok(())
     }
+}
+
+/// Staging sibling for [`JsonlRecorder::swap_to_fresh_file`]: the audit path
+/// with `.tmp` appended to the whole file name. Appending (rather than
+/// `with_extension`) keeps dotless paths from colliding with each other's
+/// staged files.
+fn staged_swap_path(path: &Path) -> PathBuf {
+    let mut staged = path.as_os_str().to_owned();
+    staged.push(".tmp");
+    PathBuf::from(staged)
 }
 
 /// Filename convention for the engine-scoped audit log.

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -70,8 +70,8 @@ fn audit_file_is_owner_only_on_open_and_rotation() {
     let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
     assert_eq!(mode(&path), 0o600);
 
-    // Rotation unlinks and recreates the file; the fresh file must be
-    // owner-only too.
+    // Rotation stages a fresh file and renames it over the live path; the
+    // fresh file must be owner-only too.
     recorder.rotate().unwrap();
     assert_eq!(mode(&path), 0o600);
 }
@@ -892,6 +892,182 @@ fn set_data_mode_is_a_no_op_when_mode_is_unchanged() {
 
     assert_eq!(fs::read_to_string(&path).unwrap(), before);
     assert_eq!(recorder.data_mode(), AuditDataMode::ObfuscatedSensitiveData);
+}
+
+#[test]
+#[cfg(unix)]
+fn set_data_mode_failure_leaves_mode_file_and_recording_intact() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    // A dedicated subdir takes the chmod fault so TempDir cleanup of the root
+    // is never blocked if an assertion fails before the mode is restored.
+    let logs = dir.path().join("logs");
+    fs::create_dir(&logs).unwrap();
+    let path = default_jsonl_path(&logs, "engine-abc");
+    let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+    recorder.record(AuditRecord::new(
+        None,
+        AuditEventKind::SendEntry {
+            intent_kind: "app_message".into(),
+        },
+    ));
+    let before = fs::read_to_string(&path).unwrap();
+
+    // Injected fault: a read-only directory rejects creating the staged swap
+    // file. Root bypasses directory modes, so probe and skip silently in that
+    // case (the repo-wide tracing audit bans direct output under src/).
+    fs::set_permissions(&logs, fs::Permissions::from_mode(0o500)).unwrap();
+    if fs::write(logs.join("probe.tmp"), b"").is_ok() {
+        fs::set_permissions(&logs, fs::Permissions::from_mode(0o700)).unwrap();
+        return;
+    }
+
+    let err = recorder
+        .set_data_mode(AuditDataMode::FullData, "settings_changed")
+        .unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    // The failed swap must not advance the mode nor touch the live file.
+    assert_eq!(recorder.data_mode(), AuditDataMode::ObfuscatedSensitiveData);
+    assert_eq!(fs::read_to_string(&path).unwrap(), before);
+
+    fs::set_permissions(&logs, fs::Permissions::from_mode(0o700)).unwrap();
+
+    // Recording continues into the original file: old mode, continuing seq,
+    // no recorder-session reset.
+    recorder.record(AuditRecord::new(
+        None,
+        AuditEventKind::SendEntry {
+            intent_kind: "app_message".into(),
+        },
+    ));
+    let events: Vec<AuditEvent> = fs::read_to_string(&path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[2].seq, 2);
+    assert_eq!(
+        events[2].audit_data_mode,
+        AuditDataMode::ObfuscatedSensitiveData
+    );
+    assert_eq!(events[2].recorder_session_id, events[0].recorder_session_id);
+
+    // With the fault cleared the mode change is retryable: a fresh file holds
+    // exactly the two boundary rows, both stamped with the new mode.
+    recorder
+        .set_data_mode(AuditDataMode::FullData, "settings_changed")
+        .unwrap();
+    assert_eq!(recorder.data_mode(), AuditDataMode::FullData);
+    let events: Vec<AuditEvent> = fs::read_to_string(&path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(events.len(), 2);
+    assert!(matches!(
+        events[0].kind,
+        AuditEventKind::RecorderStarted { .. }
+    ));
+    assert!(matches!(
+        events[1].kind,
+        AuditEventKind::AuditDataModeChanged { .. }
+    ));
+    assert!(
+        events
+            .iter()
+            .all(|event| event.audit_data_mode == AuditDataMode::FullData)
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn rotate_failure_keeps_recording_to_original_file() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    // A dedicated subdir takes the chmod fault so TempDir cleanup of the root
+    // is never blocked if an assertion fails before the mode is restored.
+    let logs = dir.path().join("logs");
+    fs::create_dir(&logs).unwrap();
+    let path = default_jsonl_path(&logs, "engine-abc");
+    let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+    recorder.record(AuditRecord::new(
+        None,
+        AuditEventKind::SendEntry {
+            intent_kind: "app_message".into(),
+        },
+    ));
+    let before = fs::read_to_string(&path).unwrap();
+
+    // Injected fault: a read-only directory rejects creating the staged swap
+    // file. Root bypasses directory modes, so probe and skip silently in that
+    // case (the repo-wide tracing audit bans direct output under src/).
+    fs::set_permissions(&logs, fs::Permissions::from_mode(0o500)).unwrap();
+    if fs::write(logs.join("probe.tmp"), b"").is_ok() {
+        fs::set_permissions(&logs, fs::Permissions::from_mode(0o700)).unwrap();
+        return;
+    }
+
+    let err = recorder.rotate().unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    assert_eq!(fs::read_to_string(&path).unwrap(), before);
+
+    fs::set_permissions(&logs, fs::Permissions::from_mode(0o700)).unwrap();
+
+    // The failed rotation must leave the recorder appending to the original
+    // file with a continuing sequence.
+    recorder.record(AuditRecord::new(
+        None,
+        AuditEventKind::SendEntry {
+            intent_kind: "app_message".into(),
+        },
+    ));
+    let events: Vec<AuditEvent> = fs::read_to_string(&path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[2].seq, 2);
+}
+
+#[test]
+fn set_data_mode_recovers_from_stale_staged_swap_file() {
+    let dir = TempDir::new().unwrap();
+    let path = default_jsonl_path(dir.path(), "engine-abc");
+    let recorder = JsonlRecorder::open(&path, "engine-abc".to_string()).unwrap();
+
+    // A staged file left behind by an interrupted earlier swap must be
+    // discarded, never adopted into the fresh log.
+    let staged = staged_swap_path(&path);
+    fs::write(&staged, b"stale staged junk\n").unwrap();
+
+    recorder
+        .set_data_mode(AuditDataMode::FullData, "settings_changed")
+        .unwrap();
+
+    assert!(!staged.exists());
+    let events: Vec<AuditEvent> = fs::read_to_string(&path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(events.len(), 2);
+    assert!(matches!(
+        events[0].kind,
+        AuditEventKind::RecorderStarted { .. }
+    ));
+    assert!(matches!(
+        events[1].kind,
+        AuditEventKind::AuditDataModeChanged { .. }
+    ));
+    assert!(
+        events
+            .iter()
+            .all(|event| event.audit_data_mode == AuditDataMode::FullData)
+    );
 }
 
 #[test]

--- a/crates/marmot-uniffi/src/conversions/event.rs
+++ b/crates/marmot-uniffi/src/conversions/event.rs
@@ -69,6 +69,16 @@ pub enum MarmotEventFfi {
         account_id_hex: String,
         account_label: String,
     },
+    /// A confirmed create/invite could not deliver a welcome to `recipient_hex`;
+    /// that member is in the group but unjoinable until the welcome is
+    /// re-delivered via `redeliver_welcome(message_id_hex)` (mdk#352).
+    WelcomeDeliveryPending {
+        account_id_hex: String,
+        account_label: String,
+        group_id_hex: String,
+        message_id_hex: String,
+        recipient_hex: String,
+    },
 }
 
 /// FFI projection of [`cgka_traits::engine::GroupEvent`]. The previous FFI
@@ -309,6 +319,19 @@ impl From<MarmotAppEvent> for MarmotEventFfi {
             MarmotAppEvent::AgentStreamStarted(m) => Self::AgentStreamActivity {
                 account_id_hex: m.account_id_hex,
                 account_label: m.account_label,
+            },
+            MarmotAppEvent::WelcomeDeliveryPending {
+                account_id_hex,
+                account_label,
+                group_id,
+                message_id_hex,
+                recipient_hex,
+            } => Self::WelcomeDeliveryPending {
+                account_id_hex,
+                account_label,
+                group_id_hex: hex::encode(group_id.as_slice()),
+                message_id_hex,
+                recipient_hex,
             },
         }
     }

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -12,6 +12,7 @@ mod connection;
 mod encrypted_media_secrets;
 mod migrations;
 mod openmls_storage;
+mod pending_welcome_delivery;
 mod shared;
 mod storage;
 mod timeline;
@@ -31,6 +32,7 @@ pub use connection::{
     SqliteStorageOptions, SqliteSynchronous, open_hardened_sqlcipher,
 };
 pub use openmls_storage::SqliteOpenMlsStorageError;
+pub use pending_welcome_delivery::PendingWelcomeDeliveryRecord;
 pub use shared::{
     PublicDirectoryUserRecord, SqliteSharedStorage, StoredAuditLogSettings,
     StoredRelayTelemetrySettings,

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -44,6 +44,8 @@ mod migration_0021_push_token_owner_signatures;
 mod migration_0022_chat_list_self_membership;
 #[path = "migrations/0023_chat_list_projection_version.rs"]
 mod migration_0023_chat_list_projection_version;
+#[path = "migrations/0024_pending_welcome_delivery.rs"]
+mod migration_0024_pending_welcome_delivery;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -170,6 +172,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 23,
         name: "0023_chat_list_projection_version",
         apply: migration_0023_chat_list_projection_version::apply,
+    },
+    Migration {
+        version: 24,
+        name: "0024_pending_welcome_delivery",
+        apply: migration_0024_pending_welcome_delivery::apply,
     },
 ];
 

--- a/crates/storage-sqlite/src/migrations/0024_pending_welcome_delivery.rs
+++ b/crates/storage-sqlite/src/migrations/0024_pending_welcome_delivery.rs
@@ -1,0 +1,19 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE app_pending_welcome_delivery (
+    message_id_hex TEXT PRIMARY KEY,
+    group_id_hex   TEXT NOT NULL,
+    recipient_hex  TEXT NOT NULL,
+    recorded_at    INTEGER NOT NULL
+);
+CREATE INDEX app_pending_welcome_delivery_group_idx
+    ON app_pending_welcome_delivery (group_id_hex);
+"#,
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/pending_welcome_delivery.rs
+++ b/crates/storage-sqlite/src/pending_welcome_delivery.rs
@@ -1,0 +1,171 @@
+use crate::{SqliteAccountStorage, SqliteResultExt, u64_to_i64};
+use cgka_traits::storage::StorageResult;
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+
+/// Durable pointer to a confirmed group create/invite whose welcome publish
+/// failed, so the welcome can be re-delivered later (mdk#352). Keyed by
+/// `message_id_hex`, the identity of the welcome message; re-recording the same
+/// message updates the group/recipient/timestamp in place.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingWelcomeDeliveryRecord {
+    pub message_id_hex: String,
+    pub group_id_hex: String,
+    pub recipient_hex: String,
+    pub recorded_at: u64,
+}
+
+impl SqliteAccountStorage {
+    /// Record (or re-record) a pending welcome delivery. Idempotent on
+    /// `message_id_hex`: re-recording overwrites the group, recipient, and
+    /// timestamp rather than inserting a duplicate.
+    pub fn record_pending_welcome_delivery(
+        &self,
+        message_id_hex: &str,
+        group_id_hex: &str,
+        recipient_hex: &str,
+        recorded_at: u64,
+    ) -> StorageResult<()> {
+        self.lock()?
+            .execute(
+                "INSERT INTO app_pending_welcome_delivery (
+                    message_id_hex, group_id_hex, recipient_hex, recorded_at
+                 )
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(message_id_hex) DO UPDATE SET
+                    group_id_hex = excluded.group_id_hex,
+                    recipient_hex = excluded.recipient_hex,
+                    recorded_at = excluded.recorded_at",
+                params![
+                    message_id_hex,
+                    group_id_hex,
+                    recipient_hex,
+                    u64_to_i64(recorded_at)?
+                ],
+            )
+            .storage()?;
+        Ok(())
+    }
+
+    /// List every pending welcome delivery in stable oldest-first order.
+    pub fn list_pending_welcome_deliveries(
+        &self,
+    ) -> StorageResult<Vec<PendingWelcomeDeliveryRecord>> {
+        let conn = self.lock()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT message_id_hex, group_id_hex, recipient_hex, recorded_at
+                 FROM app_pending_welcome_delivery
+                 ORDER BY recorded_at ASC, message_id_hex ASC",
+            )
+            .storage()?;
+        stmt.query_map([], |row| {
+            Ok(PendingWelcomeDeliveryRecord {
+                message_id_hex: row.get(0)?,
+                group_id_hex: row.get(1)?,
+                recipient_hex: row.get(2)?,
+                recorded_at: row.get::<_, i64>(3)? as u64,
+            })
+        })
+        .storage()?
+        .collect::<Result<Vec<_>, _>>()
+        .storage()
+    }
+
+    /// Clear the pending welcome delivery for `message_id_hex`, if any.
+    pub fn clear_pending_welcome_delivery(&self, message_id_hex: &str) -> StorageResult<()> {
+        self.lock()?
+            .execute(
+                "DELETE FROM app_pending_welcome_delivery WHERE message_id_hex = ?1",
+                params![message_id_hex],
+            )
+            .storage()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_then_list_roundtrips_fields() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .record_pending_welcome_delivery("aa", "bb", "cc", 7)
+            .unwrap();
+
+        let records = store.list_pending_welcome_deliveries().unwrap();
+        assert_eq!(
+            records,
+            vec![PendingWelcomeDeliveryRecord {
+                message_id_hex: "aa".to_owned(),
+                group_id_hex: "bb".to_owned(),
+                recipient_hex: "cc".to_owned(),
+                recorded_at: 7,
+            }]
+        );
+    }
+
+    #[test]
+    fn re_record_same_message_updates_in_place() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .record_pending_welcome_delivery("aa", "bb", "cc", 7)
+            .unwrap();
+        store
+            .record_pending_welcome_delivery("aa", "bb2", "cc2", 9)
+            .unwrap();
+
+        let records = store.list_pending_welcome_deliveries().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0],
+            PendingWelcomeDeliveryRecord {
+                message_id_hex: "aa".to_owned(),
+                group_id_hex: "bb2".to_owned(),
+                recipient_hex: "cc2".to_owned(),
+                recorded_at: 9,
+            }
+        );
+    }
+
+    #[test]
+    fn clear_removes_exactly_one() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .record_pending_welcome_delivery("aa", "bb", "cc", 1)
+            .unwrap();
+        store
+            .record_pending_welcome_delivery("dd", "ee", "ff", 2)
+            .unwrap();
+
+        store.clear_pending_welcome_delivery("aa").unwrap();
+
+        let records = store.list_pending_welcome_deliveries().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].message_id_hex, "dd");
+    }
+
+    #[test]
+    fn list_orders_by_recorded_at() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .record_pending_welcome_delivery("c", "g", "r", 30)
+            .unwrap();
+        store
+            .record_pending_welcome_delivery("a", "g", "r", 10)
+            .unwrap();
+        store
+            .record_pending_welcome_delivery("b", "g", "r", 20)
+            .unwrap();
+
+        let order: Vec<String> = store
+            .list_pending_welcome_deliveries()
+            .unwrap()
+            .into_iter()
+            .map(|record| record.message_id_hex)
+            .collect();
+        assert_eq!(order, vec!["a".to_owned(), "b".to_owned(), "c".to_owned()]);
+    }
+}

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -294,6 +294,12 @@ pub trait TransportAdapter: Send + Sync {
     ) -> Result<(), TransportAdapterError>;
 
     /// Refresh only the group subscription plane for an active account.
+    ///
+    /// Subscribe failures for added groups fail fast and leave adapter state
+    /// untouched. Unsubscribe failures for removed groups are absorbed: the
+    /// removal takes effect in the adapter's routing state immediately, the
+    /// relay-side unsubscribe is retried on subsequent syncs, and such
+    /// failures never fail the call.
     async fn sync_account_groups(
         &self,
         sync: TransportGroupSync,

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -123,7 +123,10 @@ pub struct TransportPublishRequest {
     pub message: TransportMessage,
     pub target: TransportPublishTarget,
     /// Minimum endpoint acknowledgements the adapter should try to obtain
-    /// before reporting success. A value of `0` means best effort.
+    /// before reporting success. A value of `0` means best effort: the adapter
+    /// does not wait for a specific ack count, but a publish that no endpoint
+    /// accepted still fails — [`TransportPublishReport::met_required_acks`]
+    /// always requires at least one acceptance.
     pub required_acks: usize,
 }
 
@@ -181,6 +184,10 @@ pub struct TransportPublishReport {
     pub message_id: MessageId,
     pub accepted: Vec<TransportEndpointReceipt>,
     pub failed: Vec<TransportEndpointFailure>,
+    /// Threshold copied from the request; `0` relaxes the threshold but never
+    /// the at-least-one-acceptance requirement (see [`met_required_acks`]).
+    ///
+    /// [`met_required_acks`]: Self::met_required_acks
     pub required_acks: usize,
 }
 
@@ -189,8 +196,14 @@ impl TransportPublishReport {
         self.accepted.len()
     }
 
+    /// Whether the publish reached enough endpoints to count as published.
+    ///
+    /// At least one acceptance is always required: a "best effort"
+    /// (`required_acks == 0`) publish that no endpoint accepted reached no
+    /// one, and confirming it would advance local state (epoch, membership)
+    /// past a message that was never exposed.
     pub fn met_required_acks(&self) -> bool {
-        self.accepted_count() >= self.required_acks
+        self.accepted_count() >= self.required_acks.max(1)
     }
 }
 
@@ -305,5 +318,49 @@ fn envelope_label(envelope: &TransportEnvelope) -> &'static str {
     match envelope {
         TransportEnvelope::GroupMessage { .. } => "group",
         TransportEnvelope::Welcome { .. } => "welcome",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(accepted: usize, failed: usize, required_acks: usize) -> TransportPublishReport {
+        TransportPublishReport {
+            message_id: MessageId::new(*b"m1"),
+            accepted: (0..accepted)
+                .map(|i| TransportEndpointReceipt {
+                    endpoint: TransportEndpoint(format!("wss://accepted-{i}.example")),
+                    accepted_at: None,
+                })
+                .collect(),
+            failed: (0..failed)
+                .map(|i| TransportEndpointFailure {
+                    endpoint: TransportEndpoint(format!("wss://failed-{i}.example")),
+                    reason: "unreachable".into(),
+                })
+                .collect(),
+            required_acks,
+        }
+    }
+
+    #[test]
+    fn met_required_acks_zero_required_fails_with_zero_accepted() {
+        assert!(!report(0, 0, 0).met_required_acks());
+        assert!(!report(0, 2, 0).met_required_acks());
+    }
+
+    #[test]
+    fn met_required_acks_zero_required_passes_with_one_accepted() {
+        assert!(report(1, 0, 0).met_required_acks());
+        assert!(report(1, 3, 0).met_required_acks());
+    }
+
+    #[test]
+    fn met_required_acks_nonzero_threshold_unchanged() {
+        assert!(!report(0, 0, 1).met_required_acks());
+        assert!(report(1, 0, 1).met_required_acks());
+        assert!(!report(1, 1, 2).met_required_acks());
+        assert!(report(2, 0, 2).met_required_acks());
     }
 }

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -135,6 +135,13 @@ impl NostrSubscription {
         }
     }
 
+    /// Account this subscription belongs to.
+    pub fn account_id(&self) -> &MemberId {
+        match self {
+            Self::AccountInbox { account_id, .. } | Self::Group { account_id, .. } => account_id,
+        }
+    }
+
     fn route_key(&self) -> NostrSubscriptionRouteKey {
         match self {
             Self::AccountInbox {
@@ -185,6 +192,10 @@ pub struct NostrAdapterMetrics {
     pub active_group_subscriptions: usize,
     pub subscriptions_created: usize,
     pub subscriptions_removed: usize,
+    /// Gauge: relay unsubscribes that failed and await retry on a later group
+    /// sync. Routing state already reflects the removals.
+    #[serde(default)]
+    pub unsubscribe_retries_pending: usize,
     pub inbound_events_seen: usize,
     pub inbound_events_delivered: usize,
     pub inbound_events_dropped: usize,
@@ -284,6 +295,7 @@ impl NostrTransportAdapter {
             .values()
             .map(|account| account.groups.len())
             .sum();
+        metrics.unsubscribe_retries_pending = state.pending_unsubscribes.len();
         metrics
     }
 
@@ -514,6 +526,11 @@ impl TransportAdapter for NostrTransportAdapter {
         // old subscription ids first (before recording the new starts, since
         // unchanged endpoint sets reuse the same ids).
         state.forget_account_subscription_starts(&account_id);
+        if replaced_count > 0 {
+            // The blanket `unsubscribe_account` above supersedes any queued
+            // per-subscription unsubscribes for this account.
+            state.clear_pending_unsubscribes_for_account(&account_id);
+        }
         state.record_subscription_starts(&issued, now_ms);
         state.activate(activation, replaced_count);
         Ok(())
@@ -553,23 +570,55 @@ impl TransportAdapter for NostrTransportAdapter {
             )
         };
 
+        // Additions stay fail-fast: on error the adapter state is untouched, a
+        // retry re-diffs against the old group set, and re-subscribing the same
+        // deterministic subscription id is idempotent.
         self.subscribe_all("sync_account_groups", &to_add).await?;
-        for subscription in &to_remove {
-            self.relay_client.unsubscribe(subscription.clone()).await?;
+
+        // Commit routing intent BEFORE relay teardown: a failed unsubscribe
+        // must never leave the routing index serving the old group set.
+        // Removals are queued and drained below (plus any left over from
+        // earlier syncs); failures there are absorbed and retried, never
+        // surfaced as an error.
+        let now_ms = self.now_ms();
+        let drainable = {
+            let mut state = self.state.write().await;
+            state.forget_subscription_starts(&to_remove);
+            state.record_subscription_starts(&to_add, now_ms);
+            state.sync_groups(sync, to_add.len());
+            state.queue_pending_unsubscribes(to_remove);
+            state.take_drainable_unsubscribes()
+        };
+
+        let mut confirmed = 0_usize;
+        let mut requeue = Vec::new();
+        for subscription in drainable {
+            match self.relay_client.unsubscribe(subscription.clone()).await {
+                Ok(()) => confirmed += 1,
+                Err(_) => requeue.push(subscription),
+            }
         }
 
         tracing::debug!(
             target: "transport_nostr_adapter::adapter",
             method = "sync_account_groups",
             subscriptions_created = to_add.len(),
-            subscriptions_removed = to_remove.len(),
+            unsubscribes_confirmed = confirmed,
             "applied transport group subscription diff"
         );
-        let now_ms = self.now_ms();
         let mut state = self.state.write().await;
-        state.forget_subscription_starts(&to_remove);
-        state.record_subscription_starts(&to_add, now_ms);
-        state.sync_groups(sync, to_add.len(), to_remove.len());
+        state.record_confirmed_unsubscribes(confirmed);
+        if !requeue.is_empty() {
+            let failed_unsubscribe_count = requeue.len();
+            state.queue_pending_unsubscribes(requeue);
+            tracing::warn!(
+                target: "transport_nostr_adapter::adapter",
+                method = "sync_account_groups",
+                failed_unsubscribe_count,
+                pending_retry_total = state.pending_unsubscribes.len(),
+                "deferred relay unsubscribes; will retry on next group sync"
+            );
+        }
         Ok(())
     }
 
@@ -591,6 +640,9 @@ impl TransportAdapter for NostrTransportAdapter {
         self.relay_client.unsubscribe_account(account_id).await?;
         let mut state = self.state.write().await;
         state.forget_account_subscription_starts(account_id);
+        // The blanket `unsubscribe_account` above supersedes any queued
+        // per-subscription unsubscribes for this account.
+        state.clear_pending_unsubscribes_for_account(account_id);
         state.deactivate(account_id, removed_count);
         Ok(())
     }
@@ -788,6 +840,11 @@ struct AdapterState {
     /// authoritative signed-routing state) at every mutation
     /// (activate/sync_groups/deactivate), so it can never drift.
     by_transport_group: HashMap<Vec<u8>, Vec<GroupRouteEntry>>,
+    /// Relay unsubscribes that failed and await retry. Routing state
+    /// (`accounts`/`by_transport_group`) already reflects the removal; these
+    /// are relay-side cleanups only, drained on later `sync_account_groups`
+    /// calls (never a reason to fail a sync).
+    pending_unsubscribes: Vec<NostrSubscription>,
     metrics: NostrAdapterMetrics,
     relay_index: RelayIndexRegistry,
     telemetry: RelayDeliveryTelemetry,
@@ -832,13 +889,69 @@ impl AdapterState {
         self.rebuild_transport_group_index();
     }
 
-    fn sync_groups(&mut self, sync: TransportGroupSync, created: usize, removed: usize) {
+    fn sync_groups(&mut self, sync: TransportGroupSync, created: usize) {
         if let Some(account) = self.accounts.get_mut(&sync.account_id) {
             account.groups = sync.group_subscriptions;
             self.metrics.subscriptions_created += created;
-            self.metrics.subscriptions_removed += removed;
             self.rebuild_transport_group_index();
         }
+    }
+
+    /// Queue relay unsubscribes whose relay-side teardown has not been
+    /// confirmed yet, deduplicated by subscription id (ids are deterministic
+    /// content hashes, so a retried removal re-queues the same id).
+    fn queue_pending_unsubscribes(&mut self, subscriptions: Vec<NostrSubscription>) {
+        for subscription in subscriptions {
+            let id = subscription.subscription_id();
+            if self
+                .pending_unsubscribes
+                .iter()
+                .any(|pending| pending.subscription_id() == id)
+            {
+                continue;
+            }
+            self.pending_unsubscribes.push(subscription);
+        }
+    }
+
+    /// Take the queued unsubscribes that are safe to replay against relays.
+    ///
+    /// Entries whose route key is live again are silently dropped, never
+    /// drained: subscription ids are deterministic content hashes, so a group
+    /// removed (unsubscribe failed, queued here) and then re-added mints the
+    /// SAME id, and replaying the stale entry would tear down the
+    /// just-re-established subscription. Only group subscriptions enter this
+    /// queue, so liveness is checked against every account's stored groups.
+    fn take_drainable_unsubscribes(&mut self) -> Vec<NostrSubscription> {
+        let queued = std::mem::take(&mut self.pending_unsubscribes);
+        if queued.is_empty() {
+            return queued;
+        }
+        let live_route_keys = self
+            .accounts
+            .iter()
+            .flat_map(|(account_id, routes)| {
+                routes
+                    .groups
+                    .iter()
+                    .map(|group| group_subscription(account_id, group, None).route_key())
+            })
+            .collect::<HashSet<_>>();
+        queued
+            .into_iter()
+            .filter(|subscription| !live_route_keys.contains(&subscription.route_key()))
+            .collect()
+    }
+
+    /// Drop queued per-subscription unsubscribes for an account whose relay
+    /// state is being torn down wholesale via `unsubscribe_account`.
+    fn clear_pending_unsubscribes_for_account(&mut self, account_id: &MemberId) {
+        self.pending_unsubscribes
+            .retain(|subscription| subscription.account_id() != account_id);
+    }
+
+    fn record_confirmed_unsubscribes(&mut self, count: usize) {
+        self.metrics.subscriptions_removed += count;
     }
 
     fn deactivate(&mut self, account_id: &MemberId, removed_count: usize) {

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -265,6 +265,14 @@ pub struct NostrTransportAdapter {
     state: Arc<RwLock<AdapterState>>,
     delivery_tx: mpsc::Sender<TransportDelivery>,
     delivery_rx: Arc<Mutex<mpsc::Receiver<TransportDelivery>>>,
+    /// Serializes the subscription-lifecycle operations (activate / deactivate /
+    /// group sync) so their relay-side subscribe/unsubscribe network calls —
+    /// which run OUTSIDE the `state` `RwLock` — cannot interleave. Without it a
+    /// concurrent sync could re-add a group (minting the same deterministic
+    /// subscription id) in the window between another sync's live-route filter
+    /// and its stale `unsubscribe`, tearing the fresh subscription back down.
+    /// The `RwLock` still guards the fast delivery/routing path independently.
+    subscription_lock: Arc<Mutex<()>>,
     /// Local monotonic origin for delivery telemetry. Never `created_at`.
     monotonic_start: std::time::Instant,
 }
@@ -277,6 +285,7 @@ impl NostrTransportAdapter {
             state: Arc::new(RwLock::new(AdapterState::default())),
             delivery_tx,
             delivery_rx: Arc::new(Mutex::new(delivery_rx)),
+            subscription_lock: Arc::new(Mutex::new(())),
             monotonic_start: std::time::Instant::now(),
         }
     }
@@ -483,6 +492,9 @@ impl TransportAdapter for NostrTransportAdapter {
         &self,
         activation: TransportAccountActivation,
     ) -> Result<(), TransportAdapterError> {
+        // Serialize with sync/deactivate so this account's re-subscribe cannot
+        // interleave a concurrent sync's unsubscribe drain (see the field doc).
+        let _subscription_guard = self.subscription_lock.lock().await;
         let account_id = activation.account_id.clone();
         tracing::debug!(
             target: "transport_nostr_adapter::adapter",
@@ -540,6 +552,10 @@ impl TransportAdapter for NostrTransportAdapter {
         &self,
         sync: TransportGroupSync,
     ) -> Result<(), TransportAdapterError> {
+        // Serialize against other subscription-lifecycle operations so the
+        // drain's live-route filter and its relay unsubscribes cannot race a
+        // concurrent re-add of the same deterministic subscription id.
+        let _subscription_guard = self.subscription_lock.lock().await;
         tracing::debug!(
             target: "transport_nostr_adapter::adapter",
             method = "sync_account_groups",
@@ -623,6 +639,9 @@ impl TransportAdapter for NostrTransportAdapter {
     }
 
     async fn deactivate_account(&self, account_id: &MemberId) -> Result<(), TransportAdapterError> {
+        // Serialize with sync/activate so the blanket unsubscribe cannot
+        // interleave a concurrent sync's unsubscribe drain (see the field doc).
+        let _subscription_guard = self.subscription_lock.lock().await;
         let removed_count = {
             let state = self.state.read().await;
             state

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -205,6 +205,135 @@ impl NostrRelayClient for FlakyUnsubscribeRelayClient {
     }
 }
 
+/// Records the maximum number of `unsubscribe` calls observed in flight at
+/// once. Each `unsubscribe` yields several times so that, absent serialization,
+/// a concurrent lifecycle op's `unsubscribe` would be seen overlapping.
+#[derive(Default)]
+struct UnsubscribeOverlapProbeRelayClient {
+    in_flight: AtomicUsize,
+    max_in_flight: AtomicUsize,
+    subscriptions: Mutex<Vec<transport_nostr_adapter::NostrSubscription>>,
+}
+
+#[async_trait]
+impl NostrRelayClient for UnsubscribeOverlapProbeRelayClient {
+    async fn subscribe(
+        &self,
+        subscription: transport_nostr_adapter::NostrSubscription,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        self.subscriptions.lock().unwrap().push(subscription);
+        Ok(())
+    }
+
+    async fn unsubscribe(
+        &self,
+        _subscription: transport_nostr_adapter::NostrSubscription,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_in_flight.fetch_max(now, Ordering::SeqCst);
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn unsubscribe_account(
+        &self,
+        _account_id: &MemberId,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        Ok(())
+    }
+
+    async fn publish_event(
+        &self,
+        endpoints: &[TransportEndpoint],
+        _event: &NostrTransportEvent,
+        _required_acks: usize,
+    ) -> Result<NostrPublishOutcome, cgka_traits::TransportAdapterError> {
+        Ok(NostrPublishOutcome::accepted(endpoints.to_vec()))
+    }
+}
+
+/// Regression for the unsubscribe/re-add race: two group syncs on different
+/// accounts, run concurrently, each remove their account's group and so each
+/// drives an `unsubscribe`. The subscription-lifecycle lock must serialize
+/// them, so the relay never sees two `unsubscribe` calls overlapping — the
+/// window in which a concurrent re-add could tear down a freshly re-subscribed
+/// deterministic subscription id.
+#[tokio::test]
+async fn concurrent_group_syncs_do_not_overlap_relay_unsubscribes() {
+    let relay = Arc::new(UnsubscribeOverlapProbeRelayClient::default());
+    let adapter = Arc::new(NostrTransportAdapter::new(relay.clone()));
+
+    let alice = MemberId::new(vec![0xA1; 32]);
+    let bob = MemberId::new(vec![0xB2; 32]);
+    let alice_group = TransportGroupSubscription {
+        group_id: cgka_traits::GroupId::new(vec![0xC1; 32]),
+        transport_group_id: vec![0xD1; 32],
+        endpoints: vec![TransportEndpoint("wss://group-a.example".into())],
+    };
+    let bob_group = TransportGroupSubscription {
+        group_id: cgka_traits::GroupId::new(vec![0xC2; 32]),
+        transport_group_id: vec![0xD2; 32],
+        endpoints: vec![TransportEndpoint("wss://group-b.example".into())],
+    };
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: alice.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://alice-inbox.example".into())],
+            group_subscriptions: vec![alice_group],
+            since: None,
+        })
+        .await
+        .expect("alice activation succeeds");
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: bob.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://bob-inbox.example".into())],
+            group_subscriptions: vec![bob_group],
+            since: None,
+        })
+        .await
+        .expect("bob activation succeeds");
+
+    // Each sync drops its account's only group, so each drains one unsubscribe.
+    let adapter_a = Arc::clone(&adapter);
+    let adapter_b = Arc::clone(&adapter);
+    let sync_a = tokio::spawn(async move {
+        adapter_a
+            .sync_account_groups(TransportGroupSync {
+                account_id: alice,
+                group_subscriptions: vec![],
+                since: None,
+            })
+            .await
+    });
+    let sync_b = tokio::spawn(async move {
+        adapter_b
+            .sync_account_groups(TransportGroupSync {
+                account_id: bob,
+                group_subscriptions: vec![],
+                since: None,
+            })
+            .await
+    });
+    sync_a.await.unwrap().expect("alice sync succeeds");
+    sync_b.await.unwrap().expect("bob sync succeeds");
+
+    assert_eq!(
+        relay.max_in_flight.load(Ordering::SeqCst),
+        1,
+        "subscription-lifecycle ops must not run relay unsubscribes concurrently"
+    );
+    assert_eq!(
+        adapter.metrics().await.subscriptions_removed,
+        2,
+        "both group unsubscribes should have been confirmed"
+    );
+}
+
 #[tokio::test]
 async fn group_subscription_id_fans_out_to_matching_accounts_and_replays_route_again() {
     let relay = Arc::new(FakeRelayClient::default());

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -145,6 +145,66 @@ impl NostrRelayClient for FakeRelayClient {
     }
 }
 
+/// Like [`FakeRelayClient`], but `unsubscribe` fails (without recording) while
+/// `fail_next_unsubscribes` decrements to zero, then records and succeeds.
+#[derive(Default)]
+struct FlakyUnsubscribeRelayClient {
+    subscriptions: Mutex<Vec<transport_nostr_adapter::NostrSubscription>>,
+    unsubscribed: Mutex<Vec<transport_nostr_adapter::NostrSubscription>>,
+    unsubscribed_accounts: Mutex<Vec<MemberId>>,
+    fail_next_unsubscribes: AtomicUsize,
+}
+
+#[async_trait]
+impl NostrRelayClient for FlakyUnsubscribeRelayClient {
+    async fn subscribe(
+        &self,
+        subscription: transport_nostr_adapter::NostrSubscription,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        self.subscriptions.lock().unwrap().push(subscription);
+        Ok(())
+    }
+
+    async fn unsubscribe(
+        &self,
+        subscription: transport_nostr_adapter::NostrSubscription,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        if self
+            .fail_next_unsubscribes
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |armed| {
+                armed.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(cgka_traits::TransportAdapterError::Subscription(
+                "injected unsubscribe failure".into(),
+            ));
+        }
+        self.unsubscribed.lock().unwrap().push(subscription);
+        Ok(())
+    }
+
+    async fn unsubscribe_account(
+        &self,
+        account_id: &MemberId,
+    ) -> Result<(), cgka_traits::TransportAdapterError> {
+        self.unsubscribed_accounts
+            .lock()
+            .unwrap()
+            .push(account_id.clone());
+        Ok(())
+    }
+
+    async fn publish_event(
+        &self,
+        endpoints: &[TransportEndpoint],
+        _event: &NostrTransportEvent,
+        _required_acks: usize,
+    ) -> Result<NostrPublishOutcome, cgka_traits::TransportAdapterError> {
+        Ok(NostrPublishOutcome::accepted(endpoints.to_vec()))
+    }
+}
+
 #[tokio::test]
 async fn group_subscription_id_fans_out_to_matching_accounts_and_replays_route_again() {
     let relay = Arc::new(FakeRelayClient::default());
@@ -635,6 +695,261 @@ async fn synced_group_subscriptions_replace_old_routes() {
             since: None,
         }]
     );
+}
+
+// Regression for mdk#337: a failed relay unsubscribe must not fail the sync or
+// leave the routing index serving the old group set. The removal takes effect
+// in routing state immediately; the relay-side teardown is queued for retry.
+#[tokio::test]
+async fn sync_with_failed_unsubscribe_returns_ok_and_routes_reflect_intent() {
+    let relay = Arc::new(FlakyUnsubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let old_transport_group_id = vec![0xC3; 32];
+    let new_group_id = cgka_traits::GroupId::new(vec![0xD4; 32]);
+    let new_transport_group_id = vec![0xE5; 32];
+    let endpoint = TransportEndpoint("wss://group.example".into());
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![TransportGroupSubscription {
+                group_id: cgka_traits::GroupId::new(vec![0xB2; 32]),
+                transport_group_id: old_transport_group_id.clone(),
+                endpoints: vec![endpoint.clone()],
+            }],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    relay.fail_next_unsubscribes.store(1, Ordering::SeqCst);
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id,
+            group_subscriptions: vec![TransportGroupSubscription {
+                group_id: new_group_id.clone(),
+                transport_group_id: new_transport_group_id.clone(),
+                endpoints: vec![endpoint.clone()],
+            }],
+            since: Some(Timestamp(1_700_000_100)),
+        })
+        .await
+        .expect("sync succeeds despite the failed unsubscribe");
+
+    let old_delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: endpoint.clone(),
+            subscription_id: Some("old-group-sub".into()),
+            event: group_event("21", &old_transport_group_id),
+        })
+        .await
+        .expect("old relay event handled");
+    let new_delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint,
+            subscription_id: Some("new-group-sub".into()),
+            event: group_event("22", &new_transport_group_id),
+        })
+        .await
+        .expect("new relay event handled");
+
+    assert_eq!(old_delivered, 0, "removed route must not deliver");
+    assert_eq!(new_delivered, 1);
+    let delivery = adapter.receive().await.unwrap().unwrap();
+    assert_eq!(delivery.group_id_hint, Some(new_group_id));
+
+    let metrics = adapter.metrics().await;
+    assert_eq!(metrics.subscriptions_removed, 0);
+    assert_eq!(metrics.unsubscribe_retries_pending, 1);
+    // Telemetry tracks only live subscriptions: inbox + the new group.
+    assert_eq!(adapter.relay_sync().await.tracked_subscriptions, 2);
+}
+
+#[tokio::test]
+async fn failed_unsubscribe_is_retried_and_drained_on_next_sync() {
+    let relay = Arc::new(FlakyUnsubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let old_group_id = cgka_traits::GroupId::new(vec![0xB2; 32]);
+    let old_transport_group_id = vec![0xC3; 32];
+    let endpoint = TransportEndpoint("wss://group.example".into());
+    let new_group = TransportGroupSubscription {
+        group_id: cgka_traits::GroupId::new(vec![0xD4; 32]),
+        transport_group_id: vec![0xE5; 32],
+        endpoints: vec![endpoint.clone()],
+    };
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![TransportGroupSubscription {
+                group_id: old_group_id.clone(),
+                transport_group_id: old_transport_group_id.clone(),
+                endpoints: vec![endpoint.clone()],
+            }],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    relay.fail_next_unsubscribes.store(1, Ordering::SeqCst);
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![new_group.clone()],
+            since: None,
+        })
+        .await
+        .expect("sync succeeds despite the failed unsubscribe");
+    assert_eq!(adapter.metrics().await.unsubscribe_retries_pending, 1);
+
+    // Same desired set: an empty diff still drains the retry queue.
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![new_group],
+            since: None,
+        })
+        .await
+        .expect("retry sync succeeds");
+
+    {
+        let unsubscribed = relay.unsubscribed.lock().unwrap();
+        assert_eq!(
+            unsubscribed.as_slice(),
+            &[NostrSubscription::Group {
+                account_id,
+                group_id: old_group_id,
+                transport_group_id: old_transport_group_id,
+                endpoints: vec![endpoint],
+                since: None,
+            }],
+            "the failed unsubscribe is replayed exactly once"
+        );
+    }
+    let metrics = adapter.metrics().await;
+    assert_eq!(metrics.subscriptions_removed, 1);
+    assert_eq!(metrics.unsubscribe_retries_pending, 0);
+}
+
+#[tokio::test]
+async fn pending_unsubscribe_for_readded_group_is_discarded_not_replayed() {
+    let relay = Arc::new(FlakyUnsubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let group = TransportGroupSubscription {
+        group_id: cgka_traits::GroupId::new(vec![0xB2; 32]),
+        transport_group_id: vec![0xC3; 32],
+        endpoints: vec![TransportEndpoint("wss://group.example".into())],
+    };
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![group.clone()],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+
+    // Remove the group; the relay-side unsubscribe fails and is queued.
+    relay.fail_next_unsubscribes.store(1, Ordering::SeqCst);
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![],
+            since: None,
+        })
+        .await
+        .expect("removal sync succeeds despite the failed unsubscribe");
+    assert_eq!(adapter.metrics().await.unsubscribe_retries_pending, 1);
+
+    // Re-add the same group. Subscription ids are deterministic content
+    // hashes, so the queued unsubscribe carries the SAME id the re-add just
+    // re-established; the stale entry must be discarded, not replayed.
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![group.clone()],
+            since: None,
+        })
+        .await
+        .expect("re-add sync succeeds");
+    assert_eq!(
+        relay.subscriptions.lock().unwrap().len(),
+        3,
+        "inbox + initial group + re-added group"
+    );
+    assert_eq!(adapter.metrics().await.unsubscribe_retries_pending, 0);
+
+    // A further sync must not tear down the re-added group's subscription.
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id,
+            group_subscriptions: vec![group.clone()],
+            since: None,
+        })
+        .await
+        .expect("follow-up sync succeeds");
+    assert!(
+        relay.unsubscribed.lock().unwrap().is_empty(),
+        "the re-added group's subscription id must never be unsubscribed"
+    );
+
+    let delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: TransportEndpoint("wss://group.example".into()),
+            subscription_id: Some("group-sub".into()),
+            event: group_event("23", &group.transport_group_id),
+        })
+        .await
+        .expect("relay event handled");
+    assert_eq!(delivered, 1, "the re-added group still delivers");
+}
+
+#[tokio::test]
+async fn deactivate_account_clears_pending_unsubscribes() {
+    let relay = Arc::new(FlakyUnsubscribeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![TransportGroupSubscription {
+                group_id: cgka_traits::GroupId::new(vec![0xB2; 32]),
+                transport_group_id: vec![0xC3; 32],
+                endpoints: vec![TransportEndpoint("wss://group.example".into())],
+            }],
+            since: None,
+        })
+        .await
+        .expect("activation succeeds");
+    relay.fail_next_unsubscribes.store(1, Ordering::SeqCst);
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![],
+            since: None,
+        })
+        .await
+        .expect("sync succeeds despite the failed unsubscribe");
+    assert_eq!(adapter.metrics().await.unsubscribe_retries_pending, 1);
+
+    // The blanket account teardown supersedes the queued per-subscription
+    // entry.
+    adapter
+        .deactivate_account(&account_id)
+        .await
+        .expect("deactivation succeeds");
+    assert_eq!(
+        relay.unsubscribed_accounts.lock().unwrap().as_slice(),
+        std::slice::from_ref(&account_id)
+    );
+    assert_eq!(adapter.metrics().await.unsubscribe_retries_pending, 0);
 }
 
 #[tokio::test]

--- a/docs/marmot-architecture/AGENTS.md
+++ b/docs/marmot-architecture/AGENTS.md
@@ -39,6 +39,10 @@ Agent map for the Marmot architecture docs.
   - **Role:** One host-safety discipline for every outbound connection (validate resolved addresses, pin, trust from
     config, connect timeout); the `cgka_traits::app_components::host_safety` classifier and per-transport chokepoints.
 
+- **Path:** `overview/multi-step-state-changes.md`
+  - **Role:** No-torn-writes convention for multi-step state changes: validation/mutation ordering, compensation,
+    intent-first reconciliation, and reality-reflecting confirmation.
+
 - **Path:** `further-context/`
   - **Role:** Older or deeper context. Check status and dates before relying on it.
 

--- a/docs/marmot-architecture/index.md
+++ b/docs/marmot-architecture/index.md
@@ -80,6 +80,10 @@ Written to be readable in 5 minutes each, shareable as a package.
   - **What it covers:** Restrictive-by-construction creation of local files, sockets, and databases: the
     `fs-private` helpers, the one octal-mode parser, and the DB sidecar/PRAGMA-at-open rules.
 
+- **Doc:** [`overview/multi-step-state-changes.md`](./overview/multi-step-state-changes.md)
+  - **What it covers:** The no-torn-writes convention for multi-step operations: validate-before-mutate, full
+    compensation on error paths, intent-before-side-effects, and confirmation that reflects reality (mdk#711).
+
 - **Doc:** [`overview/current-state.md`](./overview/current-state.md)
   - **What it covers:** Implementations, merged MIPs, the current CGKA engine workspace, and known gaps.
 

--- a/docs/marmot-architecture/overview/multi-step-state-changes.md
+++ b/docs/marmot-architecture/overview/multi-step-state-changes.md
@@ -1,0 +1,56 @@
+---
+title: "Multi-Step State Changes"
+created: 2026-07-04
+updated: 2026-07-04
+tags: [marmot, overview, state, atomicity, error-paths]
+status: overview
+---
+
+# Multi-Step State Changes
+
+After any multi-step operation, local state must reflect what actually happened — especially on the error path. A
+failure in the middle of a sequence must never leave a torn record, an unreachable retry, or a stale marker that
+disagrees with the step that actually failed. This generalizes the engine's atomic snapshot/rollback rule
+("Snapshot and rollback MUST be atomic across Marmot metadata and OpenMLS state" — `cgka-engine-spec.md`, Engine State
+Snapshots and Horizons) to every crate in the workspace. Tracking issue: mdk#711.
+
+## Rules
+
+1. **Validate before you mutate.** An operation that both validates input (client-supplied or derived) and tears down
+   or advances durable state runs the validation first and mutates only on success. If teardown and validation cannot
+   be separated, move the validation to where it is atomic with the teardown decision (the agent stream finalize path
+   validates inside the compose task's `Finish` handling — mdk#366).
+
+2. **Compensation covers every applied step.** Where staging must precede a fallible step, the error path restores
+   *all* state the operation already advanced — not just one layer of it. Prefer restructuring so the hard-to-undo
+   step runs last (swap-then-assign in the forensic recorder — mdk#358; record projection after `begin_pending` in
+   auto-commit staging — mdk#333). Where an RAII guard provides the compensation, it must cover everything the guarded
+   window applied (`PendingCommitCleanupGuard` clears the staged commit, releases the snapshot, and removes the stored
+   proposal).
+
+3. **Record intent before external side effects.** Reconciliation against an external system (relays, brokers)
+   persists the desired state first, then drives the side effects, re-enqueueing failures for retry instead of
+   abandoning the state update (the Nostr adapter's group sync updates routing state before unsubscribing and queues
+   failed unsubscribes — mdk#337). Purely local observable state that exists to mirror a successful external effect
+   advances only after that effect succeeds (the chat read marker advances post-publish — mdk#338).
+
+4. **Confirmation reflects reality.** Never confirm work that reached no one: zero accepted endpoints is a failure
+   regardless of the acknowledgement policy (mdk#375). When a confirmed operation leaves a partial failure behind
+   (a confirmed commit with an undelivered welcome), surface it with structured context that makes targeted repair
+   possible without redoing the confirmed part (`WelcomeDeliveryFailure` + `redeliver_welcome` — mdk#352).
+
+## Checklist for new multi-step flows
+
+- What does each step mutate (durable storage, in-memory state machines, external systems, user-visible projections)?
+- For every fallible step: what has already been applied at that point, and what compensates it on failure?
+- Can the sequence be reordered so validation and pure reads come first and the irreversible step comes last?
+- What does a crash between steps leave behind, and does the recovery path (hydrate, retry, next sync) converge on it?
+- Does the error path have a regression test that injects the failure at the widest window?
+
+## Existing anchors
+
+- Engine snapshot/rollback atomicity: `docs/marmot-architecture/cgka-engine-spec.md`, "Engine State Snapshots and
+  Horizons".
+- Publish-before-apply: `crates/cgka-engine/src/publish.rs` module docs (stage, publish, then confirm/fail).
+- Exposure-aware confirmation: mdk#483 / mdk#499 (a message any endpoint accepted is externally visible; never roll it
+  back).


### PR DESCRIPTION
## Summary

Fixes all seven open child issues of the #711 tracking bundle — multi-step operations that advanced durable or observable state before the fallible step that justified it, with no compensation on failure — and adds the workspace convention doc #711 asks for. One commit per issue.

| Commit | Issue | Fix |
| --- | --- | --- |
| `f6792b6` | #375 | `met_required_acks` requires at least one accepted endpoint; `required_acks == 0` relaxes the threshold, never the existence requirement. Zero-ack publishes now surface a `PublishFailure` and roll back unexposed work. |
| `0267d1e` | #352 | Post-confirm welcome misses surface as structured `WelcomeDeliveryFailure { message_id, recipient, group_id, reason }`; new `AccountDeviceRuntime::redeliver_welcome` re-publishes the stored wrapped welcome without re-committing. |
| `6e5a418` | #338 | The chat read marker advances only in the post-publish success projection; a failed send can no longer leave it pointing at an invalidated own message or silently clear inbound unreads. Safe with no compensation needed: the unread aggregate excludes the sender's own messages. |
| `c93242f` | #333 | Auto-commit staging projects the group record only after `commit_priority`/`begin_pending`; a failed `put_group` is compensated in-memory via `rollback_publish`. `PendingCommitCleanupGuard` also removes the stored SelfRemove proposal (left behind, OpenMLS 0.8.1 panics when a later `remove_members` filters it). |
| `081b6ab` | #337 | `sync_account_groups` records intent first (routing table updated before relay teardown); failed unsubscribes queue in `AdapterState` and retry on the next sync, filtered against live routes so a re-added group's identical subscription id is never torn down. New `unsubscribe_retries_pending` gauge. |
| `3bc00fd` | #358 | Audit-file swap is stage-then-rename (atomic replace, 0600 preserved); the data mode is assigned only after the swap succeeds. A mid-rotation failure leaves the original file, fd, seq, session id, and mode untouched. |
| `f5adbe3` | #366 | Stream finalize validation moved inside the compose task's `Finish` handling (atomic with teardown, no snapshot-then-finish race): a mismatch responds `Err` with zero side effects, the session stays alive, and finalize is retryable. |
| `ac8e7f3` | #711 | New `docs/marmot-architecture/overview/multi-step-state-changes.md` + repo-invariant bullet and index entries. |

## Acceptance criteria → regression tests

Every #711 acceptance criterion is pinned by a failure-injection test:

- #366 → `finish_with_mismatched_expectation_keeps_session_alive_and_retryable` (agent-stream-compose), `connector_socket_finalize_mismatch_keeps_stream_session_retryable` (agent-connector, socket-level)
- #333 → `auto_commit_record_write_failure_leaves_no_torn_group_record` (new `tests/auto_commit_atomicity.rs`, `FaultStorage` one-shot `put_group` fault)
- #358 → `set_data_mode_failure_leaves_mode_file_and_recording_intact`, `rotate_failure_keeps_recording_to_original_file`, `set_data_mode_recovers_from_stale_staged_swap_file`
- #337 → `sync_with_failed_unsubscribe_returns_ok_and_routes_reflect_intent`, `failed_unsubscribe_is_retried_and_drained_on_next_sync`, `pending_unsubscribe_for_readded_group_is_discarded_not_replayed`, `deactivate_account_clears_pending_unsubscribes`
- #338 → `failed_send_keeps_read_marker_and_inbound_unread` (relay shutdown mid-test)
- #375 → unit tests in `transport_adapter.rs` + `create_group_with_best_effort_acks_rolls_back_when_nothing_accepted`
- #352 → extended partial-exposure/welcome-failure runtime tests incl. a full `redeliver_welcome` round-trip and a commit-ack-miss misclassification guard

## Verification

- `just fast-ci` clean (fmt, check, clippy incl. OTLP builds)
- Targeted suites all green: cgka-traits, cgka-engine (incl. full integration battery), cgka-session, marmot-account, marmot-app (305 lib + 65 relay_runtime), transport-nostr-adapter (incl. `--features sdk`), marmot-forensics, agent-stream-compose, agent-connector, wn-cli, cgka-conformance-simulator (incl. the repo-wide tracing audit)

## Follow-ups noted, out of scope

- `do_send_invite` / `do_send_remove_members` / `do_send_update_app_components` share #333's put-group-before-begin_pending shape; their windows are equally unreachable in-process today, and the same mechanical reorder can follow under the new convention.
- `crates/cli/src/daemon/stream_workers.rs` `finish_stream_compose` (~line 592) comments claim a retryability the compose task doesn't provide (it exits after answering `Finish`) — a #366-class claim/behavior mismatch in the CLI daemon worth its own issue.
- If `finish_agent_text_stream` fails *after* a validated compose finish, the durable final is still unretryable (pre-existing; needs an idempotent runtime-side finish).

Closes #366
Closes #333
Closes #358
Closes #337
Closes #338
Closes #375
Closes #352
Closes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/734">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pending welcome delivery listing and welcome redelivery APIs across the app and runtime.
  * Improved stream finalization workflow to support safe retries after composition completes.
* **Bug Fixes**
  * Preserved local read/unread state when a send fails.
  * Stream finalization mismatches and marker publish failures no longer tear down sessions, allowing subsequent retries to succeed.
  * Improved robustness of audit log rotation and relay-side unsubscribe retries.
* **Documentation**
  * Added multi-step “no-torn-writes” guidance for safer state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->