### PR TITLE
Feat/commit loss fixes

### DIFF
--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -566,6 +566,10 @@ fn app_error_json(err: &AppError) -> Value {
             "code": "invalid_hex",
             "message": err.to_string(),
         }),
+        AppError::AccountCatchUp(_) => json!({
+            "code": "account_catch_up",
+            "message": err.to_string(),
+        }),
         other => json!({
             "code": "command_failed",
             "message": other.to_string(),

--- a/crates/marmot-app/src/client/audit.rs
+++ b/crates/marmot-app/src/client/audit.rs
@@ -4,7 +4,9 @@ use cgka_traits::app_components::{
     GROUP_BLOSSOM_IMAGE_COMPONENT_ID, GROUP_ENCRYPTED_MEDIA_COMPONENT_ID,
     GROUP_MESSAGE_RETENTION_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID,
 };
-use marmot_forensics::{AuditEventContext, AuditEventKind, AuditHumanActionContext};
+use marmot_forensics::{
+    AuditEventContext, AuditEventKind, AuditHumanActionContext, RelayRegistration,
+};
 
 use crate::messages::AppMessageIntent;
 use crate::{AppError, AppGroupRecord};
@@ -128,6 +130,58 @@ impl AppClient {
             audit_message_ids_from_effects(effects),
             None,
             None,
+        );
+    }
+
+    /// Record a `subscription_rebuild` forensic audit row for the just-completed
+    /// relay-plane activation: the `since` floor requested (`since_secs`; `None`
+    /// = full-history replay), the lookback subtracted from the durable cursor
+    /// to derive it, and the per-relay registration outcome. Drains the relay
+    /// plane's registration log, so each rebuild's relays land on exactly one
+    /// row. Account-scoped (no group), so `group_ref` is `None`.
+    pub(crate) async fn record_subscription_rebuild(&self, since_secs: Option<u64>) {
+        let relay_results = self
+            .relay_plane
+            .take_subscription_registrations()
+            .await
+            .into_iter()
+            .map(|outcome| RelayRegistration {
+                relay_url: outcome.relay_url,
+                accepted: outcome.accepted,
+            })
+            .collect();
+        self.runtime.session().record_audit_event(
+            None,
+            None,
+            AuditEventKind::SubscriptionRebuild {
+                since_secs,
+                lookback_secs: self.relay_plane.subscription_rebuild_lookback_secs(),
+                relay_results,
+            },
+        );
+    }
+
+    /// Record a `sync_drain` forensic audit row at the drain-loop exit: how long
+    /// the drain ran (`duration_ms`, wall-clock), how many deliveries it ingested
+    /// (`deliveries`), and the durable transport cursor immediately before and
+    /// after the drain (Nostr second-granular). Account-scoped, so `group_ref`
+    /// is `None`.
+    pub(crate) fn record_sync_drain(
+        &self,
+        duration_ms: u64,
+        deliveries: u64,
+        cursor_before_secs: Option<u64>,
+        cursor_after_secs: Option<u64>,
+    ) {
+        self.runtime.session().record_audit_event(
+            None,
+            None,
+            AuditEventKind::SyncDrain {
+                duration_ms,
+                deliveries,
+                cursor_before_secs,
+                cursor_after_secs,
+            },
         );
     }
 

--- a/crates/marmot-app/src/client/audit.rs
+++ b/crates/marmot-app/src/client/audit.rs
@@ -136,13 +136,17 @@ impl AppClient {
     /// Record a `subscription_rebuild` forensic audit row for the just-completed
     /// relay-plane activation: the `since` floor requested (`since_secs`; `None`
     /// = full-history replay), the lookback subtracted from the durable cursor
-    /// to derive it, and the per-relay registration outcome. Drains the relay
-    /// plane's registration log, so each rebuild's relays land on exactly one
-    /// row. Account-scoped (no group), so `group_ref` is `None`.
+    /// to derive it, and the per-relay registration outcome. Drains this
+    /// account's registration bucket from the shared relay plane — keyed by the
+    /// adapter's bound account id, the same `MemberId` every subscription this
+    /// account issued was planned with — so each rebuild's relays land on
+    /// exactly one row for this account and never absorb a concurrently-syncing
+    /// account's registrations. Account-scoped (no group), so `group_ref` is
+    /// `None`.
     pub(crate) async fn record_subscription_rebuild(&self, since_secs: Option<u64>) {
         let relay_results = self
             .relay_plane
-            .take_subscription_registrations()
+            .take_subscription_registrations(self.adapter.account_id())
             .await
             .into_iter()
             .map(|outcome| RelayRegistration {

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -379,6 +379,7 @@ fn read_marker_error_code(error: &AppError) -> &'static str {
         AppError::MissingDefaultRelays => "read_marker_failed:missing_default_relays",
         AppError::MissingRelayLists(_) => "read_marker_failed:missing_relay_lists",
         AppError::RelayDirectory(_) => "read_marker_failed:relay_directory",
+        AppError::AccountCatchUp(_) => "read_marker_failed:account_catch_up",
         AppError::InvalidPublicKey => "read_marker_failed:invalid_public_key",
         AppError::ExternalSignerUnavailable(_) => "read_marker_failed:external_signer_unavailable",
         AppError::ExternalSignerMismatch => "read_marker_failed:external_signer_mismatch",

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use cgka_traits::TransportAdapter;
 use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
 use cgka_traits::ingest::IngestOutcome;
+use storage_sqlite::clamp_to_max_future_skew;
 use tokio::time::timeout;
 use transport_nostr_peeler::NostrTransportEvent;
 
@@ -574,16 +575,20 @@ pub(crate) fn is_own_relay_echo(
 /// here instead of being preserved forever by the monotonic max. A benign
 /// in-range timestamp is unaffected; the skew margin tolerates ordinary sender
 /// clock drift.
+///
+/// The clamp itself is [`storage_sqlite::clamp_to_max_future_skew`] — the one
+/// definition shared with the save-time durable-cursor merge in
+/// `save_account_projection_state`, so ingest and persistence can never
+/// disagree on the ceiling.
 fn clamped_transport_cursor(
     current: Option<u64>,
     candidate: u64,
     now: u64,
     max_future_skew_secs: u64,
 ) -> u64 {
-    let max_allowed = now.saturating_add(max_future_skew_secs);
-    let clamped = candidate.min(max_allowed);
+    let clamped = clamp_to_max_future_skew(candidate, now, max_future_skew_secs);
     current
-        .map(|current| current.min(max_allowed).max(clamped))
+        .map(|current| clamp_to_max_future_skew(current, now, max_future_skew_secs).max(clamped))
         .unwrap_or(clamped)
 }
 

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -719,7 +719,7 @@ mod transport_cursor_tests {
 
     #[test]
     fn frozen_policy_never_moves_the_cursor() {
-        // Phase 4 (commit-loss): a wake-collection runtime ingests but must
+        // A wake-collection runtime ingests but must
         // not ratchet the durable floor. Under `Frozen` the cursor is exactly
         // the loaded value regardless of what the delivery carries — a newer
         // in-range timestamp, an older one, or a far-future one.
@@ -747,7 +747,7 @@ mod transport_cursor_tests {
 
     #[test]
     fn advance_policy_is_the_unchanged_clamped_monotonic_max() {
-        // `Advance` is byte-for-byte the pre-Phase-4 behavior: delegate to
+        // `Advance` is byte-for-byte the historical behavior: delegate to
         // `clamped_transport_cursor` (monotonic max with the mdk#182
         // future-skew clamp and poison heal, pinned by the tests below).
         assert_eq!(

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -550,7 +550,10 @@ impl AppClient {
         Ok(())
     }
 
-    /// Advance the persisted transport cursor from an inbound message.
+    /// Advance the persisted transport cursor from an inbound message —
+    /// unless this runtime was constructed with
+    /// [`CursorPersistence::Frozen`](crate::CursorPersistence), in which case
+    /// this is a no-op and the cursor stays at the value loaded from the store.
     ///
     /// `timestamp` is the sender-controlled Nostr `created_at` of the outer
     /// kind-445 event and is never validated upstream. The cursor is a
@@ -561,12 +564,13 @@ impl AppClient {
     /// wall-clock plus a bounded skew so a hostile or clock-skewed sender can
     /// move the cursor no further than `now + TRANSPORT_CURSOR_MAX_FUTURE_SKEW`.
     fn remember_transport_cursor(&mut self, timestamp: u64) {
-        self.state.last_transport_timestamp = Some(clamped_transport_cursor(
+        self.state.last_transport_timestamp = next_transport_cursor(
+            self.app.cursor_persistence(),
             self.state.last_transport_timestamp,
             timestamp,
             unix_now_seconds(),
             TRANSPORT_CURSOR_MAX_FUTURE_SKEW.as_secs(),
-        ));
+        );
     }
 }
 
@@ -582,6 +586,40 @@ pub(crate) fn is_own_relay_echo(
     NostrTransportEvent::from_transport_message(&delivery.message)
         .ok()
         .is_some_and(|event| event.pubkey == local_account_id_hex)
+}
+
+/// Apply the runtime's [`CursorPersistence`] policy to a candidate inbound
+/// timestamp: the policy seam behind `remember_transport_cursor`.
+///
+/// Under [`CursorPersistence::Frozen`] (the wake-collection posture — see the
+/// enum docs in `config.rs` for the full semantics) the cursor is returned
+/// unchanged, `None` included: the pass still ingests, decrypts, and projects
+/// everything, but the durable `since` floor never ratchets, so `save_state`
+/// writes back the loaded value and the storage-side clamp-then-max merge
+/// keeps a concurrent `Advance` runtime's progress intact. Deliberate
+/// consequences visible in the forensic audit rows: a frozen pass's
+/// `sync_drain` records `cursor_before == cursor_after`, and its
+/// `subscription_rebuild` rows keep recording the loaded floor — exactly the
+/// evidence that a wake pass did not move the floor.
+///
+/// Under [`CursorPersistence::Advance`] this delegates to
+/// [`clamped_transport_cursor`] unchanged.
+fn next_transport_cursor(
+    policy: crate::CursorPersistence,
+    current: Option<u64>,
+    candidate: u64,
+    now: u64,
+    max_future_skew_secs: u64,
+) -> Option<u64> {
+    match policy {
+        crate::CursorPersistence::Frozen => current,
+        crate::CursorPersistence::Advance => Some(clamped_transport_cursor(
+            current,
+            candidate,
+            now,
+            max_future_skew_secs,
+        )),
+    }
 }
 
 /// Compute the next persisted transport cursor from a candidate inbound
@@ -673,10 +711,62 @@ mod membership_change_tests {
 
 #[cfg(test)]
 mod transport_cursor_tests {
-    use super::clamped_transport_cursor;
+    use super::{clamped_transport_cursor, next_transport_cursor};
+    use crate::CursorPersistence;
 
     const SKEW: u64 = 5 * 60;
     const NOW: u64 = 1_800_000_000;
+
+    #[test]
+    fn frozen_policy_never_moves_the_cursor() {
+        // Phase 4 (commit-loss): a wake-collection runtime ingests but must
+        // not ratchet the durable floor. Under `Frozen` the cursor is exactly
+        // the loaded value regardless of what the delivery carries — a newer
+        // in-range timestamp, an older one, or a far-future one.
+        let loaded = Some(NOW - 100);
+        assert_eq!(
+            next_transport_cursor(CursorPersistence::Frozen, loaded, NOW, NOW, SKEW),
+            loaded,
+            "a newer in-range delivery must not advance a frozen cursor"
+        );
+        assert_eq!(
+            next_transport_cursor(CursorPersistence::Frozen, loaded, NOW - 500, NOW, SKEW),
+            loaded,
+            "an older delivery must not move a frozen cursor either"
+        );
+        // A store that has never advanced stays `None`: `Frozen` means "never
+        // advance", not "initialize". The save-time merge treats a `None`
+        // in-memory side as "keep stored", so this can never wipe a
+        // concurrently-advanced durable cursor.
+        assert_eq!(
+            next_transport_cursor(CursorPersistence::Frozen, None, NOW, NOW, SKEW),
+            None,
+            "a frozen cursor that never existed must stay absent"
+        );
+    }
+
+    #[test]
+    fn advance_policy_is_the_unchanged_clamped_monotonic_max() {
+        // `Advance` is byte-for-byte the pre-Phase-4 behavior: delegate to
+        // `clamped_transport_cursor` (monotonic max with the mdk#182
+        // future-skew clamp and poison heal, pinned by the tests below).
+        assert_eq!(
+            next_transport_cursor(CursorPersistence::Advance, Some(NOW - 100), NOW, NOW, SKEW),
+            Some(NOW),
+            "an in-range delivery advances the cursor under Advance"
+        );
+        assert_eq!(
+            next_transport_cursor(CursorPersistence::Advance, None, NOW, NOW, SKEW),
+            Some(NOW),
+            "a first delivery initializes the cursor under Advance"
+        );
+        let poisoned = NOW + 10 * 365 * 24 * 60 * 60;
+        assert_eq!(
+            next_transport_cursor(CursorPersistence::Advance, Some(NOW), poisoned, NOW, SKEW),
+            Some(NOW + SKEW),
+            "the future-skew clamp still bounds a hostile created_at"
+        );
+    }
 
     #[test]
     fn in_range_timestamp_advances_cursor_unchanged() {

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -57,8 +57,16 @@ impl AppClient {
         let rebuild_since = self
             .relay_plane
             .subscription_rebuild_since(self.state.last_transport_timestamp);
+        // Capture the derived `since` floor before it is moved into activation;
+        // the forensic `subscription_rebuild` row records it alongside the
+        // per-relay registration outcome the activation produces.
+        let rebuild_since_secs = rebuild_since.map(|timestamp| timestamp.0);
         self.runtime.activate_transport(rebuild_since).await?;
         self.sync_runtime_groups().await?;
+        // Both the inbox/group activation and the group-subscription refresh
+        // have now registered on relays; emit the rebuild audit row from the
+        // drained registration log before draining inbound deliveries.
+        self.record_subscription_rebuild(rebuild_since_secs).await;
         let mut summary = self.sync_sdk_relay().await?;
         // Surface engine events queued without an inbound delivery — most
         // importantly `GroupHydrationQuarantined`, queued during session
@@ -227,6 +235,13 @@ impl AppClient {
             .cloned()
             .collect::<HashSet<_>>();
         let mut first_wait = true;
+        // Forensic drain accounting: wall-clock span, count of deliveries
+        // actually ingested (echoes and already-seen duplicates are skipped and
+        // not counted), and the durable cursor before/after so an analyzer can
+        // compare the persisted floor against the ingested `created_at`s.
+        let drain_started = std::time::Instant::now();
+        let cursor_before_secs = self.state.last_transport_timestamp;
+        let mut deliveries: u64 = 0;
 
         loop {
             let wait = if first_wait {
@@ -252,8 +267,15 @@ impl AppClient {
             remember_seen_event(&mut seen, &mut self.state, event_id);
             self.ingest_delivery(delivery, &display_names, &mut summary)
                 .await?;
+            deliveries = deliveries.saturating_add(1);
         }
 
+        self.record_sync_drain(
+            drain_started.elapsed().as_millis() as u64,
+            deliveries,
+            cursor_before_secs,
+            self.state.last_transport_timestamp,
+        );
         self.app.save_state(&self.state)?;
         Ok(summary)
     }

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -10,10 +10,50 @@ const COMPILED_AUDIT_LOG_TRACKER_ENDPOINT: Option<&str> =
 const COMPILED_ENCRYPTED_MEDIA_BLOB_ENDPOINTS: Option<&str> =
     option_env!("MARMOT_ENCRYPTED_MEDIA_BLOB_ENDPOINTS");
 
+/// Policy for advancing the account's durable transport cursor
+/// (`last_transport_timestamp`) from ingested deliveries.
+///
+/// A runtime-construction policy, not a per-call switch: it is fixed on
+/// [`MarmotAppConfig`] and applies to every account client the resulting
+/// `MarmotApp`/`MarmotAppRuntime` opens for that construction's lifetime.
+///
+/// * [`Advance`](Self::Advance) — the default, normal posture: every ingested
+///   kind-445 advances the in-memory cursor (clamp-then-monotonic-max, see
+///   `client/sync.rs`) and `save_state` persists the advance.
+/// * [`Frozen`](Self::Frozen) — the wake-collection posture (iOS NSE,
+///   notification reply/mark-read actions: full runtimes with a sub-second
+///   drain budget on cold sockets). A `Frozen` pass still ingests, decrypts,
+///   and projects everything; it only cannot move the durable floor. The
+///   in-memory cursor never advances, so every `save_state` writes back the
+///   loaded value, and the save-time clamp-then-max merge in
+///   `storage_sqlite::save_account_projection_state` guarantees that write can
+///   never lower a cursor a concurrent `Advance` runtime has moved. The cursor
+///   is still *loaded* and still derives the subscription `since` floor —
+///   `Frozen` means "never advance", not "no cursor". Worst case is bounded
+///   redelivery on the next `Advance` catch-up, absorbed by seen-id dedup.
+///
+/// `Frozen` severs the commit-loss cursor ratchet at its confirmed trigger:
+/// a wake pass that drains for a fraction of a second on cold sockets must
+/// not persist a floor above events it never had time to receive
+/// (`plan.md` Phase 4).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CursorPersistence {
+    /// Ingested deliveries advance the durable cursor (default).
+    #[default]
+    Advance,
+    /// The durable cursor never advances; the pass still ingests and projects.
+    Frozen,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MarmotAppConfig {
     pub directory_max_future_skew: Duration,
     pub service_endpoints: MarmotServiceEndpoints,
+    /// Durable transport-cursor persistence policy. Defaults to
+    /// [`CursorPersistence::Advance`]; wake-collection runtimes (NSE,
+    /// notification actions) opt in to [`CursorPersistence::Frozen`] at
+    /// construction. See the enum docs for the full semantics.
+    pub cursor_persistence: CursorPersistence,
     /// Dev/test gate for loopback-HTTP blob endpoints. A loopback-HTTP endpoint
     /// (e.g. `http://127.0.0.1:PORT`) is VALID component state for everyone, but
     /// per group-encrypted-media-v1.md a client MUST NOT upload to or download
@@ -60,6 +100,7 @@ impl Default for MarmotAppConfig {
         Self {
             directory_max_future_skew: DEFAULT_DIRECTORY_MAX_FUTURE_SKEW,
             service_endpoints: MarmotServiceEndpoints::compiled(),
+            cursor_persistence: CursorPersistence::Advance,
             allow_loopback_blob_endpoints: false,
             allow_loopback_relay_endpoints: false,
             dev_settlement_quiescence_ms: None,
@@ -75,6 +116,16 @@ impl MarmotAppConfig {
 
     pub fn with_service_endpoints(mut self, endpoints: MarmotServiceEndpoints) -> Self {
         self.service_endpoints = endpoints.normalize();
+        self
+    }
+
+    /// Set the durable transport-cursor persistence policy. Defaults to
+    /// [`CursorPersistence::Advance`]; wake-collection runtimes (NSE,
+    /// notification actions) construct with [`CursorPersistence::Frozen`] so a
+    /// sub-second drain can never ratchet the durable `since` floor past
+    /// events it did not receive.
+    pub fn with_cursor_persistence(mut self, policy: CursorPersistence) -> Self {
+        self.cursor_persistence = policy;
         self
     }
 
@@ -516,6 +567,23 @@ fn host_is_loopback(host: url::Host<&str>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cursor_persistence_defaults_to_advance_and_is_opt_in() {
+        // Only wake-collection runtimes (NSE, notification actions) may opt in
+        // to the frozen posture; every other construction must keep advancing
+        // the durable cursor or catch-up floors would stop tracking delivery.
+        assert_eq!(
+            MarmotAppConfig::default().cursor_persistence,
+            CursorPersistence::Advance
+        );
+        assert_eq!(
+            MarmotAppConfig::default()
+                .with_cursor_persistence(CursorPersistence::Frozen)
+                .cursor_persistence,
+            CursorPersistence::Frozen
+        );
+    }
 
     #[test]
     fn allow_loopback_blob_endpoints_defaults_off_and_is_opt_in() {

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -32,10 +32,9 @@ const COMPILED_ENCRYPTED_MEDIA_BLOB_ENDPOINTS: Option<&str> =
 ///   `Frozen` means "never advance", not "no cursor". Worst case is bounded
 ///   redelivery on the next `Advance` catch-up, absorbed by seen-id dedup.
 ///
-/// `Frozen` severs the commit-loss cursor ratchet at its confirmed trigger:
+/// `Frozen` severs the cursor ratchet at the wake-collection trigger:
 /// a wake pass that drains for a fraction of a second on cold sockets must
-/// not persist a floor above events it never had time to receive
-/// (`plan.md` Phase 4).
+/// not persist a floor above events it never had time to receive.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum CursorPersistence {
     /// Ingested deliveries advance the durable cursor (default).

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -48,6 +48,12 @@ pub enum AppError {
     MissingRelayLists(Vec<MissingRelayListKind>),
     #[error("relay directory fetch failed: {0}")]
     RelayDirectory(String),
+    /// An account worker's transport catch-up failed (sync error or timeout).
+    /// Deliberately distinct from [`AppError::RelayDirectory`]: catch-up
+    /// failures were once wrapped as relay-directory errors, which sent the
+    /// first commit-loss investigation chasing the wrong subsystem.
+    #[error("account catch-up failed: {0}")]
+    AccountCatchUp(String),
     #[error("invalid Nostr public key")]
     InvalidPublicKey,
     #[error("external signer unavailable for account")]
@@ -136,6 +142,7 @@ impl AppError {
             Self::MissingDefaultRelays => "missing_default_relays",
             Self::MissingRelayLists(_) => "missing_relay_lists",
             Self::RelayDirectory(_) => "relay_directory",
+            Self::AccountCatchUp(_) => "account_catch_up",
             Self::InvalidPublicKey => "invalid_public_key",
             Self::ExternalSignerUnavailable(_) => "external_signer_unavailable",
             Self::ExternalSignerMismatch => "external_signer_mismatch",
@@ -221,5 +228,24 @@ fn storage_error_kind(error: &StorageError) -> &'static str {
         StorageError::Busy(_) => "storage_busy",
         StorageError::Backend(_) => "storage_backend",
         StorageError::Serialization(_) => "storage_serialization",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppError;
+
+    // Kind strings leave the runtime: `account_error_message` interpolates
+    // them into messages the CLI daemon persists and host apps log. Pin the
+    // catch-up kind so the wire-visible string cannot drift silently — it is
+    // the label operators will grep for after the RelayDirectory mislabel.
+    #[test]
+    fn account_catch_up_kind_is_stable() {
+        let err = AppError::AccountCatchUp("runtime catch-up failed: account_session".into());
+        assert_eq!(err.privacy_safe_kind(), "account_catch_up");
+        assert_eq!(
+            err.to_string(),
+            "account catch-up failed: runtime catch-up failed: account_session"
+        );
     }
 }

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -50,8 +50,8 @@ pub enum AppError {
     RelayDirectory(String),
     /// An account worker's transport catch-up failed (sync error or timeout).
     /// Deliberately distinct from [`AppError::RelayDirectory`]: catch-up
-    /// failures were once wrapped as relay-directory errors, which sent the
-    /// first commit-loss investigation chasing the wrong subsystem.
+    /// failures were once wrapped as relay-directory errors, which sent an
+    /// earlier investigation chasing the wrong subsystem.
     #[error("account catch-up failed: {0}")]
     AccountCatchUp(String),
     #[error("invalid Nostr public key")]

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -2486,11 +2486,24 @@ impl MarmotApp {
         )
     }
 
+    /// Persist the account snapshot. Concurrent runtimes (the main app and a
+    /// short-lived notification-wake process) may save over the same account
+    /// database; the durable transport cursor is merged clamp-then-max inside
+    /// the save transaction (see `save_account_projection_state` in
+    /// storage-sqlite for the full cross-process semantics), so a stale or
+    /// cursor-less save can never lower or wipe an advanced cursor, and a
+    /// stored value poisoned above `now + TRANSPORT_CURSOR_MAX_FUTURE_SKEW` is
+    /// healed down on the next save that learned a cursor. Known residual: a
+    /// skew-inflated but within-clamp cursor persists until wall clock passes
+    /// it — bounded exposure, ~180s beyond the 120s
+    /// `APP_RUNTIME_RELAY_REBUILD_LOOKBACK`. A deliberate cursor reset must be
+    /// a dedicated named API; a raw save cannot lower the merged value.
     fn save_state(&self, state: &AccountState) -> Result<(), AppError> {
         self.account_storage(&state.label)?
             .save_account_projection_state(
                 &stored_state_from_account_state(state),
                 MAX_SEEN_EVENT_IDS,
+                TRANSPORT_CURSOR_MAX_FUTURE_SKEW.as_secs(),
             )?;
         self.chat_list_projection_stale
             .lock()
@@ -2852,6 +2865,7 @@ impl MarmotApp {
         storage.save_account_projection_state(
             &stored_state_from_account_state(&state),
             MAX_SEEN_EVENT_IDS,
+            TRANSPORT_CURSOR_MAX_FUTURE_SKEW.as_secs(),
         )?;
         for message in legacy.messages(AppMessageQuery::default())? {
             if message.message_id_hex.is_empty() {

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -117,9 +117,9 @@ pub use audit_log::{
 };
 pub use client::AppClient;
 pub use config::{
-    AuditLogTrackerConfig, AuditLogUploadSource, MarmotAppConfig, MarmotServiceEndpoints,
-    RelayTelemetryExportConfig, RelayTelemetryResource, RelayTelemetryRuntimeConfig,
-    RelayTelemetrySettings,
+    AuditLogTrackerConfig, AuditLogUploadSource, CursorPersistence, MarmotAppConfig,
+    MarmotServiceEndpoints, RelayTelemetryExportConfig, RelayTelemetryResource,
+    RelayTelemetryRuntimeConfig, RelayTelemetrySettings,
 };
 pub use directory::{
     DirectoryKeyPackage, UserDirectoryLocalAccount, UserDirectoryRecord, UserDirectoryRefresh,
@@ -878,6 +878,12 @@ impl MarmotApp {
     /// upload/download act paths.
     pub(crate) fn allow_loopback_blob_endpoints(&self) -> bool {
         self.config.allow_loopback_blob_endpoints
+    }
+
+    /// The construction-time durable transport-cursor policy every client
+    /// opened from this app applies (see [`CursorPersistence`]).
+    pub(crate) fn cursor_persistence(&self) -> CursorPersistence {
+        self.config.cursor_persistence
     }
 
     pub fn telemetry_install_id(&self) -> Result<String, AppError> {

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -259,16 +259,27 @@ impl MarmotRelayPlane {
             .map(|lookback| lookback.as_secs())
     }
 
-    /// Drain the per-relay subscription-registration outcomes accumulated since
-    /// the previous drain, for the `subscription_rebuild` forensic audit row.
+    /// Drain the per-relay subscription-registration outcomes `account`
+    /// accumulated since its previous drain, for its `subscription_rebuild`
+    /// forensic audit row.
     ///
     /// Delegates to the SDK relay client, which records each subscribe's
-    /// per-endpoint acceptance. A plane built on a custom (non-SDK) relay
-    /// client does not track registration outcomes, so this returns empty for
-    /// it — the audit row then carries `since`/`lookback` without relay rows.
-    pub async fn take_subscription_registrations(&self) -> Vec<RelayRegistrationOutcome> {
+    /// per-endpoint acceptance bucketed by account. The drain is account-scoped
+    /// so concurrent account workers sharing this one relay plane each attribute
+    /// their own registrations to their own audit row; a group shared across
+    /// accounts registers once, attributed to whichever account's client
+    /// subscribed (an acceptable diagnostic attribution). A plane built on a
+    /// custom (non-SDK) relay client does not track registration outcomes, so
+    /// this returns empty for it — the audit row then carries `since`/`lookback`
+    /// without relay rows.
+    pub async fn take_subscription_registrations(
+        &self,
+        account: &MemberId,
+    ) -> Vec<RelayRegistrationOutcome> {
         if let Some(sdk_relay_client) = &self.inner.transport.sdk_relay_client {
-            return sdk_relay_client.take_subscription_registrations().await;
+            return sdk_relay_client
+                .take_subscription_registrations(account)
+                .await;
         }
         Vec::new()
     }
@@ -760,6 +771,17 @@ fn spawn_relay_notification_forwarder(
             })
             .await;
     })
+}
+
+impl MarmotRelayPlaneAccountAdapter {
+    /// The account this adapter is bound to — the `MemberId` every subscription
+    /// issued through it carries (activation and group sync reject any other
+    /// id), and the key its registrations bucket under on the shared relay
+    /// plane. Draining the `subscription_rebuild` row uses this so a rebuild is
+    /// attributed to exactly the account whose subscribes produced it.
+    pub(crate) fn account_id(&self) -> &MemberId {
+        &self.account_id
+    }
 }
 
 #[async_trait]

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -19,7 +19,7 @@ use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use transport_nostr_adapter::{
     NostrPublishOutcome, NostrRelayClient, NostrSdkRelayClient, NostrSdkRelayHealth,
-    NostrTransportAdapter, RelayExportConsent, RelayLabelResolution,
+    NostrTransportAdapter, RelayExportConsent, RelayLabelResolution, RelayRegistrationOutcome,
 };
 
 use crate::config::RelayTelemetryExportConfig;
@@ -246,6 +246,31 @@ impl MarmotRelayPlane {
         Some(Timestamp(
             last_transport_timestamp.saturating_sub(lookback.as_secs()),
         ))
+    }
+
+    /// The subscription-rebuild lookback in seconds, if this plane rebuilds
+    /// from the durable cursor. `None` means the plane rebuilds with full
+    /// history (no `since` floor). Surfaced for the `subscription_rebuild`
+    /// forensic audit row so an analyzer sees the window subtracted from the
+    /// cursor to derive the `since` floor.
+    pub fn subscription_rebuild_lookback_secs(&self) -> Option<u64> {
+        self.inner
+            .subscription_rebuild_lookback
+            .map(|lookback| lookback.as_secs())
+    }
+
+    /// Drain the per-relay subscription-registration outcomes accumulated since
+    /// the previous drain, for the `subscription_rebuild` forensic audit row.
+    ///
+    /// Delegates to the SDK relay client, which records each subscribe's
+    /// per-endpoint acceptance. A plane built on a custom (non-SDK) relay
+    /// client does not track registration outcomes, so this returns empty for
+    /// it — the audit row then carries `since`/`lookback` without relay rows.
+    pub async fn take_subscription_registrations(&self) -> Vec<RelayRegistrationOutcome> {
+        if let Some(sdk_relay_client) = &self.inner.transport.sdk_relay_client {
+            return sdk_relay_client.take_subscription_registrations().await;
+        }
+        Vec::new()
     }
 
     /// Attach an account's signing keys to the shared transport client so it

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -2838,10 +2838,10 @@ impl AccountManager {
             for response in responses {
                 match timeout(APP_RUNTIME_ACCOUNT_READY_WAIT, response).await {
                     Ok(Ok(Ok(()))) => {}
-                    Ok(Ok(Err(message))) => return Err(AppError::RelayDirectory(message)),
+                    Ok(Ok(Err(message))) => return Err(AppError::AccountCatchUp(message)),
                     Ok(Err(_)) => return Err(AppError::TransportClosed),
                     Err(_) => {
-                        return Err(AppError::RelayDirectory(
+                        return Err(AppError::AccountCatchUp(
                             "account worker catch-up timed out".into(),
                         ));
                     }

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1286,6 +1286,67 @@ fn legacy_account_projection_imports_once_into_account_storage() {
 }
 
 #[test]
+fn legacy_account_projection_clamps_poisoned_transport_cursor_on_import() {
+    // mdk#182 end-to-end: a pre-clamp-era legacy account projection can carry a
+    // transport cursor poisoned far above `now + skew`. The one-shot import
+    // (`migrate_legacy_account_projection_if_needed`) writes that legacy state
+    // into a brand-new account store through `save_account_projection_state`,
+    // which must clamp the adopted cursor to `now + skew` instead of persisting
+    // the poison. The storage-layer twin
+    // (`account_projection_state_clamps_poisoned_snapshot_into_fresh_store`)
+    // covers the same save arm directly; this test drives the real migration.
+    let now_secs = || {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    };
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    home.create_account("alice").unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let keys = app.account_home().load_signing_keys("alice").unwrap();
+    let legacy_path = app.legacy_account_projection_path("alice");
+    let legacy_key = app
+        .sqlcipher_key(
+            "alice",
+            &keys,
+            &legacy_path,
+            SqlcipherDatabaseKind::AccountProjection,
+        )
+        .unwrap();
+    let mut legacy = LegacyAccountProjectionDb::open(legacy_path.clone(), &legacy_key).unwrap();
+
+    let now_before = now_secs();
+    let poisoned = now_before + 10 * 365 * 24 * 60 * 60; // ~10 years ahead
+    legacy
+        .save_state(&AccountState {
+            label: "alice".to_owned(),
+            seen_events: Vec::new(),
+            last_transport_timestamp: Some(poisoned),
+            groups: Vec::new(),
+        })
+        .unwrap();
+
+    // First account access runs the one-shot legacy import.
+    app.groups("alice").unwrap();
+    let now_after = now_secs();
+
+    let skew = TRANSPORT_CURSOR_MAX_FUTURE_SKEW.as_secs();
+    let cursor = app
+        .account_storage("alice")
+        .unwrap()
+        .load_account_projection_state("alice", MAX_SEEN_EVENT_IDS)
+        .unwrap()
+        .last_transport_timestamp
+        .expect("imported cursor must survive the migration save");
+    assert!(
+        (now_before + skew..=now_after + skew).contains(&cursor),
+        "legacy import must clamp a poisoned transport cursor to now + skew, got {cursor}"
+    );
+}
+
+#[test]
 fn ingest_applies_owner_signed_transitive_448_and_drops_spoof() {
     use nostr::base64::Engine as _;
     use nostr::base64::engine::general_purpose::STANDARD as B64;

--- a/crates/marmot-app/tests/cursor_persistence.rs
+++ b/crates/marmot-app/tests/cursor_persistence.rs
@@ -1,0 +1,404 @@
+//! Integration test for `CursorPersistence` (`plan.md` Phase 4, commit-loss):
+//! a `Frozen` (wake-collection) runtime still ingests, decrypts, and projects
+//! a delivered message, but the durable transport cursor it persists is
+//! byte-identical to the one it loaded — and a subsequent `Advance` runtime
+//! over the same store loads exactly that untouched cursor and advances it
+//! normally on fresh delivery.
+//!
+//! # Harness shape
+//!
+//! Mirrors `since_floor.rs`: one account per store (`bob`, the account under
+//! test, has his own store; `alice` — who only creates the group and sends
+//! messages — gets a second, independent store pointed at the same relay; two
+//! accounts in one store would share the relay-plane router, a documented
+//! harness pitfall), and every bob boot is a brand-new `MarmotApp`/
+//! `MarmotAppRuntime` pair over the same on-disk store, exactly how the
+//! confirmed iOS trigger runs ("a full runtime per push"). Messages destined
+//! for a cold boot are sent while bob is fully offline so the boot's initial
+//! catch-up drain — not a live subscription — is what delivers them.
+//!
+//! # Cursor observable
+//!
+//! The persisted cursor has no public accessor by design; the observation
+//! channel is the forensic audit rows Phase 3 added for exactly this
+//! comparison. A `sync_drain` row records the in-memory cursor before/after
+//! each drain, and the *first* drain of a cold boot records the
+//! freshly-loaded persisted value as `cursor_before_secs` — so the frozen
+//! boot's rows prove the pass itself never moved the cursor, and the next
+//! (Advance) boot's rows prove the *store* still holds the pre-frozen value.
+//! `subscription_rebuild` rows double-check the derived `since` floor. This
+//! is the same evidence chain a field export would show, which is the point.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use marmot_account::AccountHome;
+use marmot_app::{
+    AppMessageQuery, AuditLogSettings, CursorPersistence, MarmotApp, MarmotAppConfig,
+    MarmotAppEvent, MarmotAppRuntime,
+};
+use nostr_relay_builder::MockRelay;
+use tokio::time::sleep;
+
+/// How long a cold boot's initial catch-up is allowed to take. Generous
+/// relative to the crate's own `SDK_FIRST_SYNC_WAIT` / `SDK_DRAIN_WAIT`.
+const CATCH_UP_DEADLINE: Duration = Duration::from_secs(10);
+
+async fn mock_relay() -> (MockRelay, String) {
+    let relay = MockRelay::run().await.unwrap();
+    let url = relay.url().await.to_string();
+    (relay, url)
+}
+
+fn open_store(
+    dir: &tempfile::TempDir,
+    relay_url: &str,
+    cursor_persistence: CursorPersistence,
+) -> MarmotApp {
+    MarmotApp::with_relay_and_config(
+        dir.path(),
+        relay_url.to_owned(),
+        MarmotAppConfig::default()
+            .with_allow_loopback_relay_endpoints(true)
+            .with_cursor_persistence(cursor_persistence),
+    )
+}
+
+fn test_unix_now_seconds() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Wait until the local wall clock has strictly passed `reference`, so the
+/// next message alice publishes gets a `created_at` strictly greater than any
+/// cursor value persisted at or before `reference`. Keeps the frozen-cursor
+/// equality assertion discriminating: under `Advance` semantics that same
+/// delivery *would* have advanced the cursor.
+async fn wait_for_wall_clock_past(reference: u64) {
+    while test_unix_now_seconds() <= reference {
+        sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn wait_for_event<F>(
+    events: &mut tokio::sync::broadcast::Receiver<MarmotAppEvent>,
+    mut matches_event: F,
+) where
+    F: FnMut(&MarmotAppEvent) -> bool,
+{
+    tokio::time::timeout(CATCH_UP_DEADLINE, async {
+        loop {
+            let event = events.recv().await.unwrap();
+            if matches_event(&event) {
+                return;
+            }
+        }
+    })
+    .await
+    .expect("runtime event");
+}
+
+/// Poll for a cold boot's first catch-up to complete: `start` returns once the
+/// worker is command-ready, not once the background catch-up finishes.
+async fn wait_for_first_catch_up(runtime: &MarmotAppRuntime) {
+    let deadline = Instant::now() + CATCH_UP_DEADLINE;
+    loop {
+        if runtime
+            .shared_services()
+            .app_performance_telemetry()
+            .snapshot()
+            .account_sync
+            .attempts
+            > 0
+        {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "cold-boot catch-up did not complete within the deadline",
+        );
+        sleep(Duration::from_millis(25)).await;
+    }
+}
+
+/// Incremental reader over an account's forensic audit JSONL files: each call
+/// returns only the rows appended since the previous call, so each boot's
+/// rows can be asserted in isolation.
+#[derive(Default)]
+struct AuditRowTracker {
+    consumed_lines: HashMap<String, usize>,
+}
+
+impl AuditRowTracker {
+    fn new_rows(&mut self, app: &MarmotApp, account_ref: &str) -> Vec<serde_json::Value> {
+        let mut files = app.audit_log_files().unwrap();
+        files.sort_by(|a, b| a.path.cmp(&b.path));
+        let mut rows = Vec::new();
+        for file in files.iter().filter(|file| file.account_ref == account_ref) {
+            let text = std::fs::read_to_string(&file.path).unwrap();
+            let lines = text.lines().collect::<Vec<_>>();
+            let seen = self.consumed_lines.entry(file.path.clone()).or_insert(0);
+            for line in &lines[*seen..] {
+                rows.push(serde_json::from_str::<serde_json::Value>(line).unwrap());
+            }
+            *seen = lines.len();
+        }
+        rows
+    }
+}
+
+fn rows_of_kind<'rows>(
+    rows: &'rows [serde_json::Value],
+    kind: &str,
+) -> Vec<&'rows serde_json::Value> {
+    rows.iter()
+        .filter(|row| row["kind"]["type"] == kind)
+        .collect()
+}
+
+#[tokio::test]
+async fn frozen_wake_collection_ingests_without_moving_the_durable_cursor() {
+    let (_relay, url) = mock_relay().await;
+
+    // --- bob: the account whose durable cursor is under test (own store) ---
+    let dir_bob = tempfile::tempdir().unwrap();
+    let home_bob = AccountHome::open(dir_bob.path());
+    home_bob.create_account("bob").unwrap();
+    let bob_id = home_bob.account("bob").unwrap().account_id_hex;
+
+    // --- alice: group creator / sender, in her own independent store ---
+    let dir_alice = tempfile::tempdir().unwrap();
+    let home_alice = AccountHome::open(dir_alice.path());
+    home_alice.create_account("alice").unwrap();
+    let app_alice = open_store(&dir_alice, &url, CursorPersistence::Advance);
+
+    // --- boot 1 (Advance): join the group, receive one ordinary message so
+    // the store holds a real advanced cursor for the frozen boot to load ---
+    let app_bob_boot1 = open_store(&dir_bob, &url, CursorPersistence::Advance);
+    // Enable forensic audit recording before any runtime starts; the setting
+    // persists in the store, so boots 2 and 3 record as well.
+    app_bob_boot1
+        .set_audit_log_settings(AuditLogSettings {
+            enabled: true,
+            ..Default::default()
+        })
+        .unwrap();
+    {
+        let mut bob_setup = app_bob_boot1.client("bob").await.unwrap();
+        bob_setup.publish_key_package().await.unwrap();
+    }
+    let runtime_bob_boot1 = MarmotAppRuntime::new(app_bob_boot1.clone());
+    let mut events_boot1 = runtime_bob_boot1.subscribe();
+    runtime_bob_boot1.start().await.unwrap();
+
+    let mut alice_client = app_alice.client("alice").await.unwrap();
+    let group_id = alice_client
+        .create_group("cursor persistence", &[bob_id.as_str()])
+        .await
+        .unwrap();
+    wait_for_event(&mut events_boot1, |event| {
+        matches!(
+            event,
+            MarmotAppEvent::GroupJoined { account_id_hex, group_id: joined, .. }
+                if account_id_hex == &bob_id && joined == &group_id
+        )
+    })
+    .await;
+    alice_client
+        .send(&group_id, b"ordinary traffic advances the cursor")
+        .await
+        .unwrap();
+    wait_for_event(&mut events_boot1, |event| {
+        matches!(
+            event,
+            MarmotAppEvent::MessageReceived(message)
+                if message.account_id_hex == bob_id
+                    && message.message.group_id == group_id
+                    && message.message.plaintext == "ordinary traffic advances the cursor"
+        )
+    })
+    .await;
+    // Upper bound on whatever cursor boot 1 persisted: captured after the
+    // message is confirmed received, before shutdown.
+    let cursor_upper_bound = test_unix_now_seconds();
+    runtime_bob_boot1.shutdown().await;
+
+    let mut audit_rows = AuditRowTracker::default();
+    // Consume boot 1's rows so each later boot is asserted in isolation.
+    let _boot1_rows = audit_rows.new_rows(&app_bob_boot1, "bob");
+
+    // The frozen boot's delivery must carry a created_at strictly above the
+    // persisted cursor, otherwise the "cursor did not move" assertion would
+    // hold vacuously even under Advance semantics.
+    wait_for_wall_clock_past(cursor_upper_bound).await;
+    alice_client
+        .send(&group_id, b"frozen wake ingests without moving the floor")
+        .await
+        .unwrap();
+
+    // --- boot 2 (Frozen): a brand-new runtime over the same store, the way
+    // the NSE runs one per push. It must ingest and project the message, and
+    // every drain must leave the cursor exactly where it loaded it. ---
+    let app_bob_boot2 = open_store(&dir_bob, &url, CursorPersistence::Frozen);
+    let runtime_bob_boot2 = MarmotAppRuntime::new(app_bob_boot2.clone());
+    let mut events_boot2 = runtime_bob_boot2.subscribe();
+    runtime_bob_boot2.start().await.unwrap();
+    wait_for_first_catch_up(&runtime_bob_boot2).await;
+    wait_for_event(&mut events_boot2, |event| {
+        matches!(
+            event,
+            MarmotAppEvent::MessageReceived(message)
+                if message.account_id_hex == bob_id
+                    && message.message.group_id == group_id
+                    && message.message.plaintext
+                        == "frozen wake ingests without moving the floor"
+        )
+    })
+    .await;
+    // Force one more completed, awaited sync so the drain rows are flushed.
+    runtime_bob_boot2.catch_up_accounts().await.unwrap();
+    // The frozen pass projected the message durably: visible in the stored
+    // app-message projection, not merely as a broadcast event.
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let frozen_boot_messages = app_bob_boot2
+        .messages_with_query(
+            "bob",
+            AppMessageQuery {
+                group_id_hex: Some(group_id_hex.clone()),
+                limit: None,
+            },
+        )
+        .unwrap();
+    assert!(
+        frozen_boot_messages
+            .iter()
+            .any(|message| message.plaintext == "frozen wake ingests without moving the floor"),
+        "the frozen runtime must still ingest, decrypt, and project the delivery"
+    );
+    runtime_bob_boot2.shutdown().await;
+
+    let boot2_rows = audit_rows.new_rows(&app_bob_boot2, "bob");
+    let boot2_drains = rows_of_kind(&boot2_rows, "sync_drain");
+    assert!(
+        !boot2_drains.is_empty(),
+        "the frozen boot must have recorded at least one sync_drain row"
+    );
+    // The first drain's cursor_before is the persisted cursor as loaded from
+    // the store — the baseline every later assertion compares against.
+    let baseline = boot2_drains[0]["kind"]["cursor_before_secs"]
+        .as_u64()
+        .expect("boot 1 advanced and persisted a cursor for the frozen boot to load");
+    assert!(
+        baseline <= cursor_upper_bound,
+        "sanity: the loaded cursor cannot postdate boot 1's shutdown, so the \
+         frozen boot's delivery (created_at > {cursor_upper_bound}) sits above \
+         it and would have advanced an Advance cursor"
+    );
+    for drain in &boot2_drains {
+        assert_eq!(
+            drain["kind"]["cursor_before_secs"].as_u64(),
+            Some(baseline),
+            "a frozen runtime's in-memory cursor never moves between drains: {drain}"
+        );
+        assert_eq!(
+            drain["kind"]["cursor_after_secs"].as_u64(),
+            Some(baseline),
+            "a frozen drain must leave the cursor exactly where it loaded it: {drain}"
+        );
+    }
+    assert!(
+        boot2_drains
+            .iter()
+            .any(|drain| drain["kind"]["deliveries"].as_u64().unwrap_or(0) >= 1),
+        "the frozen boot's catch-up drain — not a live tail — must have \
+         ingested the offline-published delivery: {boot2_drains:?}"
+    );
+    // Design point (plan.md Phase 4 step 4): frozen rebuilds keep deriving
+    // the subscription `since` floor from the loaded cursor — the audit rows
+    // themselves show wake passes not moving the floor.
+    let boot2_rebuilds = rows_of_kind(&boot2_rows, "subscription_rebuild");
+    assert!(!boot2_rebuilds.is_empty());
+    for rebuild in &boot2_rebuilds {
+        let lookback = rebuild["kind"]["lookback_secs"]
+            .as_u64()
+            .expect("rebuild rows record the lookback");
+        assert_eq!(
+            rebuild["kind"]["since_secs"].as_u64(),
+            Some(baseline - lookback),
+            "a frozen rebuild still floors at the loaded cursor minus the \
+             lookback: {rebuild}"
+        );
+    }
+
+    // A fresh message for the Advance boot: the frozen-ingested one is
+    // seen-id deduped on redelivery (by design — bounded redelivery is the
+    // documented worst case), so only genuinely new traffic advances the
+    // cursor. Published while bob is offline so the first catch-up drain
+    // ingests it.
+    alice_client
+        .send(&group_id, b"advance resumes the ratchet")
+        .await
+        .unwrap();
+
+    // --- boot 3 (Advance, the default): the same store must surface the
+    // byte-identical pre-frozen cursor, then advance it normally. ---
+    let app_bob_boot3 = open_store(&dir_bob, &url, CursorPersistence::Advance);
+    let runtime_bob_boot3 = MarmotAppRuntime::new(app_bob_boot3.clone());
+    let mut events_boot3 = runtime_bob_boot3.subscribe();
+    runtime_bob_boot3.start().await.unwrap();
+    wait_for_first_catch_up(&runtime_bob_boot3).await;
+    wait_for_event(&mut events_boot3, |event| {
+        matches!(
+            event,
+            MarmotAppEvent::MessageReceived(message)
+                if message.account_id_hex == bob_id
+                    && message.message.group_id == group_id
+                    && message.message.plaintext == "advance resumes the ratchet"
+        )
+    })
+    .await;
+    runtime_bob_boot3.catch_up_accounts().await.unwrap();
+
+    // Bounded redelivery absorbed by seen-id dedup: the rebuilt floor covers
+    // the frozen-ingested message, so the relay redelivers it, but it must
+    // not project twice.
+    let advance_boot_messages = app_bob_boot3
+        .messages_with_query(
+            "bob",
+            AppMessageQuery {
+                group_id_hex: Some(group_id_hex),
+                limit: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        advance_boot_messages
+            .iter()
+            .filter(|message| message.plaintext == "frozen wake ingests without moving the floor")
+            .count(),
+        1,
+        "redelivery of the frozen-ingested message is absorbed by seen-id dedup"
+    );
+    runtime_bob_boot3.shutdown().await;
+
+    let boot3_rows = audit_rows.new_rows(&app_bob_boot3, "bob");
+    let boot3_drains = rows_of_kind(&boot3_rows, "sync_drain");
+    // THE Phase 4 assertion: the Advance boot loaded a persisted cursor
+    // byte-identical to the pre-frozen baseline — the frozen pass's
+    // save_state never moved the durable floor — and a fresh delivery
+    // advanced it normally in the same drain.
+    assert!(
+        boot3_drains.iter().any(|drain| {
+            drain["kind"]["cursor_before_secs"].as_u64() == Some(baseline)
+                && drain["kind"]["deliveries"].as_u64().unwrap_or(0) >= 1
+                && drain["kind"]["cursor_after_secs"]
+                    .as_u64()
+                    .is_some_and(|after| after > baseline)
+        }),
+        "an Advance runtime over the same store must load the untouched \
+         pre-frozen cursor ({baseline}) and advance past it on fresh \
+         delivery: {boot3_drains:?}"
+    );
+}

--- a/crates/marmot-app/tests/cursor_persistence.rs
+++ b/crates/marmot-app/tests/cursor_persistence.rs
@@ -1,4 +1,4 @@
-//! Integration test for `CursorPersistence` (`plan.md` Phase 4, commit-loss):
+//! Integration test for `CursorPersistence`:
 //! a `Frozen` (wake-collection) runtime still ingests, decrypts, and projects
 //! a delivered message, but the durable transport cursor it persists is
 //! byte-identical to the one it loaded — and a subsequent `Advance` runtime
@@ -20,7 +20,7 @@
 //! # Cursor observable
 //!
 //! The persisted cursor has no public accessor by design; the observation
-//! channel is the forensic audit rows Phase 3 added for exactly this
+//! channel is the forensic audit rows added for exactly this
 //! comparison. A `sync_drain` row records the in-memory cursor before/after
 //! each drain, and the *first* drain of a cold boot records the
 //! freshly-loaded persisted value as `cursor_before_secs` — so the frozen
@@ -315,8 +315,8 @@ async fn frozen_wake_collection_ingests_without_moving_the_durable_cursor() {
         "the frozen boot's catch-up drain — not a live tail — must have \
          ingested the offline-published delivery: {boot2_drains:?}"
     );
-    // Design point (plan.md Phase 4 step 4): frozen rebuilds keep deriving
-    // the subscription `since` floor from the loaded cursor — the audit rows
+    // Frozen rebuilds keep deriving the subscription `since` floor from the
+    // loaded cursor — the audit rows
     // themselves show wake passes not moving the floor.
     let boot2_rebuilds = rows_of_kind(&boot2_rows, "subscription_rebuild");
     assert!(!boot2_rebuilds.is_empty());
@@ -385,7 +385,7 @@ async fn frozen_wake_collection_ingests_without_moving_the_durable_cursor() {
 
     let boot3_rows = audit_rows.new_rows(&app_bob_boot3, "bob");
     let boot3_drains = rows_of_kind(&boot3_rows, "sync_drain");
-    // THE Phase 4 assertion: the Advance boot loaded a persisted cursor
+    // Core assertion: the Advance boot loaded a persisted cursor
     // byte-identical to the pre-frozen baseline — the frozen pass's
     // save_state never moved the durable floor — and a fresh delivery
     // advanced it normally in the same drain.

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -5293,11 +5293,10 @@ async fn runtime_data_mode_toggle_rotates_live_recorder_with_boundary() {
 
 #[tokio::test]
 async fn runtime_sync_emits_subscription_rebuild_and_sync_drain_audit_rows() {
-    // Phase 3: a scripted sync produces the two forensic diagnostic rows the
-    // commit-loss investigation depends on — the subscription rebuild's `since`
-    // floor + per-relay registration, and the drain's cursor before/after — so
-    // the persisted-cursor-vs-missed-`created_at` smoking gun falls out of any
-    // export.
+    // A scripted sync produces the two forensic diagnostic rows a field export
+    // relies on — the subscription rebuild's `since` floor + per-relay
+    // registration, and the drain's cursor before/after — so the
+    // persisted-cursor-vs-missed-`created_at` mismatch is evident in any export.
     let dir = tempfile::tempdir().unwrap();
     let (_relay, app, url) = mock_app(&dir).await;
     // Enable recording before the runtime starts so the live worker records.

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -5291,6 +5291,82 @@ async fn runtime_data_mode_toggle_rotates_live_recorder_with_boundary() {
     runtime.shutdown().await;
 }
 
+#[tokio::test]
+async fn runtime_sync_emits_subscription_rebuild_and_sync_drain_audit_rows() {
+    // Phase 3: a scripted sync produces the two forensic diagnostic rows the
+    // commit-loss investigation depends on — the subscription rebuild's `since`
+    // floor + per-relay registration, and the drain's cursor before/after — so
+    // the persisted-cursor-vs-missed-`created_at` smoking gun falls out of any
+    // export.
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    // Enable recording before the runtime starts so the live worker records.
+    app.set_audit_log_settings(AuditLogSettings {
+        enabled: true,
+        ..Default::default()
+    })
+    .unwrap();
+
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = runtime.create_identity(setup).await.unwrap();
+    // Force a completed sync so the rebuild + drain rows are flushed to disk.
+    runtime.catch_up_accounts().await.unwrap();
+
+    let files = app.audit_log_files().unwrap();
+    let alice_file = files
+        .iter()
+        .find(|file| file.account_ref == alice.account.label)
+        .expect("alice has a live audit file");
+    let events = std::fs::read_to_string(&alice_file.path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .collect::<Vec<_>>();
+
+    // subscription_rebuild: exact wire tag, the lookback recorded, and the mock
+    // relay registered. A successful catch-up implies subscribe registered on
+    // >= 1 relay (the adapter hard-errors on 0-of-N), so with the single mock
+    // relay the SDK-backed plane must have marked it accepted.
+    let rebuild = events
+        .iter()
+        .find(|event| event["kind"]["type"] == "subscription_rebuild")
+        .expect("a subscription_rebuild row is emitted per rebuild");
+    assert!(
+        rebuild["kind"]["lookback_secs"].is_u64(),
+        "rebuild records the lookback: {rebuild}"
+    );
+    let relay_results = rebuild["kind"]["relay_results"]
+        .as_array()
+        .expect("relay_results is an array");
+    assert!(
+        relay_results.iter().any(|entry| {
+            entry["relay_url"]
+                .as_str()
+                .is_some_and(|relay_url| relay_url.contains("127.0.0.1"))
+                && entry["accepted"] == true
+        }),
+        "the mock relay registered the subscription: {rebuild}"
+    );
+
+    // sync_drain: exact wire tag and scalar drain accounting present. A fresh
+    // account drains no inbound 445s, so `deliveries` is 0 and the cursor
+    // fields stay absent (no delivery advanced the cursor) — both valid.
+    let drain = events
+        .iter()
+        .find(|event| event["kind"]["type"] == "sync_drain")
+        .expect("a sync_drain row is emitted at the drain exit");
+    assert!(drain["kind"]["duration_ms"].is_u64(), "{drain}");
+    assert!(drain["kind"]["deliveries"].is_u64(), "{drain}");
+
+    runtime.shutdown().await;
+}
+
 /// mdk#352 review follow-up: the welcome re-delivery surface is reachable end
 /// to end through the runtime worker. A create whose welcome delivered leaves
 /// nothing pending, and re-delivering an unknown welcome id is a clean error

--- a/crates/marmot-app/tests/since_floor.rs
+++ b/crates/marmot-app/tests/since_floor.rs
@@ -1,5 +1,4 @@
-//! Characterization test for the since-floor commit-loss defect
-//! (`plan.md`, "The defect, in two sentences"):
+//! Characterization test for the since-floor defect. In two sentences:
 //!
 //! > `last_transport_timestamp` is one account-wide durable cursor advanced
 //! > from the sender-controlled `created_at` of every ingested kind-445
@@ -11,13 +10,13 @@
 //! falls below the rebuilt subscription's `since` floor is never delivered to
 //! the runtime, while a sibling event just above the floor is delivered —
 //! and the miss survives a cold restart because the floor is derived from a
-//! durable, monotonic cursor. It is deliberately independent of Phases 1-6:
-//! Phase 4 (frozen wake-collection cursor) does not change this outcome (a
+//! durable, monotonic cursor. It is deliberately independent of the other
+//! fixes: the frozen wake-collection cursor does not change this outcome (a
 //! `Frozen` wake between the two probe events still leaves the same floor in
-//! place), and Phases 5/6 (EOSE-gated cursor completeness, epoch-gap
-//! backfill) are the fixes that are expected to flip these assertions —
-//! when they land, the below-floor probe should start arriving (via
-//! backfill) and this file's expectations must be updated accordingly.
+//! place), and EOSE-gated cursor completeness and epoch-gap backfill are the
+//! fixes that are expected to flip these assertions — when they land, the
+//! below-floor probe should start arriving (via backfill) and this file's
+//! expectations must be updated accordingly.
 //!
 //! # Why one account per store
 //!
@@ -27,7 +26,7 @@
 //! routing index. Two accounts opened from the *same* store would therefore
 //! share delivery plumbing, and an unrelated account's still-open, unfloored
 //! subscription can mask the very floor this test exists to pin (a
-//! documented harness pitfall — see `plan.md` Phase 7 and the handoff notes).
+//! known harness pitfall).
 //! This test gives the probed account (`bob`) its own store; `alice` — who
 //! only needs to create the group and send one ordinary message — gets a
 //! second, independent store pointed at the same relay.
@@ -52,7 +51,7 @@
 //! nostr-sdk documents as terminal ("the `RelayPool` can no longer be used").
 //!
 //! So this test drives the rebuild the way the confirmed iOS trigger actually
-//! does it (`plan.md`: "a full runtime per push"): it shuts a fully-live
+//! does it — a full runtime per push: it shuts a fully-live
 //! runtime down for good, publishes the probe events while `bob` has no
 //! store-side app instance running at all, then opens a *brand new*
 //! `MarmotApp`/`MarmotAppRuntime` pair against the same on-disk store. That
@@ -191,11 +190,11 @@ async fn inbound_events_delivered(app: &MarmotApp) -> usize {
 /// Publish a kind-445 group-message event at the wire level with a fresh,
 /// arbitrary (non-member) ephemeral signing key and a caller-chosen
 /// `created_at`. This is legitimate wire traffic, not a forged event: real
-/// kind-445 senders are always a fresh per-event key, never the account
-/// identity (spec/transports/nostr.md:64-66; mirrors the existing
-/// `signed_group_event_dto` precedent in
-/// `transport-nostr-adapter/src/sdk_client.rs`'s own tests). The content is
-/// undecryptable garbage — this test exercises delivery, not decryption.
+/// kind-445 senders are always a fresh per-event key, never the sender's
+/// Marmot account identity. This mirrors the existing `signed_group_event_dto`
+/// precedent in `transport-nostr-adapter/src/sdk_client.rs`'s own tests. The
+/// content is undecryptable garbage — this test exercises delivery, not
+/// decryption.
 async fn publish_garbage_group_message_at(
     relay_url: &str,
     nostr_group_id_hex: &str,
@@ -334,8 +333,7 @@ async fn cold_restart_since_floor_permanently_drops_backlog_below_it() {
         legitimate_delivery_count + 1,
         "only the above-floor sibling should reach ingest on a cold boot; the \
          below-floor probe must be silently dropped by the rebuilt \
-         subscription's since floor (plan.md Phase 7 / 'the defect, in two \
-         sentences')",
+         subscription's since floor",
     );
     runtime_bob_boot2.shutdown().await;
 
@@ -354,7 +352,7 @@ async fn cold_restart_since_floor_permanently_drops_backlog_below_it() {
         legitimate_delivery_count + 1,
         "a second, independent cold restart must still never deliver the \
          below-floor probe: the miss is permanent, not a one-off timing \
-         fluke (plan.md Phase 7 permanence property)",
+         fluke (the permanent-drop property)",
     );
     runtime_bob_boot3.shutdown().await;
 }

--- a/crates/marmot-app/tests/since_floor.rs
+++ b/crates/marmot-app/tests/since_floor.rs
@@ -1,0 +1,360 @@
+//! Characterization test for the since-floor commit-loss defect
+//! (`plan.md`, "The defect, in two sentences"):
+//!
+//! > `last_transport_timestamp` is one account-wide durable cursor advanced
+//! > from the sender-controlled `created_at` of every ingested kind-445
+//! > (undecryptable included), and every subscription rebuild floors at
+//! > `since = cursor − 120s` — so any 445 not delivered while the cursor was
+//! > still low is permanently unfetchable, with no gap detection.
+//!
+//! This test PINS today's behavior on purpose: an event whose `created_at`
+//! falls below the rebuilt subscription's `since` floor is never delivered to
+//! the runtime, while a sibling event just above the floor is delivered —
+//! and the miss survives a cold restart because the floor is derived from a
+//! durable, monotonic cursor. It is deliberately independent of Phases 1-6:
+//! Phase 4 (frozen wake-collection cursor) does not change this outcome (a
+//! `Frozen` wake between the two probe events still leaves the same floor in
+//! place), and Phases 5/6 (EOSE-gated cursor completeness, epoch-gap
+//! backfill) are the fixes that are expected to flip these assertions —
+//! when they land, the below-floor probe should start arriving (via
+//! backfill) and this file's expectations must be updated accordingly.
+//!
+//! # Why one account per store
+//!
+//! `MarmotRelayPlane` runs one shared router per `MarmotApp`/store
+//! (`relay_plane/mod.rs`): every locally managed account's group and inbox
+//! subscriptions are dispatched through the same underlying SDK client and
+//! routing index. Two accounts opened from the *same* store would therefore
+//! share delivery plumbing, and an unrelated account's still-open, unfloored
+//! subscription can mask the very floor this test exists to pin (a
+//! documented harness pitfall — see `plan.md` Phase 7 and the handoff notes).
+//! This test gives the probed account (`bob`) its own store; `alice` — who
+//! only needs to create the group and send one ordinary message — gets a
+//! second, independent store pointed at the same relay.
+//!
+//! # Why a cold restart, not `restart_account`
+//!
+//! A relay only honors NIP-01 `since` for the *initial* backlog reply to a
+//! freshly issued `REQ`; once a subscription is live, any newly published
+//! event matching its filter streams in immediately, with no regard to
+//! `created_at`. So publishing the two probe events while `bob`'s group
+//! subscription is still open would deliver *both* of them live and prove
+//! nothing about the floor. The two probe events must instead be published
+//! while `bob` is completely disconnected, so a *subsequent* fresh
+//! subscription's initial backlog replay is what the relay's `since` bound
+//! actually filters.
+//!
+//! `MarmotAppRuntime::restart_account` cannot create that disconnected
+//! window: the new worker's `activate_account` unsubscribes the old
+//! registration and re-subscribes in the same call, with no gap in which to
+//! publish. A full `MarmotAppRuntime::shutdown()` is also unsuitable to
+//! resume from: it calls the underlying SDK relay pool's `shutdown()`, which
+//! nostr-sdk documents as terminal ("the `RelayPool` can no longer be used").
+//!
+//! So this test drives the rebuild the way the confirmed iOS trigger actually
+//! does it (`plan.md`: "a full runtime per push"): it shuts a fully-live
+//! runtime down for good, publishes the probe events while `bob` has no
+//! store-side app instance running at all, then opens a *brand new*
+//! `MarmotApp`/`MarmotAppRuntime` pair against the same on-disk store. That
+//! new pair's first subscription rebuild is a genuine cold boot, and doing it
+//! twice (independently) demonstrates the permanence property: the
+//! below-floor probe never arrives, not even on a second independent boot.
+//!
+//! # Delivery observable
+//!
+//! The two probe events are deliberately undecryptable garbage (spec allows
+//! this: kind-445 senders are always a fresh per-event key, unrelated to any
+//! account identity, and this test exercises *delivery*, not decryption). An
+//! undecryptable delivery produces no `MarmotAppEvent` — decrypt failure
+//! yields `IngestOutcome::Stale` with no observable side effect at the
+//! `MarmotAppRuntime` event-stream layer. The chosen observable is instead
+//! `MarmotApp::relay_telemetry().metrics.inbound_events_delivered`
+//! (`transport-nostr-adapter`'s `NostrAdapterMetrics`, already public,
+//! already used by other tests in this crate via `relay_telemetry()`/
+//! `relay_health()`). It increments in `NostrTransportAdapter::handle_relay_event`
+//! the moment a relay event is routed to a locally subscribed account —
+//! before, and independent of, any engine-level decrypt attempt — so it is a
+//! faithful "did this reach the runtime" signal for a payload that is
+//! designed to decrypt-fail. No new test-support surface was needed for
+//! this: the existing public telemetry API is sufficient.
+//!
+//! Because a cold boot's *first* catch-up also naturally re-delivers the
+//! group's real history (the welcome and the one ordinary message this test
+//! sends to advance the cursor), the test measures that legitimate count on
+//! the very first (still-live) boot rather than assuming it, then asserts
+//! each subsequent cold boot's delivered count is exactly
+//! `legitimate_count + 1` (the sibling, and only the sibling) — never
+//! `+ 2` (which would mean the below-floor probe leaked through).
+
+use std::time::{Duration, Instant};
+
+use marmot_account::AccountHome;
+use marmot_app::{MarmotApp, MarmotAppConfig, MarmotAppEvent, MarmotAppRuntime};
+use nostr::base64::Engine as _;
+use nostr::base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use nostr_relay_builder::MockRelay;
+use nostr_sdk::prelude::{
+    Alphabet, Client as NostrSdkClient, EventBuilder, Keys, Kind, SingleLetterTag, Tag, TagKind,
+    Timestamp as NostrTimestamp,
+};
+use tokio::time::sleep;
+use transport_nostr_adapter::{NostrRelayClient, NostrSdkRelayClient};
+use transport_nostr_peeler::NostrTransportEvent;
+
+/// Mirrors `marmot_app::lib.rs`'s private `APP_RUNTIME_RELAY_REBUILD_LOOKBACK`
+/// (120s). Not importable (crate-private); every production runtime plane
+/// uses this exact fixed value, so the test must match it, not merely be
+/// consistent with itself.
+const REBUILD_LOOKBACK_SECS: u64 = 120;
+
+/// How long a cold boot's initial catch-up is allowed to take before this
+/// test gives up waiting for it. Generous relative to the crate's own
+/// `SDK_FIRST_SYNC_WAIT` (750ms) / `SDK_DRAIN_WAIT` (250ms) internals.
+const CATCH_UP_DEADLINE: Duration = Duration::from_secs(10);
+
+/// Extra settle margin after the catch-up telemetry op is recorded, in case
+/// any last delivery's routing telemetry update is still landing.
+const TELEMETRY_SETTLE_GRACE: Duration = Duration::from_millis(250);
+
+async fn mock_relay() -> (MockRelay, String) {
+    let relay = MockRelay::run().await.unwrap();
+    let url = relay.url().await.to_string();
+    (relay, url)
+}
+
+fn open_store(dir: &tempfile::TempDir, relay_url: &str) -> MarmotApp {
+    MarmotApp::with_relay_and_config(
+        dir.path(),
+        relay_url.to_owned(),
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    )
+}
+
+fn test_unix_now_seconds() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+async fn wait_for_event<F>(
+    events: &mut tokio::sync::broadcast::Receiver<MarmotAppEvent>,
+    mut matches_event: F,
+) where
+    F: FnMut(&MarmotAppEvent) -> bool,
+{
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let event = events.recv().await.unwrap();
+            if matches_event(&event) {
+                return;
+            }
+        }
+    })
+    .await
+    .expect("runtime event")
+}
+
+fn account_sync_attempts(runtime: &MarmotAppRuntime) -> u64 {
+    runtime
+        .shared_services()
+        .app_performance_telemetry()
+        .snapshot()
+        .account_sync
+        .attempts
+}
+
+/// Poll for a cold boot's first catch-up to complete. `restart`/`start` are
+/// documented (and independently confirmed by this crate's own
+/// `app_runtime_serves_member_reads_before_initial_catch_up_completes` test)
+/// to return once the worker is command-ready, not once the background
+/// catch-up finishes — so this must poll rather than assume the call awaited
+/// the sync.
+async fn wait_for_first_catch_up(runtime: &MarmotAppRuntime) {
+    let deadline = Instant::now() + CATCH_UP_DEADLINE;
+    loop {
+        if account_sync_attempts(runtime) > 0 {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "cold-boot catch-up did not complete within the deadline",
+        );
+        sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn inbound_events_delivered(app: &MarmotApp) -> usize {
+    app.relay_telemetry().await.metrics.inbound_events_delivered
+}
+
+/// Publish a kind-445 group-message event at the wire level with a fresh,
+/// arbitrary (non-member) ephemeral signing key and a caller-chosen
+/// `created_at`. This is legitimate wire traffic, not a forged event: real
+/// kind-445 senders are always a fresh per-event key, never the account
+/// identity (spec/transports/nostr.md:64-66; mirrors the existing
+/// `signed_group_event_dto` precedent in
+/// `transport-nostr-adapter/src/sdk_client.rs`'s own tests). The content is
+/// undecryptable garbage — this test exercises delivery, not decryption.
+async fn publish_garbage_group_message_at(
+    relay_url: &str,
+    nostr_group_id_hex: &str,
+    created_at: u64,
+    marker: &str,
+) {
+    let ephemeral = Keys::generate();
+    let signed = EventBuilder::new(
+        Kind::MlsGroupMessage,
+        BASE64_STANDARD.encode(format!("since-floor-probe:{marker}").as_bytes()),
+    )
+    .tags([Tag::custom(
+        TagKind::SingleLetter(SingleLetterTag::lowercase(Alphabet::H)),
+        [nostr_group_id_hex.to_owned()],
+    )])
+    .custom_created_at(NostrTimestamp::from_secs(created_at))
+    .sign_with_keys(&ephemeral)
+    .expect("sign ephemeral kind-445 test event");
+    let transport_event =
+        NostrTransportEvent::from_nostr_event(&signed).expect("dto from signed event");
+    let relay_client = NostrSdkRelayClient::new(NostrSdkClient::builder().build());
+    relay_client
+        .publish_event(
+            &[cgka_traits::TransportEndpoint(relay_url.to_owned())],
+            &transport_event,
+            1,
+        )
+        .await
+        .expect("publish garbage kind-445 test event");
+}
+
+#[tokio::test]
+async fn cold_restart_since_floor_permanently_drops_backlog_below_it() {
+    let (_relay, url) = mock_relay().await;
+
+    // --- bob's store: the account whose since-floor we are pinning ---
+    let dir_bob = tempfile::tempdir().unwrap();
+    let home_bob = AccountHome::open(dir_bob.path());
+    home_bob.create_account("bob").unwrap();
+    let bob_id = home_bob.account("bob").unwrap().account_id_hex;
+
+    // --- alice's store: a separate account/store, only used to create the
+    // group and send one ordinary message. Kept apart from bob's store per
+    // the one-account-per-store rule above. ---
+    let dir_alice = tempfile::tempdir().unwrap();
+    let home_alice = AccountHome::open(dir_alice.path());
+    home_alice.create_account("alice").unwrap();
+    let app_alice = open_store(&dir_alice, &url);
+
+    // --- boot 1: bob live, joins the group, receives one ordinary message ---
+    let app_bob_boot1 = open_store(&dir_bob, &url);
+    {
+        let mut bob_setup = app_bob_boot1.client("bob").await.unwrap();
+        bob_setup.publish_key_package().await.unwrap();
+    }
+    let runtime_bob_boot1 = MarmotAppRuntime::new(app_bob_boot1.clone());
+    let mut events_bob_boot1 = runtime_bob_boot1.subscribe();
+    runtime_bob_boot1.start().await.unwrap();
+
+    let mut alice_client = app_alice.client("alice").await.unwrap();
+    let group_id = alice_client
+        .create_group("since floor characterization", &[bob_id.as_str()])
+        .await
+        .unwrap();
+    wait_for_event(&mut events_bob_boot1, |event| {
+        matches!(
+            event,
+            MarmotAppEvent::GroupJoined { account_id_hex, group_id: joined, .. }
+                if account_id_hex == &bob_id && joined == &group_id
+        )
+    })
+    .await;
+
+    // Ordinary traffic: advances bob's durable transport cursor exactly the
+    // way the defect describes (every ingested kind-445 advances it).
+    alice_client
+        .send(&group_id, b"ordinary traffic advances the cursor")
+        .await
+        .unwrap();
+    wait_for_event(&mut events_bob_boot1, |event| {
+        matches!(
+            event,
+            MarmotAppEvent::MessageReceived(message)
+                if message.account_id_hex == bob_id
+                    && message.message.group_id == group_id
+                    && message.message.plaintext == "ordinary traffic advances the cursor"
+        )
+    })
+    .await;
+
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let nostr_group_id_hex = app_bob_boot1
+        .group("bob", &group_id_hex)
+        .unwrap()
+        .expect("bob's group projection")
+        .nostr_routing
+        .nostr_group_id_hex;
+
+    // Measure (not assume) how many kind-445/1059 deliveries a fresh cold
+    // boot will legitimately re-fetch: the welcome and this one message. This
+    // is exactly what boot 1's own live subscription needed to receive to
+    // reach this point.
+    let legitimate_delivery_count = inbound_events_delivered(&app_bob_boot1).await;
+
+    // Reference wall-clock used to place the two probe events relative to
+    // the floor. `reference_now` is captured after the message is confirmed
+    // received, so it is a safe upper bound on the real cursor (cursor <=
+    // reference_now); the margins below (180s / 60s either side of the
+    // assumed floor) comfortably absorb that skew.
+    let reference_now = test_unix_now_seconds();
+    let floor_estimate = reference_now.saturating_sub(REBUILD_LOOKBACK_SECS);
+    let below_floor_created_at = floor_estimate.saturating_sub(180);
+    let above_floor_created_at = floor_estimate.saturating_add(60);
+    assert!(above_floor_created_at < reference_now);
+
+    // bob must be fully offline before the probes are published: a still-open
+    // subscription would deliver them live regardless of `created_at` (see
+    // the module doc comment). This is boot 1's last use — never reopened.
+    runtime_bob_boot1.shutdown().await;
+
+    publish_garbage_group_message_at(&url, &nostr_group_id_hex, below_floor_created_at, "below")
+        .await;
+    publish_garbage_group_message_at(&url, &nostr_group_id_hex, above_floor_created_at, "above")
+        .await;
+
+    // --- boot 2: cold restart, first subscription rebuild since the probes
+    // landed ---
+    let app_bob_boot2 = open_store(&dir_bob, &url);
+    let runtime_bob_boot2 = MarmotAppRuntime::new(app_bob_boot2.clone());
+    runtime_bob_boot2.start().await.unwrap();
+    wait_for_first_catch_up(&runtime_bob_boot2).await;
+    sleep(TELEMETRY_SETTLE_GRACE).await;
+    let delivered_after_boot2 = inbound_events_delivered(&app_bob_boot2).await;
+    assert_eq!(
+        delivered_after_boot2,
+        legitimate_delivery_count + 1,
+        "only the above-floor sibling should reach ingest on a cold boot; the \
+         below-floor probe must be silently dropped by the rebuilt \
+         subscription's since floor (plan.md Phase 7 / 'the defect, in two \
+         sentences')",
+    );
+    runtime_bob_boot2.shutdown().await;
+
+    // --- boot 3: a second, independent cold restart — the permanence
+    // property. If the miss were a timing fluke rather than a permanent
+    // consequence of the durable cursor, a second independent rebuild could
+    // behave differently; it must not. ---
+    let app_bob_boot3 = open_store(&dir_bob, &url);
+    let runtime_bob_boot3 = MarmotAppRuntime::new(app_bob_boot3.clone());
+    runtime_bob_boot3.start().await.unwrap();
+    wait_for_first_catch_up(&runtime_bob_boot3).await;
+    sleep(TELEMETRY_SETTLE_GRACE).await;
+    let delivered_after_boot3 = inbound_events_delivered(&app_bob_boot3).await;
+    assert_eq!(
+        delivered_after_boot3,
+        legitimate_delivery_count + 1,
+        "a second, independent cold restart must still never deliver the \
+         below-floor probe: the miss is permanent, not a one-off timing \
+         fluke (plan.md Phase 7 permanence property)",
+    );
+    runtime_bob_boot3.shutdown().await;
+}

--- a/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
+++ b/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
@@ -679,6 +679,19 @@
         }
       }
     },
+    "relayRegistration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["relay_url", "accepted"],
+      "properties": {
+        "relay_url": {
+          "type": "string"
+        },
+        "accepted": {
+          "type": "boolean"
+        }
+      }
+    },
     "peelerOutcomeKind": {
       "enum": ["success", "decrypt_failed", "stale_epoch", "malformed", "other"]
     },
@@ -1580,6 +1593,50 @@
             },
             "reason": {
               "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "const": "subscription_rebuild"
+            },
+            "since_secs": {
+              "$ref": "#/$defs/u64"
+            },
+            "lookback_secs": {
+              "$ref": "#/$defs/u64"
+            },
+            "relay_results": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/relayRegistration"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "duration_ms", "deliveries"],
+          "properties": {
+            "type": {
+              "const": "sync_drain"
+            },
+            "duration_ms": {
+              "$ref": "#/$defs/u64"
+            },
+            "deliveries": {
+              "$ref": "#/$defs/u64"
+            },
+            "cursor_before_secs": {
+              "$ref": "#/$defs/u64"
+            },
+            "cursor_after_secs": {
+              "$ref": "#/$defs/u64"
             }
           }
         }

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -954,8 +954,9 @@ pub enum AuditEventKind {
     /// corrupt), the lookback subtracted from the durable cursor to derive it
     /// (`lookback_secs`), and the per-relay registration outcome
     /// (`relay_results`). Together with [`AuditEventKind::SyncDrain`] these rows
-    /// let an analyzer reconstruct the persisted-cursor-vs-missed-`created_at`
-    /// smoking gun from any export, including NSE wake sessions.
+    /// let an analyzer reconstruct the decisive
+    /// persisted-cursor-vs-missed-`created_at` evidence from any export,
+    /// including NSE wake sessions.
     ///
     /// Units: the durable transport cursor is advanced from inbound event
     /// `created_at`, which is Nostr second-granular, so the derived floor and

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -948,6 +948,59 @@ pub enum AuditEventKind {
         msg_id: MessageRefHex,
         reason: String,
     },
+    /// The account's Nostr subscription plane was rebuilt with a `since` floor.
+    /// Records the floor actually requested (`since_secs`; `None` means a
+    /// full-history replay because the durable cursor was absent or detectably
+    /// corrupt), the lookback subtracted from the durable cursor to derive it
+    /// (`lookback_secs`), and the per-relay registration outcome
+    /// (`relay_results`). Together with [`AuditEventKind::SyncDrain`] these rows
+    /// let an analyzer reconstruct the persisted-cursor-vs-missed-`created_at`
+    /// smoking gun from any export, including NSE wake sessions.
+    ///
+    /// Units: the durable transport cursor is advanced from inbound event
+    /// `created_at`, which is Nostr second-granular, so the derived floor and
+    /// lookback are `_secs` — deliberately not the `_ms` used by wall-clock
+    /// rows elsewhere in this schema.
+    ///
+    /// Privacy: `relay_results` carries relay URLs. This is deliberate and
+    /// mirrors the existing publish-path kinds — [`AuditEventKind::PublishAttempt`]
+    /// and [`AuditEventKind::PublishOutcome`] already carry `relay_url` /
+    /// `relay_urls` / `accepted_relay_urls`, and [`scrub_full_data_fields`]
+    /// leaves those relay fields untouched even in obfuscated mode. The forensic
+    /// audit channel is a consented, sensitivity-classified surface, distinct
+    /// from the tracing/logging invariant that forbids relay URLs in logs; so
+    /// rebuild rows carry the same relay identifiers the publish rows already do
+    /// rather than being the odd kind out. The URLs are caller-supplied
+    /// subscription endpoints, never a new identity minted at the transport
+    /// boundary.
+    SubscriptionRebuild {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        since_secs: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        lookback_secs: Option<u64>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        relay_results: Vec<RelayRegistration>,
+    },
+    /// The transport drain loop (`sync_sdk_relay`) finished draining inbound
+    /// deliveries and is about to persist state. Records how long the drain ran
+    /// (`duration_ms`, true wall-clock), how many deliveries it ingested
+    /// (`deliveries`), and the durable transport cursor immediately before and
+    /// after the drain (`cursor_before_secs` / `cursor_after_secs`; `None`
+    /// before any delivery has ever advanced the cursor).
+    ///
+    /// Units: the cursor is a Nostr second-granular timestamp, so those fields
+    /// are `_secs`; `duration_ms` is a genuine millisecond wall-clock duration.
+    ///
+    /// Privacy: scalar counts and timestamps only — no relay URLs, ids, or
+    /// payloads — so nothing here needs scrubbing in either data mode.
+    SyncDrain {
+        duration_ms: u64,
+        deliveries: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cursor_before_secs: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cursor_after_secs: Option<u64>,
+    },
 }
 
 impl AuditEventKind {
@@ -996,6 +1049,8 @@ impl AuditEventKind {
             AuditEventKind::AutoCommitDecision { .. } => "auto_commit_decision",
             AuditEventKind::MessageStateChanged { .. } => "message_state_changed",
             AuditEventKind::Rejection { .. } => "rejection",
+            AuditEventKind::SubscriptionRebuild { .. } => "subscription_rebuild",
+            AuditEventKind::SyncDrain { .. } => "sync_drain",
         }
     }
 }
@@ -1012,6 +1067,17 @@ pub enum ForkWinner {
 pub struct PublishRelayFailure {
     pub relay_url: String,
     pub reason: String,
+}
+
+/// One relay's registration outcome during a subscription rebuild, on
+/// [`AuditEventKind::SubscriptionRebuild`]. `relay_url` is the caller-supplied
+/// subscription endpoint; `accepted` is whether the relay acknowledged the
+/// subscription registration. See the kind doc for why the relay URL is carried
+/// here (publish-kind precedent, not scrubbed in obfuscated mode).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RelayRegistration {
+    pub relay_url: String,
+    pub accepted: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -309,6 +309,91 @@ fn audit_event_round_trips_through_serde() {
     assert_eq!(parsed, event);
 }
 
+#[test]
+fn subscription_rebuild_round_trips_through_serde() {
+    let kind = AuditEventKind::SubscriptionRebuild {
+        since_secs: Some(1_699_999_880),
+        lookback_secs: Some(120),
+        relay_results: vec![
+            RelayRegistration {
+                relay_url: "wss://relay.example".into(),
+                accepted: true,
+            },
+            RelayRegistration {
+                relay_url: "wss://down.example".into(),
+                accepted: false,
+            },
+        ],
+    };
+    let event = AuditEvent {
+        schema_version: AUDIT_LOG_SCHEMA_VERSION.into(),
+        seq: 11,
+        wall_time_ms: 1_700_000_000_000,
+        audit_data_mode: AuditDataMode::ObfuscatedSensitiveData,
+        recorder_session_id: Some("recorder-1".into()),
+        account_ref: None,
+        engine_id: "engine-xyz".into(),
+        group_ref: None,
+        context: None,
+        kind: kind.clone(),
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    let parsed: AuditEvent = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.kind, kind);
+    // Full-history replay: `None` since floor is omitted, not serialized as null.
+    let replay = AuditEventKind::SubscriptionRebuild {
+        since_secs: None,
+        lookback_secs: Some(120),
+        relay_results: Vec::new(),
+    };
+    let replay_json = serde_json::to_string(&replay).unwrap();
+    assert!(!replay_json.contains("since_secs"));
+    assert!(!replay_json.contains("relay_results"));
+    assert_eq!(
+        serde_json::from_str::<AuditEventKind>(&replay_json).unwrap(),
+        replay
+    );
+}
+
+#[test]
+fn sync_drain_round_trips_through_serde() {
+    let kind = AuditEventKind::SyncDrain {
+        duration_ms: 250,
+        deliveries: 3,
+        cursor_before_secs: Some(1_699_999_880),
+        cursor_after_secs: Some(1_700_000_000),
+    };
+    let event = AuditEvent {
+        schema_version: AUDIT_LOG_SCHEMA_VERSION.into(),
+        seq: 12,
+        wall_time_ms: 1_700_000_000_000,
+        audit_data_mode: AuditDataMode::ObfuscatedSensitiveData,
+        recorder_session_id: Some("recorder-1".into()),
+        account_ref: None,
+        engine_id: "engine-xyz".into(),
+        group_ref: None,
+        context: None,
+        kind: kind.clone(),
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    let parsed: AuditEvent = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.kind, kind);
+    // A drain before any cursor advance omits both cursor fields.
+    let empty = AuditEventKind::SyncDrain {
+        duration_ms: 8,
+        deliveries: 0,
+        cursor_before_secs: None,
+        cursor_after_secs: None,
+    };
+    let empty_json = serde_json::to_string(&empty).unwrap();
+    assert!(!empty_json.contains("cursor_before_secs"));
+    assert!(!empty_json.contains("cursor_after_secs"));
+    assert_eq!(
+        serde_json::from_str::<AuditEventKind>(&empty_json).unwrap(),
+        empty
+    );
+}
+
 fn sample_audit_event_kinds() -> Vec<AuditEventKind> {
     vec![
         AuditEventKind::RecorderStarted {
@@ -698,6 +783,26 @@ fn sample_audit_event_kinds() -> Vec<AuditEventKind> {
         AuditEventKind::Rejection {
             msg_id: "m".into(),
             reason: "unattributable_sender".into(),
+        },
+        AuditEventKind::SubscriptionRebuild {
+            since_secs: Some(1_700_000_000),
+            lookback_secs: Some(120),
+            relay_results: vec![
+                RelayRegistration {
+                    relay_url: "wss://relay.example".into(),
+                    accepted: true,
+                },
+                RelayRegistration {
+                    relay_url: "wss://down.example".into(),
+                    accepted: false,
+                },
+            ],
+        },
+        AuditEventKind::SyncDrain {
+            duration_ms: 250,
+            deliveries: 3,
+            cursor_before_secs: Some(1_699_999_880),
+            cursor_after_secs: Some(1_700_000_000),
         },
     ]
 }

--- a/crates/marmot-forensics/src/lib.rs
+++ b/crates/marmot-forensics/src/lib.rs
@@ -10,5 +10,5 @@ pub use audit::{
     GroupRefHex, GroupStateValue, JsonlRecorder, MemberRefHex, MembershipChangeSource,
     MessageArtifactKind, MessageAuthor, MessageRefHex, NoopRecorder, OutboundMessage,
     PeelerOutcomeKind, PublishRelayFailure, RecipientExpectation, RecipientScope,
-    default_jsonl_path,
+    RelayRegistration, default_jsonl_path,
 };

--- a/crates/marmot-uniffi/src/conversions/mod.rs
+++ b/crates/marmot-uniffi/src/conversions/mod.rs
@@ -88,7 +88,7 @@ mod tests {
         use marmot_app::CursorPersistence;
         // The FFI enum mirrors the app policy 1:1; a swapped variant here
         // would hand a wake-collection process the Advance posture and
-        // silently reintroduce the NSE cursor ratchet (commit-loss Phase 4).
+        // silently reintroduce the NSE cursor ratchet.
         assert!(matches!(
             CursorPersistence::from(CursorPersistenceFfi::Advance),
             CursorPersistence::Advance

--- a/crates/marmot-uniffi/src/conversions/mod.rs
+++ b/crates/marmot-uniffi/src/conversions/mod.rs
@@ -84,6 +84,22 @@ mod tests {
     }
 
     #[test]
+    fn cursor_persistence_ffi_preserves_each_variant() {
+        use marmot_app::CursorPersistence;
+        // The FFI enum mirrors the app policy 1:1; a swapped variant here
+        // would hand a wake-collection process the Advance posture and
+        // silently reintroduce the NSE cursor ratchet (commit-loss Phase 4).
+        assert!(matches!(
+            CursorPersistence::from(CursorPersistenceFfi::Advance),
+            CursorPersistence::Advance
+        ));
+        assert!(matches!(
+            CursorPersistence::from(CursorPersistenceFfi::Frozen),
+            CursorPersistence::Frozen
+        ));
+    }
+
+    #[test]
     fn self_membership_ffi_preserves_each_variant() {
         use marmot_app::SelfMembership;
         // The FFI enum mirrors the app enum 1:1; a swapped Left/Removed here

--- a/crates/marmot-uniffi/src/conversions/notification.rs
+++ b/crates/marmot-uniffi/src/conversions/notification.rs
@@ -1,9 +1,37 @@
-//! Notification settings, triggers, users, and update FFI conversions.
+//! Notification settings, triggers, users, and update FFI conversions —
+//! plus the wake-path cursor-persistence policy.
 
 use marmot_app::{
-    NotificationCollectionStatus, NotificationSettings, NotificationTrigger, NotificationUpdate,
-    NotificationUser, NotificationWakeSource,
+    CursorPersistence, NotificationCollectionStatus, NotificationSettings, NotificationTrigger,
+    NotificationUpdate, NotificationUser, NotificationWakeSource,
 };
+
+/// Durable transport-cursor persistence policy, chosen at [`crate::Marmot`]
+/// construction (`Marmot::new_with_cursor_persistence`).
+///
+/// `Frozen` is the wake-collection posture for runtimes with a sub-second
+/// drain budget on cold sockets — the iOS NSE (one runtime per push around
+/// `collect_notifications_after_wake`) and the notification reply/mark-read
+/// action paths. A `Frozen` pass still ingests, decrypts, and projects
+/// everything; it only cannot move the durable `since` floor, so a wake that
+/// drained for a fraction of a second can never make events permanently
+/// unfetchable. Worst case is bounded redelivery on the next `Advance`
+/// catch-up, absorbed by seen-id dedup. Foreground app runtimes must keep the
+/// default `Advance`. Full semantics: `marmot_app::CursorPersistence`.
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum CursorPersistenceFfi {
+    Advance,
+    Frozen,
+}
+
+impl From<CursorPersistenceFfi> for CursorPersistence {
+    fn from(value: CursorPersistenceFfi) -> Self {
+        match value {
+            CursorPersistenceFfi::Advance => Self::Advance,
+            CursorPersistenceFfi::Frozen => Self::Frozen,
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, uniffi::Enum)]
 pub enum NotificationWakeSourceFfi {

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -28,8 +28,8 @@ pub enum MarmotKitError {
     /// An account worker's transport catch-up failed (sync error or timeout).
     /// Distinct, typed variant — separate from [`MarmotKitError::Runtime`] —
     /// so hosts (notably the NSE wake path) can tell a catch-up failure from
-    /// a generic runtime error; the untyped bucket is what sent the first
-    /// commit-loss investigation chasing the wrong subsystem.
+    /// a generic runtime error; the untyped bucket is what sent an earlier
+    /// investigation chasing the wrong subsystem.
     #[error("account catch-up failed: {details}")]
     AccountCatchUp { details: String },
     #[error("local account is not an admin of group {group_id_hex}")]
@@ -231,10 +231,10 @@ mod tests {
     // boundary as the typed `StorageBusy` variant — never the untyped `Runtime`
     // bucket — so Android can distinguish transient contention from a fatal
     // failure without string-parsing "database is locked".
-    // Commit-loss follow-up: an account catch-up failure must cross the UniFFI
+    // An account catch-up failure must cross the UniFFI
     // boundary as the typed `AccountCatchUp` variant — never the untyped
-    // `Runtime` bucket, and never `RelayDirectory` (the mislabel that sent the
-    // first commit-loss investigation chasing the wrong subsystem).
+    // `Runtime` bucket, and never `RelayDirectory` (the mislabel that sent an
+    // earlier investigation chasing the wrong subsystem).
     #[test]
     fn account_catch_up_crosses_ffi_as_typed_variant() {
         let app_err = AppError::AccountCatchUp("runtime catch-up failed: account_session".into());

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -25,6 +25,13 @@ pub enum MarmotKitError {
     TransportClosed,
     #[error("marmot runtime is shutting down")]
     RuntimeStopping,
+    /// An account worker's transport catch-up failed (sync error or timeout).
+    /// Distinct, typed variant — separate from [`MarmotKitError::Runtime`] —
+    /// so hosts (notably the NSE wake path) can tell a catch-up failure from
+    /// a generic runtime error; the untyped bucket is what sent the first
+    /// commit-loss investigation chasing the wrong subsystem.
+    #[error("account catch-up failed: {details}")]
+    AccountCatchUp { details: String },
     #[error("local account is not an admin of group {group_id_hex}")]
     NotGroupAdmin { group_id_hex: String },
     #[error("admin must self-demote before leaving group {group_id_hex}")]
@@ -159,6 +166,7 @@ impl From<AppError> for MarmotKitError {
             AppError::Publish(details) => Self::Publish { details },
             AppError::TransportClosed => Self::TransportClosed,
             AppError::RuntimeStopping => Self::RuntimeStopping,
+            AppError::AccountCatchUp(details) => Self::AccountCatchUp { details },
             // #484: a transient storage busy error can also surface directly at
             // the app layer (not only wrapped in an EngineError). Classify it
             // as the typed transient variant here too, so Android never sees
@@ -223,6 +231,25 @@ mod tests {
     // boundary as the typed `StorageBusy` variant — never the untyped `Runtime`
     // bucket — so Android can distinguish transient contention from a fatal
     // failure without string-parsing "database is locked".
+    // Commit-loss follow-up: an account catch-up failure must cross the UniFFI
+    // boundary as the typed `AccountCatchUp` variant — never the untyped
+    // `Runtime` bucket, and never `RelayDirectory` (the mislabel that sent the
+    // first commit-loss investigation chasing the wrong subsystem).
+    #[test]
+    fn account_catch_up_crosses_ffi_as_typed_variant() {
+        let app_err = AppError::AccountCatchUp("runtime catch-up failed: account_session".into());
+        let ffi: MarmotKitError = app_err.into();
+        match ffi {
+            MarmotKitError::AccountCatchUp { details } => {
+                assert!(
+                    details.contains("account_session"),
+                    "typed AccountCatchUp should carry the worker detail, got: {details}"
+                );
+            }
+            other => panic!("expected AccountCatchUp, got {other:?}"),
+        }
+    }
+
     #[test]
     fn storage_busy_crosses_ffi_as_typed_variant_via_engine() {
         // Send path: storage Busy wrapped in EngineError, wrapped in AppError

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -20,7 +20,9 @@
 use std::sync::Arc;
 
 use cgka_traits::TransportEndpoint;
-use marmot_app::{MarmotApp, MarmotAppRuntime, TimelineMessageQuery, TimelinePagination};
+use marmot_app::{
+    MarmotApp, MarmotAppConfig, MarmotAppRuntime, TimelineMessageQuery, TimelinePagination,
+};
 
 mod commands;
 mod conversions;
@@ -45,14 +47,15 @@ pub use conversions::{
     AuditLogDeleteResultFfi, AuditLogFileFfi, AuditLogSettingsFfi, AuditLogTrackerConfigFfi,
     AuditLogTrackerUpdateResultFfi, AuditLogUploadResultFfi, AuditLogUploadSourceFfi,
     BackgroundNotificationCollectionFfi, ChatListAvatarFfi, ChatListMessagePreviewFfi,
-    ChatListRowFfi, ChatListSubscriptionUpdateFfi, ChatListUpdateTriggerFfi, GroupPushDebugInfoFfi,
-    GroupPushTokenDebugEntryFfi, GroupSystemEventFfi, LocalPushRegistrationDebugFfi,
-    MediaAttachmentReferenceFfi, MediaDownloadResultFfi, MediaLocatorFfi, MediaRecordFfi,
-    MediaUploadAttachmentRequestFfi, MediaUploadAttachmentResultFfi, MediaUploadRequestFfi,
-    MediaUploadResultFfi, MessageDraftAttachmentFfi, MessageDraftAttachmentSummaryFfi,
-    MessageDraftFfi, MessageDraftSummaryFfi, NotificationCollectionStatusFfi,
-    NotificationSettingsFfi, NotificationTriggerFfi, NotificationUpdateFfi, NotificationUserFfi,
-    NotificationWakeSourceFfi, PushPlatformFfi, PushRegistrationFfi, RelayTelemetryResourceFfi,
+    ChatListRowFfi, ChatListSubscriptionUpdateFfi, ChatListUpdateTriggerFfi, CursorPersistenceFfi,
+    GroupPushDebugInfoFfi, GroupPushTokenDebugEntryFfi, GroupSystemEventFfi,
+    LocalPushRegistrationDebugFfi, MediaAttachmentReferenceFfi, MediaDownloadResultFfi,
+    MediaLocatorFfi, MediaRecordFfi, MediaUploadAttachmentRequestFfi,
+    MediaUploadAttachmentResultFfi, MediaUploadRequestFfi, MediaUploadResultFfi,
+    MessageDraftAttachmentFfi, MessageDraftAttachmentSummaryFfi, MessageDraftFfi,
+    MessageDraftSummaryFfi, NotificationCollectionStatusFfi, NotificationSettingsFfi,
+    NotificationTriggerFfi, NotificationUpdateFfi, NotificationUserFfi, NotificationWakeSourceFfi,
+    PushPlatformFfi, PushRegistrationFfi, RelayTelemetryResourceFfi,
     RelayTelemetryRuntimeConfigFfi, RelayTelemetrySettingsFfi, RuntimeProjectionUpdateFfi,
     SecureDeleteExpiredResultFfi, TimelineMessageChangeFfi, TimelineMessageQueryFfi,
     TimelineMessageRecordFfi, TimelinePageFfi, TimelineProjectionUpdateFfi,
@@ -138,11 +141,34 @@ impl Marmot {
     /// events.
     #[uniffi::constructor]
     pub fn new(root_path: String, relay_urls: Vec<String>) -> Result<Arc<Self>, MarmotKitError> {
-        let account_home = marmot_account::AccountHome::open_with_default_keychain(&root_path)
-            .map_err(marmot_app::AppError::from)?;
-        let app = MarmotApp::with_relays_and_account_home(&root_path, relay_urls, account_home);
-        let runtime = app.runtime();
-        Ok(Arc::new(Self { app, runtime }))
+        Self::open(root_path, relay_urls, MarmotAppConfig::default())
+    }
+
+    /// Open the Marmot app with an explicit durable transport-cursor policy.
+    /// Identical to [`Marmot::new`] except for the policy; `new` itself is
+    /// [`CursorPersistenceFfi::Advance`].
+    ///
+    /// Wake-collection processes — the iOS NSE constructing one `Marmot` per
+    /// push around [`Marmot::collect_notifications_after_wake`], and the
+    /// notification reply/mark-read action paths — construct with
+    /// [`CursorPersistenceFfi::Frozen`]: the pass still ingests, decrypts, and
+    /// projects everything, but a sub-second drain on cold sockets can never
+    /// ratchet the durable `since` floor past events it did not receive (the
+    /// commit-loss trigger). Foreground app processes keep [`Marmot::new`].
+    // Construction-surface addition: binding regeneration and the workspace
+    // version bump ride the release per this crate's lockstep invariant — do
+    // not bump versions here.
+    #[uniffi::constructor]
+    pub fn new_with_cursor_persistence(
+        root_path: String,
+        relay_urls: Vec<String>,
+        cursor_persistence: CursorPersistenceFfi,
+    ) -> Result<Arc<Self>, MarmotKitError> {
+        Self::open(
+            root_path,
+            relay_urls,
+            MarmotAppConfig::default().with_cursor_persistence(cursor_persistence.into()),
+        )
     }
 
     /// Bring the runtime online: reconcile known accounts, start workers,
@@ -164,6 +190,27 @@ impl Marmot {
     /// the background.
     pub fn is_stopping(&self) -> bool {
         self.runtime.is_stopping()
+    }
+}
+
+impl Marmot {
+    /// Shared open path behind the exported constructors: keychain-backed
+    /// account home, app configured by `config`, runtime pair.
+    fn open(
+        root_path: String,
+        relay_urls: Vec<String>,
+        config: MarmotAppConfig,
+    ) -> Result<Arc<Self>, MarmotKitError> {
+        let account_home = marmot_account::AccountHome::open_with_default_keychain(&root_path)
+            .map_err(marmot_app::AppError::from)?;
+        let app = MarmotApp::with_relays_and_account_home_and_config(
+            &root_path,
+            relay_urls,
+            account_home,
+            config,
+        );
+        let runtime = app.runtime();
+        Ok(Arc::new(Self { app, runtime }))
     }
 }
 

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -154,7 +154,7 @@ impl Marmot {
     /// [`CursorPersistenceFfi::Frozen`]: the pass still ingests, decrypts, and
     /// projects everything, but a sub-second drain on cold sockets can never
     /// ratchet the durable `since` floor past events it did not receive (the
-    /// commit-loss trigger). Foreground app processes keep [`Marmot::new`].
+    /// wake-collection trigger). Foreground app processes keep [`Marmot::new`].
     // Construction-surface addition: binding regeneration and the workspace
     // version bump ride the release per this crate's lockstep invariant — do
     // not bump versions here.

--- a/crates/marmot-uniffi/tests/smoke.rs
+++ b/crates/marmot-uniffi/tests/smoke.rs
@@ -460,7 +460,7 @@ async fn notification_binding_methods_are_public_and_validate_missing_accounts()
 
 #[tokio::test]
 async fn frozen_cursor_persistence_constructor_opens_and_collects() {
-    // The NSE construction surface (commit-loss Phase 4): a per-push process
+    // The NSE construction surface: a per-push process
     // opens the kit with the Frozen policy and runs a wake collection. The
     // cursor semantics themselves are covered in marmot-app
     // (`tests/cursor_persistence.rs`); the job here is to prove the FFI

--- a/crates/marmot-uniffi/tests/smoke.rs
+++ b/crates/marmot-uniffi/tests/smoke.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Once};
 use marmot_account::AccountHome;
 use marmot_uniffi::{
     AuditDataModeFfi, AuditLogSettingsFfi, AuditLogTrackerConfigFfi, AuditLogUploadSourceFfi,
-    Marmot, MarmotKitError, MediaAttachmentReferenceFfi, MediaLocatorFfi,
+    CursorPersistenceFfi, Marmot, MarmotKitError, MediaAttachmentReferenceFfi, MediaLocatorFfi,
     MediaUploadAttachmentRequestFfi, MediaUploadRequestFfi, MessageDraftAttachmentFfi,
     NotificationWakeSourceFfi, PushPlatformFfi, RelayTelemetrySettingsFfi, TimelineMessageQueryFfi,
 };
@@ -456,6 +456,38 @@ async fn notification_binding_methods_are_public_and_validate_missing_accounts()
         .subscribe_notifications()
         .await
         .expect("empty notification subscription should be valid");
+}
+
+#[tokio::test]
+async fn frozen_cursor_persistence_constructor_opens_and_collects() {
+    // The NSE construction surface (commit-loss Phase 4): a per-push process
+    // opens the kit with the Frozen policy and runs a wake collection. The
+    // cursor semantics themselves are covered in marmot-app
+    // (`tests/cursor_persistence.rs`); the job here is to prove the FFI
+    // constructor + enum cross the boundary and drive the wake path.
+    install_mock_keyring();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let kit = Marmot::new_with_cursor_persistence(
+        tmp.path().to_string_lossy().into_owned(),
+        vec!["wss://relay.invalid.test".to_string()],
+        CursorPersistenceFfi::Frozen,
+    )
+    .expect("open frozen marmot kit");
+    let collected = kit
+        .collect_notifications_after_wake(1, NotificationWakeSourceFfi::ApnsNse)
+        .await
+        .expect("empty frozen wake collection should be valid");
+    assert!(collected.notifications.is_empty());
+    kit.shutdown().await;
+
+    // The same store reopens under the default constructor (Advance): the
+    // policy is a per-construction posture, not persisted store state.
+    let reopened = Marmot::new(
+        tmp.path().to_string_lossy().into_owned(),
+        vec!["wss://relay.invalid.test".to_string()],
+    )
+    .expect("reopen marmot kit with the default Advance policy");
+    assert!(!reopened.is_stopping());
 }
 
 #[tokio::test]

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -1,6 +1,6 @@
 use crate::{
     SqliteAccountStorage, SqliteResultExt, bool_i64, connection::retry_on_busy, tags_from_json,
-    unix_now_ms, unix_now_seconds_i64, usize_to_i64,
+    unix_now_ms, unix_now_seconds, unix_now_seconds_i64, usize_to_i64,
 };
 use cgka_traits::storage::{StorageError, StorageResult};
 use rusqlite::{
@@ -360,14 +360,62 @@ impl SqliteAccountStorage {
         })
     }
 
+    /// Persist one account-projection snapshot.
+    ///
+    /// # Cross-process semantics
+    ///
+    /// Multiple runtimes may save over the same account database concurrently
+    /// (for example a main app process and a short-lived notification-wake
+    /// process). The transaction is `BEGIN IMMEDIATE`, so everything below is
+    /// atomic against concurrent writers, and the write is shaped so a stale
+    /// or fresh writer can never regress durable delivery state:
+    ///
+    /// - `last_transport_timestamp` is merged, never overwritten: the stored
+    ///   cursor is read back inside the transaction and folded with the
+    ///   snapshot cursor via [`merged_transport_timestamp`] — both sides
+    ///   clamped to `now + max_future_skew_secs`, then the max wins. A
+    ///   snapshot that never learned a cursor (`None`) preserves an advanced
+    ///   stored one, and a stored value poisoned above the clamp ceiling comes
+    ///   out healed instead of winning the max forever. Known residual: a
+    ///   skew-inflated but still within-clamp value persists until wall clock
+    ///   passes it (bounded by `max_future_skew_secs`). Any future deliberate
+    ///   cursor reset must be a dedicated, named API — a raw save cannot lower
+    ///   the merged value.
+    /// - `seen_events` is a `seen_at`-refreshing union pruned to the newest
+    ///   `max_seen_events` rows, so a re-seen event outlives rows whose only
+    ///   sighting is old. It only narrows cross-restart redelivery;
+    ///   engine-level dedup stays the authoritative duplicate guard.
+    /// - Group and component rows are snapshot-replaced (last writer wins).
+    ///   Full multi-writer reconciliation is an explicit non-goal.
+    ///
+    /// `max_future_skew_secs` is caller policy (the app layer passes its
+    /// transport-cursor skew); this crate only enforces the column merge rule.
     pub fn save_account_projection_state(
         &self,
         state: &StoredAccountState,
         max_seen_events: usize,
+        max_future_skew_secs: u64,
     ) -> StorageResult<()> {
-        let now = unix_now_seconds_i64();
+        let now = unix_now_seconds();
+        let now_i64 = i64::try_from(now).unwrap_or(i64::MAX);
         self.connection.with_transaction(|| {
             let conn = self.lock()?;
+            let stored_cursor = conn
+                .query_row(
+                    "SELECT last_transport_timestamp FROM account_state WHERE label = ?1",
+                    params![&state.label],
+                    |row| row.get::<_, Option<i64>>(0),
+                )
+                .optional()
+                .storage()?
+                .flatten()
+                .and_then(|value| u64::try_from(value).ok());
+            let last_transport_timestamp = merged_transport_timestamp(
+                stored_cursor,
+                state.last_transport_timestamp,
+                now,
+                max_future_skew_secs,
+            );
             conn.execute(
                 "INSERT INTO account_state (label, updated_at, last_transport_timestamp)
                  VALUES (?1, ?2, ?3)
@@ -376,10 +424,8 @@ impl SqliteAccountStorage {
                     last_transport_timestamp = excluded.last_transport_timestamp",
                 params![
                     &state.label,
-                    now,
-                    state
-                        .last_transport_timestamp
-                        .and_then(|value| i64::try_from(value).ok()),
+                    now_i64,
+                    last_transport_timestamp.and_then(|value| i64::try_from(value).ok()),
                 ],
             )
             .storage()?;
@@ -391,7 +437,7 @@ impl SqliteAccountStorage {
                      VALUES (?1, ?2)
                      ON CONFLICT(event_id) DO UPDATE SET
                         seen_at = excluded.seen_at",
-                    params![event_id, now],
+                    params![event_id, now_i64],
                 )
                 .storage()?;
             }
@@ -478,14 +524,14 @@ impl SqliteAccountStorage {
                         bool_i64(group.pending_confirmation),
                         &group.welcomer_account_id_hex,
                         &group.via_welcome_message_id_hex,
-                        now
+                        now_i64
                     ],
                 )
                 .storage()?;
 
                 delete_stale_group_components(&conn, &group.group_id_hex, &group.components)?;
                 for component in &group.components {
-                    upsert_group_component(&conn, &group.group_id_hex, component, now)?;
+                    upsert_group_component(&conn, &group.group_id_hex, component, now_i64)?;
                 }
             }
             Ok(())
@@ -1283,6 +1329,45 @@ impl SqliteAccountStorage {
             )
             .storage()?;
         Ok(())
+    }
+}
+
+/// Clamp a cursor timestamp to `now + max_future_skew_secs`.
+///
+/// This is the single definition of the future-skew clamp for the persisted
+/// `last_transport_timestamp` column: the app layer applies it at ingest time
+/// (marmot-app's `clamped_transport_cursor`) and
+/// [`merged_transport_timestamp`] applies it to both sides of the save-time
+/// merge. The bound is caller policy; this crate only enforces the arithmetic.
+pub fn clamp_to_max_future_skew(timestamp: u64, now: u64, max_future_skew_secs: u64) -> u64 {
+    timestamp.min(now.saturating_add(max_future_skew_secs))
+}
+
+/// Merge the stored and snapshot `last_transport_timestamp` into the value a
+/// save may persist: the monotonic max of both sides, each first clamped to
+/// `now + max_future_skew_secs` via [`clamp_to_max_future_skew`].
+///
+/// The `Option` cases are deliberate:
+/// - `(None, snapshot)` — a fresh store adopts whatever the runtime learned.
+/// - `(stored, None)` — a runtime that never learned a cursor is
+///   cursor-neutral: it must never wipe (or otherwise move) the stored value.
+/// - `(Some, Some)` — clamp-then-max: clamping the *stored* side at save-time
+///   `now` is what heals a cursor poisoned above the ceiling instead of
+///   letting it win the max forever.
+fn merged_transport_timestamp(
+    stored: Option<u64>,
+    snapshot: Option<u64>,
+    now: u64,
+    max_future_skew_secs: u64,
+) -> Option<u64> {
+    match (stored, snapshot) {
+        (None, snapshot) => snapshot,
+        (stored, None) => stored,
+        (Some(stored), Some(snapshot)) => Some(
+            clamp_to_max_future_skew(stored, now, max_future_skew_secs).max(
+                clamp_to_max_future_skew(snapshot, now, max_future_skew_secs),
+            ),
+        ),
     }
 }
 

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -372,15 +372,16 @@ impl SqliteAccountStorage {
     ///
     /// - `last_transport_timestamp` is merged, never overwritten: the stored
     ///   cursor is read back inside the transaction and folded with the
-    ///   snapshot cursor via [`merged_transport_timestamp`] — both sides
-    ///   clamped to `now + max_future_skew_secs`, then the max wins. A
-    ///   snapshot that never learned a cursor (`None`) preserves an advanced
-    ///   stored one, and a stored value poisoned above the clamp ceiling comes
-    ///   out healed instead of winning the max forever. Known residual: a
-    ///   skew-inflated but still within-clamp value persists until wall clock
-    ///   passes it (bounded by `max_future_skew_secs`). Any future deliberate
-    ///   cursor reset must be a dedicated, named API — a raw save cannot lower
-    ///   the merged value.
+    ///   snapshot cursor via [`merged_transport_timestamp`]. When both sides
+    ///   are present they are each clamped to `now + max_future_skew_secs` and
+    ///   the max wins, so a stored value poisoned above the ceiling comes out
+    ///   healed instead of winning the max forever. A snapshot that never
+    ///   learned a cursor (`None`) is cursor-neutral and preserves the stored
+    ///   value unchanged; a fresh store adopts the snapshot side clamped to the
+    ///   same ceiling. Known residual: a skew-inflated but still within-clamp
+    ///   value persists until wall clock passes it (bounded by
+    ///   `max_future_skew_secs`). Any future deliberate cursor reset must be a
+    ///   dedicated, named API — a raw save cannot lower the merged value.
     /// - `seen_events` is a `seen_at`-refreshing union pruned to the newest
     ///   `max_seen_events` rows, so a re-seen event outlives rows whose only
     ///   sighting is old. It only narrows cross-restart redelivery;
@@ -1344,16 +1345,26 @@ pub fn clamp_to_max_future_skew(timestamp: u64, now: u64, max_future_skew_secs: 
 }
 
 /// Merge the stored and snapshot `last_transport_timestamp` into the value a
-/// save may persist: the monotonic max of both sides, each first clamped to
-/// `now + max_future_skew_secs` via [`clamp_to_max_future_skew`].
+/// save may persist. Every arm is deliberate:
 ///
-/// The `Option` cases are deliberate:
-/// - `(None, snapshot)` — a fresh store adopts whatever the runtime learned.
-/// - `(stored, None)` — a runtime that never learned a cursor is
-///   cursor-neutral: it must never wipe (or otherwise move) the stored value.
-/// - `(Some, Some)` — clamp-then-max: clamping the *stored* side at save-time
-///   `now` is what heals a cursor poisoned above the ceiling instead of
-///   letting it win the max forever.
+/// - `(None, None)` — nothing to persist; stays `None`.
+/// - `(None, Some(snapshot))` — a fresh store adopts the snapshot cursor,
+///   clamped to `now + max_future_skew_secs`. The clamp is load-bearing here:
+///   the legacy-import migration (marmot-app's
+///   `migrate_legacy_account_projection_if_needed`) writes a legacy-loaded
+///   state into a brand-new store through this arm, and a pre-clamp-era legacy
+///   projection can carry a cursor poisoned above the ceiling (mdk#182).
+///   Adopting it raw would persist that poison.
+/// - `(Some(stored), None)` — a save that never learned a cursor is
+///   cursor-neutral: the stored value passes through unchanged, never clamped
+///   or otherwise moved. Healing a poisoned stored value is the job of a save
+///   that *did* learn a cursor (the arm below); a cursor-less save must not
+///   move durable state at all.
+/// - `(Some(stored), Some(snapshot))` — both sides are clamped to
+///   `now + max_future_skew_secs` via [`clamp_to_max_future_skew`], then the
+///   max wins. Clamping the *stored* side at save-time `now` is what heals a
+///   cursor poisoned above the ceiling instead of letting it win the max
+///   forever.
 fn merged_transport_timestamp(
     stored: Option<u64>,
     snapshot: Option<u64>,
@@ -1361,8 +1372,13 @@ fn merged_transport_timestamp(
     max_future_skew_secs: u64,
 ) -> Option<u64> {
     match (stored, snapshot) {
-        (None, snapshot) => snapshot,
-        (stored, None) => stored,
+        (None, None) => None,
+        (None, Some(snapshot)) => Some(clamp_to_max_future_skew(
+            snapshot,
+            now,
+            max_future_skew_secs,
+        )),
+        (Some(stored), None) => Some(stored),
         (Some(stored), Some(snapshot)) => Some(
             clamp_to_max_future_skew(stored, now, max_future_skew_secs).max(
                 clamp_to_max_future_skew(snapshot, now, max_future_skew_secs),

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -301,6 +301,44 @@ fn account_projection_state_heals_poisoned_stored_cursor_on_save() {
     );
 }
 
+#[test]
+fn account_projection_state_clamps_poisoned_snapshot_into_fresh_store() {
+    // Legacy-import shape (mdk#182): the marmot-app migration
+    // (`migrate_legacy_account_projection_if_needed`) writes a legacy-loaded
+    // state into a brand-new account store through this same
+    // `save_account_projection_state`. A pre-clamp-era legacy projection can
+    // carry a transport cursor poisoned above `now + skew`; adopting it into the
+    // fresh store (the `stored = None` arm) must clamp it to save-time
+    // `now + skew`, never persist the poison. Because the migration routes
+    // through this exact save, a fresh-store save with a poisoned snapshot is
+    // the faithful reproduction of that path — no separate migration fixture is
+    // needed for the storage layer. A true end-to-end counterpart that drives
+    // the migration itself lives in marmot-app
+    // (`legacy_account_projection_clamps_poisoned_transport_cursor_on_import`).
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let now_before = unix_now_seconds();
+    let poisoned = now_before + 10 * 365 * 24 * 60 * 60; // ~10 years ahead
+    let imported = StoredAccountState {
+        label: "alice".to_owned(),
+        seen_events: Vec::new(),
+        last_transport_timestamp: Some(poisoned),
+        groups: Vec::new(),
+    };
+    store
+        .save_account_projection_state(&imported, 16, MAX_FUTURE_SKEW_SECS)
+        .unwrap();
+    let now_after = unix_now_seconds();
+
+    let restored = store.load_account_projection_state("alice", 16).unwrap();
+    let cursor = restored
+        .last_transport_timestamp
+        .expect("cursor must survive the save");
+    assert!(
+        (now_before + MAX_FUTURE_SKEW_SECS..=now_after + MAX_FUTURE_SKEW_SECS).contains(&cursor),
+        "poisoned snapshot adopted into a fresh store must clamp to save-time now + skew, got {cursor}"
+    );
+}
+
 /// Fixed merge-time "now" for the pure cursor-merge tests below.
 const MERGE_NOW: u64 = 1_800_000_000;
 
@@ -381,6 +419,20 @@ fn merged_transport_timestamp_is_cursor_neutral_without_snapshot() {
     assert_eq!(
         merged_transport_timestamp(Some(poisoned), None, MERGE_NOW, MAX_FUTURE_SKEW_SECS),
         Some(poisoned)
+    );
+}
+
+#[test]
+fn merged_transport_timestamp_clamps_snapshot_adopted_into_fresh_store() {
+    // A fresh store (`stored = None`) adopts the snapshot cursor, but must clamp
+    // it on the way in rather than adopt it raw. The legacy-import migration can
+    // carry a pre-clamp-era transport cursor poisoned above `now + skew` into a
+    // brand-new store through exactly this arm, so the adopted value has to be
+    // bounded to the ceiling.
+    let poisoned = MERGE_NOW + 10 * 365 * 24 * 60 * 60; // ~10 years ahead
+    assert_eq!(
+        merged_transport_timestamp(None, Some(poisoned), MERGE_NOW, MAX_FUTURE_SKEW_SECS),
+        Some(MERGE_NOW + MAX_FUTURE_SKEW_SECS)
     );
 }
 

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -5,6 +5,11 @@ use cgka_traits::app_event::{
     MARMOT_APP_EVENT_KIND_DELETE, MARMOT_APP_EVENT_KIND_REACTION, QUOTE_REF_TAG, STREAM_TAG,
 };
 
+/// Test twin of the app layer's transport-cursor future-skew policy (five
+/// minutes). The storage layer treats it as an injected bound, so any value
+/// works; mirroring production keeps the cursor tests realistic.
+const MAX_FUTURE_SKEW_SECS: u64 = 5 * 60;
+
 fn no_mentions(_plaintext: &str, _tags: &[Vec<String>]) -> bool {
     false
 }
@@ -150,7 +155,9 @@ fn account_projection_state_roundtrips_groups_components_and_seen_events() {
         groups: vec![group("aa", "alpha")],
     };
 
-    store.save_account_projection_state(&state, 1).unwrap();
+    store
+        .save_account_projection_state(&state, 1, MAX_FUTURE_SKEW_SECS)
+        .unwrap();
 
     let restored = store.load_account_projection_state("alice", 16).unwrap();
     assert_eq!(restored.seen_events, vec!["kept"]);
@@ -190,10 +197,222 @@ fn account_projection_state_refreshes_reseen_event_recency_before_pruning() {
         last_transport_timestamp: None,
         groups: Vec::new(),
     };
-    store.save_account_projection_state(&state, 2).unwrap();
+    store
+        .save_account_projection_state(&state, 2, MAX_FUTURE_SKEW_SECS)
+        .unwrap();
 
     let restored = store.load_account_projection_state("alice", 16).unwrap();
     assert_eq!(restored.seen_events, vec!["stale-b", "repeat"]);
+}
+
+#[test]
+fn account_projection_state_keeps_max_cursor_across_racing_saves() {
+    // Two runtimes over the same account database race their saves; whichever
+    // order the writes land in, the durable cursor must end at the max — a
+    // stale writer must never lower an advanced cursor.
+    let ahead = StoredAccountState {
+        label: "alice".to_owned(),
+        seen_events: Vec::new(),
+        last_transport_timestamp: Some(1_700_000_200),
+        groups: Vec::new(),
+    };
+    let behind = StoredAccountState {
+        last_transport_timestamp: Some(1_700_000_100),
+        ..ahead.clone()
+    };
+
+    for saves in [[&ahead, &behind], [&behind, &ahead]] {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        for state in saves {
+            store
+                .save_account_projection_state(state, 16, MAX_FUTURE_SKEW_SECS)
+                .unwrap();
+        }
+        let restored = store.load_account_projection_state("alice", 16).unwrap();
+        assert_eq!(restored.last_transport_timestamp, Some(1_700_000_200));
+    }
+}
+
+#[test]
+fn account_projection_state_save_without_cursor_preserves_stored_cursor() {
+    // A runtime that never learned a cursor (fresh process, no deliveries yet)
+    // still saves other state; that save must never wipe an advanced stored
+    // cursor back to NULL.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let advanced = StoredAccountState {
+        label: "alice".to_owned(),
+        seen_events: Vec::new(),
+        last_transport_timestamp: Some(1_700_000_200),
+        groups: Vec::new(),
+    };
+    store
+        .save_account_projection_state(&advanced, 16, MAX_FUTURE_SKEW_SECS)
+        .unwrap();
+
+    let never_learned = StoredAccountState {
+        last_transport_timestamp: None,
+        ..advanced
+    };
+    store
+        .save_account_projection_state(&never_learned, 16, MAX_FUTURE_SKEW_SECS)
+        .unwrap();
+
+    let restored = store.load_account_projection_state("alice", 16).unwrap();
+    assert_eq!(restored.last_transport_timestamp, Some(1_700_000_200));
+}
+
+#[test]
+fn account_projection_state_heals_poisoned_stored_cursor_on_save() {
+    // A stored cursor poisoned above `now + skew` (persisted by a version that
+    // predates the write-side clamp) must come out of the merge healed down to
+    // save-time `now + skew`, not preserved forever by the monotonic max —
+    // the save-side twin of the app layer's ingest-time heal.
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let now_before = unix_now_seconds();
+    let poisoned = now_before + 10 * 365 * 24 * 60 * 60; // ~10 years ahead
+    store.ensure_account_projection("alice").unwrap();
+    store
+        .lock()
+        .unwrap()
+        .execute(
+            "UPDATE account_state SET last_transport_timestamp = ?1 WHERE label = ?2",
+            params![i64::try_from(poisoned).unwrap(), "alice"],
+        )
+        .unwrap();
+
+    let honest = StoredAccountState {
+        label: "alice".to_owned(),
+        seen_events: Vec::new(),
+        last_transport_timestamp: Some(now_before),
+        groups: Vec::new(),
+    };
+    store
+        .save_account_projection_state(&honest, 16, MAX_FUTURE_SKEW_SECS)
+        .unwrap();
+    let now_after = unix_now_seconds();
+
+    let restored = store.load_account_projection_state("alice", 16).unwrap();
+    let cursor = restored
+        .last_transport_timestamp
+        .expect("cursor must survive the save");
+    assert!(
+        (now_before + MAX_FUTURE_SKEW_SECS..=now_after + MAX_FUTURE_SKEW_SECS).contains(&cursor),
+        "poisoned stored cursor must heal to save-time now + skew, got {cursor}"
+    );
+}
+
+/// Fixed merge-time "now" for the pure cursor-merge tests below.
+const MERGE_NOW: u64 = 1_800_000_000;
+
+#[test]
+fn merged_transport_timestamp_is_explicit_over_missing_sides() {
+    assert_eq!(
+        merged_transport_timestamp(None, None, MERGE_NOW, MAX_FUTURE_SKEW_SECS),
+        None
+    );
+    // A fresh store adopts whatever the runtime learned.
+    assert_eq!(
+        merged_transport_timestamp(None, Some(MERGE_NOW), MERGE_NOW, MAX_FUTURE_SKEW_SECS),
+        Some(MERGE_NOW)
+    );
+    // A runtime that never learned a cursor must never wipe the stored one.
+    assert_eq!(
+        merged_transport_timestamp(Some(MERGE_NOW), None, MERGE_NOW, MAX_FUTURE_SKEW_SECS),
+        Some(MERGE_NOW)
+    );
+}
+
+#[test]
+fn merged_transport_timestamp_takes_max_of_in_range_sides() {
+    assert_eq!(
+        merged_transport_timestamp(
+            Some(MERGE_NOW - 100),
+            Some(MERGE_NOW),
+            MERGE_NOW,
+            MAX_FUTURE_SKEW_SECS
+        ),
+        Some(MERGE_NOW)
+    );
+    assert_eq!(
+        merged_transport_timestamp(
+            Some(MERGE_NOW),
+            Some(MERGE_NOW - 100),
+            MERGE_NOW,
+            MAX_FUTURE_SKEW_SECS
+        ),
+        Some(MERGE_NOW)
+    );
+}
+
+#[test]
+fn merged_transport_timestamp_clamps_both_sides_before_max() {
+    let poisoned = MERGE_NOW + 10 * 365 * 24 * 60 * 60; // ~10 years ahead
+    // A poisoned stored side is healed to the ceiling instead of winning the
+    // max forever.
+    assert_eq!(
+        merged_transport_timestamp(
+            Some(poisoned),
+            Some(MERGE_NOW),
+            MERGE_NOW,
+            MAX_FUTURE_SKEW_SECS
+        ),
+        Some(MERGE_NOW + MAX_FUTURE_SKEW_SECS)
+    );
+    // A poisoned snapshot side is bounded the same way (defense in depth; the
+    // ingest path already clamps before the value reaches a save).
+    assert_eq!(
+        merged_transport_timestamp(
+            Some(MERGE_NOW),
+            Some(poisoned),
+            MERGE_NOW,
+            MAX_FUTURE_SKEW_SECS
+        ),
+        Some(MERGE_NOW + MAX_FUTURE_SKEW_SECS)
+    );
+}
+
+#[test]
+fn merged_transport_timestamp_is_cursor_neutral_without_snapshot() {
+    // Without a snapshot cursor there is nothing to merge against: the stored
+    // value passes through byte-identical, even when poisoned. Healing waits
+    // for the next save that learned a cursor, so a cursor-less save never
+    // moves the durable value in either direction.
+    let poisoned = MERGE_NOW + 10 * 365 * 24 * 60 * 60;
+    assert_eq!(
+        merged_transport_timestamp(Some(poisoned), None, MERGE_NOW, MAX_FUTURE_SKEW_SECS),
+        Some(poisoned)
+    );
+}
+
+#[test]
+fn clamp_to_max_future_skew_bounds_only_future_values() {
+    // In-range values pass through unchanged.
+    assert_eq!(
+        clamp_to_max_future_skew(MERGE_NOW - 1, MERGE_NOW, MAX_FUTURE_SKEW_SECS),
+        MERGE_NOW - 1
+    );
+    assert_eq!(
+        clamp_to_max_future_skew(
+            MERGE_NOW + MAX_FUTURE_SKEW_SECS,
+            MERGE_NOW,
+            MAX_FUTURE_SKEW_SECS
+        ),
+        MERGE_NOW + MAX_FUTURE_SKEW_SECS
+    );
+    // Values beyond the ceiling are pulled back to it.
+    assert_eq!(
+        clamp_to_max_future_skew(
+            MERGE_NOW + MAX_FUTURE_SKEW_SECS + 1,
+            MERGE_NOW,
+            MAX_FUTURE_SKEW_SECS
+        ),
+        MERGE_NOW + MAX_FUTURE_SKEW_SECS
+    );
+    // The ceiling saturates instead of overflowing.
+    assert_eq!(
+        clamp_to_max_future_skew(MERGE_NOW, u64::MAX, MAX_FUTURE_SKEW_SECS),
+        MERGE_NOW
+    );
 }
 
 #[test]
@@ -205,13 +424,17 @@ fn account_projection_state_deletes_groups_removed_from_snapshot() {
         last_transport_timestamp: None,
         groups: vec![group("aa", "alpha"), group("bb", "beta")],
     };
-    store.save_account_projection_state(&state, 16).unwrap();
+    store
+        .save_account_projection_state(&state, 16, MAX_FUTURE_SKEW_SECS)
+        .unwrap();
 
     let updated = StoredAccountState {
         groups: vec![group("bb", "beta")],
         ..state
     };
-    store.save_account_projection_state(&updated, 16).unwrap();
+    store
+        .save_account_projection_state(&updated, 16, MAX_FUTURE_SKEW_SECS)
+        .unwrap();
 
     let restored = store.load_account_projection_state("alice", 16).unwrap();
     assert_eq!(restored.groups.len(), 1);
@@ -237,7 +460,9 @@ fn account_projection_state_does_not_rewrite_unchanged_group_rows() {
         last_transport_timestamp: None,
         groups: vec![group("aa", "alpha")],
     };
-    store.save_account_projection_state(&state, 16).unwrap();
+    store
+        .save_account_projection_state(&state, 16, MAX_FUTURE_SKEW_SECS)
+        .unwrap();
     {
         let conn = store.lock().unwrap();
         conn.execute_batch(
@@ -273,7 +498,9 @@ fn account_projection_state_does_not_rewrite_unchanged_group_rows() {
 
     let mut updated = state;
     updated.seen_events.push("event-after".to_owned());
-    store.save_account_projection_state(&updated, 16).unwrap();
+    store
+        .save_account_projection_state(&updated, 16, MAX_FUTURE_SKEW_SECS)
+        .unwrap();
 
     let writes: i64 = store
         .lock()
@@ -447,6 +674,7 @@ fn secure_prune_checkpoint_removes_plaintext_from_database_and_wal_files() {
                 groups: vec![group("aa", "alpha")],
             },
             16,
+            MAX_FUTURE_SKEW_SECS,
         )
         .unwrap();
     let mut old = app_event("old-disk", "aa", 10);
@@ -586,6 +814,7 @@ fn secure_prune_clears_chat_list_preview_for_pruned_latest_message() {
                 groups: vec![group("aa", "alpha")],
             },
             16,
+            MAX_FUTURE_SKEW_SECS,
         )
         .unwrap();
     let mut old = app_event("old-aa", "aa", 10);
@@ -994,6 +1223,7 @@ fn chat_notification_settings_track_timed_forever_and_cleared_mutes() {
                 groups: vec![group("aa", "Muted")],
             },
             1,
+            MAX_FUTURE_SKEW_SECS,
         )
         .unwrap();
 
@@ -1075,7 +1305,9 @@ fn delete_local_group_data_removes_app_local_rows_without_touching_protocol_stat
         last_transport_timestamp: Some(1_700_000_001),
         groups: vec![group("aa", "alpha"), group("bb", "beta")],
     };
-    store.save_account_projection_state(&state, 16).unwrap();
+    store
+        .save_account_projection_state(&state, 16, MAX_FUTURE_SKEW_SECS)
+        .unwrap();
     store
         .record_app_event(&app_event("msg-aa", "aa", 10))
         .unwrap();
@@ -1161,7 +1393,9 @@ fn delete_local_group_data_rolls_back_all_tables_on_failure() {
         last_transport_timestamp: None,
         groups: vec![group("aa", "alpha")],
     };
-    store.save_account_projection_state(&state, 16).unwrap();
+    store
+        .save_account_projection_state(&state, 16, MAX_FUTURE_SKEW_SECS)
+        .unwrap();
     store
         .record_app_event(&app_event("msg-aa", "aa", 10))
         .unwrap();

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -14,6 +14,7 @@ use cgka_traits::app_event::{
 const LOCAL: &str = "aa";
 const REMOTE: &str = "bb";
 const GROUP: &str = "11";
+const MAX_FUTURE_SKEW_SECS: u64 = 5 * 60;
 
 fn group() -> StoredAccountGroup {
     StoredAccountGroup {
@@ -107,6 +108,7 @@ fn setup_store_with_group(group: StoredAccountGroup) -> SqliteAccountStorage {
                 ..StoredAccountState::default()
             },
             256,
+            MAX_FUTURE_SKEW_SECS,
         )
         .unwrap();
     store
@@ -1044,6 +1046,7 @@ fn set_group_self_membership_survives_projection_resave() {
                 ..StoredAccountState::default()
             },
             256,
+            MAX_FUTURE_SKEW_SECS,
         )
         .unwrap();
 
@@ -1071,6 +1074,7 @@ fn account_group_ids_defaulting_to_member_lists_only_default_rows() {
                 ..StoredAccountState::default()
             },
             256,
+            MAX_FUTURE_SKEW_SECS,
         )
         .unwrap();
 

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -22,7 +22,7 @@ pub use account_projection::{
     AccountChatNotificationSettings, AccountGroupPushToken, AccountNotificationSettings,
     AccountPushRegistration, AccountStoredPushRegistration, AppEventReplayCursor, SelfMembership,
     StoredAccountGroup, StoredAccountGroupComponent, StoredAccountState, StoredAppMessageQuery,
-    StoredAppMessageRecord,
+    StoredAppMessageRecord, clamp_to_max_future_skew,
 };
 pub use chat_list::{
     AccountUnreadTotal, ChatListAvatar, ChatListMessagePreview, ChatListQuery, ChatListRow,

--- a/crates/storage-sqlite/src/message_drafts.rs
+++ b/crates/storage-sqlite/src/message_drafts.rs
@@ -505,6 +505,8 @@ mod tests {
     use super::*;
     use crate::{SelfMembership, StoredAccountGroup, StoredAccountState};
 
+    const MAX_FUTURE_SKEW_SECS: u64 = 5 * 60;
+
     fn group(group_id_hex: &str) -> StoredAccountGroup {
         StoredAccountGroup {
             group_id_hex: group_id_hex.to_owned(),
@@ -556,6 +558,7 @@ mod tests {
                     groups: vec![group(&group_id_hex)],
                 },
                 100,
+                MAX_FUTURE_SKEW_SECS,
             )
             .unwrap();
 
@@ -635,6 +638,7 @@ mod tests {
                     groups: vec![],
                 },
                 100,
+                MAX_FUTURE_SKEW_SECS,
             )
             .unwrap();
         assert!(storage.message_draft(&group_id_hex).unwrap().is_none());
@@ -653,6 +657,7 @@ mod tests {
                     groups: vec![group(&group_id_hex)],
                 },
                 100,
+                MAX_FUTURE_SKEW_SECS,
             )
             .unwrap();
         let first = StoredMessageDraftAttachment {

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -68,7 +68,9 @@ pub use relay_list::{
     NostrAccountRelayListPublication,
 };
 #[cfg(feature = "sdk")]
-pub use sdk_client::{NostrSdkRelayClient, NostrSdkRelayHealth, NostrSdkSubscriptionPlan};
+pub use sdk_client::{
+    NostrSdkRelayClient, NostrSdkRelayHealth, NostrSdkSubscriptionPlan, RelayRegistrationOutcome,
+};
 pub use telemetry::{
     DurationHistogramSnapshot, HistogramBucket, RelayDeliverySpread, RelayDeliveryStats,
     RelayDeliveryTelemetry, RelayExportConsent, RelayIndex, RelayIndexRegistry,

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -657,6 +657,12 @@ impl NostrRelayClient for NostrSdkRelayClient {
         &self,
         account_id: &MemberId,
     ) -> Result<(), TransportAdapterError> {
+        // Drop the account's undrained registration bucket along with its
+        // subscriptions: a sign-out between a subscribe and the next sync's
+        // drain would otherwise orphan the bucket, and a later reactivation
+        // would OR-merge fresh registrations into the stale session's relays —
+        // misstating the next `subscription_rebuild` audit row.
+        self.registration_log.lock().await.remove(account_id);
         let ids = self
             .account_subscriptions
             .write()
@@ -1097,6 +1103,34 @@ mod tests {
             sdk.take_subscription_registrations(&account_b)
                 .await
                 .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_account_drops_the_undrained_registration_bucket() {
+        // A sign-out between a subscribe and the next sync's drain must not
+        // orphan the bucket: a later reactivation would OR-merge fresh
+        // registrations into the stale session's relays and misstate the next
+        // `subscription_rebuild` audit row (PR #825 follow-up).
+        let client = Client::builder().build();
+        let sdk = NostrSdkRelayClient::new(client);
+        let account = MemberId::new(vec![0xC3; 32]);
+        merge_registration_log(
+            sdk.registration_log
+                .lock()
+                .await
+                .entry(account.clone())
+                .or_default(),
+            [(relay("wss://stale.example"), true)],
+        );
+
+        sdk.unsubscribe_account(&account).await.unwrap();
+
+        assert!(
+            sdk.take_subscription_registrations(&account)
+                .await
+                .is_empty(),
+            "sign-out must drop the account's undrained registrations"
         );
     }
 

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -70,12 +70,35 @@ pub struct NostrSdkRelayHealth {
     pub connection_successes: usize,
 }
 
+/// One relay's subscription-registration outcome, surfaced to the app so it can
+/// be recorded in the forensic audit log's `subscription_rebuild` row.
+///
+/// `relay_url` is the caller-supplied subscription endpoint (the app already
+/// holds it — it is not a reverse-mapped [`crate::RelayIndex`], so this crosses
+/// no new identity over the boundary); `accepted` is whether the relay pool
+/// acknowledged the subscription registration. This is only returned to the
+/// caller — the adapter never logs the URL (the privacy invariant applies to
+/// tracing, not to this return value).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RelayRegistrationOutcome {
+    pub relay_url: String,
+    pub accepted: bool,
+}
+
 /// `nostr-sdk` backed implementation of [`NostrRelayClient`].
 #[derive(Clone)]
 pub struct NostrSdkRelayClient {
     client: Client,
     account_subscriptions: Arc<RwLock<HashMap<MemberId, Vec<SubscriptionId>>>>,
     publish_relay_refs: Arc<Mutex<HashMap<RelayUrl, usize>>>,
+    /// Per-relay subscription-registration outcomes accumulated since the last
+    /// [`take_subscription_registrations`](Self::take_subscription_registrations)
+    /// drain, keyed by endpoint. Merged monotonically (a relay counts as
+    /// registered once any subscription lands on it) so the app can attribute
+    /// one rebuild's registration results to a single audit row. Shared via
+    /// `Arc` so the clone the adapter drives during activation and the clone the
+    /// app holds observe the same log.
+    registration_log: Arc<Mutex<HashMap<RelayUrl, bool>>>,
 }
 
 impl NostrSdkRelayClient {
@@ -84,6 +107,7 @@ impl NostrSdkRelayClient {
             client,
             account_subscriptions: Arc::new(RwLock::new(HashMap::new())),
             publish_relay_refs: Arc::new(Mutex::new(HashMap::new())),
+            registration_log: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -101,6 +125,26 @@ impl NostrSdkRelayClient {
             health.record_status(relay.status());
         }
         health
+    }
+
+    /// Drain the per-relay subscription-registration outcomes accumulated since
+    /// the previous drain, sorted by relay URL for stable audit output.
+    ///
+    /// Draining attributes each outcome to exactly one caller (one
+    /// `subscription_rebuild` audit row); a subsequent rebuild starts from an
+    /// empty log. Returns an empty vec when no subscription has been registered
+    /// since the last drain.
+    pub async fn take_subscription_registrations(&self) -> Vec<RelayRegistrationOutcome> {
+        let mut log = self.registration_log.lock().await;
+        let mut outcomes: Vec<RelayRegistrationOutcome> = log
+            .drain()
+            .map(|(relay, accepted)| RelayRegistrationOutcome {
+                relay_url: relay.to_string(),
+                accepted,
+            })
+            .collect();
+        outcomes.sort_by(|a, b| a.relay_url.cmp(&b.relay_url));
+        outcomes
     }
 
     /// Start forwarding `nostr-sdk` notifications into the adapter's delivery
@@ -546,6 +590,16 @@ impl NostrRelayClient for NostrSdkRelayClient {
             "SDK relay subscription registered"
         );
 
+        // Record which of the requested endpoints acknowledged the registration
+        // so the app can surface it in the `subscription_rebuild` audit row.
+        // Only reached on the success path (>=1 relay registered): a total
+        // failure returned above, aborting activation before any audit row.
+        let outcomes = plan
+            .endpoints
+            .iter()
+            .map(|endpoint| (endpoint.clone(), output.success.contains(endpoint)));
+        merge_registration_log(&mut *self.registration_log.lock().await, outcomes);
+
         self.account_subscriptions
             .write()
             .await
@@ -782,6 +836,24 @@ impl<T: PartialEq> PushUnique<T> for Vec<T> {
     }
 }
 
+/// Fold one subscribe attempt's per-endpoint outcomes into the running
+/// registration log.
+///
+/// A relay counts as registered for the rebuild if it acknowledged *any*
+/// subscription (monotonic OR), so a group subscription that lands on a relay
+/// after a transient inbox miss still marks that relay accepted for the rebuild
+/// as a whole. Kept as a free function so the merge is unit-testable without a
+/// live relay pool.
+fn merge_registration_log(
+    log: &mut HashMap<RelayUrl, bool>,
+    outcomes: impl IntoIterator<Item = (RelayUrl, bool)>,
+) {
+    for (relay, accepted) in outcomes {
+        let entry = log.entry(relay).or_insert(false);
+        *entry = *entry || accepted;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -867,6 +939,74 @@ mod tests {
             serde_json::json!([hex::encode(&transport_group_id)])
         );
         assert_eq!(json["since"], serde_json::json!(1_700_000_000));
+    }
+
+    fn relay(url: &str) -> RelayUrl {
+        RelayUrl::parse(url).expect("relay url")
+    }
+
+    #[test]
+    fn registration_log_pairs_each_endpoint_with_its_acceptance() {
+        let one = relay("wss://one.example");
+        let two = relay("wss://two.example");
+        let mut log = HashMap::new();
+        // The requested endpoints are the authoritative key set: `two` failed
+        // to register (absent from the success set), `one` succeeded.
+        let success: HashSet<RelayUrl> = [one.clone()].into_iter().collect();
+        merge_registration_log(
+            &mut log,
+            [&one, &two]
+                .into_iter()
+                .map(|endpoint| (endpoint.clone(), success.contains(endpoint))),
+        );
+        assert_eq!(log.get(&one), Some(&true));
+        assert_eq!(log.get(&two), Some(&false));
+    }
+
+    #[test]
+    fn registration_log_merge_is_monotonic_ok() {
+        let one = relay("wss://one.example");
+        let mut log = HashMap::new();
+        // A first subscription misses the relay, a second lands on it: the
+        // relay counts as registered for the rebuild as a whole.
+        merge_registration_log(&mut log, [(one.clone(), false)]);
+        merge_registration_log(&mut log, [(one.clone(), true)]);
+        assert_eq!(log.get(&one), Some(&true));
+        // A later miss must not flip an already-accepted relay back to failed.
+        merge_registration_log(&mut log, [(one.clone(), false)]);
+        assert_eq!(log.get(&one), Some(&true));
+    }
+
+    #[tokio::test]
+    async fn take_subscription_registrations_drains_sorted_and_resets() {
+        let client = Client::builder().build();
+        let sdk = NostrSdkRelayClient::new(client);
+        // Seed the log directly (the network subscribe path is exercised by the
+        // MockRelay tests below); this pins the drain/sort/reset contract the
+        // app relies on for one audit row per rebuild.
+        merge_registration_log(
+            &mut *sdk.registration_log.lock().await,
+            [
+                (relay("wss://b.example"), true),
+                (relay("wss://a.example"), false),
+            ],
+        );
+        let outcomes = sdk.take_subscription_registrations().await;
+        assert_eq!(
+            outcomes,
+            vec![
+                RelayRegistrationOutcome {
+                    relay_url: "wss://a.example".into(),
+                    accepted: false,
+                },
+                RelayRegistrationOutcome {
+                    relay_url: "wss://b.example".into(),
+                    accepted: true,
+                },
+            ]
+        );
+        // Draining resets: a subsequent rebuild starts from an empty log.
+        assert!(sdk.take_subscription_registrations().await.is_empty());
     }
 
     #[test]

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -91,14 +91,18 @@ pub struct NostrSdkRelayClient {
     client: Client,
     account_subscriptions: Arc<RwLock<HashMap<MemberId, Vec<SubscriptionId>>>>,
     publish_relay_refs: Arc<Mutex<HashMap<RelayUrl, usize>>>,
-    /// Per-relay subscription-registration outcomes accumulated since the last
+    /// Per-account, per-relay subscription-registration outcomes accumulated
+    /// since that account's last
     /// [`take_subscription_registrations`](Self::take_subscription_registrations)
-    /// drain, keyed by endpoint. Merged monotonically (a relay counts as
-    /// registered once any subscription lands on it) so the app can attribute
-    /// one rebuild's registration results to a single audit row. Shared via
-    /// `Arc` so the clone the adapter drives during activation and the clone the
-    /// app holds observe the same log.
-    registration_log: Arc<Mutex<HashMap<RelayUrl, bool>>>,
+    /// drain, bucketed by account then keyed by endpoint. Within an account's
+    /// bucket a relay is merged monotonically (it counts as registered once any
+    /// of that account's subscriptions lands on it) so the app can attribute one
+    /// rebuild's registration results to a single audit row. Bucketing by
+    /// account keeps concurrent account workers on the one shared relay plane
+    /// from draining each other's registrations. Shared via `Arc` so the clone
+    /// the adapter drives during activation and the clone the app holds observe
+    /// the same log.
+    registration_log: Arc<Mutex<HashMap<MemberId, HashMap<RelayUrl, bool>>>>,
 }
 
 impl NostrSdkRelayClient {
@@ -127,17 +131,28 @@ impl NostrSdkRelayClient {
         health
     }
 
-    /// Drain the per-relay subscription-registration outcomes accumulated since
-    /// the previous drain, sorted by relay URL for stable audit output.
+    /// Drain the per-relay subscription-registration outcomes `account`
+    /// accumulated since its previous drain, sorted by relay URL for stable
+    /// audit output.
     ///
-    /// Draining attributes each outcome to exactly one caller (one
-    /// `subscription_rebuild` audit row); a subsequent rebuild starts from an
-    /// empty log. Returns an empty vec when no subscription has been registered
-    /// since the last drain.
-    pub async fn take_subscription_registrations(&self) -> Vec<RelayRegistrationOutcome> {
+    /// Draining is account-scoped: it removes and returns only `account`'s
+    /// bucket, so concurrent account workers sharing this one relay plane each
+    /// attribute their own registrations to their own `subscription_rebuild`
+    /// audit row. Each outcome lands on exactly one row for that account; a
+    /// subsequent rebuild for the same account starts from an empty bucket.
+    /// Returns an empty vec when `account` has registered no subscription since
+    /// its last drain. A group shared across accounts registers once, attributed
+    /// to whichever account's client subscribed (an acceptable diagnostic
+    /// attribution).
+    pub async fn take_subscription_registrations(
+        &self,
+        account: &MemberId,
+    ) -> Vec<RelayRegistrationOutcome> {
         let mut log = self.registration_log.lock().await;
         let mut outcomes: Vec<RelayRegistrationOutcome> = log
-            .drain()
+            .remove(account)
+            .unwrap_or_default()
+            .into_iter()
             .map(|(relay, accepted)| RelayRegistrationOutcome {
                 relay_url: relay.to_string(),
                 accepted,
@@ -598,7 +613,14 @@ impl NostrRelayClient for NostrSdkRelayClient {
             .endpoints
             .iter()
             .map(|endpoint| (endpoint.clone(), output.success.contains(endpoint)));
-        merge_registration_log(&mut *self.registration_log.lock().await, outcomes);
+        merge_registration_log(
+            self.registration_log
+                .lock()
+                .await
+                .entry(plan.account_id.clone())
+                .or_default(),
+            outcomes,
+        );
 
         self.account_subscriptions
             .write()
@@ -836,14 +858,15 @@ impl<T: PartialEq> PushUnique<T> for Vec<T> {
     }
 }
 
-/// Fold one subscribe attempt's per-endpoint outcomes into the running
-/// registration log.
+/// Fold one subscribe attempt's per-endpoint outcomes into one account's
+/// registration bucket.
 ///
-/// A relay counts as registered for the rebuild if it acknowledged *any*
-/// subscription (monotonic OR), so a group subscription that lands on a relay
-/// after a transient inbox miss still marks that relay accepted for the rebuild
-/// as a whole. Kept as a free function so the merge is unit-testable without a
-/// live relay pool.
+/// A relay counts as registered for that account's rebuild if it acknowledged
+/// *any* of the account's subscriptions (monotonic OR), so a group subscription
+/// that lands on a relay after a transient inbox miss still marks that relay
+/// accepted for the rebuild as a whole. Kept as a free function operating on a
+/// single account's bucket so the merge is unit-testable without a live relay
+/// pool.
 fn merge_registration_log(
     log: &mut HashMap<RelayUrl, bool>,
     outcomes: impl IntoIterator<Item = (RelayUrl, bool)>,
@@ -981,17 +1004,22 @@ mod tests {
     async fn take_subscription_registrations_drains_sorted_and_resets() {
         let client = Client::builder().build();
         let sdk = NostrSdkRelayClient::new(client);
+        let account = MemberId::new(vec![0xA1; 32]);
         // Seed the log directly (the network subscribe path is exercised by the
         // MockRelay tests below); this pins the drain/sort/reset contract the
         // app relies on for one audit row per rebuild.
         merge_registration_log(
-            &mut *sdk.registration_log.lock().await,
+            sdk.registration_log
+                .lock()
+                .await
+                .entry(account.clone())
+                .or_default(),
             [
                 (relay("wss://b.example"), true),
                 (relay("wss://a.example"), false),
             ],
         );
-        let outcomes = sdk.take_subscription_registrations().await;
+        let outcomes = sdk.take_subscription_registrations(&account).await;
         assert_eq!(
             outcomes,
             vec![
@@ -1006,7 +1034,70 @@ mod tests {
             ]
         );
         // Draining resets: a subsequent rebuild starts from an empty log.
-        assert!(sdk.take_subscription_registrations().await.is_empty());
+        assert!(
+            sdk.take_subscription_registrations(&account)
+                .await
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn take_subscription_registrations_is_scoped_to_the_draining_account() {
+        // The one relay plane per app shares this log across every account while
+        // account workers subscribe concurrently. A drain must return only the
+        // draining account's registrations: a global drain lets account A's
+        // rebuild row absorb account B's relays and leaves B's own drain empty —
+        // a misattribution in a trust-critical forensic channel (PR #825).
+        let client = Client::builder().build();
+        let sdk = NostrSdkRelayClient::new(client);
+        let account_a = MemberId::new(vec![0xA1; 32]);
+        let account_b = MemberId::new(vec![0xB2; 32]);
+        // Interleave two accounts' subscribe outcomes, each landing on its own
+        // relay, into the shared log.
+        merge_registration_log(
+            sdk.registration_log
+                .lock()
+                .await
+                .entry(account_a.clone())
+                .or_default(),
+            [(relay("wss://a.example"), true)],
+        );
+        merge_registration_log(
+            sdk.registration_log
+                .lock()
+                .await
+                .entry(account_b.clone())
+                .or_default(),
+            [(relay("wss://b.example"), true)],
+        );
+
+        // A's drain returns only A's relay...
+        assert_eq!(
+            sdk.take_subscription_registrations(&account_a).await,
+            vec![RelayRegistrationOutcome {
+                relay_url: "wss://a.example".into(),
+                accepted: true,
+            }]
+        );
+        // ...leaving B's registration intact for B's own rebuild row.
+        assert_eq!(
+            sdk.take_subscription_registrations(&account_b).await,
+            vec![RelayRegistrationOutcome {
+                relay_url: "wss://b.example".into(),
+                accepted: true,
+            }]
+        );
+        // Each account's bucket resets independently on its own drain.
+        assert!(
+            sdk.take_subscription_registrations(&account_a)
+                .await
+                .is_empty()
+        );
+        assert!(
+            sdk.take_subscription_registrations(&account_b)
+                .await
+                .is_empty()
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/825">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable transport-cursor persistence with **Frozen** mode (exposed via config, app accessor, and a UniFFI constructor).
  * Added audit-log diagnostics for **subscription rebuild** and **sync drain** (including relay registration outcomes), with updated schema support.
* **Bug Fixes**
  * Improved account catch-up error mapping with stable JSON/error codes across layers.
  * Prevented poisoned/future cursor timestamps from corrupting durable sync state via consistent clamping and merge behavior.
* **Tests**
  * Added/expanded regression coverage for Frozen cursor behavior, since-floor delivery, emitted audit rows, and legacy cursor clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->