### PR TITLE
fix(uniffi): distinguish invalid key package events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -757,7 +757,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "hex",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "tempfile",
 ]
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cgka-conformance-simulator",
  "serde",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "fs-private",
  "serde",
@@ -2871,7 +2871,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -4890,7 +4890,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -5543,7 +5543,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -6488,7 +6488,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -6516,7 +6516,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "agent-control",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.4"
+version = "0.9.5"
 license = "MIT"
 publish = false
 

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -17,6 +17,11 @@ pub enum MarmotKitError {
     InvalidHex { details: String },
     #[error("invalid nostr identity: {details}")]
     InvalidIdentity { details: String },
+    /// A fetched Nostr event exists for the recipient but cannot be used as a
+    /// valid Marmot KeyPackage. Kept distinct from malformed recipient input so
+    /// host apps can present a setup/invite state without string matching.
+    #[error("invalid key package event: {details}")]
+    InvalidKeyPackageEvent { details: String },
     #[error("missing key package for {account}")]
     MissingKeyPackage { account: String },
     #[error("publish failed: {details}")]
@@ -155,7 +160,7 @@ impl From<AppError> for MarmotKitError {
             AppError::InvalidPublicKey => Self::InvalidIdentity {
                 details: "invalid nostr public key".into(),
             },
-            AppError::InvalidKeyPackageEvent(details) => Self::InvalidIdentity { details },
+            AppError::InvalidKeyPackageEvent(details) => Self::InvalidKeyPackageEvent { details },
             AppError::Publish(details) => Self::Publish { details },
             AppError::TransportClosed => Self::TransportClosed,
             AppError::RuntimeStopping => Self::RuntimeStopping,
@@ -333,6 +338,20 @@ mod tests {
         assert!(
             matches!(wrapped, MarmotKitError::Io { .. }),
             "AccountHome IO failure must map to Io, got {wrapped:?}"
+        );
+    }
+
+    #[test]
+    fn invalid_key_package_event_crosses_ffi_as_typed_variant() {
+        let app_err = AppError::InvalidKeyPackageEvent("unsupported cipher suite".to_string());
+        let ffi: MarmotKitError = app_err.into();
+        assert!(
+            matches!(
+                ffi,
+                MarmotKitError::InvalidKeyPackageEvent { ref details }
+                    if details == "unsupported cipher suite"
+            ),
+            "invalid KeyPackage events must not be flattened into InvalidIdentity, got {ffi:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- expose `InvalidKeyPackageEvent` as a distinct `MarmotKitError` UniFFI variant
- preserve invalid public keys as `InvalidIdentity`
- bump the workspace binding version to 0.9.5 and cover the conversion with a regression test

## Verification
- `cargo test -p marmot-uniffi` (54 unit + 20 smoke tests)
- `just fast-ci`

Required by marmot-protocol/whitenoise-android#1266.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/826">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a distinct error type for invalid key package events, making these failures easier to identify.

* **Bug Fixes**
  * Corrected error reporting so invalid key package events are no longer incorrectly classified as invalid identities.

* **Chores**
  * Updated the workspace version from 0.9.4 to 0.9.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->