### PR TITLE
fix(openclaw): declare plugin workspace package

### DIFF
--- a/integrations/openclaw/marmot/pnpm-workspace.yaml
+++ b/integrations/openclaw/marmot/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages:
+  - '.'
 allowBuilds:
   '@google/genai': true
   esbuild: true


### PR DESCRIPTION
Fixes #879

## Summary
- declare the OpenClaw plugin root as the pnpm workspace package
- retain the existing dependency build allowlist unchanged
- restore the documented plain `pnpm typecheck` and `pnpm test` commands under pnpm 9

## Verification
- `pnpm install --frozen-lockfile` (pnpm 9.15.9)
- `pnpm typecheck` (pnpm 9.15.9)
- `pnpm test` (pnpm 9.15.9; 196 passed, 1 connector E2E skipped)
- `just openclaw-dev-test` (pnpm 9.15.9)
- `pnpm install --frozen-lockfile && pnpm build` (pnpm 10.13.1; matches the release workflow)

## Sensitive paths
None.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/880">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace configuration to recognize the current project directory.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->