### PR TITLE
chore: pin OpenMLS draft-10 last-resort support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -61,7 +61,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -563,6 +563,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bip39"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +680,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -801,6 +830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,7 +867,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "storage-sqlite",
  "tempfile",
  "tls_codec",
@@ -859,7 +897,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "storage-sqlite",
  "tempfile",
  "test-log",
@@ -881,7 +919,7 @@ dependencies = [
  "nostr",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "storage-sqlite",
  "tempfile",
  "thiserror 2.0.18",
@@ -901,7 +939,7 @@ dependencies = [
  "openmls_traits",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "url",
  "zeroize",
@@ -915,7 +953,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -925,7 +974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -948,9 +997,20 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -992,6 +1052,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "color_quant"
@@ -1056,6 +1122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,13 +1154,13 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-models"
-version = "0.0.5"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657f625ff361906f779745d08375ae3cc9fef87a35fba5f22874cf773010daf4"
+checksum = "ee3344d349528f449816cfa85e558c439bdca5a6d8a738cfb21e69f0b2b1952f"
 dependencies = [
  "hax-lib",
  "pastey",
- "rand 0.9.4",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -1098,6 +1170,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crabgrind"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7459e07732f6de74001fcf73a3fdfbb0f368e4fd8e2392f4a2206a065e6e95"
+dependencies = [
+ "bindgen",
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1207,6 +1299,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,19 +1329,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.9",
  "rustc_version",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.3.0",
+ "rustc_version",
+ "subtle",
 ]
 
 [[package]]
@@ -1304,8 +1430,18 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -1330,7 +1466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde_core",
 ]
 
 [[package]]
@@ -1361,10 +1496,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1393,12 +1540,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
- "digest",
+ "der 0.7.10",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1407,8 +1554,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -1417,11 +1564,11 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1440,13 +1587,13 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -1612,6 +1759,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filedescriptor"
@@ -1965,9 +2118,9 @@ dependencies = [
 
 [[package]]
 name = "hax-lib"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543f93241d32b3f00569201bfce9d7a93c92c6421b23c77864ac929dc947b9fc"
+checksum = "01a33cb227f97ee5c419064c31d7c55a7d895f28d8019ccdadc311cc036500c4"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -1976,9 +2129,9 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8755751e760b11021765bb04cb4a6c4e24742688d9f3aa14c2079638f537b0f"
+checksum = "28da835a5f153e9f3d0cc1f42ee605a1cfa9093c93348193793d60a1b0908b51"
 dependencies = [
  "hax-lib-macros-types",
  "proc-macro-error2",
@@ -1989,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "hax-lib-macros-types"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f177c9ae8ea456e2f71ff3c1ea47bf4464f772a05133fcbba56cd5ba169035a2"
+checksum = "eed327e9a28d6ee018a4a9ba842d4ee27e378c8a591d2beb6f42f32b24a02fcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2017,9 +2170,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "hex-conservative"
@@ -2036,7 +2186,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2045,21 +2204,29 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "hpke-rs"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ad6a58eb3e0ee30be8bfc7a9770ae98adcfa1d9bc820a5847732ce84f70837"
+checksum = "812de62ab573b876c6c40d7553bae9402ae3bad95b64af06f964388eecb9b7b1"
 dependencies = [
  "hpke-rs-crypto",
  "hpke-rs-libcrux",
  "hpke-rs-rust-crypto",
  "libcrux-sha3",
  "log",
- "rand_core 0.9.5",
  "serde",
  "subtle",
  "tls_codec",
@@ -2068,22 +2235,22 @@ dependencies = [
 
 [[package]]
 name = "hpke-rs-crypto"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a73a99d9008010d73289f41335a3f6e14fb8c04eaf60e9111b450463b1bbc7f"
+checksum = "d2c461da2e0c9c93d875b597f0c78214fb0d2d5c57834b2ef2a2fa057fa20e24"
 dependencies = [
- "rand_core 0.9.5",
+ "rand 0.10.1",
  "zeroize",
 ]
 
 [[package]]
 name = "hpke-rs-libcrux"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ce6b7e54aebe540faee869c67ee253bede44ea6cb67c6e72c7847d6c59f1df"
+checksum = "4c1ace95ef11fbbd84527eada5fc1304f66720fc4c008db30d888d62d3c52613"
 dependencies = [
  "hpke-rs-crypto",
- "libcrux-aead 0.0.7",
+ "libcrux-aead",
  "libcrux-ecdh",
  "libcrux-hkdf",
  "libcrux-kem",
@@ -2096,24 +2263,25 @@ dependencies = [
 
 [[package]]
 name = "hpke-rs-rust-crypto"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b28be6cba9081c7feda2651d51c2a900029798e78b4c1e093e792f4571a870"
+checksum = "3a606ac19851da841862ef5f39d26d6227bfcfb4047417801a66c1f6e6652d71"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
- "hkdf",
+ "hkdf 0.13.0",
  "hpke-rs-crypto",
  "k256",
+ "ml-kem",
  "p256",
  "p384",
- "rand 0.8.6",
- "rand_chacha 0.3.1",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rand_core 0.10.1",
- "rand_core 0.6.4",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
- "x25519-dalek",
+ "x-wing",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -2155,6 +2323,16 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "ctutils",
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2486,6 +2664,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2564,8 +2751,8 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2",
- "signature",
+ "sha2 0.10.9",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -2577,6 +2764,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2614,33 +2821,21 @@ checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libcrux-aead"
-version = "0.0.6"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44098a02cdfd8f41cffe672e1d449538a75fd77a9a8093b3d6d77c4b43a7363"
+checksum = "22acbe68be84b7b41aaba6e39b87036fc4324dee628d94773750bf3d7e906d69"
 dependencies = [
- "libcrux-aesgcm",
- "libcrux-chacha20poly1305 0.0.6",
+ "libcrux-aes",
+ "libcrux-chacha20poly1305",
  "libcrux-secrets",
  "libcrux-traits",
 ]
 
 [[package]]
-name = "libcrux-aead"
-version = "0.0.7"
+name = "libcrux-aes"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13297ce29869a5c0edab0378837b0fc5f88bf99a843712d9201c3b1150b3b476"
-dependencies = [
- "libcrux-aesgcm",
- "libcrux-chacha20poly1305 0.0.7",
- "libcrux-secrets",
- "libcrux-traits",
-]
-
-[[package]]
-name = "libcrux-aesgcm"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f2a019dab4097585a7d4f5b9deebe46cd1e628b16a5bc4cb0ce35e1da334e6"
+checksum = "57cc95b11dbc797b1e169467b1fc4205c4e6ee2ce516a035ad7342ce5f6ae971"
 dependencies = [
  "libcrux-intrinsics",
  "libcrux-platform",
@@ -2650,35 +2845,22 @@ dependencies = [
 
 [[package]]
 name = "libcrux-chacha20poly1305"
-version = "0.0.6"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627fca7f9cb4cedaa9667670de8f591859dd2417ce4006c4f0ebbe5626f5e0a"
+checksum = "537e6eee5cdc9a980014d058784b0be09614f0596df789b114f7833aa9f35d75"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
- "libcrux-poly1305 0.0.4",
- "libcrux-secrets",
- "libcrux-traits",
-]
-
-[[package]]
-name = "libcrux-chacha20poly1305"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc08d044676af21343b32b988411fa98dbb5cf65a03c9df478ced221bbdfdb1b"
-dependencies = [
- "libcrux-hacl-rs",
- "libcrux-macros",
- "libcrux-poly1305 0.0.5",
+ "libcrux-poly1305",
  "libcrux-secrets",
  "libcrux-traits",
 ]
 
 [[package]]
 name = "libcrux-curve25519"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1e5fd8476a6ed609d24ef42aee5ab6f99f7c65d054f92412da9f499e423299"
+checksum = "e4f3cfd5e31cb9745e290ee061222c380ec42884654b09fc7d12a5b0ed63e028"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -2688,41 +2870,30 @@ dependencies = [
 
 [[package]]
 name = "libcrux-ecdh"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65f73ce79337c762eb38bbac91e4c9b9e60cf318e8501b812750c640814d45e"
+checksum = "4a227590b89ff55ce7cd97b5a7468c82d231db8f3b890bb4d4fb6d271e7524d7"
 dependencies = [
  "libcrux-curve25519",
  "libcrux-p256",
- "rand 0.9.4",
-]
-
-[[package]]
-name = "libcrux-ed25519"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3970fc899de0a430a4bd04acdbbfb5236057a895759bea42d36b0f52afb3e418"
-dependencies = [
- "libcrux-hacl-rs",
- "libcrux-macros",
- "libcrux-sha2",
- "rand_core 0.9.5",
+ "rand 0.10.1",
+ "tls_codec",
 ]
 
 [[package]]
 name = "libcrux-hacl-rs"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2637dc87d158e1f1b550fd9b226443e84153fded4de69028d897b534d16d22e6"
+checksum = "66106db376ae249af86911aee048cf73ea1f394d6653026fc988dd22cf2a4ace"
 dependencies = [
  "libcrux-macros",
 ]
 
 [[package]]
 name = "libcrux-hkdf"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1a89ca0c89be3a268a921e47105fb7873badf7267f5e3ebf4ea46baedd73ef"
+checksum = "dc94e651dca4d47edbcdd88bb2428ce16a2bd86b7a4e7170da87b505478f9839"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-hmac",
@@ -2731,20 +2902,21 @@ dependencies = [
 
 [[package]]
 name = "libcrux-hmac"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7a242707d65960770bd7e14e4f18a92bdf0b967777dd404887db8d087a643b"
+checksum = "500ad9b32c715161b594172ca1fb11503a1c033b393ff4c0c33505ce51c1943c"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
  "libcrux-sha2",
+ "libcrux-traits",
 ]
 
 [[package]]
 name = "libcrux-intrinsics"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b5db005ff8001e026b73a6842ee81bbef8ec5ff0e1915a67ae65fd2a9fafa5"
+checksum = "98a0c574d4eb81d0814bc2b91e4a433d7e0b35851b1d62eb5dd95c064f1f76d0"
 dependencies = [
  "core-models",
  "hax-lib",
@@ -2752,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-kem"
-version = "0.0.7"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12631592f491d22fd1a176d32b2c6edfb673998fd3987e9d95f8fa79ad2a737b"
+checksum = "541a7377fb35060892e0620982e224e47419f10da8c212453bf642dafe529691"
 dependencies = [
  "libcrux-curve25519",
  "libcrux-ecdh",
@@ -2762,7 +2934,7 @@ dependencies = [
  "libcrux-p256",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.4",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -2777,9 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-ml-kem"
-version = "0.0.8"
+version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a14ab3e477de9df6ee1273a114018ff62c4996ca9220070c4e5cb1743f94a67d"
+checksum = "1d8160f7d64fd2716b4fd05cc886a042f8dcda18d9206c0d506e2c67bdf97daa"
 dependencies = [
  "hax-lib",
  "libcrux-intrinsics",
@@ -2787,15 +2959,15 @@ dependencies = [
  "libcrux-secrets",
  "libcrux-sha3",
  "libcrux-traits",
- "rand 0.9.4",
+ "rand 0.10.1",
  "tls_codec",
 ]
 
 [[package]]
 name = "libcrux-p256"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4778ba25cb08bb8a96bd100e19ed9aecf78337198fd176036e21042b2dd99bc"
+checksum = "3400732702d578be622257b98cec85e9b0cd34a67f1f06d3ebe9ae34963cdf02"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -2815,19 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-poly1305"
-version = "0.0.4"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccfb6399682b2dee13b728c779ab5dcc51afbe982b63508ca524806994336134"
-dependencies = [
- "libcrux-hacl-rs",
- "libcrux-macros",
-]
-
-[[package]]
-name = "libcrux-poly1305"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02491808ee5b9db8cb65fad64ae0be812db64beef179d945c00c7787dc7dfcf9"
+checksum = "76a9144949845813a0b8787d08cbba47baabe59c83f3043e558e6e92385c40cc"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -2835,18 +2997,19 @@ dependencies = [
 
 [[package]]
 name = "libcrux-secrets"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce650f3041b44ba40d4263852347d007cd2cd9d1cc856a6f6c8b2e10c3fd40b"
+checksum = "79054fc9037cb70d6a546cf094cea7d7df06af5e49d230ba24103d27ccc886f1"
 dependencies = [
+ "crabgrind",
  "hax-lib",
 ]
 
 [[package]]
 name = "libcrux-sha2"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d253473f259fc74a280c43f29c464f7e374abdf28b4942234dc707f529d4b7"
+checksum = "960e46e1be0b77098cc6ce82137864936ecad3a1b9fd4303dd51202ca140dd1e"
 dependencies = [
  "libcrux-hacl-rs",
  "libcrux-macros",
@@ -2855,9 +3018,9 @@ dependencies = [
 
 [[package]]
 name = "libcrux-sha3"
-version = "0.0.8"
+version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ae0b7d0e1cc4793a609fd0ff2ca3b3a3fabae523770c619a3d4bc86417b0d7"
+checksum = "c09f5c39afae0528e1f70a3c1e3c6ee649ec1f19dda26fc9b6ea91108fb879ef"
 dependencies = [
  "hax-lib",
  "libcrux-intrinsics",
@@ -2867,12 +3030,22 @@ dependencies = [
 
 [[package]]
 name = "libcrux-traits"
-version = "0.0.6"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e4fa89f3f5e34b47f928b22b1b78395a0d4ec23b1f583db635f128159d65f"
+checksum = "3fa7a21e8c2e8baa8b40f0b176740f2ca4baadd79d1b00e48d6b1e363c42085a"
 dependencies = [
  "libcrux-secrets",
- "rand 0.9.4",
+ "rand 0.10.1",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
 ]
 
 [[package]]
@@ -2990,7 +3163,7 @@ dependencies = [
  "nostr",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "storage-sqlite",
  "tempfile",
  "thiserror 2.0.18",
@@ -3012,7 +3185,7 @@ dependencies = [
  "chacha20poly1305",
  "fs-private",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "marmot-account",
  "marmot-forensics",
  "marmot-markdown",
@@ -3027,7 +3200,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "storage-sqlite",
  "tempfile",
  "thiserror 2.0.18",
@@ -3158,6 +3331,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-dsa"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "shake",
+ "signature 3.0.0",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "rand_core 0.10.1",
+ "sha3 0.11.0",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,7 +3426,7 @@ dependencies = [
  "bip39",
  "bitcoin_hashes",
  "cbc",
- "chacha20",
+ "chacha20 0.9.1",
  "chacha20poly1305",
  "getrandom 0.2.17",
  "hex",
@@ -3435,13 +3648,10 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb512bfe6a55777518853ea535c6241f069cb0e8984678c117151d2a1e7e903"
+source = "git+https://github.com/erskingardner/openmls.git?rev=85990fd44634bd054f010f14dc4d8987c9adfb3d#85990fd44634bd054f010f14dc4d8987c9adfb3d"
 dependencies = [
  "log",
- "openmls_libcrux_crypto",
- "openmls_memory_storage",
- "openmls_sqlite_storage",
+ "openmls_serialization_helpers",
  "openmls_traits",
  "rayon",
  "serde",
@@ -3454,46 +3664,24 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983e8be1457dd6f316f409292cec334af3b57b49a19deadc925c83c3c35e15b6"
+source = "git+https://github.com/erskingardner/openmls.git?rev=85990fd44634bd054f010f14dc4d8987c9adfb3d#85990fd44634bd054f010f14dc4d8987c9adfb3d"
 dependencies = [
  "ed25519-dalek",
+ "ml-dsa",
  "openmls_traits",
  "p256",
- "rand 0.8.6",
+ "p384",
+ "rand_core 0.6.4",
  "serde",
  "tls_codec",
-]
-
-[[package]]
-name = "openmls_libcrux_crypto"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82db6d14bcea364a2f078353cf081ead79950c57dcb307a865fe1eb05d390204"
-dependencies = [
- "hpke-rs",
- "hpke-rs-crypto",
- "hpke-rs-libcrux",
- "libcrux-aead 0.0.6",
- "libcrux-ed25519",
- "libcrux-hkdf",
- "libcrux-hmac",
- "libcrux-sha2",
- "libcrux-traits",
- "openmls_memory_storage",
- "openmls_traits",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
- "tls_codec",
+ "zeroize",
 ]
 
 [[package]]
 name = "openmls_memory_storage"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a52c927ddb9940acb96d51aebd54b8b9c601c7119e6609622fb3f2cbe16abe3"
+source = "git+https://github.com/erskingardner/openmls.git?rev=85990fd44634bd054f010f14dc4d8987c9adfb3d#85990fd44634bd054f010f14dc4d8987c9adfb3d"
 dependencies = [
- "hex",
  "log",
  "openmls_traits",
  "serde",
@@ -3504,47 +3692,44 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafcc8a3552b10fbb3ab757cccaf1a34081e826ca819f49aa7e6645b1d95c00f"
+source = "git+https://github.com/erskingardner/openmls.git?rev=85990fd44634bd054f010f14dc4d8987c9adfb3d#85990fd44634bd054f010f14dc4d8987c9adfb3d"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
  "ed25519-dalek",
- "hkdf",
- "hmac",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "hpke-rs",
  "hpke-rs-crypto",
  "hpke-rs-rust-crypto",
+ "ml-dsa",
  "openmls_memory_storage",
  "openmls_traits",
  "p256",
- "rand 0.8.6",
+ "p384",
  "rand_chacha 0.3.1",
- "serde",
- "sha2",
+ "rand_core 0.10.1",
+ "rand_core 0.6.4",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tls_codec",
 ]
 
 [[package]]
-name = "openmls_sqlite_storage"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19fa5f88e6f52b6933e78dcfc9e3a7e87eed99a0ab2a4ecade7ff620431fe31"
+name = "openmls_serialization_helpers"
+version = "0.1.0"
+source = "git+https://github.com/erskingardner/openmls.git?rev=85990fd44634bd054f010f14dc4d8987c9adfb3d#85990fd44634bd054f010f14dc4d8987c9adfb3d"
 dependencies = [
- "log",
- "openmls_traits",
- "refinery",
- "rusqlite",
- "serde",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "openmls_traits"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f88ccdd53448dfdbfa5b8da8ba4e527c418fdb966418172bace2e3b41eedd56"
+source = "git+https://github.com/erskingardner/openmls.git?rev=85990fd44634bd054f010f14dc4d8987c9adfb3d#85990fd44634bd054f010f14dc4d8987c9adfb3d"
 dependencies = [
  "serde",
  "tls_codec",
@@ -3655,7 +3840,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3664,8 +3849,10 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
+ "ecdsa",
  "elliptic-curve",
  "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3751,8 +3938,8 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -3897,8 +4084,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3946,7 +4143,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3958,7 +4155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4018,7 +4215,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4088,7 +4285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4257,6 +4454,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
+ "chacha20 0.10.1",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -4359,7 +4557,7 @@ dependencies = [
  "compact_str",
  "critical-section",
  "hashbrown 0.17.0",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru 0.18.0",
  "palette",
@@ -4440,7 +4638,7 @@ dependencies = [
  "hashbrown 0.17.0",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -4511,50 +4709,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.2",
-]
-
-[[package]]
-name = "refinery"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee5133e5b207e5703c2a4a9dc9bd8c8f2cc74c4ac04ca5510acaa907012c77ac"
-dependencies = [
- "refinery-core",
- "refinery-macros",
-]
-
-[[package]]
-name = "refinery-core"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023a2a96d959c9b5b5da78e965bfdb1363b365bf5e84531a67d0eee827a702a3"
-dependencies = [
- "async-trait",
- "cfg-if",
- "log",
- "regex",
- "rusqlite",
- "serde",
- "siphasher 1.0.3",
- "thiserror 2.0.18",
- "time",
- "toml 0.8.23",
- "url",
- "walkdir",
-]
-
-[[package]]
-name = "refinery-macros"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56c2e960c8e47c7c5c30ad334afea8b5502da796a59e34d640d6239d876d924"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "refinery-core",
- "regex",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4633,7 +4787,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -4893,7 +5047,7 @@ dependencies = [
  "password-hash",
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4903,9 +5057,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -4941,11 +5095,11 @@ dependencies = [
  "futures-util",
  "generic-array",
  "getrandom 0.2.17",
- "hkdf",
+ "hkdf 0.12.4",
  "num",
  "once_cell",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "zbus",
 ]
 
@@ -5047,15 +5201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5074,8 +5219,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5085,8 +5230,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -5141,8 +5329,18 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5204,8 +5402,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "stable_deref_trait"
@@ -5401,7 +5615,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
- "sha2",
+ "sha2 0.10.9",
  "signal-hook",
  "siphasher 1.0.3",
  "terminfo",
@@ -5568,20 +5782,21 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls_codec"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+checksum = "18cc98286004cea38f717e2b03d990fc774fbfd38a82720de40e5c94365067c8"
 dependencies = [
  "serde",
+ "serde_bytes",
  "tls_codec_derive",
  "zeroize",
 ]
 
 [[package]]
 name = "tls_codec_derive"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+checksum = "674f41dd95f76cdeb005c83f9444e20cf43daebef37cde9e49a9ca6f4e87b423"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5676,27 +5891,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5707,28 +5901,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -5737,14 +5917,8 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -5865,7 +6039,7 @@ dependencies = [
  "nostr-sdk",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -5884,7 +6058,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -5902,7 +6076,7 @@ dependencies = [
  "rustls-pemfile",
  "rustls-platform-verifier",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -5915,13 +6089,13 @@ version = "0.9.5"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
- "hkdf",
+ "hkdf 0.12.4",
  "quinn",
  "rand 0.8.6",
  "rcgen",
  "rustls",
  "rustls-platform-verifier",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -6019,7 +6193,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -6069,7 +6243,7 @@ dependencies = [
  "paste",
  "serde",
  "textwrap",
- "toml 0.5.11",
+ "toml",
  "uniffi_meta",
  "uniffi_udl",
 ]
@@ -6113,7 +6287,7 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "toml 0.5.11",
+ "toml",
  "uniffi_meta",
 ]
 
@@ -6161,7 +6335,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -6482,7 +6656,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "uuid",
 ]
@@ -6863,15 +7037,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
@@ -7036,15 +7201,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "x-wing"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51507b887016c3925c84591108dadb8c099f776eb04fec6a60ae3519fee856f"
+dependencies = [
+ "kem",
+ "ml-kem",
+ "sha3 0.12.0",
+ "shake",
+ "x25519-dalek 3.0.0",
+]
+
+[[package]]
 name = "x25519-dalek"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -7127,7 +7315,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.3",
+ "winnow",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -7166,7 +7354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow 1.0.3",
+ "winnow",
  "zvariant",
 ]
 
@@ -7213,18 +7401,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7294,7 +7482,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.3",
+ "winnow",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -7322,5 +7510,5 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "winnow 1.0.3",
+ "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ publish = false
 [workspace.dependencies]
 # OpenMLS family — exact-pinned to the draft-10 last-resort KeyPackage fix.
 # Keep every companion crate on the same repository commit to prevent source skew.
+# Migration: once an upstream OpenMLS release contains this fix, replace all five
+# git entries together with one matching upstream release series and remove the fork pin.
 openmls = { git = "https://github.com/erskingardner/openmls.git", rev = "85990fd44634bd054f010f14dc4d8987c9adfb3d", features = ["extensions-draft"] }
 openmls_basic_credential = { git = "https://github.com/erskingardner/openmls.git", rev = "85990fd44634bd054f010f14dc4d8987c9adfb3d" }
 openmls_memory_storage = { git = "https://github.com/erskingardner/openmls.git", rev = "85990fd44634bd054f010f14dc4d8987c9adfb3d", features = ["extensions-draft"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,14 @@ license = "MIT"
 publish = false
 
 [workspace.dependencies]
-# OpenMLS family — tilde-pinned to avoid silent companion-crate skew.
-openmls = { version = "~0.8.1", features = ["extensions-draft-08"] }
-openmls_basic_credential = "~0.5"
-openmls_memory_storage = { version = "~0.5", features = ["extensions-draft-08"] }
-openmls_rust_crypto = "~0.5"
-openmls_traits = { version = "~0.5", features = ["extensions-draft-08"] }
-tls_codec = "~0.4"
+# OpenMLS family — exact-pinned to the draft-10 last-resort KeyPackage fix.
+# Keep every companion crate on the same repository commit to prevent source skew.
+openmls = { git = "https://github.com/erskingardner/openmls.git", rev = "85990fd44634bd054f010f14dc4d8987c9adfb3d", features = ["extensions-draft"] }
+openmls_basic_credential = { git = "https://github.com/erskingardner/openmls.git", rev = "85990fd44634bd054f010f14dc4d8987c9adfb3d" }
+openmls_memory_storage = { git = "https://github.com/erskingardner/openmls.git", rev = "85990fd44634bd054f010f14dc4d8987c9adfb3d", features = ["extensions-draft"] }
+openmls_rust_crypto = { git = "https://github.com/erskingardner/openmls.git", rev = "85990fd44634bd054f010f14dc4d8987c9adfb3d" }
+openmls_traits = { git = "https://github.com/erskingardner/openmls.git", rev = "85990fd44634bd054f010f14dc4d8987c9adfb3d", features = ["extensions-draft"] }
+tls_codec = "~0.5"
 
 # async
 tokio = { version = "1", features = ["sync", "macros", "rt", "rt-multi-thread", "time"] }

--- a/Dockerfile.hermes-marmot
+++ b/Dockerfile.hermes-marmot
@@ -1,4 +1,4 @@
-FROM rust:1.90-bookworm
+FROM rust:1.91-bookworm
 
 ARG HERMES_AGENT_REPO_URL=https://github.com/NousResearch/hermes-agent.git
 ARG HERMES_AGENT_REF=

--- a/Dockerfile.openclaw-marmot
+++ b/Dockerfile.openclaw-marmot
@@ -1,4 +1,4 @@
-FROM rust:1.90-bookworm
+FROM rust:1.91-bookworm
 
 ARG OPENCLAW_VERSION=2026.6.8
 

--- a/Dockerfile.quic-broker
+++ b/Dockerfile.quic-broker
@@ -1,13 +1,13 @@
 # syntax=docker/dockerfile:1.7
 
-FROM rust:1.90-bookworm AS builder
+FROM rust:1.91-bookworm AS builder
 
 WORKDIR /workspace
 COPY . .
 ARG TARGETARCH
 RUN case "${TARGETARCH:-$(uname -m)}" in \
-        amd64|x86_64) rustup_toolchain="1.90.0-x86_64-unknown-linux-gnu" ;; \
-        arm64|aarch64) rustup_toolchain="1.90.0-aarch64-unknown-linux-gnu" ;; \
+        amd64|x86_64) rustup_toolchain="1.91.0-x86_64-unknown-linux-gnu" ;; \
+        arm64|aarch64) rustup_toolchain="1.91.0-aarch64-unknown-linux-gnu" ;; \
         *) echo "unsupported build architecture: ${TARGETARCH:-$(uname -m)}" >&2; exit 1 ;; \
     esac \
     && RUSTUP_TOOLCHAIN="$rustup_toolchain" cargo build --locked --release -p transport-quic-broker --bin marmot-quic-broker

--- a/crates/cgka-engine/src/key_package.rs
+++ b/crates/cgka-engine/src/key_package.rs
@@ -198,7 +198,7 @@ fn validate_key_package(
 
 fn key_package_verify_error(err: KeyPackageVerifyError) -> EngineError {
     match err {
-        KeyPackageVerifyError::InvalidLifetime | KeyPackageVerifyError::MissingLifetime => {
+        KeyPackageVerifyError::LifetimeError(_) | KeyPackageVerifyError::MissingLifetime => {
             EngineError::InvalidKeyPackageLifetime {
                 not_before: None,
                 not_after: None,

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1252,6 +1252,10 @@ impl<S: StorageProvider> Engine<S> {
                     // pending commit: MDK applies local commits only through
                     // its explicit publish-before-apply confirmation path.
                     self.update_stored_message_state(&msg.id, MessageState::Processed)?;
+                    self.mark_raw_transport_message_failed_if_awaiting_retry(
+                        &raw_msg_id,
+                        "own_echo",
+                    )?;
                     self.seen_message_ids.insert(msg.id.clone());
                     Ok(IngestOutcome::Stale {
                         reason: StaleReason::OwnEcho,

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1244,6 +1244,28 @@ impl<S: StorageProvider> Engine<S> {
                     self.update_stored_message_state(&msg.id, MessageState::Processed)?;
                     Ok(IngestOutcome::Processed)
                 }
+                ProcessedMessageContent::OwnPendingCommit
+                | ProcessedMessageContent::OwnPrivateMessage => {
+                    // This normally returns through the durable sent-content
+                    // marker before OpenMLS processing. Keep the library-level
+                    // classification as a safe fallback, but do not merge the
+                    // pending commit: MDK applies local commits only through
+                    // its explicit publish-before-apply confirmation path.
+                    self.update_stored_message_state(&msg.id, MessageState::Processed)?;
+                    self.seen_message_ids.insert(msg.id.clone());
+                    Ok(IngestOutcome::Stale {
+                        reason: StaleReason::OwnEcho,
+                    })
+                }
+                ProcessedMessageContent::UnresolvedAppDataCommit(_) => {
+                    // `process_commit_with_app_data_updates` must resolve this
+                    // before returning. Retain the message for diagnosis and
+                    // retry rather than accepting a partially processed commit.
+                    self.update_stored_message_state(&msg.id, MessageState::Retryable)?;
+                    Err(EngineError::Backend(
+                        "commit retained unresolved app-data updates".into(),
+                    ))
+                }
             };
         }
     }

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -17,11 +17,13 @@ use cgka_traits::storage::{StorageError, StorageProvider};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use openmls::component::ComponentData;
-use openmls::group::{MlsGroup, MlsGroupStateError, ProcessMessageError, ValidationError};
-use openmls::messages::proposals::{AppDataUpdateOperation, Proposal, ProposalOrRef};
+use openmls::group::{
+    MlsGroup, MlsGroupStateError, ProcessMessageError, ResolveAppDataCommitError, ValidationError,
+};
+use openmls::messages::proposals::AppDataUpdateOperation;
 use openmls::prelude::{
     BasicCredential, ContentType, MlsMessageBodyIn, MlsMessageIn, ProcessedMessage,
-    ProcessedMessageContent, ProtocolMessage, ProtocolVersion,
+    ProcessedMessageContent, ProtocolMessage,
 };
 use openmls_rust_crypto::RustCrypto;
 use openmls_traits::OpenMlsProvider;
@@ -2181,6 +2183,26 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                     kind: projection.kind,
                 });
             }
+            ProcessedMessageContent::OwnPendingCommit
+            | ProcessedMessageContent::OwnPrivateMessage => {
+                // Own sends are replay evidence only. In particular, never
+                // merge an OwnPendingCommit here: MDK realizes confirmed own
+                // commits from retained anchor snapshots above, preserving
+                // the publish-before-apply lifecycle.
+                observations.push(OpenMlsReplayObservation::Ignored {
+                    message_id,
+                    kind: projection.kind,
+                });
+            }
+            ProcessedMessageContent::UnresolvedAppDataCommit(_) => {
+                // Commit processing above always resolves this variant before
+                // returning. Treat an unexpected residual value as a replay
+                // error instead of accepting a commit without applying its
+                // AppDataDictionary changes.
+                return Err(OpenMlsProjectionError::Replay(
+                    "commit retained unresolved app-data updates".into(),
+                ));
+            }
         }
     }
     Ok(OpenMlsReplayOutput {
@@ -2251,58 +2273,59 @@ pub(crate) fn process_commit_with_app_data_updates<S: StorageProvider>(
         >>::Error,
     >,
 > {
-    let unverified = mls_group.unprotect_message(provider, proto)?;
+    let processed = mls_group.process_message(provider, proto)?;
+    let ProcessedMessageContent::UnresolvedAppDataCommit(unresolved) = processed.content() else {
+        return Ok(processed);
+    };
+
+    // OpenMLS has already resolved referenced proposals and ordered them by
+    // component id. Clone the small proposal list so the processed message can
+    // subsequently be consumed by `resolve_app_data_commit`.
+    let app_data_updates = unresolved
+        .app_data_update_proposals()
+        .cloned()
+        .collect::<Vec<_>>();
     let mut updater = mls_group.app_data_dictionary_updater();
-    if let Some(committed_proposals) = unverified.committed_proposals() {
-        for proposal_or_ref in committed_proposals {
-            let validated = proposal_or_ref.clone().validate(
-                provider.crypto(),
-                mls_group.ciphersuite(),
-                ProtocolVersion::Mls10,
-            )?;
-            let proposal = match validated {
-                ProposalOrRef::Proposal(proposal) => proposal,
-                ProposalOrRef::Reference(reference) => mls_group
-                    .proposal_store()
-                    .proposals()
-                    .find(|p| p.proposal_reference_ref() == &*reference)
-                    .map(|p| Box::new(p.proposal().clone()))
-                    .ok_or(ProcessMessageError::FoundAppDataUpdateProposal)?,
-            };
-            if let Proposal::AppDataUpdate(update) = proposal.as_ref() {
-                match update.operation() {
-                    AppDataUpdateOperation::Update(data) => {
-                        crate::app_components::validate_app_component_update(&AppComponentData {
-                            component_id: update.component_id(),
-                            data: data.as_slice().to_vec(),
-                        })
-                        .map_err(|_| {
-                            ProcessMessageError::ValidationError(ValidationError::WrongWireFormat)
-                        })?;
-                        updater.set(ComponentData::from_parts(
-                            update.component_id(),
-                            data.clone(),
-                        ));
-                    }
-                    AppDataUpdateOperation::Remove => {
-                        crate::app_components::validate_app_component_remove(
-                            mls_group,
-                            update.component_id(),
-                        )
-                        .map_err(|_| {
-                            ProcessMessageError::ValidationError(ValidationError::WrongWireFormat)
-                        })?;
-                        updater.remove(&update.component_id());
-                    }
-                }
+    for update in app_data_updates {
+        match update.operation() {
+            AppDataUpdateOperation::Update(data) => {
+                crate::app_components::validate_app_component_update(&AppComponentData {
+                    component_id: update.component_id(),
+                    data: data.as_slice().to_vec(),
+                })
+                .map_err(|_| {
+                    ProcessMessageError::ValidationError(ValidationError::WrongWireFormat)
+                })?;
+                updater.set(ComponentData::from_parts(
+                    update.component_id(),
+                    data.clone(),
+                ));
+            }
+            AppDataUpdateOperation::Remove => {
+                crate::app_components::validate_app_component_remove(
+                    mls_group,
+                    update.component_id(),
+                )
+                .map_err(|_| {
+                    ProcessMessageError::ValidationError(ValidationError::WrongWireFormat)
+                })?;
+                updater.remove(&update.component_id());
             }
         }
     }
-    mls_group.process_unverified_message_with_app_data_updates(
-        provider,
-        unverified,
-        updater.changes(),
-    )
+
+    mls_group
+        .resolve_app_data_commit(provider, processed, updater.changes())
+        .map_err(|error| match error {
+            ResolveAppDataCommitError::StageCommit(error) => {
+                ProcessMessageError::InvalidCommit(error)
+            }
+            ResolveAppDataCommitError::NotAnUnresolvedAppDataCommit => {
+                // Guarded by the content match above. Keep this non-panicking
+                // because the value still originated from inbound data.
+                ProcessMessageError::ValidationError(ValidationError::WrongWireFormat)
+            }
+        })
 }
 
 fn message_digest(bytes: &[u8]) -> [u8; 32] {

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -32,7 +32,9 @@ use cgka_traits::transport::{
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use openmls::component::ComponentData;
 use openmls::extensions::{AppDataDictionary, AppDataDictionaryExtension, Extension, Extensions};
-use openmls::group::MlsGroup;
+use openmls::group::{
+    AppDataUpdateValidationError, CreateCommitError, CreateGroupContextExtProposalError, MlsGroup,
+};
 use openmls::messages::proposals::{AppDataUpdateOperation, AppDataUpdateProposal, Proposal};
 use openmls::prelude::BasicCredential;
 use openmls_basic_credential::SignatureKeyPair;
@@ -406,19 +408,20 @@ fn raw_app_message_with_payload(
     }
 }
 
-/// Raw OpenMLS commit that removes `targets` and ALSO replaces the
+/// Assert that OpenMLS rejects a commit that removes `targets` and ALSO replaces the
 /// GroupContext extensions with a copy that drops the `app_data_dictionary`
 /// entirely, so the resulting epoch carries no admin-policy bytes at all.
-/// OpenMLS accepts this shape (its draft-08 dictionary guard only applies to
-/// commits that carry AppDataUpdate proposals), so the Marmot engine must
-/// evaluate the admin/leaf coupling against the carried-forward admin set
-/// (admin-policy-v1.md "Validation") instead of skipping the check.
-fn raw_remove_members_commit_dropping_app_data_dictionary(
+///
+/// This used to construct a malicious wire commit for the MDK receive seams.
+/// OpenMLS upstream commit 34222ef6 now enforces the draft rule during both
+/// construction and receive-side staging, so the public API can no longer
+/// produce that fixture.
+fn assert_openmls_rejects_remove_members_commit_dropping_app_data_dictionary(
     storage: &SqliteAccountStorage,
     sender: &MemberId,
     group_id: &GroupId,
     targets: &[MemberId],
-) -> TransportMessage {
+) {
     let crypto = openmls_rust_crypto::RustCrypto::default();
     let provider =
         EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, storage.mls_storage());
@@ -456,31 +459,24 @@ fn raw_remove_members_commit_dropping_app_data_dictionary(
 
     let mut stripped_extensions = mls_group.extensions().clone();
     stripped_extensions.remove(openmls::extensions::ExtensionType::AppDataDictionary);
-    let commit_bundle = mls_group
+    let result = mls_group
         .commit_builder()
         .propose_removals(leaf_indices)
         .propose_group_context_extensions(stripped_extensions)
         .expect("propose GCE without app_data_dictionary")
         .load_psks(provider.storage())
         .expect("load PSKs")
-        .build(provider.rand(), provider.crypto(), &signer, |_| true)
-        .expect("build raw remove+GCE commit")
-        .stage_commit(&provider)
-        .expect("stage raw remove+GCE commit");
-    let (commit, _welcome, _group_info) = commit_bundle.into_contents();
-    let payload = commit
-        .tls_serialize_detached()
-        .expect("serialize raw remove+GCE commit");
-    TransportMessage {
-        id: hash_id(&payload),
-        payload,
-        timestamp: Timestamp(0),
-        causal_deps: vec![],
-        source: TransportSource("raw-openmls-remove-drop-dict".into()),
-        envelope: TransportEnvelope::GroupMessage {
-            transport_group_id: group_id.as_slice().to_vec(),
-        },
-    }
+        .build(provider.rand(), provider.crypto(), &signer, |_| true);
+    let error = match result {
+        Ok(_) => panic!("OpenMLS accepted remove+GCE commit that drops app_data_dictionary"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        error,
+        CreateCommitError::AppDataUpdateValidationError(
+            AppDataUpdateValidationError::CannotUpdateDictionaryDirectly
+        )
+    );
 }
 
 fn raw_remove_members_commit_with_admin_policy(
@@ -566,8 +562,8 @@ fn raw_remove_members_commit_with_admin_policy(
     }
 }
 
-/// How a raw GroupContextExtensions commit tampers with the group's
-/// `app_data_dictionary` (see [`raw_group_context_extensions_tamper_commit`]).
+/// How a GroupContextExtensions commit attempts to tamper with the group's
+/// `app_data_dictionary`.
 enum GceDictionaryTamper {
     /// Replace the extensions with a set omitting the dictionary entirely.
     StripDictionary,
@@ -578,17 +574,14 @@ enum GceDictionaryTamper {
     ReplaceEntry(AppComponentId, Vec<u8>),
 }
 
-/// Build a raw OpenMLS GroupContextExtensions-only commit (no member changes)
-/// that tampers with the Marmot component state in the resulting GroupContext.
-/// OpenMLS's draft-08 dictionary guard only runs when a commit carries
-/// `AppDataUpdate` proposals, so every tamper here builds and stages cleanly —
-/// only the engine's app-component integrity check can reject it.
-fn raw_group_context_extensions_tamper_commit(
+/// Assert that OpenMLS rejects a GroupContextExtensions-only commit (no member
+/// changes) that tampers with the app-data dictionary.
+fn assert_openmls_rejects_group_context_extensions_tamper(
     storage: &SqliteAccountStorage,
     sender: &MemberId,
     group_id: &GroupId,
     tamper: GceDictionaryTamper,
-) -> TransportMessage {
+) {
     let crypto = openmls_rust_crypto::RustCrypto::default();
     let provider =
         EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, storage.mls_storage());
@@ -637,22 +630,19 @@ fn raw_group_context_extensions_tamper_commit(
     }
     let new_extensions = Extensions::from_vec(new_extensions).expect("tampered extensions build");
 
-    let (commit, _welcome, _group_info) = mls_group
-        .update_group_context_extensions(&provider, new_extensions, &signer)
-        .expect("raw OpenMLS GroupContextExtensions tamper commit");
-    let payload = commit
-        .tls_serialize_detached()
-        .expect("serialize raw GCE tamper commit");
-    TransportMessage {
-        id: hash_id(&payload),
-        payload,
-        timestamp: Timestamp(0),
-        causal_deps: vec![],
-        source: TransportSource("raw-openmls-gce-tamper".to_string()),
-        envelope: TransportEnvelope::GroupMessage {
-            transport_group_id: group_id.as_slice().to_vec(),
-        },
-    }
+    let error = match mls_group.update_group_context_extensions(&provider, new_extensions, &signer)
+    {
+        Ok(_) => panic!("OpenMLS accepted direct app_data_dictionary tamper"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        CreateGroupContextExtProposalError::CreateCommitError(
+            CreateCommitError::AppDataUpdateValidationError(
+                AppDataUpdateValidationError::CannotUpdateDictionaryDirectly
+            )
+        )
+    ));
 }
 
 #[tokio::test]
@@ -888,29 +878,23 @@ async fn convergence_rejects_remove_that_leaves_orphan_admin_key() {
 }
 
 #[tokio::test]
-async fn convergence_rejects_remove_whose_context_carries_no_admin_policy_bytes() {
-    // mdk#393 / admin-policy-v1.md "Validation": the cross-component
-    // check runs on every commit that changes the member leaf set, whether or
-    // not the commit carries admin-policy bytes. Bob's raw commit removes
-    // Alice's last member leaf and swaps in GroupContext extensions with no
-    // app_data_dictionary, so the staged context has no admin-policy entry to
-    // read. The resulting epoch's admin set is the prior set carried forward
-    // ({Alice, Bob}), so the commit must be rejected instead of skipping the
-    // check on the missing bytes.
+async fn openmls_rejects_remove_commit_dropping_app_data_dictionary_at_construction() {
+    // OpenMLS upstream commit 34222ef6 moved this draft invariant into the
+    // shared validation used by commit construction and receive-side staging.
+    // Pin the construction seam here: a malicious wire fixture can no longer
+    // be produced through the public API, and the same validation method runs
+    // before an inbound commit is staged.
     let (mut alice, _alice_storage) = build_client(b"alice");
     let (mut bob, bob_storage) = build_client(b"bob");
-    let (mut carol, carol_storage) = build_client(b"carol");
     let bob_id = bob.self_id();
     let alice_id = alice.self_id();
-    let carol_id = carol.self_id();
     let bob_kp = bob.fresh_key_package().await.unwrap();
-    let carol_kp = carol.fresh_key_package().await.unwrap();
 
     let (group_id, create) = alice
         .create_group(CreateGroupRequest {
-            name: "convergence-carried-forward-admins".into(),
+            name: "openmls-rejects-dictionary-drop".into(),
             description: "".into(),
-            members: vec![bob_kp, carol_kp],
+            members: vec![bob_kp],
             required_features: vec![],
             app_components: vec![],
             initial_admins: vec![bob_id.clone()],
@@ -925,158 +909,12 @@ async fn convergence_rejects_remove_whose_context_carries_no_admin_policy_bytes(
     bob.join_welcome(welcome_for(&welcomes, b"bob"))
         .await
         .unwrap();
-    carol
-        .join_welcome(welcome_for(&welcomes, b"carol"))
-        .await
-        .unwrap();
 
-    let invalid_remove = route(
-        raw_remove_members_commit_dropping_app_data_dictionary(
-            &bob_storage,
-            &bob.self_id(),
-            &group_id,
-            std::slice::from_ref(&alice_id),
-        ),
+    assert_openmls_rejects_remove_members_commit_dropping_app_data_dictionary(
+        &bob_storage,
+        &bob.self_id(),
         &group_id,
-    );
-    carol
-        .buffer_openmls_convergence_message(&group_id, invalid_remove.clone(), 1_000)
-        .expect("invalid remove commit buffered");
-
-    let result = carol
-        .converge_stored_openmls_messages(&group_id, 1_000_000)
-        .expect("stored OpenMLS messages converge");
-
-    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
-    assert!(
-        result.accepted_commits.is_empty(),
-        "remove with no admin-policy bytes must not be accepted: {result:?}"
-    );
-    assert!(
-        result.dropped_messages.iter().any(|dropped| {
-            dropped.kind == MessageKind::Commit
-                && dropped.reason == DroppedMessageReason::InvalidAgainstCandidateState
-                && dropped.message_id == content_hex(&invalid_remove)
-        }),
-        "expected invalid remove dropped as InvalidAgainstCandidateState, got {:?}",
-        result.dropped_messages
-    );
-    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
-    let stored_group = carol_storage.get_group(&group_id).expect("group stored");
-    assert_eq!(stored_group.epoch, EpochId(1));
-    assert_eq!(
-        stored_group.members.len(),
-        3,
-        "invalid convergence commit must not change stored member count"
-    );
-    let projected_members = carol.members(&group_id).expect("members projected");
-    assert_eq!(
-        projected_members.len(),
-        3,
-        "invalid convergence commit must not change projected member count"
-    );
-    for expected in [&alice_id, &bob_id, &carol_id] {
-        assert!(
-            projected_members
-                .iter()
-                .any(|member| member.id == *expected),
-            "projected members should still contain {expected:?}: {projected_members:?}"
-        );
-    }
-    assert_message_state(
-        &carol_storage,
-        &invalid_remove,
-        MessageState::EpochInvalidated,
-    );
-}
-
-#[tokio::test]
-async fn live_ingest_rejects_remove_whose_context_carries_no_admin_policy_bytes() {
-    // Sibling of the stored-convergence test above, pushed through the live
-    // `ingest` entry point instead of pre-buffering — pinning the hot path a
-    // relay-delivered commit takes. The invalid remove must never be applied:
-    // the outcome is terminal, and Carol's epoch, membership, and admin view
-    // stay untouched.
-    let (mut alice, _alice_storage) = build_client(b"alice");
-    let (mut bob, bob_storage) = build_client(b"bob");
-    let (mut carol, carol_storage) = build_client(b"carol");
-    let bob_id = bob.self_id();
-    let alice_id = alice.self_id();
-    let bob_kp = bob.fresh_key_package().await.unwrap();
-    let carol_kp = carol.fresh_key_package().await.unwrap();
-
-    let (group_id, create) = alice
-        .create_group(CreateGroupRequest {
-            name: "live-ingest-carried-forward-admins".into(),
-            description: "".into(),
-            members: vec![bob_kp, carol_kp],
-            required_features: vec![],
-            app_components: vec![],
-            initial_admins: vec![bob_id.clone()],
-        })
-        .await
-        .unwrap();
-    let (pending, welcomes) = match create {
-        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
-        other => panic!("expected GroupCreated, got {other:?}"),
-    };
-    alice.confirm_published(pending).await.unwrap();
-    bob.join_welcome(welcome_for(&welcomes, b"bob"))
-        .await
-        .unwrap();
-    carol
-        .join_welcome(welcome_for(&welcomes, b"carol"))
-        .await
-        .unwrap();
-
-    let invalid_remove = route(
-        raw_remove_members_commit_dropping_app_data_dictionary(
-            &bob_storage,
-            &bob.self_id(),
-            &group_id,
-            std::slice::from_ref(&alice_id),
-        ),
-        &group_id,
-    );
-
-    let outcome = carol.ingest(invalid_remove.clone()).await.unwrap();
-    assert!(
-        !matches!(outcome, IngestOutcome::Processed),
-        "invalid remove must not be applied via live ingest, got {outcome:?}"
-    );
-    // Drive convergence to quiescence in case the inline pass left the commit
-    // pending; the commit must still never be accepted.
-    let result = carol
-        .converge_stored_openmls_messages(&group_id, u64::MAX)
-        .expect("stored OpenMLS messages converge");
-    assert!(
-        result.accepted_commits.is_empty(),
-        "invalid remove must not be accepted after quiescence: {result:?}"
-    );
-
-    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
-    let stored_group = carol_storage.get_group(&group_id).expect("group stored");
-    assert_eq!(stored_group.epoch, EpochId(1));
-    assert_eq!(stored_group.members.len(), 3);
-    let projected_members = carol.members(&group_id).expect("members projected");
-    assert_eq!(projected_members.len(), 3);
-    assert!(
-        projected_members.iter().any(|member| member.id == alice_id),
-        "alice must remain a member on carol's view: {projected_members:?}"
-    );
-    let alice_admin: [u8; 32] = alice_id.as_slice().try_into().unwrap();
-    let bob_admin: [u8; 32] = bob_id.as_slice().try_into().unwrap();
-    let mut expected_admins = vec![alice_admin, bob_admin];
-    expected_admins.sort();
-    assert_eq!(
-        carol.admin_pubkeys(&group_id).unwrap(),
-        expected_admins,
-        "carol's admin view must be unchanged"
-    );
-    assert_message_state(
-        &carol_storage,
-        &invalid_remove,
-        MessageState::EpochInvalidated,
+        std::slice::from_ref(&alice_id),
     );
 }
 
@@ -1199,264 +1037,44 @@ async fn bootstrap_gce_tamper_group(
     group_id
 }
 
-fn admin_key(member: &MemberId) -> [u8; 32] {
-    member
-        .as_slice()
-        .try_into()
-        .expect("test identities are 32-byte account keys")
-}
-
-/// Ingest `tampered` on `recipient` and assert the GCE tamper commit is
-/// rejected: outcome `Stale`, epoch and sole admin unchanged, and the stored
-/// message never `Processed`. Inbound same-epoch commits route through
-/// convergence, and the ingest-driven pass runs inside the input window, so
-/// the terminal disposition may not be persisted yet — the pinned invariant is
-/// that the tamper commit is never applied.
-async fn assert_gce_tamper_rejected_by_ingest(
-    recipient: &mut Engine<SqliteAccountStorage>,
-    recipient_storage: &SqliteAccountStorage,
-    group_id: &GroupId,
-    tampered: &TransportMessage,
-    expected_admin: &MemberId,
-) {
-    let outcome = recipient
-        .ingest(tampered.clone())
-        .await
-        .expect("ingest completes");
-    assert!(
-        matches!(outcome, IngestOutcome::Stale { .. }),
-        "GCE tamper commit must not be processed: {outcome:?}"
-    );
-    assert_eq!(recipient.epoch(group_id).unwrap(), EpochId(1));
-    assert_eq!(
-        recipient.admin_pubkeys(group_id).unwrap(),
-        vec![admin_key(expected_admin)],
-        "the tampered component state must not take effect"
-    );
-    let record = recipient_storage
-        .get_message(&content_id(tampered))
-        .expect("tamper commit remains stored");
-    assert_ne!(record.state, MessageState::Processed);
-}
-
-/// Buffer `tampered` into STORED CONVERGENCE on `recipient` and converge with
-/// a closed input window; assert the pass settles with the commit dropped as
-/// `InvalidAgainstCandidateState`, epoch and sole admin unchanged, and the
-/// message `EpochInvalidated`.
-fn assert_gce_tamper_rejected_by_convergence(
-    recipient: &mut Engine<SqliteAccountStorage>,
-    recipient_storage: &SqliteAccountStorage,
-    group_id: &GroupId,
-    tampered: &TransportMessage,
-    expected_admin: &MemberId,
-) {
-    recipient
-        .buffer_openmls_convergence_message(group_id, tampered.clone(), 1_000)
-        .expect("GCE tamper commit buffered");
-    let result = recipient
-        .converge_stored_openmls_messages(group_id, 1_000_000)
-        .expect("stored OpenMLS messages converge");
-
-    assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
-    assert!(
-        result.accepted_commits.is_empty(),
-        "GCE tamper commit must not be accepted: {result:?}"
-    );
-    assert!(
-        result.dropped_messages.iter().any(|dropped| {
-            dropped.kind == MessageKind::Commit
-                && dropped.reason == DroppedMessageReason::InvalidAgainstCandidateState
-                && dropped.message_id == content_hex(tampered)
-        }),
-        "expected GCE tamper commit dropped as InvalidAgainstCandidateState, got {:?}",
-        result.dropped_messages
-    );
-    assert_eq!(recipient.epoch(group_id).unwrap(), EpochId(1));
-    assert_eq!(
-        recipient_storage
-            .get_group(group_id)
-            .expect("group stored")
-            .epoch,
-        EpochId(1)
-    );
-    assert_eq!(
-        recipient.admin_pubkeys(group_id).unwrap(),
-        vec![admin_key(expected_admin)],
-        "the tampered component state must not take effect"
-    );
-    assert_message_state(recipient_storage, tampered, MessageState::EpochInvalidated);
-}
-
 #[tokio::test]
-async fn ingest_rejects_group_context_commit_stripping_app_data_dictionary() {
-    // Regression: OpenMLS's draft-08 dictionary guard only validates the
-    // GroupContext against a commit's AppDataUpdate proposals, so an
-    // admin-authored GroupContextExtensions-only commit could replace the
-    // extensions with a set that omits the app_data_dictionary entirely.
-    // Merging it cannot orphan an admin key (the absent component is the empty
-    // admin set), but it silently makes the group admin-less and freezes every
-    // admin-gated operation. `ingest` must classify the strip commit invalid
-    // instead of materializing the admin-less epoch.
+async fn openmls_rejects_bare_gce_dictionary_tampering_at_construction() {
+    // OpenMLS upstream commit 34222ef6 closes the bare-GCE bypass before the
+    // no-AppDataUpdate early return. The same validator is called by inbound
+    // staged-commit processing, while this test pins all three mutations at
+    // the public construction seam available to MDK integration tests.
     let (mut alice, alice_storage) = build_client(b"alice");
-    let (mut bob, bob_storage) = build_client(b"bob");
-    let alice_id = alice.self_id();
-    let group_id =
-        bootstrap_gce_tamper_group(&mut alice, &mut bob, b"bob", "ingest-gce-dictionary-strip")
-            .await;
-
-    let strip = route(
-        raw_group_context_extensions_tamper_commit(
-            &alice_storage,
-            &alice_id,
-            &group_id,
-            GceDictionaryTamper::StripDictionary,
-        ),
-        &group_id,
-    );
-    assert_gce_tamper_rejected_by_ingest(&mut bob, &bob_storage, &group_id, &strip, &alice_id)
-        .await;
-}
-
-#[tokio::test]
-async fn ingest_rejects_group_context_commit_dropping_required_component_entry() {
-    // Entry-level variant of the dictionary strip: the GroupContextExtensions
-    // commit keeps the app_data_dictionary but replaces it with one that omits
-    // the required admin-policy component's state. validate_app_component_remove
-    // only sees AppDataUpdate::Remove operations, so without the staged-commit
-    // integrity check this strip would also merge.
-    let (mut alice, alice_storage) = build_client(b"alice");
-    let (mut bob, bob_storage) = build_client(b"bob");
-    let alice_id = alice.self_id();
-    let group_id = bootstrap_gce_tamper_group(
-        &mut alice,
-        &mut bob,
-        b"bob",
-        "ingest-gce-admin-policy-strip",
-    )
-    .await;
-
-    let strip = route(
-        raw_group_context_extensions_tamper_commit(
-            &alice_storage,
-            &alice_id,
-            &group_id,
-            GceDictionaryTamper::DropEntry(GROUP_ADMIN_POLICY_COMPONENT_ID),
-        ),
-        &group_id,
-    );
-    assert_gce_tamper_rejected_by_ingest(&mut bob, &bob_storage, &group_id, &strip, &alice_id)
-        .await;
-}
-
-#[tokio::test]
-async fn convergence_rejects_group_context_commit_stripping_app_data_dictionary() {
-    // The same dictionary-strip commit through STORED CONVERGENCE. Before the
-    // integrity check, a GCE-only strip commit with no member removals was
-    // ACCEPTED here — convergence materialized the admin-less epoch. It must
-    // classify the commit as invalid instead.
-    let (mut alice, alice_storage) = build_client(b"alice");
-    let (mut carol, carol_storage) = build_client(b"carol");
-    let alice_id = alice.self_id();
-    let group_id = bootstrap_gce_tamper_group(
-        &mut alice,
-        &mut carol,
-        b"carol",
-        "convergence-gce-dictionary-strip",
-    )
-    .await;
-
-    let strip = route(
-        raw_group_context_extensions_tamper_commit(
-            &alice_storage,
-            &alice_id,
-            &group_id,
-            GceDictionaryTamper::StripDictionary,
-        ),
-        &group_id,
-    );
-    assert_gce_tamper_rejected_by_convergence(
-        &mut carol,
-        &carol_storage,
-        &group_id,
-        &strip,
-        &alice_id,
-    );
-}
-
-#[tokio::test]
-async fn ingest_rejects_group_context_commit_rewriting_admin_policy_bytes() {
-    // Content-integrity variant: the GroupContextExtensions commit keeps the
-    // app_data_dictionary and every required entry PRESENT, but rewrites the
-    // admin-policy bytes to a different (well-formed) admin set — with no
-    // AppDataUpdate proposal carrying the change. The rewritten set names a
-    // member with a leaf, so the admin-leaf coupling check passes, and the
-    // presence rules pass too; only the AppDataUpdate attribution rule can
-    // reject it. Without it, an admin could rewrite any required component's
-    // bytes (admin set, profile, routing, retention) bypassing the component
-    // validators entirely.
-    let (mut alice, alice_storage) = build_client(b"alice");
-    let (mut bob, bob_storage) = build_client(b"bob");
+    let (mut bob, _bob_storage) = build_client(b"bob");
     let alice_id = alice.self_id();
     let bob_id = bob.self_id();
     let group_id = bootstrap_gce_tamper_group(
         &mut alice,
         &mut bob,
         b"bob",
-        "ingest-gce-admin-policy-rewrite",
+        "openmls-rejects-bare-gce-tamper",
     )
     .await;
 
-    let rewrite = route(
-        raw_group_context_extensions_tamper_commit(
-            &alice_storage,
-            &alice_id,
-            &group_id,
-            GceDictionaryTamper::ReplaceEntry(
-                GROUP_ADMIN_POLICY_COMPONENT_ID,
-                encode_admin_policy_for_test(std::slice::from_ref(&bob_id)),
-            ),
-        ),
-        &group_id,
-    );
-    assert_gce_tamper_rejected_by_ingest(&mut bob, &bob_storage, &group_id, &rewrite, &alice_id)
-        .await;
-}
-
-#[tokio::test]
-async fn convergence_rejects_group_context_commit_rewriting_admin_policy_bytes() {
-    // The same admin-policy byte rewrite through STORED CONVERGENCE with a
-    // closed input window: the commit must be classified invalid, not
-    // materialize an epoch whose admin set was swapped outside AppDataUpdate.
-    let (mut alice, alice_storage) = build_client(b"alice");
-    let (mut carol, carol_storage) = build_client(b"carol");
-    let alice_id = alice.self_id();
-    let carol_id = carol.self_id();
-    let group_id = bootstrap_gce_tamper_group(
-        &mut alice,
-        &mut carol,
-        b"carol",
-        "convergence-gce-admin-policy-rewrite",
-    )
-    .await;
-
-    let rewrite = route(
-        raw_group_context_extensions_tamper_commit(
-            &alice_storage,
-            &alice_id,
-            &group_id,
-            GceDictionaryTamper::ReplaceEntry(
-                GROUP_ADMIN_POLICY_COMPONENT_ID,
-                encode_admin_policy_for_test(std::slice::from_ref(&carol_id)),
-            ),
-        ),
-        &group_id,
-    );
-    assert_gce_tamper_rejected_by_convergence(
-        &mut carol,
-        &carol_storage,
-        &group_id,
-        &rewrite,
+    assert_openmls_rejects_group_context_extensions_tamper(
+        &alice_storage,
         &alice_id,
+        &group_id,
+        GceDictionaryTamper::StripDictionary,
+    );
+    assert_openmls_rejects_group_context_extensions_tamper(
+        &alice_storage,
+        &alice_id,
+        &group_id,
+        GceDictionaryTamper::DropEntry(GROUP_ADMIN_POLICY_COMPONENT_ID),
+    );
+    assert_openmls_rejects_group_context_extensions_tamper(
+        &alice_storage,
+        &alice_id,
+        &group_id,
+        GceDictionaryTamper::ReplaceEntry(
+            GROUP_ADMIN_POLICY_COMPONENT_ID,
+            encode_admin_policy_for_test(std::slice::from_ref(&bob_id)),
+        ),
     );
 }
 

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -29,14 +29,16 @@ use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
 use cgka_traits::types::{MemberId, MessageId};
+use openmls::component::ComponentType;
 use openmls::prelude::{
     BasicCredential, Capabilities, CredentialWithKey, ExtensionType, Extensions,
-    KeyPackage as MlsKeyPackage, Lifetime, MlsMessageOut,
+    KeyPackage as MlsKeyPackage, Lifetime, MlsMessageBodyIn, MlsMessageIn, MlsMessageOut,
+    ProtocolVersion,
 };
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_traits::types::Ciphersuite;
 use storage_sqlite::SqliteAccountStorage;
-use tls_codec::Serialize as _;
+use tls_codec::{Deserialize as _, Serialize as _};
 
 mod support;
 use support::proof_signer;
@@ -127,7 +129,9 @@ fn key_package_with_account_identity_proof_and_lifetime(
             Some(&[ciphersuite]),
             Some(&[
                 ExtensionType::Unknown(ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE),
-                ExtensionType::LastResort,
+                // Draft-10 encodes the last-resort marker as component 0x0004
+                // inside the KeyPackage app_data_dictionary.
+                ExtensionType::AppDataDictionary,
             ]),
             None,
             None,
@@ -795,11 +799,37 @@ async fn fresh_key_package_roundtrips_bytes() {
 }
 
 #[tokio::test]
-async fn fresh_key_package_is_mls_last_resort() {
+async fn fresh_key_package_uses_draft10_last_resort_component() {
     let mut alice = build_client(b"a", selfremove_registry());
     let kp = alice.fresh_key_package().await.unwrap();
 
     assert!(is_last_resort_key_package(&kp).unwrap());
+
+    let message = MlsMessageIn::tls_deserialize_exact(kp.bytes()).unwrap();
+    let key_package = match message.extract() {
+        MlsMessageBodyIn::KeyPackage(key_package) => key_package,
+        other => panic!("expected KeyPackage, got {other:?}"),
+    }
+    .validate(
+        &openmls_rust_crypto::RustCrypto::default(),
+        ProtocolVersion::Mls10,
+    )
+    .unwrap();
+    assert!(
+        !key_package.extensions().contains(ExtensionType::LastResort),
+        "new KeyPackages must not use the legacy last_resort extension"
+    );
+    let dictionary = key_package
+        .extensions()
+        .app_data_dictionary()
+        .expect("draft-10 last-resort marker requires app_data_dictionary");
+    assert_eq!(
+        dictionary
+            .dictionary()
+            .get(&ComponentType::LastResortKeyPackage.into()),
+        Some(&[][..]),
+        "draft-10 last-resort component 0x0004 must carry empty data"
+    );
 }
 
 #[tokio::test]

--- a/crates/cgka-engine/tests/ingest.rs
+++ b/crates/cgka-engine/tests/ingest.rs
@@ -14,7 +14,7 @@ use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage, StaleReason};
 use cgka_traits::message::MessageState;
 use cgka_traits::peeler::{GroupMessageMetadata, TransportPeeler};
-use cgka_traits::storage::MessageStorage;
+use cgka_traits::storage::{MessageStorage, StorageError};
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
@@ -1130,6 +1130,127 @@ async fn ingest_own_created_message_returns_own_echo() {
         }
     ));
     let _ = (bob, create);
+}
+
+/// A database created before durable sent-content markers existed can still
+/// contain an outbound MLS message that OpenMLS itself recognizes as ours.
+/// If that echo was buffered before peeling, the library-level `OwnPrivateMessage`
+/// fallback must retire the raw retry row instead of leaving it replayable.
+#[tokio::test]
+async fn buffered_legacy_own_echo_retires_raw_retry_row() {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let mut alice = build_client_with_storage(storage.clone(), b"alice-legacy-own-echo");
+    let mut bob = build_client(b"bob-legacy-own-echo");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "legacy own echo".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, mut welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcomes.remove(0)).await.unwrap();
+
+    // Roll the local store back across the send to model a legacy database
+    // that has the MLS group state but no durable sent-content marker.
+    const SNAPSHOT: &str = "before-legacy-own-echo";
+    storage.create_group_snapshot(&group_id, SNAPSHOT).unwrap();
+    let own_message = match alice
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(&alice, b"legacy own echo"),
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::ApplicationMessage { msg } => msg,
+        other => panic!("expected ApplicationMessage, got {other:?}"),
+    };
+    let own_content_id = content_id(&own_message);
+    assert_eq!(
+        storage.get_message(&own_content_id).unwrap().state,
+        MessageState::Sent,
+        "the modern send path must first create the marker removed below"
+    );
+    storage
+        .rollback_group_to_snapshot(&group_id, SNAPSHOT)
+        .unwrap();
+    storage.release_group_snapshot(&group_id, SNAPSHOT).unwrap();
+    assert!(
+        matches!(
+            storage.get_message(&own_content_id),
+            Err(StorageError::NotFound)
+        ),
+        "the simulated legacy store must not retain the sent-content marker"
+    );
+
+    // Rebuild to clear the hot-process sent-id cache as a real restart would.
+    drop(alice);
+    let mut alice = build_client_with_storage(storage.clone(), b"alice-legacy-own-echo");
+    alice.hydrate_stable_groups_from_storage().unwrap();
+
+    // Buffer the echo before peeling while a local commit awaits publication.
+    let staged = match alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("pending".into()),
+            description: None,
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { pending, .. } => pending,
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    let raw_id = MessageId::new(b"legacy-own-echo-wrapper".to_vec());
+    let echoed = TransportMessage {
+        id: raw_id.clone(),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..own_message
+    };
+    assert!(
+        matches!(
+            alice.ingest(echoed).await.unwrap(),
+            IngestOutcome::Buffered { .. }
+        ),
+        "the own echo must enter through the raw retry lifecycle"
+    );
+    assert_eq!(
+        storage.get_message(&raw_id).unwrap().state,
+        MessageState::Retryable
+    );
+
+    alice.publish_failed(staged).await.unwrap();
+
+    assert_eq!(
+        storage.get_message(&own_content_id).unwrap().state,
+        MessageState::Processed,
+        "OpenMLS must classify and terminalize the legacy own content"
+    );
+    assert_eq!(
+        storage.get_message(&raw_id).unwrap().state,
+        MessageState::Failed,
+        "the raw retry row must be retired by the OwnEcho fallback"
+    );
+    assert!(
+        alice
+            .drain_events()
+            .into_iter()
+            .all(|event| !matches!(event, GroupEvent::MessageReceived { .. })),
+        "an own echo must not surface as an inbound application message"
+    );
 }
 
 #[tokio::test]

--- a/crates/marmot-markdown/Cargo.toml
+++ b/crates/marmot-markdown/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 description = "CommonMark + nostr extensions Markdown AST for Marmot"
 authors = ["Marmot Authors"]
 edition = "2024"
-rust-version = "1.90.0"
+rust-version = "1.91.0"
 publish = false
 
 [dependencies]

--- a/crates/storage-sqlite/Cargo.toml
+++ b/crates/storage-sqlite/Cargo.toml
@@ -23,4 +23,4 @@ zeroize.workspace = true
 tempfile.workspace = true
 
 [features]
-extensions-draft-08 = ["openmls_traits/extensions-draft-08"]
+extensions-draft = ["openmls_traits/extensions-draft"]

--- a/docs/marmot-architecture/further-context/codebase-survey.md
+++ b/docs/marmot-architecture/further-context/codebase-survey.md
@@ -92,7 +92,7 @@
 
 - serde + serde_json, postcard, tls_codec
 
-**Config:** Edition 2024, MSRV 1.90.0, workspace version 0.7.1
+**Config:** Edition 2024, MSRV 1.91.0, workspace version 0.7.1
 
 ### whitenoise-rs Dependencies
 
@@ -247,7 +247,7 @@ rust/src/api/ (20 modules, 4.8K LOC — thin FFI wrapper)
 | Total LOC | ~66K Rust | ~100K Rust | 66K Dart + 5K Rust |
 | Crates/packages | 6 | 2 | 1 |
 | Edition | 2024 | 2024 | Flutter 3.x |
-| MSRV | 1.90.0 | 1.90.0 | — |
+| MSRV | 1.91.0 | 1.90.0 | — |
 | DB technology | SQLCipher (rusqlite) | SQLite (sqlx) | — (delegates to Rust) |
 | Async model | Synchronous | Tokio (full) | Dart async |
 | FFI | UniFFI | flutter_rust_bridge | flutter_rust_bridge |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.91.0"
 components = ["rustfmt", "clippy"]
 profile = "default"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced ingest/replay handling for own outgoing message echoes so they no longer affect group state, returning a stale/own-echo outcome.
  - Added clearer behavior for commits with unresolved application-data updates by keeping them in the retry lifecycle.
- **Bug Fixes**
  - Improved key package lifetime error classification between invalid vs missing-lifetime cases.
  - Strengthened projection/app-data resolution and replay validation to reject unexpected unresolved app-data.
- **Tests**
  - Expanded coverage to verify OpenMLS rejects group context/dictionary tampering at construction time, plus updated draft-10 last-resort KeyPackage assertions and legacy ingest regression tests.
- **Chores / Documentation**
  - Updated Rust/MSRV and Docker images to 1.91, refreshed OpenMLS feature naming, and bumped TLS codec; pinned OpenMLS dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->