### PR TITLE
TUI hardening: cell-exact media, guarded interactions, logout, and review follow-ups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7001,6 +7001,7 @@ dependencies = [
  "transport-quic-broker",
  "transport-quic-stream",
  "unicode-properties",
+ "unicode-segmentation",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 # General-category lookups for the terminal untrusted-text sanitizer (drop the
 # whole Cf format class instead of a drifting hardcoded denylist).
 unicode-properties = { version = "0.1", default-features = false, features = ["general-category"] }
+# Extended grapheme-cluster segmentation for the TUI /react guard (one cluster ==
+# one emoji). Already in the tree via ratatui; declared here so wn-cli can depend
+# on it directly at the workspace-consistent version.
+unicode-segmentation = "1"
 unicode-normalization = "0.1"
 rand = "0.8"
 sha2 = "0.10"

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -84,12 +84,15 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 - TUI: inbound media renders inline in the message pane. Image attachments are downloaded and decoded off the event
   loop (a worker thread runs `wn media download <group> <plaintext-hash> --output <cache path>` and the `image`
-  decode, delivering the result over an `mpsc` channel drained on tick) and drawn inline via `ratatui-image` on
-  terminals with a graphics protocol (Kitty/iTerm2/Sixel; iTerm2 forced via `ITERM_SESSION_ID`). Placeholders walk
-  `[img name]` -> `[downloading name...]` -> `[loading name...]` -> the image, or `[name failed: err]`, and stay
-  `[img name]` where no image protocol exists. `o` opens the selected message's image full-size in a dismiss-on-any-key
-  viewer. Decrypted files cache under the TUI home in `tui-media-cache/`. No JSON response shapes changed (the
-  existing `media download --json` `output_path` is passed via `--output`).
+  decode, delivering the result over an `mpsc` channel drained on tick) and drawn via `ratatui-image` as cell-exact
+  half-block glyphs (`▀` colored cells) on any image-capable terminal. The fidelity choice is deliberate: half-blocks
+  are ordinary colored cells rather than a native pixel image (iTerm2/Kitty/Sixel), so an image is bounded strictly to
+  its reserved block and can never overdraw a neighboring message or leave a terminal-side artifact behind on scroll.
+  Placeholders walk `[img name]` -> `[downloading name...]` -> `[loading name...]` -> the image, or
+  `[name failed: err]`, and stay `[img name]` on a terminal with no image capability. `o` opens the selected message's
+  image full-size (same cell-exact rendering) in a dismiss-on-any-key viewer. Decrypted files cache under the TUI home
+  in `tui-media-cache/`. No JSON response shapes changed (the existing `media download --json` `output_path` is passed
+  via `--output`).
 - TUI: message interactions on the selected message. New `/react [emoji]` (default `+`), `/unreact`, `/delete`, and
   `/retry <event-id>` slash commands call the real `messages react|unreact|delete|retry` commands; keyboard
   accelerators `r` (prefills `/react` followed by a space), `u` (removes your reaction immediately), and `d`

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,19 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Changed
 
+- TUI: made the armed message-interaction state durable and guarded reaction content, fixing a field report where a
+  user armed `/react` (via `r`), did not register the prefill, typed a whole message, and published his prose as a
+  reaction. While the composer begins with `/react`, `/reply`, or `/delete`, the hints line now shows a persistent
+  hint recomputed each frame from the composer text and the selected row — `reacting to <sender>: <preview> — Enter
+  sends the reaction, Esc clears` — instead of a one-shot status a later event could overwrite. `Esc` clears an armed
+  interaction prefill (pristine or edited) as that escape hatch, while leaving a hand-typed draft intact; `Ctrl-U` is
+  the readline kill-line that clears the whole composer whatever it holds (armed prefill or hand-typed draft) and also
+  clears the masked nsec-entry field, so the idle composer hint reads `Enter send  Ctrl-U clear`. `/react` accepts
+  only one emoji — exactly one grapheme cluster carrying a non-ASCII scalar (real emoji, including ZWJ families, skin
+  tones, flags, and keycaps), or the NIP-25 `+`/`-` sentinels — and refuses anything else (multi-word prose,
+  plain-ASCII tokens, and non-Latin or accented words like `café`, `你好吗`, and `привет`) with `reactions are a single
+  emoji (Enter sends the default +); Esc clears`. The `messages react` CLI command stays protocol-faithful and is
+  unchanged. No JSON response shapes changed.
 - TUI: `R` on the selected message replies to it. It prefills `/reply` followed by a space in the composer
   (draft-protected like the `r`
   and `d` accelerators) and names the reply target on the status line; you type the reply and `Enter` sends it. Also

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -210,6 +210,14 @@ versioning through the workspace version in the root `Cargo.toml`.
   compiled with different defaults resolve them against different endpoints until the group image is re-set on a
   current build.
 
+### Security
+
+- TUI: inline media no longer leaves decrypted image files in the home directory. The decrypted download artifact is
+  removed immediately after it is decoded (on both the success and decode-failure paths) instead of accumulating under
+  `tui-media-cache/`, and any files a prior crashed session left behind are swept from that directory at startup. The
+  files had no reuse value — the viewer draws the in-memory image and a new session never reads them — so they were
+  decrypted plaintext at rest, outliving message deletion, with nothing to gain by keeping them.
+
 ## [0.9.3] - 2026-07-07
 
 ### Added

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,12 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Changed
 
+- TUI: `a` on a user-search result now picks which chat the found user is added to. It opens a group picker over the
+  loaded chats list (`j`/`k` move, `Enter` picks, `Esc` closes without side effects), one row per chat in the list's
+  order with the open chat preselected when one is loaded; `Enter` then opens the same confirm popup that guards the
+  add (`groups add-members`), naming both the user and the chosen chat. With no chats a status notice explains and
+  points at `c` (start a new chat with the found user). Previously the action targeted only the open chat and errored
+  without one. No JSON response shapes changed.
 - TUI: made the armed message-interaction state durable and guarded reaction content, fixing a field report where a
   user armed `/react` (via `r`), did not register the prefill, typed a whole message, and published his prose as a
   reaction. While the composer begins with `/react`, `/reply`, or `/delete`, the hints line now shows a persistent
@@ -33,8 +39,8 @@ versioning through the workspace version in the root `Cargo.toml`.
   profile (`p`), and relay health (`h`) — each a one-shot load that returns to the main view on `Esc`. User search runs
   `users search` (default radius `0..2`) over the cached follow graph; its two-region screen types the query in query
   focus (`Enter` runs it) and navigates results in results focus, where `Enter` opens a profile card (`users show`),
-  `c` starts a new chat, and `a` adds the user to the open chat (guarded to when a chat is loaded) — both return to
-  the main view on the affected chat on success. Profile shows your
+  `c` starts a new chat, and `a` adds the user to an existing chat (via the group picker described above) — both
+  return to the main view on the affected chat on success. Profile shows your
   `profile show` fields (picture URL as literal text — no avatar fetch) and `follows list`; editing a field publishes
   only that field via `profile update --<field>`, `f` follows (`follows add`) and `x` unfollows (`follows remove`), and
   there is no nsec export. Relay health renders the redacted `relay-stats` snapshot — health summary, counters,

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -95,6 +95,17 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Added
 
+- TUI: `/logout` removes the currently selected account. `wn logout` is destructive — it permanently erases the
+  account's local data (messages, group membership, and MLS state) from this device and, for a local-signing account,
+  deletes its signing key too — so the confirmation scales to the consequence. A local-signing logout is irreversible,
+  so it requires typing the literal word `logout` and pressing `Enter`; an empty or mismatched entry keeps the popup
+  open (so the wipe is never reachable by a stray Enter-then-Enter) and `Esc` cancels. A public-only account is
+  re-addable and keeps the lighter `y`/`Enter` confirm (`n` or `Esc` cancels). The confirmation body states the
+  consequences plainly, never softens the wording, tailors the irreversibility line to the account type (a public-only
+  account has no key to erase), and always shows the account npub so it is unambiguous which account is destroyed. On
+  confirmation the command runs, the account list reloads, and the TUI lands on a remaining account or drops back to the
+  login menu when the last account is removed — never left pointing at a removed account or a stale subscription. Listed
+  in the in-app help card and slash-command suggestions. No JSON response shapes changed.
 - TUI: inbound media renders inline in the message pane. Image attachments are downloaded and decoded off the event
   loop (a worker thread runs `wn media download <group> <plaintext-hash> --output <cache path>` and the `image`
   decode, delivering the result over an `mpsc` channel drained on tick) and drawn via `ratatui-image` as cell-exact

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { workspace = true, features = ["io-util", "net"] }
 transport-quic-broker.workspace = true
 transport-quic-stream.workspace = true
 unicode-properties.workspace = true
+unicode-segmentation.workspace = true
 url.workspace = true
 
 [dev-dependencies]

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -576,8 +576,10 @@ Main view controls:
   downloaded and decoded in the background — never blocking the event loop — and its placeholder walks `[img name]` ->
   `[downloading name...]` -> `[loading name...]` -> the inline image, or `[name failed: err]` on error. A terminal
   with no image capability keeps the `[img name]` placeholder (and non-image attachments always show `[file name]`).
-  The `o` full-size viewer uses the same cell-exact rendering. Downloaded files are cached under the TUI home in
-  `tui-media-cache/` (a private directory), so passing `--home` keeps the cache with the account data.
+  The `o` full-size viewer uses the same cell-exact rendering. Each image is decrypted to a private
+  `tui-media-cache/` directory under the TUI home, decoded into memory, and the decrypted file is then removed right
+  away — the viewer draws the in-memory image, so nothing reads the file again and no decrypted media is left at rest.
+  Any files a prior crashed session left behind are swept from that directory at startup.
 - Composer: full cursor editing — `Left`/`Right`/`Home`/`End` move the cursor, `Backspace`/`Delete` remove a
   character, `Ctrl-U` clears the whole composer (a readline kill-line that empties it whatever it holds — armed prefill
   or hand-typed draft), and mid-string edits keep multi-byte characters intact. `Enter` submits; there is no keyboard

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -554,7 +554,16 @@ Main view controls:
   shows the reply target on the status line, so you type the reply and `Enter` sends it). Counts update live in both
   directions from the timeline projection; the list is not reloaded, and a sent reply upserts optimistically the same
   way a plain send does. The `r`, `d`, and `R` prefills are skipped when the composer already holds a draft, so an
-  in-progress message is never clobbered (a status-line notice explains the skip). These also work as the `/react`,
+  in-progress message is never clobbered (a status-line notice explains the skip). While the composer holds one of
+  these prefills, the hints line shows a persistent reminder of what `Enter` will do and to which message (for
+  example `reacting to <sender>: <preview> — Enter sends the reaction, Esc clears`), recomputed each frame so it stays
+  visible until you send or clear; `Esc` clears the armed prefill (pristine or after you have typed into it) as that
+  escape hatch, while a hand-typed draft is left intact (use `Ctrl-U` to clear a hand-typed draft). `/react` accepts
+  only one emoji — exactly one grapheme cluster carrying a non-ASCII scalar (real emoji, including ZWJ families, skin
+  tones, flags, and keycaps), or the NIP-25 `+`/`-` sentinels. Anything else — multi-word prose, plain-ASCII tokens,
+  and non-Latin or accented words like `café`, `你好吗`, or `привет` — is refused with a status-line error that names
+  the contract and the escape hatch (`reactions are a single emoji (Enter sends the default +); Esc clears`), so typed
+  prose is never published as a reaction. These also work as the `/react`,
   `/unreact`, `/delete`, and `/reply <text>` slash commands, which resolve the target at submit and error to the
   status line when no message is selected (and `/delete` when the message is not yours). `/reply` sends
   `messages send --group <loaded-group> --reply-to <selected-message-id> <text>`, keeping `--reply-to` before the
@@ -570,11 +579,15 @@ Main view controls:
   The `o` full-size viewer uses the same cell-exact rendering. Downloaded files are cached under the TUI home in
   `tui-media-cache/` (a private directory), so passing `--home` keeps the cache with the account data.
 - Composer: full cursor editing — `Left`/`Right`/`Home`/`End` move the cursor, `Backspace`/`Delete` remove a
-  character, and mid-string edits keep multi-byte characters intact. `Enter` submits; there is no keyboard newline, so
-  multi-line content only arrives by paste. The composer auto-grows with its wrapped content (up to 8 rows), taking
-  the space from the messages pane.
+  character, `Ctrl-U` clears the whole composer (a readline kill-line that empties it whatever it holds — armed prefill
+  or hand-typed draft), and mid-string edits keep multi-byte characters intact. `Enter` submits; there is no keyboard
+  newline, so multi-line content only arrives by paste. The composer auto-grows with its wrapped content (up to 8
+  rows), taking the space from the messages pane.
 - `?`: open the help popup.
-- `Esc`: clear the composer input (or, with a popup open, close it).
+- `Esc`: clear an armed message-interaction prefill (`/react`, `/reply`, or `/delete`, whether untouched or after you
+  have typed into it); a hand-typed draft is left intact so `Esc` never destroys text you wrote — use `Ctrl-U` to
+  clear a hand-typed draft. With a popup open, `Esc` closes it.
+- `Ctrl-U`: clear the whole composer (readline kill-line), whatever it holds. Also clears the masked nsec-entry field.
 - `Ctrl-C`: quit.
 
 Popups are modal: while one is open it captures every key and the screen behind it is inert. A text-entry popup
@@ -673,7 +686,10 @@ Composer slash commands:
 visible-chat list. Member commands operate on the selected chat and call the same group membership commands exposed by
 the CLI.
 `/react`, `/unreact`, and `/delete` operate on the selected message in the messages pane and call the real
-`messages react|unreact|delete` commands; `/react` defaults to the `+` emoji. On success they only update the status
+`messages react|unreact|delete` commands; `/react` defaults to the `+` emoji. `/react` also guards its content: it is a
+single emoji or the `+` default, so content with whitespace, plain ASCII text, or too long for one emoji is rejected
+with a status-line error rather than published as a reaction (the guard lives in the TUI; the `messages react` CLI
+command stays protocol-faithful). On success they only update the status
 line — the timeline projection folds the reaction or tombstone into the existing row, so the list is not reloaded.
 `/retry <event-id>` retries a failed outbound event by id; it takes the id as an argument rather than acting on the
 selected message, because timeline rows do not carry per-message failed-send state to target from.

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -490,9 +490,9 @@ real time.
 
 `wn tui` is a Ratatui interface over the real `wn --json` command surface. It opens on a login screen when it has
 no single obvious account, then drops into a chat-first main view: the chat list on the left, the materialized
-message timeline on the right (with reactions, reply context, deletion tombstones, and inline images on graphics-capable
-terminals with `[img name]`/`[file name]` placeholders otherwise), the composer below them, and a one-line hints bar
-plus a one-line status bar at the bottom.
+message timeline on the right (with reactions, reply context, deletion tombstones, and inline images as cell-exact
+half-blocks on image-capable terminals, with `[img name]`/`[file name]` placeholders otherwise), the composer below
+them, and a one-line hints bar plus a one-line status bar at the bottom.
 
 ```sh
 wn tui
@@ -560,13 +560,15 @@ Main view controls:
   `messages send --group <loaded-group> --reply-to <selected-message-id> <text>`, keeping `--reply-to` before the
   text as the guard requires. `o` opens the selected message's downloaded image full-size in a dismiss-on-any-key
   viewer (see "Inbound media" below).
-- Inbound media: an image attachment renders inline in the message pane on terminals with a graphics protocol
-  (Kitty, iTerm2, or Sixel; iTerm2 is detected via `ITERM_SESSION_ID`). Each image is downloaded and decoded in the
-  background — never blocking the event loop — and its placeholder walks `[img name]` -> `[downloading name...]` ->
-  `[loading name...]` -> the inline image, or `[name failed: err]` on error. Terminals without an image protocol keep
-  the `[img name]` placeholder (and non-image attachments always show `[file name]`). Downloaded files are cached
-  under the TUI home in `tui-media-cache/` (a private directory), so passing `--home` keeps the cache with the
-  account data.
+- Inbound media: an image attachment renders inline in the message pane as cell-exact half-block glyphs (`▀` colored
+  cells) on any image-capable terminal. The rendering is deliberately cell-exact rather than a native pixel image
+  (iTerm2/Kitty/Sixel): half-blocks are ordinary colored cells bounded strictly to the reserved block, so an image can
+  never overdraw a neighboring message or leave a terminal-side artifact behind when you scroll. Each image is
+  downloaded and decoded in the background — never blocking the event loop — and its placeholder walks `[img name]` ->
+  `[downloading name...]` -> `[loading name...]` -> the inline image, or `[name failed: err]` on error. A terminal
+  with no image capability keeps the `[img name]` placeholder (and non-image attachments always show `[file name]`).
+  The `o` full-size viewer uses the same cell-exact rendering. Downloaded files are cached under the TUI home in
+  `tui-media-cache/` (a private directory), so passing `--home` keeps the cache with the account data.
 - Composer: full cursor editing — `Left`/`Right`/`Home`/`End` move the cursor, `Backspace`/`Delete` remove a
   character, and mid-string edits keep multi-byte characters intact. `Enter` submits; there is no keyboard newline, so
   multi-line content only arrives by paste. The composer auto-grows with its wrapped content (up to 8 rows), taking

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -614,9 +614,11 @@ User search (`s` from the chat list, or `/users [query]`) is a one-shot search o
 (`users search`, default radius `0..2`). The screen has two regions and a two-state focus: in query focus you type the
 query (so `j`/`k` are literal text) and `Enter` runs the search; once there are results, focus moves to the list where
 `j`/`k` (or arrows) navigate, `Enter` opens the selected user's profile card (`users show`, dismiss-on-any-key), `c`
-starts a new chat with them (a text popup names it, then `group create`), and `a` adds them to the open chat (a confirm
-popup, guarded so it only offers this when a chat is loaded). `i` returns to the query, and `Esc` returns to the main
-view. Result rows show the display name/name, a shortened npub, and the `matched_field · match_quality · radius`
+starts a new chat with them (a text popup names it, then `group create`), and `a` adds them to an existing chat: a
+group picker lists your chats (`j`/`k` move, `Enter` picks, `Esc` closes without side effects), preselecting the open
+chat when one is loaded, and `Enter` opens the confirm popup that guards the add (`groups add-members`), naming both
+the user and the chosen chat. With no chats a status notice explains and points at `c`. `i` returns to the query, and
+`Esc` returns to the main view. Result rows show the display name/name, a shortened npub, and the `matched_field · match_quality · radius`
 attribution the search returns.
 
 Profile (`p` from the chat list) shows your own profile — name, display name, about, picture URL (as literal text; no

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -646,6 +646,7 @@ Composer slash commands:
 /account <npub-or-hex>
 /create-identity
 /login <nsec-or-npub>
+/logout
 /daemon status
 /daemon start
 /daemon stop
@@ -680,6 +681,16 @@ Composer slash commands:
 ```
 
 `/stream` uses `quic://quic-broker.ipf.dev:4450` when no candidate is supplied.
+
+`/logout` acts on the currently selected account and is always confirmed first. `wn logout` is destructive: it
+permanently removes that account's local data (messages, group membership, and MLS state) from this device, and for a
+local-signing account it deletes the signing key too, so the confirmation says so plainly, never softens the wording,
+and always shows the account npub so it is unambiguous which account is destroyed. A local-signing logout is
+irreversible, so its confirmation requires typing the literal word `logout` and pressing `Enter`; an empty or
+mismatched entry keeps the popup open (so the wipe is never reachable by a stray Enter-then-Enter) and `Esc` cancels. A
+public-only account is re-addable, so it keeps the lighter `y`/`Enter` confirm (`n` or `Esc` cancels). On confirmation
+the account list reloads; if the removed account was the last one, the TUI returns to the login menu rather than
+pointing at a removed account.
 
 `/login <nsec>` redacts the secret in the composer and pipes it to the child `wn` process over stdin instead of argv.
 `/chat archived` shows archived chats so they can be selected and unarchived; `/chat archived off` returns to the

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -666,6 +666,7 @@ Composer slash commands:
 /react [emoji]
 /unreact
 /delete
+/reply <text>
 /retry <event-id>
 /image <file-path> [caption]
 /keys fetch <npub-or-hex>

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -897,6 +897,10 @@ impl TuiApp {
             SlashCommand::AccountImportSecret(secret) => {
                 self.create_or_import_account(Some(secret), "logged in identity")
             }
+            SlashCommand::Logout => {
+                self.open_logout_popup();
+                Ok(())
+            }
             SlashCommand::DaemonStatus => {
                 self.refresh_daemon_status()?;
                 self.status = daemon_status_sentence(&self.daemon);
@@ -1129,6 +1133,7 @@ impl TuiApp {
                 self.reveal_chat_from_search();
                 Ok(())
             }
+            PopupSubmit::Logout { account_id, npub } => self.logout_account(&account_id, &npub),
         }
     }
 
@@ -1190,6 +1195,7 @@ impl TuiApp {
                     group_id: view.group_id.clone(),
                 },
                 title: "Add Member".to_owned(),
+                body: Vec::new(),
                 input: Input::default(),
             });
         }
@@ -1204,6 +1210,7 @@ impl TuiApp {
                     group_id: view.group_id.clone(),
                 },
                 title: "Rename Group".to_owned(),
+                body: Vec::new(),
                 input,
             });
         }
@@ -1282,6 +1289,66 @@ impl TuiApp {
                 },
             },
         );
+    }
+
+    /// Arm the logout popup for the currently selected account, scaling the guard
+    /// to the consequence. `wn logout` is a destructive wipe
+    /// (`AccountHome::remove_account`): it erases the account's local data from
+    /// this device, and for a local-signing account it also deletes the signing
+    /// key. That irreversible case is gated behind a typed-token confirmation —
+    /// the user must type `logout` — so the TUI's only identity-destroying action
+    /// is never reachable by a stray Enter-then-Enter. A public-only account is
+    /// re-addable, so it keeps the lighter `y`/`Enter` confirm. Both bodies state
+    /// plainly what is erased and never soften the wording.
+    fn open_logout_popup(&mut self) {
+        let Some(account) = self.selected_account_row() else {
+            self.status = "no account selected".to_owned();
+            return;
+        };
+        let label = shorten(&terminal_safe_text(&account_display_label(account)), 24);
+        let account_id = account.account_id.clone();
+        let npub = account.npub.clone();
+        let local_signing = account.local_signing;
+        // The npub is the unambiguous identifier for which account is about to be
+        // destroyed. Always surface it: when a display name labels the account the
+        // first line would otherwise hide the npub, so add an explicit line; with
+        // no display name the label already is the npub.
+        let mut body = vec![format!("Log out {label}?")];
+        if account.display_name.is_some() {
+            body.push(format!("npub {}", shorten(&npub, 24)));
+        }
+        body.push(
+            "This permanently erases this account's local data — messages, group membership, \
+             and MLS state — from this device."
+                .to_owned(),
+        );
+        if local_signing {
+            body.push(
+                "Its signing key is deleted too. Unless your nsec is backed up elsewhere, this \
+                 cannot be undone."
+                    .to_owned(),
+            );
+            body.push(format!(
+                "Type {LOGOUT_CONFIRMATION_TOKEN} to confirm; Esc cancels."
+            ));
+            self.popup = Some(Popup::Text {
+                purpose: TextPurpose::ConfirmLogout { account_id, npub },
+                title: "Log Out".to_owned(),
+                body,
+                input: Input::default(),
+            });
+        } else {
+            body.push(
+                "Local data cannot be recovered; the account would have to be added again from \
+                 scratch."
+                    .to_owned(),
+            );
+            self.popup = Some(Popup::Confirm {
+                purpose: ConfirmPurpose::Logout { account_id, npub },
+                title: "Log Out".to_owned(),
+                body,
+            });
+        }
     }
 
     /// Drop any Phase 5b full-view state and return to the main view. Shared by
@@ -1397,6 +1464,7 @@ impl TuiApp {
         self.popup = Some(Popup::Text {
             purpose: TextPurpose::NewChatWithUser { pubkey },
             title: "New Chat".to_owned(),
+            body: Vec::new(),
             input,
         });
     }
@@ -1447,6 +1515,7 @@ impl TuiApp {
                 self.popup = Some(Popup::Text {
                     purpose: TextPurpose::FollowByPubkey,
                     title: "Follow User".to_owned(),
+                    body: Vec::new(),
                     input: Input::default(),
                 });
             }
@@ -1474,6 +1543,7 @@ impl TuiApp {
         self.popup = Some(Popup::Text {
             purpose: TextPurpose::EditProfileField { field },
             title: format!("Edit {}", field.label()),
+            body: Vec::new(),
             input,
         });
     }

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -138,6 +138,9 @@ impl TuiApp {
         // before the event loop starts reading stdin. Detection failure leaves
         // media placeholders in place (no image protocol).
         self.media.detect_capability();
+        // Sweep any decrypted-media artifacts a prior crashed session left in the
+        // cache dir before this session starts writing its own downloads.
+        self.sweep_media_cache();
         // Bracketed paste delivers a paste as one `Event::Paste(text)` instead of a
         // burst of key events, so a multi-line paste keeps its newlines instead of
         // firing Enter (send) on every line. Best-effort chrome: ignore failures
@@ -572,19 +575,33 @@ impl TuiApp {
         started
     }
 
+    /// The directory holding decrypted-media download artifacts, under the TUI
+    /// home when one is set (else a private temp dir).
+    fn media_cache_dir(&self) -> PathBuf {
+        self.client
+            .home
+            .clone()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("tui-media-cache")
+    }
+
     /// The per-hash cache path for a decrypted download, under the TUI home when
     /// one is set (else a private temp dir). Passed as `--output` so the CLI does
     /// not write the file's basename into the current directory. The directory is
     /// created restrictive-by-construction; the CLI writes the file privately.
     fn media_cache_path(&self, hash: &str) -> TuiResult<PathBuf> {
-        let cache_dir = self
-            .client
-            .home
-            .clone()
-            .unwrap_or_else(std::env::temp_dir)
-            .join("tui-media-cache");
+        let cache_dir = self.media_cache_dir();
         fs_private::create_dir_all_private(&cache_dir)?;
         Ok(cache_dir.join(hash))
+    }
+
+    /// Sweep decrypted-media artifacts left by a prior (possibly crashed) session
+    /// at startup. Each artifact is removed right after decode, so anything still
+    /// on disk is decrypted plaintext with no reader; clearing it keeps decrypted
+    /// media from lingering at rest. Best-effort and non-recursive; see
+    /// `sweep_media_cache_dir`.
+    pub(crate) fn sweep_media_cache(&self) {
+        sweep_media_cache_dir(&self.media_cache_dir());
     }
 
     /// Open the selected message's downloaded image full-size, or explain on the

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -393,7 +393,13 @@ impl TuiApp {
             }
             KeyCode::Tab => self.focus = self.focus.next(),
             KeyCode::BackTab => self.focus = self.focus.previous(),
-            KeyCode::Esc => {
+            // Esc is the escape hatch the armed-interaction hint advertises: it
+            // clears an armed `/react`/`/reply`/`/delete` prefill (pristine or
+            // edited) so a user who armed a reaction by accident can back out. A
+            // hand-typed draft is never an armed command, so Esc leaves it intact
+            // — Esc must not silently destroy text the user wrote by hand, the
+            // same reason r/d/R refuse to clobber a draft.
+            KeyCode::Esc if is_armed_interaction(self.input.value()) => {
                 self.input.clear();
             }
             KeyCode::Char('/') if self.focus != Focus::Composer => {
@@ -495,6 +501,17 @@ impl TuiApp {
             KeyCode::Delete if self.focus == Focus::Composer => self.input.delete(),
             KeyCode::Backspace if self.focus == Focus::Composer => {
                 self.input.backspace();
+            }
+            // Ctrl-U is the readline kill-line: an unconditional composer clear
+            // whatever the field holds — an armed interaction prefill or a
+            // hand-typed draft — so the composer hint can name a key that always
+            // clears. It precedes the plain-Char insert so Ctrl-U is never typed
+            // as a literal `u`.
+            KeyCode::Char('u')
+                if self.focus == Focus::Composer
+                    && key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                self.input.clear();
             }
             KeyCode::Char(character) if self.focus == Focus::Composer => {
                 self.input.insert(character);
@@ -807,6 +824,12 @@ impl TuiApp {
             KeyCode::End => self.input.end(),
             KeyCode::Delete => self.input.delete(),
             KeyCode::Backspace => self.input.backspace(),
+            // Ctrl-U kill-line, shared with the composer: the nsec field reuses the
+            // same `Input`, so the readline convention carries over and clearing
+            // key material promptly is safety-positive. Nothing else binds it here.
+            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.input.clear();
+            }
             KeyCode::Char(character) => self.input.insert(character),
             _ => {}
         }

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -1076,6 +1076,9 @@ impl TuiApp {
         match popup_key(popup, key.code) {
             PopupAction::None => {}
             PopupAction::Dismiss => self.popup = None,
+            // A multi-step flow: the reducer resolved the next popup (the group
+            // picker's Enter opens the add-user confirm). No CLI call yet.
+            PopupAction::Open(next) => self.popup = Some(next),
             PopupAction::Submit(submit) => {
                 // The invites picker stays open across actions so one
                 // accept/decline does not lose the user's place: capture the
@@ -1137,7 +1140,7 @@ impl TuiApp {
         }
     }
 
-    /// After a user-search action opens a new chat or adds someone to the open one,
+    /// After a user-search action opens a new chat or adds someone to a picked chat,
     /// leave the search screen for the main view so the freshly selected chat is
     /// visible. Mirrors the invite-accept return: the search screen would otherwise
     /// hide the chat the action just targeted. A no-op off the search screen, so the
@@ -1415,8 +1418,8 @@ impl TuiApp {
     }
 
     /// Results-focus keys: `j`/`k` navigate (with `k` at the top returning to the
-    /// query), `Enter` opens the profile card, `c` starts a chat, `a` adds to the
-    /// open chat, and `i`/`/` return to the query.
+    /// query), `Enter` opens the profile card, `c` starts a chat, `a` picks a chat
+    /// to add the user to, and `i`/`/` return to the query.
     fn handle_user_search_results_key(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Up | KeyCode::Char('k') => {
@@ -1469,8 +1472,11 @@ impl TuiApp {
         });
     }
 
-    /// Add the selected found user to the open chat. Guarded: only when a chat is
-    /// loaded (the open conversation); otherwise a status-line notice explains.
+    /// Add the selected found user to an existing chat: opens a group picker
+    /// over the loaded chats list (one row per chat, in the list's order),
+    /// preselecting the open chat when one is loaded. `Enter` chains into the
+    /// add-user confirm for the highlighted chat; `Esc` closes with no side
+    /// effects. With no chats a status-line notice explains.
     fn open_add_user_to_chat_popup(&mut self) {
         let Some(result) = self
             .user_search
@@ -1481,18 +1487,24 @@ impl TuiApp {
         };
         let pubkey = result.pubkey.clone();
         let label = result.display_label();
-        let Some(group_id) = self.messages_group_id.clone() else {
-            self.status = "open a chat first to add a user to it".to_owned();
+        if self.chats.is_empty() {
+            self.status = "no chats to add a user to; c starts a new chat".to_owned();
             return;
-        };
-        self.popup = Some(Popup::Confirm {
-            purpose: ConfirmPurpose::AddUserToChat { group_id, pubkey },
-            title: "Add to Chat".to_owned(),
-            body: vec![format!(
-                "Add {} to the open chat?",
-                shorten(&terminal_safe_text(&label), 24)
-            )],
-        });
+        }
+        let items = self
+            .chats
+            .iter()
+            .map(|chat| PickerItem {
+                id: chat.group_id.clone(),
+                label: chat.name.clone(),
+            })
+            .collect();
+        let selected = self
+            .messages_group_id
+            .as_deref()
+            .and_then(|group_id| self.chats.iter().position(|chat| chat.group_id == group_id))
+            .unwrap_or(0);
+        self.popup = Some(Popup::add_user_group_picker(pubkey, label, items, selected));
     }
 
     /// Profile-screen keys: `j`/`k` move the field/follow cursor, `Enter` edits

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -868,6 +868,21 @@ impl TuiApp {
         Ok(())
     }
 
+    /// Log out (permanently remove) an account via `wn logout <pubkey>`, then
+    /// reload accounts and chats. `wn logout` is destructive: it removes the
+    /// account's local data and signing key from this device. Because the
+    /// selected account is usually its own target, it is gone from `account list`
+    /// afterward, so this reuses the `/refresh` helper to reload accounts + chats
+    /// and drop back to the login menu when the last account is removed — never
+    /// leaving the TUI pointed at a removed account or a stale subscription (the
+    /// account-switch and empty-account clearing both live in that refresh path).
+    pub(crate) fn logout_account(&mut self, account_id: &str, npub: &str) -> TuiResult<()> {
+        self.client.run_json(None, &["logout", account_id])?;
+        self.refresh_or_return_to_login()?;
+        self.status = format!("logged out {}", shorten(&terminal_safe_text(npub), 18));
+        Ok(())
+    }
+
     /// Open the pending-invites list picker (`groups invites`). An empty result
     /// shows an info card rather than an empty picker.
     pub(crate) fn open_invites(&mut self) -> TuiResult<()> {

--- a/crates/cli/src/tui/media.rs
+++ b/crates/cli/src/tui/media.rs
@@ -71,20 +71,17 @@ impl MediaState {
 
     /// Detect the terminal's image capability once, querying stdio. Called after
     /// raw-mode init and before the event loop owns stdin. A non-tty query fails
-    /// fast; the shorter timeout bounds a tty that never answers. iTerm2 answers
-    /// the Kitty query and is misdetected, so `ITERM_SESSION_ID` forces iTerm2.
-    /// On any query failure the picker stays `None` (placeholders only).
+    /// fast; the shorter timeout bounds a tty that never answers. On any query
+    /// failure the picker stays `None` (placeholders only). The query is kept only
+    /// as the "is this an image-capable terminal" gate: the reported protocol is
+    /// discarded and replaced with the cell-exact halfblocks protocol by
+    /// `adopt_picker`, so the earlier iTerm2/Kitty misdetection no longer matters.
     pub(crate) fn detect_capability(&mut self) {
         let mut options = QueryStdioOptions::default();
         options.timeout = Duration::from_millis(500);
-        self.picker = Picker::from_query_stdio_with_options(options)
-            .ok()
-            .map(|mut picker| {
-                if std::env::var_os("ITERM_SESSION_ID").is_some() {
-                    picker.set_protocol_type(ProtocolType::Iterm2);
-                }
-                picker
-            });
+        if let Ok(picker) = Picker::from_query_stdio_with_options(options) {
+            self.adopt_picker(picker);
+        }
     }
 
     /// Whether the terminal has a usable image protocol.
@@ -188,12 +185,15 @@ impl MediaState {
         }
     }
 
-    /// Inject a picker for headless tests (`Picker::halfblocks()`), so the
-    /// `Decoded` reducer path and the renderer run without a real terminal.
+    /// Inject a picker for headless tests, so the `Decoded` reducer path and the
+    /// renderer run without a real terminal. Routes through the same `adopt_picker`
+    /// chokepoint the runtime uses, so a test picker forced to a pixel protocol is
+    /// still normalized to cell-exact halfblocks (proving the invariant holds
+    /// whatever the terminal reports).
     #[cfg(test)]
     pub(crate) fn with_test_picker(picker: Picker) -> Self {
         let mut state = Self::new();
-        state.picker = Some(picker);
+        state.adopt_picker(picker);
         state
     }
 
@@ -201,6 +201,42 @@ impl MediaState {
     #[cfg(test)]
     pub(crate) fn apply_for_test(&mut self, load: MediaLoad) {
         self.apply(load);
+    }
+
+    /// Adopt `picker` as the terminal image picker, normalizing it to the
+    /// cell-exact halfblocks protocol whatever the terminal reported. This is the
+    /// single chokepoint through which any picker enters `MediaState` — both the
+    /// runtime capability query and the test hook store their picker here — so no
+    /// caller can install an un-normalized (pixel-protocol) picker.
+    ///
+    /// The protocol chosen here governs *every* image render path: the inline
+    /// timeline blocks and the full-screen image viewer popup (`o`) both draw the
+    /// one shared `StatefulProtocol` built per hash from this picker. It must be
+    /// cell-exact for both:
+    ///
+    /// - Inline, images occupy a reserved block of cells *inside a scrolling
+    ///   message list*. Halfblocks draws ordinary colored cells (`▀` with fg/bg),
+    ///   bounded strictly to the reserved rect, so it never spills past the block
+    ///   and is erased and redrawn correctly on scroll through ratatui's normal
+    ///   cell diff.
+    /// - The popup has no full clear on close: ratatui erases it by diffing cells.
+    ///   A pixel protocol stores its image terminal-side, out of that diff's reach,
+    ///   so it cannot be reliably erased and would linger after the popup is
+    ///   dismissed.
+    ///
+    /// The pixel protocols (iTerm2/Kitty/Sixel) map the cell rect to pixels via the
+    /// terminal's detected font size and store the image terminal-side behind
+    /// `set_skip` cells. When font-size detection falls back to the arbitrary
+    /// `(10, 20)` default (`ratatui-image` first tries a `TIOCGWINSZ` ioctl for the
+    /// window pixel size and only reaches `(10, 20)` when both the escape-sequence
+    /// cell-size query and that ioctl fail), the pixels overflow the reserved block
+    /// and occlude the next message, and the terminal-side image is left as an
+    /// artifact a partial redraw cannot erase on scroll. Halfblocks depends on no
+    /// font size for containment (the font size only tunes intermediate sampling
+    /// detail), so it is robust in every terminal.
+    fn adopt_picker(&mut self, mut picker: Picker) {
+        picker.set_protocol_type(ProtocolType::Halfblocks);
+        self.picker = Some(picker);
     }
 }
 

--- a/crates/cli/src/tui/media.rs
+++ b/crates/cli/src/tui/media.rs
@@ -259,7 +259,13 @@ pub(crate) fn spawn_media_download(
             Ok(_) => {
                 // Advance to the decoding ladder step, then decode off-loop.
                 let _ = tx.send(MediaLoad::Downloaded { hash: hash.clone() });
-                match decode_image(&output_path) {
+                let decoded = decode_image(&output_path);
+                // Whether decode produced an in-memory image or an error, the file
+                // has no remaining reader; remove the decrypted plaintext artifact
+                // before signalling completion so it never lingers at rest.
+                // Best-effort: it may already be gone.
+                let _ = std::fs::remove_file(&output_path);
+                match decoded {
                     Ok(image) => {
                         let _ = tx.send(MediaLoad::Decoded {
                             hash,
@@ -272,6 +278,8 @@ pub(crate) fn spawn_media_download(
                 }
             }
             Err(err) => {
+                // A failed download may still have written a partial file (e.g.
+                // ENOSPC mid-write); the startup sweep clears it next session.
                 let _ = tx.send(MediaLoad::Failed {
                     hash,
                     error: shorten(&err.to_string(), 60),
@@ -279,6 +287,24 @@ pub(crate) fn spawn_media_download(
             }
         }
     });
+}
+
+/// Best-effort sweep of the flat media-cache directory: remove every entry it
+/// holds, keeping the directory itself. Decrypted-media artifacts are deleted
+/// right after decode, so anything still here is litter from a crashed session —
+/// decrypted plaintext at rest — swept at startup so it never lingers.
+///
+/// A missing directory and per-entry errors are ignored (the sweep is advisory).
+/// Only the directory's own entries are touched — the layout is flat, so no
+/// recursion is needed — and `remove_file` unlinks a symlink rather than
+/// following it, so nothing outside the directory is ever removed.
+pub(crate) fn sweep_media_cache_dir(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let _ = std::fs::remove_file(entry.path());
+    }
 }
 
 /// Decode a downloaded file with `image`, guessing the format from content (the

--- a/crates/cli/src/tui/media.rs
+++ b/crates/cli/src/tui/media.rs
@@ -297,8 +297,19 @@ pub(crate) fn spawn_media_download(
 /// A missing directory and per-entry errors are ignored (the sweep is advisory).
 /// Only the directory's own entries are touched — the layout is flat, so no
 /// recursion is needed — and `remove_file` unlinks a symlink rather than
-/// following it, so nothing outside the directory is ever removed.
+/// following it, so nothing outside the directory is ever removed. The root
+/// itself must be a real directory: `read_dir` follows a symlink at the path,
+/// and the no-home fallback lives under the shared temp dir where a symlinked
+/// `tui-media-cache` could be pre-planted to redirect the unlinks. The check
+/// races `read_dir` in principle; the sweep is best-effort startup cleanup,
+/// not a security boundary for an already-writable directory.
 pub(crate) fn sweep_media_cache_dir(dir: &Path) {
+    let is_real_dir = dir
+        .symlink_metadata()
+        .is_ok_and(|meta| meta.file_type().is_dir());
+    if !is_real_dir {
+        return;
+    }
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -453,10 +453,17 @@ impl ProfileField {
     }
 }
 
-/// What a list picker acts on. Extends for 5b (group picker for user search).
+/// What a list picker acts on.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum PickerPurpose {
     Invites,
+    /// Choose which existing chat to add a found user to (user-search `a`).
+    /// Carries the found user's pubkey and display label so `Enter` can chain
+    /// into the add-user confirm for the highlighted chat.
+    Groups {
+        pubkey: String,
+        label: String,
+    },
 }
 
 /// One row of a list-picker popup: an opaque id the action targets plus a
@@ -470,12 +477,14 @@ pub(crate) struct PickerItem {
 /// The outcome of routing one key into an open popup. `None` means the popup
 /// handled the key internally (edit/navigate) and stays open; `Dismiss` closes
 /// it with no side effect; `Submit` closes it and asks the app to run one CLI
-/// call.
+/// call; `Open` replaces it with the next popup of a multi-step flow (the
+/// group picker's `Enter` opens the add-user confirm) with no CLI call yet.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum PopupAction {
     None,
     Dismiss,
     Submit(PopupSubmit),
+    Open(Popup),
 }
 
 /// A resolved popup submission: exactly one CLI call, chosen by mapping the
@@ -524,6 +533,46 @@ impl Popup {
             title: "Pending Invites".to_owned(),
             items,
             selected,
+        }
+    }
+
+    /// The group picker for adding a found user to an existing chat
+    /// (user-search `a`): one row per loaded chat, `Enter` chains into the
+    /// add-user confirm for the highlighted chat.
+    pub(crate) fn add_user_group_picker(
+        pubkey: String,
+        label: String,
+        items: Vec<PickerItem>,
+        selected: usize,
+    ) -> Self {
+        Popup::Picker {
+            purpose: PickerPurpose::Groups { pubkey, label },
+            title: "Add to Chat".to_owned(),
+            items,
+            selected,
+        }
+    }
+
+    /// The add-user-to-chat confirm. Built by the group picker's `Enter` (which
+    /// chose the target chat), so the guarding step and its wording live in one
+    /// place.
+    pub(crate) fn confirm_add_user_to_chat(
+        group_id: &str,
+        chat_label: &str,
+        pubkey: &str,
+        user_label: &str,
+    ) -> Self {
+        Popup::Confirm {
+            purpose: ConfirmPurpose::AddUserToChat {
+                group_id: group_id.to_owned(),
+                pubkey: pubkey.to_owned(),
+            },
+            title: "Add to Chat".to_owned(),
+            body: vec![format!(
+                "Add {} to {}?",
+                shorten(&terminal_safe_text(user_label), 24),
+                shorten(&terminal_safe_text(chat_label), 24),
+            )],
         }
     }
 
@@ -697,6 +746,17 @@ fn picker_purpose_action(
             }),
             _ => PopupAction::None,
         },
+        PickerPurpose::Groups { pubkey, label } => match key {
+            // The picker only chooses the target chat; the confirm it opens
+            // still guards the actual add.
+            KeyCode::Enter => PopupAction::Open(Popup::confirm_add_user_to_chat(
+                &item.id,
+                &item.label,
+                pubkey,
+                label,
+            )),
+            _ => PopupAction::None,
+        },
     }
 }
 
@@ -710,6 +770,10 @@ pub(crate) fn popup_hint(popup: &Popup) -> &'static str {
             purpose: PickerPurpose::Invites,
             ..
         } => "[a] accept  [d] decline  [j/k] move  [Esc] close",
+        Popup::Picker {
+            purpose: PickerPurpose::Groups { .. },
+            ..
+        } => "[Enter] select  [j/k] move  [Esc] close",
         Popup::Card { .. } | Popup::Image { .. } => "[any key] dismiss",
     }
 }
@@ -724,7 +788,7 @@ pub(crate) fn help_card_lines() -> Vec<String> {
         "On the selected message: r react (Enter sends +), u unreact, d delete, R reply.",
         "Composer: cursor editing (arrows/Home/End, Backspace/Delete); Enter sends.",
         "Group detail: j/k move; A add member; x remove; P promote; R rename; L leave.",
-        "User search: type + Enter searches; Enter opens a card; c chat; a add to open chat.",
+        "User search: type + Enter searches; Enter opens a card; c chat; a add to a chat.",
         "Profile: j/k move; Enter edits a field; f follow; x unfollow. Relay health: r refresh.",
         "Popups capture every key; Esc or the shown key closes them.",
         "",

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -283,10 +283,14 @@ pub(crate) enum Screen {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum Popup {
     /// Text entry. `Enter` submits when non-empty, `Esc` cancels. Reuses the
-    /// composer's `Input` so cursor editing and masking behave identically.
+    /// composer's `Input` so cursor editing and masking behave identically. The
+    /// optional `body` renders explanatory lines above the input (empty for the
+    /// plain prompts); a typed-token confirmation uses it to carry the honest
+    /// consequence wording plus the instruction on what to type.
     Text {
         purpose: TextPurpose,
         title: String,
+        body: Vec<String>,
         input: Input,
     },
     /// Confirm. `y`/`Enter` confirms, `n`/`Esc` cancels.
@@ -332,17 +336,72 @@ pub(crate) enum TextPurpose {
     NewChatWithUser {
         pubkey: String,
     },
+    /// Typed-token confirmation for logging out (permanently removing) a
+    /// local-signing account. Unlike the free-form purposes, this does not
+    /// capture arbitrary input: the user must type the literal
+    /// [`LOGOUT_CONFIRMATION_TOKEN`] to submit the irreversible wipe (the
+    /// signing key is destroyed with the local data). `account_id` is the
+    /// `wn logout` target; `npub` identifies it in the post-logout status once
+    /// the account row is gone.
+    ConfirmLogout {
+        account_id: String,
+        npub: String,
+    },
+}
+
+/// The literal word a user must type to confirm the irreversible logout of a
+/// local-signing account (see [`TextPurpose::ConfirmLogout`]). Defined once so
+/// the reducer's exact-match check, the popup's instruction line, and the tests
+/// all share a single source of truth.
+pub(crate) const LOGOUT_CONFIRMATION_TOKEN: &str = "logout";
+
+impl TextPurpose {
+    /// The literal token that must be typed before `Enter` submits a typed-token
+    /// confirmation. Free-form entry purposes return `None` (any non-empty value
+    /// submits); a confirmation purpose returns the exact word the user must
+    /// type, so the reducer submits only on an exact match and treats an empty or
+    /// mismatched value as a no-op that keeps the popup open.
+    fn confirmation_token(&self) -> Option<&'static str> {
+        match self {
+            TextPurpose::ConfirmLogout { .. } => Some(LOGOUT_CONFIRMATION_TOKEN),
+            TextPurpose::RenameGroup { .. }
+            | TextPurpose::AddMemberByPubkey { .. }
+            | TextPurpose::EditProfileField { .. }
+            | TextPurpose::FollowByPubkey
+            | TextPurpose::NewChatWithUser { .. } => None,
+        }
+    }
 }
 
 /// What a confirm popup does on `y`/`Enter`. 5b adds unfollow and
 /// add-found-user-to-the-current-chat here.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum ConfirmPurpose {
-    RemoveMember { group_id: String, pubkey: String },
-    PromoteMember { group_id: String, pubkey: String },
-    LeaveGroup { group_id: String },
-    Unfollow { pubkey: String },
-    AddUserToChat { group_id: String, pubkey: String },
+    RemoveMember {
+        group_id: String,
+        pubkey: String,
+    },
+    PromoteMember {
+        group_id: String,
+        pubkey: String,
+    },
+    LeaveGroup {
+        group_id: String,
+    },
+    Unfollow {
+        pubkey: String,
+    },
+    AddUserToChat {
+        group_id: String,
+        pubkey: String,
+    },
+    /// Log out (permanently remove) an account. `account_id` is the `wn logout`
+    /// target; `npub` identifies it in the post-logout status once the account
+    /// row is gone.
+    Logout {
+        account_id: String,
+        npub: String,
+    },
 }
 
 /// An editable own-profile field. Each maps to exactly one `profile update`
@@ -436,6 +495,7 @@ pub(crate) enum PopupSubmit {
     Unfollow { pubkey: String },
     NewChat { name: String, pubkey: String },
     AddUserToChat { group_id: String, pubkey: String },
+    Logout { account_id: String, npub: String },
 }
 
 impl Popup {
@@ -490,10 +550,18 @@ pub(crate) fn popup_key(popup: &mut Popup, key: KeyCode) -> PopupAction {
         Popup::Text { purpose, input, .. } => match key {
             KeyCode::Enter => {
                 let value = input.value().trim().to_owned();
-                if value.is_empty() {
-                    PopupAction::None
-                } else {
+                let ready = match purpose.confirmation_token() {
+                    // Typed-token confirmation: submit only on an exact match.
+                    // Empty (the double-Enter case) or any mismatch is a no-op
+                    // that keeps the popup open.
+                    Some(token) => value == token,
+                    // Free-form entry: submit any non-empty value.
+                    None => !value.is_empty(),
+                };
+                if ready {
                     PopupAction::Submit(text_purpose_submit(purpose, value))
+                } else {
+                    PopupAction::None
                 }
             }
             KeyCode::Esc => PopupAction::Dismiss,
@@ -575,6 +643,12 @@ fn text_purpose_submit(purpose: &TextPurpose, value: String) -> PopupSubmit {
             name: value,
             pubkey: pubkey.clone(),
         },
+        // The typed token was already matched by the reducer; it is a fixed
+        // confirmation word, not user data, so it is discarded here.
+        TextPurpose::ConfirmLogout { account_id, npub } => PopupSubmit::Logout {
+            account_id: account_id.clone(),
+            npub: npub.clone(),
+        },
     }
 }
 
@@ -597,6 +671,10 @@ fn confirm_purpose_submit(purpose: &ConfirmPurpose) -> PopupSubmit {
         ConfirmPurpose::AddUserToChat { group_id, pubkey } => PopupSubmit::AddUserToChat {
             group_id: group_id.clone(),
             pubkey: pubkey.clone(),
+        },
+        ConfirmPurpose::Logout { account_id, npub } => PopupSubmit::Logout {
+            account_id: account_id.clone(),
+            npub: npub.clone(),
         },
     }
 }
@@ -651,7 +729,7 @@ pub(crate) fn help_card_lines() -> Vec<String> {
         "Popups capture every key; Esc or the shown key closes them.",
         "",
         "/refresh   /diagnostics   /account <npub-or-hex>   /create-identity",
-        "/login <nsec-or-npub>   /daemon status|start|stop   /users [query]",
+        "/login <nsec-or-npub>   /logout   /daemon status|start|stop   /users [query]",
         "/chat new|rename|describe|archive|unarchive|archived",
         "/members add|remove|list   /react [emoji]   /unreact   /delete   /reply <text>   /retry <id>",
         "/keys fetch|rotate   /profile name <display-name>   /quit",
@@ -1592,6 +1670,10 @@ pub(crate) enum SlashCommand {
     AccountCreate,
     AccountAddPublic(String),
     AccountImportSecret(String),
+    /// Log out the currently selected account. Always routed through a confirm
+    /// popup because `wn logout` permanently removes the account's local data and
+    /// signing key from this device.
+    Logout,
     DaemonStatus,
     DaemonStart,
     DaemonStop,
@@ -1697,6 +1779,10 @@ pub(crate) const SLASH_COMMAND_SUGGESTIONS: &[SlashCommandSuggestion] = &[
     SlashCommandSuggestion {
         usage: "/login <nsec-or-npub>",
         description: "import or add an identity",
+    },
+    SlashCommandSuggestion {
+        usage: "/logout",
+        description: "remove the selected account from this device",
     },
     SlashCommandSuggestion {
         usage: "/daemon status",

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -1514,9 +1514,73 @@ pub(crate) fn hints_line(screen: Screen, focus: Focus, entered_main: bool) -> &'
             Focus::Messages => {
                 "j/k select  G/g ends  r react  u unreact  d delete  R reply  i compose"
             }
-            Focus::Composer => "Enter send  Esc clear",
+            Focus::Composer => "Enter send  Ctrl-U clear",
         },
     }
+}
+
+/// A composer prefix that arms a selected-message interaction, paired with the
+/// verb and the Enter action the persistent hint advertises. When the composer
+/// begins with one of these, Enter acts on the selected message instead of
+/// sending a chat message, so the armed state must stay visible until resolved.
+struct ArmedInteraction {
+    command: &'static str,
+    verb: &'static str,
+    action: &'static str,
+}
+
+const ARMED_INTERACTIONS: &[ArmedInteraction] = &[
+    ArmedInteraction {
+        command: "/react",
+        verb: "reacting to",
+        action: "Enter sends the reaction",
+    },
+    ArmedInteraction {
+        command: "/reply",
+        verb: "replying to",
+        action: "Enter sends the reply",
+    },
+    ArmedInteraction {
+        command: "/delete",
+        verb: "deleting",
+        action: "Enter deletes",
+    },
+];
+
+/// The armed interaction the composer text begins with, if any: `input` is the
+/// command exactly (`/delete`) or the command followed by whitespace (`/react `,
+/// `/reply hello`). Matching on the whole command word (not a bare prefix) keeps
+/// `/refresh` and `/reactor` from counting. Shared by the persistent armed hint
+/// and the `Esc` escape hatch so they agree on what "armed" means.
+fn armed_interaction(input: &str) -> Option<&'static ArmedInteraction> {
+    ARMED_INTERACTIONS.iter().find(|armed| {
+        input
+            .strip_prefix(armed.command)
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with(|ch: char| ch.is_whitespace()))
+    })
+}
+
+/// True when the composer holds an armed selected-message interaction, so `Esc`
+/// should clear it as the escape hatch rather than leaving the user trapped.
+pub(crate) fn is_armed_interaction(input: &str) -> bool {
+    armed_interaction(input).is_some()
+}
+
+/// The persistent hint shown while the composer holds an armed interaction: what
+/// Enter will do and to which message, plus the `Esc` escape hatch. Recomputed
+/// from the composer text and the selected row at render time (not stored as a
+/// one-shot status a later event would overwrite), so the armed state stays
+/// visible until the command is sent or cleared. `None` when not armed.
+pub(crate) fn armed_interaction_hint(input: &str, row: Option<&TimelineRow>) -> Option<String> {
+    let armed = armed_interaction(input)?;
+    let target = match row {
+        Some(row) => timeline_target_label(row),
+        None => "the selected message".to_owned(),
+    };
+    Some(format!(
+        "{} {target} — {}, Esc clears",
+        armed.verb, armed.action
+    ))
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -3091,11 +3155,11 @@ mod timeline {
         ])
     }
 
-    /// The `R`-accelerator status line naming the reply target:
-    /// `replying to <name>: "<first 30 chars>"`. Mirrors `timeline_reply_line`'s
-    /// clip and terminal-control stripping; the author falls back to a shortened
-    /// sender id when the row carries no display name.
-    pub(crate) fn reply_target_status(row: &TimelineRow) -> String {
+    /// `<name>: "<first 30 chars>"` for a timeline row: the sender's display name
+    /// (falling back to a shortened id) and a clipped, terminal-control-stripped
+    /// body preview. Shared by the reply status line and the armed-interaction
+    /// hint so they name the target identically.
+    pub(crate) fn timeline_target_label(row: &TimelineRow) -> String {
         let name = match row.from_display_name.as_deref() {
             Some(name) if !name.is_empty() => terminal_safe_text(name),
             _ => terminal_safe_text(&shorten(&row.from, 12)),
@@ -3107,10 +3171,18 @@ mod timeline {
         };
         let clipped = body.chars().take(30).collect::<String>();
         if body.chars().count() > 30 {
-            format!("replying to {name}: \"{clipped}...\"")
+            format!("{name}: \"{clipped}...\"")
         } else {
-            format!("replying to {name}: \"{clipped}\"")
+            format!("{name}: \"{clipped}\"")
         }
+    }
+
+    /// The `R`-accelerator status line naming the reply target:
+    /// `replying to <name>: "<first 30 chars>"`. Mirrors `timeline_reply_line`'s
+    /// clip and terminal-control stripping; the author falls back to a shortened
+    /// sender id when the row carries no display name.
+    pub(crate) fn reply_target_status(row: &TimelineRow) -> String {
+        format!("replying to {}", timeline_target_label(row))
     }
 
     /// The reactions line rendered below a message: yellow `<emoji> <count>` pairs

--- a/crates/cli/src/tui/slash.rs
+++ b/crates/cli/src/tui/slash.rs
@@ -42,6 +42,13 @@ pub(crate) fn parse_slash_command(input: &str) -> Result<SlashCommand, String> {
             [] => Err("/login expects one nsec or npub".to_owned()),
             _ => Err("/login expects exactly one nsec or npub".to_owned()),
         },
+        "logout" => {
+            if rest.is_empty() {
+                Ok(SlashCommand::Logout)
+            } else {
+                Err("/logout acts on the selected account and takes no arguments".to_owned())
+            }
+        }
         "account" => parse_account_command(rest),
         "daemon" => parse_daemon_command(rest),
         "chat" => parse_chat_command(rest),

--- a/crates/cli/src/tui/slash.rs
+++ b/crates/cli/src/tui/slash.rs
@@ -1,6 +1,7 @@
 //! Slash-command parsing for the TUI composer.
 
 use super::*;
+use unicode_segmentation::UnicodeSegmentation;
 
 pub(crate) fn parse_slash_command(input: &str) -> Result<SlashCommand, String> {
     let trimmed = input.trim();
@@ -257,17 +258,59 @@ pub(crate) fn parse_members_command(args: Vec<String>) -> Result<SlashCommand, S
     }
 }
 
+/// The status-line error a rejected `/react` teaches: it names the contract (a
+/// single emoji), the bare-Enter default, and the `Esc` escape hatch. Shown when
+/// reaction content looks like typed prose rather than one emoji.
+pub(crate) const REACTION_GUARD_HINT: &str =
+    "reactions are a single emoji (Enter sends the default +); Esc clears";
+
+/// The most Unicode scalar values a single-emoji reaction may span. The longest
+/// standardized emoji sequences — the four-person ZWJ family and the two-skin-tone
+/// "people holding hands" — run to roughly ten scalars once joiners and variation
+/// selectors are counted; this cap leaves generous headroom for future sequences
+/// while still rejecting a pathological ZWJ chain packed into one cluster.
+const MAX_REACTION_SCALARS: usize = 16;
+
+/// Reject reaction content that is typed prose rather than a single emoji.
+///
+/// A valid reaction is the `+`/`-` NIP-25 sentinel or exactly one extended
+/// grapheme cluster that carries at least one non-ASCII scalar — the shape of
+/// every real emoji, including multi-scalar ZWJ/skin-tone/flag/keycap sequences.
+/// Prose is refused because it spans more than one cluster (any script: `café`,
+/// `你好吗`, `привет`) or is an all-ASCII token (`hello`, `:)`). A single CJK
+/// character is one non-ASCII cluster and so is accepted; that is the documented,
+/// acceptable ceiling. `MAX_REACTION_SCALARS` stays as a backstop against a
+/// pathological ZWJ chain crammed into one cluster. This is the TUI's UX guard;
+/// the `messages react` CLI stays protocol-faithful and publishes whatever
+/// content it is given.
+pub(crate) fn validate_reaction_content(content: &str) -> Result<(), String> {
+    if matches!(content, "+" | "-") {
+        return Ok(());
+    }
+    let mut clusters = content.graphemes(true);
+    let is_single_cluster = clusters.next().is_some() && clusters.next().is_none();
+    if is_single_cluster && !content.is_ascii() && content.chars().count() <= MAX_REACTION_SCALARS {
+        return Ok(());
+    }
+    Err(REACTION_GUARD_HINT.to_owned())
+}
+
 /// `/react [emoji]`: the emoji defaults to `+` (matching the `messages react`
-/// CLI default) so the `r` accelerator sends the default on a bare Enter.
+/// CLI default) so the `r` accelerator sends the default on a bare Enter. Any
+/// supplied content passes `validate_reaction_content` so typed prose (the field
+/// defect) is refused with the teaching hint instead of published as a reaction.
 pub(crate) fn parse_react_command(args: Vec<String>) -> Result<SlashCommand, String> {
     match args.as_slice() {
         [] => Ok(SlashCommand::React {
             emoji: "+".to_owned(),
         }),
-        [emoji] => Ok(SlashCommand::React {
-            emoji: emoji.clone(),
-        }),
-        _ => Err("/react expects an optional single emoji".to_owned()),
+        [emoji] => {
+            validate_reaction_content(emoji)?;
+            Ok(SlashCommand::React {
+                emoji: emoji.clone(),
+            })
+        }
+        _ => Err(REACTION_GUARD_HINT.to_owned()),
     }
 }
 

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -3731,7 +3731,14 @@ fn image_attachment(hash: &str) -> TimelineAttachment {
 /// A media state with an image-capable (halfblocks) picker and one decoded,
 /// ready image, built without a terminal or network via the test hooks.
 fn media_with_ready_image(hash: &str) -> MediaState {
-    let mut media = MediaState::with_test_picker(ratatui_image::picker::Picker::halfblocks());
+    media_ready_image_with_picker(ratatui_image::picker::Picker::halfblocks(), hash)
+}
+
+/// As `media_with_ready_image`, but adopting a specific `picker`. Used to prove
+/// the inline renderer stays cell-exact even when the terminal reports (or is
+/// mis-detected as) a pixel protocol such as iTerm2/Kitty/Sixel.
+fn media_ready_image_with_picker(picker: ratatui_image::picker::Picker, hash: &str) -> MediaState {
+    let mut media = MediaState::with_test_picker(picker);
     // Larger than the halfblocks font cell (10x20) so it occupies cells, and
     // vertically varied so the encoder emits half-block glyphs (a uniform image
     // collapses each cell to a space).
@@ -3744,6 +3751,25 @@ fn media_with_ready_image(hash: &str) -> MediaState {
         image: Box::new(image::DynamicImage::ImageRgb8(buffer)),
     });
     media
+}
+
+/// Each terminal row of a full frame render, top to bottom, as a string. Unlike
+/// `rendered_buffer` (which flattens the whole grid) this keeps row boundaries so
+/// a test can assert *where* content lands — e.g. that an image block never draws
+/// onto the following message's row.
+fn rendered_rows(app: &mut TuiApp) -> Vec<String> {
+    let backend = ratatui::backend::TestBackend::new(100, 30);
+    let mut terminal = ratatui::Terminal::new(backend).expect("test terminal");
+    terminal.draw(|frame| app.render(frame)).expect("draw TUI");
+    let buffer = terminal.backend().buffer().clone();
+    let area = buffer.area;
+    (0..area.height)
+        .map(|y| {
+            (0..area.width)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect::<String>()
+        })
+        .collect()
 }
 
 #[test]
@@ -3941,6 +3967,163 @@ fn ready_image_renders_over_its_placeholder_in_the_message_pane() {
     assert!(
         !rendered.contains("pixel.png"),
         "the placeholder should be replaced by the image"
+    );
+}
+
+/// Row index of the first rendered row containing `needle`, or `None`.
+fn row_index_containing(rows: &[String], needle: &str) -> Option<usize> {
+    rows.iter().position(|row| row.contains(needle))
+}
+
+/// Render `app` and return the row index where the second timeline message
+/// ("SENTINELREPLY") lands. Used to observe how far the first message's image
+/// slot pushes it down — measure (row height) must equal draw (rendered rows).
+fn second_message_row(app: &mut TuiApp) -> usize {
+    let rows = rendered_rows(app);
+    row_index_containing(&rows, "SENTINELREPLY")
+        .unwrap_or_else(|| panic!("second message not rendered:\n{}", rows.join("\n")))
+}
+
+fn image_row_pair() -> Vec<TimelineRow> {
+    let mut first = timeline_row("m0", 0);
+    first.from_display_name = Some("Al".to_owned());
+    first.display_text = "look".to_owned();
+    first.attachments = vec![image_attachment("cafebabe")];
+    let mut second = timeline_row("m1", 1);
+    second.from_display_name = Some("Bo".to_owned());
+    second.display_text = "SENTINELREPLY".to_owned();
+    vec![first, second]
+}
+
+#[test]
+fn ready_image_reserves_exactly_its_block_and_placeholders_reserve_one_row() {
+    // measure==draw: the rows a message occupies in the height model must equal
+    // the rows it draws. Observe it through where the *next* message lands. Every
+    // placeholder ladder state is one row, so the second message sits at the same
+    // row; a ready image reserves MEDIA_IMAGE_ROWS, pushing it down by exactly the
+    // difference. A block that drew more (or fewer) rows than it measured would
+    // move the next message and occlude/leave a gap — the reported symptom.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Main;
+    app.focus = Focus::Messages;
+    app.timeline = image_row_pair();
+
+    // `[img ...]` placeholder: capable terminal, image not yet requested.
+    app.media = MediaState::with_test_picker(ratatui_image::picker::Picker::halfblocks());
+    let img_row = second_message_row(&mut app);
+
+    // `[downloading ...]`
+    app.media = MediaState::with_test_picker(ratatui_image::picker::Picker::halfblocks());
+    app.media.begin_download("cafebabe".to_owned());
+    assert_eq!(
+        second_message_row(&mut app),
+        img_row,
+        "the downloading placeholder is one row, like [img ...]"
+    );
+
+    // `[loading ...]`
+    app.media = MediaState::with_test_picker(ratatui_image::picker::Picker::halfblocks());
+    app.media.begin_download("cafebabe".to_owned());
+    app.media.apply_for_test(MediaLoad::Downloaded {
+        hash: "cafebabe".to_owned(),
+    });
+    assert_eq!(
+        second_message_row(&mut app),
+        img_row,
+        "the loading placeholder is one row, like [img ...]"
+    );
+
+    // `[... failed: ...]`
+    app.media = MediaState::with_test_picker(ratatui_image::picker::Picker::halfblocks());
+    app.media.apply_for_test(MediaLoad::Failed {
+        hash: "cafebabe".to_owned(),
+        error: "boom".to_owned(),
+    });
+    assert_eq!(
+        second_message_row(&mut app),
+        img_row,
+        "the failed placeholder is one row, like [img ...]"
+    );
+
+    // Ready image: reserves MEDIA_IMAGE_ROWS rows where the placeholder used one.
+    app.media = media_with_ready_image("cafebabe");
+    let ready_row = second_message_row(&mut app);
+    assert_eq!(
+        ready_row - img_row,
+        usize::from(MEDIA_IMAGE_ROWS) - 1,
+        "a ready image reserves exactly MEDIA_IMAGE_ROWS rows, pushing the next \
+         message down by the block minus the one placeholder row it replaced"
+    );
+}
+
+#[test]
+fn ready_image_never_draws_onto_the_next_message_row() {
+    // Symptom 1, cell-exact form: the image must stay inside its reserved block
+    // and never draw onto (occlude) the following message's row.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Main;
+    app.focus = Focus::Messages;
+    app.timeline = image_row_pair();
+    app.media = media_with_ready_image("cafebabe");
+
+    let rows = rendered_rows(&mut app);
+    let sentinel_row = row_index_containing(&rows, "SENTINELREPLY")
+        .expect("second message must remain visible below the image");
+    let last_glyph_row = rows
+        .iter()
+        .rposition(|row| row.contains('▀') || row.contains('▄'))
+        .expect("the ready image must draw halfblock glyphs");
+    assert!(
+        last_glyph_row < sentinel_row,
+        "image glyphs (last at row {last_glyph_row}) must stay above the next \
+         message (row {sentinel_row}); an image drawn onto it is the occlusion bug"
+    );
+}
+
+#[test]
+fn inline_images_render_cell_exact_not_a_pixel_protocol() {
+    // A terminal that reports (or is mis-detected as) a pixel protocol must not
+    // make the inline timeline draw a pixel-protocol image. In a scrolling message
+    // list a pixel image (iTerm2/Kitty/Sixel) maps its reserved cell block to
+    // pixels via a font size and stores image bytes terminal-side; if the detected
+    // font is off it overflows the block (occluding the next message) and cannot be
+    // erased on scroll. The renderer must adopt the cell-exact halfblocks protocol
+    // regardless of what the terminal reported.
+    //
+    // Structural guard: the picker here is force-set to a pixel protocol and then
+    // handed to `MediaState` through the *same* `adopt_picker` chokepoint the
+    // runtime's `detect_capability` uses (via the `with_test_picker` hook, which
+    // now just delegates to it). This test therefore fails if anyone removes or
+    // bypasses the chokepoint's cell-exact normalization — not merely if a
+    // test-only normalization is dropped.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Main;
+    app.focus = Focus::Messages;
+    let mut row = timeline_row("m", 0);
+    row.display_text = "look".to_owned();
+    row.attachments = vec![image_attachment("cafebabe")];
+    app.timeline = vec![row];
+
+    // Build the media state the way a pixel-protocol terminal (iTerm2 answers the
+    // Kitty query and would be force-set to iTerm2) hands the picker over.
+    let mut picker = ratatui_image::picker::Picker::halfblocks();
+    picker.set_protocol_type(ratatui_image::picker::ProtocolType::Iterm2);
+    app.media = media_ready_image_with_picker(picker, "cafebabe");
+
+    let rendered = rendered_buffer(&mut app);
+    // No raw pixel-protocol control sequence may be emitted into a cell: the iTerm2
+    // inline-image marker (OSC 1337) is the mechanism that overflows the block.
+    assert!(
+        !rendered.contains("1337"),
+        "an iTerm2 pixel escape must never be drawn inline in the scrolling timeline"
+    );
+    // The reserved block is filled by cell-exact halfblock glyphs instead.
+    assert!(
+        rendered.contains('▀') || rendered.contains('▄'),
+        "expected a cell-exact halfblock image in the reserved block"
     );
 }
 

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -1151,10 +1151,81 @@ fn chat_row_line_shows_unread_count_in_bold() {
 }
 
 #[test]
+fn chat_row_line_renders_the_unread_badge_yellow_and_bold() {
+    let chat = ChatRow {
+        group_id: "group-a".to_owned(),
+        name: "Project Room".to_owned(),
+        archived: false,
+        projection: ChatProjection::default(),
+    };
+
+    let line = chat_row_line(&chat, false, 3);
+
+    // The name keeps its own style while the `(N)` badge is a separate yellow
+    // bold span (the wn-tui look the spec pins).
+    assert_eq!(line_text(&line), "  Project Room (3)");
+    let name = &line.spans[1];
+    assert_eq!(name.content.as_ref(), "Project Room");
+    assert_eq!(name.style.fg, Some(Color::Green));
+    assert!(name.style.add_modifier.contains(Modifier::BOLD));
+    let badge = &line.spans[2];
+    assert_eq!(badge.content.as_ref(), " (3)");
+    assert_eq!(badge.style.fg, Some(Color::Yellow));
+    assert!(badge.style.add_modifier.contains(Modifier::BOLD));
+}
+
+#[test]
+fn chat_row_line_selected_badge_takes_the_row_fg_bump() {
+    let chat = ChatRow {
+        group_id: "group-a".to_owned(),
+        name: "Project Room".to_owned(),
+        archived: false,
+        projection: ChatProjection::default(),
+    };
+
+    let line = chat_row_line(&chat, true, 3);
+
+    // The selected row renders black-on-white; the badge takes the same fg bump
+    // as the name (`row_label_style`) so it stays readable on the white bg.
+    let badge = &line.spans[2];
+    assert_eq!(badge.content.as_ref(), " (3)");
+    assert_eq!(badge.style.fg, Some(Color::Black));
+    assert!(badge.style.add_modifier.contains(Modifier::BOLD));
+}
+
+#[test]
+fn chat_row_line_read_chat_has_no_badge_span() {
+    let chat = ChatRow {
+        group_id: "group-a".to_owned(),
+        name: "Project Room".to_owned(),
+        archived: false,
+        projection: ChatProjection::default(),
+    };
+
+    let line = chat_row_line(&chat, false, 0);
+
+    assert_eq!(line_text(&line), "  Project Room");
+    assert!(
+        !line
+            .spans
+            .iter()
+            .any(|span| span.style.fg == Some(Color::Yellow)),
+        "a read chat renders no badge span"
+    );
+}
+
+#[test]
 fn chat_label_keeps_unread_count_when_truncated() {
+    // The name is truncated to leave room for the whole badge within `max_len`,
+    // so the badge always survives truncation intact.
     assert_eq!(
         chat_label("A very long group display name", 12, 18),
-        "A very ...ame (12)"
+        ("A ver... name".to_owned(), Some(" (12)".to_owned()))
+    );
+    assert_eq!(
+        chat_label("ops", 0, 18),
+        ("ops".to_owned(), None),
+        "a read chat has no badge part"
     );
 }
 
@@ -5698,6 +5769,60 @@ fn popup_key_invites_picker_navigates_accepts_and_declines() {
 }
 
 #[test]
+fn popup_key_group_picker_navigates_and_chains_into_the_add_confirm() {
+    let items = vec![
+        PickerItem {
+            id: "g1".to_owned(),
+            label: "Room A".to_owned(),
+        },
+        PickerItem {
+            id: "g2".to_owned(),
+            label: "Room B".to_owned(),
+        },
+    ];
+    let picker =
+        || Popup::add_user_group_picker("pk".to_owned(), "Alice".to_owned(), items.clone(), 0);
+
+    // j then Enter chains into the add-user confirm for the highlighted chat —
+    // the picker chooses the target, the confirm still guards the action.
+    let mut choose = picker();
+    assert_eq!(
+        popup_key(&mut choose, KeyCode::Char('j')),
+        PopupAction::None
+    );
+    let action = popup_key(&mut choose, KeyCode::Enter);
+    let PopupAction::Open(Popup::Confirm {
+        purpose,
+        title,
+        body,
+    }) = action
+    else {
+        panic!("Enter must open the add-user confirm, got {action:?}");
+    };
+    assert_eq!(
+        purpose,
+        ConfirmPurpose::AddUserToChat {
+            group_id: "g2".to_owned(),
+            pubkey: "pk".to_owned(),
+        }
+    );
+    assert_eq!(title, "Add to Chat");
+    assert_eq!(body, vec!["Add Alice to Room B?".to_owned()]);
+
+    // The invites action keys mean nothing here, and Esc closes the picker.
+    let mut dismiss = picker();
+    assert_eq!(
+        popup_key(&mut dismiss, KeyCode::Char('a')),
+        PopupAction::None
+    );
+    assert_eq!(
+        popup_key(&mut dismiss, KeyCode::Char('d')),
+        PopupAction::None
+    );
+    assert_eq!(popup_key(&mut dismiss, KeyCode::Esc), PopupAction::Dismiss);
+}
+
+#[test]
 fn leave_group_decision_covers_sole_admin_co_admin_and_non_admin() {
     assert_eq!(
         leave_group_decision(true, 1),
@@ -7955,43 +8080,43 @@ fn slash_users_query_runs_the_search_immediately() {
 }
 
 #[test]
-fn user_search_add_to_chat_is_guarded_on_no_loaded_chat() {
-    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
-    let view = UserSearchView {
-        results: vec![UserSearchResultRow {
-            pubkey: "aa".to_owned(),
-            npub: "npubaa".to_owned(),
-            display_name: Some("Alice".to_owned()),
-            matched_field: "name".to_owned(),
-            match_quality: "exact".to_owned(),
-            radius: 0,
-        }],
-        focus: UserSearchFocus::Results,
-        ..UserSearchView::default()
-    };
-    app.user_search = Some(view);
-    app.screen = Screen::UserSearch;
-    app.messages_group_id = None;
+fn user_search_add_is_guarded_when_there_are_no_chats() {
+    let mut app = user_search_app_with_selected_result(test_unused_client());
+    assert!(app.chats.is_empty());
 
-    // No loaded chat: the add action is guarded to a status notice, no popup.
+    // No chats at all: the add action is guarded to a status notice, no popup.
     app.handle_key(char_key('a')).expect("a guarded");
-    assert!(app.popup.is_none(), "no popup without a loaded chat");
+    assert!(app.popup.is_none(), "no popup without any chat");
     assert!(
-        app.status.contains("open a chat"),
+        app.status.contains("no chats"),
         "status explains the guard: {}",
         app.status
     );
+}
 
-    // With a loaded chat: a confirm popup targets the open chat.
-    app.messages_group_id = Some("g1".to_owned());
-    app.handle_key(char_key('a')).expect("a add");
-    assert!(matches!(
-        app.popup,
-        Some(Popup::Confirm {
-            purpose: ConfirmPurpose::AddUserToChat { .. },
-            ..
-        })
-    ));
+#[test]
+fn user_search_add_preselects_the_open_chat_in_the_picker() {
+    let mut app = user_search_app_with_selected_result(test_unused_client());
+    app.chats = vec![
+        ChatRow {
+            group_id: "g1".to_owned(),
+            name: "Room One".to_owned(),
+            ..ChatRow::default()
+        },
+        ChatRow {
+            group_id: "g2".to_owned(),
+            name: "Room Two".to_owned(),
+            ..ChatRow::default()
+        },
+    ];
+    app.messages_group_id = Some("g2".to_owned());
+
+    app.handle_key(char_key('a')).expect("a opens the picker");
+
+    let Some(Popup::Picker { selected, .. }) = &app.popup else {
+        panic!("a must open the group picker, got {:?}", app.popup);
+    };
+    assert_eq!(*selected, 1, "the open chat is preselected");
 }
 
 #[test]
@@ -8358,6 +8483,46 @@ fn user_search_app_with_selected_result(client: WnClient) -> TuiApp {
 }
 
 #[test]
+fn user_search_add_opens_the_group_picker_over_the_chats_list() {
+    let mut app = user_search_app_with_selected_result(test_unused_client());
+    app.chats = vec![
+        ChatRow {
+            group_id: "g1".to_owned(),
+            name: "Room One".to_owned(),
+            ..ChatRow::default()
+        },
+        ChatRow {
+            group_id: "g2".to_owned(),
+            name: "Room Two".to_owned(),
+            ..ChatRow::default()
+        },
+    ];
+
+    app.handle_key(char_key('a')).expect("a opens the picker");
+
+    let Some(Popup::Picker {
+        purpose: PickerPurpose::Groups { pubkey, label },
+        items,
+        selected,
+        ..
+    }) = &app.popup
+    else {
+        panic!("a must open the group picker, got {:?}", app.popup);
+    };
+    assert_eq!(pubkey, "bb", "the picker carries the found user");
+    assert_eq!(label, "Bob");
+    assert_eq!(
+        items
+            .iter()
+            .map(|item| (item.id.as_str(), item.label.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("g1", "Room One"), ("g2", "Room Two")],
+        "one row per chat, in the chats-list order already in state"
+    );
+    assert_eq!(*selected, 0, "no open chat: the first row is preselected");
+}
+
+#[test]
 fn new_chat_from_search_navigates_into_the_created_chat() {
     let (_dir, client) = test_json_client(
         r#"{"ok":true,"result":{"group_id":"abcd","chats":[{"group_id":"abcd","profile":{"name":"New Room"}}]}}"#,
@@ -8393,8 +8558,9 @@ fn add_to_open_chat_from_search_navigates_into_that_chat() {
         },
     ];
     app.messages_group_id = Some("g1".to_owned());
-    app.handle_key(char_key('a'))
-        .expect("a opens add-to-chat popup");
+    app.handle_key(char_key('a')).expect("a opens the picker");
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("Enter picks the preselected open chat");
     app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
         .expect("confirm add to chat");
     assert_eq!(app.screen, Screen::Main, "leaves search for the main view");
@@ -8404,4 +8570,101 @@ fn add_to_open_chat_from_search_navigates_into_that_chat() {
         Some("g1"),
         "the affected chat is selected"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn add_to_a_picker_chosen_chat_from_search_confirms_and_navigates_into_it() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) =
+        test_appending_arg_executable(tempdir.path(), r#"{"ok":true,"result":{}}"#);
+    let client = WnClient {
+        exe,
+        home: None,
+        socket: None,
+        relay: None,
+        discovery_relays: Vec::new(),
+        default_account_relays: Vec::new(),
+        secret_store: None,
+        keychain_service: None,
+    };
+    let mut app = user_search_app_with_selected_result(client);
+    app.chats = vec![
+        ChatRow {
+            group_id: "other".to_owned(),
+            name: "Other".to_owned(),
+            ..ChatRow::default()
+        },
+        ChatRow {
+            group_id: "g1".to_owned(),
+            name: "Open Room".to_owned(),
+            ..ChatRow::default()
+        },
+    ];
+    app.messages_group_id = Some("g1".to_owned());
+
+    // k moves off the preselected open chat; Enter reaches the confirm for the
+    // chosen group, not the open one.
+    app.handle_key(char_key('a')).expect("a opens the picker");
+    app.handle_key(char_key('k')).expect("k moves up");
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("Enter picks the highlighted chat");
+    let Some(Popup::Confirm {
+        purpose: ConfirmPurpose::AddUserToChat { group_id, pubkey },
+        ..
+    }) = &app.popup
+    else {
+        panic!("Enter must open the add-user confirm, got {:?}", app.popup);
+    };
+    assert_eq!(group_id, "other", "the confirm targets the chosen group");
+    assert_eq!(pubkey, "bb");
+
+    // The confirm still guards the action; y runs the real add and navigates.
+    app.handle_key(char_key('y')).expect("y confirms the add");
+    assert_eq!(app.screen, Screen::Main, "leaves search for the main view");
+    assert!(app.user_search.is_none(), "the search view is cleared");
+    assert_eq!(
+        app.selected_chat_row().map(|chat| chat.group_id.as_str()),
+        Some("other"),
+        "the chosen chat is selected"
+    );
+    let recorded = std::fs::read_to_string(&args_file).expect("recorded args");
+    assert!(
+        recorded.contains("groups add-members other bb"),
+        "the confirm submit runs the real add against the chosen group: {recorded}"
+    );
+}
+
+#[test]
+fn group_picker_esc_closes_with_zero_side_effects() {
+    let mut app = user_search_app_with_selected_result(test_unused_client());
+    app.chats = vec![ChatRow {
+        group_id: "g1".to_owned(),
+        name: "Room One".to_owned(),
+        ..ChatRow::default()
+    }];
+    app.status = "before".to_owned();
+
+    // One consistent rule: the picker opens whenever any chat exists, even for
+    // a single chat (no direct-to-confirm special case).
+    app.handle_key(char_key('a')).expect("a opens the picker");
+    assert!(
+        matches!(
+            app.popup,
+            Some(Popup::Picker {
+                purpose: PickerPurpose::Groups { .. },
+                ..
+            })
+        ),
+        "a single chat still goes through the picker"
+    );
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .expect("Esc closes the picker");
+
+    assert!(app.popup.is_none(), "the picker is closed");
+    assert_eq!(app.status, "before", "no status change");
+    assert_eq!(app.screen, Screen::UserSearch, "still on the search screen");
+    assert!(app.user_search.is_some(), "the search view is intact");
+    assert_eq!(app.chats.len(), 1, "chats untouched");
+    assert_eq!(app.selected_chat, 0, "selection untouched");
 }

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -4731,6 +4731,151 @@ fn inline_images_render_cell_exact_not_a_pixel_protocol() {
 }
 
 #[test]
+fn startup_media_sweep_removes_leftover_cache_files_but_keeps_the_dir() {
+    // Decrypted-media artifacts are deleted right after decode, so any file still
+    // in the cache dir is litter left by a crashed session — decrypted plaintext
+    // at rest. The startup sweep must clear those files while leaving the
+    // directory itself in place for this session's downloads.
+    let home = tempfile::tempdir().expect("tempdir");
+    let cache_dir = home.path().join("tui-media-cache");
+    std::fs::create_dir_all(&cache_dir).expect("seed cache dir");
+    for name in ["deadbeef", "cafebabe", "f00dface"] {
+        std::fs::write(cache_dir.join(name), b"decrypted-plaintext").expect("seed leftover");
+    }
+
+    let client = WnClient {
+        home: Some(home.path().to_path_buf()),
+        ..test_unused_client()
+    };
+    let app = test_tui_app(client, &"aa".repeat(32));
+    app.sweep_media_cache();
+
+    assert!(cache_dir.is_dir(), "the sweep keeps the cache directory");
+    let remaining: Vec<_> = std::fs::read_dir(&cache_dir)
+        .expect("cache dir readable")
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name())
+        .collect();
+    assert!(
+        remaining.is_empty(),
+        "the sweep removes every leftover decrypted file; remaining: {remaining:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn startup_media_sweep_unlinks_symlinks_without_following_them() {
+    // The sweep's security contract: a symlink inside the cache dir is removed
+    // as a link, and the file it points to — outside the directory — survives.
+    let home = tempfile::tempdir().expect("tempdir");
+    let cache_dir = home.path().join("tui-media-cache");
+    std::fs::create_dir_all(&cache_dir).expect("seed cache dir");
+    let sentinel = home.path().join("sentinel-outside-cache");
+    std::fs::write(&sentinel, b"must survive").expect("seed sentinel");
+    std::os::unix::fs::symlink(&sentinel, cache_dir.join("deadbeef")).expect("seed symlink");
+
+    let client = WnClient {
+        home: Some(home.path().to_path_buf()),
+        ..test_unused_client()
+    };
+    let app = test_tui_app(client, &"aa".repeat(32));
+    app.sweep_media_cache();
+
+    assert!(
+        cache_dir.join("deadbeef").symlink_metadata().is_err(),
+        "the sweep unlinks the symlink itself"
+    );
+    assert!(
+        sentinel.exists(),
+        "the sweep never follows a link out of the cache dir"
+    );
+}
+
+/// Drive the download worker to completion and return its terminal result,
+/// skipping the intermediate `Downloaded` ladder step. The worker removes the
+/// on-disk artifact before sending the terminal result, so once this returns the
+/// file state is settled and race-free to assert on.
+#[cfg(unix)]
+fn run_media_worker(exe: &std::path::Path, output_path: PathBuf) -> MediaLoad {
+    let (tx, rx) = mpsc::channel();
+    spawn_media_download(StdCommand::new(exe), output_path, "deadbeef".to_owned(), tx);
+    loop {
+        match rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("worker result")
+        {
+            MediaLoad::Downloaded { .. } => continue,
+            terminal => return terminal,
+        }
+    }
+}
+
+/// A real, decodable PNG on disk, standing in for the CLI's decrypted write that
+/// the worker sees at `--output` after a successful `media download`.
+#[cfg(unix)]
+fn seed_decodable_image(path: &std::path::Path) {
+    let mut buffer = image::RgbImage::new(4, 4);
+    for (_, _, pixel) in buffer.enumerate_pixels_mut() {
+        *pixel = image::Rgb([10, 20, 30]);
+    }
+    let mut encoded = std::io::Cursor::new(Vec::new());
+    image::DynamicImage::ImageRgb8(buffer)
+        .write_to(&mut encoded, image::ImageFormat::Png)
+        .expect("encode png");
+    std::fs::write(path, encoded.into_inner()).expect("seed decrypted file");
+}
+
+#[cfg(unix)]
+#[test]
+fn media_worker_removes_the_decrypted_file_after_a_successful_decode() {
+    // The decrypted image is decoded into memory and never read from disk again,
+    // so the worker must remove the plaintext artifact once decode succeeds —
+    // decrypted media must not linger at rest.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let wn = test_json_executable(dir.path(), r#"{"ok":true}"#);
+    let output_path = dir.path().join("deadbeef");
+    seed_decodable_image(&output_path);
+    assert!(
+        output_path.exists(),
+        "the artifact exists before the worker runs"
+    );
+
+    let result = run_media_worker(&wn, output_path.clone());
+
+    assert!(
+        matches!(result, MediaLoad::Decoded { .. }),
+        "a valid image decodes"
+    );
+    assert!(
+        !output_path.exists(),
+        "the worker removes the decrypted artifact after a successful decode"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn media_worker_removes_the_decrypted_file_after_a_failed_decode() {
+    // A download that succeeds but yields undecodable bytes still wrote decrypted
+    // plaintext to disk; the worker must remove it on the decode-failure path too,
+    // not only when decode succeeds.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let wn = test_json_executable(dir.path(), r#"{"ok":true}"#);
+    let output_path = dir.path().join("deadbeef");
+    std::fs::write(&output_path, b"decrypted-but-not-an-image").expect("seed decrypted file");
+
+    let result = run_media_worker(&wn, output_path.clone());
+
+    assert!(
+        matches!(result, MediaLoad::Failed { .. }),
+        "undecodable bytes fail to decode"
+    );
+    assert!(
+        !output_path.exists(),
+        "the worker removes the decrypted artifact after a failed decode"
+    );
+}
+
+#[test]
 fn timeline_row_lines_strip_terminal_control_sequences() {
     let mut row = timeline_row("m", 0);
     row.from_display_name = Some("Al\u{202e}ice".to_owned());

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -4967,7 +4967,7 @@ fn hints_line_matches_the_keymap_per_screen_and_focus() {
     );
     assert_eq!(
         hints_line(Screen::Main, Focus::Composer, true),
-        "Enter send  Esc clear"
+        "Enter send  Ctrl-U clear"
     );
     assert_eq!(
         hints_line(Screen::Login(LoginMode::Menu), Focus::Chats, false),
@@ -6365,6 +6365,106 @@ fn slash_command_parser_handles_message_interactions() {
 }
 
 #[test]
+fn react_content_guard_rejects_typed_prose() {
+    // The field defect: `/react ` was prefilled, the user typed a whole message,
+    // and the prose published as a NIP-25 reaction. The guard now refuses content
+    // that is not a single emoji cluster and teaches the escape hatch on the way
+    // out. Prose spans more than one grapheme cluster, or is an all-ASCII token.
+    let hint = "reactions are a single emoji (Enter sends the default +); Esc clears";
+    for prose in [
+        "/react hello world",                              // whitespace between words
+        "/react \"hello world\"",                          // quoted -> one whitespaced arg
+        "/react hello",                                    // a plain-ASCII word is not an emoji
+        "/react 👍👍👍👍👍👍👍👍👍👍👍👍👍👍👍👍👍👍👍👍", // a wall of emoji is not one reaction
+    ] {
+        assert_eq!(
+            parse_slash_command(prose),
+            Err(hint.to_owned()),
+            "{prose:?} must be refused with the teaching hint"
+        );
+    }
+}
+
+#[test]
+fn react_content_guard_accepts_the_default_and_real_emoji() {
+    // The guard must never break the sanctioned reactions: the `+` default and a
+    // single emoji, including multi-scalar ZWJ families, skin tones, and flags.
+    for (input, emoji) in [
+        ("/react", "+"),     // bare -> default +
+        ("/react +", "+"),   // the explicit + sentinel
+        ("/react 👍", "👍"), // single-scalar emoji
+        ("/react 👍🏾", "👍🏾"), // emoji + skin-tone modifier
+        ("/react 👨‍👩‍👧‍👦", "👨‍👩‍👧‍👦"), // ZWJ family: many scalars, one emoji
+        ("/react 🏳️‍🌈", "🏳️‍🌈"), // rainbow flag: base + VS16 + ZWJ + rainbow
+    ] {
+        assert_eq!(
+            parse_slash_command(input),
+            Ok(SlashCommand::React {
+                emoji: emoji.to_owned()
+            }),
+            "{input:?} must be accepted unchanged"
+        );
+    }
+}
+
+#[test]
+fn react_content_guard_accepts_counterintuitive_single_graphemes() {
+    // Regression pins for the accepted survivors that look like edge cases but are
+    // each exactly one non-ASCII grapheme cluster: the NIP-25 `-` downvote, the
+    // keycap and copyright emoji (base + variation/keycap scalars), and a lone CJK
+    // character (the documented, acceptable ceiling — one cluster, non-ASCII).
+    for (input, emoji) in [
+        ("/react -", "-"),   // NIP-25 dislike sentinel
+        ("/react 1️⃣", "1️⃣"), // keycap: '1' + VS16 + combining enclosing keycap
+        ("/react ©️", "©️"), // copyright + VS16
+        ("/react 你", "你"), // a single CJK character is one non-ASCII cluster
+    ] {
+        assert_eq!(
+            parse_slash_command(input),
+            Ok(SlashCommand::React {
+                emoji: emoji.to_owned()
+            }),
+            "{input:?} is one non-ASCII grapheme cluster and must be accepted"
+        );
+    }
+}
+
+#[test]
+fn react_content_guard_rejects_non_latin_and_accented_prose() {
+    // The length/ASCII heuristic let short non-Latin and accented prose through:
+    // `café`, `你好吗`, and `привет` all published. Real reactions are a single
+    // grapheme cluster, so multi-character words are refused whatever their
+    // script. `你好吗` is frozen here so this intent cannot silently regress.
+    let hint = "reactions are a single emoji (Enter sends the default +); Esc clears";
+    for prose in [
+        "/react café",   // Latin-1 accented word (4 clusters)
+        "/react 你好吗", // CJK prose (3 clusters)
+        "/react привет", // Cyrillic word (6 clusters)
+        "/react 👍👍",   // a run of emoji is not one reaction
+    ] {
+        assert_eq!(
+            parse_slash_command(prose),
+            Err(hint.to_owned()),
+            "{prose:?} must be refused: a reaction is one grapheme cluster"
+        );
+    }
+}
+
+#[test]
+fn react_content_guard_accepts_the_nip25_downvote_sentinel() {
+    // NIP-25 defines `-` as the dislike sentinel, and `messages react` already
+    // accepts it. A lone `-` is a single unambiguous token with no typed-prose
+    // risk, so the TUI guard must let it through alongside the `+` default.
+    assert_eq!(
+        parse_slash_command("/react -"),
+        Ok(SlashCommand::React {
+            emoji: "-".to_owned()
+        }),
+        "the NIP-25 - downvote sentinel must be accepted"
+    );
+}
+
+#[test]
 fn messages_r_prefills_the_react_command_in_the_composer() {
     let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
     app.focus = Focus::Messages;
@@ -6434,6 +6534,200 @@ fn messages_d_preserves_a_composer_draft_and_warns_instead_of_clobbering_it() {
         app.status.contains("draft"),
         "the status line explains why r/d was suppressed, got {}",
         app.status
+    );
+}
+
+#[test]
+fn armed_interaction_hint_names_the_action_and_target() {
+    // While the composer holds an interaction command, the hint tells the user
+    // what Enter will do and to which message — the durable signal the field
+    // report was missing. Recomputed from the composer text and selected row.
+    let mut row = timeline_row("m0", 0);
+    row.from_display_name = Some("Alice".to_owned());
+    row.display_text = "hello world".to_owned();
+
+    assert_eq!(
+        armed_interaction_hint("/react ", Some(&row)).as_deref(),
+        Some("reacting to Alice: \"hello world\" — Enter sends the reaction, Esc clears")
+    );
+    assert_eq!(
+        armed_interaction_hint("/reply ", Some(&row)).as_deref(),
+        Some("replying to Alice: \"hello world\" — Enter sends the reply, Esc clears")
+    );
+    assert_eq!(
+        armed_interaction_hint("/delete", Some(&row)).as_deref(),
+        Some("deleting Alice: \"hello world\" — Enter deletes, Esc clears")
+    );
+    // An edited prefill (the trapped scenario: `/react ` then typed prose) stays
+    // armed, so the escape-hatch hint persists.
+    assert_eq!(
+        armed_interaction_hint("/react this is not an emoji", Some(&row)).as_deref(),
+        Some("reacting to Alice: \"hello world\" — Enter sends the reaction, Esc clears")
+    );
+}
+
+#[test]
+fn armed_interaction_hint_is_none_for_drafts_and_unrelated_commands() {
+    let row = timeline_row("m0", 0);
+    // A hand-typed chat draft is not an armed interaction.
+    assert_eq!(armed_interaction_hint("hello everyone", Some(&row)), None);
+    // An unrelated slash command that merely shares a prefix must not match.
+    assert_eq!(armed_interaction_hint("/refresh", Some(&row)), None);
+    assert_eq!(armed_interaction_hint("/chat new ops", Some(&row)), None);
+    // A word that only starts like a command (no boundary) must not match.
+    assert_eq!(armed_interaction_hint("/reactor", Some(&row)), None);
+}
+
+#[test]
+fn render_hints_shows_the_persistent_armed_interaction_hint() {
+    // The armed hint replaces the static keymap in the hints bar while the
+    // composer holds an interaction command, so the pending action stays visible
+    // even if a later status event fires. Clearing the composer restores the
+    // normal keymap.
+    let account_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let mut app = test_tui_app(test_unused_client(), account_id);
+    app.focus = Focus::Messages;
+    let mut row = timeline_row("m0", 0);
+    row.from_display_name = Some("Alice".to_owned());
+    row.display_text = "hello world".to_owned();
+    app.timeline = vec![row];
+    app.input.set_value("/react ");
+
+    let armed = rendered_buffer(&mut app);
+    assert!(
+        armed.contains("reacting to Alice") && armed.contains("Esc clears"),
+        "armed hint must name the action and target, got: {armed:?}"
+    );
+    assert!(
+        !armed.contains("r react  u unreact"),
+        "the static messages keymap must be replaced while armed, got: {armed:?}"
+    );
+
+    app.input.clear();
+    let idle = rendered_buffer(&mut app);
+    assert!(
+        idle.contains("r react  u unreact"),
+        "the static keymap returns once the composer is cleared, got: {idle:?}"
+    );
+}
+
+#[test]
+fn armed_interaction_hint_handles_an_empty_timeline() {
+    // Armed with nothing selected (empty timeline): the hint still shows so the
+    // escape hatch is visible; the submit path reports "no message selected".
+    assert_eq!(
+        armed_interaction_hint("/react ", None).as_deref(),
+        Some("reacting to the selected message — Enter sends the reaction, Esc clears")
+    );
+}
+
+#[test]
+fn esc_clears_an_armed_interaction_prefill() {
+    // Esc is the escape hatch the armed hint advertises. It clears an interaction
+    // prefill — pristine or edited — so a user who armed a reaction by accident
+    // (the field defect) can back out instead of publishing prose as a reaction.
+    for armed in [
+        "/react ",
+        "/react this is not an emoji",
+        "/reply hi",
+        "/delete",
+    ] {
+        let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+        app.focus = Focus::Composer;
+        app.input.set_value(armed);
+
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+            .expect("esc");
+
+        assert!(
+            app.input.is_empty(),
+            "Esc must clear the armed interaction {armed:?}, left {:?}",
+            app.input.value()
+        );
+    }
+}
+
+#[test]
+fn esc_preserves_a_hand_typed_draft() {
+    // Esc must not silently destroy text the user wrote by hand: a chat draft (or
+    // any non-interaction slash command) survives Esc, matching the draft
+    // protection that keeps r/d/R from clobbering it.
+    for draft in ["hello everyone", "/chat new ops"] {
+        let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+        app.focus = Focus::Composer;
+        app.input.set_value(draft);
+
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+            .expect("esc");
+
+        assert_eq!(
+            app.input.value(),
+            draft,
+            "Esc must preserve a hand-typed draft, not destroy it"
+        );
+    }
+}
+
+#[test]
+fn ctrl_u_clears_the_composer_regardless_of_state() {
+    // Ctrl-U is the readline kill-line: it empties the composer whatever it holds
+    // — a hand-typed draft (which Esc deliberately preserves) or an armed
+    // interaction prefill — so the composer hint can honestly name a key that
+    // always clears the field.
+    for content in ["a half-typed draft", "/chat new ops", "/react ", "/delete"] {
+        let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+        app.focus = Focus::Composer;
+        app.input.set_value(content);
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL))
+            .expect("ctrl-u");
+
+        assert!(
+            app.input.is_empty(),
+            "Ctrl-U must clear the composer holding {content:?}, left {:?}",
+            app.input.value()
+        );
+    }
+}
+
+#[test]
+fn armed_hint_and_send_target_resolve_to_the_same_selected_row() {
+    // The armed hint names a row and Enter sends to a row: both must be the same
+    // row. Arm /react, move the selection off the default newest row, and pin that
+    // the hint names the NEW row's sender while the send target
+    // (`selected_timeline_message_id`, the resolution the Enter path uses) points
+    // at that same row — so the hint can never advertise a different message than
+    // the one that gets reacted to.
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    let mut oldest = timeline_row("m0", 0);
+    oldest.from_display_name = Some("Oldest".to_owned());
+    let mut middle = timeline_row("m1", 1);
+    middle.from_display_name = Some("Middle".to_owned());
+    let mut newest = timeline_row("m2", 2);
+    newest.from_display_name = Some("Newest".to_owned());
+    app.timeline = vec![oldest, middle, newest];
+
+    // Move the selection off the default newest row, then arm /react via `r`.
+    app.focus = Focus::Messages;
+    app.handle_key(char_key('k')).expect("select up");
+    app.handle_key(char_key('r')).expect("arm react");
+
+    let target = app
+        .selected_timeline_message_id()
+        .expect("a row is selected");
+    assert_eq!(target, "m1", "the send target follows the moved selection");
+
+    let selected = app.selected_timeline_row().expect("a row is selected");
+    assert_eq!(
+        selected.message_id, target,
+        "the hint row and the send target are the same resolution"
+    );
+
+    let hint = armed_interaction_hint(app.input.value(), Some(selected))
+        .expect("an armed /react shows a hint");
+    assert!(
+        hint.contains("reacting to Middle") && !hint.contains("Newest"),
+        "the armed hint names the selected row's sender, got: {hint:?}"
     );
 }
 

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -4791,6 +4791,34 @@ fn startup_media_sweep_unlinks_symlinks_without_following_them() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn startup_media_sweep_refuses_a_symlinked_cache_root() {
+    // `read_dir` follows a symlink at the path itself, so a cache root replaced
+    // by a symlink would redirect the sweep's unlinks into the target directory
+    // (the no-home fallback lives under the shared temp dir, where such a root
+    // can be pre-planted). The sweep must refuse a root that is not a real
+    // directory.
+    let home = tempfile::tempdir().expect("tempdir");
+    let target = home.path().join("victim-dir");
+    std::fs::create_dir_all(&target).expect("seed target dir");
+    std::fs::write(target.join("precious"), b"must survive").expect("seed victim file");
+    std::os::unix::fs::symlink(&target, home.path().join("tui-media-cache"))
+        .expect("seed symlinked cache root");
+
+    let client = WnClient {
+        home: Some(home.path().to_path_buf()),
+        ..test_unused_client()
+    };
+    let app = test_tui_app(client, &"aa".repeat(32));
+    app.sweep_media_cache();
+
+    assert!(
+        target.join("precious").exists(),
+        "a symlinked cache root must never redirect the sweep's unlinks"
+    );
+}
+
 /// Drive the download worker to completion and return its terminal result,
 /// skipping the intermediate `Downloaded` ladder step. The worker removes the
 /// on-disk artifact before sending the terminal result, so once this returns the

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -348,6 +348,529 @@ fn slash_command_parser_handles_account_onboarding_commands() {
 }
 
 #[test]
+fn slash_command_parser_handles_logout() {
+    // `/logout` acts on the currently selected account and takes no arguments, so
+    // a stray argument is a parse error rather than a silently ignored token.
+    assert_eq!(parse_slash_command("/logout"), Ok(SlashCommand::Logout));
+    assert!(parse_slash_command("/logout npub1bob").is_err());
+}
+
+#[test]
+fn logout_local_signing_account_arms_typed_token_popup() {
+    // A local-signing logout is irreversible (the signing key is destroyed with
+    // the local data), so `/logout` arms a typed-token confirmation for the
+    // selected account rather than a one-key confirm. The body must state
+    // honestly that the wipe is permanent, deletes the signing key, and cannot be
+    // undone, and must instruct the user to type the token — a destructive
+    // action's description is never softened.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+
+    app.run_slash_command(SlashCommand::Logout)
+        .expect("/logout arms the popup");
+
+    match &app.popup {
+        Some(Popup::Text {
+            purpose:
+                TextPurpose::ConfirmLogout {
+                    account_id: target,
+                    npub,
+                },
+            title,
+            body,
+            input,
+        }) => {
+            assert_eq!(target, &account_id, "popup targets the selected account");
+            assert_eq!(npub, "npub1alice");
+            assert_eq!(title, "Log Out");
+            assert!(input.value().is_empty(), "the token field starts empty");
+            let text = body.join(" ");
+            assert!(
+                text.contains("permanently"),
+                "wording must be honest about permanence: {text:?}"
+            );
+            assert!(
+                text.contains("signing key"),
+                "a local-signing account is told its key is deleted: {text:?}"
+            );
+            assert!(
+                text.contains("device"),
+                "wording must scope the wipe to this device: {text:?}"
+            );
+            assert!(
+                text.contains(&format!("Type {LOGOUT_CONFIRMATION_TOKEN}")),
+                "the body instructs the user to type the token: {text:?}"
+            );
+        }
+        other => panic!("expected a typed-token logout popup, got {other:?}"),
+    }
+}
+
+#[test]
+fn logout_confirm_body_omits_signing_key_line_for_public_only_accounts() {
+    // A public-only account has no signing key to erase, so the honest wording
+    // must not claim one is deleted; it warns about the unrecoverable local data
+    // instead.
+    let account_id = "bb".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.accounts[0].local_signing = false;
+
+    app.run_slash_command(SlashCommand::Logout)
+        .expect("/logout arms the popup");
+
+    match &app.popup {
+        Some(Popup::Confirm { body, .. }) => {
+            let text = body.join(" ");
+            assert!(
+                !text.contains("signing key"),
+                "public-only account has no signing key to mention: {text:?}"
+            );
+            assert!(
+                text.contains("recover"),
+                "public-only wording still warns the local data is unrecoverable: {text:?}"
+            );
+        }
+        other => panic!("expected a logout confirm popup, got {other:?}"),
+    }
+}
+
+#[test]
+fn logout_popup_shows_the_npub_even_with_a_display_name() {
+    // The npub is the unambiguous identifier for which account is about to be
+    // destroyed. A display name must not hide it: the body shows the npub for
+    // both account types even when a display name is set.
+    for local_signing in [true, false] {
+        let account_id = "aa".repeat(32);
+        let mut app = test_tui_app(test_unused_client(), &account_id);
+        app.accounts[0].display_name = Some("Alice".to_owned());
+        app.accounts[0].local_signing = local_signing;
+
+        app.run_slash_command(SlashCommand::Logout)
+            .expect("/logout arms the popup");
+
+        let body = match &app.popup {
+            Some(Popup::Text { body, .. } | Popup::Confirm { body, .. }) => body.join(" "),
+            other => panic!("expected a logout popup, got {other:?}"),
+        };
+        assert!(
+            body.contains("Alice"),
+            "the display name still labels the account: {body:?}"
+        );
+        assert!(
+            body.contains("npub1alice"),
+            "the npub is shown regardless of the display name: {body:?}"
+        );
+    }
+}
+
+#[test]
+fn logout_popup_sanitizes_a_hostile_display_name() {
+    // A hostile display name (ANSI/control/format characters) must be
+    // terminal-safe in the logout popup body specifically: the dangerous bytes
+    // are stripped, the visible text survives, and the npub still identifies the
+    // account.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.accounts[0].display_name = Some("Al\u{1b}\u{7}ice\u{202e}".to_owned());
+
+    app.run_slash_command(SlashCommand::Logout)
+        .expect("/logout arms the popup");
+
+    let body = match &app.popup {
+        Some(Popup::Text { body, .. }) => body.join(" "),
+        other => panic!("expected a typed-token logout popup, got {other:?}"),
+    };
+    assert!(
+        !body.contains('\u{1b}'),
+        "the ANSI escape is stripped: {body:?}"
+    );
+    assert!(
+        !body.contains('\u{7}'),
+        "the BEL control byte is stripped: {body:?}"
+    );
+    assert!(
+        !body.contains('\u{202e}'),
+        "the BiDi override is stripped: {body:?}"
+    );
+    assert!(
+        body.contains("Alice"),
+        "the visible display-name text survives sanitization: {body:?}"
+    );
+    assert!(
+        body.contains("npub1alice"),
+        "the npub identifies the account: {body:?}"
+    );
+}
+
+#[test]
+fn logout_slash_command_without_a_selected_account_reports_instead_of_arming() {
+    // With no account loaded there is nothing to log out; the command reports on
+    // the status line rather than opening a popup with an empty target.
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.accounts.clear();
+
+    app.run_slash_command(SlashCommand::Logout)
+        .expect("/logout with no account is not an error");
+
+    assert!(app.popup.is_none(), "no popup without an account to target");
+    assert_eq!(app.status, "no account selected");
+}
+
+#[cfg(unix)]
+#[test]
+fn typing_the_logout_token_runs_wn_logout_and_refreshes() {
+    // The whole point of the typed-token confirm: typing the token and pressing
+    // Enter runs the real `wn logout <pubkey>` for the selected account, then
+    // reloads accounts so the TUI lands on a remaining account rather than the
+    // removed one.
+    let removed = "aa".repeat(32);
+    let remaining = "bb".repeat(32);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) = test_appending_arg_executable(
+        dir.path(),
+        r#"{"ok":true,"result":{"accounts":[{"account_id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","npub":"npub1bob","local_signing":true}]}}"#,
+    );
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = test_tui_app(client, &removed);
+    // No daemon so the refresh does not spawn subscription subprocesses; the flow
+    // under test is the command dispatch and account reload.
+    app.daemon.running = false;
+
+    app.run_slash_command(SlashCommand::Logout)
+        .expect("/logout arms the popup");
+    type_logout_token(&mut app);
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("Enter on the exact token confirms logout");
+
+    let recorded = std::fs::read_to_string(&args_file).expect("the fake wn ran");
+    assert!(
+        recorded
+            .lines()
+            .any(|line| line == format!("--json logout {removed}")),
+        "confirming runs `wn logout <selected-account>`; recorded: {recorded:?}"
+    );
+    assert!(app.popup.is_none(), "the popup closes after submit");
+    assert_eq!(
+        app.accounts.len(),
+        1,
+        "accounts reloaded after the wipe: {:?}",
+        app.accounts
+    );
+    assert_eq!(
+        app.accounts[0].account_id, remaining,
+        "the TUI lands on the remaining account, not the removed one"
+    );
+    assert!(
+        app.status.starts_with("logged out"),
+        "status: {}",
+        app.status
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn logout_subprocess_failure_surfaces_on_status_without_clobbering_accounts() {
+    // A failed `wn logout` must be non-destructive to the TUI's view: the error
+    // surfaces on the status line, the popup closes, and the account list is left
+    // intact (the account still appears) rather than being cleared as if the wipe
+    // had succeeded.
+    let account_id = "aa".repeat(32);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) = test_appending_arg_executable(
+        dir.path(),
+        r#"{"ok":false,"error":{"message":"keychain locked"}}"#,
+    );
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = test_tui_app(client, &account_id);
+    app.daemon.running = false;
+
+    app.run_slash_command(SlashCommand::Logout)
+        .expect("/logout arms the popup");
+    type_logout_token(&mut app);
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("Enter on the exact token confirms logout");
+
+    let recorded = std::fs::read_to_string(&args_file).expect("the fake wn ran");
+    assert!(
+        recorded
+            .lines()
+            .any(|line| line == format!("--json logout {account_id}")),
+        "the wipe was attempted; recorded: {recorded:?}"
+    );
+    assert!(
+        app.popup.is_none(),
+        "the popup closes even when the wipe fails"
+    );
+    assert!(
+        app.status.starts_with("error:"),
+        "the failure surfaces on the status line: {}",
+        app.status
+    );
+    assert_eq!(
+        app.accounts.len(),
+        1,
+        "a failed wipe does not clobber the account list"
+    );
+    assert_eq!(
+        app.accounts[0].account_id, account_id,
+        "the account still appears after a failed wipe"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn canceling_the_typed_token_logout_with_esc_runs_nothing() {
+    // Esc cancels the typed-token confirm with no side effect — even after part
+    // of the token was typed: no `wn` process is spawned and the account list is
+    // unchanged.
+    let account_id = "aa".repeat(32);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) = test_appending_arg_executable(dir.path(), r#"{"ok":true,"result":{}}"#);
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = test_tui_app(client, &account_id);
+
+    app.run_slash_command(SlashCommand::Logout)
+        .expect("/logout arms the popup");
+    for character in "log".chars() {
+        app.handle_key(char_key(character))
+            .expect("partial token typed");
+    }
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .expect("Esc cancels the typed-token popup");
+
+    assert!(app.popup.is_none(), "Esc dismisses the typed-token popup");
+    assert!(!args_file.exists(), "canceling never spawns a `wn` process");
+    assert_eq!(app.accounts.len(), 1, "the account list is untouched");
+    assert_eq!(app.accounts[0].account_id, account_id);
+}
+
+#[cfg(unix)]
+#[test]
+fn public_only_logout_confirms_with_y_enter_and_runs_wn_logout() {
+    // A public-only account is re-addable, so it keeps the lighter y/Enter
+    // confirm (medium-tier friction is proportional there): `y` runs the real
+    // `wn logout <pubkey>`.
+    let account_id = "bb".repeat(32);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) =
+        test_appending_arg_executable(dir.path(), r#"{"ok":true,"result":{"accounts":[]}}"#);
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = test_tui_app(client, &account_id);
+    app.daemon.running = false;
+    app.accounts[0].local_signing = false;
+
+    app.run_slash_command(SlashCommand::Logout)
+        .expect("/logout arms the popup");
+    assert!(
+        matches!(app.popup, Some(Popup::Confirm { .. })),
+        "a public-only account keeps the y/Enter confirm"
+    );
+    app.handle_key(char_key('y')).expect("y confirms logout");
+
+    let recorded = std::fs::read_to_string(&args_file).expect("the fake wn ran");
+    assert!(
+        recorded
+            .lines()
+            .any(|line| line == format!("--json logout {account_id}")),
+        "y runs `wn logout <account>`; recorded: {recorded:?}"
+    );
+    assert!(app.popup.is_none(), "the confirm closes after submit");
+}
+
+#[cfg(unix)]
+#[test]
+fn canceling_public_only_logout_with_n_or_esc_runs_nothing() {
+    // The public-only confirm keeps its two cancel keys: both `n` and `Esc`
+    // dismiss it with no `wn` process spawned and the account list unchanged.
+    let account_id = "bb".repeat(32);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) = test_appending_arg_executable(dir.path(), r#"{"ok":true,"result":{}}"#);
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = test_tui_app(client, &account_id);
+    app.accounts[0].local_signing = false;
+
+    for cancel in [
+        char_key('n'),
+        KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+    ] {
+        app.run_slash_command(SlashCommand::Logout)
+            .expect("/logout arms the popup");
+        app.handle_key(cancel).expect("cancel key handled");
+        assert!(app.popup.is_none(), "cancel dismisses the confirm");
+    }
+
+    assert!(!args_file.exists(), "canceling never spawns a `wn` process");
+    assert_eq!(app.accounts.len(), 1, "the account list is untouched");
+    assert_eq!(app.accounts[0].account_id, account_id);
+}
+
+#[test]
+fn logout_popup_captures_keys_without_leaking_to_the_composer() {
+    // The typed-token popup is modal: characters land in its own token field and
+    // never reach the composer draft hidden behind it.
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.focus = Focus::Composer;
+    app.input.set_value("draft");
+
+    app.run_slash_command(SlashCommand::Logout)
+        .expect("/logout arms the popup");
+    app.handle_key(char_key('x')).expect("stray key handled");
+
+    match &app.popup {
+        Some(Popup::Text { input, .. }) => {
+            assert_eq!(
+                input.value(),
+                "x",
+                "the key lands in the popup's own token field"
+            );
+        }
+        other => panic!("expected the typed-token popup to stay open, got {other:?}"),
+    }
+    assert_eq!(
+        app.input.value(),
+        "draft",
+        "the key does not leak into the composer behind the popup"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn logging_out_the_last_account_returns_to_the_login_menu_and_clears_state() {
+    // When the removed account was the only one, the TUI must not be left pointed
+    // at nothing: it clears chat/subscription state and drops to the login menu.
+    let account_id = "aa".repeat(32);
+    let group_id = "bb".repeat(32);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (exe, _args_file) =
+        test_appending_arg_executable(dir.path(), r#"{"ok":true,"result":{"accounts":[]}}"#);
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = test_tui_app(client, &account_id);
+    app.daemon.running = false;
+    app.chats = vec![ChatRow {
+        group_id: group_id.clone(),
+        name: "general".to_owned(),
+        archived: false,
+        projection: ChatProjection::default(),
+    }];
+    app.chat_subscription = Some(test_chat_subscription(&account_id, false));
+    app.notification_subscription = Some(test_notification_subscription(&account_id));
+
+    app.run_slash_command(SlashCommand::Logout)
+        .expect("/logout arms the popup");
+    type_logout_token(&mut app);
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("Enter on the exact token confirms logout");
+
+    assert!(app.accounts.is_empty(), "the last account is gone");
+    assert!(app.chats.is_empty(), "chats cleared");
+    assert!(
+        app.chat_subscription.is_none(),
+        "chat subscription torn down"
+    );
+    assert!(
+        app.notification_subscription.is_none(),
+        "notification subscription torn down"
+    );
+    assert_eq!(
+        app.screen,
+        Screen::Login(LoginMode::Menu),
+        "the TUI drops back to the login menu"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn double_enter_after_slash_logout_does_not_wipe_a_local_signing_account() {
+    // The fixed footgun: `/logout` submitted from the composer used to arm a
+    // y/Enter confirm, so Enter-then-Enter (slash submit, then confirm accept)
+    // instantly ran the destructive wipe — the identity-destroying action was
+    // uniquely reachable by two Enters. For a local-signing account the second
+    // Enter must be a no-op that keeps the popup open and spawns no `wn` process.
+    let account_id = "aa".repeat(32);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) =
+        test_appending_arg_executable(dir.path(), r#"{"ok":true,"result":{"accounts":[]}}"#);
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = test_tui_app(client, &account_id);
+    app.daemon.running = false;
+    app.focus = Focus::Composer;
+    app.input.set_value("/logout");
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("first Enter submits /logout and arms the popup");
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("second Enter is handled");
+
+    assert!(
+        app.popup.is_some(),
+        "the logout popup stays open after the second Enter"
+    );
+    assert!(
+        !args_file.exists(),
+        "Enter-then-Enter never spawns a `wn` process"
+    );
+    assert_eq!(app.accounts.len(), 1, "the account is untouched");
+}
+
+#[cfg(unix)]
+#[test]
+fn logout_token_mismatch_is_a_noop_that_keeps_the_popup_open() {
+    // A local-signing logout requires typing the exact token `logout`. Anything
+    // else — a near miss included — keeps the popup open and spawns no `wn`
+    // process, so a fat-fingered confirmation never destroys the identity.
+    let account_id = "aa".repeat(32);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) =
+        test_appending_arg_executable(dir.path(), r#"{"ok":true,"result":{"accounts":[]}}"#);
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = test_tui_app(client, &account_id);
+    app.daemon.running = false;
+
+    app.run_slash_command(SlashCommand::Logout)
+        .expect("/logout arms the popup");
+    for character in "logoutt".chars() {
+        app.handle_key(char_key(character))
+            .expect("typing the wrong token");
+    }
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("Enter on a mismatched token is handled");
+
+    assert!(
+        app.popup.is_some(),
+        "a mismatched token keeps the popup open"
+    );
+    assert!(
+        !args_file.exists(),
+        "a mismatched token spawns no `wn` process"
+    );
+    assert_eq!(app.accounts.len(), 1, "the account is untouched");
+}
+
+#[test]
 fn slash_command_parser_handles_daemon_commands() {
     assert_eq!(
         parse_slash_command("/daemon status"),
@@ -1596,6 +2119,15 @@ fn move_index_clamps_at_list_edges() {
 
 fn char_key(character: char) -> KeyEvent {
     KeyEvent::new(KeyCode::Char(character), KeyModifiers::NONE)
+}
+
+/// Type the exact logout confirmation token into an open typed-token popup,
+/// keyed off the shared constant so the tests track its value.
+fn type_logout_token(app: &mut TuiApp) {
+    for character in LOGOUT_CONFIRMATION_TOKEN.chars() {
+        app.handle_key(char_key(character))
+            .expect("typing the logout token");
+    }
 }
 
 #[test]
@@ -4998,6 +5530,7 @@ fn popup_key_text_entry_submits_purpose_and_cancels() {
             group_id: "g1".to_owned(),
         },
         title: "Rename Group".to_owned(),
+        body: Vec::new(),
         input: Input::default(),
     };
     for character in "ops".chars() {
@@ -5019,6 +5552,7 @@ fn popup_key_text_entry_submits_purpose_and_cancels() {
             group_id: "g1".to_owned(),
         },
         title: "Add Member".to_owned(),
+        body: Vec::new(),
         input: Input::default(),
     };
     // An empty submit is a no-op; Esc cancels with no side effect.
@@ -5038,8 +5572,54 @@ fn popup_key_text_entry_submits_purpose_and_cancels() {
             group_id: "g1".to_owned(),
         },
         title: "Add Member".to_owned(),
+        body: Vec::new(),
         input: Input::default(),
     };
+    assert_eq!(popup_key(&mut cancel, KeyCode::Esc), PopupAction::Dismiss);
+}
+
+#[test]
+fn popup_key_confirm_logout_requires_the_exact_token() {
+    // The typed-token confirm submits only when the input is exactly the token.
+    // Both an empty submit (the double-Enter case) and any mismatch are no-ops
+    // that keep the popup open; Esc always cancels. This is the reducer-level
+    // guard behind the local-signing logout.
+    let logout = || Popup::Text {
+        purpose: TextPurpose::ConfirmLogout {
+            account_id: "aa".repeat(32),
+            npub: "npub1alice".to_owned(),
+        },
+        title: "Log Out".to_owned(),
+        body: vec!["Log out npub1alice?".to_owned()],
+        input: Input::default(),
+    };
+
+    // Empty submit: no-op, popup stays open.
+    let mut empty = logout();
+    assert_eq!(popup_key(&mut empty, KeyCode::Enter), PopupAction::None);
+
+    // A near-miss token: no-op, popup stays open.
+    let mut mismatch = logout();
+    for character in "logoutt".chars() {
+        popup_key(&mut mismatch, KeyCode::Char(character));
+    }
+    assert_eq!(popup_key(&mut mismatch, KeyCode::Enter), PopupAction::None);
+
+    // The exact token submits the wipe.
+    let mut exact = logout();
+    for character in LOGOUT_CONFIRMATION_TOKEN.chars() {
+        popup_key(&mut exact, KeyCode::Char(character));
+    }
+    assert_eq!(
+        popup_key(&mut exact, KeyCode::Enter),
+        PopupAction::Submit(PopupSubmit::Logout {
+            account_id: "aa".repeat(32),
+            npub: "npub1alice".to_owned(),
+        })
+    );
+
+    // Esc cancels regardless of typed content.
+    let mut cancel = logout();
     assert_eq!(popup_key(&mut cancel, KeyCode::Esc), PopupAction::Dismiss);
 }
 
@@ -7144,6 +7724,7 @@ fn handle_paste_into_a_text_popup_lands_in_its_input_not_the_composer() {
             group_id: "g1".to_owned(),
         },
         title: "Add Member".to_owned(),
+        body: Vec::new(),
         input: Input::default(),
     });
 
@@ -7667,6 +8248,18 @@ fn help_card_documents_the_new_screens() {
     assert!(help.contains("p profile"), "help mentions profile");
     assert!(help.contains("h relays"), "help mentions relay health");
     assert!(help.contains("/users"), "help mentions the /users command");
+}
+
+#[test]
+fn logout_is_discoverable_in_help_and_suggestions() {
+    let help = help_card_lines().join("\n");
+    assert!(help.contains("/logout"), "help card lists /logout");
+    assert!(
+        slash_command_suggestions("/logout")
+            .iter()
+            .any(|suggestion| suggestion.usage == "/logout"),
+        "slash suggestions offer /logout"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -960,7 +960,10 @@ impl TuiApp {
         frame.render_widget(Clear, rect);
         let mut lines: Vec<Line<'static>> = Vec::new();
         match popup {
-            Popup::Text { input, .. } => lines.push(input_cursor_line("> ", input)),
+            Popup::Text { body, input, .. } => {
+                lines.extend(body.iter().map(|line| Line::from(terminal_safe_text(line))));
+                lines.push(input_cursor_line("> ", input));
+            }
             Popup::Confirm { body, .. } | Popup::Card { body, .. } => {
                 lines.extend(body.iter().map(|line| Line::from(terminal_safe_text(line))))
             }

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -190,19 +190,39 @@ pub(crate) fn chat_row_line(chat: &ChatRow, selected: bool, unread_count: usize)
         ambient_style = ambient_style.add_modifier(Modifier::BOLD);
         label_style = label_style.add_modifier(Modifier::BOLD);
     }
-    Line::from(vec![
+    let (name, badge) = chat_label(&chat.name, unread_count, 24);
+    let mut spans = vec![
         Span::styled(format!("{marker} "), ambient_style),
-        Span::styled(chat_label(&chat.name, unread_count, 24), label_style),
-        Span::styled(archived.to_owned(), ambient_style),
-    ])
+        Span::styled(name, label_style),
+    ];
+    if let Some(badge) = badge {
+        // The yellow bold unread badge. On the selected (black-on-white) row it
+        // takes the same fg bump as the name so it stays readable.
+        spans.push(Span::styled(
+            badge,
+            row_label_style(selected, Color::Yellow).add_modifier(Modifier::BOLD),
+        ));
+    }
+    spans.push(Span::styled(archived.to_owned(), ambient_style));
+    Line::from(spans)
 }
 
-pub(crate) fn chat_label(name: &str, unread_count: usize, max_len: usize) -> String {
+/// A chat row's name and unread badge, split so the badge can carry its own
+/// style: `(name, Some(" (N)"))` when unread, `(name, None)` when read. The
+/// name is truncated to leave the whole badge within `max_len`, so the badge
+/// survives truncation intact.
+pub(crate) fn chat_label(
+    name: &str,
+    unread_count: usize,
+    max_len: usize,
+) -> (String, Option<String>) {
     let name = terminal_safe_text(name);
     if unread_count == 0 {
-        return shorten(&name, max_len);
+        return (shorten(&name, max_len), None);
     }
-    shorten(&format!("{name} ({unread_count})"), max_len)
+    let badge = format!(" ({unread_count})");
+    let budget = max_len.saturating_sub(badge.chars().count());
+    (shorten(&name, budget), Some(badge))
 }
 
 /// The dark-gray last-message preview line under a chat row (wn-tui style):

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -716,10 +716,19 @@ impl TuiApp {
 
     fn render_hints(&self, frame: &mut Frame, area: Rect) {
         // The user-search screen's hint depends on its internal focus, which the
-        // shared `hints_line` signature cannot carry; derive it here instead.
+        // shared `hints_line` signature cannot carry; derive it here instead. On
+        // the main view, an armed interaction command in the composer replaces the
+        // static keymap with a persistent "what Enter does, Esc clears" hint,
+        // recomputed here each frame so it survives later status events.
         let text = match (self.screen, self.user_search.as_ref()) {
-            (Screen::UserSearch, Some(view)) => user_search_hint(view.focus),
-            _ => hints_line(self.screen, self.focus, self.entered_main),
+            (Screen::UserSearch, Some(view)) => user_search_hint(view.focus).to_owned(),
+            (Screen::Main, _) => {
+                armed_interaction_hint(self.input.value(), self.selected_timeline_row())
+                    .unwrap_or_else(|| {
+                        hints_line(self.screen, self.focus, self.entered_main).to_owned()
+                    })
+            }
+            _ => hints_line(self.screen, self.focus, self.entered_main).to_owned(),
         };
         frame.render_widget(
             Paragraph::new(Line::from(Span::styled(

--- a/scripts/check_legacy_naming.sh
+++ b/scripts/check_legacy_naming.sh
@@ -26,18 +26,18 @@ report() {
 }
 
 # One-word and two-word project-name forms, any case.
-if hits="$(rg --hidden --glob '!.git' -n -i 'dark[- ]?matter' "${HISTORY_EXCLUDES[@]}" . 2>/dev/null)" && [ -n "$hits" ]; then
+if hits="$(rg --hidden --glob '!.git' --glob '!.claude' -n -i 'dark[- ]?matter' "${HISTORY_EXCLUDES[@]}" . 2>/dev/null)" && [ -n "$hits" ]; then
     report 'darkmatter / dark matter' "$hits"
 fi
 
 # Retired binary/artifact tokens. No legitimate uses remain anywhere.
-if hits="$(rg --hidden --glob '!.git' -n '\bdmd\b|dm-agent|dm_agent|\bDM Agent\b|\bDM_[A-Z]' "${HISTORY_EXCLUDES[@]}" . 2>/dev/null)" && [ -n "$hits" ]; then
+if hits="$(rg --hidden --glob '!.git' --glob '!.claude' -n '\bdmd\b|dm-agent|dm_agent|\bDM Agent\b|\bDM_[A-Z]' "${HISTORY_EXCLUDES[@]}" . 2>/dev/null)" && [ -n "$hits" ]; then
     report 'dmd / dm-agent / DM_* tokens' "$hits"
 fi
 
 # Bare "dm" word (the retired CLI binary). Excluded under integrations/,
 # where standalone `dm` keys mean direct-message config (dm.allowFrom).
-if hits="$(rg --hidden --glob '!.git' -n '\bdm\b' "${HISTORY_EXCLUDES[@]}" --glob '!integrations/**' . 2>/dev/null)" && [ -n "$hits" ]; then
+if hits="$(rg --hidden --glob '!.git' --glob '!.claude' -n '\bdm\b' "${HISTORY_EXCLUDES[@]}" --glob '!integrations/**' . 2>/dev/null)" && [ -n "$hits" ]; then
     report 'bare dm word' "$hits"
 fi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/logout` with typed confirmation safeguards (local-signing vs public-only).
  * User search “add” now uses a group picker to add to an existing chat or start a new one.
  * Added `/reply <text>` and strengthened multi-step popup flows.
* **Bug Fixes**
  * Hardened `/react` validation to a single non-ASCII emoji grapheme (plus sentinels).
  * Preserved armed reactions while typing; `Ctrl-U` now reliably clears drafts/input.
  * Improved cell-exact inline media rendering and now removes decrypted artifacts promptly.
  * Refined unread badge rendering and terminal-safe hint/popup text.
* **Documentation**
  * Updated TUI README and command/behavior descriptions to match the new flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->