### PR TITLE
Bound the advisory directory steps during external signer login

### DIFF
--- a/crates/marmot-app/src/app_telemetry.rs
+++ b/crates/marmot-app/src/app_telemetry.rs
@@ -6,7 +6,7 @@
 //! key material.
 
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use transport_nostr_adapter::{DurationHistogramSnapshot, HistogramBucket};
@@ -24,6 +24,7 @@ pub(crate) enum AppPerformanceOperation {
     AccountOpen,
     AccountCatchUp,
     AccountSync,
+    AccountSetupAdvisoryStep,
     OutboundMessageSend,
     GroupInviteMembers,
     GroupInviteKeyPackageLookup,
@@ -60,6 +61,7 @@ pub struct AppPerformanceSnapshot {
     pub account_open: AppPerformanceOperationSnapshot,
     pub account_catch_up: AppPerformanceOperationSnapshot,
     pub account_sync: AppPerformanceOperationSnapshot,
+    pub account_setup_advisory_step: AppPerformanceOperationSnapshot,
     pub outbound_message_send: AppPerformanceOperationSnapshot,
     #[serde(default)]
     pub group_invite_members: AppPerformanceOperationSnapshot,
@@ -100,6 +102,7 @@ struct AppPerformanceTelemetryInner {
     account_open: AppPerformanceOperationTelemetry,
     account_catch_up: AppPerformanceOperationTelemetry,
     account_sync: AppPerformanceOperationTelemetry,
+    account_setup_advisory_step: AppPerformanceOperationTelemetry,
     outbound_message_send: AppPerformanceOperationTelemetry,
     group_invite_members: AppPerformanceOperationTelemetry,
     group_invite_key_package_lookup: AppPerformanceOperationTelemetry,
@@ -211,6 +214,9 @@ impl AppPerformanceTelemetry {
                 inner.account_catch_up.record(duration, success);
             }
             AppPerformanceOperation::AccountSync => inner.account_sync.record(duration, success),
+            AppPerformanceOperation::AccountSetupAdvisoryStep => {
+                inner.account_setup_advisory_step.record(duration, success)
+            }
             AppPerformanceOperation::OutboundMessageSend => {
                 inner.outbound_message_send.record(duration, success);
             }
@@ -272,6 +278,7 @@ impl AppPerformanceTelemetry {
             account_open: inner.account_open.snapshot(),
             account_catch_up: inner.account_catch_up.snapshot(),
             account_sync: inner.account_sync.snapshot(),
+            account_setup_advisory_step: inner.account_setup_advisory_step.snapshot(),
             outbound_message_send: inner.outbound_message_send.snapshot(),
             group_invite_members: inner.group_invite_members.snapshot(),
             group_invite_key_package_lookup: inner.group_invite_key_package_lookup.snapshot(),
@@ -288,6 +295,45 @@ impl AppPerformanceTelemetry {
             group_mls_state_read: inner.group_mls_state_read.snapshot(),
             media_upload: inner.media_upload.snapshot(),
             media_download: inner.media_download.snapshot(),
+        }
+    }
+}
+
+/// Run a best-effort account-setup step under a hard time cap. A capped step
+/// behaves exactly like its error path — the caller proceeds without it — and
+/// the cap firing is traced and recorded as a failed
+/// [`AppPerformanceOperation::AccountSetupAdvisoryStep`] sample, so the cap
+/// value can be validated against the fleet rather than the one device it was
+/// tuned on.
+pub(crate) async fn bounded_advisory_step<F: std::future::Future>(
+    telemetry: &AppPerformanceTelemetry,
+    cap: Duration,
+    step: &'static str,
+    future: F,
+) -> Option<F::Output> {
+    let started = Instant::now();
+    match tokio::time::timeout(cap, future).await {
+        Ok(value) => {
+            telemetry.record(
+                AppPerformanceOperation::AccountSetupAdvisoryStep,
+                started.elapsed(),
+                true,
+            );
+            Some(value)
+        }
+        Err(_) => {
+            tracing::debug!(
+                target: "marmot_app::app_telemetry",
+                step,
+                cap_ms = cap.as_millis() as u64,
+                "advisory account-setup step hit its time cap"
+            );
+            telemetry.record(
+                AppPerformanceOperation::AccountSetupAdvisoryStep,
+                started.elapsed(),
+                false,
+            );
+            None
         }
     }
 }
@@ -334,5 +380,35 @@ mod tests {
                 .any(|bucket| bucket.upper_bound_ms == 50 && bucket.count == 1)
         );
         assert_eq!(snapshot.app_start.duration_ms.overflow_count, 1);
+    }
+
+    #[tokio::test]
+    async fn bounded_advisory_step_returns_the_value_and_records_success() {
+        let telemetry = AppPerformanceTelemetry::default();
+        let value =
+            bounded_advisory_step(&telemetry, Duration::from_secs(5), "test_step", async { 7 })
+                .await;
+        assert_eq!(value, Some(7));
+        let snapshot = telemetry.snapshot();
+        assert_eq!(snapshot.account_setup_advisory_step.attempts, 1);
+        assert_eq!(snapshot.account_setup_advisory_step.successes, 1);
+        assert_eq!(snapshot.account_setup_advisory_step.failures, 0);
+    }
+
+    #[tokio::test]
+    async fn bounded_advisory_step_caps_a_stalled_future_and_records_the_cap() {
+        let telemetry = AppPerformanceTelemetry::default();
+        let value: Option<()> = bounded_advisory_step(
+            &telemetry,
+            Duration::from_millis(50),
+            "test_step",
+            std::future::pending(),
+        )
+        .await;
+        assert_eq!(value, None);
+        let snapshot = telemetry.snapshot();
+        assert_eq!(snapshot.account_setup_advisory_step.attempts, 1);
+        assert_eq!(snapshot.account_setup_advisory_step.successes, 0);
+        assert_eq!(snapshot.account_setup_advisory_step.failures, 1);
     }
 }

--- a/crates/marmot-app/src/app_telemetry.rs
+++ b/crates/marmot-app/src/app_telemetry.rs
@@ -324,6 +324,7 @@ pub(crate) async fn bounded_advisory_step<F: std::future::Future>(
         Err(_) => {
             tracing::debug!(
                 target: "marmot_app::app_telemetry",
+                method = "bounded_advisory_step",
                 step,
                 cap_ms = cap.as_millis() as u64,
                 "advisory account-setup step hit its time cap"

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -207,6 +207,9 @@ const KEY_PACKAGE_DIR: &str = "key-packages";
 const SDK_FIRST_SYNC_WAIT: Duration = Duration::from_millis(750);
 const SDK_DRAIN_WAIT: Duration = Duration::from_millis(250);
 const APP_RUNTIME_ACCOUNT_READY_WAIT: Duration = Duration::from_secs(45);
+/// Cap for advisory account-setup steps (directory discovery/refresh): their
+/// results are best-effort, so a slow indexer must not stall login.
+pub(crate) const ACCOUNT_SETUP_ADVISORY_WAIT: Duration = Duration::from_secs(10);
 const APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT: Duration = Duration::from_secs(5);
 const APP_RUNTIME_RELAY_REBUILD_LOOKBACK: Duration = Duration::from_secs(120);
 /// Maximum amount the persisted transport cursor may run ahead of local

--- a/crates/marmot-app/src/relay_telemetry_export.rs
+++ b/crates/marmot-app/src/relay_telemetry_export.rs
@@ -139,6 +139,14 @@ pub mod metric_names {
     pub const APP_ACCOUNT_SYNC_SUCCESSES: &str = "app_account_sync_successes";
     /// Failed per-account syncs.
     pub const APP_ACCOUNT_SYNC_FAILURES: &str = "app_account_sync_failures";
+    pub const APP_ACCOUNT_SETUP_ADVISORY_STEP_DURATION: &str =
+        "app_account_setup_advisory_step_duration_ms";
+    pub const APP_ACCOUNT_SETUP_ADVISORY_STEP_ATTEMPTS: &str =
+        "app_account_setup_advisory_step_attempts";
+    pub const APP_ACCOUNT_SETUP_ADVISORY_STEP_SUCCESSES: &str =
+        "app_account_setup_advisory_step_successes";
+    pub const APP_ACCOUNT_SETUP_ADVISORY_STEP_FAILURES: &str =
+        "app_account_setup_advisory_step_failures";
     /// One-sided outbound message send duration histogram.
     pub const APP_OUTBOUND_MESSAGE_SEND_DURATION: &str = "app_outbound_message_send_duration_ms";
     /// One-sided outbound message send attempts.
@@ -586,6 +594,14 @@ fn append_app_performance_points(
         metric_names::APP_ACCOUNT_SYNC_ATTEMPTS,
         metric_names::APP_ACCOUNT_SYNC_SUCCESSES,
         metric_names::APP_ACCOUNT_SYNC_FAILURES,
+    );
+    append_app_operation_points(
+        points,
+        &app_performance.account_setup_advisory_step,
+        metric_names::APP_ACCOUNT_SETUP_ADVISORY_STEP_DURATION,
+        metric_names::APP_ACCOUNT_SETUP_ADVISORY_STEP_ATTEMPTS,
+        metric_names::APP_ACCOUNT_SETUP_ADVISORY_STEP_SUCCESSES,
+        metric_names::APP_ACCOUNT_SETUP_ADVISORY_STEP_FAILURES,
     );
     append_app_operation_points(
         points,

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -18,7 +18,9 @@ use tokio::task::{JoinHandle, JoinSet};
 use tokio::time::timeout;
 
 use crate::agent_streams::AgentStreamWatchManager;
-use crate::app_telemetry::{AppPerformanceOperation, AppPerformanceTelemetry};
+use crate::app_telemetry::{
+    AppPerformanceOperation, AppPerformanceTelemetry, bounded_advisory_step,
+};
 use crate::directory::{DirectorySyncHandle, DirectorySyncRunSummary};
 use crate::ids::normalize_group_id_hex_app;
 use crate::messages::AppMessageIntent;
@@ -2958,12 +2960,18 @@ impl AccountManager {
             // the app's own messaging relays, where its outbox metadata does not
             // live. Runs before the relay-list setup below so discovery never
             // clobbers, or is clobbered by, the publish-missing-relay-lists step.
-            let _ = self
-                .preflight_existing_account_directory(
+            // Advisory: bounded so a stalled indexer cannot hang import or
+            // reactivation, exactly like the external-signer login path.
+            let _ = bounded_advisory_step(
+                &self.shared.app_performance_telemetry(),
+                ACCOUNT_SETUP_ADVISORY_WAIT,
+                "import_directory_preflight",
+                self.preflight_existing_account_directory(
                     &account.account_id_hex,
                     directory_discovery_relays_for_setup(&request),
-                )
-                .await;
+                ),
+            )
+            .await;
         }
 
         let relay_lists = match self
@@ -3091,8 +3099,10 @@ impl AccountManager {
         // discovery keeps its anti-clobber ordering.
         // Discovery is advisory (its error path already proceeds without it),
         // so a stalled indexer must not hold the whole login hostage.
-        let _ = timeout(
+        let _ = bounded_advisory_step(
+            &self.shared.app_performance_telemetry(),
             ACCOUNT_SETUP_ADVISORY_WAIT,
+            "login_directory_preflight",
             self.preflight_existing_account_directory(
                 &account.account_id_hex,
                 directory_discovery_relays_for_setup(&request),
@@ -3132,8 +3142,10 @@ impl AccountManager {
         };
 
         // Advisory refresh, same bound as the preflight above.
-        let _ = timeout(
+        let _ = bounded_advisory_step(
+            &self.shared.app_performance_telemetry(),
             ACCOUNT_SETUP_ADVISORY_WAIT,
+            "login_directory_refresh",
             self.app.refresh_user_directory_for_account_id(
                 &account.account_id_hex,
                 directory_bootstrap_relays,

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -24,7 +24,7 @@ use crate::ids::normalize_group_id_hex_app;
 use crate::messages::AppMessageIntent;
 use crate::notifications;
 use crate::{
-    APP_RUNTIME_ACCOUNT_READY_WAIT, APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT,
+    ACCOUNT_SETUP_ADVISORY_WAIT, APP_RUNTIME_ACCOUNT_READY_WAIT, APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT,
     APP_RUNTIME_RELAY_REBUILD_LOOKBACK, AccountKeyPackageRecord, AccountRelayListBootstrap,
     AccountRelayListStatus, AccountUnread, AgentOperationEventRequest,
     AgentTextStreamFinishRequest, AppBlobEndpoint, AppError, AppGroupMemberRecord,
@@ -3089,12 +3089,16 @@ impl AccountManager {
         // its profile from public indexers (its outbox metadata does not live on
         // the app's messaging relays). Runs before the relay-list setup so
         // discovery keeps its anti-clobber ordering.
-        let _ = self
-            .preflight_existing_account_directory(
+        // Discovery is advisory (its error path already proceeds without it),
+        // so a stalled indexer must not hold the whole login hostage.
+        let _ = timeout(
+            ACCOUNT_SETUP_ADVISORY_WAIT,
+            self.preflight_existing_account_directory(
                 &account.account_id_hex,
                 directory_discovery_relays_for_setup(&request),
-            )
-            .await;
+            ),
+        )
+        .await;
 
         let relay_lists = match self
             .setup_relay_lists_for_account(&account, &request, true, false)
@@ -3127,13 +3131,15 @@ impl AccountManager {
             None
         };
 
-        let _ = self
-            .app
-            .refresh_user_directory_for_account_id(
+        // Advisory refresh, same bound as the preflight above.
+        let _ = timeout(
+            ACCOUNT_SETUP_ADVISORY_WAIT,
+            self.app.refresh_user_directory_for_account_id(
                 &account.account_id_hex,
                 directory_bootstrap_relays,
-            )
-            .await;
+            ),
+        )
+        .await;
         if account.signed_out {
             account = self
                 .app

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -3026,13 +3026,18 @@ impl AccountManager {
         };
 
         self.shared.lifecycle().ensure_running()?;
-        let _ = self
-            .app
-            .refresh_user_directory_for_account_id(
+        // Advisory refresh, bounded like the matching step in
+        // login_external_signer.
+        let _ = bounded_advisory_step(
+            &self.shared.app_performance_telemetry(),
+            ACCOUNT_SETUP_ADVISORY_WAIT,
+            "import_directory_refresh",
+            self.app.refresh_user_directory_for_account_id(
                 &account.account_id_hex,
                 directory_bootstrap_relays.clone(),
-            )
-            .await;
+            ),
+        )
+        .await;
         if account.signed_out {
             account = self
                 .app

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -463,6 +463,42 @@ fn sqlite_file_requires_key_for_test(path: &Path) -> bool {
 }
 
 #[tokio::test]
+async fn import_with_stalled_discovery_endpoint_completes_within_the_advisory_cap() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+
+    // A discovery endpoint that accepts TCP and then never speaks: the
+    // advisory directory preflight against it can only end via its time cap.
+    let stall = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let stall_url = format!("ws://{}", stall.local_addr().unwrap());
+    tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Ok((socket, _)) = stall.accept().await {
+            held.push(socket);
+        }
+    });
+
+    use nostr::prelude::ToBech32;
+    let secret = nostr::Keys::generate().secret_key().to_bech32().unwrap();
+    let imported = timeout(
+        Duration::from_secs(40),
+        runtime.create_or_import_account(AccountSetupRequest {
+            identity: Some(secret),
+            default_relays: vec![endpoint(&url)],
+            bootstrap_relays: vec![endpoint(&url)],
+            discovery_relays: vec![endpoint(&stall_url)],
+            publish_missing_relay_lists: true,
+            publish_initial_key_package: true,
+        }),
+    )
+    .await
+    .expect("import must not hang on a stalled discovery endpoint")
+    .expect("import should succeed without the advisory preflight");
+    assert!(imported.account.local_signing);
+}
+
+#[tokio::test]
 async fn app_runtime_create_identity_bootstraps_managed_account_and_key_package() {
     let dir = tempfile::tempdir().unwrap();
     let (_relay, app, url) = mock_app(&dir).await;

--- a/crates/marmot-uniffi/kotlin-bindings.sh
+++ b/crates/marmot-uniffi/kotlin-bindings.sh
@@ -192,7 +192,7 @@ echo "==> Building host dylib (used for binding generation)"
 # reads the uniffi metadata through it, and with RUSTFLAGS="-C strip=symbols"
 # (release.sh sets it for the Android .so's) bindgen exits 0 while emitting
 # NOTHING. Strip only the Android target builds below, never this one.
-RUSTFLAGS="" cargo build --release -p "$CRATE_NAME" "${FEATURE_ARGS[@]}"
+RUSTFLAGS="" cargo build --release -p "$CRATE_NAME" ${FEATURE_ARGS[@]+"${FEATURE_ARGS[@]}"}
 
 echo "==> Generating Kotlin bindings"
 RUSTFLAGS="" cargo run --release -p "$CRATE_NAME" --features "$BINDGEN_FEATURES" --bin uniffi-bindgen -- \
@@ -218,7 +218,7 @@ for abi in $ANDROID_ABIS; do
   target="$(abi_to_target "$abi")"
   echo "==> Building Android target $target ($abi)"
   configure_android_toolchain "$NDK_DIR" "$HOST_TAG" "$target"
-  cargo build --release -p "$CRATE_NAME" --target "$target" "${FEATURE_ARGS[@]}"
+  cargo build --release -p "$CRATE_NAME" --target "$target" ${FEATURE_ARGS[@]+"${FEATURE_ARGS[@]}"}
   mkdir -p "$JNI_OUT_DIR/$abi"
   cp "$TARGET_DIR/$target/release/lib${LIB_BASENAME}.so" "$JNI_OUT_DIR/$abi/"
 done

--- a/crates/marmot-uniffi/xcframework.sh
+++ b/crates/marmot-uniffi/xcframework.sh
@@ -54,13 +54,13 @@ rm -rf "$BUILD_DIR" "$OUT_DIR/$FRAMEWORK_NAME.xcframework" "$OUT_DIR/$FRAMEWORK_
 mkdir -p "$BUILD_DIR/headers" "$OUT_DIR"
 
 echo "==> Building host dylib (used for binding generation)"
-cargo build --release -p "$CRATE_NAME" "${FEATURE_ARGS[@]}"
+cargo build --release -p "$CRATE_NAME" ${FEATURE_ARGS[@]+"${FEATURE_ARGS[@]}"}
 
 echo "==> Building iOS device target (aarch64-apple-ios)"
-cargo build --release -p "$CRATE_NAME" --target aarch64-apple-ios "${FEATURE_ARGS[@]}"
+cargo build --release -p "$CRATE_NAME" --target aarch64-apple-ios ${FEATURE_ARGS[@]+"${FEATURE_ARGS[@]}"}
 
 echo "==> Building iOS simulator target (aarch64-apple-ios-sim)"
-cargo build --release -p "$CRATE_NAME" --target aarch64-apple-ios-sim "${FEATURE_ARGS[@]}"
+cargo build --release -p "$CRATE_NAME" --target aarch64-apple-ios-sim ${FEATURE_ARGS[@]+"${FEATURE_ARGS[@]}"}
 
 echo "==> Generating Swift bindings"
 cargo run --release -p "$CRATE_NAME" --features "$BINDGEN_FEATURES" --bin uniffi-bindgen -- \


### PR DESCRIPTION
`login_external_signer` awaits two advisory steps inline — the existing-account directory preflight and the post-setup directory refresh. Both already proceed on error (their results are best-effort), but neither was bounded in time, so a stalled indexer could hold the whole login hostage.

This caps each at a 10s `ACCOUNT_SETUP_ADVISORY_WAIT`. Measured on an Android device via step instrumentation: cold-cache preflight ran 7.7s (comfortably inside the cap), warm-cache 1.6s; total external-signer login 5-11s. The anti-clobber ordering (preflight completes before relay-list setup) is preserved — a timeout behaves exactly like the existing error path.

Also fixes the Kotlin bindings script under macOS's default bash 3.2, where expanding an empty `FEATURE_ARGS` array with `set -u` aborts the build.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/793">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login and account import now avoid long stalls by bounding directory discovery/refresh with an advisory time limit, keeping sign-in and setup responsive even when indexing or discovery is slow.

* **Chores**
  * Improved UniFFI/Kotlin and xcframework build scripts to only pass feature flags when provided, avoiding unnecessary empty feature arguments during compilation.

* **Tests**
  * Added coverage to ensure stalled discovery endpoints still complete promptly within the advisory cap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->