### PR TITLE
cgka-engine: close the admin/identity seam-parity gaps (#728, #737, #746, #747)

### DIFF
--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -436,6 +436,18 @@ pub(crate) fn member_account_pubkeys(mls_group: &MlsGroup) -> BTreeSet<[u8; 32]>
 /// resolves it from the joined group. Keeping them on one function is why a
 /// phantom/pre-provisioned admin can no longer slip in at a seam that "forgot"
 /// the check (mdk#737).
+///
+/// Note the callers build `member_accounts` on two different bases, and that is
+/// intentional. Creation uses `member_id_of_key_package` /
+/// `validated_member_id_of_leaf` (secp256k1-validated) because it is the
+/// authoring path and controls exactly which invitees it admits. The
+/// `MlsGroup`-backed callers use [`member_account_pubkeys`] /
+/// `credential_account_pubkey` (32-byte length only) because every leaf already
+/// present in the tree passed credential validation at its own ingress seam
+/// (welcome-join step 5b `validate_member_credentials_and_account_proofs`, and
+/// add/commit ingest), so the tree cannot carry an unvalidated member leaf here.
+/// The admin set (`decode_admin_policy`) is likewise length-only, so both sides
+/// of the coupling comparison share a basis.
 pub(crate) fn reject_admins_without_member_accounts(
     admins: &[[u8; 32]],
     member_accounts: &BTreeSet<[u8; 32]>,
@@ -446,7 +458,7 @@ pub(crate) fn reject_admins_without_member_accounts(
     }
     if admins.iter().any(|admin| !member_accounts.contains(admin)) {
         return Err(EngineError::Other(format!(
-            "admin-policy update is invalid: an admin key has no member leaf (group {group_id:?})"
+            "admin key has no member leaf (group {group_id:?})"
         )));
     }
     Ok(())
@@ -465,17 +477,28 @@ fn reject_admin_self_remove_proposals(
         if !matches!(queued.proposal(), Proposal::SelfRemove) {
             continue;
         }
-        // Resolve the sender through the shared, validating chokepoint
-        // (mdk#728): `identity::member_id_of_sender` runs
-        // `validate_credential_identity` (x-only secp256k1) before trusting a
-        // leaf's identity as a `MemberId`, exactly as the direct-ingest and
-        // stored-convergence seams do. A malformed identity resolves to `None`
-        // and is skipped — safe, because a malformed identity can never appear
-        // in the validated admin set it would be compared against.
-        let Some(sender) = crate::identity::member_id_of_sender(queued.sender(), mls_group) else {
-            continue;
+        // Resolve the sender's account pubkey on the SAME (length-based) basis
+        // the admin set is decoded on (`decode_admin_policy` /
+        // `credential_account_pubkey`), NOT the secp256k1-validating
+        // `identity::member_id_of_sender` (mdk#728 review). The admin set is not
+        // curve-validated, so a leaf whose 32-byte identity equals a listed
+        // admin key but fails secp256k1 validation would resolve to `None` under
+        // the validating chokepoint and SKIP this guard — letting that admin
+        // self-remove in violation of MIP-03. Matching the admin-set basis keeps
+        // both sides of the comparison comparable. Fail CLOSED: a `SelfRemove`
+        // whose sender cannot be resolved to a member account is rejected, never
+        // waved through (mirrors the Sm7 auto-committer / fork-recovery posture).
+        let sender_pubkey = match queued.sender() {
+            Sender::Member(leaf_idx) => mls_group
+                .member_at(*leaf_idx)
+                .and_then(|member| credential_account_pubkey(member.credential)),
+            _ => None,
         };
-        let sender_pubkey = admin_pubkey_from_member_id(&sender)?;
+        let Some(sender_pubkey) = sender_pubkey else {
+            return Err(EngineError::AdminCannotSelfRemove {
+                group_id: group_id.clone(),
+            });
+        };
         if admins.iter().any(|admin| admin == &sender_pubkey) {
             return Err(EngineError::AdminCannotSelfRemove {
                 group_id: group_id.clone(),

--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -412,16 +412,39 @@ pub(crate) fn reject_admins_without_member_leaf(
     group_id: &GroupId,
     admins: &[[u8; 32]],
 ) -> Result<(), EngineError> {
-    if admins.is_empty() {
-        return Ok(());
-    }
+    reject_admins_without_member_accounts(admins, &member_account_pubkeys(mls_group), group_id)
+}
+
+/// Member account pubkeys currently in the group's ratchet tree.
+pub(crate) fn member_account_pubkeys(mls_group: &MlsGroup) -> BTreeSet<[u8; 32]> {
     let mut accounts: BTreeSet<[u8; 32]> = BTreeSet::new();
     for member in mls_group.members() {
         if let Some(pk) = credential_account_pubkey(member.credential) {
             accounts.insert(pk);
         }
     }
-    if admins.iter().any(|admin| !accounts.contains(admin)) {
+    accounts
+}
+
+/// Core admin-leaf-coupling check (admin-policy-v1.md "Validation") over an
+/// explicit set of member account pubkeys: every admin key MUST correspond to a
+/// member account. This is the single validator shared by every seam that
+/// establishes or mutates a group's admin set — outbound component updates and
+/// commit apply resolve the set from the live `MlsGroup`
+/// ([`reject_admins_without_member_leaf`]); group creation resolves it from the
+/// projected creator+invitee set (no `MlsGroup` exists yet); welcome-join
+/// resolves it from the joined group. Keeping them on one function is why a
+/// phantom/pre-provisioned admin can no longer slip in at a seam that "forgot"
+/// the check (mdk#737).
+pub(crate) fn reject_admins_without_member_accounts(
+    admins: &[[u8; 32]],
+    member_accounts: &BTreeSet<[u8; 32]>,
+    group_id: &GroupId,
+) -> Result<(), EngineError> {
+    if admins.is_empty() {
+        return Ok(());
+    }
+    if admins.iter().any(|admin| !member_accounts.contains(admin)) {
         return Err(EngineError::Other(format!(
             "admin-policy update is invalid: an admin key has no member leaf (group {group_id:?})"
         )));
@@ -442,7 +465,14 @@ fn reject_admin_self_remove_proposals(
         if !matches!(queued.proposal(), Proposal::SelfRemove) {
             continue;
         }
-        let Some(sender) = member_id_of_sender(queued.sender(), mls_group) else {
+        // Resolve the sender through the shared, validating chokepoint
+        // (mdk#728): `identity::member_id_of_sender` runs
+        // `validate_credential_identity` (x-only secp256k1) before trusting a
+        // leaf's identity as a `MemberId`, exactly as the direct-ingest and
+        // stored-convergence seams do. A malformed identity resolves to `None`
+        // and is skipped — safe, because a malformed identity can never appear
+        // in the validated admin set it would be compared against.
+        let Some(sender) = crate::identity::member_id_of_sender(queued.sender(), mls_group) else {
             continue;
         };
         let sender_pubkey = admin_pubkey_from_member_id(&sender)?;
@@ -453,17 +483,6 @@ fn reject_admin_self_remove_proposals(
         }
     }
     Ok(())
-}
-
-fn member_id_of_sender(sender: &Sender, group: &MlsGroup) -> Option<MemberId> {
-    match sender {
-        Sender::Member(leaf_idx) => {
-            let member = group.member_at(*leaf_idx)?;
-            let basic = BasicCredential::try_from(member.credential).ok()?;
-            Some(MemberId::new(basic.identity().to_vec()))
-        }
-        _ => None,
-    }
 }
 
 /// Does this staged commit require the sender to be a group admin?

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -142,10 +142,12 @@ impl<S: StorageProvider> Engine<S> {
             parsed_kps.push(parsed);
         }
         required_caps.app_components = negotiated_components;
-        // Belt-and-suspenders (mdk#746): the engine-owned components survived
-        // negotiation. Guaranteed by the per-invitee guard above plus the
-        // engine's own support; the assert catches a future refactor of the
-        // negotiation flow that reintroduces the drop.
+        // Invariant check (mdk#746): the engine-owned components survived
+        // negotiation. The per-invitee guard above is the real runtime gate (it
+        // rejects any invitee lacking them in every build); this assertion just
+        // documents the post-condition and, because `cargo test` builds with
+        // debug assertions on, trips CI if a future negotiation refactor
+        // reintroduces the drop despite the guard.
         debug_assert!(
             mandatory_components
                 .missing_from(&required_caps.app_components)
@@ -163,6 +165,11 @@ impl<S: StorageProvider> Engine<S> {
         ])
         .map_err(|e| EngineError::Backend(format!("leaf extensions: {e:?}")))?;
 
+        // Validate the creator (implicit admin) on the SAME x-only secp256k1
+        // basis as the co-admins below (mdk#737 review), so no admin-set entry
+        // is accepted on length alone regardless of how the engine identity was
+        // constructed.
+        crate::identity::validate_credential_identity(self.identity.self_id().as_slice())?;
         let creator_pubkey =
             crate::app_components::admin_pubkey_from_member_id(self.identity.self_id())?;
         let mut admin_set: Vec<[u8; 32]> = vec![creator_pubkey];

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -101,6 +101,9 @@ impl<S: StorageProvider> Engine<S> {
         let mut parsed_kps = Vec::with_capacity(req.members.len());
         let mut negotiated_components =
             desired_components.intersection(&self.supported_app_components);
+        // Engine-owned components (profile + admin policy) are NON-NEGOTIABLE
+        // (mdk#746).
+        let mandatory_components = AppComponentSet::from(default_group_components());
         for kp in &req.members {
             let parsed = self.parse_key_package(kp)?;
             let had = capabilities_of_key_package(&parsed);
@@ -118,10 +121,37 @@ impl<S: StorageProvider> Engine<S> {
                     had: Box::new(had),
                 });
             }
+            // The per-invitee intersection below would otherwise let an invitee
+            // whose leaf omits the profile/admin-policy component negotiate it
+            // out. A group created without admin-policy bytes has an empty admin
+            // set and frozen membership — every admin-gated operation (and every
+            // later join) fails closed forever. Reject such an invitee up front,
+            // exactly like a missing required capability; legitimate clients
+            // always advertise these (mdk#746).
+            let mandatory_missing = mandatory_components.missing_from(&had.app_components);
+            if !mandatory_missing.is_empty() {
+                return Err(EngineError::MissingRequiredCapabilities {
+                    required: Box::new(GroupCapabilities {
+                        app_components: mandatory_components.clone(),
+                        ..GroupCapabilities::default()
+                    }),
+                    had: Box::new(had),
+                });
+            }
             negotiated_components = negotiated_components.intersection(&had.app_components);
             parsed_kps.push(parsed);
         }
         required_caps.app_components = negotiated_components;
+        // Belt-and-suspenders (mdk#746): the engine-owned components survived
+        // negotiation. Guaranteed by the per-invitee guard above plus the
+        // engine's own support; the assert catches a future refactor of the
+        // negotiation flow that reintroduces the drop.
+        debug_assert!(
+            mandatory_components
+                .missing_from(&required_caps.app_components)
+                .is_empty(),
+            "engine-owned components must not be negotiated out of a created group"
+        );
         let required_caps_ext = extension_from_group_capabilities(&required_caps);
 
         // 2. Build the group config with leaf capabilities, MLS
@@ -137,11 +167,16 @@ impl<S: StorageProvider> Engine<S> {
             crate::app_components::admin_pubkey_from_member_id(self.identity.self_id())?;
         let mut admin_set: Vec<[u8; 32]> = vec![creator_pubkey];
         for extra in &req.initial_admins {
+            // Validate each co-admin as a real x-only secp256k1 account key, not
+            // just a 32-byte blob (mdk#737); `admin_pubkey_from_member_id` only
+            // length-checks.
+            crate::identity::validate_credential_identity(extra.as_slice())?;
             let pk = crate::app_components::admin_pubkey_from_member_id(extra)?;
             if !admin_set.contains(&pk) {
                 admin_set.push(pk);
             }
         }
+        let admin_set_for_coupling = admin_set.clone();
 
         let app_data_ext = crate::app_components::app_data_dictionary_extension_for_group(
             &required_caps.app_components,
@@ -179,6 +214,30 @@ impl<S: StorageProvider> Engine<S> {
         )
         .map_err(|e| EngineError::Backend(format!("group new: {e:?}")))?;
         let group_id = GroupId::new(mls_group.group_id().as_slice().to_vec());
+
+        // Admin-leaf coupling at creation (mdk#737): every admin key MUST
+        // correspond to a member of the initial group (creator + invitees).
+        // `req.initial_admins` is independent of `req.members`, so without this
+        // a group could be created with a phantom/pre-provisioned admin that
+        // becomes active the instant a matching leaf appears — with no
+        // `AdminAdded` commit other members observe, bypassing the audit trail
+        // every commit seam enforces. Runs the SAME coupling validator those
+        // seams use, resolved against the PROJECTED initial member accounts (no
+        // post-merge MlsGroup exists yet). Placed before `add_members` so an
+        // invalid admin set produces no membership/commit side effects.
+        let mut projected_member_accounts = std::collections::BTreeSet::new();
+        projected_member_accounts.insert(creator_pubkey);
+        for parsed in &parsed_kps {
+            let member_id = member_id_of_key_package(parsed)?;
+            projected_member_accounts.insert(crate::app_components::admin_pubkey_from_member_id(
+                &member_id,
+            )?);
+        }
+        crate::app_components::reject_admins_without_member_accounts(
+            &admin_set_for_coupling,
+            &projected_member_accounts,
+            &group_id,
+        )?;
 
         // 3. Add members to produce a staged commit + welcome (skipped for
         //    solo creation). Publish-before-apply keeps the staged commit
@@ -530,6 +589,18 @@ impl<S: StorageProvider> Engine<S> {
         // signer leaf's MLS-authenticated account identity to be authorized for
         // admin-gated member additions (joining.md, admin-policy-v1.md).
         crate::app_components::require_admin(&mls_group, &group_id, &welcome_sender_id)?;
+
+        // 5e. Admin-leaf coupling on the joined group (mdk#737): reject a
+        // Welcome whose admin set lists an admin with no member leaf. The
+        // Welcome embeds the full ratchet tree, so every current member's leaf
+        // is present here — a phantom/pre-provisioned admin is detectable and
+        // must be rejected, mirroring the check every commit seam enforces so a
+        // joiner never silently accepts a group with a pre-provisioned admin.
+        crate::app_components::reject_admins_without_member_leaf(
+            &mls_group,
+            &group_id,
+            &crate::app_components::admins_of_group(&mls_group)?,
+        )?;
 
         // 6. Persist Marmot group record from signed group-context data.
         let mut group_record = Group {

--- a/crates/cgka-engine/src/key_package.rs
+++ b/crates/cgka-engine/src/key_package.rs
@@ -42,9 +42,14 @@ pub fn key_package_metadata(kp: &KeyPackage) -> Result<KeyPackageMetadata, Engin
     let crypto = RustCrypto::default();
     let key_package = validate_key_package(kp_in, &crypto)?;
     let member_id = crate::identity::validated_member_id_of_leaf(key_package.leaf_node())?;
+    // Validate the account-identity proof against the KeyPackage's OWN
+    // ciphersuite, matching `parse_key_package` (mdk#747). `DEFAULT_CIPHERSUITE`
+    // is correct only while the engine is single-ciphersuite; deriving it from
+    // the KeyPackage keeps these directory helpers consistent with the invite
+    // path the instant a second ciphersuite is supported.
     crate::account_identity_proof::validate_leaf_account_identity_proof(
         key_package.leaf_node(),
-        crate::DEFAULT_CIPHERSUITE,
+        key_package.ciphersuite(),
     )?;
     let key_package_ref = key_package
         .hash_ref(&crypto)
@@ -71,9 +76,11 @@ pub fn is_last_resort_key_package(kp: &KeyPackage) -> Result<bool, EngineError> 
     let crypto = RustCrypto::default();
     let key_package = validate_key_package(kp_in, &crypto)?;
     crate::identity::validated_member_id_of_leaf(key_package.leaf_node())?;
+    // See `key_package_metadata`: validate against the KeyPackage's own
+    // ciphersuite, not `DEFAULT_CIPHERSUITE` (mdk#747).
     crate::account_identity_proof::validate_leaf_account_identity_proof(
         key_package.leaf_node(),
-        crate::DEFAULT_CIPHERSUITE,
+        key_package.ciphersuite(),
     )?;
     Ok(key_package.last_resort())
 }

--- a/crates/cgka-engine/tests/capabilities.rs
+++ b/crates/cgka-engine/tests/capabilities.rs
@@ -225,12 +225,17 @@ fn build_engine_on_storage_with_registry_and_components(
 }
 
 #[tokio::test]
-async fn group_creation_negotiates_app_component_intersection() {
-    let mut alice = build_engine_with_components(
-        b"alice",
-        [GROUP_PROFILE_COMPONENT_ID, GROUP_ADMIN_POLICY_COMPONENT_ID],
-    );
-    let mut bob = build_engine_with_components(b"bob", [GROUP_PROFILE_COMPONENT_ID]);
+async fn group_creation_retains_non_negotiable_mandatory_components() {
+    // Engine-owned components (profile + admin policy) are non-negotiable at
+    // creation (mdk#746). Even when an invitee advertises exactly the mandatory
+    // set — a subset of the creator's broader support — the created group still
+    // requires both; they can no longer be intersected out (which would leave an
+    // empty admin set and frozen membership). A NON-mandatory component the
+    // creator merely supports but does not require is not forced in.
+    let mut alice_supported = default_group_components();
+    alice_supported.insert(TEST_APP_COMPONENT);
+    let mut alice = build_engine_with_components(b"alice", alice_supported);
+    let mut bob = build_engine_with_components(b"bob", default_group_components());
     let bob_kp = bob.fresh_key_package().await.unwrap();
 
     let constructable = alice
@@ -242,7 +247,7 @@ async fn group_creation_negotiates_app_component_intersection() {
             .contains(GROUP_PROFILE_COMPONENT_ID)
     );
     assert!(
-        !constructable
+        constructable
             .app_components
             .contains(GROUP_ADMIN_POLICY_COMPONENT_ID)
     );
@@ -267,10 +272,16 @@ async fn group_creation_negotiates_app_component_intersection() {
             .contains(GROUP_PROFILE_COMPONENT_ID)
     );
     assert!(
-        !group
+        group
             .required_capabilities
             .app_components
             .contains(GROUP_ADMIN_POLICY_COMPONENT_ID)
+    );
+    assert!(
+        !group
+            .required_capabilities
+            .app_components
+            .contains(TEST_APP_COMPONENT)
     );
 }
 

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -10,7 +10,7 @@ use cgka_engine::account_identity_proof::{
     ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE, account_identity_proof_extension,
 };
 use cgka_engine::feature_registry::FeatureRegistry;
-use cgka_engine::key_package::is_last_resort_key_package;
+use cgka_engine::key_package::{is_last_resort_key_package, key_package_metadata};
 use cgka_engine::{Engine, EngineBuilder};
 use cgka_traits::EngineError;
 use cgka_traits::app_components::{
@@ -401,6 +401,97 @@ async fn create_group_with_three_members_happy_path() {
             }
         }
     }
+}
+
+/// mdk#737: an admin key that corresponds to no initial member (creator or
+/// invitee) is a phantom/pre-provisioned admin — it would become active the
+/// instant a matching leaf appears, with no `AdminAdded` commit other members
+/// observe. Group creation must reject it, mirroring the admin-leaf-coupling
+/// check every commit seam enforces.
+#[tokio::test]
+async fn create_group_rejects_uninvited_initial_admin() {
+    let mut alice = build_client_with_components(b"alice", default_group_components());
+    let mut bob = build_client_with_components(b"bob", default_group_components());
+    let mallory = build_client_with_components(b"mallory", default_group_components());
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let err = alice
+        .create_group(CreateGroupRequest {
+            name: "phantom-admin".into(),
+            description: "".into(),
+            members: vec![bob_kp], // bob invited; mallory NOT a member
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![mallory.self_id()],
+        })
+        .await
+        .expect_err("an uninvited initial admin must be rejected");
+    assert!(
+        matches!(err, EngineError::Other(ref msg) if msg.contains("no member leaf")),
+        "expected admin-leaf-coupling rejection, got {err:?}"
+    );
+}
+
+/// mdk#737 positive control: a co-admin who IS an invited member is accepted.
+#[tokio::test]
+async fn create_group_accepts_invited_initial_admin() {
+    let mut alice = build_client_with_components(b"alice", default_group_components());
+    let mut bob = build_client_with_components(b"bob", default_group_components());
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let (group_id, _result) = alice
+        .create_group(CreateGroupRequest {
+            name: "co-admin".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .expect("an invited co-admin is accepted");
+    assert_eq!(alice.members(&group_id).unwrap().len(), 2);
+}
+
+/// mdk#746: an invitee whose KeyPackage omits an engine-owned mandatory
+/// component (here admin policy) is rejected at creation, instead of the
+/// component being negotiated out — which would create a group with an empty
+/// admin set and permanently frozen membership.
+#[tokio::test]
+async fn create_group_rejects_invitee_missing_mandatory_component() {
+    let mut alice = build_client_with_components(b"alice", default_group_components());
+    // Bob advertises only the profile component, NOT admin policy.
+    let mut bob = build_client_with_components(b"bob", [GROUP_PROFILE_COMPONENT_ID]);
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let err = alice
+        .create_group(CreateGroupRequest {
+            name: "missing-mandatory".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .expect_err("an invitee missing a mandatory component must be rejected");
+    assert!(
+        matches!(err, EngineError::MissingRequiredCapabilities { ref required, .. }
+            if required.app_components.contains(GROUP_ADMIN_POLICY_COMPONENT_ID)),
+        "expected MissingRequiredCapabilities naming admin policy, got {err:?}"
+    );
+}
+
+/// mdk#747: the transport-directory KeyPackage helpers validate the account
+/// identity proof against the KeyPackage's OWN ciphersuite (matching
+/// `parse_key_package`), so a validly-proofed KeyPackage passes both.
+#[tokio::test]
+async fn directory_key_package_helpers_validate_against_own_ciphersuite() {
+    let mut alice = build_client(b"alice", selfremove_registry());
+    let kp = alice.fresh_key_package().await.unwrap();
+    let meta = key_package_metadata(&kp).expect("key_package_metadata validates the proof");
+    assert!(!meta.credential_identity_hex.is_empty());
+    assert!(is_last_resort_key_package(&kp).expect("last-resort check validates the proof"));
 }
 
 #[tokio::test]
@@ -873,12 +964,20 @@ async fn join_welcome_rejected_when_client_lacks_required_app_component() {
     // advertising a custom app component; alice requires it; carol then rejoins
     // with an engine that does not support that component.
     const CUSTOM_COMPONENT: u16 = 0xF300;
-    let mut alice = build_client_with_components(b"alice", [CUSTOM_COMPONENT]);
+    // Advertise the engine-owned mandatory components (profile + admin policy)
+    // alongside the custom one: they are non-negotiable at creation (mdk#746),
+    // so an invitee KP that omitted them would be rejected at create time before
+    // this test could reach the join-capability path it exercises.
+    let components: Vec<u16> = default_group_components()
+        .into_iter()
+        .chain([CUSTOM_COMPONENT])
+        .collect();
+    let mut alice = build_client_with_components(b"alice", components.clone());
     let carol_storage = SqliteAccountStorage::in_memory().unwrap();
     let capable_carol = EngineBuilder::new(carol_storage.clone())
         .identity(pad32(b"carol"))
         .account_identity_proof_signer(proof_signer(b"carol"))
-        .supported_app_components([CUSTOM_COMPONENT])
+        .supported_app_components(components)
         .peeler(Box::new(MockPeeler))
         .build()
         .expect("build capable carol");

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -432,6 +432,32 @@ async fn create_group_rejects_uninvited_initial_admin() {
     );
 }
 
+/// mdk#737 review: an `initial_admins` entry that is 32 bytes but not a valid
+/// x-only secp256k1 key is rejected (not accepted on length alone). Guards the
+/// new `validate_credential_identity` call on the co-admin path.
+#[tokio::test]
+async fn create_group_rejects_off_curve_initial_admin() {
+    let mut alice = build_client_with_components(b"alice", default_group_components());
+    let mut bob = build_client_with_components(b"bob", default_group_components());
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let err = alice
+        .create_group(CreateGroupRequest {
+            name: "off-curve-admin".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![MemberId::new(vec![0xFF; 32])],
+        })
+        .await
+        .expect_err("an off-curve 32-byte admin identity must be rejected");
+    assert!(
+        matches!(err, EngineError::InvalidCredentialIdentity(_)),
+        "expected InvalidCredentialIdentity, got {err:?}"
+    );
+}
+
 /// mdk#737 positive control: a co-admin who IS an invited member is accepted.
 #[tokio::test]
 async fn create_group_accepts_invited_initial_admin() {

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -1648,6 +1648,79 @@ async fn join_accepts_welcome_from_fork_with_self_promoted_admin() {
 }
 
 #[tokio::test]
+async fn join_rejects_welcome_whose_admin_set_lists_a_phantom_admin() {
+    // mdk#737: welcome-join runs the admin-leaf-coupling check (step 5e). A fork
+    // whose rewritten admin policy lists a pubkey with NO ratchet-tree leaf — a
+    // phantom/pre-provisioned admin — is rejected at join, before any group
+    // record is persisted. This is distinct from the self-promotion case in
+    // `join_accepts_welcome_from_fork_with_self_promoted_admin`, where the forger
+    // holds a real leaf (coupling satisfied) and the residual gap is a documented
+    // Welcome-bootstrap-trust limit, not a coupling violation.
+    let mut alice = build_client(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let mut carol = build_client(b"carol");
+    let mut david = build_client(b"david");
+    let mallory = build_client(b"mallory"); // valid account key, never a member
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "welcome-fork-phantom-admin".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (welcome_for_bob, welcome_for_carol) = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            (welcomes.remove(0), welcomes.remove(0))
+        }
+        _ => unreachable!(),
+    };
+    bob.join_welcome(welcome_for_bob).await.unwrap();
+    carol.join_welcome(welcome_for_carol).await.unwrap();
+
+    // Bob forks: ONE commit adds david AND rewrites admin policy to
+    // {alice, bob, mallory}. Bob is included so the fork passes the join-time
+    // `require_admin` author check (5d) and reaches the coupling check (5e);
+    // mallory is a valid account key with NO leaf — the phantom that 5e rejects.
+    let forged_admins = encode_admin_policy_for_test(&[
+        alice.self_id().as_slice().to_vec(),
+        bob.self_id().as_slice().to_vec(),
+        mallory.self_id().as_slice().to_vec(),
+    ]);
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let malicious_welcome = welcome_from_fork_with_self_promoted_admin(
+        &bob_storage,
+        &bob.self_id(),
+        &group_id,
+        &david_kp,
+        forged_admins,
+    );
+
+    let err = david
+        .join_welcome(malicious_welcome)
+        .await
+        .expect_err("a Welcome whose admin set lists a phantom admin must be rejected");
+    assert!(
+        matches!(err, EngineError::Other(ref msg) if msg.contains("no member leaf")),
+        "expected admin-leaf-coupling rejection at join, got {err:?}"
+    );
+    assert!(
+        david.members(&group_id).is_err(),
+        "david must not hold any joined group state after a rejected join"
+    );
+}
+
+#[tokio::test]
 async fn engine_rejects_malformed_local_credential_identity_at_build() {
     // foundation/identity.md: a Marmot credential identity MUST be a valid
     // 32-byte x-only secp256k1 public key. A short, non-curve identity is

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -41,6 +41,13 @@ versioning through the workspace version in the root `Cargo.toml`.
   to dial (300 s) and the TLS handshake; broker control frames are capped at 256 bytes pre-auth (previously a peer
   could demand a ~66 KB allocation per stream before validation); and broker frame reads apply one deadline across the
   whole frame, so a peer dribbling one byte per timeout window can no longer stretch pre-auth reads.
+- Group creation now enforces the same admin-policy invariants every commit already enforces. A group can no longer be
+  created listing an admin who is not one of the initial members (a "phantom" admin that would silently gain admin
+  rights the moment a matching member joined, with no admin-grant event anyone observes), and admin identities are
+  validated as real secp256k1 keys rather than accepted on length alone. The engine-owned profile and admin-policy
+  components are also non-negotiable: an invitee whose KeyPackage omits them is rejected up front instead of the group
+  being created with an empty admin set that permanently freezes all membership changes. Welcome-join applies the same
+  admin-leaf check before accepting a group.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

PR-B of a two-PR sweep closing the six `cgka-engine:` issues (PR-A [#752](https://github.com/marmot-protocol/mdk/pull/752) covered the convergence send-gate). These four are **one meta-defect** — an invariant enforced at some seams but not all of them, the crate's own *"a guard that exists on one seam only is a bug"* rule (mdk#707). Where cheap, the fix collapses duplicated logic onto a single chokepoint so the next seam can't drift.

### #728 — third sender resolver bypassed identity validation
`app_components.rs` had a private `member_id_of_sender` that built a `MemberId` via raw `BasicCredential::try_from`, skipping the `validate_credential_identity` (x-only secp256k1) check the shared `identity::member_id_of_sender` runs on the direct-ingest and stored-convergence seams. **Deleted the copy**; the admin-self-remove policy path now resolves through the validating chokepoint. A malformed-identity sender resolves to `None` and is skipped — safe, since a malformed identity can never be in the validated admin set it would be compared against.

### #737 (MEDIUM) — creation & welcome-join skipped admin-leaf coupling
Every commit seam runs `validate_admin_leaf_coupling_*`, but `do_create_group` and `do_join_welcome` didn't — letting a group be created with a phantom/pre-provisioned admin (`initial_admins` is independent of `members`) that activates the instant a matching leaf appears, with no `AdminAdded` event other members observe. Extracted the set-membership core into **`reject_admins_without_member_accounts`** (one validator, three callers). Creation now x-only-validates each `initial_admins` entry and runs the coupling check against the projected creator+invitee accounts *before* any membership side effects; welcome-join runs it against the joined group.

### #746 — mandatory components negotiable out at creation
Profile + admin-policy lived in `desired_components` but not `required_caps`, so the per-invitee intersection let an invitee whose KeyPackage omitted them negotiate them out — creating a group with an **empty admin set and permanently frozen membership**. Treat `default_group_components()` as non-negotiable: reject an invitee lacking them up front (like a missing required capability), plus a post-negotiation assert.

### #747 (LOW/latent) — proof validated against the wrong ciphersuite
`key_package_metadata` / `is_last_resort_key_package` validated the account-identity proof against a hardcoded `DEFAULT_CIPHERSUITE`, while `parse_key_package` uses the KeyPackage's own ciphersuite — they'd disagree the moment a second ciphersuite exists. Derive it from the KeyPackage in both helpers.

## Tests

New: `create_group_rejects_uninvited_initial_admin` (+ `create_group_accepts_invited_initial_admin` control), `create_group_rejects_invitee_missing_mandatory_component`, `directory_key_package_helpers_validate_against_own_ciphersuite`.

Updated two existing tests that **encoded the #746 bug** (asserting admin-policy gets silently negotiated out) to assert the fixed non-negotiable behavior. Existing admin-self-remove tests cover the #728 valid-path parity.

`just fast-ci` + `cargo test -p cgka-engine` pass.

Closes #728, closes #737, closes #746, closes #747.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/753">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->