### PR TITLE
Feat/incident replay membership fork

### DIFF
--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -150,6 +150,20 @@ the top-level portable-vector test (Phase 5 wires the directory into CI).
 - Expected: the engine fork-recovers on delivery, the designated winner's branch survives, and both clients converge at
   epoch 2 with the full recovery summary matching the recorded incident.
 
+### `membership-fork-recovery-incident/v1`
+
+- File: `vectors/incidents/membership-fork-recovery-incident.v1.json`
+- Setup: two committers create a group, then raise competing membership commits (an invite race) from the same epoch,
+  with the two invitees held out by a partition — the membership-fork shape the adapter derives from a fork-recovery
+  incident whose contested tip is a membership/admin commit (`member_added`/`member_removed`/`admin_added`/`admin_removed`).
+- Pressure: same-epoch membership commit race with deferred delivery; the fork-recovery seam — not the convergence
+  selector — resolves it.
+- Expected: the engine fork-recovers on delivery and both committers converge at epoch 2 with `member_count == 3` — the
+  winner-agnostic proof that exactly one branch's invite survived — and the full recovery summary matching the recorded
+  incident. Unlike the group-data fork, the recovery is winner-agnostic (no branch-name label search), because real
+  observer-recorded exports cannot join a commit's publisher (`account_ref`, the observing engine) to its committer
+  (`actor_member_ref`, an MLS member id).
+
 ### `convergence-incident/v1`
 
 - File: `vectors/incidents/convergence-incident.v1.json`

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,0 +1,119 @@
+{
+  "scenario_name": "membership-fork-recovery-incident/v1",
+  "vector_version": "1",
+  "conformance_version": "0.9.4",
+  "seed": null,
+  "scenario": {
+    "name": "membership-fork-recovery-incident/v1",
+    "spec_version": "1",
+    "clients": [
+      "alice",
+      "bob",
+      "david",
+      "eve"
+    ],
+    "steps": [
+      {
+        "type": "create_group",
+        "creator": "alice",
+        "name": "replay",
+        "invitees": [
+          "bob"
+        ],
+        "required_features": [],
+        "pending": "create"
+      },
+      {
+        "type": "confirm_pending",
+        "client": "alice",
+        "pending": "create"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob"
+        ]
+      },
+      {
+        "type": "clear_events",
+        "clients": [
+          "alice",
+          "bob",
+          "david",
+          "eve"
+        ]
+      },
+      {
+        "type": "set_partition",
+        "allow": [
+          "alice",
+          "bob"
+        ]
+      },
+      {
+        "type": "invite_members",
+        "inviter": "alice",
+        "invitees": [
+          "david"
+        ],
+        "pending": "w"
+      },
+      {
+        "type": "invite_members",
+        "inviter": "bob",
+        "invitees": [
+          "eve"
+        ],
+        "pending": "l"
+      },
+      {
+        "type": "confirm_pending",
+        "client": "alice",
+        "pending": "w"
+      },
+      {
+        "type": "confirm_pending",
+        "client": "bob",
+        "pending": "l"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "alice",
+          "bob"
+        ]
+      },
+      {
+        "type": "observe",
+        "clients": [
+          "alice",
+          "bob"
+        ]
+      }
+    ]
+  },
+  "expected_outcomes": [
+    {
+      "type": "recovery_summary",
+      "count": 1,
+      "source_epoch": 1,
+      "recovered_epoch": 2,
+      "winner_differs_from_invalidated": true
+    },
+    {
+      "type": "clients_converged",
+      "clients": [
+        "alice",
+        "bob"
+      ],
+      "epoch": 2,
+      "member_count": 3
+    }
+  ]
+}

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -203,6 +203,19 @@
       "next": "Wire vectors/incidents/ into the portable vector fixture test (Phase 5)."
     },
     {
+      "id": "membership-fork-recovery-incident/v1",
+      "kind": "scenario_vector",
+      "status": "incident_replay",
+      "artifact": "incidents/membership-fork-recovery-incident.v1.json",
+      "coverage": [
+        "Goggles forensic export replayed as a conformance vector",
+        "same-epoch membership/admin fork recovery (competing-invite race)",
+        "winner-agnostic branch survival via post-recovery member count",
+        "full recovery-summary reproduction"
+      ],
+      "next": "Wire vectors/incidents/ into the portable vector fixture test (Phase 5)."
+    },
+    {
       "id": "convergence-incident/v1",
       "kind": "scenario_vector",
       "status": "incident_replay",

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -32,9 +32,16 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
     group from reading as healthy.
 - **Module:** `src/fork.rs`
   - **Role:** `recover_fork` turns a fork-recovery export into a `RecoveredFork`
-    (source epoch, commit kind, and the designated winner recovered tier-b from
-    the invalidated message's publisher), or a `ForkRecoveryError` when it cannot
-    be replayed. Only metadata (group-data) forks are supported today.
+    (source epoch + commit kind), or a `ForkRecoveryError` when it cannot be
+    replayed. Two `ForkCommitKind`s are synthesizable: **group-data** forks
+    (topic/name/avatar/retention) and **membership** forks (member add/remove,
+    admin grant/revoke — all collapse to one `Membership` kind, so a real
+    add-vs-promote race is one shape, not `MixedCommitKinds`). Rule-3 tier-b
+    winner attribution (the invalidated message's publisher is the loser) runs
+    **only for group-data forks** — the membership fork is winner-agnostic, and
+    real observer-recorded exports cannot join a publisher's `account_ref` (the
+    observing engine) to a committer's `actor_member_ref` (an MLS member id), so
+    the join is structurally impossible on real data.
 - **Module:** `src/convergence.rs`
   - **Role:** `recover_convergence` turns a convergence-selected export into a
     `RecoveredConvergence` (the decisive rule + a `ConvergenceDecisionKind`), or a
@@ -47,8 +54,12 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
     on raw commit depth, not the boost), indistinct candidate branch ids, or a
     priority/digest rule.
 - **Module:** `src/synth.rs`
-  - **Role:** `synthesize` builds the concurrent-fork `VectorFixture` (two
-    committers race group-data commits, no `SetPartition`). `synthesize_convergence`
+  - **Role:** `synthesize` builds the concurrent-fork `VectorFixture`, dispatching
+    on the commit kind: a **group-data** fork (two committers race `UpdateGroupData`
+    commits, no `SetPartition`) or a **membership** fork (two committers race
+    competing invites with the two invitees held out by a partition; after
+    recovery `member_count == 3` proves exactly one branch survived — the proven
+    `convergence-chaos/v1` invite-fork shape). `synthesize_convergence`
     dispatches on `ConvergenceDecisionKind`: the committer-decided vector (two
     admins race invite commits observed by a passive third client) or the
     witness-decided vector (the observer delivers two senders' app messages on one
@@ -56,9 +67,12 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
     overrides the committer tiebreak on the reorg). Both normalise real epochs to
     the simulator's `1 → 2` range; the convergence assertion is winner-agnostic.
 - **Module:** `src/accept.rs`
-  - **Role:** `accept` (fork) tries both label orderings and returns the vector
-    only when the full `RecoverySummary` matches **and** the designated winner's
-    branch survives. `accept_convergence` is a single run-and-compare (winner-agnostic
+  - **Role:** `accept` (fork) dispatches on the commit kind. A **group-data** fork
+    tries both label orderings and returns the vector only when the full
+    `RecoverySummary` matches **and** the designated winner's branch survives. A
+    **membership** fork is a single run-and-compare (winner-agnostic ⇒ no label
+    search): `member_count == 3` is the survival proof. `accept_convergence` is a
+    single run-and-compare (winner-agnostic
     ⇒ no label search) that returns the vector only when the recorded convergence
     decision reproduces. No reproduction ⇒ `AcceptError` (no vector).
 - **Module:** `src/main.rs`

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -29,7 +29,10 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
     ConvergenceSelected | Quarantine { reason }`. Everything downstream is gated
     behind this, so a healthy export yields zero vectors and a clean exit. Also
     home of the liveness gate (rule 5 below), which keeps a silently split
-    group from reading as healthy.
+    group from reading as healthy. `liveness_advisory` exposes that same rule-5
+    computation independent of the verdict, so a co-occurring liveness incident
+    that loses the single verdict to a higher-precedence incident (fork or
+    convergence) is still surfaced — the CLI prints it as a secondary advisory.
 - **Module:** `src/fork.rs`
   - **Role:** `recover_fork` turns a fork-recovery export into a `RecoveredFork`
     (source epoch + commit kind), or a `ForkRecoveryError` when it cannot be
@@ -79,7 +82,11 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
   - **Role:** CLI — classify one export file; for a fork-recovery or convergence
     incident, run the recover → accept → write pipeline. Exits 0 for any
     classification (healthy, quarantine, and accepted are all valid), 2 on
-    usage/IO/parse/write failure.
+    usage/IO/parse/write failure. Also prints a secondary `advisory (liveness):`
+    line whenever `liveness_advisory` fires and the primary verdict is not
+    already the epoch-divergence quarantine, so an accepted or quarantined
+    incident never masks a co-occurring engine left behind (the real e1a04e82
+    export carried both an accepted membership fork and a lag-12 stuck device).
 
 ## Classification rules (verified against real Goggles exports)
 

--- a/crates/incident-replay/src/accept.rs
+++ b/crates/incident-replay/src/accept.rs
@@ -3,7 +3,7 @@
 use cgka_conformance_simulator::{VectorFixture, run_scenario_spec};
 
 use crate::convergence::RecoveredConvergence;
-use crate::fork::RecoveredFork;
+use crate::fork::{ForkCommitKind, RecoveredFork};
 use crate::synth::{WINNER_BRANCH, synthesize, synthesize_convergence};
 
 /// Why an accept attempt produced no vector (fail-closed).
@@ -19,13 +19,20 @@ pub enum AcceptError {
 /// orderings puts the designated winner's key below the loser's.
 const LABEL_ORDERINGS: [(&str, &str); 2] = [("alice", "bob"), ("bob", "alice")];
 
-/// Synthesize and verify a vector for a recovered fork.
-///
-/// Bounded label search: for each ordering, run the synthesized scenario and
-/// accept iff the full `RecoverySummary` (and convergence) expectations hold
-/// **and** the designated winner's branch is the one that survived. The summary
-/// is the gate; branch survival only selects the correct ordering.
+/// Synthesize and verify a vector for a recovered fork, dispatching on the
+/// commit kind (the two shapes verify differently).
 pub fn accept(fork: &RecoveredFork, name: &str) -> Result<VectorFixture, AcceptError> {
+    match fork.commit {
+        ForkCommitKind::GroupData => accept_group_data_fork(fork, name),
+        ForkCommitKind::Membership => accept_membership_fork(fork, name),
+    }
+}
+
+/// Group-data fork: bounded label search. For each ordering, run the synthesized
+/// scenario and accept iff the full `RecoverySummary` expectations hold **and**
+/// the designated winner's branch (its group name) is the one that survived. The
+/// summary is the gate; branch survival only selects the correct ordering.
+fn accept_group_data_fork(fork: &RecoveredFork, name: &str) -> Result<VectorFixture, AcceptError> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_time()
         .build()
@@ -49,6 +56,30 @@ pub fn accept(fork: &RecoveredFork, name: &str) -> Result<VectorFixture, AcceptE
     Err(AcceptError::NotReproduced {
         tries: LABEL_ORDERINGS.len(),
     })
+}
+
+/// Membership fork: a single run-and-compare. The recovery is winner-agnostic —
+/// `member_count == 3` after recovery proves exactly one branch's invite
+/// survived — so there is no group-name to search label orderings for (unlike
+/// the group-data fork). Accept iff the synthesized scenario reproduces the
+/// recovery summary and the surviving-member count.
+fn accept_membership_fork(fork: &RecoveredFork, name: &str) -> Result<VectorFixture, AcceptError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .map_err(|err| AcceptError::Run(err.to_string()))?;
+
+    let (winner, loser) = LABEL_ORDERINGS[0];
+    let vector = synthesize(fork, name, winner, loser);
+    let trace = runtime
+        .block_on(run_scenario_spec(&vector.scenario))
+        .map_err(|err| AcceptError::Run(err.to_string()))?;
+
+    if vector.compare_observed_trace(&trace).is_empty() {
+        Ok(vector)
+    } else {
+        Err(AcceptError::NotReproduced { tries: 1 })
+    }
 }
 
 /// Synthesize and verify a vector for a recovered convergence decision.

--- a/crates/incident-replay/src/classify.rs
+++ b/crates/incident-replay/src/classify.rs
@@ -216,6 +216,21 @@ pub fn classify(export: &AgentStateExport) -> Verdict {
     Verdict::Healthy
 }
 
+/// The liveness (epoch-divergence) incident an export carries, independent of
+/// its routing [`Verdict`].
+///
+/// [`classify`] returns a single verdict, and a reproducible incident (fork or
+/// convergence) outranks the liveness gate on purpose — so an export that
+/// carries *both* a replayable incident and an engine left behind routes to the
+/// incident, and the liveness signal never reaches the operator. This exposes the
+/// same rule-5 computation so a caller (the CLI) can surface it as a secondary
+/// advisory alongside the primary outcome. Returns `None` when no engine is left
+/// behind — the gate stays unarmed on untimed or synthetic exports, exactly as
+/// [`classify`]'s healthy path does.
+pub fn liveness_advisory(export: &AgentStateExport) -> Option<QuarantineReason> {
+    epoch_divergence(export)
+}
+
 /// Per-engine activity, folded from the event log.
 #[derive(Default)]
 struct EngineActivity {

--- a/crates/incident-replay/src/fork.rs
+++ b/crates/incident-replay/src/fork.rs
@@ -8,13 +8,20 @@ use std::collections::BTreeSet;
 
 use crate::export::{AgentStateExport, EventKind, ForkWinner};
 
-/// The kind of commit both branches raced with. Only group-metadata forks are
-/// synthesizable today; membership/admin forks are deferred (they need a
-/// distinct scenario shape) and quarantine as unmapped.
+/// The kind of commit both branches raced with. Two shapes are synthesizable:
+/// group-metadata forks (`UpdateGroupData`) and membership/admin forks (a
+/// competing-invite race). The fork-recovery mechanism is content-independent —
+/// what matters is that two committers raced a commit at the same epoch and one
+/// branch was invalidated — so a membership-changing commit race reproduces the
+/// same `RecoverySummary` (outcome-equivalence, as the convergence path does).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ForkCommitKind {
     /// A group-metadata commit (topic/name/avatar/retention) → `UpdateGroupData`.
     GroupData,
+    /// A membership/admin commit (member add/remove, admin grant/revoke) →
+    /// reproduced by a competing-invite race, where `member_count == 3` after
+    /// recovery is the winner-agnostic proof that exactly one branch survived.
+    Membership,
 }
 
 /// The minimal, reproducible facts of a recovered fork.
@@ -48,12 +55,20 @@ pub enum ForkRecoveryError {
     UnrecoverableWinner,
     #[error("unmapped commit kind `{0}` at the contested tip")]
     UnmappedCommitKind(String),
+    #[error(
+        "the contested tip mixes a group-metadata commit with a membership commit, which has no \
+         single vector shape"
+    )]
+    MixedCommitKinds,
 }
 
 fn commit_kind(change_kind: &str) -> Result<ForkCommitKind, ForkRecoveryError> {
     match change_kind {
         "topic_changed" | "group_renamed" | "avatar_changed" | "retention_changed" => {
             Ok(ForkCommitKind::GroupData)
+        }
+        "member_added" | "member_removed" | "admin_added" | "admin_removed" => {
+            Ok(ForkCommitKind::Membership)
         }
         other => Err(ForkRecoveryError::UnmappedCommitKind(other.to_string())),
     }
@@ -99,26 +114,49 @@ pub fn recover_fork(export: &AgentStateExport) -> Result<RecoveredFork, ForkReco
         return Err(ForkRecoveryError::AmbiguousCommitters(committers.len()));
     }
 
-    // Every competing commit must map to one synthesizable kind.
-    let mut commit = None;
+    // Every competing commit must map to one synthesizable kind. A single fork
+    // is one shape: a tip that mixes a group-metadata commit with a membership
+    // commit has no single vector to race, so it fail-closes. (The membership
+    // variants all collapse to one `Membership` kind, so the real add-vs-promote
+    // race — `member_added` on one branch, `admin_added` on the other — is not
+    // mixed.)
+    let mut kinds: Vec<ForkCommitKind> = Vec::new();
     for (_, change_kind) in &tip {
-        commit = Some(commit_kind(change_kind)?);
+        let kind = commit_kind(change_kind)?;
+        if !kinds.contains(&kind) {
+            kinds.push(kind);
+        }
     }
-    let commit = commit.expect("two committers implies at least one tip change");
+    let commit = match kinds.as_slice() {
+        [only] => *only,
+        [] => unreachable!("two committers implies at least one tip change"),
+        _ => return Err(ForkRecoveryError::MixedCommitKinds),
+    };
 
-    // Rule 3 tier-b: the account that published the invalidated commit is the
-    // loser; the winner is the other committer. If the invalidated commit can't
-    // be attributed to one of the two committers, the winner is unrecoverable.
-    let loser = invalidated
-        .and_then(|inv| {
-            export
-                .events
-                .iter()
-                .find(|e| e.published_msg_id() == Some(inv))
-        })
-        .and_then(|event| event.account_ref.as_deref());
-    if !loser.is_some_and(|loser| committers.contains(loser)) {
-        return Err(ForkRecoveryError::UnrecoverableWinner);
+    // Rule 3 tier-b winner attribution is only needed for the group-data fork,
+    // whose accept path label-searches for the ordering that makes the designated
+    // winner's branch survive. The membership fork is winner-agnostic
+    // (`member_count == 3` is the survival proof, so accept is a single run with
+    // no label search), and real observer-recorded exports cannot even provide
+    // the join it would need: `account_ref` on a publish event is the *observing*
+    // engine, while the committers are `actor_member_ref` (MLS member ids) — a
+    // disjoint id space, so the publisher never matches a committer. Gating this
+    // to `GroupData` is what lets a real membership fork recover.
+    if commit == ForkCommitKind::GroupData {
+        // The account that published the invalidated commit is the loser; the
+        // winner is the other committer. If the invalidated commit can't be
+        // attributed to one of the two committers, the winner is unrecoverable.
+        let loser = invalidated
+            .and_then(|inv| {
+                export
+                    .events
+                    .iter()
+                    .find(|e| e.published_msg_id() == Some(inv))
+            })
+            .and_then(|event| event.account_ref.as_deref());
+        if !loser.is_some_and(|loser| committers.contains(loser)) {
+            return Err(ForkRecoveryError::UnrecoverableWinner);
+        }
     }
 
     Ok(RecoveredFork {

--- a/crates/incident-replay/src/lib.rs
+++ b/crates/incident-replay/src/lib.rs
@@ -35,7 +35,9 @@ pub mod ndjson;
 pub mod synth;
 
 pub use accept::{AcceptError, accept, accept_convergence};
-pub use classify::{BehindEngine, BehindMode, QuarantineReason, Verdict, classify};
+pub use classify::{
+    BehindEngine, BehindMode, QuarantineReason, Verdict, classify, liveness_advisory,
+};
 pub use convergence::{
     ConvergenceDecisionKind, ConvergenceRecoveryError, RecoveredConvergence, recover_convergence,
 };

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -14,12 +14,15 @@ use std::process::ExitCode;
 
 use cgka_conformance_simulator::VectorFixture;
 use incident_replay::{
-    AgentStateExport, Verdict, accept, accept_convergence, classify, is_stream, parse,
-    parse_stream, recover_convergence, recover_fork,
+    AgentStateExport, ForkCommitKind, Verdict, accept, accept_convergence, classify, is_stream,
+    parse, parse_stream, recover_convergence, recover_fork,
 };
 
-/// Vector name for a fork-recovery incident (one incident per export today).
+/// Vector name for a group-metadata fork-recovery incident.
 const INCIDENT_NAME: &str = "fork-recovery-incident/v1";
+/// Vector name for a membership/admin fork-recovery incident (a distinct shape,
+/// so a distinct name and file — it must not overwrite the group-data vector).
+const MEMBERSHIP_INCIDENT_NAME: &str = "membership-fork-recovery-incident/v1";
 /// Vector name for a convergence incident.
 const CONVERGENCE_NAME: &str = "convergence-incident/v1";
 
@@ -72,7 +75,11 @@ fn run_fork_recovery(export: &AgentStateExport, out_dir: Option<&Path>) -> ExitC
         Ok(fork) => fork,
         Err(err) => return quarantine(&err),
     };
-    match accept(&fork, INCIDENT_NAME) {
+    let name = match fork.commit {
+        ForkCommitKind::GroupData => INCIDENT_NAME,
+        ForkCommitKind::Membership => MEMBERSHIP_INCIDENT_NAME,
+    };
+    match accept(&fork, name) {
         Ok(vector) => persist_or_report(&vector, out_dir),
         Err(err) => quarantine(&err),
     }

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -14,8 +14,8 @@ use std::process::ExitCode;
 
 use cgka_conformance_simulator::VectorFixture;
 use incident_replay::{
-    AgentStateExport, ForkCommitKind, Verdict, accept, accept_convergence, classify, is_stream,
-    parse, parse_stream, recover_convergence, recover_fork,
+    AgentStateExport, ForkCommitKind, QuarantineReason, Verdict, accept, accept_convergence,
+    classify, is_stream, liveness_advisory, parse, parse_stream, recover_convergence, recover_fork,
 };
 
 /// Vector name for a group-metadata fork-recovery incident.
@@ -59,7 +59,17 @@ fn main() -> ExitCode {
         }
     };
 
-    match classify(&export) {
+    let verdict = classify(&export);
+    // A co-occurring liveness incident (rule 5) loses the single verdict to any
+    // higher-precedence incident, so surface it as a secondary advisory — unless
+    // it *is* the primary verdict, where it is already printed.
+    let liveness_is_primary = matches!(
+        &verdict,
+        Verdict::Quarantine {
+            reason: QuarantineReason::EpochDivergence { .. }
+        }
+    );
+    let code = match verdict {
         Verdict::ForkRecovery => run_fork_recovery(&export, out_dir.as_deref()),
         Verdict::Healthy => {
             println!("healthy: 0 vectors");
@@ -67,7 +77,11 @@ fn main() -> ExitCode {
         }
         Verdict::ConvergenceSelected => run_convergence(&export, out_dir.as_deref()),
         Verdict::Quarantine { reason } => quarantine(&reason),
+    };
+    if !liveness_is_primary && let Some(reason) = liveness_advisory(&export) {
+        println!("advisory (liveness): {reason}");
     }
+    code
 }
 
 fn run_fork_recovery(export: &AgentStateExport, out_dir: Option<&Path>) -> ExitCode {

--- a/crates/incident-replay/src/synth.rs
+++ b/crates/incident-replay/src/synth.rs
@@ -20,21 +20,29 @@ pub const WINNER_BRANCH: &str = "winner-branch";
 /// The group name the losing branch commits.
 pub const LOSER_BRANCH: &str = "loser-branch";
 
-fn commit_step(kind: ForkCommitKind, client: &str, name: &str, pending: &str) -> ScenarioStep {
-    match kind {
-        ForkCommitKind::GroupData => ScenarioStep::UpdateGroupData {
-            client: client.to_owned(),
-            name: name.to_owned(),
-            pending: pending.to_owned(),
-        },
+/// The two new members each competing branch invites in a membership fork. An
+/// invite race is the proven reproduction (the `convergence-chaos/v1`
+/// invite-fork arm): after recovery, `member_count == 3` is the winner-agnostic
+/// proof that exactly one branch's invite survived (both would be 4, neither 2).
+const FORK_INVITEE_A: &str = "david";
+const FORK_INVITEE_B: &str = "eve";
+
+/// Build the concurrent-fork vector for a recovered fork, dispatching on the
+/// commit kind: a group-metadata fork races two `UpdateGroupData` commits and is
+/// winner-branch-checked by the accept path's label search; a membership fork
+/// races two competing invites and is winner-agnostic (see [`ForkCommitKind`]).
+pub fn synthesize(fork: &RecoveredFork, name: &str, winner: &str, loser: &str) -> VectorFixture {
+    match fork.commit {
+        ForkCommitKind::GroupData => synthesize_group_data_fork(name, winner, loser),
+        ForkCommitKind::Membership => synthesize_membership_fork(name, winner, loser),
     }
 }
 
-/// Build the concurrent-fork vector. `winner`/`loser` are the synthetic client
-/// labels; the caller (the accept path) tries both orderings so the label whose
-/// committer key wins the `CommitOrderingKey` tiebreak is the one on the winning
-/// branch.
-pub fn synthesize(fork: &RecoveredFork, name: &str, winner: &str, loser: &str) -> VectorFixture {
+/// Build the group-metadata concurrent-fork vector. `winner`/`loser` are the
+/// synthetic client labels; the caller (the accept path) tries both orderings so
+/// the label whose committer key wins the `CommitOrderingKey` tiebreak is the one
+/// on the winning branch.
+fn synthesize_group_data_fork(name: &str, winner: &str, loser: &str) -> VectorFixture {
     let steps = vec![
         ScenarioStep::CreateGroup {
             creator: winner.to_owned(),
@@ -55,9 +63,17 @@ pub fn synthesize(fork: &RecoveredFork, name: &str, winner: &str, loser: &str) -
         ScenarioStep::ClearEvents {
             clients: vec![winner.to_owned(), loser.to_owned()],
         },
-        // Competing commits from the same epoch — the fork.
-        commit_step(fork.commit, winner, WINNER_BRANCH, "w"),
-        commit_step(fork.commit, loser, LOSER_BRANCH, "l"),
+        // Competing group-data commits from the same epoch — the fork.
+        ScenarioStep::UpdateGroupData {
+            client: winner.to_owned(),
+            name: WINNER_BRANCH.to_owned(),
+            pending: "w".to_owned(),
+        },
+        ScenarioStep::UpdateGroupData {
+            client: loser.to_owned(),
+            name: LOSER_BRANCH.to_owned(),
+            pending: "l".to_owned(),
+        },
         ScenarioStep::ConfirmPending {
             client: winner.to_owned(),
             pending: "w".to_owned(),
@@ -100,6 +116,105 @@ pub fn synthesize(fork: &RecoveredFork, name: &str, winner: &str, loser: &str) -
                 clients: vec![winner.to_owned(), loser.to_owned()],
                 epoch: Some(2),
                 member_count: Some(2),
+            },
+        ],
+    }
+}
+
+/// Build the membership concurrent-fork vector: two committers race competing
+/// invites from the same epoch and the engine fork-recovers on delivery. The two
+/// invitees are held out of the race with a partition so only the committers'
+/// competing commits reach each other (the proven `convergence-chaos/v1`
+/// invite-fork shape). The assertion is winner-agnostic: `member_count == 3`
+/// after recovery proves exactly one branch's invite survived, so unlike the
+/// group-data fork no branch-name survival check (and no label search) is needed.
+fn synthesize_membership_fork(name: &str, winner: &str, loser: &str) -> VectorFixture {
+    let clients = vec![
+        winner.to_owned(),
+        loser.to_owned(),
+        FORK_INVITEE_A.to_owned(),
+        FORK_INVITEE_B.to_owned(),
+    ];
+    let steps = vec![
+        ScenarioStep::CreateGroup {
+            creator: winner.to_owned(),
+            name: "replay".to_owned(),
+            invitees: vec![loser.to_owned()],
+            required_features: Vec::new(),
+            initial_admins: None,
+            pending: "create".to_owned(),
+        },
+        ScenarioStep::ConfirmPending {
+            client: winner.to_owned(),
+            pending: "create".to_owned(),
+        },
+        ScenarioStep::DeliverAll,
+        ScenarioStep::Tick {
+            clients: vec![loser.to_owned()],
+        },
+        ScenarioStep::ClearEvents {
+            clients: clients.clone(),
+        },
+        // Hold the invitees out so only the two committers' competing commits
+        // race each other. (The runner auto-promotes `loser` to admin when it
+        // sends the competing invite.)
+        ScenarioStep::SetPartition {
+            allow: vec![winner.to_owned(), loser.to_owned()],
+        },
+        // Competing membership commits from the same epoch — the fork.
+        ScenarioStep::InviteMembers {
+            inviter: winner.to_owned(),
+            invitees: vec![FORK_INVITEE_A.to_owned()],
+            pending: "w".to_owned(),
+        },
+        ScenarioStep::InviteMembers {
+            inviter: loser.to_owned(),
+            invitees: vec![FORK_INVITEE_B.to_owned()],
+            pending: "l".to_owned(),
+        },
+        ScenarioStep::ConfirmPending {
+            client: winner.to_owned(),
+            pending: "w".to_owned(),
+        },
+        ScenarioStep::ConfirmPending {
+            client: loser.to_owned(),
+            pending: "l".to_owned(),
+        },
+        ScenarioStep::DeliverAll,
+        ScenarioStep::Tick {
+            clients: vec![winner.to_owned(), loser.to_owned()],
+        },
+        ScenarioStep::Observe {
+            clients: vec![winner.to_owned(), loser.to_owned()],
+        },
+    ];
+
+    VectorFixture {
+        scenario_name: name.to_owned(),
+        vector_version: "1".to_owned(),
+        conformance_version: env!("CARGO_PKG_VERSION").to_owned(),
+        seed: None,
+        scenario: ScenarioSpec {
+            name: name.to_owned(),
+            spec_version: "1".to_owned(),
+            clients,
+            steps,
+        },
+        expected_trace: None,
+        expected_outcomes: vec![
+            // Rule 4: assert the full recovery summary, not just the winner.
+            TraceExpectation::RecoverySummary {
+                count: 1,
+                source_epoch: Some(1),
+                recovered_epoch: Some(2),
+                winner_differs_from_invalidated: true,
+            },
+            // member_count 3 == exactly one branch's invite survived (both would
+            // be 4, neither 2): the winner-agnostic survival proof.
+            TraceExpectation::ClientsConverged {
+                clients: vec![winner.to_owned(), loser.to_owned()],
+                epoch: Some(2),
+                member_count: Some(3),
             },
         ],
     }

--- a/crates/incident-replay/tests/accept.rs
+++ b/crates/incident-replay/tests/accept.rs
@@ -14,6 +14,17 @@ const PURE_METADATA_FORK: &str = r#"{
   ]
 }"#;
 
+/// The real e1a04e82 shape: two committers race membership commits (one
+/// `admin_added`, one `member_added`) at the same epoch.
+const MEMBERSHIP_FORK: &str = r#"{
+  "events": [
+    { "kind": { "type": "fork_resolution", "source_epoch": 30, "invalidated_msg_id": "inv-1", "winner": "candidate" } },
+    { "account_ref": "alpha", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "admin_added", "actor_member_ref": "alpha" } },
+    { "account_ref": "beta", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "member_added", "actor_member_ref": "beta" } },
+    { "account_ref": "beta", "kind": { "type": "publish_outcome", "msg_id": "inv-1" } }
+  ]
+}"#;
+
 #[test]
 fn metadata_fork_accepts_with_a_reproducible_vector() {
     let fork = recover_fork(&parse(PURE_METADATA_FORK).expect("parses")).expect("recovers");
@@ -23,5 +34,18 @@ fn metadata_fork_accepts_with_a_reproducible_vector() {
     assert_eq!(vector.scenario_name, "test-topic-fork/v1");
     assert_eq!(vector.scenario.clients.len(), 2);
     // RecoverySummary + ClientsConverged.
+    assert_eq!(vector.expected_outcomes.len(), 2);
+}
+
+#[test]
+fn membership_fork_accepts_with_a_reproducible_vector() {
+    let fork = recover_fork(&parse(MEMBERSHIP_FORK).expect("parses")).expect("recovers");
+    let vector = accept(&fork, "test-membership-fork/v1")
+        .expect("run-and-compare reproduces the membership fork recovery");
+
+    assert_eq!(vector.scenario_name, "test-membership-fork/v1");
+    // Two committers race competing invites; the two invitees round it out.
+    assert_eq!(vector.scenario.clients.len(), 4);
+    // RecoverySummary + ClientsConverged(member_count 3).
     assert_eq!(vector.expected_outcomes.len(), 2);
 }

--- a/crates/incident-replay/tests/classify.rs
+++ b/crates/incident-replay/tests/classify.rs
@@ -1,7 +1,9 @@
 //! Classification behaviour, exercised through the public parse + classify API
 //! against synthetic, non-sensitive fixtures.
 
-use incident_replay::{BehindEngine, BehindMode, QuarantineReason, Verdict, classify, parse};
+use incident_replay::{
+    BehindEngine, BehindMode, QuarantineReason, Verdict, classify, liveness_advisory, parse,
+};
 
 fn load(name: &str) -> incident_replay::AgentStateExport {
     let path = format!("{}/tests/fixtures/{name}", env!("CARGO_MANIFEST_DIR"));
@@ -161,6 +163,28 @@ fn a_reproducible_incident_outranks_the_liveness_gate() {
     assert_eq!(
         classify(&load("fork-recovery-with-behind-engine.json")),
         Verdict::ForkRecovery
+    );
+}
+
+#[test]
+fn liveness_advisory_surfaces_behind_an_incident_verdict() {
+    // The export routes to ForkRecovery (rule 4 outranks the rule-5 liveness
+    // gate), so classify's single verdict hides engine-b, which sits 12 epochs
+    // behind while still active — exactly the shape the real e1a04e82 export
+    // carried. liveness_advisory exposes that co-occurring incident so the CLI
+    // can print it as a secondary advisory alongside the accepted vector.
+    let export = load("fork-with-active-behind-engine.json");
+    assert_eq!(classify(&export), Verdict::ForkRecovery);
+    assert_eq!(
+        liveness_advisory(&export),
+        Some(QuarantineReason::EpochDivergence {
+            group_epoch: 31,
+            engines: vec![BehindEngine {
+                engine_id: "engine-b".into(),
+                epoch: 19,
+                mode: BehindMode::ActiveWhileBehind,
+            }],
+        })
     );
 }
 

--- a/crates/incident-replay/tests/fixtures/fork-with-active-behind-engine.json
+++ b/crates/incident-replay/tests/fixtures/fork-with-active-behind-engine.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "message_state_changed", "epoch": 31, "new_state": "processed" }
+    },
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": {
+        "type": "fork_resolution",
+        "source_epoch": 22,
+        "invalidated_msg_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "winner": "candidate"
+      }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "message_state_changed", "epoch": 19, "new_state": "processed" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000007200000,
+      "kind": { "type": "message_state_changed", "epoch": 19, "new_state": "processed" }
+    }
+  ]
+}

--- a/crates/incident-replay/tests/fork.rs
+++ b/crates/incident-replay/tests/fork.rs
@@ -77,16 +77,50 @@ fn an_unattributable_invalidated_commit_makes_the_winner_unrecoverable() {
 }
 
 #[test]
-fn an_unmapped_commit_kind_is_quarantined() {
-    // A membership fork (member_added) is not synthesizable yet.
+fn recovers_a_membership_fork() {
+    // The real e1a04e82 shape: one committer `admin_added`, the other
+    // `member_added`, at the same epoch. Both collapse to `Membership`, so the
+    // heterogeneous add-vs-promote race is one shape, not mixed.
     let json = r#"{ "events": [
-        { "kind": { "type": "fork_resolution", "source_epoch": 30, "invalidated_msg_id": "inv-1", "winner": "incumbent" } },
-        { "account_ref": "alpha", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "member_added", "actor_member_ref": "alpha" } },
+        { "kind": { "type": "fork_resolution", "source_epoch": 30, "invalidated_msg_id": "inv-1", "winner": "candidate" } },
+        { "account_ref": "alpha", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "admin_added", "actor_member_ref": "alpha" } },
         { "account_ref": "beta", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "member_added", "actor_member_ref": "beta" } },
         { "account_ref": "beta", "kind": { "type": "publish_outcome", "msg_id": "inv-1" } }
     ] }"#;
     assert_eq!(
         recover(json),
-        Err(ForkRecoveryError::UnmappedCommitKind("member_added".into()))
+        Ok(RecoveredFork {
+            source_epoch: 30,
+            commit: ForkCommitKind::Membership,
+        })
+    );
+}
+
+#[test]
+fn a_tip_mixing_group_data_and_membership_is_quarantined() {
+    // A group-metadata commit racing a membership commit has no single vector.
+    let json = r#"{ "events": [
+        { "kind": { "type": "fork_resolution", "source_epoch": 30, "invalidated_msg_id": "inv-1", "winner": "incumbent" } },
+        { "account_ref": "alpha", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "topic_changed", "actor_member_ref": "alpha" } },
+        { "account_ref": "beta", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "member_added", "actor_member_ref": "beta" } },
+        { "account_ref": "beta", "kind": { "type": "publish_outcome", "msg_id": "inv-1" } }
+    ] }"#;
+    assert_eq!(recover(json), Err(ForkRecoveryError::MixedCommitKinds));
+}
+
+#[test]
+fn an_unmapped_commit_kind_is_quarantined() {
+    // A commit kind with no vector shape yet still fail-closes as unmapped.
+    let json = r#"{ "events": [
+        { "kind": { "type": "fork_resolution", "source_epoch": 30, "invalidated_msg_id": "inv-1", "winner": "incumbent" } },
+        { "account_ref": "alpha", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "capability_upgraded", "actor_member_ref": "alpha" } },
+        { "account_ref": "beta", "kind": { "type": "group_state_changed", "epoch": 31, "change_kind": "capability_upgraded", "actor_member_ref": "beta" } },
+        { "account_ref": "beta", "kind": { "type": "publish_outcome", "msg_id": "inv-1" } }
+    ] }"#;
+    assert_eq!(
+        recover(json),
+        Err(ForkRecoveryError::UnmappedCommitKind(
+            "capability_upgraded".into()
+        ))
     );
 }


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/877">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recovering membership forks caused by competing invitations.
  * Added a new membership fork-recovery incident scenario and conformance vector.
  * Added optional liveness advisories when an export includes an engine that has fallen behind.

* **Bug Fixes**
  * Improved fork classification and fail-closed handling for mixed or unsupported fork types.
  * Membership recovery now validates convergence and confirms that exactly one invitation survives.

* **Documentation**
  * Expanded incident-replay guidance and scenario documentation for membership recovery and liveness reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->