### PR TITLE
Stabilize agent connectors and fill CLI/TUI surfaces

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -129,6 +129,36 @@ openclaw-dev-teardown args="":
 openclaw-dev-test:
     cd integrations/openclaw/marmot && pnpm install && pnpm typecheck && pnpm test
 
+openclaw-dev-script-test:
+    integrations/openclaw/marmot/test/dev-scripts.sh
+
+openclaw-dev-smoke root="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    root="{{root}}"
+    if [ -z "$root" ]; then
+        root="${OPENCLAW_MARMOT_DEV_ROOT:-${TMPDIR:-/tmp}/openclaw-marmot-test}"
+    fi
+    "$root/smoke-plugin.sh"
+
+openclaw-dev-control-smoke root="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    root="{{root}}"
+    if [ -z "$root" ]; then
+        root="${OPENCLAW_MARMOT_DEV_ROOT:-${TMPDIR:-/tmp}/openclaw-marmot-test}"
+    fi
+    "$root/control-smoketest.sh"
+
+openclaw-dev-e2e-connector root="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -z "{{root}}" ]; then
+        ./scripts/openclaw_marmot_connector_e2e.sh
+    else
+        ./scripts/openclaw_marmot_connector_e2e.sh --root "{{root}}"
+    fi
+
 openclaw-phone-test-up:
     docker compose --profile openclaw-phone-test up -d --build openclaw-marmot-phone-test
 

--- a/crates/agent-connector/AGENTS.md
+++ b/crates/agent-connector/AGENTS.md
@@ -41,7 +41,8 @@ several files in the same crate); methods shared across those files are `pub(cra
 - `src/allowlist.rs` — `AllowlistStore`/`AllowlistRecord` per-account welcomer allowlist persistence.
 - `src/stream_session.rs` — `StreamSessionStore`/`ActiveStreamSession`, the persisted
   `SendIdempotencyStore` (`$MARMOT_HOME/dev/send-idempotency.json`, 1024-entry FIFO,
-  versioned SHA-256 request fingerprints, crash-safe atomic writes), and the
+  versioned SHA-256 request fingerprints, `stream_finalize:` keys for durable finalized sends,
+  crash-safe atomic writes), and the
   `DebugFinalSendStore` recorder.
 - `src/media_temp.rs` — TTL sweep of decrypted inbound media temp dirs under
   `$TMPDIR/marmot-media/`.

--- a/crates/agent-connector/src/bin/wn-agent.rs
+++ b/crates/agent-connector/src/bin/wn-agent.rs
@@ -340,9 +340,9 @@ fn safe_error_message(err: &ConnectorError) -> String {
     match err {
         ConnectorError::Io(io) => {
             format!(
-                "startup failed code={} detail={}",
+                "startup failed code={} io_kind={:?}",
                 err.privacy_safe_code(),
-                io
+                io.kind()
             )
         }
         _ => format!("startup failed code={}", err.privacy_safe_code()),

--- a/crates/agent-connector/src/bin/wn-agent.rs
+++ b/crates/agent-connector/src/bin/wn-agent.rs
@@ -337,7 +337,16 @@ fn which_qrencode() -> Option<String> {
 }
 
 fn safe_error_message(err: &ConnectorError) -> String {
-    format!("startup failed code={}", err.privacy_safe_code())
+    match err {
+        ConnectorError::Io(io) => {
+            format!(
+                "startup failed code={} detail={}",
+                err.privacy_safe_code(),
+                io
+            )
+        }
+        _ => format!("startup failed code={}", err.privacy_safe_code()),
+    }
 }
 
 fn read_auth_token(path: Option<&PathBuf>) -> Result<Option<String>, String> {

--- a/crates/agent-connector/src/connection.rs
+++ b/crates/agent-connector/src/connection.rs
@@ -188,12 +188,14 @@ impl AgentConnector {
                 final_text,
                 transcript_hash_hex,
                 chunk_count,
+                idempotency_key,
             } => {
                 self.stream_finalize_response(
                     &stream_id_hex,
                     final_text,
                     &transcript_hash_hex,
                     chunk_count,
+                    idempotency_key,
                 )
                 .await
             }

--- a/crates/agent-connector/src/stream.rs
+++ b/crates/agent-connector/src/stream.rs
@@ -24,6 +24,41 @@ use crate::{
     STREAM_SESSION_IDLE_TIMEOUT, STREAM_SESSION_SWEEP_INTERVAL,
 };
 
+/// Current schema version for persisted `stream_finalize` request fingerprints.
+pub(crate) const STREAM_FINALIZE_FINGERPRINT_VERSION: u8 = 1;
+
+/// Server-derived fingerprint of a `stream_finalize` request. A retry can return
+/// cached message ids only when the stream id and sealed transcript exactly
+/// match the first successful finalize for the idempotency key.
+pub(crate) fn stream_finalize_fingerprint(
+    stream_id_hex: &str,
+    final_text: &str,
+    transcript_hash: &[u8; 32],
+    chunk_count: u64,
+) -> String {
+    use sha2::{Digest, Sha256};
+
+    let preimage = serde_json::json!([
+        STREAM_FINALIZE_FINGERPRINT_VERSION,
+        stream_id_hex,
+        final_text,
+        hex::encode(transcript_hash),
+        chunk_count,
+    ]);
+    let bytes =
+        serde_json::to_vec(&preimage).expect("stream_finalize fingerprint preimage cannot fail");
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn stream_finalize_idempotency_key(key: &str) -> String {
+    format!("stream_finalize:{key}")
+}
+
+struct StreamFinalizeIdempotency {
+    key: String,
+    fingerprint: String,
+}
+
 impl AgentConnector {
     pub(crate) async fn stream_begin_response(
         &self,
@@ -197,9 +232,25 @@ impl AgentConnector {
         final_text: String,
         transcript_hash_hex: &str,
         chunk_count: u64,
+        idempotency_key: Option<String>,
     ) -> Result<AgentControlResponse, ConnectorError> {
         let stream_id_hex = normalize_hex(stream_id_hex)?;
         let transcript_hash = transcript_hash_from_hex(transcript_hash_hex)?;
+        let fingerprint =
+            stream_finalize_fingerprint(&stream_id_hex, &final_text, &transcript_hash, chunk_count);
+        let idempotency_key = idempotency_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|key| !key.is_empty())
+            .map(stream_finalize_idempotency_key);
+        if let Some(key) = idempotency_key.as_deref()
+            && let Some(message_ids_hex) = self.idempotency.get(key, &fingerprint)
+        {
+            return Ok(AgentControlResponse::StreamFinalized {
+                stream_id_hex,
+                message_ids_hex,
+            });
+        }
         // Clone (not remove) the session: the final text/hash/chunk-count
         // expectation is validated inside the compose task, atomically with
         // its teardown. On mismatch the session stays registered and the
@@ -227,6 +278,7 @@ impl AgentConnector {
                     final_text,
                     transcript_hash,
                     chunk_count,
+                    idempotency_key.map(|key| StreamFinalizeIdempotency { key, fingerprint }),
                 )
                 .await;
         }
@@ -295,6 +347,7 @@ impl AgentConnector {
             final_text,
             transcript_hash,
             chunk_count,
+            idempotency_key.map(|key| StreamFinalizeIdempotency { key, fingerprint }),
         )
         .await
     }
@@ -310,6 +363,7 @@ impl AgentConnector {
         final_text: String,
         transcript_hash: [u8; 32],
         chunk_count: u64,
+        idempotency: Option<StreamFinalizeIdempotency>,
     ) -> Result<AgentControlResponse, ConnectorError> {
         let (_payload, summary) = self
             .runtime
@@ -326,6 +380,13 @@ impl AgentConnector {
                 },
             )
             .await?;
+        if let Some(idempotency) = idempotency {
+            self.idempotency.record(
+                idempotency.key,
+                idempotency.fingerprint,
+                summary.message_ids.clone(),
+            );
+        }
         // Durable final published: it is now safe to drop the session.
         let _ = self.streams.remove_if_same(stream_id_hex, session);
         Ok(AgentControlResponse::StreamFinalized {

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -1986,6 +1986,7 @@ async fn connector_socket_composes_and_finalizes_stream() {
             final_text: "hello stream".to_owned(),
             transcript_hash_hex,
             chunk_count: 2,
+            idempotency_key: None,
         },
     )
     .await;
@@ -2095,6 +2096,7 @@ async fn connector_socket_finalize_mismatch_keeps_stream_session_retryable() {
             final_text: "hello stream".to_owned(),
             transcript_hash_hex: first_hash,
             chunk_count: 7,
+            idempotency_key: None,
         },
     )
     .await;
@@ -2137,6 +2139,7 @@ async fn connector_socket_finalize_mismatch_keeps_stream_session_retryable() {
             final_text: "hello stream again".to_owned(),
             transcript_hash_hex: corrected_hash,
             chunk_count: 2,
+            idempotency_key: None,
         },
     )
     .await;
@@ -2249,6 +2252,7 @@ async fn connector_finalize_retries_durable_finish_without_compose_task() {
             "different final".to_owned(),
             &hex::encode(transcript_hash),
             1,
+            Some("frozen-finalize".to_owned()),
         )
         .await;
     assert!(
@@ -2269,6 +2273,7 @@ async fn connector_finalize_retries_durable_finish_without_compose_task() {
             "frozen final".to_owned(),
             &hex::encode(transcript_hash),
             1,
+            Some("frozen-finalize".to_owned()),
         )
         .await
         .expect("frozen-transcript retry finalizes without the compose task");
@@ -2284,6 +2289,28 @@ async fn connector_finalize_retries_durable_finish_without_compose_task() {
         connector.streams.get(&stream_id_norm).is_err(),
         "a successful durable finish must remove the session"
     );
+
+    // A client retry after receiving a timeout from the successful durable
+    // publish path must return the original ids even though the stream session
+    // is gone. This is the post-success half of stream_finalize idempotency.
+    let retried_after_success = connector
+        .stream_finalize_response(
+            &stream_id_hex,
+            "frozen final".to_owned(),
+            &hex::encode(transcript_hash),
+            1,
+            Some("frozen-finalize".to_owned()),
+        )
+        .await
+        .expect("idempotent stream_finalize retry returns cached ids");
+    let AgentControlResponse::StreamFinalized {
+        message_ids_hex: retried_ids,
+        ..
+    } = retried_after_success
+    else {
+        panic!("expected stream finalized response");
+    };
+    assert_eq!(retried_ids, message_ids_hex);
 }
 
 #[tokio::test]

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -117,6 +117,11 @@ pub enum AgentControlRequest {
         final_text: String,
         transcript_hash_hex: String,
         chunk_count: u64,
+        /// Optional client-supplied dedup key. When present, the connector
+        /// returns the original stream-final message ids for a retry whose
+        /// finalized transcript matches the first successful finalize.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        idempotency_key: Option<String>,
     },
     StreamCancel {
         stream_id_hex: String,
@@ -573,6 +578,36 @@ mod tests {
     }
 
     #[test]
+    fn stream_finalize_idempotency_key_is_omitted_when_absent_and_present_when_set() {
+        // Same additive contract as send_final: old peers see the same frame
+        // when the key is absent, while newer clients can opt into dedup.
+        let without = AgentControlRequest::StreamFinalize {
+            stream_id_hex: "55".repeat(32),
+            final_text: "done".to_owned(),
+            transcript_hash_hex: "ab".repeat(32),
+            chunk_count: 1,
+            idempotency_key: None,
+        };
+        let value = serde_json::to_value(&without).unwrap();
+        assert!(
+            value.get("idempotency_key").is_none(),
+            "absent key must not be serialized"
+        );
+
+        let with = AgentControlRequest::StreamFinalize {
+            stream_id_hex: "55".repeat(32),
+            final_text: "done".to_owned(),
+            transcript_hash_hex: "ab".repeat(32),
+            chunk_count: 1,
+            idempotency_key: Some("stream-key-1".to_owned()),
+        };
+        let value = serde_json::to_value(&with).unwrap();
+        assert_eq!(value["idempotency_key"], "stream-key-1");
+        let round_tripped: AgentControlRequest = serde_json::from_value(value).unwrap();
+        assert_eq!(round_tripped, with);
+    }
+
+    #[test]
     fn stream_begun_response_carries_policy_plaintext_cap_when_present() {
         let begun = AgentControlResponse::StreamBegun {
             stream_id_hex: "aa".repeat(32),
@@ -801,6 +836,7 @@ mod tests {
                     final_text: "hello".to_owned(),
                     transcript_hash_hex: hash(),
                     chunk_count: 1,
+                    idempotency_key: Some("stream-final-1".to_owned()),
                 },
                 "stream_finalize",
             ),

--- a/crates/cli/AGENTS.md
+++ b/crates/cli/AGENTS.md
@@ -35,9 +35,10 @@ Command-line app, background daemon, and terminal UI for the White Noise/Marmot 
 - `create-identity`, `login`, `logout`, `whoami`, `account`, and `accounts`: create/import/remove public or local
   signing accounts, list accounts, inspect status, and inspect relay lists. `export-nsec` is present but must not print
   private key material.
-- `keys`: list/publish/check the selected local account's KeyPackage, force-mint a replacement with `keys rotate`
-  (alias `force-publish`), and fetch another account's latest KeyPackage.
-- `chats`: list, list-archived, show, subscribe, subscribe-archived, archive, and unarchive local chat projections.
+- `keys`: list/publish/check/delete the selected local account's KeyPackage records, force-mint a replacement with
+  `keys rotate` (alias `force-publish`), and fetch another account's latest KeyPackage.
+- `chats`: list, list-archived, show, subscribe, subscribe-archived, archive, unarchive, mute, and unmute local chat
+  projections/notification policy.
 - `group` and `groups`: create groups, list/show groups, list members/admins/relays, invite/add/remove members, update
   profile fields, and subscribe to runtime-owned group-state updates through the daemon.
 - `messages`: send text messages, list/search projected messages with Whitenoise-shaped cursor flags, subscribe to
@@ -46,9 +47,8 @@ Command-line app, background daemon, and terminal UI for the White Noise/Marmot 
 - `follows`, `profile`, `relays`, `settings`, and `users`: expose the current Nostr directory/settings behavior.
 - Reaction, delete, retry, encrypted media, and admin/member management commands have implemented CLI behavior; keep
   their JSON shapes aligned with the `Unreleased` changelog entries when changing them.
-- `notifications` and user-driven invite accept/decline commands: keep the Whitenoise-shaped command names but return
-  `unsupported_command` until real behavior exists.
-- `stream`: anchor, watch, receive, send, finish, and verify provisional QUIC agent text stream previews.
+- `notifications`: subscribe to runtime-owned local notification updates through the daemon.
+- `stream`: anchor, watch, receive, send, daemon-compose, finish, and verify provisional QUIC agent text stream previews.
 - `sync`: diagnostic catch-up for processing relay events for the selected local signing account.
 - `relay-stats`: print device-local relay performance telemetry (aggregate counters, cross-relay spread, per-relay
   first-deliverer and first-event/EOSE timing, redacted relay health). Reads the live `wnd` runtime when a socket

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -12,6 +12,26 @@ versioning through the workspace version in the root `Cargo.toml`.
 - Workspace version unified at `0.9.0` across all crates (successor to MDK `0.8.0`).
 - Documentation refresh: current-state inventory, missing crate READMEs, agent integration agent maps, and release
   doc alignment.
+- The TUI now supports `/image <file-path> [caption]` by calling the real encrypted `wn media upload --send` path for
+  the selected chat instead of rejecting image sends or inventing a plaintext placeholder.
+- `wn groups invites`, `wn groups accept <group>`, and `wn groups decline <group>` now use the app runtime's
+  pending-invite state and accept/decline paths instead of returning `unsupported_command`.
+- `wn notifications subscribe` is now visible in help and streams daemon-backed local notification updates instead of
+  returning `unsupported_command`.
+- `wn keys list` now returns KeyPackage event ids and local/relay origin, and `wn keys delete` / `wn keys delete-all
+  --confirm` publish real Nostr deletion events through the app runtime.
+- The daemon-backed `wn stream compose-open`, `compose-append`, `compose-finish`, and `compose-cancel` commands are now
+  visible in help and return a daemon-required error instead of `unsupported_command` when `wnd` is unavailable.
+- `wn chats mute <group> <duration>`, `wn chats unmute <group>`, `/chat mute`, and `/chat unmute` now manage real
+  per-chat local notification suppression instead of hiding or rejecting that surface.
+- `wn sync` is visible in top-level help as the CLI diagnostic/repair catch-up path. The TUI still rejects `/sync`
+  because live updates come from daemon subscriptions.
+- `export-nsec`, relay type validation, and confirmation-gated destructive commands now return specific JSON error
+  codes instead of sharing a generic unsupported-command shape.
+- `wn-agent` stream finalization now accepts idempotency keys, and the OpenClaw/Hermes adapters retry
+  `stream_finalize` with stable per-stream keys so a post-write timeout does not duplicate the durable final.
+- Hermes dev setup now mirrors OpenClaw by passing custom QUIC preview candidates through the generated
+  `bootstrap-agent.sh` helper and syntax-checking every generated helper script in its contract test.
 
 ### Security
 

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -138,8 +138,8 @@ When a daemon is running, `create-identity` and `wn login --nsec-stdin` use the 
 publish the required relay lists and an initial KeyPackage. `printf '%s\n' "$NSEC" | wn login --nsec-stdin --relay
 <url>` is the command-local fallback for a custom relay-list publish during import. Public `npub` logins only check
 relay-list availability because they cannot sign.
-`export-nsec` is present for command-shape compatibility but returns `unsupported_command`; this CLI does not print
-private keys.
+`export-nsec` is present for command-shape compatibility but returns `private_key_export_disabled`; this CLI does not
+print private keys.
 
 KeyPackage commands:
 
@@ -156,8 +156,9 @@ wn --account <npub-or-hex> keys delete-all --confirm
 `keys publish` republishes the currently cached KeyPackage; `keys rotate` (alias `force-publish`) force-mints and
 publishes a fresh replacement KeyPackage.
 
-KeyPackage publish/fetch/check/list use the current relay-directory path. KeyPackage deletion commands (`keys delete`,
-`keys delete-all`) are present but return `unsupported_command` until Nostr deletion is wired through the app runtime.
+KeyPackage publish/fetch/check/list use the current relay-directory path. `keys list` returns the relay event id for
+each known KeyPackage record. `keys delete` publishes a Nostr deletion for one event id, and `keys delete-all
+--confirm` publishes deletions for every relay-published KeyPackage record found for the selected account.
 
 Chat projection commands:
 
@@ -170,6 +171,9 @@ wn --account <npub-or-hex> chats subscribe
 wn --account <npub-or-hex> chats subscribe-archived
 wn --account <npub-or-hex> chats archive <group-hex>
 wn --account <npub-or-hex> chats unarchive <group-hex>
+wn --account <npub-or-hex> chats mute <group-hex> 1h
+wn --account <npub-or-hex> chats mute <group-hex> forever
+wn --account <npub-or-hex> chats unmute <group-hex>
 ```
 
 Group commands:
@@ -183,6 +187,9 @@ wn --account <npub-or-hex> groups remove-members <group-hex> <member-npub-or-hex
 wn --account <npub-or-hex> groups members <group-hex>
 wn --account <npub-or-hex> groups admins <group-hex>
 wn --account <npub-or-hex> groups relays <group-hex>
+wn --account <npub-or-hex> groups invites
+wn --account <npub-or-hex> groups accept <group-hex>
+wn --account <npub-or-hex> groups decline <group-hex>
 wn --account <npub-or-hex> groups leave <group-hex>
 wn --account <npub-or-hex> groups rename <group-hex> <name>
 wn --account <npub-or-hex> groups set-avatar-url <group-hex> --url <https-url> [--dim <WxH>] [--thumbhash <hex>]
@@ -271,6 +278,7 @@ wn settings theme dark
 wn settings language en
 wn users show <npub-or-hex>
 wn users search <query> --radius 0..2
+wn notifications subscribe
 wn relay-stats
 wn relay-stats --json
 wn reset --confirm
@@ -281,8 +289,10 @@ spread, per-relay first-deliverer and first-event/EOSE timing, and redacted rela
 runtime when a daemon socket exists. The numbers are aggregate-only and per-relay rows use opaque device-local indices,
 never relay URLs.
 
-`notifications subscribe`, chat mute/unmute, and user-driven invite accept/decline commands currently return
-`unsupported_command` rather than faking behavior.
+`groups invites` lists groups still awaiting local confirmation; `groups accept` clears that pending state, and
+`groups decline` leaves and archives the auto-joined pending group. `notifications subscribe` streams daemon-backed
+local notification updates as JSON lines. `chats mute` and `chats unmute` control local per-chat notification
+suppression; mute durations accept `s`, `m`, `h`, `d`, or `w` suffixes, plus `forever`.
 
 Agent text stream preview commands:
 
@@ -295,6 +305,11 @@ wn --account <npub-or-hex> stream watch <group-hex> --stream-id <stream-hex> --i
 wn stream send --broker --connect 127.0.0.1:4450 --insecure-local \
   --stream-id <stream-hex> --start-event-id <start-message-id-hex> "hello over quic"
 wn stream send --connect <host:port> --server-name <dns-name> "hello over quic"
+wn --account <npub-or-hex> stream compose-open <group-hex> \
+  --stream-id <stream-hex> --quic-candidate quic://127.0.0.1:4450 --insecure-local
+wn --account <npub-or-hex> stream compose-append --stream-id <stream-hex> "hello "
+wn --account <npub-or-hex> stream compose-finish --stream-id <stream-hex>
+wn --account <npub-or-hex> stream compose-cancel --stream-id <stream-hex>
 wn --account <npub-or-hex> stream finish <group-hex> \
   --stream-id <stream-hex> --start-event-id <start-message-id-hex> \
   --transcript-hash <hash-hex> --chunk-count <n> "hello over quic"
@@ -317,6 +332,11 @@ immediately. The runtime stream manager owns the running/completed/failed previe
 includes that state under `stream_watches`, including received preview text and transcript hash after the brokered stream
 arrives. The same preview state is emitted as typed `stream_preview` updates from `wn messages subscribe <group-hex>`,
 while individual broker chunks arrive as `agent_stream_delta` updates.
+
+`stream compose-open`, `stream compose-append`, `stream compose-finish`, and `stream compose-cancel` are the
+daemon-owned live composer used by the TUI and agent connectors. They require `wnd`: opening a session publishes the
+durable stream anchor and starts live preview publication, append feeds preview text, finish publishes the durable final
+message, and cancel tears down the active session without faking a final marker.
 
 Sync command:
 
@@ -459,10 +479,13 @@ Composer slash commands:
 /chat describe <description>
 /chat archive
 /chat unarchive
+/chat mute <duration>
+/chat unmute
 /chat archived [on|off]
 /members add <npub-or-hex> [...]
 /members remove <npub-or-hex> [...]
 /members list
+/image <file-path> [caption]
 /keys fetch <npub-or-hex>
 /keys rotate
 /name <display-name>
@@ -482,6 +505,8 @@ Composer slash commands:
 `/chat archived` shows archived chats so they can be selected and unarchived; `/chat archived off` returns to the
 visible-chat list. Member commands operate on the selected chat and call the same group membership commands exposed by
 the CLI.
+`/image` uses the real encrypted media path (`wn media upload <group> <file> --send`) and sends the optional caption
+as the media message text; it does not send plaintext file paths or placeholder messages.
 Stream commands operate on the selected chat. `/stream watch` starts a daemon background watch and completed previews
 appear as provisional preview rows in the message panel. `/stream` opens the TUI stream composer, publishes the stream
 anchor, starts the receiver watch through the daemon, and then treats the next submitted composer line as the streamed

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -197,7 +197,7 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: UsersCommand,
     },
-    #[command(hide = true)]
+    #[command(about = "Subscribe to local notification updates")]
     Notifications {
         #[command(subcommand)]
         command: NotificationsCommand,
@@ -212,7 +212,7 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: DaemonCommand,
     },
-    #[command(hide = true)]
+    #[command(about = "Process relay events for the selected account")]
     Sync,
     #[command(
         name = "relay-stats",
@@ -235,8 +235,6 @@ pub(crate) enum DebugCommand {
     RelayControlState,
     #[command(about = "Run a local runtime health check for the selected account")]
     Health,
-    #[command(name = "ratchet-tree", hide = true)]
-    RatchetTree { group_id: String },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Subcommand)]
@@ -312,9 +310,12 @@ pub(crate) enum KeyPackageCommand {
         alias = "force-publish"
     )]
     Rotate,
-    #[command(hide = true)]
+    #[command(about = "Publish a Nostr deletion for one KeyPackage event")]
     Delete { event_id: String },
-    #[command(name = "delete-all", hide = true)]
+    #[command(
+        name = "delete-all",
+        about = "Publish Nostr deletions for all relay-published KeyPackage events"
+    )]
     DeleteAll {
         #[arg(long)]
         confirm: bool,
@@ -372,10 +373,18 @@ pub(crate) enum ChatsCommand {
         about = "Subscribe to live archived-chat updates through the daemon"
     )]
     SubscribeArchived,
-    #[command(hide = true)]
-    Mute { group: String, duration: String },
-    #[command(hide = true)]
-    Unmute { group: String },
+    #[command(about = "Mute local notifications for a chat")]
+    Mute {
+        #[arg(help = "Group id to mute")]
+        group: String,
+        #[arg(help = "Mute duration: forever, or a number with s/m/h/d/w suffix")]
+        duration: String,
+    },
+    #[command(about = "Unmute local notifications for a chat")]
+    Unmute {
+        #[arg(help = "Group id to unmute")]
+        group: String,
+    },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Subcommand)]
@@ -550,12 +559,18 @@ pub(crate) enum GroupsCommand {
         #[arg(long, help = "Clear the group URL avatar")]
         clear: bool,
     },
-    #[command(hide = true)]
+    #[command(about = "List pending group invites for the selected account")]
     Invites,
-    #[command(hide = true)]
-    Accept { group_id: String },
-    #[command(hide = true)]
-    Decline { group_id: String },
+    #[command(about = "Accept a pending group invite")]
+    Accept {
+        #[arg(help = "Group id to accept")]
+        group_id: String,
+    },
+    #[command(about = "Decline a pending group invite by leaving and archiving it")]
+    Decline {
+        #[arg(help = "Group id to decline")]
+        group_id: String,
+    },
     #[command(about = "Promote a member to group admin")]
     Promote {
         #[arg(help = "Group id to update")]
@@ -931,33 +946,53 @@ pub(crate) enum StreamCommand {
         )]
         background: bool,
     },
-    #[command(hide = true)]
+    #[command(about = "Open a daemon-owned live stream compose session")]
     ComposeOpen {
+        #[arg(help = "Group id that will receive the stream anchor and final message")]
         group: String,
-        #[arg(long, value_name = "HEX")]
+        #[arg(long, value_name = "HEX", help = "Stream id to use")]
         stream_id: Option<String>,
-        #[arg(long = "quic-candidate", value_name = "ADDR")]
+        #[arg(
+            long = "quic-candidate",
+            value_name = "ADDR",
+            help = "Broker candidate to advertise, e.g. quic://host:port"
+        )]
         quic_candidates: Vec<String>,
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "Trust loopback QUIC broker certificates for local testing"
+        )]
         insecure_local: bool,
-        #[arg(long, default_value_t = 32, value_name = "BYTES")]
+        #[arg(
+            long,
+            default_value_t = 32,
+            value_name = "BYTES",
+            help = "Maximum bytes per streamed preview chunk"
+        )]
         chunk_bytes: usize,
     },
-    #[command(hide = true)]
+    #[command(about = "Append text to an active daemon stream compose session")]
     ComposeAppend {
-        #[arg(long, value_name = "HEX")]
+        #[arg(long, value_name = "HEX", help = "Stream id to append to")]
         stream_id: String,
-        #[arg(value_name = "TEXT", required = true, allow_hyphen_values = true)]
+        #[arg(
+            value_name = "TEXT",
+            required = true,
+            allow_hyphen_values = true,
+            help = "Text to append"
+        )]
         text: Vec<String>,
     },
-    #[command(hide = true)]
+    #[command(
+        about = "Finish a daemon stream compose session and publish the durable final message"
+    )]
     ComposeFinish {
-        #[arg(long, value_name = "HEX")]
+        #[arg(long, value_name = "HEX", help = "Stream id to finish")]
         stream_id: String,
     },
-    #[command(hide = true)]
+    #[command(about = "Cancel a daemon stream compose session")]
     ComposeCancel {
-        #[arg(long, value_name = "HEX")]
+        #[arg(long, value_name = "HEX", help = "Stream id to cancel")]
         stream_id: String,
     },
     #[command(about = "Commit the final agent text stream transcript over the MLS message path")]

--- a/crates/cli/src/commands/account.rs
+++ b/crates/cli/src/commands/account.rs
@@ -11,7 +11,7 @@ use serde_json::{Value, json};
 use crate::{
     AccountCommand, CliRuntimeInfo, CommandOutput, SecretStoreKind, WnError,
     account_selector_or_default, is_nostr_secret, npub_for_account_id, parse_public_key,
-    profile_display_name, relay_endpoints, relay_lists_json, resolve_account, unsupported_command,
+    profile_display_name, relay_endpoints, relay_lists_json, resolve_account,
     validate_materialized_secret_identity,
 };
 
@@ -136,10 +136,7 @@ pub(crate) fn logout_command(
 }
 
 pub(crate) fn export_nsec_command(_pubkey: String) -> Result<CommandOutput, WnError> {
-    unsupported_command(
-        "export-nsec",
-        "White Noise CLI policy forbids printing private keys",
-    )
+    Err(WnError::PrivateKeyExportDisabled)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/cli/src/commands/chats.rs
+++ b/crates/cli/src/commands/chats.rs
@@ -1,13 +1,14 @@
 //! `chats` command namespace handlers and chat-archive output helper.
 
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use marmot_account::AccountHome;
-use marmot_app::{MarmotApp, MarmotAppRuntime};
-use serde_json::json;
+use marmot_app::{ChatNotificationSettings, MarmotApp, MarmotAppRuntime};
+use serde_json::{Value, json};
 
 use crate::{
     ChatsCommand, CommandOutput, WnError, ensure_local_signing, group_json, group_list_plain,
     group_show_output, normalize_group_id_hex, npub_for_account_id, resolve_account,
-    unsupported_command,
 };
 
 pub(crate) async fn chats_command(
@@ -82,15 +83,88 @@ pub(crate) async fn chats_command_with_runtime(
             })
         }
         ChatsCommand::SubscribeArchived => Err(WnError::ChatsSubscribeRequiresDaemon),
-        ChatsCommand::Mute { .. } => unsupported_command(
-            "chats mute",
-            "chat notification mute state is not modeled in marmot-app yet",
-        ),
-        ChatsCommand::Unmute { .. } => unsupported_command(
-            "chats unmute",
-            "chat notification mute state is not modeled in marmot-app yet",
-        ),
+        ChatsCommand::Mute { group, duration } => {
+            let account = resolve_account(account_home, account_flag)?;
+            ensure_local_signing(&account)?;
+            let group_id = normalize_group_id_hex(&group)?;
+            let muted_until_ms = parse_mute_duration(&duration)?;
+            let settings = runtime.set_chat_muted(&account.label, &group_id, muted_until_ms)?;
+            Ok(CommandOutput {
+                plain: chat_notification_plain("muted", &settings),
+                json: chat_notification_json(account.account_id_hex, settings),
+            })
+        }
+        ChatsCommand::Unmute { group } => {
+            let account = resolve_account(account_home, account_flag)?;
+            ensure_local_signing(&account)?;
+            let group_id = normalize_group_id_hex(&group)?;
+            let settings = runtime.clear_chat_muted(&account.label, &group_id)?;
+            Ok(CommandOutput {
+                plain: chat_notification_plain("unmuted", &settings),
+                json: chat_notification_json(account.account_id_hex, settings),
+            })
+        }
     }
+}
+
+fn parse_mute_duration(duration: &str) -> Result<Option<i64>, WnError> {
+    let trimmed = duration.trim();
+    if trimmed.eq_ignore_ascii_case("forever") || trimmed.eq_ignore_ascii_case("always") {
+        return Ok(None);
+    }
+    let Some((number, unit)) = trimmed.split_at_checked(trimmed.len().saturating_sub(1)) else {
+        return Err(WnError::InvalidMuteDuration(duration.to_owned()));
+    };
+    let amount = number
+        .parse::<i64>()
+        .map_err(|_| WnError::InvalidMuteDuration(duration.to_owned()))?;
+    if amount <= 0 {
+        return Err(WnError::InvalidMuteDuration(duration.to_owned()));
+    }
+    let unit_seconds = match unit {
+        "s" | "S" => 1,
+        "m" | "M" => 60,
+        "h" | "H" => 60 * 60,
+        "d" | "D" => 24 * 60 * 60,
+        "w" | "W" => 7 * 24 * 60 * 60,
+        _ => return Err(WnError::InvalidMuteDuration(duration.to_owned())),
+    };
+    let duration_ms = amount
+        .checked_mul(unit_seconds)
+        .and_then(|seconds| seconds.checked_mul(1000))
+        .ok_or_else(|| WnError::InvalidMuteDuration(duration.to_owned()))?;
+    current_time_ms()
+        .checked_add(duration_ms)
+        .map(Some)
+        .ok_or_else(|| WnError::InvalidMuteDuration(duration.to_owned()))
+}
+
+fn current_time_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or_default()
+}
+
+fn chat_notification_plain(verb: &str, settings: &ChatNotificationSettings) -> String {
+    match settings.muted_until_ms {
+        Some(until) if settings.muted => {
+            format!("{} chat {} until {}", verb, settings.group_id_hex, until)
+        }
+        None if settings.muted => format!("{} chat {} forever", verb, settings.group_id_hex),
+        _ => format!("{} chat {}", verb, settings.group_id_hex),
+    }
+}
+
+fn chat_notification_json(account_id: String, settings: ChatNotificationSettings) -> Value {
+    json!({
+        "account_id": account_id,
+        "account_ref": settings.account_ref,
+        "group_id": settings.group_id_hex,
+        "muted": settings.muted,
+        "muted_until_ms": settings.muted_until_ms,
+        "updated_at_ms": settings.updated_at_ms,
+    })
 }
 
 async fn group_archive_output(

--- a/crates/cli/src/commands/debug.rs
+++ b/crates/cli/src/commands/debug.rs
@@ -6,7 +6,6 @@ use serde_json::json;
 
 use crate::{
     CommandOutput, DebugCommand, WnError, npub_for_account_id, relay_lists_json, resolve_account,
-    unsupported_command,
 };
 
 pub(crate) fn debug_command(
@@ -56,9 +55,5 @@ pub(crate) fn debug_command(
                 }),
             })
         }
-        DebugCommand::RatchetTree { .. } => unsupported_command(
-            "debug ratchet-tree",
-            "ratchet-tree diagnostics are not exposed by marmot-app yet",
-        ),
     }
 }

--- a/crates/cli/src/commands/groups.rs
+++ b/crates/cli/src/commands/groups.rs
@@ -8,7 +8,7 @@ use serde_json::{Value, json};
 use crate::{
     CommandOutput, GroupCommand, GroupsCommand, WnError, ensure_local_signing, group_json,
     group_list_plain, group_show_output, normalize_group_id_hex, npub_for_account_id,
-    parse_public_key, resolve_account, unsupported_command,
+    parse_public_key, resolve_account,
 };
 
 pub(crate) async fn group_command(
@@ -423,18 +423,67 @@ pub(crate) async fn groups_command_with_runtime(
             )
             .await
         }
-        GroupsCommand::Invites => unsupported_command(
-            "groups invites",
-            "user-driven invite accept/decline state is not modeled yet",
-        ),
-        GroupsCommand::Accept { .. } => unsupported_command(
-            "groups accept",
-            "welcomes are auto-accepted today; user-driven accept is not modeled yet",
-        ),
-        GroupsCommand::Decline { .. } => unsupported_command(
-            "groups decline",
-            "user-driven invite decline is not modeled yet",
-        ),
+        GroupsCommand::Invites => {
+            let account = resolve_account(account_home, account_flag)?;
+            ensure_local_signing(&account)?;
+            app.status(&account.label)?;
+            let invites = app
+                .groups(&account.label)?
+                .into_iter()
+                .filter(|group| group.pending_confirmation)
+                .collect::<Vec<_>>();
+            Ok(CommandOutput {
+                plain: pending_invites_plain(&invites),
+                json: json!({
+                    "account_id": account.account_id_hex,
+                    "npub": npub_for_account_id(&account.account_id_hex)?,
+                    "invites": invites.into_iter().map(group_json).collect::<Vec<_>>(),
+                }),
+            })
+        }
+        GroupsCommand::Accept { group_id } => {
+            let account = resolve_account(account_home, account_flag)?;
+            ensure_local_signing(&account)?;
+            app.status(&account.label)?;
+            let group_id = GroupId::new(hex::decode(normalize_group_id_hex(&group_id)?)?);
+            let group = runtime
+                .accept_group_invite(&account.label, &group_id)
+                .await?;
+            let group_id_hex = hex::encode(group_id.as_slice());
+            Ok(CommandOutput {
+                plain: format!("accepted invite {group_id_hex}"),
+                json: json!({
+                    "account_id": account.account_id_hex,
+                    "npub": npub_for_account_id(&account.account_id_hex)?,
+                    "group": group_json(group),
+                    "accepted": true,
+                }),
+            })
+        }
+        GroupsCommand::Decline { group_id } => {
+            let account = resolve_account(account_home, account_flag)?;
+            ensure_local_signing(&account)?;
+            app.status(&account.label)?;
+            let group_id = GroupId::new(hex::decode(normalize_group_id_hex(&group_id)?)?);
+            let declined = runtime
+                .decline_group_invite(&account.label, &group_id)
+                .await?;
+            let group_id_hex = hex::encode(group_id.as_slice());
+            Ok(CommandOutput {
+                plain: format!(
+                    "declined invite {group_id_hex} published={}",
+                    declined.summary.published
+                ),
+                json: json!({
+                    "account_id": account.account_id_hex,
+                    "npub": npub_for_account_id(&account.account_id_hex)?,
+                    "group": group_json(declined.group),
+                    "declined": true,
+                    "published": declined.summary.published,
+                    "message_ids": declined.summary.message_ids,
+                }),
+            })
+        }
         GroupsCommand::Promote { group_id, pubkey } => {
             let account = resolve_account(account_home, account_flag)?;
             ensure_local_signing(&account)?;
@@ -549,6 +598,27 @@ fn group_members_plain(members: &[AppGroupMemberRecord]) -> Result<String, WnErr
         .map(|member| npub_for_account_id(&member.member_id_hex))
         .collect::<Result<Vec<_>, _>>()?
         .join("\n"))
+}
+
+fn pending_invites_plain(invites: &[marmot_app::AppGroupRecord]) -> String {
+    if invites.is_empty() {
+        return "no pending invites".to_owned();
+    }
+    invites
+        .iter()
+        .map(|group| {
+            let name = if group.profile.name.trim().is_empty() {
+                "unnamed"
+            } else {
+                group.profile.name.as_str()
+            };
+            match group.welcomer_account_id_hex.as_deref() {
+                Some(welcomer) => format!("{} {} from {}", group.group_id_hex, name, welcomer),
+                None => format!("{} {}", group.group_id_hex, name),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn group_members_json(members: Vec<AppGroupMemberRecord>) -> Result<Vec<Value>, WnError> {

--- a/crates/cli/src/commands/key_package.rs
+++ b/crates/cli/src/commands/key_package.rs
@@ -1,13 +1,12 @@
 //! `keys` (KeyPackage) command namespace handlers and output helpers.
 
 use marmot_account::AccountHome;
-use marmot_app::{FetchedKeyPackage, MarmotApp, MarmotAppRuntime};
+use marmot_app::{AccountKeyPackageRecord, FetchedKeyPackage, MarmotApp, MarmotAppRuntime};
 use serde_json::{Value, json};
 
 use crate::{
     CommandOutput, KeyPackageCommand, WnError, account_selector_or_default, ensure_local_signing,
     npub_for_account_id, parse_public_key, relay_endpoints, relay_lists_json, resolve_account,
-    unsupported_command,
 };
 
 pub(crate) async fn key_package_command(
@@ -30,22 +29,12 @@ pub(crate) async fn key_package_command_with_runtime(
     match command {
         KeyPackageCommand::List => {
             let account = resolve_account(account_home, account_flag)?;
-            let relay_lists =
-                app.account_relay_list_status_for_account_id(&account.account_id_hex)?;
-            let fetched = if relay_lists.nip65.relays.is_empty() {
-                None
-            } else {
-                Some(
-                    app.fetch_latest_key_package_for_account_id(
-                        &account.account_id_hex,
-                        relay_endpoints(relay_lists.nip65.relays.clone())?,
-                    )
-                    .await?,
-                )
-            };
-            let keys = fetched
+            let records = runtime
+                .account_key_packages(&account.label, Vec::new())
+                .await?;
+            let keys = records
                 .into_iter()
-                .map(key_package_fetch_json)
+                .map(account_key_package_record_json)
                 .collect::<Vec<_>>();
             Ok(CommandOutput {
                 plain: if keys.is_empty() {
@@ -132,23 +121,96 @@ pub(crate) async fn key_package_command_with_runtime(
                 }),
             })
         }
-        KeyPackageCommand::Delete { .. } => unsupported_command(
-            "keys delete",
-            "relay deletion for KeyPackage events is not implemented yet",
-        ),
+        KeyPackageCommand::Delete { event_id } => {
+            let account = resolve_account(account_home, account_flag)?;
+            ensure_local_signing(&account)?;
+            app.status(&account.label)?;
+            let deleted = runtime
+                .delete_key_package(&account.label, &event_id, Vec::new())
+                .await?;
+            Ok(CommandOutput {
+                plain: format!("deleted key package event {event_id} relays={deleted}"),
+                json: json!({
+                    "account_id": account.account_id_hex,
+                    "npub": npub_for_account_id(&account.account_id_hex)?,
+                    "event_id": event_id,
+                    "deleted": true,
+                    "accepted_relays": deleted,
+                }),
+            })
+        }
         KeyPackageCommand::DeleteAll { confirm } => {
             if !confirm {
-                return unsupported_command(
-                    "keys delete-all",
-                    "pass --confirm once relay deletion is implemented",
-                );
+                return Err(WnError::ConfirmationRequired {
+                    command: "keys delete-all",
+                    flag: "--confirm",
+                    reason: "pass --confirm to publish deletion events for every relay-published KeyPackage",
+                });
             }
-            unsupported_command(
-                "keys delete-all",
-                "relay deletion for KeyPackage events is not implemented yet",
-            )
+            let account = resolve_account(account_home, account_flag)?;
+            ensure_local_signing(&account)?;
+            app.status(&account.label)?;
+            let records = runtime
+                .account_key_packages(&account.label, Vec::new())
+                .await?;
+            let mut deleted = Vec::new();
+            let mut accepted_relays = 0_usize;
+            for record in records.into_iter().filter(|record| record.relay) {
+                if deleted.iter().any(|deleted: &DeletedKeyPackage| {
+                    deleted.event_id == record.key_package_event_id
+                }) {
+                    continue;
+                }
+                let relays = relay_endpoints(record.source_relays.clone())?;
+                let accepted = runtime
+                    .delete_key_package(&account.label, &record.key_package_event_id, relays)
+                    .await?;
+                accepted_relays += accepted;
+                deleted.push(DeletedKeyPackage {
+                    event_id: record.key_package_event_id,
+                    key_package_id: record.key_package_id,
+                    key_package_ref: record.key_package_ref_hex,
+                    accepted_relays: accepted,
+                });
+            }
+            Ok(CommandOutput {
+                plain: format!(
+                    "deleted {} key package event(s) relays={accepted_relays}",
+                    deleted.len()
+                ),
+                json: json!({
+                    "account_id": account.account_id_hex,
+                    "npub": npub_for_account_id(&account.account_id_hex)?,
+                    "deleted": deleted,
+                    "deleted_count": deleted.len(),
+                    "accepted_relays": accepted_relays,
+                }),
+            })
         }
     }
+}
+
+#[derive(serde::Serialize)]
+struct DeletedKeyPackage {
+    event_id: String,
+    key_package_id: String,
+    key_package_ref: String,
+    accepted_relays: usize,
+}
+
+fn account_key_package_record_json(record: AccountKeyPackageRecord) -> Value {
+    json!({
+        "account_label": record.account_label,
+        "account_id": record.account_id_hex,
+        "key_package_id": record.key_package_id,
+        "key_package_ref": record.key_package_ref_hex,
+        "key_package_event_id": record.key_package_event_id,
+        "published_at": record.published_at,
+        "key_package_bytes": record.key_package_bytes,
+        "source_relays": record.source_relays,
+        "local": record.local,
+        "relay": record.relay,
+    })
 }
 
 fn key_package_fetch_json(fetched: FetchedKeyPackage) -> Value {
@@ -156,6 +218,7 @@ fn key_package_fetch_json(fetched: FetchedKeyPackage) -> Value {
         "account_id": fetched.account_id_hex,
         "key_package_id": fetched.key_package_id,
         "key_package_ref": fetched.key_package_ref_hex,
+        "key_package_event_id": fetched.key_package_event_id,
         "key_package_bytes": fetched.key_package.bytes().len(),
         "created_at": fetched.created_at,
         "source_relays": fetched.source_relays,

--- a/crates/cli/src/commands/key_package.rs
+++ b/crates/cli/src/commands/key_package.rs
@@ -1,5 +1,7 @@
 //! `keys` (KeyPackage) command namespace handlers and output helpers.
 
+use std::collections::HashSet;
+
 use marmot_account::AccountHome;
 use marmot_app::{AccountKeyPackageRecord, FetchedKeyPackage, MarmotApp, MarmotAppRuntime};
 use serde_json::{Value, json};
@@ -154,17 +156,30 @@ pub(crate) async fn key_package_command_with_runtime(
                 .account_key_packages(&account.label, Vec::new())
                 .await?;
             let mut deleted = Vec::new();
+            let mut failed = Vec::new();
+            let mut seen_event_ids = HashSet::new();
             let mut accepted_relays = 0_usize;
             for record in records.into_iter().filter(|record| record.relay) {
-                if deleted.iter().any(|deleted: &DeletedKeyPackage| {
-                    deleted.event_id == record.key_package_event_id
-                }) {
+                if !seen_event_ids.insert(record.key_package_event_id.clone()) {
                     continue;
                 }
-                let relays = relay_endpoints(record.source_relays.clone())?;
-                let accepted = runtime
+                let relays = match relay_endpoints(record.source_relays.clone()) {
+                    Ok(relays) => relays,
+                    Err(err) => {
+                        failed.push(FailedKeyPackageDeletion::from_record(&record, &err));
+                        continue;
+                    }
+                };
+                let accepted = match runtime
                     .delete_key_package(&account.label, &record.key_package_event_id, relays)
-                    .await?;
+                    .await
+                {
+                    Ok(accepted) => accepted,
+                    Err(err) => {
+                        failed.push(FailedKeyPackageDeletion::from_record(&record, &err));
+                        continue;
+                    }
+                };
                 accepted_relays += accepted;
                 deleted.push(DeletedKeyPackage {
                     event_id: record.key_package_event_id,
@@ -175,14 +190,17 @@ pub(crate) async fn key_package_command_with_runtime(
             }
             Ok(CommandOutput {
                 plain: format!(
-                    "deleted {} key package event(s) relays={accepted_relays}",
-                    deleted.len()
+                    "deleted {} key package event(s), failed {} relays={accepted_relays}",
+                    deleted.len(),
+                    failed.len()
                 ),
                 json: json!({
                     "account_id": account.account_id_hex,
                     "npub": npub_for_account_id(&account.account_id_hex)?,
                     "deleted": deleted,
                     "deleted_count": deleted.len(),
+                    "failed": failed,
+                    "failed_count": failed.len(),
                     "accepted_relays": accepted_relays,
                 }),
             })
@@ -196,6 +214,25 @@ struct DeletedKeyPackage {
     key_package_id: String,
     key_package_ref: String,
     accepted_relays: usize,
+}
+
+#[derive(serde::Serialize)]
+struct FailedKeyPackageDeletion {
+    event_id: String,
+    key_package_id: String,
+    key_package_ref: String,
+    error: String,
+}
+
+impl FailedKeyPackageDeletion {
+    fn from_record(record: &AccountKeyPackageRecord, err: &impl std::fmt::Display) -> Self {
+        Self {
+            event_id: record.key_package_event_id.clone(),
+            key_package_id: record.key_package_id.clone(),
+            key_package_ref: record.key_package_ref_hex.clone(),
+            error: err.to_string(),
+        }
+    }
 }
 
 fn account_key_package_record_json(record: AccountKeyPackageRecord) -> Value {

--- a/crates/cli/src/commands/notifications.rs
+++ b/crates/cli/src/commands/notifications.rs
@@ -1,14 +1,11 @@
 //! `notifications` command namespace handlers.
 
-use crate::{CommandOutput, NotificationsCommand, WnError, unsupported_command};
+use crate::{CommandOutput, NotificationsCommand, WnError};
 
 pub(crate) fn notifications_command(
     command: NotificationsCommand,
 ) -> Result<CommandOutput, WnError> {
     match command {
-        NotificationsCommand::Subscribe => unsupported_command(
-            "notifications subscribe",
-            "notification derivation and delivery are not exposed by the daemon yet",
-        ),
+        NotificationsCommand::Subscribe => Err(WnError::NotificationsSubscribeRequiresDaemon),
     }
 }

--- a/crates/cli/src/commands/relays.rs
+++ b/crates/cli/src/commands/relays.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 use crate::{
     CommandOutput, RelaysCommand, WnError, ensure_local_signing, npub_for_account_id,
     relay_endpoints, relay_lists_json, replaceable_list_inconclusive, resolve_account,
-    unsupported_command, validate_relay_url,
+    validate_relay_url,
 };
 
 pub(crate) async fn relays_command(
@@ -159,6 +159,6 @@ fn normalize_relay_type(value: &str) -> Result<String, WnError> {
     match value {
         "nip65" => Ok("nip65".to_owned()),
         "inbox" => Ok("inbox".to_owned()),
-        _ => unsupported_command("relays", "relay type must be nip65 or inbox"),
+        _ => Err(WnError::InvalidRelayType(value.to_owned())),
     }
 }

--- a/crates/cli/src/commands/stream.rs
+++ b/crates/cli/src/commands/stream.rs
@@ -24,7 +24,7 @@ use transport_quic_stream::{
 use crate::{
     AgentStreamDelta, CommandOutput, StreamCommand, WnError, agent_text_stream_payload_value,
     ensure_local_signing, normalize_group_id_hex, npub_for_account_id, resolve_account,
-    resolve_account_ref, stream_route_label, unix_now_seconds, unsupported_command,
+    resolve_account_ref, stream_route_label, unix_now_seconds,
 };
 
 const AGENT_STREAM_START_LOOKBACK_LIMIT: usize = 200;
@@ -357,10 +357,7 @@ pub(crate) async fn stream_command_app_with_runtime(
         StreamCommand::ComposeOpen { .. }
         | StreamCommand::ComposeAppend { .. }
         | StreamCommand::ComposeFinish { .. }
-        | StreamCommand::ComposeCancel { .. } => unsupported_command(
-            "stream compose",
-            "stream compose sessions require the daemon",
-        ),
+        | StreamCommand::ComposeCancel { .. } => Err(WnError::StreamComposeRequiresDaemon),
         StreamCommand::Finish {
             group,
             stream_id,

--- a/crates/cli/src/daemon/mod.rs
+++ b/crates/cli/src/daemon/mod.rs
@@ -349,6 +349,21 @@ async fn handle_daemon_connection(
             };
             let _ = handle_group_state_subscription(&mut stream, &defaults, runtime, *cli).await;
         }
+        DaemonRequest::NotificationsSubscribe { mut cli } => {
+            apply_defaults(&mut cli, &defaults);
+            let runtime = {
+                let mut workers_guard = workers.lock().await;
+                reconcile_app_runtime(
+                    &defaults,
+                    state.clone(),
+                    events.clone(),
+                    &mut workers_guard.runtime,
+                )
+                .await;
+                workers_guard.runtime.runtime.clone()
+            };
+            let _ = handle_notifications_subscription(&mut stream, runtime, *cli).await;
+        }
         DaemonRequest::StreamWatch { cli } => {
             let _ = handle_stream_watch_connection(
                 cli,

--- a/crates/cli/src/daemon/protocol.rs
+++ b/crates/cli/src/daemon/protocol.rs
@@ -105,6 +105,7 @@ pub(crate) enum DaemonRequest {
     MessagesSubscribe { cli: Box<Cli> },
     ChatsSubscribe { cli: Box<Cli> },
     GroupStateSubscribe { cli: Box<Cli> },
+    NotificationsSubscribe { cli: Box<Cli> },
     Execute { cli: Box<Cli> },
 }
 
@@ -212,6 +213,13 @@ pub(crate) async fn send_group_state_subscribe(
     DaemonClient::new(socket).group_state_subscribe(cli).await
 }
 
+pub(crate) async fn send_notifications_subscribe(
+    socket: &Path,
+    cli: Cli,
+) -> Result<CliOutput, DaemonClientError> {
+    DaemonClient::new(socket).notifications_subscribe(cli).await
+}
+
 #[derive(Clone, Debug)]
 pub struct DaemonClient {
     pub(crate) socket: PathBuf,
@@ -283,6 +291,19 @@ impl DaemonClient {
         stream_request(
             &self.socket,
             &DaemonRequest::GroupStateSubscribe { cli: Box::new(cli) },
+            json,
+        )
+        .await
+    }
+
+    pub(crate) async fn notifications_subscribe(
+        &self,
+        cli: Cli,
+    ) -> Result<CliOutput, DaemonClientError> {
+        let json = cli.json;
+        stream_request(
+            &self.socket,
+            &DaemonRequest::NotificationsSubscribe { cli: Box::new(cli) },
             json,
         )
         .await
@@ -566,8 +587,40 @@ pub(crate) fn stream_result_plain(result: &serde_json::Value) -> String {
             timeline_stream_page_plain(result)
         }
         Some("timeline_projection_updated") => timeline_projection_stream_plain(result),
+        Some("notification_subscription_ready") => "notification subscription ready".to_owned(),
+        Some("notification") => notification_stream_plain(result),
         _ => result.to_string(),
     }
+}
+
+pub(crate) fn notification_stream_plain(result: &serde_json::Value) -> String {
+    let notification = result
+        .get("notification")
+        .unwrap_or(&serde_json::Value::Null);
+    let trigger = notification
+        .get("trigger")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("<unknown>");
+    let group_id = notification
+        .get("group_id_hex")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("<unknown>");
+    let sender = notification
+        .get("sender")
+        .and_then(|sender| sender.get("display_name"))
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| {
+            notification
+                .get("sender")
+                .and_then(|sender| sender.get("account_id_hex"))
+                .and_then(serde_json::Value::as_str)
+        })
+        .unwrap_or("<unknown>");
+    let preview = notification
+        .get("preview_text")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    format!("notification {trigger} group={group_id} from={sender}: {preview}")
 }
 
 pub(crate) fn timeline_stream_page_plain(result: &serde_json::Value) -> String {

--- a/crates/cli/src/daemon/responses.rs
+++ b/crates/cli/src/daemon/responses.rs
@@ -63,6 +63,20 @@ pub(crate) fn group_state_stream_response(
     DaemonStreamResponse::ok(result)
 }
 
+pub(crate) fn notification_stream_response(
+    notification: marmot_app::NotificationUpdate,
+) -> DaemonStreamResponse {
+    DaemonStreamResponse::ok(serde_json::json!({
+        "trigger": "Notification",
+        "type": "notification",
+        "account_id": notification.account_id_hex,
+        "account_ref": notification.account_ref,
+        "group_id": notification.group_id_hex,
+        "notification_key": notification.notification_key,
+        "notification": notification,
+    }))
+}
+
 pub(crate) fn cli_output_result(output: CliOutput) -> Result<serde_json::Value, String> {
     let value = serde_json::from_str::<serde_json::Value>(output.stdout.trim())
         .map_err(|err| format!("daemon command returned invalid JSON: {err}"))?;

--- a/crates/cli/src/daemon/subscriptions.rs
+++ b/crates/cli/src/daemon/subscriptions.rs
@@ -476,6 +476,59 @@ pub(crate) async fn handle_group_state_subscription(
     Ok(())
 }
 
+pub(crate) async fn handle_notifications_subscription(
+    stream: &mut UnixStream,
+    runtime: Option<marmot_app::MarmotAppRuntime>,
+    cli: Cli,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if notifications_subscribe_args(&cli).is_err() {
+        let _ = write_stream_response(
+            stream,
+            &DaemonStreamResponse::err(
+                "notifications subscribe requires wn notifications subscribe".to_owned(),
+            ),
+        )
+        .await;
+        let _ = write_stream_end(stream).await;
+        return Ok(());
+    }
+    let Some(runtime) = runtime else {
+        let _ = write_stream_response(
+            stream,
+            &DaemonStreamResponse::err("app runtime is not running".to_owned()),
+        )
+        .await;
+        let _ = write_stream_end(stream).await;
+        return Ok(());
+    };
+    let mut subscription = match runtime.subscribe_notifications() {
+        Ok(subscription) => subscription,
+        Err(err) => {
+            let _ =
+                write_stream_response(stream, &DaemonStreamResponse::err(err.to_string())).await;
+            let _ = write_stream_end(stream).await;
+            return Ok(());
+        }
+    };
+    if !write_stream_response(
+        stream,
+        &DaemonStreamResponse::ok(serde_json::json!({
+            "trigger": "SubscriptionReady",
+            "type": "notification_subscription_ready",
+        })),
+    )
+    .await
+    {
+        return Ok(());
+    }
+    while let Some(notification) = subscription.recv().await {
+        if !write_stream_response(stream, &notification_stream_response(notification)).await {
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn group_state_subscribe_args(cli: &Cli) -> Result<String, String> {
     match &cli.command {
         crate::Command::Groups {
@@ -515,6 +568,15 @@ pub(crate) fn messages_subscribe_args(
         .transpose()
         .map_err(|err| err.to_string())?;
     Ok((group_id, Some(limit.unwrap_or(50).min(200))))
+}
+
+pub(crate) fn notifications_subscribe_args(cli: &Cli) -> Result<(), String> {
+    match &cli.command {
+        crate::Command::Notifications {
+            command: crate::NotificationsCommand::Subscribe,
+        } => Ok(()),
+        _ => Err("notifications subscribe requires wn notifications subscribe".to_owned()),
+    }
 }
 
 pub(crate) fn is_timeline_messages_subscribe(cli: &Cli) -> bool {

--- a/crates/cli/src/daemon/tests.rs
+++ b/crates/cli/src/daemon/tests.rs
@@ -1237,6 +1237,34 @@ fn timeline_messages_subscribe_is_routed_by_command_shape() {
 }
 
 #[test]
+fn notifications_subscribe_args_accept_only_notifications_subscribe() {
+    let cli = Cli {
+        home: None,
+        socket: None,
+        relay: None,
+        daemon_discovery_relays: Vec::new(),
+        daemon_default_account_relays: Vec::new(),
+        secret_store: None,
+        keychain_service: None,
+        account: None,
+        json: true,
+        command: crate::Command::Notifications {
+            command: crate::NotificationsCommand::Subscribe,
+        },
+    };
+
+    assert_eq!(notifications_subscribe_args(&cli), Ok(()));
+
+    let wrong = Cli {
+        command: crate::Command::Chats {
+            command: crate::ChatsCommand::Subscribe,
+        },
+        ..cli
+    };
+    assert!(notifications_subscribe_args(&wrong).is_err());
+}
+
+#[test]
 fn timeline_stream_plain_output_is_human_readable() {
     let ready = serde_json::json!({
         "type": "timeline_subscription_ready",
@@ -1245,6 +1273,31 @@ fn timeline_stream_plain_output_is_human_readable() {
     assert_eq!(
         stream_result_plain(&ready),
         "timeline subscription ready group=aa"
+    );
+
+    let notification_ready = serde_json::json!({
+        "type": "notification_subscription_ready"
+    });
+    assert_eq!(
+        stream_result_plain(&notification_ready),
+        "notification subscription ready"
+    );
+
+    let notification = serde_json::json!({
+        "type": "notification",
+        "notification": {
+            "trigger": "NewMessage",
+            "group_id_hex": "aa",
+            "preview_text": "hello",
+            "sender": {
+                "display_name": "Alice Example",
+                "account_id_hex": "bb"
+            }
+        }
+    });
+    assert_eq!(
+        stream_result_plain(&notification),
+        "notification NewMessage group=aa from=Alice Example: hello"
     );
 
     let page = serde_json::json!({

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -80,6 +80,10 @@ pub(crate) enum WnError {
     MessagesSubscribeRequiresDaemon,
     #[error("chats subscribe requires the daemon; start it with `wn daemon start`")]
     ChatsSubscribeRequiresDaemon,
+    #[error("notifications subscribe requires the daemon; start it with `wn daemon start`")]
+    NotificationsSubscribeRequiresDaemon,
+    #[error("stream compose requires the daemon; start it with `wn daemon start`")]
+    StreamComposeRequiresDaemon,
     #[error("login requires --nsec-stdin or an npub identity")]
     MissingLoginIdentity,
     #[error(
@@ -96,11 +100,18 @@ pub(crate) enum WnError {
     MediaAttachmentNotFound(String),
     #[error("invalid media attachment: {0}")]
     InvalidMediaAttachment(String),
-    #[error("{command} is not implemented yet: {reason}")]
-    UnsupportedCommand {
+    #[error("invalid mute duration: {0}")]
+    InvalidMuteDuration(String),
+    #[error("exporting private keys is disabled by White Noise CLI policy")]
+    PrivateKeyExportDisabled,
+    #[error("{command} requires {flag}: {reason}")]
+    ConfirmationRequired {
         command: &'static str,
+        flag: &'static str,
         reason: &'static str,
     },
+    #[error("invalid relay type: {0}")]
+    InvalidRelayType(String),
     #[error("missing account relay lists: {0:?}")]
     MissingRelayLists(Vec<MissingRelayListKind>, Box<AccountRelayListStatus>),
     #[error(
@@ -280,6 +291,20 @@ pub(crate) fn wn_error_json(err: &WnError) -> Value {
                 "start": "wn daemon start",
             },
         }),
+        WnError::NotificationsSubscribeRequiresDaemon => json!({
+            "code": "daemon_required",
+            "message": err.to_string(),
+            "repair": {
+                "start": "wn daemon start",
+            },
+        }),
+        WnError::StreamComposeRequiresDaemon => json!({
+            "code": "daemon_required",
+            "message": err.to_string(),
+            "repair": {
+                "start": "wn daemon start",
+            },
+        }),
         WnError::MissingLoginIdentity => json!({
             "code": "missing_login_identity",
             "message": err.to_string(),
@@ -322,11 +347,37 @@ pub(crate) fn wn_error_json(err: &WnError) -> Value {
             "message": err.to_string(),
             "reason": reason,
         }),
-        WnError::UnsupportedCommand { command, reason } => json!({
-            "code": "unsupported_command",
+        WnError::InvalidMuteDuration(duration) => json!({
+            "code": "invalid_mute_duration",
+            "message": err.to_string(),
+            "duration": duration,
+            "repair": {
+                "examples": ["15m", "1h", "8h", "1d", "1w", "forever"],
+            },
+        }),
+        WnError::PrivateKeyExportDisabled => json!({
+            "code": "private_key_export_disabled",
+            "message": err.to_string(),
+            "repair": {
+                "import_nsec": "printf '%s\\n' \"$NSEC\" | wn login --nsec-stdin",
+            },
+        }),
+        WnError::ConfirmationRequired {
+            command,
+            flag,
+            reason,
+        } => json!({
+            "code": "confirmation_required",
             "message": err.to_string(),
             "command": command,
+            "flag": flag,
             "reason": reason,
+        }),
+        WnError::InvalidRelayType(relay_type) => json!({
+            "code": "invalid_relay_type",
+            "message": err.to_string(),
+            "relay_type": relay_type,
+            "allowed": ["nip65", "inbox"],
         }),
         WnError::MissingGroupId => json!({
             "code": "missing_group_id",

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -193,6 +193,14 @@ where
         };
     }
 
+    if is_notifications_subscribe(&cli) {
+        let socket = daemon_socket_path_for_client(&cli, &home);
+        return match daemon::send_notifications_subscribe(&socket, cli.clone()).await {
+            Ok(output) => output,
+            Err(err) => daemon_client_error(cli.json, err),
+        };
+    }
+
     if let Some(socket) = daemon_socket_for_client(&cli, &home) {
         let explicit_daemon_socket =
             cli.socket.is_some() || std::env::var_os("WN_SOCKET").is_some();
@@ -332,6 +340,15 @@ fn is_group_state_subscribe(cli: &Cli) -> bool {
         &cli.command,
         Command::Groups {
             command: GroupsCommand::SubscribeState { .. },
+        }
+    )
+}
+
+fn is_notifications_subscribe(cli: &Cli) -> bool {
+    matches!(
+        &cli.command,
+        Command::Notifications {
+            command: NotificationsCommand::Subscribe,
         }
     )
 }
@@ -662,13 +679,6 @@ fn daemon_client_error(json_output: bool, err: daemon::DaemonClientError) -> Cli
     }
 }
 
-pub(crate) fn unsupported_command<T>(
-    command: &'static str,
-    reason: &'static str,
-) -> Result<T, WnError> {
-    Err(WnError::UnsupportedCommand { command, reason })
-}
-
 pub(crate) fn group_show_output(
     app: &MarmotApp,
     account: marmot_account::AccountSummary,
@@ -715,10 +725,11 @@ pub(crate) fn replaceable_list_inconclusive(
 
 fn reset_command(home: &Path, confirm: bool) -> Result<CommandOutput, WnError> {
     if !confirm {
-        return unsupported_command(
-            "reset",
-            "pass --confirm to delete all local White Noise data",
-        );
+        return Err(WnError::ConfirmationRequired {
+            command: "reset",
+            flag: "--confirm",
+            reason: "pass --confirm to delete all local White Noise data",
+        });
     }
     match std::fs::remove_dir_all(home) {
         Ok(()) => {}
@@ -832,6 +843,9 @@ pub(crate) fn group_json(group: AppGroupRecord) -> Value {
         "agent_text_stream": group.agent_text_stream,
         "encrypted_media": group.encrypted_media,
         "archived": group.archived,
+        "pending_confirmation": group.pending_confirmation,
+        "welcomer_account_id": group.welcomer_account_id_hex,
+        "via_welcome_message_id": group.via_welcome_message_id_hex,
     })
 }
 
@@ -1821,6 +1835,28 @@ mod tests {
             "expected messages-specific subscribe message, got {messages_message:?}"
         );
         assert_ne!(message, messages_message);
+
+        let notifications = super::wn_error_json(&WnError::NotificationsSubscribeRequiresDaemon);
+        assert_eq!(notifications["code"], "daemon_required");
+        assert_eq!(notifications["repair"]["start"], "wn daemon start");
+        let notifications_message = notifications["message"]
+            .as_str()
+            .expect("notifications message");
+        assert!(
+            notifications_message.starts_with("notifications subscribe"),
+            "expected notification-specific subscribe message, got {notifications_message:?}"
+        );
+
+        let stream_compose = super::wn_error_json(&WnError::StreamComposeRequiresDaemon);
+        assert_eq!(stream_compose["code"], "daemon_required");
+        assert_eq!(stream_compose["repair"]["start"], "wn daemon start");
+        let stream_compose_message = stream_compose["message"]
+            .as_str()
+            .expect("stream compose message");
+        assert!(
+            stream_compose_message.starts_with("stream compose"),
+            "expected stream-compose-specific daemon message, got {stream_compose_message:?}"
+        );
     }
 
     // Regression for #190: an oversized request on the *implicit* daemon socket

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -292,10 +292,13 @@ impl TuiApp {
             }
             SlashCommand::ChatArchive => self.set_selected_chat_archived(true),
             SlashCommand::ChatUnarchive => self.set_selected_chat_archived(false),
+            SlashCommand::ChatMute(duration) => self.set_selected_chat_muted(duration),
+            SlashCommand::ChatUnmute => self.clear_selected_chat_muted(),
             SlashCommand::ChatArchived(include) => self.set_archived_chat_visibility(include),
             SlashCommand::MembersAdd(members) => self.add_selected_chat_members(members),
             SlashCommand::MembersRemove(members) => self.remove_selected_chat_members(members),
             SlashCommand::MembersList => self.show_selected_chat_members(),
+            SlashCommand::Image { file_path, caption } => self.send_image(file_path, caption),
             SlashCommand::KeysFetch(account) => {
                 let result = self.client.run_json(None, &["keys", "fetch", &account])?;
                 let bytes = result

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -123,6 +123,25 @@ pub(crate) fn parse_json_output(output: Output) -> TuiResult<Value> {
     Err(TuiError::Cli(message.to_owned()))
 }
 
+pub(crate) fn media_upload_send_args(
+    group_id: String,
+    file_path: String,
+    caption: Option<String>,
+) -> Vec<String> {
+    let mut args = vec![
+        "media".to_owned(),
+        "upload".to_owned(),
+        group_id,
+        file_path,
+        "--send".to_owned(),
+    ];
+    if let Some(caption) = caption.filter(|caption| !caption.trim().is_empty()) {
+        args.push("--message".to_owned());
+        args.push(caption);
+    }
+    args
+}
+
 pub(crate) fn spawn_subscription_reader(
     child: &mut Child,
     label: &'static str,
@@ -199,6 +218,34 @@ impl TuiApp {
             self.refresh_messages()?;
         }
         self.status = status;
+        Ok(())
+    }
+
+    pub(crate) fn send_image(
+        &mut self,
+        file_path: String,
+        caption: Option<String>,
+    ) -> TuiResult<()> {
+        let account_id = self.message_account_id()?;
+        let group_id = self.message_group_id()?;
+        let args = media_upload_send_args(group_id, file_path, caption);
+        let result = self.client.run_json(Some(&account_id), &args)?;
+        self.refresh_messages()?;
+        let file_name = result
+            .get("attachments")
+            .and_then(Value::as_array)
+            .and_then(|attachments| attachments.first())
+            .and_then(|attachment| attachment.get("media"))
+            .and_then(|media| media.get("file_name"))
+            .and_then(Value::as_str)
+            .unwrap_or("media");
+        let message_count = result
+            .get("sent")
+            .and_then(|sent| sent.get("message_ids"))
+            .and_then(Value::as_array)
+            .map(Vec::len)
+            .unwrap_or_default();
+        self.status = format!("sent {file_name} ({message_count} message(s))");
         Ok(())
     }
 
@@ -524,6 +571,29 @@ impl TuiApp {
         } else {
             format!("unarchived chat {}", shorten(&group_id, 18))
         };
+        Ok(())
+    }
+
+    pub(crate) fn set_selected_chat_muted(&mut self, duration: String) -> TuiResult<()> {
+        let account_id = self.require_selected_local_account()?;
+        let group_id = self.require_selected_group()?;
+        let result = self
+            .client
+            .run_json(Some(&account_id), &["chats", "mute", &group_id, &duration])?;
+        let muted_until = result.get("muted_until_ms").and_then(Value::as_i64);
+        self.status = match muted_until {
+            Some(until) => format!("muted chat {} until {}", shorten(&group_id, 18), until),
+            None => format!("muted chat {} forever", shorten(&group_id, 18)),
+        };
+        Ok(())
+    }
+
+    pub(crate) fn clear_selected_chat_muted(&mut self) -> TuiResult<()> {
+        let account_id = self.require_selected_local_account()?;
+        let group_id = self.require_selected_group()?;
+        self.client
+            .run_json(Some(&account_id), &["chats", "unmute", &group_id])?;
+        self.status = format!("unmuted chat {}", shorten(&group_id, 18));
         Ok(())
     }
 

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -221,10 +221,16 @@ pub(crate) enum SlashCommand {
     ChatDescribe(String),
     ChatArchive,
     ChatUnarchive,
+    ChatMute(String),
+    ChatUnmute,
     ChatArchived(bool),
     MembersAdd(Vec<String>),
     MembersRemove(Vec<String>),
     MembersList,
+    Image {
+        file_path: String,
+        caption: Option<String>,
+    },
     KeysFetch(String),
     KeysRotate,
     ProfileName(String),
@@ -315,6 +321,14 @@ pub(crate) const SLASH_COMMAND_SUGGESTIONS: &[SlashCommandSuggestion] = &[
         description: "unarchive the selected chat",
     },
     SlashCommandSuggestion {
+        usage: "/chat mute <duration>",
+        description: "mute selected-chat notifications",
+    },
+    SlashCommandSuggestion {
+        usage: "/chat unmute",
+        description: "unmute selected-chat notifications",
+    },
+    SlashCommandSuggestion {
         usage: "/chat archived [on|off]",
         description: "toggle archived chat visibility",
     },
@@ -329,6 +343,10 @@ pub(crate) const SLASH_COMMAND_SUGGESTIONS: &[SlashCommandSuggestion] = &[
     SlashCommandSuggestion {
         usage: "/members list",
         description: "show selected chat members",
+    },
+    SlashCommandSuggestion {
+        usage: "/image <file-path> [caption]",
+        description: "encrypt, upload, and send image/media",
     },
     SlashCommandSuggestion {
         usage: "/keys fetch <npub-or-hex>",

--- a/crates/cli/src/tui/slash.rs
+++ b/crates/cli/src/tui/slash.rs
@@ -38,6 +38,7 @@ pub(crate) fn parse_slash_command(input: &str) -> Result<SlashCommand, String> {
         "daemon" => parse_daemon_command(rest),
         "chat" => parse_chat_command(rest),
         "members" => parse_members_command(rest),
+        "image" => parse_image_command(rest),
         "keys" => parse_keys_command(rest),
         "profile" => parse_profile_command(rest),
         "name" => parse_profile_name_command(rest),
@@ -188,14 +189,21 @@ pub(crate) fn parse_chat_command(args: Vec<String>) -> Result<SlashCommand, Stri
         }
         [command] if command == "archive" => Ok(SlashCommand::ChatArchive),
         [command] if command == "unarchive" => Ok(SlashCommand::ChatUnarchive),
+        [command, duration] if command == "mute" => Ok(SlashCommand::ChatMute(duration.clone())),
+        [command] if command == "mute" => Err("/chat mute requires a duration".to_owned()),
+        [command] if command == "unmute" => Ok(SlashCommand::ChatUnmute),
         [command] if command == "archived" => Ok(SlashCommand::ChatArchived(true)),
         [command, value] if command == "archived" => {
             parse_on_off(value).map(SlashCommand::ChatArchived)
         }
-        [] => {
-            Err("/chat expects new, rename, describe, archive, unarchive, or archived".to_owned())
-        }
-        _ => Err("/chat expects new, rename, describe, archive, unarchive, or archived".to_owned()),
+        [] => Err(
+            "/chat expects new, rename, describe, archive, unarchive, mute, unmute, or archived"
+                .to_owned(),
+        ),
+        _ => Err(
+            "/chat expects new, rename, describe, archive, unarchive, mute, unmute, or archived"
+                .to_owned(),
+        ),
     }
 }
 
@@ -219,6 +227,20 @@ pub(crate) fn parse_members_command(args: Vec<String>) -> Result<SlashCommand, S
         }
         [] => Err("/members expects add, remove, or list".to_owned()),
         _ => Err("/members expects add, remove, or list".to_owned()),
+    }
+}
+
+pub(crate) fn parse_image_command(args: Vec<String>) -> Result<SlashCommand, String> {
+    match args.as_slice() {
+        [] => Err("/image expects a file path".to_owned()),
+        [file_path] => Ok(SlashCommand::Image {
+            file_path: file_path.clone(),
+            caption: None,
+        }),
+        [file_path, caption @ ..] => Ok(SlashCommand::Image {
+            file_path: file_path.clone(),
+            caption: Some(caption.join(" ")),
+        }),
     }
 }
 

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -166,6 +166,7 @@ fn slash_command_suggestions_open_on_bare_slash_and_filter_nested_commands() {
     assert!(bare.contains(&"/help"));
     assert!(bare.contains(&"/chat new <name> [member-npub-or-hex ...]"));
     assert!(bare.contains(&"/members add <npub-or-hex> [...]"));
+    assert!(bare.contains(&"/image <file-path> [caption]"));
 
     let chat_rename = slash_command_suggestions("/chat r")
         .iter()
@@ -373,6 +374,14 @@ fn slash_command_parser_handles_chat_and_member_management_commands() {
         Ok(SlashCommand::ChatUnarchive)
     );
     assert_eq!(
+        parse_slash_command("/chat mute 1h"),
+        Ok(SlashCommand::ChatMute("1h".to_owned()))
+    );
+    assert_eq!(
+        parse_slash_command("/chat unmute"),
+        Ok(SlashCommand::ChatUnmute)
+    );
+    assert_eq!(
         parse_slash_command("/chat archived"),
         Ok(SlashCommand::ChatArchived(true))
     );
@@ -401,6 +410,25 @@ fn slash_command_parser_handles_chat_and_member_management_commands() {
     assert!(parse_slash_command("/members clear").is_err());
     assert!(parse_slash_command("/invite npub1bob").is_err());
     assert!(parse_slash_command("/remove npub1bob").is_err());
+}
+
+#[test]
+fn slash_command_parser_handles_image_sends() {
+    assert_eq!(
+        parse_slash_command("/image /tmp/photo.jpg"),
+        Ok(SlashCommand::Image {
+            file_path: "/tmp/photo.jpg".to_owned(),
+            caption: None,
+        })
+    );
+    assert_eq!(
+        parse_slash_command("/image \"/tmp/family photo.jpg\" hello there"),
+        Ok(SlashCommand::Image {
+            file_path: "/tmp/family photo.jpg".to_owned(),
+            caption: Some("hello there".to_owned()),
+        })
+    );
+    assert!(parse_slash_command("/image").is_err());
 }
 
 #[test]
@@ -767,8 +795,31 @@ fn render_lines_strip_terminal_control_sequences_from_untrusted_text() {
 }
 
 #[test]
-fn slash_command_parser_rejects_unimplemented_image_send() {
-    assert!(parse_slash_command("/image /tmp/photo.jpg").is_err());
+fn image_slash_command_uses_real_media_upload_send_surface() {
+    assert_eq!(
+        media_upload_send_args(
+            "group-a".to_owned(),
+            "/tmp/photo.jpg".to_owned(),
+            Some("hello image".to_owned()),
+        ),
+        vec![
+            "media",
+            "upload",
+            "group-a",
+            "/tmp/photo.jpg",
+            "--send",
+            "--message",
+            "hello image",
+        ]
+    );
+    assert_eq!(
+        media_upload_send_args(
+            "group-a".to_owned(),
+            "/tmp/photo.jpg".to_owned(),
+            Some("   ".to_owned()),
+        ),
+        vec!["media", "upload", "group-a", "/tmp/photo.jpg", "--send"]
+    );
 }
 
 #[test]

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -504,8 +504,10 @@ fn whitenoise_command_surface_names_are_present() {
         ("relays", "Inspect and update account relay lists"),
         ("settings", "Read and update local CLI preferences"),
         ("users", "Look up known Nostr users"),
+        ("notifications", "Subscribe to local notification updates"),
         ("keys", "Inspect and repair MLS KeyPackage"),
         ("stream", "Start, watch, finish"),
+        ("sync", "Process relay events for the selected account"),
         ("reset", "Delete all local White Noise CLI data"),
     ] {
         assert!(wn_help.contains(command), "wn --help missing {command}");
@@ -518,10 +520,41 @@ fn whitenoise_command_surface_names_are_present() {
         !wn_help.contains("--relay"),
         "wn --help should not expose a global relay flag"
     );
+    let stream_help = Command::new(env!("CARGO_BIN_EXE_wn"))
+        .args(["stream", "--help"])
+        .output()
+        .expect("wn stream help should run");
     assert!(
-        !wn_help.contains("notifications"),
-        "wn --help should not expose placeholder notification commands"
+        stream_help.status.success(),
+        "{}",
+        command_output_summary(&stream_help)
     );
+    let stream_help = format!(
+        "{}{}",
+        String::from_utf8_lossy(&stream_help.stdout),
+        String::from_utf8_lossy(&stream_help.stderr)
+    );
+    for (command, description) in [
+        (
+            "compose-open",
+            "Open a daemon-owned live stream compose session",
+        ),
+        (
+            "compose-append",
+            "Append text to an active daemon stream compose session",
+        ),
+        ("compose-finish", "Finish a daemon stream compose session"),
+        ("compose-cancel", "Cancel a daemon stream compose session"),
+    ] {
+        assert!(
+            stream_help.contains(command),
+            "wn stream --help missing {command}"
+        );
+        assert!(
+            stream_help.contains(description),
+            "wn stream --help missing description for {command}: {description}"
+        );
+    }
 
     let login_help = Command::new(env!("CARGO_BIN_EXE_wn"))
         .args(["login", "--help"])
@@ -661,18 +694,14 @@ fn whitenoise_command_surface_names_are_present() {
     for expected in [
         "Republish the currently cached KeyPackage",
         "Force mint and publish a fresh replacement KeyPackage",
+        "Publish a Nostr deletion for one KeyPackage event",
+        "Publish Nostr deletions for all relay-published KeyPackage events",
         "Check whether a user has relay lists",
         "Fetch and cache another user's KeyPackage",
     ] {
         assert!(
             keys_help.contains(expected),
             "wn keys --help missing {expected}"
-        );
-    }
-    for stale in ["delete", "delete-all"] {
-        assert!(
-            !keys_help.contains(stale),
-            "wn keys --help should not expose stale {stale}"
         );
     }
 
@@ -690,30 +719,31 @@ fn whitenoise_command_surface_names_are_present() {
         String::from_utf8_lossy(&groups_help.stdout),
         String::from_utf8_lossy(&groups_help.stderr)
     );
-    for stale in ["invites", "accept", "decline"] {
+    for expected in ["invites", "accept", "decline"] {
         assert!(
-            !groups_help.contains(stale),
-            "wn groups --help should not expose stale {stale}"
+            groups_help.contains(expected),
+            "wn groups --help should expose invite command {expected}"
         );
     }
 
-    for (args, hidden) in [
-        (vec!["debug", "--help"], "ratchet-tree"),
-        (vec!["chats", "--help"], "mute"),
-    ] {
-        let help = Command::new(env!("CARGO_BIN_EXE_wn"))
-            .args(args)
-            .output()
-            .expect("nested help should run");
-        assert!(help.status.success(), "{}", command_output_summary(&help));
-        let help = format!(
-            "{}{}",
-            String::from_utf8_lossy(&help.stdout),
-            String::from_utf8_lossy(&help.stderr)
-        );
+    let chats_help = Command::new(env!("CARGO_BIN_EXE_wn"))
+        .args(["chats", "--help"])
+        .output()
+        .expect("chats help should run");
+    assert!(
+        chats_help.status.success(),
+        "{}",
+        command_output_summary(&chats_help)
+    );
+    let chats_help = format!(
+        "{}{}",
+        String::from_utf8_lossy(&chats_help.stdout),
+        String::from_utf8_lossy(&chats_help.stderr)
+    );
+    for expected in ["mute", "unmute"] {
         assert!(
-            !help.contains(hidden),
-            "nested help should not expose stale {hidden}"
+            chats_help.contains(expected),
+            "wn chats --help should expose notification command {expected}"
         );
     }
 
@@ -1655,6 +1685,23 @@ impl JsonLineSubscription {
                 .unwrap_or_else(|| "<none>".to_owned())
         );
     }
+
+    #[track_caller]
+    fn assert_no_line_for(&self, timeout: Duration, predicate: impl Fn(&Value) -> bool) {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let wait = remaining.min(Duration::from_millis(100));
+            match self.lines.recv_timeout(wait) {
+                Ok(value) if predicate(&value) => {
+                    panic!("subscription emitted unexpected line\nline={}", value);
+                }
+                Ok(_) => {}
+                Err(std_mpsc::RecvTimeoutError::Timeout) => {}
+                Err(std_mpsc::RecvTimeoutError::Disconnected) => return,
+            }
+        }
+    }
 }
 
 impl Drop for JsonLineSubscription {
@@ -1985,8 +2032,7 @@ fn whitenoise_parity_commands_have_real_or_explicit_contracts() {
     assert!(!relays["relays"].as_array().expect("relays").is_empty());
 
     let export_error = run_json_error(home.path(), &["export-nsec", &alice]);
-    assert_eq!(export_error["code"], "unsupported_command");
-    assert_eq!(export_error["command"], "export-nsec");
+    assert_eq!(export_error["code"], "private_key_export_disabled");
     let media = run_json(
         home.path(),
         &["--account", &alice, "media", "list", group_id],
@@ -2725,18 +2771,14 @@ fn keys_namespace_uses_account_resolution() {
 }
 
 #[test]
-fn keys_list_surfaces_fetch_errors_instead_of_reporting_no_key_packages() {
+fn keys_list_reports_no_key_packages_without_faking_a_fetch_error() {
     let home = tempfile::tempdir().expect("tempdir");
 
-    // The account has nip65 relays (so `keys list` takes the fetch branch) but
-    // never publishes a KeyPackage, so the upstream fetch returns
-    // `MissingKeyPackage`. The handler must propagate that error rather than
-    // swallowing it via `.ok()` and printing a false "no key packages" result.
     let account_id = create_account(home.path());
 
-    let error = run_json_error(home.path(), &["--account", &account_id, "keys", "list"]);
-    assert_eq!(error["code"], "missing_key_package");
-    assert_eq!(error["account_id"], account_id);
+    let listed = run_json(home.path(), &["--account", &account_id, "keys", "list"]);
+    assert_eq!(listed["account_id"], account_id);
+    assert_eq!(listed["keys"], serde_json::json!([]));
 }
 
 #[test]
@@ -2757,6 +2799,56 @@ fn keys_list_reports_published_key_package() {
         "expected the published key package, got {keys:?}"
     );
     assert_eq!(keys[0]["account_id"], account_id);
+    assert!(
+        keys[0]["key_package_event_id"]
+            .as_str()
+            .is_some_and(|event_id| !event_id.is_empty())
+    );
+    assert_eq!(keys[0]["local"], true);
+    assert_eq!(keys[0]["relay"], true);
+}
+
+#[test]
+fn keys_delete_and_delete_all_use_runtime_relay_deletion() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let relay = TestRelay::new();
+    let relay_url = relay.url();
+
+    let account_id = create_account_with_real_relay(home.path(), relay_url);
+    run_json(home.path(), &["--account", &account_id, "keys", "publish"]);
+    let listed = run_json(home.path(), &["--account", &account_id, "keys", "list"]);
+    let event_id = listed["keys"][0]["key_package_event_id"]
+        .as_str()
+        .expect("key package event id")
+        .to_owned();
+
+    let deleted = run_json(
+        home.path(),
+        &["--account", &account_id, "keys", "delete", &event_id],
+    );
+    assert_eq!(deleted["event_id"], event_id);
+    assert_eq!(deleted["deleted"], true);
+    assert!(
+        deleted["accepted_relays"]
+            .as_u64()
+            .is_some_and(|count| count > 0)
+    );
+
+    run_json(home.path(), &["--account", &account_id, "keys", "publish"]);
+    let delete_all = run_json(
+        home.path(),
+        &["--account", &account_id, "keys", "delete-all", "--confirm"],
+    );
+    assert!(
+        delete_all["deleted_count"]
+            .as_u64()
+            .is_some_and(|count| count > 0)
+    );
+    assert!(
+        delete_all["accepted_relays"]
+            .as_u64()
+            .is_some_and(|count| count > 0)
+    );
 }
 
 #[test]
@@ -4168,6 +4260,80 @@ fn groups_leave_publishes_self_remove() {
 }
 
 #[test]
+fn groups_invites_accept_and_decline_use_pending_invite_state() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let relay = TestRelay::new();
+    let relay_url = relay.url();
+
+    let alice = create_account_with_real_relay(home.path(), relay_url);
+    let bob = create_account_with_real_relay(home.path(), relay_url);
+    let carol = create_account_with_real_relay(home.path(), relay_url);
+    run_json(home.path(), &["--account", &bob, "keys", "publish"]);
+    run_json(home.path(), &["--account", &carol, "keys", "publish"]);
+
+    let accept_group = run_json(
+        home.path(),
+        &["--account", &alice, "groups", "create", "accept-me", &bob],
+    );
+    let accept_group_id = accept_group["group_id"].as_str().expect("accept group id");
+    sync_until_joined(home.path(), relay_url, &bob, accept_group_id);
+
+    let bob_invites = run_json(home.path(), &["--account", &bob, "groups", "invites"]);
+    assert_eq!(bob_invites["invites"][0]["group_id"], accept_group_id);
+    assert_eq!(bob_invites["invites"][0]["pending_confirmation"], true);
+    assert_eq!(bob_invites["invites"][0]["welcomer_account_id"], alice);
+
+    let accepted = run_json(
+        home.path(),
+        &["--account", &bob, "groups", "accept", accept_group_id],
+    );
+    assert_eq!(accepted["accepted"], true);
+    assert_eq!(accepted["group"]["group_id"], accept_group_id);
+    assert_eq!(accepted["group"]["pending_confirmation"], false);
+    assert_eq!(accepted["group"]["archived"], false);
+    let bob_invites = run_json(home.path(), &["--account", &bob, "groups", "invites"]);
+    assert_eq!(bob_invites["invites"], serde_json::json!([]));
+
+    let decline_group = run_json(
+        home.path(),
+        &[
+            "--account",
+            &alice,
+            "groups",
+            "create",
+            "decline-me",
+            &carol,
+        ],
+    );
+    let decline_group_id = decline_group["group_id"]
+        .as_str()
+        .expect("decline group id");
+    sync_until_joined(home.path(), relay_url, &carol, decline_group_id);
+
+    let carol_invites = run_json(home.path(), &["--account", &carol, "groups", "invites"]);
+    assert_eq!(carol_invites["invites"][0]["group_id"], decline_group_id);
+    assert_eq!(carol_invites["invites"][0]["pending_confirmation"], true);
+
+    let declined = run_json(
+        home.path(),
+        &["--account", &carol, "groups", "decline", decline_group_id],
+    );
+    assert_eq!(declined["declined"], true);
+    assert_eq!(declined["published"], 1);
+    assert_eq!(declined["group"]["group_id"], decline_group_id);
+    assert_eq!(declined["group"]["pending_confirmation"], false);
+    assert_eq!(declined["group"]["archived"], true);
+    let carol_visible = run_json(home.path(), &["--account", &carol, "groups", "list"]);
+    assert!(
+        !carol_visible["groups"]
+            .as_array()
+            .expect("groups")
+            .iter()
+            .any(|group| group["group_id"] == decline_group_id)
+    );
+}
+
+#[test]
 fn chats_subscribe_streams_initial_chat_rows_from_daemon() {
     let home = tempfile::tempdir().expect("tempdir");
     let socket = home.path().join("dev").join("wnd.sock");
@@ -4232,6 +4398,189 @@ fn chats_subscribe_streams_initial_chat_rows_from_daemon() {
             && line["result"]["chat"]["profile"]["name"] == "general-renamed"
     });
     assert_eq!(updated["result"]["group_id"], group_id);
+
+    drop(subscription);
+    stop_daemon(&socket, &mut child);
+}
+
+#[test]
+fn notifications_subscribe_streams_runtime_notifications_from_daemon() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let socket = home.path().join("dev").join("wnd.sock");
+
+    let alice = create_account(home.path());
+    let bob = create_account(home.path());
+    run_json(home.path(), &["--account", &bob, "keys", "publish"]);
+    let created_group = run_json(
+        home.path(),
+        &["--account", &alice, "groups", "create", "notify", &bob],
+    );
+    let group_id = created_group["group_id"].as_str().expect("group id");
+    sync_until_joined(home.path(), test_relay_url(), &bob, group_id);
+    run_json(
+        home.path(),
+        &["--account", &bob, "groups", "accept", group_id],
+    );
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_wnd"))
+        .arg("--home")
+        .arg(home.path())
+        .arg("--socket")
+        .arg(&socket)
+        .arg("--discovery-relays")
+        .arg(test_relay_url())
+        .arg("--default-account-relays")
+        .arg(test_relay_url())
+        .arg("--secret-store")
+        .arg("file")
+        // Daemon tests drive an in-process `MockRelay` at loopback; production
+        // rejects non-public relay hosts unless this dev gate is set.
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
+        // Instant convergence settlement (dev/test) so the daemon surfaces
+        // synced state without waiting on the pinned quiescence window.
+        .env("WN_DEV_SETTLEMENT_QUIESCENCE_MS", "0")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("wnd should start");
+    wait_for_daemon(&socket);
+
+    let subscription = spawn_json_subscription(home.path(), &["notifications", "subscribe"]);
+    let ready = subscription.wait_for(Duration::from_secs(20), |line| {
+        line["result"]["trigger"] == "SubscriptionReady"
+            && line["result"]["type"] == "notification_subscription_ready"
+    });
+    assert_eq!(ready["result"]["type"], "notification_subscription_ready");
+
+    run_json(
+        home.path(),
+        &[
+            "--account",
+            &alice,
+            "messages",
+            "send",
+            group_id,
+            "hello notification",
+        ],
+    );
+    let notification = subscription.wait_for(Duration::from_secs(20), |line| {
+        line["result"]["trigger"] == "Notification"
+            && line["result"]["type"] == "notification"
+            && line["result"]["group_id"] == group_id
+            && line["result"]["notification"]["trigger"] == "NewMessage"
+            && line["result"]["notification"]["preview_text"] == "hello notification"
+    });
+    assert_eq!(
+        notification["result"]["notification"]["account_id_hex"],
+        bob
+    );
+    assert_eq!(
+        notification["result"]["notification"]["group_id_hex"],
+        group_id
+    );
+
+    drop(subscription);
+    stop_daemon(&socket, &mut child);
+}
+
+#[test]
+fn chats_mute_suppresses_and_unmute_restores_notifications() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let socket = home.path().join("dev").join("wnd.sock");
+
+    let alice = create_account(home.path());
+    let bob = create_account(home.path());
+    run_json(home.path(), &["--account", &bob, "keys", "publish"]);
+    let created_group = run_json(
+        home.path(),
+        &["--account", &alice, "groups", "create", "muted", &bob],
+    );
+    let group_id = created_group["group_id"].as_str().expect("group id");
+    sync_until_joined(home.path(), test_relay_url(), &bob, group_id);
+    run_json(
+        home.path(),
+        &["--account", &bob, "groups", "accept", group_id],
+    );
+
+    let muted = run_json(
+        home.path(),
+        &["--account", &bob, "chats", "mute", group_id, "1h"],
+    );
+    assert_eq!(muted["group_id"], group_id);
+    assert_eq!(muted["muted"], true);
+    assert!(muted["muted_until_ms"].as_i64().is_some());
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_wnd"))
+        .arg("--home")
+        .arg(home.path())
+        .arg("--socket")
+        .arg(&socket)
+        .arg("--discovery-relays")
+        .arg(test_relay_url())
+        .arg("--default-account-relays")
+        .arg(test_relay_url())
+        .arg("--secret-store")
+        .arg("file")
+        .env("WN_ALLOW_LOOPBACK_RELAYS", "1")
+        .env("WN_DEV_SETTLEMENT_QUIESCENCE_MS", "0")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("wnd should start");
+    wait_for_daemon(&socket);
+
+    let subscription = spawn_json_subscription(home.path(), &["notifications", "subscribe"]);
+    subscription.wait_for(Duration::from_secs(20), |line| {
+        line["result"]["trigger"] == "SubscriptionReady"
+            && line["result"]["type"] == "notification_subscription_ready"
+    });
+
+    run_json(
+        home.path(),
+        &[
+            "--account",
+            &alice,
+            "messages",
+            "send",
+            group_id,
+            "quiet while muted",
+        ],
+    );
+    subscription.assert_no_line_for(Duration::from_secs(2), |line| {
+        line["result"]["trigger"] == "Notification"
+            && line["result"]["type"] == "notification"
+            && line["result"]["group_id"] == group_id
+            && line["result"]["notification"]["preview_text"] == "quiet while muted"
+    });
+
+    let unmuted = run_json(
+        home.path(),
+        &["--account", &bob, "chats", "unmute", group_id],
+    );
+    assert_eq!(unmuted["group_id"], group_id);
+    assert_eq!(unmuted["muted"], false);
+
+    run_json(
+        home.path(),
+        &[
+            "--account",
+            &alice,
+            "messages",
+            "send",
+            group_id,
+            "loud after unmute",
+        ],
+    );
+    let notification = subscription.wait_for(Duration::from_secs(20), |line| {
+        line["result"]["trigger"] == "Notification"
+            && line["result"]["type"] == "notification"
+            && line["result"]["group_id"] == group_id
+            && line["result"]["notification"]["preview_text"] == "loud after unmute"
+    });
+    assert_eq!(
+        notification["result"]["notification"]["account_id_hex"],
+        bob
+    );
 
     drop(subscription);
     stop_daemon(&socket, &mut child);

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -2849,6 +2849,8 @@ fn keys_delete_and_delete_all_use_runtime_relay_deletion() {
             .as_u64()
             .is_some_and(|count| count > 0)
     );
+    assert_eq!(delete_all["failed"], serde_json::json!([]));
+    assert_eq!(delete_all["failed_count"], 0);
 }
 
 #[test]

--- a/crates/marmot-app/src/conversions.rs
+++ b/crates/marmot-app/src/conversions.rs
@@ -12,15 +12,15 @@ use crate::{
     AppGroupAdminPolicyComponent, AppGroupAvatarUrlComponent, AppGroupEncryptedMediaComponent,
     AppGroupImageInput, AppGroupMessageRetentionComponent, AppGroupNostrRoutingComponent,
     AppGroupRecord, AppMessageProjection, AppMessageRecord, AuditLogSettings,
-    GROUP_AVATAR_URL_COMPONENT_ID, GROUP_ENCRYPTED_MEDIA_COMPONENT_ID,
+    ChatNotificationSettings, GROUP_AVATAR_URL_COMPONENT_ID, GROUP_ENCRYPTED_MEDIA_COMPONENT_ID,
     GROUP_MESSAGE_RETENTION_COMPONENT_ID, GroupPushTokenRecord, NOSTR_ROUTING_COMPONENT_ID,
     NotificationSettings, PushPlatform, PushRegistration, RelayTelemetrySettings,
 };
 use storage_sqlite::{
-    AccountGroupPushToken, AccountNotificationSettings, AccountPushRegistration,
-    AccountStoredPushRegistration, StoredAccountGroup, StoredAccountGroupComponent,
-    StoredAccountState, StoredAppEvent, StoredAppMessageRecord, StoredAuditLogSettings,
-    StoredRelayTelemetrySettings,
+    AccountChatNotificationSettings, AccountGroupPushToken, AccountNotificationSettings,
+    AccountPushRegistration, AccountStoredPushRegistration, StoredAccountGroup,
+    StoredAccountGroupComponent, StoredAccountState, StoredAppEvent, StoredAppMessageRecord,
+    StoredAuditLogSettings, StoredRelayTelemetrySettings,
 };
 
 pub(crate) fn stored_state_from_account_state(state: &AccountState) -> StoredAccountState {
@@ -268,6 +268,21 @@ pub(crate) fn notification_settings_from_account(
         account_id_hex: settings.account_id_hex,
         local_notifications_enabled: settings.local_notifications_enabled,
         native_push_enabled: settings.native_push_enabled,
+    }
+}
+
+pub(crate) fn chat_notification_settings_from_account(
+    account_ref: String,
+    account_id_hex: String,
+    settings: AccountChatNotificationSettings,
+) -> ChatNotificationSettings {
+    ChatNotificationSettings {
+        account_ref,
+        account_id_hex,
+        group_id_hex: settings.group_id_hex,
+        muted: settings.muted,
+        muted_until_ms: settings.muted_until_ms,
+        updated_at_ms: settings.updated_at_ms,
     }
 }
 

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -146,14 +146,15 @@ pub use media::{
 };
 pub use messages::{is_stream_final_event, tag_value, tag_values};
 pub use notifications::{
-    BackgroundNotificationCollection, GroupPushDebugInfo, GroupPushTokenDebugEntry,
-    GroupPushTokenRecord, KIND_MARMOT_NOTIFICATION_RUMOR, KIND_MARMOT_NOTIFICATION_SERVER_RELAYS,
-    LocalPushRegistrationDebug, MARMOT_APP_EVENT_KIND_PUSH_TOKEN_LIST,
-    MARMOT_APP_EVENT_KIND_PUSH_TOKEN_REMOVAL, MARMOT_APP_EVENT_KIND_PUSH_TOKEN_UPDATE,
-    NotificationCollectionStatus, NotificationSettings, NotificationTrigger, NotificationUpdate,
-    NotificationUser, NotificationWakeSource, PUSH_ENCRYPTED_TOKEN_LEN, PUSH_VERSION, PushPlatform,
-    PushRegistration, build_notification_gift_wrap, build_notification_rumor_content,
-    encrypted_push_token, parse_provider_token, push_token_fingerprint,
+    BackgroundNotificationCollection, ChatNotificationSettings, GroupPushDebugInfo,
+    GroupPushTokenDebugEntry, GroupPushTokenRecord, KIND_MARMOT_NOTIFICATION_RUMOR,
+    KIND_MARMOT_NOTIFICATION_SERVER_RELAYS, LocalPushRegistrationDebug,
+    MARMOT_APP_EVENT_KIND_PUSH_TOKEN_LIST, MARMOT_APP_EVENT_KIND_PUSH_TOKEN_REMOVAL,
+    MARMOT_APP_EVENT_KIND_PUSH_TOKEN_UPDATE, NotificationCollectionStatus, NotificationSettings,
+    NotificationTrigger, NotificationUpdate, NotificationUser, NotificationWakeSource,
+    PUSH_ENCRYPTED_TOKEN_LEN, PUSH_VERSION, PushPlatform, PushRegistration,
+    build_notification_gift_wrap, build_notification_rumor_content, encrypted_push_token,
+    parse_provider_token, push_token_fingerprint,
 };
 pub use relay_plane::{
     EngineReorgMetrics, MarmotRelayPlane, MarmotRelayPlaneAccountAdapter, RelayPlaneHealth,
@@ -176,7 +177,8 @@ pub use transport_nostr_adapter::{
 
 use conversions::{
     account_group_push_token_from_app, account_push_registration_from_app,
-    account_state_from_stored, app_message_record_from_stored, group_push_token_from_account,
+    account_state_from_stored, app_message_record_from_stored,
+    chat_notification_settings_from_account, group_push_token_from_account,
     normalize_relay_telemetry_settings, notification_settings_from_account,
     relay_telemetry_settings_from_storage, relay_telemetry_settings_to_storage,
     stored_app_event_from_message_record, stored_app_event_from_projection,
@@ -1501,6 +1503,64 @@ impl MarmotApp {
         Ok(notification_settings_from_account(
             self.account_storage(&account.label)?
                 .notification_settings(&account.label, &account.account_id_hex)?,
+        ))
+    }
+
+    pub fn chat_notification_settings(
+        &self,
+        account_ref: &str,
+        group_id_hex: &str,
+    ) -> Result<ChatNotificationSettings, AppError> {
+        let account = self.account_home().account(account_ref)?;
+        self.ensure_account_state(&account.label)?;
+        self.group(&account.label, group_id_hex)?
+            .ok_or_else(|| AppError::UnknownGroup(group_id_hex.to_owned()))?;
+        let settings = self
+            .account_storage(&account.label)?
+            .chat_notification_settings(group_id_hex)?;
+        Ok(chat_notification_settings_from_account(
+            account.label,
+            account.account_id_hex,
+            settings,
+        ))
+    }
+
+    pub fn set_chat_muted(
+        &self,
+        account_ref: &str,
+        group_id_hex: &str,
+        muted_until_ms: Option<i64>,
+    ) -> Result<ChatNotificationSettings, AppError> {
+        let account = self.account_home().account(account_ref)?;
+        self.ensure_account_state(&account.label)?;
+        self.group(&account.label, group_id_hex)?
+            .ok_or_else(|| AppError::UnknownGroup(group_id_hex.to_owned()))?;
+        let settings = self
+            .account_storage(&account.label)?
+            .set_chat_muted(group_id_hex, muted_until_ms)?;
+        Ok(chat_notification_settings_from_account(
+            account.label,
+            account.account_id_hex,
+            settings,
+        ))
+    }
+
+    pub fn clear_chat_muted(
+        &self,
+        account_ref: &str,
+        group_id_hex: &str,
+    ) -> Result<ChatNotificationSettings, AppError> {
+        let account = self.account_home().account(account_ref)?;
+        self.ensure_account_state(&account.label)?;
+        self.group(&account.label, group_id_hex)?
+            .ok_or_else(|| AppError::UnknownGroup(group_id_hex.to_owned()))?;
+        let settings = self
+            .account_storage(&account.label)?
+            .clear_chat_muted(group_id_hex)?;
+        Ok(chat_notification_settings_from_account(
+            account.label,
+            account.account_id_hex,
+            settings,
         ))
     }
 

--- a/crates/marmot-app/src/notifications.rs
+++ b/crates/marmot-app/src/notifications.rs
@@ -127,6 +127,16 @@ pub struct NotificationSettings {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChatNotificationSettings {
+    pub account_ref: String,
+    pub account_id_hex: String,
+    pub group_id_hex: String,
+    pub muted: bool,
+    pub muted_until_ms: Option<i64>,
+    pub updated_at_ms: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PushRegistration {
     pub account_ref: String,
     pub account_id_hex: String,
@@ -924,6 +934,7 @@ pub(crate) fn is_push_gossip_kind(kind: u64) -> bool {
 #[derive(Default)]
 pub(crate) struct NotificationResolver {
     settings: HashMap<String, NotificationSettings>,
+    chat_muted: HashMap<(String, String), bool>,
     groups: HashMap<(String, String), Option<AppGroupRecord>>,
     users: HashMap<String, NotificationUser>,
 }
@@ -956,6 +967,23 @@ impl NotificationResolver {
         let group = app.group(account_label, group_id_hex)?;
         self.groups.insert(key, group.clone());
         Ok(group)
+    }
+
+    fn chat_muted(
+        &mut self,
+        app: &MarmotApp,
+        account_label: &str,
+        group_id_hex: &str,
+    ) -> Result<bool, AppError> {
+        let key = (account_label.to_owned(), group_id_hex.to_owned());
+        if let Some(muted) = self.chat_muted.get(&key) {
+            return Ok(*muted);
+        }
+        let muted = app
+            .chat_notification_settings(account_label, group_id_hex)?
+            .muted;
+        self.chat_muted.insert(key, muted);
+        Ok(muted)
     }
 
     fn user(
@@ -1039,6 +1067,9 @@ fn notification_update_from_message(
         return Ok(None);
     }
     let group_id_hex = hex::encode(event.message.group_id.as_slice());
+    if resolver.chat_muted(app, &event.account_label, &group_id_hex)? {
+        return Ok(None);
+    }
     let group = resolver.group(app, &event.account_label, &group_id_hex)?;
     let receiver = resolver.user(app, &event.account_id_hex)?;
     let sender = notification_user_from_message(app, resolver, &event.message)?;

--- a/crates/marmot-app/src/notifications.rs
+++ b/crates/marmot-app/src/notifications.rs
@@ -1067,10 +1067,19 @@ fn notification_update_from_message(
         return Ok(None);
     }
     let group_id_hex = hex::encode(event.message.group_id.as_slice());
-    if resolver.chat_muted(app, &event.account_label, &group_id_hex)? {
+    let group = match resolver.group(app, &event.account_label, &group_id_hex) {
+        Ok(group) => group,
+        Err(AppError::UnknownGroup(_)) => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    let muted = match resolver.chat_muted(app, &event.account_label, &group_id_hex) {
+        Ok(muted) => muted,
+        Err(AppError::UnknownGroup(_)) => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    if muted {
         return Ok(None);
     }
-    let group = resolver.group(app, &event.account_label, &group_id_hex)?;
     let receiver = resolver.user(app, &event.account_id_hex)?;
     let sender = notification_user_from_message(app, resolver, &event.message)?;
     let is_from_self = event.message.sender == event.account_id_hex;

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -31,14 +31,15 @@ use crate::{
     AppGroupMlsState, AppGroupRecord, AppMessageQuery, AppMessageRecord, AppProjectionUpdate,
     AppQuarantinedGroup, AuditLogDeleteOutcome, AuditLogFile, AuditLogSettings,
     AuditLogTrackerConfig, AuditLogTrackerUpdateResult, AuditLogUploadResult,
-    BackgroundNotificationCollection, ChatListRow, GroupInviteDeclineResult, GroupPushDebugInfo,
-    MAX_SEEN_EVENT_IDS, MarmotApp, MarmotRelayPlane, MarmotServiceEndpoints,
-    MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest, MediaUploadResult,
-    NotificationCollectionStatus, NotificationSettings, NotificationUpdate, NotificationWakeSource,
-    PendingWelcomeDelivery, PushPlatform, PushRegistration, ReceivedMessage,
-    RelayTelemetryExportConfig, RelayTelemetryRuntimeConfig, RelayTelemetrySettings,
-    SecureDeleteExpiredResult, SendSummary, TimelineMessageQuery, TimelinePage,
-    UserDirectoryRefresh, UserProfileMetadata, default_profile_pseudonym, unix_now_seconds,
+    BackgroundNotificationCollection, ChatListRow, ChatNotificationSettings,
+    GroupInviteDeclineResult, GroupPushDebugInfo, MAX_SEEN_EVENT_IDS, MarmotApp, MarmotRelayPlane,
+    MarmotServiceEndpoints, MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest,
+    MediaUploadResult, NotificationCollectionStatus, NotificationSettings, NotificationUpdate,
+    NotificationWakeSource, PendingWelcomeDelivery, PushPlatform, PushRegistration,
+    ReceivedMessage, RelayTelemetryExportConfig, RelayTelemetryRuntimeConfig,
+    RelayTelemetrySettings, SecureDeleteExpiredResult, SendSummary, TimelineMessageQuery,
+    TimelinePage, UserDirectoryRefresh, UserProfileMetadata, default_profile_pseudonym,
+    unix_now_seconds,
 };
 
 mod account_worker;
@@ -1389,6 +1390,16 @@ impl MarmotAppRuntime {
         self.accounts.app.notification_settings(account_ref)
     }
 
+    pub fn chat_notification_settings(
+        &self,
+        account_ref: &str,
+        group_id_hex: &str,
+    ) -> Result<ChatNotificationSettings, AppError> {
+        self.accounts
+            .app
+            .chat_notification_settings(account_ref, group_id_hex)
+    }
+
     pub fn relay_telemetry_settings(&self) -> Result<RelayTelemetrySettings, AppError> {
         self.accounts.app.relay_telemetry_settings()
     }
@@ -1510,6 +1521,27 @@ impl MarmotAppRuntime {
         self.accounts
             .app
             .set_local_notifications_enabled(account_ref, enabled)
+    }
+
+    pub fn set_chat_muted(
+        &self,
+        account_ref: &str,
+        group_id_hex: &str,
+        muted_until_ms: Option<i64>,
+    ) -> Result<ChatNotificationSettings, AppError> {
+        self.accounts
+            .app
+            .set_chat_muted(account_ref, group_id_hex, muted_until_ms)
+    }
+
+    pub fn clear_chat_muted(
+        &self,
+        account_ref: &str,
+        group_id_hex: &str,
+    ) -> Result<ChatNotificationSettings, AppError> {
+        self.accounts
+            .app
+            .clear_chat_muted(account_ref, group_id_hex)
     }
 
     pub async fn set_native_push_enabled(

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -823,6 +823,8 @@ impl SqliteAccountStorage {
             )
             .optional()
             .storage()?;
+        // Missing rows are unmuted. `None` means "muted forever", so the
+        // absent-row default must be a timestamp that is already expired.
         let (muted_until_ms, updated_at_ms) = row.unwrap_or((Some(0), 0));
         Ok(AccountChatNotificationSettings {
             group_id_hex: group_id_hex.to_owned(),

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -179,6 +179,14 @@ pub struct AccountNotificationSettings {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AccountChatNotificationSettings {
+    pub group_id_hex: String,
+    pub muted: bool,
+    pub muted_until_ms: Option<i64>,
+    pub updated_at_ms: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AccountPushRegistration {
     pub account_label: String,
     pub account_id_hex: String,
@@ -511,6 +519,7 @@ impl SqliteAccountStorage {
                 "account_group_app_components",
                 "group_push_tokens",
                 "group_push_token_tombstones",
+                "chat_notification_settings",
                 "encrypted_media_epoch_secrets",
                 "account_groups",
             ] {
@@ -789,6 +798,71 @@ impl SqliteAccountStorage {
             )
             .storage()?;
         self.notification_settings(account_label, account_id_hex)
+    }
+
+    pub fn chat_notification_settings(
+        &self,
+        group_id_hex: &str,
+    ) -> StorageResult<AccountChatNotificationSettings> {
+        self.chat_notification_settings_at(group_id_hex, unix_now_ms())
+    }
+
+    pub fn chat_notification_settings_at(
+        &self,
+        group_id_hex: &str,
+        now_ms: i64,
+    ) -> StorageResult<AccountChatNotificationSettings> {
+        let row = self
+            .lock()?
+            .query_row(
+                "SELECT muted_until_ms, updated_at_ms
+                 FROM chat_notification_settings
+                 WHERE group_id_hex = ?1",
+                params![group_id_hex],
+                |row| Ok((row.get::<_, Option<i64>>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .optional()
+            .storage()?;
+        let (muted_until_ms, updated_at_ms) = row.unwrap_or((Some(0), 0));
+        Ok(AccountChatNotificationSettings {
+            group_id_hex: group_id_hex.to_owned(),
+            muted: muted_until_ms.is_none_or(|until| until > now_ms),
+            muted_until_ms,
+            updated_at_ms,
+        })
+    }
+
+    pub fn set_chat_muted(
+        &self,
+        group_id_hex: &str,
+        muted_until_ms: Option<i64>,
+    ) -> StorageResult<AccountChatNotificationSettings> {
+        self.lock()?
+            .execute(
+                "INSERT INTO chat_notification_settings (
+                    group_id_hex, muted_until_ms, updated_at_ms
+                 )
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(group_id_hex) DO UPDATE SET
+                    muted_until_ms = excluded.muted_until_ms,
+                    updated_at_ms = excluded.updated_at_ms",
+                params![group_id_hex, muted_until_ms, unix_now_ms()],
+            )
+            .storage()?;
+        self.chat_notification_settings(group_id_hex)
+    }
+
+    pub fn clear_chat_muted(
+        &self,
+        group_id_hex: &str,
+    ) -> StorageResult<AccountChatNotificationSettings> {
+        self.lock()?
+            .execute(
+                "DELETE FROM chat_notification_settings WHERE group_id_hex = ?1",
+                params![group_id_hex],
+            )
+            .storage()?;
+        self.chat_notification_settings(group_id_hex)
     }
 
     pub fn push_registration(

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -983,6 +983,58 @@ fn notification_settings_default_local_notifications_on() {
 }
 
 #[test]
+fn chat_notification_settings_track_timed_forever_and_cleared_mutes() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                seen_events: Vec::new(),
+                last_transport_timestamp: None,
+                groups: vec![group("aa", "Muted")],
+            },
+            1,
+        )
+        .unwrap();
+
+    let default = store.chat_notification_settings_at("aa", 1000).unwrap();
+    assert!(!default.muted);
+    assert_eq!(default.muted_until_ms, Some(0));
+
+    let timed = store.set_chat_muted("aa", Some(5000)).unwrap();
+    assert_eq!(timed.muted_until_ms, Some(5000));
+    let timed = store.chat_notification_settings_at("aa", 1000).unwrap();
+    assert!(timed.muted);
+    assert_eq!(timed.muted_until_ms, Some(5000));
+    assert!(
+        store
+            .chat_notification_settings_at("aa", 4999)
+            .unwrap()
+            .muted
+    );
+    assert!(
+        !store
+            .chat_notification_settings_at("aa", 5000)
+            .unwrap()
+            .muted
+    );
+
+    let forever = store.set_chat_muted("aa", None).unwrap();
+    assert!(forever.muted);
+    assert_eq!(forever.muted_until_ms, None);
+    assert!(
+        store
+            .chat_notification_settings_at("aa", i64::MAX)
+            .unwrap()
+            .muted
+    );
+
+    let cleared = store.clear_chat_muted("aa").unwrap();
+    assert!(!cleared.muted);
+    assert_eq!(cleared.muted_until_ms, Some(0));
+}
+
+#[test]
 fn push_registration_preserves_created_at_when_token_rotates() {
     let store = SqliteAccountStorage::in_memory().unwrap();
     let registration = AccountPushRegistration {

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -18,9 +18,10 @@ mod storage;
 mod timeline;
 
 pub use account_projection::{
-    AccountGroupPushToken, AccountNotificationSettings, AccountPushRegistration,
-    AccountStoredPushRegistration, AppEventReplayCursor, SelfMembership, StoredAccountGroup,
-    StoredAccountGroupComponent, StoredAccountState, StoredAppMessageQuery, StoredAppMessageRecord,
+    AccountChatNotificationSettings, AccountGroupPushToken, AccountNotificationSettings,
+    AccountPushRegistration, AccountStoredPushRegistration, AppEventReplayCursor, SelfMembership,
+    StoredAccountGroup, StoredAccountGroupComponent, StoredAccountState, StoredAppMessageQuery,
+    StoredAppMessageRecord,
 };
 pub use chat_list::{
     AccountUnreadTotal, ChatListAvatar, ChatListMessagePreview, ChatListQuery, ChatListRow,

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -46,6 +46,8 @@ mod migration_0022_chat_list_self_membership;
 mod migration_0023_chat_list_projection_version;
 #[path = "migrations/0024_pending_welcome_delivery.rs"]
 mod migration_0024_pending_welcome_delivery;
+#[path = "migrations/0025_chat_notification_settings.rs"]
+mod migration_0025_chat_notification_settings;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -177,6 +179,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 24,
         name: "0024_pending_welcome_delivery",
         apply: migration_0024_pending_welcome_delivery::apply,
+    },
+    Migration {
+        version: 25,
+        name: "0025_chat_notification_settings",
+        apply: migration_0025_chat_notification_settings::apply,
     },
 ];
 
@@ -391,6 +398,22 @@ mod tests {
             &conn,
             "message_timeline",
             "idx_message_timeline_reply_lookup"
+        ));
+    }
+
+    #[test]
+    fn chat_notification_settings_table_is_migrated() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let conn = store.lock().unwrap();
+        assert!(connection_has_column(
+            &conn,
+            "chat_notification_settings",
+            "group_id_hex"
+        ));
+        assert!(connection_has_column(
+            &conn,
+            "chat_notification_settings",
+            "muted_until_ms"
         ));
     }
 

--- a/crates/storage-sqlite/src/migrations/0025_chat_notification_settings.rs
+++ b/crates/storage-sqlite/src/migrations/0025_chat_notification_settings.rs
@@ -1,0 +1,17 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE chat_notification_settings (
+    group_id_hex TEXT PRIMARY KEY NOT NULL,
+    muted_until_ms INTEGER,
+    updated_at_ms INTEGER NOT NULL,
+    FOREIGN KEY (group_id_hex) REFERENCES account_groups(group_id_hex) ON DELETE CASCADE
+);
+"#,
+    )
+    .storage()
+}

--- a/integrations/hermes/marmot/AGENTS.md
+++ b/integrations/hermes/marmot/AGENTS.md
@@ -35,4 +35,6 @@ integrations/hermes/marmot/tests/test_dev_scripts.sh
 # or from the repo root:
 just hermes-dev-script-test
 just hermes-dev-smoke
+just hermes-dev-e2e-deterministic
+just hermes-dev-e2e-connector
 ```

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -45,6 +45,7 @@ TOOL_EVENT_PREFIX = "\x1fMARMOT_TOOL_EVENT:"
 # is reused across these attempts so a retry after a post-write timeout dedups at
 # the connector instead of double-posting. Mirrors OpenClaw dispatch ([100, 300]ms).
 SEND_FINAL_RETRY_BACKOFF_S = (0.1, 0.3)
+STREAM_FINALIZE_RETRY_BACKOFF_S = (0.1, 0.3)
 DEFAULT_STREAMING_CURSOR = "\u2589"
 _DEFAULT_READ_TIMEOUT = object()
 MAX_TOOL_PROGRESS_MESSAGES = 512
@@ -908,7 +909,9 @@ class MarmotAgentControlClient:
         final_text: str,
         transcript_hash_hex: str,
         chunk_count: int,
+        idempotency_key: Optional[str] = None,
     ) -> Dict[str, Any]:
+        key = str(idempotency_key or "").strip()
         return await self.request(
             {
                 "type": "stream_finalize",
@@ -916,6 +919,7 @@ class MarmotAgentControlClient:
                 "final_text": str(final_text or ""),
                 "transcript_hash_hex": _normalize_hex(transcript_hash_hex, "transcript_hash_hex"),
                 "chunk_count": int(chunk_count),
+                **({"idempotency_key": key} if key else {}),
             }
         )
 
@@ -1131,6 +1135,7 @@ class MarmotLiveStream:
             start_message_id_hex,
             chunk_bytes=chunk_bytes,
         )
+        self.finalize_idempotency_key = uuid.uuid4().hex
         self.finalized = False
 
     @classmethod
@@ -1180,12 +1185,33 @@ class MarmotLiveStream:
 
     async def finalize(self, final_text: str) -> Dict[str, Any]:
         await self.append_replacement(final_text)
-        response = await self.client.stream_finalize(
-            self.stream_id_hex,
-            final_text,
-            self.transcript.hash_hex,
-            self.transcript.chunk_count,
-        )
+        response: Optional[Dict[str, Any]] = None
+        for attempt in range(len(STREAM_FINALIZE_RETRY_BACKOFF_S) + 1):
+            try:
+                response = await self.client.stream_finalize(
+                    self.stream_id_hex,
+                    final_text,
+                    self.transcript.hash_hex,
+                    self.transcript.chunk_count,
+                    idempotency_key=self.finalize_idempotency_key,
+                )
+                break
+            except Exception as exc:
+                if attempt < len(STREAM_FINALIZE_RETRY_BACKOFF_S) and is_retryable(exc):
+                    logger.debug(
+                        "Marmot stream_finalize failed; retrying (attempt %d): %s",
+                        attempt + 1,
+                        exc,
+                    )
+                    await asyncio.sleep(STREAM_FINALIZE_RETRY_BACKOFF_S[attempt])
+                    continue
+                raise
+        if response is None:
+            raise AgentControlError(
+                "Marmot stream finalize failed without a response",
+                code="unexpected_stream_finalize_response",
+                retryable=True,
+            )
         self.finalized = True
         return response
 

--- a/integrations/hermes/marmot/tests/e2e_connector.py
+++ b/integrations/hermes/marmot/tests/e2e_connector.py
@@ -124,7 +124,9 @@ async def run() -> None:
 
     from gateway.config import PlatformConfig
 
-    with tempfile.TemporaryDirectory(prefix="marmot-hermes-connector-e2e-") as tmp:
+    # Keep Unix socket paths short for macOS sockaddr_un limits. Python's
+    # default temp dir can live under a long /var/folders/... path.
+    with tempfile.TemporaryDirectory(prefix="mhce-", dir="/tmp") as tmp:
         tmp_path = Path(tmp)
         marmot_home = tmp_path / "marmot-home"
         socket_path = tmp_path / "wn-agent.sock"
@@ -159,6 +161,7 @@ async def run() -> None:
                     "socket_path": str(socket_path),
                     "account_id_hex": ACCOUNT_ID_HEX,
                     "group_id_hex": GROUP_ID_HEX,
+                    "group_activation": "always",
                     "profile_name_onboarding": False,
                 },
             )

--- a/integrations/hermes/marmot/tests/e2e_deterministic.py
+++ b/integrations/hermes/marmot/tests/e2e_deterministic.py
@@ -192,7 +192,9 @@ async def run() -> None:
             )
         )
 
-    with tempfile.TemporaryDirectory(prefix="marmot-hermes-e2e-") as tmp:
+    # Keep Unix socket paths short for macOS sockaddr_un limits. Python's
+    # default temp dir can live under a long /var/folders/... path.
+    with tempfile.TemporaryDirectory(prefix="mhe-", dir="/tmp") as tmp:
         fake_server = FakeAgentControlServer(Path(tmp) / "wn-agent.sock")
         await fake_server.start()
         prior_socket = os.environ.get("MARMOT_AGENT_SOCKET")
@@ -204,6 +206,7 @@ async def run() -> None:
                     "socket_path": str(fake_server.socket_path),
                     "account_id_hex": ACCOUNT_ID_HEX,
                     "group_id_hex": GROUP_ID_HEX,
+                    "group_activation": "always",
                     "profile_name_onboarding": False,
                 },
             )

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -218,6 +218,35 @@ class AgentControlClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("idempotency_key", requests[1])
         self.assertNotIn("idempotency_key", requests[2])
 
+    async def test_stream_finalize_includes_idempotency_key_only_when_supplied(self):
+        requests = []
+
+        async def handler(reader, writer):
+            request = await read_json_line(reader)
+            requests.append(request)
+            await write_json_line(
+                writer,
+                {
+                    "marmot_agent_control": "marmot.agent-control.v1",
+                    "id": request["id"],
+                    "type": "stream_finalized",
+                    "stream_id_hex": request["stream_id_hex"],
+                    "message_ids_hex": ["aa"],
+                },
+            )
+            writer.close()
+
+        await self.start_server(handler)
+        client = self.adapter.MarmotAgentControlClient(self.socket_path)
+
+        await client.stream_finalize("55" * 32, "final", "ab" * 32, 1, idempotency_key="key-1")
+        await client.stream_finalize("55" * 32, "final", "ab" * 32, 1, idempotency_key="   ")
+        await client.stream_finalize("55" * 32, "final", "ab" * 32, 1)
+
+        self.assertEqual(requests[0]["idempotency_key"], "key-1")
+        self.assertNotIn("idempotency_key", requests[1])
+        self.assertNotIn("idempotency_key", requests[2])
+
     async def test_auth_token_is_written_when_configured(self):
         requests = []
 
@@ -792,6 +821,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                 "message_id_hex": "33" * 32,
                 "sender_account_id_hex": "44" * 32,
                 "text": "ping",
+                "mentions_self": True,
             }
         ]
 
@@ -880,6 +910,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                         "message_id_hex": "33" * 32,
                         "sender_account_id_hex": "44" * 32,
                         "text": "recovered after resync",
+                        "mentions_self": True,
                     }
                 else:
                     # No further events; idle so the loop parks instead of busy-spinning.
@@ -929,6 +960,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                 "message_id_hex": message_id_hex,
                 "sender_account_id_hex": "44" * 32,
                 "text": text,
+                "mentions_self": True,
             }
 
         events = [
@@ -1010,6 +1042,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                 "message_id_hex": "01" * 32,
                 "sender_account_id_hex": "44" * 32,
                 "text": "first",
+                "mentions_self": True,
             },
             {
                 "type": "inbound_message",
@@ -1018,6 +1051,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                 "message_id_hex": "02" * 32,
                 "sender_account_id_hex": "44" * 32,
                 "text": "second",
+                "mentions_self": True,
             },
         ]
 
@@ -1066,6 +1100,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                 "message_id_hex": "33" * 32,
                 "sender_account_id_hex": "44" * 32,
                 "text": "hello",
+                "mentions_self": True,
             }
         ]
 
@@ -1101,7 +1136,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
         account_id, group_id, text, reply_to = fake_client.final_sends[0]
         self.assertEqual(account_id, "11" * 32)
         self.assertEqual(group_id, "22" * 32)
-        self.assertIn("public Nostr profile name", text)
+        self.assertIn("public Nostr profile", text)
         self.assertEqual(reply_to, "33" * 32)
 
     async def test_profile_name_reply_publishes_profile_and_acknowledges(self):
@@ -1115,6 +1150,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                 "message_id_hex": "33" * 32,
                 "sender_account_id_hex": "44" * 32,
                 "text": "  Hermes Agent  ",
+                "mentions_self": True,
             }
         ]
 
@@ -1187,6 +1223,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                         "message_id_hex": "01" * 32,
                         "sender_account_id_hex": "44" * 32,
                         "text": "slow group A",
+                        "mentions_self": True,
                     }
                     yield {
                         "type": "resync_required",
@@ -1203,6 +1240,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                         "message_id_hex": "02" * 32,
                         "sender_account_id_hex": "44" * 32,
                         "text": "fast group B",
+                        "mentions_self": True,
                     }
                 else:
                     await asyncio.sleep(3600)
@@ -1281,6 +1319,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                 "message_id_hex": message_id_hex,
                 "sender_account_id_hex": "44" * 32,
                 "text": text,
+                "mentions_self": True,
             }
 
         class FakeClient:
@@ -1432,7 +1471,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                 self.stream_appends.append((stream_id_hex, append_text))
                 return {"type": "ack"}
 
-            async def stream_finalize(self, stream_id_hex, final_text, transcript_hash_hex, chunk_count):
+            async def stream_finalize(self, stream_id_hex, final_text, transcript_hash_hex, chunk_count, idempotency_key=None):
                 self.stream_finalizes.append((stream_id_hex, final_text, transcript_hash_hex, chunk_count))
                 return {
                     "type": "stream_finalized",
@@ -1498,7 +1537,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                 self.stream_appends.append((stream_id_hex, append_text))
                 return {"type": "ack"}
 
-            async def stream_finalize(self, stream_id_hex, final_text, transcript_hash_hex, chunk_count):
+            async def stream_finalize(self, stream_id_hex, final_text, transcript_hash_hex, chunk_count, idempotency_key=None):
                 self.stream_finalizes.append((stream_id_hex, final_text, transcript_hash_hex, chunk_count))
                 return {
                     "type": "stream_finalized",
@@ -1723,7 +1762,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                 self.stream_appends.append((stream_id_hex, append_text))
                 return {"type": "ack"}
 
-            async def stream_finalize(self, stream_id_hex, final_text, transcript_hash_hex, chunk_count):
+            async def stream_finalize(self, stream_id_hex, final_text, transcript_hash_hex, chunk_count, idempotency_key=None):
                 self.stream_finalizes.append((stream_id_hex, final_text, transcript_hash_hex, chunk_count))
                 return {
                     "type": "stream_finalized",
@@ -1777,7 +1816,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
             async def stream_append(self, stream_id_hex, append_text):
                 return {"type": "ack"}
 
-            async def stream_finalize(self, stream_id_hex, final_text, transcript_hash_hex, chunk_count):
+            async def stream_finalize(self, stream_id_hex, final_text, transcript_hash_hex, chunk_count, idempotency_key=None):
                 self.stream_finalizes.append((stream_id_hex, final_text))
                 return {
                     "type": "stream_finalized",
@@ -1841,7 +1880,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                 self.stream_appends.append((stream_id_hex, append_text))
                 return {"type": "ack"}
 
-            async def stream_finalize(self, stream_id_hex, final_text, transcript_hash_hex, chunk_count):
+            async def stream_finalize(self, stream_id_hex, final_text, transcript_hash_hex, chunk_count, idempotency_key=None):
                 self.stream_finalizes.append((stream_id_hex, final_text, transcript_hash_hex, chunk_count))
                 return {"type": "stream_finalized", "stream_id_hex": stream_id_hex}
 
@@ -2053,6 +2092,7 @@ class ParityBehaviorTests(unittest.IsolatedAsyncioTestCase):
             "message_id_hex": "33" * 32,
             "sender_account_id_hex": "44" * 32,
             "text": "ping",
+            "mentions_self": True,
         }
 
         class FakeClient:
@@ -2077,6 +2117,7 @@ class ParityBehaviorTests(unittest.IsolatedAsyncioTestCase):
             "message_id_hex": "33" * 32,
             "sender_account_id_hex": "44" * 32,
             "text": "ping",
+            "mentions_self": True,
         }
         adapter = self._adapter(client=object())
 
@@ -2146,6 +2187,7 @@ class ParityBehaviorTests(unittest.IsolatedAsyncioTestCase):
             "message_id_hex": "33" * 32,
             "sender_account_id_hex": "44" * 32,
             "text": "ping",
+            "mentions_self": True,
             "sender_display_name": "Alice",
             "reply_to_message_id_hex": "99" * 32,
         }
@@ -2175,6 +2217,7 @@ class ParityBehaviorTests(unittest.IsolatedAsyncioTestCase):
             "message_id_hex": "33" * 32,
             "sender_account_id_hex": "44" * 32,
             "text": "ping",
+            "mentions_self": True,
             "sender_display_name": "   ",
         }
 
@@ -2234,6 +2277,7 @@ class ParityBehaviorTests(unittest.IsolatedAsyncioTestCase):
                 "message_id_hex": "a1" * 32,
                 "sender_account_id_hex": "44" * 32,
                 "text": "hello there",
+                "mentions_self": True,
             },
         ]
 
@@ -2366,6 +2410,7 @@ class ParityBehaviorTests(unittest.IsolatedAsyncioTestCase):
                 "message_id_hex": "a1" * 32,
                 "sender_account_id_hex": "44" * 32,
                 "text": "first",
+                "mentions_self": True,
             },
             {
                 "type": "inbound_message",
@@ -2374,6 +2419,7 @@ class ParityBehaviorTests(unittest.IsolatedAsyncioTestCase):
                 "message_id_hex": "a2" * 32,
                 "sender_account_id_hex": "44" * 32,
                 "text": "second",
+                "mentions_self": True,
             },
         ]
 
@@ -2429,6 +2475,7 @@ class ParityBehaviorTests(unittest.IsolatedAsyncioTestCase):
                         "message_id_hex": "33" * 32,
                         "sender_account_id_hex": "44" * 32,
                         "text": "healthy",
+                        "mentions_self": True,
                     }
                     raise RuntimeError("dropped after healthy")
                 else:
@@ -2563,6 +2610,73 @@ class FinalizeFallbackTests(unittest.IsolatedAsyncioTestCase):
         self.adapter_module = load_adapter_module()
         self.config_cls = sys.modules["gateway.config"].PlatformConfig
 
+    async def test_stream_finalize_retries_retryable_failure_with_same_idempotency_key(self):
+        adapter_module = self.adapter_module
+
+        class FakeClient:
+            def __init__(self):
+                self.stream_finalizes = []
+                self.final_sends = []
+
+            async def stream_begin(self, account_id_hex, group_id_hex, *, stream_id_hex=None, quic_candidates=()):
+                return {
+                    "type": "stream_begun",
+                    "stream_id_hex": "55" * 32,
+                    "start_message_id_hex": "66" * 32,
+                    "quic_candidates": list(quic_candidates),
+                }
+
+            async def stream_append(self, stream_id_hex, append_text):
+                return {"type": "ack"}
+
+            async def stream_finalize(
+                self,
+                stream_id_hex,
+                final_text,
+                transcript_hash_hex,
+                chunk_count,
+                idempotency_key=None,
+            ):
+                self.stream_finalizes.append(
+                    (stream_id_hex, final_text, transcript_hash_hex, chunk_count, idempotency_key)
+                )
+                if len(self.stream_finalizes) == 1:
+                    raise adapter_module.AgentControlError(
+                        "timed out waiting for stream finalize",
+                        code="timeout",
+                        retryable=True,
+                    )
+                return {
+                    "type": "stream_finalized",
+                    "stream_id_hex": stream_id_hex,
+                    "message_ids_hex": ["77" * 32],
+                }
+
+            async def send_final(self, account_id_hex, group_id_hex, text, reply_to_message_id_hex=None, idempotency_key=None):
+                self.final_sends.append((account_id_hex, group_id_hex, text, reply_to_message_id_hex, idempotency_key))
+                return {"type": "final_sent", "message_ids_hex": ["88" * 32]}
+
+        fake_client = FakeClient()
+        adapter = self.adapter_module.MarmotPlatformAdapter(
+            self.config_cls(
+                extra={
+                    "account_id_hex": "11" * 32,
+                    "quic_candidates": ["quic://127.0.0.1:4433"],
+                }
+            ),
+            client=fake_client,
+        )
+
+        preview = await adapter.send("22" * 32, "hello\u2589")
+        final = await adapter.send("22" * 32, "hello world")
+
+        self.assertTrue(preview.success)
+        self.assertTrue(final.success)
+        self.assertEqual(fake_client.final_sends, [])
+        self.assertEqual(len(fake_client.stream_finalizes), 2)
+        self.assertTrue(fake_client.stream_finalizes[0][4])
+        self.assertEqual(fake_client.stream_finalizes[1][4], fake_client.stream_finalizes[0][4])
+
     async def test_finalize_rejection_falls_back_to_plain_send_final(self):
         adapter_module = self.adapter_module
 
@@ -2582,7 +2696,7 @@ class FinalizeFallbackTests(unittest.IsolatedAsyncioTestCase):
             async def stream_append(self, stream_id_hex, append_text):
                 return {"type": "ack"}
 
-            async def stream_finalize(self, stream_id_hex, final_text, transcript_hash_hex, chunk_count):
+            async def stream_finalize(self, stream_id_hex, final_text, transcript_hash_hex, chunk_count, idempotency_key=None):
                 raise adapter_module.AgentControlError(
                     "transcript hash mismatch",
                     code="stream_finalize_rejected",

--- a/integrations/openclaw/marmot/AGENTS.md
+++ b/integrations/openclaw/marmot/AGENTS.md
@@ -39,12 +39,16 @@ The OpenClaw counterpart of `integrations/hermes/marmot`. Read `README.md` first
 - Keep the `openclaw` dependency pinned; before bumping, verify the
   `openclaw/plugin-sdk/*` subpath exports against the new version's types.
 - The inbound→agent and live-preview-pipeline seams use OpenClaw gateway runtime
-  internals and are validated by the docker phone test, not the unit tests.
+  internals and are validated by the deterministic connector E2E plus the docker
+  phone test, not the unit tests alone.
 
 ## Verification
 
 ```sh
 cd integrations/openclaw/marmot && pnpm install && pnpm typecheck && pnpm test
+integrations/openclaw/marmot/test/dev-scripts.sh
 # or from the repo root:
 just openclaw-dev-test
+just openclaw-dev-script-test
+just openclaw-dev-e2e-connector
 ```

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -35,6 +35,9 @@ curl -fsSL ".../install-openclaw-marmot.sh" | bash -s -- --bootstrap
 The installer puts `wn-agent` in `~/.local/bin`, downloads and verifies the plugin
 tarball, runs `openclaw plugins install`, and enables the `marmot` channel.
 Supported platforms match the Hermes installer.
+Set `MARMOT_RELEASE_REPO`, `MARMOT_RELEASE_TAG`, and `WN_AGENT_VERSION` (or the
+legacy `WN_AGENT_SHA` alias) to install a non-default release asset, matching
+the Hermes installer.
 
 Then start the connector and bootstrap (same public relays as the phone app):
 
@@ -52,13 +55,69 @@ Invite the printed agent account from the phone app.
 
 ```sh
 just openclaw-dev-test                 # pnpm install + typecheck + vitest
+just openclaw-dev-script-test          # generated helper/env/installer contract test
 just openclaw-dev-setup --print-env    # build + isolated dev root + helper scripts
+just openclaw-dev-e2e-connector        # real wn-agent + debug control deterministic E2E
 just openclaw-dev-teardown --force     # remove the throwaway dev root
 ```
 
 `openclaw-dev-setup` builds the plugin, prepares an isolated dev root under
-`${TMPDIR:-/tmp}/openclaw-marmot-test`, and generates `run-wn-agent.sh`,
-`run-openclaw-gateway.sh`, `smoke-plugin.sh`, and `env.sh`.
+`${TMPDIR:-/tmp}/openclaw-marmot-test`, and generates:
+
+- `env.sh` with isolated `OPENCLAW_HOME`, `MARMOT_HOME`, socket, relay,
+  account/group, auth-token, and QUIC-preview environment variables.
+- `run-wn-agent.sh` / `start-wn-agent.sh` for the local connector.
+- `bootstrap-agent.sh` for `wn-agent bootstrap --qr` against that connector.
+- `run-openclaw-gateway.sh` / `start-openclaw-gateway.sh` for the gateway.
+- `smoke-plugin.sh` for typecheck + Vitest.
+- `control-smoketest.sh` for the real `wn-agent` control socket smoke test.
+- `e2e-connector.sh` for a model-free real `wn-agent` connector E2E.
+- `stop-dev-processes.sh` for background helper cleanup.
+
+Useful variants:
+
+```sh
+# Pin account/group env used by the plugin and smoke helpers.
+just openclaw-dev-setup --account-id-hex <agent-account-hex> --group-id-hex <group-hex> --print-env
+
+# Include relay and QUIC preview settings for generated helpers.
+just openclaw-dev-setup \
+  --relay wss://relay.eu.whitenoise.chat \
+  --relay wss://relay.us.whitenoise.chat \
+  --quic-candidate quic://quic-broker.ipf.dev:4450 \
+  --print-env
+
+# Use a token-gated local control socket for a group-shared OpenClaw/wn-agent setup.
+just openclaw-dev-setup --auth-token "$(openssl rand -hex 32)" --socket-dir-mode 0770 --socket-mode 0660 --print-env
+```
+
+After setup:
+
+```sh
+source "${OPENCLAW_MARMOT_DEV_ROOT:-${TMPDIR:-/tmp}/openclaw-marmot-test}/env.sh"
+"$OPENCLAW_MARMOT_DEV_ROOT/start-wn-agent.sh"
+"$OPENCLAW_MARMOT_DEV_ROOT/bootstrap-agent.sh"
+"$OPENCLAW_MARMOT_DEV_ROOT/start-openclaw-gateway.sh"
+```
+
+The control-socket smoke test is model-free but requires a running `wn-agent`
+and a `MARMOT_GROUP_ID_HEX` for send/delete/media steps:
+
+```sh
+just openclaw-dev-control-smoke
+```
+
+Run the deterministic connector E2E:
+
+```sh
+just openclaw-dev-e2e-connector
+```
+
+This test starts a real `wn-agent` process with debug controls enabled, injects
+one inbound message through its local control socket, runs the OpenClaw Marmot
+inbound runtime, and verifies the deterministic reply is sent back through
+`wn-agent`. It is model-free and does not need a real Marmot account, group,
+relay, phone, or OpenClaw gateway.
 
 ## Docker phone test
 
@@ -145,7 +204,9 @@ set `MARMOT_AGENT_AUTH_TOKEN_FILE`. See
   reusing the same key so `wn-agent` dedups instead of double-posting. A repeated
   key returns the original message ids without a second send, so a retry after a
   post-write timeout cannot double-post an unrecallable encrypted message.
-  (Follow-up: `stream_finalize` is not yet idempotent.)
+  Live-preview `stream_finalize` uses the same posture: one idempotency key per
+  preview stream, bounded retry on retryable failures, and connector-side cached
+  final message ids for post-success retries.
 - **`message`-tool target resolution** (`src/messaging.ts`): a Marmot reply is
   delivered automatically from the assistant's final text, so the agent does not
   need the shared `message` tool to answer. When it *does* call
@@ -159,12 +220,10 @@ set `MARMOT_AGENT_AUTH_TOKEN_FILE`. See
 - **Message deletion**: the control client can retract a prior message via
   `delete_message` (kind-5, `MarmotAppRuntime::delete_message`), and inbound
   kind-5 deletions from other members surface as a `message_deleted` event,
-  routed to the agent as quiet ambient context (below). The agent-facing *delete
-  trigger* is scaffolded — the message adapter records a `messageId → {account,
-  group}` map at send time and exposes `deleteByMessageId(...)` — but wiring the
-  agent's `delete` message-action requires the larger `base.actions`
-  message-tool surface (`ChannelMessageActionAdapter`), which is typed but
-  runtime-unvalidated and left as a follow-up.
+  routed to the agent as quiet ambient context (below). The agent-facing delete
+  message action is wired through the channel's `base.actions` adapter: it first
+  uses the bounded send-time `messageId → {account, group}` cache, then falls
+  back to an explicit `to` group id when the cache misses.
 - **Group state changes**: durable, MLS-authenticated changes (member
   add/remove/leave, admin grant/revoke, rename/avatar) surface as a
   `group_state_changed` event carrying only a coarse `change` kind and, for a

--- a/integrations/openclaw/marmot/pnpm-workspace.yaml
+++ b/integrations/openclaw/marmot/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@google/genai': true
+  esbuild: true
+  openclaw: true
+  protobufjs: true
+  tree-sitter-bash: true

--- a/integrations/openclaw/marmot/src/client.ts
+++ b/integrations/openclaw/marmot/src/client.ts
@@ -380,6 +380,7 @@ export class MarmotAgentControlClient {
     finalText: string,
     transcriptHashHex: string,
     chunkCount: number,
+    idempotencyKey?: string,
   ): Promise<StreamFinalizedResponse> {
     // Durable commit: keep the full request timeout. Abandoning a live finalize
     // early could re-send via send_final and duplicate the kind-9, so this op is
@@ -390,6 +391,7 @@ export class MarmotAgentControlClient {
       final_text: String(finalText ?? ""),
       transcript_hash_hex: normalizeHex(transcriptHashHex, "transcript_hash_hex"),
       chunk_count: Math.trunc(chunkCount),
+      ...(idempotencyKey?.trim() ? { idempotency_key: idempotencyKey.trim() } : {}),
     })) as unknown as StreamFinalizedResponse;
   }
 

--- a/integrations/openclaw/marmot/src/live.ts
+++ b/integrations/openclaw/marmot/src/live.ts
@@ -7,9 +7,12 @@
 // the transcript hash + chunk count wn-agent validates against its own. A
 // non-append-only update throws so the caller can cancel + send a plain final.
 
+import { randomUUID } from "node:crypto";
 import { AppendOnlyText, NonAppendOnlyUpdateError } from "./append-only.js";
-import type { MarmotAgentControlClient } from "./client.js";
+import { isRetryable, type MarmotAgentControlClient } from "./client.js";
 import { AgentTextStreamTranscript, DEFAULT_STREAM_CHUNK_BYTES } from "./transcript.js";
+
+const STREAM_FINALIZE_RETRY_BACKOFF_MS = [100, 300] as const;
 
 /** Narrow control-client surface used by the live preview (eases testing). */
 export type StreamControlClient = Pick<
@@ -37,6 +40,7 @@ export class MarmotLivePreview {
   private streamIdHex: string | null = null;
   private startMessageIdHex: string | null = null;
   private transcript: AgentTextStreamTranscript | null = null;
+  private readonly finalizeIdempotencyKey = randomUUID();
   private readonly appendOnly = new AppendOnlyText();
   private readonly chunkBytes: number;
 
@@ -194,12 +198,28 @@ export class MarmotLivePreview {
       this.transcript!.appendText(suffix, this.chunkBytes);
       this.appendOnly.suffixFor(finalText);
     }
-    const response = await this.client.streamFinalize(
-      this.streamIdHex!,
-      finalText,
-      this.transcript!.hashHex,
-      this.transcript!.chunkCount,
-    );
+    let response: Awaited<ReturnType<StreamControlClient["streamFinalize"]>> | null = null;
+    for (let attempt = 0; attempt <= STREAM_FINALIZE_RETRY_BACKOFF_MS.length; attempt += 1) {
+      try {
+        response = await this.client.streamFinalize(
+          this.streamIdHex!,
+          finalText,
+          this.transcript!.hashHex,
+          this.transcript!.chunkCount,
+          this.finalizeIdempotencyKey,
+        );
+        break;
+      } catch (error) {
+        const backoff = STREAM_FINALIZE_RETRY_BACKOFF_MS[attempt];
+        if (backoff === undefined || !isRetryable(error)) {
+          throw error;
+        }
+        await new Promise((resolve) => setTimeout(resolve, backoff));
+      }
+    }
+    if (!response) {
+      throw new Error("stream finalize failed without a response");
+    }
     this.closed = true;
     return {
       streamIdHex: this.streamIdHex!,

--- a/integrations/openclaw/marmot/test/client.test.ts
+++ b/integrations/openclaw/marmot/test/client.test.ts
@@ -59,6 +59,14 @@ function handleRequest(socket: Socket, req: Record<string, unknown>): void {
         quic_candidates: [],
       });
       break;
+    case "stream_finalize":
+      send(socket, id, {
+        type: "stream_finalized",
+        stream_id_hex: req.stream_id_hex ?? HEX32("ee"),
+        message_ids_hex: [HEX32("99")],
+        echoed_idempotency_key: req.idempotency_key ?? null,
+      });
+      break;
     case "group_info":
       send(socket, id, {
         type: "group_info",
@@ -172,6 +180,25 @@ describe("MarmotAgentControlClient", () => {
       HEX32("aa"),
       HEX32("cc"),
       "done",
+    )) as unknown as { echoed_idempotency_key?: string | null };
+    expect(withoutKey.echoed_idempotency_key).toBeNull();
+  });
+
+  it("forwards an idempotency_key on stream_finalize when supplied, and omits it otherwise", async () => {
+    const withKey = (await client.streamFinalize(
+      HEX32("ee"),
+      "done",
+      HEX32("aa"),
+      1,
+      "stream-key-1",
+    )) as unknown as { echoed_idempotency_key?: string | null };
+    expect(withKey.echoed_idempotency_key).toBe("stream-key-1");
+
+    const withoutKey = (await client.streamFinalize(
+      HEX32("ee"),
+      "done",
+      HEX32("aa"),
+      1,
     )) as unknown as { echoed_idempotency_key?: string | null };
     expect(withoutKey.echoed_idempotency_key).toBeNull();
   });

--- a/integrations/openclaw/marmot/test/dev-scripts.sh
+++ b/integrations/openclaw/marmot/test/dev-scripts.sh
@@ -5,13 +5,12 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 tmp_parent="$(mktemp -d)"
 trap 'rm -rf "$tmp_parent"' EXIT
 
-dev_root="$tmp_parent/nested/hermes-marmot-test"
+dev_root="$tmp_parent/nested/openclaw-marmot-test"
 account_id="$(printf '11%.0s' {1..32})"
 group_id="$(printf '22%.0s' {1..32})"
 
-"$repo_root/scripts/hermes_marmot_dev_setup.sh" \
+"$repo_root/scripts/openclaw_marmot_dev_setup.sh" \
     --root "$dev_root" \
-    --skip-hermes-install \
     --account-id-hex "$account_id" \
     --group-id-hex "$group_id" \
     --auth-token "script-token" \
@@ -23,24 +22,23 @@ group_id="$(printf '22%.0s' {1..32})"
 
 [ -f "$dev_root/env.sh" ]
 [ -x "$dev_root/run-wn-agent.sh" ]
-[ -x "$dev_root/run-hermes-gateway.sh" ]
+[ -x "$dev_root/run-openclaw-gateway.sh" ]
 [ -x "$dev_root/start-wn-agent.sh" ]
-[ -x "$dev_root/start-hermes-gateway.sh" ]
+[ -x "$dev_root/start-openclaw-gateway.sh" ]
 [ -x "$dev_root/stop-dev-processes.sh" ]
 [ -x "$dev_root/smoke-plugin.sh" ]
-[ -x "$dev_root/e2e-deterministic.sh" ]
+[ -x "$dev_root/control-smoketest.sh" ]
 [ -x "$dev_root/e2e-connector.sh" ]
 [ -x "$dev_root/bootstrap-agent.sh" ]
-[ -L "$dev_root/hermes-home/plugins/marmot" ]
 
 for helper in \
     "$dev_root/run-wn-agent.sh" \
-    "$dev_root/run-hermes-gateway.sh" \
+    "$dev_root/run-openclaw-gateway.sh" \
     "$dev_root/start-wn-agent.sh" \
-    "$dev_root/start-hermes-gateway.sh" \
+    "$dev_root/start-openclaw-gateway.sh" \
     "$dev_root/stop-dev-processes.sh" \
     "$dev_root/smoke-plugin.sh" \
-    "$dev_root/e2e-deterministic.sh" \
+    "$dev_root/control-smoketest.sh" \
     "$dev_root/e2e-connector.sh" \
     "$dev_root/bootstrap-agent.sh"; do
     bash -n "$helper"
@@ -49,7 +47,10 @@ done
 # shellcheck disable=SC1091
 source "$dev_root/env.sh"
 
-[ "$HERMES_HOME" = "$dev_root/hermes-home" ]
+[ "$OPENCLAW_MARMOT_DEV_ROOT" = "$dev_root" ]
+[ "$MDK_REPO" = "$repo_root" ]
+[ "$OPENCLAW_PLUGIN_SRC" = "$repo_root/integrations/openclaw/marmot" ]
+[ "$OPENCLAW_HOME" = "$dev_root/openclaw-home" ]
 [ "$MARMOT_HOME" = "$dev_root/marmot-agent-home" ]
 [ "$MARMOT_AGENT_SOCKET" = "$dev_root/marmot-agent-home/dev/wn-agent.sock" ]
 [ "$MARMOT_AGENT_AUTH_TOKEN_FILE" = "$dev_root/control.token" ]
@@ -65,50 +66,47 @@ source "$dev_root/env.sh"
 [ "${wn_agent_quic_args[0]}" = "--quic-candidate" ]
 [ "${wn_agent_quic_args[1]}" = "quic://127.0.0.1:4433" ]
 
-"$repo_root/scripts/hermes_marmot_dev_teardown.sh" --root "$dev_root" --dry-run
+"$repo_root/scripts/openclaw_marmot_dev_teardown.sh" --root "$dev_root" --dry-run
 [ -d "$dev_root" ]
-"$repo_root/scripts/hermes_marmot_dev_teardown.sh" --root "$dev_root" --force
+"$repo_root/scripts/openclaw_marmot_dev_teardown.sh" --root "$dev_root" --force
 [ ! -e "$dev_root" ]
 
-unset MARMOT_AGENT_AUTH_TOKEN
-unset MARMOT_AGENT_AUTH_TOKEN_FILE
-unset MARMOT_AGENT_SOCKET_DIR_MODE
-unset MARMOT_AGENT_SOCKET_MODE
-default_root="$tmp_parent/defaults/hermes-marmot-test"
-"$repo_root/scripts/hermes_marmot_dev_setup.sh" \
-    --root "$default_root" \
-    --skip-hermes-install
+default_root="$tmp_parent/defaults/openclaw-marmot-test"
+"$repo_root/scripts/openclaw_marmot_dev_setup.sh" \
+    --root "$default_root"
 
 # shellcheck disable=SC1091
 source "$default_root/env.sh"
 
+[ "$MARMOT_ACCOUNT_ID_HEX" = "" ]
+[ "$MARMOT_GROUP_ID_HEX" = "" ]
 [ "$MARMOT_QUIC_CANDIDATES" = "" ]
 [ "$MARMOT_AGENT_AUTH_TOKEN_FILE" = "" ]
 [ "$MARMOT_AGENT_SOCKET_DIR_MODE" = "0700" ]
 [ "$MARMOT_AGENT_SOCKET_MODE" = "0600" ]
-[ "$MARMOT_RELAYS" = "" ]
-[ "${#wn_agent_relay_args[@]}" -eq 0 ]
+[ "$MARMOT_RELAYS" = "wss://relay.eu.whitenoise.chat,wss://relay.us.whitenoise.chat" ]
+[ "${#wn_agent_relay_args[@]}" -eq 4 ]
 [ "${#wn_agent_quic_args[@]}" -eq 0 ]
-"$repo_root/scripts/hermes_marmot_dev_teardown.sh" --root "$default_root" --force
+"$repo_root/scripts/openclaw_marmot_dev_teardown.sh" --root "$default_root" --force
 [ ! -e "$default_root" ]
 
-[ -x "$repo_root/scripts/install-hermes-marmot.sh" ]
+[ -x "$repo_root/scripts/install-openclaw-marmot.sh" ]
 installer_dry_run="$(
     WN_AGENT_SHA="9.9.9" \
     MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
-    "$repo_root/scripts/install-hermes-marmot.sh" --dry-run
+    "$repo_root/scripts/install-openclaw-marmot.sh" --dry-run
 )"
 case "$installer_dry_run" in
     *"wn-agent-"*"9.9.9.tar.gz"* ) ;;
-    *) echo "Hermes installer dry-run did not use WN_AGENT_SHA asset suffix" >&2; exit 1;;
+    *) echo "OpenClaw installer dry-run did not use WN_AGENT_SHA asset suffix" >&2; exit 1;;
 esac
 case "$installer_dry_run" in
-    *"hermes-marmot-plugin-9.9.9.tar.gz"* ) ;;
-    *) echo "Hermes installer dry-run did not use expected plugin asset" >&2; exit 1;;
+    *"openclaw-marmot-plugin-9.9.9.tgz"* ) ;;
+    *) echo "OpenClaw installer dry-run did not use expected plugin asset" >&2; exit 1;;
 esac
 case "$installer_dry_run" in
     *"wn-agent-v9.9.9-test"* ) ;;
-    *) echo "Hermes installer dry-run did not use requested release tag" >&2; exit 1;;
+    *) echo "OpenClaw installer dry-run did not use requested release tag" >&2; exit 1;;
 esac
 
-echo "dev script test passed"
+echo "OpenClaw dev script test passed"

--- a/integrations/openclaw/marmot/test/dev-scripts.sh
+++ b/integrations/openclaw/marmot/test/dev-scripts.sh
@@ -44,6 +44,15 @@ for helper in \
     bash -n "$helper"
 done
 
+stop_marker="$tmp_parent/stop-marker"
+cat > "$dev_root/stop-dev-processes.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${OPENCLAW_STOP_MARKER:?}"
+printf 'stopped\n' > "$OPENCLAW_STOP_MARKER"
+SCRIPT
+chmod +x "$dev_root/stop-dev-processes.sh"
+
 # shellcheck disable=SC1091
 source "$dev_root/env.sh"
 
@@ -66,9 +75,12 @@ source "$dev_root/env.sh"
 [ "${wn_agent_quic_args[0]}" = "--quic-candidate" ]
 [ "${wn_agent_quic_args[1]}" = "quic://127.0.0.1:4433" ]
 
-"$repo_root/scripts/openclaw_marmot_dev_teardown.sh" --root "$dev_root" --dry-run
+OPENCLAW_STOP_MARKER="$stop_marker" "$repo_root/scripts/openclaw_marmot_dev_teardown.sh" --root "$dev_root" --dry-run
+[ "$(cat "$stop_marker")" = "stopped" ]
 [ -d "$dev_root" ]
-"$repo_root/scripts/openclaw_marmot_dev_teardown.sh" --root "$dev_root" --force
+rm "$stop_marker"
+OPENCLAW_STOP_MARKER="$stop_marker" "$repo_root/scripts/openclaw_marmot_dev_teardown.sh" --root "$dev_root" --force
+[ "$(cat "$stop_marker")" = "stopped" ]
 [ ! -e "$dev_root" ]
 
 default_root="$tmp_parent/defaults/openclaw-marmot-test"

--- a/integrations/openclaw/marmot/test/e2e-connector.test.ts
+++ b/integrations/openclaw/marmot/test/e2e-connector.test.ts
@@ -1,0 +1,230 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { MarmotAgentControlClient } from "../src/client.js";
+import { startMarmotInbound, type InboundPluginApi } from "../src/inbound-runtime.js";
+import type { MarmotInboundMessage } from "../src/inbound.js";
+import { resetMarmotInboundRuntimeForTests } from "../src/runtime-state.js";
+
+const RUN_CONNECTOR_E2E = process.env.MARMOT_OPENCLAW_CONNECTOR_E2E === "1";
+const maybeDescribe = RUN_CONNECTOR_E2E ? describe : describe.skip;
+
+const ACCOUNT_ID_HEX = "11".repeat(32);
+const GROUP_ID_HEX = "22".repeat(32);
+const MESSAGE_ID_HEX = "33".repeat(32);
+const SENDER_ACCOUNT_ID_HEX = "44".repeat(32);
+const INBOUND_TEXT = "ping from connector";
+const DETERMINISTIC_RESPONSE = `marmot-e2e-ok: ${INBOUND_TEXT}`;
+
+interface DebugRecordedFinalSend {
+  account_id_hex: string;
+  group_id_hex: string;
+  text: string;
+  reply_to_message_id_hex?: string | null;
+  message_ids_hex: string[];
+}
+
+interface DebugRecordedFinalsResponse {
+  type: "debug_recorded_finals";
+  sends: DebugRecordedFinalSend[];
+}
+
+function repoRoot(): string {
+  return join(import.meta.dirname, "..", "..", "..", "..");
+}
+
+async function waitFor<T>(
+  probe: () => Promise<T | null | undefined> | T | null | undefined,
+  options: { timeoutMs?: number; intervalMs?: number; label?: string } = {},
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const intervalMs = options.intervalMs ?? 50;
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const value = await probe();
+      if (value) {
+        return value;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  const suffix = lastError instanceof Error ? `: ${lastError.message}` : "";
+  throw new Error(`${options.label ?? "waitFor"} timed out${suffix}`);
+}
+
+async function stopProcess(proc: ChildProcess): Promise<void> {
+  if (proc.exitCode !== null || proc.signalCode !== null) {
+    return;
+  }
+  proc.kill("SIGTERM");
+  await Promise.race([
+    new Promise<void>((resolve) => proc.once("exit", () => resolve())),
+    new Promise<void>((resolve) => setTimeout(resolve, 5_000)),
+  ]);
+  if (proc.exitCode === null && proc.signalCode === null) {
+    proc.kill("SIGKILL");
+  }
+}
+
+async function recordedFinals(
+  client: MarmotAgentControlClient,
+): Promise<DebugRecordedFinalsResponse> {
+  return (await client.request({
+    type: "debug_recorded_finals",
+  })) as unknown as DebugRecordedFinalsResponse;
+}
+
+afterEach(() => {
+  resetMarmotInboundRuntimeForTests();
+});
+
+maybeDescribe("OpenClaw Marmot connector E2E", () => {
+  it(
+    "dispatches debug-injected inbound through the OpenClaw inbound runtime into real wn-agent send_final",
+    async () => {
+      // Keep the Unix socket path short for macOS sockaddr_un limits.
+      const tempRoot = await mkdtemp("/tmp/omce-");
+      const marmotHome = join(tempRoot, "marmot-home");
+      const socketPath = join(tempRoot, "a.sock");
+      const proc = spawn(
+        "cargo",
+        [
+          "run",
+          "-q",
+          "-p",
+          "agent-connector",
+          "--bin",
+          "wn-agent",
+          "--",
+          "--home",
+          marmotHome,
+          "--socket",
+          socketPath,
+          "--debug-controls",
+        ],
+        {
+          cwd: repoRoot(),
+          env: { ...process.env, RUST_LOG: process.env.RUST_LOG ?? "warn" },
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      const stdout: string[] = [];
+      const stderr: string[] = [];
+      proc.stdout.on("data", (chunk) => stdout.push(String(chunk)));
+      proc.stderr.on("data", (chunk) => stderr.push(String(chunk)));
+
+      try {
+        const client = new MarmotAgentControlClient({
+          socketPath,
+          requestTimeoutMs: 5_000,
+        });
+        await waitFor(
+          async () => {
+            await recordedFinals(client);
+            return true;
+          },
+          { timeoutMs: 60_000, label: "wn-agent debug control socket" },
+        );
+
+        let resolveReady: () => void = () => {};
+        const ready = new Promise<void>((resolve) => {
+          resolveReady = resolve;
+        });
+        let resolveDispatched: (message: MarmotInboundMessage) => void = () => {};
+        const dispatched = new Promise<MarmotInboundMessage>((resolve) => {
+          resolveDispatched = resolve;
+        });
+        const api: InboundPluginApi = {
+          config: {
+            channels: {
+              marmot: {
+                socketPath,
+                accountIdHex: ACCOUNT_ID_HEX,
+                groupIdHex: GROUP_ID_HEX,
+                profileNameOnboarding: false,
+              },
+            },
+          },
+          logger: {
+            info: (message) => {
+              if (message.includes("inbound subscription established")) {
+                resolveReady();
+              }
+            },
+            warn: () => {},
+          },
+        };
+
+        const stopInbound = startMarmotInbound(
+          api,
+          async (message) => {
+            await client.sendFinal(
+              message.accountIdHex,
+              message.groupIdHex,
+              DETERMINISTIC_RESPONSE,
+              message.messageIdHex,
+            );
+            resolveDispatched(message);
+          },
+          { clientFactory: () => client },
+        );
+
+        try {
+          await ready;
+          await client.request({
+            type: "debug_inject_inbound",
+            account_id_hex: ACCOUNT_ID_HEX,
+            group_id_hex: GROUP_ID_HEX,
+            message_id_hex: MESSAGE_ID_HEX,
+            sender_account_id_hex: SENDER_ACCOUNT_ID_HEX,
+            text: INBOUND_TEXT,
+          });
+
+          await expect(dispatched).resolves.toMatchObject({
+            accountIdHex: ACCOUNT_ID_HEX,
+            groupIdHex: GROUP_ID_HEX,
+            messageIdHex: MESSAGE_ID_HEX,
+            senderAccountIdHex: SENDER_ACCOUNT_ID_HEX,
+            text: INBOUND_TEXT,
+          });
+          const final = await waitFor(
+            async () => {
+              const recorded = await recordedFinals(client);
+              return recorded.sends[0] ?? null;
+            },
+            { timeoutMs: 10_000, label: "recorded final send" },
+          );
+          expect(final).toMatchObject({
+            account_id_hex: ACCOUNT_ID_HEX,
+            group_id_hex: GROUP_ID_HEX,
+            text: DETERMINISTIC_RESPONSE,
+            reply_to_message_id_hex: MESSAGE_ID_HEX,
+            message_ids_hex: ["1".padStart(64, "0")],
+          });
+        } finally {
+          stopInbound();
+        }
+      } catch (error) {
+        const detail = [
+          error instanceof Error ? error.message : String(error),
+          stdout.length ? `stdout:\n${stdout.join("")}` : "",
+          stderr.length ? `stderr:\n${stderr.join("")}` : "",
+        ]
+          .filter(Boolean)
+          .join("\n\n");
+        throw new Error(detail);
+      } finally {
+        await stopProcess(proc);
+        await rm(tempRoot, { recursive: true, force: true });
+      }
+    },
+    90_000,
+  );
+});

--- a/integrations/openclaw/marmot/test/live.test.ts
+++ b/integrations/openclaw/marmot/test/live.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { NonAppendOnlyUpdateError } from "../src/append-only.js";
+import { AgentControlError } from "../src/client.js";
 import { MarmotLivePreview, type StreamControlClient } from "../src/live.js";
 import { AgentTextStreamTranscript } from "../src/transcript.js";
 
@@ -18,7 +19,7 @@ interface Calls {
   append: { streamId: string; text: string }[];
   status: { streamId: string; text: string }[];
   progress: { streamId: string; text: string }[];
-  finalize: { streamId: string; finalText: string; hash: string; count: number }[];
+  finalize: { streamId: string; finalText: string; hash: string; count: number; idempotencyKey?: string }[];
   cancel: { streamId: string; reason: string | null }[];
 }
 
@@ -50,8 +51,14 @@ function stubStreamClient(calls: Calls): StreamControlClient {
       calls.progress.push({ streamId, text });
       return { type: "ack" };
     },
-    async streamFinalize(streamId: string, finalText: string, hash: string, count: number) {
-      calls.finalize.push({ streamId, finalText, hash, count });
+    async streamFinalize(
+      streamId: string,
+      finalText: string,
+      hash: string,
+      count: number,
+      idempotencyKey?: string,
+    ) {
+      calls.finalize.push({ streamId, finalText, hash, count, idempotencyKey });
       return { type: "stream_finalized", stream_id_hex: streamId, message_ids_hex: [HEX32("ab")] };
     },
     async streamCancel(streamId: string, reason?: string | null) {
@@ -146,6 +153,39 @@ describe("MarmotLivePreview", () => {
 
     expect(calls.append.map((a) => a.text)).toEqual(["hel", "lo", " world"]);
     expect(calls.finalize[0]).toMatchObject({ hash: INCREMENTAL_HASH, count: 3 });
+  });
+
+  it("retries stream_finalize with the same idempotency key before falling back", async () => {
+    const calls = emptyCalls();
+    let attempts = 0;
+    const client = {
+      ...stubStreamClient(calls),
+      async streamFinalize(
+        streamId: string,
+        finalText: string,
+        hash: string,
+        count: number,
+        idempotencyKey?: string,
+      ) {
+        attempts += 1;
+        calls.finalize.push({ streamId, finalText, hash, count, idempotencyKey });
+        if (attempts === 1) {
+          throw new AgentControlError("timed out waiting for stream finalize", {
+            code: "timeout",
+            retryable: true,
+          });
+        }
+        return { type: "stream_finalized", stream_id_hex: streamId, message_ids_hex: [HEX32("ab")] };
+      },
+    } as unknown as StreamControlClient;
+    const live = previewWithClient(client);
+
+    const result = await live.finalize("hello world");
+
+    expect(result.messageIdsHex).toEqual([HEX32("ab")]);
+    expect(calls.finalize).toHaveLength(2);
+    expect(calls.finalize[0]?.idempotencyKey).toBeTruthy();
+    expect(calls.finalize[1]?.idempotencyKey).toBe(calls.finalize[0]?.idempotencyKey);
   });
 
   it("can begin before text arrives without adding transcript records", async () => {

--- a/integrations/openclaw/marmot/test/outbound.test.ts
+++ b/integrations/openclaw/marmot/test/outbound.test.ts
@@ -120,57 +120,73 @@ describe("createMarmotMessageAdapter", () => {
   });
 
   it("routes a media send with a local path to send_media with the caption", async () => {
-    const calls = emptyClientCalls();
-    const adapter = createMarmotMessageAdapter({
-      resolveTarget: () => ({ client: stubClient(calls), marmotAccountIdHex: HEX32("aa") }),
-      nowMs: () => 5678,
-    });
+    const tmpRoot = await mkdtemp(join(tmpdir(), "marmot-outbound-test-"));
+    try {
+      const filePath = join(tmpRoot, "cat.png");
+      await writeFile(filePath, Buffer.from("png-bytes"));
+      const calls = emptyClientCalls();
+      const adapter = createMarmotMessageAdapter({
+        resolveTarget: () => ({ client: stubClient(calls), marmotAccountIdHex: HEX32("aa") }),
+        nowMs: () => 5678,
+      });
 
-    const ctx = {
-      cfg: {},
-      to: HEX32("cc"),
-      text: "look at this",
-      mediaUrl: "/tmp/openclaw/cat.png",
-    } as unknown as ChannelMessageSendMediaContext;
+      const ctx = {
+        cfg: {},
+        to: HEX32("cc"),
+        text: "look at this",
+        mediaUrl: filePath,
+        mediaLocalRoots: [tmpRoot],
+      } as unknown as ChannelMessageSendMediaContext;
 
-    const result = await adapter.send!.media!(ctx);
+      const result = await adapter.send!.media!(ctx);
 
-    expect(calls.sendMedia).toHaveLength(1);
-    expect(calls.sendMedia[0]).toMatchObject({
-      accountIdHex: HEX32("aa"),
-      groupIdHex: HEX32("cc"),
-      caption: "look at this",
-    });
-    expect(calls.sendMedia[0]?.attachments[0]).toMatchObject({
-      path: "/tmp/openclaw/cat.png",
-      media_type: "image/png",
-      file_name: "cat.png",
-    });
-    expect(result.receipt.parts[0]).toMatchObject({ kind: "media", index: 0 });
-    expect(result.receipt.sentAt).toBe(5678);
+      expect(calls.sendMedia).toHaveLength(1);
+      expect(calls.sendMedia[0]).toMatchObject({
+        accountIdHex: HEX32("aa"),
+        groupIdHex: HEX32("cc"),
+        caption: "look at this",
+      });
+      expect(calls.sendMedia[0]?.attachments[0]).toMatchObject({
+        path: filePath,
+        media_type: "image/png",
+        file_name: "cat.png",
+      });
+      expect(result.receipt.parts[0]).toMatchObject({ kind: "media", index: 0 });
+      expect(result.receipt.sentAt).toBe(5678);
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true });
+    }
   });
 
   it("resolves a file:// media url to a local path", async () => {
-    const calls = emptyClientCalls();
-    const adapter = createMarmotMessageAdapter({
-      resolveTarget: () => ({ client: stubClient(calls), marmotAccountIdHex: HEX32("aa") }),
-    });
-    const ctx = {
-      cfg: {},
-      to: HEX32("cc"),
-      text: "",
-      mediaUrl: "file:///tmp/openclaw/clip.mp4",
-    } as unknown as ChannelMessageSendMediaContext;
+    const tmpRoot = await mkdtemp(join(tmpdir(), "marmot-outbound-test-"));
+    try {
+      const filePath = join(tmpRoot, "clip.mp4");
+      await writeFile(filePath, Buffer.from("mp4-bytes"));
+      const calls = emptyClientCalls();
+      const adapter = createMarmotMessageAdapter({
+        resolveTarget: () => ({ client: stubClient(calls), marmotAccountIdHex: HEX32("aa") }),
+      });
+      const ctx = {
+        cfg: {},
+        to: HEX32("cc"),
+        text: "",
+        mediaUrl: `file://${filePath}`,
+        mediaLocalRoots: [tmpRoot],
+      } as unknown as ChannelMessageSendMediaContext;
 
-    await adapter.send!.media!(ctx);
+      await adapter.send!.media!(ctx);
 
-    expect(calls.sendMedia[0]?.attachments[0]).toMatchObject({
-      path: "/tmp/openclaw/clip.mp4",
-      media_type: "video/mp4",
-      file_name: "clip.mp4",
-    });
-    // An empty caption is sent as null.
-    expect(calls.sendMedia[0]?.caption).toBeNull();
+      expect(calls.sendMedia[0]?.attachments[0]).toMatchObject({
+        path: filePath,
+        media_type: "video/mp4",
+        file_name: "clip.mp4",
+      });
+      // An empty caption is sent as null.
+      expect(calls.sendMedia[0]?.caption).toBeNull();
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true });
+    }
   });
 
   it("materializes a remote media url with mediaReadFile into a temp file", async () => {

--- a/scripts/hermes_marmot_dev_setup.sh
+++ b/scripts/hermes_marmot_dev_setup.sh
@@ -294,6 +294,14 @@ write_env_file() {
             done
         fi
         echo ')'
+        echo 'wn_agent_quic_args=('
+        if [ "${#quic_candidates[@]}" -gt 0 ]; then
+            for candidate in "${quic_candidates[@]}"; do
+                printf '  %q\n' "--quic-candidate"
+                printf '  %q\n' "$candidate"
+            done
+        fi
+        echo ')'
     } >"$env_file"
 }
 
@@ -389,7 +397,10 @@ bootstrap_args=(bootstrap --home "$MARMOT_HOME" --socket "$MARMOT_AGENT_SOCKET")
 if [ -n "${MARMOT_AGENT_AUTH_TOKEN_FILE:-}" ]; then
     bootstrap_args+=(--auth-token-file "$MARMOT_AGENT_AUTH_TOKEN_FILE")
 fi
-exec cargo run -p agent-connector --bin wn-agent -- "${bootstrap_args[@]}" "$@"
+if [ -n "${MARMOT_ACCOUNT_ID_HEX:-}" ]; then
+    bootstrap_args+=(--account-id-hex "$MARMOT_ACCOUNT_ID_HEX")
+fi
+exec cargo run -p agent-connector --bin wn-agent -- "${bootstrap_args[@]}" "${wn_agent_relay_args[@]}" "${wn_agent_quic_args[@]}" --qr "$@"
 SCRIPT
 
     cat >"$dev_root/start-wn-agent.sh" <<'SCRIPT'

--- a/scripts/install-openclaw-marmot.sh
+++ b/scripts/install-openclaw-marmot.sh
@@ -15,7 +15,7 @@ workspace_version_default="${workspace_version_default:-latest}"
 
 MARMOT_RELEASE_REPO="${MARMOT_RELEASE_REPO:-marmot-protocol/mdk}"
 WN_AGENT_VERSION_DEFAULT="${WN_AGENT_VERSION_DEFAULT:-$workspace_version_default}"
-WN_AGENT_VERSION="${WN_AGENT_VERSION:-$WN_AGENT_VERSION_DEFAULT}"
+WN_AGENT_VERSION="${WN_AGENT_VERSION:-${WN_AGENT_SHA:-$WN_AGENT_VERSION_DEFAULT}}"
 MARMOT_RELEASE_TAG_DEFAULT="${MARMOT_RELEASE_TAG_DEFAULT:-wn-agent-v${WN_AGENT_VERSION}}"
 MARMOT_RELEASE_TAG="${MARMOT_RELEASE_TAG:-$MARMOT_RELEASE_TAG_DEFAULT}"
 MARMOT_INSTALL_PREFIX="${MARMOT_INSTALL_PREFIX:-${HOME}/.local}"
@@ -47,6 +47,7 @@ Environment:
   MARMOT_RELEASE_REPO   GitHub repo (default: marmot-protocol/mdk)
   MARMOT_RELEASE_TAG    Release tag (default: wn-agent-v<version>)
   WN_AGENT_VERSION      Asset version suffix
+  WN_AGENT_SHA          Legacy alias for WN_AGENT_VERSION
   MARMOT_INSTALL_PREFIX Install root for wn-agent (default: ~/.local)
   MARMOT_HOME           wn-agent home used by bootstrap (default: ~/.marmot-agent)
   MARMOT_RELAYS         Relay CSV used when --bootstrap starts wn-agent

--- a/scripts/openclaw_marmot_connector_e2e.sh
+++ b/scripts/openclaw_marmot_connector_e2e.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/openclaw_marmot_connector_e2e.sh [options]
+
+Runs a deterministic OpenClaw/Marmot E2E against a real wn-agent process started
+with debug controls. No model, real Marmot account, group, relay, or OpenClaw
+gateway is required.
+
+Options:
+  --root PATH      Dev root (default: ${OPENCLAW_MARMOT_DEV_ROOT:-${TMPDIR:-/tmp}/openclaw-marmot-test})
+  -h, --help       Show this help
+USAGE
+}
+
+default_tmp="${TMPDIR:-/tmp}"
+dev_root="${OPENCLAW_MARMOT_DEV_ROOT:-${default_tmp%/}/openclaw-marmot-test}"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --root)
+            dev_root="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ ! -f "$dev_root/env.sh" ]; then
+    echo "error: $dev_root/env.sh not found. Run scripts/openclaw_marmot_dev_setup.sh first." >&2
+    exit 1
+fi
+
+source "$dev_root/env.sh"
+
+cd "$OPENCLAW_PLUGIN_SRC"
+exec env MARMOT_OPENCLAW_CONNECTOR_E2E=1 pnpm exec vitest run test/e2e-connector.test.ts

--- a/scripts/openclaw_marmot_dev_setup.sh
+++ b/scripts/openclaw_marmot_dev_setup.sh
@@ -2,8 +2,9 @@
 # Repeatable, throwaway dev setup for the OpenClaw Marmot channel plugin without
 # touching your normal OpenClaw home. Mirrors scripts/hermes_marmot_dev_setup.sh.
 #
-# It builds the plugin, prepares an isolated dev root + env, and generates helper
-# scripts to run wn-agent and the OpenClaw gateway against it.
+# It builds/tests the plugin, prepares an isolated dev root + env, and generates
+# helper scripts to run wn-agent, exercise a deterministic connector E2E, and
+# run the OpenClaw gateway against it.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -14,9 +15,12 @@ ROOT="${OPENCLAW_MARMOT_DEV_ROOT:-${TMPDIR:-/tmp}/openclaw-marmot-test}"
 PRINT_ENV=0
 RELAYS=()
 QUIC_CANDIDATES=()
+AUTH_TOKEN=""
 AUTH_TOKEN_FILE=""
-SOCKET_DIR_MODE=""
-SOCKET_MODE=""
+SOCKET_DIR_MODE="0700"
+SOCKET_MODE="0600"
+ACCOUNT_ID_HEX=""
+GROUP_ID_HEX=""
 
 usage() {
     cat <<'USAGE'
@@ -24,11 +28,14 @@ Usage: openclaw_marmot_dev_setup.sh [options]
 
 Options:
   --root DIR              Dev root (default: ${TMPDIR:-/tmp}/openclaw-marmot-test)
-  --relay URL             Public relay URL (repeatable)
+  --relay URL             Public relay URL (repeatable; defaults to the White Noise pilot relays)
   --quic-candidate URL    quic:// preview broker candidate (repeatable)
-  --auth-token-file PATH  Use a token-gated control socket
-  --socket-dir-mode MODE  Octal parent-dir mode for the control socket (e.g. 0770)
-  --socket-mode MODE      Octal socket mode (e.g. 0660)
+  --account-id-hex HEX    Marmot account id exported for plugin/gateway helpers
+  --group-id-hex HEX      Marmot group id exported for smoke/helper scripts
+  --auth-token TOKEN      Write TOKEN to ROOT/control.token for a token-gated control socket
+  --auth-token-file PATH  Use an existing token-gated control socket token file
+  --socket-dir-mode MODE  Octal parent-dir mode for the control socket (default: 0700)
+  --socket-mode MODE      Octal socket mode (default: 0600)
   --print-env             Print the path to the generated env.sh on success
   -h, --help              Show this help
 USAGE
@@ -39,6 +46,9 @@ while [ $# -gt 0 ]; do
         --root) ROOT="$2"; shift 2;;
         --relay) RELAYS+=("$2"); shift 2;;
         --quic-candidate) QUIC_CANDIDATES+=("$2"); shift 2;;
+        --account-id-hex) ACCOUNT_ID_HEX="$2"; shift 2;;
+        --group-id-hex) GROUP_ID_HEX="$2"; shift 2;;
+        --auth-token) AUTH_TOKEN="$2"; shift 2;;
         --auth-token-file) AUTH_TOKEN_FILE="$2"; shift 2;;
         --socket-dir-mode) SOCKET_DIR_MODE="$2"; shift 2;;
         --socket-mode) SOCKET_MODE="$2"; shift 2;;
@@ -48,77 +58,249 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+if [ -n "$AUTH_TOKEN" ] && [ -n "$AUTH_TOKEN_FILE" ]; then
+    echo "error: use only one of --auth-token or --auth-token-file" >&2
+    exit 2
+fi
+
 MARMOT_HOME="$ROOT/marmot-agent-home"
 OPENCLAW_HOME="$ROOT/openclaw-home"
 LOGS_DIR="$ROOT/logs"
-mkdir -p "$MARMOT_HOME" "$OPENCLAW_HOME" "$LOGS_DIR"
+SOCKET_PATH="$MARMOT_HOME/dev/wn-agent.sock"
+ENV_FILE="$ROOT/env.sh"
+mkdir -p "$MARMOT_HOME/dev" "$OPENCLAW_HOME" "$LOGS_DIR"
+
+if [ -n "$AUTH_TOKEN" ]; then
+    AUTH_TOKEN_FILE="$ROOT/control.token"
+    printf '%s\n' "$AUTH_TOKEN" >"$AUTH_TOKEN_FILE"
+    chmod 0600 "$AUTH_TOKEN_FILE"
+fi
 
 echo "openclaw-marmot dev setup: building plugin in $PLUGIN_SRC"
-( cd "$PLUGIN_SRC" && pnpm install && pnpm typecheck && pnpm test )
+(
+    cd "$PLUGIN_SRC"
+    CI=true pnpm install
+    pnpm typecheck
+    env \
+        -u MARMOT_ACCOUNT_ID_HEX \
+        -u MARMOT_AGENT_AUTH_TOKEN \
+        -u MARMOT_AGENT_AUTH_TOKEN_FILE \
+        -u MARMOT_AGENT_SOCKET \
+        -u MARMOT_DM_ALLOW_FROM \
+        -u MARMOT_GROUP_ID_HEX \
+        -u MARMOT_HOME \
+        -u MARMOT_QUIC_CANDIDATE \
+        -u MARMOT_QUIC_CANDIDATES \
+        -u MARMOT_RELAYS \
+        -u MARMOT_WELCOMER_ALLOWLIST \
+        pnpm test
+)
 
-# Default relays/candidates match the public pilot set.
+# Default relays match the public pilot set for phone/manual tests.
 if [ "${#RELAYS[@]}" -eq 0 ]; then
     RELAYS=(wss://relay.eu.whitenoise.chat wss://relay.us.whitenoise.chat)
 fi
-RELAY_ARGS=()
-for relay in "${RELAYS[@]}"; do RELAY_ARGS+=(--relay "$relay"); done
-QUIC_CSV="$(IFS=,; echo "${QUIC_CANDIDATES[*]:-}")"
 
-SOCKET_PATH="$MARMOT_HOME/dev/wn-agent.sock"
-WN_AGENT_EXTRA=()
-[ -n "$AUTH_TOKEN_FILE" ] && WN_AGENT_EXTRA+=(--auth-token-file "$AUTH_TOKEN_FILE")
-[ -n "$SOCKET_DIR_MODE" ] && WN_AGENT_EXTRA+=(--socket-dir-mode "$SOCKET_DIR_MODE")
-[ -n "$SOCKET_MODE" ] && WN_AGENT_EXTRA+=(--socket-mode "$SOCKET_MODE")
+write_env_file() {
+    local quic_csv=""
+    local relay_csv=""
+    local candidate
+    if [ "${#QUIC_CANDIDATES[@]}" -gt 0 ]; then
+        for candidate in "${QUIC_CANDIDATES[@]}"; do
+            if [ -z "$quic_csv" ]; then
+                quic_csv="$candidate"
+            else
+                quic_csv="$quic_csv,$candidate"
+            fi
+        done
+    fi
+    local relay
+    for relay in "${RELAYS[@]}"; do
+        if [ -z "$relay_csv" ]; then
+            relay_csv="$relay"
+        else
+            relay_csv="$relay_csv,$relay"
+        fi
+    done
 
-cat > "$ROOT/env.sh" <<ENV
-# Source this to configure the OpenClaw Marmot dev environment.
-export OPENCLAW_MARMOT_DEV_ROOT="$ROOT"
-export OPENCLAW_HOME="$OPENCLAW_HOME"
-export MARMOT_HOME="$MARMOT_HOME"
-export MARMOT_AGENT_SOCKET="$SOCKET_PATH"
-export MARMOT_QUIC_CANDIDATES="$QUIC_CSV"
-${AUTH_TOKEN_FILE:+export MARMOT_AGENT_AUTH_TOKEN_FILE="$AUTH_TOKEN_FILE"}
-ENV
+    {
+        echo "# Generated by scripts/openclaw_marmot_dev_setup.sh"
+        echo "# shellcheck shell=bash"
+        printf 'export OPENCLAW_MARMOT_DEV_ROOT=%q\n' "$ROOT"
+        printf 'export MDK_REPO=%q\n' "$REPO_ROOT"
+        printf 'export OPENCLAW_PLUGIN_SRC=%q\n' "$PLUGIN_SRC"
+        printf 'export OPENCLAW_HOME=%q\n' "$OPENCLAW_HOME"
+        printf 'export MARMOT_HOME=%q\n' "$MARMOT_HOME"
+        printf 'export MARMOT_AGENT_SOCKET=%q\n' "$SOCKET_PATH"
+        printf 'export MARMOT_AGENT_AUTH_TOKEN_FILE=%q\n' "$AUTH_TOKEN_FILE"
+        printf 'export MARMOT_AGENT_SOCKET_DIR_MODE=%q\n' "$SOCKET_DIR_MODE"
+        printf 'export MARMOT_AGENT_SOCKET_MODE=%q\n' "$SOCKET_MODE"
+        printf 'export MARMOT_ACCOUNT_ID_HEX=%q\n' "$ACCOUNT_ID_HEX"
+        printf 'export MARMOT_GROUP_ID_HEX=%q\n' "$GROUP_ID_HEX"
+        printf 'export MARMOT_RELAYS=%q\n' "$relay_csv"
+        printf 'export MARMOT_QUIC_CANDIDATES=%q\n' "$quic_csv"
+        echo 'wn_agent_relay_args=('
+        for relay in "${RELAYS[@]}"; do
+            printf '  %q\n' "--relay"
+            printf '  %q\n' "$relay"
+        done
+        echo ')'
+        echo 'wn_agent_quic_args=('
+        if [ "${#QUIC_CANDIDATES[@]}" -gt 0 ]; then
+            for candidate in "${QUIC_CANDIDATES[@]}"; do
+                printf '  %q\n' "--quic-candidate"
+                printf '  %q\n' "$candidate"
+            done
+        fi
+        echo ')'
+    } >"$ENV_FILE"
+}
 
-# Bake the args shell-quoted so paths/tokens with spaces survive the wrapper.
-RELAY_ARGS_QUOTED="$(printf '%q ' "${RELAY_ARGS[@]}")"
-WN_AGENT_EXTRA_QUOTED=""
-if [ "${#WN_AGENT_EXTRA[@]}" -gt 0 ]; then
-    WN_AGENT_EXTRA_QUOTED="$(printf '%q ' "${WN_AGENT_EXTRA[@]}")"
+write_helper_scripts() {
+    cat >"$ROOT/run-wn-agent.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+dev_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$dev_root/env.sh"
+cd "$MDK_REPO"
+wn_agent_control_args=(
+    --socket "$MARMOT_AGENT_SOCKET"
+    --socket-dir-mode "${MARMOT_AGENT_SOCKET_DIR_MODE:-0700}"
+    --socket-mode "${MARMOT_AGENT_SOCKET_MODE:-0600}"
+)
+if [ -n "${MARMOT_AGENT_AUTH_TOKEN_FILE:-}" ]; then
+    wn_agent_control_args+=(--auth-token-file "$MARMOT_AGENT_AUTH_TOKEN_FILE")
 fi
+exec cargo run -p agent-connector --bin wn-agent -- --home "$MARMOT_HOME" "${wn_agent_control_args[@]}" "${wn_agent_relay_args[@]}" "$@"
+SCRIPT
 
-cat > "$ROOT/run-wn-agent.sh" <<RUN
+    cat >"$ROOT/run-openclaw-gateway.sh" <<'SCRIPT'
 #!/usr/bin/env bash
 set -euo pipefail
-exec cargo run -p agent-connector --bin wn-agent -- \\
-  --home "$MARMOT_HOME" \\
-  $RELAY_ARGS_QUOTED$WN_AGENT_EXTRA_QUOTED
-RUN
-chmod +x "$ROOT/run-wn-agent.sh"
+dev_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$dev_root/env.sh"
+if ! command -v openclaw >/dev/null 2>&1; then
+    echo "error: openclaw launcher not found on PATH. Install OpenClaw before running the gateway helper." >&2
+    exit 1
+fi
+openclaw plugins install --force "$OPENCLAW_PLUGIN_SRC" 2>/dev/null || openclaw plugins install "$OPENCLAW_PLUGIN_SRC"
+openclaw plugins enable marmot || true
+exec openclaw gateway run "$@"
+SCRIPT
 
-cat > "$ROOT/run-openclaw-gateway.sh" <<RUN
+    cat >"$ROOT/smoke-plugin.sh" <<'SCRIPT'
 #!/usr/bin/env bash
 set -euo pipefail
-source "$ROOT/env.sh"
-# Install the local plugin into the isolated OpenClaw home, then run the gateway.
-# Adjust the run subcommand to match your OpenClaw version if needed.
-openclaw plugins install "$PLUGIN_SRC"
-exec openclaw gateway run
-RUN
-chmod +x "$ROOT/run-openclaw-gateway.sh"
+dev_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$dev_root/env.sh"
+cd "$OPENCLAW_PLUGIN_SRC"
+pnpm typecheck
+pnpm test
+SCRIPT
 
-cat > "$ROOT/smoke-plugin.sh" <<RUN
+    cat >"$ROOT/control-smoketest.sh" <<'SCRIPT'
 #!/usr/bin/env bash
 set -euo pipefail
-cd "$PLUGIN_SRC"
-pnpm typecheck && pnpm test
-RUN
-chmod +x "$ROOT/smoke-plugin.sh"
+dev_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$dev_root/env.sh"
+cd "$OPENCLAW_PLUGIN_SRC"
+pnpm build
+exec pnpm smoketest "$@"
+SCRIPT
+
+    cat >"$ROOT/e2e-connector.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+dev_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$dev_root/env.sh"
+exec "$MDK_REPO/scripts/openclaw_marmot_connector_e2e.sh" --root "$dev_root"
+SCRIPT
+
+    cat >"$ROOT/bootstrap-agent.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+dev_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$dev_root/env.sh"
+cd "$MDK_REPO"
+bootstrap_args=(bootstrap --home "$MARMOT_HOME" --socket "$MARMOT_AGENT_SOCKET")
+if [ -n "${MARMOT_AGENT_AUTH_TOKEN_FILE:-}" ]; then
+    bootstrap_args+=(--auth-token-file "$MARMOT_AGENT_AUTH_TOKEN_FILE")
+fi
+if [ -n "${MARMOT_ACCOUNT_ID_HEX:-}" ]; then
+    bootstrap_args+=(--account-id-hex "$MARMOT_ACCOUNT_ID_HEX")
+fi
+exec cargo run -p agent-connector --bin wn-agent -- "${bootstrap_args[@]}" "${wn_agent_relay_args[@]}" "${wn_agent_quic_args[@]}" --qr "$@"
+SCRIPT
+
+    cat >"$ROOT/start-wn-agent.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+dev_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+pid_file="$dev_root/wn-agent.pid"
+if [ -f "$pid_file" ] && kill -0 "$(cat "$pid_file")" 2>/dev/null; then
+    echo "wn-agent already running: $(cat "$pid_file")"
+    exit 0
+fi
+nohup "$dev_root/run-wn-agent.sh" "$@" >"$dev_root/logs/wn-agent.log" 2>&1 &
+echo "$!" >"$pid_file"
+echo "wn-agent pid: $(cat "$pid_file")"
+echo "log: $dev_root/logs/wn-agent.log"
+SCRIPT
+
+    cat >"$ROOT/start-openclaw-gateway.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+dev_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+pid_file="$dev_root/openclaw-gateway.pid"
+if [ -f "$pid_file" ] && kill -0 "$(cat "$pid_file")" 2>/dev/null; then
+    echo "OpenClaw gateway already running: $(cat "$pid_file")"
+    exit 0
+fi
+nohup "$dev_root/run-openclaw-gateway.sh" "$@" >"$dev_root/logs/openclaw-gateway.log" 2>&1 &
+echo "$!" >"$pid_file"
+echo "OpenClaw gateway pid: $(cat "$pid_file")"
+echo "log: $dev_root/logs/openclaw-gateway.log"
+SCRIPT
+
+    cat >"$ROOT/stop-dev-processes.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+dev_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+for name in openclaw-gateway wn-agent; do
+    pid_file="$dev_root/$name.pid"
+    if [ ! -f "$pid_file" ]; then
+        continue
+    fi
+    pid="$(cat "$pid_file")"
+    if kill -0 "$pid" 2>/dev/null; then
+        kill "$pid" 2>/dev/null || true
+        echo "stopped $name pid $pid"
+    fi
+    rm -f "$pid_file"
+done
+SCRIPT
+
+    chmod +x \
+        "$ROOT/run-wn-agent.sh" \
+        "$ROOT/run-openclaw-gateway.sh" \
+        "$ROOT/smoke-plugin.sh" \
+        "$ROOT/control-smoketest.sh" \
+        "$ROOT/e2e-connector.sh" \
+        "$ROOT/bootstrap-agent.sh" \
+        "$ROOT/start-wn-agent.sh" \
+        "$ROOT/start-openclaw-gateway.sh" \
+        "$ROOT/stop-dev-processes.sh"
+}
+
+write_env_file
+write_helper_scripts
 
 echo "openclaw-marmot dev setup ready under: $ROOT"
 echo "  1. start wn-agent:        $ROOT/run-wn-agent.sh"
-echo "  2. bootstrap the account: cargo run -p agent-connector --bin wn-agent -- bootstrap --home '$MARMOT_HOME' --qr"
+echo "  2. bootstrap the account: $ROOT/bootstrap-agent.sh"
 echo "  3. run the gateway:       $ROOT/run-openclaw-gateway.sh"
+echo "  4. smoke control socket:  $ROOT/control-smoketest.sh"
+echo "  5. connector E2E:         $ROOT/e2e-connector.sh"
 if [ "$PRINT_ENV" -eq 1 ]; then
-    echo "$ROOT/env.sh"
+    echo "$ENV_FILE"
 fi

--- a/scripts/openclaw_marmot_dev_teardown.sh
+++ b/scripts/openclaw_marmot_dev_teardown.sh
@@ -5,12 +5,14 @@ set -euo pipefail
 
 ROOT="${OPENCLAW_MARMOT_DEV_ROOT:-${TMPDIR:-/tmp}/openclaw-marmot-test}"
 FORCE=0
+DRY_RUN=0
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --root) ROOT="$2"; shift 2;;
         --force) FORCE=1; shift;;
-        -h|--help) echo "Usage: openclaw_marmot_dev_teardown.sh [--root DIR] [--force]"; exit 0;;
+        --dry-run) DRY_RUN=1; shift;;
+        -h|--help) echo "Usage: openclaw_marmot_dev_teardown.sh [--root DIR] [--force] [--dry-run]"; exit 0;;
         *) echo "unknown option: $1" >&2; exit 2;;
     esac
 done
@@ -20,18 +22,23 @@ if [ ! -d "$ROOT" ]; then
     exit 0
 fi
 
-if [ "$FORCE" -ne 1 ]; then
-    printf 'Delete dev root %s? [y/N] ' "$ROOT"
-    read -r reply
-    case "$reply" in y|Y|yes|YES) ;; *) echo "aborted"; exit 1;; esac
-fi
-
 case "$ROOT" in
     ""|"/"|"."|"/home"|"/root"|"/usr"|"/opt"|"/etc"|"/var"|"$HOME")
         echo "refusing to delete unsafe root path: '$ROOT'" >&2
         exit 1
         ;;
 esac
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo "openclaw-marmot teardown: would remove $ROOT"
+    exit 0
+fi
+
+if [ "$FORCE" -ne 1 ]; then
+    printf 'Delete dev root %s? [y/N] ' "$ROOT"
+    read -r reply
+    case "$reply" in y|Y|yes|YES) ;; *) echo "aborted"; exit 1;; esac
+fi
 
 rm -rf "$ROOT"
 echo "openclaw-marmot teardown: removed $ROOT"

--- a/scripts/openclaw_marmot_dev_teardown.sh
+++ b/scripts/openclaw_marmot_dev_teardown.sh
@@ -3,42 +3,121 @@
 # scripts/openclaw_marmot_dev_setup.sh. Mirrors the Hermes teardown.
 set -euo pipefail
 
-ROOT="${OPENCLAW_MARMOT_DEV_ROOT:-${TMPDIR:-/tmp}/openclaw-marmot-test}"
-FORCE=0
-DRY_RUN=0
+usage() {
+    cat <<'USAGE'
+Usage: openclaw_marmot_dev_teardown.sh [--root DIR] [--force] [--dry-run]
+USAGE
+}
+
+default_tmp="${TMPDIR:-/tmp}"
+dev_root="${OPENCLAW_MARMOT_DEV_ROOT:-${default_tmp%/}/openclaw-marmot-test}"
+force=0
+dry_run=0
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --root) ROOT="$2"; shift 2;;
-        --force) FORCE=1; shift;;
-        --dry-run) DRY_RUN=1; shift;;
-        -h|--help) echo "Usage: openclaw_marmot_dev_teardown.sh [--root DIR] [--force] [--dry-run]"; exit 0;;
-        *) echo "unknown option: $1" >&2; exit 2;;
+        --root) dev_root="$2"; shift 2;;
+        --force) force=1; shift;;
+        --dry-run) dry_run=1; shift;;
+        -h|--help) usage; exit 0;;
+        *) echo "unknown option: $1" >&2; usage >&2; exit 2;;
     esac
 done
 
-if [ ! -d "$ROOT" ]; then
-    echo "openclaw-marmot teardown: nothing at $ROOT"
+if [ -z "$dev_root" ]; then
+    echo "error: empty dev root" >&2
+    exit 1
+fi
+
+dev_parent="$(dirname "$dev_root")"
+dev_base="$(basename "$dev_root")"
+if [ ! -d "$dev_parent" ]; then
+    echo "openclaw-marmot teardown: nothing at $dev_root"
+    exit 0
+fi
+dev_root="$(cd "$dev_parent" && pwd)/$dev_base"
+
+same_or_within() {
+    local path="${1%/}"
+    local root="${2%/}"
+    if [ -z "$path" ]; then
+        path="/"
+    fi
+    if [ -z "$root" ]; then
+        root="/"
+    fi
+    if [ "$root" = "/" ]; then
+        [ "$path" = "/" ]
+        return
+    fi
+    [ "$path" = "$root" ] || [[ "$path" = "$root/"* ]]
+}
+
+within_root() {
+    local path="${1%/}"
+    local root="${2%/}"
+    if [ -z "$path" ]; then
+        path="/"
+    fi
+    if [ -z "$root" ]; then
+        root="/"
+    fi
+    if [ "$root" = "/" ]; then
+        [ "$path" != "/" ]
+        return
+    fi
+    [[ "$path" = "$root/"* ]]
+}
+
+default_tmp_root="${default_tmp%/}"
+if [ -d "$default_tmp_root" ]; then
+    default_tmp_root="$(cd "$default_tmp_root" && pwd)"
+fi
+
+home_root="${HOME%/}"
+home_data_root="$home_root/.local/share"
+if same_or_within "$dev_root" "/" \
+    || same_or_within "$dev_root" "$PWD" \
+    || same_or_within "$dev_root" "/etc" \
+    || same_or_within "$dev_root" "/usr" \
+    || same_or_within "$dev_root" "/bin" \
+    || same_or_within "$dev_root" "/sbin" \
+    || same_or_within "$dev_root" "/System" \
+    || same_or_within "$dev_root" "/Library"; then
+    echo "error: refusing to delete unsafe root: $dev_root" >&2
+    exit 1
+fi
+if same_or_within "$dev_root" "$home_root" && ! within_root "$dev_root" "$home_data_root"; then
+    echo "error: refusing to delete unsafe root: $dev_root" >&2
+    exit 1
+fi
+if ! within_root "$dev_root" "/tmp" \
+    && ! within_root "$dev_root" "/var/tmp" \
+    && ! within_root "$dev_root" "$default_tmp_root" \
+    && ! within_root "$dev_root" "$home_data_root"; then
+    echo "error: refusing to delete unsafe root: $dev_root" >&2
+    exit 1
+fi
+
+if [ ! -e "$dev_root" ]; then
+    echo "openclaw-marmot teardown: nothing at $dev_root"
     exit 0
 fi
 
-case "$ROOT" in
-    ""|"/"|"."|"/home"|"/root"|"/usr"|"/opt"|"/etc"|"/var"|"$HOME")
-        echo "refusing to delete unsafe root path: '$ROOT'" >&2
-        exit 1
-        ;;
-esac
+if [ -x "$dev_root/stop-dev-processes.sh" ]; then
+    "$dev_root/stop-dev-processes.sh" || true
+fi
 
-if [ "$DRY_RUN" -eq 1 ]; then
-    echo "openclaw-marmot teardown: would remove $ROOT"
+if [ "$dry_run" -eq 1 ]; then
+    echo "openclaw-marmot teardown: would remove $dev_root"
     exit 0
 fi
 
-if [ "$FORCE" -ne 1 ]; then
-    printf 'Delete dev root %s? [y/N] ' "$ROOT"
+if [ "$force" -ne 1 ]; then
+    printf 'Delete dev root %s? [y/N] ' "$dev_root"
     read -r reply
     case "$reply" in y|Y|yes|YES) ;; *) echo "aborted"; exit 1;; esac
 fi
 
-rm -rf "$ROOT"
-echo "openclaw-marmot teardown: removed $ROOT"
+rm -rf "$dev_root"
+echo "openclaw-marmot teardown: removed $dev_root"


### PR DESCRIPTION
## Summary

- Stabilize `wn-agent` finalization with optional `stream_finalize` idempotency keys and matching Hermes/OpenClaw retry behavior.
- Bring Hermes and OpenClaw closer to parity for install/dev setup, generated helpers, deterministic connector E2Es, and onboarding docs.
- Fill CLI/TUI gaps with real backing behavior for invites, notifications, key deletion/listing, stream compose, chat mute/unmute, TUI image upload, and visible `wn sync`.
- Add app/storage backing for per-chat notification suppression and tighten CLI JSON error contracts.

## Verification

- `just fast-ci`
- `cargo test -p wn-cli`
- `cargo test -p agent-control -p agent-connector -p agent-stream-compose`
- `python3 -m unittest discover -s integrations/hermes/marmot/tests`
- `cd integrations/openclaw/marmot && pnpm typecheck && pnpm test`
- `integrations/hermes/marmot/tests/test_dev_scripts.sh`
- `integrations/openclaw/marmot/test/dev-scripts.sh`
- Hermes deterministic E2E via `scripts/hermes_marmot_deterministic_e2e.sh`
- Hermes real `wn-agent` connector E2E via `scripts/hermes_marmot_connector_e2e.sh`
- OpenClaw real `wn-agent` connector E2E via `scripts/openclaw_marmot_connector_e2e.sh`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/751">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chat mute/unmute controls, notification subscriptions, group invite actions, key-package deletion, and improved stream finalization reliability.
  * Added new dev helper commands and scripts for smoke tests and deterministic connector E2E runs.
  * Expanded TUI support for `/chat mute`, `/chat unmute`, and `/image`.

* **Bug Fixes**
  * Improved error messages and validation for daemon-required commands, mute durations, relay types, and confirmation flows.
  * Fixed notification delivery to respect per-chat mute settings and retry-safe finalize behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->