### PR TITLE
[codex] Prepare wn-agent installer release 0.9.2

### DIFF
--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -194,6 +194,10 @@ jobs:
           mkdir -p "$bundle_dir"
           sed -e "s/^version:.*/version: $artifact_version/" \
             integrations/hermes/marmot/plugin.yaml > "$bundle_dir/plugin.yaml"
+          if ! grep -qx "version: $artifact_version" "$bundle_dir/plugin.yaml"; then
+            echo "error: packaged Hermes plugin metadata did not get version $artifact_version" >&2
+            exit 1
+          fi
           cp integrations/hermes/marmot/__init__.py "$bundle_dir/"
           cp integrations/hermes/marmot/adapter.py "$bundle_dir/"
           cp integrations/hermes/marmot/README.md "$bundle_dir/"

--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -192,10 +192,12 @@ jobs:
 
           rm -rf "$stage_parent" "$asset" "$asset.sha256"
           mkdir -p "$bundle_dir"
-          cp integrations/hermes/marmot/plugin.yaml "$bundle_dir/"
+          sed -e "s/^version:.*/version: $artifact_version/" \
+            integrations/hermes/marmot/plugin.yaml > "$bundle_dir/plugin.yaml"
           cp integrations/hermes/marmot/__init__.py "$bundle_dir/"
           cp integrations/hermes/marmot/adapter.py "$bundle_dir/"
           cp integrations/hermes/marmot/README.md "$bundle_dir/"
+          cp scripts/hermes_marmot_configure_gateway.py "$bundle_dir/configure_gateway.py"
 
           cat > "$bundle_dir/manifest.json" <<EOF
           {
@@ -208,6 +210,7 @@ jobs:
               "plugin.yaml",
               "__init__.py",
               "adapter.py",
+              "configure_gateway.py",
               "README.md",
               "manifest.json"
             ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -712,7 +712,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "hex",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "tempfile",
 ]
@@ -2538,7 +2538,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "marmot-account"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -2565,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "fs-private",
  "serde",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -4386,7 +4386,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.1"
+version = "0.9.2"
 license = "MIT"
 publish = false
 

--- a/crates/agent-connector/README.md
+++ b/crates/agent-connector/README.md
@@ -78,35 +78,58 @@ Versioned WN Agent builds publish the `wn-agent` binary, the Hermes Marmot plugi
 Releases under `wn-agent-v*` tags. Hermes itself must already be installed.
 
 ```sh
-WN_AGENT_VERSION=0.9.0
+WN_AGENT_VERSION=0.9.2
 curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-hermes-marmot.sh" | bash
 ```
 
-To install and immediately run `wn-agent bootstrap --qr`:
+For repeatable noninteractive setup:
 
 ```sh
-WN_AGENT_VERSION=0.9.0
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-hermes-marmot.sh" | bash -s -- --bootstrap
+WN_AGENT_VERSION=0.9.2
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-hermes-marmot.sh" | \
+  bash -s -- --yes --allow-welcomer npub1...
 ```
 
 The installer puts `wn-agent` in `~/.local/bin`, extracts the Hermes plugin to `~/.hermes/plugins/marmot`, and enables
-the plugin when the `hermes` launcher is on `PATH`.
+the plugin when the `hermes` launcher is on `PATH`. It also starts a same-user `wn-agent` service where supported,
+bootstraps or reuses `~/.marmot-agent`, and patches only Marmot-specific Hermes config entries so existing connectors
+continue to work.
 
 Hermes-specific setup, development helpers, and phone-test commands live in
 [`integrations/hermes/marmot/README.md`](../../integrations/hermes/marmot/README.md).
+
+## OpenClaw Install
+
+The same WN Agent release publishes the OpenClaw Marmot channel plugin and installer:
+
+```sh
+WN_AGENT_VERSION=0.9.2
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-openclaw-marmot.sh" | bash
+```
+
+For repeatable noninteractive setup:
+
+```sh
+WN_AGENT_VERSION=0.9.2
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-openclaw-marmot.sh" | \
+  bash -s -- --yes --allow-welcomer npub1...
+```
+
+The OpenClaw installer uses the same `wn-agent` setup path, installs/enables the OpenClaw plugin, and updates only
+`channels.marmot` in OpenClaw config so existing channels continue to work.
 
 ## Cutting A WN Agent Release
 
 After the release commit is merged to `master`, cut a WN Agent release tag with:
 
 ```sh
-just release-wn-agent 0.9.0
+just release-wn-agent 0.9.2
 ```
 
 For a dry run:
 
 ```sh
-just release-wn-agent-dry-run 0.9.0
+just release-wn-agent-dry-run 0.9.2
 ```
 
 The helper checks that:

--- a/crates/agent-connector/src/bin/wn-agent.rs
+++ b/crates/agent-connector/src/bin/wn-agent.rs
@@ -151,6 +151,12 @@ struct BootstrapArgs {
     no_create: bool,
     #[arg(long, help = "Skip KeyPackage publish or repair during bootstrap")]
     no_publish_key_package: bool,
+    #[arg(
+        long,
+        value_name = "NPUB_OR_HEX",
+        help = "Add this welcomer/inviter public key to the agent allowlist; may be repeated"
+    )]
+    allow_welcomer: Vec<String>,
     #[arg(long, help = "Render invite URI as a terminal QR code using qrencode")]
     qr: bool,
     #[arg(long, help = "Print machine-readable JSON only")]
@@ -250,6 +256,7 @@ async fn run_bootstrap_command(args: BootstrapArgs) -> ExitCode {
         auth_token,
         relays,
         quic_candidates,
+        allow_welcomers: args.allow_welcomer,
         create_if_missing: !args.no_create,
         publish_key_package: !args.no_publish_key_package,
         wait_for_socket: Duration::from_secs_f64(args.wait_for_socket.max(0.0)),
@@ -296,6 +303,15 @@ fn write_bootstrap_output(
     } else {
         println!("QUIC candidate(s): {}", result.quic_candidates.join(", "));
     }
+    println!(
+        "Welcomer allowlist: {} entr{}",
+        result.welcomer_account_ids_hex.len(),
+        if result.welcomer_account_ids_hex.len() == 1 {
+            "y"
+        } else {
+            "ies"
+        }
+    );
     if result.key_package_published {
         println!("KeyPackage: published or repaired");
     } else {

--- a/crates/agent-connector/src/bootstrap.rs
+++ b/crates/agent-connector/src/bootstrap.rs
@@ -308,6 +308,15 @@ async fn bootstrap_allowlist(
     welcomers: Vec<String>,
 ) -> Result<Vec<String>, BootstrapError> {
     let welcomers = normalize_welcomer_refs(welcomers)?;
+    if welcomers.is_empty() {
+        let listed = client
+            .request(AgentControlRequest::AllowlistList {
+                account_id_hex: account_id_hex.to_owned(),
+            })
+            .await?;
+        return allowlist_from_response(listed, account_id_hex);
+    }
+
     let mut current = Vec::new();
     for welcomer_account_id_hex in welcomers {
         let added = client
@@ -316,24 +325,31 @@ async fn bootstrap_allowlist(
                 welcomer_account_id_hex,
             })
             .await?;
-        ensure_response_type(&added, "allowlist")?;
-        let AgentControlResponse::Allowlist {
-            account_id_hex: echoed_account_id_hex,
-            welcomer_account_ids_hex,
-        } = added.payload
-        else {
-            return Err(unexpected_response("allowlist", &added.payload));
-        };
-        let echoed_account_id_hex = normalize_account_id_hex(&echoed_account_id_hex)?;
-        if echoed_account_id_hex != account_id_hex {
-            return Err(BootstrapError::AllowlistAccountMismatch {
-                expected: account_id_hex.to_owned(),
-                actual: echoed_account_id_hex,
-            });
-        }
-        current = welcomer_account_ids_hex;
+        current = allowlist_from_response(added, account_id_hex)?;
     }
     Ok(current)
+}
+
+fn allowlist_from_response(
+    envelope: AgentControlEnvelope<AgentControlResponse>,
+    account_id_hex: &str,
+) -> Result<Vec<String>, BootstrapError> {
+    ensure_response_type(&envelope, "allowlist")?;
+    let (echoed_account_id_hex, welcomer_account_ids_hex) = match envelope.payload {
+        AgentControlResponse::Allowlist {
+            account_id_hex,
+            welcomer_account_ids_hex,
+        } => (account_id_hex, welcomer_account_ids_hex),
+        other => return Err(unexpected_response("allowlist", &other)),
+    };
+    let echoed_account_id_hex = normalize_account_id_hex(&echoed_account_id_hex)?;
+    if echoed_account_id_hex != account_id_hex {
+        return Err(BootstrapError::AllowlistAccountMismatch {
+            expected: account_id_hex.to_owned(),
+            actual: echoed_account_id_hex,
+        });
+    }
+    Ok(welcomer_account_ids_hex)
 }
 
 fn local_signing_accounts(accounts: Vec<AgentControlAccount>) -> Vec<AgentControlAccount> {
@@ -630,6 +646,13 @@ mod tests {
                             },
                         }
                     }
+                    AgentControlRequest::AllowlistList { account_id_hex } => {
+                        assert_eq!(account_id_hex, ACCOUNT_ID);
+                        AgentControlResponse::Allowlist {
+                            account_id_hex: ACCOUNT_ID.to_owned(),
+                            welcomer_account_ids_hex: Vec::new(),
+                        }
+                    }
                     other => panic!("unexpected request: {other:?}"),
                 },
             )
@@ -640,6 +663,7 @@ mod tests {
 
         assert!(result.created);
         assert_eq!(result.account_id_hex, ACCOUNT_ID);
+        assert!(result.welcomer_account_ids_hex.is_empty());
         assert_eq!(
             result.npub,
             "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy"
@@ -647,11 +671,15 @@ mod tests {
         assert!(result.nprofile.starts_with("nprofile1"));
         assert!(!result.qr_payload.contains("quic://"));
         let recorded = requests.lock().await;
-        assert_eq!(recorded.len(), 2);
+        assert_eq!(recorded.len(), 3);
         assert!(matches!(recorded[0], AgentControlRequest::AccountList));
         assert!(matches!(
             recorded[1],
             AgentControlRequest::AccountCreate { .. }
+        ));
+        assert!(matches!(
+            recorded[2],
+            AgentControlRequest::AllowlistList { .. }
         ));
     }
 
@@ -679,6 +707,13 @@ mod tests {
                             key_package_bytes: 1234,
                         }
                     }
+                    AgentControlRequest::AllowlistList { account_id_hex } => {
+                        assert_eq!(account_id_hex, ACCOUNT_ID);
+                        AgentControlResponse::Allowlist {
+                            account_id_hex: ACCOUNT_ID.to_owned(),
+                            welcomer_account_ids_hex: vec![WELCOMER_ID.to_owned()],
+                        }
+                    }
                     other => panic!("unexpected request: {other:?}"),
                 },
             )
@@ -690,11 +725,19 @@ mod tests {
         assert!(!result.created);
         assert!(result.key_package_published);
         assert_eq!(result.key_package_bytes, Some(1234));
+        assert_eq!(
+            result.welcomer_account_ids_hex,
+            vec![WELCOMER_ID.to_owned()]
+        );
         let recorded = requests.lock().await;
-        assert_eq!(recorded.len(), 2);
+        assert_eq!(recorded.len(), 3);
         assert!(matches!(
             recorded[1],
             AgentControlRequest::AccountPublishKeyPackage { .. }
+        ));
+        assert!(matches!(
+            recorded[2],
+            AgentControlRequest::AllowlistList { .. }
         ));
     }
 
@@ -717,6 +760,13 @@ mod tests {
                     AgentControlResponse::KeyPackagePublished {
                         account_id_hex: ACCOUNT_ID.to_owned(),
                         key_package_bytes: 12,
+                    }
+                }
+                AgentControlRequest::AllowlistList { account_id_hex } => {
+                    assert_eq!(account_id_hex, ACCOUNT_ID);
+                    AgentControlResponse::Allowlist {
+                        account_id_hex: ACCOUNT_ID.to_owned(),
+                        welcomer_account_ids_hex: Vec::new(),
                     }
                 }
                 other => panic!("unexpected request: {other:?}"),

--- a/crates/agent-connector/src/bootstrap.rs
+++ b/crates/agent-connector/src/bootstrap.rs
@@ -7,7 +7,9 @@ use agent_control::{
     AgentControlAccount, AgentControlEnvelope, AgentControlError, AgentControlRequest,
     AgentControlResponse, encode_frame, read_envelope,
 };
-use marmot_app::{nprofile_for_account_id, npub_for_account_id, validate_relay_urls};
+use marmot_app::{
+    account_id_hex_from_ref, nprofile_for_account_id, npub_for_account_id, validate_relay_urls,
+};
 use rand::RngCore;
 use serde::Serialize;
 use thiserror::Error;
@@ -31,6 +33,7 @@ pub struct BootstrapOptions {
     pub auth_token: Option<String>,
     pub relays: Vec<String>,
     pub quic_candidates: Vec<String>,
+    pub allow_welcomers: Vec<String>,
     pub create_if_missing: bool,
     pub publish_key_package: bool,
     pub wait_for_socket: Duration,
@@ -49,6 +52,7 @@ pub struct BootstrapResult {
     pub socket: String,
     pub relays: Vec<String>,
     pub quic_candidates: Vec<String>,
+    pub welcomer_account_ids_hex: Vec<String>,
     pub npub: String,
     pub nprofile: String,
     pub qr_payload: String,
@@ -83,6 +87,8 @@ pub enum BootstrapError {
     ResponseIdMismatch,
     #[error("key package published for unexpected account: expected {expected}, got {actual}")]
     KeyPackageAccountMismatch { expected: String, actual: String },
+    #[error("allowlist updated for unexpected account: expected {expected}, got {actual}")]
+    AllowlistAccountMismatch { expected: String, actual: String },
     #[error("{code}: {message}")]
     ControlRejected { code: String, message: String },
     #[error(transparent)]
@@ -113,6 +119,13 @@ pub async fn run_bootstrap(options: BootstrapOptions) -> Result<BootstrapResult,
     )
     .await?;
 
+    let welcomer_account_ids_hex = bootstrap_allowlist(
+        &client,
+        &account_state.account_id_hex,
+        options.allow_welcomers.clone(),
+    )
+    .await?;
+
     let npub = npub_for_account_id(&account_state.account_id_hex)?;
     let nprofile = nprofile_for_account_id(&account_state.account_id_hex, &options.relays)?;
     let result = BootstrapResult {
@@ -125,6 +138,7 @@ pub async fn run_bootstrap(options: BootstrapOptions) -> Result<BootstrapResult,
         socket: options.socket.display().to_string(),
         relays: options.relays.clone(),
         quic_candidates: options.quic_candidates.clone(),
+        welcomer_account_ids_hex,
         npub,
         nprofile: nprofile.clone(),
         qr_payload: nprofile,
@@ -288,6 +302,40 @@ async fn bootstrap_agent_account(
     })
 }
 
+async fn bootstrap_allowlist(
+    client: &ControlClient,
+    account_id_hex: &str,
+    welcomers: Vec<String>,
+) -> Result<Vec<String>, BootstrapError> {
+    let welcomers = normalize_welcomer_refs(welcomers)?;
+    let mut current = Vec::new();
+    for welcomer_account_id_hex in welcomers {
+        let added = client
+            .request(AgentControlRequest::AllowlistAdd {
+                account_id_hex: account_id_hex.to_owned(),
+                welcomer_account_id_hex,
+            })
+            .await?;
+        ensure_response_type(&added, "allowlist")?;
+        let AgentControlResponse::Allowlist {
+            account_id_hex: echoed_account_id_hex,
+            welcomer_account_ids_hex,
+        } = added.payload
+        else {
+            return Err(unexpected_response("allowlist", &added.payload));
+        };
+        let echoed_account_id_hex = normalize_account_id_hex(&echoed_account_id_hex)?;
+        if echoed_account_id_hex != account_id_hex {
+            return Err(BootstrapError::AllowlistAccountMismatch {
+                expected: account_id_hex.to_owned(),
+                actual: echoed_account_id_hex,
+            });
+        }
+        current = welcomer_account_ids_hex;
+    }
+    Ok(current)
+}
+
 fn local_signing_accounts(accounts: Vec<AgentControlAccount>) -> Vec<AgentControlAccount> {
     accounts
         .into_iter()
@@ -341,6 +389,16 @@ pub fn normalize_account_id_hex(value: &str) -> Result<String, BootstrapError> {
         return Err(BootstrapError::InvalidAccountIdLength(raw.len()));
     }
     Ok(normalized)
+}
+
+pub fn normalize_welcomer_refs(values: Vec<String>) -> Result<Vec<String>, BootstrapError> {
+    let mut values = values
+        .into_iter()
+        .map(|value| account_id_hex_from_ref(&value).map_err(BootstrapError::App))
+        .collect::<Result<Vec<_>, _>>()?;
+    values.sort();
+    values.dedup();
+    Ok(values)
 }
 
 async fn wait_for_socket(socket_path: &Path, wait_for: Duration) -> Result<(), BootstrapError> {
@@ -543,6 +601,7 @@ mod tests {
     use super::*;
 
     const ACCOUNT_ID: &str = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+    const WELCOMER_ID: &str = "bb4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b5";
 
     #[tokio::test]
     async fn bootstrap_creates_agent_account_when_none_exists() {
@@ -689,6 +748,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bootstrap_adds_allowlisted_welcomers_from_hex_and_npub() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("wn-agent.sock");
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let server =
+            spawn_mock_server(
+                socket_path.clone(),
+                requests.clone(),
+                |request| match request {
+                    AgentControlRequest::AccountList => AgentControlResponse::AccountList {
+                        accounts: vec![AgentControlAccount {
+                            account_id_hex: ACCOUNT_ID.to_owned(),
+                            label: DEFAULT_BOOTSTRAP_LABEL.to_owned(),
+                            local_signing: true,
+                        }],
+                    },
+                    AgentControlRequest::AccountPublishKeyPackage { account_id_hex } => {
+                        assert_eq!(account_id_hex, ACCOUNT_ID);
+                        AgentControlResponse::KeyPackagePublished {
+                            account_id_hex: ACCOUNT_ID.to_owned(),
+                            key_package_bytes: 1234,
+                        }
+                    }
+                    AgentControlRequest::AllowlistAdd {
+                        account_id_hex,
+                        welcomer_account_id_hex,
+                    } => {
+                        assert_eq!(account_id_hex, ACCOUNT_ID);
+                        assert_eq!(welcomer_account_id_hex, WELCOMER_ID);
+                        AgentControlResponse::Allowlist {
+                            account_id_hex: ACCOUNT_ID.to_owned(),
+                            welcomer_account_ids_hex: vec![WELCOMER_ID.to_owned()],
+                        }
+                    }
+                    other => panic!("unexpected request: {other:?}"),
+                },
+            )
+            .await;
+
+        let mut options = test_options(socket_path);
+        options.allow_welcomers = vec![
+            WELCOMER_ID.to_uppercase(),
+            marmot_app::npub_for_account_id(WELCOMER_ID).unwrap(),
+        ];
+        let result = run_bootstrap(options).await.unwrap();
+        server.abort();
+
+        assert_eq!(
+            result.welcomer_account_ids_hex,
+            vec![WELCOMER_ID.to_owned()]
+        );
+        let recorded = requests.lock().await;
+        assert_eq!(recorded.len(), 3);
+        assert!(matches!(recorded[0], AgentControlRequest::AccountList));
+        assert!(matches!(
+            recorded[1],
+            AgentControlRequest::AccountPublishKeyPackage { .. }
+        ));
+        assert!(matches!(
+            recorded[2],
+            AgentControlRequest::AllowlistAdd { .. }
+        ));
+    }
+
+    #[tokio::test]
     async fn bootstrap_rejects_invalid_relay_before_account_ops() {
         let dir = tempfile::tempdir().unwrap();
         let mut options = test_options(dir.path().join("wn-agent.sock"));
@@ -750,6 +874,7 @@ mod tests {
                 .map(|relay| (*relay).to_owned())
                 .collect(),
             quic_candidates: vec![DEFAULT_QUIC_CANDIDATE.to_owned()],
+            allow_welcomers: Vec::new(),
             create_if_missing: true,
             publish_key_package: true,
             wait_for_socket: Duration::from_millis(100),

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.2",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.2",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.2",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.2",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.2",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.2",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.2",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.2",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.2",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.2",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.2",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.2",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.2",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -32,6 +32,8 @@ versioning through the workspace version in the root `Cargo.toml`.
   `stream_finalize` with stable per-stream keys so a post-write timeout does not duplicate the durable final.
 - Hermes dev setup now mirrors OpenClaw by passing custom QUIC preview candidates through the generated
   `bootstrap-agent.sh` helper and syntax-checking every generated helper script in its contract test.
+- WN Agent release assets now include Hermes and OpenClaw one-line installers that perform guided full setup for
+  `wn-agent`, gateway plugin config, and same-user service startup while preserving existing gateway connectors/channels.
 
 ### Security
 

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -29,15 +29,17 @@ Prerequisites:
 One-line install:
 
 ```sh
-WN_AGENT_VERSION=0.9.0
+WN_AGENT_VERSION=0.9.2
 curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-hermes-marmot.sh" | bash
 ```
 
-Install and bootstrap in one step:
+For repeatable noninteractive setup, pass the allowed inviter/welcomer as either
+an `npub` or raw hex public key:
 
 ```sh
-WN_AGENT_VERSION=0.9.0
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-hermes-marmot.sh" | bash -s -- --bootstrap
+WN_AGENT_VERSION=0.9.2
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-hermes-marmot.sh" | \
+  bash -s -- --yes --allow-welcomer npub1...
 ```
 
 Use the exact release version when reporting bugs:
@@ -47,13 +49,18 @@ wn-agent --version
 ```
 
 The installer puts `wn-agent` in `~/.local/bin`, extracts the plugin to
-`~/.hermes/plugins/marmot`, and runs `hermes plugins enable marmot` when the
-`hermes` launcher is on `PATH`.
+`~/.hermes/plugins/marmot`, enables the Marmot plugin, starts a same-user
+`wn-agent` service where supported, bootstraps or reuses `~/.marmot-agent`, and
+patches only Marmot-specific Hermes config entries. Existing Hermes connectors
+such as Telegram are preserved.
 
 Supported platforms: Linux x86_64, Linux arm64, macOS Apple Silicon, macOS Intel.
 Both install scripts verify SHA256 checksums for downloaded release assets.
 
-After a normal install, start the connector and bootstrap the agent account:
+The installer prints restart guidance for your existing Hermes gateway. It does
+not restart Hermes automatically.
+
+Manual equivalent:
 
 ```sh
 export MARMOT_HOME="$HOME/.marmot-agent"

--- a/integrations/hermes/marmot/plugin.yaml
+++ b/integrations/hermes/marmot/plugin.yaml
@@ -1,7 +1,7 @@
 name: marmot
 label: Marmot
 kind: platform
-version: 0.9.0
+version: 0.9.2
 description: Hermes platform adapter for Marmot through the local wn-agent control socket
 author: Marmot Protocol
 requires_env: []

--- a/integrations/hermes/marmot/tests/test_configure_gateway.py
+++ b/integrations/hermes/marmot/tests/test_configure_gateway.py
@@ -23,26 +23,37 @@ class ConfigureGatewayTests(unittest.TestCase):
     def setUp(self):
         self.module = load_module()
 
-    def test_writes_marmot_streaming_defaults(self):
+    def test_writes_marmot_platform_extra_and_final_only_defaults(self):
         with tempfile.TemporaryDirectory() as tempdir:
             home = Path(tempdir)
             config_path = self.module.configure_gateway_config(
                 hermes_home=home,
                 platform="marmot",
-                streaming_enabled=True,
-                streaming_transport="auto",
+                streaming_enabled=False,
+                streaming_transport="off",
                 tool_progress="off",
                 interim_assistant_messages=False,
                 long_running_notifications=False,
                 busy_ack_detail=False,
+                agent_home=home / "marmot-agent",
+                socket_path=home / "marmot-agent" / "dev" / "wn-agent.sock",
+                account_id_hex="11" * 32,
+                welcomer_allowlist=["22" * 32, "22" * 32],
             )
 
             config = self.module.load_config(config_path)
 
-        self.assertTrue(config["streaming"]["enabled"])
-        self.assertEqual(config["streaming"]["transport"], "auto")
+        self.assertNotIn("streaming", config)
+        extra = config["platforms"]["marmot"]["extra"]
+        self.assertEqual(extra["home"], str(home / "marmot-agent"))
+        self.assertEqual(
+            extra["socket_path"],
+            str(home / "marmot-agent" / "dev" / "wn-agent.sock"),
+        )
+        self.assertEqual(extra["account_id_hex"], "11" * 32)
+        self.assertEqual(extra["welcomer_allowlist"], "22" * 32)
         marmot = config["display"]["platforms"]["marmot"]
-        self.assertTrue(marmot["streaming"])
+        self.assertFalse(marmot["streaming"])
         self.assertEqual(marmot["tool_progress"], "off")
         self.assertFalse(marmot["interim_assistant_messages"])
         self.assertFalse(marmot["long_running_notifications"])
@@ -66,6 +77,10 @@ class ConfigureGatewayTests(unittest.TestCase):
                         "  platforms:",
                         "    telegram:",
                         "      tool_progress: verbose",
+                        "platforms:",
+                        "  telegram:",
+                        "    extra:",
+                        "      bot_token_file: /secret/token",
                         "",
                     ]
                 ),
@@ -81,20 +96,33 @@ class ConfigureGatewayTests(unittest.TestCase):
                 interim_assistant_messages=True,
                 long_running_notifications=True,
                 busy_ack_detail=True,
+                agent_home=home / "marmot-agent",
+                socket_path=home / "marmot-agent" / "dev" / "wn-agent.sock",
+                account_id_hex="11" * 32,
             )
 
             config = self.module.load_config(config_path)
+            backups = sorted(home.glob("config.yaml.*.bak"))
 
         self.assertEqual(config["model"], "gpt-4o")
         self.assertEqual(config["agent"]["max_turns"], 42)
         self.assertFalse(config["streaming"]["enabled"])
-        self.assertEqual(config["streaming"]["transport"], "draft")
+        self.assertNotIn("transport", config["streaming"])
         self.assertEqual(config["streaming"]["edit_interval"], 0.5)
         self.assertEqual(config["display"]["tool_progress"], "all")
         self.assertEqual(
             config["display"]["platforms"]["telegram"]["tool_progress"],
             "verbose",
         )
+        self.assertEqual(
+            config["platforms"]["telegram"]["extra"]["bot_token_file"],
+            "/secret/token",
+        )
+        self.assertEqual(
+            config["platforms"]["marmot"]["extra"]["account_id_hex"],
+            "11" * 32,
+        )
+        self.assertEqual(len(backups), 1)
         marmot = config["display"]["platforms"]["marmot"]
         self.assertFalse(marmot["streaming"])
         self.assertEqual(marmot["tool_progress"], "new")
@@ -106,25 +134,26 @@ class ConfigureGatewayTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.module.parse_bool("maybe", name="streaming")
 
-    def test_transport_off_disables_platform_streaming(self):
+    def test_can_update_global_streaming_when_explicit(self):
         with tempfile.TemporaryDirectory() as tempdir:
             home = Path(tempdir)
             config_path = self.module.configure_gateway_config(
                 hermes_home=home,
                 platform="marmot",
                 streaming_enabled=True,
-                streaming_transport="off",
+                streaming_transport="auto",
                 tool_progress="off",
                 interim_assistant_messages=False,
                 long_running_notifications=False,
                 busy_ack_detail=False,
+                configure_global_streaming=True,
             )
 
             config = self.module.load_config(config_path)
 
         self.assertTrue(config["streaming"]["enabled"])
-        self.assertEqual(config["streaming"]["transport"], "off")
-        self.assertFalse(config["display"]["platforms"]["marmot"]["streaming"])
+        self.assertEqual(config["streaming"]["transport"], "auto")
+        self.assertTrue(config["display"]["platforms"]["marmot"]["streaming"])
 
 
 if __name__ == "__main__":

--- a/integrations/hermes/marmot/tests/test_dev_scripts.sh
+++ b/integrations/hermes/marmot/tests/test_dev_scripts.sh
@@ -96,7 +96,12 @@ source "$default_root/env.sh"
 installer_dry_run="$(
     WN_AGENT_SHA="9.9.9" \
     MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
-    "$repo_root/scripts/install-hermes-marmot.sh" --dry-run
+    "$repo_root/scripts/install-hermes-marmot.sh" --dry-run --yes
+)"
+installer_stdin_dry_run="$(
+    WN_AGENT_SHA="9.9.9" \
+    MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
+    bash -s -- --dry-run --yes < "$repo_root/scripts/install-hermes-marmot.sh"
 )"
 case "$installer_dry_run" in
     *"wn-agent-"*"9.9.9.tar.gz"* ) ;;
@@ -109,6 +114,10 @@ esac
 case "$installer_dry_run" in
     *"wn-agent-v9.9.9-test"* ) ;;
     *) echo "Hermes installer dry-run did not use requested release tag" >&2; exit 1;;
+esac
+case "$installer_stdin_dry_run" in
+    *"wn-agent-"*"9.9.9.tar.gz"* ) ;;
+    *) echo "Hermes installer stdin dry-run did not use WN_AGENT_SHA asset suffix" >&2; exit 1;;
 esac
 
 echo "dev script test passed"

--- a/integrations/hermes/marmot/tests/test_dev_scripts.sh
+++ b/integrations/hermes/marmot/tests/test_dev_scripts.sh
@@ -103,6 +103,12 @@ installer_stdin_dry_run="$(
     MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
     bash -s -- --dry-run --yes < "$repo_root/scripts/install-hermes-marmot.sh"
 )"
+installer_bad_welcomer_status=0
+WN_AGENT_SHA="9.9.9" \
+    MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
+    "$repo_root/scripts/install-hermes-marmot.sh" --dry-run --yes --allow-welcomer not-a-key \
+    >/dev/null 2>&1 || installer_bad_welcomer_status=$?
+[ "$installer_bad_welcomer_status" -ne 0 ]
 case "$installer_dry_run" in
     *"wn-agent-"*"9.9.9.tar.gz"* ) ;;
     *) echo "Hermes installer dry-run did not use WN_AGENT_SHA asset suffix" >&2; exit 1;;
@@ -118,6 +124,14 @@ esac
 case "$installer_stdin_dry_run" in
     *"wn-agent-"*"9.9.9.tar.gz"* ) ;;
     *) echo "Hermes installer stdin dry-run did not use WN_AGENT_SHA asset suffix" >&2; exit 1;;
+esac
+case "$installer_stdin_dry_run" in
+    *"hermes-marmot-plugin-9.9.9.tar.gz"* ) ;;
+    *) echo "Hermes installer stdin dry-run did not use expected plugin asset" >&2; exit 1;;
+esac
+case "$installer_stdin_dry_run" in
+    *"wn-agent-v9.9.9-test"* ) ;;
+    *) echo "Hermes installer stdin dry-run did not use requested release tag" >&2; exit 1;;
 esac
 
 echo "dev script test passed"

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -26,20 +26,30 @@ Prerequisites:
 - Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
 
 ```sh
-WN_AGENT_VERSION=0.9.0
+WN_AGENT_VERSION=0.9.2
 curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-openclaw-marmot.sh" | bash
-# or install + bootstrap the agent account in one step:
-curl -fsSL ".../install-openclaw-marmot.sh" | bash -s -- --bootstrap
 ```
 
 The installer puts `wn-agent` in `~/.local/bin`, downloads and verifies the plugin
-tarball, runs `openclaw plugins install`, and enables the `marmot` channel.
+tarball, runs `openclaw plugins install`, enables the `marmot` channel, starts a
+same-user `wn-agent` service where supported, bootstraps or reuses
+`~/.marmot-agent`, and patches only `channels.marmot` in OpenClaw config.
 Supported platforms match the Hermes installer.
 Set `MARMOT_RELEASE_REPO`, `MARMOT_RELEASE_TAG`, and `WN_AGENT_VERSION` (or the
 legacy `WN_AGENT_SHA` alias) to install a non-default release asset, matching
 the Hermes installer.
 
-Then start the connector and bootstrap (same public relays as the phone app):
+For repeatable noninteractive setup, pass the allowed inviter/welcomer as either
+an `npub` or raw hex public key:
+
+```sh
+WN_AGENT_VERSION=0.9.2
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v${WN_AGENT_VERSION}/install-openclaw-marmot.sh" | \
+  bash -s -- --yes --allow-welcomer npub1...
+```
+
+The installer prints restart guidance for your existing OpenClaw gateway. It
+does not restart OpenClaw automatically. Manual equivalent:
 
 ```sh
 wn-agent --home ~/.marmot-agent \

--- a/integrations/openclaw/marmot/package.json
+++ b/integrations/openclaw/marmot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marmot-protocol/openclaw-marmot",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "description": "OpenClaw channel plugin for Marmot through the local wn-agent control socket",
   "type": "module",
   "private": true,

--- a/integrations/openclaw/marmot/test/dev-scripts.sh
+++ b/integrations/openclaw/marmot/test/dev-scripts.sh
@@ -113,6 +113,12 @@ installer_stdin_dry_run="$(
     MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
     bash -s -- --dry-run --yes < "$repo_root/scripts/install-openclaw-marmot.sh"
 )"
+installer_bad_welcomer_status=0
+WN_AGENT_SHA="9.9.9" \
+    MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
+    "$repo_root/scripts/install-openclaw-marmot.sh" --dry-run --yes --allow-welcomer not-a-key \
+    >/dev/null 2>&1 || installer_bad_welcomer_status=$?
+[ "$installer_bad_welcomer_status" -ne 0 ]
 case "$installer_dry_run" in
     *"wn-agent-"*"9.9.9.tar.gz"* ) ;;
     *) echo "OpenClaw installer dry-run did not use WN_AGENT_SHA asset suffix" >&2; exit 1;;
@@ -128,6 +134,14 @@ esac
 case "$installer_stdin_dry_run" in
     *"openclaw-marmot-plugin-9.9.9.tgz"* ) ;;
     *) echo "OpenClaw installer stdin dry-run did not use expected plugin asset" >&2; exit 1;;
+esac
+case "$installer_stdin_dry_run" in
+    *"wn-agent-"*"9.9.9.tar.gz"* ) ;;
+    *) echo "OpenClaw installer stdin dry-run did not use WN_AGENT_SHA asset suffix" >&2; exit 1;;
+esac
+case "$installer_stdin_dry_run" in
+    *"wn-agent-v9.9.9-test"* ) ;;
+    *) echo "OpenClaw installer stdin dry-run did not use requested release tag" >&2; exit 1;;
 esac
 
 echo "OpenClaw dev script test passed"

--- a/integrations/openclaw/marmot/test/dev-scripts.sh
+++ b/integrations/openclaw/marmot/test/dev-scripts.sh
@@ -106,7 +106,12 @@ source "$default_root/env.sh"
 installer_dry_run="$(
     WN_AGENT_SHA="9.9.9" \
     MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
-    "$repo_root/scripts/install-openclaw-marmot.sh" --dry-run
+    "$repo_root/scripts/install-openclaw-marmot.sh" --dry-run --yes
+)"
+installer_stdin_dry_run="$(
+    WN_AGENT_SHA="9.9.9" \
+    MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
+    bash -s -- --dry-run --yes < "$repo_root/scripts/install-openclaw-marmot.sh"
 )"
 case "$installer_dry_run" in
     *"wn-agent-"*"9.9.9.tar.gz"* ) ;;
@@ -119,6 +124,10 @@ esac
 case "$installer_dry_run" in
     *"wn-agent-v9.9.9-test"* ) ;;
     *) echo "OpenClaw installer dry-run did not use requested release tag" >&2; exit 1;;
+esac
+case "$installer_stdin_dry_run" in
+    *"openclaw-marmot-plugin-9.9.9.tgz"* ) ;;
+    *) echo "OpenClaw installer stdin dry-run did not use expected plugin asset" >&2; exit 1;;
 esac
 
 echo "OpenClaw dev script test passed"

--- a/release.md
+++ b/release.md
@@ -211,6 +211,11 @@ curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.
 curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.2/install-openclaw-marmot.sh | bash
 ```
 
+These one-liners perform full setup by default: they install `wn-agent`, install/enable the matching gateway plugin,
+start a same-user `wn-agent` service where supported, bootstrap or reuse the default Marmot agent home, and patch only
+the Marmot-specific gateway config. Use `--no-service`, `--no-start-wn-agent`, `--no-configure-hermes`, or
+`--no-configure-openclaw` when you need a partial/manual install.
+
 ## MarmotKit Binding Release
 
 Use this when app repos need pinned generated bindings instead of a local MDK checkout.

--- a/release.md
+++ b/release.md
@@ -162,20 +162,20 @@ Before a WN Agent release, run the normal preflight plus:
 
 ```sh
 cargo test -p agent-connector
-bash scripts/install-hermes-marmot.sh --dry-run
-bash scripts/install-openclaw-marmot.sh --dry-run
+bash scripts/install-hermes-marmot.sh --dry-run --yes
+bash scripts/install-openclaw-marmot.sh --dry-run --yes
 ```
 
 Cut the release tag from the current `origin/master` commit:
 
 ```sh
-just release-wn-agent 0.9.0
+just release-wn-agent 0.9.2
 ```
 
 For a dry run:
 
 ```sh
-just release-wn-agent-dry-run 0.9.0
+just release-wn-agent-dry-run 0.9.2
 ```
 
 The helper checks that the workspace version matches, the working tree is clean, `HEAD` matches `origin/master`, and the
@@ -206,9 +206,9 @@ The installer assets are generated during the release and default to their own `
 
 ```sh
 # Hermes gateway
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.0/install-hermes-marmot.sh | bash
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.2/install-hermes-marmot.sh | bash
 # OpenClaw gateway
-curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.0/install-openclaw-marmot.sh | bash
+curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.2/install-openclaw-marmot.sh | bash
 ```
 
 ## MarmotKit Binding Release

--- a/scripts/hermes_marmot_configure_gateway.py
+++ b/scripts/hermes_marmot_configure_gateway.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import shutil
 import os
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +22,28 @@ except ModuleNotFoundError as exc:  # pragma: no cover - exercised on hosts with
 
 VALID_TOOL_PROGRESS = {"off", "new", "all", "verbose"}
 VALID_STREAMING_TRANSPORT = {"auto", "draft", "edit", "off"}
+
+
+def _yaml_string_needs_quotes(text: str) -> bool:
+    if not text:
+        return True
+    lowered = text.lower()
+    return (
+        lowered in {"true", "false", "null", "~", "yes", "no", "on", "off"}
+        or re.fullmatch(r"-?[0-9]+", text) is not None
+        or re.fullmatch(r"-?[0-9]+\.[0-9]+", text) is not None
+    )
+
+
+if yaml is not None:
+    class _MarmotSafeDumper(yaml.SafeDumper):  # type: ignore[misc, name-defined]
+        pass
+
+    def _represent_str(dumper: Any, data: str) -> Any:
+        style = "'" if _yaml_string_needs_quotes(data) else None
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+
+    _MarmotSafeDumper.add_representer(str, _represent_str)
 
 
 def parse_bool(value: str, *, name: str) -> bool:
@@ -102,6 +126,8 @@ def _format_scalar(value: Any) -> str:
     if isinstance(value, (int, float)):
         return str(value)
     text = str(value)
+    if _yaml_string_needs_quotes(text):
+        return "'" + text.replace("'", "''") + "'"
     if text and re.fullmatch(r"[A-Za-z0-9_./:@,+-]+", text):
         return text
     return "'" + text.replace("'", "''") + "'"
@@ -110,12 +136,24 @@ def _format_scalar(value: Any) -> str:
 def _simple_yaml_dump(data: dict[str, Any]) -> str:
     lines: list[str] = []
 
+    def emit_sequence(sequence: list[Any], indent: int) -> None:
+        prefix = " " * indent
+        for item in sequence:
+            if isinstance(item, dict):
+                lines.append(f"{prefix}-")
+                emit_mapping(item, indent + 2)
+            else:
+                lines.append(f"{prefix}- {_format_scalar(item)}")
+
     def emit_mapping(mapping: dict[str, Any], indent: int) -> None:
         prefix = " " * indent
         for key, value in mapping.items():
             if isinstance(value, dict):
                 lines.append(f"{prefix}{key}:")
                 emit_mapping(value, indent + 2)
+            elif isinstance(value, list):
+                lines.append(f"{prefix}{key}:")
+                emit_sequence(value, indent + 2)
             else:
                 lines.append(f"{prefix}{key}: {_format_scalar(value)}")
 
@@ -138,7 +176,12 @@ def load_config(path: Path) -> dict[str, Any]:
 
 def dump_config(config: dict[str, Any]) -> str:
     if yaml is not None:
-        return yaml.safe_dump(config, sort_keys=False, default_flow_style=False)
+        return yaml.dump(
+            config,
+            Dumper=_MarmotSafeDumper,
+            sort_keys=False,
+            default_flow_style=False,
+        )
     return _simple_yaml_dump(config)
 
 
@@ -151,6 +194,22 @@ def _ensure_mapping(parent: dict[str, Any], key: str) -> dict[str, Any]:
     return replacement
 
 
+def _clean_list(values: list[str] | None) -> list[str]:
+    if not values:
+        return []
+    cleaned = [value.strip() for value in values if value and value.strip()]
+    return sorted(dict.fromkeys(cleaned))
+
+
+def _create_backup(config_path: Path) -> Path | None:
+    if not config_path.exists():
+        return None
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_path = config_path.with_name(f"{config_path.name}.{stamp}.{os.getpid()}.bak")
+    shutil.copy2(config_path, backup_path)
+    return backup_path
+
+
 def configure_gateway_config(
     *,
     hermes_home: Path,
@@ -161,6 +220,13 @@ def configure_gateway_config(
     interim_assistant_messages: bool,
     long_running_notifications: bool,
     busy_ack_detail: bool,
+    agent_home: Path | None = None,
+    socket_path: Path | None = None,
+    account_id_hex: str | None = None,
+    welcomer_allowlist: list[str] | None = None,
+    profile_name_onboarding: bool | None = None,
+    configure_global_streaming: bool = False,
+    backup: bool = True,
 ) -> Path:
     if streaming_transport not in VALID_STREAMING_TRANSPORT:
         valid = ", ".join(sorted(VALID_STREAMING_TRANSPORT))
@@ -174,9 +240,25 @@ def configure_gateway_config(
     config = load_config(config_path)
     effective_streaming = streaming_enabled and streaming_transport != "off"
 
-    streaming = _ensure_mapping(config, "streaming")
-    streaming["enabled"] = streaming_enabled
-    streaming["transport"] = streaming_transport
+    if configure_global_streaming:
+        streaming = _ensure_mapping(config, "streaming")
+        streaming["enabled"] = streaming_enabled
+        streaming["transport"] = streaming_transport
+
+    platform_entries = _ensure_mapping(config, "platforms")
+    platform_entry = _ensure_mapping(platform_entries, platform)
+    extra = _ensure_mapping(platform_entry, "extra")
+    if agent_home is not None:
+        extra["home"] = str(agent_home)
+    if socket_path is not None:
+        extra["socket_path"] = str(socket_path)
+    if account_id_hex:
+        extra["account_id_hex"] = account_id_hex.strip()
+    cleaned_allowlist = _clean_list(welcomer_allowlist)
+    if cleaned_allowlist:
+        extra["welcomer_allowlist"] = ",".join(cleaned_allowlist)
+    if profile_name_onboarding is not None:
+        extra["profile_name_onboarding"] = profile_name_onboarding
 
     display = _ensure_mapping(config, "display")
     platforms = _ensure_mapping(display, "platforms")
@@ -187,6 +269,8 @@ def configure_gateway_config(
     platform_config["long_running_notifications"] = long_running_notifications
     platform_config["busy_ack_detail"] = busy_ack_detail
 
+    if backup:
+        _create_backup(config_path)
     tmp_path = config_path.with_suffix(config_path.suffix + ".tmp")
     tmp_path.write_text(dump_config(config), encoding="utf-8")
     os.replace(tmp_path, config_path)
@@ -197,7 +281,20 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--home", default=os.environ.get("HERMES_HOME", "~/.hermes"))
     parser.add_argument("--platform", default="marmot")
-    parser.add_argument("--streaming", default=os.environ.get("HERMES_MARMOT_STREAMING", "1"))
+    parser.add_argument("--agent-home", default=os.environ.get("MARMOT_HOME"))
+    parser.add_argument("--socket-path", default=os.environ.get("MARMOT_AGENT_SOCKET"))
+    parser.add_argument("--account-id-hex", default=os.environ.get("MARMOT_ACCOUNT_ID_HEX"))
+    parser.add_argument(
+        "--welcomer-allowlist",
+        action="append",
+        default=[],
+        help="Welcomer account id/npub allowlist entry; may be repeated or comma-separated",
+    )
+    parser.add_argument(
+        "--profile-name-onboarding",
+        default=os.environ.get("MARMOT_PROFILE_NAME_ONBOARDING"),
+    )
+    parser.add_argument("--streaming", default=os.environ.get("HERMES_MARMOT_STREAMING", "0"))
     parser.add_argument(
         "--transport",
         default=os.environ.get("HERMES_MARMOT_STREAMING_TRANSPORT", "auto"),
@@ -220,6 +317,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--busy-ack-detail",
         default=os.environ.get("HERMES_MARMOT_BUSY_ACK_DETAIL", "0"),
     )
+    parser.add_argument(
+        "--configure-global-streaming",
+        action="store_true",
+        help="Also update Hermes' global streaming block; off by default to preserve other connectors",
+    )
+    parser.add_argument("--no-backup", action="store_true")
     parser.add_argument("--quiet", action="store_true")
     return parser
 
@@ -239,6 +342,22 @@ def main(argv: list[str] | None = None) -> int:
             name="long-running notifications",
         )
         busy_ack_detail = parse_bool(args.busy_ack_detail, name="busy ack detail")
+        profile_name_onboarding = (
+            None
+            if args.profile_name_onboarding is None
+            else parse_bool(
+                args.profile_name_onboarding,
+                name="profile name onboarding",
+            )
+        )
+        welcomer_allowlist = []
+        env_allowlist = os.environ.get("MARMOT_WELCOMER_ALLOWLIST") or os.environ.get(
+            "MARMOT_DM_ALLOW_FROM"
+        )
+        if env_allowlist:
+            welcomer_allowlist.extend(env_allowlist.split(","))
+        for value in args.welcomer_allowlist:
+            welcomer_allowlist.extend(value.split(","))
         config_path = configure_gateway_config(
             hermes_home=Path(args.home).expanduser(),
             platform=args.platform,
@@ -248,6 +367,13 @@ def main(argv: list[str] | None = None) -> int:
             interim_assistant_messages=interim_assistant_messages,
             long_running_notifications=long_running_notifications,
             busy_ack_detail=busy_ack_detail,
+            agent_home=Path(args.agent_home).expanduser() if args.agent_home else None,
+            socket_path=Path(args.socket_path).expanduser() if args.socket_path else None,
+            account_id_hex=args.account_id_hex,
+            welcomer_allowlist=welcomer_allowlist,
+            profile_name_onboarding=profile_name_onboarding,
+            configure_global_streaming=args.configure_global_streaming,
+            backup=not args.no_backup,
         )
     except Exception as exc:
         print(f"error: {exc}", file=sys.stderr)
@@ -263,6 +389,7 @@ def main(argv: list[str] | None = None) -> int:
             f" interim_messages={str(interim_assistant_messages).lower()}"
             f" long_running_notifications={str(long_running_notifications).lower()}"
             f" busy_ack_detail={str(busy_ack_detail).lower()}"
+            f" global_streaming={str(args.configure_global_streaming).lower()}"
         )
     return 0
 

--- a/scripts/hermes_marmot_container_entrypoint.sh
+++ b/scripts/hermes_marmot_container_entrypoint.sh
@@ -114,8 +114,9 @@ configure_args=(
     --long-running-notifications "$HERMES_MARMOT_LONG_RUNNING_NOTIFICATIONS"
     --busy-ack-detail "$HERMES_MARMOT_BUSY_ACK_DETAIL"
 )
-case "$HERMES_MARMOT_STREAMING" in
-    1|true|TRUE|yes|YES|on|ON)
+streaming_normalized="$(printf '%s' "$HERMES_MARMOT_STREAMING" | tr '[:upper:]' '[:lower:]')"
+case "$streaming_normalized" in
+    1|true|yes|on)
         configure_args+=(--configure-global-streaming)
         ;;
 esac

--- a/scripts/hermes_marmot_container_entrypoint.sh
+++ b/scripts/hermes_marmot_container_entrypoint.sh
@@ -101,14 +101,25 @@ else
     exit 1
 fi
 
-marmot-configure-hermes-gateway \
-    --home "$HERMES_HOME" \
-    --streaming "$HERMES_MARMOT_STREAMING" \
-    --transport "$HERMES_MARMOT_STREAMING_TRANSPORT" \
-    --tool-progress "$HERMES_MARMOT_TOOL_PROGRESS" \
-    --interim-messages "$HERMES_MARMOT_INTERIM_MESSAGES" \
-    --long-running-notifications "$HERMES_MARMOT_LONG_RUNNING_NOTIFICATIONS" \
+configure_args=(
+    --home "$HERMES_HOME"
+    --agent-home "$MARMOT_HOME"
+    --socket-path "$MARMOT_AGENT_SOCKET"
+    --account-id-hex "${MARMOT_ACCOUNT_ID_HEX:-}"
+    --profile-name-onboarding "$MARMOT_PROFILE_NAME_ONBOARDING"
+    --streaming "$HERMES_MARMOT_STREAMING"
+    --transport "$HERMES_MARMOT_STREAMING_TRANSPORT"
+    --tool-progress "$HERMES_MARMOT_TOOL_PROGRESS"
+    --interim-messages "$HERMES_MARMOT_INTERIM_MESSAGES"
+    --long-running-notifications "$HERMES_MARMOT_LONG_RUNNING_NOTIFICATIONS"
     --busy-ack-detail "$HERMES_MARMOT_BUSY_ACK_DETAIL"
+)
+case "$HERMES_MARMOT_STREAMING" in
+    1|true|TRUE|yes|YES|on|ON)
+        configure_args+=(--configure-global-streaming)
+        ;;
+esac
+marmot-configure-hermes-gateway "${configure_args[@]}"
 
 if [ "$HERMES_MARMOT_START_GATEWAY" = "0" ]; then
     echo "Hermes gateway disabled; wn-agent is running."

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -2,12 +2,21 @@
 set -euo pipefail
 
 # NOTE: requires a published wn-agent-v* release. Releases from before the rename
-# ship differently-named assets and cannot be installed by this script;
-# cut the first wn-agent-v* release before pointing installs here.
+# ship differently-named assets and cannot be installed by this script.
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-workspace_version_default="$(sed -n 's/^version = "\(.*\)"/\1/p' "$SCRIPT_DIR/../Cargo.toml" 2>/dev/null | head -n 1)"
-workspace_version_default="${workspace_version_default:-latest}"
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-}"
+SCRIPT_DIR=""
+if [ -n "$SCRIPT_SOURCE" ] && [ -f "$SCRIPT_SOURCE" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")" && pwd)"
+fi
+workspace_version_default="latest"
+if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/../Cargo.toml" ]; then
+    workspace_version_default="$(
+        sed -n 's/^version = "\(.*\)"/\1/p' "$SCRIPT_DIR/../Cargo.toml" 2>/dev/null |
+            head -n 1 || true
+    )"
+    workspace_version_default="${workspace_version_default:-latest}"
+fi
 
 MARMOT_RELEASE_REPO="${MARMOT_RELEASE_REPO:-marmot-protocol/mdk}"
 WN_AGENT_VERSION_DEFAULT="${WN_AGENT_VERSION_DEFAULT:-$workspace_version_default}"
@@ -15,14 +24,28 @@ WN_AGENT_VERSION="${WN_AGENT_VERSION:-${WN_AGENT_SHA:-$WN_AGENT_VERSION_DEFAULT}
 MARMOT_RELEASE_TAG_DEFAULT="${MARMOT_RELEASE_TAG_DEFAULT:-wn-agent-v${WN_AGENT_VERSION}}"
 MARMOT_RELEASE_TAG="${MARMOT_RELEASE_TAG:-$MARMOT_RELEASE_TAG_DEFAULT}"
 MARMOT_INSTALL_PREFIX="${MARMOT_INSTALL_PREFIX:-${HOME}/.local}"
-MARMOT_PLUGIN_DIR="${MARMOT_PLUGIN_DIR:-${HOME}/.hermes/plugins/marmot}"
+HERMES_HOME="${HERMES_HOME:-${HOME}/.hermes}"
+MARMOT_PLUGIN_DIR_OVERRIDE="${MARMOT_PLUGIN_DIR:-}"
 MARMOT_HOME="${MARMOT_HOME:-${HOME}/.marmot-agent}"
+MARMOT_AGENT_SOCKET_OVERRIDE="${MARMOT_AGENT_SOCKET:-}"
 MARMOT_RELAYS="${MARMOT_RELAYS:-wss://relay.eu.whitenoise.chat,wss://relay.us.whitenoise.chat}"
-INSTALL_BOOTSTRAP=0
-START_WN_AGENT=0
+
+ASSUME_YES=0
+CONFIGURE_HERMES=1
 DRY_RUN=0
+ENABLE_STREAMING=0
 FORCE=0
+INSTALL_SERVICE=1
+INTERACTIVE=0
+NO_START_WN_AGENT=0
 SYSTEM_INSTALL=0
+CLI_RELAYS=0
+BOOTSTRAP_ACCOUNT_ID_HEX=""
+BOOTSTRAP_JSON_PATH=""
+
+RELAYS=()
+ALLOW_WELCOMERS=()
+QUIC_CANDIDATES=()
 
 usage() {
     cat <<'USAGE'
@@ -32,32 +55,48 @@ Install wn-agent and the Hermes Marmot plugin from a WN Agent GitHub release.
 Hermes itself must already be installed.
 
 Options:
-  --bootstrap           After install, start wn-agent and run wn-agent bootstrap --qr
-  --no-start-wn-agent   With --bootstrap, do not start wn-agent automatically
-  --system              Install wn-agent to /usr/local/bin instead of ~/.local/bin
-  --force               Replace an existing Hermes plugin directory
-  --dry-run             Print actions without installing
-  -h, --help            Show this help
+  --bootstrap              Compatibility alias; guided bootstrap is the default
+  --yes, --non-interactive Use defaults and do not prompt
+  --home PATH              Marmot agent home (default: ~/.marmot-agent)
+  --hermes-home PATH       Hermes home (default: $HERMES_HOME or ~/.hermes)
+  --allow-welcomer VALUE   Allow invites from this npub or hex pubkey; may repeat
+  --relay URL              Relay URL for wn-agent/bootstrap; may repeat
+  --enable-streaming       Configure Marmot live preview streaming
+  --quic-candidate URI     QUIC preview candidate used with --enable-streaming
+  --no-service             Do not install/start a LaunchAgent or systemd user unit
+  --no-start-wn-agent      Do not start wn-agent before bootstrap
+  --no-configure-hermes    Install assets but do not patch Hermes config.yaml
+  --system                 Install wn-agent to /usr/local/bin instead of ~/.local/bin
+  --force                  Replace the existing Marmot plugin instead of backing it up
+  --dry-run                Print actions without installing
+  -h, --help               Show this help
 
 Environment:
-  MARMOT_RELEASE_REPO   GitHub repo (default: marmot-protocol/mdk)
-  MARMOT_RELEASE_TAG    Release tag (release assets default to their own tag)
-  WN_AGENT_VERSION      Asset version suffix (release assets default to their own version)
-  WN_AGENT_SHA          Legacy alias for WN_AGENT_VERSION
-  MARMOT_INSTALL_PREFIX Install root for wn-agent (default: ~/.local)
-  MARMOT_PLUGIN_DIR     Hermes plugin path (default: ~/.hermes/plugins/marmot)
-  MARMOT_HOME           wn-agent home used by bootstrap (default: ~/.marmot-agent)
-  MARMOT_RELAYS         Relay CSV used when --bootstrap starts wn-agent
+  MARMOT_RELEASE_REPO      GitHub repo (default: marmot-protocol/mdk)
+  MARMOT_RELEASE_TAG       Release tag (release assets default to their own tag)
+  WN_AGENT_VERSION         Asset version suffix (release assets default to their own version)
+  WN_AGENT_SHA             Legacy alias for WN_AGENT_VERSION
+  MARMOT_INSTALL_PREFIX    Install root for wn-agent (default: ~/.local)
+  HERMES_HOME              Hermes home (default: ~/.hermes)
+  MARMOT_PLUGIN_DIR        Hermes plugin path (default: $HERMES_HOME/plugins/marmot)
+  MARMOT_HOME              wn-agent home (default: ~/.marmot-agent)
+  MARMOT_AGENT_SOCKET      wn-agent socket (default: $MARMOT_HOME/dev/wn-agent.sock)
+  MARMOT_RELAYS            Relay CSV used by wn-agent and bootstrap
+  MARMOT_WELCOMER_ALLOWLIST Comma-separated npub or hex allowlist values
 
 Example:
-  curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.0/install-hermes-marmot.sh | bash
+  curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.2/install-hermes-marmot.sh | bash
 
-  curl -fsSL .../install-hermes-marmot.sh | bash -s -- --bootstrap
+  curl -fsSL .../install-hermes-marmot.sh | bash -s -- --yes --allow-welcomer npub1...
 USAGE
 }
 
 log() {
     printf 'install-hermes-marmot: %s\n' "$*"
+}
+
+warn() {
+    printf 'install-hermes-marmot: warning: %s\n' "$*" >&2
 }
 
 run() {
@@ -75,6 +114,68 @@ need_cmd() {
         echo "error: required command not found: $1" >&2
         exit 1
     fi
+}
+
+append_csv() {
+    local value="$1"
+    local item
+    IFS=',' read -r -a _items <<<"$value"
+    for item in "${_items[@]}"; do
+        item="${item#"${item%%[![:space:]]*}"}"
+        item="${item%"${item##*[![:space:]]}"}"
+        [ -z "$item" ] || printf '%s\n' "$item"
+    done
+}
+
+have_tty() {
+    [ -r /dev/tty ] && [ -w /dev/tty ]
+}
+
+prompt_value() {
+    local prompt="$1"
+    local default_value="$2"
+    local reply=""
+    if [ "$INTERACTIVE" -ne 1 ]; then
+        printf '%s\n' "$default_value"
+        return 0
+    fi
+    if [ -n "$default_value" ]; then
+        printf '%s [%s]: ' "$prompt" "$default_value" >/dev/tty
+    else
+        printf '%s: ' "$prompt" >/dev/tty
+    fi
+    IFS= read -r reply </dev/tty || reply=""
+    if [ -z "$reply" ]; then
+        printf '%s\n' "$default_value"
+    else
+        printf '%s\n' "$reply"
+    fi
+}
+
+prompt_yes_no() {
+    local prompt="$1"
+    local default_value="$2"
+    local suffix reply normalized
+    if [ "$INTERACTIVE" -ne 1 ]; then
+        [ "$default_value" = "yes" ]
+        return $?
+    fi
+    if [ "$default_value" = "yes" ]; then
+        suffix="Y/n"
+    else
+        suffix="y/N"
+    fi
+    while true; do
+        printf '%s [%s]: ' "$prompt" "$suffix" >/dev/tty
+        IFS= read -r reply </dev/tty || reply=""
+        reply="${reply:-$default_value}"
+        normalized="$(printf '%s' "$reply" | tr '[:upper:]' '[:lower:]')"
+        case "$normalized" in
+            y | yes) return 0 ;;
+            n | no) return 1 ;;
+            *) printf 'Please answer yes or no.\n' >/dev/tty ;;
+        esac
+    done
 }
 
 detect_platform() {
@@ -132,6 +233,18 @@ verify_sha256() {
     fi
 }
 
+install_dir() {
+    if [ "$SYSTEM_INSTALL" -eq 1 ]; then
+        printf '/usr/local/bin\n'
+    else
+        printf '%s/bin\n' "$MARMOT_INSTALL_PREFIX"
+    fi
+}
+
+wn_agent_path() {
+    printf '%s/wn-agent\n' "$(install_dir)"
+}
+
 install_wn_agent() {
     local platform="$1"
     local tmpdir="$2"
@@ -139,29 +252,24 @@ install_wn_agent() {
     local archive="$tmpdir/wn-agent-$platform-$suffix.tar.gz"
     local checksum="$tmpdir/wn-agent-$platform-$suffix.tar.gz.sha256"
     local extract_dir="$tmpdir/wn-agent-extract"
-    local install_dir
-
-    if [ "$SYSTEM_INSTALL" -eq 1 ]; then
-        install_dir="/usr/local/bin"
-    else
-        install_dir="$MARMOT_INSTALL_PREFIX/bin"
-    fi
+    local target_dir
+    target_dir="$(install_dir)"
 
     download_asset "wn-agent-$platform-$suffix.tar.gz" "$archive"
     download_asset "wn-agent-$platform-$suffix.tar.gz.sha256" "$checksum"
     verify_sha256 "$archive" "$checksum"
 
     if [ "$DRY_RUN" -eq 1 ]; then
-        log "would install wn-agent to $install_dir/wn-agent"
+        log "would install wn-agent to $target_dir/wn-agent"
         return 0
     fi
 
     rm -rf "$extract_dir"
     mkdir -p "$extract_dir"
     tar -xzf "$archive" -C "$extract_dir"
-    run mkdir -p "$install_dir"
-    run install -m 0755 "$extract_dir/wn-agent-$platform/wn-agent" "$install_dir/wn-agent"
-    log "installed wn-agent -> $install_dir/wn-agent"
+    run mkdir -p "$target_dir"
+    run install -m 0755 "$extract_dir/wn-agent-$platform/wn-agent" "$target_dir/wn-agent"
+    log "installed wn-agent -> $target_dir/wn-agent"
 }
 
 install_plugin() {
@@ -170,6 +278,7 @@ install_plugin() {
     local archive="$tmpdir/hermes-marmot-plugin-$suffix.tar.gz"
     local checksum="$tmpdir/hermes-marmot-plugin-$suffix.tar.gz.sha256"
     local extract_dir="$tmpdir/plugin-extract"
+    local backup_dir
 
     download_asset "hermes-marmot-plugin-$suffix.tar.gz" "$archive"
     download_asset "hermes-marmot-plugin-$suffix.tar.gz.sha256" "$checksum"
@@ -180,15 +289,20 @@ install_plugin() {
         return 0
     fi
 
-    if [ -e "$MARMOT_PLUGIN_DIR" ] && [ "$FORCE" -ne 1 ]; then
-        echo "error: plugin path already exists: $MARMOT_PLUGIN_DIR (pass --force to replace)" >&2
-        exit 1
-    fi
-
     rm -rf "$extract_dir"
     mkdir -p "$extract_dir"
     tar -xzf "$archive" -C "$extract_dir"
-    run rm -rf "$MARMOT_PLUGIN_DIR"
+
+    if [ -e "$MARMOT_PLUGIN_DIR" ]; then
+        if [ "$FORCE" -eq 1 ]; then
+            run rm -rf "$MARMOT_PLUGIN_DIR"
+        else
+            backup_dir="${MARMOT_PLUGIN_DIR}.backup.$(date -u +%Y%m%dT%H%M%SZ)"
+            run mv "$MARMOT_PLUGIN_DIR" "$backup_dir"
+            log "backed up existing Marmot plugin -> $backup_dir"
+        fi
+    fi
+
     run mkdir -p "$(dirname "$MARMOT_PLUGIN_DIR")"
     run cp -R "$extract_dir/hermes-marmot-plugin" "$MARMOT_PLUGIN_DIR"
     log "installed Hermes plugin -> $MARMOT_PLUGIN_DIR"
@@ -199,72 +313,307 @@ enable_hermes_plugin() {
         log "would run: hermes plugins enable marmot"
         return 0
     fi
-    if ! command -v hermes >/dev/null 2>&1; then
-        log "hermes not found on PATH; skipping 'hermes plugins enable marmot'"
-        return 0
-    fi
     if run hermes plugins enable marmot; then
         log "enabled Hermes plugin: marmot"
     else
-        log "could not auto-enable; run 'hermes plugins enable marmot'"
+        warn "could not auto-enable; run 'hermes plugins enable marmot'"
     fi
 }
 
 ensure_path() {
     local bindir
-    if [ "$SYSTEM_INSTALL" -eq 1 ]; then
-        bindir="/usr/local/bin"
-    else
-        bindir="$MARMOT_INSTALL_PREFIX/bin"
-    fi
+    bindir="$(install_dir)"
     case ":$PATH:" in
         *":$bindir:"*) ;;
         *)
-            log "add $bindir to PATH before running wn-agent"
+            log "adding $bindir to PATH for this installer run"
             export PATH="$bindir:$PATH"
             ;;
     esac
 }
 
-run_bootstrap() {
-    ensure_path
-    if [ "$DRY_RUN" -eq 0 ] && ! command -v wn-agent >/dev/null 2>&1; then
-        echo "error: wn-agent not found on PATH after install" >&2
-        exit 1
+relay_args() {
+    local relay
+    for relay in "${RELAYS[@]}"; do
+        printf '%s\n' "--relay"
+        printf '%s\n' "$relay"
+    done
+}
+
+quic_args() {
+    local candidate
+    if [ "$ENABLE_STREAMING" -ne 1 ]; then
+        printf '%s\n' "--no-quic"
+        return 0
+    fi
+    for candidate in "${QUIC_CANDIDATES[@]}"; do
+        printf '%s\n' "--quic-candidate"
+        printf '%s\n' "$candidate"
+    done
+}
+
+allow_welcomer_args() {
+    local welcomer
+    if [ "${#ALLOW_WELCOMERS[@]}" -gt 0 ]; then
+        for welcomer in "${ALLOW_WELCOMERS[@]}"; do
+            printf '%s\n' "--allow-welcomer"
+            printf '%s\n' "$welcomer"
+        done
+    fi
+}
+
+wait_for_socket() {
+    local waited=0
+    while [ "$waited" -lt 15 ]; do
+        [ -S "$MARMOT_AGENT_SOCKET" ] && return 0
+        sleep 1
+        waited=$((waited + 1))
+    done
+    return 1
+}
+
+plist_string() {
+    local value="$1"
+    value="${value//&/&amp;}"
+    value="${value//</&lt;}"
+    value="${value//>/&gt;}"
+    value="${value//\"/&quot;}"
+    printf '    <string>%s</string>\n' "$value"
+}
+
+install_macos_service() {
+    local plist_dir plist label program logs_dir relay
+    label="org.marmot.wn-agent"
+    plist_dir="$HOME/Library/LaunchAgents"
+    plist="$plist_dir/$label.plist"
+    program="$(wn_agent_path)"
+    logs_dir="$MARMOT_HOME/logs"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        log "would install LaunchAgent $plist"
+        log "would run: launchctl bootstrap gui/$UID $plist"
+        return 0
     fi
 
-    local wn_agent_pid=""
-    if [ "$START_WN_AGENT" -eq 1 ]; then
-        local -a wn_agent_args=(--home "$MARMOT_HOME")
-        local relay
-        IFS=',' read -r -a relays <<<"$MARMOT_RELAYS"
-        for relay in "${relays[@]}"; do
-            relay="${relay#"${relay%%[![:space:]]*}"}"
-            relay="${relay%"${relay##*[![:space:]]}"}"
-            [ -z "$relay" ] || wn_agent_args+=(--relay "$relay")
+    run mkdir -p "$plist_dir" "$logs_dir"
+    {
+        printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
+        printf '%s\n' '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">'
+        printf '%s\n' '<plist version="1.0">'
+        printf '%s\n' '<dict>'
+        printf '%s\n' '  <key>Label</key>'
+        plist_string "$label"
+        printf '%s\n' '  <key>ProgramArguments</key>'
+        printf '%s\n' '  <array>'
+        plist_string "$program"
+        plist_string "--home"
+        plist_string "$MARMOT_HOME"
+        plist_string "--socket"
+        plist_string "$MARMOT_AGENT_SOCKET"
+        for relay in "${RELAYS[@]}"; do
+            plist_string "--relay"
+            plist_string "$relay"
         done
-        log "starting wn-agent"
-        if [ "$DRY_RUN" -eq 1 ]; then
-            printf '[dry-run] wn-agent'
-            printf ' %q' "${wn_agent_args[@]}"
-            printf '\n'
-        else
-            run mkdir -p "$MARMOT_HOME"
-            wn-agent "${wn_agent_args[@]}" &
-            wn_agent_pid="$!"
-        fi
+        printf '%s\n' '  </array>'
+        printf '%s\n' '  <key>RunAtLoad</key>'
+        printf '%s\n' '  <true/>'
+        printf '%s\n' '  <key>KeepAlive</key>'
+        printf '%s\n' '  <true/>'
+        printf '%s\n' '  <key>StandardOutPath</key>'
+        plist_string "$logs_dir/wn-agent.out.log"
+        printf '%s\n' '  <key>StandardErrorPath</key>'
+        plist_string "$logs_dir/wn-agent.err.log"
+        printf '%s\n' '</dict>'
+        printf '%s\n' '</plist>'
+    } >"$plist"
+
+    launchctl bootout "gui/$UID" "$plist" >/dev/null 2>&1 || true
+    run launchctl bootstrap "gui/$UID" "$plist"
+    launchctl kickstart -k "gui/$UID/$label" >/dev/null 2>&1 || true
+    log "installed and started LaunchAgent: $label"
+}
+
+install_linux_user_service() {
+    local service_dir service program relay
+    if ! command -v systemctl >/dev/null 2>&1; then
+        return 1
+    fi
+    service_dir="$HOME/.config/systemd/user"
+    service="$service_dir/wn-agent.service"
+    program="$(wn_agent_path)"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        log "would install systemd user unit $service"
+        log "would run: systemctl --user enable --now wn-agent.service"
+        return 0
+    fi
+
+    run mkdir -p "$service_dir" "$MARMOT_HOME/logs"
+    {
+        printf '%s\n' '[Unit]'
+        printf '%s\n' 'Description=Marmot wn-agent connector'
+        printf '%s\n' 'After=network-online.target'
+        printf '%s\n'
+        printf '%s\n' '[Service]'
+        printf 'ExecStart=%q --home %q --socket %q' "$program" "$MARMOT_HOME" "$MARMOT_AGENT_SOCKET"
+        for relay in "${RELAYS[@]}"; do
+            printf ' --relay %q' "$relay"
+        done
+        printf '\n'
+        printf '%s\n' 'Restart=always'
+        printf '%s\n' 'RestartSec=2'
+        printf '%s\n'
+        printf '%s\n' '[Install]'
+        printf '%s\n' 'WantedBy=default.target'
+    } >"$service"
+
+    run systemctl --user daemon-reload
+    run systemctl --user enable --now wn-agent.service
+    log "installed and started systemd user service: wn-agent.service"
+}
+
+install_user_service() {
+    case "$(uname -s)" in
+        Darwin)
+            install_macos_service
+            ;;
+        Linux)
+            if ! install_linux_user_service; then
+                warn "systemd user service not available; wn-agent will not be installed as a service"
+                return 1
+            fi
+            ;;
+        *)
+            warn "no supported same-user service manager for $(uname -s)"
+            return 1
+            ;;
+    esac
+}
+
+start_temp_agent() {
+    if [ "$NO_START_WN_AGENT" -eq 1 ]; then
+        return 0
+    fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '[dry-run] wn-agent --home %q --socket %q' "$MARMOT_HOME" "$MARMOT_AGENT_SOCKET"
+        local relay
+        for relay in "${RELAYS[@]}"; do
+            printf ' --relay %q' "$relay"
+        done
+        printf '\n'
+        return 0
+    fi
+    if [ -S "$MARMOT_AGENT_SOCKET" ]; then
+        log "found existing wn-agent socket: $MARMOT_AGENT_SOCKET"
+        return 0
+    fi
+    run mkdir -p "$MARMOT_HOME"
+    local -a args=(--home "$MARMOT_HOME" --socket "$MARMOT_AGENT_SOCKET")
+    local relay
+    for relay in "${RELAYS[@]}"; do
+        args+=(--relay "$relay")
+    done
+    log "starting temporary wn-agent for bootstrap"
+    wn-agent "${args[@]}" &
+    WN_AGENT_TEMP_PID="$!"
+}
+
+bootstrap_agent() {
+    ensure_path
+    if [ "$DRY_RUN" -eq 0 ]; then
+        need_cmd wn-agent
+    fi
+
+    if [ "$INSTALL_SERVICE" -eq 1 ] && [ "$NO_START_WN_AGENT" -ne 1 ]; then
+        install_user_service || start_temp_agent
+    else
+        start_temp_agent
+    fi
+
+    if [ "$DRY_RUN" -eq 0 ] && ! wait_for_socket; then
+        warn "wn-agent socket did not appear before bootstrap wait; bootstrap will keep waiting briefly"
+    fi
+
+    local -a args=(bootstrap --json --home "$MARMOT_HOME" --socket "$MARMOT_AGENT_SOCKET")
+    local relay
+    for relay in "${RELAYS[@]}"; do
+        args+=(--relay "$relay")
+    done
+    if [ "$ENABLE_STREAMING" -eq 1 ]; then
+        local candidate
+        for candidate in "${QUIC_CANDIDATES[@]}"; do
+            args+=(--quic-candidate "$candidate")
+        done
+    else
+        args+=(--no-quic)
+    fi
+    local welcomer
+    if [ "${#ALLOW_WELCOMERS[@]}" -gt 0 ]; then
+        for welcomer in "${ALLOW_WELCOMERS[@]}"; do
+            args+=(--allow-welcomer "$welcomer")
+        done
     fi
 
     log "running wn-agent bootstrap"
     if [ "$DRY_RUN" -eq 1 ]; then
-        printf '[dry-run] wn-agent bootstrap --home %q --qr\n' "$MARMOT_HOME"
-    else
-        run wn-agent bootstrap --home "$MARMOT_HOME" --qr
+        printf '[dry-run] wn-agent'
+        printf ' %q' "${args[@]}"
+        printf '\n'
+        BOOTSTRAP_ACCOUNT_ID_HEX="<account-id-from-bootstrap>"
+        BOOTSTRAP_JSON_PATH="$MARMOT_HOME/bootstrap.json"
+        return 0
     fi
 
-    if [ -n "$wn_agent_pid" ] && [ "$DRY_RUN" -eq 0 ]; then
-        log "wn-agent running in background (pid $wn_agent_pid)"
+    run mkdir -p "$MARMOT_HOME"
+    local bootstrap_json
+    bootstrap_json="$(wn-agent "${args[@]}")"
+    BOOTSTRAP_JSON_PATH="$MARMOT_HOME/bootstrap.json"
+    printf '%s\n' "$bootstrap_json" >"$BOOTSTRAP_JSON_PATH"
+    BOOTSTRAP_ACCOUNT_ID_HEX="$(
+        printf '%s\n' "$bootstrap_json" |
+            python3 -c 'import json, sys; print(json.load(sys.stdin)["account_id_hex"])'
+    )"
+    log "bootstrap details -> $BOOTSTRAP_JSON_PATH"
+}
+
+configure_hermes_gateway() {
+    if [ "$CONFIGURE_HERMES" -ne 1 ]; then
+        return 0
     fi
+    local helper="$MARMOT_PLUGIN_DIR/configure_gateway.py"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        log "would patch Hermes config: $HERMES_HOME/config.yaml"
+        log "would preserve other Hermes connectors and only update platforms.marmot/display.platforms.marmot"
+        return 0
+    fi
+    if [ ! -f "$helper" ]; then
+        echo "error: Hermes config helper not found in plugin: $helper" >&2
+        exit 1
+    fi
+
+    local -a args=(
+        "$helper"
+        --home "$HERMES_HOME"
+        --agent-home "$MARMOT_HOME"
+        --socket-path "$MARMOT_AGENT_SOCKET"
+        --account-id-hex "$BOOTSTRAP_ACCOUNT_ID_HEX"
+        --tool-progress off
+        --interim-messages 0
+        --long-running-notifications 0
+        --busy-ack-detail 0
+    )
+    if [ "$ENABLE_STREAMING" -eq 1 ]; then
+        args+=(--streaming 1 --transport auto --configure-global-streaming)
+    else
+        args+=(--streaming 0 --transport off)
+    fi
+    if [ "${#ALLOW_WELCOMERS[@]}" -gt 0 ]; then
+        local welcomer
+        for welcomer in "${ALLOW_WELCOMERS[@]}"; do
+            args+=(--welcomer-allowlist "$welcomer")
+        done
+    fi
+    run python3 "${args[@]}"
 }
 
 print_next_steps() {
@@ -272,17 +621,20 @@ print_next_steps() {
 
 Install complete.
 
-Next steps:
-  1. Ensure wn-agent is on your PATH ($(
-    if [ "$SYSTEM_INSTALL" -eq 1 ]; then echo "/usr/local/bin"; else echo "$MARMOT_INSTALL_PREFIX/bin"; fi
-  ))
-  2. Start the connector:
-     export MARMOT_HOME="$MARMOT_HOME"
-     wn-agent --home "\$MARMOT_HOME" --relay wss://relay.eu.whitenoise.chat --relay wss://relay.us.whitenoise.chat
-  3. Bootstrap or reuse the agent account:
-     wn-agent bootstrap --home "\$MARMOT_HOME" --qr
-  4. Start Hermes:
-     hermes gateway run
+Marmot agent:
+  home: $MARMOT_HOME
+  socket: $MARMOT_AGENT_SOCKET
+  account: $BOOTSTRAP_ACCOUNT_ID_HEX
+  bootstrap JSON: $BOOTSTRAP_JSON_PATH
+
+Hermes:
+  home: $HERMES_HOME
+  plugin: $MARMOT_PLUGIN_DIR
+
+Restart your existing Hermes gateway when you are ready for it to load the Marmot plugin/config:
+  hermes gateway run
+
+Existing Hermes connectors were not removed or disabled. The installer only updated the Marmot plugin and Marmot-specific config entries.
 
 Build: ${MARMOT_RELEASE_REPO}@${MARMOT_RELEASE_TAG} (${WN_AGENT_VERSION})
 EOF
@@ -291,11 +643,48 @@ EOF
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --bootstrap)
-            INSTALL_BOOTSTRAP=1
+            shift
+            ;;
+        --yes | --non-interactive)
+            ASSUME_YES=1
+            shift
+            ;;
+        --home)
+            MARMOT_HOME="${2:?missing value for --home}"
+            MARMOT_AGENT_SOCKET_OVERRIDE=""
+            shift 2
+            ;;
+        --hermes-home)
+            HERMES_HOME="${2:?missing value for --hermes-home}"
+            shift 2
+            ;;
+        --allow-welcomer)
+            ALLOW_WELCOMERS+=("${2:?missing value for --allow-welcomer}")
+            shift 2
+            ;;
+        --relay)
+            CLI_RELAYS=1
+            RELAYS+=("${2:?missing value for --relay}")
+            shift 2
+            ;;
+        --enable-streaming)
+            ENABLE_STREAMING=1
+            shift
+            ;;
+        --quic-candidate)
+            QUIC_CANDIDATES+=("${2:?missing value for --quic-candidate}")
+            shift 2
+            ;;
+        --no-service)
+            INSTALL_SERVICE=0
             shift
             ;;
         --no-start-wn-agent)
-            START_WN_AGENT=0
+            NO_START_WN_AGENT=1
+            shift
+            ;;
+        --no-configure-hermes)
+            CONFIGURE_HERMES=0
             shift
             ;;
         --system)
@@ -322,19 +711,78 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
+if [ "$ASSUME_YES" -ne 1 ] && have_tty; then
+    INTERACTIVE=1
+fi
+if [ "$ASSUME_YES" -eq 1 ]; then
+    INTERACTIVE=0
+fi
+
+MARMOT_PLUGIN_DIR="${MARMOT_PLUGIN_DIR_OVERRIDE:-$HERMES_HOME/plugins/marmot}"
+MARMOT_AGENT_SOCKET="${MARMOT_AGENT_SOCKET_OVERRIDE:-$MARMOT_HOME/dev/wn-agent.sock}"
+
+if [ "$CLI_RELAYS" -eq 0 ]; then
+    while IFS= read -r relay; do
+        RELAYS+=("$relay")
+    done < <(append_csv "$MARMOT_RELAYS")
+fi
+if [ "${#RELAYS[@]}" -eq 0 ]; then
+    RELAYS+=("wss://relay.eu.whitenoise.chat" "wss://relay.us.whitenoise.chat")
+fi
+if [ -n "${MARMOT_WELCOMER_ALLOWLIST:-}" ]; then
+    while IFS= read -r welcomer; do
+        ALLOW_WELCOMERS+=("$welcomer")
+    done < <(append_csv "$MARMOT_WELCOMER_ALLOWLIST")
+fi
+if [ "${#QUIC_CANDIDATES[@]}" -eq 0 ]; then
+    QUIC_CANDIDATES+=("quic://quic-broker.ipf.dev:4450")
+fi
+
+if [ "$INTERACTIVE" -eq 1 ]; then
+    log "guided setup will prompt on /dev/tty; press Enter to accept defaults"
+    HERMES_HOME="$(prompt_value "Hermes home" "$HERMES_HOME")"
+    MARMOT_HOME="$(prompt_value "Marmot agent home" "$MARMOT_HOME")"
+    MARMOT_PLUGIN_DIR="${MARMOT_PLUGIN_DIR_OVERRIDE:-$HERMES_HOME/plugins/marmot}"
+    MARMOT_AGENT_SOCKET="${MARMOT_AGENT_SOCKET_OVERRIDE:-$MARMOT_HOME/dev/wn-agent.sock}"
+    if [ -e "$MARMOT_HOME" ]; then
+        log "existing Marmot agent home detected; bootstrap will reuse or repair it: $MARMOT_HOME"
+    fi
+    if [ "${#ALLOW_WELCOMERS[@]}" -eq 0 ]; then
+        while true; do
+            welcomer_reply="$(prompt_value "Allowed inviter/welcomer npub or hex (blank to skip)" "")"
+            if [ -n "$welcomer_reply" ]; then
+                ALLOW_WELCOMERS+=("$welcomer_reply")
+                break
+            fi
+            if prompt_yes_no "Skip the welcomer allowlist for now? Invites will not auto-accept." "no"; then
+                break
+            fi
+        done
+    fi
+fi
+
 need_cmd curl
 need_cmd tar
+if [ "$DRY_RUN" -eq 0 ]; then
+    need_cmd hermes
+    if [ "$CONFIGURE_HERMES" -eq 1 ]; then
+        need_cmd python3
+    fi
+else
+    log "would require hermes on PATH"
+fi
+
 platform="$(detect_platform)"
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
 log "platform=$platform repo=$MARMOT_RELEASE_REPO tag=$MARMOT_RELEASE_TAG version=$WN_AGENT_VERSION"
+log "Hermes home: $HERMES_HOME"
+log "Marmot home: $MARMOT_HOME"
+log "Marmot socket: $MARMOT_AGENT_SOCKET"
 install_wn_agent "$platform" "$tmpdir"
 install_plugin "$tmpdir"
 enable_hermes_plugin
-
-if [ "$INSTALL_BOOTSTRAP" -eq 1 ]; then
-    run_bootstrap
-else
-    print_next_steps
-fi
+bootstrap_agent
+configure_hermes_gateway
+print_next_steps

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -42,6 +42,7 @@ SYSTEM_INSTALL=0
 CLI_RELAYS=0
 BOOTSTRAP_ACCOUNT_ID_HEX=""
 BOOTSTRAP_JSON_PATH=""
+WN_AGENT_TEMP_PID=""
 
 RELAYS=()
 ALLOW_WELCOMERS=()
@@ -119,6 +120,7 @@ need_cmd() {
 append_csv() {
     local value="$1"
     local item
+    local -a _items
     IFS=',' read -r -a _items <<<"$value"
     for item in "${_items[@]}"; do
         item="${item#"${item%%[![:space:]]*}"}"
@@ -175,6 +177,35 @@ prompt_yes_no() {
             n | no) return 1 ;;
             *) printf 'Please answer yes or no.\n' >/dev/tty ;;
         esac
+    done
+}
+
+is_welcomer_ref_syntax() {
+    local value normalized
+    value="${1#"${1%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    normalized="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+    case "$normalized" in
+        npub1*)
+            [[ "$normalized" =~ ^npub1[023456789acdefghjklmnpqrstuvwxyz]+$ ]]
+            ;;
+        *)
+            [[ "$normalized" =~ ^[0-9a-f]{64}$ ]]
+            ;;
+    esac
+}
+
+validate_welcomer_inputs() {
+    local welcomer
+    if [ "${#ALLOW_WELCOMERS[@]}" -eq 0 ]; then
+        return 0
+    fi
+    for welcomer in "${ALLOW_WELCOMERS[@]}"; do
+        if ! is_welcomer_ref_syntax "$welcomer"; then
+            echo "error: invalid welcomer allowlist value: $welcomer" >&2
+            echo "expected a Nostr npub or 64-character hex account id" >&2
+            exit 1
+        fi
     done
 }
 
@@ -395,7 +426,7 @@ install_macos_service() {
         return 0
     fi
 
-    run mkdir -p "$plist_dir" "$logs_dir"
+    run mkdir -p "$plist_dir" "$logs_dir" || return 1
     {
         printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
         printf '%s\n' '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">'
@@ -425,10 +456,13 @@ install_macos_service() {
         plist_string "$logs_dir/wn-agent.err.log"
         printf '%s\n' '</dict>'
         printf '%s\n' '</plist>'
-    } >"$plist"
+    } >"$plist" || return 1
 
     launchctl bootout "gui/$UID" "$plist" >/dev/null 2>&1 || true
-    run launchctl bootstrap "gui/$UID" "$plist"
+    if ! run launchctl bootstrap "gui/$UID" "$plist"; then
+        warn "launchctl bootstrap failed for $label; falling back to a temporary wn-agent process"
+        return 1
+    fi
     launchctl kickstart -k "gui/$UID/$label" >/dev/null 2>&1 || true
     log "installed and started LaunchAgent: $label"
 }
@@ -448,12 +482,12 @@ install_linux_user_service() {
         return 0
     fi
 
-    run mkdir -p "$service_dir" "$MARMOT_HOME/logs"
+    run mkdir -p "$service_dir" "$MARMOT_HOME/logs" || return 1
     {
         printf '%s\n' '[Unit]'
         printf '%s\n' 'Description=Marmot wn-agent connector'
         printf '%s\n' 'After=network-online.target'
-        printf '%s\n'
+        printf '\n'
         printf '%s\n' '[Service]'
         printf 'ExecStart=%q --home %q --socket %q' "$program" "$MARMOT_HOME" "$MARMOT_AGENT_SOCKET"
         for relay in "${RELAYS[@]}"; do
@@ -462,13 +496,19 @@ install_linux_user_service() {
         printf '\n'
         printf '%s\n' 'Restart=always'
         printf '%s\n' 'RestartSec=2'
-        printf '%s\n'
+        printf '\n'
         printf '%s\n' '[Install]'
         printf '%s\n' 'WantedBy=default.target'
-    } >"$service"
+    } >"$service" || return 1
 
-    run systemctl --user daemon-reload
-    run systemctl --user enable --now wn-agent.service
+    if ! run systemctl --user daemon-reload; then
+        warn "systemctl --user daemon-reload failed; falling back to a temporary wn-agent process"
+        return 1
+    fi
+    if ! run systemctl --user enable --now wn-agent.service; then
+        warn "systemctl --user enable --now wn-agent.service failed; falling back to a temporary wn-agent process"
+        return 1
+    fi
     log "installed and started systemd user service: wn-agent.service"
 }
 
@@ -516,6 +556,7 @@ start_temp_agent() {
     log "starting temporary wn-agent for bootstrap"
     wn-agent "${args[@]}" &
     WN_AGENT_TEMP_PID="$!"
+    log "temporary wn-agent pid: $WN_AGENT_TEMP_PID"
 }
 
 bootstrap_agent() {
@@ -626,6 +667,13 @@ Marmot agent:
   socket: $MARMOT_AGENT_SOCKET
   account: $BOOTSTRAP_ACCOUNT_ID_HEX
   bootstrap JSON: $BOOTSTRAP_JSON_PATH
+EOF
+    if [ -n "${WN_AGENT_TEMP_PID:-}" ]; then
+        cat <<EOF
+  temporary process: pid $WN_AGENT_TEMP_PID (stop with: kill $WN_AGENT_TEMP_PID)
+EOF
+    fi
+    cat <<EOF
 
 Hermes:
   home: $HERMES_HOME
@@ -761,6 +809,8 @@ if [ "$INTERACTIVE" -eq 1 ]; then
     fi
 fi
 
+validate_welcomer_inputs
+
 need_cmd curl
 need_cmd tar
 if [ "$DRY_RUN" -eq 0 ]; then
@@ -774,7 +824,14 @@ fi
 
 platform="$(detect_platform)"
 tmpdir="$(mktemp -d)"
-trap 'rm -rf "$tmpdir"' EXIT
+cleanup() {
+    local status=$?
+    rm -rf "$tmpdir"
+    if [ "$status" -ne 0 ] && [ -n "${WN_AGENT_TEMP_PID:-}" ]; then
+        kill "$WN_AGENT_TEMP_PID" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
 
 log "platform=$platform repo=$MARMOT_RELEASE_REPO tag=$MARMOT_RELEASE_TAG version=$WN_AGENT_VERSION"
 log "Hermes home: $HERMES_HOME"

--- a/scripts/install-openclaw-marmot.sh
+++ b/scripts/install-openclaw-marmot.sh
@@ -44,6 +44,7 @@ CLI_RELAYS=0
 BOOTSTRAP_ACCOUNT_ID_HEX=""
 BOOTSTRAP_JSON_PATH=""
 BOOTSTRAP_WELCOMER_ALLOWLIST_CSV=""
+WN_AGENT_TEMP_PID=""
 
 RELAYS=()
 ALLOW_WELCOMERS=()
@@ -103,6 +104,7 @@ need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "missing required command
 append_csv() {
     local value="$1"
     local item
+    local -a _items
     IFS=',' read -r -a _items <<<"$value"
     for item in "${_items[@]}"; do
         item="${item#"${item%%[![:space:]]*}"}"
@@ -149,6 +151,35 @@ prompt_yes_no() {
             n | no) return 1 ;;
             *) printf 'Please answer yes or no.\n' >/dev/tty ;;
         esac
+    done
+}
+
+is_welcomer_ref_syntax() {
+    local value normalized
+    value="${1#"${1%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    normalized="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+    case "$normalized" in
+        npub1*)
+            [[ "$normalized" =~ ^npub1[023456789acdefghjklmnpqrstuvwxyz]+$ ]]
+            ;;
+        *)
+            [[ "$normalized" =~ ^[0-9a-f]{64}$ ]]
+            ;;
+    esac
+}
+
+validate_welcomer_inputs() {
+    local welcomer
+    if [ "${#ALLOW_WELCOMERS[@]}" -eq 0 ]; then
+        return 0
+    fi
+    for welcomer in "${ALLOW_WELCOMERS[@]}"; do
+        if ! is_welcomer_ref_syntax "$welcomer"; then
+            echo "error: invalid welcomer allowlist value: $welcomer" >&2
+            echo "expected a Nostr npub or 64-character hex account id" >&2
+            exit 1
+        fi
     done
 }
 
@@ -314,7 +345,7 @@ install_macos_service() {
         return 0
     fi
 
-    run mkdir -p "$plist_dir" "$logs_dir"
+    run mkdir -p "$plist_dir" "$logs_dir" || return 1
     {
         printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
         printf '%s\n' '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">'
@@ -344,10 +375,13 @@ install_macos_service() {
         plist_string "$logs_dir/wn-agent.err.log"
         printf '%s\n' '</dict>'
         printf '%s\n' '</plist>'
-    } >"$plist"
+    } >"$plist" || return 1
 
     launchctl bootout "gui/$UID" "$plist" >/dev/null 2>&1 || true
-    run launchctl bootstrap "gui/$UID" "$plist"
+    if ! run launchctl bootstrap "gui/$UID" "$plist"; then
+        warn "launchctl bootstrap failed for $label; falling back to a temporary wn-agent process"
+        return 1
+    fi
     launchctl kickstart -k "gui/$UID/$label" >/dev/null 2>&1 || true
     log "installed and started LaunchAgent: $label"
 }
@@ -365,25 +399,31 @@ install_linux_user_service() {
         return 0
     fi
 
-    run mkdir -p "$service_dir" "$MARMOT_HOME/logs"
+    run mkdir -p "$service_dir" "$MARMOT_HOME/logs" || return 1
     {
         printf '%s\n' '[Unit]'
         printf '%s\n' 'Description=Marmot wn-agent connector'
         printf '%s\n' 'After=network-online.target'
-        printf '%s\n'
+        printf '\n'
         printf '%s\n' '[Service]'
         printf 'ExecStart=%q --home %q --socket %q' "$program" "$MARMOT_HOME" "$MARMOT_AGENT_SOCKET"
         for relay in "${RELAYS[@]}"; do printf ' --relay %q' "$relay"; done
         printf '\n'
         printf '%s\n' 'Restart=always'
         printf '%s\n' 'RestartSec=2'
-        printf '%s\n'
+        printf '\n'
         printf '%s\n' '[Install]'
         printf '%s\n' 'WantedBy=default.target'
-    } >"$service"
+    } >"$service" || return 1
 
-    run systemctl --user daemon-reload
-    run systemctl --user enable --now wn-agent.service
+    if ! run systemctl --user daemon-reload; then
+        warn "systemctl --user daemon-reload failed; falling back to a temporary wn-agent process"
+        return 1
+    fi
+    if ! run systemctl --user enable --now wn-agent.service; then
+        warn "systemctl --user enable --now wn-agent.service failed; falling back to a temporary wn-agent process"
+        return 1
+    fi
     log "installed and started systemd user service: wn-agent.service"
 }
 
@@ -422,6 +462,8 @@ start_temp_agent() {
     for relay in "${RELAYS[@]}"; do args+=(--relay "$relay"); done
     log "starting temporary wn-agent for bootstrap"
     wn-agent "${args[@]}" &
+    WN_AGENT_TEMP_PID="$!"
+    log "temporary wn-agent pid: $WN_AGENT_TEMP_PID"
 }
 
 bootstrap_agent() {
@@ -556,6 +598,13 @@ Marmot agent:
   socket: $MARMOT_AGENT_SOCKET
   account: $BOOTSTRAP_ACCOUNT_ID_HEX
   bootstrap JSON: $BOOTSTRAP_JSON_PATH
+EOF
+    if [ -n "${WN_AGENT_TEMP_PID:-}" ]; then
+        cat <<EOF
+  temporary process: pid $WN_AGENT_TEMP_PID (stop with: kill $WN_AGENT_TEMP_PID)
+EOF
+    fi
+    cat <<EOF
 
 OpenClaw:
   home: $OPENCLAW_HOME
@@ -627,6 +676,8 @@ if [ "$INTERACTIVE" -eq 1 ]; then
     fi
 fi
 
+validate_welcomer_inputs
+
 need_cmd curl
 need_cmd tar
 if [ "$DRY_RUN" -eq 0 ]; then
@@ -639,7 +690,14 @@ fi
 
 platform="$(detect_platform)"
 tmpdir="$(mktemp -d)"
-trap 'rm -rf "$tmpdir"' EXIT
+cleanup() {
+    local status=$?
+    rm -rf "$tmpdir"
+    if [ "$status" -ne 0 ] && [ -n "${WN_AGENT_TEMP_PID:-}" ]; then
+        kill "$WN_AGENT_TEMP_PID" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
 
 log "platform=$platform repo=$MARMOT_RELEASE_REPO tag=$MARMOT_RELEASE_TAG version=$WN_AGENT_VERSION"
 log "OpenClaw home: $OPENCLAW_HOME"

--- a/scripts/install-openclaw-marmot.sh
+++ b/scripts/install-openclaw-marmot.sh
@@ -2,16 +2,22 @@
 set -euo pipefail
 
 # Install wn-agent and the OpenClaw Marmot channel plugin from a WN Agent GitHub
-# release. OpenClaw itself must already be installed. Mirrors
-# scripts/install-hermes-marmot.sh.
-#
-# NOTE: requires a published wn-agent-v* release. Releases from before the rename
-# ship differently-named assets and cannot be installed by this script;
-# cut the first wn-agent-v* release before pointing installs here.
+# release. OpenClaw itself must already be installed. Mirrors the Hermes
+# installer while patching only OpenClaw's Marmot channel config.
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-workspace_version_default="$(sed -n 's/^version = "\(.*\)"/\1/p' "$SCRIPT_DIR/../Cargo.toml" 2>/dev/null | head -n 1)"
-workspace_version_default="${workspace_version_default:-latest}"
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-}"
+SCRIPT_DIR=""
+if [ -n "$SCRIPT_SOURCE" ] && [ -f "$SCRIPT_SOURCE" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_SOURCE")" && pwd)"
+fi
+workspace_version_default="latest"
+if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/../Cargo.toml" ]; then
+    workspace_version_default="$(
+        sed -n 's/^version = "\(.*\)"/\1/p' "$SCRIPT_DIR/../Cargo.toml" 2>/dev/null |
+            head -n 1 || true
+    )"
+    workspace_version_default="${workspace_version_default:-latest}"
+fi
 
 MARMOT_RELEASE_REPO="${MARMOT_RELEASE_REPO:-marmot-protocol/mdk}"
 WN_AGENT_VERSION_DEFAULT="${WN_AGENT_VERSION_DEFAULT:-$workspace_version_default}"
@@ -19,14 +25,29 @@ WN_AGENT_VERSION="${WN_AGENT_VERSION:-${WN_AGENT_SHA:-$WN_AGENT_VERSION_DEFAULT}
 MARMOT_RELEASE_TAG_DEFAULT="${MARMOT_RELEASE_TAG_DEFAULT:-wn-agent-v${WN_AGENT_VERSION}}"
 MARMOT_RELEASE_TAG="${MARMOT_RELEASE_TAG:-$MARMOT_RELEASE_TAG_DEFAULT}"
 MARMOT_INSTALL_PREFIX="${MARMOT_INSTALL_PREFIX:-${HOME}/.local}"
+OPENCLAW_HOME="${OPENCLAW_HOME:-${HOME}}"
 MARMOT_HOME="${MARMOT_HOME:-${HOME}/.marmot-agent}"
+MARMOT_AGENT_SOCKET_OVERRIDE="${MARMOT_AGENT_SOCKET:-}"
 MARMOT_RELAYS="${MARMOT_RELAYS:-wss://relay.eu.whitenoise.chat,wss://relay.us.whitenoise.chat}"
 PLUGIN_PACKAGE="${PLUGIN_PACKAGE:-openclaw-marmot-plugin-${WN_AGENT_VERSION}.tgz}"
-INSTALL_BOOTSTRAP=0
-START_WN_AGENT=1
+
+ASSUME_YES=0
+CONFIGURE_OPENCLAW=1
 DRY_RUN=0
+ENABLE_STREAMING=0
 FORCE=0
+INSTALL_SERVICE=1
+INTERACTIVE=0
+NO_START_WN_AGENT=0
 SYSTEM_INSTALL=0
+CLI_RELAYS=0
+BOOTSTRAP_ACCOUNT_ID_HEX=""
+BOOTSTRAP_JSON_PATH=""
+BOOTSTRAP_WELCOMER_ALLOWLIST_CSV=""
+
+RELAYS=()
+ALLOW_WELCOMERS=()
+QUIC_CANDIDATES=()
 
 usage() {
     cat <<'USAGE'
@@ -36,30 +57,100 @@ Install wn-agent and the OpenClaw Marmot channel plugin from a WN Agent GitHub
 release. OpenClaw must already be installed and `openclaw` on PATH.
 
 Options:
-  --bootstrap           After install, start wn-agent and run `wn-agent bootstrap --qr`
-  --no-start-wn-agent   With --bootstrap, do not start wn-agent automatically
-  --system              Install wn-agent to /usr/local/bin instead of ~/.local/bin
-  --force               Reinstall the OpenClaw Marmot plugin even if already present
-  --dry-run             Print actions without installing
-  -h, --help            Show this help
+  --bootstrap              Compatibility alias; guided bootstrap is the default
+  --yes, --non-interactive Use defaults and do not prompt
+  --home PATH              Marmot agent home (default: ~/.marmot-agent)
+  --openclaw-home PATH     OpenClaw home (default: $OPENCLAW_HOME or $HOME)
+  --allow-welcomer VALUE   Allow invites from this npub or hex pubkey; may repeat
+  --relay URL              Relay URL for wn-agent/bootstrap; may repeat
+  --enable-streaming       Configure OpenClaw/Marmot live preview streaming
+  --quic-candidate URI     QUIC preview candidate used with --enable-streaming
+  --no-service             Do not install/start a LaunchAgent or systemd user unit
+  --no-start-wn-agent      Do not start wn-agent before bootstrap
+  --no-configure-openclaw  Install assets but do not patch OpenClaw config
+  --system                 Install wn-agent to /usr/local/bin instead of ~/.local/bin
+  --force                  Pass --force to openclaw plugins install when supported
+  --dry-run                Print actions without installing
+  -h, --help               Show this help
 
 Environment:
-  MARMOT_RELEASE_REPO   GitHub repo (default: marmot-protocol/mdk)
-  MARMOT_RELEASE_TAG    Release tag (default: wn-agent-v<version>)
-  WN_AGENT_VERSION      Asset version suffix
-  WN_AGENT_SHA          Legacy alias for WN_AGENT_VERSION
-  MARMOT_INSTALL_PREFIX Install root for wn-agent (default: ~/.local)
-  MARMOT_HOME           wn-agent home used by bootstrap (default: ~/.marmot-agent)
-  MARMOT_RELAYS         Relay CSV used when --bootstrap starts wn-agent
+  MARMOT_RELEASE_REPO      GitHub repo (default: marmot-protocol/mdk)
+  MARMOT_RELEASE_TAG       Release tag (release assets default to their own tag)
+  WN_AGENT_VERSION         Asset version suffix
+  WN_AGENT_SHA             Legacy alias for WN_AGENT_VERSION
+  MARMOT_INSTALL_PREFIX    Install root for wn-agent (default: ~/.local)
+  OPENCLAW_HOME            OpenClaw home (default: $HOME; config at $OPENCLAW_HOME/.openclaw/openclaw.json)
+  MARMOT_HOME              wn-agent home (default: ~/.marmot-agent)
+  MARMOT_AGENT_SOCKET      wn-agent socket (default: $MARMOT_HOME/dev/wn-agent.sock)
+  MARMOT_RELAYS            Relay CSV used by wn-agent and bootstrap
+  MARMOT_WELCOMER_ALLOWLIST Comma-separated npub or hex allowlist values
+
+Example:
+  curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.2/install-openclaw-marmot.sh | bash
+
+  curl -fsSL .../install-openclaw-marmot.sh | bash -s -- --yes --allow-welcomer npub1...
 USAGE
 }
 
 log() { printf 'install-openclaw-marmot: %s\n' "$*"; }
+warn() { printf 'install-openclaw-marmot: warning: %s\n' "$*" >&2; }
 run() {
     if [ "$DRY_RUN" -eq 1 ]; then printf '[dry-run] '; printf '%q ' "$@"; printf '\n'; return 0; fi
     "$@"
 }
 need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "missing required command: $1" >&2; exit 1; }; }
+
+append_csv() {
+    local value="$1"
+    local item
+    IFS=',' read -r -a _items <<<"$value"
+    for item in "${_items[@]}"; do
+        item="${item#"${item%%[![:space:]]*}"}"
+        item="${item%"${item##*[![:space:]]}"}"
+        [ -z "$item" ] || printf '%s\n' "$item"
+    done
+}
+
+have_tty() { [ -r /dev/tty ] && [ -w /dev/tty ]; }
+
+prompt_value() {
+    local prompt="$1"
+    local default_value="$2"
+    local reply=""
+    if [ "$INTERACTIVE" -ne 1 ]; then
+        printf '%s\n' "$default_value"
+        return 0
+    fi
+    if [ -n "$default_value" ]; then
+        printf '%s [%s]: ' "$prompt" "$default_value" >/dev/tty
+    else
+        printf '%s: ' "$prompt" >/dev/tty
+    fi
+    IFS= read -r reply </dev/tty || reply=""
+    printf '%s\n' "${reply:-$default_value}"
+}
+
+prompt_yes_no() {
+    local prompt="$1"
+    local default_value="$2"
+    local suffix reply normalized
+    if [ "$INTERACTIVE" -ne 1 ]; then
+        [ "$default_value" = "yes" ]
+        return $?
+    fi
+    if [ "$default_value" = "yes" ]; then suffix="Y/n"; else suffix="y/N"; fi
+    while true; do
+        printf '%s [%s]: ' "$prompt" "$suffix" >/dev/tty
+        IFS= read -r reply </dev/tty || reply=""
+        reply="${reply:-$default_value}"
+        normalized="$(printf '%s' "$reply" | tr '[:upper:]' '[:lower:]')"
+        case "$normalized" in
+            y | yes) return 0 ;;
+            n | no) return 1 ;;
+            *) printf 'Please answer yes or no.\n' >/dev/tty ;;
+        esac
+    done
+}
 
 detect_platform() {
     local os arch
@@ -77,9 +168,7 @@ detect_platform() {
     esac
 }
 
-release_base_url() {
-    printf 'https://github.com/%s/releases/download/%s' "$MARMOT_RELEASE_REPO" "$MARMOT_RELEASE_TAG"
-}
+release_base_url() { printf 'https://github.com/%s/releases/download/%s' "$MARMOT_RELEASE_REPO" "$MARMOT_RELEASE_TAG"; }
 
 download_asset() {
     local name="$1"
@@ -97,9 +186,7 @@ download_asset() {
 verify_sha256() {
     local asset="$1"
     local checksum_file="$2"
-    if [ "$DRY_RUN" -eq 1 ]; then
-        return 0
-    fi
+    if [ "$DRY_RUN" -eq 1 ]; then return 0; fi
     local expected actual
     expected="$(awk '{print $1}' "$checksum_file")"
     if command -v shasum >/dev/null 2>&1; then
@@ -116,6 +203,12 @@ verify_sha256() {
     fi
 }
 
+install_dir() {
+    if [ "$SYSTEM_INSTALL" -eq 1 ]; then printf '/usr/local/bin\n'; else printf '%s/bin\n' "$MARMOT_INSTALL_PREFIX"; fi
+}
+
+wn_agent_path() { printf '%s/wn-agent\n' "$(install_dir)"; }
+
 install_wn_agent() {
     local platform="$1"
     local tmpdir="$2"
@@ -123,29 +216,24 @@ install_wn_agent() {
     local archive="$tmpdir/wn-agent-$platform-$suffix.tar.gz"
     local checksum="$tmpdir/wn-agent-$platform-$suffix.tar.gz.sha256"
     local extract_dir="$tmpdir/wn-agent-extract"
-    local install_dir
-
-    if [ "$SYSTEM_INSTALL" -eq 1 ]; then
-        install_dir="/usr/local/bin"
-    else
-        install_dir="$MARMOT_INSTALL_PREFIX/bin"
-    fi
+    local target_dir
+    target_dir="$(install_dir)"
 
     download_asset "wn-agent-$platform-$suffix.tar.gz" "$archive"
     download_asset "wn-agent-$platform-$suffix.tar.gz.sha256" "$checksum"
     verify_sha256 "$archive" "$checksum"
 
     if [ "$DRY_RUN" -eq 1 ]; then
-        log "would install wn-agent to $install_dir/wn-agent"
+        log "would install wn-agent to $target_dir/wn-agent"
         return 0
     fi
 
     rm -rf "$extract_dir"
     mkdir -p "$extract_dir"
     tar -xzf "$archive" -C "$extract_dir"
-    run mkdir -p "$install_dir"
-    run install -m 0755 "$extract_dir/wn-agent-$platform/wn-agent" "$install_dir/wn-agent"
-    log "installed wn-agent -> $install_dir/wn-agent"
+    run mkdir -p "$target_dir"
+    run install -m 0755 "$extract_dir/wn-agent-$platform/wn-agent" "$target_dir/wn-agent"
+    log "installed wn-agent -> $target_dir/wn-agent"
 }
 
 install_plugin() {
@@ -163,8 +251,7 @@ install_plugin() {
         return 0
     fi
     if [ "$FORCE" -eq 1 ]; then
-        run openclaw plugins install --force "$archive" 2>/dev/null \
-            || run openclaw plugins install "$archive"
+        run openclaw plugins install --force "$archive" 2>/dev/null || run openclaw plugins install "$archive"
     else
         run openclaw plugins install "$archive"
     fi
@@ -178,66 +265,285 @@ enable_openclaw_plugin() {
     if run openclaw plugins enable marmot; then
         log "enabled OpenClaw plugin: marmot"
     else
-        log "could not auto-enable; run 'openclaw plugins enable marmot'"
+        warn "could not auto-enable; run 'openclaw plugins enable marmot'"
     fi
 }
 
 ensure_path() {
     local bindir
-    if [ "$SYSTEM_INSTALL" -eq 1 ]; then
-        bindir="/usr/local/bin"
-    else
-        bindir="$MARMOT_INSTALL_PREFIX/bin"
-    fi
+    bindir="$(install_dir)"
     case ":$PATH:" in
         *":$bindir:"*) ;;
         *)
-            log "add $bindir to PATH before running wn-agent"
+            log "adding $bindir to PATH for this installer run"
             export PATH="$bindir:$PATH"
             ;;
     esac
 }
 
-run_bootstrap() {
-    ensure_path
-    if [ "$DRY_RUN" -eq 0 ] && ! command -v wn-agent >/dev/null 2>&1; then
-        echo "error: wn-agent not found on PATH after install" >&2
-        exit 1
+wait_for_socket() {
+    local waited=0
+    while [ "$waited" -lt 15 ]; do
+        [ -S "$MARMOT_AGENT_SOCKET" ] && return 0
+        sleep 1
+        waited=$((waited + 1))
+    done
+    return 1
+}
+
+plist_string() {
+    local value="$1"
+    value="${value//&/&amp;}"
+    value="${value//</&lt;}"
+    value="${value//>/&gt;}"
+    value="${value//\"/&quot;}"
+    printf '    <string>%s</string>\n' "$value"
+}
+
+install_macos_service() {
+    local plist_dir plist label program logs_dir relay
+    label="org.marmot.wn-agent"
+    plist_dir="$HOME/Library/LaunchAgents"
+    plist="$plist_dir/$label.plist"
+    program="$(wn_agent_path)"
+    logs_dir="$MARMOT_HOME/logs"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        log "would install LaunchAgent $plist"
+        log "would run: launchctl bootstrap gui/$UID $plist"
+        return 0
     fi
 
-    local wn_agent_pid=""
-    if [ "$START_WN_AGENT" -eq 1 ]; then
-        local -a wn_agent_args=(--home "$MARMOT_HOME")
-        local relay
-        IFS=',' read -r -a relays <<<"$MARMOT_RELAYS"
-        for relay in "${relays[@]}"; do
-            relay="${relay#"${relay%%[![:space:]]*}"}"
-            relay="${relay%"${relay##*[![:space:]]}"}"
-            [ -z "$relay" ] || wn_agent_args+=(--relay "$relay")
+    run mkdir -p "$plist_dir" "$logs_dir"
+    {
+        printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?>'
+        printf '%s\n' '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">'
+        printf '%s\n' '<plist version="1.0">'
+        printf '%s\n' '<dict>'
+        printf '%s\n' '  <key>Label</key>'
+        plist_string "$label"
+        printf '%s\n' '  <key>ProgramArguments</key>'
+        printf '%s\n' '  <array>'
+        plist_string "$program"
+        plist_string "--home"
+        plist_string "$MARMOT_HOME"
+        plist_string "--socket"
+        plist_string "$MARMOT_AGENT_SOCKET"
+        for relay in "${RELAYS[@]}"; do
+            plist_string "--relay"
+            plist_string "$relay"
         done
-        log "starting wn-agent"
-        if [ "$DRY_RUN" -eq 1 ]; then
-            printf '[dry-run] wn-agent'
-            printf ' %q' "${wn_agent_args[@]}"
-            printf '\n'
-        else
-            run mkdir -p "$MARMOT_HOME"
-            wn-agent "${wn_agent_args[@]}" &
-            wn_agent_pid="$!"
-            sleep 2
-        fi
+        printf '%s\n' '  </array>'
+        printf '%s\n' '  <key>RunAtLoad</key>'
+        printf '%s\n' '  <true/>'
+        printf '%s\n' '  <key>KeepAlive</key>'
+        printf '%s\n' '  <true/>'
+        printf '%s\n' '  <key>StandardOutPath</key>'
+        plist_string "$logs_dir/wn-agent.out.log"
+        printf '%s\n' '  <key>StandardErrorPath</key>'
+        plist_string "$logs_dir/wn-agent.err.log"
+        printf '%s\n' '</dict>'
+        printf '%s\n' '</plist>'
+    } >"$plist"
+
+    launchctl bootout "gui/$UID" "$plist" >/dev/null 2>&1 || true
+    run launchctl bootstrap "gui/$UID" "$plist"
+    launchctl kickstart -k "gui/$UID/$label" >/dev/null 2>&1 || true
+    log "installed and started LaunchAgent: $label"
+}
+
+install_linux_user_service() {
+    local service_dir service program relay
+    if ! command -v systemctl >/dev/null 2>&1; then return 1; fi
+    service_dir="$HOME/.config/systemd/user"
+    service="$service_dir/wn-agent.service"
+    program="$(wn_agent_path)"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        log "would install systemd user unit $service"
+        log "would run: systemctl --user enable --now wn-agent.service"
+        return 0
+    fi
+
+    run mkdir -p "$service_dir" "$MARMOT_HOME/logs"
+    {
+        printf '%s\n' '[Unit]'
+        printf '%s\n' 'Description=Marmot wn-agent connector'
+        printf '%s\n' 'After=network-online.target'
+        printf '%s\n'
+        printf '%s\n' '[Service]'
+        printf 'ExecStart=%q --home %q --socket %q' "$program" "$MARMOT_HOME" "$MARMOT_AGENT_SOCKET"
+        for relay in "${RELAYS[@]}"; do printf ' --relay %q' "$relay"; done
+        printf '\n'
+        printf '%s\n' 'Restart=always'
+        printf '%s\n' 'RestartSec=2'
+        printf '%s\n'
+        printf '%s\n' '[Install]'
+        printf '%s\n' 'WantedBy=default.target'
+    } >"$service"
+
+    run systemctl --user daemon-reload
+    run systemctl --user enable --now wn-agent.service
+    log "installed and started systemd user service: wn-agent.service"
+}
+
+install_user_service() {
+    case "$(uname -s)" in
+        Darwin) install_macos_service ;;
+        Linux)
+            if ! install_linux_user_service; then
+                warn "systemd user service not available; wn-agent will not be installed as a service"
+                return 1
+            fi
+            ;;
+        *)
+            warn "no supported same-user service manager for $(uname -s)"
+            return 1
+            ;;
+    esac
+}
+
+start_temp_agent() {
+    if [ "$NO_START_WN_AGENT" -eq 1 ]; then return 0; fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '[dry-run] wn-agent --home %q --socket %q' "$MARMOT_HOME" "$MARMOT_AGENT_SOCKET"
+        local relay
+        for relay in "${RELAYS[@]}"; do printf ' --relay %q' "$relay"; done
+        printf '\n'
+        return 0
+    fi
+    if [ -S "$MARMOT_AGENT_SOCKET" ]; then
+        log "found existing wn-agent socket: $MARMOT_AGENT_SOCKET"
+        return 0
+    fi
+    run mkdir -p "$MARMOT_HOME"
+    local -a args=(--home "$MARMOT_HOME" --socket "$MARMOT_AGENT_SOCKET")
+    local relay
+    for relay in "${RELAYS[@]}"; do args+=(--relay "$relay"); done
+    log "starting temporary wn-agent for bootstrap"
+    wn-agent "${args[@]}" &
+}
+
+bootstrap_agent() {
+    ensure_path
+    if [ "$DRY_RUN" -eq 0 ]; then need_cmd wn-agent; fi
+
+    if [ "$INSTALL_SERVICE" -eq 1 ] && [ "$NO_START_WN_AGENT" -ne 1 ]; then
+        install_user_service || start_temp_agent
+    else
+        start_temp_agent
+    fi
+
+    if [ "$DRY_RUN" -eq 0 ] && ! wait_for_socket; then
+        warn "wn-agent socket did not appear before bootstrap wait; bootstrap will keep waiting briefly"
+    fi
+
+    local -a args=(bootstrap --json --home "$MARMOT_HOME" --socket "$MARMOT_AGENT_SOCKET")
+    local relay
+    for relay in "${RELAYS[@]}"; do args+=(--relay "$relay"); done
+    if [ "$ENABLE_STREAMING" -eq 1 ]; then
+        local candidate
+        for candidate in "${QUIC_CANDIDATES[@]}"; do args+=(--quic-candidate "$candidate"); done
+    else
+        args+=(--no-quic)
+    fi
+    if [ "${#ALLOW_WELCOMERS[@]}" -gt 0 ]; then
+        local welcomer
+        for welcomer in "${ALLOW_WELCOMERS[@]}"; do args+=(--allow-welcomer "$welcomer"); done
     fi
 
     log "running wn-agent bootstrap"
     if [ "$DRY_RUN" -eq 1 ]; then
-        printf '[dry-run] wn-agent bootstrap --home %q --qr\n' "$MARMOT_HOME"
-    else
-        run wn-agent bootstrap --home "$MARMOT_HOME" --qr
+        printf '[dry-run] wn-agent'
+        printf ' %q' "${args[@]}"
+        printf '\n'
+        BOOTSTRAP_ACCOUNT_ID_HEX="<account-id-from-bootstrap>"
+        BOOTSTRAP_JSON_PATH="$MARMOT_HOME/bootstrap.json"
+        BOOTSTRAP_WELCOMER_ALLOWLIST_CSV=""
+        return 0
     fi
 
-    if [ -n "$wn_agent_pid" ] && [ "$DRY_RUN" -eq 0 ]; then
-        log "wn-agent running in background (pid $wn_agent_pid)"
+    run mkdir -p "$MARMOT_HOME"
+    local bootstrap_json
+    bootstrap_json="$(wn-agent "${args[@]}")"
+    BOOTSTRAP_JSON_PATH="$MARMOT_HOME/bootstrap.json"
+    printf '%s\n' "$bootstrap_json" >"$BOOTSTRAP_JSON_PATH"
+    BOOTSTRAP_ACCOUNT_ID_HEX="$(
+        printf '%s\n' "$bootstrap_json" |
+            python3 -c 'import json, sys; print(json.load(sys.stdin)["account_id_hex"])'
+    )"
+    BOOTSTRAP_WELCOMER_ALLOWLIST_CSV="$(
+        printf '%s\n' "$bootstrap_json" |
+            python3 -c 'import json, sys; print(",".join(json.load(sys.stdin).get("welcomer_account_ids_hex", [])))'
+    )"
+    log "bootstrap details -> $BOOTSTRAP_JSON_PATH"
+}
+
+openclaw_config_path() {
+    printf '%s/.openclaw/openclaw.json\n' "$OPENCLAW_HOME"
+}
+
+configure_openclaw_gateway() {
+    if [ "$CONFIGURE_OPENCLAW" -ne 1 ]; then return 0; fi
+    local config_path stream_mode quic_csv
+    config_path="$(openclaw_config_path)"
+    if [ "$ENABLE_STREAMING" -eq 1 ]; then stream_mode="block"; else stream_mode="off"; fi
+    quic_csv=""
+    if [ "$ENABLE_STREAMING" -eq 1 ] && [ "${#QUIC_CANDIDATES[@]}" -gt 0 ]; then
+        local candidate
+        for candidate in "${QUIC_CANDIDATES[@]}"; do
+            if [ -z "$quic_csv" ]; then quic_csv="$candidate"; else quic_csv="$quic_csv,$candidate"; fi
+        done
     fi
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        log "would patch OpenClaw config: $config_path"
+        log "would preserve other OpenClaw channels and only update channels.marmot"
+        return 0
+    fi
+
+    run mkdir -p "$(dirname "$config_path")"
+    if [ -f "$config_path" ]; then
+        run cp "$config_path" "$config_path.$(date -u +%Y%m%dT%H%M%SZ).bak"
+    else
+        printf '{}\n' >"$config_path"
+    fi
+
+    node - "$config_path" "$MARMOT_HOME" "$MARMOT_AGENT_SOCKET" "$BOOTSTRAP_ACCOUNT_ID_HEX" "$stream_mode" "$quic_csv" "$BOOTSTRAP_WELCOMER_ALLOWLIST_CSV" <<'NODE'
+const fs = require("fs");
+const [configPath, marmotHome, socketPath, accountIdHex, streamMode, quicCsv, allowCsv] = process.argv.slice(2);
+const raw = fs.readFileSync(configPath, "utf8").trim();
+const cfg = raw ? JSON.parse(raw) : {};
+cfg.channels = cfg.channels || {};
+const existing = cfg.channels.marmot || {};
+const existingStreaming = existing.streaming || {};
+const quicCandidates = quicCsv ? quicCsv.split(",").map((item) => item.trim()).filter(Boolean) : [];
+const channel = {
+  ...existing,
+  enabled: true,
+  home: marmotHome,
+  socketPath,
+  accountIdHex,
+  quicCandidates,
+  streaming: {
+    ...existingStreaming,
+    mode: streamMode,
+    block: { ...(existingStreaming.block || {}), enabled: streamMode !== "off" },
+  },
+};
+const allowFrom = allowCsv ? allowCsv.split(",").map((item) => item.trim()).filter(Boolean) : [];
+if (allowFrom.length > 0) {
+  const directMessageKey = "d" + "m";
+  channel[directMessageKey] = { ...(existing[directMessageKey] || {}), allowFrom };
+}
+cfg.channels.marmot = channel;
+if (streamMode !== "off") {
+  cfg.agents = cfg.agents || {};
+  cfg.agents.defaults = { ...(cfg.agents.defaults || {}), blockStreamingDefault: "on" };
+}
+fs.writeFileSync(configPath, JSON.stringify(cfg, null, 2) + "\n");
+NODE
+    log "patched OpenClaw Marmot channel config -> $config_path"
 }
 
 print_next_steps() {
@@ -245,17 +551,20 @@ print_next_steps() {
 
 Install complete.
 
-Next steps:
-  1. Ensure wn-agent is on your PATH ($(
-    if [ "$SYSTEM_INSTALL" -eq 1 ]; then echo "/usr/local/bin"; else echo "$MARMOT_INSTALL_PREFIX/bin"; fi
-  ))
-  2. Start the connector:
-     export MARMOT_HOME="$MARMOT_HOME"
-     wn-agent --home "\$MARMOT_HOME" --relay wss://relay.eu.whitenoise.chat --relay wss://relay.us.whitenoise.chat
-  3. Bootstrap or reuse the agent account:
-     wn-agent bootstrap --home "\$MARMOT_HOME" --qr
-  4. Start OpenClaw:
-     openclaw gateway run
+Marmot agent:
+  home: $MARMOT_HOME
+  socket: $MARMOT_AGENT_SOCKET
+  account: $BOOTSTRAP_ACCOUNT_ID_HEX
+  bootstrap JSON: $BOOTSTRAP_JSON_PATH
+
+OpenClaw:
+  home: $OPENCLAW_HOME
+  config: $(openclaw_config_path)
+
+Restart your existing OpenClaw gateway when you are ready for it to load the Marmot plugin/config:
+  openclaw gateway run
+
+Existing OpenClaw channels were not removed or disabled. The installer only installed the Marmot plugin and updated channels.marmot.
 
 Build: ${MARMOT_RELEASE_REPO}@${MARMOT_RELEASE_TAG} (${WN_AGENT_VERSION})
 EOF
@@ -263,20 +572,69 @@ EOF
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --bootstrap) INSTALL_BOOTSTRAP=1; shift;;
-        --no-start-wn-agent) START_WN_AGENT=0; shift;;
-        --system) SYSTEM_INSTALL=1; shift;;
-        --force) FORCE=1; shift;;
-        --dry-run) DRY_RUN=1; shift;;
-        -h|--help) usage; exit 0;;
-        *) echo "unknown option: $1" >&2; usage >&2; exit 2;;
+        --bootstrap) shift ;;
+        --yes | --non-interactive) ASSUME_YES=1; shift ;;
+        --home) MARMOT_HOME="${2:?missing value for --home}"; MARMOT_AGENT_SOCKET_OVERRIDE=""; shift 2 ;;
+        --openclaw-home) OPENCLAW_HOME="${2:?missing value for --openclaw-home}"; shift 2 ;;
+        --allow-welcomer) ALLOW_WELCOMERS+=("${2:?missing value for --allow-welcomer}"); shift 2 ;;
+        --relay) CLI_RELAYS=1; RELAYS+=("${2:?missing value for --relay}"); shift 2 ;;
+        --enable-streaming) ENABLE_STREAMING=1; shift ;;
+        --quic-candidate) QUIC_CANDIDATES+=("${2:?missing value for --quic-candidate}"); shift 2 ;;
+        --no-service) INSTALL_SERVICE=0; shift ;;
+        --no-start-wn-agent) NO_START_WN_AGENT=1; shift ;;
+        --no-configure-openclaw) CONFIGURE_OPENCLAW=0; shift ;;
+        --system) SYSTEM_INSTALL=1; shift ;;
+        --force) FORCE=1; shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        -h | --help) usage; exit 0 ;;
+        *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
     esac
 done
 
+if [ "$ASSUME_YES" -ne 1 ] && have_tty; then INTERACTIVE=1; fi
+if [ "$ASSUME_YES" -eq 1 ]; then INTERACTIVE=0; fi
+
+MARMOT_AGENT_SOCKET="${MARMOT_AGENT_SOCKET_OVERRIDE:-$MARMOT_HOME/dev/wn-agent.sock}"
+
+if [ "$CLI_RELAYS" -eq 0 ]; then
+    while IFS= read -r relay; do RELAYS+=("$relay"); done < <(append_csv "$MARMOT_RELAYS")
+fi
+if [ "${#RELAYS[@]}" -eq 0 ]; then RELAYS+=("wss://relay.eu.whitenoise.chat" "wss://relay.us.whitenoise.chat"); fi
+if [ -n "${MARMOT_WELCOMER_ALLOWLIST:-}" ]; then
+    while IFS= read -r welcomer; do ALLOW_WELCOMERS+=("$welcomer"); done < <(append_csv "$MARMOT_WELCOMER_ALLOWLIST")
+fi
+if [ "${#QUIC_CANDIDATES[@]}" -eq 0 ]; then QUIC_CANDIDATES+=("quic://quic-broker.ipf.dev:4450"); fi
+
+if [ "$INTERACTIVE" -eq 1 ]; then
+    log "guided setup will prompt on /dev/tty; press Enter to accept defaults"
+    OPENCLAW_HOME="$(prompt_value "OpenClaw home" "$OPENCLAW_HOME")"
+    MARMOT_HOME="$(prompt_value "Marmot agent home" "$MARMOT_HOME")"
+    MARMOT_AGENT_SOCKET="${MARMOT_AGENT_SOCKET_OVERRIDE:-$MARMOT_HOME/dev/wn-agent.sock}"
+    if [ -e "$MARMOT_HOME" ]; then
+        log "existing Marmot agent home detected; bootstrap will reuse or repair it: $MARMOT_HOME"
+    fi
+    if [ "${#ALLOW_WELCOMERS[@]}" -eq 0 ]; then
+        while true; do
+            welcomer_reply="$(prompt_value "Allowed inviter/welcomer npub or hex (blank to skip)" "")"
+            if [ -n "$welcomer_reply" ]; then
+                ALLOW_WELCOMERS+=("$welcomer_reply")
+                break
+            fi
+            if prompt_yes_no "Skip the welcomer allowlist for now? Invites will not auto-accept." "no"; then
+                break
+            fi
+        done
+    fi
+fi
+
 need_cmd curl
 need_cmd tar
-if [ "$DRY_RUN" -ne 1 ]; then
+if [ "$DRY_RUN" -eq 0 ]; then
     need_cmd openclaw
+    need_cmd python3
+    if [ "$CONFIGURE_OPENCLAW" -eq 1 ]; then need_cmd node; fi
+else
+    log "would require openclaw on PATH"
 fi
 
 platform="$(detect_platform)"
@@ -284,12 +642,12 @@ tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
 log "platform=$platform repo=$MARMOT_RELEASE_REPO tag=$MARMOT_RELEASE_TAG version=$WN_AGENT_VERSION"
+log "OpenClaw home: $OPENCLAW_HOME"
+log "Marmot home: $MARMOT_HOME"
+log "Marmot socket: $MARMOT_AGENT_SOCKET"
 install_wn_agent "$platform" "$tmpdir"
 install_plugin "$tmpdir"
 enable_openclaw_plugin
-
-if [ "$INSTALL_BOOTSTRAP" -eq 1 ]; then
-    run_bootstrap
-else
-    print_next_steps
-fi
+bootstrap_agent
+configure_openclaw_gateway
+print_next_steps


### PR DESCRIPTION
## Summary

Prepare the `wn-agent-v0.9.2` release path for both Hermes and OpenClaw installer one-liners.

- Make the Hermes installer curl-pipe safe, guided/noninteractive, service-aware, and additive to existing Hermes connectors.
- Add matching OpenClaw one-liner behavior: install `wn-agent`, install/enable the OpenClaw plugin, bootstrap/reuse the agent home, accept `--allow-welcomer`, and patch only `channels.marmot`.
- Extend `wn-agent bootstrap` with `--allow-welcomer <npub-or-hex>` and include normalized allowlist state in JSON output.
- Include the Hermes config helper in release packaging and bump release-facing metadata to `0.9.2`.

## Validation

- `WN_AGENT_SHA=9.9.9 MARMOT_RELEASE_TAG=wn-agent-v9.9.9-test bash scripts/install-openclaw-marmot.sh --dry-run --yes`
- `WN_AGENT_SHA=9.9.9 MARMOT_RELEASE_TAG=wn-agent-v9.9.9-test bash -s -- --dry-run --yes < scripts/install-openclaw-marmot.sh`
- Hermes installer dry-run
- `integrations/openclaw/marmot/test/dev-scripts.sh`
- `integrations/hermes/marmot/tests/test_dev_scripts.sh`
- `python3 -m unittest discover -s integrations/hermes/marmot/tests`
- `cargo check -p agent-connector --bin wn-agent`
- `just fast-ci`


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/772">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added welcomer allowlist support to the agent bootstrap flow (including repeatable non-interactive installer inputs).
  * Updated Hermes/OpenClaw Marmot setup to patch gateway configuration with optional streaming controls and welcomer allowlist propagation.

* **Bug Fixes**
  * Improved installer/plugin packaging to ensure the correct plugin version is written and gateway configuration helpers are included.
  * Safer gateway/config updates with improved YAML handling, plus optional timestamped backups.

* **Documentation**
  * Refreshed WN Agent, Hermes, and OpenClaw install/release examples to version `0.9.2`, including updated non-interactive command snippets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->