### PR TITLE
Close remaining convergence, daemon, and dial-safety gaps

### DIFF
--- a/crates/cgka-conformance-simulator/tests/candidate_state_graph.rs
+++ b/crates/cgka-conformance-simulator/tests/candidate_state_graph.rs
@@ -234,6 +234,50 @@ fn digest_tiebreak_picks_lower_digest_after_commit_and_witness_ties() {
 }
 
 #[test]
+fn app_witness_score_beats_priority_after_depth_and_quorum_ties() {
+    let policy = ConvergencePolicy {
+        max_rewind_commits: 5,
+        witness_quorum_senders_per_epoch: 10,
+        witness_quorum_epochs: 2,
+        max_witness_override_depth: 2,
+    };
+    let witnessed_ordinary = BranchCandidate {
+        id: "witnessed-ordinary".into(),
+        fork_epoch: 1,
+        tip_epoch: 3,
+        tip_priority: CommitOrderingPriority::Ordinary,
+        tip_committer: b"z".to_vec(),
+        tip_digest: digest(0xff),
+        app_witnesses: vec![witness(2, "alice"), witness(2, "bob")],
+    };
+    let unwitnessed_privileged = BranchCandidate {
+        id: "unwitnessed-privileged".into(),
+        fork_epoch: 1,
+        tip_epoch: 3,
+        tip_priority: CommitOrderingPriority::Privileged,
+        tip_committer: b"a".to_vec(),
+        tip_digest: digest(0x00),
+        app_witnesses: vec![],
+    };
+    let witnessed_score = witnessed_ordinary.score(&policy);
+    let privileged_score = unwitnessed_privileged.score(&policy);
+    let candidates = [witnessed_ordinary.clone(), unwitnessed_privileged];
+
+    assert_eq!(witnessed_score.effective_commit_depth, 2);
+    assert_eq!(
+        witnessed_score.effective_commit_depth,
+        privileged_score.effective_commit_depth
+    );
+    assert!(!witnessed_score.witness_quorum_met);
+    assert!(!privileged_score.witness_quorum_met);
+    assert_eq!(witnessed_score.app_witness_score, 2);
+    assert_eq!(privileged_score.app_witness_score, 0);
+
+    let winner = select_canonical_branch(3, &candidates, &policy).expect("one branch should win");
+    assert_eq!(winner.id, witnessed_ordinary.id);
+}
+
+#[test]
 fn privileged_tiebreak_beats_digest_after_depth_and_witness_ties() {
     let policy = ConvergencePolicy {
         max_rewind_commits: 5,

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -60,8 +60,9 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Fixed
 
-- Release builds now reject `WN_DEV_SETTLEMENT_QUIESCENCE_MS` instead of allowing it to override the protocol-pinned
-  convergence window. Debug builds retain the override for local development and integration tests.
+- Release builds now fail app startup with a clear error when `WN_DEV_SETTLEMENT_QUIESCENCE_MS` is set instead of
+  allowing it to override the protocol-pinned convergence window. Debug builds retain the override for local
+  development and integration tests.
 - `wnd` streaming subscription responses now have a 15-second whole-frame write deadline, including socket flush, so
   a client that stops reading cannot retain a connection permit indefinitely.
 - `wnd` one-shot responses now apply the same deadline across write, flush, and socket shutdown, preventing a

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -60,6 +60,8 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Fixed
 
+- Release builds now reject `WN_DEV_SETTLEMENT_QUIESCENCE_MS` instead of allowing it to override the protocol-pinned
+  convergence window. Debug builds retain the override for local development and integration tests.
 - `wn-agent` now denies path-based media sends by default and accepts only regular, non-symlink files beneath explicit
   repeatable `--media-allowed-root` directories. Bundled Hermes and OpenClaw launchers stage short-lived copies in a
   dedicated approved directory and clean them up after each send.

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -62,6 +62,8 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 - Release builds now reject `WN_DEV_SETTLEMENT_QUIESCENCE_MS` instead of allowing it to override the protocol-pinned
   convergence window. Debug builds retain the override for local development and integration tests.
+- `wnd` streaming subscription responses now have a 15-second whole-frame write deadline, including socket flush, so
+  a client that stops reading cannot retain a connection permit indefinitely.
 - `wn-agent` now denies path-based media sends by default and accepts only regular, non-symlink files beneath explicit
   repeatable `--media-allowed-root` directories. Bundled Hermes and OpenClaw launchers stage short-lived copies in a
   dedicated approved directory and clean them up after each send.

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -64,6 +64,8 @@ versioning through the workspace version in the root `Cargo.toml`.
   convergence window. Debug builds retain the override for local development and integration tests.
 - `wnd` streaming subscription responses now have a 15-second whole-frame write deadline, including socket flush, so
   a client that stops reading cannot retain a connection permit indefinitely.
+- `wnd` one-shot responses now apply the same deadline across write, flush, and socket shutdown, preventing a
+  non-reading local client from pinning status, stop, or command workers.
 - `wn-agent` now denies path-based media sends by default and accepts only regular, non-symlink files beneath explicit
   repeatable `--media-allowed-root` directories. Bundled Hermes and OpenClaw launchers stage short-lived copies in a
   dedicated approved directory and clean them up after each send.

--- a/crates/cli/src/daemon/mod.rs
+++ b/crates/cli/src/daemon/mod.rs
@@ -14,7 +14,7 @@ use std::os::unix::process::CommandExt;
 use agent_stream_compose::{StreamComposeCommand, StreamComposeReport, run_stream_compose_session};
 use clap::Parser;
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{Mutex as AsyncMutex, broadcast, mpsc, oneshot};
 use tokio::task::JoinHandle;
@@ -59,6 +59,9 @@ const MAX_DAEMON_REQUEST_BYTES: usize = 1024 * 1024;
 /// and starve every other client of `Status`/`Ping`/etc. On timeout the read is
 /// treated like any other per-connection failure: report and `continue`.
 const DAEMON_REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(30);
+/// Whole-frame deadline for daemon responses. A client that stops draining its
+/// socket must release its connection permit instead of pinning the worker.
+const DAEMON_RESPONSE_WRITE_TIMEOUT: Duration = Duration::from_secs(15);
 const DAEMON_SOCKET_DIR_MODE: u32 = 0o700;
 const DAEMON_SOCKET_MODE: u32 = 0o600;
 /// Cap on concurrently served daemon connections. The socket is same-UID

--- a/crates/cli/src/daemon/protocol.rs
+++ b/crates/cli/src/daemon/protocol.rs
@@ -330,6 +330,11 @@ pub(crate) async fn write_daemon_output(stream: &mut UnixStream, output: &CliOut
     let _ = write_daemon_output_within(stream, output, DAEMON_RESPONSE_WRITE_TIMEOUT).await;
 }
 
+/// Write, flush, and close one daemon response within one deadline.
+///
+/// `false` is connection-fatal: the future may have been dropped after a
+/// partial frame was written, so callers must drop the stream and never retry
+/// or write another frame on it.
 pub(crate) async fn write_daemon_output_within<W>(
     stream: &mut W,
     output: &CliOutput,
@@ -410,6 +415,11 @@ pub(crate) async fn write_stream_response(
     write_stream_response_within(stream, response, DAEMON_RESPONSE_WRITE_TIMEOUT).await
 }
 
+/// Write and flush one streaming response within one deadline.
+///
+/// `false` is connection-fatal: the future may have been dropped after a
+/// partial frame was written, so callers must drop the stream and never retry
+/// or write another frame on it.
 pub(crate) async fn write_stream_response_within<W>(
     stream: &mut W,
     response: &DaemonStreamResponse,

--- a/crates/cli/src/daemon/protocol.rs
+++ b/crates/cli/src/daemon/protocol.rs
@@ -389,11 +389,29 @@ pub(crate) async fn write_stream_response(
     stream: &mut UnixStream,
     response: &DaemonStreamResponse,
 ) -> bool {
+    write_stream_response_within(stream, response, DAEMON_RESPONSE_WRITE_TIMEOUT).await
+}
+
+pub(crate) async fn write_stream_response_within<W>(
+    stream: &mut W,
+    response: &DaemonStreamResponse,
+    timeout_after: Duration,
+) -> bool
+where
+    W: AsyncWrite + Unpin,
+{
     let Ok(mut bytes) = serde_json::to_vec(response) else {
         return false;
     };
     bytes.push(b'\n');
-    stream.write_all(&bytes).await.is_ok()
+    matches!(
+        tokio::time::timeout(timeout_after, async {
+            stream.write_all(&bytes).await?;
+            stream.flush().await
+        })
+        .await,
+        Ok(Ok(()))
+    )
 }
 
 pub(crate) async fn write_stream_end(stream: &mut UnixStream) -> bool {

--- a/crates/cli/src/daemon/protocol.rs
+++ b/crates/cli/src/daemon/protocol.rs
@@ -327,12 +327,30 @@ impl DaemonClient {
 }
 
 pub(crate) async fn write_daemon_output(stream: &mut UnixStream, output: &CliOutput) {
+    let _ = write_daemon_output_within(stream, output, DAEMON_RESPONSE_WRITE_TIMEOUT).await;
+}
+
+pub(crate) async fn write_daemon_output_within<W>(
+    stream: &mut W,
+    output: &CliOutput,
+    timeout_after: Duration,
+) -> bool
+where
+    W: AsyncWrite + Unpin,
+{
     let Ok(mut response) = serde_json::to_vec(output) else {
-        return;
+        return false;
     };
     response.push(b'\n');
-    let _ = stream.write_all(&response).await;
-    let _ = stream.shutdown().await;
+    matches!(
+        tokio::time::timeout(timeout_after, async {
+            stream.write_all(&response).await?;
+            stream.flush().await?;
+            stream.shutdown().await
+        })
+        .await,
+        Ok(Ok(()))
+    )
 }
 
 pub(crate) async fn read_daemon_request(

--- a/crates/cli/src/daemon/runtime_host.rs
+++ b/crates/cli/src/daemon/runtime_host.rs
@@ -163,11 +163,14 @@ async fn dispatch_hosted_runtime_command(
             Ok(account_home) => account_home,
             Err(err) => return Some(crate::command_output_result(cli.json, Err(err))),
         };
-    let app = crate::app_for(
+    let app = match crate::app_for(
         defaults.home.clone(),
         defaults.relay.clone(),
         account_home.clone(),
-    );
+    ) {
+        Ok(app) => app,
+        Err(err) => return Some(crate::command_output_result(cli.json, Err(err))),
+    };
 
     let output = match cli.command.clone() {
         crate::Command::Group { command } => {
@@ -539,7 +542,7 @@ pub(crate) fn open_app_runtime(
     let secret_store = crate::resolve_secret_store(defaults.secret_store)?;
     let keychain_service = crate::resolve_keychain_service(defaults.keychain_service.clone());
     let account_home = crate::open_account_home(&defaults.home, secret_store, &keychain_service)?;
-    let app = crate::app_for(defaults.home.clone(), defaults.relay.clone(), account_home);
+    let app = crate::app_for(defaults.home.clone(), defaults.relay.clone(), account_home)?;
     Ok(app.runtime())
 }
 
@@ -688,11 +691,14 @@ pub(crate) async fn auto_watch_agent_stream_starts(
             Ok(account_home) => account_home,
             Err(_) => return,
         };
-    let app = crate::app_for(
+    let app = match crate::app_for(
         defaults.home.clone(),
         defaults.relay.clone(),
         account_home.clone(),
-    );
+    ) {
+        Ok(app) => app,
+        Err(_) => return,
+    };
     for message in &summary.messages {
         let Some(start) = marmot_app::StreamStartView::from_event(message.kind, &message.tags)
         else {

--- a/crates/cli/src/daemon/stream_workers.rs
+++ b/crates/cli/src/daemon/stream_workers.rs
@@ -114,11 +114,14 @@ pub(crate) async fn start_stream_watch(
             Ok(account_home) => account_home,
             Err(err) => return daemon_error(json, "stream_watch_failed", err.to_string()),
         };
-    let app = crate::app_for(
+    let app = match crate::app_for(
         defaults.home.clone(),
         defaults.relay.clone(),
         account_home.clone(),
-    );
+    ) {
+        Ok(app) => app,
+        Err(err) => return daemon_error(json, "stream_watch_failed", err.to_string()),
+    };
     let (report, handle) =
         match spawn_stream_watch(cli, account_home, app, runtime.clone(), stream_manager) {
             Ok(spawned) => spawned,

--- a/crates/cli/src/daemon/stream_workers.rs
+++ b/crates/cli/src/daemon/stream_workers.rs
@@ -120,7 +120,7 @@ pub(crate) async fn start_stream_watch(
         account_home.clone(),
     ) {
         Ok(app) => app,
-        Err(err) => return daemon_error(json, "stream_watch_failed", err.to_string()),
+        Err(err) => return crate::command_output_result(json, Err(err)),
     };
     let (report, handle) =
         match spawn_stream_watch(cli, account_home, app, runtime.clone(), stream_manager) {

--- a/crates/cli/src/daemon/tests.rs
+++ b/crates/cli/src/daemon/tests.rs
@@ -49,6 +49,50 @@ async fn daemon_stream_response_write_times_out_when_flush_stalls() {
 }
 
 #[tokio::test]
+async fn daemon_one_shot_response_timeout_includes_shutdown() {
+    struct ShutdownStallingWriter;
+
+    impl tokio::io::AsyncWrite for ShutdownStallingWriter {
+        fn poll_write(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            bytes: &[u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            std::task::Poll::Ready(Ok(bytes.len()))
+        }
+
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Pending
+        }
+    }
+
+    let started = Instant::now();
+    let written = write_daemon_output_within(
+        &mut ShutdownStallingWriter,
+        &CliOutput {
+            code: 0,
+            stdout: "test".to_owned(),
+            stderr: String::new(),
+        },
+        Duration::from_millis(10),
+    )
+    .await;
+
+    assert!(!written, "a stalled shutdown must fail the one-shot write");
+    assert!(started.elapsed() < Duration::from_secs(1));
+}
+
+#[tokio::test]
 async fn run_server_validates_relays_before_creating_runtime_artifacts() {
     let home = tempfile::tempdir().expect("tempdir");
     let home_path = home.path().to_path_buf();

--- a/crates/cli/src/daemon/tests.rs
+++ b/crates/cli/src/daemon/tests.rs
@@ -9,6 +9,46 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::os::unix::fs::PermissionsExt;
 
 #[tokio::test]
+async fn daemon_stream_response_write_times_out_when_flush_stalls() {
+    struct FlushStallingWriter;
+
+    impl tokio::io::AsyncWrite for FlushStallingWriter {
+        fn poll_write(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            bytes: &[u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            std::task::Poll::Ready(Ok(bytes.len()))
+        }
+
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Pending
+        }
+
+        fn poll_shutdown(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    let started = Instant::now();
+    let written = write_stream_response_within(
+        &mut FlushStallingWriter,
+        &DaemonStreamResponse::ok(serde_json::json!({"type": "test"})),
+        Duration::from_millis(10),
+    )
+    .await;
+
+    assert!(!written, "a stalled flush must fail the stream write");
+    assert!(started.elapsed() < Duration::from_secs(1));
+}
+
+#[tokio::test]
 async fn run_server_validates_relays_before_creating_runtime_artifacts() {
     let home = tempfile::tempdir().expect("tempdir");
     let home_path = home.path().to_path_buf();

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -51,6 +51,10 @@ pub(crate) enum WnError {
     PublicAccountCannotSign,
     #[error("invalid secret store: {0}")]
     InvalidSecretStore(String),
+    #[error(
+        "WN_DEV_SETTLEMENT_QUIESCENCE_MS is only available in debug builds; unset it when running a release binary"
+    )]
+    DevSettlementOverrideInRelease,
     #[error("stream text is required")]
     EmptyStreamText,
     #[error("no brokered stream start found")]
@@ -447,6 +451,13 @@ pub(crate) fn wn_error_json(err: &WnError) -> Value {
             "code": "invalid_secret_store",
             "message": err.to_string(),
             "secret_store": store,
+        }),
+        WnError::DevSettlementOverrideInRelease => json!({
+            "code": "dev_settlement_override_in_release",
+            "message": err.to_string(),
+            "repair": {
+                "unset": "WN_DEV_SETTLEMENT_QUIESCENCE_MS",
+            },
         }),
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1032,10 +1032,19 @@ fn wn_allow_loopback_relays() -> bool {
     )
 }
 
+fn resolve_dev_settlement_quiescence_ms(
+    value: Option<&str>,
+    dev_overrides_enabled: bool,
+) -> Option<u64> {
+    if !dev_overrides_enabled {
+        return None;
+    }
+    value.and_then(|value| value.trim().parse().ok())
+}
+
 fn wn_dev_settlement_quiescence_ms() -> Option<u64> {
-    std::env::var("WN_DEV_SETTLEMENT_QUIESCENCE_MS")
-        .ok()
-        .and_then(|value| value.trim().parse().ok())
+    let value = std::env::var("WN_DEV_SETTLEMENT_QUIESCENCE_MS").ok();
+    resolve_dev_settlement_quiescence_ms(value.as_deref(), cfg!(debug_assertions))
 }
 
 fn open_account_home(
@@ -1190,7 +1199,8 @@ mod tests {
     };
     use super::{
         Cli, Command, StreamCommand, WnError, daemon, daemon_socket_for_client,
-        default_home_from_env, npub_for_account_id, relay_endpoints, resolve_relay, run_from,
+        default_home_from_env, npub_for_account_id, relay_endpoints,
+        resolve_dev_settlement_quiescence_ms, resolve_relay, run_from,
     };
 
     use marmot_app::{
@@ -1268,6 +1278,28 @@ mod tests {
             .expect_err("invalid account ids must surface as a CLI error");
         let rendered = super::wn_error_json(&err);
         assert_eq!(rendered["code"], "invalid_public_key");
+    }
+
+    #[test]
+    fn dev_settlement_override_is_available_in_debug_builds() {
+        assert_eq!(
+            resolve_dev_settlement_quiescence_ms(Some("0"), true),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn dev_settlement_override_is_rejected_in_release_builds() {
+        assert_eq!(resolve_dev_settlement_quiescence_ms(Some("0"), false), None);
+    }
+
+    #[test]
+    fn invalid_dev_settlement_override_remains_inactive_without_a_warning() {
+        assert_eq!(
+            resolve_dev_settlement_quiescence_ms(Some("not-a-duration"), false),
+            None
+        );
+        assert_eq!(resolve_dev_settlement_quiescence_ms(None, false), None);
     }
 
     fn test_cli(command: Command) -> Cli {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -437,7 +437,7 @@ async fn execute_inner(cli: Cli) -> Result<CommandOutput, WnError> {
             .or_else(|| cli.daemon_discovery_relays.first().cloned())
             .or_else(|| cli.daemon_default_account_relays.first().cloned()),
         account_home.clone(),
-    );
+    )?;
     match command {
         Command::Debug { command } => {
             commands::debug::debug_command(&account_home, &app, command, account_flag)
@@ -990,7 +990,11 @@ pub(crate) fn relay_lists_json(status: AccountRelayListStatus) -> Value {
     })
 }
 
-fn app_for(home: PathBuf, relay: Option<String>, account_home: AccountHome) -> MarmotApp {
+fn app_for(
+    home: PathBuf,
+    relay: Option<String>,
+    account_home: AccountHome,
+) -> Result<MarmotApp, WnError> {
     // Loopback-HTTP blob endpoints are only acted on when explicitly enabled for
     // dev/test (see MarmotAppConfig::allow_loopback_blob_endpoints). Opt in via
     // WN_ALLOW_LOOPBACK_BLOB_ENDPOINTS=1 for local Blossom servers; production
@@ -1002,15 +1006,15 @@ fn app_for(home: PathBuf, relay: Option<String>, account_home: AccountHome) -> M
     // convergence settlement window (e.g. `0` for instant settlement in
     // integration tests). Production installs leave it unset and use the pinned
     // default.
-    if let Some(ms) = wn_dev_settlement_quiescence_ms() {
+    if let Some(ms) = wn_dev_settlement_quiescence_ms()? {
         config = config.with_dev_settlement_quiescence_ms(ms);
     }
-    MarmotApp::with_relays_and_account_home_and_config(
+    Ok(MarmotApp::with_relays_and_account_home_and_config(
         home,
         relay.into_iter().collect(),
         account_home,
         config,
-    )
+    ))
 }
 
 fn wn_allow_loopback_blob_endpoints() -> bool {
@@ -1035,14 +1039,14 @@ fn wn_allow_loopback_relays() -> bool {
 fn resolve_dev_settlement_quiescence_ms(
     value: Option<&str>,
     dev_overrides_enabled: bool,
-) -> Option<u64> {
-    if !dev_overrides_enabled {
-        return None;
+) -> Result<Option<u64>, WnError> {
+    if value.is_some() && !dev_overrides_enabled {
+        return Err(WnError::DevSettlementOverrideInRelease);
     }
-    value.and_then(|value| value.trim().parse().ok())
+    Ok(value.and_then(|value| value.trim().parse().ok()))
 }
 
-fn wn_dev_settlement_quiescence_ms() -> Option<u64> {
+fn wn_dev_settlement_quiescence_ms() -> Result<Option<u64>, WnError> {
     let value = std::env::var("WN_DEV_SETTLEMENT_QUIESCENCE_MS").ok();
     resolve_dev_settlement_quiescence_ms(value.as_deref(), cfg!(debug_assertions))
 }
@@ -1283,23 +1287,36 @@ mod tests {
     #[test]
     fn dev_settlement_override_is_available_in_debug_builds() {
         assert_eq!(
-            resolve_dev_settlement_quiescence_ms(Some("0"), true),
+            resolve_dev_settlement_quiescence_ms(Some("0"), true).unwrap(),
             Some(0)
         );
     }
 
     #[test]
     fn dev_settlement_override_is_rejected_in_release_builds() {
-        assert_eq!(resolve_dev_settlement_quiescence_ms(Some("0"), false), None);
+        let error =
+            resolve_dev_settlement_quiescence_ms(Some("0"), false).expect_err("release rejection");
+        assert!(matches!(&error, WnError::DevSettlementOverrideInRelease));
+        assert_eq!(
+            super::wn_error_json(&error)["code"],
+            "dev_settlement_override_in_release"
+        );
+        assert_eq!(
+            resolve_dev_settlement_quiescence_ms(None, false).unwrap(),
+            None
+        );
     }
 
     #[test]
-    fn invalid_dev_settlement_override_remains_inactive_without_a_warning() {
+    fn invalid_or_missing_dev_settlement_override_remains_inactive_when_enabled() {
         assert_eq!(
-            resolve_dev_settlement_quiescence_ms(Some("not-a-duration"), false),
+            resolve_dev_settlement_quiescence_ms(Some("not-a-duration"), true).unwrap(),
             None
         );
-        assert_eq!(resolve_dev_settlement_quiescence_ms(None, false), None);
+        assert_eq!(
+            resolve_dev_settlement_quiescence_ms(None, true).unwrap(),
+            None
+        );
     }
 
     fn test_cli(command: Command) -> Cli {

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -547,7 +547,9 @@ where
                 .push(PendingResolution::Confirmed { pending });
             output.absorb_session_effects(effects, queue);
             for failure in &mut welcome_failures {
-                failure.group_id = group_id.clone();
+                if failure.group_id.is_none() {
+                    failure.group_id = group_id.clone();
+                }
             }
             // Only a confirmed create leaves welcomes worth re-delivering; a
             // rolled-back create discards the whole evolution, welcomes
@@ -845,10 +847,13 @@ fn welcome_recipient(message: &TransportMessage) -> Option<MemberId> {
 
 /// Extract the group id from the event that confirms a create/evolution.
 ///
-/// `confirm_published` emits exactly one `GroupCreated` or `EpochChanged`
-/// event for the pending operation. Keeping this best-effort preserves the
-/// existing `WelcomeDeliveryFailure::group_id` contract without re-reading the
-/// durable sent-welcome record.
+/// Session effects are drained after every session call, so the confirmation
+/// effects contain exactly one `GroupCreated` or `EpochChanged` for this
+/// pending operation rather than events left by earlier work. This per-call
+/// drain is load-bearing: batching effects across calls would require matching
+/// the event to the pending operation explicitly. Keeping extraction
+/// best-effort preserves the existing `WelcomeDeliveryFailure::group_id`
+/// contract without re-reading the durable sent-welcome record.
 fn confirmed_group_id(effects: &SessionEffects) -> Option<GroupId> {
     effects.events.iter().find_map(|event| match event {
         GroupEvent::GroupCreated { group_id } | GroupEvent::EpochChanged { group_id, .. } => {

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -527,6 +527,7 @@ where
                     welcome_failures.push(self.welcome_delivery_failure(
                         welcome_id,
                         recipient,
+                        None,
                         output,
                         failures_before,
                     ));
@@ -540,10 +541,14 @@ where
 
         if all_published || any_welcome_exposed {
             let effects = self.confirm_published_retrying(pending).await?;
+            let group_id = confirmed_group_id(&effects);
             output
                 .pending
                 .push(PendingResolution::Confirmed { pending });
             output.absorb_session_effects(effects, queue);
+            for failure in &mut welcome_failures {
+                failure.group_id = group_id.clone();
+            }
             // Only a confirmed create leaves welcomes worth re-delivering; a
             // rolled-back create discards the whole evolution, welcomes
             // included.
@@ -574,6 +579,7 @@ where
             // the sender from peers that ingest it, so treat unreached endpoints
             // as recoverable and proceed with welcome publication.
             let effects = self.confirm_published_retrying(pending).await?;
+            let group_id = confirmed_group_id(&effects);
             output
                 .pending
                 .push(PendingResolution::Confirmed { pending });
@@ -591,6 +597,7 @@ where
                         let failure = self.welcome_delivery_failure(
                             welcome_id,
                             recipient,
+                            group_id.clone(),
                             output,
                             failures_before,
                         );
@@ -630,13 +637,13 @@ where
         if !status.met_required_acks
             && let Some(recipient) = recipient
         {
-            let mut failure = self.welcome_delivery_failure(
+            let failure = self.welcome_delivery_failure(
                 message_id.clone(),
                 recipient,
+                Some(group_id),
                 &output,
                 failures_before,
             );
-            failure.group_id = Some(group_id);
             output.welcome_failures.push(failure);
         }
         Ok(output)
@@ -648,6 +655,7 @@ where
         &self,
         message_id: cgka_traits::MessageId,
         recipient: MemberId,
+        group_id: Option<GroupId>,
         output: &AccountDeviceEffects,
         failures_before: usize,
     ) -> WelcomeDeliveryFailure {
@@ -660,11 +668,6 @@ where
             .and_then(<[PublishFailure]>::last)
             .map(|failure| failure.reason.clone())
             .unwrap_or_else(|| "welcome publish failed".into());
-        let group_id = self
-            .session
-            .stored_sent_welcome(&message_id)
-            .ok()
-            .map(|(group_id, _)| group_id);
         WelcomeDeliveryFailure {
             message_id,
             recipient,
@@ -840,6 +843,21 @@ fn welcome_recipient(message: &TransportMessage) -> Option<MemberId> {
     }
 }
 
+/// Extract the group id from the event that confirms a create/evolution.
+///
+/// `confirm_published` emits exactly one `GroupCreated` or `EpochChanged`
+/// event for the pending operation. Keeping this best-effort preserves the
+/// existing `WelcomeDeliveryFailure::group_id` contract without re-reading the
+/// durable sent-welcome record.
+fn confirmed_group_id(effects: &SessionEffects) -> Option<GroupId> {
+    effects.events.iter().find_map(|event| match event {
+        GroupEvent::GroupCreated { group_id } | GroupEvent::EpochChanged { group_id, .. } => {
+            Some(group_id.clone())
+        }
+        _ => None,
+    })
+}
+
 /// Build the outbound transport wire envelope for a publish, from the message's
 /// transport source and (for group messages) the transport-visible group id.
 /// Transport-generic: the post-wrap relay event id and ephemeral pubkey are
@@ -909,7 +927,8 @@ pub struct PublishFailure {
 pub struct WelcomeDeliveryFailure {
     pub message_id: cgka_traits::MessageId,
     pub recipient: MemberId,
-    /// From the stored sent-welcome record; best-effort.
+    /// From the already-known confirmation or stored sent-welcome record;
+    /// best-effort.
     pub group_id: Option<GroupId>,
     pub reason: String,
 }

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -171,6 +171,13 @@ impl MessageSubscriptionSeenIds {
         true
     }
 
+    /// Apply the shared live/recovery subscription dedupe rule. Empty ids are
+    /// emitted without entering the seen set, so one malformed update cannot
+    /// suppress later distinct updates that also lack a canonical id.
+    fn should_emit(&mut self, id: String) -> bool {
+        id.is_empty() || self.insert(id)
+    }
+
     #[cfg(test)]
     fn len(&self) -> usize {
         self.ids.len()

--- a/crates/marmot-app/src/runtime/subscriptions.rs
+++ b/crates/marmot-app/src/runtime/subscriptions.rs
@@ -830,7 +830,7 @@ impl MarmotAppRuntime {
                                 continue;
                             }
                             let message_id = message.message_id_hex.clone();
-                            if !message_id.is_empty() && !seen_message_ids.insert(message_id) {
+                            if !seen_message_ids.should_emit(message_id) {
                                 continue;
                             }
                             if updates_tx.send(update).await.is_err() {
@@ -855,7 +855,7 @@ impl MarmotAppRuntime {
                     continue;
                 }
                 let message_id = message.message_id_hex.clone();
-                if !message_id.is_empty() && !seen_message_ids.insert(message_id) {
+                if !seen_message_ids.should_emit(message_id) {
                     continue;
                 }
                 if updates_tx.send(update).await.is_err() {

--- a/crates/marmot-app/src/runtime/subscriptions.rs
+++ b/crates/marmot-app/src/runtime/subscriptions.rs
@@ -854,7 +854,8 @@ impl MarmotAppRuntime {
                 {
                     continue;
                 }
-                if !seen_message_ids.insert(message.message_id_hex.clone()) {
+                let message_id = message.message_id_hex.clone();
+                if !message_id.is_empty() && !seen_message_ids.insert(message_id) {
                     continue;
                 }
                 if updates_tx.send(update).await.is_err() {

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -19,12 +19,16 @@ fn message_subscription_seen_ids_are_bounded_to_recent_ids() {
 }
 
 #[test]
-fn message_subscription_seen_ids_do_not_store_empty_ids() {
+fn live_message_subscription_emits_each_empty_id_without_storing_it() {
     let mut seen = MessageSubscriptionSeenIds::with_limit(1);
 
-    assert!(seen.insert(String::new()));
-    assert!(seen.insert(String::new()));
+    // Both live updates must be emitted; the first empty id must not poison
+    // dedupe state for the second. `subscribe_messages` routes its live and
+    // recovery paths through this same decision.
+    assert!(seen.should_emit(String::new()));
+    assert!(seen.should_emit(String::new()));
     assert_eq!(seen.len(), 0);
+    assert!(!seen.contains(""));
 }
 
 #[test]

--- a/crates/traits/src/app_components/host_safety.rs
+++ b/crates/traits/src/app_components/host_safety.rs
@@ -101,9 +101,16 @@ pub fn is_public_ipv6(addr: Ipv6Addr) -> bool {
     if (first & 0xfe00) == 0xfc00 || (first & 0xffc0) == 0xfe80 {
         return false;
     }
-    // Reject IPv6 transition mechanisms that can route to an embedded IPv4
-    // endpoint through host-local tunnel configuration, bypassing IPv4 checks.
-    if first == 0x2002 || (first == 0x2001 && second == 0x0000) {
+    // Reject the IANA IPv6 special-purpose pool 2001::/23. Individual
+    // allocations include transition, benchmarking, anycast, and identifier
+    // ranges; they are not general public dial targets. The adjacent
+    // 2001:200::/23 RIR allocation remains eligible.
+    if first == 0x2001 && second <= 0x01ff {
+        return false;
+    }
+    // Reject 6to4, which can route to an embedded IPv4 endpoint through
+    // host-local tunnel configuration and bypass IPv4 checks.
+    if first == 0x2002 {
         return false;
     }
     if first == 0x2001 && second == 0x0db8 {

--- a/crates/traits/src/app_components/tests.rs
+++ b/crates/traits/src/app_components/tests.rs
@@ -166,6 +166,10 @@ fn encrypted_media_policy_rejects_non_https_except_loopback_dev_http() {
         validate_and_normalize_blob_endpoint_url("https://10.0.0.1", false),
         Err("encrypted media endpoint URL must not point at a non-routable address".into())
     );
+    assert_eq!(
+        validate_and_normalize_blob_endpoint_url("https://[2001:2::1]", false),
+        Err("encrypted media endpoint URL must not point at a non-routable address".into())
+    );
     for raw in ["https://localhost./", "https://sub.localhost./"] {
         assert_eq!(
             validate_and_normalize_blob_endpoint_url(raw, false),
@@ -386,6 +390,23 @@ fn group_avatar_url_rejects_documentation_ipv6_ranges() {
     assert!(validate_and_normalize_group_avatar_url("https://[3ffe::1]/a.png").is_ok());
     assert!(validate_and_normalize_group_avatar_url("https://[3fff:1000::1]/a.png").is_ok());
     assert!(validate_and_normalize_group_avatar_url("https://[2606:4700::1]/a.png").is_ok());
+}
+
+#[test]
+fn group_avatar_url_rejects_iana_special_purpose_ipv6_pool() {
+    for raw in [
+        "https://[2001:1::1]/a.png",
+        "https://[2001:2::1]/a.png",
+        "https://[2001:4:112::1]/a.png",
+        "https://[2001:20::1]/a.png",
+        "https://[2001:1ff:ffff::1]/a.png",
+    ] {
+        assert!(
+            validate_and_normalize_group_avatar_url(raw).is_err(),
+            "{raw} should be rejected"
+        );
+    }
+    assert!(validate_and_normalize_group_avatar_url("https://[2001:200::1]/a.png").is_ok());
 }
 
 #[test]

--- a/crates/traits/tests/host_safety_public.rs
+++ b/crates/traits/tests/host_safety_public.rs
@@ -81,6 +81,7 @@ fn shared_host_safety_classifies_canonical_ipv6_ranges() {
     assert!(is_public_ip(IpAddr::V6("2606:4700::1".parse().unwrap())));
     assert!(is_public_ipv6("3ffe::1".parse().unwrap()));
     assert!(is_public_ipv6("3fff:1000::1".parse().unwrap()));
+    assert!(is_public_ipv6("2001:200::1".parse().unwrap()));
 
     for raw in [
         "::1",              // loopback
@@ -92,6 +93,11 @@ fn shared_host_safety_classifies_canonical_ipv6_ranges() {
         "fe80::1",          // link-local
         "2002::1",          // 6to4 transition prefix
         "2001::1",          // Teredo 2001:0000::/32
+        "2001:1::1",        // PCP anycast in IANA special-purpose 2001::/23
+        "2001:2::1",        // IPv6 benchmarking
+        "2001:4:112::1",    // AS112-v6
+        "2001:20::1",       // ORCHIDv2
+        "2001:1ff:ffff::1", // end of IANA special-purpose 2001::/23
         "2001:db8::1",      // documentation
         "3fff::1",          // documentation 3fff::/20
         "4000::1",          // outside global-unicast 2000::/3
@@ -130,6 +136,7 @@ fn shared_dial_gate_rejects_non_public_addresses() {
         "192.168.1.1",      // private
         "fc00::1",          // unique-local
         "fe80::1",          // link-local
+        "2001:2::1",        // IPv6 benchmarking
         "::ffff:10.0.0.1",  // mapped private IPv4
         "::ffff:127.0.0.1", // mapped loopback
     ] {

--- a/docs/marmot-architecture/cgka-engine-canonicalization-contract.md
+++ b/docs/marmot-architecture/cgka-engine-canonicalization-contract.md
@@ -9,7 +9,8 @@ ids, relay order, relay timestamps, and local arrival order are not consensus in
 
 The transport layer may buffer, retry, and fetch from relays. The CGKA engine receives peeled messages and decides which
 protocol artifacts become canonical. Any ordering supplied by the transport adapter is advisory. The engine may use it
-as input order for buffering, but branch selection depends on MLS replay, retained anchors, and the negotiated policy.
+as input order for buffering, but branch selection depends on MLS replay, retained anchors, and the pinned protocol
+policy.
 
 The handoff is:
 
@@ -28,19 +29,19 @@ canonicalize(engine_state, pending_messages, outbound_intents, policy, clock)
 ```
 
 Implementations may call this operation after each ingest, after a sync batch, after relay input becomes idle, or on
-demand. The result MUST be the same for the same inputs, retained anchor, policy, engine version, and lifecycle clock
-state.
+demand. The result MUST be the same for the same inputs, retained anchor, pinned protocol policy, engine version, and
+lifecycle clock state.
 
 ## Core Invariant
 
-Two honest engines with the same retained anchor, the same pending set, the same negotiated policy, and the same engine
-version MUST produce the same canonical branch and the same protocol message dispositions.
+Two honest engines with the same retained anchor, the same pending set, the same pinned protocol policy, and the same
+engine version MUST produce the same canonical branch and the same protocol message dispositions.
 
 ```text
 same anchor
 + same retained candidate states
 + same pending messages
-+ same policy
++ same pinned protocol policy
 + same engine version
 = same CanonicalizationResult
 ```
@@ -85,9 +86,10 @@ Statuses:
 Convergence-relevant input includes commits, proposals, and app messages that can affect branch witness scores. Pure
 duplicate messages do not reset the quiescence timer.
 
-`settlement_quiescence_ms` MUST be tunable. Groups SHOULD publish a recommended value. Clients MAY choose a longer local
-value, but MUST NOT choose a value below a group-required minimum. A value that is too high can pin clients in
-`Syncing`; a value that is too low can cause avoidable forks. Conformance tests SHOULD model both failure modes.
+Under v1, `settlement_quiescence_ms` is the protocol-pinned `1000` ms. It is not group-negotiated or a local production
+preference. Dev/test builds MAY expose an explicit override for deterministic harnesses, but production clients MUST
+use the pinned value. A future change requires a new app component behind a required capability so every participant
+uses the same policy version.
 
 The branch selection function itself MUST NOT depend on wall-clock time. Time only gates when the engine is willing to
 publish outbound work.
@@ -184,26 +186,23 @@ The engine MUST queue outbound intents while convergence is not `Settled`.
 
 ## Policy
 
-The convergence policy is a group policy. Unsupported policy is a capability mismatch.
+The adopted v1 convergence policy is pinned by the protocol:
 
 ```text
-ConvergencePolicy {
+convergence_policy = {
   max_rewind_commits: 5,
-  app_message_past_epoch_limit: FromMlsConfiguration,
-  settlement_quiescence_ms,
-  witness_quorum,
-  max_witness_override_depth,
+  app_payload_past_epoch_limit: 5,
+  settlement_quiescence_ms: 1000,
+  witness_quorum_senders_per_epoch: 2,
+  witness_quorum_epochs: 1,
+  max_witness_override_depth: 1,
 }
 ```
 
-`max_rewind_commits` defaults to 5 and is normative for v0 groups unless the group negotiates another value.
-
-Engines MUST persist the negotiated policy per group. After restart, the engine MUST load the stored group policy before
-computing retained anchors, pruning snapshots, selecting candidate branches, or deciding whether a stale commit is
-inside the rewind horizon. A local default is only a fallback for groups that do not yet have a stored policy.
-
-Until MLS app components carry this policy, v0 engines use the local default policy and store explicit policy bytes when
-a group has negotiated or otherwise configured an override.
+These values are protocol constants, not per-group state or local production preferences. Engines MUST NOT negotiate,
+persist, or accept alternate values under v1. A future policy change requires a new app component behind a required
+capability. The canonical definition lives in the adopted Marmot
+[`protocol-core/convergence.md`](https://github.com/marmot-protocol/marmot/blob/master/protocol-core/convergence.md).
 
 The same value bounds retained anchor snapshots. At current tip `T`, the oldest retained anchor is:
 
@@ -214,30 +213,12 @@ oldest_retained_anchor = T - max_rewind_commits
 Engines MUST retain snapshots for the current tip and every epoch at or after that anchor. Engines MUST prune older
 retained anchors as soon as a successful canonicalization pass reaches `Settled` and advances the current tip.
 
-`app_message_past_epoch_limit` MUST follow the MLS configuration used by the engine for decrypting past-epoch
-application messages. App messages outside that limit are discarded or reported as expired. The engine MUST NOT invent a
-separate app-message rewind horizon.
+`app_payload_past_epoch_limit` MUST also configure the MLS past-epoch decryption window. App messages outside that
+limit are discarded or reported as expired. The engine MUST NOT invent a separate app-message rewind horizon.
 
-`witness_quorum` SHOULD be derived from active group size. The exact function is part of group policy:
-
-```text
-DerivedWitnessQuorum {
-  min_senders_per_epoch,
-  max_senders_per_epoch,
-  sender_fraction_bps,
-  required_epochs,
-}
-
-witness_quorum_senders_per_epoch =
-  clamp(
-    ceil(active_members_at_epoch * sender_fraction_bps / 10000),
-    min_senders_per_epoch,
-    max_senders_per_epoch
-  )
-```
-
-The derived sender count is evaluated per epoch against that epoch's active membership. This keeps the rule
-deterministic across membership changes.
+Witness quorum is met when at least `witness_quorum_senders_per_epoch` distinct senders produced valid app messages on
+at least `witness_quorum_epochs` branch epochs. The bounded witness boost adds at most
+`max_witness_override_depth` to effective commit depth.
 
 ## Candidate-State Graph
 
@@ -276,7 +257,9 @@ Branch scoring follows [`distributed-convergence.md`](./distributed-convergence.
 2. Witness quorum beats no quorum.
 3. Higher raw commit depth.
 4. Higher app-witness score.
-5. Lower tip commit digest.
+5. Lower tip commit priority (`Privileged` before `Ordinary`).
+6. Lower authenticated tip committer account id.
+7. Lower tip commit digest.
 
 ## Proposals
 
@@ -427,7 +410,6 @@ The engine MUST persist enough state to reproduce canonicalization after a resta
 
 Required storage:
 
-- negotiated convergence policy and engine version, stored per group and loaded before convergence after restart,
 - finalized anchor and anchor epoch,
 - retained Marmot and OpenMLS epoch snapshots from the current tip back through `max_rewind_commits`,
 - canonical commit sequence from the anchor to the selected tip,
@@ -444,10 +426,15 @@ Required storage:
 - last successful canonicalization result,
 - last convergence-relevant input time for sync quiescence.
 
-Storage MAY discard candidate states, pending messages, retained anchors, and app payloads outside their negotiated
-retention horizons. Once discarded, those artifacts cannot cause rollback or app-message acceptance. Invalidated message
-records SHOULD remain durable audit/debug records even when they are no longer replayable. Applications MAY surface
-invalidated app messages according to local UX policy.
+The current v1 implementation does not persist convergence-policy constants or an engine version per group: the policy
+is protocol-pinned, and the on-disk schema is versioned through storage migrations. If a future policy revision needs
+on-disk compatibility detection, it MUST introduce an explicit policy-version stamp and migration before engines accept
+that revision.
+
+Storage MAY discard candidate states, pending messages, retained anchors, and app payloads outside their pinned
+retention horizons. Once discarded, those artifacts cannot cause rollback or app-message acceptance. Invalidated
+message records SHOULD remain durable audit/debug records even when they are no longer replayable. Applications MAY
+surface invalidated app messages according to local UX policy.
 
 When storage discards a retained anchor, later commits that require that anchor fall into one of two outcomes:
 `MissingRetainedAnchor` if the commit is still inside the configured rewind window but the snapshot is absent, or

--- a/docs/marmot-architecture/cgka-engine-spec.md
+++ b/docs/marmot-architecture/cgka-engine-spec.md
@@ -262,6 +262,9 @@ Branches are compared in this order:
 6. Lower authenticated tip committer account id.
 7. Lower tip commit digest.
 
+The conformance scenario
+`app_witness_score_beats_priority_after_depth_and_quorum_ties` pins the adjacency between rules 4 and 5.
+
 Application witnesses are valid application messages that decrypt against a candidate state. Witness score counts
 distinct senders per epoch. One sender cannot increase score by sending many messages in the same epoch.
 
@@ -400,7 +403,6 @@ Required storage:
 
 - group metadata and current epoch,
 - OpenMLS state,
-- convergence policy version, pinned values, and engine version,
 - retained Marmot and OpenMLS snapshots from current tip back through `max_rewind_commits`,
 - durable message records for retained commits, proposals, app messages, and welcomes, with typed stored payloads
   distinguishing raw transport bytes from peeled OpenMLS wire bytes,
@@ -411,6 +413,10 @@ Required storage:
 - dedupe index,
 - queued outbound intents,
 - last convergence-relevant input time.
+
+The current storage does not persist convergence-policy constants or an engine version per group. V1 constants are
+protocol-pinned, and the on-disk schema is versioned through storage migrations. A future policy revision that needs
+on-disk compatibility detection requires an explicit policy-version stamp and migration.
 
 Snapshot and rollback MUST be atomic across Marmot metadata and OpenMLS state. A rollback that restores only one side is
 invalid.

--- a/docs/marmot-architecture/cgka-engine-spec.md
+++ b/docs/marmot-architecture/cgka-engine-spec.md
@@ -55,13 +55,13 @@ The engine emits:
 
 ## Core Invariant
 
-Two honest engines with the same retained anchor, pending message set, negotiated policy, engine version, and lifecycle
-clock inputs MUST select the same canonical branch and produce the same protocol dispositions.
+Two honest engines with the same retained anchor, pending message set, pinned protocol policy, engine version, and
+lifecycle clock inputs MUST select the same canonical branch and produce the same protocol dispositions.
 
 ```text
 same retained anchor
 + same pending messages
-+ same negotiated policy
++ same pinned protocol policy
 + same engine version
 + same lifecycle clock inputs
 = same canonical branch and dispositions
@@ -194,8 +194,8 @@ pause later queued work until `confirm_published` or `publish_failed` resolves t
 
 ## Commit Convergence
 
-Commits are the consensus log. All honest engines that see the same valid commit set and policy MUST process commits in
-the same canonical order.
+Commits are the consensus log. All honest engines that see the same valid commit set under the same pinned protocol
+policy MUST process commits in the same canonical order.
 
 The engine builds a bounded candidate-state graph from retained MLS snapshots. Production engines MUST derive candidate
 edges by replaying MLS bytes against retained snapshots. They MUST NOT trust transport-provided parent metadata.
@@ -246,7 +246,7 @@ Branch selection uses these values:
 - `app_witness_score`: the sum of distinct app-message senders counted per branch epoch, capped by that epoch's sender
   quorum.
 - `witness_quorum_met`: true when the branch has enough distinct app-message senders in enough branch epochs under the
-  group policy.
+  pinned protocol policy.
 - `effective_commit_depth`: `raw_commit_depth` plus the bounded witness boost when `witness_quorum_met` is true.
 
 Witnesses are evidence that group members used a branch after it was created. They do not create epochs, apply commits,
@@ -258,12 +258,14 @@ Branches are compared in this order:
 2. Witness quorum beats no quorum.
 3. Higher raw commit depth.
 4. Higher app-witness score.
-5. Lower tip commit digest.
+5. Lower tip commit priority (`Privileged` before `Ordinary`).
+6. Lower authenticated tip committer account id.
+7. Lower tip commit digest.
 
 Application witnesses are valid application messages that decrypt against a candidate state. Witness score counts
 distinct senders per epoch. One sender cannot increase score by sending many messages in the same epoch.
 
-The group policy defines the quorum. A typical policy uses:
+The pinned protocol policy defines the quorum through:
 
 ```text
 witness_quorum_senders_per_epoch
@@ -282,7 +284,7 @@ epoch_witness_score =
 A branch meets witness quorum when at least `witness_quorum_senders_per_epoch` distinct senders witnessed at least
 `witness_quorum_epochs` branch epochs.
 
-When a branch meets witness quorum, the selector MAY add a bounded boost:
+When a branch meets witness quorum, the selector adds the pinned bounded boost:
 
 ```text
 effective_commit_depth =
@@ -290,42 +292,42 @@ effective_commit_depth =
   + (witness_quorum_met ? max_witness_override_depth : 0)
 ```
 
-This boost is capped. If `max_witness_override_depth = 2`, witness quorum can make a branch compare as up to two commits
-deeper. It cannot compare as three or more commits deeper, no matter how many app messages exist.
+This boost is capped. Under the pinned v1 policy, `max_witness_override_depth = 1`, so witness quorum can make a branch
+compare as one commit deeper. It cannot compare as two or more commits deeper, no matter how many app messages exist.
 
-Example with `max_witness_override_depth = 2`:
+Example with the pinned v1 policy:
 
 ```text
 live branch:
   raw_commit_depth = 3
   witness_quorum_met = true
-  effective_commit_depth = 5
+  effective_commit_depth = 4
+
+private branch:
+  raw_commit_depth = 4
+  witness_quorum_met = false
+  effective_commit_depth = 4
+
+winner: live branch, because effective depth ties and witness quorum beats no quorum
+```
+
+The witnessed branch wins because the group had broad app-message evidence on that branch, and the competing branch is
+only one commit deeper.
+
+Another example with the pinned v1 policy:
+
+```text
+live branch:
+  raw_commit_depth = 3
+  witness_quorum_met = true
+  effective_commit_depth = 4
 
 private branch:
   raw_commit_depth = 5
   witness_quorum_met = false
   effective_commit_depth = 5
 
-winner: live branch, because effective depth ties and witness quorum beats no quorum
-```
-
-The witnessed branch wins because the group had broad app-message evidence on that branch, and the competing branch is
-only two commits deeper.
-
-Another example with the same policy:
-
-```text
-live branch:
-  raw_commit_depth = 3
-  witness_quorum_met = true
-  effective_commit_depth = 5
-
-private branch:
-  raw_commit_depth = 6
-  witness_quorum_met = false
-  effective_commit_depth = 6
-
-winner: private branch, because it is more than two valid commits deeper
+winner: private branch, because it is more than one valid commit deeper
 ```
 
 The cap keeps app-message evidence secondary to the commit log. Witness quorum can protect the branch most members were
@@ -371,19 +373,21 @@ The engine MUST NOT emit an invalidated message as a normal received message.
 
 ## Policy
 
-Convergence policy is group policy. Engines MUST persist the negotiated policy per group and load it before convergence
-after restart.
+The adopted v1 convergence policy is pinned by the protocol:
 
-The policy contains:
+```text
+max_rewind_commits = 5
+app_payload_past_epoch_limit = 5
+settlement_quiescence_ms = 1000
+witness_quorum_senders_per_epoch = 2
+witness_quorum_epochs = 1
+max_witness_override_depth = 1
+```
 
-- `max_rewind_commits`, default 5 for v0 groups.
-- app-message past-epoch limit, derived from the MLS configuration.
-- stable quiescence duration.
-- witness quorum parameters.
-- `max_witness_override_depth`.
-
-Unsupported policy is a capability mismatch. A local default is only a fallback for groups that do not yet have a stored
-policy.
+These are protocol constants, not group state or local preferences. A future policy change requires a new app component
+behind a required capability; clients MUST NOT negotiate or accept alternate values under v1. The canonical definition
+lives in the adopted Marmot
+[`protocol-core/convergence.md`](https://github.com/marmot-protocol/marmot/blob/master/protocol-core/convergence.md).
 
 The branch selection function MUST NOT depend on wall-clock time. Local monotonic time only gates sync stability and
 outbound publication.
@@ -396,7 +400,7 @@ Required storage:
 
 - group metadata and current epoch,
 - OpenMLS state,
-- negotiated convergence policy and engine version,
+- convergence policy version, pinned values, and engine version,
 - retained Marmot and OpenMLS snapshots from current tip back through `max_rewind_commits`,
 - durable message records for retained commits, proposals, app messages, and welcomes, with typed stored payloads
   distinguishing raw transport bytes from peeled OpenMLS wire bytes,
@@ -411,8 +415,8 @@ Required storage:
 Snapshot and rollback MUST be atomic across Marmot metadata and OpenMLS state. A rollback that restores only one side is
 invalid.
 
-Storage MAY discard artifacts outside negotiated retention horizons. Once discarded, those artifacts cannot cause
-rollback or app-message acceptance.
+Storage MAY discard artifacts outside the pinned protocol retention horizons. Once discarded, those artifacts cannot
+cause rollback or app-message acceptance.
 
 ## Errors And Dispositions
 

--- a/docs/marmot-architecture/distributed-convergence.md
+++ b/docs/marmot-architecture/distributed-convergence.md
@@ -137,7 +137,7 @@ Branches are compared in this order:
 2. Witness quorum beats no quorum.
 3. Higher `valid_commit_depth`.
 4. Higher `app_witness_score`.
-5. Lower tip commit priority (`Privileged` before `Ordinary`).
+5. Prefer a `Privileged` tip commit over an `Ordinary` one.
 6. Lower authenticated tip committer account id.
 7. Lower tip commit digest.
 
@@ -253,9 +253,9 @@ Tamarin is a good fit for the security-adjacent part of this model if we keep th
 
 The initial scaffold lives in
 [`formal/tamarin/distributed_convergence_v0.spthy`](../../formal/tamarin/distributed_convergence_v0.spthy). It models
-the selector boundary only: two honest clients, the same valid candidate set, the same pinned policy, and
-deterministic branch selection. Scores are represented as bounded symbolic classes so the model can prove the comparison
-order without modeling MLS internals.
+the selector boundary only: two honest clients, the same valid candidate set, a projection of the pinned policy containing
+only the selector-relevant rewind and quorum fields, and deterministic branch selection. Scores are represented as bounded
+symbolic classes so the model can prove the comparison order without modeling MLS internals.
 
 Model first:
 

--- a/docs/marmot-architecture/distributed-convergence.md
+++ b/docs/marmot-architecture/distributed-convergence.md
@@ -80,7 +80,7 @@ Late commits are handled by their source epoch:
   as invalidated.
 
 This rule is the local storage boundary for the forward-secrecy tradeoff. A client cannot be forced to replay commits
-older than the group policy says it will retain.
+older than the pinned protocol policy says it will retain.
 
 ## Convergence Status
 
@@ -137,7 +137,9 @@ Branches are compared in this order:
 2. Witness quorum beats no quorum.
 3. Higher `valid_commit_depth`.
 4. Higher `app_witness_score`.
-5. Lower tip commit digest.
+5. Lower tip commit priority (`Privileged` before `Ordinary`).
+6. Lower authenticated tip committer account id.
+7. Lower tip commit digest.
 
 ```mermaid
 flowchart TD
@@ -145,7 +147,7 @@ flowchart TD
     B --> C["Drop branches outside rewind horizon"]
     C --> D["Count distinct app witnesses per epoch"]
     D --> E["Apply bounded quorum boost"]
-    E --> F["Tie-break by raw depth, witness score, digest"]
+    E --> F["Tie-break by raw depth, witness score, priority, committer, digest"]
     F --> G["Materialize selected branch"]
     F --> H["Mark losing-branch messages invalidated"]
 ```
@@ -156,51 +158,51 @@ with message volume.
 
 ## Policy
 
-The convergence policy should be group-negotiated. Working defaults:
+The adopted v1 convergence policy is pinned by the protocol:
 
 ```text
 convergence_policy = {
   max_rewind_commits: 5,
-  witness_quorum_senders_per_epoch: <group policy>,
-  witness_quorum_epochs: <group policy>,
-  max_witness_override_depth: <group policy>,   // MUST be <= max_rewind_commits
+  app_payload_past_epoch_limit: 5,
+  settlement_quiescence_ms: 1000,
+  witness_quorum_senders_per_epoch: 2,
+  witness_quorum_epochs: 1,
+  max_witness_override_depth: 1,
 }
 ```
 
-`max_witness_override_depth` MUST NOT exceed `max_rewind_commits` (the worked example below uses `2` against the default
-`5`). The engine enforces this bound — `ConvergencePolicy::validate` rejects an out-of-bound policy when it is set or
-decoded — so the witness-quorum boost can never push a branch past the rollback horizon.
-
-`max_rewind_commits` also bounds snapshot retention, so the forward-secrecy cost is explicit. The engine persists the
-per-group policy and uses that stored value after restart. Once MLS app components are available, the policy should live
-there. Until then, Marmot can carry it in a group context extension and treat an unsupported policy as a capability
-mismatch.
+These are protocol constants, not group state or local preferences. `max_witness_override_depth` remains bounded by
+`max_rewind_commits`, so the witness-quorum boost can never push a branch past the rollback horizon.
+`max_rewind_commits` also bounds snapshot retention, making the forward-secrecy cost explicit. A future policy change
+requires a new app component behind a required capability; v1 clients MUST NOT negotiate or accept alternate values.
+The canonical definition lives in the adopted Marmot
+[`protocol-core/convergence.md`](https://github.com/marmot-protocol/marmot/blob/master/protocol-core/convergence.md).
 
 ## Examples
 
 ### Equal-depth fork
 
 Two branches both have depth 2. One branch has app witnesses from more distinct members. The witnessed branch wins
-before digest tie-break.
+before priority, committer, and digest tie-breaks.
 
 ### Withheld private branch
 
-The live branch has 3 commits and witness quorum across 2 epochs. A private branch later publishes 5 commits from the
-same fork. If `max_witness_override_depth = 2`, the live branch receives a bounded boost and wins the tie:
+The live branch has 3 commits and witness quorum. A private branch later publishes 4 commits from the same fork. Under
+the pinned v1 `max_witness_override_depth = 1`, the live branch receives a bounded boost and wins the tie:
 
 ```text
-live:     depth 3 + quorum boost 2 = effective 5
-private:  depth 5 + quorum boost 0 = effective 5
+live:     depth 3 + quorum boost 1 = effective 4
+private:  depth 4 + quorum boost 0 = effective 4
 winner:   live branch, because quorum beats no quorum
 ```
 
 ### Longer valid branch
 
-The live branch has 3 commits plus quorum boost 2. A competing branch has 6 valid commits. The longer branch wins:
+The live branch has 3 commits plus quorum boost 1. A competing branch has 5 valid commits. The longer branch wins:
 
 ```text
-live:      effective 5
-competing: effective 6
+live:      effective 4
+competing: effective 5
 winner:    competing branch
 ```
 
@@ -248,7 +250,7 @@ Tamarin is a good fit for the security-adjacent part of this model if we keep th
 
 The initial scaffold lives in
 [`formal/tamarin/distributed_convergence_v0.spthy`](../../formal/tamarin/distributed_convergence_v0.spthy). It models
-the selector boundary only: two honest clients, the same valid candidate set, the same negotiated policy, and
+the selector boundary only: two honest clients, the same valid candidate set, the same pinned policy, and
 deterministic branch selection. Scores are represented as bounded symbolic classes so the model can prove the comparison
 order without modeling MLS internals.
 

--- a/docs/marmot-architecture/distributed-convergence.md
+++ b/docs/marmot-architecture/distributed-convergence.md
@@ -141,6 +141,9 @@ Branches are compared in this order:
 6. Lower authenticated tip committer account id.
 7. Lower tip commit digest.
 
+The conformance scenario
+`app_witness_score_beats_priority_after_depth_and_quorum_ties` pins the adjacency between rules 4 and 5.
+
 ```mermaid
 flowchart TD
     A["Message bag"] --> B["Build candidate states by MLS replay"]

--- a/docs/marmot-architecture/relay-delivery-telemetry.md
+++ b/docs/marmot-architecture/relay-delivery-telemetry.md
@@ -17,8 +17,8 @@ Completeness is unsolvable in the strong sense, and no ordering or consensus mec
 The convergence model already accepts this. It does not try to *achieve* completeness; it makes gaps **detectable** (a
 commit whose parent is unknown is deferred, not applied) and **bounds the damage** of a missing message (`max_rewind_commits`
 plus witness quorum). What remains is the one place where the design still substitutes a heuristic for completeness: the
-decision to stop waiting and settle. Today that decision is `settlement_quiescence_ms`, a group-negotiated constant. We
-do not have a principled basis for its value.
+decision to stop waiting and settle. Today that decision is the protocol-pinned
+`settlement_quiescence_ms = 1000`. We need evidence to validate that value and to inform any future protocol revision.
 
 This note specifies what to measure to set it, and how the measurement maps onto the convergence machine.
 
@@ -117,21 +117,22 @@ timing land via the raw per-relay event/EOSE stream (phase 2; see [Instrumentati
 
 ## Choosing the static value
 
-`settlement_quiescence_ms` is a single group-negotiated constant. It is **not** computed per client and it does **not**
-adapt at runtime. The point of this telemetry is the opposite of auto-tuning: it lets an operator choose the right
-constant from real data, once, and set it in group policy. The procedure is offline:
+`settlement_quiescence_ms` is a single protocol-pinned constant. It is **not** computed per client, negotiated per
+group, or adapted at runtime. The point of this telemetry is the opposite of auto-tuning: it lets protocol maintainers
+validate the current value from real data and evaluate a future policy revision. The procedure is offline:
 
 - **Gather.** Collect `cross_relay_spread` (and, for the initial-sync side, the EOSE / first-event timing) across the
   real relay population and real groups, aggregated into the histograms this telemetry already produces.
 - **Read the distribution.** Pick a candidate operating point — for example a high percentile of the steady-state spread
   plus margin. The loss function is asymmetric: too low costs extra post-settle reorgs (observable as
   `observed_reorg_rate`), too high costs liveness. Move the candidate until the reorg rate is acceptable.
-- **Set the constant.** Encode the chosen value in the negotiated convergence policy. Every member processing an epoch
-  uses the same policy bytes; this is not a local preference.
+- **Propose a protocol revision.** If the evidence justifies a different value, specify it through a new app component
+  behind a required capability. Every participant processing an epoch must use the same policy version; this is not a
+  per-group or local preference.
 
-The existing policy already treats `settlement_quiescence_ms` as a floor a client MAY exceed, but only as a deliberate
-static configuration choice — never derived from a client's own live measurements. The measurement-to-value step is a
-human decision fed by dashboards, not a runtime controller.
+V1 clients use the exact pinned value in production. Dev/test-only overrides exist to make harnesses deterministic, but
+must not ship as production policy. The measurement-to-value step is a human protocol-design decision fed by
+dashboards, not a runtime controller.
 
 ## Validation: post-settle reorg rate
 
@@ -261,8 +262,9 @@ the engine against settle outcomes and is out of scope for the adapter.
    convergence apply site and exposes them via `Engine::engine_metrics()`
    ([`crates/cgka-engine/src/engine_metrics.rs`](../../crates/cgka-engine/src/engine_metrics.rs)); see
    [Validation: post-settle reorg rate](#validation-post-settle-reorg-rate).
-4. **Set the static value from data.** Aggregate (1) and (3) over real relays and groups, read the distributions, and
-   choose the negotiated `settlement_quiescence_ms`. An offline operator/analysis step, not a runtime controller.
+4. **Validate the static value from data.** Aggregate (1) and (3) over real relays and groups, read the distributions,
+   and decide whether the pinned `settlement_quiescence_ms` needs a capability-gated protocol revision. An offline
+   protocol-design step, not a runtime controller.
 5. **Set reconciliation (NIP-77).** Fetch-completeness backstop for backdated late commits.
 
 Each phase is independently useful and independently shippable, and (1) de-risks the rest by telling us what our relay


### PR DESCRIPTION
## Summary

- align the local convergence architecture documentation with the adopted seven-rule v1 ordering and add the missing symbolic witness-score adjacency test
- keep the development quiescence override out of release behavior
- apply bounded whole-response writes to the remaining streaming and one-shot daemon paths
- reuse known welcome group IDs instead of performing a redundant durable read
- reject the complete IANA `2001::/23` IPv6 special-purpose range while preserving the adjacent public allocation
- bypass live message deduplication when an update has no canonical message ID

## Why

These are the small, clear follow-up gaps left by the broader MDK issue audit. The changes apply patterns and policies already established elsewhere in the workspace, while keeping each issue in a separate bisectable commit.

## Validation

- `just fast-ci`
- `cargo test -p cgka-conformance-simulator`
- `cargo test -p wn-cli -p marmot-account -p marmot-app -p cgka-traits`

Fixes #977
Fixes #992
Fixes #996
Fixes #817
Fixes #855
Fixes #1041
Fixes #1035
Fixes #807

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a 15-second write deadline for daemon framed responses and stream replies (including flush/shutdown) to prevent stalled clients from blocking output.
  * Fixed subscription update deduplication so empty message IDs no longer suppress later updates.
  * Corrected welcome-delivery failure reporting with the confirmation-derived group identifier.
  * Strengthened public/non-public IPv6 address handling and related URL validation rules.
  * Release builds now reject the development-only settlement timing override at startup.
* **Documentation**
  * Clarified v1 pinned protocol convergence/determinism and canonical branch selection.
* **Tests**
  * Added/updated coverage for daemon write timeouts, branch scoring/tie-breaking, IPv6 safety, subscription dedupe behavior, and build-specific override handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->