### PR TITLE
[codex] fix UniFFI group id validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,10 @@ The canonical protocol specification lives in
 - Keep Tamarin model names, Rust test names, and vector names easy to grep across layers.
 - Keep protocol principles and app-component documents implementation-neutral in `marmot-protocol/marmot`. Local engine,
   storage, queue, and diagnostic notes belong in architecture docs or crate docs here.
+- Keep MLS group ids distinct from transport routing ids. `GroupId` is opaque MLS group id bytes; OpenMLS-generated ids
+  are 16 bytes today, but spec surfaces that bind raw MLS group ids length-prefix them because they are variable-length.
+  `nostr_group_id` / `transport_group_id` is the 32-byte Nostr routing handle. Do not apply the 32-byte Nostr route-id
+  rule to `GroupId` validation, FFI parsing, storage lookups, or CLI/app group-id filters.
 - Keep tracing/logging privacy-safe: explicit crate/module `target` and `method` fields, aggregate values only, and no
   account ids, group ids, message ids, relay URLs, pubkeys, payloads, ciphertext, plaintext, or key material. See
   `docs/marmot-architecture/overview/observability.md`.

--- a/crates/marmot-uniffi/AGENTS.md
+++ b/crates/marmot-uniffi/AGENTS.md
@@ -16,6 +16,9 @@ UniFFI bindings for the Marmot app runtime. Read `README.md` first for build scr
 - Android consumers must call `MarmotAndroid.initialize(context)` before constructing `Marmot` (Keystore JNI via
   `ndk-context`).
 - Endpoint env vars set route URLs only; bearer tokens and runtime secrets stay with the host app.
+- Host-supplied `group_id_hex` values are variable-length MLS `GroupId` bytes, not Nostr `nostr_group_id` route handles.
+  Accept non-empty opaque MLS group ids, including the 16-byte ids OpenMLS generates for MDK today, and do not validate
+  them with the 32-byte route-id/pubkey/message-id rule.
 - Keep binding changes in lockstep with `marmot-app` public API changes; bump the workspace version when UniFFI records,
   enums, object methods, or error variants change.
 

--- a/crates/marmot-uniffi/src/conversions/common.rs
+++ b/crates/marmot-uniffi/src/conversions/common.rs
@@ -5,6 +5,11 @@ use marmot_app::SelfMembership;
 
 use crate::markdown::{MarkdownDocumentFfi, parse_markdown_document};
 
+// MLS group ids are opaque bytes. OpenMLS-generated ids are 16 bytes today,
+// but protocol surfaces that bind raw MLS group ids treat them as variable
+// length and cap them at 1024 bytes.
+const MLS_GROUP_ID_MAX_LEN: usize = 1024;
+
 /// The local account's own membership in a group: an active `Member`, or a
 /// terminal state describing how it left — `Left` (a voluntary self-removal or
 /// declined invite) or `Removed` (evicted by another member). Surfaced on both
@@ -50,13 +55,19 @@ pub(crate) fn markdown_content_tokens(kind: u64, plaintext: &str) -> MarkdownDoc
 
 /// Decode a hex-encoded group id back into the engine's byte newtype.
 pub fn group_id_from_hex(group_id_hex: &str) -> Result<GroupId, crate::errors::MarmotKitError> {
+    let group_id_hex = group_id_hex.trim();
+    if group_id_hex.len() > MLS_GROUP_ID_MAX_LEN * 2 {
+        return Err(crate::errors::MarmotKitError::InvalidHex {
+            details: format!("group id exceeds {MLS_GROUP_ID_MAX_LEN} bytes"),
+        });
+    }
     let bytes =
         hex::decode(group_id_hex).map_err(|err| crate::errors::MarmotKitError::InvalidHex {
             details: err.to_string(),
         })?;
-    if bytes.len() != 32 {
+    if bytes.is_empty() {
         return Err(crate::errors::MarmotKitError::InvalidHex {
-            details: format!("expected 32-byte group id, got {} bytes", bytes.len()),
+            details: "group id must not be empty".into(),
         });
     }
     Ok(GroupId::new(bytes))

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -187,13 +187,20 @@ mod tests {
         // Uppercase + surrounding whitespace canonicalize to lowercase hex so the
         // case-sensitive storage match and live filter compare against the same form.
         assert_eq!(
-            optional_group_id_hex(Some(format!(" {} ", "AB".repeat(32)))).unwrap(),
-            Some("ab".repeat(32))
+            optional_group_id_hex(Some(format!(" {} ", "AB".repeat(16)))).unwrap(),
+            Some("ab".repeat(16))
+        );
+        // MLS group ids are opaque variable-length bytes. MDK-created OpenMLS
+        // ids are 16 bytes today, but the FFI boundary must not reject other
+        // non-empty lengths before storage/runtime can resolve them.
+        assert_eq!(
+            optional_group_id_hex(Some("ABCD".into())).unwrap(),
+            Some("abcd".into())
         );
         // Invalid hex is rejected rather than silently yielding empty history.
         assert!(optional_group_id_hex(Some("nothex".into())).is_err());
-        // Hex that decodes but is not a Marmot 32-byte group id is rejected at
-        // the FFI boundary instead of surfacing later as UnknownGroup.
-        assert!(optional_group_id_hex(Some("abcd".into())).is_err());
+        // Absurdly large group ids are rejected at the FFI boundary instead of
+        // allocating arbitrary host input.
+        assert!(optional_group_id_hex(Some("ab".repeat(1025))).is_err());
     }
 }

--- a/crates/marmot-uniffi/tests/smoke.rs
+++ b/crates/marmot-uniffi/tests/smoke.rs
@@ -434,7 +434,7 @@ async fn notification_binding_methods_are_public_and_validate_missing_accounts()
             "missing".into(),
             PushPlatformFfi::Fcm,
             "opaque-token".into(),
-            "00".repeat(32),
+            "00aa".into(),
             None,
         )
         .await
@@ -442,7 +442,7 @@ async fn notification_binding_methods_are_public_and_validate_missing_accounts()
     );
     assert!(kit.clear_push_registration("missing".into()).await.is_err());
     assert!(
-        kit.group_push_debug_info("missing".into(), "00".repeat(32))
+        kit.group_push_debug_info("missing".into(), "00aa".into())
             .await
             .is_err()
     );
@@ -765,7 +765,7 @@ async fn chat_list_binding_methods_are_public_and_validate_inputs() {
     assert!(format!("{invalid_group}").contains("invalid hex"));
 
     let invalid_message = kit
-        .mark_timeline_message_read("missing".into(), "00".repeat(32), "not-hex".into())
+        .mark_timeline_message_read("missing".into(), "00aa".into(), "not-hex".into())
         .expect_err("invalid message hex should fail before account lookup");
     assert!(format!("{invalid_message}").contains("invalid hex"));
 
@@ -808,11 +808,7 @@ async fn message_history_binding_methods_validate_group_hex() {
     // then fails on the missing account, proving the value was canonicalized
     // rather than treated as an opaque host string.
     let missing_account = kit
-        .messages(
-            "missing".into(),
-            Some(format!(" {} ", "AB".repeat(32))),
-            Some(25),
-        )
+        .messages("missing".into(), Some(" ABCD ".into()), Some(25))
         .expect_err("missing account should fail after hex validation");
     assert!(format!("{missing_account}").contains("missing"));
 }
@@ -839,7 +835,7 @@ async fn retry_group_convergence_binding_is_public_and_validates_inputs() {
     // Valid hex gets past validation and then fails on the missing account,
     // proving the value was decoded rather than treated as an opaque string.
     let missing_account = kit
-        .retry_group_convergence("missing".into(), "AB".repeat(32))
+        .retry_group_convergence("missing".into(), "ABCD".into())
         .await
         .expect_err("missing account should fail after hex validation");
     assert!(format!("{missing_account}").contains("missing"));


### PR DESCRIPTION
## Summary

Fix the UniFFI `group_id_hex` boundary so it treats host-supplied group ids as opaque MLS `GroupId` bytes instead of applying the 32-byte Nostr route-id rule.

## Root cause

A recent Nostr transport hardening correctly enforced 32-byte `nostr_group_id` / `h` tag route ids. That rule leaked into UniFFI `group_id_hex` parsing, but those values are MLS group ids: private, opaque, and variable-length. OpenMLS-generated ids are 16 bytes today, and protocol surfaces that bind raw MLS group ids length-prefix them rather than fixing them to 32 bytes.

## Changes

- Validate UniFFI group ids as non-empty hex with a 1024-byte cap, not exactly 32 bytes.
- Add regression coverage proving non-16/non-32 opaque group ids can pass FFI shape validation and resolve later through storage/runtime.
- Update AGENTS guidance to keep MLS group ids distinct from 32-byte Nostr routing ids.

## Validation

- `cargo test -p marmot-uniffi`
- `cargo fmt --check`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/770">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group IDs now accept valid non-empty MLS byte values instead of incorrectly requiring a fixed 32-byte format.
  * Hex input is trimmed before validation, so IDs with surrounding whitespace are handled more consistently.
  * Extremely large group ID values are rejected to avoid invalid or oversized input.

* **Documentation**
  * Clarified accepted group ID formats and validation rules in developer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->