### PR TITLE
Feat/incident replay ndjson liveness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ reviews/
 
 # Local Docker relay state.
 dev/data/
+
+# Project specific optional env-vars
+.env

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -1,9 +1,11 @@
 # AGENTS.md — incident-replay
 
-Goggles `agent-state.json` forensic export → CGKA conformance-vector adapter. The
-pipeline is **parse → classify → recover → synthesize → accept**: a fork-recovery
-or convergence incident becomes a vector only if the simulator reproduces the
-recorded outcome (fail-closed).
+Goggles forensic export → CGKA conformance-vector adapter. Two wire formats are
+read — the `agent-state.json` document and the streamed NDJSON group export
+(`goggles-group-export/v1`) — into one model. The pipeline is **parse →
+classify → recover → synthesize → accept**: a fork-recovery or convergence
+incident becomes a vector only if the simulator reproduces the recorded outcome
+(fail-closed).
 
 ## Pieces
 
@@ -13,10 +15,21 @@ recorded outcome (fail-closed).
     the export growing new fields. Deliberately decoupled from `marmot-forensics`:
     it tracks the stable `marmot-forensics-audit/v2` wire shape Goggles
     serialises, not the engine's internal `AuditEventKind` enum.
+- **Module:** `src/ndjson.rs`
+  - **Role:** `parse_stream` — the second parser: the streaming NDJSON group
+    export into the same `AgentStateExport`. Enforces the stream's completeness
+    contract fail-closed at parse time (leading `manifest`, terminal `eof` with
+    `complete: true`, per-section counts matching what arrived, and no in-band
+    `error` line — the server's only failure surface once the HTTP status is
+    committed), which replaces the `has_more` truncation signal of the document
+    shape. `is_stream` detects the format from the contract's manifest-first
+    rule, so the CLI needs no format flag.
 - **Module:** `src/classify.rs`
   - **Role:** The `classify` gate → `Verdict`: `Healthy | ForkRecovery |
     ConvergenceSelected | Quarantine { reason }`. Everything downstream is gated
-    behind this, so a healthy export yields zero vectors and a clean exit.
+    behind this, so a healthy export yields zero vectors and a clean exit. Also
+    home of the liveness gate (rule 5 below), which keeps a silently split
+    group from reading as healthy.
 - **Module:** `src/fork.rs`
   - **Role:** `recover_fork` turns a fork-recovery export into a `RecoveredFork`
     (source epoch, commit kind, and the designated winner recovered tier-b from
@@ -68,14 +81,72 @@ Precedence, highest first:
    `missing_snapshot` (the winning snapshot was unavailable, so it can't be
    replayed) on the fork-recovery route.
 4. **`ForkRecovery`** — any other `fork_resolution`.
-5. **`Healthy`** — none of the above.
+5. **Quarantine `epoch_divergence`** — an engine trails the group's epoch
+   high-water mark by ≥ 2 epochs (one epoch is routine commit propagation).
+   The reason names every engine left behind with its epoch and a per-engine
+   mode: **`went_dark`** (its events end before — or within one hour of — the
+   group provably advancing past it: a dead device, stopped uploads, or a
+   member who left; telling a departure apart needs a member↔engine linkage
+   the export does not carry yet) or **`active_while_behind`** (it kept
+   recording events for over an hour after the group moved past it without
+   catching up: commits are not reaching it while its other traffic flows).
+   A real liveness incident, but not a branch contest, so there is nothing to
+   replay — the named engines are the triage starting point.
+6. **`Healthy`** — none of the above.
+
+Rule 5 ranks *below* the incident routes on purpose: a reproducible contest is
+worth replaying even when another engine's data is stale (recovery fail-closes
+downstream if the data it needs is missing). It fires only on positive
+evidence — no engine ids or timestamps means the gate stays unarmed — so
+synthetic fixtures and older exports classify as before. Lag is measured in
+epochs, not wall-clock silence: a device that is offline while nothing is
+committed misses nothing, and an idle group never reads as stale. The ≥ 2
+threshold is derived, not tuned — lag 1 is the propagation noise floor, so 2 is
+the smallest lag that cannot be a single in-flight commit; the backtest over the
+incident's hourly slices is the falsification check, not the calibration.
+Verified against both real exports on hand (2026-07-09): the reported incident
+(three engines dark at epochs 11–14 of 16, one active engine cut off from
+commits for hours) and a second real export (one engine eighteen hours behind
+the other's epoch 17) — **both previously classified `Healthy`**; the second
+export's earlier "healthy" label predates this gate and was a false negative.
+Both come from one cohort on a single day, so the healthy-side margins are
+demonstrated, not proven general.
+
+A single quarantine is a re-pull trigger, not a verdict: read it across pulls.
+Entries that vanish on the next pull were catch-up in flight — a pre-merge
+backtest (hourly slices of the 2026-07-09 incident export replayed through the
+CLI) measured the overnight batch-delivery shape (a device quiet through a
+burst of commits, then processing the backlog in one go) on half the engines,
+and every one labeled `went_dark` on the pull that caught it. Entries that
+persist across pulls are the signal.
+
+Gate designs evaluated against real exports and deliberately **rejected**:
+
+- *Member-count coverage* (`group_context.member_count` > exporting engines):
+  audit is opt-in, so healthy groups routinely have more members than engines
+  (a real six-member group exported from only two engines) — the gate would
+  quarantine them all, permanently, and its precedence masked the sharper
+  per-engine signals on the real incident.
+- *Wall-clock staleness* (engine silent > 24 h behind the export's latest
+  activity): a device that is merely offline while no commits land misses
+  nothing and converges on return; epoch-anchored lag subsumes the cases that
+  matter.
+- *Softer arming* (two variants, both refuted by the same backtest): arming only
+  on `active_while_behind` would have missed the incident's genuinely-stuck
+  device entirely — its uploads had stopped, so it read as dark in the export,
+  and absent a second, active stuck device there would have been nothing to fire
+  on. And grace-gating the arming (fire only once the group's evidence extends
+  past `moved_past + grace`) delays the first true detection by an hour on the
+  backtest while still firing on any device offline longer than the grace —
+  nearly all the noise, none of the earliness.
 
 ## Fixtures
 
-- `tests/fixtures/*.json` are **synthetic and non-sensitive** — the committed test
-  set. Real exports carry relay URLs / message ids and must never enter VCS.
+- `tests/fixtures/*.json` / `*.ndjson` are **synthetic and non-sensitive** — the
+  committed test set. Real exports carry relay URLs / message ids and must never
+  enter VCS.
 - Real exports are the manual pre-PR verification set:
-  `cargo run -p incident-replay -- <export.json>`.
+  `cargo run -p incident-replay -- <export.json | export.ndjson>`.
 
 ## Verification
 

--- a/crates/incident-replay/src/classify.rs
+++ b/crates/incident-replay/src/classify.rs
@@ -4,8 +4,52 @@
 //! this verdict, so a healthy export yields zero vectors and a clean exit rather
 //! than a crash. Built incrementally, one rule per behaviour.
 
+use std::collections::BTreeMap;
+use std::fmt;
+
 use crate::export::{AgentStateExport, EventKind};
 use serde::Serialize;
+
+/// How many epochs an engine may trail the group's epoch high-water mark
+/// before it counts as left behind. The value is derived, not tuned. Lag 1 is
+/// the noise floor: every commit leaves every other engine one epoch behind
+/// until it propagates, so a snapshot routinely catches healthy engines there —
+/// indistinguishable from a commit in flight, and so carrying no information.
+/// Lag 2 is the smallest lag that *cannot* be one in-flight commit: the engine
+/// missed a commit and the group then produced another it also missed (e.g. two
+/// members invited back-to-back), so the gap provably outlived an inter-commit
+/// interval. Being event-anchored rather than clock-anchored, it means the same
+/// in a chatty group and a weekly one — the property that disqualified
+/// wall-clock staleness. Any higher threshold is the arbitrary one: "one
+/// survived commit is fine but two are not" has no structural answer, whereas 2
+/// is just the noise floor plus one. A commit burst can still park healthy
+/// engines at lag 2 for its propagation window — the claim bounds transients,
+/// it does not erase them — so an entry here is fail-closed evidence to
+/// re-pull, not a verdict; persistence across pulls is the signal. A backtest
+/// over hourly slices of the 2026-07-09 incident export could have refuted 2 by
+/// firing through healthy windows; instead the neighbors failed exactly as the
+/// structure predicts — lag 1 on engines merely one behind during a routine
+/// multi-commit rollout, lag 3 losing half the incident (stuck devices exactly
+/// two behind the tip, including its only active-while-behind signal) — and 2
+/// held.
+const EPOCH_DIVERGENCE_MIN_LAG: u64 = 2;
+
+/// How long an engine may keep recording events after the group provably moved
+/// past its final epoch before its lag counts as *active while behind* rather
+/// than *went dark*. Unlike the lag threshold, this constant is empirical, not
+/// derived: an operational estimate — ordinary catch-up after a reconnect
+/// drains in seconds to minutes, plus a margin that absorbs cross-device clock
+/// skew. Its safety is nonetheless structural. The grace only chooses between
+/// the two hedged mode labels; it never decides whether the quarantine fires
+/// (arming needs only the lag and the timestamps that order it), so a wrong
+/// grace can yield neither a false healthy nor a false quarantine, only a
+/// mislabeled mode. And the estimate sat
+/// on a plateau, not a knife-edge: the same backtest measured the verdict
+/// insensitive across any grace in [15 min, ~6 h], and no engine that later
+/// caught up was ever labeled active-while-behind. The real incidents it was
+/// validated on stayed behind for six hours (a live device no longer receiving
+/// commits) and eighteen hours (the second real export on hand).
+const CATCH_UP_GRACE_MS: u64 = 60 * 60 * 1000;
 
 /// How the pipeline should route an export.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -23,7 +67,7 @@ pub enum Verdict {
 }
 
 /// Why an export was quarantined.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum QuarantineReason {
     /// A `derived_projections` section was capped server-side (`has_more`), so
@@ -31,6 +75,97 @@ pub enum QuarantineReason {
     TruncatedProjections,
     /// A fork resolution's winning snapshot was missing — unreproducible.
     MissingSnapshot,
+    /// Engines trail the group's epoch high-water mark by at least
+    /// [`EPOCH_DIVERGENCE_MIN_LAG`] epochs with no recorded contest explaining
+    /// it. Persistent across pulls this is a silent split; on any single pull an
+    /// entry can equally be catch-up in flight or an engine whose audit uploads
+    /// merely lagged (the incident exports carry a proven instance of each), so
+    /// the named engines are a re-pull target first and a triage starting point
+    /// second.
+    /// Either way it is not a branch contest, so there is nothing to replay as a
+    /// vector.
+    EpochDivergence {
+        /// The group's epoch high-water mark across all engines.
+        group_epoch: u64,
+        /// Every engine left behind it, in engine-id order.
+        engines: Vec<BehindEngine>,
+    },
+}
+
+impl fmt::Display for QuarantineReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            QuarantineReason::TruncatedProjections => {
+                f.write_str("a derived_projections section was truncated server-side (has_more)")
+            }
+            QuarantineReason::MissingSnapshot => {
+                f.write_str("a fork resolution's winning snapshot was missing")
+            }
+            QuarantineReason::EpochDivergence {
+                group_epoch,
+                engines,
+            } => {
+                write!(f, "engines behind the group tip (epoch {group_epoch}):")?;
+                for (index, engine) in engines.iter().enumerate() {
+                    let separator = if index == 0 { " " } else { ", " };
+                    write!(f, "{separator}{engine}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// One engine left behind the group's epoch high-water mark.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BehindEngine {
+    /// The engine that fell behind.
+    pub engine_id: String,
+    /// The highest epoch the engine's own events place it at.
+    pub epoch: u64,
+    /// How the engine was behaving once the group moved past it.
+    pub mode: BehindMode,
+}
+
+impl fmt::Display for BehindEngine {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} at epoch {} ({})",
+            self.engine_id, self.epoch, self.mode
+        )
+    }
+}
+
+/// How an engine that fell behind was behaving.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BehindMode {
+    /// The engine stopped recording events before — or within the catch-up
+    /// grace of — the group provably advancing past it: a dead device, an
+    /// uninstalled app, or stopped uploads. (An engine belonging to a member
+    /// who *left* the group looks identical; telling the two apart needs a
+    /// member-to-engine linkage the export does not carry yet.) A healthy engine
+    /// sitting at the tip whose audit uploads merely lag reads the same way —
+    /// the 2026-07-09 incident export carried a proven instance, uploads three
+    /// days behind a live tip — so within one export this mode is not a
+    /// diagnosis; only persistence across pulls tells a dark device from a live
+    /// one whose stream just ended early.
+    WentDark,
+    /// The engine kept recording events for longer than the catch-up grace
+    /// after the group provably advanced past its final epoch, without
+    /// catching up: commits are not reaching it even though its other traffic
+    /// flows.
+    ActiveWhileBehind,
+}
+
+impl fmt::Display for BehindMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            BehindMode::WentDark => "went dark",
+            BehindMode::ActiveWhileBehind => "active while behind",
+        })
+    }
 }
 
 /// Classify an export into its routing verdict.
@@ -66,5 +201,96 @@ pub fn classify(export: &AgentStateExport) -> Verdict {
     if kinds().any(EventKind::is_fork_resolution) {
         return Verdict::ForkRecovery;
     }
+    // No contested branch anywhere — the liveness gate now guards the healthy
+    // verdict. It ranks below the incident routes deliberately: a reproducible
+    // contest is worth replaying even when another engine's data is stale
+    // (recovery fail-closes downstream if the data it needs is missing). It
+    // exists because a stuck or dead device is only visible *across* engines:
+    // both real exports this gate was validated on previously classified
+    // healthy while genuinely split (2026-07-09 incident: three engines dark
+    // and one active engine cut off from commits; the second real export: one
+    // engine eighteen hours behind the other).
+    if let Some(reason) = epoch_divergence(export) {
+        return Verdict::Quarantine { reason };
+    }
     Verdict::Healthy
+}
+
+/// Per-engine activity, folded from the event log.
+#[derive(Default)]
+struct EngineActivity {
+    /// The engine's newest event timestamp, when its events carry one.
+    last_seen_ms: Option<u64>,
+    /// The highest epoch the engine reported itself at.
+    high_water_epoch: Option<u64>,
+}
+
+/// The gate that separates "no contested branch" from "healthy": engines left
+/// ≥ [`EPOCH_DIVERGENCE_MIN_LAG`] epochs behind the group's high-water mark.
+///
+/// It fires only on positive evidence — events without an `engine_id` or
+/// `wall_time_ms` leave it unarmed — so synthetic fixtures and older exports
+/// classify as before. Lag is measured in epochs, not wall-clock silence: a
+/// device that is merely offline while nothing is committed misses nothing and
+/// stays healthy, and an idle group never reads as stale. A device offline
+/// *while* commits land is the transient case: it reads as went-dark on that
+/// pull and self-resolves on the next — quarantined fail-closed by choice
+/// (measured on the incident-export backtest).
+fn epoch_divergence(export: &AgentStateExport) -> Option<QuarantineReason> {
+    let mut engines: BTreeMap<&str, EngineActivity> = BTreeMap::new();
+    // Per epoch, the earliest timed evidence of it from any engine: the moment
+    // after which staying behind that epoch stops being propagation delay.
+    let mut epoch_first_seen: BTreeMap<u64, u64> = BTreeMap::new();
+    for event in &export.events {
+        let Some(engine_id) = event.engine_id.as_deref() else {
+            continue;
+        };
+        let activity = engines.entry(engine_id).or_default();
+        activity.last_seen_ms = activity.last_seen_ms.max(event.wall_time_ms);
+        let observed = event.kind.observed_epoch();
+        activity.high_water_epoch = activity.high_water_epoch.max(observed);
+        if let (Some(epoch), Some(ms)) = (observed, event.wall_time_ms) {
+            epoch_first_seen
+                .entry(epoch)
+                .and_modify(|first| *first = (*first).min(ms))
+                .or_insert(ms);
+        }
+    }
+
+    let group_epoch = engines
+        .values()
+        .filter_map(|activity| activity.high_water_epoch)
+        .max()?;
+    let behind: Vec<BehindEngine> = engines
+        .iter()
+        .filter_map(|(engine_id, activity)| {
+            let epoch = activity.high_water_epoch?;
+            if group_epoch - epoch < EPOCH_DIVERGENCE_MIN_LAG {
+                return None;
+            }
+            // Both the engine's own liveness and the group's advance past it
+            // must be timestamped to order them; untimed evidence stays
+            // unarmed rather than guessing.
+            let last_seen = activity.last_seen_ms?;
+            let moved_past = epoch_first_seen
+                .range(epoch + 1..)
+                .map(|(_, first_seen)| *first_seen)
+                .min()?;
+            let mode = if last_seen > moved_past + CATCH_UP_GRACE_MS {
+                BehindMode::ActiveWhileBehind
+            } else {
+                BehindMode::WentDark
+            };
+            Some(BehindEngine {
+                engine_id: (*engine_id).to_owned(),
+                epoch,
+                mode,
+            })
+        })
+        .collect();
+
+    (!behind.is_empty()).then_some(QuarantineReason::EpochDivergence {
+        group_epoch,
+        engines: behind,
+    })
 }

--- a/crates/incident-replay/src/convergence.rs
+++ b/crates/incident-replay/src/convergence.rs
@@ -105,6 +105,7 @@ pub fn recover_convergence(
                 candidates,
                 rule_trace,
                 losing_branch_ids,
+                ..
             } if !losing_branch_ids.is_empty() || candidates.len() >= 2 => {
                 Some((selected_branch_id.as_deref(), candidates, rule_trace))
             }

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -37,12 +37,18 @@ pub struct Pagination {
     pub has_more: bool,
 }
 
-/// One forensic audit event. The classifier reads only `kind`; extraction also
-/// uses the event-level `account_ref` (the acting account).
+/// One forensic audit event. The classifier reads `kind` plus the envelope's
+/// `engine_id` and `wall_time_ms` (the liveness gates aggregate per-engine
+/// activity from them); extraction also uses the event-level `account_ref`
+/// (the acting account).
 #[derive(Debug, Clone, Deserialize)]
 pub struct AuditEvent {
     #[serde(default)]
     pub account_ref: Option<String>,
+    #[serde(default)]
+    pub engine_id: Option<String>,
+    #[serde(default)]
+    pub wall_time_ms: Option<u64>,
     pub kind: EventKind,
 }
 
@@ -87,6 +93,15 @@ pub enum EventKind {
         rule_trace: Vec<ConvergenceRule>,
         #[serde(default)]
         losing_branch_ids: Vec<String>,
+        /// The canonical tip the selector started from and the tip it adopted:
+        /// both are epochs the engine has locally materialized, so they feed
+        /// the epoch high-water mark. (Real case: an engine whose final acts
+        /// before going dark were convergence selections would otherwise read
+        /// older than it was.)
+        #[serde(default)]
+        current_tip_epoch: Option<u64>,
+        #[serde(default)]
+        selected_tip_epoch: Option<u64>,
     },
     /// A commit changed canonical group state (membership, admin set, profile).
     /// Extraction reads the actor and epoch to find the committers at the
@@ -109,8 +124,43 @@ pub enum EventKind {
         #[serde(default)]
         msg_id: Option<String>,
     },
+    /// The engine handled a message while at `epoch`. The densest per-engine
+    /// epoch signal in real exports; feeds the epoch high-water mark.
+    MessageStateChanged {
+        #[serde(default)]
+        epoch: Option<u64>,
+    },
+    /// The engine's epoch machine moved (commit confirmed, group hydrated, …).
+    EpochStateChanged {
+        #[serde(default)]
+        epoch: Option<u64>,
+    },
+    /// A snapshot of the group as the engine sees it; its epoch is the
+    /// engine's own current epoch.
+    GroupContext {
+        #[serde(default)]
+        context: GroupContextSnapshot,
+    },
+    /// A user-visible action; `epoch_changed` observations carry the epoch the
+    /// engine advanced to.
+    HumanAction {
+        #[serde(default)]
+        to_epoch: Option<u64>,
+    },
     #[serde(other)]
     Other,
+}
+
+/// The group snapshot inside a `group_context` event. Only the epoch is
+/// modelled: it is the engine's own view, so the liveness gate reads it. The
+/// snapshot's member count is deliberately *not* a gate input — audit is
+/// opt-in, so real groups routinely have more members than exporting engines
+/// (a real six-member group exported from only two engines) and a coverage gate
+/// would quarantine them all, permanently.
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+pub struct GroupContextSnapshot {
+    #[serde(default)]
+    pub epoch: Option<u64>,
 }
 
 /// One branch the convergence selector evaluated. Only the fields extraction
@@ -182,6 +232,26 @@ impl EventKind {
     /// Any fork resolution, regardless of winner.
     pub fn is_fork_resolution(&self) -> bool {
         matches!(self, EventKind::ForkResolution { .. })
+    }
+
+    /// The group epoch this event reports the engine itself to be at, if it
+    /// reports one. The liveness gates fold these into a per-engine epoch
+    /// high-water mark, so only kinds that reflect the engine's *own* state
+    /// contribute — kinds describing another engine's traffic do not.
+    pub fn observed_epoch(&self) -> Option<u64> {
+        match self {
+            EventKind::GroupStateChanged { epoch, .. }
+            | EventKind::MessageStateChanged { epoch }
+            | EventKind::EpochStateChanged { epoch } => *epoch,
+            EventKind::GroupContext { context } => context.epoch,
+            EventKind::HumanAction { to_epoch } => *to_epoch,
+            EventKind::ConvergenceDecision {
+                current_tip_epoch,
+                selected_tip_epoch,
+                ..
+            } => (*current_tip_epoch).max(*selected_tip_epoch),
+            _ => None,
+        }
     }
 }
 

--- a/crates/incident-replay/src/lib.rs
+++ b/crates/incident-replay/src/lib.rs
@@ -9,6 +9,10 @@
 //! - [`export`] — a lenient, self-owned model of the export (decoupled from the
 //!   engine's forensic types; it tracks the stable `marmot-forensics-audit/v2`
 //!   wire shape Goggles emits, not the Rust enum).
+//! - [`ndjson`] — [`ndjson::parse_stream`], the second parser: the Goggles
+//!   streaming NDJSON export (`goggles-group-export/v1`) into the same
+//!   [`export::AgentStateExport`], enforcing the stream's fail-closed
+//!   completeness contract (terminal `eof`, matching section counts).
 //! - [`classify`] — the [`classify::classify`] gate: `Healthy | ForkRecovery |
 //!   ConvergenceSelected | Quarantine`. Everything downstream is gated behind it.
 //! - [`fork`] — [`fork::recover_fork`] extracts a [`fork::RecoveredFork`] from a
@@ -27,13 +31,15 @@ pub mod classify;
 pub mod convergence;
 pub mod export;
 pub mod fork;
+pub mod ndjson;
 pub mod synth;
 
 pub use accept::{AcceptError, accept, accept_convergence};
-pub use classify::{QuarantineReason, Verdict, classify};
+pub use classify::{BehindEngine, BehindMode, QuarantineReason, Verdict, classify};
 pub use convergence::{
     ConvergenceDecisionKind, ConvergenceRecoveryError, RecoveredConvergence, recover_convergence,
 };
 pub use export::{AgentStateExport, ParseError, parse};
 pub use fork::{ForkCommitKind, ForkRecoveryError, RecoveredFork, recover_fork};
+pub use ndjson::{StreamParseError, is_stream, parse_stream};
 pub use synth::{synthesize, synthesize_convergence};

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -1,5 +1,9 @@
-//! `incident-replay` CLI: classify a Goggles `agent-state.json` export and, for a
-//! fork-recovery incident, synthesize and verify a conformance vector.
+//! `incident-replay` CLI: classify a Goggles export — either an
+//! `agent-state.json` document or a streamed NDJSON group export — and, for a
+//! fork-recovery or convergence incident, synthesize and verify a conformance
+//! vector. The format is recognised from the content: a stream leads with its
+//! `manifest` line (the `goggles-group-export/v1` contract), anything else is
+//! parsed as `agent-state.json`.
 //!
 //! Prints a human-readable outcome and exits 0 for any successful classification
 //! (healthy, quarantine, and accepted are all valid outcomes). Exits 2 on usage,
@@ -10,8 +14,8 @@ use std::process::ExitCode;
 
 use cgka_conformance_simulator::VectorFixture;
 use incident_replay::{
-    AgentStateExport, Verdict, accept, accept_convergence, classify, parse, recover_convergence,
-    recover_fork,
+    AgentStateExport, Verdict, accept, accept_convergence, classify, is_stream, parse,
+    parse_stream, recover_convergence, recover_fork,
 };
 
 /// Vector name for a fork-recovery incident (one incident per export today).
@@ -22,7 +26,7 @@ const CONVERGENCE_NAME: &str = "convergence-incident/v1";
 fn main() -> ExitCode {
     let mut args = std::env::args_os().skip(1);
     let Some(path) = args.next() else {
-        eprintln!("usage: incident-replay <agent-state.json> [out-dir]");
+        eprintln!("usage: incident-replay <agent-state.json | group-export.ndjson> [out-dir]");
         return ExitCode::from(2);
     };
     let out_dir = args.next().map(PathBuf::from);
@@ -34,11 +38,21 @@ fn main() -> ExitCode {
             return ExitCode::from(2);
         }
     };
-    let export = match parse(&json) {
-        Ok(export) => export,
-        Err(err) => {
-            eprintln!("error: {err}");
-            return ExitCode::from(2);
+    let export = if is_stream(&json) {
+        match parse_stream(&json) {
+            Ok(export) => export,
+            Err(err) => {
+                eprintln!("error: {err}");
+                return ExitCode::from(2);
+            }
+        }
+    } else {
+        match parse(&json) {
+            Ok(export) => export,
+            Err(err) => {
+                eprintln!("error: {err}");
+                return ExitCode::from(2);
+            }
         }
     };
 
@@ -49,10 +63,7 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         Verdict::ConvergenceSelected => run_convergence(&export, out_dir.as_deref()),
-        Verdict::Quarantine { reason } => {
-            println!("quarantine: {reason:?}");
-            ExitCode::SUCCESS
-        }
+        Verdict::Quarantine { reason } => quarantine(&reason),
     }
 }
 

--- a/crates/incident-replay/src/ndjson.rs
+++ b/crates/incident-replay/src/ndjson.rs
@@ -1,0 +1,189 @@
+//! Parser for the Goggles streaming NDJSON group export
+//! (`goggles-group-export/v1`).
+//!
+//! The stream is a sequence of JSON lines discriminated by a `t` field: a
+//! leading `manifest`, data sections (`event`, `source`, `delivery_artifact`,
+//! …), and a terminal `eof` that carries `complete` plus per-section counts.
+//! Completeness is enforced here, fail-closed: the parse succeeds only when the
+//! stream ends with `eof`, the server marked it `complete`, every section
+//! count matches what was actually received, and no in-band `error` line (the
+//! server's only failure surface once the HTTP status is committed) appeared.
+//! That replaces the `derived_projections.has_more` truncation signal of the
+//! `agent-state.json` shape — the stream is uncapped, so the parsed export
+//! carries empty projections and the classifier's truncation gate is vacuously
+//! satisfied.
+//!
+//! Like [`crate::export`], the line model is lenient to growth: unknown `t`
+//! sections and unknown fields are tolerated (they still participate in the
+//! count check), so the parser survives Goggles adding data without a schema
+//! bump.
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+use crate::export::{AgentStateExport, AuditEvent};
+
+/// The `t` discriminator of the leading manifest line.
+const MANIFEST: &str = "manifest";
+/// The `t` discriminator of the terminal completeness line.
+const EOF: &str = "eof";
+/// The `t` discriminator of forensic event lines.
+const EVENT: &str = "event";
+/// The `t` discriminator of the in-band failure line: once the HTTP status is
+/// committed the server can only signal a mid-stream failure in-band, as a
+/// terminal `{"t":"error","complete":false}` line with no `eof`.
+const ERROR: &str = "error";
+
+/// Whether `input` is a Goggles NDJSON group-export stream. The v1 contract
+/// requires the first line to be the manifest, so this checks exactly that; an
+/// `agent-state.json` document (one JSON object, no `t` discriminator) is never
+/// mistaken for a stream.
+pub fn is_stream(input: &str) -> bool {
+    let Some(first_line) = input.lines().find(|line| !line.trim().is_empty()) else {
+        return false;
+    };
+    matches!(
+        serde_json::from_str::<TagProbe>(first_line),
+        Ok(TagProbe { t }) if t == MANIFEST
+    )
+}
+
+/// Parse a streamed group export into the same [`AgentStateExport`] the rest of
+/// the pipeline consumes. Fails closed on any break of the streaming contract.
+pub fn parse_stream(input: &str) -> Result<AgentStateExport, StreamParseError> {
+    let mut events = Vec::new();
+    let mut received: BTreeMap<String, u64> = BTreeMap::new();
+    let mut eof: Option<EofLine> = None;
+    let mut saw_manifest = false;
+
+    for (index, line) in input.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let number = index + 1;
+        if eof.is_some() {
+            return Err(StreamParseError::LineAfterEof { line: number });
+        }
+        let value: serde_json::Value =
+            serde_json::from_str(line).map_err(|source| StreamParseError::Line {
+                line: number,
+                source,
+            })?;
+        let TagProbe { t } =
+            TagProbe::deserialize(&value).map_err(|source| StreamParseError::Line {
+                line: number,
+                source,
+            })?;
+
+        if !saw_manifest {
+            if t != MANIFEST {
+                return Err(StreamParseError::MissingManifest);
+            }
+            saw_manifest = true;
+            continue;
+        }
+        match t.as_str() {
+            MANIFEST => return Err(StreamParseError::DuplicateManifest { line: number }),
+            ERROR => return Err(StreamParseError::ServerReportedError { line: number }),
+            EOF => {
+                eof = Some(EofLine::deserialize(&value).map_err(|source| {
+                    StreamParseError::Line {
+                        line: number,
+                        source,
+                    }
+                })?);
+            }
+            EVENT => {
+                events.push(AuditEvent::deserialize(&value).map_err(|source| {
+                    StreamParseError::Line {
+                        line: number,
+                        source,
+                    }
+                })?);
+                *received.entry(t).or_default() += 1;
+            }
+            _ => *received.entry(t).or_default() += 1,
+        }
+    }
+
+    if !saw_manifest {
+        return Err(StreamParseError::MissingManifest);
+    }
+    let eof = eof.ok_or(StreamParseError::MissingEof)?;
+    if !eof.complete {
+        return Err(StreamParseError::MarkedIncomplete);
+    }
+    verify_counts(&eof.counts, &received)?;
+
+    Ok(AgentStateExport {
+        events,
+        derived_projections: Default::default(),
+    })
+}
+
+/// Compare the server's per-section counts against what actually arrived, in
+/// both directions: a recorded section that fell short *and* a received
+/// section the server never counted both mean the stream cannot be trusted.
+fn verify_counts(
+    recorded: &BTreeMap<String, u64>,
+    received: &BTreeMap<String, u64>,
+) -> Result<(), StreamParseError> {
+    let sections = recorded.keys().chain(received.keys());
+    for section in sections {
+        let want = recorded.get(section).copied().unwrap_or(0);
+        let got = received.get(section).copied().unwrap_or(0);
+        if want != got {
+            return Err(StreamParseError::SectionCountMismatch {
+                section: section.clone(),
+                recorded: want,
+                received: got,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// The `t` discriminator of one stream line.
+#[derive(Deserialize)]
+struct TagProbe {
+    t: String,
+}
+
+/// The terminal completeness line. `complete` and `counts` are contractual, so
+/// their absence fails the parse rather than defaulting.
+#[derive(Deserialize)]
+struct EofLine {
+    complete: bool,
+    counts: BTreeMap<String, u64>,
+}
+
+/// Why a streamed export could not be parsed. Every variant means the stream
+/// broke the `goggles-group-export/v1` contract; none of them may be classified
+/// around, because a short stream would otherwise read as a healthy group.
+#[derive(Debug, thiserror::Error)]
+pub enum StreamParseError {
+    #[error("line {line} is not valid stream JSON: {source}")]
+    Line {
+        line: usize,
+        source: serde_json::Error,
+    },
+    #[error("stream does not begin with the manifest line")]
+    MissingManifest,
+    #[error("line {line} is a second manifest")]
+    DuplicateManifest { line: usize },
+    #[error("stream ended without the terminal eof line")]
+    MissingEof,
+    #[error("line {line}: the server reported a mid-stream failure (in-band error line)")]
+    ServerReportedError { line: usize },
+    #[error("line {line} follows the terminal eof line")]
+    LineAfterEof { line: usize },
+    #[error("server marked the stream incomplete (eof.complete = false)")]
+    MarkedIncomplete,
+    #[error("section `{section}` count mismatch: server recorded {recorded}, received {received}")]
+    SectionCountMismatch {
+        section: String,
+        recorded: u64,
+        received: u64,
+    },
+}

--- a/crates/incident-replay/src/synth.rs
+++ b/crates/incident-replay/src/synth.rs
@@ -1,9 +1,10 @@
 //! Synthesize a conformance vector from a recovered fork.
 //!
-//! The shape is the validated exp-06 blueprint: the two committers raise
-//! competing metadata commits at the same epoch and the engine fork-recovers on
-//! delivery — no `SetPartition` fault is needed, because the commits are
-//! concurrent (neither is delivered before the other is staged). Epochs are
+//! The shape follows the blueprint validated by replaying a real two-committer
+//! fork incident: the two committers raise competing metadata commits at the
+//! same epoch and the engine fork-recovers on delivery — no `SetPartition`
+//! fault is needed, because the commits are concurrent (neither is delivered
+//! before the other is staged). Epochs are
 //! normalized to the simulator's range (real `N → N+1` becomes `1 → 2`) by
 //! outcome-equivalence, and the committer identities are synthetic labels the
 //! caller assigns so the designated winner's branch wins.

--- a/crates/incident-replay/tests/classify.rs
+++ b/crates/incident-replay/tests/classify.rs
@@ -1,7 +1,7 @@
 //! Classification behaviour, exercised through the public parse + classify API
 //! against synthetic, non-sensitive fixtures.
 
-use incident_replay::{QuarantineReason, Verdict, classify, parse};
+use incident_replay::{BehindEngine, BehindMode, QuarantineReason, Verdict, classify, parse};
 
 fn load(name: &str) -> incident_replay::AgentStateExport {
     let path = format!("{}/tests/fixtures/{name}", env!("CARGO_MANIFEST_DIR"));
@@ -22,8 +22,8 @@ fn fork_resolution_without_contested_convergence_is_fork_recovery() {
 
 #[test]
 fn routine_single_branch_convergence_is_healthy() {
-    // exp-07 shape: real traffic emits many convergence_decisions that select the
-    // sole branch with no loser. Those are not incidents.
+    // Real traffic emits many convergence_decisions that select the sole branch
+    // with no loser. Those are not incidents.
     assert_eq!(
         classify(&load("healthy-routine-convergence.json")),
         Verdict::Healthy
@@ -32,8 +32,8 @@ fn routine_single_branch_convergence_is_healthy() {
 
 #[test]
 fn contested_convergence_dominates_fork_recovery() {
-    // exp-03 shape: a real incident carries both a fork_resolution and a
-    // contested convergence_decision; the convergence selection wins the route.
+    // A real incident carries both a fork_resolution and a contested
+    // convergence_decision; the convergence selection wins the route.
     assert_eq!(
         classify(&load("convergence-selected.json")),
         Verdict::ConvergenceSelected
@@ -60,6 +60,107 @@ fn contested_convergence_outranks_a_missing_snapshot_fork() {
     assert_eq!(
         classify(&load("convergence-with-missing-snapshot-fork.json")),
         Verdict::ConvergenceSelected
+    );
+}
+
+#[test]
+fn partial_audit_coverage_alone_stays_healthy() {
+    // The group_context reports 3 members while only 2 engines contributed
+    // events. Audit is opt-in, so real groups routinely have more members than
+    // exporting engines (a real six-member group exported from only two
+    // engines); coverage alone is not an incident, and gating on it would
+    // quarantine those groups forever.
+    assert_eq!(
+        classify(&load("healthy-partial-audit-coverage.json")),
+        Verdict::Healthy
+    );
+}
+
+#[test]
+fn an_engine_the_group_advanced_past_quarantines_as_went_dark() {
+    // engine-a's audit stream ends at epoch 4 — with one stray event *within*
+    // the catch-up grace of the group reaching epoch 6 — so its lag reads as
+    // going dark, not as an engine demonstrably running without its commits.
+    // This shape is also exactly what a member offline through two quick commits
+    // looks like on a single pull; it quarantines fail-closed by design,
+    // and cross-pull persistence — not this one verdict — is the operator's
+    // discriminator between a genuine split and catch-up still in flight.
+    assert_eq!(
+        classify(&load("quarantine-went-dark-engine.json")),
+        Verdict::Quarantine {
+            reason: QuarantineReason::EpochDivergence {
+                group_epoch: 6,
+                engines: vec![BehindEngine {
+                    engine_id: "engine-a".into(),
+                    epoch: 4,
+                    mode: BehindMode::WentDark,
+                }],
+            }
+        }
+    );
+}
+
+#[test]
+fn an_active_engine_two_epochs_behind_quarantines_as_active_while_behind() {
+    // engine-b keeps recording events well past the catch-up grace after
+    // engine-a evidenced epoch 6, yet never advances beyond 4: commits are not
+    // reaching it while its other traffic flows.
+    assert_eq!(
+        classify(&load("quarantine-epoch-divergence.json")),
+        Verdict::Quarantine {
+            reason: QuarantineReason::EpochDivergence {
+                group_epoch: 6,
+                engines: vec![BehindEngine {
+                    engine_id: "engine-b".into(),
+                    epoch: 4,
+                    mode: BehindMode::ActiveWhileBehind,
+                }],
+            }
+        }
+    );
+}
+
+#[test]
+fn one_epoch_of_lag_is_routine_propagation_not_divergence() {
+    assert_eq!(
+        classify(&load("healthy-lagging-engine.json")),
+        Verdict::Healthy
+    );
+}
+
+#[test]
+fn a_behind_engine_without_timestamps_leaves_the_gate_unarmed() {
+    // engine-b sits two epochs back, but its own events carry no wall clock, so
+    // there is no moment to time its lag from. The gate refuses to arm on
+    // untimed evidence rather than guess when the engine went quiet — legacy and
+    // partially-instrumented exports classify as before.
+    assert_eq!(
+        classify(&load("healthy-untimed-behind-engine.json")),
+        Verdict::Healthy
+    );
+}
+
+#[test]
+fn an_untimed_group_advance_leaves_the_gate_unarmed() {
+    // engine-b's lag is plainly visible — its high-water epoch trails the group
+    // by two — but the only evidence of the group moving past it carries no wall
+    // clock, so there is no moment to order the lag against. It is the missing
+    // order evidence, not the lag, that keeps the gate unarmed rather than
+    // guessing when the group left the engine behind.
+    assert_eq!(
+        classify(&load("healthy-untimed-group-advance.json")),
+        Verdict::Healthy
+    );
+}
+
+#[test]
+fn a_reproducible_incident_outranks_the_liveness_gate() {
+    // A fork resolution is a replayable incident; an engine left behind
+    // elsewhere in the export must not preempt it (recovery fail-closes
+    // downstream if the data it needs turns out to be missing).
+    assert_eq!(
+        classify(&load("fork-recovery-with-behind-engine.json")),
+        Verdict::ForkRecovery
     );
 }
 

--- a/crates/incident-replay/tests/fixtures/fork-recovery-with-behind-engine.json
+++ b/crates/incident-replay/tests/fixtures/fork-recovery-with-behind-engine.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "message_state_changed", "epoch": 28, "new_state": "processed" }
+    },
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000007200000,
+      "kind": { "type": "epoch_confirmed", "epoch": 30 }
+    },
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000007200000,
+      "kind": {
+        "type": "fork_resolution",
+        "source_epoch": 30,
+        "candidate_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "incumbent_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "invalidated_msg_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "winner": "incumbent"
+      }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 0 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/fixtures/group-export.ndjson
+++ b/crates/incident-replay/tests/fixtures/group-export.ndjson
@@ -1,0 +1,7 @@
+{"t": "manifest", "schema_version": "goggles-group-export/v1", "group": {"slug": "synthetic-group", "summary": {"event_count": 3}}}
+{"t": "source", "id": 1, "source_platform": "synthetic", "validation_status": "valid"}
+{"t": "event", "engine_id": "engine-a", "wall_time_ms": 1000000000000, "kind": {"type": "epoch_state_changed", "epoch": 2, "new_state": "stable"}}
+{"t": "event", "engine_id": "engine-b", "wall_time_ms": 1000000060000, "kind": {"type": "message_state_changed", "epoch": 2, "new_state": "processed"}}
+{"t": "event", "engine_id": "engine-a", "wall_time_ms": 1000000120000, "kind": {"type": "group_context", "context": {"epoch": 2, "member_count": 2}}}
+{"t": "delivery_artifact", "artifact_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"}
+{"t": "eof", "complete": true, "counts": {"source": 1, "event": 3, "delivery_artifact": 1, "state_delta": 0}}

--- a/crates/incident-replay/tests/fixtures/healthy-lagging-engine.json
+++ b/crates/incident-replay/tests/fixtures/healthy-lagging-engine.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 6, "new_state": "stable" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "message_state_changed", "epoch": 5, "new_state": "processed" }
+    },
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000120000,
+      "kind": { "type": "group_context", "context": { "epoch": 6, "member_count": 2 } }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 0 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/fixtures/healthy-partial-audit-coverage.json
+++ b/crates/incident-replay/tests/fixtures/healthy-partial-audit-coverage.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 4, "new_state": "stable" }
+    },
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "group_context", "context": { "epoch": 4, "member_count": 3 } }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "message_state_changed", "epoch": 4, "new_state": "processed" }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 0 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/fixtures/healthy-untimed-behind-engine.json
+++ b/crates/incident-replay/tests/fixtures/healthy-untimed-behind-engine.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 6, "new_state": "stable" }
+    },
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000120000,
+      "kind": { "type": "group_context", "context": { "epoch": 6, "member_count": 2 } }
+    },
+    {
+      "engine_id": "engine-b",
+      "kind": { "type": "message_state_changed", "epoch": 4, "new_state": "processed" }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 0 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/fixtures/healthy-untimed-group-advance.json
+++ b/crates/incident-replay/tests/fixtures/healthy-untimed-group-advance.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "kind": { "type": "epoch_state_changed", "epoch": 6, "new_state": "stable" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "message_state_changed", "epoch": 4, "new_state": "processed" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000120000,
+      "kind": { "type": "publish_outcome", "msg_id": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 0 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-epoch-divergence.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-epoch-divergence.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 6, "new_state": "stable" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "message_state_changed", "epoch": 4, "new_state": "processed" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000007200000,
+      "kind": { "type": "publish_outcome", "msg_id": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 0 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-went-dark-engine.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-went-dark-engine.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 4, "new_state": "stable" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000003600000,
+      "kind": { "type": "epoch_state_changed", "epoch": 6, "new_state": "stable" }
+    },
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000005400000,
+      "kind": { "type": "publish_outcome", "msg_id": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {
+      "convergence_runs": { "has_more": false, "limit": 500, "offset": 0, "returned": 0 }
+    }
+  }
+}

--- a/crates/incident-replay/tests/ndjson.rs
+++ b/crates/incident-replay/tests/ndjson.rs
@@ -1,0 +1,211 @@
+//! Streaming NDJSON export parsing: format detection, the fail-closed
+//! completeness contract, and end-to-end classification of a parsed stream.
+
+use incident_replay::{
+    BehindEngine, BehindMode, QuarantineReason, StreamParseError, Verdict, classify, is_stream,
+    parse_stream,
+};
+
+fn load(name: &str) -> String {
+    let path = format!("{}/tests/fixtures/{name}", env!("CARGO_MANIFEST_DIR"));
+    std::fs::read_to_string(&path).unwrap_or_else(|err| panic!("read fixture {path}: {err}"))
+}
+
+#[test]
+fn a_complete_stream_parses_and_classifies_healthy() {
+    let input = load("group-export.ndjson");
+    assert!(is_stream(&input));
+    let export = parse_stream(&input).expect("complete stream parses");
+    assert_eq!(export.events.len(), 3);
+    assert_eq!(classify(&export), Verdict::Healthy);
+}
+
+#[test]
+fn an_agent_state_document_is_not_detected_as_a_stream() {
+    assert!(!is_stream(&load("healthy.json")));
+}
+
+#[test]
+fn a_stream_carrying_an_engine_left_behind_quarantines() {
+    // The envelope fields the liveness gate reads (engine_id, wall_time_ms)
+    // survive the stream parse: an engine the group advanced two epochs past
+    // quarantines instead of reading as healthy.
+    let input = concat!(
+        r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#,
+        "\n",
+        r#"{"t": "event", "engine_id": "engine-a", "wall_time_ms": 1000000000000, "kind": {"type": "epoch_state_changed", "epoch": 4}}"#,
+        "\n",
+        r#"{"t": "event", "engine_id": "engine-b", "wall_time_ms": 1000007200000, "kind": {"type": "epoch_state_changed", "epoch": 6}}"#,
+        "\n",
+        r#"{"t": "eof", "complete": true, "counts": {"event": 2}}"#,
+        "\n",
+    );
+    let export = parse_stream(input).expect("stream parses");
+    assert_eq!(
+        classify(&export),
+        Verdict::Quarantine {
+            reason: QuarantineReason::EpochDivergence {
+                group_epoch: 6,
+                engines: vec![BehindEngine {
+                    engine_id: "engine-a".into(),
+                    epoch: 4,
+                    mode: BehindMode::WentDark,
+                }],
+            }
+        }
+    );
+}
+
+#[test]
+fn a_stream_reporting_a_mid_stream_failure_is_rejected() {
+    // Once the HTTP status is committed the server can only fail in-band: a
+    // terminal error line with no eof. The parse must name that surface
+    // precisely — an operator retries the export, not their network.
+    let input = concat!(
+        r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#,
+        "\n",
+        r#"{"t": "event", "kind": {"type": "epoch_confirmed", "epoch": 1}}"#,
+        "\n",
+        r#"{"t": "error", "complete": false}"#,
+        "\n",
+    );
+    assert!(matches!(
+        parse_stream(input),
+        Err(StreamParseError::ServerReportedError { line: 3 })
+    ));
+}
+
+#[test]
+fn a_stream_without_a_leading_manifest_is_rejected() {
+    let input = r#"{"t": "event", "kind": {"type": "epoch_confirmed", "epoch": 1}}"#;
+    assert!(!is_stream(input));
+    assert!(matches!(
+        parse_stream(input),
+        Err(StreamParseError::MissingManifest)
+    ));
+}
+
+#[test]
+fn a_stream_without_a_terminal_eof_is_rejected() {
+    let input = concat!(
+        r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#,
+        "\n",
+        r#"{"t": "event", "kind": {"type": "epoch_confirmed", "epoch": 1}}"#,
+        "\n",
+    );
+    assert!(matches!(
+        parse_stream(input),
+        Err(StreamParseError::MissingEof)
+    ));
+}
+
+#[test]
+fn a_stream_the_server_marked_incomplete_is_rejected() {
+    let input = concat!(
+        r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#,
+        "\n",
+        r#"{"t": "eof", "complete": false, "counts": {}}"#,
+        "\n",
+    );
+    assert!(matches!(
+        parse_stream(input),
+        Err(StreamParseError::MarkedIncomplete)
+    ));
+}
+
+#[test]
+fn a_section_count_shortfall_is_rejected() {
+    // The server recorded two events but only one arrived: a silently short
+    // stream must never read as a healthy group.
+    let input = concat!(
+        r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#,
+        "\n",
+        r#"{"t": "event", "kind": {"type": "epoch_confirmed", "epoch": 1}}"#,
+        "\n",
+        r#"{"t": "eof", "complete": true, "counts": {"event": 2}}"#,
+        "\n",
+    );
+    assert!(matches!(
+        parse_stream(input),
+        Err(StreamParseError::SectionCountMismatch { ref section, recorded: 2, received: 1 })
+            if section == "event"
+    ));
+}
+
+#[test]
+fn a_section_the_server_never_counted_is_rejected() {
+    let input = concat!(
+        r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#,
+        "\n",
+        r#"{"t": "source", "id": 1}"#,
+        "\n",
+        r#"{"t": "eof", "complete": true, "counts": {}}"#,
+        "\n",
+    );
+    assert!(matches!(
+        parse_stream(input),
+        Err(StreamParseError::SectionCountMismatch { ref section, recorded: 0, received: 1 })
+            if section == "source"
+    ));
+}
+
+#[test]
+fn unknown_sections_are_tolerated_but_still_counted() {
+    // A future Goggles section type must not fail the parse — and must still
+    // reconcile against the eof counts.
+    let input = concat!(
+        r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#,
+        "\n",
+        r#"{"t": "some_future_section", "detail": 7}"#,
+        "\n",
+        r#"{"t": "eof", "complete": true, "counts": {"some_future_section": 1}}"#,
+        "\n",
+    );
+    let export = parse_stream(input).expect("unknown sections parse");
+    assert!(export.events.is_empty());
+}
+
+#[test]
+fn data_after_the_terminal_eof_is_rejected() {
+    let input = concat!(
+        r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#,
+        "\n",
+        r#"{"t": "eof", "complete": true, "counts": {}}"#,
+        "\n",
+        r#"{"t": "event", "kind": {"type": "epoch_confirmed", "epoch": 1}}"#,
+        "\n",
+    );
+    assert!(matches!(
+        parse_stream(input),
+        Err(StreamParseError::LineAfterEof { line: 3 })
+    ));
+}
+
+#[test]
+fn a_second_manifest_is_rejected() {
+    let input = concat!(
+        r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#,
+        "\n",
+        r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#,
+        "\n",
+        r#"{"t": "eof", "complete": true, "counts": {}}"#,
+        "\n",
+    );
+    assert!(matches!(
+        parse_stream(input),
+        Err(StreamParseError::DuplicateManifest { line: 2 })
+    ));
+}
+
+#[test]
+fn an_invalid_line_is_rejected_with_its_line_number() {
+    let input = concat!(
+        r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#,
+        "\n",
+        "not json\n",
+    );
+    assert!(matches!(
+        parse_stream(input),
+        Err(StreamParseError::Line { line: 2, .. })
+    ));
+}


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/804">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incident replay now supports streaming Goggles `goggles-group-export/v1` NDJSON inputs (fail-closed) in addition to `agent-state.json`.
  * Added an epoch-divergence liveness quarantine gate that reports `WentDark` vs `ActiveWhileBehind`.
* **Bug Fixes**
  * Strengthened NDJSON stream validation (manifest/eof handling, completeness, strict protocol enforcement, and per-section count reconciliation).
  * Classification now uses additional exported epoch/liveness signals and improves a prior liveness mislabeling scenario.
* **Documentation**
  * Updated incident-replay adapter documentation and CLI help for both input formats and the new gate behavior.
* **Tests**
  * Added new JSON/NDJSON fixtures and expanded classification and stream-parse test coverage.
* **Chores**
  * Updated `.gitignore` to ignore local `.env`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->