### PR TITLE
feat(cli): add --reply-to to messages send

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -31,6 +31,16 @@ versioning through the workspace version in the root `Cargo.toml`.
   `wn daemon start`). They are forwarded to the `daemon start` child and to `create-identity`/`login` account setup
   so a first run with no relay configuration can supply relays without dead-ending. Flag passthrough only; no JSON
   response shapes changed.
+- `wn messages send` (and the older `wn message send`) accept `--reply-to <message-id>` to send the text as a reply to
+  an existing message. The reply carries the same `q`/`e` reference tags other Marmot clients produce, so recipients'
+  timelines parse it into `reply_to_message_id` with a hydrated `reply_preview`. `--reply-to` is additive input only:
+  the JSON response shape is unchanged, pass the group with `--group` when replying, and a reply to a not-yet-synced
+  parent is still sent (its preview hydrates when the parent arrives). No new runtime API was needed; the CLI routes
+  reply sends through the existing `MarmotAppRuntime::reply_to_message`. Because the trailing message text is
+  hyphen-tolerant, a `--reply-to` placed *after* the text is read as literal text; rather than silently sending that
+  stray flag as part of the body, the send now fails loudly with error code `reply_to_after_message_text` (put
+  `--reply-to` before the text with `--group`). Tradeoff: message text that is itself exactly `--reply-to` can no
+  longer be sent.
 - MarmotKit/UniFFI now exposes encrypted per-account composer draft storage with metadata-only list, full load, upsert,
   and delete operations. Drafts retain their text, reply target, ordered attachment bytes, and attachment presentation
   metadata in the account's SQLCipher database; attachment bytes are loaded only for the selected draft.

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -37,10 +37,11 @@ versioning through the workspace version in the root `Cargo.toml`.
   the JSON response shape is unchanged, pass the group with `--group` when replying, and a reply to a not-yet-synced
   parent is still sent (its preview hydrates when the parent arrives). No new runtime API was needed; the CLI routes
   reply sends through the existing `MarmotAppRuntime::reply_to_message`. Because the trailing message text is
-  hyphen-tolerant, a `--reply-to` placed *after* the text is read as literal text; rather than silently sending that
-  stray flag as part of the body, the send now fails loudly with error code `reply_to_after_message_text` (put
-  `--reply-to` before the text with `--group`). Tradeoff: message text that is itself exactly `--reply-to` can no
-  longer be sent.
+  hyphen-tolerant, a `--reply-to` placed *after* the text (either spelling: `--reply-to <id>` or `--reply-to=<id>`) is
+  read as literal text; rather than silently sending that stray flag as part of the body, the send now fails loudly with
+  error code `reply_to_after_message_text` (put `--reply-to` before the text with `--group`). Tradeoff: the guard
+  rejects any message whose text contains a bare `--reply-to` or `--reply-to=<id>` token anywhere (e.g.
+  `hello --reply-to friend`), so such text can no longer be sent this way.
 - MarmotKit/UniFFI now exposes encrypted per-account composer draft storage with metadata-only list, full load, upsert,
   and delete operations. Drafts retain their text, reply target, ordered attachment bytes, and attachment presentation
   metadata in the account's SQLCipher database; attachment bytes are loaded only for the selected draft.

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -214,6 +214,7 @@ Message commands:
 ```sh
 wn --account <npub-or-hex> messages send <group-hex> "hello"
 wn --account <npub-or-hex> messages send --group <group-hex> "--text that starts with a dash"
+wn --account <npub-or-hex> messages send --group <group-hex> --reply-to <message-id> "replying to you"
 wn --account <npub-or-hex> messages list
 wn --account <npub-or-hex> messages list <group-hex> --limit 20
 wn --account <npub-or-hex> messages list <group-hex> --before <unix-seconds> --before-message-id <event-id>
@@ -229,6 +230,16 @@ wn --account <npub-or-hex> messages timeline list <group-hex> --limit 20
 wn --account <npub-or-hex> messages timeline search <group-hex> <query> --limit 20
 wn --account <npub-or-hex> messages timeline subscribe <group-hex>
 ```
+
+`messages send --reply-to <message-id>` sends the text as a reply to an existing message. It uses the same wire
+format other Marmot clients produce, so recipients see the row with its reply reference and a hydrated reply preview
+of the parent. Pass the group with `--group` and put `--reply-to` before the text when replying: the message text uses
+hyphen-tolerant parsing, so a `--reply-to` placed after the text (in either the positional-group or the `--group`
+form) is read as literal text rather than as the flag. Instead of silently sending that stray `--reply-to` as part of
+the body, the CLI rejects the mis-ordering with a clear error (code `reply_to_after_message_text`) so it fails loudly.
+The tradeoff: message text that is itself exactly `--reply-to` can no longer be sent. The parent id is not required to
+exist locally; a reply to a message you have not yet synced is still sent (its preview hydrates once the parent
+arrives). The JSON response is the same shape as a plain send.
 
 The `messages timeline` subcommands list, search, and subscribe to the materialized message timeline (the projection
 that interleaves messages, media, and agent-stream anchors/finals in conversation order).

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -235,9 +235,11 @@ wn --account <npub-or-hex> messages timeline subscribe <group-hex>
 format other Marmot clients produce, so recipients see the row with its reply reference and a hydrated reply preview
 of the parent. Pass the group with `--group` and put `--reply-to` before the text when replying: the message text uses
 hyphen-tolerant parsing, so a `--reply-to` placed after the text (in either the positional-group or the `--group`
-form) is read as literal text rather than as the flag. Instead of silently sending that stray `--reply-to` as part of
-the body, the CLI rejects the mis-ordering with a clear error (code `reply_to_after_message_text`) so it fails loudly.
-The tradeoff: message text that is itself exactly `--reply-to` can no longer be sent. The parent id is not required to
+form, and in either spelling: `--reply-to <id>` or `--reply-to=<id>`) is read as literal text rather than as the flag.
+Instead of silently sending that stray `--reply-to` as part of the body, the CLI rejects the mis-ordering with a clear
+error (code `reply_to_after_message_text`) so it fails loudly. The tradeoff: the guard rejects any message whose text
+contains a bare `--reply-to` or `--reply-to=<id>` token anywhere (e.g. `hello --reply-to friend`), so such text can no
+longer be sent this way. The parent id is not required to
 exist locally; a reply to a message you have not yet synced is still sent (its preview hydrates once the parent
 arrives). The JSON response is the same shape as a plain send.
 

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -622,6 +622,12 @@ pub(crate) enum MessageCommand {
         #[arg(long = "group", value_name = "GROUP", help = "Group id to send to")]
         group_flag: Option<String>,
         #[arg(
+            long = "reply-to",
+            value_name = "MESSAGE_ID",
+            help = "Send as a reply to this message id (use with --group, before the text)"
+        )]
+        reply_to: Option<String>,
+        #[arg(
             value_name = "GROUP_OR_TEXT",
             allow_hyphen_values = true,
             help = "Either GROUP TEXT... or TEXT... when --group is provided"

--- a/crates/cli/src/commands/messages.rs
+++ b/crates/cli/src/commands/messages.rs
@@ -38,6 +38,26 @@ fn message_target_and_text(
     Ok((group, args))
 }
 
+/// Reject a `--reply-to` that landed inside the resolved message `text`.
+///
+/// The trailing message args use `allow_hyphen_values`, so a `--reply-to` placed
+/// *after* the text (in the `--group` form) or after the positional group id is
+/// swallowed as literal text instead of setting `reply_to` (see the parse-lock
+/// tests in `lib.rs`). Sending anyway would publish a body carrying a stray
+/// `--reply-to <id>` that attaches to no reply — a silent footgun. When
+/// `reply_to` was already parsed the flag did its job, so we only guard the
+/// `None` case. Tradeoff: message text that is itself exactly `--reply-to` can no
+/// longer be sent; put `--reply-to` before the text with `--group` to reply.
+pub(crate) fn reject_misplaced_reply_to(
+    reply_to: Option<&str>,
+    text: &[String],
+) -> Result<(), WnError> {
+    if reply_to.is_none() && text.iter().any(|token| token == "--reply-to") {
+        return Err(WnError::ReplyToAfterMessageText);
+    }
+    Ok(())
+}
+
 pub(crate) async fn message_command(
     account_home: &AccountHome,
     app: &MarmotApp,
@@ -56,20 +76,40 @@ pub(crate) async fn message_command_with_runtime(
     account_flag: Option<String>,
 ) -> Result<CommandOutput, WnError> {
     match command {
-        MessageCommand::Send { group_flag, args } => {
+        MessageCommand::Send {
+            group_flag,
+            reply_to,
+            args,
+        } => {
             let (group, text) = message_target_and_text(group_flag, args)?;
             if text.is_empty() {
                 return Err(WnError::EmptyMessage);
             }
+            reject_misplaced_reply_to(reply_to.as_deref(), &text)?;
             let account = resolve_account(account_home, account_flag)?;
             ensure_local_signing(&account)?;
             app.status(&account.label)?;
             let group_id_hex = normalize_group_id_hex(&group)?;
             let group_id = GroupId::new(hex::decode(&group_id_hex)?);
             let payload = text.join(" ");
-            let summary = runtime
-                .send_message(&account.label, &group_id, payload.into_bytes())
-                .await?;
+            // A `--reply-to` send routes through the reply-capable runtime API,
+            // which emits a kind-9 chat carrying `q`/`e` reference tags to the
+            // parent. That is the exact wire format timeline ingest parses back
+            // into `reply_to_message_id` + a hydrated `reply_preview`. A plain
+            // send stays on the raw-payload path. The response shape is identical
+            // either way, so `--reply-to` is additive input only.
+            let summary = match reply_to.as_deref() {
+                Some(reply_to) => {
+                    runtime
+                        .reply_to_message(&account.label, &group_id, reply_to, &payload)
+                        .await?
+                }
+                None => {
+                    runtime
+                        .send_message(&account.label, &group_id, payload.into_bytes())
+                        .await?
+                }
+            };
             Ok(CommandOutput {
                 plain: format!("sent message published={}", summary.published),
                 json: json!({

--- a/crates/cli/src/commands/messages.rs
+++ b/crates/cli/src/commands/messages.rs
@@ -43,16 +43,22 @@ fn message_target_and_text(
 /// The trailing message args use `allow_hyphen_values`, so a `--reply-to` placed
 /// *after* the text (in the `--group` form) or after the positional group id is
 /// swallowed as literal text instead of setting `reply_to` (see the parse-lock
-/// tests in `lib.rs`). Sending anyway would publish a body carrying a stray
-/// `--reply-to <id>` that attaches to no reply — a silent footgun. When
-/// `reply_to` was already parsed the flag did its job, so we only guard the
-/// `None` case. Tradeoff: message text that is itself exactly `--reply-to` can no
-/// longer be sent; put `--reply-to` before the text with `--group` to reply.
+/// tests in `lib.rs`). Both spellings are swallowed: the separate-value form
+/// `--reply-to <id>` and the equals form `--reply-to=<id>` (a single token).
+/// Sending anyway would publish a body carrying a stray reply flag that attaches
+/// to no reply — a silent footgun. When `reply_to` was already parsed the flag
+/// did its job, so we only guard the `None` case. Tradeoff: the guard rejects any
+/// message whose text contains a bare `--reply-to` / `--reply-to=…` token
+/// anywhere (e.g. `hello --reply-to friend`), so such text can no longer be sent;
+/// put `--reply-to` before the text with `--group` to reply.
 pub(crate) fn reject_misplaced_reply_to(
     reply_to: Option<&str>,
     text: &[String],
 ) -> Result<(), WnError> {
-    if reply_to.is_none() && text.iter().any(|token| token == "--reply-to") {
+    let has_stray_flag = text
+        .iter()
+        .any(|token| token == "--reply-to" || token.starts_with("--reply-to="));
+    if reply_to.is_none() && has_stray_flag {
         return Err(WnError::ReplyToAfterMessageText);
     }
     Ok(())

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -29,6 +29,8 @@ pub(crate) enum WnError {
     EmptyMessage,
     #[error("group id is required")]
     MissingGroupId,
+    #[error("--reply-to must come before the message text; it was read as literal text here")]
+    ReplyToAfterMessageText,
     #[error("relay URL cannot be empty")]
     EmptyRelayUrl,
     #[error("invalid relay URL: {0}")]
@@ -382,6 +384,13 @@ pub(crate) fn wn_error_json(err: &WnError) -> Value {
         WnError::MissingGroupId => json!({
             "code": "missing_group_id",
             "message": err.to_string(),
+        }),
+        WnError::ReplyToAfterMessageText => json!({
+            "code": "reply_to_after_message_text",
+            "message": err.to_string(),
+            "repair": {
+                "reply": "put --reply-to before the text: wn messages send --group <group> --reply-to <message-id> <text>",
+            },
         }),
         WnError::EmptyRelayUrl => json!({
             "code": "empty_relay_url",

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -389,7 +389,7 @@ pub(crate) fn wn_error_json(err: &WnError) -> Value {
             "code": "reply_to_after_message_text",
             "message": err.to_string(),
             "repair": {
-                "reply": "put --reply-to before the text: wn messages send --group <group> --reply-to <message-id> <text>",
+                "reorder": "put --reply-to before the text: wn messages send --group <group> --reply-to <message-id> <text>",
             },
         }),
         WnError::EmptyRelayUrl => json!({

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1965,6 +1965,47 @@ mod tests {
     }
 
     #[test]
+    fn message_send_stray_reply_to_equals_form_is_rejected() {
+        // The equals spelling `--reply-to=PARENT` placed *after* the text is also
+        // swallowed as one literal `allow_hyphen_values` token (verified: it parses
+        // to `reply_to=None`, args `["hello", "--reply-to=PARENT"]`). An exact-token
+        // guard would miss it and publish a body carrying a stray reply flag, so the
+        // guard must reject the `=` form on both send surfaces too.
+        let cases: [&[&str]; 2] = [
+            &[
+                "wn",
+                "messages",
+                "send",
+                "--group",
+                "GROUP",
+                "hello",
+                "--reply-to=PARENT",
+            ],
+            &[
+                "wn",
+                "messages",
+                "send",
+                "GROUP",
+                "hello",
+                "--reply-to=PARENT",
+            ],
+        ];
+        for argv in cases {
+            let (group_flag, reply_to, args) = parse_send(argv);
+            assert_eq!(reply_to, None);
+            // Mirror the handler: the positional-group form drops the leading group.
+            let text = if group_flag.is_some() {
+                args.as_slice()
+            } else {
+                &args[1..]
+            };
+            let err = reject_misplaced_reply_to(reply_to.as_deref(), text)
+                .expect_err("a stray --reply-to=<id> in the text must be rejected");
+            assert!(matches!(err, WnError::ReplyToAfterMessageText));
+        }
+    }
+
+    #[test]
     fn message_list_cursors_accept_valid_compound_and_no_cursor() {
         assert!(validate_message_list_cursors(None, None, None, None).is_ok());
         assert!(validate_message_list_cursors(Some(101), Some("d"), None, None).is_ok());

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1159,8 +1159,12 @@ mod tests {
     use std::ffi::OsString;
     use std::path::{Path, PathBuf};
 
+    use clap::Parser;
+
     use super::commands::account::{GlobalRelayDefaults, apply_global_relay_defaults};
-    use super::commands::messages::{apply_message_cursors, validate_message_list_cursors};
+    use super::commands::messages::{
+        apply_message_cursors, reject_misplaced_reply_to, validate_message_list_cursors,
+    };
     use super::commands::relay_stats::{relay_stats_output, relay_stats_plain};
     use super::commands::stream::{
         first_quic_candidate_is_loopback, parse_quic_candidate, quic_candidate_host,
@@ -1756,6 +1760,208 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["b", "c"]
         );
+    }
+
+    fn parse_send(argv: &[&str]) -> (Option<String>, Option<String>, Vec<String>) {
+        let cli = Cli::try_parse_from(argv.iter().copied()).expect("send args parse");
+        match cli.command {
+            Command::Message {
+                command:
+                    crate::MessageCommand::Send {
+                        group_flag,
+                        reply_to,
+                        args,
+                    },
+            }
+            | Command::Messages {
+                command:
+                    crate::MessageCommand::Send {
+                        group_flag,
+                        reply_to,
+                        args,
+                    },
+            } => (group_flag, reply_to, args),
+            other => panic!("expected a message send command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_send_reply_to_flag_parses_before_positional_text() {
+        // `--group` + `--reply-to` before the text: the canonical reply form.
+        let (group_flag, reply_to, args) = parse_send(&[
+            "wn",
+            "messages",
+            "send",
+            "--group",
+            "GROUP",
+            "--reply-to",
+            "PARENT",
+            "hello",
+            "world",
+        ]);
+        assert_eq!(group_flag.as_deref(), Some("GROUP"));
+        assert_eq!(reply_to.as_deref(), Some("PARENT"));
+        assert_eq!(args, vec!["hello".to_owned(), "world".to_owned()]);
+
+        // Positional group works too, as long as `--reply-to` precedes the
+        // positional group (the older singular `message` surface shares the enum).
+        let (group_flag, reply_to, args) = parse_send(&[
+            "wn",
+            "message",
+            "send",
+            "--reply-to",
+            "PARENT",
+            "GROUP",
+            "hi",
+        ]);
+        assert_eq!(group_flag, None);
+        assert_eq!(reply_to.as_deref(), Some("PARENT"));
+        assert_eq!(args, vec!["GROUP".to_owned(), "hi".to_owned()]);
+    }
+
+    #[test]
+    fn message_send_reply_to_after_positional_group_is_literal_text() {
+        // The trailing positional text uses `allow_hyphen_values`, so once a
+        // positional group is consumed everything after it (including a stray
+        // `--reply-to`) is literal message text — the same rule that lets
+        // `send --group <g> "--dash text"` work. Callers must use the `--group`
+        // form to attach `--reply-to`. This locks that intentional behavior.
+        let (group_flag, reply_to, args) = parse_send(&[
+            "wn",
+            "messages",
+            "send",
+            "GROUP",
+            "--reply-to",
+            "PARENT",
+            "text",
+        ]);
+        assert_eq!(group_flag, None);
+        assert_eq!(reply_to, None);
+        assert_eq!(
+            args,
+            vec![
+                "GROUP".to_owned(),
+                "--reply-to".to_owned(),
+                "PARENT".to_owned(),
+                "text".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn message_send_reply_to_after_group_flag_text_is_literal_text() {
+        // The `--group` form carries the same footgun as the positional-group form
+        // above: the trailing message args use `allow_hyphen_values`, so a
+        // `--reply-to` placed *after* the text is swallowed as literal message text
+        // (`reply_to` stays `None`) instead of setting the reply target. The send
+        // handler turns this exact parse into a loud error (see
+        // `reject_misplaced_reply_to`); this locks the parse the guard fires on.
+        let (group_flag, reply_to, args) = parse_send(&[
+            "wn",
+            "messages",
+            "send",
+            "--group",
+            "GROUP",
+            "hello",
+            "--reply-to",
+            "PARENT",
+        ]);
+        assert_eq!(group_flag.as_deref(), Some("GROUP"));
+        assert_eq!(reply_to, None);
+        assert_eq!(
+            args,
+            vec![
+                "hello".to_owned(),
+                "--reply-to".to_owned(),
+                "PARENT".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn message_send_without_reply_to_leaves_it_unset() {
+        let (group_flag, reply_to, args) =
+            parse_send(&["wn", "messages", "send", "GROUP", "hello"]);
+        assert_eq!(group_flag, None);
+        assert_eq!(reply_to, None);
+        assert_eq!(args, vec!["GROUP".to_owned(), "hello".to_owned()]);
+    }
+
+    #[test]
+    fn message_send_stray_reply_to_in_text_is_rejected() {
+        // A `--reply-to` that lands *after* the message text is swallowed as
+        // literal text (see the parse-lock tests above). The send handler must
+        // reject that mis-ordering loudly instead of publishing a body carrying a
+        // stray `--reply-to <id>` that silently attaches to no reply.
+        let err = reject_misplaced_reply_to(
+            None,
+            &[
+                "hello".to_owned(),
+                "--reply-to".to_owned(),
+                "PARENT".to_owned(),
+            ],
+        )
+        .expect_err("a stray --reply-to in the message text must be rejected");
+        assert!(matches!(err, WnError::ReplyToAfterMessageText));
+    }
+
+    #[test]
+    fn message_send_reply_to_guard_allows_real_replies_and_plain_text() {
+        // A parsed `--reply-to` already did its job (the flag was consumed), so an
+        // identical token surviving in the body is fine and the guard stays quiet.
+        assert!(
+            reject_misplaced_reply_to(Some("PARENT"), &["--reply-to".to_owned(), "b".to_owned()])
+                .is_ok()
+        );
+        // Plain text with no stray flag is always fine.
+        assert!(reject_misplaced_reply_to(None, &["hello".to_owned(), "world".to_owned()]).is_ok());
+    }
+
+    #[test]
+    fn reply_to_after_message_text_error_renders_reply_to_code() {
+        let value = super::wn_error_json(&WnError::ReplyToAfterMessageText);
+        assert_eq!(value["code"], "reply_to_after_message_text");
+        assert_eq!(
+            value["message"],
+            "--reply-to must come before the message text; it was read as literal text here"
+        );
+    }
+
+    #[test]
+    fn message_send_reply_to_footgun_is_rejected_on_both_send_surfaces() {
+        // The guard lives on the shared `MessageCommand::Send` arm, so the plural
+        // `messages send` and the older singular `message send` are protected
+        // identically. With `--group`, the parsed positional args are the message
+        // text, so a trailing `--reply-to` is exactly what the guard rejects.
+        for argv in [
+            [
+                "wn",
+                "messages",
+                "send",
+                "--group",
+                "GROUP",
+                "hello",
+                "--reply-to",
+                "PARENT",
+            ],
+            [
+                "wn",
+                "message",
+                "send",
+                "--group",
+                "GROUP",
+                "hello",
+                "--reply-to",
+                "PARENT",
+            ],
+        ] {
+            let (group_flag, reply_to, text) = parse_send(&argv);
+            assert_eq!(group_flag.as_deref(), Some("GROUP"));
+            assert_eq!(reply_to, None);
+            let err = reject_misplaced_reply_to(reply_to.as_deref(), &text)
+                .expect_err("stray --reply-to must be rejected on both send surfaces");
+            assert!(matches!(err, WnError::ReplyToAfterMessageText));
+        }
     }
 
     #[test]

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -1392,9 +1392,18 @@ fn first_message_with_kind_and_target<'a>(
 
 /// First `e` tag value on a projected message's `tags` array.
 fn message_e_tag(message: &Value) -> Option<&str> {
+    message_tag_value(message, "e")
+}
+
+/// First `q` (quote/reply) tag value on a projected message's `tags` array.
+fn message_q_tag(message: &Value) -> Option<&str> {
+    message_tag_value(message, "q")
+}
+
+fn message_tag_value<'a>(message: &'a Value, name: &str) -> Option<&'a str> {
     message["tags"].as_array()?.iter().find_map(|tag| {
         let tag = tag.as_array()?;
-        if tag.first()?.as_str()? == "e" {
+        if tag.first()?.as_str()? == name {
             tag.get(1)?.as_str()
         } else {
             None
@@ -4164,6 +4173,209 @@ fn messages_react_unreact_and_delete_are_typed_app_messages() {
     );
     assert_eq!(retry["target_event_id"], target_message_id);
     assert_eq!(retry["retry_scope"], "group_convergence");
+}
+
+#[test]
+fn messages_send_reply_to_round_trips_into_timeline_reply_preview() {
+    let home = tempfile::tempdir().expect("tempdir");
+
+    let alice = create_account(home.path());
+    let bob = create_account(home.path());
+    run_json(home.path(), &["--account", &bob, "keys", "publish"]);
+
+    let created_group = run_json(
+        home.path(),
+        &["--account", &alice, "groups", "create", "replies", &bob],
+    );
+    let group_id = created_group["group_id"].as_str().expect("group id");
+    sync_until_joined(home.path(), test_relay_url(), &bob, group_id);
+
+    // Alice sends the message Bob will reply to.
+    let parent = run_json(
+        home.path(),
+        &[
+            "--account",
+            &alice,
+            "messages",
+            "send",
+            group_id,
+            "original from alice",
+        ],
+    );
+    let parent_id = parent["message_ids"][0]
+        .as_str()
+        .expect("parent message id")
+        .to_owned();
+    sync_until_message(home.path(), test_relay_url(), &bob, "original from alice");
+
+    // Bob replies to Alice's message. `--reply-to` is additive input; the JSON
+    // response shape matches a plain send.
+    let reply = run_json(
+        home.path(),
+        &[
+            "--account",
+            &bob,
+            "messages",
+            "send",
+            "--group",
+            group_id,
+            "--reply-to",
+            &parent_id,
+            "reply from bob",
+        ],
+    );
+    assert!(
+        reply["published"]
+            .as_u64()
+            .is_some_and(|published| published >= 1),
+        "reply should publish to at least one relay, got {reply}"
+    );
+    assert!(
+        reply["message_ids"][0].as_str().is_some(),
+        "reply response keeps the plain-send shape with message_ids, got {reply}"
+    );
+    sync_until_message(home.path(), test_relay_url(), &alice, "reply from bob");
+
+    // Alice's materialized timeline shows Bob's reply row with the reply
+    // reference and a hydrated preview of Alice's original text. This proves the
+    // send-side wire format (`q`/`e` tags on a kind-9 chat) matches the
+    // ingest-side reply parser.
+    let timeline = run_json(
+        home.path(),
+        &[
+            "--account",
+            &alice,
+            "messages",
+            "timeline",
+            "list",
+            group_id,
+            "--limit",
+            "20",
+        ],
+    );
+    let bob_reply = timeline["messages"]
+        .as_array()
+        .expect("timeline messages")
+        .iter()
+        .find(|message| message["plaintext"] == "reply from bob")
+        .expect("bob reply row");
+    assert_eq!(
+        bob_reply["reply_to_message_id"].as_str(),
+        Some(parent_id.as_str())
+    );
+    assert_eq!(
+        bob_reply["reply_preview"]["plaintext"].as_str(),
+        Some("original from alice")
+    );
+    // The authoritative wire contract: the reply carries a `q` (quote) tag with
+    // the parent id, which timeline ingest reads into `reply_to_message_id`.
+    assert_eq!(message_q_tag(bob_reply), Some(parent_id.as_str()));
+}
+
+#[test]
+fn messages_send_reply_to_unknown_parent_still_sends() {
+    let home = tempfile::tempdir().expect("tempdir");
+
+    let alice = create_account(home.path());
+    let bob = create_account(home.path());
+    run_json(home.path(), &["--account", &bob, "keys", "publish"]);
+
+    let created_group = run_json(
+        home.path(),
+        &["--account", &alice, "groups", "create", "dangling", &bob],
+    );
+    let group_id = created_group["group_id"].as_str().expect("group id");
+
+    // A well-formed but locally-unknown parent id: replies to messages that have
+    // not synced yet are legitimate (the preview hydrates lazily on arrival), so
+    // the send must succeed rather than be rejected.
+    let unknown_parent = "ab".repeat(32);
+    let reply = run_json(
+        home.path(),
+        &[
+            "--account",
+            &alice,
+            "messages",
+            "send",
+            "--group",
+            group_id,
+            "--reply-to",
+            &unknown_parent,
+            "reply to a ghost",
+        ],
+    );
+    assert!(
+        reply["published"]
+            .as_u64()
+            .is_some_and(|published| published >= 1),
+        "reply to an unknown parent should still publish, got {reply}"
+    );
+
+    // The sender's own timeline carries the reply reference but no hydrated
+    // preview, because the parent is not present locally.
+    let timeline = run_json(
+        home.path(),
+        &[
+            "--account",
+            &alice,
+            "messages",
+            "timeline",
+            "list",
+            group_id,
+            "--limit",
+            "20",
+        ],
+    );
+    let reply_row = timeline["messages"]
+        .as_array()
+        .expect("timeline messages")
+        .iter()
+        .find(|message| message["plaintext"] == "reply to a ghost")
+        .expect("reply row");
+    assert_eq!(
+        reply_row["reply_to_message_id"].as_str(),
+        Some(unknown_parent.as_str())
+    );
+    assert!(
+        reply_row["reply_preview"].is_null(),
+        "an unknown parent hydrates no preview, got {}",
+        reply_row["reply_preview"]
+    );
+}
+
+#[test]
+fn messages_send_reply_to_after_text_errors_loudly_on_both_surfaces() {
+    let home = tempfile::tempdir().expect("tempdir");
+
+    // A `--reply-to` placed *after* the message text parses as literal text
+    // (allow_hyphen_values), so the reply target is silently dropped. The send
+    // handler must reject that loudly instead of publishing a message whose body
+    // carries a stray `--reply-to <id>`. The guard sits on the shared `Send` arm
+    // before any account/relay work, so the plural `messages send` and the older
+    // singular `message send` fail identically.
+    for namespace in ["messages", "message"] {
+        let error = run_json_error(
+            home.path(),
+            &[
+                namespace,
+                "send",
+                "--group",
+                "GROUP",
+                "hello",
+                "--reply-to",
+                "PARENT",
+            ],
+        );
+        assert_eq!(
+            error["code"], "reply_to_after_message_text",
+            "namespace={namespace}: {error}"
+        );
+        assert_eq!(
+            error["message"],
+            "--reply-to must come before the message text; it was read as literal text here",
+            "namespace={namespace}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Route replies through the runtime's existing reply_to_message, which emits the same q and e tags timeline ingest parses, so replies from the CLI are wire-identical to other Marmot clients. A reply to a parent that has not synced yet sends fine and hydrates its preview when the parent arrives.

A --reply-to placed after the message text would previously be swallowed as literal text by the hyphen-tolerant trailing argument; it now fails loudly with error code reply_to_after_message_text. JSON response shapes are unchanged; no new runtime API was needed.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/mdk/pull/960">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--reply-to <message-id>` to `wn messages send` and legacy `wn message send` for sending replies.
  * Replies keep the original-message link and show a hydrated reply preview when the parent message becomes available (even if it isn’t stored locally yet).
* **Bug Fixes**
  * Validates argument ordering: placing `--reply-to` after the message text now fails loudly with error code `reply_to_after_message_text` instead of being sent as body text.
  * Prevents sending messages containing a bare `--reply-to` / `--reply-to=<id>` token in the text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->