### PR TITLE
Feat/repro loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ This repo owns the Rust implementation workspace for Marmot:
 - UniFFI bindings for the app runtime,
 - CLI surface, daemon, and TUI,
 - conformance simulator and vector fixtures,
+- Goggles-incident replay adapter (agent-state export parse + classify),
 - Tamarin models for distributed convergence,
 - architecture notes and CGKA contracts.
 
@@ -51,6 +52,7 @@ The canonical protocol specification lives in
 | App runtime UniFFI bindings | `crates/marmot-uniffi/AGENTS.md` |
 | CLI / daemon / TUI surface | `crates/cli/AGENTS.md` |
 | Multi-client harness / vectors | `crates/cgka-conformance-simulator/AGENTS.md` |
+| Goggles incident replay adapter | `crates/incident-replay/AGENTS.md` |
 | Architecture docs | `docs/AGENTS.md` and `docs/marmot-architecture/AGENTS.md` |
 | Formal model | `formal/tamarin/AGENTS.md` |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,7 @@ dependencies = [
  "cgka-engine",
  "cgka-traits",
  "hex",
+ "marmot-forensics",
  "nostr",
  "openmls",
  "openmls_rust_crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.1"
+version = "0.9.3"
 dependencies = [
  "cgka-conformance-simulator",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,9 +2021,11 @@ dependencies = [
 name = "incident-replay"
 version = "0.9.1"
 dependencies = [
+ "cgka-conformance-simulator",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,6 +2018,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "incident-replay"
+version = "0.9.1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/cgka-session",
     "crates/storage-sqlite",
     "crates/cgka-conformance-simulator",
+    "crates/incident-replay",
     "crates/transport-nostr-peeler",
     "crates/transport-nostr-adapter",
     "crates/transport-quic-stream",

--- a/crates/cgka-conformance-simulator/Cargo.toml
+++ b/crates/cgka-conformance-simulator/Cargo.toml
@@ -14,6 +14,7 @@ conformance-slow = []
 [dependencies]
 cgka-traits.workspace = true
 cgka-engine.workspace = true
+marmot-forensics.workspace = true
 storage-sqlite.workspace = true
 transport-nostr-peeler.workspace = true
 openmls.workspace = true

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -122,6 +122,21 @@ These are the scenarios another implementation should be able to load from JSON 
 - Pressure: Bob's message is delayed, Alice restarts, and the released message is duplicated and reordered.
 - Expected: Alice hydrates the stable group after restart and receives Bob's payload once.
 
+## Incident-Replay Vectors
+
+These vectors are synthesized from Goggles `agent-state.json` forensic exports by the `incident-replay` adapter, then
+verified against the simulator before they are committed. They live under `vectors/incidents/` and are not yet part of
+the top-level portable-vector test (Phase 5 wires the directory into CI).
+
+### `fork-recovery-incident/v1`
+
+- File: `vectors/incidents/fork-recovery-incident.v1.json`
+- Setup: two clients create a group, then raise competing group-data commits from the same epoch — the concurrent-fork
+  shape the adapter derives from a fork-recovery incident.
+- Pressure: same-epoch group-data commit race with deferred delivery (no partition needed; the commits are concurrent).
+- Expected: the engine fork-recovers on delivery, the designated winner's branch survives, and both clients converge at
+  epoch 2 with the full recovery summary matching the recorded incident.
+
 ## Rust-Only Harness Scenarios
 
 These are real simulator scenarios that are still tied to Rust harness details.

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -80,6 +80,13 @@ These are the scenarios another implementation should be able to load from JSON 
 - Pressure: same-epoch invite commit race.
 - Expected: one invite branch wins, the other is invalidated, and active clients converge on the same member set.
 
+### `convergence-committer-selected/v1`
+
+- File: `vectors/convergence-committer-selected.v1.json`
+- Setup: Alice and Bob are both admins; each invites a different member from the same epoch. Carol is a passive observer who commits nothing.
+- Pressure: two competing privileged commits reach Carol at once, so her convergence selector — not the fork-recovery seam — picks the canonical branch.
+- Expected: Carol's settled `convergence_decision` selects the branch by authenticated committer identity (`tip_committer`) at tip epoch 2, with no app-witness quorum.
+
 ### `drop-queued/v1`
 
 - File: `vectors/drop-queued.v1.json`

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -87,6 +87,19 @@ These are the scenarios another implementation should be able to load from JSON 
 - Pressure: two competing privileged commits reach Carol at once, so her convergence selector — not the fork-recovery seam — picks the canonical branch.
 - Expected: Carol's settled `convergence_decision` selects the branch by authenticated committer identity (`tip_committer`) at tip epoch 2, with no app-witness quorum.
 
+### `convergence-witness-selected/v1`
+
+- File: `vectors/convergence-witness-selected.v1.json`
+- Setup: Alice and Bob are both admins; each invites a different member from the same epoch. Carol is a passive
+  observer. Two distinct senders post app messages on Alice's branch, and Carol delivers (applies) them before Bob's
+  competing same-epoch commit reaches her.
+- Pressure: Carol has already delivered the app messages on Alice's branch when Bob's competing commit arrives, forcing
+  a fork reorg. The app-witness quorum must survive that reorg and override the committer tiebreak — the case that
+  matches real convergence-driven traffic.
+- Expected: Carol's settled `convergence_decision` selects the witnessed branch at tip epoch 2 with `witness_quorum_met`
+  and an app-witness score of 2 (decisive rule `effective_commit_depth`), and each app payload is delivered exactly once
+  (no re-delivery on the reorg).
+
 ### `drop-queued/v1`
 
 - File: `vectors/drop-queued.v1.json`

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -150,6 +150,17 @@ the top-level portable-vector test (Phase 5 wires the directory into CI).
 - Expected: the engine fork-recovers on delivery, the designated winner's branch survives, and both clients converge at
   epoch 2 with the full recovery summary matching the recorded incident.
 
+### `convergence-incident/v1`
+
+- File: `vectors/incidents/convergence-incident.v1.json`
+- Setup: two admins create a group with a passive observer, then raise competing invite commits from the same epoch —
+  the committer-decided convergence shape the adapter derives from a convergence incident.
+- Pressure: two competing same-epoch branches reach the observer, whose convergence selector — not the fork-recovery
+  seam — picks the canonical branch.
+- Expected: the observer's settled `convergence_decision` is decided by the authenticated-committer tiebreak
+  (`tip_committer`) at tip epoch 2 with no app-witness quorum. Witness-decided convergence (the real-traffic case) is a
+  documented follow-up: the harness does not yet count app-message witnesses through the stored-convergence path.
+
 ## Rust-Only Harness Scenarios
 
 These are real simulator scenarios that are still tied to Rust harness details.

--- a/crates/cgka-conformance-simulator/src/audit_capture.rs
+++ b/crates/cgka-conformance-simulator/src/audit_capture.rs
@@ -1,0 +1,67 @@
+//! In-memory forensic capture for the harness.
+//!
+//! The engine discards forensic audit events under its default
+//! [`marmot_forensics::NoopRecorder`], so decisions it makes but never surfaces
+//! as a [`cgka_traits::engine::GroupEvent`] — notably `convergence_decision` —
+//! are invisible to a scenario. [`CapturingRecorder`] retains those decisions in
+//! memory so the harness can assert on them.
+//!
+//! It captures **only** `convergence_decision` events: that is the sole consumer
+//! today, and a general recorder would accumulate every audit event a
+//! chaos-family run emits for no benefit. Widen the filter when a second
+//! consumer appears.
+
+use std::sync::{Arc, Mutex, PoisonError};
+
+use marmot_forensics::{AuditEventKind, AuditRecord, ForensicRecorder};
+
+/// Shared, append-only buffer of captured `convergence_decision` events.
+///
+/// Cloning shares the same buffer, so a client and every engine it builds —
+/// including the fresh engine a [`crate::HarnessClient::restart`] constructs —
+/// record into one place, and captures survive a restart.
+pub(crate) type AuditCapture = Arc<Mutex<Vec<AuditEventKind>>>;
+
+/// A [`ForensicRecorder`] that retains `convergence_decision` events in a shared
+/// in-memory buffer and drops everything else.
+#[derive(Clone)]
+pub(crate) struct CapturingRecorder {
+    decisions: AuditCapture,
+}
+
+impl CapturingRecorder {
+    pub(crate) fn new(decisions: AuditCapture) -> Self {
+        Self { decisions }
+    }
+}
+
+impl ForensicRecorder for CapturingRecorder {
+    fn record(&self, record: AuditRecord) {
+        if !matches!(record.kind, AuditEventKind::ConvergenceDecision { .. }) {
+            return;
+        }
+        // The recorder sits on the engine's audit hot path and must never panic
+        // there. A poisoned lock means a prior panic already doomed the
+        // scenario; recover the buffer rather than masking that panic with a
+        // second one here.
+        self.decisions
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(record.kind);
+    }
+}
+
+/// Remove and return the captured `convergence_decision` events, oldest-first.
+pub(crate) fn drain_convergence_decisions(capture: &AuditCapture) -> Vec<AuditEventKind> {
+    std::mem::take(&mut *capture.lock().unwrap_or_else(PoisonError::into_inner))
+}
+
+/// Discard all captured events, resetting the observation window. Used by the
+/// `ClearEvents` scenario step so a vector can isolate a decision that happens
+/// after setup, the way a hand-written test drains between phases.
+pub(crate) fn clear(capture: &AuditCapture) {
+    capture
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .clear();
+}

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -2,6 +2,7 @@
 //! attachment. Provides scenario-level affordances: `send`, `tick`,
 //! `confirm_all_pending`, `assert_at_epoch`.
 
+use crate::audit_capture::{AuditCapture, CapturingRecorder};
 use crate::bus::{ClientId, TransportBus};
 use cgka_engine::account_identity_proof::{
     AccountIdentityProofRequest, AccountIdentityProofSigner,
@@ -50,6 +51,9 @@ pub struct HarnessClient {
     /// automatically after the first create/join.
     default_group: Option<GroupId>,
     app_event_counter: u64,
+    /// Shared in-memory capture of the engine's forensic audit events, used to
+    /// observe decisions no `GroupEvent` exposes (e.g. `convergence_decision`).
+    audit_capture: AuditCapture,
 }
 
 pub struct ClientBuilder {
@@ -124,17 +128,14 @@ impl ClientBuilder {
 
     pub fn attach(self, bus: &TransportBus) -> HarnessClient {
         let (storage, storage_dir) = self.storage_mode.open().expect("storage opens");
-        let peeler = NostrMlsPeeler::new().with_welcome_signer(self.signer.clone());
-        let engine = EngineBuilder::new(storage.clone())
-            .identity(self.identity.clone())
-            .account_identity_proof_signer(Arc::new(NostrAccountIdentityProofSigner {
-                keys: self.signer.clone(),
-            }))
-            .feature_registry(self.registry.clone())
-            .supported_app_components(harness_supported_app_components())
-            .peeler(Box::new(peeler))
-            .build()
-            .expect("engine builds");
+        let audit_capture = AuditCapture::default();
+        let engine = build_harness_engine(
+            &storage,
+            &self.identity,
+            &self.signer,
+            &self.registry,
+            &audit_capture,
+        );
         let bus_id = bus.attach(MemberId::new(self.identity.clone()));
         HarnessClient {
             engine,
@@ -148,8 +149,34 @@ impl ClientBuilder {
             pending_events: Vec::new(),
             default_group: None,
             app_event_counter: 0,
+            audit_capture,
         }
     }
+}
+
+/// Build an engine wired the way every harness client needs it, including the
+/// [`CapturingRecorder`] that retains forensic events. `attach` and `restart`
+/// both go through here so a rebuilt engine keeps recording into the same shared
+/// buffer — otherwise a restart would silently drop captured decisions.
+fn build_harness_engine(
+    storage: &SqliteAccountStorage,
+    identity: &[u8],
+    signer: &nostr::Keys,
+    registry: &FeatureRegistry,
+    audit_capture: &AuditCapture,
+) -> Engine<SqliteAccountStorage> {
+    let peeler = NostrMlsPeeler::new().with_welcome_signer(signer.clone());
+    EngineBuilder::new(storage.clone())
+        .identity(identity.to_vec())
+        .account_identity_proof_signer(Arc::new(NostrAccountIdentityProofSigner {
+            keys: signer.clone(),
+        }))
+        .feature_registry(registry.clone())
+        .supported_app_components(harness_supported_app_components())
+        .peeler(Box::new(peeler))
+        .recorder(Box::new(CapturingRecorder::new(audit_capture.clone())))
+        .build()
+        .expect("engine builds")
 }
 
 fn deterministic_nostr_keys(seed: &[u8]) -> nostr::Keys {
@@ -270,22 +297,36 @@ impl HarnessClient {
     }
 
     pub fn restart(&mut self) {
-        let peeler = NostrMlsPeeler::new().with_welcome_signer(self.signer.clone());
-        let mut engine = EngineBuilder::new(self.storage.clone())
-            .identity(self.identity.clone())
-            .account_identity_proof_signer(Arc::new(NostrAccountIdentityProofSigner {
-                keys: self.signer.clone(),
-            }))
-            .feature_registry(self.registry.clone())
-            .supported_app_components(harness_supported_app_components())
-            .peeler(Box::new(peeler))
-            .build()
-            .expect("engine rebuilds");
+        let mut engine = build_harness_engine(
+            &self.storage,
+            &self.identity,
+            &self.signer,
+            &self.registry,
+            &self.audit_capture,
+        );
         engine
             .hydrate_stable_groups_from_storage()
             .expect("engine hydrates from storage");
         self.engine = engine;
         self.pending_events.clear();
+    }
+
+    /// Drain the `convergence_decision` events the engine has emitted since the
+    /// last call.
+    ///
+    /// The engine surfaces these only through its forensic recorder, so — unlike
+    /// fork recoveries — no `GroupEvent` carries them and [`Self::drain_events`]
+    /// never sees them. Returns them oldest-first; other captured audit records
+    /// are left in place.
+    pub fn drain_convergence_decisions(&mut self) -> Vec<marmot_forensics::AuditEventKind> {
+        crate::audit_capture::drain_convergence_decisions(&self.audit_capture)
+    }
+
+    /// Discard captured convergence decisions, resetting the observation window.
+    /// Mirrors what `ScenarioStep::ClearEvents` does for `GroupEvent`s so a
+    /// scenario can isolate a decision that happens after setup.
+    pub fn clear_audit_capture(&mut self) {
+        crate::audit_capture::clear(&self.audit_capture);
     }
 
     pub fn member_id(&self) -> MemberId {

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -18,6 +18,7 @@
 //!
 //! See [`tests/`](../../tests/) in this crate for canonical scenarios.
 
+mod audit_capture;
 pub mod bus;
 pub mod client;
 pub mod family;
@@ -54,9 +55,9 @@ pub use scenario::{
     run_vector_fixture_report,
 };
 pub use vector::{
-    AppInvalidationObservation, ClientEventCounts, ClientObservation, EpochChangeObservation,
-    ExpectationFailure, ForkRecoveryObservation, PendingResolutionObservation,
-    RecoveryOrderingKeyObservation, ScenarioAdminPolicyObservation, ScenarioErrorObservation,
-    ScenarioTrace, TraceExpectation, VectorFixture, VectorMismatch, compare_trace_expectations,
-    observe_client,
+    AppInvalidationObservation, ClientEventCounts, ClientObservation,
+    ConvergenceDecisionObservation, EpochChangeObservation, ExpectationFailure,
+    ForkRecoveryObservation, PendingResolutionObservation, RecoveryOrderingKeyObservation,
+    ScenarioAdminPolicyObservation, ScenarioErrorObservation, ScenarioTrace, TraceExpectation,
+    VectorFixture, VectorMismatch, compare_trace_expectations, observe_client,
 };

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -52,6 +52,7 @@ pub enum OracleBehavior {
     MemberRemoved,
     EpochChanged,
     ForkRecovered,
+    ConvergenceDecisionObserved,
     AppInvalidated,
     LargeGroupObserved,
     SelectorDeterminism,
@@ -78,6 +79,7 @@ pub struct BehaviorEvidenceSummary {
     pub epoch_changes: usize,
     pub app_invalidations: usize,
     pub recoveries: usize,
+    pub convergence_decisions: usize,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -372,6 +374,9 @@ pub fn trace_behaviors(trace: &ScenarioTrace) -> Vec<OracleBehavior> {
     if evidence.recoveries > 0 {
         behaviors.insert(OracleBehavior::ForkRecovered);
     }
+    if evidence.convergence_decisions > 0 {
+        behaviors.insert(OracleBehavior::ConvergenceDecisionObserved);
+    }
     if evidence.max_member_count >= 20 {
         behaviors.insert(OracleBehavior::LargeGroupObserved);
     }
@@ -412,6 +417,7 @@ pub fn behavior_evidence(trace: &ScenarioTrace) -> BehaviorEvidenceSummary {
         evidence.epoch_changes += observation.epoch_changes.len();
         evidence.app_invalidations += observation.app_invalidations.len();
         evidence.recoveries += observation.recoveries.len();
+        evidence.convergence_decisions += observation.convergence_decisions.len();
     }
     evidence
 }
@@ -477,6 +483,9 @@ fn expectation_behaviors(expectation: &TraceExpectation) -> BTreeSet<OracleBehav
         }
         TraceExpectation::ClientRecoveries { .. } | TraceExpectation::RecoverySummary { .. } => {
             behaviors.insert(OracleBehavior::ForkRecovered);
+        }
+        TraceExpectation::ConvergenceDecision { .. } => {
+            behaviors.insert(OracleBehavior::ConvergenceDecisionObserved);
         }
     }
     behaviors
@@ -614,6 +623,7 @@ mod tests {
             epoch_changes: Vec::new(),
             app_invalidations: Vec::new(),
             recoveries: Vec::new(),
+            convergence_decisions: Vec::new(),
         }
     }
 

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -469,6 +469,7 @@ async fn run_scenario_report_inner(
                 for label in labels {
                     let client = client_mut(&mut clients, label, step_index)?;
                     client.drain_events();
+                    client.clear_audit_capture();
                 }
             }
             ScenarioStep::DropQueued { index } => {

--- a/crates/cgka-conformance-simulator/src/vector.rs
+++ b/crates/cgka-conformance-simulator/src/vector.rs
@@ -9,6 +9,7 @@ use cgka_traits::engine::{
     AppMessageInvalidationReason, CommitOrderingKey, CommitOrderingPriority, GroupEvent,
     GroupStateChange,
 };
+use marmot_forensics::AuditEventKind;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -129,6 +130,30 @@ pub enum TraceExpectation {
         recovered_epoch: Option<u64>,
         #[serde(default)]
         winner_differs_from_invalidated: bool,
+    },
+    /// Assert against the client's **settled** convergence decision: the last
+    /// convergence pass that actually evaluated a candidate set. Not count-based
+    /// like [`Self::RecoverySummary`], and deliberately not any-match — the
+    /// engine emits one decision per settle pass, and an earlier pass can select
+    /// a branch a later pass supersedes, so any-match would let a vector bind to
+    /// a superseded intermediate (or a trailing no-candidate pass). A field left
+    /// `None` is not checked; `min_app_witness_score` asserts the winning branch
+    /// scored at least that many app witnesses. With `client` set, the scope is
+    /// that client's settled decision; with `client` `None`, any observed
+    /// client's settled decision.
+    ConvergenceDecision {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        client: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        selected_branch_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        selected_tip_epoch: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        decisive_rule: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        witness_quorum_met: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        min_app_witness_score: Option<u64>,
     },
 }
 
@@ -369,6 +394,27 @@ impl TraceExpectation {
                     mismatches,
                 );
             }
+            TraceExpectation::ConvergenceDecision {
+                client,
+                selected_branch_id,
+                selected_tip_epoch,
+                decisive_rule,
+                witness_quorum_met,
+                min_app_witness_score,
+            } => {
+                compare_convergence_decision(
+                    ConvergenceDecisionExpectation {
+                        client: client.as_deref(),
+                        selected_branch_id: selected_branch_id.as_deref(),
+                        selected_tip_epoch: *selected_tip_epoch,
+                        decisive_rule: decisive_rule.as_deref(),
+                        witness_quorum_met: *witness_quorum_met,
+                        min_app_witness_score: *min_app_witness_score,
+                    },
+                    observed,
+                    mismatches,
+                );
+            }
         }
     }
 }
@@ -450,6 +496,96 @@ fn compare_recoveries(
     }
 }
 
+struct ConvergenceDecisionExpectation<'a> {
+    client: Option<&'a str>,
+    selected_branch_id: Option<&'a str>,
+    selected_tip_epoch: Option<u64>,
+    decisive_rule: Option<&'a str>,
+    witness_quorum_met: Option<bool>,
+    min_app_witness_score: Option<u64>,
+}
+
+impl ConvergenceDecisionExpectation<'_> {
+    fn matches(&self, decision: &ConvergenceDecisionObservation) -> bool {
+        self.selected_branch_id
+            .is_none_or(|id| decision.selected_branch_id.as_deref() == Some(id))
+            && self
+                .selected_tip_epoch
+                .is_none_or(|epoch| decision.selected_tip_epoch == Some(epoch))
+            && self
+                .decisive_rule
+                .is_none_or(|rule| decision.decisive_rule.as_deref() == Some(rule))
+            && self
+                .witness_quorum_met
+                .is_none_or(|met| decision.witness_quorum_met == met)
+            && self.min_app_witness_score.is_none_or(|min| {
+                decision
+                    .selected_app_witness_score
+                    .is_some_and(|score| score >= min)
+            })
+    }
+
+    fn expected_json(&self) -> Value {
+        json!({
+            "client": self.client,
+            "selected_branch_id": self.selected_branch_id,
+            "selected_tip_epoch": self.selected_tip_epoch,
+            "decisive_rule": self.decisive_rule,
+            "witness_quorum_met": self.witness_quorum_met,
+            "min_app_witness_score": self.min_app_witness_score,
+        })
+    }
+}
+
+/// The client's settled convergence decision: the last pass that actually
+/// evaluated a candidate set. The engine emits one decision per settle pass, so
+/// this skips both superseded intermediates and trailing no-candidate passes.
+fn settled_decision(
+    decisions: &[ConvergenceDecisionObservation],
+) -> Option<&ConvergenceDecisionObservation> {
+    decisions
+        .iter()
+        .rev()
+        .find(|decision| decision.candidate_count > 0)
+}
+
+fn compare_convergence_decision(
+    expectation: ConvergenceDecisionExpectation<'_>,
+    observed: &ScenarioTrace,
+    mismatches: &mut Vec<ExpectationFailure>,
+) {
+    let settled: Vec<&ConvergenceDecisionObservation> = match expectation.client {
+        Some(client) => match client_observation(observed, client) {
+            Some(observation) => settled_decision(&observation.convergence_decisions)
+                .into_iter()
+                .collect(),
+            None => {
+                mismatches.push(ExpectationFailure {
+                    kind: "missing_client_observation".into(),
+                    message: format!("missing observation for client {client}"),
+                    expected: expectation.expected_json(),
+                    actual: Value::Null,
+                });
+                return;
+            }
+        },
+        None => observed
+            .observations
+            .iter()
+            .filter_map(|observation| settled_decision(&observation.convergence_decisions))
+            .collect(),
+    };
+    if settled.iter().any(|decision| expectation.matches(decision)) {
+        return;
+    }
+    mismatches.push(ExpectationFailure {
+        kind: "missing_convergence_decision".into(),
+        message: "no settled convergence decision matched the expectation".into(),
+        expected: expectation.expected_json(),
+        actual: json!(settled),
+    });
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ScenarioTrace {
     pub name: String,
@@ -510,6 +646,11 @@ pub struct ClientObservation {
     #[serde(default)]
     pub app_invalidations: Vec<AppInvalidationObservation>,
     pub recoveries: Vec<ForkRecoveryObservation>,
+    /// Convergence decisions the engine emitted, captured via the forensic
+    /// recorder (no `GroupEvent` carries them). Defaulted for backward
+    /// compatibility with serialized traces that predate the field.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub convergence_decisions: Vec<ConvergenceDecisionObservation>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -575,8 +716,69 @@ pub struct RecoveryOrderingKeyObservation {
     pub commit_digest: String,
 }
 
+/// A convergence decision projected from an
+/// [`AuditEventKind::ConvergenceDecision`] down to the scalar facts a vector can
+/// assert on. The raw audit event carries free-form `serde_json::Value` rule
+/// traces that are not `Eq`; this projection stays comparable and
+/// implementation-neutral.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConvergenceDecisionObservation {
+    pub current_tip_epoch: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_branch_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_tip_epoch: Option<u64>,
+    /// `rule_name` of the selector rule the engine marked decisive, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decisive_rule: Option<String>,
+    /// Whether the winning branch met the app-witness quorum.
+    #[serde(default)]
+    pub witness_quorum_met: bool,
+    /// App-witness score of the winning branch, when the selector scored one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_app_witness_score: Option<u64>,
+    pub candidate_count: usize,
+}
+
+fn observe_convergence_decision(kind: &AuditEventKind) -> Option<ConvergenceDecisionObservation> {
+    let AuditEventKind::ConvergenceDecision {
+        current_tip_epoch,
+        candidates,
+        rule_trace,
+        selected_branch_id,
+        selected_tip_epoch,
+        ..
+    } = kind
+    else {
+        return None;
+    };
+    let selected_score = selected_branch_id
+        .as_ref()
+        .and_then(|id| {
+            candidates
+                .iter()
+                .find(|candidate| &candidate.branch_id == id)
+        })
+        .and_then(|candidate| candidate.score.as_ref());
+    Some(ConvergenceDecisionObservation {
+        current_tip_epoch: *current_tip_epoch,
+        selected_branch_id: selected_branch_id.clone(),
+        selected_tip_epoch: *selected_tip_epoch,
+        decisive_rule: rule_trace
+            .iter()
+            .find(|rule| rule.decisive == Some(true))
+            .map(|rule| rule.rule_name.clone()),
+        witness_quorum_met: selected_score
+            .and_then(|score| score.witness_quorum_met)
+            .unwrap_or(false),
+        selected_app_witness_score: selected_score.and_then(|score| score.app_witness_score),
+        candidate_count: candidates.len(),
+    })
+}
+
 pub fn observe_client(label: impl Into<String>, client: &mut HarnessClient) -> ClientObservation {
     let events = client.drain_events();
+    let captured_decisions = client.drain_convergence_decisions();
     let event_counts = ClientEventCounts {
         message_received: events
             .iter()
@@ -702,6 +904,10 @@ pub fn observe_client(label: impl Into<String>, client: &mut HarnessClient) -> C
                 _ => None,
             })
             .collect(),
+        convergence_decisions: captured_decisions
+            .iter()
+            .filter_map(observe_convergence_decision)
+            .collect(),
     }
 }
 
@@ -760,6 +966,7 @@ mod tests {
             epoch_changes: Vec::new(),
             app_invalidations: Vec::new(),
             recoveries: Vec::new(),
+            convergence_decisions: Vec::new(),
         }
     }
 
@@ -770,6 +977,24 @@ mod tests {
             errors: Vec::new(),
             admin_policies: Vec::new(),
             observations,
+        }
+    }
+
+    fn convergence_decision(
+        selected_branch_id: &str,
+        selected_tip_epoch: u64,
+        decisive_rule: &str,
+        witness_quorum_met: bool,
+        selected_app_witness_score: u64,
+    ) -> ConvergenceDecisionObservation {
+        ConvergenceDecisionObservation {
+            current_tip_epoch: selected_tip_epoch.saturating_sub(1),
+            selected_branch_id: Some(selected_branch_id.into()),
+            selected_tip_epoch: Some(selected_tip_epoch),
+            decisive_rule: Some(decisive_rule.into()),
+            witness_quorum_met,
+            selected_app_witness_score: Some(selected_app_witness_score),
+            candidate_count: 2,
         }
     }
 
@@ -881,5 +1106,273 @@ mod tests {
         );
 
         assert!(failures.is_empty(), "unexpected failures: {failures:#?}");
+    }
+
+    #[test]
+    fn observe_convergence_decision_projects_selected_branch_scalars() {
+        use marmot_forensics::{ConvergenceCandidate, ConvergenceRuleEvaluation, ConvergenceScore};
+
+        let scored = |branch: &str, quorum: bool, app_witnesses: u64| ConvergenceCandidate {
+            branch_id: branch.into(),
+            tip_epoch: 2,
+            score: Some(ConvergenceScore {
+                witness_quorum_met: Some(quorum),
+                app_witness_score: Some(app_witnesses),
+                ..ConvergenceScore::default()
+            }),
+            ..ConvergenceCandidate::default()
+        };
+        let kind = AuditEventKind::ConvergenceDecision {
+            current_tip_epoch: 1,
+            max_rewind_commits: 5,
+            candidates: vec![scored("winner", true, 2), scored("loser", false, 0)],
+            rule_trace: vec![ConvergenceRuleEvaluation {
+                rule_name: "witness_quorum_met".into(),
+                scope: None,
+                candidate_branch_id: None,
+                other_candidate_branch_id: None,
+                inputs: None,
+                result: Value::Null,
+                decisive: Some(true),
+                selected_branch_id: None,
+                rejected_branch_id: None,
+            }],
+            selected_branch_id: Some("winner".into()),
+            selected_fork_epoch: Some(1),
+            selected_tip_epoch: Some(2),
+            losing_branch_ids: vec!["loser".into()],
+            error_kinds: Vec::new(),
+        };
+
+        let projected = observe_convergence_decision(&kind).expect("projects a decision");
+        assert_eq!(projected.selected_branch_id.as_deref(), Some("winner"));
+        assert_eq!(projected.selected_tip_epoch, Some(2));
+        assert_eq!(
+            projected.decisive_rule.as_deref(),
+            Some("witness_quorum_met")
+        );
+        assert!(
+            projected.witness_quorum_met,
+            "winner met the app-witness quorum"
+        );
+        assert_eq!(projected.selected_app_witness_score, Some(2));
+        assert_eq!(projected.candidate_count, 2);
+    }
+
+    #[test]
+    fn observe_convergence_decision_ignores_unrelated_kind() {
+        let kind = AuditEventKind::RecorderStarted {
+            recorder: "test".into(),
+        };
+        assert!(observe_convergence_decision(&kind).is_none());
+    }
+
+    #[test]
+    fn convergence_decision_expectation_distinguishes_witness_win_from_tiebreak() {
+        let mut carol = observation("carol", 2, 4);
+        carol.convergence_decisions = vec![convergence_decision(
+            "witnessed",
+            2,
+            "witness_quorum_met",
+            true,
+            2,
+        )];
+        let observed = trace(vec![carol]);
+
+        // The witness-decided winner is asserted through the new expectation.
+        let matched = compare_trace_expectations(
+            None,
+            &[TraceExpectation::ConvergenceDecision {
+                client: Some("carol".into()),
+                selected_branch_id: Some("witnessed".into()),
+                selected_tip_epoch: Some(2),
+                decisive_rule: Some("witness_quorum_met".into()),
+                witness_quorum_met: Some(true),
+                min_app_witness_score: Some(2),
+            }],
+            &observed,
+        );
+        assert!(matched.is_empty(), "witness win should match: {matched:#?}");
+
+        // The same decision must NOT satisfy a digest-tiebreak expectation — the
+        // decisive rule and quorum flag are what tell the two apart.
+        let mismatch = compare_trace_expectations(
+            None,
+            &[TraceExpectation::ConvergenceDecision {
+                client: Some("carol".into()),
+                selected_branch_id: None,
+                selected_tip_epoch: None,
+                decisive_rule: Some("tip_digest".into()),
+                witness_quorum_met: Some(false),
+                min_app_witness_score: None,
+            }],
+            &observed,
+        );
+        assert_eq!(
+            mismatch.len(),
+            1,
+            "digest expectation must not match: {mismatch:#?}"
+        );
+        assert_eq!(mismatch[0].kind, "missing_convergence_decision");
+    }
+
+    #[test]
+    fn convergence_decision_min_app_witness_score_is_a_threshold() {
+        let mut carol = observation("carol", 2, 4);
+        carol.convergence_decisions = vec![convergence_decision(
+            "winner",
+            2,
+            "app_witness_score",
+            true,
+            3,
+        )];
+        let observed = trace(vec![carol]);
+
+        let at_threshold = compare_trace_expectations(
+            None,
+            &[TraceExpectation::ConvergenceDecision {
+                client: None,
+                selected_branch_id: None,
+                selected_tip_epoch: None,
+                decisive_rule: None,
+                witness_quorum_met: None,
+                min_app_witness_score: Some(3),
+            }],
+            &observed,
+        );
+        assert!(
+            at_threshold.is_empty(),
+            "score 3 meets min 3: {at_threshold:#?}"
+        );
+
+        let above_threshold = compare_trace_expectations(
+            None,
+            &[TraceExpectation::ConvergenceDecision {
+                client: None,
+                selected_branch_id: None,
+                selected_tip_epoch: None,
+                decisive_rule: None,
+                witness_quorum_met: None,
+                min_app_witness_score: Some(4),
+            }],
+            &observed,
+        );
+        assert_eq!(above_threshold.len(), 1, "score 3 is below min 4");
+    }
+
+    #[test]
+    fn convergence_decision_expectation_reports_missing_client() {
+        let mut carol = observation("carol", 2, 4);
+        carol.convergence_decisions =
+            vec![convergence_decision("winner", 2, "tip_committer", false, 0)];
+        let observed = trace(vec![carol]);
+
+        let failures = compare_trace_expectations(
+            None,
+            &[TraceExpectation::ConvergenceDecision {
+                client: Some("dave".into()),
+                selected_branch_id: None,
+                selected_tip_epoch: None,
+                decisive_rule: None,
+                witness_quorum_met: None,
+                min_app_witness_score: None,
+            }],
+            &observed,
+        );
+        assert_eq!(failures.len(), 1, "missing client must fail: {failures:#?}");
+        assert_eq!(failures[0].kind, "missing_client_observation");
+    }
+
+    #[test]
+    fn convergence_decision_expectation_matches_settled_not_superseded() {
+        // The engine emits a decision per settle pass. An early pass selected a
+        // single-candidate branch; a later pass, once the competing commit
+        // arrived, superseded it (committer-decided among two). The expectation
+        // must bind to the settled decision, never the superseded intermediate.
+        let superseded = ConvergenceDecisionObservation {
+            current_tip_epoch: 1,
+            selected_branch_id: Some("superseded".into()),
+            selected_tip_epoch: Some(2),
+            decisive_rule: None,
+            witness_quorum_met: false,
+            selected_app_witness_score: Some(0),
+            candidate_count: 1,
+        };
+        let settled = convergence_decision("settled", 2, "tip_committer", false, 0);
+        let mut carol = observation("carol", 2, 4);
+        carol.convergence_decisions = vec![superseded, settled];
+        let observed = trace(vec![carol]);
+
+        let matched = compare_trace_expectations(
+            None,
+            &[TraceExpectation::ConvergenceDecision {
+                client: Some("carol".into()),
+                selected_branch_id: Some("settled".into()),
+                selected_tip_epoch: Some(2),
+                decisive_rule: Some("tip_committer".into()),
+                witness_quorum_met: Some(false),
+                min_app_witness_score: None,
+            }],
+            &observed,
+        );
+        assert!(
+            matched.is_empty(),
+            "settled decision should match: {matched:#?}"
+        );
+
+        let superseded_match = compare_trace_expectations(
+            None,
+            &[TraceExpectation::ConvergenceDecision {
+                client: Some("carol".into()),
+                selected_branch_id: Some("superseded".into()),
+                selected_tip_epoch: None,
+                decisive_rule: None,
+                witness_quorum_met: None,
+                min_app_witness_score: None,
+            }],
+            &observed,
+        );
+        assert_eq!(
+            superseded_match.len(),
+            1,
+            "a superseded intermediate must not match: {superseded_match:#?}"
+        );
+        assert_eq!(superseded_match[0].kind, "missing_convergence_decision");
+    }
+
+    #[test]
+    fn convergence_decision_expectation_skips_trailing_empty_pass() {
+        // A settled selection followed by a no-candidate convergence pass: the
+        // settled decision is the one that evaluated candidates, not the trailer.
+        let settled = convergence_decision("settled", 2, "tip_committer", false, 0);
+        let trailing_empty = ConvergenceDecisionObservation {
+            current_tip_epoch: 2,
+            selected_branch_id: None,
+            selected_tip_epoch: None,
+            decisive_rule: None,
+            witness_quorum_met: false,
+            selected_app_witness_score: None,
+            candidate_count: 0,
+        };
+        let mut carol = observation("carol", 2, 4);
+        carol.convergence_decisions = vec![settled, trailing_empty];
+        let observed = trace(vec![carol]);
+
+        let matched = compare_trace_expectations(
+            None,
+            &[TraceExpectation::ConvergenceDecision {
+                client: Some("carol".into()),
+                selected_branch_id: None,
+                selected_tip_epoch: None,
+                decisive_rule: Some("tip_committer".into()),
+                witness_quorum_met: None,
+                min_app_witness_score: None,
+            }],
+            &observed,
+        );
+        assert!(
+            matched.is_empty(),
+            "must skip the empty trailing pass and match the settled decision: {matched:#?}"
+        );
     }
 }

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -7,10 +7,10 @@
 use cgka_conformance_simulator::{
     ClientBuilder, EpochChangeObservation, GeneratedScenarioCase, HarnessClient,
     PendingResolutionObservation, ScenarioReport, ScenarioSpec, ScenarioStep, ScenarioTrace,
-    TraceExpectation, TransportBus, VectorFixture, generate_convergence_chaos_family,
-    generate_convergence_e2e_delivery_family, generate_send_leave_family, observe_client,
-    run_generated_case_report, run_scenario_report, run_scenario_report_with_outcomes,
-    run_scenario_spec, run_vector_fixture_report,
+    TraceExpectation, TransportBus, VectorFixture, compare_trace_expectations,
+    generate_convergence_chaos_family, generate_convergence_e2e_delivery_family,
+    generate_send_leave_family, observe_client, run_generated_case_report, run_scenario_report,
+    run_scenario_report_with_outcomes, run_scenario_spec, run_vector_fixture_report,
 };
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::openmls_projection::{OpenMlsContentKind, project_mls_message};
@@ -282,6 +282,7 @@ async fn three_client_message_exchange_vector_is_stable() {
                     epoch_changes: vec![],
                     app_invalidations: vec![],
                     recoveries: vec![],
+                    convergence_decisions: vec![],
                 },
                 cgka_conformance_simulator::ClientObservation {
                     client: "bob".into(),
@@ -298,6 +299,7 @@ async fn three_client_message_exchange_vector_is_stable() {
                     epoch_changes: vec![],
                     app_invalidations: vec![],
                     recoveries: vec![],
+                    convergence_decisions: vec![],
                 },
                 cgka_conformance_simulator::ClientObservation {
                     client: "carol".into(),
@@ -314,6 +316,7 @@ async fn three_client_message_exchange_vector_is_stable() {
                     epoch_changes: vec![],
                     app_invalidations: vec![],
                     recoveries: vec![],
+                    convergence_decisions: vec![],
                 },
             ],
         }
@@ -1951,4 +1954,90 @@ async fn welcome_before_commit_rejects_commit_echo_cleanly_via_harness() {
         "expected welcome to be processed: {outcomes:?}"
     );
     assert!(saw_peel_failed, "expected stale peel failure: {outcomes:?}");
+}
+
+/// End-to-end proof of the convergence assert surface: an observer's engine
+/// makes a real `convergence_decision`, the harness recorder captures it, and it
+/// is asserted through `TraceExpectation::ConvergenceDecision`. Two admins invite
+/// different members at the same epoch, so carol's convergence selects the
+/// canonical branch by authenticated committer identity — deterministic, and
+/// distinct from a witness-decided win (covered by the vector.rs unit tests).
+#[tokio::test]
+async fn harness_captures_and_asserts_convergence_decision() {
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut carol = ClientBuilder::new(pad32(b"carol"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut david = ClientBuilder::new(pad32(b"david"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut eve = ClientBuilder::new(pad32(b"eve"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+
+    let bob_kp = bob.fresh_key_package().await;
+    let carol_kp = carol.fresh_key_package().await;
+    let (_group_id, pending) = alice
+        .create_group_with_admins(
+            "convergence-decision-capture",
+            vec![bob_kp, carol_kp],
+            vec![],
+            vec![bob.member_id()],
+        )
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+    carol.tick().await;
+    // Discard setup-phase captures so the assertion sees only the contested
+    // convergence decision under test.
+    for client in [&mut alice, &mut bob, &mut carol] {
+        client.drain_events();
+        client.clear_audit_capture();
+    }
+
+    // Two admins invite different members at the same source epoch: two branches.
+    let david_kp = david.fresh_key_package().await;
+    let eve_kp = eve.fresh_key_package().await;
+    let alice_pending = alice.invite(vec![david_kp]).await;
+    let bob_pending = bob.invite(vec![eve_kp]).await;
+    alice.confirm(alice_pending).await;
+    bob.confirm(bob_pending).await;
+
+    // Carol ingests both commits and runs convergence, which selects the
+    // canonical branch. Both commits are privileged admin invites with no
+    // app-witness quorum, so the committer-identity rule is decisive.
+    bus.deliver_all();
+    let carol_outcomes = carol.tick().await;
+    assert_tick_reached_convergence("carol", &carol_outcomes);
+
+    let observed = ScenarioTrace {
+        name: "convergence-decision-capture".into(),
+        pending_resolutions: Vec::new(),
+        errors: Vec::new(),
+        admin_policies: Vec::new(),
+        observations: vec![observe_client("carol", &mut carol)],
+    };
+    let failures = compare_trace_expectations(
+        None,
+        &[TraceExpectation::ConvergenceDecision {
+            client: Some("carol".into()),
+            selected_branch_id: None,
+            selected_tip_epoch: Some(2),
+            decisive_rule: Some("tip_committer".into()),
+            witness_quorum_met: Some(false),
+            min_app_witness_score: None,
+        }],
+        &observed,
+    );
+    assert!(
+        failures.is_empty(),
+        "carol should observe the committer-decided convergence decision: {failures:#?}"
+    );
 }

--- a/crates/cgka-conformance-simulator/tests/canonicalization_contract.rs
+++ b/crates/cgka-conformance-simulator/tests/canonicalization_contract.rs
@@ -201,6 +201,7 @@ fn app_message(
                 .map(|branch| (*branch).to_owned())
                 .collect(),
             decrypted_payload_ref: payload_ref.map(str::to_owned),
+            already_delivered: false,
         },
     }
 }

--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -368,6 +368,7 @@ async fn openmls_canonicalization_maps_consumed_proposal_refs_to_pending_proposa
                 messages: vec![commit_msg.clone()],
             }],
             pending_messages: vec![proposal_msg.clone()],
+            already_delivered_app_ids: BTreeSet::new(),
             outbound_intents: vec![],
             policy: CanonicalizationPolicy {
                 convergence: ConvergencePolicy {
@@ -483,6 +484,7 @@ async fn openmls_canonicalization_uses_app_messages_as_branch_witnesses() {
                 },
             ],
             pending_messages: vec![app_msg.clone()],
+            already_delivered_app_ids: BTreeSet::new(),
             outbound_intents: vec![],
             policy: CanonicalizationPolicy {
                 convergence: ConvergencePolicy {

--- a/crates/cgka-conformance-simulator/tests/proptest_invariants.rs
+++ b/crates/cgka-conformance-simulator/tests/proptest_invariants.rs
@@ -515,6 +515,7 @@ fn app_message(id: &str, sender: u8, decrypts_on_branch: &str) -> PeeledMessage 
             epoch: 3,
             decrypts_on_branches: vec![decrypts_on_branch.into()],
             decrypted_payload_ref: Some(format!("payload-{id}")),
+            already_delivered: false,
         },
     }
 }

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,0 +1,106 @@
+{
+  "scenario_name": "convergence-committer-selected/v1",
+  "vector_version": "1",
+  "conformance_version": "0.9.1",
+  "seed": null,
+  "scenario": {
+    "name": "convergence-committer-selected/v1",
+    "spec_version": "1",
+    "clients": [
+      "alice",
+      "bob",
+      "carol",
+      "david",
+      "eve"
+    ],
+    "steps": [
+      {
+        "type": "create_group",
+        "creator": "alice",
+        "name": "convergence",
+        "invitees": [
+          "bob",
+          "carol"
+        ],
+        "required_features": [],
+        "initial_admins": [
+          "bob"
+        ],
+        "pending": "create"
+      },
+      {
+        "type": "confirm_pending",
+        "client": "alice",
+        "pending": "create"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob",
+          "carol"
+        ]
+      },
+      {
+        "type": "clear_events",
+        "clients": [
+          "alice",
+          "bob",
+          "carol"
+        ]
+      },
+      {
+        "type": "invite_members",
+        "inviter": "alice",
+        "invitees": [
+          "david"
+        ],
+        "pending": "alice-invite"
+      },
+      {
+        "type": "invite_members",
+        "inviter": "bob",
+        "invitees": [
+          "eve"
+        ],
+        "pending": "bob-invite"
+      },
+      {
+        "type": "confirm_pending",
+        "client": "alice",
+        "pending": "alice-invite"
+      },
+      {
+        "type": "confirm_pending",
+        "client": "bob",
+        "pending": "bob-invite"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "carol"
+        ]
+      },
+      {
+        "type": "observe",
+        "clients": [
+          "carol"
+        ]
+      }
+    ]
+  },
+  "expected_outcomes": [
+    {
+      "type": "convergence_decision",
+      "client": "carol",
+      "selected_tip_epoch": 2,
+      "decisive_rule": "tip_committer",
+      "witness_quorum_met": false
+    }
+  ]
+}

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.3",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",
@@ -41,6 +41,23 @@
       "selected_tip_epoch": 2,
       "witness_quorum_met": true,
       "min_app_witness_score": 2
+    },
+    {
+      "type": "pending_resolution",
+      "step_index": 1,
+      "client": "alice",
+      "pending": "create",
+      "resolution": "confirmed"
+    },
+    {
+      "type": "client_state",
+      "client": "carol",
+      "epoch": 2,
+      "member_count": 4,
+      "received_payloads": [
+        "wA-1",
+        "wA-2"
+      ]
     }
   ]
 }

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,0 +1,46 @@
+{
+  "scenario_name": "convergence-witness-selected/v1",
+  "vector_version": "1",
+  "conformance_version": "0.9.1",
+  "seed": null,
+  "scenario": {
+    "name": "convergence-witness-selected/v1",
+    "spec_version": "1",
+    "clients": ["alice", "bob", "carol", "david", "eve"],
+    "steps": [
+      { "type": "create_group", "creator": "alice", "name": "convergence", "invitees": ["bob", "carol"], "required_features": [], "initial_admins": ["bob"], "pending": "create" },
+      { "type": "confirm_pending", "client": "alice", "pending": "create" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["bob", "carol"] },
+      { "type": "clear_events", "clients": ["alice", "bob", "carol"] },
+
+      { "type": "invite_members", "inviter": "alice", "invitees": ["david"], "pending": "invite-a" },
+      { "type": "invite_members", "inviter": "bob", "invitees": ["eve"], "pending": "invite-b" },
+      { "type": "confirm_pending", "client": "alice", "pending": "invite-a" },
+      { "type": "confirm_pending", "client": "bob", "pending": "invite-b" },
+
+      { "type": "delay_queued", "index": 3, "delayed": "held-b" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["david"] },
+
+      { "type": "send_app_message", "sender": "alice", "payload": "wA-1" },
+      { "type": "send_app_message", "sender": "david", "payload": "wA-2" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["carol"] },
+
+      { "type": "release_delayed", "delayed": "held-b" },
+      { "type": "deliver_all" },
+      { "type": "tick", "clients": ["carol"] },
+      { "type": "observe", "clients": ["carol"] }
+    ]
+  },
+  "expected_outcomes": [
+    {
+      "type": "convergence_decision",
+      "client": "carol",
+      "selected_tip_epoch": 2,
+      "witness_quorum_met": true,
+      "min_app_witness_score": 2
+    }
+  ]
+}

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,10 +1,10 @@
 {
-  "scenario_name": "convergence-committer-selected/v1",
+  "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
   "conformance_version": "0.9.3",
   "seed": null,
   "scenario": {
-    "name": "convergence-committer-selected/v1",
+    "name": "convergence-incident/v1",
     "spec_version": "1",
     "clients": [
       "alice",
@@ -17,7 +17,7 @@
       {
         "type": "create_group",
         "creator": "alice",
-        "name": "convergence",
+        "name": "replay",
         "invitees": [
           "bob",
           "carol"
@@ -57,7 +57,7 @@
         "invitees": [
           "david"
         ],
-        "pending": "alice-invite"
+        "pending": "invite-a"
       },
       {
         "type": "invite_members",
@@ -65,17 +65,17 @@
         "invitees": [
           "eve"
         ],
-        "pending": "bob-invite"
+        "pending": "invite-b"
       },
       {
         "type": "confirm_pending",
         "client": "alice",
-        "pending": "alice-invite"
+        "pending": "invite-a"
       },
       {
         "type": "confirm_pending",
         "client": "bob",
-        "pending": "bob-invite"
+        "pending": "invite-b"
       },
       {
         "type": "deliver_all"
@@ -101,20 +101,6 @@
       "selected_tip_epoch": 2,
       "decisive_rule": "tip_committer",
       "witness_quorum_met": false
-    },
-    {
-      "type": "pending_resolution",
-      "step_index": 1,
-      "client": "alice",
-      "pending": "create",
-      "resolution": "confirmed"
-    },
-    {
-      "type": "client_state",
-      "client": "carol",
-      "epoch": 2,
-      "member_count": 4,
-      "received_payloads": []
     }
   ]
 }

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,0 +1,104 @@
+{
+  "scenario_name": "fork-recovery-incident/v1",
+  "vector_version": "1",
+  "conformance_version": "0.9.1",
+  "seed": null,
+  "scenario": {
+    "name": "fork-recovery-incident/v1",
+    "spec_version": "1",
+    "clients": [
+      "bob",
+      "alice"
+    ],
+    "steps": [
+      {
+        "type": "create_group",
+        "creator": "bob",
+        "name": "replay",
+        "invitees": [
+          "alice"
+        ],
+        "required_features": [],
+        "pending": "create"
+      },
+      {
+        "type": "confirm_pending",
+        "client": "bob",
+        "pending": "create"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice"
+        ]
+      },
+      {
+        "type": "clear_events",
+        "clients": [
+          "bob",
+          "alice"
+        ]
+      },
+      {
+        "type": "update_group_data",
+        "client": "bob",
+        "name": "winner-branch",
+        "pending": "w"
+      },
+      {
+        "type": "update_group_data",
+        "client": "alice",
+        "name": "loser-branch",
+        "pending": "l"
+      },
+      {
+        "type": "confirm_pending",
+        "client": "bob",
+        "pending": "w"
+      },
+      {
+        "type": "confirm_pending",
+        "client": "alice",
+        "pending": "l"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob",
+          "alice"
+        ]
+      },
+      {
+        "type": "observe",
+        "clients": [
+          "bob",
+          "alice"
+        ]
+      }
+    ]
+  },
+  "expected_outcomes": [
+    {
+      "type": "recovery_summary",
+      "count": 1,
+      "source_epoch": 1,
+      "recovered_epoch": 2,
+      "winner_differs_from_invalidated": true
+    },
+    {
+      "type": "clients_converged",
+      "clients": [
+        "bob",
+        "alice"
+      ],
+      "epoch": 2,
+      "member_count": 2
+    }
+  ]
+}

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.1",
+  "conformance_version": "0.9.3",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": "1",
-  "updated": "2026-05-13",
+  "updated": "2026-07-06",
   "purpose": "Inventory of current CGKA conformance artifacts and the next vectorization state for each one.",
   "entries": [
     {
@@ -175,6 +175,19 @@
         "single app payload emission after replay"
       ],
       "next": "Use as the restart-plus-delivery-fault fixture."
+    },
+    {
+      "id": "fork-recovery-incident/v1",
+      "kind": "scenario_vector",
+      "status": "incident_replay",
+      "artifact": "incidents/fork-recovery-incident.v1.json",
+      "coverage": [
+        "Goggles forensic export replayed as a conformance vector",
+        "same-epoch group-data fork recovery",
+        "designated-winner branch survival",
+        "full recovery-summary reproduction"
+      ],
+      "next": "Wire vectors/incidents/ into the portable vector fixture test (Phase 5)."
     },
     {
       "id": "convergence-e2e-group-events/v1",

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -203,6 +203,19 @@
       "next": "Wire vectors/incidents/ into the portable vector fixture test (Phase 5)."
     },
     {
+      "id": "convergence-incident/v1",
+      "kind": "scenario_vector",
+      "status": "incident_replay",
+      "artifact": "incidents/convergence-incident.v1.json",
+      "coverage": [
+        "Goggles forensic export replayed as a conformance vector",
+        "observer-side committer-decided convergence selection",
+        "tip-committer decisive rule with no witness quorum",
+        "settled convergence-decision reproduction"
+      ],
+      "next": "Extend to witness-decided convergence once the harness counts app-message witnesses (Phase 4 follow-up)."
+    },
+    {
       "id": "convergence-e2e-group-events/v1",
       "kind": "scenario",
       "status": "rust_only_bridge",

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -104,6 +104,18 @@
       "next": "Extend the trace format so the selected branch member identity can be asserted portably."
     },
     {
+      "id": "convergence-committer-selected/v1",
+      "kind": "scenario_vector",
+      "status": "portable",
+      "artifact": "convergence-committer-selected.v1.json",
+      "coverage": [
+        "observer-side convergence decision (not fork recovery)",
+        "committer-identity decisive rule",
+        "settled convergence_decision assertion"
+      ],
+      "next": "Add a witness-decided companion vector once engine-driven app-witness quorum is stageable in the harness."
+    },
+    {
       "id": "drop-queued/v1",
       "kind": "scenario_vector",
       "status": "portable",

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -113,7 +113,20 @@
         "committer-identity decisive rule",
         "settled convergence_decision assertion"
       ],
-      "next": "Add a witness-decided companion vector once engine-driven app-witness quorum is stageable in the harness."
+      "next": "See convergence-witness-selected/v1 for the witness-decided companion."
+    },
+    {
+      "id": "convergence-witness-selected/v1",
+      "kind": "scenario_vector",
+      "status": "portable",
+      "artifact": "convergence-witness-selected.v1.json",
+      "coverage": [
+        "observer-side witness-decided convergence",
+        "app-witness quorum overrides the committer tiebreak",
+        "witness weight retained across a post-delivery fork reorg",
+        "delivered app payloads not re-delivered on reorg"
+      ],
+      "next": "Use as the witness-decided convergence contract; source of the convergence incident-replay witness path."
     },
     {
       "id": "drop-queued/v1",

--- a/crates/cgka-engine/src/canonicalization.rs
+++ b/crates/cgka-engine/src/canonicalization.rs
@@ -98,6 +98,14 @@ pub enum PeeledMessageKind {
         epoch: u64,
         decrypts_on_branches: Vec<String>,
         decrypted_payload_ref: Option<String>,
+        /// This message was already applied/delivered on a prior convergence
+        /// pass (its stored record is `Processed`). It is re-admitted so it can
+        /// still witness its branch during scoring — a same-epoch fork resolved
+        /// *after* the message was delivered must not lose the message's witness
+        /// weight (that would make branch selection depend on local arrival
+        /// order, violating the convergence contract's order-independence). It is
+        /// never re-delivered: [`handle_app_message`] resolves it as already-seen.
+        already_delivered: bool,
     },
 }
 
@@ -222,7 +230,19 @@ fn canonicalize_internal(
     let mut unique_messages = Vec::new();
 
     for message in input.pending_messages.iter() {
-        if !observed_ids.insert(message.message_id.clone()) {
+        // An already-delivered app is intentionally in `seen_message_ids`, but it
+        // must still reach materialization + `attach_app_witnesses` to witness its
+        // branch. Exempt it from the seen-dedup here; `handle_app_message` resolves
+        // it as already-seen so it is counted (not `Resolving`) yet never
+        // re-delivered.
+        let readmitted_witness = matches!(
+            message.kind,
+            PeeledMessageKind::AppMessage {
+                already_delivered: true,
+                ..
+            }
+        );
+        if !readmitted_witness && !observed_ids.insert(message.message_id.clone()) {
             already_seen.push(AlreadySeen {
                 message_id: message.message_id.clone(),
                 kind: message.kind_name(),
@@ -344,6 +364,7 @@ fn canonicalize_internal(
                 epoch,
                 decrypts_on_branches,
                 decrypted_payload_ref,
+                already_delivered,
             } => handle_app_message(
                 &mut result,
                 &input,
@@ -351,6 +372,7 @@ fn canonicalize_internal(
                 *epoch,
                 decrypts_on_branches,
                 decrypted_payload_ref.clone(),
+                *already_delivered,
             ),
         }
     }
@@ -701,7 +723,19 @@ fn handle_app_message(
     epoch: u64,
     decrypts_on_branches: &[String],
     decrypted_payload_ref: Option<String>,
+    already_delivered: bool,
 ) {
+    // A message applied on a prior pass is re-admitted only so it can witness its
+    // branch again (see `attach_app_witnesses`). It must never be re-delivered or
+    // re-invalidated, so it takes no delivery disposition — it resolves as
+    // already-seen (which keeps the pass out of `Resolving`).
+    if already_delivered {
+        result.already_seen.push(AlreadySeen {
+            message_id: message.message_id.clone(),
+            kind: message.kind_name(),
+        });
+        return;
+    }
     if epoch < input.state.retained_anchor_epoch {
         result.invalidated_app_messages.push(invalidated_app(
             message,

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -114,6 +114,10 @@ pub struct OpenMlsCanonicalizationBatch {
     pub state: CanonicalizationState,
     pub candidate_paths: Vec<OpenMlsCandidatePath>,
     pub pending_messages: Vec<TransportMessage>,
+    /// Hex ids of app messages in `pending_messages` already applied on a prior
+    /// pass (stored `Processed`), re-admitted for witness scoring only — never
+    /// re-delivered. Empty for callers that pass only fresh messages.
+    pub already_delivered_app_ids: BTreeSet<String>,
     pub outbound_intents: Vec<OutboundIntent>,
     pub policy: CanonicalizationPolicy,
     pub now_ms: u64,
@@ -209,6 +213,9 @@ struct StoredOpenMlsCanonicalizationWork {
     state: CanonicalizationState,
     commit_messages: Vec<StoredCommitMessage>,
     pending_messages: Vec<TransportMessage>,
+    /// App ids in `pending_messages` re-admitted for witness scoring only (stored
+    /// `Processed`). See [`OpenMlsCanonicalizationBatch::already_delivered_app_ids`].
+    already_delivered_app_ids: BTreeSet<String>,
     outbound_intents: Vec<OutboundIntent>,
     policy: CanonicalizationPolicy,
     now_ms: u64,
@@ -633,6 +640,7 @@ fn canonicalize_openmls_batch_with_materialized(
     let pending_messages = project_pending_canonicalization_messages(
         group_id,
         &batch.pending_messages,
+        &batch.already_delivered_app_ids,
         &proposal_branch_by_id,
         &app_messages_by_id,
     )?;
@@ -668,6 +676,7 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
     let mut commit_messages = Vec::new();
     let mut pending_messages = Vec::new();
+    let mut already_delivered_app_ids = BTreeSet::new();
     let mut stale_commit_drops = Vec::new();
     let mut own_commits = PrevalidatedOwnCommits::default();
 
@@ -714,10 +723,27 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
                     state: record.state,
                 });
             }
-            OpenMlsContentKind::Proposal | OpenMlsContentKind::Application
+            OpenMlsContentKind::Proposal
                 if record_state_is_canonicalization_input(record.state)
                     && source_epoch.is_some_and(|epoch| epoch >= state.retained_anchor_epoch) =>
             {
+                pending_messages.push(message)
+            }
+            // App messages within the retained window are admitted for scoring
+            // when fresh (`Created`/`Retryable`/`Sent`, to be delivered) AND when
+            // already `Processed` on a prior pass. A `Processed` app is re-admitted
+            // for witness scoring only (tracked in `already_delivered_app_ids` so
+            // it is never re-delivered): without it, a same-epoch fork resolved
+            // *after* the app was delivered loses that app's witness weight, so
+            // branch selection would depend on local arrival order (the
+            // convergence contract requires order-independence).
+            OpenMlsContentKind::Application
+                if record_state_can_contribute_to_openmls_graph(record.state)
+                    && source_epoch.is_some_and(|epoch| epoch >= state.retained_anchor_epoch) =>
+            {
+                if record.state == MessageState::Processed {
+                    already_delivered_app_ids.insert(hex::encode(message.id.as_slice()));
+                }
                 pending_messages.push(message)
             }
             OpenMlsContentKind::Welcome | OpenMlsContentKind::Other => {}
@@ -744,6 +770,7 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
                 state,
                 commit_messages,
                 pending_messages,
+                already_delivered_app_ids,
                 outbound_intents,
                 policy,
                 now_ms,
@@ -762,6 +789,7 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
             state,
             commit_messages,
             pending_messages,
+            already_delivered_app_ids,
             outbound_intents,
             policy,
             now_ms,
@@ -824,6 +852,31 @@ fn canonicalize_stored_openmls_messages_from_retained_anchor<S: StorageProvider>
     result
 }
 
+/// Whether the pass may reuse the candidates the BFS already materialized instead
+/// of a second full replay (#635).
+///
+/// Reuse is sound only with **no pending application messages**: the BFS probes
+/// fold pending proposals but not applications, so with pending apps the reused
+/// candidate would lack the `ApplicationProcessed` observations the
+/// canonicalization core consumes (for delivery *and* app-witness scoring), so the
+/// pass falls back to a fresh full materialize.
+///
+/// Perf note: re-admitting already-delivered (`Processed`) app messages as
+/// witnesses (see `canonicalize_stored_openmls_messages`) means `has_pending_apps`
+/// is true on any pass where a delivered app is still inside the retained window —
+/// so those passes pay the full-materialize cost instead of reusing. The cost is
+/// bounded by `max_rewind_commits` and convergence is not the per-message hot path,
+/// so it is negligible for small groups. If a benchmark ever shows it matters for
+/// large, busy groups, gate the witness re-admission on the presence of a contested
+/// fork (competing branches) rather than on any retained app.
+fn can_reuse_bfs_materialization(
+    has_pending_apps: bool,
+    materialized_len: usize,
+    candidate_paths_len: usize,
+) -> bool {
+    !has_pending_apps && materialized_len == candidate_paths_len
+}
+
 fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
@@ -839,19 +892,18 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
         &work.own_commits,
     )?;
 
-    // Reuse the candidates the BFS already materialized instead of replaying every completed
-    // path a second time — but ONLY when the pass has no pending application messages. The BFS
-    // probes fold pending proposals but not applications, so with pending apps the reused
-    // candidate would be missing the ApplicationProcessed observations the canonicalization
-    // core consumes; that case falls back to a fresh full materialize (#635).
     let has_pending_apps = pending_messages_contain_application(&work.pending_messages)?;
-    let can_reuse_materialized =
-        !has_pending_apps && path_result.materialized.len() == path_result.candidate_paths.len();
+    let can_reuse_materialized = can_reuse_bfs_materialization(
+        has_pending_apps,
+        path_result.materialized.len(),
+        path_result.candidate_paths.len(),
+    );
 
     let batch = OpenMlsCanonicalizationBatch {
         state: work.state,
         candidate_paths: path_result.candidate_paths,
         pending_messages: work.pending_messages,
+        already_delivered_app_ids: work.already_delivered_app_ids,
         outbound_intents: work.outbound_intents,
         policy: work.policy,
         now_ms: work.now_ms,
@@ -1674,6 +1726,7 @@ fn app_messages_by_id(
 fn project_pending_canonicalization_messages(
     group_id: &GroupId,
     messages: &[TransportMessage],
+    already_delivered_app_ids: &BTreeSet<String>,
     proposal_branch_by_id: &BTreeMap<String, String>,
     app_messages_by_id: &BTreeMap<String, AppMessageBranches>,
 ) -> Result<Vec<PeeledMessage>, OpenMlsProjectionError> {
@@ -1702,6 +1755,7 @@ fn project_pending_canonicalization_messages(
                         .unwrap_or_default(),
                     decrypted_payload_ref: observed
                         .map(|observed| observed.decrypted_payload_ref.clone()),
+                    already_delivered: already_delivered_app_ids.contains(&message_id),
                 }
             }
             OpenMlsContentKind::Commit
@@ -2229,5 +2283,32 @@ mod replay_budget_tests {
                 .consume()
                 .expect("unlimited budget never fails closed");
         }
+    }
+}
+
+#[cfg(test)]
+mod reuse_scope_tests {
+    use super::can_reuse_bfs_materialization;
+
+    #[test]
+    fn app_free_pass_reuses_bfs_materialization() {
+        // has_pending_apps == false ⇒ reuse the #635 BFS materialization, so the
+        // witness re-admission's full-materialize cost is scoped to app-bearing
+        // passes and never taxes an app-free convergence.
+        assert!(can_reuse_bfs_materialization(false, 3, 3));
+    }
+
+    #[test]
+    fn pending_apps_force_full_materialize() {
+        // A pending app — fresh, or a re-admitted already-delivered witness —
+        // bypasses reuse so its ApplicationProcessed observations are recomputed.
+        assert!(!can_reuse_bfs_materialization(true, 3, 3));
+    }
+
+    #[test]
+    fn incomplete_bfs_materialization_does_not_reuse() {
+        // Reuse also requires the BFS to have materialized every candidate path;
+        // a partial materialization falls back to a full replay even app-free.
+        assert!(!can_reuse_bfs_materialization(false, 2, 3));
     }
 }

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -17,7 +17,7 @@ use cgka_traits::storage::{StorageError, StorageProvider};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use openmls::component::ComponentData;
-use openmls::group::{MlsGroup, ProcessMessageError, ValidationError};
+use openmls::group::{MlsGroup, MlsGroupStateError, ProcessMessageError, ValidationError};
 use openmls::messages::proposals::{AppDataUpdateOperation, Proposal, ProposalOrRef};
 use openmls::prelude::{
     BasicCredential, ContentType, MlsMessageBodyIn, MlsMessageIn, ProcessedMessage,
@@ -1870,14 +1870,22 @@ fn process_openmls_messages_inner<S: StorageProvider>(
             Ok(processed) => processed,
             Err(err) if projection.kind == OpenMlsContentKind::Application => {
                 // App-message replay against a candidate state is best-
-                // effort: an app message that doesn't decrypt on this
-                // branch is just evidence that it belongs to a different
-                // branch, not a fatal error. ValidationError covers the
-                // expected failure modes (WrongEpoch, decryption fail,
-                // sender-membership, etc.). LibraryError or any other
-                // structural failure is a real bug — propagate so we
-                // don't silently mask malformed input.
-                if matches!(err, ProcessMessageError::ValidationError(_)) {
+                // effort: an app message that doesn't apply on this branch is
+                // just evidence that it belongs elsewhere, not a fatal error.
+                // ValidationError covers the expected failure modes (WrongEpoch,
+                // decryption fail, sender-membership, etc.); GroupStateError's
+                // UseAfterEviction covers a re-admitted witness (a `Processed`
+                // app, see `canonicalize_stored_openmls_messages`) whose sender
+                // was evicted on this branch — it simply isn't a witness here.
+                // LibraryError or any other structural failure is a real bug —
+                // propagate so we don't silently mask malformed input.
+                if matches!(
+                    err,
+                    ProcessMessageError::ValidationError(_)
+                        | ProcessMessageError::GroupStateError(
+                            MlsGroupStateError::UseAfterEviction
+                        )
+                ) {
                     observations.push(OpenMlsReplayObservation::Ignored {
                         message_id,
                         kind: projection.kind,

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -27,9 +27,12 @@ recorded outcome (fail-closed).
     `RecoveredConvergence` (the decisive rule + a `ConvergenceDecisionKind`), or a
     `ConvergenceRecoveryError`. It reproduces the **committer-decided** case
     (`tip_committer` decisive, no quorum) and the **witness-decided** case
-    (`effective_commit_depth` decisive, winner met the app-witness quorum — the
-    real-traffic case). Any other shape (a committer tiebreak that itself met a
-    quorum, or a priority/digest/differing-depth rule) fail-closes.
+    (`effective_commit_depth` decisive between two *equal-depth* branches, where
+    the winner's app-witness quorum boost broke the tie — the real-traffic case).
+    Any other shape fail-closes: a committer tiebreak that itself met a quorum, a
+    witness winner whose branches were not at equal `valid_commit_depth` (so it won
+    on raw commit depth, not the boost), indistinct candidate branch ids, or a
+    priority/digest rule.
 - **Module:** `src/synth.rs`
   - **Role:** `synthesize` builds the concurrent-fork `VectorFixture` (two
     committers race group-data commits, no `SetPartition`). `synthesize_convergence`

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -1,15 +1,15 @@
 # AGENTS.md — incident-replay
 
-Goggles `agent-state.json` forensic export → CGKA conformance-vector adapter. This
-crate is the Phase 2 skeleton: **parse + classify**. Extraction, fault synthesis,
-and run-and-compare against `cgka-conformance-simulator` are later phases and are
-deliberately absent.
+Goggles `agent-state.json` forensic export → CGKA conformance-vector adapter. The
+pipeline is **parse → classify → recover → synthesize → accept**: a fork-recovery
+incident becomes a vector only if the simulator reproduces the recorded outcome
+(fail-closed). Convergence-selected incidents route to a later phase.
 
 ## Pieces
 
 - **Module:** `src/export.rs`
   - **Role:** Lenient, self-owned model of the export plus `parse`. Models only
-    the fields the classifier needs and ignores everything else, so it tolerates
+    the fields the pipeline needs and ignores everything else, so it tolerates
     the export growing new fields. Deliberately decoupled from `marmot-forensics`:
     it tracks the stable `marmot-forensics-audit/v2` wire shape Goggles
     serialises, not the engine's internal `AuditEventKind` enum.
@@ -17,9 +17,26 @@ deliberately absent.
   - **Role:** The `classify` gate → `Verdict`: `Healthy | ForkRecovery |
     ConvergenceSelected | Quarantine { reason }`. Everything downstream is gated
     behind this, so a healthy export yields zero vectors and a clean exit.
+- **Module:** `src/fork.rs`
+  - **Role:** `recover_fork` turns a fork-recovery export into a `RecoveredFork`
+    (source epoch, commit kind, and the designated winner recovered tier-b from
+    the invalidated message's publisher), or a `ForkRecoveryError` when it cannot
+    be replayed. Only metadata (group-data) forks are supported today.
+- **Module:** `src/synth.rs`
+  - **Role:** `synthesize` builds the concurrent-fork `VectorFixture`: two
+    committers raise competing group-data commits from the same epoch (no
+    `SetPartition` — the commits are concurrent), with real epochs normalised to
+    the simulator's `1 → 2` range and synthetic client labels the caller assigns.
+- **Module:** `src/accept.rs`
+  - **Role:** `accept` run-and-compares: it tries both label orderings, and
+    returns the vector only when the full `RecoverySummary` matches **and** the
+    designated winner's branch survives. The summary is the gate; branch survival
+    only selects the correct ordering. No reproduction ⇒ `AcceptError` (no vector).
 - **Module:** `src/main.rs`
-  - **Role:** CLI — classify one export file, print the verdict JSON, exit 0 for
-    any classification (quarantine included), 2 on usage/IO/parse failure.
+  - **Role:** CLI — classify one export file; for a fork-recovery incident, run
+    the recover → accept → write pipeline. Exits 0 for any classification
+    (healthy, quarantine, and accepted are all valid), 2 on usage/IO/parse/write
+    failure.
 
 ## Classification rules (verified against real Goggles exports)
 

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -2,8 +2,8 @@
 
 Goggles `agent-state.json` forensic export → CGKA conformance-vector adapter. The
 pipeline is **parse → classify → recover → synthesize → accept**: a fork-recovery
-incident becomes a vector only if the simulator reproduces the recorded outcome
-(fail-closed). Convergence-selected incidents route to a later phase.
+or convergence incident becomes a vector only if the simulator reproduces the
+recorded outcome (fail-closed).
 
 ## Pieces
 
@@ -22,21 +22,34 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
     (source epoch, commit kind, and the designated winner recovered tier-b from
     the invalidated message's publisher), or a `ForkRecoveryError` when it cannot
     be replayed. Only metadata (group-data) forks are supported today.
+- **Module:** `src/convergence.rs`
+  - **Role:** `recover_convergence` turns a convergence-selected export into a
+    `RecoveredConvergence` (the decisive rule + a `ConvergenceDecisionKind`), or a
+    `ConvergenceRecoveryError`. It reproduces the **committer-decided** case
+    (`tip_committer` decisive, no quorum) and the **witness-decided** case
+    (`effective_commit_depth` decisive, winner met the app-witness quorum — the
+    real-traffic case). Any other shape (a committer tiebreak that itself met a
+    quorum, or a priority/digest/differing-depth rule) fail-closes.
 - **Module:** `src/synth.rs`
-  - **Role:** `synthesize` builds the concurrent-fork `VectorFixture`: two
-    committers raise competing group-data commits from the same epoch (no
-    `SetPartition` — the commits are concurrent), with real epochs normalised to
-    the simulator's `1 → 2` range and synthetic client labels the caller assigns.
+  - **Role:** `synthesize` builds the concurrent-fork `VectorFixture` (two
+    committers race group-data commits, no `SetPartition`). `synthesize_convergence`
+    dispatches on `ConvergenceDecisionKind`: the committer-decided vector (two
+    admins race invite commits observed by a passive third client) or the
+    witness-decided vector (the observer delivers two senders' app messages on one
+    branch, then a held competing commit is released — the app-witness quorum
+    overrides the committer tiebreak on the reorg). Both normalise real epochs to
+    the simulator's `1 → 2` range; the convergence assertion is winner-agnostic.
 - **Module:** `src/accept.rs`
-  - **Role:** `accept` run-and-compares: it tries both label orderings, and
-    returns the vector only when the full `RecoverySummary` matches **and** the
-    designated winner's branch survives. The summary is the gate; branch survival
-    only selects the correct ordering. No reproduction ⇒ `AcceptError` (no vector).
+  - **Role:** `accept` (fork) tries both label orderings and returns the vector
+    only when the full `RecoverySummary` matches **and** the designated winner's
+    branch survives. `accept_convergence` is a single run-and-compare (winner-agnostic
+    ⇒ no label search) that returns the vector only when the recorded convergence
+    decision reproduces. No reproduction ⇒ `AcceptError` (no vector).
 - **Module:** `src/main.rs`
-  - **Role:** CLI — classify one export file; for a fork-recovery incident, run
-    the recover → accept → write pipeline. Exits 0 for any classification
-    (healthy, quarantine, and accepted are all valid), 2 on usage/IO/parse/write
-    failure.
+  - **Role:** CLI — classify one export file; for a fork-recovery or convergence
+    incident, run the recover → accept → write pipeline. Exits 0 for any
+    classification (healthy, quarantine, and accepted are all valid), 2 on
+    usage/IO/parse/write failure.
 
 ## Classification rules (verified against real Goggles exports)
 

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md — incident-replay
+
+Goggles `agent-state.json` forensic export → CGKA conformance-vector adapter. This
+crate is the Phase 2 skeleton: **parse + classify**. Extraction, fault synthesis,
+and run-and-compare against `cgka-conformance-simulator` are later phases and are
+deliberately absent.
+
+## Pieces
+
+- **Module:** `src/export.rs`
+  - **Role:** Lenient, self-owned model of the export plus `parse`. Models only
+    the fields the classifier needs and ignores everything else, so it tolerates
+    the export growing new fields. Deliberately decoupled from `marmot-forensics`:
+    it tracks the stable `marmot-forensics-audit/v2` wire shape Goggles
+    serialises, not the engine's internal `AuditEventKind` enum.
+- **Module:** `src/classify.rs`
+  - **Role:** The `classify` gate → `Verdict`: `Healthy | ForkRecovery |
+    ConvergenceSelected | Quarantine { reason }`. Everything downstream is gated
+    behind this, so a healthy export yields zero vectors and a clean exit.
+- **Module:** `src/main.rs`
+  - **Role:** CLI — classify one export file, print the verdict JSON, exit 0 for
+    any classification (quarantine included), 2 on usage/IO/parse failure.
+
+## Classification rules (verified against real Goggles exports)
+
+Precedence, highest first:
+
+1. **Quarantine `truncated_projections`** — any `derived_projections.pagination`
+   section has `has_more == true`. A capped export is incomplete, so reproduction
+   could silently miss witnesses or state.
+2. **`ConvergenceSelected`** — any `convergence_decision` is *contested*
+   (`losing_branch_ids` non-empty, or ≥2 candidates). Routine single-branch passes
+   are not incidents; healthy real traffic is full of them.
+3. **Quarantine `missing_snapshot`** — a `fork_resolution` won with
+   `missing_snapshot` (the winning snapshot was unavailable, so it can't be
+   replayed) on the fork-recovery route.
+4. **`ForkRecovery`** — any other `fork_resolution`.
+5. **`Healthy`** — none of the above.
+
+## Fixtures
+
+- `tests/fixtures/*.json` are **synthetic and non-sensitive** — the committed test
+  set. Real exports carry relay URLs / message ids and must never enter VCS.
+- Real exports are the manual pre-PR verification set:
+  `cargo run -p incident-replay -- <export.json>`.
+
+## Verification
+
+```sh
+cargo test -p incident-replay
+cargo clippy -p incident-replay --all-targets
+```

--- a/crates/incident-replay/CLAUDE.md
+++ b/crates/incident-replay/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/incident-replay/Cargo.toml
+++ b/crates/incident-replay/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "incident-replay"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "Goggles agent-state export → conformance-vector adapter: parse forensic incident exports and classify them for replay in the CGKA conformance simulator."
+
+[dependencies]
+serde = { workspace = true }
+serde_json.workspace = true
+thiserror.workspace = true
+
+[[bin]]
+name = "incident-replay"
+path = "src/main.rs"

--- a/crates/incident-replay/Cargo.toml
+++ b/crates/incident-replay/Cargo.toml
@@ -10,6 +10,8 @@ description = "Goggles agent-state export → conformance-vector adapter: parse 
 serde = { workspace = true }
 serde_json.workspace = true
 thiserror.workspace = true
+cgka-conformance-simulator.workspace = true
+tokio = { workspace = true, features = ["rt", "time"] }
 
 [[bin]]
 name = "incident-replay"

--- a/crates/incident-replay/src/accept.rs
+++ b/crates/incident-replay/src/accept.rs
@@ -1,0 +1,51 @@
+//! Run-and-compare: turn a recovered fork into an accepted vector, or quarantine.
+
+use cgka_conformance_simulator::{VectorFixture, run_scenario_spec};
+
+use crate::fork::RecoveredFork;
+use crate::synth::{WINNER_BRANCH, synthesize};
+
+/// Why an accept attempt produced no vector (fail-closed).
+#[derive(Debug, thiserror::Error)]
+pub enum AcceptError {
+    #[error("the simulator could not be driven: {0}")]
+    Run(String),
+    #[error("run-and-compare did not reproduce the recorded winner in {tries} label orderings")]
+    NotReproduced { tries: usize },
+}
+
+/// The winner is decided by committer bytes, so exactly one of these two
+/// orderings puts the designated winner's key below the loser's.
+const LABEL_ORDERINGS: [(&str, &str); 2] = [("alice", "bob"), ("bob", "alice")];
+
+/// Synthesize and verify a vector for a recovered fork.
+///
+/// Bounded label search: for each ordering, run the synthesized scenario and
+/// accept iff the full `RecoverySummary` (and convergence) expectations hold
+/// **and** the designated winner's branch is the one that survived. The summary
+/// is the gate; branch survival only selects the correct ordering.
+pub fn accept(fork: &RecoveredFork, name: &str) -> Result<VectorFixture, AcceptError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .map_err(|err| AcceptError::Run(err.to_string()))?;
+
+    for (winner, loser) in LABEL_ORDERINGS {
+        let vector = synthesize(fork, name, winner, loser);
+        let trace = runtime
+            .block_on(run_scenario_spec(&vector.scenario))
+            .map_err(|err| AcceptError::Run(err.to_string()))?;
+
+        let summary_matches = vector.compare_observed_trace(&trace).is_empty();
+        let winner_branch_survived = trace
+            .observations
+            .iter()
+            .any(|observation| observation.group_name == WINNER_BRANCH);
+        if summary_matches && winner_branch_survived {
+            return Ok(vector);
+        }
+    }
+    Err(AcceptError::NotReproduced {
+        tries: LABEL_ORDERINGS.len(),
+    })
+}

--- a/crates/incident-replay/src/accept.rs
+++ b/crates/incident-replay/src/accept.rs
@@ -2,15 +2,16 @@
 
 use cgka_conformance_simulator::{VectorFixture, run_scenario_spec};
 
+use crate::convergence::RecoveredConvergence;
 use crate::fork::RecoveredFork;
-use crate::synth::{WINNER_BRANCH, synthesize};
+use crate::synth::{WINNER_BRANCH, synthesize, synthesize_convergence};
 
 /// Why an accept attempt produced no vector (fail-closed).
 #[derive(Debug, thiserror::Error)]
 pub enum AcceptError {
     #[error("the simulator could not be driven: {0}")]
     Run(String),
-    #[error("run-and-compare did not reproduce the recorded winner in {tries} label orderings")]
+    #[error("run-and-compare did not reproduce the recorded outcome after {tries} attempt(s)")]
     NotReproduced { tries: usize },
 }
 
@@ -48,4 +49,31 @@ pub fn accept(fork: &RecoveredFork, name: &str) -> Result<VectorFixture, AcceptE
     Err(AcceptError::NotReproduced {
         tries: LABEL_ORDERINGS.len(),
     })
+}
+
+/// Synthesize and verify a vector for a recovered convergence decision.
+///
+/// A single run-and-compare: the committer-decided decision is winner-agnostic
+/// (`tip_committer` is decisive whichever committer key wins), so unlike the fork
+/// path there is no label search. Accept iff the synthesized scenario reproduces
+/// the recorded convergence decision (decisive rule + no witness quorum).
+pub fn accept_convergence(
+    conv: &RecoveredConvergence,
+    name: &str,
+) -> Result<VectorFixture, AcceptError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .map_err(|err| AcceptError::Run(err.to_string()))?;
+
+    let vector = synthesize_convergence(conv, name);
+    let trace = runtime
+        .block_on(run_scenario_spec(&vector.scenario))
+        .map_err(|err| AcceptError::Run(err.to_string()))?;
+
+    if vector.compare_observed_trace(&trace).is_empty() {
+        Ok(vector)
+    } else {
+        Err(AcceptError::NotReproduced { tries: 1 })
+    }
 }

--- a/crates/incident-replay/src/classify.rs
+++ b/crates/incident-replay/src/classify.rs
@@ -1,0 +1,70 @@
+//! The classification gate.
+//!
+//! Everything downstream (extraction, fault synthesis, replay) is gated behind
+//! this verdict, so a healthy export yields zero vectors and a clean exit rather
+//! than a crash. Built incrementally, one rule per behaviour.
+
+use crate::export::{AgentStateExport, EventKind};
+use serde::Serialize;
+
+/// How the pipeline should route an export.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "verdict", rename_all = "snake_case")]
+pub enum Verdict {
+    /// No contested branch — the common case. Zero vectors, clean exit.
+    Healthy,
+    /// A same-epoch commit race resolved by the fork-recovery seam (Phase 3).
+    ForkRecovery,
+    /// A quiescence-window branch selection (Phase 4; needs the convergence
+    /// assert surface).
+    ConvergenceSelected,
+    /// Unusable for faithful replay; never fabricate a vector from it.
+    Quarantine { reason: QuarantineReason },
+}
+
+/// Why an export was quarantined.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QuarantineReason {
+    /// A `derived_projections` section was capped server-side (`has_more`), so
+    /// the export is incomplete.
+    TruncatedProjections,
+    /// A fork resolution's winning snapshot was missing — unreproducible.
+    MissingSnapshot,
+}
+
+/// Classify an export into its routing verdict.
+pub fn classify(export: &AgentStateExport) -> Verdict {
+    // A truncated projection means the export is incomplete: reproduction could
+    // miss witnesses or hidden state, so it is unusable regardless of what the
+    // (uncapped) event log shows. Gate this first.
+    if export
+        .derived_projections
+        .pagination
+        .values()
+        .any(|section| section.has_more)
+    {
+        return Verdict::Quarantine {
+            reason: QuarantineReason::TruncatedProjections,
+        };
+    }
+    let kinds = || export.events.iter().map(|event| &event.kind);
+    // A contested convergence selection dominates: a real incident can carry
+    // both a fork resolution and a convergence decision, and the convergence
+    // route (Phase 4) is the one that reproduces it.
+    if kinds().any(EventKind::is_contested_convergence) {
+        return Verdict::ConvergenceSelected;
+    }
+    // Below here the export routes to fork recovery, where an unrecoverable
+    // winner (missing snapshot) can't be replayed — quarantine instead of
+    // fabricating a vector.
+    if kinds().any(EventKind::is_missing_snapshot_fork) {
+        return Verdict::Quarantine {
+            reason: QuarantineReason::MissingSnapshot,
+        };
+    }
+    if kinds().any(EventKind::is_fork_resolution) {
+        return Verdict::ForkRecovery;
+    }
+    Verdict::Healthy
+}

--- a/crates/incident-replay/src/convergence.rs
+++ b/crates/incident-replay/src/convergence.rs
@@ -8,11 +8,13 @@
 //!
 //! Two reproducible shapes are recovered: the **committer-decided** case (the
 //! selector reached the authenticated-committer tiebreak with no app-witness
-//! quorum) and the **witness-decided** case (an app-witness quorum won by greater
-//! effective depth) — the case that matches real convergence traffic. Anything
-//! else (a committer tiebreak that itself met a quorum, or a priority/digest/
-//! differing-depth rule) fail-closes rather than synthesize a vector that would
-//! silently assert the wrong outcome.
+//! quorum) and the **witness-decided** case (two equal-depth branches where an
+//! app-witness quorum's boost broke the tie) — the case that matches real
+//! convergence traffic. Anything else fail-closes rather than synthesize a
+//! vector that would silently assert the wrong outcome: a committer tiebreak that
+//! itself met a quorum, a witness winner whose branches were *not* at equal depth
+//! (so it won on raw commit depth, not the quorum boost), indistinguishable
+//! candidate branches, or a priority/digest rule.
 
 use crate::export::{AgentStateExport, ConvergenceCandidate, ConvergenceRule, EventKind};
 
@@ -57,6 +59,8 @@ pub enum ConvergenceRecoveryError {
     NoConvergenceDecision,
     #[error("expected exactly two contested branches, found {0}")]
     AmbiguousCandidates(usize),
+    #[error("the two candidates do not have distinct, non-empty branch ids")]
+    IndistinctCandidates,
     #[error("the convergence_decision recorded no decisive selector rule")]
     NoDecisiveRule,
     #[error(
@@ -76,6 +80,12 @@ pub enum ConvergenceRecoveryError {
          won by commit depth, which the witness-decided vector cannot reproduce"
     )]
     WitnessQuorumUnconfirmed,
+    #[error(
+        "the effective-depth winner's quorum boost is not provably decisive: the two branches are \
+         not recorded at equal valid commit depth, so a deeper branch could have won on raw depth, \
+         which the equal-depth witness-decided vector cannot reproduce"
+    )]
+    WitnessBoostNotDecisive,
 }
 
 /// Recover the convergence decision, or return the fail-closed reason it can't
@@ -109,8 +119,20 @@ pub fn recover_convergence(
         ));
     }
 
+    // A faithful two-branch race needs two distinguishable branches. A missing
+    // (empty) or duplicated branch id means the export did not actually record two
+    // distinct branches — `selected_branch_id` could not pick a unique winner and
+    // the loser would be ambiguous — so fail closed rather than reproduce a
+    // fictional race.
+    if candidates[0].branch_id.is_empty()
+        || candidates[1].branch_id.is_empty()
+        || candidates[0].branch_id == candidates[1].branch_id
+    {
+        return Err(ConvergenceRecoveryError::IndistinctCandidates);
+    }
+
     let decisive = decisive_rule(rule_trace).ok_or(ConvergenceRecoveryError::NoDecisiveRule)?;
-    let winner = winning_candidate(selected_branch_id, candidates)
+    let (winner, loser) = winner_and_loser(selected_branch_id, candidates)
         .ok_or(ConvergenceRecoveryError::MissingSelectedBranch)?;
     let quorum_met = winner
         .score
@@ -122,16 +144,21 @@ pub fn recover_convergence(
     // - `tip_committer` is committer-decided only with *no* quorum; a committer
     //   tiebreak that met (or might have met) a quorum can't be reproduced by the
     //   no-witness committer vector.
-    // - `effective_commit_depth` is witness-decided only with a *met* quorum (which
-    //   implies an app-witness score at the quorum threshold); without one the
-    //   winner won by raw commit depth (a differing-depth branch), which the
-    //   equal-depth witness vector can't reproduce. The rule is supported here — the
-    //   quorum status is what is not — so this is a quorum error, not an
-    //   `UnsupportedDecisiveRule`.
-    // - any other rule (priority, digest, valid-depth) has no v1 vector shape.
+    // - `effective_commit_depth` is witness-decided only with a *met* quorum whose
+    //   boost was decisive. It won by `effective = valid_commit_depth + boost`, so a
+    //   winner that is simply deeper wins on raw depth whether or not it has a
+    //   quorum; only when both branches sit at equal valid depth did the quorum
+    //   boost break the tie — the shape the equal-depth witness vector reproduces.
+    //   No met quorum ⇒ `WitnessQuorumUnconfirmed`; a met quorum on unequal (or
+    //   unrecorded) depths ⇒ `WitnessBoostNotDecisive`. The rule is supported in
+    //   both, so neither is an `UnsupportedDecisiveRule`.
+    // - any other rule (priority, digest) has no v1 vector shape.
     let kind = match (decisive, quorum_met) {
         (TIP_COMMITTER_RULE, Some(false)) => ConvergenceDecisionKind::CommitterDecided,
-        (EFFECTIVE_COMMIT_DEPTH_RULE, Some(true)) => ConvergenceDecisionKind::WitnessDecided,
+        (EFFECTIVE_COMMIT_DEPTH_RULE, Some(true)) => {
+            confirm_witness_boost_decisive(winner, loser)?;
+            ConvergenceDecisionKind::WitnessDecided
+        }
         (TIP_COMMITTER_RULE, _) => return Err(ConvergenceRecoveryError::WitnessQuorumUnsupported),
         (EFFECTIVE_COMMIT_DEPTH_RULE, _) => {
             return Err(ConvergenceRecoveryError::WitnessQuorumUnconfirmed);
@@ -157,13 +184,42 @@ fn decisive_rule(rule_trace: &[ConvergenceRule]) -> Option<&str> {
         .map(|rule| rule.rule_name.as_str())
 }
 
-/// The candidate the decision selected, matched by `selected_branch_id`.
-fn winning_candidate<'a>(
+/// The (winner, loser) pair for a two-candidate decision, matched by
+/// `selected_branch_id`. Returns `None` if the selected id matches no candidate.
+/// The caller guarantees exactly two candidates with distinct branch ids, so the
+/// loser is the candidate the selected id does not name.
+fn winner_and_loser<'a>(
     selected_branch_id: Option<&str>,
     candidates: &'a [ConvergenceCandidate],
-) -> Option<&'a ConvergenceCandidate> {
+) -> Option<(&'a ConvergenceCandidate, &'a ConvergenceCandidate)> {
     let selected = selected_branch_id?;
-    candidates
+    let winner = candidates
         .iter()
-        .find(|candidate| candidate.branch_id == selected)
+        .find(|candidate| candidate.branch_id == selected)?;
+    let loser = candidates
+        .iter()
+        .find(|candidate| candidate.branch_id != selected)?;
+    Some((winner, loser))
+}
+
+/// Confirm the app-witness quorum boost — not raw commit depth — won the
+/// `effective_commit_depth` comparison. The selector ranks on `effective =
+/// valid_commit_depth + boost`, so the witness-decided vector (which races two
+/// equal-depth branches) only reproduces a win where both branches sit at the
+/// same valid commit depth and the winner's quorum boost broke the tie. A deeper
+/// winner, or an export that did not record both depths, fail-closes.
+fn confirm_witness_boost_decisive(
+    winner: &ConvergenceCandidate,
+    loser: &ConvergenceCandidate,
+) -> Result<(), ConvergenceRecoveryError> {
+    let depth = |candidate: &ConvergenceCandidate| {
+        candidate
+            .score
+            .as_ref()
+            .and_then(|score| score.valid_commit_depth)
+    };
+    match (depth(winner), depth(loser)) {
+        (Some(winner_depth), Some(loser_depth)) if winner_depth == loser_depth => Ok(()),
+        _ => Err(ConvergenceRecoveryError::WitnessBoostNotDecisive),
+    }
 }

--- a/crates/incident-replay/src/convergence.rs
+++ b/crates/incident-replay/src/convergence.rs
@@ -1,0 +1,169 @@
+//! Recover the convergence decision from a `ConvergenceSelected`-classified
+//! export (Phase 4).
+//!
+//! This is the extraction gate for the observer-side convergence path: it turns
+//! the forensic record of a contested branch selection into the minimal facts
+//! needed to synthesize a vector, and fail-closes (quarantines) on anything it
+//! cannot faithfully reproduce.
+//!
+//! Two reproducible shapes are recovered: the **committer-decided** case (the
+//! selector reached the authenticated-committer tiebreak with no app-witness
+//! quorum) and the **witness-decided** case (an app-witness quorum won by greater
+//! effective depth) — the case that matches real convergence traffic. Anything
+//! else (a committer tiebreak that itself met a quorum, or a priority/digest/
+//! differing-depth rule) fail-closes rather than synthesize a vector that would
+//! silently assert the wrong outcome.
+
+use crate::export::{AgentStateExport, ConvergenceCandidate, ConvergenceRule, EventKind};
+
+/// The authenticated-committer tiebreak, reached only when every witness and
+/// priority rule tied — the committer-decided shape.
+const TIP_COMMITTER_RULE: &str = "tip_committer";
+/// The rule an app-witness quorum wins by: the witnessed branch's quorum boost
+/// gives it greater effective depth — the witness-decided shape.
+const EFFECTIVE_COMMIT_DEPTH_RULE: &str = "effective_commit_depth";
+
+/// Which selector rule decided the convergence, and thus which vector shape
+/// reproduces it. Both are winner-agnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConvergenceDecisionKind {
+    /// The authenticated-committer tiebreak decided it, with no witness quorum.
+    CommitterDecided,
+    /// An app-witness quorum decided it: the witnessed branch's greater
+    /// effective depth won over the competing branch.
+    WitnessDecided,
+}
+
+/// The minimal, reproducible facts of a recovered convergence decision.
+///
+/// Like [`crate::fork::RecoveredFork`], the winning branch identity is never
+/// stored: the synthesized vector uses synthetic labels and asserts the
+/// winner-agnostic decision (the decisive rule and the witness-quorum status),
+/// which the selector reproduces regardless of which label's committer key wins.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveredConvergence {
+    /// The selector rule the engine marked decisive.
+    pub decisive_rule: String,
+    /// The reproducible shape this decision maps to.
+    pub kind: ConvergenceDecisionKind,
+}
+
+/// Why a convergence export cannot be turned into a vector. Every variant is a
+/// fail-closed quarantine: better no vector than one that asserts the wrong
+/// convergence outcome.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ConvergenceRecoveryError {
+    #[error("no contested convergence_decision event")]
+    NoConvergenceDecision,
+    #[error("expected exactly two contested branches, found {0}")]
+    AmbiguousCandidates(usize),
+    #[error("the convergence_decision recorded no decisive selector rule")]
+    NoDecisiveRule,
+    #[error(
+        "unsupported decisive selector rule `{0}` (v1 reproduces `tip_committer` and \
+         `effective_commit_depth` only)"
+    )]
+    UnsupportedDecisiveRule(String),
+    #[error("the selected branch is not among the recorded candidates")]
+    MissingSelectedBranch,
+    #[error(
+        "the committer-tiebreak winner met (or may have met) an app-witness quorum, which the \
+         no-witness committer vector cannot reproduce"
+    )]
+    WitnessQuorumUnsupported,
+    #[error(
+        "the effective-depth winner did not meet (or did not confirm) an app-witness quorum, so it \
+         won by commit depth, which the witness-decided vector cannot reproduce"
+    )]
+    WitnessQuorumUnconfirmed,
+}
+
+/// Recover the convergence decision, or return the fail-closed reason it can't
+/// be reproduced.
+pub fn recover_convergence(
+    export: &AgentStateExport,
+) -> Result<RecoveredConvergence, ConvergenceRecoveryError> {
+    // The settled decision is the last contested pass (mirrors the simulator's
+    // `settled_decision`: the last pass that actually evaluated a candidate set).
+    let (selected_branch_id, candidates, rule_trace) = export
+        .events
+        .iter()
+        .rev()
+        .find_map(|event| match &event.kind {
+            EventKind::ConvergenceDecision {
+                selected_branch_id,
+                candidates,
+                rule_trace,
+                losing_branch_ids,
+            } if !losing_branch_ids.is_empty() || candidates.len() >= 2 => {
+                Some((selected_branch_id.as_deref(), candidates, rule_trace))
+            }
+            _ => None,
+        })
+        .ok_or(ConvergenceRecoveryError::NoConvergenceDecision)?;
+
+    // v1 synthesizes a two-branch race; more branches need a distinct shape.
+    if candidates.len() != 2 {
+        return Err(ConvergenceRecoveryError::AmbiguousCandidates(
+            candidates.len(),
+        ));
+    }
+
+    let decisive = decisive_rule(rule_trace).ok_or(ConvergenceRecoveryError::NoDecisiveRule)?;
+    let winner = winning_candidate(selected_branch_id, candidates)
+        .ok_or(ConvergenceRecoveryError::MissingSelectedBranch)?;
+    let quorum_met = winner
+        .score
+        .as_ref()
+        .and_then(|score| score.witness_quorum_met);
+
+    // The decisive rule plus the winner's quorum status selects the reproducible
+    // shape; every other combination fail-closes with the reason that fits it:
+    // - `tip_committer` is committer-decided only with *no* quorum; a committer
+    //   tiebreak that met (or might have met) a quorum can't be reproduced by the
+    //   no-witness committer vector.
+    // - `effective_commit_depth` is witness-decided only with a *met* quorum (which
+    //   implies an app-witness score at the quorum threshold); without one the
+    //   winner won by raw commit depth (a differing-depth branch), which the
+    //   equal-depth witness vector can't reproduce. The rule is supported here — the
+    //   quorum status is what is not — so this is a quorum error, not an
+    //   `UnsupportedDecisiveRule`.
+    // - any other rule (priority, digest, valid-depth) has no v1 vector shape.
+    let kind = match (decisive, quorum_met) {
+        (TIP_COMMITTER_RULE, Some(false)) => ConvergenceDecisionKind::CommitterDecided,
+        (EFFECTIVE_COMMIT_DEPTH_RULE, Some(true)) => ConvergenceDecisionKind::WitnessDecided,
+        (TIP_COMMITTER_RULE, _) => return Err(ConvergenceRecoveryError::WitnessQuorumUnsupported),
+        (EFFECTIVE_COMMIT_DEPTH_RULE, _) => {
+            return Err(ConvergenceRecoveryError::WitnessQuorumUnconfirmed);
+        }
+        (other, _) => {
+            return Err(ConvergenceRecoveryError::UnsupportedDecisiveRule(
+                other.to_owned(),
+            ));
+        }
+    };
+
+    Ok(RecoveredConvergence {
+        decisive_rule: decisive.to_owned(),
+        kind,
+    })
+}
+
+/// The `rule_name` of the rule the selector marked decisive, if any.
+fn decisive_rule(rule_trace: &[ConvergenceRule]) -> Option<&str> {
+    rule_trace
+        .iter()
+        .find(|rule| rule.decisive == Some(true))
+        .map(|rule| rule.rule_name.as_str())
+}
+
+/// The candidate the decision selected, matched by `selected_branch_id`.
+fn winning_candidate<'a>(
+    selected_branch_id: Option<&str>,
+    candidates: &'a [ConvergenceCandidate],
+) -> Option<&'a ConvergenceCandidate> {
+    let selected = selected_branch_id?;
+    candidates
+        .iter()
+        .find(|candidate| candidate.branch_id == selected)
+}

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -37,10 +37,26 @@ pub struct Pagination {
     pub has_more: bool,
 }
 
-/// One forensic audit event. Only its `kind` matters to the classifier.
+/// One forensic audit event. The classifier reads only `kind`; extraction also
+/// uses the event-level `account_ref` (the acting account).
 #[derive(Debug, Clone, Deserialize)]
 pub struct AuditEvent {
+    #[serde(default)]
+    pub account_ref: Option<String>,
     pub kind: EventKind,
+}
+
+impl AuditEvent {
+    /// The `msg_id` this event reports publishing, if it is a publish event.
+    /// Paired with `account_ref`, it attributes a message to its publisher.
+    pub fn published_msg_id(&self) -> Option<&str> {
+        match &self.kind {
+            EventKind::PublishOutcome { msg_id } | EventKind::PublishAttempt { msg_id } => {
+                msg_id.as_deref()
+            }
+            _ => None,
+        }
+    }
 }
 
 /// The event kinds the classifier reasons about. Every other kind maps to
@@ -48,8 +64,16 @@ pub struct AuditEvent {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EventKind {
-    /// `ForkRecoveryManager` resolved a same-epoch commit race.
-    ForkResolution { winner: ForkWinner },
+    /// `ForkRecoveryManager` resolved a same-epoch commit race. `source_epoch`
+    /// is the epoch the branches forked *from*; the racers land at
+    /// `source_epoch + 1`. `invalidated_msg_id` is the losing branch's commit.
+    ForkResolution {
+        winner: ForkWinner,
+        #[serde(default)]
+        source_epoch: Option<u64>,
+        #[serde(default)]
+        invalidated_msg_id: Option<String>,
+    },
     /// `select_canonical_branch` evaluated a candidate set. Contested iff a
     /// branch actually lost (or more than one candidate was in play).
     ConvergenceDecision {
@@ -57,6 +81,27 @@ pub enum EventKind {
         candidates: Vec<serde_json::Value>,
         #[serde(default)]
         losing_branch_ids: Vec<String>,
+    },
+    /// A commit changed canonical group state (membership, admin set, profile).
+    /// Extraction reads the actor and epoch to find the committers at the
+    /// contested tip and the kind of commit they raced with.
+    GroupStateChanged {
+        #[serde(default)]
+        epoch: Option<u64>,
+        #[serde(default)]
+        change_kind: Option<String>,
+        #[serde(default)]
+        actor_member_ref: Option<String>,
+    },
+    /// A publish attempt/outcome carrying the `msg_id`; with the event-level
+    /// `account_ref` this attributes a message to the account that published it.
+    PublishOutcome {
+        #[serde(default)]
+        msg_id: Option<String>,
+    },
+    PublishAttempt {
+        #[serde(default)]
+        msg_id: Option<String>,
     },
     #[serde(other)]
     Other,
@@ -89,7 +134,8 @@ impl EventKind {
         matches!(
             self,
             EventKind::ForkResolution {
-                winner: ForkWinner::MissingSnapshot
+                winner: ForkWinner::MissingSnapshot,
+                ..
             }
         )
     }

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -75,10 +75,16 @@ pub enum EventKind {
         invalidated_msg_id: Option<String>,
     },
     /// `select_canonical_branch` evaluated a candidate set. Contested iff a
-    /// branch actually lost (or more than one candidate was in play).
+    /// branch actually lost (or more than one candidate was in play). Extraction
+    /// (Phase 4) also reads which selector rule was decisive and the winning
+    /// branch's witness quorum, to decide whether the decision is reproducible.
     ConvergenceDecision {
         #[serde(default)]
-        candidates: Vec<serde_json::Value>,
+        selected_branch_id: Option<String>,
+        #[serde(default)]
+        candidates: Vec<ConvergenceCandidate>,
+        #[serde(default)]
+        rule_trace: Vec<ConvergenceRule>,
         #[serde(default)]
         losing_branch_ids: Vec<String>,
     },
@@ -107,6 +113,34 @@ pub enum EventKind {
     Other,
 }
 
+/// One branch the convergence selector evaluated. Only the fields extraction
+/// reads are modelled; every other field the export carries is ignored.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConvergenceCandidate {
+    #[serde(default)]
+    pub branch_id: String,
+    #[serde(default)]
+    pub score: Option<ConvergenceScore>,
+}
+
+/// The selector's score for a candidate. Only the witness-quorum flag is read:
+/// a winner that met the app-witness quorum needs the (not-yet-wired) harness
+/// witness path to reproduce, so it fail-closes at extraction.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ConvergenceScore {
+    #[serde(default)]
+    pub witness_quorum_met: Option<bool>,
+}
+
+/// One selector-rule evaluation. Extraction reads which rule was decisive.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConvergenceRule {
+    #[serde(default)]
+    pub rule_name: String,
+    #[serde(default)]
+    pub decisive: Option<bool>,
+}
+
 /// The role that won a fork resolution. `MissingSnapshot` means the winner's
 /// pre-commit snapshot was unavailable, so the incident is unreproducible.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -124,7 +158,7 @@ impl EventKind {
     pub fn is_contested_convergence(&self) -> bool {
         matches!(
             self,
-            EventKind::ConvergenceDecision { candidates, losing_branch_ids }
+            EventKind::ConvergenceDecision { candidates, losing_branch_ids, .. }
                 if !losing_branch_ids.is_empty() || candidates.len() >= 2
         )
     }

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -123,13 +123,18 @@ pub struct ConvergenceCandidate {
     pub score: Option<ConvergenceScore>,
 }
 
-/// The selector's score for a candidate. Only the witness-quorum flag is read:
-/// a winner that met the app-witness quorum needs the (not-yet-wired) harness
-/// witness path to reproduce, so it fail-closes at extraction.
+/// The selector's score for a candidate. Extraction reads two fields: the
+/// witness-quorum flag (which distinguishes the committer- and witness-decided
+/// shapes) and the valid commit depth (the branch's `tip_epoch - fork_epoch`,
+/// before any witness boost). The witness-decided shape reproduces only an
+/// *equal-depth* race, so extraction compares the two branches' `valid_commit_depth`
+/// to confirm the quorum boost — not raw depth — is what won.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct ConvergenceScore {
     #[serde(default)]
     pub witness_quorum_met: Option<bool>,
+    #[serde(default)]
+    pub valid_commit_depth: Option<u64>,
 }
 
 /// One selector-rule evaluation. Extraction reads which rule was decisive.

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -1,0 +1,113 @@
+//! A lenient, self-owned model of a Goggles `agent-state.json` export.
+//!
+//! Only the fields the classifier needs are modelled; every other field is
+//! ignored, so the parser tolerates the export growing new fields. The model is
+//! deliberately decoupled from `marmot-forensics`: it tracks the stable
+//! `marmot-forensics-audit/v2` wire shape that Goggles serialises, not the
+//! engine's internal `AuditEventKind` enum (which carries ~40 variants this
+//! adapter has no reason to depend on).
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+/// A parsed export, reduced to the classifier's inputs.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentStateExport {
+    #[serde(default)]
+    pub events: Vec<AuditEvent>,
+    #[serde(default)]
+    pub derived_projections: DerivedProjections,
+}
+
+/// Server-side projections. Only the pagination cursors are modelled: they carry
+/// the authoritative truncation signal (`has_more`).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct DerivedProjections {
+    #[serde(default)]
+    pub pagination: BTreeMap<String, Pagination>,
+}
+
+/// One projection section's pagination cursor.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Pagination {
+    /// The section was capped and more rows exist server-side. A truncated
+    /// export cannot be reproduced faithfully, so it is quarantined.
+    #[serde(default)]
+    pub has_more: bool,
+}
+
+/// One forensic audit event. Only its `kind` matters to the classifier.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AuditEvent {
+    pub kind: EventKind,
+}
+
+/// The event kinds the classifier reasons about. Every other kind maps to
+/// [`EventKind::Other`], so unknown or irrelevant events never fail the parse.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EventKind {
+    /// `ForkRecoveryManager` resolved a same-epoch commit race.
+    ForkResolution { winner: ForkWinner },
+    /// `select_canonical_branch` evaluated a candidate set. Contested iff a
+    /// branch actually lost (or more than one candidate was in play).
+    ConvergenceDecision {
+        #[serde(default)]
+        candidates: Vec<serde_json::Value>,
+        #[serde(default)]
+        losing_branch_ids: Vec<String>,
+    },
+    #[serde(other)]
+    Other,
+}
+
+/// The role that won a fork resolution. `MissingSnapshot` means the winner's
+/// pre-commit snapshot was unavailable, so the incident is unreproducible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ForkWinner {
+    Incumbent,
+    Candidate,
+    MissingSnapshot,
+}
+
+impl EventKind {
+    /// A convergence decision that recorded a real contest: a branch lost, or
+    /// more than one candidate was evaluated. Routine single-branch passes
+    /// (the common case in healthy traffic) are not contests.
+    pub fn is_contested_convergence(&self) -> bool {
+        matches!(
+            self,
+            EventKind::ConvergenceDecision { candidates, losing_branch_ids }
+                if !losing_branch_ids.is_empty() || candidates.len() >= 2
+        )
+    }
+
+    /// A fork resolution whose winning snapshot was missing — unreproducible.
+    pub fn is_missing_snapshot_fork(&self) -> bool {
+        matches!(
+            self,
+            EventKind::ForkResolution {
+                winner: ForkWinner::MissingSnapshot
+            }
+        )
+    }
+
+    /// Any fork resolution, regardless of winner.
+    pub fn is_fork_resolution(&self) -> bool {
+        matches!(self, EventKind::ForkResolution { .. })
+    }
+}
+
+/// Parse a Goggles `agent-state.json` export.
+pub fn parse(json: &str) -> Result<AgentStateExport, ParseError> {
+    Ok(serde_json::from_str(json)?)
+}
+
+/// Why an export could not be parsed.
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("agent-state export does not match the expected schema: {0}")]
+    Json(#[from] serde_json::Error),
+}

--- a/crates/incident-replay/src/fork.rs
+++ b/crates/incident-replay/src/fork.rs
@@ -1,0 +1,128 @@
+//! Recover the fork from a `ForkRecovery`-classified export (rules 2 & 3).
+//!
+//! This is the extraction gate: it turns the forensic record of a same-epoch
+//! commit race into the minimal facts needed to synthesize a vector, and
+//! fail-closes (quarantines) on anything it cannot faithfully reproduce.
+
+use std::collections::BTreeSet;
+
+use crate::export::{AgentStateExport, EventKind, ForkWinner};
+
+/// The kind of commit both branches raced with. Only group-metadata forks are
+/// synthesizable today; membership/admin forks are deferred (they need a
+/// distinct scenario shape) and quarantine as unmapped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForkCommitKind {
+    /// A group-metadata commit (topic/name/avatar/retention) → `UpdateGroupData`.
+    GroupData,
+}
+
+/// The minimal, reproducible facts of a recovered fork.
+///
+/// The winning committer is recovered as a *gate* (rule 3) but is not stored:
+/// the synthesized vector uses synthetic labels and asserts the winner-agnostic
+/// `RecoverySummary`, so the identity of the real committer never leaves this
+/// step. What downstream needs is the source epoch (normalized to the sim's
+/// range) and the commit kind to race.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveredFork {
+    pub source_epoch: u64,
+    pub commit: ForkCommitKind,
+}
+
+/// Why a fork-recovery export cannot be turned into a vector. Every variant is a
+/// fail-closed quarantine: better no vector than a wrong one.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ForkRecoveryError {
+    #[error("no fork_resolution event")]
+    NoForkResolution,
+    #[error("fork_resolution has no source_epoch")]
+    MissingSourceEpoch,
+    #[error("the winning branch's pre-commit snapshot was missing")]
+    MissingSnapshot,
+    #[error("expected exactly two committers at the contested tip, found {0}")]
+    AmbiguousCommitters(usize),
+    #[error(
+        "could not recover the winner: the invalidated commit has no attributable publisher among the committers"
+    )]
+    UnrecoverableWinner,
+    #[error("unmapped commit kind `{0}` at the contested tip")]
+    UnmappedCommitKind(String),
+}
+
+fn commit_kind(change_kind: &str) -> Result<ForkCommitKind, ForkRecoveryError> {
+    match change_kind {
+        "topic_changed" | "group_renamed" | "avatar_changed" | "retention_changed" => {
+            Ok(ForkCommitKind::GroupData)
+        }
+        other => Err(ForkRecoveryError::UnmappedCommitKind(other.to_string())),
+    }
+}
+
+/// Recover the fork, or return the fail-closed reason it can't be reproduced.
+pub fn recover_fork(export: &AgentStateExport) -> Result<RecoveredFork, ForkRecoveryError> {
+    let (winner_role, source_epoch, invalidated) = export
+        .events
+        .iter()
+        .find_map(|event| match &event.kind {
+            EventKind::ForkResolution {
+                winner,
+                source_epoch,
+                invalidated_msg_id,
+            } => Some((*winner, *source_epoch, invalidated_msg_id.as_deref())),
+            _ => None,
+        })
+        .ok_or(ForkRecoveryError::NoForkResolution)?;
+
+    if winner_role == ForkWinner::MissingSnapshot {
+        return Err(ForkRecoveryError::MissingSnapshot);
+    }
+    let source_epoch = source_epoch.ok_or(ForkRecoveryError::MissingSourceEpoch)?;
+    let contested_tip = source_epoch + 1; // rule 2: the racers land at source_epoch + 1.
+
+    // The competing commits are the group-state changes at the contested tip.
+    let tip: Vec<(&str, &str)> = export
+        .events
+        .iter()
+        .filter_map(|event| match &event.kind {
+            EventKind::GroupStateChanged {
+                epoch: Some(epoch),
+                change_kind: Some(change_kind),
+                actor_member_ref: Some(actor),
+            } if *epoch == contested_tip => Some((actor.as_str(), change_kind.as_str())),
+            _ => None,
+        })
+        .collect();
+
+    let committers: BTreeSet<&str> = tip.iter().map(|(actor, _)| *actor).collect();
+    if committers.len() != 2 {
+        return Err(ForkRecoveryError::AmbiguousCommitters(committers.len()));
+    }
+
+    // Every competing commit must map to one synthesizable kind.
+    let mut commit = None;
+    for (_, change_kind) in &tip {
+        commit = Some(commit_kind(change_kind)?);
+    }
+    let commit = commit.expect("two committers implies at least one tip change");
+
+    // Rule 3 tier-b: the account that published the invalidated commit is the
+    // loser; the winner is the other committer. If the invalidated commit can't
+    // be attributed to one of the two committers, the winner is unrecoverable.
+    let loser = invalidated
+        .and_then(|inv| {
+            export
+                .events
+                .iter()
+                .find(|e| e.published_msg_id() == Some(inv))
+        })
+        .and_then(|event| event.account_ref.as_deref());
+    if !loser.is_some_and(|loser| committers.contains(loser)) {
+        return Err(ForkRecoveryError::UnrecoverableWinner);
+    }
+
+    Ok(RecoveredFork {
+        source_epoch,
+        commit,
+    })
+}

--- a/crates/incident-replay/src/lib.rs
+++ b/crates/incident-replay/src/lib.rs
@@ -2,34 +2,38 @@
 //!
 //! Adapter that turns a Goggles `agent-state.json` forensic export into a
 //! conformance vector for the CGKA simulator. The pipeline is: **parse** the
-//! export, **classify** it, and — for a fork-recovery incident — **recover** the
-//! fork, **synthesize** a scenario, and **accept** it only if the simulator
-//! reproduces the recorded outcome (fail-closed).
+//! export, **classify** it, and — for a fork-recovery or convergence incident —
+//! **recover** the decision, **synthesize** a scenario, and **accept** it only if
+//! the simulator reproduces the recorded outcome (fail-closed).
 //!
 //! - [`export`] — a lenient, self-owned model of the export (decoupled from the
 //!   engine's forensic types; it tracks the stable `marmot-forensics-audit/v2`
 //!   wire shape Goggles emits, not the Rust enum).
 //! - [`classify`] — the [`classify::classify`] gate: `Healthy | ForkRecovery |
 //!   ConvergenceSelected | Quarantine`. Everything downstream is gated behind it.
-//! - [`fork`] — [`fork::recover_fork`] extracts a [`fork::RecoveredFork`] (source
-//!   epoch, commit kind, designated winner) from a fork-recovery export, or
-//!   quarantines when it cannot be replayed.
-//! - [`synth`] — [`synth::synthesize`] builds the concurrent-fork vector for a
-//!   recovered fork.
-//! - [`accept`] — [`accept::accept`] runs the synthesized scenario against the
-//!   simulator and returns the vector only if the recorded winner reproduces.
-//!
-//! Convergence-selected incidents route to a later phase and are not synthesized
-//! here.
+//! - [`fork`] — [`fork::recover_fork`] extracts a [`fork::RecoveredFork`] from a
+//!   fork-recovery export, or quarantines when it cannot be replayed.
+//! - [`convergence`] — [`convergence::recover_convergence`] extracts a
+//!   [`convergence::RecoveredConvergence`] from a convergence-selected export
+//!   (committer- or witness-decided), or quarantines a shape it cannot reproduce.
+//! - [`synth`] — [`synth::synthesize`] / [`synth::synthesize_convergence`] build
+//!   the vector for a recovered fork / convergence decision.
+//! - [`accept`] — [`accept::accept`] / [`accept::accept_convergence`] run the
+//!   synthesized scenario against the simulator and return the vector only if the
+//!   recorded outcome reproduces.
 
 pub mod accept;
 pub mod classify;
+pub mod convergence;
 pub mod export;
 pub mod fork;
 pub mod synth;
 
-pub use accept::{AcceptError, accept};
+pub use accept::{AcceptError, accept, accept_convergence};
 pub use classify::{QuarantineReason, Verdict, classify};
+pub use convergence::{
+    ConvergenceDecisionKind, ConvergenceRecoveryError, RecoveredConvergence, recover_convergence,
+};
 pub use export::{AgentStateExport, ParseError, parse};
 pub use fork::{ForkCommitKind, ForkRecoveryError, RecoveredFork, recover_fork};
-pub use synth::synthesize;
+pub use synth::{synthesize, synthesize_convergence};

--- a/crates/incident-replay/src/lib.rs
+++ b/crates/incident-replay/src/lib.rs
@@ -1,0 +1,21 @@
+//! # incident-replay
+//!
+//! Adapter that turns a Goggles `agent-state.json` forensic export into
+//! conformance vectors for the CGKA simulator. This crate is the skeleton
+//! (Phase 2): it **parses** an export and **classifies** it, gating everything
+//! downstream behind that verdict.
+//!
+//! - [`export`] — a lenient, self-owned model of the export (decoupled from the
+//!   engine's forensic types; it tracks the stable `marmot-forensics-audit/v2`
+//!   wire shape Goggles emits, not the Rust enum).
+//! - [`classify`] — the [`classify::classify`] gate: `Healthy | ForkRecovery |
+//!   ConvergenceSelected | Quarantine`.
+//!
+//! Extraction, fault synthesis, and run-and-compare against the simulator are
+//! later phases and deliberately absent here.
+
+pub mod classify;
+pub mod export;
+
+pub use classify::{QuarantineReason, Verdict, classify};
+pub use export::{AgentStateExport, ParseError, parse};

--- a/crates/incident-replay/src/lib.rs
+++ b/crates/incident-replay/src/lib.rs
@@ -1,21 +1,35 @@
 //! # incident-replay
 //!
-//! Adapter that turns a Goggles `agent-state.json` forensic export into
-//! conformance vectors for the CGKA simulator. This crate is the skeleton
-//! (Phase 2): it **parses** an export and **classifies** it, gating everything
-//! downstream behind that verdict.
+//! Adapter that turns a Goggles `agent-state.json` forensic export into a
+//! conformance vector for the CGKA simulator. The pipeline is: **parse** the
+//! export, **classify** it, and — for a fork-recovery incident — **recover** the
+//! fork, **synthesize** a scenario, and **accept** it only if the simulator
+//! reproduces the recorded outcome (fail-closed).
 //!
 //! - [`export`] — a lenient, self-owned model of the export (decoupled from the
 //!   engine's forensic types; it tracks the stable `marmot-forensics-audit/v2`
 //!   wire shape Goggles emits, not the Rust enum).
 //! - [`classify`] — the [`classify::classify`] gate: `Healthy | ForkRecovery |
-//!   ConvergenceSelected | Quarantine`.
+//!   ConvergenceSelected | Quarantine`. Everything downstream is gated behind it.
+//! - [`fork`] — [`fork::recover_fork`] extracts a [`fork::RecoveredFork`] (source
+//!   epoch, commit kind, designated winner) from a fork-recovery export, or
+//!   quarantines when it cannot be replayed.
+//! - [`synth`] — [`synth::synthesize`] builds the concurrent-fork vector for a
+//!   recovered fork.
+//! - [`accept`] — [`accept::accept`] runs the synthesized scenario against the
+//!   simulator and returns the vector only if the recorded winner reproduces.
 //!
-//! Extraction, fault synthesis, and run-and-compare against the simulator are
-//! later phases and deliberately absent here.
+//! Convergence-selected incidents route to a later phase and are not synthesized
+//! here.
 
+pub mod accept;
 pub mod classify;
 pub mod export;
+pub mod fork;
+pub mod synth;
 
+pub use accept::{AcceptError, accept};
 pub use classify::{QuarantineReason, Verdict, classify};
 pub use export::{AgentStateExport, ParseError, parse};
+pub use fork::{ForkCommitKind, ForkRecoveryError, RecoveredFork, recover_fork};
+pub use synth::synthesize;

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -9,10 +9,15 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use cgka_conformance_simulator::VectorFixture;
-use incident_replay::{AgentStateExport, Verdict, accept, classify, parse, recover_fork};
+use incident_replay::{
+    AgentStateExport, Verdict, accept, accept_convergence, classify, parse, recover_convergence,
+    recover_fork,
+};
 
 /// Vector name for a fork-recovery incident (one incident per export today).
 const INCIDENT_NAME: &str = "fork-recovery-incident/v1";
+/// Vector name for a convergence incident.
+const CONVERGENCE_NAME: &str = "convergence-incident/v1";
 
 fn main() -> ExitCode {
     let mut args = std::env::args_os().skip(1);
@@ -43,10 +48,7 @@ fn main() -> ExitCode {
             println!("healthy: 0 vectors");
             ExitCode::SUCCESS
         }
-        Verdict::ConvergenceSelected => {
-            println!("convergence_selected: routes to the Phase 4 convergence path");
-            ExitCode::SUCCESS
-        }
+        Verdict::ConvergenceSelected => run_convergence(&export, out_dir.as_deref()),
         Verdict::Quarantine { reason } => {
             println!("quarantine: {reason:?}");
             ExitCode::SUCCESS
@@ -57,20 +59,36 @@ fn main() -> ExitCode {
 fn run_fork_recovery(export: &AgentStateExport, out_dir: Option<&Path>) -> ExitCode {
     let fork = match recover_fork(export) {
         Ok(fork) => fork,
-        Err(err) => {
-            println!("quarantine: {err}");
-            return ExitCode::SUCCESS;
-        }
+        Err(err) => return quarantine(&err),
     };
-    let vector = match accept(&fork, INCIDENT_NAME) {
-        Ok(vector) => vector,
-        Err(err) => {
-            println!("quarantine: {err}");
-            return ExitCode::SUCCESS;
-        }
+    match accept(&fork, INCIDENT_NAME) {
+        Ok(vector) => persist_or_report(&vector, out_dir),
+        Err(err) => quarantine(&err),
+    }
+}
+
+fn run_convergence(export: &AgentStateExport, out_dir: Option<&Path>) -> ExitCode {
+    let conv = match recover_convergence(export) {
+        Ok(conv) => conv,
+        Err(err) => return quarantine(&err),
     };
+    match accept_convergence(&conv, CONVERGENCE_NAME) {
+        Ok(vector) => persist_or_report(&vector, out_dir),
+        Err(err) => quarantine(&err),
+    }
+}
+
+/// Report a fail-closed quarantine and exit cleanly: producing no vector is a
+/// valid outcome, so it is not an error exit.
+fn quarantine(reason: &dyn std::fmt::Display) -> ExitCode {
+    println!("quarantine: {reason}");
+    ExitCode::SUCCESS
+}
+
+/// Write the accepted vector to `out_dir`, or print it when no dir was given.
+fn persist_or_report(vector: &VectorFixture, out_dir: Option<&Path>) -> ExitCode {
     match out_dir {
-        Some(dir) => match write_vector(&vector, dir) {
+        Some(dir) => match write_vector(vector, dir) {
             Ok(path) => {
                 println!("accepted: wrote {}", path.display());
                 ExitCode::SUCCESS

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -1,0 +1,34 @@
+//! `incident-replay` CLI: classify a Goggles `agent-state.json` export.
+//!
+//! Prints the machine-readable verdict as JSON and exits 0 for any successful
+//! classification (a quarantine is a valid outcome, not an error). Exits 2 on
+//! usage, I/O, or parse failure.
+
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let Some(path) = std::env::args_os().nth(1) else {
+        eprintln!("usage: incident-replay <agent-state.json>");
+        return ExitCode::from(2);
+    };
+    let json = match std::fs::read_to_string(&path) {
+        Ok(json) => json,
+        Err(err) => {
+            eprintln!("error: cannot read {}: {err}", path.to_string_lossy());
+            return ExitCode::from(2);
+        }
+    };
+    let export = match incident_replay::parse(&json) {
+        Ok(export) => export,
+        Err(err) => {
+            eprintln!("error: {err}");
+            return ExitCode::from(2);
+        }
+    };
+    let verdict = incident_replay::classify(&export);
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&verdict).expect("verdict serialises")
+    );
+    ExitCode::SUCCESS
+}

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -1,16 +1,27 @@
-//! `incident-replay` CLI: classify a Goggles `agent-state.json` export.
+//! `incident-replay` CLI: classify a Goggles `agent-state.json` export and, for a
+//! fork-recovery incident, synthesize and verify a conformance vector.
 //!
-//! Prints the machine-readable verdict as JSON and exits 0 for any successful
-//! classification (a quarantine is a valid outcome, not an error). Exits 2 on
-//! usage, I/O, or parse failure.
+//! Prints a human-readable outcome and exits 0 for any successful classification
+//! (healthy, quarantine, and accepted are all valid outcomes). Exits 2 on usage,
+//! I/O, or parse failure.
 
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
+use cgka_conformance_simulator::VectorFixture;
+use incident_replay::{AgentStateExport, Verdict, accept, classify, parse, recover_fork};
+
+/// Vector name for a fork-recovery incident (one incident per export today).
+const INCIDENT_NAME: &str = "fork-recovery-incident/v1";
+
 fn main() -> ExitCode {
-    let Some(path) = std::env::args_os().nth(1) else {
-        eprintln!("usage: incident-replay <agent-state.json>");
+    let mut args = std::env::args_os().skip(1);
+    let Some(path) = args.next() else {
+        eprintln!("usage: incident-replay <agent-state.json> [out-dir]");
         return ExitCode::from(2);
     };
+    let out_dir = args.next().map(PathBuf::from);
+
     let json = match std::fs::read_to_string(&path) {
         Ok(json) => json,
         Err(err) => {
@@ -18,17 +29,76 @@ fn main() -> ExitCode {
             return ExitCode::from(2);
         }
     };
-    let export = match incident_replay::parse(&json) {
+    let export = match parse(&json) {
         Ok(export) => export,
         Err(err) => {
             eprintln!("error: {err}");
             return ExitCode::from(2);
         }
     };
-    let verdict = incident_replay::classify(&export);
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&verdict).expect("verdict serialises")
-    );
-    ExitCode::SUCCESS
+
+    match classify(&export) {
+        Verdict::ForkRecovery => run_fork_recovery(&export, out_dir.as_deref()),
+        Verdict::Healthy => {
+            println!("healthy: 0 vectors");
+            ExitCode::SUCCESS
+        }
+        Verdict::ConvergenceSelected => {
+            println!("convergence_selected: routes to the Phase 4 convergence path");
+            ExitCode::SUCCESS
+        }
+        Verdict::Quarantine { reason } => {
+            println!("quarantine: {reason:?}");
+            ExitCode::SUCCESS
+        }
+    }
+}
+
+fn run_fork_recovery(export: &AgentStateExport, out_dir: Option<&Path>) -> ExitCode {
+    let fork = match recover_fork(export) {
+        Ok(fork) => fork,
+        Err(err) => {
+            println!("quarantine: {err}");
+            return ExitCode::SUCCESS;
+        }
+    };
+    let vector = match accept(&fork, INCIDENT_NAME) {
+        Ok(vector) => vector,
+        Err(err) => {
+            println!("quarantine: {err}");
+            return ExitCode::SUCCESS;
+        }
+    };
+    match out_dir {
+        Some(dir) => match write_vector(&vector, dir) {
+            Ok(path) => {
+                println!("accepted: wrote {}", path.display());
+                ExitCode::SUCCESS
+            }
+            Err(err) => {
+                eprintln!("error: cannot write vector: {err}");
+                ExitCode::from(2)
+            }
+        },
+        None => {
+            println!(
+                "accepted: {} (pass an out-dir to persist)",
+                vector.scenario_name
+            );
+            ExitCode::SUCCESS
+        }
+    }
+}
+
+/// Write a vector as `<dir>/<name>.v1.json` (creating `dir`), returning the path.
+fn write_vector(vector: &VectorFixture, dir: &Path) -> std::io::Result<PathBuf> {
+    std::fs::create_dir_all(dir)?;
+    let stem = vector
+        .scenario_name
+        .rsplit_once('/')
+        .map_or(vector.scenario_name.as_str(), |(stem, _version)| stem);
+    let path = dir.join(format!("{stem}.v1.json"));
+    let json = serde_json::to_string_pretty(vector).expect("vector serializes");
+    std::fs::write(&path, format!("{json}\n"))?;
+    Ok(path)
 }

--- a/crates/incident-replay/src/synth.rs
+++ b/crates/incident-replay/src/synth.rs
@@ -10,6 +10,7 @@
 
 use cgka_conformance_simulator::{ScenarioSpec, ScenarioStep, TraceExpectation, VectorFixture};
 
+use crate::convergence::{ConvergenceDecisionKind, RecoveredConvergence};
 use crate::fork::{ForkCommitKind, RecoveredFork};
 
 /// The group name the winning branch commits; its survival after convergence is
@@ -101,4 +102,192 @@ pub fn synthesize(fork: &RecoveredFork, name: &str, winner: &str, loser: &str) -
             },
         ],
     }
+}
+
+/// The observer that runs the convergence selector over the competing branches.
+const OBSERVER: &str = "carol";
+/// The two admins that raise competing commits from the same epoch.
+const COMMITTER_A: &str = "alice";
+const COMMITTER_B: &str = "bob";
+/// The new members each competing branch adds (an invite race is the proven way
+/// to create two competing stored branches the observer must converge).
+const INVITEE_A: &str = "david";
+const INVITEE_B: &str = "eve";
+
+/// Build the convergence vector for a recovered decision.
+///
+/// Both shapes start from the validated `convergence-committer-selected/v1`
+/// blueprint: two admins raise competing invite commits from the same epoch and a
+/// passive observer runs the convergence selector over both stored branches. The
+/// selector's outcome is content-independent for the reproduced rules, so the
+/// invite race reproduces the recorded convergence regardless of what the real
+/// branches committed (outcome-equivalence). The assertion is winner-agnostic —
+/// the recorded decisive rule and witness-quorum status, not which branch won —
+/// so no label search is needed.
+pub fn synthesize_convergence(conv: &RecoveredConvergence, name: &str) -> VectorFixture {
+    match conv.kind {
+        ConvergenceDecisionKind::CommitterDecided => synthesize_committer_decided(conv, name),
+        ConvergenceDecisionKind::WitnessDecided => synthesize_witness_decided(conv, name),
+    }
+}
+
+/// The setup both shapes share: a two-admin group with a passive observer, then
+/// two competing same-epoch invite commits (confirmed, not yet delivered).
+fn convergence_preamble() -> Vec<ScenarioStep> {
+    vec![
+        ScenarioStep::CreateGroup {
+            creator: COMMITTER_A.to_owned(),
+            name: "replay".to_owned(),
+            invitees: vec![COMMITTER_B.to_owned(), OBSERVER.to_owned()],
+            required_features: Vec::new(),
+            // Both committers must be admins to raise competing commits.
+            initial_admins: Some(vec![COMMITTER_B.to_owned()]),
+            pending: "create".to_owned(),
+        },
+        ScenarioStep::ConfirmPending {
+            client: COMMITTER_A.to_owned(),
+            pending: "create".to_owned(),
+        },
+        ScenarioStep::DeliverAll,
+        ScenarioStep::Tick {
+            clients: vec![COMMITTER_B.to_owned(), OBSERVER.to_owned()],
+        },
+        ScenarioStep::ClearEvents {
+            clients: vec![
+                COMMITTER_A.to_owned(),
+                COMMITTER_B.to_owned(),
+                OBSERVER.to_owned(),
+            ],
+        },
+        // Competing commits from the same epoch — the contested branches.
+        ScenarioStep::InviteMembers {
+            inviter: COMMITTER_A.to_owned(),
+            invitees: vec![INVITEE_A.to_owned()],
+            pending: "invite-a".to_owned(),
+        },
+        ScenarioStep::InviteMembers {
+            inviter: COMMITTER_B.to_owned(),
+            invitees: vec![INVITEE_B.to_owned()],
+            pending: "invite-b".to_owned(),
+        },
+        ScenarioStep::ConfirmPending {
+            client: COMMITTER_A.to_owned(),
+            pending: "invite-a".to_owned(),
+        },
+        ScenarioStep::ConfirmPending {
+            client: COMMITTER_B.to_owned(),
+            pending: "invite-b".to_owned(),
+        },
+    ]
+}
+
+/// Wrap `steps` and the winner-agnostic convergence assertion into a fixture.
+fn convergence_fixture(
+    name: &str,
+    steps: Vec<ScenarioStep>,
+    expected: TraceExpectation,
+) -> VectorFixture {
+    VectorFixture {
+        scenario_name: name.to_owned(),
+        vector_version: "1".to_owned(),
+        conformance_version: env!("CARGO_PKG_VERSION").to_owned(),
+        seed: None,
+        scenario: ScenarioSpec {
+            name: name.to_owned(),
+            spec_version: "1".to_owned(),
+            clients: [COMMITTER_A, COMMITTER_B, OBSERVER, INVITEE_A, INVITEE_B]
+                .into_iter()
+                .map(str::to_owned)
+                .collect(),
+            steps,
+        },
+        expected_trace: None,
+        expected_outcomes: vec![expected],
+    }
+}
+
+/// Committer-decided: both branches reach the observer at once and the
+/// `tip_committer` tiebreak picks the winner (no witnesses).
+fn synthesize_committer_decided(conv: &RecoveredConvergence, name: &str) -> VectorFixture {
+    let mut steps = convergence_preamble();
+    steps.extend([
+        ScenarioStep::DeliverAll,
+        // Convergence runs on Tick, not DeliverAll.
+        ScenarioStep::Tick {
+            clients: vec![OBSERVER.to_owned()],
+        },
+        ScenarioStep::Observe {
+            clients: vec![OBSERVER.to_owned()],
+        },
+    ]);
+    convergence_fixture(
+        name,
+        steps,
+        TraceExpectation::ConvergenceDecision {
+            client: Some(OBSERVER.to_owned()),
+            selected_branch_id: None,
+            selected_tip_epoch: Some(2),
+            decisive_rule: Some(conv.decisive_rule.clone()),
+            witness_quorum_met: Some(false),
+            min_app_witness_score: None,
+        },
+    )
+}
+
+/// Witness-decided: the observer delivers two distinct senders' app messages on
+/// one branch *before* the competing commit arrives, so on the reorg the
+/// app-witness quorum overrides the committer tiebreak. Holding the competing
+/// commit (`DelayQueued`/`ReleaseDelayed`) is what stages the "delivered, then
+/// contested" ordering; the second observer `Tick` after release is the reorg.
+fn synthesize_witness_decided(conv: &RecoveredConvergence, name: &str) -> VectorFixture {
+    let mut steps = convergence_preamble();
+    steps.extend([
+        // Hold the competing branch-B commit (queue index 3: welcome-a, commit-a,
+        // welcome-b, commit-b) so only branch A reaches the observer first.
+        ScenarioStep::DelayQueued {
+            index: 3,
+            delayed: "held-b".to_owned(),
+        },
+        ScenarioStep::DeliverAll,
+        // The invitee joins branch A so it can be the second witness sender.
+        ScenarioStep::Tick {
+            clients: vec![INVITEE_A.to_owned()],
+        },
+        ScenarioStep::SendAppMessage {
+            sender: COMMITTER_A.to_owned(),
+            payload: "witness-a-1".to_owned(),
+        },
+        ScenarioStep::SendAppMessage {
+            sender: INVITEE_A.to_owned(),
+            payload: "witness-a-2".to_owned(),
+        },
+        ScenarioStep::DeliverAll,
+        // The observer delivers (applies) both branch-A app messages.
+        ScenarioStep::Tick {
+            clients: vec![OBSERVER.to_owned()],
+        },
+        // The competing branch-B commit now arrives, forcing a reorg.
+        ScenarioStep::ReleaseDelayed {
+            delayed: "held-b".to_owned(),
+        },
+        ScenarioStep::DeliverAll,
+        ScenarioStep::Tick {
+            clients: vec![OBSERVER.to_owned()],
+        },
+        ScenarioStep::Observe {
+            clients: vec![OBSERVER.to_owned()],
+        },
+    ]);
+    convergence_fixture(
+        name,
+        steps,
+        TraceExpectation::ConvergenceDecision {
+            client: Some(OBSERVER.to_owned()),
+            selected_branch_id: None,
+            selected_tip_epoch: Some(2),
+            decisive_rule: Some(conv.decisive_rule.clone()),
+            witness_quorum_met: Some(true),
+            min_app_witness_score: Some(2),
+        },
+    )
 }

--- a/crates/incident-replay/src/synth.rs
+++ b/crates/incident-replay/src/synth.rs
@@ -1,0 +1,104 @@
+//! Synthesize a conformance vector from a recovered fork.
+//!
+//! The shape is the validated exp-06 blueprint: the two committers raise
+//! competing metadata commits at the same epoch and the engine fork-recovers on
+//! delivery — no `SetPartition` fault is needed, because the commits are
+//! concurrent (neither is delivered before the other is staged). Epochs are
+//! normalized to the simulator's range (real `N → N+1` becomes `1 → 2`) by
+//! outcome-equivalence, and the committer identities are synthetic labels the
+//! caller assigns so the designated winner's branch wins.
+
+use cgka_conformance_simulator::{ScenarioSpec, ScenarioStep, TraceExpectation, VectorFixture};
+
+use crate::fork::{ForkCommitKind, RecoveredFork};
+
+/// The group name the winning branch commits; its survival after convergence is
+/// how the accept path confirms the designated winner won.
+pub const WINNER_BRANCH: &str = "winner-branch";
+/// The group name the losing branch commits.
+pub const LOSER_BRANCH: &str = "loser-branch";
+
+fn commit_step(kind: ForkCommitKind, client: &str, name: &str, pending: &str) -> ScenarioStep {
+    match kind {
+        ForkCommitKind::GroupData => ScenarioStep::UpdateGroupData {
+            client: client.to_owned(),
+            name: name.to_owned(),
+            pending: pending.to_owned(),
+        },
+    }
+}
+
+/// Build the concurrent-fork vector. `winner`/`loser` are the synthetic client
+/// labels; the caller (the accept path) tries both orderings so the label whose
+/// committer key wins the `CommitOrderingKey` tiebreak is the one on the winning
+/// branch.
+pub fn synthesize(fork: &RecoveredFork, name: &str, winner: &str, loser: &str) -> VectorFixture {
+    let steps = vec![
+        ScenarioStep::CreateGroup {
+            creator: winner.to_owned(),
+            name: "replay".to_owned(),
+            invitees: vec![loser.to_owned()],
+            required_features: Vec::new(),
+            initial_admins: None,
+            pending: "create".to_owned(),
+        },
+        ScenarioStep::ConfirmPending {
+            client: winner.to_owned(),
+            pending: "create".to_owned(),
+        },
+        ScenarioStep::DeliverAll,
+        ScenarioStep::Tick {
+            clients: vec![loser.to_owned()],
+        },
+        ScenarioStep::ClearEvents {
+            clients: vec![winner.to_owned(), loser.to_owned()],
+        },
+        // Competing commits from the same epoch — the fork.
+        commit_step(fork.commit, winner, WINNER_BRANCH, "w"),
+        commit_step(fork.commit, loser, LOSER_BRANCH, "l"),
+        ScenarioStep::ConfirmPending {
+            client: winner.to_owned(),
+            pending: "w".to_owned(),
+        },
+        ScenarioStep::ConfirmPending {
+            client: loser.to_owned(),
+            pending: "l".to_owned(),
+        },
+        ScenarioStep::DeliverAll,
+        ScenarioStep::Tick {
+            clients: vec![winner.to_owned(), loser.to_owned()],
+        },
+        ScenarioStep::Observe {
+            clients: vec![winner.to_owned(), loser.to_owned()],
+        },
+    ];
+
+    VectorFixture {
+        scenario_name: name.to_owned(),
+        vector_version: "1".to_owned(),
+        conformance_version: env!("CARGO_PKG_VERSION").to_owned(),
+        seed: None,
+        scenario: ScenarioSpec {
+            name: name.to_owned(),
+            spec_version: "1".to_owned(),
+            clients: vec![winner.to_owned(), loser.to_owned()],
+            steps,
+        },
+        expected_trace: None,
+        expected_outcomes: vec![
+            // Rule 4: assert the full recovery summary, not just the winner.
+            TraceExpectation::RecoverySummary {
+                count: 1,
+                source_epoch: Some(1),
+                recovered_epoch: Some(2),
+                winner_differs_from_invalidated: true,
+            },
+            // Both committers settle on the one surviving branch.
+            TraceExpectation::ClientsConverged {
+                clients: vec![winner.to_owned(), loser.to_owned()],
+                epoch: Some(2),
+                member_count: Some(2),
+            },
+        ],
+    }
+}

--- a/crates/incident-replay/tests/accept.rs
+++ b/crates/incident-replay/tests/accept.rs
@@ -1,0 +1,27 @@
+//! End-to-end accept path: a recovered metadata fork synthesizes a vector whose
+//! scenario the simulator reproduces — the designated winner's branch survives
+//! and the full `RecoverySummary` matches. `accept` returning `Ok` *is* that
+//! proof (it run-and-compares internally).
+
+use incident_replay::{accept, parse, recover_fork};
+
+const PURE_METADATA_FORK: &str = r#"{
+  "events": [
+    { "kind": { "type": "fork_resolution", "source_epoch": 30, "invalidated_msg_id": "inv-1", "winner": "incumbent" } },
+    { "account_ref": "alpha", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "topic_changed", "actor_member_ref": "alpha" } },
+    { "account_ref": "beta", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "topic_changed", "actor_member_ref": "beta" } },
+    { "account_ref": "beta", "kind": { "type": "publish_outcome", "msg_id": "inv-1" } }
+  ]
+}"#;
+
+#[test]
+fn metadata_fork_accepts_with_a_reproducible_vector() {
+    let fork = recover_fork(&parse(PURE_METADATA_FORK).expect("parses")).expect("recovers");
+    let vector =
+        accept(&fork, "test-topic-fork/v1").expect("run-and-compare reproduces the fork winner");
+
+    assert_eq!(vector.scenario_name, "test-topic-fork/v1");
+    assert_eq!(vector.scenario.clients.len(), 2);
+    // RecoverySummary + ClientsConverged.
+    assert_eq!(vector.expected_outcomes.len(), 2);
+}

--- a/crates/incident-replay/tests/accept_convergence.rs
+++ b/crates/incident-replay/tests/accept_convergence.rs
@@ -1,0 +1,79 @@
+//! End-to-end convergence accept path: a recovered committer-decided
+//! convergence synthesizes a vector whose scenario the simulator reproduces —
+//! the observer's settled decision is `tip_committer`-decided with no witness
+//! quorum. `accept_convergence` returning `Ok` *is* that proof (it
+//! run-and-compares internally).
+
+use incident_replay::{accept_convergence, parse, recover_convergence};
+
+const COMMITTER_DECIDED_CONVERGENCE: &str = r#"{
+  "events": [
+    {
+      "kind": {
+        "type": "convergence_decision",
+        "current_tip_epoch": 30,
+        "selected_branch_id": "win",
+        "candidates": [
+          { "branch_id": "win", "score": { "witness_quorum_met": false } },
+          { "branch_id": "lose", "score": { "witness_quorum_met": false } }
+        ],
+        "rule_trace": [
+          { "rule_name": "effective_commit_depth", "decisive": false },
+          { "rule_name": "tip_committer", "decisive": true }
+        ],
+        "selected_tip_epoch": 31,
+        "losing_branch_ids": ["lose"]
+      }
+    }
+  ]
+}"#;
+
+/// Witness-decided: `effective_commit_depth` decisive with the winner meeting an
+/// app-witness quorum — the case that matches real convergence traffic.
+const WITNESS_DECIDED_CONVERGENCE: &str = r#"{
+  "events": [
+    {
+      "kind": {
+        "type": "convergence_decision",
+        "current_tip_epoch": 30,
+        "selected_branch_id": "win",
+        "candidates": [
+          { "branch_id": "win", "score": { "witness_quorum_met": true } },
+          { "branch_id": "lose", "score": { "witness_quorum_met": false } }
+        ],
+        "rule_trace": [
+          { "rule_name": "effective_commit_depth", "decisive": true },
+          { "rule_name": "tip_committer", "decisive": false }
+        ],
+        "selected_tip_epoch": 31,
+        "losing_branch_ids": ["lose"]
+      }
+    }
+  ]
+}"#;
+
+#[test]
+fn committer_decided_convergence_accepts_with_a_reproducible_vector() {
+    let conv = recover_convergence(&parse(COMMITTER_DECIDED_CONVERGENCE).expect("parses"))
+        .expect("recovers");
+    let vector = accept_convergence(&conv, "test-committer-convergence/v1")
+        .expect("run-and-compare reproduces the convergence decision");
+
+    assert_eq!(vector.scenario_name, "test-committer-convergence/v1");
+    // observer + two committers + two invitees.
+    assert_eq!(vector.scenario.clients.len(), 5);
+    // A single ConvergenceDecision expectation.
+    assert_eq!(vector.expected_outcomes.len(), 1);
+}
+
+#[test]
+fn witness_decided_convergence_accepts_with_a_reproducible_vector() {
+    let conv = recover_convergence(&parse(WITNESS_DECIDED_CONVERGENCE).expect("parses"))
+        .expect("recovers");
+    let vector = accept_convergence(&conv, "test-witness-convergence/v1")
+        .expect("run-and-compare reproduces the witnessed convergence decision");
+
+    assert_eq!(vector.scenario_name, "test-witness-convergence/v1");
+    assert_eq!(vector.scenario.clients.len(), 5);
+    assert_eq!(vector.expected_outcomes.len(), 1);
+}

--- a/crates/incident-replay/tests/accept_convergence.rs
+++ b/crates/incident-replay/tests/accept_convergence.rs
@@ -28,8 +28,10 @@ const COMMITTER_DECIDED_CONVERGENCE: &str = r#"{
   ]
 }"#;
 
-/// Witness-decided: `effective_commit_depth` decisive with the winner meeting an
-/// app-witness quorum — the case that matches real convergence traffic.
+/// Witness-decided: `effective_commit_depth` decisive because both branches
+/// forked from epoch 30 to tip 31 (equal `valid_commit_depth`) and the winner's
+/// app-witness quorum boost broke the tie — the case that matches real
+/// convergence traffic.
 const WITNESS_DECIDED_CONVERGENCE: &str = r#"{
   "events": [
     {
@@ -38,8 +40,8 @@ const WITNESS_DECIDED_CONVERGENCE: &str = r#"{
         "current_tip_epoch": 30,
         "selected_branch_id": "win",
         "candidates": [
-          { "branch_id": "win", "score": { "witness_quorum_met": true } },
-          { "branch_id": "lose", "score": { "witness_quorum_met": false } }
+          { "branch_id": "win", "score": { "witness_quorum_met": true, "valid_commit_depth": 1 } },
+          { "branch_id": "lose", "score": { "witness_quorum_met": false, "valid_commit_depth": 1 } }
         ],
         "rule_trace": [
           { "rule_name": "effective_commit_depth", "decisive": true },

--- a/crates/incident-replay/tests/classify.rs
+++ b/crates/incident-replay/tests/classify.rs
@@ -1,0 +1,77 @@
+//! Classification behaviour, exercised through the public parse + classify API
+//! against synthetic, non-sensitive fixtures.
+
+use incident_replay::{QuarantineReason, Verdict, classify, parse};
+
+fn load(name: &str) -> incident_replay::AgentStateExport {
+    let path = format!("{}/tests/fixtures/{name}", env!("CARGO_MANIFEST_DIR"));
+    let json =
+        std::fs::read_to_string(&path).unwrap_or_else(|err| panic!("read fixture {path}: {err}"));
+    parse(&json).unwrap_or_else(|err| panic!("parse fixture {name}: {err}"))
+}
+
+#[test]
+fn healthy_export_classifies_as_healthy() {
+    assert_eq!(classify(&load("healthy.json")), Verdict::Healthy);
+}
+
+#[test]
+fn fork_resolution_without_contested_convergence_is_fork_recovery() {
+    assert_eq!(classify(&load("fork-recovery.json")), Verdict::ForkRecovery);
+}
+
+#[test]
+fn routine_single_branch_convergence_is_healthy() {
+    // exp-07 shape: real traffic emits many convergence_decisions that select the
+    // sole branch with no loser. Those are not incidents.
+    assert_eq!(
+        classify(&load("healthy-routine-convergence.json")),
+        Verdict::Healthy
+    );
+}
+
+#[test]
+fn contested_convergence_dominates_fork_recovery() {
+    // exp-03 shape: a real incident carries both a fork_resolution and a
+    // contested convergence_decision; the convergence selection wins the route.
+    assert_eq!(
+        classify(&load("convergence-selected.json")),
+        Verdict::ConvergenceSelected
+    );
+}
+
+#[test]
+fn fork_resolution_with_missing_snapshot_quarantines() {
+    // The winning branch's pre-commit snapshot was unavailable, so the fork
+    // cannot be replayed — quarantine rather than emit a wrong vector.
+    assert_eq!(
+        classify(&load("quarantine-missing-snapshot.json")),
+        Verdict::Quarantine {
+            reason: QuarantineReason::MissingSnapshot
+        }
+    );
+}
+
+#[test]
+fn contested_convergence_outranks_a_missing_snapshot_fork() {
+    // A reproducible convergence selection routes to Phase 4 even alongside an
+    // unrecoverable fork: the missing-snapshot quarantine only applies when the
+    // fork-recovery path is the one being taken.
+    assert_eq!(
+        classify(&load("convergence-with-missing-snapshot-fork.json")),
+        Verdict::ConvergenceSelected
+    );
+}
+
+#[test]
+fn truncated_projection_quarantines_even_when_contested() {
+    // A capped derived_projections section means the export is incomplete;
+    // reproduction could miss witnesses, so truncation quarantines regardless of
+    // any incident signal in the (uncapped) event log.
+    assert_eq!(
+        classify(&load("quarantine-truncated.json")),
+        Verdict::Quarantine {
+            reason: QuarantineReason::TruncatedProjections
+        }
+    );
+}

--- a/crates/incident-replay/tests/convergence.rs
+++ b/crates/incident-replay/tests/convergence.rs
@@ -41,7 +41,8 @@ fn recovers_a_committer_decided_two_branch_convergence() {
 }
 
 /// A witness-decided contested convergence: `effective_commit_depth` decisive
-/// (the witnessed branch's quorum boost) and the winner met the quorum.
+/// because both branches sit at equal valid depth and the winner's quorum boost
+/// broke the tie.
 const WITNESS_DECIDED: &str = r#"{
   "events": [
     {
@@ -49,8 +50,8 @@ const WITNESS_DECIDED: &str = r#"{
         "type": "convergence_decision",
         "selected_branch_id": "win",
         "candidates": [
-          { "branch_id": "win", "score": { "witness_quorum_met": true } },
-          { "branch_id": "lose", "score": { "witness_quorum_met": false } }
+          { "branch_id": "win", "score": { "witness_quorum_met": true, "valid_commit_depth": 1 } },
+          { "branch_id": "lose", "score": { "witness_quorum_met": false, "valid_commit_depth": 1 } }
         ],
         "rule_trace": [
           { "rule_name": "effective_commit_depth", "decisive": true },
@@ -76,12 +77,39 @@ fn an_effective_depth_win_without_a_quorum_is_quarantined() {
     // witness vector cannot reproduce. The rule *is* supported, so the reason is a
     // quorum error — not `UnsupportedDecisiveRule` (which would be self-contradictory).
     let json = WITNESS_DECIDED.replace(
-        r#"{ "branch_id": "win", "score": { "witness_quorum_met": true } }"#,
-        r#"{ "branch_id": "win", "score": { "witness_quorum_met": false } }"#,
+        r#"{ "branch_id": "win", "score": { "witness_quorum_met": true, "valid_commit_depth": 1 } }"#,
+        r#"{ "branch_id": "win", "score": { "witness_quorum_met": false, "valid_commit_depth": 1 } }"#,
     );
     assert_eq!(
         recover(&json),
         Err(ConvergenceRecoveryError::WitnessQuorumUnconfirmed)
+    );
+}
+
+#[test]
+fn a_witness_win_from_raw_commit_depth_is_quarantined() {
+    // `effective_commit_depth` decided it and the winner met a quorum, but the
+    // winner sits at *greater* valid commit depth than the loser — so it would win
+    // on raw depth regardless of witnesses. The quorum boost was incidental, not
+    // decisive, and the equal-depth witness vector would assert the wrong shape.
+    let json = WITNESS_DECIDED.replace(
+        r#"{ "branch_id": "win", "score": { "witness_quorum_met": true, "valid_commit_depth": 1 } }"#,
+        r#"{ "branch_id": "win", "score": { "witness_quorum_met": true, "valid_commit_depth": 2 } }"#,
+    );
+    assert_eq!(
+        recover(&json),
+        Err(ConvergenceRecoveryError::WitnessBoostNotDecisive)
+    );
+}
+
+#[test]
+fn a_witness_win_without_recorded_depths_is_quarantined() {
+    // The winner met a quorum, but neither branch recorded its valid commit
+    // depth, so the boost cannot be proven decisive over a raw-depth win.
+    let json = WITNESS_DECIDED.replace(r#", "valid_commit_depth": 1"#, "");
+    assert_eq!(
+        recover(&json),
+        Err(ConvergenceRecoveryError::WitnessBoostNotDecisive)
     );
 }
 
@@ -136,6 +164,34 @@ fn more_than_two_candidates_is_quarantined() {
     assert_eq!(
         recover(&json),
         Err(ConvergenceRecoveryError::AmbiguousCandidates(3))
+    );
+}
+
+#[test]
+fn duplicate_candidate_branch_ids_are_quarantined() {
+    // Both candidates carry the same id, so `selected_branch_id` cannot name a
+    // unique winner and the loser is ambiguous — not a real two-branch race.
+    let json = COMMITTER_DECIDED.replace(
+        r#"{ "branch_id": "lose", "score": { "witness_quorum_met": false } }"#,
+        r#"{ "branch_id": "win", "score": { "witness_quorum_met": false } }"#,
+    );
+    assert_eq!(
+        recover(&json),
+        Err(ConvergenceRecoveryError::IndistinctCandidates)
+    );
+}
+
+#[test]
+fn an_empty_candidate_branch_id_is_quarantined() {
+    // A candidate with a missing (empty) branch id is a malformed entry, not a
+    // distinguishable branch.
+    let json = COMMITTER_DECIDED.replace(
+        r#"{ "branch_id": "lose", "score": { "witness_quorum_met": false } }"#,
+        r#"{ "branch_id": "", "score": { "witness_quorum_met": false } }"#,
+    );
+    assert_eq!(
+        recover(&json),
+        Err(ConvergenceRecoveryError::IndistinctCandidates)
     );
 }
 

--- a/crates/incident-replay/tests/convergence.rs
+++ b/crates/incident-replay/tests/convergence.rs
@@ -1,0 +1,166 @@
+//! Extraction gate for the convergence path: `recover_convergence` turns a
+//! contested `convergence_decision` into the facts needed to synthesize a
+//! vector, and fail-closes on anything it cannot faithfully reproduce.
+
+use incident_replay::{
+    ConvergenceDecisionKind, ConvergenceRecoveryError, parse, recover_convergence,
+};
+
+/// A committer-decided contested convergence: two branches, `tip_committer`
+/// decisive, and the winner met no witness quorum.
+const COMMITTER_DECIDED: &str = r#"{
+  "events": [
+    {
+      "kind": {
+        "type": "convergence_decision",
+        "selected_branch_id": "win",
+        "candidates": [
+          { "branch_id": "win", "score": { "witness_quorum_met": false } },
+          { "branch_id": "lose", "score": { "witness_quorum_met": false } }
+        ],
+        "rule_trace": [
+          { "rule_name": "effective_commit_depth", "decisive": false },
+          { "rule_name": "witness_quorum_met", "decisive": false },
+          { "rule_name": "tip_committer", "decisive": true }
+        ],
+        "losing_branch_ids": ["lose"]
+      }
+    }
+  ]
+}"#;
+
+fn recover(json: &str) -> Result<incident_replay::RecoveredConvergence, ConvergenceRecoveryError> {
+    recover_convergence(&parse(json).expect("parses"))
+}
+
+#[test]
+fn recovers_a_committer_decided_two_branch_convergence() {
+    let recovered = recover(COMMITTER_DECIDED).expect("recovers");
+    assert_eq!(recovered.decisive_rule, "tip_committer");
+    assert_eq!(recovered.kind, ConvergenceDecisionKind::CommitterDecided);
+}
+
+/// A witness-decided contested convergence: `effective_commit_depth` decisive
+/// (the witnessed branch's quorum boost) and the winner met the quorum.
+const WITNESS_DECIDED: &str = r#"{
+  "events": [
+    {
+      "kind": {
+        "type": "convergence_decision",
+        "selected_branch_id": "win",
+        "candidates": [
+          { "branch_id": "win", "score": { "witness_quorum_met": true } },
+          { "branch_id": "lose", "score": { "witness_quorum_met": false } }
+        ],
+        "rule_trace": [
+          { "rule_name": "effective_commit_depth", "decisive": true },
+          { "rule_name": "tip_committer", "decisive": false }
+        ],
+        "losing_branch_ids": ["lose"]
+      }
+    }
+  ]
+}"#;
+
+#[test]
+fn recovers_a_witness_decided_two_branch_convergence() {
+    let recovered = recover(WITNESS_DECIDED).expect("recovers");
+    assert_eq!(recovered.decisive_rule, "effective_commit_depth");
+    assert_eq!(recovered.kind, ConvergenceDecisionKind::WitnessDecided);
+}
+
+#[test]
+fn an_effective_depth_win_without_a_quorum_is_quarantined() {
+    // `effective_commit_depth` decided it, but the winner met no quorum — it won
+    // by raw commit depth (a differing-depth branch), which the equal-depth
+    // witness vector cannot reproduce. The rule *is* supported, so the reason is a
+    // quorum error — not `UnsupportedDecisiveRule` (which would be self-contradictory).
+    let json = WITNESS_DECIDED.replace(
+        r#"{ "branch_id": "win", "score": { "witness_quorum_met": true } }"#,
+        r#"{ "branch_id": "win", "score": { "witness_quorum_met": false } }"#,
+    );
+    assert_eq!(
+        recover(&json),
+        Err(ConvergenceRecoveryError::WitnessQuorumUnconfirmed)
+    );
+}
+
+#[test]
+fn a_committer_tiebreak_that_met_a_quorum_is_quarantined() {
+    // `tip_committer` decided it, yet the winner met a quorum — the no-witness
+    // committer vector would assert quorum-false, so this is not reproducible.
+    let json = COMMITTER_DECIDED.replace(
+        r#"{ "branch_id": "win", "score": { "witness_quorum_met": false } }"#,
+        r#"{ "branch_id": "win", "score": { "witness_quorum_met": true } }"#,
+    );
+    assert_eq!(
+        recover(&json),
+        Err(ConvergenceRecoveryError::WitnessQuorumUnsupported)
+    );
+}
+
+#[test]
+fn an_unconfirmed_witness_quorum_is_quarantined() {
+    // The winner carries no score, so a witness quorum cannot be ruled out.
+    let json = COMMITTER_DECIDED.replace(
+        r#"{ "branch_id": "win", "score": { "witness_quorum_met": false } }"#,
+        r#"{ "branch_id": "win" }"#,
+    );
+    assert_eq!(
+        recover(&json),
+        Err(ConvergenceRecoveryError::WitnessQuorumUnsupported)
+    );
+}
+
+#[test]
+fn a_non_committer_decisive_rule_is_quarantined() {
+    let json = COMMITTER_DECIDED.replace(
+        r#"{ "rule_name": "tip_committer", "decisive": true }"#,
+        r#"{ "rule_name": "app_witness_score", "decisive": true }"#,
+    );
+    assert_eq!(
+        recover(&json),
+        Err(ConvergenceRecoveryError::UnsupportedDecisiveRule(
+            "app_witness_score".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn more_than_two_candidates_is_quarantined() {
+    let json = COMMITTER_DECIDED.replace(
+        r#"{ "branch_id": "lose", "score": { "witness_quorum_met": false } }"#,
+        r#"{ "branch_id": "lose", "score": { "witness_quorum_met": false } },
+          { "branch_id": "third", "score": { "witness_quorum_met": false } }"#,
+    );
+    assert_eq!(
+        recover(&json),
+        Err(ConvergenceRecoveryError::AmbiguousCandidates(3))
+    );
+}
+
+#[test]
+fn a_decision_without_a_decisive_rule_is_quarantined() {
+    let json = r#"{
+      "events": [
+        {
+          "kind": {
+            "type": "convergence_decision",
+            "selected_branch_id": "win",
+            "candidates": [{ "branch_id": "win" }, { "branch_id": "lose" }],
+            "losing_branch_ids": ["lose"]
+          }
+        }
+      ]
+    }"#;
+    assert_eq!(recover(json), Err(ConvergenceRecoveryError::NoDecisiveRule));
+}
+
+#[test]
+fn an_export_without_a_contested_convergence_is_quarantined() {
+    let json = r#"{ "events": [ { "kind": { "type": "epoch_confirmed", "epoch": 3 } } ] }"#;
+    assert_eq!(
+        recover(json),
+        Err(ConvergenceRecoveryError::NoConvergenceDecision)
+    );
+}

--- a/crates/incident-replay/tests/fixtures/convergence-selected.json
+++ b/crates/incident-replay/tests/fixtures/convergence-selected.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    { "kind": { "type": "epoch_confirmed", "epoch": 30 } },
+    {
+      "kind": {
+        "type": "fork_resolution",
+        "source_epoch": 30,
+        "winner": "incumbent"
+      }
+    },
+    {
+      "kind": {
+        "type": "convergence_decision",
+        "current_tip_epoch": 30,
+        "candidates": [
+          { "branch_id": "winner", "eligible": true },
+          { "branch_id": "loser", "eligible": false }
+        ],
+        "selected_branch_id": "winner",
+        "losing_branch_ids": ["loser"]
+      }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 1 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/fixtures/convergence-with-missing-snapshot-fork.json
+++ b/crates/incident-replay/tests/fixtures/convergence-with-missing-snapshot-fork.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "kind": {
+        "type": "fork_resolution",
+        "source_epoch": 12,
+        "winner": "missing_snapshot"
+      }
+    },
+    {
+      "kind": {
+        "type": "convergence_decision",
+        "candidates": [{ "branch_id": "a" }, { "branch_id": "b" }],
+        "selected_branch_id": "a",
+        "losing_branch_ids": ["b"]
+      }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 1 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/fixtures/fork-recovery.json
+++ b/crates/incident-replay/tests/fixtures/fork-recovery.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    { "kind": { "type": "epoch_confirmed", "epoch": 30 } },
+    {
+      "kind": {
+        "type": "fork_resolution",
+        "source_epoch": 30,
+        "candidate_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "incumbent_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "invalidated_msg_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "winner": "incumbent"
+      }
+    },
+    { "kind": { "type": "epoch_rolled_back", "epoch": 31 } }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 0 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/fixtures/healthy-routine-convergence.json
+++ b/crates/incident-replay/tests/fixtures/healthy-routine-convergence.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "kind": {
+        "type": "convergence_decision",
+        "current_tip_epoch": 5,
+        "candidates": [{ "branch_id": "only" }],
+        "selected_branch_id": "only",
+        "losing_branch_ids": []
+      }
+    },
+    {
+      "kind": {
+        "type": "convergence_decision",
+        "current_tip_epoch": 6,
+        "candidates": [{ "branch_id": "only-next" }],
+        "selected_branch_id": "only-next",
+        "losing_branch_ids": []
+      }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 2 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/fixtures/healthy.json
+++ b/crates/incident-replay/tests/fixtures/healthy.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    { "kind": { "type": "recorder_started", "recorder": "synthetic" } },
+    { "kind": { "type": "epoch_confirmed", "epoch": 1 } },
+    { "kind": { "type": "group_state_changed", "change": "member_added" } }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 0 },
+      "delivery_artifacts": { "has_more": false, "limit": 500, "offset": 0, "returned": 3 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-missing-snapshot.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-missing-snapshot.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    { "kind": { "type": "epoch_confirmed", "epoch": 12 } },
+    {
+      "kind": {
+        "type": "fork_resolution",
+        "source_epoch": 12,
+        "candidate_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "winner": "missing_snapshot"
+      }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 0 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-truncated.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-truncated.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "kind": {
+        "type": "convergence_decision",
+        "candidates": [{ "branch_id": "a" }, { "branch_id": "b" }],
+        "selected_branch_id": "a",
+        "losing_branch_ids": ["b"]
+      }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 1 },
+      "delivery_artifacts": { "has_more": true, "limit": 500, "offset": 0, "returned": 500, "next_offset": 500 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/fork.rs
+++ b/crates/incident-replay/tests/fork.rs
@@ -1,0 +1,92 @@
+//! `recover_fork` behaviour: rule 2 (racers at source_epoch+1), rule 3 tier-b
+//! (invalidated commit's publisher is the loser), and the fail-closed gates.
+
+use incident_replay::{ForkCommitKind, ForkRecoveryError, RecoveredFork, parse, recover_fork};
+
+/// A pure two-committer group-metadata fork: alpha and beta both `topic_changed`
+/// at epoch 31 (= source 30 + 1); the invalidated commit was published by beta.
+fn pure_fork_json(winner_change: &str) -> String {
+    format!(
+        r#"{{
+          "events": [
+            {{ "kind": {{ "type": "fork_resolution", "source_epoch": 30,
+                          "invalidated_msg_id": "inv-1", "winner": "incumbent" }} }},
+            {{ "account_ref": "alpha",
+               "kind": {{ "type": "group_state_changed", "epoch": 31, "change_kind": "{winner_change}",
+                          "actor_member_ref": "alpha" }} }},
+            {{ "account_ref": "beta",
+               "kind": {{ "type": "group_state_changed", "epoch": 31, "change_kind": "topic_changed",
+                          "actor_member_ref": "beta" }} }},
+            {{ "account_ref": "beta",
+               "kind": {{ "type": "publish_outcome", "msg_id": "inv-1" }} }}
+          ]
+        }}"#
+    )
+}
+
+fn recover(json: &str) -> Result<RecoveredFork, ForkRecoveryError> {
+    recover_fork(&parse(json).expect("parses"))
+}
+
+#[test]
+fn recovers_a_pure_two_committer_metadata_fork() {
+    assert_eq!(
+        recover(&pure_fork_json("topic_changed")),
+        Ok(RecoveredFork {
+            source_epoch: 30,
+            commit: ForkCommitKind::GroupData,
+        })
+    );
+}
+
+#[test]
+fn missing_snapshot_winner_is_quarantined() {
+    let json = r#"{ "events": [
+        { "kind": { "type": "fork_resolution", "source_epoch": 30, "winner": "missing_snapshot" } }
+    ] }"#;
+    assert_eq!(recover(json), Err(ForkRecoveryError::MissingSnapshot));
+}
+
+#[test]
+fn no_fork_resolution_is_quarantined() {
+    let json = r#"{ "events": [ { "kind": { "type": "epoch_confirmed" } } ] }"#;
+    assert_eq!(recover(json), Err(ForkRecoveryError::NoForkResolution));
+}
+
+#[test]
+fn a_single_committer_at_the_tip_is_ambiguous() {
+    let json = r#"{ "events": [
+        { "kind": { "type": "fork_resolution", "source_epoch": 30, "invalidated_msg_id": "inv-1", "winner": "incumbent" } },
+        { "account_ref": "alpha", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "topic_changed", "actor_member_ref": "alpha" } }
+    ] }"#;
+    assert_eq!(
+        recover(json),
+        Err(ForkRecoveryError::AmbiguousCommitters(1))
+    );
+}
+
+#[test]
+fn an_unattributable_invalidated_commit_makes_the_winner_unrecoverable() {
+    // No publish event ties `inv-1` to a committer.
+    let json = r#"{ "events": [
+        { "kind": { "type": "fork_resolution", "source_epoch": 30, "invalidated_msg_id": "inv-1", "winner": "incumbent" } },
+        { "account_ref": "alpha", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "topic_changed", "actor_member_ref": "alpha" } },
+        { "account_ref": "beta", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "topic_changed", "actor_member_ref": "beta" } }
+    ] }"#;
+    assert_eq!(recover(json), Err(ForkRecoveryError::UnrecoverableWinner));
+}
+
+#[test]
+fn an_unmapped_commit_kind_is_quarantined() {
+    // A membership fork (member_added) is not synthesizable yet.
+    let json = r#"{ "events": [
+        { "kind": { "type": "fork_resolution", "source_epoch": 30, "invalidated_msg_id": "inv-1", "winner": "incumbent" } },
+        { "account_ref": "alpha", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "member_added", "actor_member_ref": "alpha" } },
+        { "account_ref": "beta", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "member_added", "actor_member_ref": "beta" } },
+        { "account_ref": "beta", "kind": { "type": "publish_outcome", "msg_id": "inv-1" } }
+    ] }"#;
+    assert_eq!(
+        recover(json),
+        Err(ForkRecoveryError::UnmappedCommitKind("member_added".into()))
+    );
+}

--- a/crates/incident-replay/tests/parse.rs
+++ b/crates/incident-replay/tests/parse.rs
@@ -1,0 +1,19 @@
+//! Parser behaviour: lenient to unknown shapes, loud on invalid input.
+
+use incident_replay::{Verdict, classify, parse};
+
+#[test]
+fn invalid_json_is_a_parse_error() {
+    assert!(parse("not json at all").is_err());
+}
+
+#[test]
+fn unknown_event_kinds_and_absent_projections_are_tolerated() {
+    // Real exports carry ~40 event kinds and many fields this adapter ignores;
+    // unknown kinds map to a no-op and an absent derived_projections defaults
+    // cleanly rather than failing the parse.
+    let export =
+        parse(r#"{ "events": [ { "kind": { "type": "some_future_kind", "detail": 7 } } ] }"#)
+            .expect("unknown kinds and absent derived_projections parse");
+    assert_eq!(classify(&export), Verdict::Healthy);
+}


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/782">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an incident replay tool and CLI to classify exports, recover fork/convergence outcomes, synthesize conformance vectors, and accept only reproducible results.
  * Added new conformance vectors for committer- vs witness-based convergence selection, plus incident recovery scenarios.
  * Simulator now captures and lets scenarios assert “settled” convergence decision observations.
* **Bug Fixes**
  * Re-admits previously delivered app messages for witness scoring.
  * Improves replay robustness by treating a specific OpenMLS replay failure mode as non-fatal.
* **Documentation**
  * Added incident-replay adapter documentation and updated the repository vector/incident manifest.
* **Tests**
  * Expanded simulator and incident-replay end-to-end coverage, including convergence decision assertions and acceptance/recovery flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->