### PR TITLE
Standardize wire-boundary validation fixes

### DIFF
--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -759,6 +759,7 @@ fn observe_engine_error(error: &EngineError) -> String {
         EngineError::MissingRequiredCapabilities { .. } => "missing_required_capabilities",
         EngineError::InvalidCredentialIdentity(_) => "invalid_credential_identity",
         EngineError::InvalidAccountIdentityProof(_) => "invalid_account_identity_proof",
+        EngineError::InvalidKeyPackageLifetime { .. } => "invalid_key_package_lifetime",
         EngineError::UnsupportedCiphersuite { .. } => "unsupported_ciphersuite",
         EngineError::InvalidAppMessagePayload(_) => "invalid_app_message_payload",
         EngineError::UnknownPending => "unknown_pending",

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -63,7 +63,8 @@ realises. Read those rustdocs as the source of truth — this table is just an i
   - **Owns:** `feature_status`, `upgradeable_capabilities`, write-through cache population
 
 - **Module:** `key_package.rs`
-  - **Owns:** `fresh_key_package` (no expiry; that's a higher-layer concern)
+  - **Owns:** `fresh_key_package` and KeyPackage parse-time lifetime/range acceptance policy; refresh scheduling remains
+    a higher-layer concern.
 
 - **Module:** `group_lifecycle.rs`
   - **Owns:** `do_create_group`, `do_join_welcome`

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -63,8 +63,8 @@ realises. Read those rustdocs as the source of truth — this table is just an i
   - **Owns:** `feature_status`, `upgradeable_capabilities`, write-through cache population
 
 - **Module:** `key_package.rs`
-  - **Owns:** `fresh_key_package` and KeyPackage parse-time lifetime/range acceptance policy; refresh scheduling remains
-    a higher-layer concern.
+  - **Owns:** `fresh_key_package` and KeyPackage parse-time lifetime validity / OpenMLS accepted-range checks; refresh
+    scheduling remains a higher-layer concern.
 
 - **Module:** `group_lifecycle.rs`
   - **Owns:** `do_create_group`, `do_join_welcome`

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -573,6 +573,7 @@ pub(crate) fn engine_error_kind(err: &EngineError) -> &'static str {
         EngineError::UnsupportedCiphersuite { .. } => "unsupported_ciphersuite",
         EngineError::InvalidAppMessagePayload(_) => "invalid_app_message_payload",
         EngineError::InvalidAccountIdentityProof(_) => "invalid_account_identity_proof",
+        EngineError::InvalidKeyPackageLifetime { .. } => "invalid_key_package_lifetime",
         EngineError::ForkedEpoch { .. } => "forked_epoch",
         EngineError::InvalidTransition(_) => "invalid_transition",
         EngineError::Storage(_) => "storage",

--- a/crates/cgka-engine/src/key_package.rs
+++ b/crates/cgka-engine/src/key_package.rs
@@ -2,7 +2,7 @@
 //!
 //! Scope for 0.1.0: produce a fresh KeyPackage whose leaf capabilities are
 //! derived from the [`crate::FeatureRegistry`]. Transported KeyPackages are
-//! validated for OpenMLS lifetime validity and Marmot lifetime range policy;
+//! validated for OpenMLS lifetime validity and accepted lifetime range;
 //! refresh scheduling is handled above the engine.
 
 use crate::capabilities::leaf_capabilities;
@@ -12,11 +12,12 @@ use cgka_traits::engine::KeyPackage;
 use cgka_traits::error::EngineError;
 use cgka_traits::storage::StorageProvider;
 use openmls::prelude::{
-    Extensions, KeyPackage as MlsKeyPackage, MlsMessageBodyIn, MlsMessageIn, MlsMessageOut,
-    ProtocolVersion,
+    Extensions, KeyPackage as MlsKeyPackage, KeyPackageVerifyError, MlsMessageBodyIn, MlsMessageIn,
+    MlsMessageOut, ProtocolVersion,
 };
 use openmls_rust_crypto::RustCrypto;
 use openmls_traits::OpenMlsProvider as _;
+use openmls_traits::crypto::OpenMlsCrypto;
 use tls_codec::{Deserialize as _, Serialize as _};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -39,10 +40,7 @@ pub fn key_package_metadata(kp: &KeyPackage) -> Result<KeyPackageMetadata, Engin
         }
     };
     let crypto = RustCrypto::default();
-    let key_package = kp_in
-        .validate(&crypto, ProtocolVersion::Mls10)
-        .map_err(|e| EngineError::Backend(format!("key_package validate: {e:?}")))?;
-    validate_key_package_lifetime_policy(&key_package)?;
+    let key_package = validate_key_package(kp_in, &crypto)?;
     let member_id = crate::identity::validated_member_id_of_leaf(key_package.leaf_node())?;
     crate::account_identity_proof::validate_leaf_account_identity_proof(
         key_package.leaf_node(),
@@ -71,10 +69,7 @@ pub fn is_last_resort_key_package(kp: &KeyPackage) -> Result<bool, EngineError> 
         }
     };
     let crypto = RustCrypto::default();
-    let key_package = kp_in
-        .validate(&crypto, ProtocolVersion::Mls10)
-        .map_err(|e| EngineError::Backend(format!("key_package validate: {e:?}")))?;
-    validate_key_package_lifetime_policy(&key_package)?;
+    let key_package = validate_key_package(kp_in, &crypto)?;
     crate::identity::validated_member_id_of_leaf(key_package.leaf_node())?;
     crate::account_identity_proof::validate_leaf_account_identity_proof(
         key_package.leaf_node(),
@@ -140,9 +135,7 @@ impl<S: StorageProvider> Engine<S> {
             }
         };
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
-        let key_package = kp_in
-            .validate(provider.crypto(), ProtocolVersion::Mls10)
-            .map_err(|e| EngineError::Backend(format!("key_package validate: {e:?}")))?;
+        let key_package = validate_key_package(kp_in, provider.crypto())?;
         let hash_ref = key_package
             .hash_ref(provider.crypto())
             .map_err(|e| EngineError::Backend(format!("key_package ref: {e:?}")))?;
@@ -172,10 +165,7 @@ impl<S: StorageProvider> Engine<S> {
         };
 
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
-        let key_package = kp_in
-            .validate(provider.crypto(), ProtocolVersion::Mls10)
-            .map_err(|e| EngineError::Backend(format!("key_package validate: {e:?}")))?;
-        validate_key_package_lifetime_policy(&key_package)?;
+        let key_package = validate_key_package(kp_in, provider.crypto())?;
         // foundation/key-packages.md: reject a KeyPackage whose credential
         // identity is not a valid Marmot account identity. This single gate
         // covers both the create-group and invite invitee paths.
@@ -188,14 +178,36 @@ impl<S: StorageProvider> Engine<S> {
     }
 }
 
+fn validate_key_package(
+    kp_in: openmls::prelude::KeyPackageIn,
+    crypto: &impl OpenMlsCrypto,
+) -> Result<MlsKeyPackage, EngineError> {
+    let key_package = kp_in
+        .validate(crypto, ProtocolVersion::Mls10)
+        .map_err(key_package_verify_error)?;
+    validate_key_package_lifetime_policy(&key_package)?;
+    Ok(key_package)
+}
+
+fn key_package_verify_error(err: KeyPackageVerifyError) -> EngineError {
+    match err {
+        KeyPackageVerifyError::InvalidLifetime | KeyPackageVerifyError::MissingLifetime => {
+            EngineError::InvalidKeyPackageLifetime {
+                not_before: None,
+                not_after: None,
+            }
+        }
+        other => EngineError::Backend(format!("key_package validate: {other:?}")),
+    }
+}
+
 fn validate_key_package_lifetime_policy(key_package: &MlsKeyPackage) -> Result<(), EngineError> {
     let lifetime = key_package.life_time();
     if !lifetime.has_acceptable_range() {
-        return Err(EngineError::Backend(format!(
-            "key_package lifetime range exceeds Marmot maximum: not_before={} not_after={}",
-            lifetime.not_before(),
-            lifetime.not_after()
-        )));
+        return Err(EngineError::InvalidKeyPackageLifetime {
+            not_before: Some(lifetime.not_before()),
+            not_after: Some(lifetime.not_after()),
+        });
     }
     Ok(())
 }

--- a/crates/cgka-engine/src/key_package.rs
+++ b/crates/cgka-engine/src/key_package.rs
@@ -1,8 +1,9 @@
 //! KeyPackage generation + validation.
 //!
 //! Scope for 0.1.0: produce a fresh KeyPackage whose leaf capabilities are
-//! derived from the [`crate::FeatureRegistry`]. Expiry and refresh scheduling
-//! are handled above the engine.
+//! derived from the [`crate::FeatureRegistry`]. Transported KeyPackages are
+//! validated for OpenMLS lifetime validity and Marmot lifetime range policy;
+//! refresh scheduling is handled above the engine.
 
 use crate::capabilities::leaf_capabilities;
 use crate::engine::Engine;
@@ -41,6 +42,7 @@ pub fn key_package_metadata(kp: &KeyPackage) -> Result<KeyPackageMetadata, Engin
     let key_package = kp_in
         .validate(&crypto, ProtocolVersion::Mls10)
         .map_err(|e| EngineError::Backend(format!("key_package validate: {e:?}")))?;
+    validate_key_package_lifetime_policy(&key_package)?;
     let member_id = crate::identity::validated_member_id_of_leaf(key_package.leaf_node())?;
     crate::account_identity_proof::validate_leaf_account_identity_proof(
         key_package.leaf_node(),
@@ -72,6 +74,7 @@ pub fn is_last_resort_key_package(kp: &KeyPackage) -> Result<bool, EngineError> 
     let key_package = kp_in
         .validate(&crypto, ProtocolVersion::Mls10)
         .map_err(|e| EngineError::Backend(format!("key_package validate: {e:?}")))?;
+    validate_key_package_lifetime_policy(&key_package)?;
     crate::identity::validated_member_id_of_leaf(key_package.leaf_node())?;
     crate::account_identity_proof::validate_leaf_account_identity_proof(
         key_package.leaf_node(),
@@ -172,6 +175,7 @@ impl<S: StorageProvider> Engine<S> {
         let key_package = kp_in
             .validate(provider.crypto(), ProtocolVersion::Mls10)
             .map_err(|e| EngineError::Backend(format!("key_package validate: {e:?}")))?;
+        validate_key_package_lifetime_policy(&key_package)?;
         // foundation/key-packages.md: reject a KeyPackage whose credential
         // identity is not a valid Marmot account identity. This single gate
         // covers both the create-group and invite invitee paths.
@@ -182,4 +186,16 @@ impl<S: StorageProvider> Engine<S> {
         )?;
         Ok(key_package)
     }
+}
+
+fn validate_key_package_lifetime_policy(key_package: &MlsKeyPackage) -> Result<(), EngineError> {
+    let lifetime = key_package.life_time();
+    if !lifetime.has_acceptable_range() {
+        return Err(EngineError::Backend(format!(
+            "key_package lifetime range exceeds Marmot maximum: not_before={} not_after={}",
+            lifetime.not_before(),
+            lifetime.not_after()
+        )));
+    }
+    Ok(())
 }

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -598,8 +598,15 @@ async fn create_group_rejects_expired_invitee_keypackage() {
         })
         .await
         .expect_err("create_group must reject an expired invitee KeyPackage");
+    assert_eq!(err.to_string(), "invalid KeyPackage lifetime");
     assert!(
-        matches!(err, EngineError::Backend(ref message) if message.contains("InvalidLifetime")),
+        matches!(
+            &err,
+            EngineError::InvalidKeyPackageLifetime {
+                not_before: None,
+                not_after: None,
+            }
+        ),
         "unexpected error: {err:?}"
     );
 }
@@ -627,8 +634,15 @@ async fn create_group_rejects_invitee_keypackage_with_excessive_lifetime_range()
         })
         .await
         .expect_err("create_group must reject an over-long invitee KeyPackage");
+    assert_eq!(err.to_string(), "invalid KeyPackage lifetime");
     assert!(
-        matches!(err, EngineError::Backend(ref message) if message.contains("lifetime range exceeds Marmot maximum")),
+        matches!(
+            &err,
+            EngineError::InvalidKeyPackageLifetime {
+                not_before: Some(_),
+                not_after: Some(_),
+            }
+        ),
         "unexpected error: {err:?}"
     );
 }

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -30,7 +30,7 @@ use cgka_traits::transport::{
 use cgka_traits::types::{MemberId, MessageId};
 use openmls::prelude::{
     BasicCredential, Capabilities, CredentialWithKey, ExtensionType, Extensions,
-    KeyPackage as MlsKeyPackage, MlsMessageOut,
+    KeyPackage as MlsKeyPackage, Lifetime, MlsMessageOut,
 };
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_traits::types::Ciphersuite;
@@ -93,6 +93,47 @@ fn key_package_with_mismatched_account_identity_proof(
             None,
         ))
         .leaf_node_extensions(Extensions::single(proof_extension).unwrap())
+        .build(ciphersuite, &provider, &signer, credential_with_key)
+        .unwrap();
+    let mls_msg: MlsMessageOut = bundle.key_package().clone().into();
+    cgka_traits::engine::KeyPackage::new(mls_msg.tls_serialize_detached().unwrap())
+}
+
+fn key_package_with_account_identity_proof_and_lifetime(
+    identity_seed: &[u8],
+    lifetime: Lifetime,
+) -> cgka_traits::engine::KeyPackage {
+    let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let provider = openmls_rust_crypto::OpenMlsRustCrypto::default();
+    let signer = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
+    let credential_identity = pad32(identity_seed);
+    let credential = BasicCredential::new(credential_identity.clone());
+    let credential_with_key = CredentialWithKey {
+        credential: credential.into(),
+        signature_key: signer.public().into(),
+    };
+    let proof_extension = account_identity_proof_extension(
+        &credential_identity,
+        &signer.to_public_vec(),
+        ciphersuite,
+        ciphersuite.signature_algorithm(),
+        proof_signer(identity_seed).as_ref(),
+    )
+    .unwrap();
+    let bundle = MlsKeyPackage::builder()
+        .leaf_node_capabilities(Capabilities::new(
+            None,
+            Some(&[ciphersuite]),
+            Some(&[
+                ExtensionType::Unknown(ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE),
+                ExtensionType::LastResort,
+            ]),
+            None,
+            None,
+        ))
+        .leaf_node_extensions(Extensions::single(proof_extension).unwrap())
+        .key_package_lifetime(lifetime)
+        .mark_as_last_resort()
         .build(ciphersuite, &provider, &signer, credential_with_key)
         .unwrap();
     let mls_msg: MlsMessageOut = bundle.key_package().clone().into();
@@ -532,6 +573,64 @@ async fn create_group_rejects_invitee_keypackage_with_mismatched_account_identit
         .unwrap_err();
 
     assert!(matches!(err, EngineError::InvalidAccountIdentityProof(_)));
+}
+
+#[tokio::test]
+async fn create_group_rejects_expired_invitee_keypackage() {
+    let mut alice = build_client(b"alice", selfremove_registry());
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let expired_kp = key_package_with_account_identity_proof_and_lifetime(
+        b"bob-expired",
+        Lifetime::init(now.saturating_sub(7200), now.saturating_sub(3600)),
+    );
+
+    let err = alice
+        .create_group(CreateGroupRequest {
+            name: "expired-invitee".into(),
+            description: "".into(),
+            members: vec![expired_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .expect_err("create_group must reject an expired invitee KeyPackage");
+    assert!(
+        matches!(err, EngineError::Backend(ref message) if message.contains("InvalidLifetime")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn create_group_rejects_invitee_keypackage_with_excessive_lifetime_range() {
+    let mut alice = build_client(b"alice", selfremove_registry());
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let excessive_kp = key_package_with_account_identity_proof_and_lifetime(
+        b"bob-long-lived",
+        Lifetime::init(now.saturating_sub(60), now + 60 * 60 * 24 * 365),
+    );
+
+    let err = alice
+        .create_group(CreateGroupRequest {
+            name: "long-lived-invitee".into(),
+            description: "".into(),
+            members: vec![excessive_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .expect_err("create_group must reject an over-long invitee KeyPackage");
+    assert!(
+        matches!(err, EngineError::Backend(ref message) if message.contains("lifetime range exceeds Marmot maximum")),
+        "unexpected error: {err:?}"
+    );
 }
 
 #[tokio::test]

--- a/crates/marmot-app/AGENTS.md
+++ b/crates/marmot-app/AGENTS.md
@@ -55,8 +55,8 @@ App runtime bridge for the first real Marmot app surfaces.
 - Keep directory search bounded over cached follow edges. Do not add web-of-trust scoring unless that is reopened as a
   deliberate product decision.
 - Keep runtime directory subscriptions chunked and privacy-safe. Subscription identifiers must not embed raw pubkeys.
-- Treat Marmot kind `30443` KeyPackages as long-lived last-resort packages. Normal publish should reuse the cached
-  package and stable replaceable d-tag; only explicit rotate/manual repair should create a new package ref.
+- Treat Marmot kind `30443` KeyPackages as cached last-resort packages. Normal publish should reuse the cached valid
+  package and stable replaceable d-tag; expired or policy-invalid packages rotate to a fresh package ref.
 - Incoming welcomes may auto-join MLS state, but app projections must preserve local confirmation state. Pending invites
   should stay visible until accepted, and decline should leave the group before archiving the local projection.
 - Keep protocol engine behavior in `cgka-engine` and session ownership in `cgka-session`.

--- a/crates/marmot-app/README.md
+++ b/crates/marmot-app/README.md
@@ -26,8 +26,8 @@ published to (and fetched from) the account's NIP-65 relays; there is no dedicat
 can check whether those lists are already present before writing local account state. The same status API can fetch
 those relay-list events from supplied bootstrap relays and store discovered user relay/KeyPackage data for deterministic
 CLI/TUI development. KeyPackage publication keeps a stable replaceable d-tag for the account and tracks the decoded
-KeyPackage ref separately; normal publish reuses the cached last-resort package, while explicit rotate creates a new
-package under the same slot.
+KeyPackage ref separately; normal publish reuses the cached valid last-resort package, while explicit rotate or lifetime
+policy rejection creates a new package under the same slot.
 
 The user directory is keyed by Nostr pubkey. Account setup and the daemon can refresh a local account's contact-list
 event, pre-cache direct follows, and cache profile metadata for those likely contacts. Runtime startup builds chunked

--- a/crates/marmot-uniffi/src/conversions/common.rs
+++ b/crates/marmot-uniffi/src/conversions/common.rs
@@ -54,5 +54,10 @@ pub fn group_id_from_hex(group_id_hex: &str) -> Result<GroupId, crate::errors::M
         hex::decode(group_id_hex).map_err(|err| crate::errors::MarmotKitError::InvalidHex {
             details: err.to_string(),
         })?;
+    if bytes.len() != 32 {
+        return Err(crate::errors::MarmotKitError::InvalidHex {
+            details: format!("expected 32-byte group id, got {} bytes", bytes.len()),
+        });
+    }
     Ok(GroupId::new(bytes))
 }

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -192,5 +192,8 @@ mod tests {
         );
         // Invalid hex is rejected rather than silently yielding empty history.
         assert!(optional_group_id_hex(Some("nothex".into())).is_err());
+        // Hex that decodes but is not a Marmot 32-byte group id is rejected at
+        // the FFI boundary instead of surfacing later as UnknownGroup.
+        assert!(optional_group_id_hex(Some("abcd".into())).is_err());
     }
 }

--- a/crates/storage-sqlite/src/openmls_storage/labels.rs
+++ b/crates/storage-sqlite/src/openmls_storage/labels.rs
@@ -21,7 +21,29 @@ pub(crate) const EPOCH_SECRETS_LABEL: &[u8] = b"EpochSecrets";
 pub(crate) const RESUMPTION_PSK_STORE_LABEL: &[u8] = b"ResumptionPsk";
 pub(crate) const MESSAGE_SECRETS_LABEL: &[u8] = b"MessageSecrets";
 
+const VALUE_STORAGE_KEY_V1: &[u8] = b"mdk.openmls.value-key.v1";
+
 pub(crate) fn build_key(label: &[u8], key: Vec<u8>) -> Vec<u8> {
+    let mut out = Vec::with_capacity(
+        VALUE_STORAGE_KEY_V1.len() + 8 + label.len() + 8 + key.len() + std::mem::size_of::<u16>(),
+    );
+    out.extend_from_slice(VALUE_STORAGE_KEY_V1);
+    out.extend_from_slice(&(label.len() as u64).to_be_bytes());
+    out.extend_from_slice(label);
+    out.extend_from_slice(&(key.len() as u64).to_be_bytes());
+    out.extend_from_slice(&key);
+    out.extend_from_slice(&CURRENT_VERSION.to_be_bytes());
+    out
+}
+
+/// Reconstructs the pre-#349 generic value-store key: the bare concatenation
+/// of label, key, and provider version.
+///
+/// This format is ambiguous because the label/key boundary is not encoded:
+/// `(label = "A", key = "BC")` and `(label = "AB", key = "C")` collide. New
+/// writes must use [`build_key`]. Legacy keys remain readable/deletable so
+/// upgraded databases do not strand OpenMLS rows written by older builds.
+pub(crate) fn build_key_legacy(label: &[u8], key: Vec<u8>) -> Vec<u8> {
     let mut out = label.to_vec();
     out.extend_from_slice(&key);
     out.extend_from_slice(&CURRENT_VERSION.to_be_bytes());

--- a/crates/storage-sqlite/src/openmls_storage/value_store.rs
+++ b/crates/storage-sqlite/src/openmls_storage/value_store.rs
@@ -1,4 +1,4 @@
-use super::labels::build_key;
+use super::labels::{build_key, build_key_legacy};
 use super::{SqliteOpenMlsStorage, SqliteOpenMlsStorageError};
 use crate::connection::retry_on_busy;
 use openmls_traits::storage::{CURRENT_VERSION, Entity, Key};
@@ -13,24 +13,38 @@ impl SqliteOpenMlsStorage {
         group_key: Option<Vec<u8>>,
         value: Vec<u8>,
     ) -> Result<(), SqliteOpenMlsStorageError> {
-        let storage_key = build_key(label, key);
-        // Single autocommit statement: retry the whole write on transient lock
-        // contention (issue #484).
-        retry_on_busy(|| {
-            self.lock()?.execute(
-                "INSERT OR REPLACE INTO openmls_values
-                (provider_version, label, storage_key, group_key, value)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
-                params![
-                    CURRENT_VERSION,
-                    label,
-                    storage_key,
-                    group_key.as_deref(),
-                    value
-                ],
+        let storage_key = build_key(label, key.clone());
+        let legacy_storage_key = build_key_legacy(label, key);
+        if self.connection.is_current_thread_transaction_owner() {
+            let conn = self.lock()?;
+            write_value_on_connection(
+                &conn,
+                label,
+                storage_key.as_slice(),
+                legacy_storage_key.as_slice(),
+                group_key.as_deref(),
+                value.as_slice(),
             )?;
             Ok(())
-        })
+        } else {
+            // Own a fresh transaction so the new row and legacy cleanup commit
+            // together; retry the whole idempotent write on transient lock
+            // contention (issue #484).
+            retry_on_busy(|| {
+                let mut conn = self.lock()?;
+                let tx = conn.transaction()?;
+                write_value_on_connection(
+                    &tx,
+                    label,
+                    storage_key.as_slice(),
+                    legacy_storage_key.as_slice(),
+                    group_key.as_deref(),
+                    value.as_slice(),
+                )?;
+                tx.commit()?;
+                Ok(())
+            })
+        }
     }
 
     pub(in crate::openmls_storage) fn write_entity<T: Entity<CURRENT_VERSION>>(
@@ -63,13 +77,21 @@ impl SqliteOpenMlsStorage {
         group_key: Option<Vec<u8>>,
         value: &T,
     ) -> Result<(), SqliteOpenMlsStorageError> {
-        let storage_key = build_key(label, key);
+        let storage_key = build_key(label, key.clone());
+        let legacy_storage_key = build_key_legacy(label, key);
         if self.connection.is_current_thread_transaction_owner() {
             // Inside a broader engine-owned OpenMLS transaction: execute directly
             // and let the owning transaction handle retry/rollback. Retrying a
             // single statement inside someone else's transaction would corrupt it.
             let conn = self.lock()?;
-            append_entity_on_connection(&conn, label, storage_key, group_key.as_deref(), value)?;
+            append_entity_on_connection(
+                &conn,
+                label,
+                storage_key,
+                legacy_storage_key,
+                group_key.as_deref(),
+                value,
+            )?;
             Ok(())
         } else {
             // Own a fresh transaction: the whole read-modify-write is idempotent,
@@ -81,6 +103,7 @@ impl SqliteOpenMlsStorage {
                     &tx,
                     label,
                     storage_key.clone(),
+                    legacy_storage_key.clone(),
                     group_key.as_deref(),
                     value,
                 )?;
@@ -98,7 +121,8 @@ impl SqliteOpenMlsStorage {
         value: &T,
     ) -> Result<(), SqliteOpenMlsStorageError> {
         let encoded = serde_json::to_vec(value)?;
-        let storage_key = build_key(label, key);
+        let storage_key = build_key(label, key.clone());
+        let legacy_storage_key = build_key_legacy(label, key);
         if self.connection.is_current_thread_transaction_owner() {
             // Inside a broader engine-owned OpenMLS transaction: see append_entity.
             let conn = self.lock()?;
@@ -106,6 +130,7 @@ impl SqliteOpenMlsStorage {
                 &conn,
                 label,
                 storage_key,
+                legacy_storage_key,
                 group_key.as_deref(),
                 encoded.as_slice(),
             )?;
@@ -118,6 +143,7 @@ impl SqliteOpenMlsStorage {
                     &tx,
                     label,
                     storage_key.clone(),
+                    legacy_storage_key.clone(),
                     group_key.as_deref(),
                     encoded.as_slice(),
                 )?;
@@ -133,15 +159,12 @@ impl SqliteOpenMlsStorage {
         key: &[u8],
     ) -> Result<Option<Vec<Vec<u8>>>, SqliteOpenMlsStorageError> {
         let storage_key = build_key(label, key.to_vec());
-        let value: Option<Vec<u8>> = self
-            .lock()?
-            .query_row(
-                "SELECT value FROM openmls_values
-                 WHERE provider_version = ?1 AND storage_key = ?2",
-                params![CURRENT_VERSION, storage_key],
-                |row| row.get(0),
-            )
-            .optional()?;
+        let legacy_storage_key = build_key_legacy(label, key.to_vec());
+        let conn = self.lock()?;
+        let value = match read_value_on_connection(&conn, &storage_key)? {
+            Some(value) => Some(value),
+            None => read_value_on_connection(&conn, &legacy_storage_key)?,
+        };
         value
             .map(|value| serde_json::from_slice(&value).map_err(Into::into))
             .transpose()
@@ -160,16 +183,13 @@ impl SqliteOpenMlsStorage {
         label: &[u8],
         key: Vec<u8>,
     ) -> Result<Option<T>, SqliteOpenMlsStorageError> {
-        let storage_key = build_key(label, key);
-        let value: Option<Vec<u8>> = self
-            .lock()?
-            .query_row(
-                "SELECT value FROM openmls_values
-                 WHERE provider_version = ?1 AND storage_key = ?2",
-                params![CURRENT_VERSION, storage_key],
-                |row| row.get(0),
-            )
-            .optional()?;
+        let storage_key = build_key(label, key.clone());
+        let legacy_storage_key = build_key_legacy(label, key);
+        let conn = self.lock()?;
+        let value = match read_value_on_connection(&conn, &storage_key)? {
+            Some(value) => Some(value),
+            None => read_value_on_connection(&conn, &legacy_storage_key)?,
+        };
         value
             .map(|value| serde_json::from_slice(&value).map_err(Into::into))
             .transpose()
@@ -203,15 +223,14 @@ impl SqliteOpenMlsStorage {
         label: &[u8],
         key: Vec<u8>,
     ) -> Result<(), SqliteOpenMlsStorageError> {
-        let storage_key = build_key(label, key);
+        let storage_key = build_key(label, key.clone());
+        let legacy_storage_key = build_key_legacy(label, key);
         // Single autocommit statement: retry the whole delete on transient lock
         // contention (issue #484).
         retry_on_busy(|| {
-            self.lock()?.execute(
-                "DELETE FROM openmls_values
-             WHERE provider_version = ?1 AND storage_key = ?2",
-                params![CURRENT_VERSION, storage_key],
-            )?;
+            let conn = self.lock()?;
+            delete_value_on_connection(&conn, storage_key.as_slice())?;
+            delete_value_on_connection(&conn, legacy_storage_key.as_slice())?;
             Ok(())
         })
     }
@@ -256,6 +275,37 @@ impl SqliteOpenMlsStorage {
     }
 }
 
+fn read_value_on_connection(
+    conn: &rusqlite::Connection,
+    storage_key: &[u8],
+) -> Result<Option<Vec<u8>>, SqliteOpenMlsStorageError> {
+    Ok(conn
+        .query_row(
+            "SELECT value FROM openmls_values
+             WHERE provider_version = ?1 AND storage_key = ?2",
+            params![CURRENT_VERSION, storage_key],
+            |row| row.get(0),
+        )
+        .optional()?)
+}
+
+fn write_value_on_connection(
+    conn: &rusqlite::Connection,
+    label: &[u8],
+    storage_key: &[u8],
+    legacy_storage_key: &[u8],
+    group_key: Option<&[u8]>,
+    value: &[u8],
+) -> Result<(), SqliteOpenMlsStorageError> {
+    conn.execute(
+        "INSERT OR REPLACE INTO openmls_values
+            (provider_version, label, storage_key, group_key, value)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![CURRENT_VERSION, label, storage_key, group_key, value],
+    )?;
+    delete_value_on_connection(conn, legacy_storage_key)
+}
+
 fn list_values_on_connection(
     conn: &rusqlite::Connection,
     storage_key: &[u8],
@@ -271,6 +321,18 @@ fn list_values_on_connection(
     .transpose()
     .map(|value| value.unwrap_or_default())
     .map_err(Into::into)
+}
+
+fn list_values_with_legacy_fallback_on_connection(
+    conn: &rusqlite::Connection,
+    storage_key: &[u8],
+    legacy_storage_key: &[u8],
+) -> Result<Vec<Vec<u8>>, SqliteOpenMlsStorageError> {
+    if read_value_on_connection(conn, storage_key)?.is_some() {
+        list_values_on_connection(conn, storage_key)
+    } else {
+        list_values_on_connection(conn, legacy_storage_key)
+    }
 }
 
 fn write_list_on_connection(
@@ -299,26 +361,50 @@ fn append_entity_on_connection<T: Entity<CURRENT_VERSION>>(
     conn: &rusqlite::Connection,
     label: &[u8],
     storage_key: Vec<u8>,
+    legacy_storage_key: Vec<u8>,
     group_key: Option<&[u8]>,
     value: &T,
 ) -> Result<(), SqliteOpenMlsStorageError> {
-    let mut list = list_values_on_connection(conn, storage_key.as_slice())?;
+    let mut list = list_values_with_legacy_fallback_on_connection(
+        conn,
+        storage_key.as_slice(),
+        legacy_storage_key.as_slice(),
+    )?;
     list.push(serde_json::to_vec(value)?);
-    write_list_on_connection(conn, label, storage_key.as_slice(), group_key, &list)
+    write_list_on_connection(conn, label, storage_key.as_slice(), group_key, &list)?;
+    delete_value_on_connection(conn, legacy_storage_key.as_slice())
 }
 
 fn remove_entity_on_connection(
     conn: &rusqlite::Connection,
     label: &[u8],
     storage_key: Vec<u8>,
+    legacy_storage_key: Vec<u8>,
     group_key: Option<&[u8]>,
     encoded: &[u8],
 ) -> Result<(), SqliteOpenMlsStorageError> {
-    let mut list = list_values_on_connection(conn, storage_key.as_slice())?;
+    let mut list = list_values_with_legacy_fallback_on_connection(
+        conn,
+        storage_key.as_slice(),
+        legacy_storage_key.as_slice(),
+    )?;
     if let Some(pos) = list.iter().position(|stored| stored == encoded) {
         list.remove(pos);
     }
-    write_list_on_connection(conn, label, storage_key.as_slice(), group_key, &list)
+    write_list_on_connection(conn, label, storage_key.as_slice(), group_key, &list)?;
+    delete_value_on_connection(conn, legacy_storage_key.as_slice())
+}
+
+fn delete_value_on_connection(
+    conn: &rusqlite::Connection,
+    storage_key: &[u8],
+) -> Result<(), SqliteOpenMlsStorageError> {
+    conn.execute(
+        "DELETE FROM openmls_values
+         WHERE provider_version = ?1 AND storage_key = ?2",
+        params![CURRENT_VERSION, storage_key],
+    )?;
+    Ok(())
 }
 
 fn delete_group_labels_on_connection(
@@ -338,6 +424,142 @@ fn delete_group_labels_on_connection(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::SqliteAccountStorage;
+    use openmls_traits::storage::Entity;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct TestEntity(u8);
+
+    impl Entity<CURRENT_VERSION> for TestEntity {}
+
+    #[test]
+    fn value_storage_key_length_delimits_label_and_key() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let mls = &store.openmls;
+
+        // These two rows collide under the legacy concatenation:
+        // label("A") + key("BC") == label("AB") + key("C").
+        mls.write_value(
+            b"A",
+            b"BC".to_vec(),
+            None,
+            serde_json::to_vec(&1u8).unwrap(),
+        )
+        .unwrap();
+        mls.write_value(
+            b"AB",
+            b"C".to_vec(),
+            None,
+            serde_json::to_vec(&2u8).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(mls.read_json::<u8>(b"A", b"BC".to_vec()).unwrap(), Some(1));
+        assert_eq!(mls.read_json::<u8>(b"AB", b"C".to_vec()).unwrap(), Some(2));
+    }
+
+    #[test]
+    fn value_storage_reads_and_deletes_legacy_concatenated_key() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let mls = &store.openmls;
+        let label = b"LegacyValue";
+        let key = b"row".to_vec();
+        let legacy_key = build_key_legacy(label, key.clone());
+
+        mls.lock()
+            .unwrap()
+            .execute(
+                "INSERT OR REPLACE INTO openmls_values
+                    (provider_version, label, storage_key, group_key, value)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    CURRENT_VERSION,
+                    label,
+                    legacy_key.clone(),
+                    Option::<&[u8]>::None,
+                    serde_json::to_vec(&7u8).unwrap()
+                ],
+            )
+            .unwrap();
+
+        assert_eq!(mls.read_json::<u8>(label, key.clone()).unwrap(), Some(7));
+
+        mls.write_value(label, key.clone(), None, serde_json::to_vec(&8u8).unwrap())
+            .unwrap();
+        let legacy_count: u64 = mls
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM openmls_values
+                 WHERE provider_version = ?1 AND storage_key = ?2",
+                params![CURRENT_VERSION, legacy_key],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(legacy_count, 0, "new write should migrate legacy row away");
+        assert_eq!(
+            mls.read_json::<u8>(label, key.clone()).unwrap(),
+            Some(8),
+            "new length-delimited row must shadow the legacy row"
+        );
+
+        mls.delete_value(label, key.clone()).unwrap();
+        assert_eq!(mls.read_json::<u8>(label, key).unwrap(), None);
+    }
+
+    #[test]
+    fn list_storage_migrates_legacy_concatenated_key_on_mutation() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let mls = &store.openmls;
+        let label = b"LegacyList";
+        let key = b"list".to_vec();
+        let legacy_key = build_key_legacy(label, key.clone());
+        let legacy_list = vec![serde_json::to_vec(&TestEntity(1)).unwrap()];
+
+        mls.lock()
+            .unwrap()
+            .execute(
+                "INSERT OR REPLACE INTO openmls_values
+                    (provider_version, label, storage_key, group_key, value)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    CURRENT_VERSION,
+                    label,
+                    legacy_key.clone(),
+                    Option::<&[u8]>::None,
+                    serde_json::to_vec(&legacy_list).unwrap()
+                ],
+            )
+            .unwrap();
+
+        mls.append_entity(label, key.clone(), None, &TestEntity(2))
+            .unwrap();
+        assert_eq!(
+            mls.read_list::<TestEntity>(label, key.clone()).unwrap(),
+            vec![TestEntity(1), TestEntity(2)]
+        );
+        let legacy_count: u64 = mls
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM openmls_values
+                 WHERE provider_version = ?1 AND storage_key = ?2",
+                params![CURRENT_VERSION, legacy_key],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(legacy_count, 0, "legacy row should be migrated away");
+
+        mls.remove_entity(label, key.clone(), None, &TestEntity(1))
+            .unwrap();
+        assert_eq!(
+            mls.read_list::<TestEntity>(label, key).unwrap(),
+            vec![TestEntity(2)]
+        );
+    }
+
     #[test]
     fn list_mutations_keep_read_modify_write_under_one_transaction() {
         let source = include_str!("value_store.rs");

--- a/crates/storage-sqlite/src/openmls_storage/value_store.rs
+++ b/crates/storage-sqlite/src/openmls_storage/value_store.rs
@@ -225,14 +225,24 @@ impl SqliteOpenMlsStorage {
     ) -> Result<(), SqliteOpenMlsStorageError> {
         let storage_key = build_key(label, key.clone());
         let legacy_storage_key = build_key_legacy(label, key);
-        // Single autocommit statement: retry the whole delete on transient lock
-        // contention (issue #484).
-        retry_on_busy(|| {
+        if self.connection.is_current_thread_transaction_owner() {
             let conn = self.lock()?;
             delete_value_on_connection(&conn, storage_key.as_slice())?;
             delete_value_on_connection(&conn, legacy_storage_key.as_slice())?;
             Ok(())
-        })
+        } else {
+            // Own a fresh transaction so the new-format row and legacy row are
+            // removed atomically; retry the whole idempotent delete on transient
+            // lock contention (issue #484).
+            retry_on_busy(|| {
+                let mut conn = self.lock()?;
+                let tx = conn.transaction()?;
+                delete_value_on_connection(&tx, storage_key.as_slice())?;
+                delete_value_on_connection(&tx, legacy_storage_key.as_slice())?;
+                tx.commit()?;
+                Ok(())
+            })
+        }
     }
 
     pub(in crate::openmls_storage) fn delete_group_value<GroupId: Key<CURRENT_VERSION>>(

--- a/crates/traits/src/error.rs
+++ b/crates/traits/src/error.rs
@@ -68,6 +68,17 @@ pub enum EngineError {
     #[error("invalid account identity proof: {0}")]
     InvalidAccountIdentityProof(String),
 
+    /// A transported KeyPackage is missing its MLS lifetime, is not currently
+    /// valid, or exceeds the accepted OpenMLS lifetime range. The raw
+    /// timestamps stay on the typed variant for callers that need them, but the
+    /// display string intentionally omits them so audit details stay
+    /// privacy-safe.
+    #[error("invalid KeyPackage lifetime")]
+    InvalidKeyPackageLifetime {
+        not_before: Option<u64>,
+        not_after: Option<u64>,
+    },
+
     /// Epoch fork detected that the current recovery manager could not
     /// resolve, usually because no pre-commit snapshot was available.
     /// Recoverable same-epoch commit races roll back and replay internally.

--- a/docs/marmot-architecture/hermes-openclaw-agent-integration-plan.md
+++ b/docs/marmot-architecture/hermes-openclaw-agent-integration-plan.md
@@ -78,8 +78,8 @@ wn-agent connector
 
 4. Reuse cached KeyPackages on startup.
 
-   `marmot-app` treats kind `30443` KeyPackages as long-lived last-resort packages. Connector startup should publish or
-   repair the cached package. It should rotate only when explicitly asked or when the cached package is unusable.
+   `marmot-app` treats kind `30443` KeyPackages as cached last-resort packages. Connector startup should publish or
+   repair the cached package. It should rotate when explicitly asked or when validation rejects the cached package.
 
 5. Keep the local socket deployment explicit.
 

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -169,9 +169,8 @@ first-party endpoint remains ops work; see [`../relay-observability.md`](../rela
 - **Safe Extensions framework support** — still gated on backend library support and migration design.
 - **`IdentityRemove` proposal type** — identified as the first likely Marmot-custom proposal, not specified or
   implemented.
-- **KeyPackage refresh/expiry policy** — still a higher-layer production scheduling concern. The transport adapter can
-  publish a Marmot kind `30443` KeyPackage event when supplied with the required MIP-00 metadata, but deriving that
-  metadata from a fresh engine KeyPackage is still follow-up work.
+- **KeyPackage refresh scheduling** — still a higher-layer production scheduling concern. The engine validates transported
+  KeyPackage lifetime validity and range policy; product/session orchestration owns proactive refresh cadence.
 
 ## See also
 


### PR DESCRIPTION
## Summary

- length-delimit OpenMLS value-store keys and migrate/delete legacy concatenated rows
- reject non-32-byte UniFFI group id hex at the boundary
- enforce KeyPackage lifetime validity/range checks at parse/invite boundaries

## Verification

- cargo test -p storage-sqlite openmls_storage::value_store::tests -- --nocapture
- cargo test -p marmot-uniffi optional_group_id_hex_trims_and_canonicalizes -- --nocapture
- cargo test -p cgka-engine keypackage --test group_creation -- --nocapture
- just fast-ci

Closes #349
Closes #386
Closes #398
Refs marmot-protocol/marmot#77

Spec-side companion PR: marmot-protocol/marmot#236.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KeyPackage validation now enforces Marmot lifetime-range acceptance during transported KeyPackage parsing.
  * SQLite-backed OpenMLS value storage now uses a length-delimited key format and migrates legacy entries forward on write/delete.

* **Bug Fixes**
  * Group ID hex inputs are rejected unless they decode to exactly 32 bytes.
  * Group creation now rejects invitee KeyPackages with expired lifetimes or lifetime ranges exceeding Marmot limits.

* **Documentation & Tests**
  * Updated Marmot kind 30443 last-resort/caching behavior guidance and refresh/rotation documentation; added/expanded lifetime-validation test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->