### PR TITLE
test(installer): exercise systemd service activation

### DIFF
--- a/integrations/opencode/marmot/tests/test_installer.sh
+++ b/integrations/opencode/marmot/tests/test_installer.sh
@@ -8,6 +8,152 @@ allow_hex="$(printf '11%.0s' {1..32})"
 [ -x "$installer" ]
 bash -n "$installer"
 
+assert_log_contains() {
+    local log_file="$1"
+    local expected="$2"
+    local line
+    while IFS= read -r line; do
+        [ "$line" != "$expected" ] || return 0
+    done <"$log_file"
+    echo "missing systemctl call: $expected" >&2
+    return 1
+}
+
+assert_log_excludes() {
+    local log_file="$1"
+    local unexpected="$2"
+    local line
+    while IFS= read -r line; do
+        if [ "$line" = "$unexpected" ]; then
+            echo "unexpected systemctl call: $unexpected" >&2
+            return 1
+        fi
+    done <"$log_file"
+}
+
+run_linux_service_case() {
+    local fixture_root="$1"
+    local active="$2"
+    local log_file="$3"
+    local mock_bin="$fixture_root/mock-bin"
+    shift 3
+
+    : >"$log_file"
+    SYSTEMCTL_ACTIVE="$active" \
+    SYSTEMCTL_LOG="$log_file" \
+    HOME="$fixture_root/home" \
+    MARMOT_HOME="$fixture_root/marmot-home" \
+    MARMOT_INSTALL_PREFIX="$fixture_root/install" \
+    PATH="$mock_bin:/usr/bin:/bin" \
+    WN_AGENT_SHA="9.9.9" \
+    MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
+    WN_OPENCODE_BIN="/bin/echo" \
+        "$installer" --yes --allow-welcomer "$allow_hex" "$@" >/dev/null 2>&1 || {
+        echo "installer failed for systemd scenario (log: $log_file)" >&2
+        return 1
+    }
+}
+
+if [ "$(uname -s)" = Linux ]; then
+    fixture_root="$(mktemp -d)"
+    trap 'rm -rf "$fixture_root"' EXIT
+    mock_bin="$fixture_root/mock-bin"
+    mkdir -p "$mock_bin"
+
+    cat >"$mock_bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+destination=""
+url=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o) destination="$2"; shift 2 ;;
+        http*) url="$1"; shift ;;
+        *) shift ;;
+    esac
+done
+if [[ "$url" == *.sha256 ]]; then
+    printf '%s\n' fixture-hash >"$destination"
+else
+    : >"$destination"
+fi
+EOF
+
+    cat >"$mock_bin/shasum" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' fixture-hash
+EOF
+
+    cat >"$mock_bin/tar" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+archive=""
+destination=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -xzf) archive="$2"; shift 2 ;;
+        -C) destination="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+archive_name="$(basename "$archive")"
+case "$archive_name" in
+    wn-agent-*) binary=wn-agent ;;
+    wn-opencode-*) binary=wn-opencode ;;
+    *) exit 1 ;;
+esac
+platform="${archive_name#"$binary-"}"
+platform="${platform%-9.9.9.tar.gz}"
+mkdir -p "$destination/$binary-$platform"
+cat >"$destination/$binary-$platform/$binary" <<'SCRIPT'
+#!/usr/bin/env bash
+if [ "${1:-}" = bootstrap ]; then
+    printf '%s\n' '{"account_id_hex":"aa","welcomer_account_ids_hex":["bb"]}'
+fi
+SCRIPT
+chmod +x "$destination/$binary-$platform/$binary"
+EOF
+
+    cat >"$mock_bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$SYSTEMCTL_LOG"
+if [ "${1:-}" = --user ] && [ "${2:-}" = is-active ]; then
+    [ "$SYSTEMCTL_ACTIVE" = 1 ]
+fi
+EOF
+
+    cat >"$mock_bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$mock_bin"/*
+
+    fresh_log="$fixture_root/systemctl-fresh.log"
+    run_linux_service_case "$fixture_root" 0 "$fresh_log"
+    assert_log_contains "$fresh_log" "--user enable --now wn-agent-harnesses.service"
+    assert_log_contains "$fresh_log" "--user enable --now wn-opencode.service"
+    assert_log_excludes "$fresh_log" "--user restart wn-agent-harnesses.service"
+    assert_log_excludes "$fresh_log" "--user restart wn-opencode.service"
+
+    upgrade_log="$fixture_root/systemctl-upgrade.log"
+    run_linux_service_case "$fixture_root" 1 "$upgrade_log"
+    assert_log_contains "$upgrade_log" "--user enable wn-agent-harnesses.service"
+    assert_log_contains "$upgrade_log" "--user restart wn-agent-harnesses.service"
+    assert_log_contains "$upgrade_log" "--user enable wn-opencode.service"
+    assert_log_contains "$upgrade_log" "--user restart wn-opencode.service"
+    assert_log_excludes "$upgrade_log" "--user enable --now wn-agent-harnesses.service"
+    assert_log_excludes "$upgrade_log" "--user enable --now wn-opencode.service"
+
+    no_start_opencode_log="$fixture_root/systemctl-no-start-opencode.log"
+    run_linux_service_case "$fixture_root" 1 "$no_start_opencode_log" --no-start-wn-opencode
+    assert_log_contains "$no_start_opencode_log" "--user restart wn-agent-harnesses.service"
+    assert_log_excludes "$no_start_opencode_log" "--user is-active --quiet wn-opencode.service"
+    assert_log_excludes "$no_start_opencode_log" "--user enable wn-opencode.service"
+    assert_log_excludes "$no_start_opencode_log" "--user enable --now wn-opencode.service"
+    assert_log_excludes "$no_start_opencode_log" "--user restart wn-opencode.service"
+fi
+
 installer_dry_run="$(
     env -u MARMOT_HOME -u MARMOT_AGENT_SOCKET \
         WN_AGENT_SHA="9.9.9" \


### PR DESCRIPTION
## Summary
- rebase onto current `master` after the production restart behavior landed through #1043
- retain only the Linux execution fixture with mocked `systemctl` calls
- cover fresh installs, active-service upgrades, and `--no-start-wn-opencode`

## Test plan
- `just opencode-installer-test`
- Linux container: `integrations/opencode/marmot/tests/test_installer.sh`
- `bash -n scripts/install-opencode-marmot.sh integrations/opencode/marmot/tests/test_installer.sh`
- `just fast-ci`

Follow-up regression coverage for #832; the production fix is already on `master`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Linux integration coverage for installer service management.
  * Verified service behavior during initial installation, upgrades, and runs that disable starting the OpenCode service.
  * Added checks to confirm expected systemd actions occur and unintended actions are prevented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->