### PR TITLE
docs(openclaw): sync documented SDK pin

### DIFF
--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -11,7 +11,7 @@ local Unix socket. It never opens a QUIC connection, encrypts a record, or talks
 to a relay — all of that stays in `wn-agent`. It is the OpenClaw counterpart of
 the Python Hermes plugin in [`../../hermes/marmot/`](../../hermes/marmot).
 
-- Pinned OpenClaw SDK: **`openclaw@2026.6.8`** (`openclaw/plugin-sdk/*`).
+- Pinned OpenClaw SDK: **`openclaw@2026.6.11`** (`openclaw/plugin-sdk/*`).
 - Toolchain: TypeScript, pnpm, Node ≥ 22.19, Vitest.
 
 ## Install (release)
@@ -21,7 +21,7 @@ GitHub pre-releases. OpenClaw must already be installed with `openclaw` on `PATH
 
 Prerequisites:
 
-- OpenClaw **2026.6.8** or compatible (this plugin pins `openclaw@2026.6.8`)
+- OpenClaw **2026.6.11** or compatible (this plugin pins `openclaw@2026.6.11`)
 - Node ≥ 22.19
 - Linux x86_64, Linux arm64, macOS Apple Silicon, or macOS Intel
 

--- a/integrations/openclaw/marmot/test/readme-version.test.ts
+++ b/integrations/openclaw/marmot/test/readme-version.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as {
+  devDependencies?: { openclaw?: string };
+};
+const pinnedOpenClaw = pkg.devDependencies?.openclaw;
+if (!pinnedOpenClaw) {
+  throw new Error("package.json must pin openclaw in devDependencies");
+}
+
+const readme = readFileSync(new URL("../README.md", import.meta.url), "utf8");
+const pinnedLabel = `openclaw@${pinnedOpenClaw}`;
+
+describe("README OpenClaw SDK pin", () => {
+  it("documents the pinned SDK version from package.json", () => {
+    expect(readme).toContain(`Pinned OpenClaw SDK: **\`${pinnedLabel}\`**`);
+  });
+
+  it("documents the OpenClaw prerequisite version from package.json", () => {
+    expect(readme).toContain(`OpenClaw **${pinnedOpenClaw}** or compatible`);
+    expect(readme).toContain(`this plugin pins \`${pinnedLabel}\``);
+  });
+});


### PR DESCRIPTION
Fixes #881

## Summary
- Update both README SDK/prerequisite references from `openclaw@2026.6.8` to the package pin, `openclaw@2026.6.11`.
- Add a Vitest regression guard that derives the expected version from `package.json` and checks both README claims.

## Verification
- RED: with the original README restored temporarily, `npx vitest run test/readme-version.test.ts` failed 2/2 assertions against the `2026.6.11` package pin.
- `npm run typecheck`
- `npx vitest run test/readme-version.test.ts` — 2 passed
- `npx vitest run` — 198 passed, 1 skipped
- `just fmt-check`
- `git diff --check origin/master...HEAD`

`pnpm install --frozen-lockfile` remains blocked on current `master` by the missing `packages` entry tracked in #879 / draft PR #880 (`ERROR packages field missing or empty`). That unrelated workspace fix is intentionally not duplicated here.

## Sensitive paths
None.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/882">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented OpenClaw SDK requirement to version 2026.6.11.
  * Updated installation prerequisites to reference the new compatible version.

* **Tests**
  * Added validation to ensure the documented SDK version matches the pinned project dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->