### PR TITLE
Expose agent notification traffic classification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -766,7 +766,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "hex",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "libc",
  "tempfile",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cgka-conformance-simulator",
  "serde",
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "fs-private",
  "serde",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -4937,7 +4937,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -5590,7 +5590,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -5610,7 +5610,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -6588,7 +6588,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -6617,7 +6617,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "agent-control",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -766,7 +766,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "async-trait",
  "hex",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "libc",
  "tempfile",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "cgka-conformance-simulator",
  "serde",
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "fs-private",
  "serde",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -4937,7 +4937,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -5590,7 +5590,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -5610,7 +5610,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -6588,7 +6588,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -6617,7 +6617,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.5"
+version = "0.9.4"
 dependencies = [
  "agent-control",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.4"
+version = "0.9.5"
 license = "MIT"
 publish = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.5"
+version = "0.9.4"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.4",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -155,8 +155,8 @@ pub use notifications::{
     KIND_MARMOT_NOTIFICATION_SERVER_RELAYS, LocalPushRegistrationDebug,
     MARMOT_APP_EVENT_KIND_PUSH_TOKEN_LIST, MARMOT_APP_EVENT_KIND_PUSH_TOKEN_REMOVAL,
     MARMOT_APP_EVENT_KIND_PUSH_TOKEN_UPDATE, NotificationCollectionStatus, NotificationSettings,
-    NotificationTrigger, NotificationUpdate, NotificationUser, NotificationWakeSource,
-    PUSH_ENCRYPTED_TOKEN_LEN, PUSH_VERSION, PushPlatform, PushRegistration,
+    NotificationTrafficClass, NotificationTrigger, NotificationUpdate, NotificationUser,
+    NotificationWakeSource, PUSH_ENCRYPTED_TOKEN_LEN, PUSH_VERSION, PushPlatform, PushRegistration,
     build_notification_gift_wrap, build_notification_rumor_content, encrypted_push_token,
     parse_provider_token, push_token_fingerprint,
 };

--- a/crates/marmot-app/src/notifications.rs
+++ b/crates/marmot-app/src/notifications.rs
@@ -1247,26 +1247,18 @@ pub(crate) fn notification_update_from_event_cached(
     }
 }
 
-/// Whether a received app-event kind should ever surface as a notification.
-/// Chat messages, reactions, and explicitly classified agent activity are
-/// eligible for notification. Deletes, edits, stream control, and group-system
-/// rows are state changes rather than new user-visible traffic.
-fn is_notifiable_message_kind(kind: u64) -> bool {
-    matches!(
-        kind,
-        MARMOT_APP_EVENT_KIND_CHAT
-            | MARMOT_APP_EVENT_KIND_REACTION
-            | MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY
-            | MARMOT_APP_EVENT_KIND_AGENT_OPERATION
-    )
-}
-
-fn notification_traffic_for_kind(kind: u64) -> NotificationTrafficClass {
+/// Classify every notification-eligible wire kind. Returning `None` for
+/// unknown kinds keeps notification eligibility and channel routing coupled:
+/// adding a kind cannot silently fall through to the audible standard channel.
+fn notification_traffic_for_kind(kind: u64) -> Option<NotificationTrafficClass> {
     match kind {
         MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY | MARMOT_APP_EVENT_KIND_AGENT_OPERATION => {
-            NotificationTrafficClass::AgentActivity
+            Some(NotificationTrafficClass::AgentActivity)
         }
-        _ => NotificationTrafficClass::Standard,
+        MARMOT_APP_EVENT_KIND_CHAT | MARMOT_APP_EVENT_KIND_REACTION => {
+            Some(NotificationTrafficClass::Standard)
+        }
+        _ => None,
     }
 }
 
@@ -1283,9 +1275,9 @@ fn notification_update_from_message(
     // alert. Deletes, edits, stream control events, and group-system rows never
     // produce notifications (e.g. deleting a message must not push a "Deleted
     // a message" alert).
-    if !is_notifiable_message_kind(event.message.kind) {
+    let Some(traffic_class) = notification_traffic_for_kind(event.message.kind) else {
         return Ok(None);
-    }
+    };
     let group_id_hex = hex::encode(event.message.group_id.as_slice());
     let group = match resolver.group(app, &event.account_label, &group_id_hex) {
         Ok(group) => group,
@@ -1335,7 +1327,7 @@ fn notification_update_from_message(
         ),
         conversation_key: conversation_key(&event.account_id_hex, &group_id_hex),
         trigger: NotificationTrigger::NewMessage,
-        traffic_class: notification_traffic_for_kind(event.message.kind),
+        traffic_class,
         account_ref: event.account_label.clone(),
         account_id_hex: event.account_id_hex.clone(),
         group_id_hex,
@@ -1460,7 +1452,9 @@ pub(crate) fn message_text_mentions_account(
 }
 
 /// Shared preview rule for an inner app event's kind/plaintext. Push-gossip
-/// kinds and blank text never produce a preview.
+/// kinds and blank text never produce a preview. Structured agent kinds expose
+/// only approved text/status fields, so raw JSON and tool output never reach a
+/// notification payload.
 fn preview_text_for_kind(kind: u64, plaintext: &str) -> Option<String> {
     if is_push_gossip_kind(kind) || plaintext.trim().is_empty() {
         None

--- a/crates/marmot-app/src/notifications.rs
+++ b/crates/marmot-app/src/notifications.rs
@@ -22,7 +22,8 @@ use sha2::{Digest, Sha256};
 use transport_nostr_peeler::NostrTransportEvent;
 
 use cgka_traits::app_event::{
-    EVENT_REF_TAG, MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_REACTION,
+    EVENT_REF_TAG, MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY, MARMOT_APP_EVENT_KIND_AGENT_OPERATION,
+    MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_REACTION,
 };
 
 use crate::messages::{PUBKEY_REF_TAG, inline_mention_pubkey_hexes, mention_pubkey_hex};
@@ -185,11 +186,18 @@ pub struct NotificationUser {
     pub picture_url: Option<String>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NotificationTrafficClass {
+    Standard,
+    AgentActivity,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NotificationUpdate {
     pub notification_key: String,
     pub conversation_key: String,
     pub trigger: NotificationTrigger,
+    pub traffic_class: NotificationTrafficClass,
     pub account_ref: String,
     pub account_id_hex: String,
     pub group_id_hex: String,
@@ -1240,10 +1248,26 @@ pub(crate) fn notification_update_from_event_cached(
 }
 
 /// Whether a received app-event kind should ever surface as a notification.
-/// Only chat messages and reactions alert; deletes, edits, agent-stream control
-/// events, and group-system rows are state changes, not new user messages.
+/// Chat messages, reactions, and explicitly classified agent activity are
+/// eligible for notification. Deletes, edits, stream control, and group-system
+/// rows are state changes rather than new user-visible traffic.
 fn is_notifiable_message_kind(kind: u64) -> bool {
-    kind == MARMOT_APP_EVENT_KIND_CHAT || kind == MARMOT_APP_EVENT_KIND_REACTION
+    matches!(
+        kind,
+        MARMOT_APP_EVENT_KIND_CHAT
+            | MARMOT_APP_EVENT_KIND_REACTION
+            | MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY
+            | MARMOT_APP_EVENT_KIND_AGENT_OPERATION
+    )
+}
+
+fn notification_traffic_for_kind(kind: u64) -> NotificationTrafficClass {
+    match kind {
+        MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY | MARMOT_APP_EVENT_KIND_AGENT_OPERATION => {
+            NotificationTrafficClass::AgentActivity
+        }
+        _ => NotificationTrafficClass::Standard,
+    }
 }
 
 fn notification_update_from_message(
@@ -1255,10 +1279,10 @@ fn notification_update_from_message(
     if !settings.local_notifications_enabled {
         return Err(AppError::NotificationsDisabled);
     }
-    // Only chat messages and reactions alert. Deletes, edits, agent-stream
-    // control events, and group-system rows are not new user-facing messages,
-    // so they never produce a notification (e.g. deleting a message must not
-    // push a "Deleted a message" alert).
+    // Only chat messages, reactions, and explicitly classified agent activity
+    // alert. Deletes, edits, stream control events, and group-system rows never
+    // produce notifications (e.g. deleting a message must not push a "Deleted
+    // a message" alert).
     if !is_notifiable_message_kind(event.message.kind) {
         return Ok(None);
     }
@@ -1311,6 +1335,7 @@ fn notification_update_from_message(
         ),
         conversation_key: conversation_key(&event.account_id_hex, &group_id_hex),
         trigger: NotificationTrigger::NewMessage,
+        traffic_class: notification_traffic_for_kind(event.message.kind),
         account_ref: event.account_label.clone(),
         account_id_hex: event.account_id_hex.clone(),
         group_id_hex,
@@ -1355,6 +1380,7 @@ fn notification_update_from_group_join(
         notification_key: format!("invite:{account_id_hex}:{invite_ref}"),
         conversation_key: conversation_key(account_id_hex, &group_id_hex),
         trigger: NotificationTrigger::GroupInvite,
+        traffic_class: NotificationTrafficClass::Standard,
         account_ref: account_label.to_owned(),
         account_id_hex: account_id_hex.to_owned(),
         group_id_hex,
@@ -1438,9 +1464,25 @@ pub(crate) fn message_text_mentions_account(
 fn preview_text_for_kind(kind: u64, plaintext: &str) -> Option<String> {
     if is_push_gossip_kind(kind) || plaintext.trim().is_empty() {
         None
+    } else if kind == MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY {
+        structured_agent_preview(plaintext, &["text", "status"])
+    } else if kind == MARMOT_APP_EVENT_KIND_AGENT_OPERATION {
+        structured_agent_preview(plaintext, &["preview", "text", "status"])
     } else {
         Some(plaintext.to_owned())
     }
+}
+
+fn structured_agent_preview(plaintext: &str, fields: &[&str]) -> Option<String> {
+    let payload = serde_json::from_str::<serde_json::Value>(plaintext).ok()?;
+    fields.iter().find_map(|field| {
+        payload
+            .get(field)?
+            .as_str()
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(str::to_owned)
+    })
 }
 
 /// Shape the (emoji, preview) pair for a reaction from its already-resolved

--- a/crates/marmot-app/src/notifications/tests.rs
+++ b/crates/marmot-app/src/notifications/tests.rs
@@ -515,6 +515,7 @@ fn group_invite_notification_is_not_a_mention() {
     .unwrap();
 
     assert!(matches!(update.trigger, NotificationTrigger::GroupInvite));
+    assert_eq!(update.traffic_class, NotificationTrafficClass::Standard);
     assert!(!update.is_mention);
 }
 
@@ -650,15 +651,26 @@ fn normal_message_yields_no_reaction_fields() {
 }
 
 #[test]
-fn only_chat_and_reaction_kinds_are_notifiable() {
+fn agent_activity_and_operation_kinds_are_notifiable() {
     use cgka_traits::app_event::{
-        MARMOT_APP_EVENT_KIND_AGENT_STREAM_START, MARMOT_APP_EVENT_KIND_CHAT,
-        MARMOT_APP_EVENT_KIND_DELETE, MARMOT_APP_EVENT_KIND_EDIT,
-        MARMOT_APP_EVENT_KIND_GROUP_SYSTEM, MARMOT_APP_EVENT_KIND_REACTION,
+        MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY, MARMOT_APP_EVENT_KIND_AGENT_OPERATION,
     };
-    assert!(is_notifiable_message_kind(MARMOT_APP_EVENT_KIND_CHAT));
-    assert!(is_notifiable_message_kind(MARMOT_APP_EVENT_KIND_REACTION));
-    // State changes, not new user messages — never alert.
+
+    assert!(is_notifiable_message_kind(
+        MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY
+    ));
+    assert!(is_notifiable_message_kind(
+        MARMOT_APP_EVENT_KIND_AGENT_OPERATION
+    ));
+}
+
+#[test]
+fn state_change_kinds_remain_non_notifiable() {
+    use cgka_traits::app_event::{
+        MARMOT_APP_EVENT_KIND_AGENT_STREAM_START, MARMOT_APP_EVENT_KIND_DELETE,
+        MARMOT_APP_EVENT_KIND_EDIT, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
+    };
+
     assert!(!is_notifiable_message_kind(MARMOT_APP_EVENT_KIND_DELETE));
     assert!(!is_notifiable_message_kind(MARMOT_APP_EVENT_KIND_EDIT));
     assert!(!is_notifiable_message_kind(
@@ -667,6 +679,73 @@ fn only_chat_and_reaction_kinds_are_notifiable() {
     assert!(!is_notifiable_message_kind(
         MARMOT_APP_EVENT_KIND_AGENT_STREAM_START
     ));
+}
+
+#[test]
+fn notification_traffic_class_is_deterministic_from_the_wire_kind() {
+    use cgka_traits::app_event::{
+        MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY, MARMOT_APP_EVENT_KIND_AGENT_OPERATION,
+        MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_REACTION,
+    };
+
+    assert_eq!(
+        notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY),
+        NotificationTrafficClass::AgentActivity,
+    );
+    assert_eq!(
+        notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_AGENT_OPERATION),
+        NotificationTrafficClass::AgentActivity,
+    );
+    assert_eq!(
+        notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_CHAT),
+        NotificationTrafficClass::Standard,
+    );
+    assert_eq!(
+        notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_REACTION),
+        NotificationTrafficClass::Standard,
+    );
+}
+
+#[test]
+fn agent_activity_notification_preview_uses_the_structured_text() {
+    use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY;
+
+    assert_eq!(
+        preview_text_for_kind(
+            MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY,
+            r#"{"status":"running","text":"Searching relays"}"#,
+        )
+        .as_deref(),
+        Some("Searching relays"),
+    );
+}
+
+#[test]
+fn agent_operation_notification_preview_prefers_the_structured_preview() {
+    use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_AGENT_OPERATION;
+
+    assert_eq!(
+        preview_text_for_kind(
+            MARMOT_APP_EVENT_KIND_AGENT_OPERATION,
+            r#"{"status":"running","text":"Executing browser tool","preview":"Opening example.com"}"#,
+        )
+        .as_deref(),
+        Some("Opening example.com"),
+    );
+}
+
+#[test]
+fn agent_operation_notification_preview_falls_back_to_text() {
+    use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_AGENT_OPERATION;
+
+    assert_eq!(
+        preview_text_for_kind(
+            MARMOT_APP_EVENT_KIND_AGENT_OPERATION,
+            r#"{"status":"running","text":"Executing browser tool"}"#,
+        )
+        .as_deref(),
+        Some("Executing browser tool"),
+    );
 }
 
 #[test]

--- a/crates/marmot-app/src/notifications/tests.rs
+++ b/crates/marmot-app/src/notifications/tests.rs
@@ -656,12 +656,8 @@ fn agent_activity_and_operation_kinds_are_notifiable() {
         MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY, MARMOT_APP_EVENT_KIND_AGENT_OPERATION,
     };
 
-    assert!(is_notifiable_message_kind(
-        MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY
-    ));
-    assert!(is_notifiable_message_kind(
-        MARMOT_APP_EVENT_KIND_AGENT_OPERATION
-    ));
+    assert!(notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY).is_some());
+    assert!(notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_AGENT_OPERATION).is_some());
 }
 
 #[test]
@@ -671,38 +667,110 @@ fn state_change_kinds_remain_non_notifiable() {
         MARMOT_APP_EVENT_KIND_EDIT, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
     };
 
-    assert!(!is_notifiable_message_kind(MARMOT_APP_EVENT_KIND_DELETE));
-    assert!(!is_notifiable_message_kind(MARMOT_APP_EVENT_KIND_EDIT));
-    assert!(!is_notifiable_message_kind(
-        MARMOT_APP_EVENT_KIND_GROUP_SYSTEM
-    ));
-    assert!(!is_notifiable_message_kind(
-        MARMOT_APP_EVENT_KIND_AGENT_STREAM_START
-    ));
+    assert!(notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_DELETE).is_none());
+    assert!(notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_EDIT).is_none());
+    assert!(notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_GROUP_SYSTEM).is_none());
+    assert!(notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_AGENT_STREAM_START).is_none());
 }
 
 #[test]
 fn notification_traffic_class_is_deterministic_from_the_wire_kind() {
     use cgka_traits::app_event::{
         MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY, MARMOT_APP_EVENT_KIND_AGENT_OPERATION,
-        MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_REACTION,
+        MARMOT_APP_EVENT_KIND_AGENT_STREAM_START, MARMOT_APP_EVENT_KIND_CHAT,
+        MARMOT_APP_EVENT_KIND_REACTION,
     };
 
     assert_eq!(
         notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY),
-        NotificationTrafficClass::AgentActivity,
+        Some(NotificationTrafficClass::AgentActivity),
     );
     assert_eq!(
         notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_AGENT_OPERATION),
-        NotificationTrafficClass::AgentActivity,
+        Some(NotificationTrafficClass::AgentActivity),
     );
     assert_eq!(
         notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_CHAT),
-        NotificationTrafficClass::Standard,
+        Some(NotificationTrafficClass::Standard),
     );
     assert_eq!(
         notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_REACTION),
-        NotificationTrafficClass::Standard,
+        Some(NotificationTrafficClass::Standard),
+    );
+    assert_eq!(
+        notification_traffic_for_kind(MARMOT_APP_EVENT_KIND_AGENT_STREAM_START),
+        None,
+    );
+    assert_eq!(notification_traffic_for_kind(u64::MAX), None);
+}
+
+#[test]
+fn agent_activity_notification_is_non_mention_and_respects_group_mute() {
+    use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY;
+
+    let dir = tempfile::tempdir().unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let account_label = "alice";
+    let account_id_hex = "aa".repeat(32);
+    let sender_id_hex = "bb".repeat(32);
+    let group_id_hex = "ee".repeat(32);
+    let message = RuntimeMessageReceived {
+        account_id_hex: account_id_hex.clone(),
+        account_label: account_label.to_owned(),
+        message: ReceivedMessage {
+            message_id_hex: "ff".repeat(32),
+            source_message_id_hex: "ff".repeat(32),
+            sender: sender_id_hex.clone(),
+            sender_display_name: Some("Agent".to_owned()),
+            group_id: cgka_traits::GroupId::new(vec![0xEE; 32]),
+            source_epoch: 1,
+            plaintext: r#"{"status":"running","text":"Searching relays"}"#.to_owned(),
+            kind: MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY,
+            // Even a receiver p-tag must not make a non-chat kind a mention.
+            tags: vec![vec![PUBKEY_REF_TAG.to_owned(), account_id_hex.clone()]],
+            recorded_at: 0,
+            received_at: 0,
+        },
+    };
+    let mut resolver = NotificationResolver::default();
+    resolver.settings.insert(
+        account_label.to_owned(),
+        NotificationSettings {
+            account_ref: account_label.to_owned(),
+            account_id_hex: account_id_hex.clone(),
+            local_notifications_enabled: true,
+            native_push_enabled: true,
+        },
+    );
+    let conversation = (account_label.to_owned(), group_id_hex.clone());
+    resolver.groups.insert(conversation.clone(), None);
+    resolver.chat_muted.insert(conversation.clone(), false);
+    for account_id in [&account_id_hex, &sender_id_hex] {
+        resolver.users.insert(
+            account_id.clone(),
+            NotificationUser {
+                account_id_hex: account_id.clone(),
+                display_name: None,
+                picture_url: None,
+            },
+        );
+    }
+
+    let update = notification_update_from_message(&app, &mut resolver, &message)
+        .unwrap()
+        .expect("unmuted agent activity should produce a notification");
+    assert_eq!(
+        update.traffic_class,
+        NotificationTrafficClass::AgentActivity
+    );
+    assert_eq!(update.preview_text.as_deref(), Some("Searching relays"));
+    assert!(!update.is_mention);
+
+    resolver.chat_muted.insert(conversation, true);
+    assert_eq!(
+        notification_update_from_message(&app, &mut resolver, &message).unwrap(),
+        None,
+        "agent activity must respect the conversation mute"
     );
 }
 

--- a/crates/marmot-uniffi/src/conversions/notification.rs
+++ b/crates/marmot-uniffi/src/conversions/notification.rs
@@ -2,8 +2,9 @@
 //! plus the wake-path cursor-persistence policy.
 
 use marmot_app::{
-    CursorPersistence, NotificationCollectionStatus, NotificationSettings, NotificationTrigger,
-    NotificationUpdate, NotificationUser, NotificationWakeSource,
+    CursorPersistence, NotificationCollectionStatus, NotificationSettings,
+    NotificationTrafficClass, NotificationTrigger, NotificationUpdate, NotificationUser,
+    NotificationWakeSource,
 };
 
 /// Durable transport-cursor persistence policy, chosen at [`crate::Marmot`]
@@ -84,6 +85,21 @@ impl From<NotificationTrigger> for NotificationTriggerFfi {
     }
 }
 
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum NotificationTrafficClassFfi {
+    Standard,
+    AgentActivity,
+}
+
+impl From<NotificationTrafficClass> for NotificationTrafficClassFfi {
+    fn from(value: NotificationTrafficClass) -> Self {
+        match value {
+            NotificationTrafficClass::Standard => Self::Standard,
+            NotificationTrafficClass::AgentActivity => Self::AgentActivity,
+        }
+    }
+}
+
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct NotificationSettingsFfi {
     pub account_ref: String,
@@ -125,6 +141,7 @@ pub struct NotificationUpdateFfi {
     pub notification_key: String,
     pub conversation_key: String,
     pub trigger: NotificationTriggerFfi,
+    pub traffic_class: NotificationTrafficClassFfi,
     pub account_ref: String,
     pub account_id_hex: String,
     pub group_id_hex: String,
@@ -147,6 +164,7 @@ impl From<NotificationUpdate> for NotificationUpdateFfi {
             notification_key: value.notification_key,
             conversation_key: value.conversation_key,
             trigger: value.trigger.into(),
+            traffic_class: value.traffic_class.into(),
             account_ref: value.account_ref,
             account_id_hex: value.account_id_hex,
             group_id_hex: value.group_id_hex,
@@ -179,5 +197,18 @@ impl From<marmot_app::BackgroundNotificationCollection> for BackgroundNotificati
             notifications: value.notifications.into_iter().map(Into::into).collect(),
             error: value.error,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_activity_traffic_class_crosses_the_ffi_boundary() {
+        assert!(matches!(
+            NotificationTrafficClassFfi::from(marmot_app::NotificationTrafficClass::AgentActivity,),
+            NotificationTrafficClassFfi::AgentActivity,
+        ));
     }
 }

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -54,13 +54,14 @@ pub use conversions::{
     MediaUploadAttachmentResultFfi, MediaUploadRequestFfi, MediaUploadResultFfi,
     MessageDraftAttachmentFfi, MessageDraftAttachmentSummaryFfi, MessageDraftFfi,
     MessageDraftSummaryFfi, NotificationCollectionStatusFfi, NotificationSettingsFfi,
-    NotificationTriggerFfi, NotificationUpdateFfi, NotificationUserFfi, NotificationWakeSourceFfi,
-    PushPlatformFfi, PushRegistrationFfi, RelayTelemetryResourceFfi,
-    RelayTelemetryRuntimeConfigFfi, RelayTelemetrySettingsFfi, RuntimeProjectionUpdateFfi,
-    SecureDeleteExpiredResultFfi, TimelineMessageChangeFfi, TimelineMessageQueryFfi,
-    TimelineMessageRecordFfi, TimelinePageFfi, TimelineProjectionUpdateFfi,
-    TimelineReactionEmojiFfi, TimelineReactionSummaryFfi, TimelineRemoveReasonFfi,
-    TimelineSubscriptionUpdateFfi, TimelineUpdateTriggerFfi, TimelineUserReactionFfi,
+    NotificationTrafficClassFfi, NotificationTriggerFfi, NotificationUpdateFfi,
+    NotificationUserFfi, NotificationWakeSourceFfi, PushPlatformFfi, PushRegistrationFfi,
+    RelayTelemetryResourceFfi, RelayTelemetryRuntimeConfigFfi, RelayTelemetrySettingsFfi,
+    RuntimeProjectionUpdateFfi, SecureDeleteExpiredResultFfi, TimelineMessageChangeFfi,
+    TimelineMessageQueryFfi, TimelineMessageRecordFfi, TimelinePageFfi,
+    TimelineProjectionUpdateFfi, TimelineReactionEmojiFfi, TimelineReactionSummaryFfi,
+    TimelineRemoveReasonFfi, TimelineSubscriptionUpdateFfi, TimelineUpdateTriggerFfi,
+    TimelineUserReactionFfi,
 };
 
 /// Convenience: turn an FFI string list of relay URLs into the engine's


### PR DESCRIPTION
## Summary

- exposes a deterministic `NotificationTrafficClass` through the notification model and UniFFI
- classifies agent activity and operation events separately from standard chat traffic
- makes agent activity/operation events eligible for local notifications while leaving other state-only kinds suppressed
- extracts safe human-readable previews from structured activity and operation payloads instead of exposing raw JSON

## Android integration

Consumed by [whitenoise-android#1595](https://github.com/marmot-protocol/whitenoise-android/pull/1595), which routes this traffic to silent-by-default, per-conversation Agent activity channels while leaving final replies on Messages.

Supports [whitenoise-android#1577](https://github.com/marmot-protocol/whitenoise-android/issues/1577).

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p marmot-app notifications` (49 passed)
- `cargo test -p marmot-uniffi agent_activity_traffic_class_crosses_the_ffi_boundary` (1 passed)
- Android UniFFI bindings generated successfully for arm64-v8a, armeabi-v7a, x86, and x86_64 and compiled in whitenoise-android


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now include a **traffic class** (**Standard** vs **Agent Activity**) and expose it to supported integrations.
  * Agent activity/operation notifications can use **structured preview text** extracted from approved event fields.
* **Bug Fixes**
  * Notification eligibility and traffic classification are driven by the event kind classifier; non-notifiable kinds are omitted.
  * Group invite/join notifications are consistently classified as **Standard**.
* **Chores**
  * Workspace and conformance vector metadata bumped to **0.9.5**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->