### PR TITLE
fix(agent): preserve stream parent relationship

### DIFF
--- a/crates/agent-connector/src/connection.rs
+++ b/crates/agent-connector/src/connection.rs
@@ -158,12 +158,14 @@ impl AgentConnector {
                 account_id_hex,
                 group_id_hex,
                 stream_id_hex,
+                parent_message_id_hex,
                 quic_candidates,
             } => {
                 self.stream_begin_response(
                     &account_id_hex,
                     &group_id_hex,
                     stream_id_hex,
+                    parent_message_id_hex,
                     quic_candidates,
                 )
                 .await

--- a/crates/agent-connector/src/stream.rs
+++ b/crates/agent-connector/src/stream.rs
@@ -65,6 +65,7 @@ impl AgentConnector {
         account_id_hex: &str,
         group_id_hex: &str,
         stream_id_hex: Option<String>,
+        parent_message_id_hex: Option<String>,
         quic_candidates: Vec<String>,
     ) -> Result<AgentControlResponse, ConnectorError> {
         let account = self.local_account_for_account_id(account_id_hex)?;
@@ -77,6 +78,17 @@ impl AgentConnector {
             .transpose()?
             .unwrap_or_else(transport_quic_stream::random_stream_id);
         let stream_id_hex = hex::encode(&stream_id);
+        let parent_message_id_hex = parent_message_id_hex
+            .map(|parent_message_id_hex| -> Result<String, ConnectorError> {
+                let normalized = normalize_hex(&parent_message_id_hex)?;
+                if normalized.len() != 64 {
+                    return Err(ConnectorError::Stream(
+                        "stream parent message id must be 32 bytes".into(),
+                    ));
+                }
+                Ok(normalized)
+            })
+            .transpose()?;
         let candidate = first_quic_candidate(&quic_candidates)?;
         let parsed_candidate = parse_quic_candidate(&candidate)?;
         let broker_addr =
@@ -88,11 +100,12 @@ impl AgentConnector {
         );
         let (_payload, summary) = self
             .runtime
-            .start_agent_text_stream(
+            .start_agent_text_stream_with_parent(
                 &account.label,
                 &group_id,
                 &stream_id,
                 unix_now_seconds(),
+                parent_message_id_hex,
                 quic_candidates.clone(),
             )
             .await?;

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -12,7 +12,7 @@ use cgka_traits::app_event::{
     MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY, MARMOT_APP_EVENT_KIND_AGENT_OPERATION,
     MARMOT_APP_EVENT_KIND_AGENT_STREAM_START, MARMOT_APP_EVENT_KIND_CHAT,
     MARMOT_APP_EVENT_KIND_DELETE, MARMOT_APP_EVENT_KIND_EDIT, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
-    MARMOT_APP_EVENT_KIND_REACTION, STREAM_TAG,
+    MARMOT_APP_EVENT_KIND_REACTION, STREAM_PARENT_TAG, STREAM_TAG,
 };
 use cgka_traits::engine::{GroupEvent, GroupStateChange};
 use cgka_traits::{EpochId, GroupId, MessageId};
@@ -1906,6 +1906,7 @@ async fn connector_socket_composes_and_finalizes_stream() {
 
     let group_id_hex = hex::encode(group_id.as_slice());
     let stream_id_hex = hex::encode([0x77; 32]);
+    let parent_message_id_hex = hex::encode([0x88; 32]);
     let socket = dir.path().join("dev").join("wn-agent.sock");
     let connector = AgentConnector::open(test_config(
         dir.path(),
@@ -1926,6 +1927,7 @@ async fn connector_socket_composes_and_finalizes_stream() {
             account_id_hex: agent.account.account_id_hex.clone(),
             group_id_hex: group_id_hex.clone(),
             stream_id_hex: Some(stream_id_hex.clone()),
+            parent_message_id_hex: Some(parent_message_id_hex.clone()),
             quic_candidates: vec!["quic://127.0.0.1:9".to_owned()],
         },
     )
@@ -1941,6 +1943,30 @@ async fn connector_socket_composes_and_finalizes_stream() {
     };
     assert_eq!(begun_stream_id_hex, stream_id_hex);
     assert_eq!(quic_candidates, vec!["quic://127.0.0.1:9"]);
+    let stored = connector
+        .runtime
+        .messages_with_query(
+            &agent.account.account_id_hex,
+            crate::AppMessageQuery {
+                group_id_hex: Some(group_id_hex.clone()),
+                limit: None,
+            },
+        )
+        .unwrap();
+    let start = stored
+        .iter()
+        .find(|message| message.message_id_hex == start_message_id_hex)
+        .expect("stream start must be in the local app projection");
+    assert_eq!(start.kind, MARMOT_APP_EVENT_KIND_AGENT_STREAM_START);
+    assert_eq!(
+        start
+            .tags
+            .iter()
+            .find(|tag| tag.first().map(String::as_str) == Some(STREAM_PARENT_TAG))
+            .and_then(|tag| tag.get(1))
+            .map(String::as_str),
+        Some(parent_message_id_hex.as_str())
+    );
 
     let appended = serve_control_request_once(
         &connector,
@@ -2054,6 +2080,7 @@ async fn connector_socket_finalize_mismatch_keeps_stream_session_retryable() {
             account_id_hex: agent.account.account_id_hex.clone(),
             group_id_hex: group_id_hex.clone(),
             stream_id_hex: Some(stream_id_hex.clone()),
+            parent_message_id_hex: None,
             quic_candidates: vec!["quic://127.0.0.1:9".to_owned()],
         },
     )
@@ -2214,6 +2241,7 @@ async fn connector_finalize_retries_durable_finish_without_compose_task() {
             account_id_hex: agent.account.account_id_hex.clone(),
             group_id_hex,
             stream_id_hex: Some(stream_id_hex.clone()),
+            parent_message_id_hex: None,
             quic_candidates: vec!["quic://127.0.0.1:9".to_owned()],
         },
     )
@@ -2361,6 +2389,7 @@ async fn connector_socket_cancels_stream_session() {
             account_id_hex: agent.account.account_id_hex,
             group_id_hex,
             stream_id_hex: Some(stream_id_hex.clone()),
+            parent_message_id_hex: None,
             quic_candidates: vec!["quic://127.0.0.1:9".to_owned()],
         },
     )

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -92,6 +92,8 @@ pub enum AgentControlRequest {
         account_id_hex: String,
         group_id_hex: String,
         stream_id_hex: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_message_id_hex: Option<String>,
         quic_candidates: Vec<String>,
     },
     StreamAppend {
@@ -547,6 +549,36 @@ mod tests {
     }
 
     #[test]
+    fn stream_begin_parent_message_id_is_optional_and_round_trips_when_present() {
+        let without = AgentControlRequest::StreamBegin {
+            account_id_hex: "aa".repeat(32),
+            group_id_hex: "cc".repeat(32),
+            stream_id_hex: None,
+            parent_message_id_hex: None,
+            quic_candidates: vec!["quic://broker.example:4450".to_owned()],
+        };
+        let value = serde_json::to_value(&without).unwrap();
+        assert!(
+            value.get("parent_message_id_hex").is_none(),
+            "absent parent must not be serialized"
+        );
+        let decoded: AgentControlRequest = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded, without);
+
+        let with = AgentControlRequest::StreamBegin {
+            account_id_hex: "aa".repeat(32),
+            group_id_hex: "cc".repeat(32),
+            stream_id_hex: Some("55".repeat(32)),
+            parent_message_id_hex: Some("dd".repeat(32)),
+            quic_candidates: vec!["quic://broker.example:4450".to_owned()],
+        };
+        let value = serde_json::to_value(&with).unwrap();
+        assert_eq!(value["parent_message_id_hex"], "dd".repeat(32));
+        let decoded: AgentControlRequest = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded, with);
+    }
+
+    #[test]
     fn send_final_idempotency_key_is_omitted_when_absent_and_present_when_set() {
         // Additive, v1-compatible field: omitted from the wire when None so an
         // old peer's frame stays byte-identical; present and round-tripping when
@@ -805,6 +837,7 @@ mod tests {
                     account_id_hex: account(),
                     group_id_hex: group(),
                     stream_id_hex: None,
+                    parent_message_id_hex: None,
                     quic_candidates: vec!["quic://127.0.0.1:4450".to_owned()],
                 },
                 "stream_begin",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -15,6 +15,11 @@ versioning through the workspace version in the root `Cargo.toml`.
 - MarmotKit/UniFFI now exposes the cached Nostr Kind 0 `website` field through a read-only profile accessor so app
   profile surfaces can display it without widening the writable profile record.
 
+### Fixed
+
+- WN Agent, Hermes, and OpenClaw now carry the triggering prompt message id on agent text-stream start events through
+  the protocol `parent` tag, preserving the durable reply chain after timeline reloads.
+
 ## [0.9.3] - 2026-07-07
 
 ### Added

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1519,9 +1519,21 @@ impl AppClient {
         stream_id: &[u8],
         quic_candidates: Vec<String>,
     ) -> Result<(MarmotInnerEvent, SendSummary), AppError> {
+        self.start_agent_text_stream_with_parent(group_id, stream_id, None, quic_candidates)
+            .await
+    }
+
+    pub async fn start_agent_text_stream_with_parent(
+        &mut self,
+        group_id: &GroupId,
+        stream_id: &[u8],
+        parent_message_id: Option<String>,
+        quic_candidates: Vec<String>,
+    ) -> Result<(MarmotInnerEvent, SendSummary), AppError> {
         self.start_agent_text_stream_with_local_projection(
             group_id,
             stream_id,
+            parent_message_id,
             quic_candidates,
             |_| {},
         )
@@ -1532,6 +1544,7 @@ impl AppClient {
         &mut self,
         group_id: &GroupId,
         stream_id: &[u8],
+        parent_message_id: Option<String>,
         quic_candidates: Vec<String>,
         on_local_projection: F,
     ) -> Result<(MarmotInnerEvent, SendSummary), AppError>
@@ -1542,6 +1555,7 @@ impl AppClient {
             group_id,
             AppMessageIntent::StreamStart {
                 stream_id: stream_id.to_vec(),
+                parent_message_id,
                 quic_candidates,
             },
             on_local_projection,

--- a/crates/marmot-app/src/messages/intents.rs
+++ b/crates/marmot-app/src/messages/intents.rs
@@ -8,8 +8,8 @@ use cgka_traits::app_event::{
     MARMOT_APP_EVENT_KIND_AGENT_STREAM_START, MARMOT_APP_EVENT_KIND_CHAT,
     MARMOT_APP_EVENT_KIND_DELETE, MARMOT_APP_EVENT_KIND_EDIT, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
     MARMOT_APP_EVENT_KIND_REACTION, MarmotAppEvent as MarmotInnerEvent, QUOTE_REF_TAG,
-    STREAM_BROKER_TAG, STREAM_CHUNKS_TAG, STREAM_FINAL_KIND_TAG, STREAM_HASH_TAG, STREAM_ROUTE_TAG,
-    STREAM_START_TAG, STREAM_TAG, STREAM_TYPE_TAG,
+    STREAM_BROKER_TAG, STREAM_CHUNKS_TAG, STREAM_FINAL_KIND_TAG, STREAM_HASH_TAG,
+    STREAM_PARENT_TAG, STREAM_ROUTE_TAG, STREAM_START_TAG, STREAM_TAG, STREAM_TYPE_TAG,
 };
 use nostr::nips::nip21::Nip21;
 use serde_json::{Map, Value, json};
@@ -184,6 +184,7 @@ pub(crate) enum AppMessageIntent {
     },
     StreamStart {
         stream_id: Vec<u8>,
+        parent_message_id: Option<String>,
         quic_candidates: Vec<String>,
     },
     StreamFinal {
@@ -343,6 +344,7 @@ pub(crate) fn build_inner_event(
         }
         AppMessageIntent::StreamStart {
             stream_id,
+            parent_message_id,
             quic_candidates,
         } => {
             let stream_id_hex = hex::encode(stream_id);
@@ -367,6 +369,12 @@ pub(crate) fn build_inner_event(
                 ],
                 vec![STREAM_ROUTE_TAG.to_owned(), STREAM_ROUTE_QUIC.to_owned()],
             ];
+            if let Some(parent_message_id) = parent_message_id {
+                tags.push(vec![
+                    STREAM_PARENT_TAG.to_owned(),
+                    normalize_stream_parent_message_id(parent_message_id)?,
+                ]);
+            }
             tags.extend(
                 brokers
                     .into_iter()
@@ -541,6 +549,20 @@ fn validate_message_ref(target_message_id: &str) -> Result<(), AppError> {
         ));
     }
     Ok(())
+}
+
+fn normalize_stream_parent_message_id(parent_message_id: &str) -> Result<String, AppError> {
+    let raw = hex::decode(parent_message_id).map_err(|_| {
+        AppError::InvalidAppMessagePayload(
+            "agent text stream parent message id must be 32-byte hex".into(),
+        )
+    })?;
+    if raw.len() != 32 {
+        return Err(AppError::InvalidAppMessagePayload(
+            "agent text stream parent message id must be 32-byte hex".into(),
+        ));
+    }
+    Ok(hex::encode(raw))
 }
 
 fn validate_non_empty_field(value: &str, field: &str) -> Result<String, AppError> {

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -226,6 +226,7 @@ pub(crate) enum AccountWorkerCommand {
     StartAgentTextStream {
         group_id: GroupId,
         stream_id: Vec<u8>,
+        parent_message_id: Option<String>,
         quic_candidates: Vec<String>,
         respond: oneshot::Sender<Result<(MarmotInnerEvent, SendSummary), AppError>>,
     },
@@ -1128,6 +1129,7 @@ async fn handle_account_worker_command(
         AccountWorkerCommand::StartAgentTextStream {
             group_id,
             stream_id,
+            parent_message_id,
             quic_candidates,
             respond,
         } => {
@@ -1135,6 +1137,7 @@ async fn handle_account_worker_command(
                 .start_agent_text_stream_with_local_projection(
                     &group_id,
                     &stream_id,
+                    parent_message_id,
                     quic_candidates,
                     |update| {
                         publish_app_runtime_projection_update(

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -878,6 +878,7 @@ impl AccountManager {
         account_ref: &str,
         group_id: &GroupId,
         stream_id: Vec<u8>,
+        parent_message_id: Option<String>,
         quic_candidates: Vec<String>,
     ) -> Result<(MarmotInnerEvent, SendSummary), AppError> {
         let command = self.worker_commands(account_ref).await?;
@@ -886,6 +887,7 @@ impl AccountManager {
             .send(AccountWorkerCommand::StartAgentTextStream {
                 group_id: group_id.clone(),
                 stream_id,
+                parent_message_id,
                 quic_candidates,
                 respond,
             })

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -1854,11 +1854,39 @@ impl MarmotAppRuntime {
         account_ref: &str,
         group_id: &GroupId,
         stream_id: &[u8],
+        created_at: u64,
+        quic_candidates: Vec<String>,
+    ) -> Result<(MarmotInnerEvent, SendSummary), AppError> {
+        self.start_agent_text_stream_with_parent(
+            account_ref,
+            group_id,
+            stream_id,
+            created_at,
+            None,
+            quic_candidates,
+        )
+        .await
+    }
+
+    /// Anchor a kind-1200 agent text stream start, optionally threading it to the
+    /// inbound message that triggered the agent turn.
+    pub async fn start_agent_text_stream_with_parent(
+        &self,
+        account_ref: &str,
+        group_id: &GroupId,
+        stream_id: &[u8],
         _created_at: u64,
+        parent_message_id: Option<String>,
         quic_candidates: Vec<String>,
     ) -> Result<(MarmotInnerEvent, SendSummary), AppError> {
         self.accounts
-            .start_agent_text_stream(account_ref, group_id, stream_id.to_vec(), quic_candidates)
+            .start_agent_text_stream(
+                account_ref,
+                group_id,
+                stream_id.to_vec(),
+                parent_message_id,
+                quic_candidates,
+            )
             .await
     }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -7,8 +7,8 @@ use cgka_traits::app_event::{
     MARMOT_APP_EVENT_KIND_AGENT_STREAM_START, MARMOT_APP_EVENT_KIND_CHAT,
     MARMOT_APP_EVENT_KIND_DELETE, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
     MARMOT_APP_EVENT_KIND_REACTION, MarmotAppEvent as MarmotInnerEvent, QUOTE_REF_TAG,
-    STREAM_CHUNKS_TAG, STREAM_FINAL_KIND_TAG, STREAM_HASH_TAG, STREAM_START_TAG, STREAM_TAG,
-    STREAM_TYPE_TAG,
+    STREAM_CHUNKS_TAG, STREAM_FINAL_KIND_TAG, STREAM_HASH_TAG, STREAM_PARENT_TAG, STREAM_START_TAG,
+    STREAM_TAG, STREAM_TYPE_TAG,
 };
 use marmot_account::AccountHomeError;
 use storage_sqlite::StoredRelayTelemetrySettings;
@@ -1804,8 +1804,10 @@ fn media_intent_builds_kind_nine_with_ordered_imeta_tags() {
 
 #[test]
 fn stream_start_intent_builds_kind_1200_with_broker_tags() {
+    let parent_message_id = "cd".repeat(32);
     let event = build(AppMessageIntent::StreamStart {
         stream_id: vec![0xab; 32],
+        parent_message_id: Some(parent_message_id.clone()),
         quic_candidates: vec![
             "quic://broker.example:4450".to_owned(),
             "quic://[::1]:4450".to_owned(),
@@ -1825,6 +1827,20 @@ fn stream_start_intent_builds_kind_1200_with_broker_tags() {
     );
     assert_eq!(tag_value(&event.tags, STREAM_TYPE_TAG), Some("text"));
     assert_eq!(tag_value(&event.tags, STREAM_FINAL_KIND_TAG), Some("9"));
+    assert_eq!(
+        tag_value(&event.tags, STREAM_PARENT_TAG),
+        Some(parent_message_id.as_str())
+    );
+}
+
+#[test]
+fn stream_start_intent_without_parent_omits_parent_tag() {
+    let event = build(AppMessageIntent::StreamStart {
+        stream_id: vec![0xab; 32],
+        parent_message_id: None,
+        quic_candidates: vec!["quic://broker.example:4450".to_owned()],
+    });
+    assert_eq!(tag_value(&event.tags, STREAM_PARENT_TAG), None);
 }
 
 #[test]
@@ -1832,12 +1848,27 @@ fn stream_start_intent_requires_a_broker() {
     let result = build_inner_event(
         &AppMessageIntent::StreamStart {
             stream_id: vec![0xab; 32],
+            parent_message_id: None,
             quic_candidates: vec!["   ".to_owned()],
         },
         SENDER_HEX,
         1,
     );
     assert!(matches!(result, Err(AppError::AgentStreamMissingCandidate)));
+}
+
+#[test]
+fn stream_start_intent_rejects_a_non_message_id_parent() {
+    let result = build_inner_event(
+        &AppMessageIntent::StreamStart {
+            stream_id: vec![0xab; 32],
+            parent_message_id: Some("abcd".to_owned()),
+            quic_candidates: vec!["quic://broker.example:4450".to_owned()],
+        },
+        SENDER_HEX,
+        1,
+    );
+    assert!(matches!(result, Err(AppError::InvalidAppMessagePayload(_))));
 }
 
 #[test]

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -17,6 +17,7 @@ import re
 import shutil
 import uuid
 from collections import OrderedDict
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Any, AsyncIterator, Dict, Iterable, Literal, Optional, Tuple
 
@@ -40,6 +41,10 @@ STATUS_RECORD = 0x03
 TRANSCRIPT_HASH_CONTEXT = b"marmot agent text stream transcript v1"
 STREAM_MESSAGE_PREFIX = "marmot-stream:"
 TOOL_PROGRESS_MESSAGE_PREFIX = "marmot-tool-progress:"
+_TURN_PARENT_MESSAGE_ID_HEX: ContextVar[Optional[str]] = ContextVar(
+    "marmot_turn_parent_message_id_hex",
+    default=None,
+)
 TOOL_EVENT_PREFIX = "\x1fMARMOT_TOOL_EVENT:"
 # Bounded backoff (seconds) for durable send_final retries. One idempotency key
 # is reused across these attempts so a retry after a post-write timeout dedups at
@@ -860,18 +865,22 @@ class MarmotAgentControlClient:
         group_id_hex: str,
         *,
         stream_id_hex: Optional[str] = None,
+        parent_message_id_hex: Optional[str] = None,
         quic_candidates: Iterable[str] = (),
     ) -> Dict[str, Any]:
-        return await self.request(
-            {
-                "type": "stream_begin",
-                "account_id_hex": _normalize_hex(account_id_hex, "account_id_hex"),
-                "group_id_hex": _normalize_hex(group_id_hex, "group_id_hex"),
-                "stream_id_hex": _normalize_hex(stream_id_hex, "stream_id_hex") if stream_id_hex else None,
-                "quic_candidates": [str(candidate).strip() for candidate in quic_candidates if str(candidate).strip()],
-            },
-            timeout=self.preview_request_timeout,
-        )
+        payload: Dict[str, Any] = {
+            "type": "stream_begin",
+            "account_id_hex": _normalize_hex(account_id_hex, "account_id_hex"),
+            "group_id_hex": _normalize_hex(group_id_hex, "group_id_hex"),
+            "stream_id_hex": _normalize_hex(stream_id_hex, "stream_id_hex") if stream_id_hex else None,
+            "quic_candidates": [str(candidate).strip() for candidate in quic_candidates if str(candidate).strip()],
+        }
+        if parent_message_id_hex:
+            payload["parent_message_id_hex"] = _normalize_hex(
+                parent_message_id_hex,
+                "parent_message_id_hex",
+            )
+        return await self.request(payload, timeout=self.preview_request_timeout)
 
     async def stream_append(self, stream_id_hex: str, append_text: str) -> Dict[str, Any]:
         return await self.request(
@@ -1148,13 +1157,15 @@ class MarmotLiveStream:
         quic_candidates: Iterable[str],
         chunk_bytes: int,
         stream_id_hex: Optional[str] = None,
+        parent_message_id_hex: Optional[str] = None,
     ) -> "MarmotLiveStream":
-        response = await client.stream_begin(
-            account_id_hex,
-            group_id_hex,
-            stream_id_hex=stream_id_hex,
-            quic_candidates=quic_candidates,
-        )
+        begin_options: Dict[str, Any] = {
+            "stream_id_hex": stream_id_hex,
+            "quic_candidates": quic_candidates,
+        }
+        if parent_message_id_hex is not None:
+            begin_options["parent_message_id_hex"] = parent_message_id_hex
+        response = await client.stream_begin(account_id_hex, group_id_hex, **begin_options)
         return cls(
             client=client,
             account_id_hex=account_id_hex,
@@ -1373,7 +1384,10 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                 return SendResult(success=False, error="Marmot live preview requires MARMOT_QUIC_CANDIDATES")
             try:
                 await self._cancel_other_chat_streams(chat_id, reason="superseded by newer preview")
-                stream = await self._begin_live_stream(chat_id)
+                stream = await self._begin_live_stream(
+                    chat_id,
+                    parent_message_id_hex=_optional_hex(reply_to),
+                )
                 await stream.append_replacement(visible_content)
                 message_id = _stream_message_id(stream.stream_id_hex)
                 self._active_streams[message_id] = stream
@@ -1490,6 +1504,29 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
     ) -> bool:
         return bool(self.quic_candidates)
 
+    def _start_session_processing(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        *,
+        interrupt_event: Optional[asyncio.Event] = None,
+    ) -> bool:
+        """Copy the triggering message id into the spawned turn's task context."""
+        source = getattr(event, "source", None)
+        parent_message_id_hex = _optional_hex(
+            getattr(event, "message_id", None) or getattr(source, "message_id", None),
+            "parent_message_id_hex",
+        )
+        token = _TURN_PARENT_MESSAGE_ID_HEX.set(parent_message_id_hex)
+        try:
+            return super()._start_session_processing(
+                event,
+                session_key,
+                interrupt_event=interrupt_event,
+            )
+        finally:
+            _TURN_PARENT_MESSAGE_ID_HEX.reset(token)
+
     def render_message_event(self, event: Any, sink: Any) -> None:
         try:
             from gateway.stream_events import Commentary, MessageChunk, MessageStop
@@ -1563,7 +1600,15 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                     reason="superseded by newer draft",
                 )
                 await self._cancel_other_chat_streams(chat_id, reason="superseded by newer draft")
-                stream = await self._begin_live_stream(chat_id)
+                metadata = metadata or {}
+                stream = await self._begin_live_stream(
+                    chat_id,
+                    parent_message_id_hex=_optional_hex(
+                        metadata.get("parent_message_id_hex")
+                        or metadata.get("reply_to_message_id_hex")
+                        or _TURN_PARENT_MESSAGE_ID_HEX.get()
+                    ),
+                )
                 self._draft_streams[key] = stream
                 self._last_chat_stream[chat_id] = stream
             await stream.append_replacement(visible_content)
@@ -1909,12 +1954,18 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             self._tool_progress_replies.pop(dropped_message_id, None)
         return seen
 
-    async def _begin_live_stream(self, chat_id: str) -> MarmotLiveStream:
+    async def _begin_live_stream(
+        self,
+        chat_id: str,
+        *,
+        parent_message_id_hex: Optional[str] = None,
+    ) -> MarmotLiveStream:
         account_id = await self._ensure_account_id()
         return await MarmotLiveStream.begin(
             client=self.client,
             account_id_hex=account_id,
             group_id_hex=chat_id,
+            parent_message_id_hex=parent_message_id_hex,
             quic_candidates=self.quic_candidates,
             chunk_bytes=self.stream_chunk_bytes,
         )

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -77,6 +77,8 @@ def install_fake_hermes_modules():
             self.platform = platform
             self._running = False
             self.events = []
+            self._message_handler = None
+            self._session_tasks = {}
 
         @property
         def enforces_own_access_policy(self):
@@ -93,6 +95,13 @@ def install_fake_hermes_modules():
 
         async def handle_message(self, event):
             self.events.append(event)
+
+        def _start_session_processing(self, event, session_key, *, interrupt_event=None):
+            if self._message_handler is None:
+                return False
+            task = asyncio.create_task(self._message_handler(event))
+            self._session_tasks[session_key] = task
+            return True
 
     gateway_base.BasePlatformAdapter = BasePlatformAdapter
     gateway_base.MessageEvent = MessageEvent
@@ -217,6 +226,38 @@ class AgentControlClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(requests[0]["idempotency_key"], "key-1")
         self.assertNotIn("idempotency_key", requests[1])
         self.assertNotIn("idempotency_key", requests[2])
+
+    async def test_stream_begin_includes_parent_message_id_only_when_supplied(self):
+        requests = []
+
+        async def handler(reader, writer):
+            request = await read_json_line(reader)
+            requests.append(request)
+            await write_json_line(
+                writer,
+                {
+                    "marmot_agent_control": "marmot.agent-control.v1",
+                    "id": request["id"],
+                    "type": "stream_begun",
+                    "stream_id_hex": "55" * 32,
+                    "start_message_id_hex": "66" * 32,
+                    "quic_candidates": [],
+                },
+            )
+            writer.close()
+
+        await self.start_server(handler)
+        client = self.adapter.MarmotAgentControlClient(self.socket_path)
+
+        await client.stream_begin(
+            "11" * 32,
+            "22" * 32,
+            parent_message_id_hex="33" * 32,
+        )
+        await client.stream_begin("11" * 32, "22" * 32)
+
+        self.assertEqual(requests[0]["parent_message_id_hex"], "33" * 32)
+        self.assertNotIn("parent_message_id_hex", requests[1])
 
     async def test_stream_finalize_includes_idempotency_key_only_when_supplied(self):
         requests = []
@@ -1451,6 +1492,88 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(len(fake_client.final_sends), 1)
             self.assertEqual((await store.get(account)).get("status"), "prompted")
 
+    async def test_inbound_turn_parent_reaches_draft_stream_without_state_leak(self):
+        class FakeClient:
+            def __init__(self):
+                self.stream_begin_parents = []
+
+            async def stream_begin(
+                self,
+                account_id_hex,
+                group_id_hex,
+                *,
+                stream_id_hex=None,
+                parent_message_id_hex=None,
+                quic_candidates=(),
+            ):
+                self.stream_begin_parents.append(parent_message_id_hex)
+                index = len(self.stream_begin_parents)
+                return {
+                    "type": "stream_begun",
+                    "stream_id_hex": f"{index:02x}" * 32,
+                    "start_message_id_hex": f"{index + 16:02x}" * 32,
+                    "quic_candidates": list(quic_candidates),
+                }
+
+            async def stream_append(self, stream_id_hex, append_text):
+                return {"type": "ack"}
+
+            async def stream_cancel(self, stream_id_hex, reason=None):
+                return {"type": "ack"}
+
+        fake_client = FakeClient()
+        adapter = self.adapter_module.MarmotPlatformAdapter(
+            self.config_cls(
+                extra={
+                    "account_id_hex": "11" * 32,
+                    "quic_candidates": ["quic://127.0.0.1:4433"],
+                    "group_activation": "always",
+                }
+            ),
+            client=fake_client,
+        )
+        next_draft_id = 0
+
+        async def message_handler(event):
+            nonlocal next_draft_id
+            next_draft_id += 1
+            result = await adapter.send_draft(
+                event.source.chat_id,
+                next_draft_id,
+                "hello",
+            )
+            self.assertTrue(result.success)
+
+        adapter._message_handler = message_handler
+
+        def turn_event(message_id_hex):
+            source = adapter.build_source(
+                chat_id="22" * 32,
+                chat_type="group",
+                user_id="44" * 32,
+                message_id=message_id_hex,
+            )
+            return self.adapter_module.MessageEvent(
+                text="hello",
+                source=source,
+                message_id=message_id_hex,
+            )
+
+        for index, parent_message_id_hex in enumerate(("33" * 32, "34" * 32, None)):
+            session_key = f"session-{index}"
+            started = adapter._start_session_processing(
+                turn_event(parent_message_id_hex),
+                session_key,
+            )
+            self.assertTrue(started)
+            await adapter._session_tasks[session_key]
+
+        self.assertEqual(
+            fake_client.stream_begin_parents,
+            ["33" * 32, "34" * 32, None],
+        )
+        self.assertIsNone(self.adapter_module._TURN_PARENT_MESSAGE_ID_HEX.get())
+
     async def test_progressive_edit_stream_finalizes_then_sends_durable_message(self):
         class FakeClient:
             def __init__(self):
@@ -1458,8 +1581,21 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                 self.stream_finalizes = []
                 self.final_sends = []
 
-            async def stream_begin(self, account_id_hex, group_id_hex, *, stream_id_hex=None, quic_candidates=()):
-                self.stream_begin_args = (account_id_hex, group_id_hex, tuple(quic_candidates))
+            async def stream_begin(
+                self,
+                account_id_hex,
+                group_id_hex,
+                *,
+                stream_id_hex=None,
+                parent_message_id_hex=None,
+                quic_candidates=(),
+            ):
+                self.stream_begin_args = (
+                    account_id_hex,
+                    group_id_hex,
+                    parent_message_id_hex,
+                    tuple(quic_candidates),
+                )
                 return {
                     "type": "stream_begun",
                     "stream_id_hex": "55" * 32,
@@ -1497,9 +1633,13 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
             client=fake_client,
         )
 
-        first = await adapter.send("22" * 32, "hel\u2589")
+        first = await adapter.send("22" * 32, "hel\u2589", reply_to="33" * 32)
         self.assertTrue(first.success)
         self.assertEqual(first.message_id, "marmot-stream:" + "55" * 32)
+        self.assertEqual(
+            fake_client.stream_begin_args,
+            ("11" * 32, "22" * 32, "33" * 32, ("quic://127.0.0.1:4433",)),
+        )
 
         edited = await adapter.edit_message("22" * 32, first.message_id, "hello\u2589")
         self.assertTrue(edited.success)

--- a/integrations/openclaw/marmot/src/client.ts
+++ b/integrations/openclaw/marmot/src/client.ts
@@ -325,17 +325,26 @@ export class MarmotAgentControlClient {
   async streamBegin(
     accountIdHex: string,
     groupIdHex: string,
-    options: { streamIdHex?: string | null; quicCandidates?: Iterable<string> } = {},
+    options: {
+      streamIdHex?: string | null;
+      parentMessageIdHex?: string | null;
+      quicCandidates?: Iterable<string>;
+    } = {},
   ): Promise<StreamBegunResponse> {
     const quicCandidates = [...(options.quicCandidates ?? [])]
       .map((candidate) => String(candidate).trim())
       .filter((candidate) => candidate.length > 0);
+    const parentMessageIdHex = optionalHex(
+      options.parentMessageIdHex,
+      "parent_message_id_hex",
+    );
     return (await this.request(
       {
         type: "stream_begin",
         account_id_hex: normalizeHex(accountIdHex, "account_id_hex"),
         group_id_hex: normalizeHex(groupIdHex, "group_id_hex"),
         stream_id_hex: optionalHex(options.streamIdHex, "stream_id_hex"),
+        ...(parentMessageIdHex ? { parent_message_id_hex: parentMessageIdHex } : {}),
         quic_candidates: quicCandidates,
       },
       { timeoutMs: this.previewRequestTimeoutMs },

--- a/integrations/openclaw/marmot/src/dispatch.ts
+++ b/integrations/openclaw/marmot/src/dispatch.ts
@@ -145,6 +145,7 @@ export class MarmotReplySink {
       this.preview = new MarmotLivePreview(this.options.client, {
         accountIdHex: this.options.accountIdHex,
         groupIdHex: this.options.groupIdHex,
+        parentMessageIdHex: this.options.replyToMessageIdHex,
         quicCandidates: this.options.quicCandidates,
         chunkBytes: this.options.chunkBytes,
       });
@@ -719,9 +720,8 @@ export function createMarmotInboundDispatcher(
       client: deps.client,
       accountIdHex: message.accountIdHex,
       groupIdHex: message.groupIdHex,
-      // Thread the reply to the triggering message (channel declares
-      // topLevelReplyToMode "reply"). Honored by the durable send_final path;
-      // the streaming finalize path threads in a later phase.
+      // Thread both the durable reply and the live stream-start event to the
+      // inbound message that triggered this agent turn.
       replyToMessageIdHex: message.messageIdHex,
       streamMode: deps.streamMode,
       quicCandidates: deps.quicCandidates,

--- a/integrations/openclaw/marmot/src/live.ts
+++ b/integrations/openclaw/marmot/src/live.ts
@@ -23,6 +23,7 @@ export type StreamControlClient = Pick<
 export interface MarmotLivePreviewOptions {
   accountIdHex: string;
   groupIdHex: string;
+  parentMessageIdHex?: string | null;
   quicCandidates: string[];
   chunkBytes?: number;
 }
@@ -95,7 +96,10 @@ export class MarmotLivePreview {
     const response = await this.client.streamBegin(
       this.options.accountIdHex,
       this.options.groupIdHex,
-      { quicCandidates: this.options.quicCandidates },
+      {
+        parentMessageIdHex: this.options.parentMessageIdHex,
+        quicCandidates: this.options.quicCandidates,
+      },
     );
     this.streamIdHex = response.stream_id_hex;
     this.startMessageIdHex = response.start_message_id_hex;

--- a/integrations/openclaw/marmot/test/client.test.ts
+++ b/integrations/openclaw/marmot/test/client.test.ts
@@ -57,6 +57,7 @@ function handleRequest(socket: Socket, req: Record<string, unknown>): void {
         stream_id_hex: HEX32("ee"),
         start_message_id_hex: HEX32("ff"),
         quic_candidates: [],
+        echoed_parent_message_id_hex: req.parent_message_id_hex ?? null,
       });
       break;
     case "stream_finalize":
@@ -201,6 +202,20 @@ describe("MarmotAgentControlClient", () => {
       1,
     )) as unknown as { echoed_idempotency_key?: string | null };
     expect(withoutKey.echoed_idempotency_key).toBeNull();
+  });
+
+  it("forwards the optional parent message id on stream_begin", async () => {
+    const parentMessageIdHex = HEX32("dd");
+    const withParent = (await client.streamBegin(HEX32("aa"), HEX32("cc"), {
+      parentMessageIdHex,
+    })) as unknown as { echoed_parent_message_id_hex?: string | null };
+    expect(withParent.echoed_parent_message_id_hex).toBe(parentMessageIdHex);
+
+    const withoutParent = (await client.streamBegin(
+      HEX32("aa"),
+      HEX32("cc"),
+    )) as unknown as { echoed_parent_message_id_hex?: string | null };
+    expect(withoutParent.echoed_parent_message_id_hex).toBeNull();
   });
 
   it("deletes a message and returns the deletion event ids", async () => {

--- a/integrations/openclaw/marmot/test/dispatch.test.ts
+++ b/integrations/openclaw/marmot/test/dispatch.test.ts
@@ -47,6 +47,7 @@ const INCREMENTAL_HASH = "412b9bd20aedf322174fab2b1dee909992044fa166391027f4b8fb
 interface Calls {
   sendFinal: { accountIdHex: string; text: string; replyTo: string | null }[];
   begin: number;
+  beginParents: (string | null)[];
   append: string[];
   status: string[];
   progress: string[];
@@ -55,7 +56,16 @@ interface Calls {
 }
 
 function emptyCalls(): Calls {
-  return { sendFinal: [], begin: 0, append: [], status: [], progress: [], finalize: [], cancel: [] };
+  return {
+    sendFinal: [],
+    begin: 0,
+    beginParents: [],
+    append: [],
+    status: [],
+    progress: [],
+    finalize: [],
+    cancel: [],
+  };
 }
 
 function stubClient(calls: Calls, opts: { isDirect?: boolean } = {}): MarmotSinkClient {
@@ -74,8 +84,13 @@ function stubClient(calls: Calls, opts: { isDirect?: boolean } = {}): MarmotSink
         subject: null,
       };
     },
-    async streamBegin() {
+    async streamBegin(
+      _accountIdHex: string,
+      _groupIdHex: string,
+      options: { parentMessageIdHex?: string | null } = {},
+    ) {
       calls.begin += 1;
+      calls.beginParents.push(options.parentMessageIdHex ?? null);
       return {
         type: "stream_begun",
         stream_id_hex: STREAM_ID,
@@ -111,6 +126,7 @@ function makeSink(
   opts: {
     streamMode?: StreamMode;
     quicCandidates?: string[];
+    replyToMessageIdHex?: string | null;
     resolveFinalText?: () => Promise<string | undefined> | string | undefined;
   } = {},
 ): MarmotReplySink {
@@ -118,6 +134,7 @@ function makeSink(
     client: stubClient(calls),
     accountIdHex: HEX32("aa"),
     groupIdHex: HEX32("cc"),
+    replyToMessageIdHex: opts.replyToMessageIdHex,
     streamMode: opts.streamMode ?? "block",
     quicCandidates: opts.quicCandidates ?? ["quic://broker:4450"],
     resolveFinalText: opts.resolveFinalText,
@@ -125,6 +142,16 @@ function makeSink(
 }
 
 describe("MarmotReplySink", () => {
+  it("passes the triggering message id to stream_begin", async () => {
+    const calls = emptyCalls();
+    const parentMessageIdHex = HEX32("dd");
+    const sink = makeSink(calls, { replyToMessageIdHex: parentMessageIdHex });
+
+    await sink.partial({ text: "hello" });
+
+    expect(calls.beginParents).toEqual([parentMessageIdHex]);
+  });
+
   it("sends a plain final when there were no preview blocks", async () => {
     const calls = emptyCalls();
     await makeSink(calls).deliver({ text: "hello world" }, { kind: "final" });


### PR DESCRIPTION
## Summary

- add an optional `parent_message_id_hex` to `stream_begin` while preserving omitted-field wire compatibility
- validate and emit the parent message ID on kind-1200 stream-start events
- propagate the triggering inbound message ID through the Hermes and OpenClaw live-preview pipelines
- document the durable reply-chain fix in the unreleased changelog

## Verification

- `just fast-ci`
- `cargo test -p agent-control`
- `cargo test -p agent-connector`
- `cargo test -p marmot-app`
- `python3 -m unittest discover -s integrations/hermes/marmot/tests`
- OpenClaw TypeScript typecheck and Vitest suite

Fixes #876


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/878">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stream-start events now preserve the triggering message relationship through an optional parent message ID.
  * Live previews and draft streams in supported integrations automatically include the parent message ID when available.
  * Parent message IDs are normalized and validated before use.

* **Bug Fixes**
  * Reply chains now remain connected after timeline reloads.
  * Prevented parent-message context from leaking between concurrent sessions.

* **Tests**
  * Added coverage for parent ID propagation, validation, serialization, and omission when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->