### PR TITLE
fix(traits): match RFC 9637 documentation /20 in is_public_ipv6

### DIFF
--- a/crates/traits/src/app_components/host_safety.rs
+++ b/crates/traits/src/app_components/host_safety.rs
@@ -109,9 +109,10 @@ pub fn is_public_ipv6(addr: Ipv6Addr) -> bool {
     if first == 0x2001 && second == 0x0db8 {
         return false;
     }
-    // Documentation 3fff::/20 (RFC 9637). It falls inside global-unicast
+    // Documentation 3fff::/20 (RFC 9637): first hextet 0x3fff with the top
+    // nibble of the second hextet zero. It falls inside global-unicast
     // 2000::/3, so the terminal rule below would otherwise accept it.
-    if (first & 0xfff0) == 0x3ff0 {
+    if first == 0x3fff && (second & 0xf000) == 0 {
         return false;
     }
     // Only global unicast 2000::/3 is routable today; reject anything else not

--- a/crates/traits/src/app_components/tests.rs
+++ b/crates/traits/src/app_components/tests.rs
@@ -350,7 +350,7 @@ fn group_avatar_url_rejects_documentation_ipv6_ranges() {
         "https://[2001:db8::1]/a.png",
         "https://[2001:db8:abcd:12::1]/a.png",
         "https://[3fff::1]/a.png",
-        "https://[3fff:ffff::1]/a.png",
+        "https://[3fff:0fff::1]/a.png",
     ] {
         assert!(
             validate_and_normalize_group_avatar_url(raw).is_err(),

--- a/crates/traits/tests/host_safety_public.rs
+++ b/crates/traits/tests/host_safety_public.rs
@@ -80,6 +80,15 @@ fn shared_host_safety_classifies_canonical_ipv6_ranges() {
     assert!(is_public_ipv6("::ffff:93.184.216.34".parse().unwrap()));
     assert!(is_public_ip(IpAddr::V6("2606:4700::1".parse().unwrap())));
 
+    // Only the actual RFC 9637 block 3fff:0000::/20 is documentation space.
+    // Neighbouring global-unicast hextets (3ff0:: to 3ffe::) and 3fff:: past the
+    // /20 boundary (second hextet >= 0x1000) are ordinary routable space.
+    for raw in ["3ff0::1", "3ffe::1", "3fff:1000::1", "3fff:ffff::1"] {
+        let addr: Ipv6Addr = raw.parse().expect("test IPv6 literal parses");
+        assert!(is_public_ipv6(addr), "{raw} should be accepted");
+        assert!(is_public_ip(IpAddr::V6(addr)), "{raw} should be accepted");
+    }
+
     for raw in [
         "::1",              // loopback
         "::",               // unspecified
@@ -91,7 +100,8 @@ fn shared_host_safety_classifies_canonical_ipv6_ranges() {
         "2002::1",          // 6to4 transition prefix
         "2001::1",          // Teredo 2001:0000::/32
         "2001:db8::1",      // documentation
-        "3fff::1",          // documentation 3fff::/20
+        "3fff::1",          // documentation 3fff::/20 (lower edge)
+        "3fff:0fff::1",     // documentation 3fff::/20 (upper edge)
         "4000::1",          // outside global-unicast 2000::/3
     ] {
         let addr: Ipv6Addr = raw.parse().expect("test IPv6 literal parses");


### PR DESCRIPTION
Fixes #913

## Problem

`is_public_ipv6` mis-classifies a large slice of global-unicast space as non-routable. The guard meant to exclude the RFC 9637 documentation range `3fff::/20` was written as:

```rust
// crates/traits/src/app_components/host_safety.rs
if (first & 0xfff0) == 0x3ff0 {
    return false;
}
```

`0xfff0` masks off only the low nibble of the first hextet, so the condition matches every first hextet in `0x3ff0..=0x3fff` — i.e. `3ff0::/16` through `3fff::/16` — regardless of the second hextet, instead of the intended `3fff::/20`.

## Root cause

`3fff::/20` fixes the full first hextet (`0x3fff`) plus the top nibble of the second hextet. The masked comparison collapses that to "first hextet in `0x3ff0..=0x3fff`", over-rejecting:

- `3ff0::` through `3ffe::` (entire hextets of ordinary global unicast), and
- `3fff::` addresses past the `/20` boundary (second hextet `>= 0x1000`).

All of these are inside global-unicast `2000::/3`, so `is_public_ipv6` returns `false` and the avatar-URL / encrypted-media SSRF validators (`reject_non_routable_ipv6`) wrongly reject legitimately-routable hosts. It fails closed (no SSRF exposure), but it is a concrete deviation from the stated RFC and the code comment, latent until IANA allocates `3xxx::` to the RIRs.

## Fix

Match the actual `/20`: first hextet `0x3fff` with the top nibble of the second hextet zero.

```rust
if first == 0x3fff && (second & 0xf000) == 0 {
    return false;
}
```

The guard still fails closed for the real documentation block and never newly accepts a non-routable address.

## Verification

Toolchain pinned `1.90.0`; `just` isn't installed locally so the equivalent cargo gates were run directly.

```
# regression added first — FAILS on the buggy mask (3ff0::1 wrongly rejected):
cargo test -p cgka-traits --test host_safety_public
  → thread panicked: 3ff0::1 should be accepted

# after the fix:
cargo test -p cgka-traits --test host_safety_public   # 6 passed
cargo test -p cgka-traits                              # lib 69 passed, integration + doctests ok
cargo fmt -p cgka-traits -- --check                    # clean
cargo clippy -p cgka-traits --all-targets              # clean, no warnings
```

Added regression coverage in `tests/host_safety_public.rs` locking both edges of the `/20`:
- now accepted (were wrongly rejected): `3ff0::1`, `3ffe::1`, `3fff:1000::1`, `3fff:ffff::1`
- still rejected (documentation range): `3fff::1` (lower edge) and `3fff:0fff::1` (upper edge)

The one existing assertion that depended on the buggy mask — `3fff:ffff::1` in `group_avatar_url_rejects_documentation_ipv6_ranges` (it is *not* documentation space) — was replaced with `3fff:0fff::1`, a genuine in-range documentation address, so that test keeps asserting exactly what its name says.

## Scope / risk

Three files, all in `crates/traits`. No previously-public address becomes rejected; the change only stops rejecting genuinely-routable space, so there is no new SSRF surface and no public-API change.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/917">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined IPv6 public/global-routable classification for the RFC 9637 documentation-only range (`3fff:0000::/20`), improving accuracy at the boundaries.
  * Ensures IPv6 addresses inside the documentation range are rejected, while adjacent global-unicast addresses are accepted.

* **Tests**
  * Updated and expanded IPv6 host-safety and avatar URL validation test cases to better cover the RFC 9637 boundary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->