### PR TITLE
Feat/tui revamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ dev/data/
 
 # Project specific optional env-vars
 .env
+
+# opencode tool artifacts
+.opencode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +881,17 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
 ]
 
 [[package]]
@@ -2094,6 +2114,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -6208,6 +6252,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6224,6 +6303,24 @@ dependencies = [
  "regex",
  "windows-sys 0.61.2",
  "zeroize",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -6493,6 +6590,7 @@ dependencies = [
  "agent-stream-compose",
  "cgka-session",
  "cgka-traits",
+ "chrono",
  "clap",
  "crossterm 0.28.1",
  "fs-private",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ async-trait = "0.1"
 futures = "0.3"
 
 # utils
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/Justfile
+++ b/Justfile
@@ -60,6 +60,22 @@ relay-logs:
 tui-reset:
     ./scripts/reset_tui_dev.sh
 
+# Open the dev TUI as a `just tui-reset` account, by display name or npub/hex.
+tui name="Alice":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    selector="$(target/debug/wn --home dev/data --json account list \
+        | jq -r --arg name "{{name}}" \
+            'first(.result.accounts[] | select((.display_name // .profile.display_name // .profile.name // "") == $name) | .account_id) // $name')"
+    exec target/debug/wn --home dev/data --account "$selector" tui
+
+# TUI on production relays in a disposable home; first run: /daemon start, then `c`.
+tui-prod relays="wss://relay.eu.whitenoise.chat,wss://relay.us.whitenoise.chat":
+    cargo build -p wn-cli --bins
+    target/debug/wn --home ~/.wn-tui-drive --secret-store file tui \
+        --discovery-relays "{{relays}},wss://purplepag.es" \
+        --default-account-relays "{{relays}}"
+
 hermes-dev-setup args="":
     ./scripts/hermes_marmot_dev_setup.sh {{args}}
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,15 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Changed
+
+- TUI: the messages pane now renders the materialized message timeline (`messages timeline list` /
+  `messages timeline subscribe`) with reactions, reply context, deletion tombstones, and `[img name]`/`[file name]`
+  media placeholders. Scrolling uses a
+  message-offset model — `j`/`k` select, `G`/`g` jump to newest/oldest, `PageUp`/`PageDown` page, and scrolling past
+  the oldest loaded message pages in older history; incoming messages hold your position unless you are pinned to the
+  bottom. Timestamps render in local wall-clock time. No JSON response shapes changed.
+
 ### Added
 
 - MarmotKit/UniFFI now exposes encrypted per-account composer draft storage with metadata-only list, full load, upsert,

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,15 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Changed
 
+- TUI: adopted a chat-first shell. A screen model replaces the fixed four-pane dashboard: a login/account-select
+  screen (create identity, nsec login, or pick from several accounts) opens when there is no single obvious account,
+  and the main view is the chat list plus the message timeline plus the composer, with the reclaimed space going to
+  the chat/messages row. The 12-row status panel and 3-row header collapse into a one-line status bar
+  (`{account} · daemon {on|off} · {n} chats · {u} unread · {latest status}`) and a per-focus hints line. Default
+  focus is the chat list, so `j`/`k` works immediately; `Enter` opens a chat and focuses the messages pane; `A`
+  reopens the account picker. Group MLS/component diagnostics move behind a new `/diagnostics` slash command that
+  toggles a diagnostics panel above the composer. An explicit `--account`/`WN_ACCOUNT` selection that resolves to a
+  loaded account opens the main view directly, even when several accounts exist. No JSON response shapes changed.
 - TUI: the messages pane now renders the materialized message timeline (`messages timeline list` /
   `messages timeline subscribe`) with reactions, reply context, deletion tombstones, and `[img name]`/`[file name]`
   media placeholders. Scrolling uses a
@@ -18,6 +27,10 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Added
 
+- `wn tui` gained optional `--discovery-relays` and `--default-account-relays` flags (comma-separated, matching
+  `wn daemon start`). They are forwarded to the `daemon start` child and to `create-identity`/`login` account setup
+  so a first run with no relay configuration can supply relays without dead-ending. Flag passthrough only; no JSON
+  response shapes changed.
 - MarmotKit/UniFFI now exposes encrypted per-account composer draft storage with metadata-only list, full load, upsert,
   and delete operations. Drafts retain their text, reply target, ordered attachment bytes, and attachment presentation
   metadata in the account's SQLCipher database; attachment bytes are loaded only for the selected draft.

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/bin/wnd.rs"
 agent-stream-compose.workspace = true
 cgka-traits.workspace = true
 cgka-session.workspace = true
+chrono.workspace = true
 clap.workspace = true
 crossterm.workspace = true
 fs-private.workspace = true

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -448,8 +448,10 @@ real time.
 ## TUI
 
 `wn tui` is a Ratatui interface over the real `wn --json` command surface. It lists local accounts, shows
-visible chats for the selected local signing account, renders recent messages, sends messages from a composer, and
-keeps the latest status plus selected-chat MLS/component state in a status panel below the composer.
+visible chats for the selected local signing account, renders the materialized message timeline (with reactions,
+reply context, deletion tombstones, and `[img name]`/`[file name]` media placeholders), sends messages from a
+composer, and keeps the latest status plus
+selected-chat MLS/component state in a status panel below the composer.
 
 ```sh
 wn tui
@@ -461,11 +463,15 @@ group-state changes, and refreshes snapshots when the composer is idle.
 
 Controls:
 
-- `Tab`: cycle accounts, chats, and composer.
-- Arrow keys or `j`/`k`: move the selected account or chat.
-- `Enter`: select the highlighted account/chat or submit the composer.
+- `Tab`: cycle accounts, chats, messages, and composer.
+- Accounts/chats: arrow keys or `j`/`k` move the selection; `Enter` selects the highlighted account/chat.
+- Messages: `j`/`k` or arrows move the message selection; `PageUp`/`PageDown` page; `G`/`End` jump to the newest
+  message (and pin to the bottom), `g`/`Home` to the oldest. New messages stay pinned to the bottom while you are at
+  the newest message and hold your position when you have scrolled up. Scrolling past the oldest loaded message loads
+  the previous page of history. `i` or `Enter` focuses the composer.
+- Composer: `Enter` submits.
 - `?`: open help.
-- `Esc`: clear help or input.
+- `Esc`: close the help popup or clear the composer input.
 - `Ctrl-C`: quit.
 
 Composer slash commands:

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -447,24 +447,48 @@ real time.
 
 ## TUI
 
-`wn tui` is a Ratatui interface over the real `wn --json` command surface. It lists local accounts, shows
-visible chats for the selected local signing account, renders the materialized message timeline (with reactions,
-reply context, deletion tombstones, and `[img name]`/`[file name]` media placeholders), sends messages from a
-composer, and keeps the latest status plus
-selected-chat MLS/component state in a status panel below the composer.
+`wn tui` is a Ratatui interface over the real `wn --json` command surface. It opens on a login screen when it has
+no single obvious account, then drops into a chat-first main view: the chat list on the left, the materialized
+message timeline on the right (with reactions, reply context, deletion tombstones, and `[img name]`/`[file name]`
+media placeholders), the composer below them, and a one-line hints bar plus a one-line status bar at the bottom.
 
 ```sh
 wn tui
 ```
 
-When a daemon is running for the same home, TUI child commands use the daemon socket. The header shows daemon
+Startup routes by how many local accounts exist: no accounts open the login menu (create an identity or log in
+with an nsec), exactly one drops straight into the main view, and several open an account picker. An explicit
+`--account <npub-or-hex>` (or `WN_ACCOUNT`) that resolves to a loaded account enters the main view directly with
+that account, even when several accounts exist. The main view no
+longer has an always-visible accounts panel; press `A` from the chat list to reopen the account picker, or use the
+`/account`, `/login`, and `/create-identity` slash commands.
+
+First run without any relay configuration would otherwise dead-end, because creating an identity and starting the
+daemon both need relays. Pass them to `wn tui` and they are forwarded to the daemon-start and account-setup child
+commands:
+
+```sh
+wn tui \
+  --discovery-relays wss://relay.discovery.example \
+  --default-account-relays wss://relay.one.example,wss://relay.two.example
+```
+
+When a daemon is running for the same home, TUI child commands use the daemon socket. The status bar shows daemon
 state. While the daemon is running, the TUI attaches to daemon-backed runtime subscriptions for live message, chat, and
 group-state changes, and refreshes snapshots when the composer is idle.
 
-Controls:
+Login screen controls:
 
-- `Tab`: cycle accounts, chats, messages, and composer.
-- Accounts/chats: arrow keys or `j`/`k` move the selection; `Enter` selects the highlighted account/chat.
+- Menu (no accounts): `c` create a new identity, `l` log in with an nsec, `q` quit.
+- Account picker (several accounts): `j`/`k` or arrows move the selection; `Enter` selects the account and enters
+  the main view; `c` create; `l` nsec login; `Esc` returns to the main view when one is already active; `q` quit.
+- Nsec entry: type or paste the nsec (rendered masked); `Enter` submits it over stdin; `Esc` cancels.
+
+Main view controls:
+
+- `Tab`/`BackTab`: cycle the chat list, messages, and composer.
+- Chats: `j`/`k` or arrows move the selection; `Enter` opens the chat and focuses the messages pane; `A` reopens the
+  account picker.
 - Messages: `j`/`k` or arrows move the message selection; `PageUp`/`PageDown` page; `G`/`End` jump to the newest
   message (and pin to the bottom), `g`/`Home` to the oldest. New messages stay pinned to the bottom while you are at
   the newest message and hold your position when you have scrolled up. Scrolling past the oldest loaded message loads
@@ -474,11 +498,15 @@ Controls:
 - `Esc`: close the help popup or clear the composer input.
 - `Ctrl-C`: quit.
 
+Group MLS/component diagnostics are hidden by default; `/diagnostics` toggles a diagnostics panel between the
+messages pane and the composer.
+
 Composer slash commands:
 
 ```text
 /help
 /refresh
+/diagnostics
 /account <npub-or-hex>
 /create-identity
 /login <nsec-or-npub>

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -81,7 +81,22 @@ impl SecretStoreKind {
 #[derive(Clone, Debug, Serialize, Deserialize, Subcommand)]
 pub(crate) enum Command {
     #[command(about = "Open the interactive terminal UI")]
-    Tui,
+    Tui {
+        #[arg(
+            long,
+            value_name = "URLS",
+            value_delimiter = ',',
+            help = "Comma-separated discovery relays forwarded to daemon start and account setup on first run"
+        )]
+        discovery_relays: Vec<String>,
+        #[arg(
+            long,
+            value_name = "URLS",
+            value_delimiter = ',',
+            help = "Comma-separated default account relays forwarded to daemon start and account setup on first run"
+        )]
+        default_account_relays: Vec<String>,
+    },
     #[command(about = "Inspect local runtime diagnostics")]
     Debug {
         #[command(subcommand)]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -156,7 +156,7 @@ where
         return daemon::run_daemon_command(cli, command).await;
     }
 
-    if matches!(cli.command, Command::Tui) {
+    if matches!(cli.command, Command::Tui { .. }) {
         return tui::run_tui(cli).await;
     }
 
@@ -543,7 +543,7 @@ async fn execute_inner(cli: Cli) -> Result<CommandOutput, WnError> {
             plain: "daemon command is handled by wn".to_owned(),
             json: json!({"handled": "client"}),
         }),
-        Command::Tui => Ok(CommandOutput {
+        Command::Tui { .. } => Ok(CommandOutput {
             plain: "tui command is handled by wn".to_owned(),
             json: json!({"handled": "client"}),
         }),

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -6,9 +6,20 @@ pub(crate) struct TuiApp {
     pub(crate) client: WnClient,
     pub(crate) initial_account: Option<String>,
     pub(crate) running: bool,
+    pub(crate) screen: Screen,
+    /// True once an account has been activated into the main view, so `Esc` from
+    /// the account picker knows whether there is a session to return to.
+    pub(crate) entered_main: bool,
+    /// Whether the opt-in MLS group diagnostics panel is shown (`/diagnostics`).
+    pub(crate) show_diagnostics: bool,
     pub(crate) focus: Focus,
     pub(crate) accounts: Vec<AccountRow>,
     pub(crate) selected_account: usize,
+    /// The account-picker highlight, kept separate from `selected_account` so
+    /// picker navigation never mutates the live selection. It is seeded from
+    /// `selected_account` when the picker opens and committed back only on
+    /// `Enter`; `Esc` discards it.
+    pub(crate) picker_selection: usize,
     pub(crate) chats: Vec<ChatRow>,
     pub(crate) selected_chat: usize,
     pub(crate) messages_account_id: Option<String>,
@@ -37,9 +48,13 @@ impl TuiApp {
             client,
             initial_account: cli.account.clone(),
             running: true,
-            focus: Focus::Composer,
+            screen: Screen::Login(LoginMode::Menu),
+            entered_main: false,
+            show_diagnostics: false,
+            focus: Focus::Chats,
             accounts: Vec::new(),
             selected_account: 0,
+            picker_selection: 0,
             chats: Vec::new(),
             selected_chat: 0,
             messages_account_id: None,
@@ -66,7 +81,7 @@ impl TuiApp {
         let mut terminal = ratatui::init();
         let result = (|| -> TuiResult<()> {
             let _ = self.refresh_daemon_status();
-            self.refresh_accounts()?;
+            self.start()?;
             let mut dirty = true;
             while self.running {
                 dirty |= self.tick();
@@ -109,11 +124,77 @@ impl TuiApp {
         changed
     }
 
+    /// Route the opening screen from the loaded account list: no accounts opens
+    /// the login menu, one drops straight into the main view, several open the
+    /// account picker.
+    pub(crate) fn start(&mut self) -> TuiResult<()> {
+        self.load_accounts()?;
+        // An explicit `--account`/`WN_ACCOUNT` selector that resolves to a loaded
+        // account is honored directly, so it wins over the several-accounts
+        // picker instead of routing purely on the account count.
+        let initial_index = self
+            .initial_account
+            .as_deref()
+            .and_then(|selector| selected_account_index(&self.accounts, Some(selector)));
+        if let Some(index) = initial_index {
+            self.selected_account = index;
+        }
+        match startup_screen(self.accounts.len(), initial_index.is_some()) {
+            Screen::Main => self.enter_main(),
+            Screen::Login(LoginMode::AccountSelect) => {
+                self.open_account_picker();
+                Ok(())
+            }
+            screen => {
+                self.screen = screen;
+                Ok(())
+            }
+        }
+    }
+
+    /// Open the account picker, seeding its highlight from the currently active
+    /// account so navigation starts on the current selection and `Esc` discards
+    /// cleanly back to that account without committing a different one.
+    pub(crate) fn open_account_picker(&mut self) {
+        self.picker_selection = self.selected_account;
+        self.screen = Screen::Login(LoginMode::AccountSelect);
+    }
+
+    /// Commit to the main view without reloading: used after account setup, which
+    /// has already loaded the new account's chats.
+    pub(crate) fn show_main(&mut self) {
+        self.screen = Screen::Main;
+        self.focus = Focus::Chats;
+        self.entered_main = true;
+    }
+
+    /// Enter the main view for the currently selected account, loading its chats.
+    pub(crate) fn enter_main(&mut self) -> TuiResult<()> {
+        self.show_main();
+        self.refresh_chats()
+    }
+
+    /// Reload accounts and chats, dropping back to the login menu if the last
+    /// account has disappeared. Backs the `/refresh` slash command.
+    pub(crate) fn refresh_or_return_to_login(&mut self) -> TuiResult<()> {
+        self.refresh_accounts()?;
+        if self.accounts.is_empty() {
+            self.entered_main = false;
+            self.screen = Screen::Login(LoginMode::Menu);
+        }
+        Ok(())
+    }
+
     pub(crate) fn handle_key(&mut self, key: KeyEvent) -> TuiResult<()> {
         if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
             self.running = false;
             return Ok(());
         }
+        // The streaming check sits ahead of the screen dispatch (behind only
+        // Ctrl-C) so the invariant is structural: while a stream is open, keys go
+        // to the composer and `tick()` keeps flushing regardless of which screen
+        // is showing. Otherwise a future Main->Login transition with a live stream
+        // would silently bypass the streaming keys.
         if self.streaming.is_some() {
             // Streaming key handling (finish/cancel/append) performs fallible
             // daemon/relay operations. Mirror the non-streaming Enter path and
@@ -125,6 +206,10 @@ impl TuiApp {
                 self.status = format!("error: {err}");
             }
             return Ok(());
+        }
+        match self.screen {
+            Screen::Login(mode) => return self.handle_login_key(mode, key),
+            Screen::Main => {}
         }
 
         match key.code {
@@ -144,6 +229,12 @@ impl TuiApp {
                 self.show_help = false;
                 self.focus = Focus::Composer;
                 self.input.push('/');
+            }
+            // Reopen the account picker from the chat list (the accounts pane is
+            // gone; `A` is its replacement entry point).
+            KeyCode::Char('A') if self.focus == Focus::Chats => {
+                self.show_help = false;
+                self.open_account_picker();
             }
             // Messages pane: the message-offset scroll model. `k`/Up and PageUp
             // may reach the oldest loaded row and page in older history.
@@ -166,7 +257,7 @@ impl TuiApp {
             KeyCode::Char('i') | KeyCode::Enter if self.focus == Focus::Messages => {
                 self.focus = Focus::Composer;
             }
-            // Accounts and chats lists.
+            // Chat list navigation.
             KeyCode::Up | KeyCode::Char('k') if self.focus != Focus::Composer => {
                 self.move_selection(-1);
             }
@@ -192,10 +283,6 @@ impl TuiApp {
 
     pub(crate) fn move_selection(&mut self, delta: isize) {
         match self.focus {
-            Focus::Accounts => {
-                self.selected_account =
-                    move_index(self.selected_account, self.accounts.len(), delta);
-            }
             Focus::Chats => {
                 self.selected_chat = move_index(self.selected_chat, self.chats.len(), delta);
             }
@@ -203,6 +290,13 @@ impl TuiApp {
             // it is driven directly in `handle_key`, not through `move_selection`.
             Focus::Messages | Focus::Composer => {}
         }
+    }
+
+    /// Move the account-picker highlight (login/account-select screen only).
+    /// This is picker-local state committed to `selected_account` on `Enter`, so
+    /// navigation never disturbs the active selection.
+    pub(crate) fn move_account_selection(&mut self, delta: isize) {
+        self.picker_selection = move_index(self.picker_selection, self.accounts.len(), delta);
     }
 
     /// Move the message selection one row older, paging in older history when the
@@ -242,8 +336,13 @@ impl TuiApp {
 
     pub(crate) fn activate_focus(&mut self) -> TuiResult<()> {
         match self.focus {
-            Focus::Accounts => self.select_current_account(),
-            Focus::Chats => self.refresh_messages(),
+            // Opening a chat also moves focus to the messages pane so the reader
+            // can immediately scroll the conversation.
+            Focus::Chats => {
+                self.refresh_messages()?;
+                self.focus = Focus::Messages;
+                Ok(())
+            }
             Focus::Messages => Ok(()),
             Focus::Composer => self.submit_input(),
         }
@@ -292,13 +391,114 @@ impl TuiApp {
         }
     }
 
+    /// Handle a keypress on the login/account-select screen. Fallible account
+    /// setup is caught into the status line so a failed create/login never tears
+    /// down the session (mirrors the streaming and main-view Enter paths).
+    pub(crate) fn handle_login_key(&mut self, mode: LoginMode, key: KeyEvent) -> TuiResult<()> {
+        match mode {
+            LoginMode::Menu => self.handle_login_menu_key(key),
+            LoginMode::AccountSelect => self.handle_account_select_key(key),
+            LoginMode::NsecEntry => self.handle_nsec_entry_key(key),
+        }
+        Ok(())
+    }
+
+    fn handle_login_menu_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Char('c') => self.create_identity_from_login(),
+            KeyCode::Char('l') => self.begin_nsec_entry(),
+            KeyCode::Char('q') => self.running = false,
+            _ => {}
+        }
+    }
+
+    fn handle_account_select_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => self.move_account_selection(-1),
+            KeyCode::Down | KeyCode::Char('j') => self.move_account_selection(1),
+            KeyCode::Enter => {
+                // Commit the picker highlight before loading; `Esc` (below) never
+                // reaches here, so the live selection only changes on `Enter`.
+                self.selected_account = self.picker_selection;
+                if let Err(err) = self.enter_main() {
+                    self.status = format!("error: {err}");
+                }
+            }
+            KeyCode::Char('c') => self.create_identity_from_login(),
+            KeyCode::Char('l') => self.begin_nsec_entry(),
+            KeyCode::Char('q') => self.running = false,
+            // Only return to the main view when one is already active (opened via
+            // `A`); at startup with several accounts there is nothing to return to.
+            KeyCode::Esc if self.entered_main => self.show_main(),
+            _ => {}
+        }
+    }
+
+    fn handle_nsec_entry_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Enter => self.submit_nsec_login(),
+            KeyCode::Esc => {
+                self.input.clear();
+                match login_mode_for_accounts(self.accounts.len()) {
+                    LoginMode::AccountSelect => self.open_account_picker(),
+                    mode => self.screen = Screen::Login(mode),
+                }
+            }
+            KeyCode::Backspace => {
+                self.input.pop();
+            }
+            KeyCode::Char(character) => self.input.push(character),
+            _ => {}
+        }
+    }
+
+    /// Create a new local signing identity from the login screen; enter the main
+    /// view on success, surface the error on the status line otherwise.
+    fn create_identity_from_login(&mut self) {
+        match self.create_or_import_account(None, "created identity") {
+            Ok(()) => self.show_main(),
+            Err(err) => self.status = format!("error: {err}"),
+        }
+    }
+
+    fn begin_nsec_entry(&mut self) {
+        self.screen = Screen::Login(LoginMode::NsecEntry);
+        self.input.clear();
+        self.status = "enter nsec; Enter submits, Esc cancels".to_owned();
+    }
+
+    /// Submit the masked nsec-entry field through the existing stdin-piped login
+    /// path. The value is cleared before shelling out (as the composer does), so
+    /// a secret never lingers in state after submission.
+    fn submit_nsec_login(&mut self) {
+        let identity = self.input.trim().to_owned();
+        self.input.clear();
+        if identity.is_empty() {
+            self.status = "nsec is empty; type an nsec or press Esc".to_owned();
+            return;
+        }
+        match self.create_or_import_account(Some(identity), "logged in identity") {
+            Ok(()) => self.show_main(),
+            Err(err) => self.status = format!("error: {err}"),
+        }
+    }
+
     pub(crate) fn run_slash_command(&mut self, command: SlashCommand) -> TuiResult<()> {
         match command {
             SlashCommand::Help => {
                 self.show_help = true;
                 Ok(())
             }
-            SlashCommand::Refresh => self.refresh_accounts(),
+            SlashCommand::Refresh => self.refresh_or_return_to_login(),
+            SlashCommand::Diagnostics => {
+                self.show_diagnostics = !self.show_diagnostics;
+                self.status = if self.show_diagnostics {
+                    "diagnostics panel on".to_owned()
+                } else {
+                    "diagnostics panel off".to_owned()
+                };
+                Ok(())
+            }
             SlashCommand::Account(selector) => self.select_account_by_selector(&selector),
             SlashCommand::AccountCreate => self.create_or_import_account(None, "created identity"),
             SlashCommand::AccountAddPublic(account) => {
@@ -383,13 +583,6 @@ impl TuiApp {
                 Ok(())
             }
         }
-    }
-
-    pub(crate) fn select_current_account(&mut self) -> TuiResult<()> {
-        if self.accounts.is_empty() {
-            return Ok(());
-        }
-        self.refresh_chats()
     }
 
     pub(crate) fn select_account_by_selector(&mut self, selector: &str) -> TuiResult<()> {

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -15,12 +15,12 @@ pub(crate) struct TuiApp {
     pub(crate) messages_group_id: Option<String>,
     pub(crate) unread_counts: HashMap<String, usize>,
     pub(crate) show_archived_chats: bool,
-    pub(crate) messages: Vec<MessageRow>,
-    pub(crate) messages_scroll: u16,
-    pub(crate) messages_viewport: u16,
+    pub(crate) timeline: Vec<TimelineRow>,
+    pub(crate) timeline_scroll: TimelineScroll,
     pub(crate) live_stream_previews: Vec<LiveStreamPreview>,
     pub(crate) chat_subscription: Option<ChatSubscription>,
     pub(crate) message_subscription: Option<MessageSubscription>,
+    pub(crate) timeline_subscription: Option<TimelineSubscription>,
     pub(crate) group_state_subscription: Option<GroupStateSubscription>,
     pub(crate) daemon: DaemonView,
     pub(crate) group_diagnostics: Option<GroupDiagnostics>,
@@ -46,12 +46,12 @@ impl TuiApp {
             messages_group_id: None,
             unread_counts: HashMap::new(),
             show_archived_chats: false,
-            messages: Vec::new(),
-            messages_scroll: 0,
-            messages_viewport: 0,
+            timeline: Vec::new(),
+            timeline_scroll: TimelineScroll::default(),
             live_stream_previews: Vec::new(),
             chat_subscription: None,
             message_subscription: None,
+            timeline_subscription: None,
             group_state_subscription: None,
             daemon: DaemonView::default(),
             group_diagnostics: None,
@@ -98,6 +98,7 @@ impl TuiApp {
         changed |= self.drain_chat_subscription();
         changed |= self.drain_group_state_subscription();
         changed |= self.drain_message_subscription();
+        changed |= self.drain_timeline_subscription();
         match self.flush_stream_append_if_due(now) {
             Ok(flushed) => changed |= flushed,
             Err(err) => {
@@ -135,41 +136,51 @@ impl TuiApp {
             }
             KeyCode::Tab => self.focus = self.focus.next(),
             KeyCode::BackTab => self.focus = self.focus.previous(),
-            KeyCode::Up => self.move_selection(-1),
-            KeyCode::Down => self.move_selection(1),
-            KeyCode::PageUp => {
-                let by = self.messages_page();
-                self.scroll_messages_up(by);
-            }
-            KeyCode::PageDown => {
-                let by = self.messages_page();
-                self.scroll_messages_down(by);
-            }
-            KeyCode::Home => {
-                self.messages_scroll = u16::MAX;
-            }
-            KeyCode::End => {
-                self.messages_scroll = 0;
-            }
-            KeyCode::Enter => {
-                if let Err(err) = self.activate_focus() {
-                    self.status = format!("error: {err}");
-                }
-            }
             KeyCode::Esc => {
                 self.show_help = false;
                 self.input.clear();
-            }
-            KeyCode::Backspace if self.focus == Focus::Composer => {
-                self.input.pop();
             }
             KeyCode::Char('/') if self.focus != Focus::Composer => {
                 self.show_help = false;
                 self.focus = Focus::Composer;
                 self.input.push('/');
             }
-            KeyCode::Char('j') if self.focus != Focus::Composer => self.move_selection(1),
-            KeyCode::Char('k') if self.focus != Focus::Composer => self.move_selection(-1),
+            // Messages pane: the message-offset scroll model. `k`/Up and PageUp
+            // may reach the oldest loaded row and page in older history.
+            KeyCode::Up | KeyCode::Char('k') if self.focus == Focus::Messages => {
+                self.messages_select_up();
+            }
+            KeyCode::Down | KeyCode::Char('j') if self.focus == Focus::Messages => {
+                self.timeline_scroll.select_down(self.timeline.len());
+            }
+            KeyCode::PageUp if self.focus == Focus::Messages => self.messages_page_up(),
+            KeyCode::PageDown if self.focus == Focus::Messages => {
+                self.timeline_scroll.page_down(self.timeline.len());
+            }
+            KeyCode::End | KeyCode::Char('G') if self.focus == Focus::Messages => {
+                self.timeline_scroll.jump_newest(self.timeline.len());
+            }
+            KeyCode::Home | KeyCode::Char('g') if self.focus == Focus::Messages => {
+                self.messages_jump_oldest();
+            }
+            KeyCode::Char('i') | KeyCode::Enter if self.focus == Focus::Messages => {
+                self.focus = Focus::Composer;
+            }
+            // Accounts and chats lists.
+            KeyCode::Up | KeyCode::Char('k') if self.focus != Focus::Composer => {
+                self.move_selection(-1);
+            }
+            KeyCode::Down | KeyCode::Char('j') if self.focus != Focus::Composer => {
+                self.move_selection(1);
+            }
+            KeyCode::Enter => {
+                if let Err(err) = self.activate_focus() {
+                    self.status = format!("error: {err}");
+                }
+            }
+            KeyCode::Backspace if self.focus == Focus::Composer => {
+                self.input.pop();
+            }
             KeyCode::Char(character) if self.focus == Focus::Composer => {
                 self.show_help = false;
                 self.input.push(character);
@@ -188,27 +199,45 @@ impl TuiApp {
             Focus::Chats => {
                 self.selected_chat = move_index(self.selected_chat, self.chats.len(), delta);
             }
-            Focus::Messages => {
-                if delta < 0 {
-                    self.scroll_messages_up(1);
-                } else if delta > 0 {
-                    self.scroll_messages_down(1);
-                }
-            }
-            Focus::Composer => {}
+            // The messages pane owns its own selection through `timeline_scroll`;
+            // it is driven directly in `handle_key`, not through `move_selection`.
+            Focus::Messages | Focus::Composer => {}
         }
     }
 
-    pub(crate) fn messages_page(&self) -> u16 {
-        self.messages_viewport.saturating_sub(1).max(1)
+    /// Move the message selection one row older, paging in older history when the
+    /// move lands on the oldest loaded row.
+    pub(crate) fn messages_select_up(&mut self) {
+        self.timeline_scroll.select_up(self.timeline.len());
+        self.request_older_if_needed();
     }
 
-    pub(crate) fn scroll_messages_up(&mut self, by: u16) {
-        self.messages_scroll = self.messages_scroll.saturating_add(by);
+    /// Page the message selection up by a screenful, paging in older history when
+    /// the move lands on the oldest loaded row.
+    pub(crate) fn messages_page_up(&mut self) {
+        self.timeline_scroll.page_up(self.timeline.len());
+        self.request_older_if_needed();
     }
 
-    pub(crate) fn scroll_messages_down(&mut self, by: u16) {
-        self.messages_scroll = self.messages_scroll.saturating_sub(by);
+    /// Jump the message selection to the oldest loaded row (the `g` / `Home`
+    /// binding), paging in older history since that lands on the oldest row.
+    pub(crate) fn messages_jump_oldest(&mut self) {
+        self.timeline_scroll.jump_oldest(self.timeline.len());
+        self.request_older_if_needed();
+    }
+
+    /// Fetch the previous history page when the selection has reached the oldest
+    /// loaded row and more history remains. Errors surface on the status line so a
+    /// failed page never tears down the session; `loading_older` is cleared on the
+    /// error path inside `load_older_messages`.
+    pub(crate) fn request_older_if_needed(&mut self) {
+        if self
+            .timeline_scroll
+            .should_request_older(self.timeline.len())
+            && let Err(err) = self.load_older_messages()
+        {
+            self.status = format!("error: {err}");
+        }
     }
 
     pub(crate) fn activate_focus(&mut self) -> TuiResult<()> {

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -8,20 +8,50 @@ pub(crate) struct WnClient {
     pub(crate) home: Option<PathBuf>,
     pub(crate) socket: Option<PathBuf>,
     pub(crate) relay: Option<String>,
+    /// First-run discovery relays from `wn tui --discovery-relays`, forwarded to
+    /// the `daemon start` child (no JSON change; flag passthrough only).
+    pub(crate) discovery_relays: Vec<String>,
+    /// First-run default account relays from `wn tui --default-account-relays`,
+    /// forwarded to the `daemon start` child and used as the account-setup relay.
+    pub(crate) default_account_relays: Vec<String>,
     pub(crate) secret_store: Option<SecretStoreKind>,
     pub(crate) keychain_service: Option<String>,
 }
 
 impl WnClient {
     pub(crate) fn from_cli(cli: &Cli) -> TuiResult<Self> {
+        let (discovery_relays, default_account_relays) = match &cli.command {
+            crate::Command::Tui {
+                discovery_relays,
+                default_account_relays,
+            } => (discovery_relays.clone(), default_account_relays.clone()),
+            _ => (Vec::new(), Vec::new()),
+        };
         Ok(Self {
             exe: std::env::current_exe()?,
             home: cli.home.clone(),
             socket: cli.socket.clone(),
             relay: cli.relay.clone(),
+            discovery_relays,
+            default_account_relays,
             secret_store: cli.secret_store,
             keychain_service: cli.keychain_service.clone(),
         })
+    }
+
+    /// The relay to hand account setup (`create-identity` / `login`) when no
+    /// global `--relay` already covers it. `command` appends `--relay` from
+    /// `self.relay` to every child, so supplying one here too would pass it
+    /// twice; only fill in when `self.relay` is absent, preferring a default
+    /// account relay and falling back to a discovery relay.
+    pub(crate) fn account_setup_relay(&self) -> Option<String> {
+        if self.relay.is_some() {
+            return None;
+        }
+        self.default_account_relays
+            .first()
+            .or_else(|| self.discovery_relays.first())
+            .cloned()
     }
 
     pub(crate) fn run_json<S>(&self, account: Option<&str>, args: &[S]) -> TuiResult<Value>
@@ -630,7 +660,7 @@ impl TuiApp {
         identity: Option<String>,
         action: &'static str,
     ) -> TuiResult<()> {
-        let invocation = account_setup_invocation(identity);
+        let invocation = account_setup_invocation(identity, self.client.account_setup_relay());
         let result = match invocation.stdin {
             Some(stdin) => self
                 .client
@@ -804,7 +834,10 @@ impl TuiApp {
     }
 
     pub(crate) fn start_daemon(&mut self) -> TuiResult<()> {
-        let args = vec!["daemon".to_owned(), "start".to_owned()];
+        let args = daemon_start_args(
+            &self.client.discovery_relays,
+            &self.client.default_account_relays,
+        );
         let result = self.client.run_json(None, &args)?;
         self.daemon = parse_daemon_view(&result);
         self.ensure_selected_chat_subscription();
@@ -826,7 +859,11 @@ impl TuiApp {
         Ok(())
     }
 
-    pub(crate) fn refresh_accounts(&mut self) -> TuiResult<()> {
+    /// Reload just the account list (`wn account list`), reselecting the
+    /// previously active account, and clear all chat/message/subscription state
+    /// when no accounts remain. Does not load chats or route the screen; the
+    /// startup/login flow decides the screen from the resulting account count.
+    pub(crate) fn load_accounts(&mut self) -> TuiResult<()> {
         let result = self.client.run_json(None, &["account", "list"])?;
         let previous_account_id = self
             .selected_account_row()
@@ -849,7 +886,14 @@ impl TuiApp {
             self.message_subscription = None;
             self.group_state_subscription = None;
             self.group_diagnostics = None;
-            self.status = "no identities yet; create one with wn create-identity".to_owned();
+            self.status = "no identities yet; create one from the login screen".to_owned();
+        }
+        Ok(())
+    }
+
+    pub(crate) fn refresh_accounts(&mut self) -> TuiResult<()> {
+        self.load_accounts()?;
+        if self.accounts.is_empty() {
             return Ok(());
         }
         self.refresh_chats()
@@ -1235,6 +1279,17 @@ impl TuiApp {
         }
     }
 
+    /// Assign a status produced by a background drain, but only while the main
+    /// view is showing. On the login/account-select screen the status line
+    /// carries the nsec prompt and picker guidance; a live drain (a picker
+    /// reached via `A` keeps its subscriptions running) must apply its state
+    /// changes without clobbering that prompt.
+    fn set_drain_status(&mut self, status: String) {
+        if self.screen == Screen::Main {
+            self.status = status;
+        }
+    }
+
     pub(crate) fn drain_chat_subscription(&mut self) -> bool {
         let Some(subscription) = self.chat_subscription.as_ref() else {
             return false;
@@ -1265,11 +1320,11 @@ impl TuiApp {
                         &result,
                     ) {
                         chats_changed = true;
-                        self.status = status;
+                        self.set_drain_status(status);
                     }
                 }
                 SubscriptionEvent::Error(err) => {
-                    self.status = format!("chat subscription failed: {err}");
+                    self.set_drain_status(format!("chat subscription failed: {err}"));
                 }
                 SubscriptionEvent::Ended => {
                     self.chat_subscription = None;
@@ -1330,12 +1385,12 @@ impl TuiApp {
                             ));
                         }
                         if let Some(status) = update.status {
-                            self.status = status;
+                            self.set_drain_status(status);
                         }
                     }
                 }
                 SubscriptionEvent::Error(err) => {
-                    self.status = format!("group state subscription failed: {err}");
+                    self.set_drain_status(format!("group state subscription failed: {err}"));
                 }
                 SubscriptionEvent::Ended => {
                     self.group_state_subscription = None;
@@ -1374,11 +1429,11 @@ impl TuiApp {
                         loaded_group_id.as_deref(),
                         &result,
                     ) {
-                        self.status = status;
+                        self.set_drain_status(status);
                     }
                 }
                 SubscriptionEvent::Error(err) => {
-                    self.status = format!("message subscription failed: {err}");
+                    self.set_drain_status(format!("message subscription failed: {err}"));
                 }
                 SubscriptionEvent::Ended => {
                     self.message_subscription = None;
@@ -1419,7 +1474,7 @@ impl TuiApp {
                     );
                 }
                 SubscriptionEvent::Error(err) => {
-                    self.status = format!("timeline subscription failed: {err}");
+                    self.set_drain_status(format!("timeline subscription failed: {err}"));
                 }
                 SubscriptionEvent::Ended => {
                     self.timeline_subscription = None;

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -199,21 +199,28 @@ impl TuiApp {
             .and_then(|ids| ids.first())
             .and_then(Value::as_str)
         {
+            // Optimistic row; the timeline projection event upserts over it by id
+            // once the send lands in the materialized view.
             let now = unix_now_seconds();
-            upsert_message(
-                &mut self.messages,
-                MessageRow {
-                    message_id: message_id.to_owned(),
-                    direction: "sent".to_owned(),
-                    from: account_id,
-                    from_display_name: None,
-                    plaintext: text.clone(),
-                    display_text: text,
-                    recorded_at: now,
-                    received_at: now,
-                },
-            );
-            sort_and_cap_messages(&mut self.messages);
+            let row = TimelineRow {
+                message_id: message_id.to_owned(),
+                direction: "sent".to_owned(),
+                from: account_id,
+                from_display_name: None,
+                plaintext: text.clone(),
+                display_text: text,
+                timeline_at: now,
+                received_at: now,
+                deleted: false,
+                reactions: Vec::new(),
+                reply: None,
+                attachments: Vec::new(),
+            };
+            if let TimelineFoldOutcome::Inserted(index) =
+                apply_timeline_change(&mut self.timeline, TimelineChange::Upsert(Box::new(row)))
+            {
+                self.timeline_scroll.on_insert(index, self.timeline.len());
+            }
         } else {
             self.refresh_messages()?;
         }
@@ -792,6 +799,7 @@ impl TuiApp {
         self.ensure_selected_chat_subscription();
         self.ensure_selected_message_subscription();
         self.ensure_selected_group_state_subscription();
+        self.ensure_selected_timeline_subscription();
         Ok(())
     }
 
@@ -802,6 +810,7 @@ impl TuiApp {
         self.ensure_selected_chat_subscription();
         self.ensure_selected_message_subscription();
         self.ensure_selected_group_state_subscription();
+        self.ensure_selected_timeline_subscription();
         self.status = daemon_status_sentence(&self.daemon);
         Ok(())
     }
@@ -812,6 +821,7 @@ impl TuiApp {
         self.chat_subscription = None;
         self.message_subscription = None;
         self.group_state_subscription = None;
+        self.timeline_subscription = None;
         self.status = "daemon stopped".to_owned();
         Ok(())
     }
@@ -831,7 +841,7 @@ impl TuiApp {
             selected_account_index(&self.accounts, previous_account_id.as_deref()).unwrap_or(0);
         if self.accounts.is_empty() {
             self.chats.clear();
-            self.messages.clear();
+            self.clear_timeline_pane();
             self.messages_account_id = None;
             self.messages_group_id = None;
             self.unread_counts.clear();
@@ -848,7 +858,7 @@ impl TuiApp {
     pub(crate) fn refresh_chats(&mut self) -> TuiResult<()> {
         let Some(account) = self.selected_account_row().cloned() else {
             self.chats.clear();
-            self.messages.clear();
+            self.clear_timeline_pane();
             self.messages_account_id = None;
             self.messages_group_id = None;
             self.chat_subscription = None;
@@ -860,7 +870,7 @@ impl TuiApp {
         };
         if !account.local_signing {
             self.chats.clear();
-            self.messages.clear();
+            self.clear_timeline_pane();
             self.messages_account_id = None;
             self.messages_group_id = None;
             self.chat_subscription = None;
@@ -890,7 +900,7 @@ impl TuiApp {
             self.status = format!("chat subscription failed: {err}");
         }
         if self.chats.is_empty() {
-            self.messages.clear();
+            self.clear_timeline_pane();
             self.messages_account_id = Some(account.account_id.clone());
             self.messages_group_id = None;
             self.group_state_subscription = None;
@@ -911,28 +921,36 @@ impl TuiApp {
         let account_id = self.require_selected_local_account()?;
         let group_id = self.require_selected_group()?;
         let args = vec![
-            "message".to_owned(),
+            "messages".to_owned(),
+            "timeline".to_owned(),
             "list".to_owned(),
             "--group".to_owned(),
             group_id.clone(),
             "--limit".to_owned(),
-            "50".to_owned(),
+            TUI_TIMELINE_PAGE_SIZE.to_string(),
         ];
         let result = self.client.run_json(Some(&account_id), &args)?;
-        self.messages = result
-            .get("messages")
-            .and_then(Value::as_array)
-            .map(|messages| messages.iter().filter_map(parse_message).collect())
-            .unwrap_or_default();
+        self.timeline = parse_timeline_page(&result);
+        self.timeline_scroll = TimelineScroll {
+            has_more_before: timeline_page_has_more_before(&result),
+            ..TimelineScroll::default()
+        };
         self.messages_account_id = Some(account_id.clone());
         self.messages_group_id = Some(group_id.clone());
-        self.messages_scroll = 0;
         self.unread_counts.remove(&group_id);
-        sort_and_cap_messages(&mut self.messages);
-        if let Err(err) = self.ensure_message_subscription(&account_id) {
-            self.status = format!("message subscription failed: {err}");
-            return Ok(());
-        }
+        // Establish all three subscriptions regardless of any one's outcome. The
+        // timeline feed drives the pane's live updates and its `ensure_*` also
+        // kills a stale prior-group child, so a failed plain feed must not skip
+        // it. Each error surfaces on the status line; the user sees the first by
+        // precedence (message, then timeline, then group state).
+        let message_subscription_error = self
+            .ensure_message_subscription(&account_id)
+            .err()
+            .map(|err| format!("message subscription failed: {err}"));
+        let timeline_subscription_error = self
+            .ensure_timeline_subscription(&account_id, &group_id)
+            .err()
+            .map(|err| format!("timeline subscription failed: {err}"));
         let group_state_subscription_error = self
             .ensure_group_state_subscription(&account_id, &group_id)
             .err()
@@ -951,8 +969,60 @@ impl TuiApp {
         } else {
             self.refresh_group_diagnostics(&account_id, &group_id);
         }
-        self.status = group_state_subscription_error
-            .unwrap_or_else(|| format!("loaded {} message(s)", self.messages.len()));
+        self.status = message_subscription_error
+            .or(timeline_subscription_error)
+            .or(group_state_subscription_error)
+            .unwrap_or_else(|| format!("loaded {} message(s)", self.timeline.len()));
+        Ok(())
+    }
+
+    /// Fetch and prepend the previous history page. Runs synchronously like every
+    /// other TUI action; `loading_older` guards against re-entry and is cleared on
+    /// both the success and error paths so a failed page does not wedge paging.
+    pub(crate) fn load_older_messages(&mut self) -> TuiResult<()> {
+        let Some(cursor) = oldest_timeline_cursor(&self.timeline) else {
+            return Ok(());
+        };
+        let account_id = self.message_account_id()?;
+        let group_id = self.message_group_id()?;
+        let args = vec![
+            "messages".to_owned(),
+            "timeline".to_owned(),
+            "list".to_owned(),
+            "--group".to_owned(),
+            group_id,
+            "--before".to_owned(),
+            cursor.timeline_at.to_string(),
+            "--before-message-id".to_owned(),
+            cursor.message_id,
+            "--limit".to_owned(),
+            TUI_TIMELINE_PAGE_SIZE.to_string(),
+        ];
+        self.timeline_scroll.loading_older = true;
+        let result = match self.client.run_json(Some(&account_id), &args) {
+            Ok(result) => result,
+            Err(err) => {
+                self.timeline_scroll.loading_older = false;
+                return Err(err);
+            }
+        };
+        // Rows arrive oldest-first. Upsert each by id — the only merge that stays
+        // idempotent if the exclusive cursor ever overlaps — and shift the scroll
+        // model by the count of genuinely new rows so an overlap neither duplicates
+        // a row nor over-shifts the selection.
+        let older = parse_timeline_page(&result);
+        let mut prepended = 0;
+        for row in older {
+            if let TimelineFoldOutcome::Inserted(_) =
+                apply_timeline_change(&mut self.timeline, TimelineChange::Upsert(Box::new(row)))
+            {
+                prepended += 1;
+            }
+        }
+        self.timeline_scroll.on_prepend(prepended);
+        self.timeline_scroll.has_more_before = timeline_page_has_more_before(&result);
+        self.timeline_scroll.loading_older = false;
+        self.status = format!("loaded {prepended} older message(s)");
         Ok(())
     }
 
@@ -1063,6 +1133,46 @@ impl TuiApp {
         Ok(())
     }
 
+    pub(crate) fn ensure_timeline_subscription(
+        &mut self,
+        account_id: &str,
+        group_id: &str,
+    ) -> TuiResult<()> {
+        if !self.daemon.running {
+            self.timeline_subscription = None;
+            return Ok(());
+        }
+        if self
+            .timeline_subscription
+            .as_ref()
+            .is_some_and(|subscription| {
+                subscription.account_id == account_id && subscription.group_id == group_id
+            })
+        {
+            return Ok(());
+        }
+
+        self.timeline_subscription = None;
+        let args = timeline_subscription_args(group_id);
+        let mut child = self.client.spawn_json_lines(Some(account_id), &args)?;
+        let rx = spawn_subscription_reader(&mut child, "timeline")?;
+        self.timeline_subscription = Some(TimelineSubscription {
+            account_id: account_id.to_owned(),
+            group_id: group_id.to_owned(),
+            child,
+            rx,
+        });
+        Ok(())
+    }
+
+    /// Clear the messages pane: drop the loaded timeline rows, reset the scroll
+    /// model to its pinned default, and stop the per-group timeline subscription.
+    pub(crate) fn clear_timeline_pane(&mut self) {
+        self.timeline.clear();
+        self.timeline_scroll = TimelineScroll::default();
+        self.timeline_subscription = None;
+    }
+
     pub(crate) fn ensure_selected_chat_subscription(&mut self) {
         let Some(account) = self.selected_account_row().cloned() else {
             self.chat_subscription = None;
@@ -1106,6 +1216,22 @@ impl TuiApp {
         };
         if let Err(err) = self.ensure_group_state_subscription(&account.account_id, &group_id) {
             self.status = format!("group state subscription failed: {err}");
+        }
+    }
+
+    /// Re-establish the timeline subscription for the currently loaded group (the
+    /// pane target), used when daemon state changes. Keyed to the loaded group,
+    /// not the highlighted chat, so it stays in lockstep with the pane snapshot.
+    pub(crate) fn ensure_selected_timeline_subscription(&mut self) {
+        let (Some(account_id), Some(group_id)) = (
+            self.messages_account_id.clone(),
+            self.messages_group_id.clone(),
+        ) else {
+            self.timeline_subscription = None;
+            return;
+        };
+        if let Err(err) = self.ensure_timeline_subscription(&account_id, &group_id) {
+            self.status = format!("timeline subscription failed: {err}");
         }
     }
 
@@ -1154,7 +1280,7 @@ impl TuiApp {
         if chats_changed {
             let selected_group_id = self.selected_chat_row().map(|chat| chat.group_id.clone());
             if previous_group_id != selected_group_id {
-                self.messages.clear();
+                self.clear_timeline_pane();
                 self.messages_account_id = None;
                 self.messages_group_id = None;
                 self.message_subscription = None;
@@ -1243,7 +1369,6 @@ impl TuiApp {
                 SubscriptionEvent::Result(result) => {
                     let loaded_group_id = self.messages_group_id.clone();
                     if let Some(status) = apply_tui_subscription_result(
-                        &mut self.messages,
                         &mut self.live_stream_previews,
                         &mut self.unread_counts,
                         loaded_group_id.as_deref(),
@@ -1257,6 +1382,47 @@ impl TuiApp {
                 }
                 SubscriptionEvent::Ended => {
                     self.message_subscription = None;
+                    break;
+                }
+            }
+        }
+        true
+    }
+
+    pub(crate) fn drain_timeline_subscription(&mut self) -> bool {
+        let Some(subscription) = self.timeline_subscription.as_ref() else {
+            return false;
+        };
+        let mut events = Vec::new();
+        loop {
+            match subscription.rx.try_recv() {
+                Ok(event) => events.push(event),
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    events.push(SubscriptionEvent::Ended);
+                    break;
+                }
+            }
+        }
+        if events.is_empty() {
+            return false;
+        }
+        let loaded_group_id = self.messages_group_id.clone();
+        for event in events {
+            match event {
+                SubscriptionEvent::Result(result) => {
+                    apply_timeline_event(
+                        &mut self.timeline,
+                        &mut self.timeline_scroll,
+                        loaded_group_id.as_deref(),
+                        parse_timeline_event(&result),
+                    );
+                }
+                SubscriptionEvent::Error(err) => {
+                    self.status = format!("timeline subscription failed: {err}");
+                }
+                SubscriptionEvent::Ended => {
+                    self.timeline_subscription = None;
                     break;
                 }
             }

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -38,6 +38,11 @@ const ACCOUNT_ACCENT: Color = Color::White;
 const DEFAULT_STREAM_CANDIDATE: &str = crate::DEFAULT_PRODUCTION_QUIC_BROKER_CANDIDATE;
 const SLASH_SUGGESTION_LIMIT: usize = 8;
 const TUI_MESSAGE_SCROLLBACK_LIMIT: usize = 1_000;
+/// Materialized-timeline page size for the snapshot load and each history page.
+const TUI_TIMELINE_PAGE_SIZE: usize = 100;
+/// Blank rows rendered below each timeline message as a separator; counted in a
+/// row's rendered height so the visibility walk and the renderer agree.
+const TIMELINE_MESSAGE_SEPARATOR_ROWS: u16 = 1;
 const TUI_LIVE_STREAM_PREVIEW_LIMIT: usize = 128;
 const TUI_LIVE_STREAM_TEXT_LIMIT: usize = 64 * 1024;
 

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::Frame;
-use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -17,8 +17,16 @@ pub(crate) struct WnInvocation {
     pub(crate) stdin: Option<String>,
 }
 
-pub(crate) fn account_setup_invocation(identity: Option<String>) -> WnInvocation {
-    match identity {
+/// Build the `wn` invocation for account setup. `setup_relay` supplies the
+/// first-run relay to `create-identity` / `login` through the one relay flag
+/// those commands actually accept — the (global, for `create-identity`;
+/// command-local, for `login`) `--relay` — appended only when the caller has no
+/// other `--relay` source, so it is never passed twice.
+pub(crate) fn account_setup_invocation(
+    identity: Option<String>,
+    setup_relay: Option<String>,
+) -> WnInvocation {
+    let mut invocation = match identity {
         Some(identity) if crate::is_nostr_secret(&identity) => WnInvocation {
             args: vec!["login".to_owned(), "--nsec-stdin".to_owned()],
             stdin: Some(format!("{identity}\n")),
@@ -31,7 +39,12 @@ pub(crate) fn account_setup_invocation(identity: Option<String>) -> WnInvocation
             args: vec!["create-identity".to_owned()],
             stdin: None,
         },
+    };
+    if let Some(relay) = setup_relay.filter(|relay| !relay.trim().is_empty()) {
+        invocation.args.push("--relay".to_owned());
+        invocation.args.push(relay);
     }
+    invocation
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -167,9 +180,11 @@ impl Drop for TimelineSubscription {
     }
 }
 
+/// The pane holding keyboard focus in the chat-first main view. The accounts
+/// pane is gone in Phase 2; account switching moves to the login/account-select
+/// screen (reopened with `A`).
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Focus {
-    Accounts,
     Chats,
     Messages,
     Composer,
@@ -178,29 +193,107 @@ pub(crate) enum Focus {
 impl Focus {
     pub(crate) fn next(self) -> Self {
         match self {
-            Self::Accounts => Self::Chats,
             Self::Chats => Self::Messages,
             Self::Messages => Self::Composer,
-            Self::Composer => Self::Accounts,
+            Self::Composer => Self::Chats,
         }
     }
 
     pub(crate) fn previous(self) -> Self {
         match self {
-            Self::Accounts => Self::Composer,
-            Self::Chats => Self::Accounts,
+            Self::Chats => Self::Composer,
             Self::Messages => Self::Chats,
             Self::Composer => Self::Messages,
         }
     }
+}
 
-    pub(crate) fn title(self) -> &'static str {
-        match self {
-            Self::Accounts => "accounts",
-            Self::Chats => "chats",
-            Self::Messages => "messages",
-            Self::Composer => "composer",
+/// The top-level screen the TUI is showing. Phase 2 has exactly two: the
+/// login/account-select flow and the chat-first main view. Group detail,
+/// profile, search, and health screens arrive in Phase 5.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Screen {
+    Login(LoginMode),
+    Main,
+}
+
+/// The three states of the login screen: the create/login menu (no accounts),
+/// the account picker (several accounts), and the masked nsec entry field.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LoginMode {
+    Menu,
+    AccountSelect,
+    NsecEntry,
+}
+
+/// Route the startup screen from the number of loaded accounts: no accounts
+/// opens the login menu, exactly one drops straight into the main view with it
+/// selected, and several open the account picker — unless `initial_selected` is
+/// set (a `--account`/`WN_ACCOUNT` selector resolved to a loaded account), which
+/// enters the main view directly with that account.
+pub(crate) fn startup_screen(account_count: usize, initial_selected: bool) -> Screen {
+    match account_count {
+        0 => Screen::Login(LoginMode::Menu),
+        1 => Screen::Main,
+        _ if initial_selected => Screen::Main,
+        _ => Screen::Login(LoginMode::AccountSelect),
+    }
+}
+
+/// The login mode to return to when leaving nsec entry: the menu when there are
+/// no accounts yet, otherwise the account picker (the two screens that open it).
+pub(crate) fn login_mode_for_accounts(account_count: usize) -> LoginMode {
+    if account_count == 0 {
+        LoginMode::Menu
+    } else {
+        LoginMode::AccountSelect
+    }
+}
+
+/// Render a secret as one `*` per character, preserving length without exposing
+/// the value. Used for the nsec-entry field (key material never renders).
+pub(crate) fn masked_secret(value: &str) -> String {
+    "*".repeat(value.chars().count())
+}
+
+/// The one-line status bar for the main view:
+/// `{account} · daemon {on|off} · {n} chats · {u} unread · {latest status}`.
+/// Untrusted fields (the account label and the status message) pass through
+/// `terminal_safe_text`, and the assembled line is shortened to `width`.
+pub(crate) fn status_bar_line(
+    account_label: &str,
+    daemon_running: bool,
+    chats: usize,
+    unread: usize,
+    status: &str,
+    width: usize,
+) -> String {
+    let account = shorten(&terminal_safe_text(account_label), 24);
+    let daemon = if daemon_running { "on" } else { "off" };
+    let status = terminal_safe_text(status);
+    let line = format!("{account} · daemon {daemon} · {chats} chats · {unread} unread · {status}");
+    shorten(&line, width)
+}
+
+/// The per-screen, per-focus hints line. Terse and kept in lockstep with the
+/// real keymap (the README and in-app help mirror these strings). `entered_main`
+/// gates the account picker's `Esc back` hint: `Esc` only returns to the main
+/// view when a session is already active, so the startup picker omits it.
+pub(crate) fn hints_line(screen: Screen, focus: Focus, entered_main: bool) -> &'static str {
+    match screen {
+        Screen::Login(LoginMode::Menu) => "c create identity  l nsec login  q quit",
+        Screen::Login(LoginMode::AccountSelect) if entered_main => {
+            "j/k navigate  Enter select  c create  l nsec  Esc back  q quit"
         }
+        Screen::Login(LoginMode::AccountSelect) => {
+            "j/k navigate  Enter select  c create  l nsec  q quit"
+        }
+        Screen::Login(LoginMode::NsecEntry) => "Enter submit  Esc back",
+        Screen::Main => match focus {
+            Focus::Chats => "j/k navigate  Enter open  A accounts  / command  ? help  q quit",
+            Focus::Messages => "j/k select  G/g ends  PgUp older  i compose  Tab cycle",
+            Focus::Composer => "Enter send  Esc clear",
+        },
     }
 }
 
@@ -208,6 +301,7 @@ impl Focus {
 pub(crate) enum SlashCommand {
     Help,
     Refresh,
+    Diagnostics,
     Account(String),
     AccountCreate,
     AccountAddPublic(String),
@@ -277,6 +371,10 @@ pub(crate) const SLASH_COMMAND_SUGGESTIONS: &[SlashCommandSuggestion] = &[
     SlashCommandSuggestion {
         usage: "/refresh",
         description: "reload accounts and chats",
+    },
+    SlashCommandSuggestion {
+        usage: "/diagnostics",
+        description: "toggle the MLS group diagnostics panel",
     },
     SlashCommandSuggestion {
         usage: "/account <npub-or-hex>",
@@ -2115,6 +2213,26 @@ pub(crate) fn composer_display_text(input: &str) -> String {
         return "/login <hidden nsec>".to_owned();
     }
     input.to_owned()
+}
+
+/// Args for the `daemon start` child, forwarding the TUI's first-run relay
+/// flags. `wn daemon start` accepts comma-delimited `--discovery-relays` /
+/// `--default-account-relays`, so each non-empty list is joined and passed as
+/// the same flag the daemon exposes (flag passthrough, no JSON change).
+pub(crate) fn daemon_start_args(
+    discovery_relays: &[String],
+    default_account_relays: &[String],
+) -> Vec<String> {
+    let mut args = vec!["daemon".to_owned(), "start".to_owned()];
+    if !discovery_relays.is_empty() {
+        args.push("--discovery-relays".to_owned());
+        args.push(discovery_relays.join(","));
+    }
+    if !default_account_relays.is_empty() {
+        args.push("--default-account-relays".to_owned());
+        args.push(default_account_relays.join(","));
+    }
+    args
 }
 
 pub(crate) fn message_subscription_args() -> Vec<String> {

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -49,18 +49,6 @@ pub(crate) struct ChatRow {
     pub(crate) archived: bool,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct MessageRow {
-    pub(crate) message_id: String,
-    pub(crate) direction: String,
-    pub(crate) from: String,
-    pub(crate) from_display_name: Option<String>,
-    pub(crate) plaintext: String,
-    pub(crate) display_text: String,
-    pub(crate) recorded_at: u64,
-    pub(crate) received_at: u64,
-}
-
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct DaemonView {
     pub(crate) running: bool,
@@ -159,6 +147,20 @@ pub(crate) struct GroupStateSubscription {
 }
 
 impl Drop for GroupStateSubscription {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+pub(crate) struct TimelineSubscription {
+    pub(crate) account_id: String,
+    pub(crate) group_id: String,
+    pub(crate) child: Child,
+    pub(crate) rx: Receiver<SubscriptionEvent>,
+}
+
+impl Drop for TimelineSubscription {
     fn drop(&mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
@@ -461,64 +463,6 @@ pub(crate) fn parse_chat(value: &Value) -> Option<ChatRow> {
     })
 }
 
-pub(crate) fn parse_message(value: &Value) -> Option<MessageRow> {
-    let plaintext = value_string(value, "plaintext")?;
-    if value
-        .get("agent_text_stream")
-        .and_then(|stream| stream.get("kind"))
-        .and_then(Value::as_str)
-        == Some("start")
-    {
-        return None;
-    }
-    let display_text = if value.get("kind").and_then(Value::as_u64) == Some(GROUP_SYSTEM_KIND) {
-        group_system_summary(value, &plaintext).unwrap_or_else(|| plaintext.clone())
-    } else {
-        value
-            .get("agent_text_stream")
-            .and_then(agent_text_stream_summary)
-            .unwrap_or_else(|| plaintext.clone())
-    };
-    Some(MessageRow {
-        message_id: value_string(value, "message_id").unwrap_or_default(),
-        direction: value_string(value, "direction").unwrap_or_else(|| "received".to_owned()),
-        from: value_string(value, "from").unwrap_or_else(|| "unknown".to_owned()),
-        from_display_name: non_empty_value_string(value, "from_display_name"),
-        plaintext,
-        display_text,
-        recorded_at: value
-            .get("recorded_at")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
-        received_at: value
-            .get("received_at")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
-    })
-}
-
-pub(crate) fn sort_messages_chronologically(messages: &mut [MessageRow]) {
-    messages.sort_by(|left, right| {
-        left.recorded_at
-            .cmp(&right.recorded_at)
-            .then_with(|| left.received_at.cmp(&right.received_at))
-            .then_with(|| left.message_id.cmp(&right.message_id))
-    });
-}
-
-pub(crate) fn sort_and_cap_messages(messages: &mut Vec<MessageRow>) {
-    sort_messages_chronologically(messages);
-    cap_message_scrollback(messages);
-}
-
-pub(crate) fn cap_message_scrollback(messages: &mut Vec<MessageRow>) {
-    if messages.len() <= TUI_MESSAGE_SCROLLBACK_LIMIT {
-        return;
-    }
-    let excess = messages.len() - TUI_MESSAGE_SCROLLBACK_LIMIT;
-    messages.drain(0..excess);
-}
-
 /// Inner app-event kind for durable group system rows (membership/admin/profile).
 pub(crate) const GROUP_SYSTEM_KIND: u64 = 1210;
 
@@ -603,6 +547,933 @@ pub(crate) fn agent_text_stream_summary(value: &Value) -> Option<String> {
     }
 }
 
+/// Phase 1 `wn tui` timeline core: row parsing, the idempotent projection fold,
+/// the message-offset scroll model, and rendering (per-row heights, the
+/// visibility walk, and line building). Consumed by the timeline
+/// client/app/view wiring in this crate.
+mod timeline {
+    use super::*;
+    use ratatui::style::{Color, Modifier, Style};
+    use ratatui::text::{Line, Span};
+    use ratatui::widgets::{Paragraph, Wrap};
+    use serde_json::Value;
+
+    use super::super::{TIMELINE_MESSAGE_SEPARATOR_ROWS, TUI_MESSAGE_SCROLLBACK_LIMIT};
+
+    /// A row of the materialized message timeline (`messages timeline`), as folded by
+    /// the runtime: reactions, reply preview, deletion tombstones, and structured
+    /// media are already resolved server-side. This is the messages-pane row for
+    /// Phase 1; the plain feed now carries only live stream previews and unread counts.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub(crate) struct TimelineRow {
+        pub(crate) message_id: String,
+        pub(crate) direction: String,
+        pub(crate) from: String,
+        pub(crate) from_display_name: Option<String>,
+        pub(crate) plaintext: String,
+        pub(crate) display_text: String,
+        pub(crate) timeline_at: u64,
+        pub(crate) received_at: u64,
+        pub(crate) deleted: bool,
+        pub(crate) reactions: Vec<TimelineReaction>,
+        pub(crate) reply: Option<TimelineReply>,
+        pub(crate) attachments: Vec<TimelineAttachment>,
+    }
+
+    /// One emoji's reaction tally on a timeline row, from `reactions.by_emoji`.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub(crate) struct TimelineReaction {
+        pub(crate) emoji: String,
+        pub(crate) count: usize,
+    }
+
+    /// Reply context for a timeline row: the parent message id plus the hydrated
+    /// preview when the runtime resolved it.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub(crate) struct TimelineReply {
+        pub(crate) reply_to_message_id: String,
+        pub(crate) preview: Option<TimelineReplyPreview>,
+    }
+
+    /// The hydrated parent-message preview carried on a reply row.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub(crate) struct TimelineReplyPreview {
+        pub(crate) sender: Option<String>,
+        pub(crate) plaintext: String,
+        pub(crate) deleted: bool,
+    }
+
+    /// A media attachment placeholder parsed from a row's `media.imeta` tags. Phase 1
+    /// keeps only the fields needed to render a placeholder; no download yet.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub(crate) struct TimelineAttachment {
+        pub(crate) mime: Option<String>,
+        pub(crate) filename: Option<String>,
+    }
+
+    /// Parse a materialized timeline row. Returns `None` for rows the pane does not
+    /// render: `agent_text_stream` `start` markers are skipped.
+    pub(crate) fn parse_timeline_row(value: &Value) -> Option<TimelineRow> {
+        if value
+            .get("agent_text_stream")
+            .and_then(|stream| stream.get("kind"))
+            .and_then(Value::as_str)
+            == Some("start")
+        {
+            return None;
+        }
+        let plaintext = value_string(value, "plaintext").unwrap_or_default();
+        let display_text = if value.get("kind").and_then(Value::as_u64) == Some(GROUP_SYSTEM_KIND) {
+            group_system_summary(value, &plaintext).unwrap_or_else(|| plaintext.clone())
+        } else {
+            value
+                .get("agent_text_stream")
+                .and_then(agent_text_stream_summary)
+                .unwrap_or_else(|| plaintext.clone())
+        };
+        Some(TimelineRow {
+            message_id: value_string(value, "message_id").unwrap_or_default(),
+            direction: value_string(value, "direction").unwrap_or_else(|| "received".to_owned()),
+            from: value_string(value, "from").unwrap_or_else(|| "unknown".to_owned()),
+            from_display_name: non_empty_value_string(value, "from_display_name"),
+            plaintext,
+            display_text,
+            timeline_at: value
+                .get("timeline_at")
+                .and_then(Value::as_u64)
+                .unwrap_or(0),
+            received_at: value
+                .get("received_at")
+                .and_then(Value::as_u64)
+                .unwrap_or(0),
+            deleted: value
+                .get("deleted")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            reactions: parse_timeline_reactions(value),
+            reply: parse_timeline_reply(value),
+            attachments: parse_timeline_attachments(value),
+        })
+    }
+
+    fn parse_timeline_reactions(value: &Value) -> Vec<TimelineReaction> {
+        let Some(by_emoji) = value
+            .get("reactions")
+            .and_then(|reactions| reactions.get("by_emoji"))
+            .and_then(Value::as_object)
+        else {
+            return Vec::new();
+        };
+        let mut reactions = by_emoji
+            .iter()
+            .filter_map(|(emoji, reactors)| {
+                let count = reactors.as_array().map_or(0, Vec::len);
+                (count > 0).then(|| TimelineReaction {
+                    emoji: emoji.clone(),
+                    count,
+                })
+            })
+            .collect::<Vec<_>>();
+        // Deterministic order independent of the JSON map's iteration order.
+        reactions.sort_by(|left, right| left.emoji.cmp(&right.emoji));
+        reactions
+    }
+
+    fn parse_timeline_reply(value: &Value) -> Option<TimelineReply> {
+        let reply_to_message_id = non_empty_value_string(value, "reply_to_message_id")?;
+        let preview = value
+            .get("reply_preview")
+            .filter(|preview| !preview.is_null())
+            .map(|preview| TimelineReplyPreview {
+                sender: non_empty_value_string(preview, "sender"),
+                plaintext: value_string(preview, "plaintext").unwrap_or_default(),
+                deleted: preview
+                    .get("deleted")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            });
+        Some(TimelineReply {
+            reply_to_message_id,
+            preview,
+        })
+    }
+
+    fn parse_timeline_attachments(value: &Value) -> Vec<TimelineAttachment> {
+        value
+            .get("media")
+            .and_then(|media| media.get("imeta"))
+            .and_then(Value::as_array)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(parse_timeline_attachment)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Parse one `imeta` tag (an array of space-delimited `key value` strings) into a
+    /// placeholder attachment, reading only `m` (mime) and `filename` for Phase 1.
+    fn parse_timeline_attachment(entry: &Value) -> Option<TimelineAttachment> {
+        let fields = entry.as_array()?;
+        let mut mime = None;
+        let mut filename = None;
+        for field in fields.iter().filter_map(Value::as_str) {
+            match field.split_once(' ') {
+                Some(("m", value)) => mime = non_empty_string(value),
+                Some(("filename", value)) => filename = non_empty_string(value),
+                _ => {}
+            }
+        }
+        (mime.is_some() || filename.is_some()).then_some(TimelineAttachment { mime, filename })
+    }
+
+    fn non_empty_string(value: &str) -> Option<String> {
+        let value = value.trim();
+        (!value.is_empty()).then(|| value.to_owned())
+    }
+
+    /// A parsed `messages timeline subscribe` event. The caller filters
+    /// `ProjectionUpdated` by `group_id` before applying the changes.
+    #[derive(Debug)]
+    pub(crate) enum TimelineEvent {
+        /// The subscription is live; no state change.
+        Ready,
+        /// The initial bulk page plus whether older history remains.
+        InitialPage {
+            rows: Vec<TimelineRow>,
+            has_more_before: bool,
+        },
+        /// Typed upsert/remove changes for one group.
+        ProjectionUpdated {
+            group_id: String,
+            changes: Vec<TimelineChange>,
+        },
+        /// Any other or unrecognized event; no state change.
+        Other,
+    }
+
+    /// One change inside a `timeline_projection_updated` event. Upserts carry the
+    /// full folded row (reactions and `deleted` already applied); removes carry only
+    /// the id to drop.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub(crate) enum TimelineChange {
+        /// Boxed so a `Vec<TimelineChange>` is not sized to the large row for
+        /// every element (most changes are small removes).
+        Upsert(Box<TimelineRow>),
+        Remove {
+            message_id: String,
+        },
+    }
+
+    pub(crate) fn parse_timeline_event(result: &Value) -> TimelineEvent {
+        match result.get("type").and_then(Value::as_str) {
+            Some("timeline_subscription_ready") => TimelineEvent::Ready,
+            Some("initial_timeline_page") => TimelineEvent::InitialPage {
+                rows: parse_timeline_rows(result.get("messages")),
+                has_more_before: result
+                    .get("has_more_before")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+            },
+            Some("timeline_projection_updated") => TimelineEvent::ProjectionUpdated {
+                group_id: value_string(result, "group_id").unwrap_or_default(),
+                changes: result
+                    .get("changes")
+                    .and_then(Value::as_array)
+                    .map(|changes| changes.iter().filter_map(parse_timeline_change).collect())
+                    .unwrap_or_default(),
+            },
+            _ => TimelineEvent::Other,
+        }
+    }
+
+    fn parse_timeline_rows(messages: Option<&Value>) -> Vec<TimelineRow> {
+        messages
+            .and_then(Value::as_array)
+            .map(|rows| rows.iter().filter_map(parse_timeline_row).collect())
+            .unwrap_or_default()
+    }
+
+    /// Parse the `messages` array of a `messages timeline list` response into rows
+    /// sorted ascending by the backend's `(timeline_at, message_id)` order (oldest
+    /// first, newest last — the order the scroll model's bottom-anchored offset
+    /// expects).
+    pub(crate) fn parse_timeline_page(result: &Value) -> Vec<TimelineRow> {
+        let mut rows = parse_timeline_rows(result.get("messages"));
+        sort_timeline_rows(&mut rows);
+        rows
+    }
+
+    /// Read `has_more_before` from a `messages timeline list` response; missing or
+    /// non-boolean means no older history remains.
+    pub(crate) fn timeline_page_has_more_before(result: &Value) -> bool {
+        result
+            .get("has_more_before")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    }
+
+    fn parse_timeline_change(change: &Value) -> Option<TimelineChange> {
+        match change.get("type").and_then(Value::as_str)? {
+            "upsert" => Some(TimelineChange::Upsert(Box::new(parse_timeline_row(
+                change.get("message")?,
+            )?))),
+            "remove" => Some(TimelineChange::Remove {
+                message_id: value_string(change, "message_id")?,
+            }),
+            _ => None,
+        }
+    }
+
+    /// Sort timeline rows ascending by the backend's deterministic order,
+    /// `(timeline_at, message_id)`. Same-second rows tiebreak by id, which can
+    /// differ from send order; that is accepted (the tiebreak is deterministic).
+    pub(crate) fn sort_timeline_rows(rows: &mut [TimelineRow]) {
+        rows.sort_by(|left, right| {
+            left.timeline_at
+                .cmp(&right.timeline_at)
+                .then_with(|| left.message_id.cmp(&right.message_id))
+        });
+    }
+
+    /// Insert or replace a row by `message_id`, keeping the list sorted. Idempotent
+    /// in effect: projection events arrive duplicated (optimistic write plus relay
+    /// echo), so re-applying the same row must not append a second copy.
+    pub(crate) fn upsert_timeline_row(rows: &mut Vec<TimelineRow>, row: TimelineRow) {
+        upsert_timeline_row_unsorted(rows, row);
+        sort_timeline_rows(rows);
+    }
+
+    /// Insert or replace by `message_id` without re-sorting; callers that upsert a
+    /// batch sort once at the end.
+    fn upsert_timeline_row_unsorted(rows: &mut Vec<TimelineRow>, row: TimelineRow) {
+        match rows
+            .iter()
+            .position(|existing| existing.message_id == row.message_id)
+        {
+            Some(index) => rows[index] = row,
+            None => rows.push(row),
+        }
+    }
+
+    /// Drop the row with `message_id`, returning the index it occupied. Removing
+    /// preserves sort order, so no re-sort is needed.
+    pub(crate) fn remove_timeline_row(
+        rows: &mut Vec<TimelineRow>,
+        message_id: &str,
+    ) -> Option<usize> {
+        let index = rows.iter().position(|row| row.message_id == message_id)?;
+        rows.remove(index);
+        Some(index)
+    }
+
+    /// What applying a single change did to the row list, so the caller can adjust
+    /// the scroll model. Indices are into the sorted list after the change.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub(crate) enum TimelineFoldOutcome {
+        /// A new row landed at this index.
+        Inserted(usize),
+        /// An existing row (same id) was replaced at this index.
+        Updated(usize),
+        /// A row was dropped from this index.
+        Removed(usize),
+        /// Nothing changed (e.g. a remove for an id that is not present).
+        Unchanged,
+    }
+
+    /// Apply one projection change to the row list, reporting the effect.
+    pub(crate) fn apply_timeline_change(
+        rows: &mut Vec<TimelineRow>,
+        change: TimelineChange,
+    ) -> TimelineFoldOutcome {
+        match change {
+            TimelineChange::Upsert(row) => {
+                let message_id = row.message_id.clone();
+                let existed = rows
+                    .iter()
+                    .any(|existing| existing.message_id == message_id);
+                upsert_timeline_row(rows, *row);
+                let index = rows
+                    .iter()
+                    .position(|existing| existing.message_id == message_id)
+                    .unwrap_or(0);
+                if existed {
+                    TimelineFoldOutcome::Updated(index)
+                } else {
+                    TimelineFoldOutcome::Inserted(index)
+                }
+            }
+            TimelineChange::Remove { message_id } => match remove_timeline_row(rows, &message_id) {
+                Some(index) => TimelineFoldOutcome::Removed(index),
+                None => TimelineFoldOutcome::Unchanged,
+            },
+        }
+    }
+
+    /// Apply one parsed `messages timeline subscribe` event to the pane's rows and
+    /// scroll model. `InitialPage` folds each row (idempotent by id) and drives the
+    /// scroll model by the reported outcome — so rows that arrived between the
+    /// snapshot and the subscribe shift a scrolled-up anchor instead of moving the
+    /// view — then adopts its `has_more_before`. `ProjectionUpdated` is gated on the
+    /// loaded group, then folds each change and drives the scroll model by the
+    /// reported outcome (`on_insert` / `on_remove`; updates and no-ops leave scroll
+    /// alone), capping scrollback afterward. `Ready` and `Other` carry no state
+    /// change.
+    pub(crate) fn apply_timeline_event(
+        rows: &mut Vec<TimelineRow>,
+        scroll: &mut TimelineScroll,
+        loaded_group_id: Option<&str>,
+        event: TimelineEvent,
+    ) {
+        match event {
+            TimelineEvent::Ready | TimelineEvent::Other => {}
+            TimelineEvent::InitialPage {
+                rows: page,
+                has_more_before,
+            } => {
+                // Fold each row through the same change path as the projection
+                // arm and drive the scroll on the reported outcome. The common
+                // case — the snapshot already loaded every row — degenerates to
+                // Updated/Unchanged no-ops; only rows that arrived between the
+                // snapshot and the subscribe are Inserted, and those must shift a
+                // scrolled-up anchor rather than move the view.
+                for row in page {
+                    match apply_timeline_change(rows, TimelineChange::Upsert(Box::new(row))) {
+                        TimelineFoldOutcome::Inserted(index) => scroll.on_insert(index, rows.len()),
+                        TimelineFoldOutcome::Removed(index) => scroll.on_remove(index, rows.len()),
+                        TimelineFoldOutcome::Updated(_) | TimelineFoldOutcome::Unchanged => {}
+                    }
+                }
+                scroll.has_more_before = has_more_before;
+            }
+            TimelineEvent::ProjectionUpdated { group_id, changes } => {
+                if loaded_group_id != Some(group_id.as_str()) {
+                    return;
+                }
+                for change in changes {
+                    match apply_timeline_change(rows, change) {
+                        TimelineFoldOutcome::Inserted(index) => scroll.on_insert(index, rows.len()),
+                        TimelineFoldOutcome::Removed(index) => scroll.on_remove(index, rows.len()),
+                        TimelineFoldOutcome::Updated(_) | TimelineFoldOutcome::Unchanged => {}
+                    }
+                }
+                cap_timeline_scrollback(rows, scroll);
+            }
+        }
+    }
+
+    /// The exclusive `(timeline_at, message_id)` cursor of the oldest loaded row, for
+    /// building the `--before` / `--before-message-id` history-paging flags.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub(crate) struct TimelineCursor {
+        pub(crate) timeline_at: u64,
+        pub(crate) message_id: String,
+    }
+
+    pub(crate) fn oldest_timeline_cursor(rows: &[TimelineRow]) -> Option<TimelineCursor> {
+        rows.first().map(|row| TimelineCursor {
+            timeline_at: row.timeline_at,
+            message_id: row.message_id.clone(),
+        })
+    }
+
+    /// Trim the timeline to `TUI_MESSAGE_SCROLLBACK_LIMIT`, dropping the oldest rows,
+    /// but only while pinned to the bottom. Capping while scrolled up would fight
+    /// history paging (it drops rows the user just paged in), so it is skipped then.
+    /// The selection and visible range are absolute indices, so they shift down by
+    /// the number of dropped rows to stay on the same messages.
+    pub(crate) fn cap_timeline_scrollback(
+        rows: &mut Vec<TimelineRow>,
+        scroll: &mut TimelineScroll,
+    ) {
+        if !scroll.is_pinned() || rows.len() <= TUI_MESSAGE_SCROLLBACK_LIMIT {
+            return;
+        }
+        let excess = rows.len() - TUI_MESSAGE_SCROLLBACK_LIMIT;
+        rows.drain(0..excess);
+        scroll.selection = scroll.selection.map(|sel| sel.saturating_sub(excess));
+        if let Some((first, last)) = scroll.visible_range {
+            scroll.visible_range =
+                Some((first.saturating_sub(excess), last.saturating_sub(excess)));
+        }
+    }
+
+    /// Message-offset scroll state for the messages pane. `offset` counts messages up
+    /// from the bottom (0 = pinned to the newest). `selection` is an absolute index
+    /// into the row list (`None` tracks the
+    /// newest). `visible_range` is fed back by the renderer each frame so navigation
+    /// only nudges the viewport when the selection leaves what is on screen.
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
+    pub(crate) struct TimelineScroll {
+        pub(crate) offset: usize,
+        pub(crate) selection: Option<usize>,
+        pub(crate) visible_range: Option<(usize, usize)>,
+        pub(crate) has_more_before: bool,
+        pub(crate) loading_older: bool,
+    }
+
+    impl TimelineScroll {
+        /// True when pinned to the newest message (auto-follow on arrival).
+        pub(crate) fn is_pinned(&self) -> bool {
+            self.offset == 0
+        }
+
+        /// The selected absolute index, defaulting to the newest row. `None` when the
+        /// list is empty.
+        pub(crate) fn resolved_selection(&self, len: usize) -> Option<usize> {
+            (len > 0).then(|| self.selection.map_or(len - 1, |sel| sel.min(len - 1)))
+        }
+
+        /// Adjust for a row inserted at `index` (new length `new_len`). A row newer
+        /// than the current anchor bumps the offset by one while scrolled up (so the
+        /// content being read does not move) and stays pinned at the bottom
+        /// otherwise; a row at or older than the anchor shifts the selection instead.
+        pub(crate) fn on_insert(&mut self, index: usize, new_len: usize) {
+            let old_len = new_len.saturating_sub(1);
+            let anchor = old_len.saturating_sub(1).saturating_sub(self.offset);
+            if index > anchor && !self.is_pinned() {
+                self.offset += 1;
+            }
+            if let Some(sel) = self.selection
+                && index <= sel
+            {
+                self.selection = Some(sel + 1);
+            }
+            if let Some((first, last)) = self.visible_range {
+                self.visible_range = Some((
+                    first + usize::from(index <= first),
+                    last + usize::from(index <= last),
+                ));
+            }
+        }
+
+        /// Adjust for `n` older rows prepended at the front (history paging). The
+        /// offset counts from the unchanged bottom, so it stays put; the selection
+        /// and last visible range are absolute indices, so they shift by `n` to keep
+        /// the same rows selected and on screen.
+        pub(crate) fn on_prepend(&mut self, n: usize) {
+            if n == 0 {
+                return;
+            }
+            if let Some(sel) = self.selection {
+                self.selection = Some(sel + n);
+            }
+            if let Some((first, last)) = self.visible_range {
+                self.visible_range = Some((first + n, last + n));
+            }
+        }
+
+        /// Adjust for the row at `index` being removed (new length `new_len`). The
+        /// mirror of `on_insert`: a row newer than the anchor pulls the offset down
+        /// while scrolled up; a row at or older than the selection shifts it down.
+        pub(crate) fn on_remove(&mut self, index: usize, new_len: usize) {
+            let old_len = new_len + 1;
+            let anchor = (old_len - 1).saturating_sub(self.offset);
+            if index > anchor && !self.is_pinned() {
+                self.offset -= 1;
+            }
+            self.selection = self.selection.and_then(|sel| {
+                let shifted = sel - usize::from(index < sel);
+                (new_len > 0).then(|| shifted.min(new_len - 1))
+            });
+            if let Some((first, last)) = self.visible_range {
+                self.visible_range = Some((
+                    first - usize::from(index < first),
+                    last - usize::from(index < last),
+                ));
+            }
+        }
+
+        /// Move the selection one row toward older messages (`k`).
+        pub(crate) fn select_up(&mut self, len: usize) {
+            self.move_selection(len, |sel| sel.saturating_sub(1));
+        }
+
+        /// Move the selection one row toward newer messages (`j`).
+        pub(crate) fn select_down(&mut self, len: usize) {
+            self.move_selection(len, |sel| sel + 1);
+        }
+
+        /// Move the selection up by the number of currently visible messages
+        /// (`PageUp`), clamped.
+        pub(crate) fn page_up(&mut self, len: usize) {
+            let count = self.visible_count();
+            self.move_selection(len, |sel| sel.saturating_sub(count));
+        }
+
+        /// Move the selection down by the number of currently visible messages
+        /// (`PageDown`), clamped.
+        pub(crate) fn page_down(&mut self, len: usize) {
+            let count = self.visible_count();
+            self.move_selection(len, |sel| sel + count);
+        }
+
+        /// The number of messages the last render reported on screen (at least one).
+        fn visible_count(&self) -> usize {
+            self.visible_range
+                .map_or(1, |(first, last)| last.saturating_sub(first) + 1)
+                .max(1)
+        }
+
+        /// Select the newest message and pin to the bottom (`G`).
+        pub(crate) fn jump_newest(&mut self, _len: usize) {
+            self.selection = None;
+            self.offset = 0;
+        }
+
+        /// Select the oldest loaded message and scroll to the top (`g`).
+        pub(crate) fn jump_oldest(&mut self, len: usize) {
+            if len == 0 {
+                return;
+            }
+            self.selection = Some(0);
+            self.offset = len - 1;
+        }
+
+        fn move_selection(&mut self, len: usize, step: impl FnOnce(usize) -> usize) {
+            let Some(sel) = self.resolved_selection(len) else {
+                return;
+            };
+            self.selection = Some(step(sel).min(len - 1));
+            self.follow_selection(len);
+        }
+
+        /// Record the message range the renderer put on screen this frame. The
+        /// follow-scroll logic reads it to decide when to move the viewport, and
+        /// it also renormalizes a stale over-large offset down to what the render
+        /// geometry actually shows.
+        ///
+        /// `jump_oldest` (and any offset larger than the list can scroll) sets an
+        /// offset the renderer clamps when it anchors and fills forward, so the
+        /// stored offset can exceed the largest offset that still draws the same
+        /// bottom row (`last`). Left uncorrected, a later `on_prepend` — which
+        /// leaves the offset put (rule 6) — would anchor below the true top and
+        /// jump the view. The drawn `last` pins the effective offset to
+        /// `(len - 1) - last`; clamp down to it, never up (a legitimately smaller
+        /// offset always has `last` at the anchor, so this leaves it untouched).
+        pub(crate) fn record_visible_range(&mut self, first: usize, last: usize, len: usize) {
+            self.visible_range = Some((first, last));
+            let effective = len.saturating_sub(1).saturating_sub(last);
+            if self.offset > effective {
+                self.offset = effective;
+            }
+        }
+
+        /// True when the selection is on the oldest loaded row.
+        pub(crate) fn at_oldest(&self, len: usize) -> bool {
+            self.resolved_selection(len) == Some(0)
+        }
+
+        /// True when the caller should fetch an older history page: the selection is
+        /// at the oldest loaded row, more history exists, and no request is in
+        /// flight. The caller sets `loading_older` when it fires the request and,
+        /// once the page arrives, prepends the rows, calls `on_prepend`, and updates
+        /// `has_more_before` / `loading_older`.
+        pub(crate) fn should_request_older(&self, len: usize) -> bool {
+            self.has_more_before && !self.loading_older && self.at_oldest(len)
+        }
+
+        /// Nudge the viewport so the selection stays on screen, using the visible
+        /// range reported by the last render. Movement inside the range scrolls
+        /// nothing; leaving it moves the offset by exactly the overshoot.
+        fn follow_selection(&mut self, len: usize) {
+            let (Some(sel), Some((first, last))) =
+                (self.resolved_selection(len), self.visible_range)
+            else {
+                return;
+            };
+            if sel < first {
+                self.offset = (self.offset + (first - sel)).min(len.saturating_sub(1));
+            } else if sel > last {
+                self.offset = self.offset.saturating_sub(sel - last);
+            }
+        }
+    }
+
+    /// Build the display lines for one timeline row: `[HH:MM] author: content`, with
+    /// an optional reply line above, an optional reactions line below, and
+    /// attachment placeholders. Deleted rows render a tombstone in place. Every
+    /// untrusted string passes through `terminal_safe_text`. Selection highlight is
+    /// applied by the renderer; this returns only the content lines (the blank
+    /// separator counted by `timeline_row_height` is added when rendering).
+    pub(crate) fn timeline_row_lines(
+        row: &TimelineRow,
+        selected_account: Option<&AccountRow>,
+    ) -> Vec<Line<'static>> {
+        let prefix = format!("[{}] ", local_hhmm(row.timeline_at));
+        let author_prefix = format!("{}: ", terminal_safe_text(&timeline_author_label(row)));
+        let indent = prefix.chars().count() + author_prefix.chars().count();
+        let author_style = Style::default()
+            .fg(if timeline_row_is_self(row, selected_account) {
+                Color::Green
+            } else {
+                Color::Cyan
+            })
+            .add_modifier(Modifier::BOLD);
+        let timestamp_style = Style::default().fg(Color::DarkGray);
+
+        let mut lines = Vec::new();
+        if let Some(reply) = &row.reply {
+            lines.push(timeline_reply_line(reply, indent));
+        }
+        if row.deleted {
+            lines.push(Line::from(vec![
+                Span::styled(prefix, timestamp_style),
+                Span::styled(author_prefix, author_style),
+                Span::styled("message deleted", timeline_muted_italic_style()),
+            ]));
+            return lines;
+        }
+        for (index, part) in row.display_text.split('\n').enumerate() {
+            let part = terminal_safe_text(part);
+            if index == 0 {
+                lines.push(Line::from(vec![
+                    Span::styled(prefix.clone(), timestamp_style),
+                    Span::styled(author_prefix.clone(), author_style),
+                    Span::raw(part),
+                ]));
+            } else {
+                lines.push(Line::from(vec![
+                    Span::raw(" ".repeat(indent)),
+                    Span::raw(part),
+                ]));
+            }
+        }
+        if !row.reactions.is_empty() {
+            lines.push(timeline_reactions_line(&row.reactions, indent));
+        }
+        for attachment in &row.attachments {
+            lines.push(timeline_attachment_line(attachment, indent));
+        }
+        lines
+    }
+
+    /// The rendered height of a timeline row at `width`: the wrapped line count of
+    /// its content plus the blank separator row. The separator makes a row's block
+    /// height, so the visibility walk and the renderer stay in lockstep.
+    pub(crate) fn timeline_row_height(
+        row: &TimelineRow,
+        selected_account: Option<&AccountRow>,
+        width: u16,
+    ) -> u16 {
+        let lines = timeline_row_lines(row, selected_account);
+        let content = if width == 0 {
+            lines.len()
+        } else {
+            Paragraph::new(lines)
+                .wrap(Wrap { trim: false })
+                .line_count(width)
+        };
+        u16::try_from(content)
+            .unwrap_or(u16::MAX)
+            .saturating_add(TIMELINE_MESSAGE_SEPARATOR_ROWS)
+    }
+
+    /// The rendered height of every row at `width`, for the visibility walk.
+    pub(crate) fn timeline_row_heights(
+        rows: &[TimelineRow],
+        selected_account: Option<&AccountRow>,
+        width: u16,
+    ) -> Vec<u16> {
+        rows.iter()
+            .map(|row| timeline_row_height(row, selected_account, width))
+            .collect()
+    }
+
+    /// Compute the visible message range `(first, last)` (both inclusive, forward
+    /// order) for a viewport, given per-row `heights` and the scroll `offset`. The
+    /// anchor is `newest - offset`; the walk fills backward from it until the
+    /// viewport is full, then renders forward from where it stopped. The anchor is
+    /// always included, so a message taller than the viewport still renders (never a
+    /// blank pane). `bottom_block_height` reserves rows for a bottom-pinned block
+    /// (live stream previews) but only when the anchor is the newest message.
+    ///
+    /// This is the single algorithm the renderer also uses to draw, so the reported
+    /// range and the drawn rows never diverge.
+    pub(crate) fn timeline_visible_range(
+        heights: &[u16],
+        viewport_height: u16,
+        offset: usize,
+        bottom_block_height: u16,
+    ) -> Option<(usize, usize)> {
+        let total = heights.len();
+        if total == 0 || viewport_height == 0 {
+            return None;
+        }
+        let anchor = total - 1 - offset.min(total - 1);
+        let viewport = if anchor == total - 1 {
+            viewport_height.saturating_sub(bottom_block_height)
+        } else {
+            viewport_height
+        };
+        let viewport = usize::from(viewport.max(1));
+        let height = |index: usize| usize::from(heights[index].max(1));
+
+        // Fill backward from the anchor to the topmost row that still fits.
+        let mut first = anchor;
+        let mut used = height(anchor);
+        for index in (0..anchor).rev() {
+            let next = used + height(index);
+            if next > viewport {
+                break;
+            }
+            used = next;
+            first = index;
+        }
+
+        // Render forward from `first`, filling the viewport. The anchor always
+        // renders (the `index != first` guard), so an oversized message is shown.
+        let mut last = first;
+        let mut filled = 0;
+        for index in first..total {
+            let next = filled + height(index);
+            if index != first && next > viewport {
+                break;
+            }
+            filled = next;
+            last = index;
+        }
+        Some((first, last))
+    }
+
+    /// The author label shown before a timeline message: the sender's display name,
+    /// falling back to a shortened id. Color (not "me") signals ownership.
+    fn timeline_author_label(row: &TimelineRow) -> String {
+        row.from_display_name
+            .clone()
+            .unwrap_or_else(|| shorten(&row.from, 18))
+    }
+
+    /// Whether a timeline row was authored by the selected account (rendered green).
+    fn timeline_row_is_self(row: &TimelineRow, selected_account: Option<&AccountRow>) -> bool {
+        row.direction == "sent"
+            || selected_account.is_some_and(|account| {
+                row.from == account.account_id
+                    || row.from == account.npub
+                    || row.from == account_display_label(account)
+            })
+    }
+
+    /// Format a Unix timestamp as local wall-clock `HH:MM`. This is the seam the
+    /// line builder calls; it depends on the machine's timezone, so tests assert
+    /// the `[HH:MM]` shape (fixed 8-column prefix) rather than the value and cover
+    /// the arithmetic through the pure `format_hhmm_with_offset` below. Falls back
+    /// to UTC when the timestamp is out of `DateTime`'s range.
+    fn local_hhmm(timeline_at: u64) -> String {
+        chrono::DateTime::from_timestamp(timeline_at as i64, 0)
+            .map(|instant| {
+                instant
+                    .with_timezone(&chrono::Local)
+                    .format("%H:%M")
+                    .to_string()
+            })
+            .unwrap_or_else(|| format_hhmm(timeline_at))
+    }
+
+    /// Format a Unix timestamp as `HH:MM` in UTC. Pure and deterministic; kept as
+    /// the `local_hhmm` fallback and as the zero-offset case of the tested
+    /// `format_hhmm_with_offset`.
+    fn format_hhmm(timeline_at: u64) -> String {
+        format_hhmm_with_offset(timeline_at, 0)
+    }
+
+    /// Format a Unix timestamp as `HH:MM` shifted by `offset_seconds` from UTC.
+    /// Pure and deterministic (no clock read), so tests can pin an offset and
+    /// assert an exact value; `rem_euclid` keeps a negative wall-clock in range.
+    pub(crate) fn format_hhmm_with_offset(timeline_at: u64, offset_seconds: i64) -> String {
+        let seconds_of_day = (timeline_at as i64 + offset_seconds).rem_euclid(86_400);
+        format!(
+            "{:02}:{:02}",
+            seconds_of_day / 3_600,
+            (seconds_of_day % 3_600) / 60
+        )
+    }
+
+    fn timeline_muted_italic_style() -> Style {
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::ITALIC)
+    }
+
+    /// The reply-context line rendered above a reply's content: dark gray italic
+    /// `reply to <name>: "<first 30 chars>"`, falling back to a shortened parent id
+    /// when the preview is absent.
+    fn timeline_reply_line(reply: &TimelineReply, indent: usize) -> Line<'static> {
+        let label = match &reply.preview {
+            Some(preview) => {
+                let name = preview
+                    .sender
+                    .as_deref()
+                    .map(terminal_safe_text)
+                    .filter(|sender| !sender.is_empty())
+                    .unwrap_or_else(|| {
+                        terminal_safe_text(&shorten(&reply.reply_to_message_id, 12))
+                    });
+                let body = if preview.deleted {
+                    "message deleted".to_owned()
+                } else {
+                    terminal_safe_text(&preview.plaintext)
+                };
+                let clipped = body.chars().take(30).collect::<String>();
+                if body.chars().count() > 30 {
+                    format!("reply to {name}: \"{clipped}...\"")
+                } else {
+                    format!("reply to {name}: \"{clipped}\"")
+                }
+            }
+            None => format!(
+                "reply to {}",
+                terminal_safe_text(&shorten(&reply.reply_to_message_id, 12))
+            ),
+        };
+        Line::from(vec![
+            Span::raw(" ".repeat(indent)),
+            Span::styled(label, timeline_muted_italic_style()),
+        ])
+    }
+
+    /// The reactions line rendered below a message: yellow `<emoji> <count>` pairs
+    /// two spaces apart, in the row's deterministic emoji order.
+    fn timeline_reactions_line(reactions: &[TimelineReaction], indent: usize) -> Line<'static> {
+        let summary = reactions
+            .iter()
+            .map(|reaction| format!("{} {}", terminal_safe_text(&reaction.emoji), reaction.count))
+            .collect::<Vec<_>>()
+            .join("  ");
+        Line::from(vec![
+            Span::raw(" ".repeat(indent)),
+            Span::styled(summary, Style::default().fg(Color::Yellow)),
+        ])
+    }
+
+    /// A placeholder line for a media attachment: `[img name]` for images,
+    /// `[file name]` otherwise. Phase 1 renders no inline media.
+    fn timeline_attachment_line(attachment: &TimelineAttachment, indent: usize) -> Line<'static> {
+        let name = attachment
+            .filename
+            .as_deref()
+            .map(terminal_safe_text)
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| "file".to_owned());
+        let label = if attachment
+            .mime
+            .as_deref()
+            .is_some_and(|mime| mime.starts_with("image/"))
+        {
+            format!("[img {name}]")
+        } else {
+            format!("[file {name}]")
+        };
+        Line::from(vec![
+            Span::raw(" ".repeat(indent)),
+            Span::styled(label, Style::default().fg(Color::DarkGray)),
+        ])
+    }
+}
+
+pub(crate) use timeline::*;
+
 pub(crate) fn value_string(value: &Value, key: &str) -> Option<String> {
     value.get(key).and_then(Value::as_str).map(str::to_owned)
 }
@@ -627,26 +1498,6 @@ pub(crate) fn account_display_label(account: &AccountRow) -> String {
         .display_name
         .clone()
         .unwrap_or_else(|| account.npub.clone())
-}
-
-pub(crate) fn message_author_label(
-    message: &MessageRow,
-    selected_account: Option<&AccountRow>,
-) -> String {
-    if message.direction == "sent" {
-        return "me".to_owned();
-    }
-    if selected_account.is_some_and(|account| {
-        message.from == account.account_id
-            || message.from == account.npub
-            || message.from == account_display_label(account)
-    }) {
-        return "me".to_owned();
-    }
-    message
-        .from_display_name
-        .clone()
-        .unwrap_or_else(|| shorten(&message.from, 18))
 }
 
 pub(crate) fn stream_preview_author(
@@ -778,14 +1629,6 @@ pub(crate) fn move_index(current: usize, len: usize, delta: isize) -> usize {
     (current as isize + delta).clamp(0, max) as usize
 }
 
-// `scrollback` counts lines up from the bottom (0 keeps the newest pinned). Returns the
-// clamped scrollback and the top-line offset to hand to `Paragraph::scroll`.
-pub(crate) fn messages_scroll_offsets(total: u16, viewport: u16, scrollback: u16) -> (u16, u16) {
-    let max_scroll = total.saturating_sub(viewport);
-    let clamped = scrollback.min(max_scroll);
-    (clamped, max_scroll - clamped)
-}
-
 pub(crate) fn publish_status(action: &str, result: &Value) -> String {
     let published = result
         .get("published")
@@ -849,7 +1692,6 @@ pub(crate) fn parse_daemon_stream_watch(value: &Value) -> Option<DaemonStreamWat
 }
 
 pub(crate) fn apply_tui_subscription_result(
-    messages: &mut Vec<MessageRow>,
     live_previews: &mut Vec<LiveStreamPreview>,
     unread_counts: &mut HashMap<String, usize>,
     selected_group_id: Option<&str>,
@@ -861,21 +1703,19 @@ pub(crate) fn apply_tui_subscription_result(
     if let Some(group_id) = subscription_result_group_id(result)
         && Some(group_id.as_str()) != selected_group_id
     {
-        if subscription_result_counts_as_unread(result) {
+        let status = subscription_result_counts_as_unread(result).then(|| {
             let unread_count = unread_counts.entry(group_id.clone()).or_default();
             *unread_count += 1;
-            let status = Some(format!(
+            format!(
                 "unread message in {}; count={}",
                 shorten(&group_id, 18),
                 unread_count
-            ));
-            let _ = apply_subscription_result(messages, live_previews, result, true);
-            return status;
-        }
-        let _ = apply_subscription_result(messages, live_previews, result, true);
-        return None;
+            )
+        });
+        apply_subscription_result(live_previews, result);
+        return status;
     }
-    apply_subscription_result(messages, live_previews, result, false)
+    apply_subscription_result(live_previews, result)
 }
 
 pub(crate) fn is_initial_subscription_result(result: &Value) -> bool {
@@ -910,31 +1750,28 @@ pub(crate) fn subscription_result_counts_as_unread(result: &Value) -> bool {
     )
 }
 
+/// Apply one plain `messages subscribe` event to the account-wide live-stream
+/// preview state. The materialized-timeline feed owns the messages pane now, so
+/// message/reaction/media/delete rows drive nothing here; the plain feed is kept
+/// only for what the timeline feed does not carry — the QUIC preview types that
+/// render in the pane's bottom block, plus the preview cleanup when an agent
+/// stream's final row lands. Unread counting for off-screen groups is the
+/// caller's (`apply_tui_subscription_result`) job.
 pub(crate) fn apply_subscription_result(
-    messages: &mut Vec<MessageRow>,
     live_previews: &mut Vec<LiveStreamPreview>,
     result: &Value,
-    suppress_message_append: bool,
 ) -> Option<String> {
     match result.get("type").and_then(Value::as_str) {
-        Some("message" | "reaction" | "message_delete" | "media" | "agent_stream_final") => {
+        Some("agent_stream_final") => {
             let message_value = result.get("message")?;
-            if result.get("type").and_then(Value::as_str) == Some("agent_stream_final")
-                && let Some(stream_id) = message_value
-                    .get("agent_text_stream")
-                    .and_then(|stream| value_string(stream, "stream_id"))
-            {
-                let group_id = value_string(message_value, "group_id");
-                remove_live_stream_preview(live_previews, group_id.as_deref(), &stream_id);
-            }
-            if suppress_message_append {
-                return None;
-            }
-            let message = parse_message(message_value)?;
-            upsert_message(messages, message);
-            sort_and_cap_messages(messages);
-            Some(format!("live update: messages={}", messages.len()))
+            let stream_id = message_value
+                .get("agent_text_stream")
+                .and_then(|stream| value_string(stream, "stream_id"))?;
+            let group_id = value_string(message_value, "group_id");
+            remove_live_stream_preview(live_previews, group_id.as_deref(), &stream_id);
+            None
         }
+        Some("message" | "reaction" | "message_delete" | "media") => None,
         Some("agent_stream_start") => {
             let message = result.get("message")?;
             let stream = message
@@ -990,18 +1827,6 @@ pub(crate) fn apply_subscription_result(
         }
         _ => None,
     }
-}
-
-pub(crate) fn upsert_message(messages: &mut Vec<MessageRow>, message: MessageRow) {
-    if !message.message_id.is_empty()
-        && let Some(existing) = messages
-            .iter_mut()
-            .find(|existing| existing.message_id == message.message_id)
-    {
-        *existing = message;
-        return;
-    }
-    messages.push(message);
 }
 
 pub(crate) fn append_live_stream_delta(
@@ -1298,5 +2123,21 @@ pub(crate) fn message_subscription_args() -> Vec<String> {
         "subscribe".to_owned(),
         "--limit".to_owned(),
         "0".to_owned(),
+    ]
+}
+
+/// Args for the per-group materialized-timeline subscription. Passes `--limit`
+/// with the TUI page size so the subscription's initial page matches the
+/// snapshot load; without it the daemon's default 50-row page transiently
+/// clobbers the snapshot's accurate `has_more_before` (a spurious "loaded 0
+/// older message(s)" fetch for 51-100-message groups).
+pub(crate) fn timeline_subscription_args(group_id: &str) -> Vec<String> {
+    vec![
+        "messages".to_owned(),
+        "timeline".to_owned(),
+        "subscribe".to_owned(),
+        group_id.to_owned(),
+        "--limit".to_owned(),
+        TUI_TIMELINE_PAGE_SIZE.to_string(),
     ]
 }

--- a/crates/cli/src/tui/slash.rs
+++ b/crates/cli/src/tui/slash.rs
@@ -16,6 +16,13 @@ pub(crate) fn parse_slash_command(input: &str) -> Result<SlashCommand, String> {
     match command.as_str() {
         "help" | "?" => Ok(SlashCommand::Help),
         "refresh" => Ok(SlashCommand::Refresh),
+        "diagnostics" => {
+            if rest.is_empty() {
+                Ok(SlashCommand::Diagnostics)
+            } else {
+                Err("/diagnostics does not accept arguments".to_owned())
+            }
+        }
         "sync" => {
             Err("manual sync is not a TUI command; live updates come from subscriptions".to_owned())
         }

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -446,7 +446,7 @@ fn group_members_status_summarizes_member_records() {
 }
 
 #[test]
-fn status_panel_lines_show_latest_status_then_mls_and_components() {
+fn diagnostics_panel_lines_show_mls_and_components() {
     let diagnostics = parse_group_diagnostics(&serde_json::json!({
         "group": {
             "group_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -473,19 +473,18 @@ fn status_panel_lines_show_latest_status_then_mls_and_components() {
     }))
     .expect("diagnostics");
 
-    let rendered = status_panel_lines("loaded 2 message(s)", Some(&diagnostics))
+    // The diagnostics panel drops the leading status line (now in the status bar):
+    // it starts straight at the MLS summary.
+    let rendered = diagnostics_panel_lines(Some(&diagnostics))
         .iter()
         .map(line_text)
         .collect::<Vec<_>>();
 
-    assert_eq!(rendered[0], "loaded 2 message(s)");
-    assert_eq!(rendered[1], "");
-    assert_eq!(rendered[2], "");
     assert_eq!(
-        rendered[3],
+        rendered[0],
         "MLS epoch=7 group=aaaaaaa...aaaaaaaa members=3"
     );
-    assert_eq!(rendered[4], "components:");
+    assert_eq!(rendered[1], "components:");
     assert!(
         rendered
             .iter()
@@ -722,12 +721,12 @@ fn render_lines_strip_terminal_control_sequences_from_untrusted_text() {
     };
     assert_eq!(line_text(&chat_row_line(&chat, false, 0)), "  ops[5m");
 
-    let status = status_panel_lines(
-        "ready\u{1b}[2J",
-        Some(&GroupDiagnostics::unavailable("aa", "bad\u{1b}[31m")),
+    let diagnostics =
+        diagnostics_panel_lines(Some(&GroupDiagnostics::unavailable("aa", "bad\u{1b}[31m")));
+    assert_eq!(
+        line_text(&diagnostics[0]),
+        "MLS group=aa unavailable: bad[31m"
     );
-    assert_eq!(line_text(&status[0]), "ready[2J");
-    assert_eq!(line_text(&status[3]), "MLS group=aa unavailable: bad[31m");
 }
 
 #[test]
@@ -759,7 +758,7 @@ fn image_slash_command_uses_real_media_upload_send_surface() {
 }
 
 #[test]
-fn daemon_status_json_becomes_header_and_status_text() {
+fn daemon_status_json_becomes_status_text() {
     let daemon = parse_daemon_view(&serde_json::json!({
         "running": true,
         "pid": 1234,
@@ -772,10 +771,6 @@ fn daemon_status_json_becomes_header_and_status_text() {
         }
     }));
 
-    assert_eq!(
-        daemon_header_label(&daemon),
-        "on pid=1234 activity=3/1/4 errors=1"
-    );
     assert_eq!(
         daemon_status_sentence(&daemon),
         "daemon running last-activity accounts=2 events=3 joined=1 messages=4 errors=1"
@@ -813,7 +808,6 @@ fn daemon_stream_watches_become_status_and_preview_rows() {
         ]
     }));
 
-    assert_eq!(daemon_header_label(&daemon), "on pid=1234 streams=1");
     assert_eq!(
         daemon_status_sentence(&daemon),
         "daemon running streams: running=1 completed=1 failed=0 latest=bbbbbbb...bbbbbbbb"
@@ -1293,6 +1287,44 @@ fn message_subscription_gates_on_loaded_chat_not_highlighted_chat() {
 }
 
 #[test]
+fn drain_status_leaves_the_login_prompt_untouched_but_updates_main() {
+    // A picker reached via `A` from an active session keeps its background
+    // drains running. On the login/account-select screen the status line carries
+    // the nsec prompt and picker guidance, so a live drain must apply its state
+    // changes without overwriting that prompt.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    let (tx, rx) = mpsc::channel();
+    app.message_subscription = Some(MessageSubscription {
+        account_id: account_id.clone(),
+        child: test_sleep_child(),
+        rx,
+    });
+
+    app.screen = Screen::Login(LoginMode::NsecEntry);
+    let prompt = "enter nsec; Enter submits, Esc cancels".to_owned();
+    app.status = prompt.clone();
+    tx.send(SubscriptionEvent::Error("relay dropped".to_owned()))
+        .expect("send error event");
+    assert!(app.drain_message_subscription());
+    assert_eq!(
+        app.status, prompt,
+        "the login prompt survives a background drain"
+    );
+
+    // The same event on the main view still surfaces on the status line.
+    app.screen = Screen::Main;
+    tx.send(SubscriptionEvent::Error("relay dropped".to_owned()))
+        .expect("send error event");
+    assert!(app.drain_message_subscription());
+    assert!(
+        app.status.contains("relay dropped"),
+        "main-view drains still set status, got: {}",
+        app.status
+    );
+}
+
+#[test]
 fn selected_message_subscription_retains_account_wide_stream_without_selected_chat() {
     let account_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     let mut app = test_tui_app(test_unused_client(), account_id);
@@ -1473,16 +1505,56 @@ fn composer_redacts_nsec_imports_without_hiding_other_input() {
 #[test]
 fn account_setup_invocation_pipes_nsec_imports_to_stdin() {
     assert_eq!(
-        account_setup_invocation(Some("nsec1secret".to_owned())),
+        account_setup_invocation(Some("nsec1secret".to_owned()), None),
         WnInvocation {
             args: vec!["login".to_owned(), "--nsec-stdin".to_owned()],
             stdin: Some("nsec1secret\n".to_owned()),
         }
     );
     assert_eq!(
-        account_setup_invocation(Some("npub1bob".to_owned())),
+        account_setup_invocation(Some("npub1bob".to_owned()), None),
         WnInvocation {
             args: vec!["login".to_owned(), "npub1bob".to_owned()],
+            stdin: None,
+        }
+    );
+}
+
+#[test]
+fn account_setup_invocation_appends_first_run_setup_relay() {
+    // The first-run setup relay is appended as the one `--relay` flag account
+    // setup accepts (global for create-identity, command-local for login).
+    assert_eq!(
+        account_setup_invocation(None, Some("wss://relay.example".to_owned())),
+        WnInvocation {
+            args: vec![
+                "create-identity".to_owned(),
+                "--relay".to_owned(),
+                "wss://relay.example".to_owned(),
+            ],
+            stdin: None,
+        }
+    );
+    assert_eq!(
+        account_setup_invocation(
+            Some("nsec1secret".to_owned()),
+            Some("wss://relay.example".to_owned())
+        ),
+        WnInvocation {
+            args: vec![
+                "login".to_owned(),
+                "--nsec-stdin".to_owned(),
+                "--relay".to_owned(),
+                "wss://relay.example".to_owned(),
+            ],
+            stdin: Some("nsec1secret\n".to_owned()),
+        }
+    );
+    // A blank relay adds no flag.
+    assert_eq!(
+        account_setup_invocation(None, Some("  ".to_owned())),
+        WnInvocation {
+            args: vec!["create-identity".to_owned()],
             stdin: None,
         }
     );
@@ -1672,6 +1744,9 @@ fn test_tui_app(client: WnClient, account_id: &str) -> TuiApp {
         client,
         initial_account: None,
         running: true,
+        screen: Screen::Main,
+        entered_main: true,
+        show_diagnostics: false,
         focus: Focus::Composer,
         accounts: vec![AccountRow {
             account_id: account_id.to_owned(),
@@ -1680,6 +1755,7 @@ fn test_tui_app(client: WnClient, account_id: &str) -> TuiApp {
             local_signing: true,
         }],
         selected_account: 0,
+        picker_selection: 0,
         chats: Vec::new(),
         selected_chat: 0,
         messages_account_id: None,
@@ -1711,6 +1787,8 @@ fn test_unused_client() -> WnClient {
         home: None,
         socket: None,
         relay: None,
+        discovery_relays: Vec::new(),
+        default_account_relays: Vec::new(),
         secret_store: None,
         keychain_service: None,
     }
@@ -1724,6 +1802,8 @@ fn test_json_client(response: &str) -> (tempfile::TempDir, WnClient) {
         home: None,
         socket: None,
         relay: None,
+        discovery_relays: Vec::new(),
+        default_account_relays: Vec::new(),
         secret_store: None,
         keychain_service: None,
     };
@@ -1799,6 +1879,46 @@ fn failed_due_stream_append_updates_last_flush_to_back_off_tick_retry() {
     let streaming = app.streaming.as_ref().expect("composer remains active");
     assert_eq!(streaming.pending_text, "queued");
     assert_eq!(streaming.last_flush, retry_gate);
+}
+
+#[test]
+fn streaming_keys_capture_input_before_screen_dispatch() {
+    // The streaming-composer check must sit ahead of the screen dispatch (behind
+    // only Ctrl-C), so any future Main->Login path with an open stream still
+    // routes keys to the stream while tick() keeps flushing, instead of the login
+    // handler consuming the key. Constructed by flipping the screen to Login with
+    // a live stream.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.streaming = Some(StreamComposer {
+        stream_id: "stream-1".to_owned(),
+        group_id: "bb".repeat(32),
+        pending_text: String::new(),
+        last_flush: Instant::now(),
+    });
+
+    // Main view: a character queues on the stream composer.
+    app.screen = Screen::Main;
+    app.handle_key(char_key('x')).expect("char in main");
+    assert_eq!(
+        app.streaming.as_ref().expect("stream active").pending_text,
+        "x"
+    );
+
+    // With the screen on the login/account-select flow, an open stream keeps
+    // capturing input; the login handler never sees the key.
+    app.screen = Screen::Login(LoginMode::AccountSelect);
+    app.handle_key(char_key('y'))
+        .expect("char while login screen");
+    assert_eq!(
+        app.streaming.as_ref().expect("stream active").pending_text,
+        "xy"
+    );
+    assert_eq!(
+        app.screen,
+        Screen::Login(LoginMode::AccountSelect),
+        "the login handler never consumed the streaming key"
+    );
 }
 
 #[test]
@@ -3558,5 +3678,560 @@ fn render_messages_wraps_long_lines_so_the_tail_is_visible() {
     assert!(
         rendered.contains("TAILMARKER"),
         "the wrapped tail of a long message must render, not truncate at the pane edge"
+    );
+}
+
+// --- Phase 2: the shell (screen model, key routing, status/hints bars) ---
+
+#[test]
+fn startup_screen_routes_by_account_count() {
+    assert_eq!(startup_screen(0, false), Screen::Login(LoginMode::Menu));
+    assert_eq!(startup_screen(1, false), Screen::Main);
+    assert_eq!(
+        startup_screen(2, false),
+        Screen::Login(LoginMode::AccountSelect)
+    );
+    assert_eq!(
+        startup_screen(9, false),
+        Screen::Login(LoginMode::AccountSelect)
+    );
+    // An explicit --account selection enters the main view even with several
+    // accounts; a resolved single/none selection is unaffected.
+    assert_eq!(startup_screen(2, true), Screen::Main);
+    assert_eq!(startup_screen(9, true), Screen::Main);
+    assert_eq!(startup_screen(0, true), Screen::Login(LoginMode::Menu));
+}
+
+#[test]
+fn focus_cycles_the_three_main_panes() {
+    assert_eq!(Focus::Chats.next(), Focus::Messages);
+    assert_eq!(Focus::Messages.next(), Focus::Composer);
+    assert_eq!(Focus::Composer.next(), Focus::Chats);
+    assert_eq!(Focus::Chats.previous(), Focus::Composer);
+    assert_eq!(Focus::Messages.previous(), Focus::Chats);
+    assert_eq!(Focus::Composer.previous(), Focus::Messages);
+}
+
+#[test]
+fn login_mode_for_accounts_picks_the_launching_screen() {
+    assert_eq!(login_mode_for_accounts(0), LoginMode::Menu);
+    assert_eq!(login_mode_for_accounts(1), LoginMode::AccountSelect);
+    assert_eq!(login_mode_for_accounts(4), LoginMode::AccountSelect);
+}
+
+#[test]
+fn masked_secret_hides_every_character() {
+    assert_eq!(masked_secret(""), "");
+    assert_eq!(masked_secret("nsec1abc"), "********");
+    // Multi-byte characters each mask to a single `*`.
+    assert_eq!(masked_secret("aé😀"), "***");
+}
+
+#[test]
+fn status_bar_line_assembles_daemon_counts_and_status() {
+    assert_eq!(
+        status_bar_line("alice", true, 3, 5, "loaded 2 message(s)", 200),
+        "alice · daemon on · 3 chats · 5 unread · loaded 2 message(s)"
+    );
+    assert_eq!(
+        status_bar_line("bob", false, 0, 0, "", 200),
+        "bob · daemon off · 0 chats · 0 unread · "
+    );
+    // Narrow widths shorten the assembled line (middle ellipsis keeps head + tail).
+    let narrow = status_bar_line("alice", true, 3, 5, "loaded", 20);
+    assert!(narrow.chars().count() <= 20, "over width: {narrow:?}");
+    assert!(narrow.contains("..."), "expected truncation: {narrow:?}");
+}
+
+#[test]
+fn status_bar_line_strips_control_sequences_from_untrusted_fields() {
+    assert_eq!(
+        status_bar_line("al\u{1b}[31mice", true, 1, 0, "ok\u{1b}[2J", 200),
+        "al[31mice · daemon on · 1 chats · 0 unread · ok[2J"
+    );
+}
+
+#[test]
+fn hints_line_matches_the_keymap_per_screen_and_focus() {
+    assert_eq!(
+        hints_line(Screen::Main, Focus::Chats, true),
+        "j/k navigate  Enter open  A accounts  / command  ? help  q quit"
+    );
+    assert_eq!(
+        hints_line(Screen::Main, Focus::Messages, true),
+        "j/k select  G/g ends  PgUp older  i compose  Tab cycle"
+    );
+    assert_eq!(
+        hints_line(Screen::Main, Focus::Composer, true),
+        "Enter send  Esc clear"
+    );
+    assert_eq!(
+        hints_line(Screen::Login(LoginMode::Menu), Focus::Chats, false),
+        "c create identity  l nsec login  q quit"
+    );
+    // The account picker shows `Esc back` only when a main session exists to
+    // return to; at the startup picker `Esc` is inert, so the hint is omitted.
+    assert_eq!(
+        hints_line(Screen::Login(LoginMode::AccountSelect), Focus::Chats, true),
+        "j/k navigate  Enter select  c create  l nsec  Esc back  q quit"
+    );
+    assert_eq!(
+        hints_line(Screen::Login(LoginMode::AccountSelect), Focus::Chats, false),
+        "j/k navigate  Enter select  c create  l nsec  q quit"
+    );
+    assert_eq!(
+        hints_line(Screen::Login(LoginMode::NsecEntry), Focus::Chats, false),
+        "Enter submit  Esc back"
+    );
+}
+
+#[test]
+fn daemon_start_args_forward_first_run_relays() {
+    assert_eq!(
+        daemon_start_args(&[], &[]),
+        vec!["daemon".to_owned(), "start".to_owned()]
+    );
+    assert_eq!(
+        daemon_start_args(
+            &["wss://a".to_owned(), "wss://b".to_owned()],
+            &["wss://c".to_owned()],
+        ),
+        vec![
+            "daemon".to_owned(),
+            "start".to_owned(),
+            "--discovery-relays".to_owned(),
+            "wss://a,wss://b".to_owned(),
+            "--default-account-relays".to_owned(),
+            "wss://c".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn account_setup_relay_fills_in_only_without_a_global_relay() {
+    let mut client = test_unused_client();
+    client.default_account_relays = vec!["wss://default".to_owned()];
+    client.discovery_relays = vec!["wss://discovery".to_owned()];
+    assert_eq!(
+        client.account_setup_relay().as_deref(),
+        Some("wss://default")
+    );
+
+    // Discovery relay is the fallback when no default account relay is set.
+    client.default_account_relays.clear();
+    assert_eq!(
+        client.account_setup_relay().as_deref(),
+        Some("wss://discovery")
+    );
+
+    // A global `--relay` already covers setup (`command` appends it), so none here.
+    client.relay = Some("wss://global".to_owned());
+    assert_eq!(client.account_setup_relay(), None);
+}
+
+#[test]
+fn slash_command_parser_handles_diagnostics_toggle() {
+    assert_eq!(
+        parse_slash_command("/diagnostics"),
+        Ok(SlashCommand::Diagnostics)
+    );
+    assert!(parse_slash_command("/diagnostics on").is_err());
+}
+
+#[test]
+fn diagnostics_slash_command_toggles_the_panel() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    assert!(!app.show_diagnostics);
+    app.run_slash_command(SlashCommand::Diagnostics)
+        .expect("toggle on");
+    assert!(app.show_diagnostics);
+    app.run_slash_command(SlashCommand::Diagnostics)
+        .expect("toggle off");
+    assert!(!app.show_diagnostics);
+}
+
+#[test]
+fn login_menu_keys_open_nsec_entry_and_quit() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::Login(LoginMode::Menu);
+
+    app.handle_key(char_key('l')).expect("l");
+    assert_eq!(app.screen, Screen::Login(LoginMode::NsecEntry));
+
+    app.screen = Screen::Login(LoginMode::Menu);
+    app.handle_key(char_key('q')).expect("q");
+    assert!(!app.running, "q quits from the login menu");
+}
+
+#[test]
+fn login_create_failure_stays_on_the_login_screen() {
+    // The fake exe does not exist, so create fails; the error must surface on the
+    // status line without leaving the login screen (errors never tear down).
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::Login(LoginMode::Menu);
+    app.handle_key(char_key('c')).expect("c");
+    assert_eq!(app.screen, Screen::Login(LoginMode::Menu));
+    assert!(
+        app.status.starts_with("error:"),
+        "expected surfaced error, got {}",
+        app.status
+    );
+}
+
+#[test]
+fn nsec_entry_accepts_masked_input_and_esc_returns_to_picker() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::Login(LoginMode::NsecEntry);
+    app.input.clear();
+
+    for character in "nsec1secret".chars() {
+        app.handle_key(char_key(character)).expect("char");
+    }
+    assert_eq!(app.input, "nsec1secret");
+    assert_eq!(masked_secret(&app.input), "***********");
+
+    app.handle_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE))
+        .expect("backspace");
+    assert_eq!(app.input, "nsec1secre");
+
+    // Esc clears the secret and returns to the picker (one account exists).
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .expect("esc");
+    assert!(app.input.is_empty(), "esc clears the entered secret");
+    assert_eq!(app.screen, Screen::Login(LoginMode::AccountSelect));
+}
+
+#[test]
+fn nsec_entry_esc_returns_to_the_menu_without_accounts() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.accounts.clear();
+    app.screen = Screen::Login(LoginMode::NsecEntry);
+    app.input = "partial".to_owned();
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .expect("esc");
+    assert!(app.input.is_empty());
+    assert_eq!(app.screen, Screen::Login(LoginMode::Menu));
+}
+
+#[test]
+fn nsec_entry_q_is_typed_not_a_quit() {
+    // `q` quits only outside the composer with an empty input; during nsec entry
+    // it is ordinary input and must append to the masked field, never quit.
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::Login(LoginMode::NsecEntry);
+    app.input.clear();
+
+    app.handle_key(char_key('q')).expect("q");
+
+    assert_eq!(app.input, "q", "q is entered into the masked nsec field");
+    assert!(app.running, "q must not quit during nsec entry");
+}
+
+#[test]
+fn nsec_entry_empty_submit_reports_and_stays() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::Login(LoginMode::NsecEntry);
+    app.input = "   ".to_owned();
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("enter");
+    assert_eq!(app.screen, Screen::Login(LoginMode::NsecEntry));
+    assert!(app.input.is_empty(), "the field is cleared on submit");
+    assert!(app.status.contains("empty"), "got {}", app.status);
+}
+
+#[test]
+fn account_picker_esc_discards_navigation_and_keeps_the_active_account() {
+    // Regression: picker navigation must not mutate the live selection. Before
+    // the fix, `j` moved `selected_account` directly, so `Esc` (which only calls
+    // `show_main` with no chat reload) left the status bar and
+    // `require_selected_local_account` reporting the highlighted account while
+    // the loaded chats/messages still belonged to the active one.
+    let alice = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &alice);
+    app.accounts.push(AccountRow {
+        account_id: "bb".repeat(32),
+        npub: "npub1bob".to_owned(),
+        display_name: Some("Bob".to_owned()),
+        local_signing: true,
+    });
+    // Alice (index 0) is the active account with her view loaded.
+    app.selected_account = 0;
+    app.messages_account_id = Some(alice.clone());
+    app.screen = Screen::Main;
+    app.focus = Focus::Chats;
+
+    // `A` opens the picker from the active session; highlight a *different*
+    // account, then cancel with `Esc`.
+    app.handle_key(char_key('A')).expect("A");
+    assert_eq!(app.screen, Screen::Login(LoginMode::AccountSelect));
+    app.handle_key(char_key('j')).expect("j");
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .expect("esc");
+
+    // Esc discards the highlight: the active account and its loaded view are
+    // untouched, so account-scoped commands still run against Alice.
+    assert_eq!(app.screen, Screen::Main);
+    assert_eq!(app.focus, Focus::Chats);
+    assert_eq!(app.selected_account, 0);
+    assert_eq!(app.require_selected_local_account().unwrap(), alice);
+    assert_eq!(app.messages_account_id.as_deref(), Some(alice.as_str()));
+}
+
+#[test]
+fn account_picker_enter_commits_the_highlighted_account() {
+    let alice = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &alice);
+    app.accounts.push(AccountRow {
+        account_id: "bb".repeat(32),
+        npub: "npub1bob".to_owned(),
+        display_name: Some("Bob".to_owned()),
+        local_signing: true,
+    });
+    app.selected_account = 0;
+    app.screen = Screen::Main;
+    app.focus = Focus::Chats;
+
+    // `A` opens the picker, `j` highlights Bob, `Enter` commits the selection.
+    app.handle_key(char_key('A')).expect("A");
+    app.handle_key(char_key('j')).expect("j");
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("enter");
+
+    assert_eq!(app.screen, Screen::Main);
+    assert_eq!(
+        app.selected_account, 1,
+        "Enter commits the highlighted account"
+    );
+}
+
+#[test]
+fn account_picker_esc_is_inert_before_main_is_active() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.entered_main = false;
+    app.screen = Screen::Login(LoginMode::AccountSelect);
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .expect("esc");
+    assert_eq!(
+        app.screen,
+        Screen::Login(LoginMode::AccountSelect),
+        "no main view to return to yet"
+    );
+}
+
+#[test]
+fn account_picker_l_opens_nsec_entry() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::Login(LoginMode::AccountSelect);
+    app.handle_key(char_key('l')).expect("l");
+    assert_eq!(app.screen, Screen::Login(LoginMode::NsecEntry));
+}
+
+#[test]
+fn shift_a_reopens_the_account_picker_from_the_chat_list() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::Main;
+    app.focus = Focus::Chats;
+    app.handle_key(char_key('A')).expect("A");
+    assert_eq!(app.screen, Screen::Login(LoginMode::AccountSelect));
+}
+
+#[test]
+fn enter_opens_the_chat_and_focuses_messages() {
+    let group_id = "bb".repeat(32);
+    let (_tempdir, client) =
+        test_json_client(r#"{"ok":true,"result":{"messages":[],"has_more_before":false}}"#);
+    let mut app = test_tui_app(client, &"aa".repeat(32));
+    app.daemon = DaemonView::default();
+    app.screen = Screen::Main;
+    app.focus = Focus::Chats;
+    app.chats = vec![ChatRow {
+        group_id: group_id.clone(),
+        name: "general".to_owned(),
+        archived: false,
+    }];
+    app.selected_chat = 0;
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("enter");
+    assert_eq!(
+        app.focus,
+        Focus::Messages,
+        "opening a chat moves focus to the messages pane"
+    );
+    assert_eq!(app.messages_group_id.as_deref(), Some(group_id.as_str()));
+}
+
+#[test]
+fn start_routes_to_login_menu_without_accounts() {
+    let (_tempdir, client) = test_json_client(r#"{"ok":true,"result":{"accounts":[]}}"#);
+    let mut app = test_tui_app(client, &"aa".repeat(32));
+    app.daemon = DaemonView::default();
+    app.start().expect("start");
+    assert_eq!(app.screen, Screen::Login(LoginMode::Menu));
+    assert!(app.accounts.is_empty());
+}
+
+#[test]
+fn start_enters_main_with_a_single_account() {
+    let account_id = "aa".repeat(32);
+    let response = format!(
+        r#"{{"ok":true,"result":{{"accounts":[{{"account_id":"{account_id}","npub":"npub1alice","local_signing":true}}]}}}}"#
+    );
+    let (_tempdir, client) = test_json_client(&response);
+    let mut app = test_tui_app(client, &account_id);
+    app.daemon = DaemonView::default();
+    app.start().expect("start");
+    assert_eq!(app.screen, Screen::Main);
+    assert_eq!(app.accounts.len(), 1);
+}
+
+#[test]
+fn start_opens_the_account_picker_with_several_accounts() {
+    let a = "aa".repeat(32);
+    let b = "bb".repeat(32);
+    let response = format!(
+        r#"{{"ok":true,"result":{{"accounts":[{{"account_id":"{a}","npub":"npub1a","local_signing":true}},{{"account_id":"{b}","npub":"npub1b","local_signing":true}}]}}}}"#
+    );
+    let (_tempdir, client) = test_json_client(&response);
+    let mut app = test_tui_app(client, &a);
+    app.daemon = DaemonView::default();
+    app.entered_main = false;
+    app.start().expect("start");
+    assert_eq!(app.screen, Screen::Login(LoginMode::AccountSelect));
+    assert_eq!(app.accounts.len(), 2);
+    assert!(
+        !app.entered_main,
+        "the startup picker has no active main yet"
+    );
+}
+
+#[test]
+fn start_with_explicit_account_enters_main_with_that_accounts_chats() {
+    // `wn tui --account <b>` with several accounts must honor the explicit
+    // selection and open the main view directly, not the account picker.
+    let a = "aa".repeat(32);
+    let b = "bb".repeat(32);
+    let response = format!(
+        r#"{{"ok":true,"result":{{"accounts":[{{"account_id":"{a}","npub":"npub1a","local_signing":true}},{{"account_id":"{b}","npub":"npub1b","local_signing":true}}],"chats":[]}}}}"#
+    );
+    let (_tempdir, client) = test_json_client(&response);
+    let mut app = test_tui_app(client, &a);
+    app.daemon = DaemonView::default();
+    app.initial_account = Some(b.clone());
+    app.entered_main = false;
+
+    app.start().expect("start");
+
+    assert_eq!(
+        app.screen,
+        Screen::Main,
+        "an explicit --account skips the picker"
+    );
+    assert_eq!(
+        app.selected_account, 1,
+        "the explicitly selected account is active"
+    );
+    assert_eq!(
+        app.messages_account_id.as_deref(),
+        Some(b.as_str()),
+        "the selected account's chats loaded"
+    );
+}
+
+fn rendered_buffer(app: &mut TuiApp) -> String {
+    let backend = ratatui::backend::TestBackend::new(100, 30);
+    let mut terminal = ratatui::Terminal::new(backend).expect("test terminal");
+    terminal.draw(|frame| app.render(frame)).expect("draw TUI");
+    terminal
+        .backend()
+        .buffer()
+        .content()
+        .iter()
+        .map(|cell| cell.symbol())
+        .collect::<String>()
+}
+
+#[test]
+fn main_frame_shows_chats_and_messages_with_bars_and_toggled_diagnostics() {
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Main;
+    app.focus = Focus::Chats;
+    app.chats = vec![ChatRow {
+        group_id: "bb".repeat(32),
+        name: "ops-room".to_owned(),
+        archived: false,
+    }];
+    let mut row = timeline_row("m0", 0);
+    row.from_display_name = Some("Al".to_owned());
+    row.display_text = "hello MESSAGEBODY".to_owned();
+    app.timeline = vec![row];
+    app.group_diagnostics = Some(GroupDiagnostics::unavailable(&"cc".repeat(32), "loading"));
+    app.status = "loaded 1 message(s)".to_owned();
+
+    let rendered = rendered_buffer(&mut app);
+    assert!(rendered.contains("Chats"), "chat panel present");
+    assert!(rendered.contains("ops-room"), "chat name visible");
+    assert!(rendered.contains("MESSAGEBODY"), "message body visible");
+    assert!(
+        !rendered.contains("Accounts"),
+        "the accounts pane is gone from the main view"
+    );
+    assert!(
+        rendered.contains("j/k navigate"),
+        "chats hints line present"
+    );
+    assert!(rendered.contains("daemon"), "status bar present");
+    assert!(
+        !rendered.contains("Diagnostics"),
+        "the diagnostics panel is off by default"
+    );
+
+    app.show_diagnostics = true;
+    let rendered = rendered_buffer(&mut app);
+    assert!(
+        rendered.contains("Diagnostics"),
+        "the diagnostics panel appears after /diagnostics"
+    );
+    assert!(
+        rendered.contains("ops-room"),
+        "chats still visible with diagnostics on"
+    );
+    assert!(
+        rendered.contains("MESSAGEBODY"),
+        "messages still visible with diagnostics on"
+    );
+}
+
+#[test]
+fn login_menu_frame_shows_options_and_hints() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::Login(LoginMode::Menu);
+    app.status = "no identities yet".to_owned();
+
+    let rendered = rendered_buffer(&mut app);
+    assert!(rendered.contains("White Noise"));
+    assert!(rendered.contains("Create a new identity"));
+    assert!(rendered.contains("Log in with an nsec"));
+    assert!(
+        rendered.contains("c create identity"),
+        "login hints line present"
+    );
+}
+
+#[test]
+fn nsec_entry_frame_masks_the_secret() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::Login(LoginMode::NsecEntry);
+    app.input = "nsec1supersecret".to_owned();
+
+    let rendered = rendered_buffer(&mut app);
+    assert!(
+        !rendered.contains("nsec1supersecret"),
+        "the secret must never render"
+    );
+    assert!(
+        rendered.contains("****"),
+        "the field renders as mask characters"
     );
 }

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -606,64 +606,6 @@ fn chat_label_keeps_unread_count_when_truncated() {
 }
 
 #[test]
-fn message_lines_keep_chronological_order_and_summarize_stream_markers() {
-    let mut messages = [
-            serde_json::json!({
-                "message_id": "03",
-                "recorded_at": 30,
-                "received_at": 30,
-                "direction": "sent",
-                "from": "alice",
-                "plaintext": "{\"marmot_payload\":\"marmot.agent_text_stream.v1\"}",
-                "agent_text_stream": {
-                    "kind": "final",
-                    "stream_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                    "final_text_or_reference": "hello from the stream",
-                    "transcript_hash": "4c88175697a7232454d93beeeb3d97eb487d9042fc5d37f75e3f9297e626ad5e",
-                    "chunk_count": 3
-                }
-            }),
-            serde_json::json!({
-                "message_id": "01",
-                "recorded_at": 10,
-                "received_at": 30,
-                "direction": "sent",
-                "from": "alice",
-                "plaintext": "hello bob from alice"
-            }),
-            serde_json::json!({
-                "message_id": "02",
-                "recorded_at": 20,
-                "received_at": 30,
-                "direction": "sent",
-                "from": "alice",
-                "plaintext": "{\"marmot_payload\":\"marmot.agent_text_stream.v1\"}",
-                "agent_text_stream": {
-                    "kind": "start",
-                    "stream_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                    "route": "brokered_quic",
-                    "quic_candidates": ["quic://127.0.0.1:4450"]
-                }
-            }),
-        ]
-        .iter()
-        .filter_map(parse_message)
-        .collect::<Vec<_>>();
-    sort_messages_chronologically(&mut messages);
-
-    let rendered = message_lines(&messages, None)
-        .iter()
-        .map(line_text)
-        .filter(|line| !line.is_empty())
-        .collect::<Vec<_>>();
-
-    assert_eq!(rendered[0], "me: hello bob from alice");
-    assert_eq!(rendered[1], "me: hello from the stream");
-    assert!(rendered.iter().all(|line| !line.contains("marmot_payload")));
-    assert!(rendered.iter().all(|line| !line.contains("stream start")));
-}
-
-#[test]
 fn terminal_safe_text_strips_bidi_and_zero_width_format_characters() {
     assert_eq!(
         terminal_safe_text(
@@ -751,21 +693,15 @@ fn terminal_safe_text_preserves_legitimate_visible_and_combining_text() {
 
 #[test]
 fn render_lines_strip_terminal_control_sequences_from_untrusted_text() {
-    let messages = vec![MessageRow {
-        message_id: "01".to_owned(),
-        direction: "received".to_owned(),
-        from: "alice".to_owned(),
-        from_display_name: Some("ali\u{1b}]0;pwn\u{7}ce".to_owned()),
-        plaintext: "hi\u{1b}[2J\nbob".to_owned(),
-        display_text: "hi\u{1b}[2J\nbob".to_owned(),
-        recorded_at: 1,
-        received_at: 1,
-    }];
-    let rendered = message_lines(&messages, None)
+    let mut row = timeline_row("01", 0);
+    row.from = "alice".to_owned();
+    row.from_display_name = Some("ali\u{1b}]0;pwn\u{7}ce".to_owned());
+    row.display_text = "hi\u{1b}[2Jbob".to_owned();
+    let rendered = timeline_row_lines(&row, None)
         .into_iter()
         .map(|line| line_text(&line))
         .collect::<Vec<_>>();
-    assert_eq!(rendered[0], "ali]0;pwnce: hi[2Jbob");
+    assert_eq!(hhmm_body(&rendered[0]), "ali]0;pwnce: hi[2Jbob");
 
     let previews = vec![LiveStreamPreview {
         group_id: "group-a".to_owned(),
@@ -977,11 +913,9 @@ fn stream_preview_lines_hide_empty_and_completed_previews() {
 fn subscription_stream_deltas_update_live_preview_text() {
     let group_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     let stream_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-    let mut messages = Vec::new();
     let mut previews = Vec::new();
 
     apply_subscription_result(
-        &mut messages,
         &mut previews,
         &serde_json::json!({
             "type": "agent_stream_delta",
@@ -991,10 +925,8 @@ fn subscription_stream_deltas_update_live_preview_text() {
                 "text": "hello "
             }
         }),
-        false,
     );
     apply_subscription_result(
-        &mut messages,
         &mut previews,
         &serde_json::json!({
             "type": "agent_stream_delta",
@@ -1004,7 +936,6 @@ fn subscription_stream_deltas_update_live_preview_text() {
                 "text": "stream"
             }
         }),
-        false,
     );
 
     let rendered_preview = stream_preview_lines(&DaemonView::default(), &previews, Some(group_id))
@@ -1014,42 +945,6 @@ fn subscription_stream_deltas_update_live_preview_text() {
     .map(|span| span.content.as_ref())
     .collect::<String>();
     assert_eq!(rendered_preview, "stream: hello stream");
-}
-
-#[test]
-fn subscription_messages_keep_bounded_scrollback() {
-    let mut messages = Vec::new();
-    let mut previews = Vec::new();
-
-    for index in 0..(TUI_MESSAGE_SCROLLBACK_LIMIT + 5) {
-        let message_id = format!("{index:04}");
-        apply_subscription_result(
-            &mut messages,
-            &mut previews,
-            &serde_json::json!({
-                "type": "message",
-                "message": {
-                    "message_id": message_id,
-                    "direction": "received",
-                    "from": "alice",
-                    "plaintext": "hello",
-                    "recorded_at": index,
-                    "received_at": index
-                }
-            }),
-            false,
-        );
-    }
-
-    assert_eq!(messages.len(), TUI_MESSAGE_SCROLLBACK_LIMIT);
-    assert_eq!(
-        messages.first().map(|message| message.message_id.as_str()),
-        Some("0005")
-    );
-    assert_eq!(
-        messages.last().map(|message| message.message_id.as_str()),
-        Some("1004")
-    );
 }
 
 #[test]
@@ -1161,12 +1056,13 @@ fn local_stream_preview_ignores_echoed_deltas() {
 }
 
 #[test]
-fn subscription_final_message_replaces_stream_marker_with_mls_text() {
-    let mut messages = Vec::new();
+fn subscription_final_message_removes_live_stream_preview() {
+    // The plain feed no longer populates the pane (the timeline feed owns it),
+    // but it still clears the live stream preview when the agent stream's final
+    // row lands so a completed stream stops rendering in the pane's bottom block.
     let mut previews = Vec::new();
 
     apply_subscription_result(
-        &mut messages,
         &mut previews,
         &serde_json::json!({
             "type": "agent_stream_start",
@@ -1182,11 +1078,9 @@ fn subscription_final_message_replaces_stream_marker_with_mls_text() {
                 }
             }
         }),
-        false,
     );
     assert_eq!(previews.len(), 1);
     apply_subscription_result(
-        &mut messages,
         &mut previews,
         &serde_json::json!({
             "type": "agent_stream_final",
@@ -1203,15 +1097,8 @@ fn subscription_final_message_replaces_stream_marker_with_mls_text() {
                 }
             }
         }),
-        false,
     );
 
-    let rendered = message_lines(&messages, None)
-        .iter()
-        .map(line_text)
-        .filter(|line| !line.is_empty())
-        .collect::<Vec<_>>();
-    assert_eq!(rendered, vec!["alice: hello from MLS"]);
     assert!(previews.is_empty());
 }
 
@@ -1219,12 +1106,10 @@ fn subscription_final_message_replaces_stream_marker_with_mls_text() {
 fn all_chat_subscription_marks_nonselected_messages_unread() {
     let selected_group_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     let unread_group_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-    let mut messages = Vec::new();
     let mut previews = Vec::new();
     let mut unread_counts = HashMap::new();
 
     let status = apply_tui_subscription_result(
-        &mut messages,
         &mut previews,
         &mut unread_counts,
         Some(selected_group_id),
@@ -1241,7 +1126,6 @@ fn all_chat_subscription_marks_nonselected_messages_unread() {
         }),
     );
 
-    assert_eq!(messages.len(), 0);
     assert_eq!(unread_counts.get(unread_group_id), Some(&1));
     assert_eq!(
         status,
@@ -1254,7 +1138,6 @@ fn all_chat_subscription_cleans_up_off_chat_stream_preview_without_appending_mes
     let selected_group_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     let unread_group_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     let stream_id = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
-    let mut messages = Vec::new();
     let mut previews = vec![LiveStreamPreview {
         group_id: unread_group_id.to_owned(),
         stream_id: stream_id.to_owned(),
@@ -1267,7 +1150,6 @@ fn all_chat_subscription_cleans_up_off_chat_stream_preview_without_appending_mes
     let mut unread_counts = HashMap::new();
 
     apply_tui_subscription_result(
-        &mut messages,
         &mut previews,
         &mut unread_counts,
         Some(selected_group_id),
@@ -1289,20 +1171,19 @@ fn all_chat_subscription_cleans_up_off_chat_stream_preview_without_appending_mes
         }),
     );
 
-    assert!(messages.is_empty());
     assert!(previews.is_empty());
     assert_eq!(unread_counts.get(unread_group_id), Some(&1));
 }
 
 #[test]
-fn all_chat_subscription_applies_selected_messages_without_unread_count() {
+fn all_chat_subscription_does_not_count_selected_group_as_unread() {
+    // A message for the loaded group must not bump its unread count; the pane is
+    // driven by the timeline feed, so the plain feed only counts off-screen groups.
     let selected_group_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-    let mut messages = Vec::new();
     let mut previews = Vec::new();
     let mut unread_counts = HashMap::new();
 
-    apply_tui_subscription_result(
-        &mut messages,
+    let status = apply_tui_subscription_result(
         &mut previews,
         &mut unread_counts,
         Some(selected_group_id),
@@ -1319,21 +1200,18 @@ fn all_chat_subscription_applies_selected_messages_without_unread_count() {
         }),
     );
 
+    assert_eq!(status, None);
     assert_eq!(unread_counts.get(selected_group_id), None);
-    assert_eq!(messages.len(), 1);
-    assert_eq!(messages[0].display_text, "hello here");
 }
 
 #[test]
 fn all_chat_subscription_ignores_initial_replay_for_unread_counts() {
     let selected_group_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     let replay_group_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-    let mut messages = Vec::new();
     let mut previews = Vec::new();
     let mut unread_counts = HashMap::new();
 
     let status = apply_tui_subscription_result(
-        &mut messages,
         &mut previews,
         &mut unread_counts,
         Some(selected_group_id),
@@ -1351,7 +1229,6 @@ fn all_chat_subscription_ignores_initial_replay_for_unread_counts() {
     );
 
     assert_eq!(status, None);
-    assert!(messages.is_empty());
     assert!(unread_counts.is_empty());
 }
 
@@ -1396,7 +1273,6 @@ fn message_subscription_gates_on_loaded_chat_not_highlighted_chat() {
     .expect("send highlighted message event");
 
     assert!(app.drain_message_subscription());
-    assert!(app.messages.is_empty());
     assert_eq!(app.unread_counts.get(highlighted_group_id), Some(&1));
 
     tx.send(SubscriptionEvent::Result(serde_json::json!({
@@ -1414,9 +1290,6 @@ fn message_subscription_gates_on_loaded_chat_not_highlighted_chat() {
 
     assert!(app.drain_message_subscription());
     assert_eq!(app.unread_counts.get(loaded_group_id), None);
-    assert_eq!(app.messages.len(), 1);
-    assert_eq!(app.messages[0].message_id, "loaded");
-    assert_eq!(app.messages[0].display_text, "hello loaded");
 }
 
 #[test]
@@ -1455,7 +1328,7 @@ fn refresh_accounts_clears_unread_counts_when_no_accounts_remain() {
 
     assert!(app.accounts.is_empty());
     assert!(app.chats.is_empty());
-    assert!(app.messages.is_empty());
+    assert!(app.timeline.is_empty());
     assert!(app.unread_counts.is_empty());
     assert!(app.chat_subscription.is_none());
     assert!(app.message_subscription.is_none());
@@ -1474,7 +1347,7 @@ fn refresh_chats_starts_account_wide_stream_when_no_chats_are_visible() {
     app.refresh_chats().expect("refresh chats");
 
     assert!(app.chats.is_empty());
-    assert!(app.messages.is_empty());
+    assert!(app.timeline.is_empty());
     assert_eq!(
         app.message_subscription
             .as_ref()
@@ -1517,7 +1390,7 @@ fn refresh_chats_clears_stale_send_targets_for_public_only_account() {
     app.refresh_chats().expect("refresh chats");
 
     assert!(app.chats.is_empty());
-    assert!(app.messages.is_empty());
+    assert!(app.timeline.is_empty());
     assert!(app.messages_account_id.is_none());
     assert!(app.messages_group_id.is_none());
     assert!(app.chat_subscription.is_none());
@@ -1535,6 +1408,23 @@ fn message_subscription_skips_initial_replay() {
             "subscribe".to_owned(),
             "--limit".to_owned(),
             "0".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn timeline_subscription_pins_the_initial_page_size() {
+    // Without --limit the daemon's default 50-row page transiently clobbers the
+    // snapshot's accurate has_more_before; pin it to the TUI page size.
+    assert_eq!(
+        timeline_subscription_args("group-1"),
+        vec![
+            "messages".to_owned(),
+            "timeline".to_owned(),
+            "subscribe".to_owned(),
+            "group-1".to_owned(),
+            "--limit".to_owned(),
+            TUI_TIMELINE_PAGE_SIZE.to_string(),
         ]
     );
 }
@@ -1668,31 +1558,11 @@ fn account_rows_prefer_profile_display_name_then_name_then_npub() {
 }
 
 #[test]
-fn message_lines_use_sender_display_name_when_available() {
-    let messages = [serde_json::json!({
-        "message_id": "01",
-        "recorded_at": 10,
-        "received_at": 10,
-        "direction": "received",
-        "from": "abc123",
-        "from_display_name": "Alice Example",
-        "plaintext": "hello"
-    })]
-    .iter()
-    .filter_map(parse_message)
-    .collect::<Vec<_>>();
-
-    let rendered = message_lines(&messages, None)
-        .iter()
-        .map(line_text)
-        .filter(|line| !line.is_empty())
-        .collect::<Vec<_>>();
-
-    assert_eq!(rendered, vec!["Alice Example: hello"]);
-}
-
-#[test]
 fn message_account_row_uses_loaded_account_not_highlighted_account() {
+    // The pane colors a row green when it belongs to the *loaded* account, even
+    // when a different account is highlighted in the accounts list. A received
+    // row whose sender is the loaded account (alice) must render green; a row
+    // from someone else renders cyan.
     let alice = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     let bob = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     let mut app = test_tui_app(test_unused_client(), alice);
@@ -1705,37 +1575,29 @@ fn message_account_row_uses_loaded_account_not_highlighted_account() {
     app.selected_account = 1;
     app.messages_account_id = Some(alice.to_owned());
 
-    let rendered = message_lines(
-        &[
-            MessageRow {
-                message_id: "01".to_owned(),
-                direction: "sent".to_owned(),
-                from: alice.to_owned(),
-                from_display_name: None,
-                plaintext: "from alice".to_owned(),
-                display_text: "from alice".to_owned(),
-                recorded_at: 1,
-                received_at: 1,
-            },
-            MessageRow {
-                message_id: "02".to_owned(),
-                direction: "received".to_owned(),
-                from: bob.to_owned(),
-                from_display_name: Some("Bob".to_owned()),
-                plaintext: "from bob".to_owned(),
-                display_text: "from bob".to_owned(),
-                recorded_at: 2,
-                received_at: 2,
-            },
-        ],
-        app.message_account_row(),
-    )
-    .iter()
-    .map(line_text)
-    .filter(|line| !line.is_empty())
-    .collect::<Vec<_>>();
+    let mut from_alice = timeline_row("01", 1);
+    from_alice.direction = "received".to_owned();
+    from_alice.from = alice.to_owned();
+    let mut from_bob = timeline_row("02", 2);
+    from_bob.direction = "received".to_owned();
+    from_bob.from = bob.to_owned();
+    from_bob.from_display_name = Some("Bob".to_owned());
 
-    assert_eq!(rendered, vec!["me: from alice", "Bob: from bob"]);
+    let selected_account = app.message_account_row();
+    assert_eq!(
+        timeline_row_lines(&from_alice, selected_account)[0].spans[1]
+            .style
+            .fg,
+        Some(Color::Green),
+        "a row from the loaded account is colored as self"
+    );
+    assert_eq!(
+        timeline_row_lines(&from_bob, selected_account)[0].spans[1]
+            .style
+            .fg,
+        Some(Color::Cyan),
+        "a row from another sender is colored as other"
+    );
 }
 
 #[test]
@@ -1758,19 +1620,6 @@ fn move_index_clamps_at_list_edges() {
     assert_eq!(move_index(0, 3, 1), 1);
     assert_eq!(move_index(2, 3, 1), 2);
     assert_eq!(move_index(0, 0, 1), 0);
-}
-
-#[test]
-fn messages_scroll_offsets_anchor_to_bottom_and_clamp() {
-    // Content fits the viewport: no scrolling is possible.
-    assert_eq!(messages_scroll_offsets(5, 10, 0), (0, 0));
-    assert_eq!(messages_scroll_offsets(5, 10, 4), (0, 0));
-    // Pinned to the bottom shows the newest lines (offset = overflow).
-    assert_eq!(messages_scroll_offsets(40, 10, 0), (0, 30));
-    // Scrolling up moves the top offset toward the first line.
-    assert_eq!(messages_scroll_offsets(40, 10, 12), (12, 18));
-    // Scrollback past the top clamps to the first line.
-    assert_eq!(messages_scroll_offsets(40, 10, u16::MAX), (30, 0));
 }
 
 fn char_key(character: char) -> KeyEvent {
@@ -1837,12 +1686,12 @@ fn test_tui_app(client: WnClient, account_id: &str) -> TuiApp {
         messages_group_id: None,
         unread_counts: HashMap::new(),
         show_archived_chats: false,
-        messages: Vec::new(),
-        messages_scroll: 0,
-        messages_viewport: 0,
+        timeline: Vec::new(),
+        timeline_scroll: TimelineScroll::default(),
         live_stream_previews: Vec::new(),
         chat_subscription: None,
         message_subscription: None,
+        timeline_subscription: None,
         group_state_subscription: None,
         daemon: DaemonView {
             running: true,
@@ -2059,4 +1908,1655 @@ fn test_sleep_child() -> Child {
         .stderr(Stdio::null())
         .spawn()
         .expect("spawn timeout test process")
+}
+
+// ── Phase 1 timeline: rows, fold, scroll, heights, line building ────────
+
+#[test]
+fn parse_timeline_row_reads_core_fields() {
+    let value = serde_json::json!({
+        "message_id": "09be",
+        "source_message_id": "5b10",
+        "direction": "sent",
+        "group_id": "cdaa",
+        "from": "5a26",
+        "from_display_name": "Witty Gecko",
+        "plaintext": "msg-15",
+        "kind": 9,
+        "timeline_at": 1784070726u64,
+        "received_at": 1784070726u64,
+        "reply_to_message_id": null,
+        "reply_preview": null,
+        "media": null,
+        "agent_text_stream": null,
+        "reactions": { "by_emoji": {}, "user_reactions": [] },
+        "deleted": false,
+        "deleted_by_message_id": null
+    });
+
+    let row = parse_timeline_row(&value).expect("row parses");
+
+    assert_eq!(row.message_id, "09be");
+    assert_eq!(row.direction, "sent");
+    assert_eq!(row.from, "5a26");
+    assert_eq!(row.from_display_name.as_deref(), Some("Witty Gecko"));
+    assert_eq!(row.plaintext, "msg-15");
+    assert_eq!(row.display_text, "msg-15");
+    assert_eq!(row.timeline_at, 1784070726);
+    assert_eq!(row.received_at, 1784070726);
+    assert!(!row.deleted);
+    assert!(row.reactions.is_empty());
+    assert!(row.reply.is_none());
+    assert!(row.attachments.is_empty());
+}
+
+#[test]
+fn parse_timeline_row_tallies_reactions_by_emoji_in_deterministic_order() {
+    let value = serde_json::json!({
+        "message_id": "1",
+        "plaintext": "hi",
+        "reactions": {
+            "by_emoji": {
+                "\u{2764}": ["a", "b"],
+                "\u{1f44d}": ["1e23"]
+            },
+            "user_reactions": [{ "emoji": "\u{2764}" }]
+        }
+    });
+
+    let row = parse_timeline_row(&value).expect("row parses");
+
+    // Deterministic order regardless of JSON object ordering, and count is the
+    // reactor-list length.
+    assert_eq!(
+        row.reactions,
+        vec![
+            TimelineReaction {
+                emoji: "\u{2764}".to_owned(),
+                count: 2
+            },
+            TimelineReaction {
+                emoji: "\u{1f44d}".to_owned(),
+                count: 1
+            },
+        ]
+    );
+}
+
+#[test]
+fn parse_timeline_row_reads_hydrated_reply_preview() {
+    let value = serde_json::json!({
+        "message_id": "2",
+        "plaintext": "a reply",
+        "reply_to_message_id": "parent-id",
+        "reply_preview": {
+            "message_id_hex": "parent-id",
+            "sender": "Alice",
+            "plaintext": "the original",
+            "kind": 9,
+            "deleted": false
+        }
+    });
+
+    let reply = parse_timeline_row(&value)
+        .expect("row parses")
+        .reply
+        .expect("reply present");
+
+    assert_eq!(reply.reply_to_message_id, "parent-id");
+    let preview = reply.preview.expect("preview hydrated");
+    assert_eq!(preview.sender.as_deref(), Some("Alice"));
+    assert_eq!(preview.plaintext, "the original");
+    assert!(!preview.deleted);
+}
+
+#[test]
+fn parse_timeline_row_reply_without_preview_keeps_parent_id_only() {
+    let value = serde_json::json!({
+        "message_id": "3",
+        "plaintext": "orphan reply",
+        "reply_to_message_id": "unresolved-parent",
+        "reply_preview": null
+    });
+
+    let reply = parse_timeline_row(&value)
+        .expect("row parses")
+        .reply
+        .expect("reply present");
+
+    assert_eq!(reply.reply_to_message_id, "unresolved-parent");
+    assert!(reply.preview.is_none());
+}
+
+#[test]
+fn parse_timeline_row_reads_media_imeta_mime_and_filename() {
+    let value = serde_json::json!({
+        "message_id": "4",
+        "plaintext": "look",
+        "media": {
+            "imeta": [
+                [
+                    "imeta",
+                    "v encrypted-media-v1",
+                    "locator blossom-v1 https://blossom.example/abc",
+                    "ciphertext_sha256 deadbeef",
+                    "plaintext_sha256 cafebabe",
+                    "nonce 00112233",
+                    "m image/png",
+                    "filename pixel.png"
+                ],
+                [
+                    "imeta",
+                    "m application/pdf",
+                    "filename spec.pdf"
+                ]
+            ]
+        }
+    });
+
+    let attachments = parse_timeline_row(&value).expect("row parses").attachments;
+
+    assert_eq!(
+        attachments,
+        vec![
+            TimelineAttachment {
+                mime: Some("image/png".to_owned()),
+                filename: Some("pixel.png".to_owned()),
+            },
+            TimelineAttachment {
+                mime: Some("application/pdf".to_owned()),
+                filename: Some("spec.pdf".to_owned()),
+            },
+        ]
+    );
+}
+
+#[test]
+fn parse_timeline_row_filters_agent_stream_start_marker() {
+    let value = serde_json::json!({
+        "message_id": "5",
+        "plaintext": "{}",
+        "agent_text_stream": { "kind": "start", "stream_id": "abc" }
+    });
+    assert!(parse_timeline_row(&value).is_none());
+}
+
+#[test]
+fn parse_timeline_row_marks_tombstone() {
+    let value = serde_json::json!({
+        "message_id": "6",
+        "plaintext": "",
+        "deleted": true,
+        "deleted_by_message_id": "a83f"
+    });
+    let row = parse_timeline_row(&value).expect("tombstone row is kept");
+    assert!(row.deleted);
+    assert_eq!(row.plaintext, "");
+}
+
+#[test]
+fn parse_timeline_row_derives_group_system_and_stream_summaries() {
+    let group_system = serde_json::json!({
+        "message_id": "7",
+        "kind": 1210,
+        "from_display_name": "alice",
+        "plaintext": "{\"system_type\":\"member_added\",\"data\":{\"subject\":\"bob\"}}"
+    });
+    assert_eq!(
+        parse_timeline_row(&group_system).unwrap().display_text,
+        "alice added bob"
+    );
+
+    let stream_final = serde_json::json!({
+        "message_id": "8",
+        "plaintext": "{\"marmot_payload\":\"marmot.agent_text_stream.v1\"}",
+        "agent_text_stream": {
+            "kind": "final",
+            "stream_id": "s1",
+            "final_text_or_reference": "hello from the stream"
+        }
+    });
+    assert_eq!(
+        parse_timeline_row(&stream_final).unwrap().display_text,
+        "hello from the stream"
+    );
+}
+
+#[test]
+fn parse_timeline_event_reads_ready_initial_and_projection() {
+    let ready = serde_json::json!({
+        "trigger": "TimelineSubscriptionReady",
+        "type": "timeline_subscription_ready"
+    });
+    assert!(matches!(parse_timeline_event(&ready), TimelineEvent::Ready));
+
+    let initial = serde_json::json!({
+        "trigger": "InitialTimelinePage",
+        "type": "initial_timeline_page",
+        "has_more_before": true,
+        "messages": [
+            { "message_id": "a", "plaintext": "one", "timeline_at": 1 },
+            { "message_id": "b", "plaintext": "two", "timeline_at": 2 }
+        ]
+    });
+    match parse_timeline_event(&initial) {
+        TimelineEvent::InitialPage {
+            rows,
+            has_more_before,
+        } => {
+            assert!(has_more_before);
+            assert_eq!(rows.len(), 2);
+            assert_eq!(rows[0].message_id, "a");
+        }
+        other => panic!("expected initial page, got {other:?}"),
+    }
+
+    let projection = serde_json::json!({
+        "trigger": "TimelineProjectionUpdated",
+        "type": "timeline_projection_updated",
+        "group_id": "cdaa",
+        "changes": [
+            {
+                "type": "upsert",
+                "trigger": "NewMessage",
+                "message": { "message_id": "c", "plaintext": "three", "timeline_at": 3 }
+            },
+            { "type": "remove", "message_id": "d", "reason": "expired" }
+        ]
+    });
+    match parse_timeline_event(&projection) {
+        TimelineEvent::ProjectionUpdated { group_id, changes } => {
+            assert_eq!(group_id, "cdaa");
+            assert_eq!(changes.len(), 2);
+            assert!(matches!(&changes[0], TimelineChange::Upsert(row) if row.message_id == "c"));
+            assert!(
+                matches!(&changes[1], TimelineChange::Remove { message_id } if message_id == "d")
+            );
+        }
+        other => panic!("expected projection update, got {other:?}"),
+    }
+
+    let unknown = serde_json::json!({ "type": "something_else" });
+    assert!(matches!(
+        parse_timeline_event(&unknown),
+        TimelineEvent::Other
+    ));
+}
+
+/// Build a minimal timeline row for fold/scroll tests.
+fn timeline_row(message_id: &str, timeline_at: u64) -> TimelineRow {
+    TimelineRow {
+        message_id: message_id.to_owned(),
+        direction: "received".to_owned(),
+        from: "someone".to_owned(),
+        from_display_name: None,
+        plaintext: format!("msg {message_id}"),
+        display_text: format!("msg {message_id}"),
+        timeline_at,
+        received_at: timeline_at,
+        deleted: false,
+        reactions: Vec::new(),
+        reply: None,
+        attachments: Vec::new(),
+    }
+}
+
+fn timeline_ids(rows: &[TimelineRow]) -> Vec<&str> {
+    rows.iter().map(|row| row.message_id.as_str()).collect()
+}
+
+/// The rendered `[HH:MM] ` timestamp is local wall-clock and machine-dependent
+/// (`local_hhmm`), so row-content tests assert its fixed 8-column shape and
+/// return the text after it instead of a timezone-specific value. The formatting
+/// arithmetic is covered deterministically by `format_hhmm_renders_local_offset`.
+fn hhmm_body(text: &str) -> String {
+    let bytes = text.as_bytes();
+    assert!(
+        bytes.len() >= 8
+            && bytes[0] == b'['
+            && bytes[1].is_ascii_digit()
+            && bytes[2].is_ascii_digit()
+            && bytes[3] == b':'
+            && bytes[4].is_ascii_digit()
+            && bytes[5].is_ascii_digit()
+            && bytes[6] == b']'
+            && bytes[7] == b' ',
+        "expected a [HH:MM] prefix, got {text:?}"
+    );
+    text[8..].to_owned()
+}
+
+#[test]
+fn format_hhmm_renders_local_offset() {
+    // 12:34:56 UTC.
+    assert_eq!(format_hhmm_with_offset(45_296, 0), "12:34");
+    // Same instant five hours west of UTC.
+    assert_eq!(format_hhmm_with_offset(45_296, -5 * 3_600), "07:34");
+    // Wall-clock wraps around midnight without panicking on the negative.
+    assert_eq!(format_hhmm_with_offset(0, -3_600), "23:00");
+}
+
+#[test]
+fn upsert_timeline_row_keeps_sorted_by_timeline_at_then_id() {
+    let mut rows = Vec::new();
+    upsert_timeline_row(&mut rows, timeline_row("b", 20));
+    upsert_timeline_row(&mut rows, timeline_row("a", 10));
+    // Same second: tiebreak by message_id ascending.
+    upsert_timeline_row(&mut rows, timeline_row("z", 20));
+    upsert_timeline_row(&mut rows, timeline_row("y", 20));
+
+    assert_eq!(timeline_ids(&rows), vec!["a", "b", "y", "z"]);
+}
+
+#[test]
+fn upsert_timeline_row_is_idempotent_by_message_id() {
+    let mut rows = Vec::new();
+    upsert_timeline_row(&mut rows, timeline_row("a", 10));
+    upsert_timeline_row(&mut rows, timeline_row("b", 20));
+
+    // Re-applying the same row (as duplicated projection events do) must not
+    // append a second copy and must leave the list unchanged in effect.
+    let before = rows.clone();
+    upsert_timeline_row(&mut rows, timeline_row("a", 10));
+    upsert_timeline_row(&mut rows, timeline_row("b", 20));
+
+    assert_eq!(rows, before);
+    assert_eq!(rows.len(), 2);
+}
+
+#[test]
+fn upsert_timeline_row_replaces_existing_row_content() {
+    let mut rows = vec![timeline_row("a", 10)];
+    let mut updated = timeline_row("a", 10);
+    updated.reactions = vec![TimelineReaction {
+        emoji: "\u{1f44d}".to_owned(),
+        count: 1,
+    }];
+    upsert_timeline_row(&mut rows, updated);
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].reactions.len(), 1);
+}
+
+#[test]
+fn apply_timeline_change_reports_insert_update_and_remove() {
+    let mut rows = vec![timeline_row("a", 10), timeline_row("c", 30)];
+
+    // New row inserted in sorted position between a and c.
+    let outcome = apply_timeline_change(
+        &mut rows,
+        TimelineChange::Upsert(Box::new(timeline_row("b", 20))),
+    );
+    assert_eq!(outcome, TimelineFoldOutcome::Inserted(1));
+    assert_eq!(timeline_ids(&rows), vec!["a", "b", "c"]);
+
+    // Same id again = update, not a second row (duplicated events).
+    let outcome = apply_timeline_change(
+        &mut rows,
+        TimelineChange::Upsert(Box::new(timeline_row("b", 20))),
+    );
+    assert_eq!(outcome, TimelineFoldOutcome::Updated(1));
+    assert_eq!(rows.len(), 3);
+
+    // Remove drops the row.
+    let outcome = apply_timeline_change(
+        &mut rows,
+        TimelineChange::Remove {
+            message_id: "b".to_owned(),
+        },
+    );
+    assert_eq!(outcome, TimelineFoldOutcome::Removed(1));
+    assert_eq!(timeline_ids(&rows), vec!["a", "c"]);
+
+    // Removing an unknown id changes nothing.
+    let outcome = apply_timeline_change(
+        &mut rows,
+        TimelineChange::Remove {
+            message_id: "zzz".to_owned(),
+        },
+    );
+    assert_eq!(outcome, TimelineFoldOutcome::Unchanged);
+    assert_eq!(rows.len(), 2);
+}
+
+#[test]
+fn oldest_timeline_cursor_reads_first_row() {
+    assert!(oldest_timeline_cursor(&[]).is_none());
+    let rows = vec![timeline_row("a", 10), timeline_row("b", 20)];
+    assert_eq!(
+        oldest_timeline_cursor(&rows),
+        Some(TimelineCursor {
+            timeline_at: 10,
+            message_id: "a".to_owned(),
+        })
+    );
+}
+
+#[test]
+fn timeline_scroll_default_is_pinned_to_newest() {
+    let scroll = TimelineScroll::default();
+    assert!(scroll.is_pinned());
+    assert_eq!(scroll.offset, 0);
+    // With no explicit selection, the newest message is selected.
+    assert_eq!(scroll.resolved_selection(4), Some(3));
+    assert!(scroll.resolved_selection(0).is_none());
+}
+
+#[test]
+fn timeline_scroll_stays_pinned_when_message_arrives_at_bottom() {
+    let mut scroll = TimelineScroll::default();
+    // A new newest row is appended: old len 3 -> new len 4, index 3.
+    scroll.on_insert(3, 4);
+    assert!(scroll.is_pinned());
+    assert_eq!(scroll.offset, 0);
+}
+
+#[test]
+fn timeline_scroll_holds_position_when_scrolled_up_and_message_arrives() {
+    // Reading history, 2 messages up from the bottom.
+    let mut scroll = TimelineScroll {
+        offset: 2,
+        ..TimelineScroll::default()
+    };
+    // A new newest row is appended (old len 4 -> new len 5, index 4).
+    scroll.on_insert(4, 5);
+    assert_eq!(scroll.offset, 3, "offset bumps by one so content stays put");
+}
+
+#[test]
+fn timeline_scroll_prepend_keeps_same_message_selected_and_visible() {
+    // Reading the top of a 5-row list.
+    let mut scroll = TimelineScroll {
+        offset: 4,
+        selection: Some(0),
+        visible_range: Some((0, 2)),
+        ..TimelineScroll::default()
+    };
+
+    // Page in 5 older rows at the front.
+    scroll.on_prepend(5);
+
+    // The same logical rows stay selected and visible; only their absolute
+    // indices shifted by N. Offset counts from the unchanged bottom, so it must
+    // NOT move (moving it would jump the view to the newly loaded oldest rows).
+    assert_eq!(scroll.selection, Some(5));
+    assert_eq!(scroll.visible_range, Some((5, 7)));
+    assert_eq!(scroll.offset, 4);
+}
+
+#[test]
+fn timeline_scroll_prepend_of_nothing_is_a_noop() {
+    let mut scroll = TimelineScroll {
+        offset: 2,
+        selection: Some(1),
+        visible_range: Some((0, 3)),
+        ..TimelineScroll::default()
+    };
+    let before = scroll.clone();
+    scroll.on_prepend(0);
+    assert_eq!(scroll, before);
+}
+
+#[test]
+fn timeline_scroll_selection_within_viewport_does_not_scroll() {
+    let mut scroll = TimelineScroll {
+        visible_range: Some((10, 19)),
+        ..TimelineScroll::default()
+    };
+    // Newest (19) selected by default; move up to 18, still on screen.
+    scroll.select_up(20);
+    assert_eq!(scroll.selection, Some(18));
+    assert_eq!(
+        scroll.offset, 0,
+        "selection inside the viewport scrolls nothing"
+    );
+}
+
+#[test]
+fn timeline_scroll_selection_leaving_top_nudges_offset_up() {
+    let mut scroll = TimelineScroll {
+        offset: 5,
+        selection: Some(10),
+        visible_range: Some((10, 19)),
+        ..TimelineScroll::default()
+    };
+    scroll.select_up(30);
+    assert_eq!(scroll.selection, Some(9));
+    assert_eq!(
+        scroll.offset, 6,
+        "viewport nudges up by one when selection exits the top"
+    );
+}
+
+#[test]
+fn timeline_scroll_selection_leaving_bottom_nudges_offset_down() {
+    let mut scroll = TimelineScroll {
+        offset: 5,
+        selection: Some(19),
+        visible_range: Some((10, 19)),
+        ..TimelineScroll::default()
+    };
+    scroll.select_down(30);
+    assert_eq!(scroll.selection, Some(20));
+    assert_eq!(
+        scroll.offset, 4,
+        "viewport nudges down by one when selection exits the bottom"
+    );
+}
+
+#[test]
+fn timeline_scroll_selection_clamps_at_both_ends() {
+    let mut scroll = TimelineScroll {
+        selection: Some(0),
+        ..TimelineScroll::default()
+    };
+    scroll.select_up(20);
+    assert_eq!(scroll.selection, Some(0));
+    scroll.selection = Some(19);
+    scroll.select_down(20);
+    assert_eq!(scroll.selection, Some(19));
+}
+
+#[test]
+fn timeline_scroll_jump_newest_selects_newest_and_pins() {
+    let mut scroll = TimelineScroll {
+        offset: 7,
+        selection: Some(3),
+        ..TimelineScroll::default()
+    };
+    scroll.jump_newest(20);
+    assert_eq!(scroll.offset, 0);
+    assert!(scroll.is_pinned());
+    assert_eq!(scroll.resolved_selection(20), Some(19));
+}
+
+#[test]
+fn timeline_scroll_jump_oldest_selects_first_and_scrolls_to_top() {
+    let mut scroll = TimelineScroll::default();
+    scroll.jump_oldest(20);
+    assert_eq!(scroll.selection, Some(0));
+    assert_eq!(scroll.offset, 19);
+    // Empty list is a no-op.
+    let mut empty = TimelineScroll::default();
+    empty.jump_oldest(0);
+    assert_eq!(empty, TimelineScroll::default());
+}
+
+#[test]
+fn timeline_scroll_page_up_moves_by_visible_count_and_follows() {
+    let mut scroll = TimelineScroll {
+        offset: 0,
+        selection: Some(50),
+        visible_range: Some((45, 54)), // 10 visible messages
+        ..TimelineScroll::default()
+    };
+    scroll.page_up(100);
+    assert_eq!(scroll.selection, Some(40), "moved up by the visible count");
+    assert_eq!(
+        scroll.offset, 5,
+        "viewport follows the selection above the top"
+    );
+}
+
+#[test]
+fn timeline_scroll_page_down_moves_by_visible_count() {
+    let mut scroll = TimelineScroll {
+        offset: 8,
+        selection: Some(40),
+        visible_range: Some((40, 49)),
+        ..TimelineScroll::default()
+    };
+    scroll.page_down(100);
+    assert_eq!(
+        scroll.selection,
+        Some(50),
+        "moved down by the visible count"
+    );
+    assert!(
+        scroll.offset < 8,
+        "viewport follows the selection below the bottom"
+    );
+}
+
+#[test]
+fn timeline_scroll_page_clamps_at_edges() {
+    let mut scroll = TimelineScroll {
+        selection: Some(3),
+        visible_range: Some((0, 9)),
+        ..TimelineScroll::default()
+    };
+    scroll.page_up(40);
+    assert_eq!(scroll.selection, Some(0));
+    scroll.selection = Some(35);
+    scroll.page_down(40);
+    assert_eq!(scroll.selection, Some(39));
+}
+
+#[test]
+fn timeline_scroll_records_visible_range_from_the_renderer() {
+    let mut scroll = TimelineScroll::default();
+    scroll.record_visible_range(3, 9, 20);
+    assert_eq!(scroll.visible_range, Some((3, 9)));
+    assert_eq!(
+        scroll.offset, 0,
+        "a small offset with `last` at the anchor is not renormalized"
+    );
+}
+
+#[test]
+fn timeline_scroll_record_visible_range_clamps_a_stale_over_large_offset() {
+    // `g` set offset to len-1 (29); the renderer clamped the anchor to 0 and
+    // filled forward to `last` = 4. The effective offset is (30-1) - 4 = 25.
+    let mut scroll = TimelineScroll {
+        offset: 29,
+        ..TimelineScroll::default()
+    };
+    scroll.record_visible_range(0, 4, 30);
+    assert_eq!(
+        scroll.offset, 25,
+        "offset clamps down to the drawn geometry"
+    );
+    // Idempotent: a second identical frame leaves it put.
+    scroll.record_visible_range(0, 4, 30);
+    assert_eq!(scroll.offset, 25);
+}
+
+#[test]
+fn timeline_scroll_requests_older_history_only_at_the_oldest_row() {
+    let mut scroll = TimelineScroll {
+        has_more_before: true,
+        selection: Some(5),
+        ..TimelineScroll::default()
+    };
+    assert!(!scroll.at_oldest(20));
+    assert!(!scroll.should_request_older(20), "not at the oldest row");
+
+    scroll.selection = Some(0);
+    assert!(scroll.at_oldest(20));
+    assert!(
+        scroll.should_request_older(20),
+        "at oldest with more history"
+    );
+
+    scroll.loading_older = true;
+    assert!(
+        !scroll.should_request_older(20),
+        "a page request is already in flight"
+    );
+
+    scroll.loading_older = false;
+    scroll.has_more_before = false;
+    assert!(!scroll.should_request_older(20), "no more history to load");
+}
+
+#[test]
+fn timeline_scroll_remove_below_selection_shifts_it_down() {
+    let mut scroll = TimelineScroll {
+        offset: 3,
+        selection: Some(10),
+        ..TimelineScroll::default()
+    };
+    // Remove a row older than the selection (index 4 of an old list of 20).
+    scroll.on_remove(4, 19);
+    assert_eq!(
+        scroll.selection,
+        Some(9),
+        "same message stays selected after older row drops"
+    );
+    assert_eq!(
+        scroll.offset, 3,
+        "removing below the anchor does not move the viewport"
+    );
+}
+
+#[test]
+fn timeline_scroll_remove_newer_than_anchor_pulls_offset_down_while_scrolled_up() {
+    let mut scroll = TimelineScroll {
+        offset: 2,
+        selection: Some(1),
+        ..TimelineScroll::default()
+    };
+    // Old list of 10; anchor = 9 - 2 = 7. Remove index 8 (newer than anchor).
+    scroll.on_remove(8, 9);
+    assert_eq!(scroll.offset, 1, "viewport follows the shrinking bottom");
+}
+
+#[test]
+fn timeline_scroll_remove_clamps_selection_when_list_empties() {
+    let mut scroll = TimelineScroll {
+        selection: Some(0),
+        ..TimelineScroll::default()
+    };
+    scroll.on_remove(0, 0);
+    assert_eq!(scroll.resolved_selection(0), None);
+}
+
+#[test]
+fn cap_timeline_scrollback_trims_oldest_only_when_pinned() {
+    let mut rows: Vec<TimelineRow> = (0..(TUI_MESSAGE_SCROLLBACK_LIMIT + 5))
+        .map(|i| timeline_row(&format!("{i:05}"), i as u64))
+        .collect();
+    let mut scroll = TimelineScroll {
+        selection: Some(rows.len() - 1),
+        ..TimelineScroll::default()
+    };
+    cap_timeline_scrollback(&mut rows, &mut scroll);
+    assert_eq!(rows.len(), TUI_MESSAGE_SCROLLBACK_LIMIT);
+    assert_eq!(
+        rows.first().unwrap().message_id,
+        "00005",
+        "oldest rows dropped"
+    );
+    assert_eq!(
+        scroll.selection,
+        Some(TUI_MESSAGE_SCROLLBACK_LIMIT - 1),
+        "selection follows the dropped rows so it stays on the same message"
+    );
+}
+
+#[test]
+fn cap_timeline_scrollback_never_trims_while_scrolled_up() {
+    let mut rows: Vec<TimelineRow> = (0..(TUI_MESSAGE_SCROLLBACK_LIMIT + 5))
+        .map(|i| timeline_row(&format!("{i:05}"), i as u64))
+        .collect();
+    let original_len = rows.len();
+    let mut scroll = TimelineScroll {
+        offset: 3,
+        ..TimelineScroll::default()
+    };
+    cap_timeline_scrollback(&mut rows, &mut scroll);
+    assert_eq!(
+        rows.len(),
+        original_len,
+        "capping while scrolled up would fight history paging"
+    );
+}
+
+#[test]
+fn timeline_row_lines_render_timestamp_author_and_content() {
+    let mut row = timeline_row("m1", 45296);
+    row.from_display_name = Some("Alice".to_owned());
+    row.display_text = "hello world".to_owned();
+
+    let lines = timeline_row_lines(&row, None);
+    assert_eq!(lines.len(), 1);
+    assert_eq!(hhmm_body(&line_text(&lines[0])), "Alice: hello world");
+    assert_eq!(
+        lines[0].spans[0].style.fg,
+        Some(Color::DarkGray),
+        "timestamp is dark gray"
+    );
+    assert_eq!(
+        lines[0].spans[1].style.fg,
+        Some(Color::Cyan),
+        "other author is cyan"
+    );
+    assert!(
+        lines[0].spans[1]
+            .style
+            .add_modifier
+            .contains(Modifier::BOLD)
+    );
+}
+
+#[test]
+fn timeline_row_lines_color_own_messages_green() {
+    let mut row = timeline_row("m2", 0);
+    row.direction = "sent".to_owned();
+    row.from_display_name = Some("Me".to_owned());
+    let lines = timeline_row_lines(&row, None);
+    assert_eq!(
+        lines[0].spans[1].style.fg,
+        Some(Color::Green),
+        "own author is green"
+    );
+}
+
+#[test]
+fn timeline_row_lines_indent_embedded_newlines_to_the_prefix_width() {
+    let mut row = timeline_row("m3", 0);
+    row.from_display_name = Some("Al".to_owned());
+    row.display_text = "one\ntwo".to_owned();
+    let lines = timeline_row_lines(&row, None);
+    assert_eq!(lines.len(), 2);
+    assert_eq!(hhmm_body(&line_text(&lines[0])), "Al: one");
+    // Continuation indents to "[HH:MM] Al: " width (12 columns).
+    assert_eq!(line_text(&lines[1]), "            two");
+}
+
+#[test]
+fn timeline_row_lines_render_reply_context_above_content() {
+    let mut row = timeline_row("m", 0);
+    row.from_display_name = Some("Bob".to_owned());
+    row.display_text = "agreed".to_owned();
+    row.reply = Some(TimelineReply {
+        reply_to_message_id: "parent".to_owned(),
+        preview: Some(TimelineReplyPreview {
+            sender: Some("Alice".to_owned()),
+            plaintext: "this is a long parent message body over thirty chars".to_owned(),
+            deleted: false,
+        }),
+    });
+    let lines = timeline_row_lines(&row, None);
+    assert_eq!(
+        line_text(&lines[0]),
+        "             reply to Alice: \"this is a long parent message ...\""
+    );
+    assert!(
+        lines[0].spans[1]
+            .style
+            .add_modifier
+            .contains(Modifier::ITALIC)
+    );
+    assert_eq!(lines[0].spans[1].style.fg, Some(Color::DarkGray));
+    assert_eq!(hhmm_body(&line_text(&lines[1])), "Bob: agreed");
+}
+
+#[test]
+fn timeline_row_lines_reply_falls_back_to_shortened_id() {
+    let mut row = timeline_row("m", 0);
+    row.reply = Some(TimelineReply {
+        reply_to_message_id: "0123456789abcdef".to_owned(),
+        preview: None,
+    });
+    let lines = timeline_row_lines(&row, None);
+    assert!(line_text(&lines[0]).contains("reply to 0123...bcdef"));
+}
+
+#[test]
+fn timeline_row_lines_reply_fallback_strips_terminal_controls_from_parent_id() {
+    // The parent id is untrusted; both fallback branches (no preview, and a
+    // preview whose sender resolves empty) must sanitize it like every sibling
+    // path. Controls sit in the surviving prefix/suffix so shortening keeps them.
+    let raw_id = "\u{202e}ab\u{7}cdefghij0123456789";
+
+    // Branch 1: no preview at all.
+    let mut row = timeline_row("m", 0);
+    row.reply = Some(TimelineReply {
+        reply_to_message_id: raw_id.to_owned(),
+        preview: None,
+    });
+    let text = line_text(&timeline_row_lines(&row, None)[0]);
+    assert!(
+        !text.contains('\u{202e}'),
+        "bidi override stripped from the no-preview fallback id"
+    );
+    assert!(
+        !text.contains('\u{7}'),
+        "control char stripped from the no-preview fallback id"
+    );
+
+    // Branch 2: a preview whose sender is absent falls back to the parent id.
+    let mut row = timeline_row("m", 0);
+    row.reply = Some(TimelineReply {
+        reply_to_message_id: raw_id.to_owned(),
+        preview: Some(TimelineReplyPreview {
+            sender: None,
+            plaintext: "hi".to_owned(),
+            deleted: false,
+        }),
+    });
+    let text = line_text(&timeline_row_lines(&row, None)[0]);
+    assert!(
+        !text.contains('\u{202e}'),
+        "bidi override stripped from the empty-sender fallback id"
+    );
+    assert!(
+        !text.contains('\u{7}'),
+        "control char stripped from the empty-sender fallback id"
+    );
+}
+
+#[test]
+fn timeline_row_lines_render_reactions_below_content() {
+    let mut row = timeline_row("m", 0);
+    row.reactions = vec![
+        TimelineReaction {
+            emoji: "\u{1f44d}".to_owned(),
+            count: 2,
+        },
+        TimelineReaction {
+            emoji: "\u{2764}".to_owned(),
+            count: 1,
+        },
+    ];
+    let lines = timeline_row_lines(&row, None);
+    let reactions = lines.last().unwrap();
+    assert_eq!(line_text(reactions).trim_start(), "\u{1f44d} 2  \u{2764} 1");
+    assert_eq!(reactions.spans[1].style.fg, Some(Color::Yellow));
+}
+
+#[test]
+fn timeline_row_lines_render_tombstone_for_deleted_rows() {
+    let mut row = timeline_row("m", 0);
+    row.from_display_name = Some("Al".to_owned());
+    row.deleted = true;
+    row.plaintext = String::new();
+    row.display_text = String::new();
+    let lines = timeline_row_lines(&row, None);
+    assert_eq!(lines.len(), 1);
+    assert_eq!(hhmm_body(&line_text(&lines[0])), "Al: message deleted");
+    let tombstone = lines[0].spans.last().unwrap();
+    assert!(tombstone.style.add_modifier.contains(Modifier::ITALIC));
+    assert_eq!(tombstone.style.fg, Some(Color::DarkGray));
+}
+
+#[test]
+fn timeline_row_lines_render_attachment_placeholders() {
+    let mut row = timeline_row("m", 0);
+    row.display_text = "look".to_owned();
+    row.attachments = vec![
+        TimelineAttachment {
+            mime: Some("image/png".to_owned()),
+            filename: Some("pixel.png".to_owned()),
+        },
+        TimelineAttachment {
+            mime: Some("application/pdf".to_owned()),
+            filename: Some("spec.pdf".to_owned()),
+        },
+    ];
+    let lines = timeline_row_lines(&row, None);
+    assert_eq!(line_text(&lines[1]).trim_start(), "[img pixel.png]");
+    assert_eq!(line_text(&lines[2]).trim_start(), "[file spec.pdf]");
+}
+
+#[test]
+fn timeline_row_lines_strip_terminal_control_sequences() {
+    let mut row = timeline_row("m", 0);
+    row.from_display_name = Some("Al\u{202e}ice".to_owned());
+    row.display_text = "hi\u{7}there".to_owned();
+    let lines = timeline_row_lines(&row, None);
+    let text = line_text(&lines[0]);
+    assert!(
+        !text.contains('\u{202e}'),
+        "bidi override stripped from author"
+    );
+    assert!(
+        !text.contains('\u{7}'),
+        "control char stripped from content"
+    );
+    assert_eq!(hhmm_body(&text), "Alice: hithere");
+}
+
+#[test]
+fn timeline_row_height_counts_content_reactions_reply_and_separator() {
+    let mut row = timeline_row("m1", 0);
+    row.from_display_name = Some("Al".to_owned());
+    row.display_text = "hi".to_owned();
+    // one content line + one blank separator row
+    assert_eq!(timeline_row_height(&row, None, 80), 2);
+
+    row.reactions = vec![TimelineReaction {
+        emoji: "x".to_owned(),
+        count: 1,
+    }];
+    assert_eq!(timeline_row_height(&row, None, 80), 3);
+
+    row.reply = Some(TimelineReply {
+        reply_to_message_id: "p".to_owned(),
+        preview: None,
+    });
+    assert_eq!(timeline_row_height(&row, None, 80), 4);
+}
+
+#[test]
+fn timeline_row_height_accounts_for_wrapping() {
+    let mut row = timeline_row("m", 0);
+    row.from_display_name = Some("A".to_owned());
+    row.display_text = "x".repeat(200);
+    assert!(
+        timeline_row_height(&row, None, 40) > 3,
+        "a 200-char body must wrap to several rows at width 40"
+    );
+}
+
+#[test]
+fn timeline_row_heights_maps_every_row() {
+    let rows = vec![timeline_row("a", 0), timeline_row("b", 1)];
+    assert_eq!(timeline_row_heights(&rows, None, 80).len(), 2);
+}
+
+#[test]
+fn timeline_visible_range_pins_newest_at_bottom() {
+    let heights = vec![1u16; 20];
+    assert_eq!(timeline_visible_range(&heights, 10, 0, 0), Some((10, 19)));
+}
+
+#[test]
+fn timeline_visible_range_walks_back_from_the_anchor() {
+    let heights = vec![1u16; 20];
+    // offset 10: anchor = 9, fill backward then render forward through the anchor.
+    assert_eq!(timeline_visible_range(&heights, 10, 10, 0), Some((0, 9)));
+}
+
+#[test]
+fn timeline_visible_range_scroll_to_top_fills_forward_not_blank() {
+    let heights = vec![1u16; 20];
+    // offset at the max (as `g` sets it) shows the oldest at the top and fills
+    // the viewport forward — never a nearly blank pane.
+    let (first, last) = timeline_visible_range(&heights, 10, 19, 0).unwrap();
+    assert_eq!(first, 0);
+    assert!(last >= 9, "viewport filled forward, got last={last}");
+}
+
+#[test]
+fn timeline_visible_range_shows_oversized_message() {
+    let heights = vec![50u16];
+    assert_eq!(timeline_visible_range(&heights, 10, 0, 0), Some((0, 0)));
+}
+
+#[test]
+fn timeline_visible_range_bottom_block_consumes_space_only_at_newest() {
+    let heights = vec![1u16; 20];
+    // Pinned at newest: a 3-row bottom block (live stream preview) shrinks the
+    // message viewport from 10 to 7.
+    assert_eq!(timeline_visible_range(&heights, 10, 0, 3), Some((13, 19)));
+    // Scrolled up: the anchor is not the newest, so the block is not shown and
+    // does not consume viewport space.
+    assert_eq!(timeline_visible_range(&heights, 10, 5, 3), Some((5, 14)));
+}
+
+#[test]
+fn timeline_visible_range_is_empty_without_rows_or_viewport() {
+    assert_eq!(timeline_visible_range(&[], 10, 0, 0), None);
+    assert_eq!(timeline_visible_range(&[1u16; 5], 0, 0, 0), None);
+}
+
+/// Render one frame: compute the visible range with the real height/visibility
+/// algorithm, feed it back to the scroll model, and return the visible ids.
+fn timeline_frame(
+    rows: &[TimelineRow],
+    scroll: &mut TimelineScroll,
+    width: u16,
+    viewport: u16,
+) -> Vec<String> {
+    let heights = timeline_row_heights(rows, None, width);
+    match timeline_visible_range(&heights, viewport, scroll.offset, 0) {
+        Some((first, last)) => {
+            scroll.record_visible_range(first, last, rows.len());
+            rows[first..=last]
+                .iter()
+                .map(|row| row.message_id.clone())
+                .collect()
+        }
+        None => Vec::new(),
+    }
+}
+
+fn uniform_row(id: &str, timeline_at: u64) -> TimelineRow {
+    let mut row = timeline_row(id, timeline_at);
+    row.from_display_name = Some("a".to_owned());
+    row.display_text = "x".to_owned();
+    row
+}
+
+#[test]
+fn scrolled_up_view_is_stable_across_arrival_and_history_paging() {
+    let (width, viewport) = (80u16, 10u16);
+    let mut rows: Vec<TimelineRow> = (10..40)
+        .map(|i| uniform_row(&format!("{i:03}"), i))
+        .collect();
+    let mut scroll = TimelineScroll::default();
+
+    // Scroll to the oldest row, rendering each frame like the real loop.
+    timeline_frame(&rows, &mut scroll, width, viewport);
+    for _ in 0..rows.len() + 5 {
+        scroll.select_up(rows.len());
+        timeline_frame(&rows, &mut scroll, width, viewport);
+    }
+    assert!(scroll.at_oldest(rows.len()));
+    let visible_before = timeline_frame(&rows, &mut scroll, width, viewport);
+    let selected_before = rows[scroll.resolved_selection(rows.len()).unwrap()]
+        .message_id
+        .clone();
+
+    // A new message arrives at the bottom while scrolled up: the view must not move.
+    let outcome = apply_timeline_change(
+        &mut rows,
+        TimelineChange::Upsert(Box::new(uniform_row("999", 999))),
+    );
+    if let TimelineFoldOutcome::Inserted(index) = outcome {
+        scroll.on_insert(index, rows.len());
+    }
+    assert_eq!(
+        timeline_frame(&rows, &mut scroll, width, viewport),
+        visible_before,
+        "an incoming message must not move a scrolled-up reader"
+    );
+
+    // Page in 5 older rows at the front: the view still must not move.
+    let older: Vec<TimelineRow> = (5..10)
+        .map(|i| uniform_row(&format!("{i:03}"), i))
+        .collect();
+    let paged_in = older.len();
+    rows.extend(older);
+    sort_timeline_rows(&mut rows);
+    scroll.on_prepend(paged_in);
+    assert_eq!(
+        timeline_frame(&rows, &mut scroll, width, viewport),
+        visible_before,
+        "history paging must not move the view (offset stays; indices shift)"
+    );
+    assert_eq!(
+        rows[scroll.resolved_selection(rows.len()).unwrap()].message_id,
+        selected_before,
+        "the same message stays selected across paging"
+    );
+}
+
+#[test]
+fn jump_oldest_then_paging_keeps_the_top_of_history_stable() {
+    // `g` (jump_oldest) sets a geometrically over-large offset; the renderer
+    // clamps the anchor to 0. If that stale offset survives, a later prepend
+    // anchors below the true top and the view jumps. Rendering must renormalize
+    // the offset from the drawn geometry so paging keeps the top stable.
+    let (width, viewport) = (80u16, 10u16);
+    let mut rows: Vec<TimelineRow> = (10..40)
+        .map(|i| uniform_row(&format!("{i:03}"), i))
+        .collect();
+    let mut scroll = TimelineScroll::default();
+
+    // Jump to the oldest row, then render one frame.
+    scroll.jump_oldest(rows.len());
+    let visible_before = timeline_frame(&rows, &mut scroll, width, viewport);
+    assert_eq!(
+        visible_before.first().map(String::as_str),
+        Some("010"),
+        "g shows the oldest row at the top"
+    );
+
+    // Page in 5 older rows at the front; the offset stays put (rule 6) and the
+    // view must not move.
+    let older: Vec<TimelineRow> = (5..10)
+        .map(|i| uniform_row(&format!("{i:03}"), i))
+        .collect();
+    let paged_in = older.len();
+    rows.extend(older);
+    sort_timeline_rows(&mut rows);
+    scroll.on_prepend(paged_in);
+
+    assert_eq!(
+        timeline_frame(&rows, &mut scroll, width, viewport),
+        visible_before,
+        "history paging after `g` must not move the view"
+    );
+}
+
+#[test]
+fn pinned_view_follows_incoming_messages() {
+    let (width, viewport) = (80u16, 10u16);
+    let mut rows: Vec<TimelineRow> = (0..12)
+        .map(|i| uniform_row(&format!("{i:03}"), i))
+        .collect();
+    let mut scroll = TimelineScroll::default();
+    timeline_frame(&rows, &mut scroll, width, viewport);
+
+    let outcome = apply_timeline_change(
+        &mut rows,
+        TimelineChange::Upsert(Box::new(uniform_row("099", 99))),
+    );
+    if let TimelineFoldOutcome::Inserted(index) = outcome {
+        scroll.on_insert(index, rows.len());
+    }
+    let visible = timeline_frame(&rows, &mut scroll, width, viewport);
+    assert!(scroll.is_pinned());
+    assert_eq!(
+        visible.last().map(String::as_str),
+        Some("099"),
+        "pinned view shows the new message"
+    );
+}
+
+// ── Phase 1 timeline: pane title, event fold, and app wiring ────────────
+
+#[test]
+fn timeline_pane_title_reports_offscreen_row_counts() {
+    // Everything on screen: the plain title.
+    assert_eq!(timeline_pane_title(5, 0, 4), "Messages");
+    // Older rows above the view.
+    assert_eq!(timeline_pane_title(10, 3, 9), "Messages [3 older]");
+    // Newer rows below the view.
+    assert_eq!(timeline_pane_title(10, 0, 6), "Messages [3 newer]");
+    // Both directions.
+    assert_eq!(
+        timeline_pane_title(10, 2, 6),
+        "Messages [2 older | 3 newer]"
+    );
+}
+
+#[test]
+fn apply_timeline_event_initial_page_sets_rows_and_more_before() {
+    let mut rows = Vec::new();
+    let mut scroll = TimelineScroll::default();
+    apply_timeline_event(
+        &mut rows,
+        &mut scroll,
+        Some("group"),
+        TimelineEvent::InitialPage {
+            rows: vec![timeline_row("b", 20), timeline_row("a", 10)],
+            has_more_before: true,
+        },
+    );
+    assert_eq!(timeline_ids(&rows), vec!["a", "b"], "merged and sorted");
+    assert!(scroll.has_more_before);
+
+    // Re-delivering the same page (the feed duplicates events) is a no-op in
+    // effect: the fold upserts by id and never appends a second copy.
+    let before = rows.clone();
+    apply_timeline_event(
+        &mut rows,
+        &mut scroll,
+        Some("group"),
+        TimelineEvent::InitialPage {
+            rows: vec![timeline_row("b", 20), timeline_row("a", 10)],
+            has_more_before: true,
+        },
+    );
+    assert_eq!(rows, before, "duplicated initial page is idempotent by id");
+}
+
+#[test]
+fn apply_timeline_event_initial_page_compensates_scroll_for_newer_rows() {
+    // The snapshot loaded rows 000..029 and the reader scrolled up. The
+    // subscription's initial page then carries the same rows plus 3 newer rows
+    // that arrived between the snapshot and the subscribe; folding them must
+    // drive the scroll model so the row being read stays anchored, exactly like
+    // the projection arm.
+    let mut rows: Vec<TimelineRow> = (0..30)
+        .map(|i| timeline_row(&format!("{i:03}"), i))
+        .collect();
+    let mut scroll = TimelineScroll {
+        offset: 5,
+        selection: Some(24),
+        visible_range: Some((20, 24)),
+        ..TimelineScroll::default()
+    };
+
+    let mut page: Vec<TimelineRow> = (0..33)
+        .map(|i| timeline_row(&format!("{i:03}"), i))
+        .collect();
+    // Deliver the page out of order to prove the fold indexes by sorted position.
+    page.reverse();
+
+    apply_timeline_event(
+        &mut rows,
+        &mut scroll,
+        Some("group"),
+        TimelineEvent::InitialPage {
+            rows: page,
+            has_more_before: false,
+        },
+    );
+
+    assert_eq!(rows.len(), 33, "3 newer rows merged in");
+    let anchor = (rows.len() - 1) - scroll.offset;
+    assert_eq!(
+        rows[anchor].message_id, "024",
+        "the row being read stays anchored despite the newer rows"
+    );
+    assert_eq!(scroll.selection, Some(24), "same row stays selected");
+}
+
+#[test]
+fn apply_timeline_event_projection_folds_and_drives_scroll_for_loaded_group() {
+    let mut rows = vec![timeline_row("a", 10), timeline_row("b", 20)];
+    let mut scroll = TimelineScroll::default();
+    apply_timeline_event(
+        &mut rows,
+        &mut scroll,
+        Some("group"),
+        TimelineEvent::ProjectionUpdated {
+            group_id: "group".to_owned(),
+            changes: vec![TimelineChange::Upsert(Box::new(timeline_row("c", 30)))],
+        },
+    );
+    assert_eq!(timeline_ids(&rows), vec!["a", "b", "c"]);
+    assert!(
+        scroll.is_pinned(),
+        "an arrival while pinned keeps the view pinned"
+    );
+
+    // A duplicated projection event (optimistic write plus relay echo) must not
+    // append a second copy.
+    apply_timeline_event(
+        &mut rows,
+        &mut scroll,
+        Some("group"),
+        TimelineEvent::ProjectionUpdated {
+            group_id: "group".to_owned(),
+            changes: vec![TimelineChange::Upsert(Box::new(timeline_row("c", 30)))],
+        },
+    );
+    assert_eq!(timeline_ids(&rows), vec!["a", "b", "c"], "idempotent by id");
+
+    apply_timeline_event(
+        &mut rows,
+        &mut scroll,
+        Some("group"),
+        TimelineEvent::ProjectionUpdated {
+            group_id: "group".to_owned(),
+            changes: vec![TimelineChange::Remove {
+                message_id: "a".to_owned(),
+            }],
+        },
+    );
+    assert_eq!(timeline_ids(&rows), vec!["b", "c"]);
+}
+
+#[test]
+fn apply_timeline_event_ignores_projection_for_other_group() {
+    let mut rows = vec![timeline_row("a", 10)];
+    let mut scroll = TimelineScroll::default();
+    apply_timeline_event(
+        &mut rows,
+        &mut scroll,
+        Some("loaded"),
+        TimelineEvent::ProjectionUpdated {
+            group_id: "elsewhere".to_owned(),
+            changes: vec![TimelineChange::Upsert(Box::new(timeline_row("z", 99)))],
+        },
+    );
+    assert_eq!(
+        timeline_ids(&rows),
+        vec!["a"],
+        "off-group changes are dropped"
+    );
+}
+
+#[test]
+fn send_message_upserts_an_optimistic_timeline_row() {
+    let account_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let group_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let (_tempdir, client) =
+        test_json_client(r#"{"ok":true,"result":{"published":1,"message_ids":["m1"]}}"#);
+    let mut app = test_tui_app(client, account_id);
+    app.messages_account_id = Some(account_id.to_owned());
+    app.messages_group_id = Some(group_id.to_owned());
+
+    app.send_message("hello there".to_owned())
+        .expect("send message");
+
+    assert_eq!(app.timeline.len(), 1);
+    assert_eq!(app.timeline[0].message_id, "m1");
+    assert_eq!(app.timeline[0].direction, "sent");
+    assert_eq!(app.timeline[0].display_text, "hello there");
+    assert!(
+        app.timeline_scroll.is_pinned(),
+        "an own send keeps the view pinned to the bottom"
+    );
+}
+
+#[test]
+fn refresh_messages_loads_the_materialized_timeline_page() {
+    let account_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let group_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let (_tempdir, client) = test_json_client(
+        r#"{"ok":true,"result":{"messages":[{"message_id":"m1","direction":"received","from":"alice","plaintext":"hello","timeline_at":100,"received_at":100}],"has_more_before":true}}"#,
+    );
+    let mut app = test_tui_app(client, account_id);
+    app.chats = vec![ChatRow {
+        group_id: group_id.to_owned(),
+        name: "general".to_owned(),
+        archived: false,
+    }];
+    app.selected_chat = 0;
+
+    app.refresh_messages().expect("refresh messages");
+
+    assert_eq!(app.timeline.len(), 1);
+    assert_eq!(app.timeline[0].message_id, "m1");
+    assert!(app.timeline_scroll.has_more_before);
+    assert!(app.timeline_scroll.is_pinned());
+    assert_eq!(app.timeline_scroll.selection, None);
+    assert_eq!(app.messages_group_id.as_deref(), Some(group_id));
+}
+
+#[test]
+fn load_older_messages_prepends_a_page_and_updates_the_cursor() {
+    let account_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let group_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let (_tempdir, client) = test_json_client(
+        r#"{"ok":true,"result":{"messages":[{"message_id":"old","direction":"received","from":"alice","plaintext":"older","timeline_at":50,"received_at":50}],"has_more_before":false}}"#,
+    );
+    let mut app = test_tui_app(client, account_id);
+    app.messages_account_id = Some(account_id.to_owned());
+    app.messages_group_id = Some(group_id.to_owned());
+    app.timeline = vec![timeline_row("new", 100)];
+    app.timeline_scroll.has_more_before = true;
+
+    app.load_older_messages().expect("load older messages");
+
+    assert_eq!(timeline_ids(&app.timeline), vec!["old", "new"]);
+    assert!(
+        !app.timeline_scroll.has_more_before,
+        "page reported no more"
+    );
+    assert!(!app.timeline_scroll.loading_older, "in-flight flag cleared");
+}
+
+#[test]
+fn load_older_messages_clears_loading_flag_on_error() {
+    let account_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let group_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let (_tempdir, client) = test_json_client(r#"{"ok":false,"error":{"message":"backend gone"}}"#);
+    let mut app = test_tui_app(client, account_id);
+    app.messages_account_id = Some(account_id.to_owned());
+    app.messages_group_id = Some(group_id.to_owned());
+    app.timeline = vec![timeline_row("new", 100)];
+    app.timeline_scroll.has_more_before = true;
+
+    let outcome = app.load_older_messages();
+
+    assert!(
+        outcome.is_err(),
+        "the backend failure propagates to the caller"
+    );
+    assert_eq!(app.timeline.len(), 1, "no rows added on failure");
+    assert!(
+        !app.timeline_scroll.loading_older,
+        "the in-flight flag is cleared on the error path so paging is not wedged"
+    );
+}
+
+#[test]
+fn load_older_messages_upserts_overlap_without_duplicating_or_overshifting() {
+    let account_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let group_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    // The fetched page overlaps the oldest loaded row ("new") and adds one
+    // genuinely older row ("old"). An exclusive cursor should not overlap, but if
+    // it ever does the merge must stay idempotent: no duplicate, no over-shift.
+    let (_tempdir, client) = test_json_client(
+        r#"{"ok":true,"result":{"messages":[
+            {"message_id":"old","direction":"received","from":"alice","plaintext":"older","timeline_at":50,"received_at":50},
+            {"message_id":"new","direction":"received","from":"alice","plaintext":"newer","timeline_at":100,"received_at":100}
+        ],"has_more_before":false}}"#,
+    );
+    let mut app = test_tui_app(client, account_id);
+    app.messages_account_id = Some(account_id.to_owned());
+    app.messages_group_id = Some(group_id.to_owned());
+    app.timeline = vec![timeline_row("new", 100)];
+    app.timeline_scroll.has_more_before = true;
+    app.timeline_scroll.selection = Some(0);
+    app.timeline_scroll.visible_range = Some((0, 0));
+
+    app.load_older_messages().expect("load older messages");
+
+    assert_eq!(
+        timeline_ids(&app.timeline),
+        vec!["old", "new"],
+        "the overlapping row is upserted, not duplicated"
+    );
+    assert_eq!(
+        app.timeline_scroll.selection,
+        Some(1),
+        "only the one genuinely-new row shifts the selection"
+    );
+    assert_eq!(app.timeline_scroll.visible_range, Some((1, 1)));
+}
+
+#[test]
+fn messages_select_up_pages_in_older_history_at_the_oldest_row() {
+    let account_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let group_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let (_tempdir, client) = test_json_client(
+        r#"{"ok":true,"result":{"messages":[{"message_id":"old","direction":"received","from":"alice","plaintext":"older","timeline_at":5,"received_at":5}],"has_more_before":false}}"#,
+    );
+    let mut app = test_tui_app(client, account_id);
+    app.focus = Focus::Messages;
+    app.messages_account_id = Some(account_id.to_owned());
+    app.messages_group_id = Some(group_id.to_owned());
+    app.timeline = vec![timeline_row("new", 10)];
+    app.timeline_scroll.has_more_before = true;
+    app.timeline_scroll.selection = Some(0);
+
+    app.handle_key(char_key('k'))
+        .expect("handle 'k' at oldest row");
+
+    assert_eq!(timeline_ids(&app.timeline), vec!["old", "new"]);
+    assert!(!app.timeline_scroll.has_more_before);
+}
+
+#[test]
+fn messages_jump_oldest_pages_in_older_history() {
+    let account_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let group_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let (_tempdir, client) = test_json_client(
+        r#"{"ok":true,"result":{"messages":[{"message_id":"old","direction":"received","from":"alice","plaintext":"older","timeline_at":5,"received_at":5}],"has_more_before":false}}"#,
+    );
+    let mut app = test_tui_app(client, account_id);
+    app.focus = Focus::Messages;
+    app.messages_account_id = Some(account_id.to_owned());
+    app.messages_group_id = Some(group_id.to_owned());
+    app.timeline = vec![timeline_row("new", 10)];
+    app.timeline_scroll.has_more_before = true;
+
+    // `g` jumps to the oldest loaded row and must fetch older history, like `k`.
+    app.handle_key(char_key('g'))
+        .expect("handle 'g' jump oldest");
+
+    assert_eq!(timeline_ids(&app.timeline), vec!["old", "new"]);
+    assert!(!app.timeline_scroll.has_more_before);
+}
+
+#[test]
+fn drain_timeline_subscription_applies_events_for_the_loaded_group_only() {
+    let account_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let group_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let other_group = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    let mut app = test_tui_app(test_unused_client(), account_id);
+    app.messages_group_id = Some(group_id.to_owned());
+    let (tx, rx) = mpsc::channel();
+    app.timeline_subscription = Some(TimelineSubscription {
+        account_id: account_id.to_owned(),
+        group_id: group_id.to_owned(),
+        child: test_sleep_child(),
+        rx,
+    });
+
+    tx.send(SubscriptionEvent::Result(serde_json::json!({
+        "type": "initial_timeline_page",
+        "has_more_before": true,
+        "messages": [
+            { "message_id": "a", "plaintext": "one", "timeline_at": 1 },
+            { "message_id": "b", "plaintext": "two", "timeline_at": 2 }
+        ]
+    })))
+    .expect("send initial page");
+    assert!(app.drain_timeline_subscription());
+    assert_eq!(timeline_ids(&app.timeline), vec!["a", "b"]);
+    assert!(app.timeline_scroll.has_more_before);
+
+    tx.send(SubscriptionEvent::Result(serde_json::json!({
+        "type": "timeline_projection_updated",
+        "group_id": group_id,
+        "changes": [
+            { "type": "upsert", "message": { "message_id": "c", "plaintext": "three", "timeline_at": 3 } }
+        ]
+    })))
+    .expect("send projection for loaded group");
+    assert!(app.drain_timeline_subscription());
+    assert_eq!(timeline_ids(&app.timeline), vec!["a", "b", "c"]);
+
+    tx.send(SubscriptionEvent::Result(serde_json::json!({
+        "type": "timeline_projection_updated",
+        "group_id": other_group,
+        "changes": [
+            { "type": "upsert", "message": { "message_id": "z", "plaintext": "nope", "timeline_at": 9 } }
+        ]
+    })))
+    .expect("send projection for another group");
+    assert!(app.drain_timeline_subscription());
+    assert_eq!(
+        timeline_ids(&app.timeline),
+        vec!["a", "b", "c"],
+        "a projection for another group is ignored"
+    );
+}
+
+#[test]
+fn messages_pane_keys_drive_the_selection_and_composer_focus() {
+    let account_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let mut app = test_tui_app(test_unused_client(), account_id);
+    app.focus = Focus::Messages;
+    app.timeline = (0..5).map(|i| timeline_row(&format!("m{i}"), i)).collect();
+    // No older history, so navigation never shells out (the client is unused).
+    app.timeline_scroll.has_more_before = false;
+
+    assert_eq!(
+        app.timeline_scroll.resolved_selection(5),
+        Some(4),
+        "newest by default"
+    );
+    app.handle_key(char_key('k')).expect("k");
+    assert_eq!(app.timeline_scroll.resolved_selection(5), Some(3));
+    app.handle_key(char_key('g')).expect("g");
+    assert_eq!(
+        app.timeline_scroll.resolved_selection(5),
+        Some(0),
+        "g jumps to oldest"
+    );
+    app.handle_key(char_key('j')).expect("j");
+    assert_eq!(app.timeline_scroll.resolved_selection(5), Some(1));
+    app.handle_key(char_key('G')).expect("G");
+    assert_eq!(
+        app.timeline_scroll.resolved_selection(5),
+        Some(4),
+        "G jumps to newest"
+    );
+    assert!(app.timeline_scroll.is_pinned(), "G pins to the bottom");
+    app.handle_key(char_key('i')).expect("i");
+    assert_eq!(app.focus, Focus::Composer, "i focuses the composer");
+}
+
+#[test]
+fn render_messages_wraps_long_lines_so_the_tail_is_visible() {
+    // The height model (`timeline_row_height`) measures with wrapping, so the
+    // renderer must wrap too or long lines truncate at the pane edge and the
+    // reserved-vs-drawn height mismatch breaks bottom-anchoring.
+    let account_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let mut app = test_tui_app(test_unused_client(), account_id);
+    app.focus = Focus::Messages;
+    let mut row = timeline_row("m", 0);
+    row.from_display_name = Some("Al".to_owned());
+    // ~100 chars, wider than the ~28-column messages pane; the tail only renders
+    // if the paragraph wraps.
+    row.display_text = format!("{}TAILMARKER", "word ".repeat(19));
+    app.timeline = vec![row];
+
+    let backend = ratatui::backend::TestBackend::new(100, 30);
+    let mut terminal = ratatui::Terminal::new(backend).expect("test terminal");
+    terminal.draw(|frame| app.render(frame)).expect("draw TUI");
+
+    let rendered = terminal
+        .backend()
+        .buffer()
+        .content()
+        .iter()
+        .map(|cell| cell.symbol())
+        .collect::<String>();
+
+    assert!(
+        rendered.contains("TAILMARKER"),
+        "the wrapped tail of a long message must render, not truncate at the pane edge"
+    );
 }

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -2,34 +2,6 @@
 
 use super::*;
 
-pub(crate) fn daemon_header_label(daemon: &DaemonView) -> String {
-    if !daemon.running {
-        return "off".to_owned();
-    }
-    let mut label = daemon
-        .pid
-        .map(|pid| format!("on pid={pid}"))
-        .unwrap_or_else(|| "on".to_owned());
-    if let Some(activity) = &daemon.last_runtime_activity {
-        label.push_str(&format!(
-            " activity={}/{}/{}",
-            activity.events, activity.joined_groups, activity.messages
-        ));
-        if activity.errors > 0 {
-            label.push_str(&format!(" errors={}", activity.errors));
-        }
-    }
-    let active_streams = daemon
-        .stream_watches
-        .iter()
-        .filter(|watch| watch.status == "running")
-        .count();
-    if active_streams > 0 {
-        label.push_str(&format!(" streams={active_streams}"));
-    }
-    label
-}
-
 pub(crate) fn daemon_status_sentence(daemon: &DaemonView) -> String {
     if !daemon.running {
         return "daemon not running".to_owned();
@@ -231,26 +203,21 @@ pub(crate) fn chat_label(name: &str, unread_count: usize, max_len: usize) -> Str
     shorten(&format!("{name} ({unread_count})"), max_len)
 }
 
-pub(crate) fn status_panel_lines(
-    status: &str,
+/// The opt-in MLS group diagnostics panel body (`/diagnostics`). This is the old
+/// status panel minus its leading status-message line, which now lives in the
+/// one-line status bar. Group id and error text pass through `terminal_safe_text`.
+pub(crate) fn diagnostics_panel_lines(
     diagnostics: Option<&GroupDiagnostics>,
 ) -> Vec<Line<'static>> {
-    let mut lines = vec![
-        Line::from(terminal_safe_text(status)),
-        Line::from(""),
-        Line::from(""),
-    ];
     let Some(diagnostics) = diagnostics else {
-        lines.push(Line::from("MLS no group selected"));
-        return lines;
+        return vec![Line::from("MLS no group selected")];
     };
     if let Some(error) = &diagnostics.error {
-        lines.push(Line::from(format!(
+        return vec![Line::from(format!(
             "MLS group={} unavailable: {}",
             shorten(&terminal_safe_text(&diagnostics.group_id), 18),
             terminal_safe_text(error)
-        )));
-        return lines;
+        ))];
     }
     let epoch = diagnostics
         .epoch
@@ -260,10 +227,10 @@ pub(crate) fn status_panel_lines(
         .member_count
         .map(|member_count| member_count.to_string())
         .unwrap_or_else(|| "unknown".to_owned());
-    lines.push(Line::from(format!(
+    let mut lines = vec![Line::from(format!(
         "MLS epoch={epoch} group={} members={member_count}",
         shorten(&terminal_safe_text(&diagnostics.group_id), 18)
-    )));
+    ))];
     if diagnostics.components.is_empty() {
         lines.push(Line::from("components: none"));
         return lines;
@@ -346,71 +313,108 @@ pub(crate) fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect 
 
 impl TuiApp {
     pub(crate) fn render(&mut self, frame: &mut Frame) {
+        match self.screen {
+            Screen::Login(mode) => self.render_login(frame, mode),
+            Screen::Main => self.render_main(frame),
+        }
+    }
+
+    fn render_main(&mut self, frame: &mut Frame) {
         let area = frame.area();
+        let show_diagnostics = self.show_diagnostics;
+        let diagnostics_lines = if show_diagnostics {
+            diagnostics_panel_lines(self.group_diagnostics.as_ref())
+        } else {
+            Vec::new()
+        };
+
+        // Vertical stack: the chat/messages row takes all reclaimed space, then
+        // the opt-in diagnostics panel, the composer, and the one-line hints and
+        // status bars that replaced the old header and status panel.
+        let mut constraints = vec![Constraint::Min(6)];
+        if show_diagnostics {
+            let height = (diagnostics_lines.len() as u16 + 2).clamp(3, 11);
+            constraints.push(Constraint::Length(height));
+        }
+        constraints.push(Constraint::Length(3));
+        constraints.push(Constraint::Length(1));
+        constraints.push(Constraint::Length(1));
         let root = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(3),
-                Constraint::Min(8),
-                Constraint::Length(3),
-                Constraint::Length(12),
-            ])
+            .constraints(constraints)
             .split(area);
-
-        self.render_header(frame, root[0]);
 
         let body = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Length(34),
-                Constraint::Length(36),
-                Constraint::Min(24),
-            ])
-            .split(root[1]);
+            .constraints([Constraint::Length(36), Constraint::Min(24)])
+            .split(root[0]);
+        self.render_chats(frame, body[0]);
+        self.render_messages(frame, body[1]);
 
-        self.render_accounts(frame, body[0]);
-        self.render_chats(frame, body[1]);
-        self.render_messages(frame, body[2]);
-        self.render_composer(frame, root[2]);
-        self.render_status_panel(frame, root[3]);
-        self.render_slash_suggestions(frame, root[2]);
+        let mut index = 1;
+        if show_diagnostics {
+            self.render_diagnostics_panel(frame, root[index], diagnostics_lines);
+            index += 1;
+        }
+        let composer_area = root[index];
+        index += 1;
+        let hints_area = root[index];
+        index += 1;
+        let status_area = root[index];
+
+        self.render_composer(frame, composer_area);
+        self.render_slash_suggestions(frame, composer_area);
+        self.render_hints(frame, hints_area);
+        self.render_status_bar(frame, status_area);
 
         if self.show_help {
             self.render_help(frame, centered_rect(70, 70, area));
         }
     }
 
-    pub(crate) fn render_header(&self, frame: &mut Frame, area: Rect) {
-        let account = self
-            .selected_account_row()
-            .map(|account| shorten(&terminal_safe_text(&account_display_label(account)), 18))
-            .unwrap_or_else(|| "no account".to_owned());
-        let chat = self
-            .selected_chat_row()
-            .map(|chat| shorten(&terminal_safe_text(&chat.name), 24))
-            .unwrap_or_else(|| "no chat".to_owned());
-        let daemon = terminal_safe_text(&daemon_header_label(&self.daemon));
-        let line = Line::from(vec![
-            Span::styled(
-                "wn",
+    fn render_login(&self, frame: &mut Frame, mode: LoginMode) {
+        let area = frame.area();
+        let root = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Min(6),
+                Constraint::Length(1),
+                Constraint::Length(1),
+            ])
+            .split(area);
+        match mode {
+            LoginMode::Menu => self.render_login_menu(frame, root[0]),
+            LoginMode::AccountSelect => self.render_account_picker(frame, root[0]),
+            LoginMode::NsecEntry => self.render_nsec_entry(frame, root[0]),
+        }
+        self.render_hints(frame, root[1]);
+        self.render_status_bar(frame, root[2]);
+    }
+
+    fn render_login_menu(&self, frame: &mut Frame, area: Rect) {
+        let lines = vec![
+            Line::from(Span::styled(
+                "White Noise",
                 Style::default()
                     .fg(FOCUS_ACCENT)
                     .add_modifier(Modifier::BOLD),
-            ),
-            Span::raw("  "),
-            Span::raw(format!("focus={}  ", self.focus.title())),
-            Span::raw(format!("daemon={daemon}  ")),
-            Span::raw(format!("account={account}  chat={chat}")),
-        ]);
+            )),
+            Line::from(""),
+            Line::from("No identities yet. Get started:"),
+            Line::from(""),
+            Line::from("  c   Create a new identity"),
+            Line::from("  l   Log in with an nsec"),
+            Line::from("  q   Quit"),
+        ];
         frame.render_widget(
-            Paragraph::new(line)
-                .block(Block::default().borders(Borders::ALL).title("White Noise"))
-                .alignment(Alignment::Left),
+            Paragraph::new(lines)
+                .block(panel_block("Welcome", false))
+                .wrap(Wrap { trim: false }),
             area,
         );
     }
 
-    pub(crate) fn render_accounts(&self, frame: &mut Frame, area: Rect) {
+    fn render_account_picker(&self, frame: &mut Frame, area: Rect) {
         let items = if self.accounts.is_empty() {
             vec![ListItem::new("no accounts")]
         } else {
@@ -418,33 +422,82 @@ impl TuiApp {
                 .iter()
                 .enumerate()
                 .map(|(index, account)| {
-                    let marker = if index == self.selected_account {
-                        ">"
-                    } else {
-                        " "
-                    };
+                    let selected = index == self.picker_selection;
+                    let marker = if selected { ">" } else { " " };
                     let signing = if account.local_signing {
                         "local"
                     } else {
                         "public"
                     };
-                    let style = selected_style(index == self.selected_account);
                     ListItem::new(Line::from(vec![
                         Span::raw(format!("{marker} ")),
                         Span::styled(
                             shorten(&terminal_safe_text(&account_display_label(account)), 22),
-                            row_label_style(index == self.selected_account, ACCOUNT_ACCENT),
+                            row_label_style(selected, ACCOUNT_ACCENT),
                         ),
                         Span::raw(format!(" {signing}")),
                     ]))
-                    .style(style)
+                    .style(selected_style(selected))
                 })
                 .collect()
         };
         frame.render_widget(
-            List::new(items).block(panel_block("Accounts", self.focus == Focus::Accounts)),
+            List::new(items).block(panel_block("Select Account", true)),
             area,
         );
+    }
+
+    fn render_nsec_entry(&self, frame: &mut Frame, area: Rect) {
+        let lines = vec![
+            Line::from("Paste or type your nsec, then press Enter:"),
+            Line::from(""),
+            Line::from(vec![
+                Span::styled("nsec ", Style::default().fg(FOCUS_ACCENT)),
+                Span::raw(masked_secret(&self.input)),
+            ]),
+        ];
+        frame.render_widget(
+            Paragraph::new(lines)
+                .block(panel_block("Log in with nsec", true))
+                .wrap(Wrap { trim: false }),
+            area,
+        );
+    }
+
+    fn render_diagnostics_panel(&self, frame: &mut Frame, area: Rect, lines: Vec<Line<'static>>) {
+        frame.render_widget(
+            Paragraph::new(lines)
+                .block(panel_block("Diagnostics", false))
+                .wrap(Wrap { trim: false }),
+            area,
+        );
+    }
+
+    fn render_hints(&self, frame: &mut Frame, area: Rect) {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                hints_line(self.screen, self.focus, self.entered_main),
+                Style::default().fg(Color::DarkGray),
+            ))),
+            area,
+        );
+    }
+
+    fn render_status_bar(&self, frame: &mut Frame, area: Rect) {
+        let account_label = self
+            .selected_account_row()
+            .map(account_display_label)
+            .unwrap_or_else(|| "no account".to_owned());
+        let unread_total = self.unread_counts.values().sum();
+        let text = status_bar_line(
+            &account_label,
+            self.daemon.running,
+            self.chats.len(),
+            unread_total,
+            &self.status,
+            area.width as usize,
+        );
+        frame.render_widget(Paragraph::new(Line::from(text)), area);
     }
 
     pub(crate) fn render_chats(&self, frame: &mut Frame, area: Rect) {
@@ -598,18 +651,6 @@ impl TuiApp {
         );
     }
 
-    pub(crate) fn render_status_panel(&self, frame: &mut Frame, area: Rect) {
-        frame.render_widget(
-            Paragraph::new(status_panel_lines(
-                &self.status,
-                self.group_diagnostics.as_ref(),
-            ))
-            .block(panel_block("Status", false))
-            .wrap(Wrap { trim: false }),
-            area,
-        );
-    }
-
     pub(crate) fn render_help(&self, frame: &mut Frame, area: Rect) {
         let lines = vec![
             Line::from(Span::styled(
@@ -619,13 +660,18 @@ impl TuiApp {
                     .add_modifier(Modifier::BOLD),
             )),
             Line::from(""),
-            Line::from("Tab cycles panels. Arrows move. Enter selects or submits. Ctrl-C quits."),
+            Line::from(
+                "Chats + messages fill the screen; the composer, hints, and status sit below.",
+            ),
+            Line::from("Tab/BackTab cycle chats, messages, and composer. Ctrl-C quits."),
+            Line::from("Chats: j/k move; Enter opens the chat; A reopens the account picker."),
             Line::from("Messages: j/k or arrows move; PageUp/PageDown page."),
             Line::from(
                 "G/g jump newest/oldest; past oldest loads history; i/Enter focus composer.",
             ),
             Line::from(""),
             Line::from("/refresh"),
+            Line::from("/diagnostics"),
             Line::from("/account <npub-or-hex>"),
             Line::from("/create-identity"),
             Line::from("/login <nsec-or-npub>"),

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -170,22 +170,39 @@ pub(crate) fn stream_preview_line_pair(
     ])
 }
 
-pub(crate) fn message_lines(
-    messages: &[MessageRow],
-    selected_account: Option<&AccountRow>,
-) -> Vec<Line<'static>> {
-    messages
-        .iter()
-        .flat_map(|message| {
-            let author = terminal_safe_text(&message_author_label(message, selected_account));
-            [
-                Line::from(vec![
-                    Span::styled(author, Style::default().fg(Color::Yellow)),
-                    Span::raw(": "),
-                    Span::raw(terminal_safe_text(&message.display_text)),
-                ]),
-                Line::from(""),
-            ]
+/// The messages-pane title: plain "Messages" when pinned with everything on
+/// screen, otherwise annotated with the row counts above and below the viewport
+/// so the reader knows history or newer content is off-screen.
+pub(crate) fn timeline_pane_title(total: usize, first: usize, last: usize) -> String {
+    let above = first;
+    let below = total.saturating_sub(last + 1);
+    match (above, below) {
+        (0, 0) => "Messages".to_owned(),
+        (above, 0) => format!("Messages [{above} older]"),
+        (0, below) => format!("Messages [{below} newer]"),
+        (above, below) => format!("Messages [{above} older | {below} newer]"),
+    }
+}
+
+/// Apply the selection highlight to a row's rendered lines: a dark-gray
+/// background over every span, bumping a dark-gray foreground to gray so the
+/// timestamp/reply/attachment text stays legible on the highlight.
+fn highlight_timeline_lines(lines: Vec<Line<'static>>) -> Vec<Line<'static>> {
+    lines
+        .into_iter()
+        .map(|line| {
+            let spans = line
+                .spans
+                .into_iter()
+                .map(|span| {
+                    let mut style = span.style.bg(Color::DarkGray);
+                    if span.style.fg == Some(Color::DarkGray) {
+                        style = style.fg(Color::Gray);
+                    }
+                    Span::styled(span.content, style)
+                })
+                .collect::<Vec<_>>();
+            Line::from(spans)
         })
         .collect()
 }
@@ -456,44 +473,81 @@ impl TuiApp {
     }
 
     pub(crate) fn render_messages(&mut self, frame: &mut Frame, area: Rect) {
-        let mut lines = if self.messages.is_empty() {
-            vec![Line::from("no messages")]
-        } else {
-            message_lines(&self.messages, self.message_account_row())
-        };
-        let group_id = self
-            .messages_group_id
-            .as_deref()
-            .or_else(|| self.selected_chat_row().map(|chat| chat.group_id.as_str()));
-        for preview in stream_preview_lines(&self.daemon, &self.live_stream_previews, group_id) {
-            lines.push(preview);
+        let focused = self.focus == Focus::Messages;
+        if self.timeline.is_empty() {
+            frame.render_widget(
+                Paragraph::new(vec![Line::from("no messages")])
+                    .block(panel_block("Messages", focused)),
+                area,
+            );
+            return;
         }
 
         let inner_width = area.width.saturating_sub(2);
         let inner_height = area.height.saturating_sub(2);
-        self.messages_viewport = inner_height;
 
-        let paragraph = Paragraph::new(lines).wrap(Wrap { trim: false });
-        let total = u16::try_from(paragraph.line_count(inner_width)).unwrap_or(u16::MAX);
-        let (clamped_scroll, scroll_top) =
-            messages_scroll_offsets(total, inner_height, self.messages_scroll);
-        self.messages_scroll = clamped_scroll;
-
-        let title = if scroll_top == 0 && self.messages_scroll == 0 {
-            "Messages".to_owned()
-        } else if self.messages_scroll == 0 {
-            format!("Messages [{scroll_top} above]")
+        // Live stream previews sit in a bottom block that only exists (and only
+        // reserves viewport rows) while the view is anchored at the newest row.
+        let group_id = self
+            .messages_group_id
+            .as_deref()
+            .or_else(|| self.selected_chat_row().map(|chat| chat.group_id.as_str()));
+        let preview_lines =
+            stream_preview_lines(&self.daemon, &self.live_stream_previews, group_id);
+        let bottom_block = if self.timeline_scroll.is_pinned() {
+            u16::try_from(preview_lines.len()).unwrap_or(u16::MAX)
         } else {
-            format!(
-                "Messages [{scroll_top} above | {} below]",
-                self.messages_scroll
-            )
+            0
         };
 
+        let selected_account = self.message_account_row();
+        let heights = timeline_row_heights(&self.timeline, selected_account, inner_width);
+        let total = self.timeline.len();
+        let selected = self.timeline_scroll.resolved_selection(total);
+
+        // One algorithm decides both the reported visible range and what is drawn,
+        // so the follow-scroll feedback and the rendered rows never diverge.
+        let (title, mut lines, range) = match timeline_visible_range(
+            &heights,
+            inner_height,
+            self.timeline_scroll.offset,
+            bottom_block,
+        ) {
+            Some((first, last)) => {
+                let mut lines = Vec::new();
+                for index in first..=last {
+                    let mut row_lines = timeline_row_lines(&self.timeline[index], selected_account);
+                    if selected == Some(index) {
+                        row_lines = highlight_timeline_lines(row_lines);
+                    }
+                    lines.extend(row_lines);
+                    // Blank separator row, counted in each row's rendered height.
+                    lines.push(Line::from(""));
+                }
+                (
+                    timeline_pane_title(total, first, last),
+                    lines,
+                    Some((first, last)),
+                )
+            }
+            None => ("Messages".to_owned(), Vec::new(), None),
+        };
+        if bottom_block > 0 {
+            lines.extend(preview_lines);
+        }
+
+        if let Some((first, last)) = range {
+            self.timeline_scroll
+                .record_visible_range(first, last, total);
+        }
+
         frame.render_widget(
-            paragraph
-                .block(panel_block(&title, self.focus == Focus::Messages))
-                .scroll((scroll_top, 0)),
+            Paragraph::new(lines)
+                .block(panel_block(&title, focused))
+                // Match `timeline_row_height`, which measures with wrapping: without
+                // this, long lines truncate at the pane edge and the reserved-vs-drawn
+                // height mismatch breaks bottom-anchoring.
+                .wrap(Wrap { trim: false }),
             area,
         );
     }
@@ -566,8 +620,9 @@ impl TuiApp {
             )),
             Line::from(""),
             Line::from("Tab cycles panels. Arrows move. Enter selects or submits. Ctrl-C quits."),
+            Line::from("Messages: j/k or arrows move; PageUp/PageDown page."),
             Line::from(
-                "Messages panel: Up/Down or j/k scroll; PageUp/PageDown, Home/End jump. New messages stick to the bottom.",
+                "G/g jump newest/oldest; past oldest loads history; i/Enter focus composer.",
             ),
             Line::from(""),
             Line::from("/refresh"),


### PR DESCRIPTION
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/941">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned the TUI to use a chat list, message timeline, composer, and a one-line status bar.
  * Added login and account-selection flows with improved focus/navigation and timeline scrolling.
  * Added `/diagnostics` to toggle an MLS diagnostics panel.
  * Added `wn tui` options for optional discovery/default-account relay provisioning.

* **Documentation**
  * Updated TUI walkthrough and slash-command help to reflect the new layout and controls.
  * Updated CLI changelog with the new TUI shell/timeline behavior and relay flags.

* **Tests**
  * Expanded and refocused TUI tests for the new timeline rendering, routing, and diagnostics behavior.

* **Chores**
  * Added `chrono` workspace dependency; updated ignore rules and Just launch recipes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->