### PR TITLE
fix(hermes/marmot): accept is_reconnect kwarg in connect()

### DIFF
--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -1297,7 +1297,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             "id": chat_id,
         }
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         try:
             await self._ensure_account_id()
             await self._sync_welcomer_allowlist()

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -88,6 +88,12 @@ def install_fake_hermes_modules():
         def _mark_disconnected(self):
             self._running = False
 
+        async def connect(self, *, is_reconnect: bool = False) -> bool:
+            # Mirrors hermes-agent's keyword-only base signature; the gateway
+            # always calls connect(is_reconnect=...), so overrides must accept
+            # the keyword even when they ignore it (#836).
+            raise NotImplementedError
+
         def build_source(self, **kwargs):
             return SessionSource(platform=self.platform, **kwargs)
 
@@ -811,6 +817,30 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(adapter._tool_progress_events, {})
         self.assertEqual(adapter._tool_progress_replies, {})
+
+    async def test_connect_accepts_gateway_is_reconnect_keyword(self):
+        # hermes-agent's gateway connects adapters via connect(is_reconnect=...)
+        # on cold boot and reconnect alike, so a signature without the
+        # keyword-only argument raises TypeError before the platform ever
+        # comes up (#836).
+        class FakeClient:
+            async def inbound_events(self, account_id_hex=None, group_id_hex=None):
+                await asyncio.Event().wait()
+                yield {}  # unreachable: marks this as an async generator
+
+        for is_reconnect in (False, True):
+            with self.subTest(is_reconnect=is_reconnect):
+                adapter = self.adapter_module.MarmotPlatformAdapter(
+                    self.config_cls(extra={"account_id_hex": "11" * 32}),
+                    client=FakeClient(),
+                )
+                try:
+                    self.assertTrue(await adapter.connect(is_reconnect=is_reconnect))
+                    self.assertTrue(adapter._running)
+                    self.assertIsNotNone(adapter._listener_task)
+                finally:
+                    await adapter.disconnect()
+                self.assertIsNone(adapter._listener_task)
 
     async def test_inbound_event_is_forwarded_to_hermes_message_event(self):
         events = [


### PR DESCRIPTION
Fixes #836.

`hermes-agent` connects platform adapters via `await adapter.connect(is_reconnect=...)`, and the base adapter plus the bundled SimpleX plugin both use the keyword-only signature `async def connect(self, *, is_reconnect: bool = False) -> bool`. The Marmot adapter's override was `async def connect(self)`, so every connect raised:

```
✗ marmot error: MarmotPlatformAdapter.connect() got an unexpected keyword argument 'is_reconnect'
```

and the platform never came up (no socket opened to `wn-agent`).

This widens the signature to match; the body doesn't need the argument. One line.

Verified on a live deployment: after this change the adapter connects and the platform reaches `connected`.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/839">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the connection interface to support reconnect scenarios via an optional keyword parameter.
  * Existing connection behavior remains unchanged.
  * Added/expanded adapter tests to verify the new reconnect keyword is accepted and returns expected results for both cold start and reconnect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->