### PR TITLE
Tolerate and auto-heal legacy account identity proofs in existing groups

### DIFF
--- a/crates/cgka-engine/src/account_identity_proof.rs
+++ b/crates/cgka-engine/src/account_identity_proof.rs
@@ -37,6 +37,11 @@ pub const ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE: u16 = 0xF2F1;
 pub const ACCOUNT_IDENTITY_PROOF_EVENT_KIND: u16 = 450;
 
 const ACCOUNT_IDENTITY_PROOF_VERSION: u8 = 2;
+/// Proof format shipped before the kind:450 event-signing rework. Member
+/// leaves created under it still exist in long-lived groups; only leaves that
+/// carry exactly this version are eligible for legacy tolerance, and only on
+/// surfaces that re-open a group this client is already a member of.
+pub(crate) const LEGACY_ACCOUNT_IDENTITY_PROOF_VERSION: u8 = 1;
 const ACCOUNT_IDENTITY_PROOF_DOMAIN: &str = "marmot.account-identity-proof.v2";
 const SCHNORR_SIGNATURE_LEN: usize = 64;
 
@@ -300,6 +305,49 @@ fn encode_proof(proof: &AccountIdentityProof) -> Vec<u8> {
     out
 }
 
+/// Version byte of a leaf's identity-proof extension, if one is present.
+pub(crate) fn leaf_account_identity_proof_version(leaf: &LeafNode) -> Option<u8> {
+    leaf.extensions()
+        .unknown(ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE)
+        .and_then(|raw| raw.0.first().copied())
+}
+
+/// Committer leaf parameters that replace a stale identity proof with the
+/// engine's current one. `None` when the own leaf already carries the current
+/// version, or has no proof extension at all (that is a validation failure on
+/// other surfaces, not a refresh case). A commit re-signs the committer's
+/// leaf anyway, so riding the next commit heals the leaf without an extra
+/// epoch, and the MLS signature key is unchanged so the cached proof stays
+/// valid.
+pub(crate) fn own_leaf_refresh_parameters(
+    mls_group: &MlsGroup,
+    current_proof_extension: &Extension,
+) -> Option<openmls::treesync::LeafNodeParameters> {
+    let leaf = mls_group.own_leaf_node()?;
+    let version = leaf_account_identity_proof_version(leaf)?;
+    if version == ACCOUNT_IDENTITY_PROOF_VERSION {
+        return None;
+    }
+    let mut extensions: Vec<Extension> = leaf
+        .extensions()
+        .iter()
+        .filter(|ext| {
+            !matches!(
+                ext,
+                Extension::Unknown(ext_type, _) if *ext_type == ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE
+            )
+        })
+        .cloned()
+        .collect();
+    extensions.push(current_proof_extension.clone());
+    let extensions = openmls::extensions::Extensions::from_vec(extensions).ok()?;
+    Some(
+        openmls::treesync::LeafNodeParameters::builder()
+            .with_extensions(extensions)
+            .build(),
+    )
+}
+
 fn decode_proof(bytes: &[u8]) -> Result<AccountIdentityProof, EngineError> {
     let mut cursor = bytes;
     let version = read_u8(&mut cursor, "version")?;
@@ -394,6 +442,31 @@ mod tests {
                     ACCOUNT_IDENTITY_PROOF_VERSION.to_string(),
                 ]
         }));
+    }
+
+    #[test]
+    fn encoded_proofs_carry_the_current_version_and_reject_the_legacy_one() {
+        let keys = nostr::Keys::generate();
+        let req = request(&keys, b"leaf-key-a");
+        let signed = req.proof_event().unwrap().sign_with_keys(&keys).unwrap();
+        let signature = req.signature_from_signed_event(signed).unwrap();
+        let proof = AccountIdentityProof {
+            request: req,
+            signature,
+        };
+
+        let mut bytes = encode_proof(&proof);
+        assert_eq!(bytes[0], ACCOUNT_IDENTITY_PROOF_VERSION);
+        assert!(decode_proof(&bytes).is_ok());
+
+        // A legacy proof must fail decoding with the version error the
+        // tolerance surfaces key on — not a generic parse failure.
+        bytes[0] = LEGACY_ACCOUNT_IDENTITY_PROOF_VERSION;
+        let err = decode_proof(&bytes).unwrap_err().to_string();
+        assert!(
+            err.contains("unsupported proof version 1"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/cgka-engine/src/capability_manager.rs
+++ b/crates/cgka-engine/src/capability_manager.rs
@@ -53,7 +53,22 @@ pub(crate) fn cache_self_capabilities<S: StorageProvider>(
     ciphersuite: Ciphersuite,
 ) -> Result<(), EngineError> {
     if let Some(leaf) = mls_group.own_leaf_node() {
-        crate::account_identity_proof::validate_leaf_account_identity_proof(leaf, ciphersuite)?;
+        // A legacy-version proof on our OWN leaf is tolerated: the retired
+        // format cannot be re-validated by current code, the account trusts
+        // itself, and the next commit this member produces replaces the leaf
+        // with a current proof (own_leaf_refresh_parameters). Every other
+        // member's proof stays strictly validated.
+        if crate::account_identity_proof::leaf_account_identity_proof_version(leaf)
+            == Some(crate::account_identity_proof::LEGACY_ACCOUNT_IDENTITY_PROOF_VERSION)
+        {
+            tracing::warn!(
+                target: "cgka_engine::capability_manager",
+                method = "cache_self_capabilities",
+                "own leaf carries a legacy account identity proof; tolerating until a commit refreshes it"
+            );
+        } else {
+            crate::account_identity_proof::validate_leaf_account_identity_proof(leaf, ciphersuite)?;
+        }
         let caps = capabilities_of_leaf(leaf);
         let bc = BasicCredential::try_from(leaf.credential().clone())
             .map_err(|e| EngineError::Backend(format!("credential: {e:?}")))?;

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -784,9 +784,10 @@ impl<S: StorageProvider> Engine<S> {
             _ => false,
         };
         if !already_validated {
-            crate::group_lifecycle::validate_member_credentials_and_account_proofs(
+            crate::group_lifecycle::validate_member_credentials_and_account_proofs_with_policy(
                 &mls_group,
                 self.ciphersuite,
+                true,
             )
             .map_err(|_| GroupHydrationQuarantineReason::MemberValidationFailed)?;
             // Validation passed for this tree state; persist the marker so the

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -887,6 +887,20 @@ pub(crate) fn validate_member_credentials_and_account_proofs(
     group: &MlsGroup,
     ciphersuite: Ciphersuite,
 ) -> Result<(), EngineError> {
+    validate_member_credentials_and_account_proofs_with_policy(group, ciphersuite, false)
+}
+
+/// `tolerate_legacy_proofs` applies ONLY to re-opening a group this client is
+/// already a member of: leaves whose proof carries exactly the legacy version
+/// were validated under the rules in force when they joined, and group
+/// membership continuity is enforced by MLS itself. Join ingress (Welcome)
+/// keeps the strict form — no new trust is extended to a proof the current
+/// code cannot verify. Every other proof defect still fails validation.
+pub(crate) fn validate_member_credentials_and_account_proofs_with_policy(
+    group: &MlsGroup,
+    ciphersuite: Ciphersuite,
+    tolerate_legacy_proofs: bool,
+) -> Result<(), EngineError> {
     validate_member_credentials(group)?;
     let tree = group.export_ratchet_tree();
     let value = serde_json::to_value(tree)
@@ -895,6 +909,17 @@ pub(crate) fn validate_member_credentials_and_account_proofs(
         .map_err(|e| EngineError::Backend(format!("decode exported ratchet tree: {e}")))?;
     for node in nodes {
         if let Some(Node::LeafNode(leaf)) = node {
+            if tolerate_legacy_proofs
+                && crate::account_identity_proof::leaf_account_identity_proof_version(&leaf)
+                    == Some(crate::account_identity_proof::LEGACY_ACCOUNT_IDENTITY_PROOF_VERSION)
+            {
+                tracing::warn!(
+                    target: "cgka_engine::group_lifecycle",
+                    method = "validate_member_credentials_and_account_proofs_with_policy",
+                    "tolerating a member leaf with a legacy account identity proof on group re-open"
+                );
+                continue;
+            }
             crate::account_identity_proof::validate_leaf_account_identity_proof(
                 &leaf,
                 ciphersuite,

--- a/crates/cgka-engine/src/update_group_data.rs
+++ b/crates/cgka-engine/src/update_group_data.rs
@@ -367,8 +367,15 @@ impl<S: StorageProvider> Engine<S> {
                 )?;
             }
         }
-        let mut builder = mls_group
-            .commit_builder()
+        let leaf_refresh = crate::account_identity_proof::own_leaf_refresh_parameters(
+            mls_group,
+            &self.identity.account_identity_proof_extension,
+        );
+        let mut commit_builder = mls_group.commit_builder();
+        if let Some(leaf_refresh) = leaf_refresh {
+            commit_builder = commit_builder.leaf_node_parameters(leaf_refresh);
+        }
+        let mut builder = commit_builder
             .propose_removals(removals)
             .add_proposals(proposals)
             .load_psks(

--- a/crates/cgka-engine/src/upgrade.rs
+++ b/crates/cgka-engine/src/upgrade.rs
@@ -167,7 +167,14 @@ impl<S: StorageProvider> Engine<S> {
         // do NOT call `merge_pending_commit` here — the merge + Marmot
         // record's required capability update both defer to
         // `do_confirm_published` (which reads the post-merge group state).
+        let leaf_refresh = crate::account_identity_proof::own_leaf_refresh_parameters(
+            &mls_group,
+            &self.identity.account_identity_proof_extension,
+        );
         let mut commit_builder = mls_group.commit_builder();
+        if let Some(leaf_refresh) = leaf_refresh {
+            commit_builder = commit_builder.leaf_node_parameters(leaf_refresh);
+        }
         if let Some(new_extensions) = new_extensions {
             commit_builder = commit_builder
                 .propose_group_context_extensions(new_extensions)


### PR DESCRIPTION
Field report: any capability mutation (e.g. removing an admin) in a group created before 0.9.3 fails with `invalid account identity proof: unsupported proof version 1`. The external-signer rework (#755) bumped the proof format to v2 (kind:450 event signing) and dropped v1 parsing entirely, but shipped no migration: every leaf minted before the bump still carries v1, and the first fresh validation rejects it.

There is also a second, latent failure behind the reported one: the whole-tree validation on group open is skipped only while the stored `validated_tree_marker` matches. The first post-upgrade commit in an old group changes the tree, invalidates the marker, and the strict re-validation would then quarantine the whole group on next open because of the *other* members' v1 leaves.

## What this does

- **Auto-heal on commit.** Both commit-builder paths (group-data updates and capability upgrades) now attach the engine's cached v2 proof extension to the committer's replacement leaf whenever the current leaf's proof version is stale (`own_leaf_refresh_parameters`). A commit re-signs the committer's leaf anyway and the MLS signature key is unchanged, so this costs no extra signing round-trip and no extra epoch. The mutation that used to fail becomes the commit that fixes the leaf.
- **Tolerance, narrowly scoped to already-established membership.**
  - Own leaf: `cache_self_capabilities` tolerates exactly the legacy version (warn-logged) — the account trusts itself and the next commit replaces the leaf.
  - Re-opening a group this client is already in: tree validation tolerates leaves carrying exactly the legacy version (warn-logged per leaf). These members were validated under the rules in force when they joined, and membership continuity is enforced by MLS itself. This defuses the quarantine time bomb above.
  - **Welcome-join stays fully strict**: no new trust is extended to a proof current code cannot verify. Joining an old group therefore still requires its stale members to have healed (each heals on their first commit).
- Every other proof defect — missing extension, unknown versions, bad signature, mismatched keys — fails validation exactly as before.

## Testing

Unit tests pin the version invariants (v2 written, v1 rejected with the exact error the field report showed). The full engine suite, clippy, and the tracing audit are green. Declared gap: the legacy-leaf paths themselves are not integration-tested — producing a v1 leaf requires the retired v1 signer. If fixture vectors of pre-0.9.3 groups exist (or are worth capturing), a follow-up could load one through hydration and the heal path; happy to do that if pointed at a vector source.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/803">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older identity-proof data so existing groups can still be opened and validated when legacy proofs are present.
  * Updated group updates and upgrades to refresh identity-proof details automatically during commits, helping keep member state consistent.
  * Added clearer handling for unsupported proof versions, including a warning path for legacy records.

* **Tests**
  * Added coverage for proof version encoding and rejection of unsupported legacy payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->