### PR TITLE
refactor(uniffi)!: rename MarkdownBlockFfi::List to ListBlock to avoid shadowing kotlin,.collections.List and let Android drop its binding patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -712,7 +712,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "hex",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "tempfile",
 ]
@@ -2538,7 +2538,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "marmot-account"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -2565,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "fs-private",
  "serde",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -4386,7 +4386,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.0"
+version = "0.9.1"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.0",
+  "conformance_version": "0.9.1",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.0",
+  "conformance_version": "0.9.1",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.0",
+  "conformance_version": "0.9.1",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.0",
+  "conformance_version": "0.9.1",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.0",
+  "conformance_version": "0.9.1",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.0",
+  "conformance_version": "0.9.1",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.0",
+  "conformance_version": "0.9.1",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.0",
+  "conformance_version": "0.9.1",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.0",
+  "conformance_version": "0.9.1",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.0",
+  "conformance_version": "0.9.1",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.0",
+  "conformance_version": "0.9.1",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.0",
+  "conformance_version": "0.9.1",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.0",
+  "conformance_version": "0.9.1",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/marmot-uniffi/src/markdown.rs
+++ b/crates/marmot-uniffi/src/markdown.rs
@@ -41,7 +41,9 @@ pub enum MarkdownBlockFfi {
     BlockQuote {
         blocks: Vec<MarkdownBlockFfi>,
     },
-    List {
+    /// Named `ListBlock` (not `List`) to match the sibling `*Block` variants and
+    /// to avoid shadowing `kotlin.collections.List` in generated Kotlin bindings.
+    ListBlock {
         kind: MarkdownListKindFfi,
         tight: bool,
         items: Vec<MarkdownListItemFfi>,
@@ -243,7 +245,7 @@ fn markdown_block_from_md(value: &MdBlock, depth: usize) -> MarkdownBlockFfi {
                 .map(|block| markdown_block_from_md(block, depth + 1))
                 .collect(),
         },
-        MdBlock::List { kind, tight, items } => MarkdownBlockFfi::List {
+        MdBlock::List { kind, tight, items } => MarkdownBlockFfi::ListBlock {
             kind: kind.into(),
             tight: *tight,
             items: items
@@ -545,6 +547,19 @@ mod tests {
     }
 
     #[test]
+    fn bridges_bullet_list() {
+        let document = parse_markdown_document("- a\n- b");
+        assert!(matches!(
+            document.blocks[0],
+            MarkdownBlockFfi::ListBlock {
+                kind: MarkdownListKindFfi::Bullet { ref marker },
+                ref items,
+                ..
+            } if marker == "-" && items.len() == 2
+        ));
+    }
+
+    #[test]
     fn bridges_pathological_nesting_without_unbounded_recursion() {
         let document = parse_markdown_document(&">".repeat(2_000));
         assert!(max_block_depth(&document.blocks) <= MAX_FFI_MARKDOWN_DEPTH);
@@ -557,7 +572,7 @@ mod tests {
     fn max_single_block_depth(block: &MarkdownBlockFfi) -> usize {
         match block {
             MarkdownBlockFfi::BlockQuote { blocks } => 1 + max_block_depth(blocks),
-            MarkdownBlockFfi::List { items, .. } => {
+            MarkdownBlockFfi::ListBlock { items, .. } => {
                 1 + items
                     .iter()
                     .map(|item| max_block_depth(&item.blocks))


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/754">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Markdown bridge to expose list blocks under a clearer name, reducing naming conflicts in generated bindings.
  * Improved Markdown support for parsing bullet lists (including additional coverage).
* **Chores**
  * Bumped the workspace version from `0.9.0` to `0.9.1`.
  * Updated conformance vector metadata to `0.9.1` across affected test vectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->