### PR TITLE
fix(app-components): tighten canonical codecs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -852,7 +852,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "hex",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "libc",
  "tempfile",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-conformance-simulator",
  "serde",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "fs-private",
  "serde",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5435,7 +5435,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6029,7 +6029,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6065,7 +6065,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6085,7 +6085,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7140,7 +7140,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7171,7 +7171,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "agent-control",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.5"
+version = "0.9.6"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -678,26 +678,45 @@ fn validate_initial_app_component(component: &AppComponentData) -> Result<(), En
     }
 }
 
+/// Validate every known component in a complete GroupContext dictionary.
+/// Unknown optional components remain opaque and are intentionally accepted.
+pub(crate) fn validate_app_component_dictionary(mls_group: &MlsGroup) -> Result<(), EngineError> {
+    let Some(dictionary) = mls_group.extensions().app_data_dictionary() else {
+        return Ok(());
+    };
+    for entry in dictionary.dictionary().entries() {
+        validate_app_component_bytes(entry.id(), entry.data())?;
+    }
+    Ok(())
+}
+
 pub(crate) fn validate_app_component_update(
     component: &AppComponentData,
 ) -> Result<(), EngineError> {
-    match component.component_id {
-        APP_COMPONENTS_COMPONENT_ID => decode_components_list(&component.data)
+    validate_app_component_bytes(component.component_id, &component.data)
+}
+
+fn validate_app_component_bytes(
+    component_id: AppComponentId,
+    data: &[u8],
+) -> Result<(), EngineError> {
+    match component_id {
+        APP_COMPONENTS_COMPONENT_ID => decode_components_list(data)
             .map(|_| ())
             .map_err(|e| EngineError::Serialize(format!("invalid app_components component: {e}"))),
         SAFE_AAD_COMPONENT_ID => Err(EngineError::Other(
             "safe_aad group-component state is not supported yet".into(),
         )),
-        GROUP_PROFILE_COMPONENT_ID => decode_group_profile(&component.data).map(|_| ()),
-        GROUP_ADMIN_POLICY_COMPONENT_ID => decode_admin_policy(&component.data).map(|_| ()),
-        NOSTR_ROUTING_COMPONENT_ID => decode_nostr_routing_v1(&component.data)
+        GROUP_PROFILE_COMPONENT_ID => decode_group_profile(data).map(|_| ()),
+        GROUP_ADMIN_POLICY_COMPONENT_ID => decode_admin_policy(data).map(|_| ()),
+        NOSTR_ROUTING_COMPONENT_ID => decode_nostr_routing_v1(data)
             .map(|_| ())
             .map_err(|e| EngineError::Serialize(format!("invalid Nostr routing component: {e}"))),
-        GROUP_BLOSSOM_IMAGE_COMPONENT_ID => validate_group_image(&component.data),
-        GROUP_AVATAR_URL_COMPONENT_ID => validate_group_avatar_url(&component.data),
-        GROUP_MESSAGE_RETENTION_COMPONENT_ID => validate_message_retention(&component.data),
-        AGENT_TEXT_STREAM_QUIC_COMPONENT_ID => validate_agent_text_stream_policy(&component.data),
-        GROUP_ENCRYPTED_MEDIA_COMPONENT_ID => validate_encrypted_media_policy(&component.data),
+        GROUP_BLOSSOM_IMAGE_COMPONENT_ID => validate_group_image(data),
+        GROUP_AVATAR_URL_COMPONENT_ID => validate_group_avatar_url(data),
+        GROUP_MESSAGE_RETENTION_COMPONENT_ID => validate_message_retention(data),
+        AGENT_TEXT_STREAM_QUIC_COMPONENT_ID => validate_agent_text_stream_policy(data),
+        GROUP_ENCRYPTED_MEDIA_COMPONENT_ID => validate_encrypted_media_policy(data),
         _ => Ok(()),
     }
 }

--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -6,10 +6,11 @@ use cgka_traits::app_components::{
     APP_COMPONENTS_COMPONENT_ID, AppComponentData, AppComponentId, AppComponentSet,
     GROUP_ADMIN_POLICY_COMPONENT_ID, GROUP_AVATAR_URL_COMPONENT_ID,
     GROUP_BLOSSOM_IMAGE_COMPONENT_ID, GROUP_ENCRYPTED_MEDIA_COMPONENT_ID,
-    GROUP_MESSAGE_RETENTION_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID, NOSTR_ROUTING_COMPONENT_ID,
-    NostrRoutingV1, SAFE_AAD_COMPONENT_ID, decode_components_list,
-    decode_encrypted_media_policy_v1, decode_group_avatar_url_v1, decode_nostr_routing_v1,
-    decode_quic_varint, encode_component_vectors, encode_components_list,
+    GROUP_MESSAGE_RETENTION_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID, GroupProfileV1,
+    NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1, SAFE_AAD_COMPONENT_ID, decode_components_list,
+    decode_encrypted_media_policy_v1, decode_group_avatar_url_v1, decode_group_blossom_image_v1,
+    decode_group_profile_v1, decode_nostr_routing_v1, decode_quic_varint, encode_component_vectors,
+    encode_components_list, encode_group_profile_v1,
 };
 use cgka_traits::engine::CommitOrderingPriority;
 use cgka_traits::error::EngineError;
@@ -129,19 +130,9 @@ pub(crate) fn group_profile_of_group(
 }
 
 pub(crate) fn decode_group_profile(bytes: &[u8]) -> Result<(String, String), EngineError> {
-    let mut cursor = bytes;
-    let name = decode_var_bytes(&mut cursor, 256, "profile name")?;
-    let description = decode_var_bytes(&mut cursor, 4096, "profile description")?;
-    if !cursor.is_empty() {
-        return Err(EngineError::Serialize(
-            "profile component has trailing bytes".into(),
-        ));
-    }
-    let name = String::from_utf8(name)
-        .map_err(|e| EngineError::Serialize(format!("profile name is not UTF-8: {e}")))?;
-    let description = String::from_utf8(description)
-        .map_err(|e| EngineError::Serialize(format!("profile description is not UTF-8: {e}")))?;
-    Ok((name, description))
+    let profile = decode_group_profile_v1(bytes)
+        .map_err(|e| EngineError::Serialize(format!("profile component decode failed: {e}")))?;
+    Ok((profile.name, profile.description))
 }
 
 pub(crate) fn admins_of_group(mls_group: &MlsGroup) -> Result<Vec<[u8; 32]>, EngineError> {
@@ -598,20 +589,11 @@ pub(crate) fn admin_pubkey_from_member_id(id: &MemberId) -> Result<[u8; 32], Eng
 }
 
 pub(crate) fn encode_group_profile(name: &str, description: &str) -> Result<Vec<u8>, EngineError> {
-    if name.len() > 256 {
-        return Err(EngineError::Other(
-            "group profile name must be at most 256 UTF-8 bytes".into(),
-        ));
-    }
-    if description.len() > 4096 {
-        return Err(EngineError::Other(
-            "group profile description must be at most 4096 UTF-8 bytes".into(),
-        ));
-    }
-    Ok(encode_component_vectors(&[
-        name.as_bytes(),
-        description.as_bytes(),
-    ]))
+    encode_group_profile_v1(&GroupProfileV1 {
+        name: name.to_owned(),
+        description: description.to_owned(),
+    })
+    .map_err(EngineError::Other)
 }
 
 pub(crate) fn encode_admin_policy(admins: &[[u8; 32]]) -> Result<Vec<u8>, EngineError> {
@@ -749,38 +731,9 @@ fn validate_group_avatar_url(bytes: &[u8]) -> Result<(), EngineError> {
 }
 
 fn validate_group_image(bytes: &[u8]) -> Result<(), EngineError> {
-    let mut cursor = bytes;
-    let image_hash = decode_var_bytes(&mut cursor, 32, "group image hash")?;
-    let image_key = decode_var_bytes(&mut cursor, 32, "group image key")?;
-    let image_nonce = decode_var_bytes(&mut cursor, 12, "group image nonce")?;
-    let image_upload_key = decode_var_bytes(&mut cursor, 32, "group image upload key")?;
-    let media_type = decode_var_bytes(&mut cursor, 128, "group image media type")?;
-    if !cursor.is_empty() {
-        return Err(EngineError::Serialize(
-            "group image component has trailing bytes".into(),
-        ));
-    }
-    let present = !image_hash.is_empty()
-        || !image_key.is_empty()
-        || !image_nonce.is_empty()
-        || !image_upload_key.is_empty()
-        || !media_type.is_empty();
-    if !present {
-        return Ok(());
-    }
-    if image_hash.len() != 32
-        || image_key.len() != 32
-        || image_nonce.len() != 12
-        || image_upload_key.len() != 32
-        || media_type.is_empty()
-    {
-        return Err(EngineError::Serialize(
-            "group image component has invalid partial state".into(),
-        ));
-    }
-    std::str::from_utf8(&media_type)
-        .map_err(|e| EngineError::Serialize(format!("group image media type is not UTF-8: {e}")))?;
-    Ok(())
+    decode_group_blossom_image_v1(bytes)
+        .map(|_| ())
+        .map_err(|e| EngineError::Serialize(format!("invalid group image component: {e}")))
 }
 
 /// Whether avatar/image component bytes encode a *present* avatar. An empty
@@ -994,6 +947,31 @@ mod tests {
 
         assert!(validate_initial_app_component(&component).is_err());
         assert!(validate_app_component_update(&component).is_err());
+    }
+
+    #[test]
+    fn blossom_image_requires_canonical_media_type() {
+        let component = |media_type: &[u8]| {
+            encode_component_vectors(&[&[1u8; 32], &[2u8; 32], &[3u8; 12], &[4u8; 32], media_type])
+        };
+
+        for canonical in [b"image/png".as_slice(), b"image/jpeg".as_slice()] {
+            validate_group_image(&component(canonical)).expect("canonical media type");
+        }
+        for non_canonical in [
+            b"Image/PNG".as_slice(),
+            b"image/png; charset=utf-8".as_slice(),
+            b"image/jpg".as_slice(),
+            b" image/png ".as_slice(),
+            b"image/png/extra".as_slice(),
+            b"image/(png)".as_slice(),
+        ] {
+            assert!(
+                validate_group_image(&component(non_canonical)).is_err(),
+                "non-canonical media type {:?} must be rejected",
+                String::from_utf8_lossy(non_canonical)
+            );
+        }
     }
 
     #[test]

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -655,7 +655,18 @@ impl<S: StorageProvider> Engine<S> {
                 // joining.md:65).
                 validate_member_credentials_and_account_proofs(&mls_group, self.ciphersuite)?;
 
-                // 5c. Reject active required capabilities this client cannot
+                // 5c. Validate every known GroupContext component before any
+                // joined state leaves this transaction. Commit ingest validates
+                // AppDataUpdate payloads, but a Welcome installs a complete
+                // dictionary without traversing that seam.
+                crate::app_components::validate_app_component_dictionary(&mls_group).map_err(
+                    |error| match error {
+                        storage @ EngineError::Storage(_) => storage,
+                        _ => EngineError::InvalidWelcome,
+                    },
+                )?;
+
+                // 5d. Reject active required capabilities this client cannot
                 // apply, including required agent-stream roles.
                 let mut group_required =
                     crate::capability_manager::required_capabilities_from_group(&mls_group);
@@ -676,10 +687,10 @@ impl<S: StorageProvider> Engine<S> {
                     });
                 }
 
-                // 5d. The authenticated Welcome sender must be an admin.
+                // 5e. The authenticated Welcome sender must be an admin.
                 crate::app_components::require_admin(&mls_group, &group_id, &welcome_sender_id)?;
 
-                // 5e. Every advertised admin must have a current member leaf.
+                // 5f. Every advertised admin must have a current member leaf.
                 crate::app_components::reject_admins_without_member_leaf(
                     &mls_group,
                     &group_id,
@@ -1054,15 +1065,20 @@ pub(crate) fn build_group_context_snapshot<S: StorageProvider>(
 }
 
 /// Mirror signed app-component state into the local app-facing group record.
-/// Missing profile state leaves the record's existing values unchanged.
 pub(crate) fn mirror_app_components_into_record(
     mls_group: &MlsGroup,
     record: &mut cgka_traits::group::Group,
 ) {
-    if let Ok(Some((name, description))) = crate::app_components::group_profile_of_group(mls_group)
-    {
-        record.name = name;
-        record.description = description;
+    match crate::app_components::group_profile_of_group(mls_group) {
+        Ok(Some((name, description))) => {
+            record.name = name;
+            record.description = description;
+        }
+        Ok(None) => {
+            record.name.clear();
+            record.description.clear();
+        }
+        Err(_) => {}
     }
     if let Ok(components) = crate::app_components::required_app_components_of_group(mls_group) {
         record.required_capabilities.app_components = components;

--- a/crates/cgka-engine/src/update_group_data.rs
+++ b/crates/cgka-engine/src/update_group_data.rs
@@ -19,6 +19,7 @@ use openmls::component::ComponentData;
 use openmls::group::MlsGroup;
 use openmls::messages::proposals::{AppDataUpdateOperation, AppDataUpdateProposal, Proposal};
 use openmls::prelude::{LeafNodeIndex, MlsMessageOut};
+use openmls_traits::OpenMlsProvider;
 use std::collections::BTreeSet;
 use tls_codec::Serialize as _;
 
@@ -35,11 +36,16 @@ impl<S: StorageProvider> Engine<S> {
             ));
         }
 
-        // A partial update must carry the other field forward exactly. Never
-        // turn a transient/corrupt storage read into an empty field that would
-        // be committed for every group member.
-        let current_group = self.storage.get_group(&group_id)?;
-        let current_profile = (current_group.name, current_group.description);
+        // A partial update must carry the other field forward from canonical
+        // MLS state. The local Group record is only a projection and can lag a
+        // component removal; using it here can resurrect removed profile data.
+        let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
+        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+        let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+            .map_err(|error| EngineError::Backend(format!("load group: {error:?}")))?
+            .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+        let current_profile =
+            crate::app_components::group_profile_of_group(&mls_group)?.unwrap_or_default();
         let projected_name = name.unwrap_or(current_profile.0);
         let projected_description = description.unwrap_or(current_profile.1);
         let profile_bytes =

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -6,7 +6,11 @@ use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::provider::EngineOpenMlsProvider;
 use cgka_engine::{DEFAULT_CIPHERSUITE, Engine, EngineBuilder};
 use cgka_traits::EngineError;
-use cgka_traits::app_components::GROUP_ADMIN_POLICY_COMPONENT_ID;
+use cgka_traits::app_components::{
+    AppComponentData, GROUP_ADMIN_POLICY_COMPONENT_ID, GROUP_AVATAR_URL_COMPONENT_ID,
+    GROUP_BLOSSOM_IMAGE_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID, NOSTR_ROUTING_COMPONENT_ID,
+    NostrRoutingV1, encode_component_vectors, encode_nostr_routing_v1,
+};
 use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, KeyPackage, SendIntent, SendResult};
@@ -364,6 +368,78 @@ fn welcome_from_fork_with_self_promoted_admin(
         timestamp: Timestamp(0),
         causal_deps: vec![],
         source: TransportSource("malicious-openmls".into()),
+        envelope: TransportEnvelope::Welcome {
+            recipient: recipient_id,
+        },
+    }
+}
+
+fn welcome_from_admin_with_component_update(
+    storage: &SqliteAccountStorage,
+    sender: &MemberId,
+    group_id: &GroupId,
+    invitee_key_package: &KeyPackage,
+    update: AppComponentData,
+) -> TransportMessage {
+    let crypto = RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mut mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load admin's MLS group")
+        .expect("admin created group");
+    let binding = storage
+        .account_device_signer(sender)
+        .expect("load signer binding")
+        .expect("signer binding exists");
+    let signer = SignatureKeyPair::read(
+        storage.mls_storage(),
+        &binding.mls_signature_public_key,
+        DEFAULT_CIPHERSUITE.signature_algorithm(),
+    )
+    .expect("MLS signer exists");
+    let invitee = clone_key_package_for_invite(invitee_key_package);
+    let recipient = BasicCredential::try_from(invitee.leaf_node().credential().clone())
+        .expect("invitee uses BasicCredential");
+    let recipient_id = MemberId::new(recipient.identity().to_vec());
+
+    let proposal = Proposal::AppDataUpdate(Box::new(AppDataUpdateProposal::update(
+        update.component_id,
+        update.data,
+    )));
+    let mut builder = mls_group
+        .commit_builder()
+        .propose_adds(std::iter::once(invitee))
+        .add_proposal(proposal)
+        .load_psks(provider.storage())
+        .expect("load PSKs");
+    let mut app_data = builder.app_data_dictionary_updater();
+    for proposal in builder.app_data_update_proposals() {
+        if let AppDataUpdateOperation::Update(data) = proposal.operation() {
+            app_data.set(ComponentData::from_parts(
+                proposal.component_id(),
+                data.clone(),
+            ));
+        }
+    }
+    builder.with_app_data_dictionary_updates(app_data.changes());
+    let welcome_msg = builder
+        .build(provider.rand(), provider.crypto(), &signer, |_| true)
+        .expect("build Add+AppDataUpdate commit")
+        .stage_commit(&provider)
+        .expect("stage Add+AppDataUpdate commit")
+        .into_welcome_msg()
+        .expect("an Add commit produces a Welcome");
+    let welcome_bytes = welcome_msg
+        .tls_serialize_detached()
+        .expect("serialize malformed-state Welcome");
+
+    TransportMessage {
+        id: hash_id(&welcome_bytes),
+        payload: welcome_bytes,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("malformed-component-welcome".into()),
         envelope: TransportEnvelope::Welcome {
             recipient: recipient_id,
         },
@@ -1565,6 +1641,99 @@ async fn join_rejects_welcome_authored_by_existing_non_admin() {
         matches!(err, EngineError::NotGroupAdmin { .. }),
         "expected NotGroupAdmin for non-admin Welcome signer, got {err:?}"
     );
+}
+
+#[tokio::test]
+async fn join_rejects_welcome_with_invalid_known_app_component_state() {
+    let blossom = encode_component_vectors(&[
+        &[0x11; 32],
+        &[0x22; 32],
+        &[0x33; 12],
+        &[0x44; 32],
+        b"IMAGE/PNG",
+    ]);
+    let mut routing = encode_nostr_routing_v1(
+        &NostrRoutingV1::new([0x55; 32], vec!["wss://relay.example".into()]).unwrap(),
+    )
+    .unwrap();
+    routing.push(0);
+
+    let invalid_components = [
+        (
+            "profile",
+            AppComponentData {
+                component_id: GROUP_PROFILE_COMPONENT_ID,
+                // A zero-length name encoded with a non-minimal two-byte QUIC varint.
+                data: vec![0x40, 0x00, 0x00],
+            },
+        ),
+        (
+            "blossom",
+            AppComponentData {
+                component_id: GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
+                // Structurally complete, but media type is not canonical lowercase.
+                data: blossom,
+            },
+        ),
+        (
+            "avatar",
+            AppComponentData {
+                component_id: GROUP_AVATAR_URL_COMPONENT_ID,
+                // The WHATWG serializer lowercases this host, so these stored bytes are noncanonical.
+                data: encode_component_vectors(&[b"https://EXAMPLE.com/avatar.png", &[], &[]]),
+            },
+        ),
+        (
+            "routing",
+            AppComponentData {
+                component_id: NOSTR_ROUTING_COMPONENT_ID,
+                // A canonical routing value followed by forbidden trailing bytes.
+                data: routing,
+            },
+        ),
+    ];
+
+    for (case, invalid_component) in invalid_components {
+        let (mut alice, alice_storage) = build_with_storage(b"welcome-component-admin");
+        let mut invitee = build_client(case.as_bytes());
+        let (group_id, created) = alice
+            .create_group(CreateGroupRequest {
+                name: "welcome component validation".into(),
+                description: "".into(),
+                members: vec![],
+                required_features: vec![],
+                app_components: vec![],
+                initial_admins: vec![],
+            })
+            .await
+            .unwrap();
+        let pending = match created {
+            SendResult::GroupCreated { pending, .. } => pending,
+            other => panic!("expected GroupCreated, got {other:?}"),
+        };
+        alice.confirm_published(pending).await.unwrap();
+
+        let invitee_kp = invitee.fresh_key_package().await.unwrap();
+        let welcome = welcome_from_admin_with_component_update(
+            &alice_storage,
+            &alice.self_id(),
+            &group_id,
+            &invitee_kp,
+            invalid_component,
+        );
+        let err = invitee
+            .join_welcome(welcome)
+            .await
+            .expect_err("invalid known component state must reject the Welcome");
+        assert!(
+            matches!(err, EngineError::InvalidWelcome),
+            "{case}: expected InvalidWelcome, got {err:?}"
+        );
+        assert!(
+            invitee.members(&group_id).is_err(),
+            "{case}: rejected Welcome must not persist joined state"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -17,9 +17,11 @@ use cgka_engine::provider::EngineOpenMlsProvider;
 use cgka_engine::{Engine, EngineBuilder};
 use cgka_traits::EngineError;
 use cgka_traits::app_components::{
-    AppComponentData, GROUP_ADMIN_POLICY_COMPONENT_ID, GROUP_AVATAR_URL_COMPONENT_ID,
-    GROUP_MESSAGE_RETENTION_COMPONENT_ID, GroupAvatarUrlV1, NOSTR_ROUTING_COMPONENT_ID,
-    NostrRoutingV1, default_group_components, encode_group_avatar_url_v1, encode_nostr_routing_v1,
+    APP_COMPONENTS_COMPONENT_ID, AppComponentData, GROUP_ADMIN_POLICY_COMPONENT_ID,
+    GROUP_AVATAR_URL_COMPONENT_ID, GROUP_MESSAGE_RETENTION_COMPONENT_ID,
+    GROUP_PROFILE_COMPONENT_ID, GroupAvatarUrlV1, NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1,
+    decode_components_list, decode_group_profile_v1, default_group_components,
+    encode_components_list, encode_group_avatar_url_v1, encode_nostr_routing_v1,
 };
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult};
@@ -492,6 +494,78 @@ fn malicious_app_component_commit(
             transport_group_id: group_id.as_slice().to_vec(),
         },
     }
+}
+
+fn remove_profile_from_live_group(
+    storage: &SqliteAccountStorage,
+    sender: &MemberId,
+    group_id: &GroupId,
+) {
+    let crypto = RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mut mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load sender MLS group")
+        .expect("sender created group");
+    let binding = storage
+        .account_device_signer(sender)
+        .expect("load signer binding")
+        .expect("signer binding exists");
+    let signer = SignatureKeyPair::read(
+        storage.mls_storage(),
+        &binding.mls_signature_public_key,
+        DEFAULT_CIPHERSUITE.signature_algorithm(),
+    )
+    .expect("MLS signer exists");
+
+    let current = mls_group
+        .extensions()
+        .app_data_dictionary()
+        .expect("group carries app_data_dictionary");
+    let mut required = current
+        .dictionary()
+        .get(&APP_COMPONENTS_COMPONENT_ID)
+        .map(|data| decode_components_list(data).unwrap())
+        .expect("group carries app_components");
+    required.remove(&GROUP_PROFILE_COMPONENT_ID);
+    let proposals = [
+        Proposal::AppDataUpdate(Box::new(AppDataUpdateProposal::update(
+            APP_COMPONENTS_COMPONENT_ID,
+            encode_components_list(&required),
+        ))),
+        Proposal::AppDataUpdate(Box::new(AppDataUpdateProposal::remove(
+            GROUP_PROFILE_COMPONENT_ID,
+        ))),
+    ];
+    let mut builder = mls_group.commit_builder();
+    for proposal in proposals {
+        builder = builder.add_proposal(proposal);
+    }
+    let mut builder = builder.load_psks(provider.storage()).expect("load PSKs");
+    let mut app_data = builder.app_data_dictionary_updater();
+    for proposal in builder.app_data_update_proposals() {
+        match proposal.operation() {
+            AppDataUpdateOperation::Update(data) => {
+                app_data.set(ComponentData::from_parts(
+                    proposal.component_id(),
+                    data.clone(),
+                ));
+            }
+            AppDataUpdateOperation::Remove => {
+                app_data.remove(&proposal.component_id());
+            }
+        }
+    }
+    builder.with_app_data_dictionary_updates(app_data.changes());
+    builder
+        .build(provider.rand(), provider.crypto(), &signer, |_| true)
+        .expect("profile removal commit builds")
+        .stage_commit(&provider)
+        .expect("profile removal commit stages");
+    mls_group
+        .merge_pending_commit(&provider)
+        .expect("profile removal commit merges");
 }
 
 async fn create_pair() -> (
@@ -1019,6 +1093,83 @@ async fn update_group_data_with_only_name_preserves_description() {
         )),
         "local rename must carry the previous group name, got: {events:?}",
     );
+}
+
+#[tokio::test]
+async fn partial_profile_update_after_absence_uses_empty_missing_field() {
+    for (identity, name, description, expected_name, expected_description) in [
+        (
+            b"name-after-absence".as_slice(),
+            Some("fresh name".to_owned()),
+            None,
+            "fresh name",
+            "",
+        ),
+        (
+            b"description-after-absence".as_slice(),
+            None,
+            Some("fresh description".to_owned()),
+            "",
+            "fresh description",
+        ),
+    ] {
+        let (mut alice, storage) = build_with_storage(identity);
+        let (group_id, created) = alice
+            .create_group(CreateGroupRequest {
+                name: "stale name".into(),
+                description: "stale description".into(),
+                members: vec![],
+                required_features: vec![],
+                app_components: vec![],
+                initial_admins: vec![],
+            })
+            .await
+            .unwrap();
+        let pending = match created {
+            SendResult::GroupCreated { pending, .. } => pending,
+            other => panic!("expected GroupCreated, got {other:?}"),
+        };
+        alice.confirm_published(pending).await.unwrap();
+
+        remove_profile_from_live_group(&storage, &alice.self_id(), &group_id);
+        drop(alice);
+        let mut alice = build_with_storage_and_peeler(identity, storage.clone(), mock_peeler());
+        assert_eq!(
+            alice
+                .app_component(&group_id, GROUP_PROFILE_COMPONENT_ID)
+                .unwrap(),
+            None,
+            "setup must have absent profile state"
+        );
+        // Reproduce the stale local projection that existed after profile removal.
+        // The replacement bytes must come from current MLS state, not these fields.
+        let mut stale_record = storage.get_group(&group_id).unwrap();
+        stale_record.name = "stale name".into();
+        stale_record.description = "stale description".into();
+        storage.put_group(&stale_record).unwrap();
+
+        let updated = alice
+            .send(SendIntent::UpdateGroupData {
+                group_id: group_id.clone(),
+                name,
+                description,
+            })
+            .await
+            .unwrap();
+        let pending = match updated {
+            SendResult::GroupEvolution { pending, .. } => pending,
+            other => panic!("expected GroupEvolution, got {other:?}"),
+        };
+        alice.confirm_published(pending).await.unwrap();
+
+        let profile_bytes = alice
+            .app_component(&group_id, GROUP_PROFILE_COMPONENT_ID)
+            .unwrap()
+            .expect("partial update installs a profile");
+        let profile = decode_group_profile_v1(&profile_bytes).unwrap();
+        assert_eq!(profile.name, expected_name);
+        assert_eq!(profile.description, expected_description);
+    }
 }
 
 // ── Rollback ────────────────────────────────────────────────────────────────

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -2586,6 +2586,50 @@ async fn update_group_data_during_pending_publish_is_rejected() {
     assert!(matches!(err, EngineError::InvalidTransition(_)));
 }
 
+#[tokio::test]
+async fn unrelated_profile_update_preserves_unknown_optional_component_bytes() {
+    const UNKNOWN_OPTIONAL_COMPONENT_ID: u16 = 0xf400;
+    let unknown_bytes = vec![0xff, 0x00, 0x80, 0x01, 0x7f];
+    let (mut alice, _bob, gid) = create_pair().await;
+
+    let add_unknown = alice
+        .send(SendIntent::UpdateAppComponents {
+            group_id: gid.clone(),
+            updates: vec![AppComponentData {
+                component_id: UNKNOWN_OPTIONAL_COMPONENT_ID,
+                data: unknown_bytes.clone(),
+            }],
+        })
+        .await
+        .unwrap();
+    let pending = match add_unknown {
+        SendResult::GroupEvolution { pending, .. } => pending,
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+
+    let rename = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: gid.clone(),
+            name: Some("renamed".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let pending = match rename {
+        SendResult::GroupEvolution { pending, .. } => pending,
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+
+    assert_eq!(
+        alice
+            .app_component(&gid, UNKNOWN_OPTIONAL_COMPONENT_ID)
+            .unwrap(),
+        Some(unknown_bytes)
+    );
+}
+
 // ── #105 group avatar-url component ──────────────────────────────────────────
 
 #[tokio::test]
@@ -2593,8 +2637,8 @@ async fn valid_group_avatar_url_component_is_accepted_and_stored() {
     let (mut alice, _bob, gid) = create_pair().await;
     let data = encode_group_avatar_url_v1(&GroupAvatarUrlV1 {
         url: "https://cdn.example.com/avatar.png".to_owned(),
-        dim: Some("512x512".to_owned()),
-        thumbhash: None,
+        dim: b"512x512".to_vec(),
+        thumbhash: Vec::new(),
     })
     .unwrap();
 

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1781,6 +1781,7 @@ impl AppClient {
         let projection = EventGroupProjection {
             nostr_routing,
             group_metadata: group_metadata.as_ref(),
+            profile: self.profile_for_group(group_id),
             admin_policy: self.admin_policy_for_group(group_id),
             message_retention: self.message_retention_for_group(group_id),
             agent_text_stream: self.agent_text_stream_for_group(group_id),

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -2,7 +2,7 @@ use cgka_traits::GroupId;
 use cgka_traits::app_components::{
     AGENT_TEXT_STREAM_QUIC_COMPONENT_ID, GROUP_AVATAR_URL_COMPONENT_ID,
     GROUP_BLOSSOM_IMAGE_COMPONENT_ID, GROUP_ENCRYPTED_MEDIA_COMPONENT_ID,
-    GROUP_MESSAGE_RETENTION_COMPONENT_ID, NOSTR_ROUTING_COMPONENT_ID,
+    GROUP_MESSAGE_RETENTION_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID, NOSTR_ROUTING_COMPONENT_ID,
 };
 use cgka_traits::app_event::{
     MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_DELETE, MarmotAppEvent as MarmotInnerEvent,
@@ -12,8 +12,8 @@ use crate::groups::{EventGroupProjection, GroupConfirmationProjection, add_group
 use crate::{
     AppAgentTextStreamComponent, AppError, AppGroupAdminPolicyComponent,
     AppGroupAvatarUrlComponent, AppGroupEncryptedMediaComponent, AppGroupImageInput,
-    AppGroupMessageRetentionComponent, AppGroupNostrRoutingComponent, AppGroupRecord,
-    AppMessageProjection, SecureDeleteExpiredResult, unix_now_seconds,
+    AppGroupMessageRetentionComponent, AppGroupNostrRoutingComponent, AppGroupProfileComponent,
+    AppGroupRecord, AppMessageProjection, SecureDeleteExpiredResult, unix_now_seconds,
 };
 
 use super::AppClient;
@@ -124,6 +124,7 @@ impl AppClient {
         let projection = EventGroupProjection {
             nostr_routing,
             group_metadata: group_metadata.as_ref(),
+            profile: self.profile_for_group(group_id),
             admin_policy: self.admin_policy_for_group(group_id),
             message_retention: self.message_retention_for_group(group_id),
             agent_text_stream: self.agent_text_stream_for_group(group_id),
@@ -146,6 +147,7 @@ impl AppClient {
         let projection = EventGroupProjection {
             nostr_routing,
             group_metadata: group_metadata.as_ref(),
+            profile: self.profile_for_group(group_id),
             admin_policy: self.admin_policy_for_group(group_id),
             message_retention: self.message_retention_for_group(group_id),
             agent_text_stream: self.agent_text_stream_for_group(group_id),
@@ -183,6 +185,15 @@ impl AppClient {
             self.add_group(group_id)?;
         }
         Ok(!missing.is_empty())
+    }
+
+    pub(crate) fn profile_for_group(&self, group_id: &GroupId) -> AppGroupProfileComponent {
+        self.runtime
+            .app_component(group_id, GROUP_PROFILE_COMPONENT_ID)
+            .ok()
+            .flatten()
+            .map(|bytes| AppGroupProfileComponent::from_bytes(&bytes))
+            .unwrap_or_else(AppGroupProfileComponent::absent)
     }
 
     pub(crate) fn admin_policy_for_group(

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -169,6 +169,7 @@ impl AppClient {
         Some(EventGroupProjection {
             nostr_routing,
             group_metadata: None,
+            profile: self.profile_for_group(group_id),
             admin_policy: self
                 .runtime
                 .admin_pubkeys(group_id)
@@ -482,6 +483,7 @@ impl AppClient {
                     Ok::<_, AppError>(EventGroupProjection {
                         nostr_routing: self.nostr_routing_for_group(group_id)?,
                         group_metadata: group_metadata.as_ref(),
+                        profile: self.profile_for_group(group_id),
                         admin_policy: self
                             .runtime
                             .admin_pubkeys(group_id)

--- a/crates/marmot-app/src/conversions.rs
+++ b/crates/marmot-app/src/conversions.rs
@@ -11,8 +11,9 @@ use crate::{
     AGENT_TEXT_STREAM_COMPONENT_ID, AccountState, AppAgentTextStreamComponent,
     AppGroupAdminPolicyComponent, AppGroupAvatarUrlComponent, AppGroupEncryptedMediaComponent,
     AppGroupImageInput, AppGroupMessageRetentionComponent, AppGroupNostrRoutingComponent,
-    AppGroupProfileComponent, AppGroupRecord, AppMessageProjection, AppMessageRecord,
-    AuditLogSettings, ChatNotificationSettings, GROUP_AVATAR_URL_COMPONENT_ID,
+    AppGroupOpaqueComponent, AppGroupProfileComponent, AppGroupRecord, AppMessageProjection,
+    AppMessageRecord, AuditLogSettings, ChatNotificationSettings, GROUP_ADMIN_POLICY_COMPONENT_ID,
+    GROUP_AVATAR_URL_COMPONENT_ID, GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
     GROUP_ENCRYPTED_MEDIA_COMPONENT_ID, GROUP_MESSAGE_RETENTION_COMPONENT_ID,
     GROUP_PROFILE_COMPONENT_ID, GroupPushTokenRecord, NOSTR_ROUTING_COMPONENT_ID,
     NotificationSettings, PushPlatform, PushRegistration, RelayTelemetrySettings,
@@ -129,12 +130,33 @@ pub(crate) fn stored_components_from_app_group(
             component_data_hex: group.encrypted_media.data_hex.clone(),
         });
     }
+    components.extend(
+        group
+            .unknown_components
+            .iter()
+            .filter(|component| !is_projected_group_component(component.component_id))
+            .map(|component| StoredAccountGroupComponent {
+                component_id: component.component_id,
+                component_name: component.component.clone(),
+                component_data_hex: component.data_hex.clone(),
+            }),
+    );
     components
 }
 
 pub(crate) fn app_group_from_stored_group(
     stored: StoredAccountGroup,
 ) -> Result<AppGroupRecord, AppError> {
+    let unknown_components = stored
+        .components
+        .iter()
+        .filter(|component| !is_projected_group_component(component.component_id))
+        .map(|component| AppGroupOpaqueComponent {
+            component_id: component.component_id,
+            component: component.component_name.clone(),
+            data_hex: component.component_data_hex.clone(),
+        })
+        .collect();
     let routing_bytes = hex::decode(
         account_component_data_hex(&stored.components, NOSTR_ROUTING_COMPONENT_ID).ok_or_else(
             || AppError::InvalidNostrRouting("stored group is missing routing".into()),
@@ -194,7 +216,22 @@ pub(crate) fn app_group_from_stored_group(
     group.self_membership = stored.self_membership;
     group.welcomer_account_id_hex = stored.welcomer_account_id_hex;
     group.via_welcome_message_id_hex = stored.via_welcome_message_id_hex;
+    group.unknown_components = unknown_components;
     Ok(group)
+}
+
+fn is_projected_group_component(component_id: u16) -> bool {
+    matches!(
+        component_id,
+        GROUP_PROFILE_COMPONENT_ID
+            | GROUP_BLOSSOM_IMAGE_COMPONENT_ID
+            | GROUP_ADMIN_POLICY_COMPONENT_ID
+            | NOSTR_ROUTING_COMPONENT_ID
+            | GROUP_MESSAGE_RETENTION_COMPONENT_ID
+            | AGENT_TEXT_STREAM_COMPONENT_ID
+            | GROUP_AVATAR_URL_COMPONENT_ID
+            | GROUP_ENCRYPTED_MEDIA_COMPONENT_ID
+    )
 }
 
 pub(crate) fn account_component_data_hex(

--- a/crates/marmot-app/src/conversions.rs
+++ b/crates/marmot-app/src/conversions.rs
@@ -11,9 +11,10 @@ use crate::{
     AGENT_TEXT_STREAM_COMPONENT_ID, AccountState, AppAgentTextStreamComponent,
     AppGroupAdminPolicyComponent, AppGroupAvatarUrlComponent, AppGroupEncryptedMediaComponent,
     AppGroupImageInput, AppGroupMessageRetentionComponent, AppGroupNostrRoutingComponent,
-    AppGroupRecord, AppMessageProjection, AppMessageRecord, AuditLogSettings,
-    ChatNotificationSettings, GROUP_AVATAR_URL_COMPONENT_ID, GROUP_ENCRYPTED_MEDIA_COMPONENT_ID,
-    GROUP_MESSAGE_RETENTION_COMPONENT_ID, GroupPushTokenRecord, NOSTR_ROUTING_COMPONENT_ID,
+    AppGroupProfileComponent, AppGroupRecord, AppMessageProjection, AppMessageRecord,
+    AuditLogSettings, ChatNotificationSettings, GROUP_AVATAR_URL_COMPONENT_ID,
+    GROUP_ENCRYPTED_MEDIA_COMPONENT_ID, GROUP_MESSAGE_RETENTION_COMPONENT_ID,
+    GROUP_PROFILE_COMPONENT_ID, GroupPushTokenRecord, NOSTR_ROUTING_COMPONENT_ID,
     NotificationSettings, PushPlatform, PushRegistration, RelayTelemetrySettings,
 };
 use storage_sqlite::{
@@ -77,12 +78,15 @@ pub(crate) fn stored_group_from_app_group(group: &AppGroupRecord) -> StoredAccou
 pub(crate) fn stored_components_from_app_group(
     group: &AppGroupRecord,
 ) -> Vec<StoredAccountGroupComponent> {
-    let mut components = vec![
-        StoredAccountGroupComponent {
+    let mut components = Vec::new();
+    if group.profile.present {
+        components.push(StoredAccountGroupComponent {
             component_id: group.profile.component_id,
             component_name: group.profile.component.clone(),
             component_data_hex: group.profile.data_hex.clone(),
-        },
+        });
+    }
+    components.extend([
         StoredAccountGroupComponent {
             component_id: group.image.component_id,
             component_name: group.image.component.clone(),
@@ -103,7 +107,7 @@ pub(crate) fn stored_components_from_app_group(
             component_name: group.nostr_routing.component.clone(),
             component_data_hex: group.nostr_routing.data_hex.clone(),
         },
-    ];
+    ]);
     if group.agent_text_stream.required {
         components.push(StoredAccountGroupComponent {
             component_id: group.agent_text_stream.component_id,
@@ -136,6 +140,9 @@ pub(crate) fn app_group_from_stored_group(
             || AppError::InvalidNostrRouting("stored group is missing routing".into()),
         )?,
     )?;
+    let profile_bytes = account_component_data_hex(&stored.components, GROUP_PROFILE_COMPONENT_ID)
+        .map(hex::decode)
+        .transpose()?;
     let retention =
         account_component_data_hex(&stored.components, GROUP_MESSAGE_RETENTION_COMPONENT_ID)
             .map(hex::decode)
@@ -157,6 +164,10 @@ pub(crate) fn app_group_from_stored_group(
         AppGroupAdminPolicyComponent::new(parse_admin_keys_hex(&stored.admin_keys_hex)),
         retention,
     );
+    group.profile = profile_bytes
+        .as_deref()
+        .map(AppGroupProfileComponent::from_bytes)
+        .unwrap_or_else(AppGroupProfileComponent::absent);
     if let Some(agent_hex) =
         account_component_data_hex(&stored.components, AGENT_TEXT_STREAM_COMPONENT_ID)
         && !agent_hex.is_empty()

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -49,6 +49,10 @@ pub struct AppGroupRecord {
     pub agent_text_stream: AppAgentTextStreamComponent,
     #[serde(default)]
     pub encrypted_media: AppGroupEncryptedMediaComponent,
+    /// Unknown optional app-component records retained byte-for-byte across
+    /// projection loads and unrelated saves.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unknown_components: Vec<AppGroupOpaqueComponent>,
     #[serde(default)]
     pub archived: bool,
     #[serde(default)]
@@ -61,6 +65,25 @@ pub struct AppGroupRecord {
     pub welcomer_account_id_hex: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub via_welcome_message_id_hex: Option<String>,
+}
+
+/// Opaque app-component state that this app version does not interpret.
+/// `data_hex` may contain sensitive MLS-protected state, so Debug redacts it.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AppGroupOpaqueComponent {
+    pub component_id: u16,
+    pub component: String,
+    pub data_hex: String,
+}
+
+impl std::fmt::Debug for AppGroupOpaqueComponent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppGroupOpaqueComponent")
+            .field("component_id", &self.component_id)
+            .field("component", &self.component)
+            .field("data_hex", &"<redacted>")
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -331,6 +354,7 @@ impl AppGroupRecord {
             message_retention,
             agent_text_stream: AppAgentTextStreamComponent::disabled(),
             encrypted_media: AppGroupEncryptedMediaComponent::disabled(),
+            unknown_components: Vec::new(),
             archived: false,
             pending_confirmation: false,
             self_membership: SelfMembership::Member,

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -11,10 +11,11 @@ use cgka_traits::app_components::{
     GROUP_BLOSSOM_IMAGE_COMPONENT_ID, GROUP_ENCRYPTED_MEDIA_COMPONENT,
     GROUP_ENCRYPTED_MEDIA_COMPONENT_ID, GROUP_MESSAGE_RETENTION_COMPONENT,
     GROUP_MESSAGE_RETENTION_COMPONENT_ID, GROUP_PROFILE_COMPONENT, GROUP_PROFILE_COMPONENT_ID,
-    GroupAvatarUrlV1, NOSTR_ROUTING_COMPONENT, NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1,
-    decode_encrypted_media_policy_v1, decode_group_avatar_url_v1, decode_nostr_routing_v1,
-    decode_quic_varint, encode_component_vectors, encode_encrypted_media_policy_v1,
-    encode_group_avatar_url_v1, encode_nostr_routing_v1, encode_quic_varint,
+    GroupAvatarUrlV1, GroupProfileV1, NOSTR_ROUTING_COMPONENT, NOSTR_ROUTING_COMPONENT_ID,
+    NostrRoutingV1, decode_encrypted_media_policy_v1, decode_group_avatar_url_v1,
+    decode_group_profile_v1, decode_nostr_routing_v1, decode_quic_varint, encode_component_vectors,
+    encode_encrypted_media_policy_v1, encode_group_avatar_url_v1, encode_nostr_routing_v1,
+    encode_quic_varint,
 };
 use cgka_traits::app_event::{
     GROUP_SYSTEM_DATA_ACTOR, GROUP_SYSTEM_DATA_NAME, GROUP_SYSTEM_DATA_NEW_RETENTION_SECONDS,
@@ -170,10 +171,16 @@ pub struct AppQuarantinedGroup {
     pub reason: AppGroupHydrationQuarantineReason,
 }
 
+fn profile_present_by_default() -> bool {
+    true
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AppGroupProfileComponent {
     pub component_id: u16,
     pub component: String,
+    #[serde(default = "profile_present_by_default")]
+    pub present: bool,
     pub name: String,
     pub description: String,
     pub data_hex: String,
@@ -372,10 +379,7 @@ impl AppGroupRecord {
         self.avatar_url = projection.avatar_url.clone();
         self.encrypted_media = projection.encrypted_media.clone();
         self.image = AppGroupImageComponent::new(projection.image.clone());
-        if let Some(group) = projection.group_metadata {
-            self.profile =
-                AppGroupProfileComponent::new(group.name.clone(), group.description.clone());
-        }
+        self.profile = projection.profile.clone();
     }
 
     pub(crate) fn apply_confirmation_state(&mut self, state: GroupConfirmationProjection) {
@@ -417,9 +421,39 @@ impl AppGroupProfileComponent {
         Self {
             component_id: GROUP_PROFILE_COMPONENT_ID,
             component: GROUP_PROFILE_COMPONENT.to_owned(),
+            present: true,
             name,
             description,
             data_hex: hex::encode(data),
+        }
+    }
+
+    pub(crate) fn absent() -> Self {
+        Self {
+            component_id: GROUP_PROFILE_COMPONENT_ID,
+            component: GROUP_PROFILE_COMPONENT.to_owned(),
+            present: false,
+            name: String::new(),
+            description: String::new(),
+            data_hex: String::new(),
+        }
+    }
+
+    pub(crate) fn from_bytes(bytes: &[u8]) -> Self {
+        match decode_group_profile_v1(bytes) {
+            Ok(GroupProfileV1 { name, description }) => {
+                let mut profile = Self::new(name, description);
+                profile.data_hex = hex::encode(bytes);
+                profile
+            }
+            Err(_) => Self {
+                component_id: GROUP_PROFILE_COMPONENT_ID,
+                component: GROUP_PROFILE_COMPONENT.to_owned(),
+                present: true,
+                name: String::new(),
+                description: String::new(),
+                data_hex: hex::encode(bytes),
+            },
         }
     }
 }
@@ -466,8 +500,8 @@ impl AppGroupAvatarUrlComponent {
     ) -> Result<Self, AppError> {
         let avatar = GroupAvatarUrlV1 {
             url,
-            dim,
-            thumbhash,
+            dim: dim.map(String::into_bytes).unwrap_or_default(),
+            thumbhash: thumbhash.map(String::into_bytes).unwrap_or_default(),
         };
         let data = encode_group_avatar_url_v1(&avatar).map_err(AppError::InvalidGroupAvatarUrl)?;
         // Decode the encoded bytes back so the struct fields carry the normalized
@@ -500,13 +534,20 @@ impl AppGroupAvatarUrlComponent {
     }
 
     fn from_decoded(avatar: GroupAvatarUrlV1, data: Vec<u8>) -> Self {
+        let GroupAvatarUrlV1 {
+            url,
+            dim,
+            thumbhash,
+        } = avatar;
         Self {
             component_id: GROUP_AVATAR_URL_COMPONENT_ID,
             component: GROUP_AVATAR_URL_COMPONENT.to_owned(),
-            present: !avatar.url.is_empty(),
-            url: avatar.url,
-            dim: avatar.dim,
-            thumbhash: avatar.thumbhash,
+            present: !url.is_empty(),
+            url,
+            dim: String::from_utf8(dim).ok().filter(|hint| !hint.is_empty()),
+            thumbhash: String::from_utf8(thumbhash)
+                .ok()
+                .filter(|hint| !hint.is_empty()),
             data_hex: hex::encode(data),
         }
     }
@@ -818,6 +859,7 @@ fn read_component_vector(cursor: &mut &[u8]) -> Option<Vec<u8>> {
 pub(crate) struct EventGroupProjection<'a> {
     pub(crate) nostr_routing: AppGroupNostrRoutingComponent,
     pub(crate) group_metadata: Option<&'a Group>,
+    pub(crate) profile: AppGroupProfileComponent,
     pub(crate) admin_policy: AppGroupAdminPolicyComponent,
     pub(crate) message_retention: AppGroupMessageRetentionComponent,
     pub(crate) agent_text_stream: AppAgentTextStreamComponent,
@@ -1175,6 +1217,7 @@ pub(crate) fn add_group(
         projection.encrypted_media.clone(),
         projection.image.clone(),
     );
+    group.profile = projection.profile.clone();
     group.apply_confirmation_state(confirmation);
     state.groups.push(group);
 }

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -133,8 +133,9 @@ pub use groups::{
     AppAgentTextStreamComponent, AppBlobEndpoint, AppGroupAdminPolicyComponent,
     AppGroupAvatarUrlComponent, AppGroupEncryptedMediaComponent, AppGroupHydrationQuarantineReason,
     AppGroupImageComponent, AppGroupMemberRecord, AppGroupMessageRetentionComponent,
-    AppGroupMlsState, AppGroupNostrRoutingComponent, AppGroupProfileComponent, AppGroupRecord,
-    AppGroupSystemEvent, AppQuarantinedGroup, group_system_event_from_message,
+    AppGroupMlsState, AppGroupNostrRoutingComponent, AppGroupOpaqueComponent,
+    AppGroupProfileComponent, AppGroupRecord, AppGroupSystemEvent, AppQuarantinedGroup,
+    group_system_event_from_message,
 };
 pub use ids::{
     account_id_hex_from_ref, nprofile_for_account_id, npub_for_account_id, validate_relay_urls,

--- a/crates/marmot-app/src/media/group_image.rs
+++ b/crates/marmot-app/src/media/group_image.rs
@@ -5,12 +5,17 @@ use rand::rngs::OsRng;
 use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
 
+use cgka_traits::app_components::canonicalize_marmot_media_type;
+
 use super::DEFAULT_BLOSSOM_SERVER_URL;
 use super::blossom::{blossom_blob_url, fetch_blossom_blob, upload_blossom_blob};
-use super::crypto::canonical_media_type;
 use crate::AppError;
 
 const GROUP_IMAGE_VERSION: &str = "marmot-group-image-v1";
+
+fn canonical_group_image_media_type(value: &str) -> Result<String, AppError> {
+    canonicalize_marmot_media_type(value).map_err(AppError::InvalidEncryptedMedia)
+}
 
 /// Result of encrypting + uploading a group avatar. Maps directly onto the
 /// `marmot.group.blossom.image.v1` component fields. Unlike message media, the
@@ -54,12 +59,8 @@ pub(crate) async fn upload_group_image(
             "group image cannot be empty".into(),
         ));
     }
-    let media_type = canonical_media_type(media_type)?;
-    if media_type.len() > 128 {
-        return Err(AppError::InvalidEncryptedMedia(
-            "group image media type must be at most 128 bytes".into(),
-        ));
-    }
+    let media_type = canonical_group_image_media_type(media_type)?;
+
     let mut content_key = Zeroizing::new([0_u8; 32]);
     OsRng.fill_bytes(content_key.as_mut());
     let mut nonce = [0_u8; 12];
@@ -105,7 +106,7 @@ pub(crate) async fn fetch_group_image(
     media_type: &str,
     server: Option<&str>,
 ) -> Result<Vec<u8>, AppError> {
-    let media_type = canonical_media_type(media_type)?;
+    let media_type = canonical_group_image_media_type(media_type)?;
     let content_key: Zeroizing<[u8; 32]> = Zeroizing::new(
         Zeroizing::new(hex::decode(image_key_hex)?)
             .as_slice()

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1145,6 +1145,36 @@ fn empty_follow_fetch_preserves_cached_edges() {
 }
 
 #[test]
+fn profile_presence_round_trips_through_account_projection() {
+    let mut group = AppGroupRecord::new(
+        "aa".to_owned(),
+        AppGroupNostrRoutingComponent::new(
+            NostrRoutingV1::new([0xAA; 32], vec!["wss://relay.example".to_owned()]).unwrap(),
+        )
+        .unwrap(),
+        String::new(),
+        String::new(),
+        AppGroupImageInput::default(),
+        AppGroupAdminPolicyComponent::new(Vec::new()),
+        AppGroupMessageRetentionComponent::disabled(),
+    );
+
+    assert!(group.profile.present);
+    assert_eq!(group.profile.data_hex, "0000");
+    let restored_present =
+        app_group_from_stored_group(stored_group_from_app_group(&group)).unwrap();
+    assert!(restored_present.profile.present);
+    assert_eq!(restored_present.profile.data_hex, "0000");
+
+    group.profile = AppGroupProfileComponent::absent();
+    let restored_absent = app_group_from_stored_group(stored_group_from_app_group(&group)).unwrap();
+    assert!(!restored_absent.profile.present);
+    assert!(restored_absent.profile.data_hex.is_empty());
+    assert_eq!(restored_absent.profile.name, "");
+    assert_eq!(restored_absent.profile.description, "");
+}
+
+#[test]
 fn avatar_url_round_trips_through_account_projection() {
     let mut group = AppGroupRecord::new(
         "aa".to_owned(),

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -11,7 +11,7 @@ use cgka_traits::app_event::{
     STREAM_TAG, STREAM_TYPE_TAG,
 };
 use marmot_account::AccountHomeError;
-use storage_sqlite::StoredRelayTelemetrySettings;
+use storage_sqlite::{StoredAccountGroupComponent, StoredRelayTelemetrySettings};
 use transport_quic_broker::BrokerServerTrust;
 
 use crate::audit_log::AUDIT_ID_BYTES;
@@ -1172,6 +1172,36 @@ fn profile_presence_round_trips_through_account_projection() {
     assert!(restored_absent.profile.data_hex.is_empty());
     assert_eq!(restored_absent.profile.name, "");
     assert_eq!(restored_absent.profile.description, "");
+}
+
+#[test]
+fn unknown_optional_component_round_trips_through_account_projection() {
+    let group = AppGroupRecord::new(
+        "aa".to_owned(),
+        AppGroupNostrRoutingComponent::new(
+            NostrRoutingV1::new([0xAA; 32], vec!["wss://relay.example".to_owned()]).unwrap(),
+        )
+        .unwrap(),
+        "group".to_owned(),
+        String::new(),
+        AppGroupImageInput::default(),
+        AppGroupAdminPolicyComponent::new(Vec::new()),
+        AppGroupMessageRetentionComponent::disabled(),
+    );
+    let unknown = StoredAccountGroupComponent {
+        component_id: 0xf400,
+        component_name: "unknown.optional.component".to_owned(),
+        component_data_hex: "ff0080017f".to_owned(),
+    };
+    let mut stored = stored_group_from_app_group(&group);
+    stored.components.push(unknown.clone());
+
+    let restored = app_group_from_stored_group(stored).unwrap();
+    let resaved = stored_group_from_app_group(&restored);
+    assert!(
+        resaved.components.contains(&unknown),
+        "projection saves must preserve unknown optional component bytes"
+    );
 }
 
 #[test]

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -17,6 +17,9 @@ use crate::errors::MarmotKitError;
 pub struct AppGroupRecordFfi {
     pub group_id_hex: String,
     pub endpoint: String,
+    /// Whether `marmot.group.profile.v1` is present. A present profile may still
+    /// carry empty `name` and `description` fields.
+    pub profile_present: bool,
     pub name: String,
     pub description: String,
     pub admins: Vec<String>,
@@ -44,11 +47,13 @@ pub struct AppGroupRecordFfi {
     pub via_welcome_message_id_hex: Option<String>,
 }
 
+fn profile_ffi_fields(profile: AppGroupProfileComponent) -> (bool, String, String) {
+    (profile.present, profile.name, profile.description)
+}
+
 impl From<AppGroupRecord> for AppGroupRecordFfi {
     fn from(value: AppGroupRecord) -> Self {
-        let AppGroupProfileComponent {
-            name, description, ..
-        } = value.profile;
+        let (profile_present, name, description) = profile_ffi_fields(value.profile);
         let AppGroupAdminPolicyComponent { admins, .. } = value.admin_policy;
         let AppGroupNostrRoutingComponent {
             nostr_group_id_hex,
@@ -60,6 +65,7 @@ impl From<AppGroupRecord> for AppGroupRecordFfi {
         Self {
             group_id_hex: value.group_id_hex,
             endpoint: value.endpoint,
+            profile_present,
             name,
             description,
             admins,
@@ -396,5 +402,37 @@ impl From<AppQuarantinedGroup> for AppQuarantinedGroupFfi {
             group_id_hex: value.group_id_hex,
             reason: value.reason.into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod profile_presence_tests {
+    use super::*;
+
+    fn profile(present: bool) -> AppGroupProfileComponent {
+        AppGroupProfileComponent {
+            component_id: 0x8001,
+            component: "marmot.group.profile.v1".to_owned(),
+            present,
+            name: String::new(),
+            description: String::new(),
+            data_hex: if present {
+                "0000".to_owned()
+            } else {
+                String::new()
+            },
+        }
+    }
+
+    #[test]
+    fn ffi_profile_fields_distinguish_absent_from_present_empty() {
+        assert_eq!(
+            profile_ffi_fields(profile(false)),
+            (false, String::new(), String::new())
+        );
+        assert_eq!(
+            profile_ffi_fields(profile(true)),
+            (true, String::new(), String::new())
+        );
     }
 }

--- a/crates/marmot-uniffi/src/conversions/mod.rs
+++ b/crates/marmot-uniffi/src/conversions/mod.rs
@@ -63,6 +63,7 @@ mod tests {
         AppGroupRecordFfi {
             group_id_hex: "01".repeat(32),
             endpoint: "marmot:group:01".into(),
+            profile_present: true,
             name: "Test".into(),
             description: String::new(),
             admins: admins.into_iter().map(ToOwned::to_owned).collect(),

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -123,8 +123,8 @@ fn setup_store() -> SqliteAccountStorage {
 fn avatar_url_component(url: &str) -> StoredAccountGroupComponent {
     let bytes = encode_group_avatar_url_v1(&GroupAvatarUrlV1 {
         url: url.to_owned(),
-        dim: None,
-        thumbhash: None,
+        dim: Vec::new(),
+        thumbhash: Vec::new(),
     })
     .unwrap();
     StoredAccountGroupComponent {

--- a/crates/traits/AGENTS.md
+++ b/crates/traits/AGENTS.md
@@ -42,6 +42,8 @@ OpenMLS appears only where the storage aggregate needs the OpenMLS storage trait
 | `src/app_components/codec.rs` | QUIC-varint / var-bytes primitives and the `ComponentsList` encoder. |
 | `src/app_components/host_safety.rs` | Canonical public-IP / loopback host classifiers shared by app-component URL policy and media SSRF guards. |
 | `src/app_components/routing.rs` | `NostrRoutingV1` state and codec. |
+| `src/app_components/profile.rs` | `GroupProfileV1` state and codec. |
+| `src/app_components/blossom_image.rs` | `GroupBlossomImageV1` state, codec, and media-type canonicalization. |
 | `src/app_components/encrypted_media.rs` | `EncryptedMediaPolicyV1` / `BlobStoreEndpointV1` state, codec, and endpoint-URL validation. |
 | `src/app_components/avatar_url.rs` | `GroupAvatarUrlV1` state, codec, and avatar-URL validation. |
 | `src/app_event.rs` | Typed `MarmotAppEvent` application-message event and sender-validation errors. |

--- a/crates/traits/src/app_components/avatar_url.rs
+++ b/crates/traits/src/app_components/avatar_url.rs
@@ -1,46 +1,45 @@
 //! `marmot.group.avatar-url.v1` component state and codec.
 
-use url::{Host, Url};
+use url::Url;
 
 use super::codec::{decode_var_bytes, encode_var_bytes};
-use super::host_safety::{is_loopback_host, reject_non_routable_ipv4, reject_non_routable_ipv6};
 use super::{GROUP_AVATAR_HINT_MAX_LEN, GROUP_AVATAR_URL_MAX_LEN};
 
 /// Decoded `marmot.group.avatar-url.v1` state. An absent avatar is an empty `url`.
+/// Render hints stay as opaque bytes so decoding and re-encoding never rewrites
+/// or drops a valid hint that an application cannot interpret.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct GroupAvatarUrlV1 {
     pub url: String,
-    pub dim: Option<String>,
-    pub thumbhash: Option<String>,
+    pub dim: Vec<u8>,
+    pub thumbhash: Vec<u8>,
 }
 
 /// Encode `marmot.group.avatar-url.v1` state. The URL is validated and normalized;
 /// an empty `url` encodes the absent/cleared avatar (all fields empty).
 pub fn encode_group_avatar_url_v1(avatar: &GroupAvatarUrlV1) -> Result<Vec<u8>, String> {
-    if avatar.url.is_empty() && (avatar.dim.is_some() || avatar.thumbhash.is_some()) {
+    if avatar.url.is_empty() && (!avatar.dim.is_empty() || !avatar.thumbhash.is_empty()) {
         return Err("group avatar absent state must not include hints".into());
+    }
+    if avatar.dim.len() > GROUP_AVATAR_HINT_MAX_LEN {
+        return Err(format!(
+            "group avatar dim exceeds {GROUP_AVATAR_HINT_MAX_LEN} bytes"
+        ));
+    }
+    if avatar.thumbhash.len() > GROUP_AVATAR_HINT_MAX_LEN {
+        return Err(format!(
+            "group avatar thumbhash exceeds {GROUP_AVATAR_HINT_MAX_LEN} bytes"
+        ));
     }
     let url = if avatar.url.is_empty() {
         String::new()
     } else {
         validate_and_normalize_group_avatar_url(&avatar.url)?
     };
-    let dim = avatar.dim.as_deref().unwrap_or("");
-    let thumbhash = avatar.thumbhash.as_deref().unwrap_or("");
-    if dim.len() > GROUP_AVATAR_HINT_MAX_LEN {
-        return Err(format!(
-            "group avatar dim exceeds {GROUP_AVATAR_HINT_MAX_LEN} bytes"
-        ));
-    }
-    if thumbhash.len() > GROUP_AVATAR_HINT_MAX_LEN {
-        return Err(format!(
-            "group avatar thumbhash exceeds {GROUP_AVATAR_HINT_MAX_LEN} bytes"
-        ));
-    }
-    let mut out = Vec::with_capacity(url.len() + dim.len() + thumbhash.len() + 6);
+    let mut out = Vec::with_capacity(url.len() + avatar.dim.len() + avatar.thumbhash.len() + 6);
     encode_var_bytes(url.as_bytes(), &mut out);
-    encode_var_bytes(dim.as_bytes(), &mut out);
-    encode_var_bytes(thumbhash.as_bytes(), &mut out);
+    encode_var_bytes(&avatar.dim, &mut out);
+    encode_var_bytes(&avatar.thumbhash, &mut out);
     Ok(out)
 }
 
@@ -69,29 +68,18 @@ pub fn decode_group_avatar_url_v1(bytes: &[u8]) -> Result<GroupAvatarUrlV1, Stri
             return Err("group avatar URL is not normalized".into());
         }
     }
-    // `dim` and `thumbhash` are opaque length-bounded hints: a decoder validates
-    // only their length (done above by decode_var_bytes) and interprets the bytes
-    // as UTF-8 only for rendering. A non-UTF-8 hint is treated as ABSENT and MUST
-    // NOT invalidate otherwise-valid state (spec/app-components/group-avatar-url-v1.md
-    // and spec/foundation/canonical-encoding.md, "opaque hints"). Rejecting it
-    // here would make the same commit accepted by some clients and not others.
+    // `dim` and `thumbhash` are opaque length-bounded hints. Preserve their exact
+    // bytes here; interpretation belongs at the application rendering boundary.
     Ok(GroupAvatarUrlV1 {
         url,
-        dim: if dim.is_empty() {
-            None
-        } else {
-            String::from_utf8(dim).ok()
-        },
-        thumbhash: if thumbhash.is_empty() {
-            None
-        } else {
-            String::from_utf8(thumbhash).ok()
-        },
+        dim,
+        thumbhash,
     })
 }
 
 /// Validate and normalize a group avatar URL: `https` only, length-bounded, no
-/// credentials or fragment, and not pointing at localhost or a non-routable IP.
+/// credentials or fragment. Destination contact safety is local application
+/// policy and deliberately does not affect component validity.
 /// Returns the normalized URL string.
 pub fn validate_and_normalize_group_avatar_url(raw: &str) -> Result<String, String> {
     if raw.is_empty() {
@@ -112,15 +100,7 @@ pub fn validate_and_normalize_group_avatar_url(raw: &str) -> Result<String, Stri
     if url.fragment().is_some() {
         return Err("group avatar URL must not include a fragment".into());
     }
-    let host = url.host().ok_or("group avatar URL must include a host")?;
-    if is_loopback_host(host.clone()) {
-        return Err("group avatar URL must not point at localhost".into());
-    }
-    match host {
-        Host::Domain(_) => {}
-        Host::Ipv4(addr) => reject_non_routable_ipv4(addr)?,
-        Host::Ipv6(addr) => reject_non_routable_ipv6(addr)?,
-    }
+    url.host().ok_or("group avatar URL must include a host")?;
     let normalized = url.as_str();
     if normalized.len() > GROUP_AVATAR_URL_MAX_LEN {
         return Err(format!(

--- a/crates/traits/src/app_components/blossom_image.rs
+++ b/crates/traits/src/app_components/blossom_image.rs
@@ -1,0 +1,168 @@
+//! `marmot.group.blossom.image.v1` component state and codec.
+
+use super::codec::{decode_var_bytes, encode_component_vectors};
+
+const IMAGE_HASH_LEN: usize = 32;
+const IMAGE_KEY_LEN: usize = 32;
+const IMAGE_NONCE_LEN: usize = 12;
+const IMAGE_UPLOAD_KEY_LEN: usize = 32;
+const MEDIA_TYPE_MAX_LEN: usize = 128;
+
+/// Decoded `marmot.group.blossom.image.v1` state.
+///
+/// The key fields are MLS-protected secret material. The custom `Debug` implementation
+/// deliberately redacts them.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct GroupBlossomImageV1 {
+    pub image_hash: Vec<u8>,
+    pub image_key: Vec<u8>,
+    pub image_nonce: Vec<u8>,
+    pub image_upload_key: Vec<u8>,
+    pub media_type: String,
+}
+
+impl std::fmt::Debug for GroupBlossomImageV1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GroupBlossomImageV1")
+            .field("image_hash", &"<redacted>")
+            .field("image_key", &"<redacted>")
+            .field("image_nonce", &"<redacted>")
+            .field("image_upload_key", &"<redacted>")
+            .field("media_type", &self.media_type)
+            .finish()
+    }
+}
+
+impl GroupBlossomImageV1 {
+    pub fn is_present(&self) -> bool {
+        !self.image_hash.is_empty()
+            || !self.image_key.is_empty()
+            || !self.image_nonce.is_empty()
+            || !self.image_upload_key.is_empty()
+            || !self.media_type.is_empty()
+    }
+}
+
+/// Encode group Blossom image state. Present-state media types are normalized with
+/// the frozen Marmot media-type algorithm before encoding.
+pub fn encode_group_blossom_image_v1(image: &GroupBlossomImageV1) -> Result<Vec<u8>, String> {
+    if !image.is_present() {
+        return Ok(encode_component_vectors(&[&[], &[], &[], &[], &[]]));
+    }
+    let media_type = validate_group_blossom_image_fields(image)?;
+    Ok(encode_component_vectors(&[
+        &image.image_hash,
+        &image.image_key,
+        &image.image_nonce,
+        &image.image_upload_key,
+        media_type.as_bytes(),
+    ]))
+}
+
+/// Decode group Blossom image state and reject non-canonical media-type bytes.
+pub fn decode_group_blossom_image_v1(bytes: &[u8]) -> Result<GroupBlossomImageV1, String> {
+    let mut cursor = bytes;
+    let image_hash = decode_var_bytes(&mut cursor, IMAGE_HASH_LEN, "group image hash")?;
+    let image_key = decode_var_bytes(&mut cursor, IMAGE_KEY_LEN, "group image key")?;
+    let image_nonce = decode_var_bytes(&mut cursor, IMAGE_NONCE_LEN, "group image nonce")?;
+    let image_upload_key =
+        decode_var_bytes(&mut cursor, IMAGE_UPLOAD_KEY_LEN, "group image upload key")?;
+    let media_type = decode_var_bytes(&mut cursor, MEDIA_TYPE_MAX_LEN, "group image media type")?;
+    if !cursor.is_empty() {
+        return Err("group image component has trailing bytes".into());
+    }
+    let media_type = String::from_utf8(media_type)
+        .map_err(|e| format!("group image media type is not UTF-8: {e}"))?;
+    let image = GroupBlossomImageV1 {
+        image_hash,
+        image_key,
+        image_nonce,
+        image_upload_key,
+        media_type,
+    };
+    if !image.is_present() {
+        return Ok(image);
+    }
+    let canonical = validate_group_blossom_image_fields(&image)?;
+    if canonical != image.media_type {
+        return Err("group image media type is not canonical".into());
+    }
+    Ok(image)
+}
+
+fn validate_group_blossom_image_fields(image: &GroupBlossomImageV1) -> Result<String, String> {
+    if image.image_hash.len() != IMAGE_HASH_LEN
+        || image.image_key.len() != IMAGE_KEY_LEN
+        || image.image_nonce.len() != IMAGE_NONCE_LEN
+        || image.image_upload_key.len() != IMAGE_UPLOAD_KEY_LEN
+        || image.media_type.is_empty()
+    {
+        return Err("group image component has invalid partial state".into());
+    }
+    canonicalize_marmot_media_type(&image.media_type)
+}
+
+/// Apply the frozen Marmot media-type canonicalization algorithm.
+pub fn canonicalize_marmot_media_type(value: &str) -> Result<String, String> {
+    let bytes = value.as_bytes();
+    let parameter_start = bytes
+        .iter()
+        .position(|byte| *byte == b';')
+        .unwrap_or(bytes.len());
+    let mut media_type = &bytes[..parameter_start];
+    while media_type
+        .first()
+        .is_some_and(|byte| is_marmot_ascii_whitespace(*byte))
+    {
+        media_type = &media_type[1..];
+    }
+    while media_type
+        .last()
+        .is_some_and(|byte| is_marmot_ascii_whitespace(*byte))
+    {
+        media_type = &media_type[..media_type.len() - 1];
+    }
+
+    let mut slash = None;
+    for (index, byte) in media_type.iter().enumerate() {
+        if *byte == b'/' && slash.replace(index).is_some() {
+            return Err("media type must contain exactly one slash".into());
+        }
+    }
+    let slash = slash.ok_or("media type must contain exactly one slash")?;
+    let type_bytes = &media_type[..slash];
+    let subtype_bytes = &media_type[slash + 1..];
+    if type_bytes.is_empty() || subtype_bytes.is_empty() {
+        return Err("media type and subtype must be non-empty".into());
+    }
+    if type_bytes.len() > 64 || subtype_bytes.len() > 64 || media_type.len() > MEDIA_TYPE_MAX_LEN {
+        return Err("media type exceeds Marmot length bounds".into());
+    }
+    if !type_bytes
+        .iter()
+        .chain(subtype_bytes)
+        .all(|byte| is_http_token_byte(*byte))
+    {
+        return Err("media type contains an invalid token byte".into());
+    }
+
+    let canonical = media_type
+        .iter()
+        .map(u8::to_ascii_lowercase)
+        .collect::<Vec<_>>();
+    let canonical = String::from_utf8(canonical)
+        .map_err(|_| "media type must contain only ASCII token bytes".to_owned())?;
+    Ok(if canonical == "image/jpg" {
+        "image/jpeg".to_owned()
+    } else {
+        canonical
+    })
+}
+
+fn is_marmot_ascii_whitespace(byte: u8) -> bool {
+    matches!(byte, b'\t' | b'\n' | 0x0c | b'\r' | b' ')
+}
+
+fn is_http_token_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || b"!#$%&'*+-.^_`|~".contains(&byte)
+}

--- a/crates/traits/src/app_components/mod.rs
+++ b/crates/traits/src/app_components/mod.rs
@@ -10,8 +10,8 @@
 //! - [`codec`]: QUIC-varint / var-bytes primitives and the `ComponentsList`
 //!   encoder,
 //! - [`host_safety`]: public-IP / loopback host classifiers,
-//! - per-schema component state and codecs: [`routing`], [`encrypted_media`],
-//!   and [`avatar_url`].
+//! - per-schema component state and codecs: [`routing`], [`profile`],
+//!   [`blossom_image`], [`encrypted_media`], and [`avatar_url`].
 //!
 //! Everything public is re-exported here, so every `cgka_traits::app_components::*`
 //! path is unchanged.
@@ -20,9 +20,11 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
 mod avatar_url;
+mod blossom_image;
 mod codec;
 mod encrypted_media;
 mod host_safety;
+mod profile;
 mod routing;
 
 #[cfg(test)]
@@ -31,6 +33,10 @@ mod tests;
 pub use avatar_url::{
     GroupAvatarUrlV1, decode_group_avatar_url_v1, encode_group_avatar_url_v1,
     validate_and_normalize_group_avatar_url,
+};
+pub use blossom_image::{
+    GroupBlossomImageV1, canonicalize_marmot_media_type, decode_group_blossom_image_v1,
+    encode_group_blossom_image_v1,
 };
 pub use codec::{
     decode_components_list, decode_quic_varint, encode_component_vectors, encode_components_list,
@@ -44,7 +50,14 @@ pub use host_safety::{
     is_loopback_candidate_host, is_loopback_host, is_loopback_ip, is_public_ip, is_public_ipv4,
     is_public_ipv6, reject_non_public_ip, reject_non_public_socket_addr,
 };
-pub use routing::{NostrRoutingV1, decode_nostr_routing_v1, encode_nostr_routing_v1};
+pub use profile::{
+    GROUP_PROFILE_DESCRIPTION_MAX_LEN, GROUP_PROFILE_NAME_MAX_LEN, GroupProfileV1,
+    decode_group_profile_v1, encode_group_profile_v1,
+};
+pub use routing::{
+    NOSTR_RELAY_URL_MAX_LEN, NOSTR_ROUTING_MAX_RELAYS, NostrRoutingV1, decode_nostr_routing_v1,
+    encode_nostr_routing_v1,
+};
 
 /// MLS ComponentID.
 pub type AppComponentId = u16;

--- a/crates/traits/src/app_components/profile.rs
+++ b/crates/traits/src/app_components/profile.rs
@@ -1,0 +1,54 @@
+//! `marmot.group.profile.v1` component state and codec.
+
+use serde::{Deserialize, Serialize};
+
+use super::codec::{decode_var_bytes, encode_component_vectors};
+
+pub const GROUP_PROFILE_NAME_MAX_LEN: usize = 256;
+pub const GROUP_PROFILE_DESCRIPTION_MAX_LEN: usize = 4096;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GroupProfileV1 {
+    pub name: String,
+    pub description: String,
+}
+
+pub fn encode_group_profile_v1(profile: &GroupProfileV1) -> Result<Vec<u8>, String> {
+    if profile.name.len() > GROUP_PROFILE_NAME_MAX_LEN {
+        return Err(format!(
+            "group profile name exceeds {GROUP_PROFILE_NAME_MAX_LEN} bytes"
+        ));
+    }
+    if profile.description.len() > GROUP_PROFILE_DESCRIPTION_MAX_LEN {
+        return Err(format!(
+            "group profile description exceeds {GROUP_PROFILE_DESCRIPTION_MAX_LEN} bytes"
+        ));
+    }
+    Ok(encode_component_vectors(&[
+        profile.name.as_bytes(),
+        profile.description.as_bytes(),
+    ]))
+}
+
+pub fn decode_group_profile_v1(bytes: &[u8]) -> Result<GroupProfileV1, String> {
+    let mut cursor = bytes;
+    let name = decode_var_bytes(
+        &mut cursor,
+        GROUP_PROFILE_NAME_MAX_LEN,
+        "group profile name",
+    )?;
+    let description = decode_var_bytes(
+        &mut cursor,
+        GROUP_PROFILE_DESCRIPTION_MAX_LEN,
+        "group profile description",
+    )?;
+    if !cursor.is_empty() {
+        return Err("group profile component has trailing bytes".into());
+    }
+    Ok(GroupProfileV1 {
+        name: String::from_utf8(name)
+            .map_err(|e| format!("group profile name is not UTF-8: {e}"))?,
+        description: String::from_utf8(description)
+            .map_err(|e| format!("group profile description is not UTF-8: {e}"))?,
+    })
+}

--- a/crates/traits/src/app_components/routing.rs
+++ b/crates/traits/src/app_components/routing.rs
@@ -5,6 +5,10 @@ use url::Url;
 
 use super::codec::{decode_var_bytes, encode_quic_varint};
 
+pub const NOSTR_ROUTING_MAX_RELAYS: usize = 16;
+pub const NOSTR_RELAY_URL_MAX_LEN: usize = 512;
+const NOSTR_RELAY_VECTOR_MAX_LEN: usize = NOSTR_ROUTING_MAX_RELAYS * (NOSTR_RELAY_URL_MAX_LEN + 2);
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NostrRoutingV1 {
     pub nostr_group_id: [u8; 32],
@@ -13,14 +17,16 @@ pub struct NostrRoutingV1 {
 
 impl NostrRoutingV1 {
     pub fn new(nostr_group_id: [u8; 32], mut relays: Vec<String>) -> Result<Self, String> {
+        validate_nostr_relay_count(relays.len())?;
+        for relay in &relays {
+            validate_nostr_relay_url(relay)?;
+        }
         relays.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
         relays.dedup();
-        let value = Self {
+        Ok(Self {
             nostr_group_id,
             relays,
-        };
-        validate_nostr_routing(&value)?;
-        Ok(value)
+        })
     }
 }
 
@@ -46,14 +52,27 @@ pub fn decode_nostr_routing_v1(bytes: &[u8]) -> Result<NostrRoutingV1, String> {
     let mut nostr_group_id = [0_u8; 32];
     nostr_group_id.copy_from_slice(&bytes[..32]);
     let mut cursor = &bytes[32..];
-    let relay_vector = decode_var_bytes(&mut cursor, usize::MAX, "Nostr relay vector")?;
+    let relay_vector = decode_var_bytes(
+        &mut cursor,
+        NOSTR_RELAY_VECTOR_MAX_LEN,
+        "Nostr relay vector",
+    )?;
     if !cursor.is_empty() {
         return Err("Nostr routing component has trailing bytes".into());
     }
     let mut relay_cursor = relay_vector.as_slice();
     let mut relays = Vec::new();
     while !relay_cursor.is_empty() {
-        let relay = decode_var_bytes(&mut relay_cursor, 512, "Nostr relay URL")?;
+        if relays.len() == NOSTR_ROUTING_MAX_RELAYS {
+            return Err(format!(
+                "Nostr routing component must contain at most {NOSTR_ROUTING_MAX_RELAYS} relays"
+            ));
+        }
+        let relay = decode_var_bytes(
+            &mut relay_cursor,
+            NOSTR_RELAY_URL_MAX_LEN,
+            "Nostr relay URL",
+        )?;
         if relay.is_empty() {
             return Err("Nostr relay URL must not be empty".into());
         }
@@ -70,9 +89,7 @@ pub fn decode_nostr_routing_v1(bytes: &[u8]) -> Result<NostrRoutingV1, String> {
 }
 
 fn validate_nostr_routing(routing: &NostrRoutingV1) -> Result<(), String> {
-    if routing.relays.is_empty() {
-        return Err("Nostr routing component must contain at least one relay".into());
-    }
+    validate_nostr_relay_count(routing.relays.len())?;
     let mut sorted = routing.relays.clone();
     sorted.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
     sorted.dedup();
@@ -85,12 +102,26 @@ fn validate_nostr_routing(routing: &NostrRoutingV1) -> Result<(), String> {
     Ok(())
 }
 
+fn validate_nostr_relay_count(count: usize) -> Result<(), String> {
+    if count == 0 {
+        return Err("Nostr routing component must contain at least one relay".into());
+    }
+    if count > NOSTR_ROUTING_MAX_RELAYS {
+        return Err(format!(
+            "Nostr routing component must contain at most {NOSTR_ROUTING_MAX_RELAYS} relays"
+        ));
+    }
+    Ok(())
+}
+
 fn validate_nostr_relay_url(relay: &str) -> Result<(), String> {
     if relay.is_empty() {
         return Err("Nostr relay URL must not be empty".into());
     }
-    if relay.len() > 512 {
-        return Err("Nostr relay URL exceeds 512 bytes".into());
+    if relay.len() > NOSTR_RELAY_URL_MAX_LEN {
+        return Err(format!(
+            "Nostr relay URL exceeds {NOSTR_RELAY_URL_MAX_LEN} bytes"
+        ));
     }
     let url = Url::parse(relay).map_err(|e| format!("Nostr relay URL is invalid: {e}"))?;
     if !matches!(url.scheme(), "wss" | "ws") {

--- a/crates/traits/src/app_components/tests.rs
+++ b/crates/traits/src/app_components/tests.rs
@@ -83,6 +83,194 @@ fn nostr_routing_keeps_plaintext_relays_structurally_representable() {
 }
 
 #[test]
+fn nostr_routing_enforces_relay_count_boundaries() {
+    assert!(NostrRoutingV1::new([0x42; 32], Vec::new()).is_err());
+    let mut zero_encoded = vec![0x42; 32];
+    encode_var_bytes(&[], &mut zero_encoded);
+    assert_eq!(
+        decode_nostr_routing_v1(&zero_encoded),
+        Err("Nostr routing component must contain at least one relay".into())
+    );
+
+    let sixteen = (0..16)
+        .map(|index| format!("wss://relay-{index:02}.example"))
+        .collect();
+    let sixteen = NostrRoutingV1::new([0x42; 32], sixteen).unwrap();
+    assert_eq!(
+        decode_nostr_routing_v1(&encode_nostr_routing_v1(&sixteen).unwrap()).unwrap(),
+        sixteen
+    );
+
+    let seventeen = (0..17)
+        .map(|index| format!("wss://relay-{index:02}.example"))
+        .collect();
+    assert_eq!(
+        NostrRoutingV1::new([0x42; 32], seventeen),
+        Err("Nostr routing component must contain at most 16 relays".into())
+    );
+    assert_eq!(
+        NostrRoutingV1::new(
+            [0x42; 32],
+            vec!["wss://relay.example".to_owned(); NOSTR_ROUTING_MAX_RELAYS + 1],
+        ),
+        Err("Nostr routing component must contain at most 16 relays".into()),
+        "known oversize input must be rejected before sorting or deduplication"
+    );
+
+    let mut seventeen_encoded = vec![0x42; 32];
+    let mut relay_vector = Vec::new();
+    for index in 0..17 {
+        encode_var_bytes(
+            format!("wss://relay-{index:02}.example").as_bytes(),
+            &mut relay_vector,
+        );
+    }
+    encode_var_bytes(&relay_vector, &mut seventeen_encoded);
+    assert_eq!(
+        decode_nostr_routing_v1(&seventeen_encoded),
+        Err("Nostr routing component must contain at most 16 relays".into())
+    );
+}
+
+#[test]
+fn nostr_routing_rejects_oversized_relay_vector_before_reading_body() {
+    let mut bytes = vec![0x42; 32];
+    encode_quic_varint(8_225, &mut bytes);
+    assert_eq!(
+        decode_nostr_routing_v1(&bytes),
+        Err("Nostr relay vector exceeds maximum length".into())
+    );
+}
+
+#[test]
+fn group_profile_golden_distinguishes_absent_from_present_empty() {
+    let absent: Option<GroupProfileV1> = None;
+    let present_empty = GroupProfileV1 {
+        name: String::new(),
+        description: String::new(),
+    };
+    let encoded = encode_group_profile_v1(&present_empty).unwrap();
+
+    assert!(absent.is_none());
+    assert_eq!(encoded, vec![0x00, 0x00]);
+    assert_eq!(decode_group_profile_v1(&encoded).unwrap(), present_empty);
+}
+
+#[test]
+fn group_profile_codec_preserves_utf8_bytes_without_unicode_normalization() {
+    let composed = GroupProfileV1 {
+        name: "é".to_owned(),
+        description: String::new(),
+    };
+    let decomposed = GroupProfileV1 {
+        name: "e\u{301}".to_owned(),
+        description: String::new(),
+    };
+    let composed_bytes = encode_group_profile_v1(&composed).unwrap();
+    let decomposed_bytes = encode_group_profile_v1(&decomposed).unwrap();
+
+    assert_ne!(composed_bytes, decomposed_bytes);
+    assert_eq!(decode_group_profile_v1(&composed_bytes).unwrap(), composed);
+    assert_eq!(
+        decode_group_profile_v1(&decomposed_bytes).unwrap(),
+        decomposed
+    );
+}
+
+#[test]
+fn group_profile_codec_rejects_oversized_length_before_reading_body() {
+    let mut bytes = Vec::new();
+    encode_quic_varint(257, &mut bytes);
+    assert_eq!(
+        decode_group_profile_v1(&bytes),
+        Err("group profile name exceeds maximum length".into())
+    );
+}
+
+#[test]
+fn blossom_image_codec_canonicalizes_on_encode_and_rejects_non_canonical_decode() {
+    let image = GroupBlossomImageV1 {
+        image_hash: vec![1; 32],
+        image_key: vec![2; 32],
+        image_nonce: vec![3; 12],
+        image_upload_key: vec![4; 32],
+        media_type: " Image/JPG; charset=utf-8 ".to_owned(),
+    };
+    let encoded = encode_group_blossom_image_v1(&image).unwrap();
+    let decoded = decode_group_blossom_image_v1(&encoded).unwrap();
+    assert_eq!(decoded.media_type, "image/jpeg");
+
+    let non_canonical =
+        encode_component_vectors(&[&[1; 32], &[2; 32], &[3; 12], &[4; 32], b"image/jpg"]);
+    assert_eq!(
+        decode_group_blossom_image_v1(&non_canonical),
+        Err("group image media type is not canonical".into())
+    );
+}
+
+#[test]
+fn marmot_media_type_algorithm_matches_frozen_boundaries() {
+    for (input, expected) in [
+        ("image/png", "image/png"),
+        ("\t Image/JPG \r; charset=utf-8", "image/jpeg"),
+        ("application/vnd.marmot+json", "application/vnd.marmot+json"),
+        ("x!#$%&'*+-.^_`|~/y", "x!#$%&'*+-.^_`|~/y"),
+    ] {
+        assert_eq!(
+            canonicalize_marmot_media_type(input),
+            Ok(expected.to_owned())
+        );
+    }
+
+    let type_too_long = format!("{}/x", "a".repeat(65));
+    for invalid in [
+        "image",
+        "image/png/extra",
+        "/png",
+        "image/",
+        "image/(png)",
+        "image/π",
+        "\u{000b}image/png",
+        type_too_long.as_str(),
+    ] {
+        assert!(
+            canonicalize_marmot_media_type(invalid).is_err(),
+            "invalid media type {invalid:?} must be rejected"
+        );
+    }
+}
+
+#[test]
+fn blossom_image_codec_rejects_oversized_length_before_reading_body() {
+    let mut bytes = Vec::new();
+    encode_quic_varint(33, &mut bytes);
+    assert_eq!(
+        decode_group_blossom_image_v1(&bytes),
+        Err("group image hash exceeds maximum length".into())
+    );
+}
+
+#[test]
+fn blossom_image_debug_redacts_cryptographic_fields() {
+    let image = GroupBlossomImageV1 {
+        image_hash: vec![222; 32],
+        image_key: vec![223; 32],
+        image_nonce: vec![224; 12],
+        image_upload_key: vec![225; 32],
+        media_type: "image/png".to_owned(),
+    };
+
+    let debug = format!("{image:?}");
+    for byte in [222, 223, 224, 225] {
+        assert!(
+            !debug.contains(&byte.to_string()),
+            "cryptographic byte {byte} leaked through Debug: {debug}"
+        );
+    }
+    assert!(debug.contains("image/png"));
+}
+
+#[test]
 fn encrypted_media_policy_round_trips_ordered_endpoints() {
     let policy = EncryptedMediaPolicyV1::blossom_default(
         vec![
@@ -371,42 +559,19 @@ fn encrypted_media_policy_decode_rejects_non_canonical_media_format() {
 }
 
 #[test]
-fn group_avatar_url_rejects_documentation_ipv6_ranges() {
-    // 2001:db8::/32 is the spec-required documentation range; 3fff::/20 is the
-    // newer RFC 9637 documentation range.
+fn group_avatar_url_validity_does_not_apply_contact_safety_policy() {
     for raw in [
-        "https://[2001:db8::1]/a.png",
-        "https://[2001:db8:abcd:12::1]/a.png",
-        "https://[3fff::1]/a.png",
-        "https://[3fff:0fff::1]/a.png",
+        "https://localhost/avatar.png",
+        "https://127.0.0.1/avatar.png",
+        "https://10.0.0.1/avatar.png",
+        "https://[::1]/avatar.png",
+        "https://[2001:db8::1]/avatar.png",
     ] {
         assert!(
-            validate_and_normalize_group_avatar_url(raw).is_err(),
-            "{raw} should be rejected"
+            validate_and_normalize_group_avatar_url(raw).is_ok(),
+            "component validity must not reject locally unsafe destination {raw}"
         );
     }
-    // Addresses immediately outside 3fff::/20 and other global-unicast IPv6
-    // addresses remain accepted.
-    assert!(validate_and_normalize_group_avatar_url("https://[3ffe::1]/a.png").is_ok());
-    assert!(validate_and_normalize_group_avatar_url("https://[3fff:1000::1]/a.png").is_ok());
-    assert!(validate_and_normalize_group_avatar_url("https://[2606:4700::1]/a.png").is_ok());
-}
-
-#[test]
-fn group_avatar_url_rejects_iana_special_purpose_ipv6_pool() {
-    for raw in [
-        "https://[2001:1::1]/a.png",
-        "https://[2001:2::1]/a.png",
-        "https://[2001:4:112::1]/a.png",
-        "https://[2001:20::1]/a.png",
-        "https://[2001:1ff:ffff::1]/a.png",
-    ] {
-        assert!(
-            validate_and_normalize_group_avatar_url(raw).is_err(),
-            "{raw} should be rejected"
-        );
-    }
-    assert!(validate_and_normalize_group_avatar_url("https://[2001:200::1]/a.png").is_ok());
 }
 
 #[test]
@@ -423,6 +588,29 @@ fn nostr_routing_rejects_non_canonical_relay_list() {
         encode_nostr_routing_v1(&routing),
         Err("Nostr relay URLs must be sorted and unique".into())
     );
+}
+
+#[test]
+fn nostr_routing_decode_rejects_duplicate_and_out_of_order_relays() {
+    let encoded = |relays: &[&str]| {
+        let mut relay_vector = Vec::new();
+        for relay in relays {
+            encode_var_bytes(relay.as_bytes(), &mut relay_vector);
+        }
+        let mut bytes = vec![0x42; 32];
+        encode_var_bytes(&relay_vector, &mut bytes);
+        bytes
+    };
+
+    for relays in [
+        ["wss://relay.example", "wss://relay.example"],
+        ["wss://relay-b.example", "wss://relay-a.example"],
+    ] {
+        assert_eq!(
+            decode_nostr_routing_v1(&encoded(&relays)),
+            Err("Nostr relay URLs must be sorted and unique".into())
+        );
+    }
 }
 
 #[test]
@@ -448,8 +636,8 @@ fn nostr_routing_rejects_invalid_relay_urls() {
 fn group_avatar_url_round_trips_all_fields() {
     let avatar = GroupAvatarUrlV1 {
         url: "https://cdn.example.com/avatar.png".to_owned(),
-        dim: Some("512x512".to_owned()),
-        thumbhash: Some("abc123".to_owned()),
+        dim: b"512x512".to_vec(),
+        thumbhash: b"abc123".to_vec(),
     };
     let bytes = encode_group_avatar_url_v1(&avatar).unwrap();
     assert_eq!(decode_group_avatar_url_v1(&bytes).unwrap(), avatar);
@@ -459,8 +647,8 @@ fn group_avatar_url_round_trips_all_fields() {
 fn group_avatar_url_round_trips_url_only() {
     let avatar = GroupAvatarUrlV1 {
         url: "https://cdn.example.com/avatar.png".to_owned(),
-        dim: None,
-        thumbhash: None,
+        dim: Vec::new(),
+        thumbhash: Vec::new(),
     };
     let bytes = encode_group_avatar_url_v1(&avatar).unwrap();
     assert_eq!(decode_group_avatar_url_v1(&bytes).unwrap(), avatar);
@@ -477,8 +665,8 @@ fn group_avatar_url_empty_state_round_trips_as_absent() {
 fn group_avatar_url_absent_state_rejects_hints() {
     let absent_with_hint = GroupAvatarUrlV1 {
         url: String::new(),
-        dim: Some("512x512".to_owned()),
-        thumbhash: None,
+        dim: b"512x512".to_vec(),
+        thumbhash: Vec::new(),
     };
 
     assert!(encode_group_avatar_url_v1(&absent_with_hint).is_err());
@@ -490,42 +678,6 @@ fn group_avatar_url_requires_https() {
         "http://cdn.example.com/a.png",
         "ftp://cdn.example.com/a.png",
         "ws://cdn.example.com/a.png",
-    ] {
-        assert!(
-            validate_and_normalize_group_avatar_url(raw).is_err(),
-            "{raw} should be rejected"
-        );
-    }
-}
-
-#[test]
-fn group_avatar_url_rejects_localhost_and_non_routable_hosts() {
-    for raw in [
-        "https://localhost/a.png",
-        "https://app.localhost/a.png",
-        "https://localhost./a.png",
-        "https://app.localhost./a.png",
-        "https://127.0.0.1/a.png",
-        "https://10.0.0.5/a.png",
-        "https://192.168.1.2/a.png",
-        "https://172.16.0.1/a.png",
-        "https://169.254.1.1/a.png",
-        // Ranges aligned with the canonical unsafe-host set / media validator.
-        "https://0.0.0.1/a.png",     // 0.0.0.0/8 this-host
-        "https://100.64.0.1/a.png",  // CGNAT 100.64.0.0/10
-        "https://192.0.0.1/a.png",   // IETF protocol assignments 192.0.0.0/24
-        "https://192.88.99.1/a.png", // 6to4 relay anycast 192.88.99.0/24
-        "https://198.18.0.1/a.png",  // benchmarking 198.18.0.0/15
-        "https://240.0.0.1/a.png",   // reserved 240.0.0.0/4
-        "https://[::1]/a.png",
-        "https://[::ffff:127.0.0.1]/a.png",
-        "https://[::ffff:10.0.0.1]/a.png",
-        "https://[fc00::1]/a.png",
-        "https://[fe80::1]/a.png",
-        "https://[2002::1]/a.png", // 6to4 transition prefix
-        "https://[2001::1]/a.png", // Teredo 2001:0000::/32
-        "https://[3fff::1]/a.png", // documentation 3fff::/20 (RFC 9637)
-        "https://[4000::1]/a.png", // outside global unicast 2000::/3
     ] {
         assert!(
             validate_and_normalize_group_avatar_url(raw).is_err(),
@@ -584,8 +736,8 @@ fn group_avatar_url_decode_rejects_absent_state_with_hints() {
 fn group_avatar_url_decode_rejects_trailing_bytes() {
     let avatar = GroupAvatarUrlV1 {
         url: "https://cdn.example.com/a.png".to_owned(),
-        dim: None,
-        thumbhash: None,
+        dim: Vec::new(),
+        thumbhash: Vec::new(),
     };
     let mut bytes = encode_group_avatar_url_v1(&avatar).unwrap();
     bytes.push(0);
@@ -593,10 +745,10 @@ fn group_avatar_url_decode_rejects_trailing_bytes() {
 }
 
 #[test]
-fn group_avatar_url_decode_treats_non_utf8_hint_as_absent() {
-    // dim/thumbhash are opaque length-bounded hints: a non-UTF-8 hint MUST NOT
-    // invalidate the component (else the same commit forks accept/reject across
-    // clients). It is interpreted as absent.
+fn group_avatar_url_codec_preserves_opaque_hint_bytes() {
+    // dim/thumbhash are opaque length-bounded hints. Decoding must preserve
+    // their bytes even when an application renderer cannot interpret them as
+    // UTF-8, otherwise encode(decode(bytes)) collapses distinct valid states.
     let url = validate_and_normalize_group_avatar_url("https://cdn.example.com/a.png").unwrap();
     let mut bytes = Vec::new();
     encode_var_bytes(url.as_bytes(), &mut bytes);
@@ -606,24 +758,19 @@ fn group_avatar_url_decode_treats_non_utf8_hint_as_absent() {
     let decoded = decode_group_avatar_url_v1(&bytes)
         .expect("non-UTF-8 opaque hints must not invalidate the avatar component");
     assert_eq!(decoded.url, url);
-    assert_eq!(decoded.dim, None);
-    assert_eq!(decoded.thumbhash, None);
-
-    // A within-bounds UTF-8 hint is still surfaced for rendering.
-    let mut bytes = Vec::new();
-    encode_var_bytes(url.as_bytes(), &mut bytes);
-    encode_var_bytes(b"512x512", &mut bytes);
-    encode_var_bytes(b"", &mut bytes);
-    let decoded = decode_group_avatar_url_v1(&bytes).unwrap();
-    assert_eq!(decoded.dim.as_deref(), Some("512x512"));
+    assert_eq!(
+        encode_group_avatar_url_v1(&decoded).unwrap(),
+        bytes,
+        "canonical decode/re-encode must preserve opaque hint bytes"
+    );
 }
 
 #[test]
 fn group_avatar_hint_length_is_bounded() {
     let avatar = GroupAvatarUrlV1 {
         url: "https://cdn.example.com/a.png".to_owned(),
-        dim: Some("a".repeat(GROUP_AVATAR_HINT_MAX_LEN + 1)),
-        thumbhash: None,
+        dim: vec![b'a'; GROUP_AVATAR_HINT_MAX_LEN + 1],
+        thumbhash: Vec::new(),
     };
     assert!(encode_group_avatar_url_v1(&avatar).is_err());
 }


### PR DESCRIPTION
## Summary

- add spec-aligned codecs for `marmot.group.profile.v1` and `marmot.group.blossom.image.v1`, including canonical media-type validation
- preserve absent versus present-empty profile state through app storage and UniFFI; preserve opaque avatar hint bytes while keeping rendering interpretation local
- enforce avatar URL validity independently from contact policy and bound Nostr routing to 1–16 sorted, unique, profile-valid relay URLs without rewriting signed bytes
- preserve unknown optional app-component bytes across unrelated profile updates
- bump the workspace to 0.9.6 for the UniFFI record change

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -q -p cgka-traits -p cgka-engine -p marmot-app -p marmot-uniffi --locked`
- [x] `cargo test -p storage-sqlite --locked`
- [x] `just fast-ci`

## Sensitive paths

- `crates/cgka-engine/src/app_components.rs`: MLS group-state component validation
- `crates/traits/src/app_components/blossom_image.rs`: MLS-protected image cryptographic metadata codec
- `crates/marmot-app/src/media/group_image.rs`: group-image AEAD media-type binding

Fixes #1058


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving group profile information, including distinguishing absent profiles from present-but-empty profiles.
  * Group profile data now remains visible across group updates, refreshes, synchronization, and account projections.
  * Added support for canonical group image media types and improved avatar rendering hints.
* **Bug Fixes**
  * Preserved unknown component data during group profile updates.
  * Improved validation for profile, image, avatar, and routing data.
* **Release**
  * Updated the application version to 0.9.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->