### PR TITLE
fix(uniffi): distinguish invalid key package events

### DIFF
--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -2285,7 +2285,7 @@ impl MarmotApp {
             return self.latest_key_package(&account.label);
         }
         let account_id = PublicKey::parse(member_ref)
-            .map_err(|_| AppError::MissingKeyPackage(member_ref.to_owned()))?
+            .map_err(|_| AppError::InvalidPublicKey)?
             .to_hex();
         if let Some(entry) = self.directory_entry_for_account_id(&account_id)? {
             if let Some(key_package) = entry.key_package {

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -14,6 +14,11 @@ pub enum MarmotKitError {
     InvalidHex { details: String },
     #[error("invalid nostr identity: {details}")]
     InvalidIdentity { details: String },
+    /// A fetched Nostr event exists for the recipient but cannot be used as a
+    /// valid Marmot KeyPackage. Kept distinct from malformed recipient input so
+    /// host apps can present a setup/invite state without string matching.
+    #[error("invalid key package event: {details}")]
+    InvalidKeyPackageEvent { details: String },
     #[error("missing key package for {account}")]
     MissingKeyPackage { account: String },
     #[error("publish failed: {details}")]
@@ -151,7 +156,7 @@ impl From<AppError> for MarmotKitError {
             AppError::InvalidPublicKey => Self::InvalidIdentity {
                 details: "invalid nostr public key".into(),
             },
-            AppError::InvalidKeyPackageEvent(details) => Self::InvalidIdentity { details },
+            AppError::InvalidKeyPackageEvent(details) => Self::InvalidKeyPackageEvent { details },
             AppError::Publish(details) => Self::Publish { details },
             AppError::TransportClosed => Self::TransportClosed,
             AppError::RuntimeStopping => Self::RuntimeStopping,
@@ -329,6 +334,20 @@ mod tests {
         assert!(
             matches!(wrapped, MarmotKitError::Io { .. }),
             "AccountHome IO failure must map to Io, got {wrapped:?}"
+        );
+    }
+
+    #[test]
+    fn invalid_key_package_event_crosses_ffi_as_typed_variant() {
+        let app_err = AppError::InvalidKeyPackageEvent("unsupported cipher suite".to_string());
+        let ffi: MarmotKitError = app_err.into();
+        assert!(
+            matches!(
+                ffi,
+                MarmotKitError::InvalidKeyPackageEvent { ref details }
+                    if details == "unsupported cipher suite"
+            ),
+            "invalid KeyPackage events must not be flattened into InvalidIdentity, got {ffi:?}"
         );
     }
 

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -338,7 +338,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_key_package_event_crosses_ffi_as_typed_variant() {
+    fn invalid_key_package_event_maps_to_typed_variant() {
         let app_err = AppError::InvalidKeyPackageEvent("unsupported cipher suite".to_string());
         let ffi: MarmotKitError = app_err.into();
         assert!(

--- a/crates/marmot-uniffi/tests/smoke.rs
+++ b/crates/marmot-uniffi/tests/smoke.rs
@@ -305,6 +305,38 @@ fn normalize_member_ref_accepts_profile_and_nostr_forms() {
 }
 
 #[tokio::test]
+async fn create_group_rejects_malformed_member_as_invalid_identity() {
+    install_mock_keyring();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let account = AccountHome::open_with_default_keychain(tmp.path())
+        .expect("open account home")
+        .create_nostr_account()
+        .expect("create local account");
+    let kit = Marmot::new(
+        tmp.path().to_string_lossy().into_owned(),
+        vec!["wss://relay.invalid.test".to_string()],
+    )
+    .expect("open marmot kit");
+    kit.start().await.expect("start marmot kit");
+
+    let error = kit
+        .create_group(
+            account.label,
+            "invalid member".into(),
+            vec!["not-a-member-ref".into()],
+            None,
+        )
+        .await
+        .expect_err("malformed member reference should fail");
+
+    assert!(
+        matches!(error, MarmotKitError::InvalidIdentity { .. }),
+        "malformed member reference must remain invalid input, got {error:?}"
+    );
+    kit.shutdown().await;
+}
+
+#[tokio::test]
 async fn delete_group_local_binding_is_public_and_validates_group_hex() {
     install_mock_keyring();
     let tmp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

- export `InvalidKeyPackageEvent` as a dedicated UniFFI error variant
- preserve malformed member references as `InvalidPublicKey` / `InvalidIdentity`
- keep unusable fetched KeyPackages distinct from missing KeyPackages
- add regression coverage through the exported `Marmot.create_group` API
- base the focused backport on `marmotkit-v0.9.3`, the artifact consumed by Android

## Verification

- `cargo test -p marmot-uniffi --locked` (52 unit + 20 smoke)
- `cargo test -p marmot-app --locked` (314 unit + 11 audit + 66 relay-runtime)
- `just fast-ci`
- GitHub CI: all checks green

Fixes marmot-protocol/whitenoise-android#1266
