### PR TITLE
opencode: allow nested workdir picker paths

### DIFF
--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -105,19 +105,22 @@ newline, then space boundaries and never splits a UTF-8 code point.
 
 ## Workdir Picker
 
-On the first message in a new Marmot group, a leading `/<name>` selects
-`~/<name>` as the OpenCode working directory if it is a direct child directory of
-`$HOME`.
+On the first message in a new Marmot group, a leading `/<path>` selects
+`~/<path>` as the OpenCode working directory if the canonical target is inside
+`$HOME`. Path segments are separated by `/` and each segment must be
+ASCII-alphanumeric or `.`, `_`, `-`; empty, `.`, and `..` segments are rejected.
 
 Examples:
 
 ```text
 /mdk fix the failing test
 /mdk
+/projects/mdk fix the failing test
 ```
 
 When the message is only the picker, `wn-opencode` stores the workdir and asks
-for the next prompt.
+for the next prompt. Symlinks that resolve outside `$HOME` are rejected after
+canonicalization.
 
 ## Security Notes
 

--- a/integrations/opencode/marmot/README.md
+++ b/integrations/opencode/marmot/README.md
@@ -120,7 +120,8 @@ Examples:
 
 When the message is only the picker, `wn-opencode` stores the workdir and asks
 for the next prompt. Symlinks that resolve outside `$HOME` are rejected after
-canonicalization.
+canonicalization. Picker-looking messages with invalid segments are rejected
+and are not forwarded to OpenCode as prompts.
 
 ## Security Notes
 

--- a/integrations/opencode/marmot/src/bridge.rs
+++ b/integrations/opencode/marmot/src/bridge.rs
@@ -14,7 +14,7 @@ use crate::config::{Config, dirs_home};
 use crate::control::ControlClient;
 use crate::error::{HarnessError, Result};
 use crate::opencode::{Invocation, Outcome, RunFailure, RunnerEvent};
-use crate::repo_picker::{parse_repo_picker, resolve_repo, validate_session_cwd};
+use crate::repo_picker::{RepoPicker, parse_repo_picker, resolve_repo, validate_session_cwd};
 use crate::store::{SessionRecord, SessionStore};
 
 pub(crate) const TRACE_TARGET: &str = "wn_opencode";
@@ -600,8 +600,21 @@ async fn resolve_cwd_and_prompt(
         return Ok(Some((cwd, inbound.text.clone())));
     }
 
-    let Some((name, rest)) = parse_repo_picker(&inbound.text) else {
-        return Ok(Some((dirs_home(), inbound.text.clone())));
+    let (name, rest) = match parse_repo_picker(&inbound.text) {
+        RepoPicker::Absent => return Ok(Some((dirs_home(), inbound.text.clone()))),
+        RepoPicker::Invalid => {
+            send_reply(
+                ctx,
+                &inbound.account_ref,
+                &inbound.group_ref,
+                &inbound.message_ref,
+                "[wn-opencode] Invalid workdir picker. Use /<path> with non-empty path segments containing only ASCII letters, digits, '.', '_', or '-'. Do not use '.' or '..' segments.",
+                0,
+            )
+            .await?;
+            return Ok(None);
+        }
+        RepoPicker::Valid { path, prompt } => (path, prompt),
     };
     let cwd = match resolve_repo(&name, &dirs_home()).await {
         Ok(cwd) => cwd,

--- a/integrations/opencode/marmot/src/repo_picker.rs
+++ b/integrations/opencode/marmot/src/repo_picker.rs
@@ -14,18 +14,23 @@ pub(crate) fn parse_repo_picker(text: &str) -> Option<(String, String)> {
         .find(|(_, c)| c.is_whitespace())
         .map(|(index, _)| index)
         .unwrap_or(rest.len());
-    let name = &rest[..end];
-    if name.is_empty() || matches!(name, "." | "..") {
+    let path = &rest[..end];
+    if path.is_empty() {
         return None;
     }
-    if !name
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
-    {
-        return None;
+    for segment in path.split('/') {
+        if segment.is_empty() || matches!(segment, "." | "..") {
+            return None;
+        }
+        if !segment
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+        {
+            return None;
+        }
     }
 
-    Some((name.to_owned(), rest[end..].trim_start().to_owned()))
+    Some((path.to_owned(), rest[end..].trim_start().to_owned()))
 }
 
 pub(crate) async fn resolve_repo(name: &str, home: &Path) -> Result<PathBuf> {
@@ -36,7 +41,7 @@ pub(crate) async fn resolve_repo(name: &str, home: &Path) -> Result<PathBuf> {
     let home_canonical = tokio::fs::canonicalize(home)
         .await
         .map_err(|_| repo_error("Cannot read $HOME."))?;
-    if canonical.parent() != Some(&home_canonical) {
+    if canonical == home_canonical || !canonical.starts_with(&home_canonical) {
         return Err(repo_error(format!(
             "Repo ~/{name} resolves outside $HOME; refusing."
         )));
@@ -57,7 +62,7 @@ pub(crate) async fn validate_session_cwd(cwd: &Path, home: &Path) -> Result<Path
     let home_canonical = tokio::fs::canonicalize(home)
         .await
         .map_err(|_| repo_error("Cannot read $HOME."))?;
-    if canonical != home_canonical && canonical.parent() != Some(&home_canonical) {
+    if !canonical.starts_with(&home_canonical) {
         return Err(repo_error(
             "Stored session workdir resolves outside $HOME; refusing.",
         ));
@@ -96,15 +101,32 @@ mod tests {
     }
 
     #[test]
-    fn parse_repo_picker_rejects_bare_slash_or_path_segments() {
+    fn parse_repo_picker_matches_nested_path() {
+        assert_eq!(
+            parse_repo_picker("/projects/mdk"),
+            Some(("projects/mdk".to_owned(), String::new()))
+        );
+        assert_eq!(
+            parse_repo_picker("/projects/mdk fix the build"),
+            Some(("projects/mdk".to_owned(), "fix the build".to_owned()))
+        );
+    }
+
+    #[test]
+    fn parse_repo_picker_rejects_bare_slash_or_empty_segments() {
         assert_eq!(parse_repo_picker("/"), None);
-        assert_eq!(parse_repo_picker("/whitenoise/subdir"), None);
+        assert_eq!(parse_repo_picker("//whitenoise"), None);
+        assert_eq!(parse_repo_picker("/whitenoise/"), None);
+        assert_eq!(parse_repo_picker("/whitenoise//subdir"), None);
     }
 
     #[test]
     fn parse_repo_picker_rejects_dot_segments() {
         assert_eq!(parse_repo_picker("/."), None);
         assert_eq!(parse_repo_picker("/.."), None);
+        assert_eq!(parse_repo_picker("/projects/.."), None);
+        assert_eq!(parse_repo_picker("/projects/./mdk"), None);
+        assert_eq!(parse_repo_picker("/../etc"), None);
     }
 
     #[test]
@@ -114,10 +136,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn validate_session_cwd_allows_home_or_direct_child() {
+    async fn validate_session_cwd_allows_home_or_nested_child() {
         let dir = tempfile::tempdir().unwrap();
         let child = dir.path().join("repo");
-        std::fs::create_dir(&child).unwrap();
+        let nested = child.join("crates").join("engine");
+        std::fs::create_dir_all(&nested).unwrap();
 
         assert_eq!(
             validate_session_cwd(dir.path(), dir.path()).await.unwrap(),
@@ -126,6 +149,10 @@ mod tests {
         assert_eq!(
             validate_session_cwd(&child, dir.path()).await.unwrap(),
             child.canonicalize().unwrap()
+        );
+        assert_eq!(
+            validate_session_cwd(&nested, dir.path()).await.unwrap(),
+            nested.canonicalize().unwrap()
         );
     }
 
@@ -136,6 +163,46 @@ mod tests {
         let err = validate_session_cwd(outside.path(), home.path())
             .await
             .unwrap_err();
+        assert_eq!(err.privacy_safe_kind(), "config");
+    }
+
+    #[tokio::test]
+    async fn resolve_repo_accepts_nested_path() {
+        let home = tempfile::tempdir().unwrap();
+        let nested = home.path().join("projects").join("mdk");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let resolved = resolve_repo("projects/mdk", home.path()).await.unwrap();
+        assert_eq!(resolved, nested.canonicalize().unwrap());
+    }
+
+    #[tokio::test]
+    async fn resolve_repo_rejects_direct_home_target() {
+        let home = tempfile::tempdir().unwrap();
+        let err = resolve_repo(".", home.path()).await.unwrap_err();
+        assert_eq!(err.privacy_safe_kind(), "config");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn resolve_repo_rejects_symlink_escaping_home() {
+        let home = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path(), home.path().join("escape")).unwrap();
+
+        let err = resolve_repo("escape", home.path()).await.unwrap_err();
+        assert_eq!(err.privacy_safe_kind(), "config");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn validate_session_cwd_rejects_symlink_escaping_home() {
+        let home = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let link = home.path().join("escape");
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+
+        let err = validate_session_cwd(&link, home.path()).await.unwrap_err();
         assert_eq!(err.privacy_safe_kind(), "config");
     }
 }

--- a/integrations/opencode/marmot/src/repo_picker.rs
+++ b/integrations/opencode/marmot/src/repo_picker.rs
@@ -2,10 +2,17 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{HarnessError, Result};
 
-pub(crate) fn parse_repo_picker(text: &str) -> Option<(String, String)> {
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RepoPicker {
+    Absent,
+    Invalid,
+    Valid { path: String, prompt: String },
+}
+
+pub(crate) fn parse_repo_picker(text: &str) -> RepoPicker {
     let trimmed = text.trim_start();
     if !trimmed.starts_with('/') {
-        return None;
+        return RepoPicker::Absent;
     }
 
     let rest = &trimmed[1..];
@@ -16,21 +23,24 @@ pub(crate) fn parse_repo_picker(text: &str) -> Option<(String, String)> {
         .unwrap_or(rest.len());
     let path = &rest[..end];
     if path.is_empty() {
-        return None;
+        return RepoPicker::Invalid;
     }
     for segment in path.split('/') {
         if segment.is_empty() || matches!(segment, "." | "..") {
-            return None;
+            return RepoPicker::Invalid;
         }
         if !segment
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
         {
-            return None;
+            return RepoPicker::Invalid;
         }
     }
 
-    Some((path.to_owned(), rest[end..].trim_start().to_owned()))
+    RepoPicker::Valid {
+        path: path.to_owned(),
+        prompt: rest[end..].trim_start().to_owned(),
+    }
 }
 
 pub(crate) async fn resolve_repo(name: &str, home: &Path) -> Result<PathBuf> {
@@ -41,7 +51,12 @@ pub(crate) async fn resolve_repo(name: &str, home: &Path) -> Result<PathBuf> {
     let home_canonical = tokio::fs::canonicalize(home)
         .await
         .map_err(|_| repo_error("Cannot read $HOME."))?;
-    if canonical == home_canonical || !canonical.starts_with(&home_canonical) {
+    if canonical == home_canonical {
+        return Err(repo_error(format!(
+            "Repo ~/{name} resolves to $HOME; refusing."
+        )));
+    }
+    if !canonical.starts_with(&home_canonical) {
         return Err(repo_error(format!(
             "Repo ~/{name} resolves outside $HOME; refusing."
         )));
@@ -88,7 +103,10 @@ mod tests {
     fn parse_repo_picker_matches_bare_name() {
         assert_eq!(
             parse_repo_picker("/whitenoise"),
-            Some(("whitenoise".to_owned(), String::new()))
+            RepoPicker::Valid {
+                path: "whitenoise".to_owned(),
+                prompt: String::new(),
+            }
         );
     }
 
@@ -96,7 +114,10 @@ mod tests {
     fn parse_repo_picker_matches_name_with_rest() {
         assert_eq!(
             parse_repo_picker("/whitenoise fix the build"),
-            Some(("whitenoise".to_owned(), "fix the build".to_owned()))
+            RepoPicker::Valid {
+                path: "whitenoise".to_owned(),
+                prompt: "fix the build".to_owned(),
+            }
         );
     }
 
@@ -104,35 +125,50 @@ mod tests {
     fn parse_repo_picker_matches_nested_path() {
         assert_eq!(
             parse_repo_picker("/projects/mdk"),
-            Some(("projects/mdk".to_owned(), String::new()))
+            RepoPicker::Valid {
+                path: "projects/mdk".to_owned(),
+                prompt: String::new(),
+            }
         );
         assert_eq!(
             parse_repo_picker("/projects/mdk fix the build"),
-            Some(("projects/mdk".to_owned(), "fix the build".to_owned()))
+            RepoPicker::Valid {
+                path: "projects/mdk".to_owned(),
+                prompt: "fix the build".to_owned(),
+            }
         );
     }
 
     #[test]
     fn parse_repo_picker_rejects_bare_slash_or_empty_segments() {
-        assert_eq!(parse_repo_picker("/"), None);
-        assert_eq!(parse_repo_picker("//whitenoise"), None);
-        assert_eq!(parse_repo_picker("/whitenoise/"), None);
-        assert_eq!(parse_repo_picker("/whitenoise//subdir"), None);
+        assert_eq!(parse_repo_picker("/"), RepoPicker::Invalid);
+        assert_eq!(parse_repo_picker("//whitenoise"), RepoPicker::Invalid);
+        assert_eq!(parse_repo_picker("/whitenoise/"), RepoPicker::Invalid);
+        assert_eq!(
+            parse_repo_picker("/whitenoise//subdir"),
+            RepoPicker::Invalid
+        );
     }
 
     #[test]
     fn parse_repo_picker_rejects_dot_segments() {
-        assert_eq!(parse_repo_picker("/."), None);
-        assert_eq!(parse_repo_picker("/.."), None);
-        assert_eq!(parse_repo_picker("/projects/.."), None);
-        assert_eq!(parse_repo_picker("/projects/./mdk"), None);
-        assert_eq!(parse_repo_picker("/../etc"), None);
+        assert_eq!(parse_repo_picker("/."), RepoPicker::Invalid);
+        assert_eq!(parse_repo_picker("/.."), RepoPicker::Invalid);
+        assert_eq!(parse_repo_picker("/projects/.."), RepoPicker::Invalid);
+        assert_eq!(parse_repo_picker("/projects/./mdk"), RepoPicker::Invalid);
+        assert_eq!(parse_repo_picker("/../etc"), RepoPicker::Invalid);
+    }
+
+    #[test]
+    fn parse_repo_picker_rejects_invalid_characters() {
+        assert_eq!(parse_repo_picker("/projects/mdk!"), RepoPicker::Invalid);
+        assert_eq!(parse_repo_picker("/projects/🦀"), RepoPicker::Invalid);
     }
 
     #[test]
     fn parse_repo_picker_ignores_non_picker_text() {
-        assert_eq!(parse_repo_picker("hello"), None);
-        assert_eq!(parse_repo_picker(" hello"), None);
+        assert_eq!(parse_repo_picker("hello"), RepoPicker::Absent);
+        assert_eq!(parse_repo_picker(" hello"), RepoPicker::Absent);
     }
 
     #[tokio::test]
@@ -181,6 +217,7 @@ mod tests {
         let home = tempfile::tempdir().unwrap();
         let err = resolve_repo(".", home.path()).await.unwrap_err();
         assert_eq!(err.privacy_safe_kind(), "config");
+        assert_eq!(err.to_string(), "Repo ~/. resolves to $HOME; refusing.");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## What

Extend the `wn-opencode` workdir picker to accept nested paths under `$HOME`, so users can send `/projects/mdk fix the failing test` in addition to the existing `/mdk` shape.

## Why

The picker previously required the selected directory to be a direct child of `$HOME`. Repos commonly live one or more levels deeper (e.g. `~/projects/mdk`, `~/work/whitenoise`), and the only workaround was a top-level symlink. Nested selection is the natural user-facing extension.

## How

- `parse_repo_picker` splits the picker on `/` and applies the existing charset rule per segment. Empty segments, `.`, and `..` are rejected at parse time.
- `resolve_repo` and `validate_session_cwd` now use a canonical `starts_with($HOME)` ancestor check instead of a `parent()` equality check. Direct `$HOME` selection is still rejected in `resolve_repo`.
- Symlinks are still resolved via `tokio::fs::canonicalize` before the ancestor check, so a symlink whose target escapes `$HOME` is rejected.

## Tests

`cargo test -p wn-opencode` — 36 unit tests pass (was 31). New coverage:

- `parse_repo_picker_matches_nested_path`
- `parse_repo_picker_rejects_bare_slash_or_empty_segments` (expanded)
- `parse_repo_picker_rejects_dot_segments` (expanded with nested `..` / `.`)
- `validate_session_cwd_allows_home_or_nested_child` (expanded)
- `resolve_repo_accepts_nested_path`
- `resolve_repo_rejects_direct_home_target`
- `resolve_repo_rejects_symlink_escaping_home` (unix)
- `validate_session_cwd_rejects_symlink_escaping_home` (unix)

`cargo fmt -p wn-opencode -- --check` clean.
`cargo clippy -p wn-opencode --all-targets -- -D warnings` clean.

## Docs

README workdir picker section updated with the nested example and the symlink-canonicalization note.

## Scope

No changes to `bridge.rs`, control protocol, chunking, session store, or the installer. Behavior for single-segment pickers is unchanged.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/791">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded workdir/repo picker support to allow nested `/`-separated paths (e.g., `/<path>`), not just direct child directories.
  * Updated picker guidance with clearer examples and selection rules.

* **Bug Fixes**
  * Strengthened picker path validation: rejects empty segments, `.`/`..`, and disallowed characters.
  * Improved home directory handling by canonicalizing paths, explicitly refusing cases that resolve to `$HOME`, and blocking symlink attempts that escape `$HOME`.
  * Updated session working-directory acceptance rules to allow `$HOME` itself and nested directories under `$HOME`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->