### PR TITLE
fix(cgka-engine): phantom committed_from from failed commit staging poisons fork detection

### DIFF
--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -190,6 +190,17 @@ These are real simulator scenarios that are still tied to Rust harness details.
   set.
 - Reason: the test inspects recovery observations and exact branch ordering keys.
 
+### `failed_invite_staging_does_not_poison_fork_detection_via_harness`
+
+- Setup: Alice's invite fails during commit staging (duplicate-member KeyPackage). Alice then advances to epoch 2 by
+  settling Bob's commit through convergence, and a partitioned Dave later delivers a sibling commit from the same
+  source epoch.
+- Expected: the sibling commit is adjudicated deterministically (stale losing branch or reorg onto the winner) — never
+  a fail-closed `ForkedEpoch` — and Alice's group stays usable for a follow-up invite.
+- Reason: regression guard for the phantom `committed_from` bookkeeping bug (fixed by recording it only inside
+  `begin_pending`); mirrors the cgka-engine test `failed_invite_staging_does_not_poison_fork_detection` at the
+  multi-client bus level.
+
 ### `convergence-e2e-group-events/v1`
 
 - Setup: Alice creates a four-member group. Alice and Bob race invite commits and each branch has an app payload. Carol

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -567,6 +567,17 @@ impl HarnessClient {
 
     /// Invite new members to the default group.
     pub async fn invite(&mut self, kps: Vec<KeyPackage>) -> PendingStateRef {
+        self.try_invite(kps).await.expect("send invite")
+    }
+
+    /// Invite new members to the default group, surfacing the engine error
+    /// instead of panicking. Nothing reaches the bus on failure. Used by
+    /// scenarios that deliberately fail an invite during commit staging
+    /// (e.g. the phantom committed-from regression).
+    pub async fn try_invite(
+        &mut self,
+        kps: Vec<KeyPackage>,
+    ) -> Result<PendingStateRef, EngineError> {
         let gid = self.default_group.clone().expect("group");
         let res = self
             .engine
@@ -574,8 +585,7 @@ impl HarnessClient {
                 group_id: gid.clone(),
                 key_packages: kps,
             })
-            .await
-            .expect("send invite");
+            .await?;
         match res {
             SendResult::GroupEvolution {
                 msg,
@@ -589,9 +599,11 @@ impl HarnessClient {
                     self.bus.send(self.bus_id, w);
                 }
                 self.bus.send(self.bus_id, route(msg, &gid));
-                pending
+                Ok(pending)
             }
-            other => panic!("expected GroupEvolution, got {other:?}"),
+            other => Err(EngineError::Other(format!(
+                "expected GroupEvolution, got {other:?}"
+            ))),
         }
     }
 

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -2041,3 +2041,121 @@ async fn harness_captures_and_asserts_convergence_decision() {
         "carol should observe the committer-decided convergence decision: {failures:#?}"
     );
 }
+
+#[tokio::test]
+async fn failed_invite_staging_does_not_poison_fork_detection_via_harness() {
+    // Harness mirror of the cgka-engine regression test
+    // `failed_invite_staging_does_not_poison_fork_detection`: a send-path
+    // staging failure must leave no phantom "we committed from this epoch"
+    // bookkeeping behind. Historically it did, and once the client advanced
+    // past that epoch via a PEER's commit (settled through convergence, so
+    // no fork-recovery incumbent of its own exists), a legitimate sibling
+    // commit for the poisoned epoch failed closed with ForkedEpoch and stuck
+    // the group in Recovering.
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"phantom-alice"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"phantom-bob"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut carol = ClientBuilder::new(pad32(b"phantom-carol"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut dave = ClientBuilder::new(pad32(b"phantom-dave"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut erin = ClientBuilder::new(pad32(b"phantom-erin"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+
+    // Bob and Dave are admins: each later commits an invite from epoch 1.
+    let bob_kp = bob.fresh_key_package().await;
+    let dave_kp = dave.fresh_key_package().await;
+    let (_group_id, pending) = alice
+        .create_group_with_admins(
+            "phantom-committed-from",
+            vec![bob_kp, dave_kp],
+            vec![],
+            vec![bob.member_id(), dave.member_id()],
+        )
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+    dave.tick().await;
+    assert_eq!(alice.epoch().0, 1);
+    assert_eq!(bob.epoch().0, 1);
+    assert_eq!(dave.epoch().0, 1);
+
+    // Alice's invite fails DURING commit staging: the duplicate-Bob
+    // KeyPackage carries Bob's existing leaf signature key, which OpenMLS
+    // rejects inside add_members — after capability validation, before the
+    // pending-publish state transition. Nothing reaches the bus.
+    let duplicate_bob_kp = bob.fresh_key_package().await;
+    let failed = alice.try_invite(vec![duplicate_bob_kp]).await;
+    assert!(
+        failed.is_err(),
+        "duplicate-member invite must fail during staging"
+    );
+
+    // Partition Dave away so he stays at epoch 1 and never sees Bob's
+    // commit. Bob invites Carol; Alice advances to epoch 2 purely by
+    // settling Bob's commit through convergence (peer-driven advance — no
+    // own commit, no fork-recovery incumbent at epoch 1).
+    bus.set_partition(Some(vec![alice.bus_id, bob.bus_id, carol.bus_id]));
+    let carol_kp = carol.fresh_key_package().await;
+    let bob_pending = bob.invite(vec![carol_kp]).await;
+    bob.confirm(bob_pending).await;
+    bus.deliver_all();
+    carol.tick().await;
+    let alice_outcomes = alice.tick().await;
+    assert_eq!(
+        alice.epoch().0,
+        2,
+        "alice must settle bob's commit via convergence: {alice_outcomes:?}"
+    );
+
+    // Heal the partition. Dave — still at epoch 1 — commits a sibling
+    // invite from the epoch Alice's failed staging attempt touched.
+    bus.set_partition(None);
+    let erin_kp = erin.fresh_key_package().await;
+    let dave_pending = dave.invite(vec![erin_kp]).await;
+    dave.confirm(dave_pending).await;
+    bus.deliver_all();
+
+    // Alice must classify the sibling (stale losing branch, or a
+    // deterministic reorg onto the winning branch) — never fail closed with
+    // ForkedEpoch, which left the group stuck in Recovering.
+    let alice_outcomes = alice.tick().await;
+    let alice_forked = alice_outcomes
+        .iter()
+        .any(|o| matches!(o, Err(cgka_traits::EngineError::ForkedEpoch { .. })));
+    assert!(
+        !alice_forked,
+        "sibling commit after failed staging must not fail closed: {alice_outcomes:?}"
+    );
+    assert_eq!(alice.epoch().0, 2);
+
+    // Whichever branch won deterministically, alice holds exactly one of
+    // the two invitees and the group remains operational.
+    let members = alice.members();
+    let has_carol = members.iter().any(|m| m.id == carol.member_id());
+    let has_erin = members.iter().any(|m| m.id == erin.member_id());
+    assert_ne!(
+        has_carol, has_erin,
+        "exactly one branch must win: {members:?}"
+    );
+    // Usability probe: a fresh valid invite from Alice must stage normally.
+    // A group stuck in Recovering rejects the send outright.
+    let mut frank = ClientBuilder::new(pad32(b"phantom-frank"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let frank_kp = frank.fresh_key_package().await;
+    let probe_pending = alice
+        .try_invite(vec![frank_kp])
+        .await
+        .expect("group must remain usable after failed staging + sibling commit");
+    alice.confirm(probe_pending).await;
+    assert_eq!(alice.epoch().0, 3);
+}

--- a/crates/cgka-engine/src/epoch_manager.rs
+++ b/crates/cgka-engine/src/epoch_manager.rs
@@ -35,6 +35,14 @@ struct PendingMeta {
     /// rows, which are emitted on a later publish-confirm call after the
     /// engine's ambient context has cleared.
     audit_context: Option<AuditEventContext>,
+    /// Whether `begin_pending` newly inserted `prior_epoch` into
+    /// `committed_from` for this pending. A group holds at most one live
+    /// pending, so a fresh insert is owned solely by it and must be removed
+    /// again on `rollback_publish` — otherwise the phantom entry poisons
+    /// fork detection for later same-epoch siblings. `false` means the epoch
+    /// was already owned (e.g. by a previously confirmed commit after a
+    /// fork rollback), and rollback must leave that incumbent in place.
+    owns_committed_from: bool,
 }
 
 /// Discriminator the engine uses when emitting the post-confirm event.
@@ -137,7 +145,8 @@ impl EpochManager {
         let new_state = prev.begin_pending(new_epoch, pending, pending_ref)?;
 
         // The transition succeeded — commit every mutation together.
-        self.committed_from
+        let owns_committed_from = self
+            .committed_from
             .entry(group_id.clone())
             .or_default()
             .insert(pre_commit_epoch);
@@ -149,6 +158,7 @@ impl EpochManager {
                 prior_epoch: pre_commit_epoch,
                 kind,
                 audit_context,
+                owns_committed_from,
             },
         );
         Ok(())
@@ -216,8 +226,10 @@ impl EpochManager {
     /// the OpenMLS `clear_pending_commit` + any Marmot/cache rewinds — this
     /// only handles the state-machine bookkeeping.
     ///
-    /// Atomic in the state map: a failed `rollback_pending` leaves both
-    /// `pending` and `states` untouched.
+    /// Atomic in the state map: a failed `rollback_pending` leaves
+    /// `pending`, `states`, and `committed_from` untouched. On success the
+    /// provisional `committed_from` entry inserted by this pending's
+    /// `begin_pending` is removed (a pre-existing incumbent survives).
     ///
     /// Returns `(group_id, prior_epoch)` so the caller can target the
     /// matching MLS group.
@@ -239,6 +251,19 @@ impl EpochManager {
             .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
         let stable = prev.rollback_pending(prior_epoch)?;
         self.pending.remove(&pending);
+        // Drop the provisional `committed_from` ownership recorded by
+        // `begin_pending` — the commit never reached anyone, so a later
+        // same-epoch sibling is a benign race, not a fork. Only the entry
+        // this pending itself inserted is removed; a pre-existing confirmed
+        // incumbent stays.
+        if meta.owns_committed_from
+            && let Some(epochs) = self.committed_from.get_mut(&group_id)
+        {
+            epochs.remove(&prior_epoch);
+            if epochs.is_empty() {
+                self.committed_from.remove(&group_id);
+            }
+        }
         self.states.insert(group_id.clone(), stable);
         Ok((group_id, prior_epoch))
     }
@@ -375,5 +400,87 @@ mod tests {
         assert_eq!(em.epoch(&group_id), Some(EpochId(8)));
         assert_eq!(em.group_for_pending(pending_ref), Some(group_id.clone()));
         assert!(em.we_committed_from(&group_id, EpochId(7)));
+    }
+
+    /// `rollback_publish` must remove the provisional `committed_from` entry
+    /// its `begin_pending` inserted — the commit reached no one, so a later
+    /// same-epoch sibling is a benign race, not a fork.
+    #[test]
+    fn rollback_publish_removes_provisional_committed_from() {
+        let mut em = EpochManager::new();
+        let group_id = gid();
+        em.set_stable(group_id.clone(), EpochId(7));
+
+        let pending_ref = em.next_pending_ref();
+        em.begin_pending(
+            group_id.clone(),
+            EpochId(7),
+            EpochId(8),
+            handle(),
+            pending_ref,
+            PendingKind::GroupEvolution,
+            None,
+        )
+        .expect("begin_pending from Stable succeeds");
+        assert!(em.we_committed_from(&group_id, EpochId(7)));
+
+        let (rolled_group, prior) = em
+            .rollback_publish(pending_ref)
+            .expect("rollback_publish succeeds");
+        assert_eq!(rolled_group, group_id);
+        assert_eq!(prior, EpochId(7));
+        assert_eq!(em.state(&group_id).map(|s| s.name()), Some("Stable"));
+        assert_eq!(em.epoch(&group_id), Some(EpochId(7)));
+        assert!(
+            !em.we_committed_from(&group_id, EpochId(7)),
+            "rolled-back pending must not leave a phantom committed_from entry"
+        );
+    }
+
+    /// A `committed_from` epoch already owned by an earlier confirmed commit
+    /// must survive a later rollback of a pending staged from the same epoch
+    /// (reachable via fork-recovery rewinding to that epoch).
+    #[test]
+    fn rollback_publish_preserves_confirmed_committed_from_incumbent() {
+        let mut em = EpochManager::new();
+        let group_id = gid();
+
+        // Confirmed commit from epoch 7 → committed_from owns 7 legitimately.
+        em.set_stable(group_id.clone(), EpochId(7));
+        let first = em.next_pending_ref();
+        em.begin_pending(
+            group_id.clone(),
+            EpochId(7),
+            EpochId(8),
+            handle(),
+            first,
+            PendingKind::GroupEvolution,
+            None,
+        )
+        .expect("first begin_pending succeeds");
+        em.confirm_publish(first).expect("confirm_publish succeeds");
+        assert!(em.we_committed_from(&group_id, EpochId(7)));
+
+        // Fork recovery rewinds the group to epoch 7; a second commit is
+        // staged from the same epoch and then rolled back.
+        em.set_stable(group_id.clone(), EpochId(7));
+        let second = em.next_pending_ref();
+        em.begin_pending(
+            group_id.clone(),
+            EpochId(7),
+            EpochId(8),
+            handle(),
+            second,
+            PendingKind::GroupEvolution,
+            None,
+        )
+        .expect("second begin_pending succeeds");
+        em.rollback_publish(second)
+            .expect("rollback_publish succeeds");
+
+        assert!(
+            em.we_committed_from(&group_id, EpochId(7)),
+            "rollback must not clear the confirmed incumbent's committed_from entry"
+        );
     }
 }

--- a/crates/cgka-engine/src/epoch_manager.rs
+++ b/crates/cgka-engine/src/epoch_manager.rs
@@ -243,15 +243,6 @@ impl EpochManager {
         Ok((group_id, prior_epoch))
     }
 
-    /// Record a committed-from epoch outside the begin_pending path (used
-    /// by the auto-committer, which doesn't go through PendingPublish).
-    pub(crate) fn record_committed_from(&mut self, group_id: &GroupId, epoch: EpochId) {
-        self.committed_from
-            .entry(group_id.clone())
-            .or_default()
-            .insert(epoch);
-    }
-
     pub(crate) fn prune_committed_from_before(
         &mut self,
         group_id: &GroupId,

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -124,8 +124,14 @@ impl<S: StorageProvider> Engine<S> {
             parsed_kps.push(parsed);
         }
 
-        // Record the pre-commit epoch so a later same-epoch commit can be
-        // compared against this locally produced branch.
+        // The pre-commit epoch is the commit origin for fork detection.
+        // `committed_from` bookkeeping is deliberately NOT recorded here: it
+        // happens atomically inside `begin_pending` below, after staging
+        // succeeds. Recording it earlier left a phantom "we committed from
+        // this epoch" entry behind when staging failed (the cleanup guard
+        // clears the OpenMLS commit but nothing prunes `committed_from`),
+        // which later mis-routed legitimate sibling commits into
+        // fail-closed fork recovery.
         let pre_commit_epoch = EpochId(mls_group.epoch().as_u64());
         // Arm the cleanup guard before creating the snapshot so the snapshot is
         // released on early return / cancellation even before a pending commit
@@ -142,8 +148,6 @@ impl<S: StorageProvider> Engine<S> {
             pre_commit_epoch,
             "pre_invite_commit",
         );
-        self.epoch_manager
-            .record_committed_from(&group_id, pre_commit_epoch);
         let pre_commit_ctx =
             crate::group_lifecycle::build_group_context_snapshot(&mls_group, &provider)?;
 
@@ -464,8 +468,6 @@ impl<S: StorageProvider> Engine<S> {
         )?;
         let commit_priority =
             crate::app_components::commit_ordering_priority_for_staged(staged_commit);
-        self.epoch_manager
-            .record_committed_from(&group_id, pre_commit_epoch);
 
         let commit_bytes = commit_out
             .tls_serialize_detached()

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -131,7 +131,9 @@ impl<S: StorageProvider> Engine<S> {
         // this epoch" entry behind when staging failed (the cleanup guard
         // clears the OpenMLS commit but nothing prunes `committed_from`),
         // which later mis-routed legitimate sibling commits into
-        // fail-closed fork recovery.
+        // fail-closed fork recovery. The post-staging counterpart —
+        // `publish_failed` after a successful `begin_pending` — is handled by
+        // `rollback_publish`, which removes the provisional entry again.
         let pre_commit_epoch = EpochId(mls_group.epoch().as_u64());
         // Arm the cleanup guard before creating the snapshot so the snapshot is
         // released on early return / cancellation even before a pending commit

--- a/crates/cgka-engine/src/update_group_data.rs
+++ b/crates/cgka-engine/src/update_group_data.rs
@@ -210,8 +210,9 @@ impl<S: StorageProvider> Engine<S> {
             pre_commit_epoch,
             "pre_update_group_data_commit",
         );
-        self.epoch_manager
-            .record_committed_from(&group_id, pre_commit_epoch);
+        // `committed_from` is recorded atomically by `begin_pending` after
+        // staging succeeds — never here, where a staging failure would leave
+        // a phantom entry behind (see do_send_invite).
         let pre_commit_ctx =
             crate::group_lifecycle::build_group_context_snapshot(&mls_group, &provider)?;
 

--- a/crates/cgka-engine/src/upgrade.rs
+++ b/crates/cgka-engine/src/upgrade.rs
@@ -158,8 +158,9 @@ impl<S: StorageProvider> Engine<S> {
             pre_commit_epoch,
             "pre_upgrade_commit",
         );
-        self.epoch_manager
-            .record_committed_from(group_id, pre_commit_epoch);
+        // `committed_from` is recorded atomically by `begin_pending` after
+        // staging succeeds — never here, where a staging failure would leave
+        // a phantom entry behind (see do_send_invite).
         let pre_commit_ctx =
             crate::group_lifecycle::build_group_context_snapshot(&mls_group, &provider)?;
 

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -815,3 +815,128 @@ async fn failed_invite_staging_does_not_poison_fork_detection() {
         SendResult::GroupEvolution { .. } | SendResult::Queued { .. }
     ));
 }
+
+#[tokio::test]
+async fn publish_failed_rollback_does_not_poison_fork_detection() {
+    // Companion regression to `failed_invite_staging_does_not_poison_fork_
+    // detection`, for the POST-staging failure: staging succeeds, so
+    // `begin_pending` records `committed_from`, and then the publish fails.
+    // `rollback_publish` used to clear the staged commit and drop its
+    // recovery snapshot but leave the provisional `committed_from` entry
+    // behind. Once Alice later advanced past that epoch via a peer's commit,
+    // a legitimate late same-epoch sibling hit the phantom entry, found no
+    // recovery snapshot, and failed closed with ForkedEpoch. Rollback now
+    // removes the provisional entry it recorded.
+    let (mut alice, _alice_storage) = build_client_with_storage(b"rollback-alice");
+    let mut bob = build_client(b"rollback-bob");
+    let mut carol = build_client(b"rollback-carol");
+    let (mut dave, dave_storage) = build_client_with_storage(b"rollback-dave");
+    let dave_id = MemberId::new(pad32(b"rollback-dave"));
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let dave_kp = dave.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "".into(),
+            description: "".into(),
+            members: vec![bob_kp, dave_kp],
+            required_features: vec![],
+            app_components: vec![],
+            // Bob must be an admin so his sibling-epoch invite below passes
+            // the MIP-03 committer guard.
+            initial_admins: vec![MemberId::new(pad32(b"rollback-bob"))],
+        })
+        .await
+        .unwrap();
+    let (bob_welcome, dave_welcome) = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            let dave_welcome = welcomes.remove(1);
+            (welcomes.remove(0), dave_welcome)
+        }
+        _ => unreachable!(),
+    };
+    bob.join_welcome(bob_welcome).await.unwrap();
+    dave.join_welcome(dave_welcome).await.unwrap();
+
+    // Dave produces (but never publishes/applies) a sibling commit from the
+    // current epoch — the legitimate same-epoch race Alice must classify
+    // later.
+    let dave_sibling_commit = raw_self_update_commit(&dave_storage, &dave_id, &group_id);
+
+    // Alice's invite stages successfully — `begin_pending` records the
+    // provisional `committed_from` entry — and then the publish fails.
+    let mut frank = build_client(b"rollback-frank");
+    let frank_kp = frank.fresh_key_package().await.unwrap();
+    let staged = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![frank_kp],
+        })
+        .await
+        .unwrap();
+    let pending = match staged {
+        SendResult::GroupEvolution { pending, .. } => pending,
+        _ => unreachable!(),
+    };
+    alice.publish_failed(pending).await.unwrap();
+
+    // Bob commits from the same epoch (invites Carol). Alice advances by
+    // settling Bob's commit through convergence — a peer-driven advance, so
+    // she has no fork-recovery incumbent of her own for the source epoch.
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let invite = bob
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![carol_kp],
+        })
+        .await
+        .unwrap();
+    let (bob_commit, pending) = match invite {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        _ => unreachable!(),
+    };
+    bob.confirm_published(pending).await.unwrap();
+    let routed_bob_commit = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..bob_commit
+    };
+    alice
+        .buffer_openmls_convergence_message(&group_id, routed_bob_commit, 1_000)
+        .expect("bob commit buffered");
+    alice
+        .converge_stored_openmls_messages(&group_id, 3_000)
+        .expect("bob commit settles");
+    assert_eq!(alice.epoch(&group_id).unwrap(), EpochId(2));
+
+    // Dave's sibling commit for the now-past epoch arrives. Alice's rolled-
+    // back commit reached no one, so ingest must classify it — NOT take the
+    // fork-recovery path and fail closed with ForkedEpoch.
+    alice
+        .ingest(dave_sibling_commit)
+        .await
+        .expect("sibling commit after rolled-back publish must not fail closed");
+
+    // The group is still operational: a fresh (valid) invite from Alice is
+    // accepted — staged immediately or queued behind unresolved convergence
+    // input. In Recovering it would error instead (`begin_pending` rejects
+    // non-Stable states).
+    let mut erin = build_client(b"rollback-erin");
+    let erin_kp = erin.fresh_key_package().await.unwrap();
+    let recovery_probe = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![erin_kp],
+        })
+        .await
+        .expect("group must remain usable after rolled-back publish + sibling commit");
+    assert!(matches!(
+        recovery_probe,
+        SendResult::GroupEvolution { .. } | SendResult::Queued { .. }
+    ));
+}

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -687,3 +687,131 @@ async fn stale_commit_without_own_commit_is_classified_as_already_at_epoch_not_f
         }
     ));
 }
+
+#[tokio::test]
+async fn failed_invite_staging_does_not_poison_fork_detection() {
+    // Regression: `do_send_invite` used to record `committed_from` BEFORE
+    // staging the commit. When staging failed, the cleanup guard cleared the
+    // OpenMLS pending commit but nothing pruned the phantom "we committed
+    // from this epoch" entry. Once Alice later advanced past that epoch via a
+    // PEER's commit (settled through convergence — so no fork-recovery
+    // incumbent of her own exists), a legitimate same-epoch sibling commit
+    // was mis-routed: the phantom blocked convergence entry, the WrongEpoch
+    // fork branch found no recovery snapshot, and ingest failed closed with
+    // ForkedEpoch, sticking the group in Recovering. `committed_from` is now
+    // recorded only inside `begin_pending`, atomically with the transition.
+    let (mut alice, _alice_storage) = build_client_with_storage(b"phantom-alice");
+    let mut bob = build_client(b"phantom-bob");
+    let mut carol = build_client(b"phantom-carol");
+    let (mut dave, dave_storage) = build_client_with_storage(b"phantom-dave");
+    let dave_id = MemberId::new(pad32(b"phantom-dave"));
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let dave_kp = dave.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "".into(),
+            description: "".into(),
+            members: vec![bob_kp, dave_kp],
+            required_features: vec![],
+            app_components: vec![],
+            // Bob must be an admin so his sibling-epoch invite below passes
+            // the MIP-03 committer guard.
+            initial_admins: vec![MemberId::new(pad32(b"phantom-bob"))],
+        })
+        .await
+        .unwrap();
+    let (bob_welcome, dave_welcome) = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            let dave_welcome = welcomes.remove(1);
+            (welcomes.remove(0), dave_welcome)
+        }
+        _ => unreachable!(),
+    };
+    bob.join_welcome(bob_welcome).await.unwrap();
+    dave.join_welcome(dave_welcome).await.unwrap();
+
+    // Dave produces (but never publishes/applies) a sibling commit from the
+    // current epoch — the legitimate same-epoch race Alice must classify
+    // later.
+    let dave_sibling_commit = raw_self_update_commit(&dave_storage, &dave_id, &group_id);
+
+    // Alice's invite fails DURING staging: the duplicate-Bob KeyPackage is
+    // signed with Bob's existing leaf signature key, which OpenMLS rejects
+    // inside `add_members` — after capability validation, before
+    // `begin_pending`.
+    let duplicate_bob_kp = bob.fresh_key_package().await.unwrap();
+    let failed = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![duplicate_bob_kp],
+        })
+        .await;
+    assert!(
+        failed.is_err(),
+        "duplicate-member invite must fail during staging"
+    );
+
+    // Bob commits from the same epoch (invites Carol). Alice advances by
+    // settling Bob's commit through convergence — a peer-driven advance, so
+    // she has no fork-recovery incumbent of her own for the source epoch.
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let invite = bob
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![carol_kp],
+        })
+        .await
+        .unwrap();
+    let (bob_commit, pending) = match invite {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        _ => unreachable!(),
+    };
+    bob.confirm_published(pending).await.unwrap();
+    let routed_bob_commit = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..bob_commit
+    };
+    alice
+        .buffer_openmls_convergence_message(&group_id, routed_bob_commit, 1_000)
+        .expect("bob commit buffered");
+    alice
+        .converge_stored_openmls_messages(&group_id, 3_000)
+        .expect("bob commit settles");
+    assert_eq!(alice.epoch(&group_id).unwrap(), EpochId(2));
+
+    // Dave's sibling commit for the now-past epoch arrives. Alice never
+    // published a commit from that epoch, so ingest must classify it (stale
+    // losing branch, or a reorg onto the winning branch) — NOT take the
+    // fork-recovery path, which with the phantom entry and no tracked
+    // snapshot failed closed with ForkedEpoch and left the group stuck in
+    // Recovering.
+    alice
+        .ingest(dave_sibling_commit)
+        .await
+        .expect("sibling commit after failed staging must not fail closed");
+
+    // The group is still operational: a fresh (valid) invite from Alice is
+    // accepted — staged immediately or queued behind unresolved convergence
+    // input. In Recovering it would error instead (`begin_pending` rejects
+    // non-Stable states).
+    let mut erin = build_client(b"phantom-erin");
+    let erin_kp = erin.fresh_key_package().await.unwrap();
+    let recovery_probe = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![erin_kp],
+        })
+        .await
+        .expect("group must remain usable after failed staging + sibling commit");
+    assert!(matches!(
+        recovery_probe,
+        SendResult::GroupEvolution { .. } | SendResult::Queued { .. }
+    ));
+}


### PR DESCRIPTION
![marmot](https://blossom.primal.net/2af7e71ec2c517645069b084c6bbaeb1b4dcfc28d7eda7c4251e89fc923907cf.jpg)

Four send paths (invite, remove-members, capability upgrade, group-data update) recorded "we committed from this epoch" while commit staging could still fail. When staging failed, the cleanup guard cleared the staged OpenMLS commit, but the committed_from entry stayed behind. A marmot that later advanced past that epoch through a peer's commit (settled via convergence, so it holds no fork-recovery snapshot of its own) then mis-routed a legitimate same-epoch sibling commit: the stale entry blocked convergence entry, the WrongEpoch fork branch found no recovery snapshot, and ingest failed closed with ForkedEpoch. The group got stuck in Recovering and rejected further sends.

begin_pending already records committed_from atomically with the pending-publish transition, so the four manual calls were redundant on success and harmful on failure. This PR removes them and deletes the now-unused EpochManager::record_committed_from.

Tests:

- cgka-engine: failed_invite_staging_does_not_poison_fork_detection reproduces the chain (failed duplicate-member invite, peer-driven advance via convergence, sibling commit for the past epoch). It fails with ForkedEpoch on the pre-fix engine and passes with the fix.
- cgka-conformance-simulator: failed_invite_staging_does_not_poison_fork_detection_via_harness mirrors the scenario across five marmots on the bus, with a partition keeping the sibling committer at the old epoch. Adds HarnessClient::try_invite so a scenario can drive a deliberately failing invite; registered in SCENARIOS.md.

Verified with just fast-ci, cargo test -p cgka-engine, and cargo test -p cgka-conformance-simulator.

fixes #885 


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/889">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed failed invite staging/publishing no longer poisoning fork detection or leaving the group stuck in recovery.
  * Corrected rollback behavior so provisional epoch bookkeeping is removed when appropriate, while preserving existing committed-history state.
  * Improved invite handling to report underlying send failures gracefully rather than crashing or misclassifying outcomes.
  * Groups remain usable after a failed invite followed by a concurrent sibling commit.
* **Documentation**
  * Added a conformance scenario covering the failed-invite regression case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->