### PR TITLE
cgka-engine: bound the future side of the convergence send-gate (#736), scope superseded scan (#745)

### DIFF
--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -917,9 +917,13 @@ impl<S: StorageProvider> Engine<S> {
         };
         let accepted: std::collections::BTreeSet<&str> =
             result.accepted_commits.iter().map(String::as_str).collect();
+        // Scope the scan to `fork_epoch` onward (mdk#745): rows below the fork
+        // epoch are skipped anyway, so listing from `EpochId(0)` re-decoded and
+        // re-projected the group's entire retained history on every apply. The
+        // storage query filters `at_or_after_epoch`, yielding an identical set.
         let records = self
             .storage
-            .list_messages(group_id, EpochId(0))
+            .list_messages(group_id, EpochId(fork_epoch))
             .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
         for record in records {
             if record.state != MessageState::Processed || record.epoch.0 < fork_epoch {

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -16,7 +16,7 @@ pub(crate) use ingest::avatar_component_snapshot;
 pub(crate) use send::merge_capabilities;
 
 use crate::engine::{Engine, ScheduledSelfRemoveAutoCommit};
-use crate::openmls_projection::{OpenMlsContentKind, project_mls_message};
+use crate::openmls_projection::{OpenMlsContentKind, decode_openmls_wire_projection};
 use cgka_traits::engine::{GroupEvent, GroupStateChange, SendIntent, SendResult};
 use cgka_traits::engine_state::EpochState;
 use cgka_traits::error::EngineError;
@@ -392,6 +392,7 @@ impl<S: StorageProvider> Engine<S> {
             Err(e) => return Err(EngineError::Storage(e)),
         };
         let records = self.storage.list_messages(group_id, EpochId(anchor))?;
+        let mut skipped_non_resolvable: usize = 0;
         for record in records {
             if !matches!(
                 record.state,
@@ -405,14 +406,12 @@ impl<S: StorageProvider> Engine<S> {
             // corrupt/garbage row permanently gate sends with no recovery path.
             // Such a row simply does not contribute to the send gate; the
             // convergence horizon (`openmls_projection`) is responsible for
-            // assigning it a terminal disposition.
-            let Ok(stored_payload) = StoredMessagePayload::decode(&record.payload) else {
-                continue;
-            };
-            let Some(message) = stored_payload.as_openmls_wire() else {
-                continue;
-            };
-            let Ok(projection) = project_mls_message(&message.payload) else {
+            // assigning it a terminal disposition. Count the skips so sustained
+            // abuse (an insider spraying undecodable rows) is visible in audits
+            // without spamming a log line per row (mdk#752 review).
+            let Some((_message, projection)) = decode_openmls_wire_projection(&record.payload)
+            else {
+                skipped_non_resolvable += 1;
                 continue;
             };
             // Beyond the future horizon: unreachable from the current tip, so
@@ -440,6 +439,18 @@ impl<S: StorageProvider> Engine<S> {
             ) {
                 return Ok(true);
             }
+        }
+        // Reached only when nothing gates: surface any fail-open skips so an
+        // insider spraying undecodable rows (which no longer wedges the gate but
+        // still costs a scan) is visible in forensic audits. Aggregate count
+        // only — no ids, epochs, or payloads (observability privacy invariant).
+        if skipped_non_resolvable > 0 {
+            tracing::debug!(
+                target: "cgka_engine::message_processor",
+                method = "has_unresolved_convergence_inputs",
+                skipped_non_resolvable,
+                "skipped non-resolvable convergence rows (fail-open)"
+            );
         }
         Ok(false)
     }

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -365,15 +365,28 @@ impl<S: StorageProvider> Engine<S> {
     }
 
     fn has_unresolved_convergence_inputs(&self, group_id: &GroupId) -> Result<bool, EngineError> {
-        let anchor = match self.storage.get_group(group_id) {
+        // The convergence horizon is bounded on BOTH sides (mdk#736). The past
+        // side (`anchor`) drops inputs older than the retained-anchor window.
+        // The future side (`ceiling`) is symmetric: a convergence input more
+        // than `max_rewind_commits` epochs ahead of the current tip cannot chain
+        // from the tip yet (the candidate-path BFS in `openmls_projection` only
+        // extends `source_epoch == tip_epoch`), so it is not *resolvable
+        // convergence work* and must not gate outbound sends. Without the
+        // ceiling, a single member could forge one far-future-epoch (e.g. 2^63)
+        // plaintext message whose buffered `Created` row is never materialized
+        // and never given a terminal disposition, permanently gating every send
+        // for the whole group. The row is left in storage (not dropped here), so
+        // it gates again correctly once the tip advances into `[anchor, ceiling]`.
+        let (anchor, ceiling) = match self.storage.get_group(group_id) {
             Ok(group) => {
                 let policy = self
                     .convergence_policy_for_group(group_id)
                     .map_err(|e| EngineError::Backend(format!("load convergence policy: {e}")))?;
-                group
-                    .epoch
-                    .0
-                    .saturating_sub(policy.convergence.max_rewind_commits)
+                let rewind = policy.convergence.max_rewind_commits;
+                (
+                    group.epoch.0.saturating_sub(rewind),
+                    group.epoch.0.saturating_add(rewind),
+                )
             }
             Err(StorageError::NotFound) => return Ok(false),
             Err(e) => return Err(EngineError::Storage(e)),
@@ -386,15 +399,27 @@ impl<S: StorageProvider> Engine<S> {
             ) {
                 continue;
             }
+            // Fail OPEN, not closed (mdk#736): a row we cannot decode, is not an
+            // openmls-wire payload, or cannot be projected is NOT resolvable
+            // convergence work — treating it as "unresolved" would let a single
+            // corrupt/garbage row permanently gate sends with no recovery path.
+            // Such a row simply does not contribute to the send gate; the
+            // convergence horizon (`openmls_projection`) is responsible for
+            // assigning it a terminal disposition.
             let Ok(stored_payload) = StoredMessagePayload::decode(&record.payload) else {
-                return Ok(true);
+                continue;
             };
             let Some(message) = stored_payload.as_openmls_wire() else {
-                return Ok(true);
+                continue;
             };
             let Ok(projection) = project_mls_message(&message.payload) else {
-                return Ok(true);
+                continue;
             };
+            // Beyond the future horizon: unreachable from the current tip, so
+            // not gating work (see the ceiling rationale above).
+            if projection.source_epoch.is_some_and(|epoch| epoch > ceiling) {
+                continue;
+            }
             // A lone uncommitted Proposal does NOT make canonical state
             // ambiguous: commits are the consensus log; a proposal only takes
             // effect once a commit consumes it (convergence.md:7-8). The

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -432,6 +432,22 @@ pub fn project_mls_message(
     })
 }
 
+/// Fail-open decode of a stored payload into its openmls-wire
+/// [`TransportMessage`] and MLS [`OpenMlsMessageProjection`]. Returns `None`
+/// when the row cannot be decoded, is not an openmls-wire payload, or does not
+/// project — the three-step `decode -> as_openmls_wire -> project_mls_message`
+/// chain used by the send-gate (mdk#752 review). Callers that must treat such a
+/// row as an error (e.g. a `Processed` row during a convergence apply) keep
+/// their own error-propagating chain rather than call this.
+pub(crate) fn decode_openmls_wire_projection(
+    payload: &[u8],
+) -> Option<(TransportMessage, OpenMlsMessageProjection)> {
+    let stored = StoredMessagePayload::decode(payload).ok()?;
+    let message = stored.as_openmls_wire()?.clone();
+    let projection = project_mls_message(&message.payload).ok()?;
+    Some((message, projection))
+}
+
 pub fn replay_openmls_messages<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -4397,6 +4397,17 @@ async fn far_future_convergence_input_beyond_ceiling_does_not_gate_sends() {
         .buffer_openmls_convergence_message(&group_id, far_future_msg.clone(), 1_000)
         .expect("far-future message buffered");
 
+    // Convergence is not perpetually unsettled on account of the beyond-ceiling
+    // row — this distinguishes "send gate fixed" from "convergence loop still
+    // wedged on the same forged input", which was the original failure mode.
+    assert!(
+        carol
+            .advance_convergence_inputs_until_settled(&group_id, 1_000_000)
+            .await
+            .unwrap(),
+        "beyond-ceiling row must not leave convergence perpetually unsettled"
+    );
+
     // The fix: the beyond-ceiling row does not gate, so Carol can still send.
     // Pre-fix this returned `SendResult::Queued` forever.
     let sent = carol
@@ -4484,6 +4495,96 @@ async fn undecodable_convergence_row_does_not_gate_sends() {
     assert!(
         matches!(sent, SendResult::ApplicationMessage { .. }),
         "an undecodable convergence row must not gate the send, got {sent:?}"
+    );
+    assert!(
+        carol_storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+/// mdk#752 review: the fail-open gate has three branches — decode failure
+/// (covered by `undecodable_convergence_row_does_not_gate_sends`), a decodable
+/// payload that is NOT openmls-wire, and an openmls-wire payload whose inner
+/// bytes do not project. The latter two are the branches an adversary is more
+/// likely to craft (a well-formed stored envelope wrapping non-MLS bytes), so
+/// pin them too.
+#[tokio::test]
+async fn non_wire_and_unprojectable_convergence_rows_do_not_gate_sends() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage) = build_client(b"carol");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-fail-open-branches".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![alice.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    carol.drain_events();
+
+    let tm = |payload: Vec<u8>| TransportMessage {
+        id: MessageId::new(b"inner".to_vec()),
+        payload,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("fail-open-branch".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    };
+
+    // Branch 2: a decodable stored payload that is NOT openmls-wire.
+    carol_storage
+        .put_message(&MessageRecord {
+            id: MessageId::new(b"not-openmls-wire-row".to_vec()),
+            group_id: group_id.clone(),
+            epoch: EpochId(1),
+            state: MessageState::Created,
+            payload: StoredMessagePayload::raw_transport(tm(b"raw-transport-bytes".to_vec()))
+                .encode()
+                .unwrap(),
+        })
+        .unwrap();
+
+    // Branch 3: an openmls-wire payload whose inner bytes do not project as MLS.
+    carol_storage
+        .put_message(&MessageRecord {
+            id: MessageId::new(b"unprojectable-wire-row".to_vec()),
+            group_id: group_id.clone(),
+            epoch: EpochId(1),
+            state: MessageState::Retryable,
+            payload: StoredMessagePayload::openmls_wire(tm(b"not-mls-bytes".to_vec()))
+                .encode()
+                .unwrap(),
+        })
+        .unwrap();
+
+    let sent = carol
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(&carol, b"send despite fail-open rows"),
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(sent, SendResult::ApplicationMessage { .. }),
+        "neither a non-wire nor an unprojectable convergence row may gate the send, got {sent:?}"
     );
     assert!(
         carol_storage

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -4322,6 +4322,177 @@ async fn engine_queues_app_send_until_convergence_is_settled() {
     );
 }
 
+/// mdk#736: a convergence input whose source epoch is beyond the FUTURE horizon
+/// (`current_tip + max_rewind_commits`) can never chain from the tip, so it is
+/// not resolvable convergence work and MUST NOT gate outbound sends. Before the
+/// fix, a single member could forge one far-future-epoch plaintext message whose
+/// buffered `Created`/`Retryable` row was never materialized and never given a
+/// terminal disposition, so `has_unresolved_convergence_inputs` reported the
+/// group unsettled forever and every send was queued and never drained — a
+/// durable, whole-group denial of service from one insider.
+#[tokio::test]
+async fn far_future_convergence_input_beyond_ceiling_does_not_gate_sends() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+    let (mut eve, _eve_storage) = build_client(b"eve");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-future-horizon-gate".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![alice.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    // Tight horizon so a small real epoch is already "far future": with the tip
+    // at epoch 1 and `max_rewind_commits = 1`, the ceiling is epoch 2.
+    carol.set_convergence_policy(CanonicalizationPolicy {
+        convergence: ConvergencePolicy {
+            max_rewind_commits: 1,
+            ..ConvergencePolicy::default()
+        },
+        ..CanonicalizationPolicy::default()
+    });
+    carol.drain_events();
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
+
+    // Alice advances her own copy to epoch 3 (Carol never ingests these), then
+    // frames an application message at epoch 3 — source_epoch 3, beyond Carol's
+    // ceiling of 2.
+    for invitee in [&mut david, &mut eve] {
+        let invitee_kp = invitee.fresh_key_package().await.unwrap();
+        let invite = alice
+            .send(SendIntent::Invite {
+                group_id: group_id.clone(),
+                key_packages: vec![invitee_kp],
+            })
+            .await
+            .unwrap();
+        let (_commit, pending) = evolution(invite);
+        alice.confirm_published(pending).await.unwrap();
+    }
+    let far_future_msg = send_app(&mut alice, &group_id, b"far future payload".to_vec()).await;
+    assert_eq!(
+        project_mls_message(&far_future_msg.payload)
+            .expect("far-future app projects")
+            .source_epoch,
+        Some(3)
+    );
+
+    carol
+        .buffer_openmls_convergence_message(&group_id, far_future_msg.clone(), 1_000)
+        .expect("far-future message buffered");
+
+    // The fix: the beyond-ceiling row does not gate, so Carol can still send.
+    // Pre-fix this returned `SendResult::Queued` forever.
+    let sent = carol
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(&carol, b"still able to send"),
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(sent, SendResult::ApplicationMessage { .. }),
+        "beyond-ceiling convergence input must not gate the send, got {sent:?}"
+    );
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
+    assert!(
+        carol_storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .is_empty()
+    );
+    // The forged row is NOT dropped — it stays retained so it would gate again
+    // (correctly) once the tip advances into `[anchor, ceiling]`.
+    assert_message_state(&carol_storage, &far_future_msg, MessageState::Created);
+}
+
+/// mdk#736 (related hardening): a `Created`/`Retryable` convergence row that
+/// cannot be decoded / is not an openmls-wire payload / fails projection is NOT
+/// resolvable convergence work and must fail OPEN (not gate sends). Before the
+/// fix, `has_unresolved_convergence_inputs` returned `true` on any such row,
+/// permanently gating sends with no recovery path.
+#[tokio::test]
+async fn undecodable_convergence_row_does_not_gate_sends() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage) = build_client(b"carol");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-fail-open-gate".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![alice.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    carol.drain_events();
+
+    // Inject a garbage convergence row within the gate's scan window (epoch 1)
+    // whose payload cannot be decoded as a stored message.
+    let garbage_id = MessageId::new(b"garbage-convergence-row".to_vec());
+    carol_storage
+        .put_message(&MessageRecord {
+            id: garbage_id.clone(),
+            group_id: group_id.clone(),
+            epoch: EpochId(1),
+            state: MessageState::Created,
+            payload: b"not-a-valid-stored-message-payload".to_vec(),
+        })
+        .unwrap();
+    assert!(
+        StoredMessagePayload::decode(&carol_storage.get_message(&garbage_id).unwrap().payload)
+            .is_err(),
+        "garbage row must fail to decode for this test to exercise the fail-open path"
+    );
+
+    // The fix: an undecodable row does not gate. Pre-fix this returned Queued.
+    let sent = carol
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(&carol, b"send despite garbage row"),
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(sent, SendResult::ApplicationMessage { .. }),
+        "an undecodable convergence row must not gate the send, got {sent:?}"
+    );
+    assert!(
+        carol_storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .is_empty()
+    );
+}
+
 #[tokio::test]
 async fn send_preflight_retries_deferred_peels_after_convergence_apply() {
     let (mut alice, _alice_storage) = build_client(b"alice");

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -68,6 +68,12 @@ versioning through the workspace version in the root `Cargo.toml`.
   components are also non-negotiable: an invitee whose KeyPackage omits them is rejected up front instead of the group
   being created with an empty admin set that permanently freezes all membership changes. Welcome-join applies the same
   admin-leaf check before accepting a group.
+- A single group member can no longer permanently disable another member's ability to send by broadcasting one crafted
+  far-future-epoch message. The convergence send-gate now bounds the future side of the horizon the same way it already
+  bounds the past: a buffered convergence input more than `max_rewind_commits` epochs ahead of the group tip (which can
+  never chain from the tip) no longer counts as unresolved work, and a convergence row that fails to decode/project now
+  fails open instead of closed. Previously such an input left the group reporting "unsettled" forever, so every outbound
+  send was queued and never drained, with no recovery short of manual database surgery.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

PR-A of a two-PR sweep closing the six `cgka-engine:` issues. This one covers the **convergence send-gate** cluster; the admin/identity-seam cluster (#728, #737, #746, #747) ships separately.

### #736 — unbounded future-epoch convergence input permanently gates all sends (HIGH, member-inflicted durable DoS)

The convergence send-gate (`has_unresolved_convergence_inputs`) bounded only the **past** side of the horizon (`>= anchor`) with **no future ceiling**, and **failed closed** on any decode/projection error. A single member could broadcast one crafted plaintext message with an attacker-chosen far-future epoch (e.g. `2^63`); every recipient buffered it as a durable `Created` row that convergence can never materialize (the candidate-path BFS only extends `source_epoch == tip_epoch`) and never assigns a terminal disposition. The gate then reported the group unsettled **forever**, so `do_send` queued every intent and the queue never drained — durable across restart, no recovery short of manual DB surgery.

**Fix** (symmetric to the existing past bound, reusing `max_rewind_commits`, `message_processor/mod.rs`):
- Add the missing **future ceiling**: a row whose projected `source_epoch > tip + max_rewind_commits` is not resolvable convergence work and does not gate. The row is **left in storage** (not dropped), so it gates again correctly once the tip advances into `[anchor, ceiling]`.
- **Fail open, not closed**: a row that fails decode / is not openmls-wire / fails projection no longer counts as unresolved work.

**Deliberately not added** — a terminal future-drop arm in the projection scan (the original plan's step 2). The candidate BFS legitimately chains a *contiguous* forward run of commits with no upper bound, and ingest buffers future-epoch inputs unbounded, so terminally dropping beyond-ceiling commits would discard data a lagging/out-of-order client still needs — a real convergence regression, unlike the past side which drops only already-applied history. The gate ceiling fixes the send-DoS without that risk.

**Follow-up (separate, lower severity):** unbounded future-epoch buffering at ingest is a storage/CPU-growth vector; bounding it safely needs transport re-delivery guarantees. I'll file it as its own issue.

### #745 — `emit_superseded_processed_commits` rescans the whole message table (LOW perf)

Listed from `EpochId(0)` and decoded/projected every row only to skip those below `fork_epoch`. Scoped the storage query to `EpochId(fork_epoch)` (`list_messages`' second arg is `at_or_after_epoch`) for an identical result set with bounded work.

## Tests

- `far_future_convergence_input_beyond_ceiling_does_not_gate_sends` — forged far-future input no longer queues sends; row stays retained.
- `undecodable_convergence_row_does_not_gate_sends` — garbage `Created` row fails open.
- Regressions green: `future_epoch_app_message_stays_retryable_until_commit_arrives`, `engine_queues_app_send_until_convergence_is_settled` (near-future within window still gates), `convergence_rollback_emits_commit_rolled_back_for_losing_branch`.

`just fast-ci` + `cargo test -p cgka-engine` pass.

Closes #736, closes #745.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/752">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where outgoing messages could be blocked by unusable convergence data, allowing sends to continue normally.
  * Improved handling of malformed or out-of-range stored records so they no longer stall messaging.
  * Reduced unnecessary convergence scanning, which may improve responsiveness in affected cases.

* **Chores**
  * Updated release notes to reflect the messaging reliability fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->