### PR TITLE
marmot-uniffi: expose encrypted group avatars (download_group_image + image_hash_hex)

### DIFF
--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1492,7 +1492,10 @@ impl AppClient {
     }
 
     /// Fetch + decrypt the group's avatar. Errors when the group has no image set.
-    pub async fn download_group_image(&mut self, group_id: &GroupId) -> Result<Vec<u8>, AppError> {
+    pub async fn download_group_blossom_image(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<Vec<u8>, AppError> {
         self.ensure_group(group_id)?;
         self.sync_runtime_groups().await?;
         let input = self.image_for_group(group_id);

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -1043,7 +1043,7 @@ async fn handle_account_worker_command(
             let _ = respond.send(result);
         }
         AccountWorkerCommand::DownloadGroupImage { group_id, respond } => {
-            let result = client.download_group_image(&group_id).await;
+            let result = client.download_group_blossom_image(&group_id).await;
             let _ = respond.send(result);
         }
         AccountWorkerCommand::SendMessage {

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -439,7 +439,7 @@ impl AccountManager {
         Ok(summary)
     }
 
-    pub async fn download_group_image(
+    pub async fn download_group_blossom_image(
         &self,
         account_ref: &str,
         group_id: &GroupId,

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -1231,13 +1231,13 @@ impl MarmotAppRuntime {
             .await
     }
 
-    pub async fn download_group_image(
+    pub async fn download_group_blossom_image(
         &self,
         account_ref: &str,
         group_id: &GroupId,
     ) -> Result<Vec<u8>, AppError> {
         self.accounts
-            .download_group_image(account_ref, group_id)
+            .download_group_blossom_image(account_ref, group_id)
             .await
     }
 

--- a/crates/marmot-uniffi/kotlin-bindings.sh
+++ b/crates/marmot-uniffi/kotlin-bindings.sh
@@ -188,16 +188,25 @@ rm -rf "$OUT_DIR"
 mkdir -p "$KOTLIN_OUT_DIR" "$JNI_OUT_DIR"
 
 echo "==> Building host dylib (used for binding generation)"
-cargo build --release -p "$CRATE_NAME" "${FEATURE_ARGS[@]}"
+# The host dylib must keep its symbol table: uniffi-bindgen's library mode
+# reads the uniffi metadata through it, and with RUSTFLAGS="-C strip=symbols"
+# (release.sh sets it for the Android .so's) bindgen exits 0 while emitting
+# NOTHING. Strip only the Android target builds below, never this one.
+RUSTFLAGS="" cargo build --release -p "$CRATE_NAME" "${FEATURE_ARGS[@]}"
 
 echo "==> Generating Kotlin bindings"
-cargo run --release -p "$CRATE_NAME" --features "$BINDGEN_FEATURES" --bin uniffi-bindgen -- \
+RUSTFLAGS="" cargo run --release -p "$CRATE_NAME" --features "$BINDGEN_FEATURES" --bin uniffi-bindgen -- \
   generate \
   --library "$(host_dylib_path)" \
   --language kotlin \
   --config "$CRATE_DIR/uniffi.toml" \
   --no-format \
   --out-dir "$KOTLIN_OUT_DIR"
+
+if [[ ! -f "$KOTLIN_OUT_DIR/dev/ipf/marmotkit/${LIB_BASENAME}.kt" ]]; then
+  echo "error: uniffi-bindgen produced no Kotlin binding (host dylib missing uniffi metadata?)" >&2
+  exit 1
+fi
 
 echo "==> Copying hand-written Android Kotlin support (ndk-context init bridge)"
 # kotlin-support/ mirrors the Kotlin package layout, so copying its contents into

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -403,6 +403,25 @@ impl Marmot {
         Ok(summary.into())
     }
 
+    /// Fetch and decrypt the group's encrypted Blossom avatar
+    /// (`marmot.group.blossom.image.v1`) into raw image bytes (PNG/JPEG/…).
+    /// Errors when the group has no Blossom image set. Presence and the
+    /// content hash (for caching) are on `AppGroupRecordFfi::image_hash_hex`;
+    /// when the group also carries a URL avatar, the URL takes precedence
+    /// for rendering.
+    pub async fn download_group_image(
+        &self,
+        account_ref: String,
+        group_id_hex: String,
+    ) -> Result<Vec<u8>, MarmotKitError> {
+        let group_id = group_id_from_hex(&group_id_hex)?;
+        let bytes = self
+            .runtime
+            .download_group_image(&account_ref, &group_id)
+            .await?;
+        Ok(bytes)
+    }
+
     /// Set (or clear, with `url = None`) the group's URL-based avatar
     /// (`marmot.group.avatar-url.v1`). The URL is validated (https-only, no
     /// localhost/private hosts) and normalized before it is committed.

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -409,7 +409,7 @@ impl Marmot {
     /// content hash (for caching) are on `AppGroupRecordFfi::image_hash_hex`;
     /// when the group also carries a URL avatar, the URL takes precedence
     /// for rendering.
-    pub async fn download_group_image(
+    pub async fn download_group_blossom_image(
         &self,
         account_ref: String,
         group_id_hex: String,
@@ -417,7 +417,7 @@ impl Marmot {
         let group_id = group_id_from_hex(&group_id_hex)?;
         let bytes = self
             .runtime
-            .download_group_image(&account_ref, &group_id)
+            .download_group_blossom_image(&account_ref, &group_id)
             .await?;
         Ok(bytes)
     }

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -27,6 +27,10 @@ pub struct AppGroupRecordFfi {
     pub avatar_url: Option<String>,
     pub avatar_dim: Option<String>,
     pub avatar_thumbhash: Option<String>,
+    /// Content hash of the encrypted Blossom avatar
+    /// (`marmot.group.blossom.image.v1`), `None` when absent. Doubles as a
+    /// cache key; fetch + decrypt via `Marmot::download_group_image`.
+    pub image_hash_hex: Option<String>,
     pub encrypted_media: AppGroupEncryptedMediaComponentFfi,
     /// Per-group disappearing-message retention in seconds
     /// (`marmot.group.message-retention.v1`). `0` means messages never expire.
@@ -64,6 +68,8 @@ impl From<AppGroupRecord> for AppGroupRecordFfi {
             avatar_url: avatar.present.then_some(avatar.url),
             avatar_dim: avatar.dim,
             avatar_thumbhash: avatar.thumbhash,
+            image_hash_hex: (value.image.present && !value.image.image_hash_hex.is_empty())
+                .then(|| value.image.image_hash_hex.clone()),
             encrypted_media: value.encrypted_media.into(),
             disappearing_message_secs,
             archived: value.archived,

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -29,7 +29,7 @@ pub struct AppGroupRecordFfi {
     pub avatar_thumbhash: Option<String>,
     /// Content hash of the encrypted Blossom avatar
     /// (`marmot.group.blossom.image.v1`), `None` when absent. Doubles as a
-    /// cache key; fetch + decrypt via `Marmot::download_group_image`.
+    /// cache key; fetch + decrypt via `Marmot::download_group_blossom_image`.
     pub image_hash_hex: Option<String>,
     pub encrypted_media: AppGroupEncryptedMediaComponentFfi,
     /// Per-group disappearing-message retention in seconds

--- a/crates/marmot-uniffi/src/conversions/mod.rs
+++ b/crates/marmot-uniffi/src/conversions/mod.rs
@@ -60,6 +60,7 @@ mod tests {
             avatar_url: None,
             avatar_dim: None,
             avatar_thumbhash: None,
+            image_hash_hex: None,
             encrypted_media: AppGroupEncryptedMediaComponentFfi {
                 component_id: 0x8008,
                 component: "marmot.group.encrypted-media.v1".into(),


### PR DESCRIPTION
![marmot](https://blossom.primal.net/ec30eca67b57da935ee9139ad7a4586f9576397653a9721961ed786c3fc898a9.jpg)

Group avatars set from the desktop client are committed as the encrypted `marmot.group.blossom.image.v1` component (0x8002). Over FFI, hosts could only reach the plain-URL avatar component (0x8007), so the Android app had no way to detect or download the encrypted image: mixed desktop-and-Android groups showed no avatar on Android.

Two changes:

- `Marmot::download_group_image(account_ref, group_id_hex)` fetches the group's Blossom blob, verifies the hash, decrypts it, and returns the raw image bytes.
- `AppGroupRecordFfi.image_hash_hex` carries the encrypted avatar's content hash, so hosts can detect presence and key their bitmap caches. Content addressing means a changed image is a new key, with no invalidation step.

Also fixes `kotlin-bindings.sh`: with `RUSTFLAGS="-C strip=symbols"` (as release pipelines set for the Android libraries) the host dylib loses the metadata uniffi-bindgen reads, and bindgen exits 0 while writing no Kotlin at all. The host build now pins RUSTFLAGS empty, and the script fails loudly when the binding file is missing.

The Android marmots can now hang the same portrait in their burrow that the desktop marmots framed.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/771">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for downloading a group’s Blossom avatar image directly in the app (returning decrypted raw image bytes when available).
* **Bug Fixes**
  * Improved binding-generation reliability by detecting missing UniFFI Kotlin output early and failing with a clear error.
  * Corrected group avatar metadata handling so empty Blossom image fields are treated as unavailable (and cache keys are only set when appropriate).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->