### PR TITLE
Adopt application-data wire carriers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5550,7 +5550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3648,7 +3648,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.8.1"
-source = "git+https://github.com/erskingardner/openmls.git?rev=85990fd44634bd054f010f14dc4d8987c9adfb3d#85990fd44634bd054f010f14dc4d8987c9adfb3d"
+source = "git+https://github.com/erskingardner/openmls.git?rev=59e7d3b27a7e95237879dd5478de1fd90eff7ada#59e7d3b27a7e95237879dd5478de1fd90eff7ada"
 dependencies = [
  "log",
  "openmls_serialization_helpers",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "openmls_basic_credential"
 version = "0.5.0"
-source = "git+https://github.com/erskingardner/openmls.git?rev=85990fd44634bd054f010f14dc4d8987c9adfb3d#85990fd44634bd054f010f14dc4d8987c9adfb3d"
+source = "git+https://github.com/erskingardner/openmls.git?rev=59e7d3b27a7e95237879dd5478de1fd90eff7ada#59e7d3b27a7e95237879dd5478de1fd90eff7ada"
 dependencies = [
  "ed25519-dalek",
  "ml-dsa",
@@ -3680,7 +3680,7 @@ dependencies = [
 [[package]]
 name = "openmls_memory_storage"
 version = "0.5.0"
-source = "git+https://github.com/erskingardner/openmls.git?rev=85990fd44634bd054f010f14dc4d8987c9adfb3d#85990fd44634bd054f010f14dc4d8987c9adfb3d"
+source = "git+https://github.com/erskingardner/openmls.git?rev=59e7d3b27a7e95237879dd5478de1fd90eff7ada#59e7d3b27a7e95237879dd5478de1fd90eff7ada"
 dependencies = [
  "log",
  "openmls_traits",
@@ -3692,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "openmls_rust_crypto"
 version = "0.5.1"
-source = "git+https://github.com/erskingardner/openmls.git?rev=85990fd44634bd054f010f14dc4d8987c9adfb3d#85990fd44634bd054f010f14dc4d8987c9adfb3d"
+source = "git+https://github.com/erskingardner/openmls.git?rev=59e7d3b27a7e95237879dd5478de1fd90eff7ada#59e7d3b27a7e95237879dd5478de1fd90eff7ada"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "openmls_serialization_helpers"
 version = "0.1.0"
-source = "git+https://github.com/erskingardner/openmls.git?rev=85990fd44634bd054f010f14dc4d8987c9adfb3d#85990fd44634bd054f010f14dc4d8987c9adfb3d"
+source = "git+https://github.com/erskingardner/openmls.git?rev=59e7d3b27a7e95237879dd5478de1fd90eff7ada#59e7d3b27a7e95237879dd5478de1fd90eff7ada"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3729,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "openmls_traits"
 version = "0.5.0"
-source = "git+https://github.com/erskingardner/openmls.git?rev=85990fd44634bd054f010f14dc4d8987c9adfb3d#85990fd44634bd054f010f14dc4d8987c9adfb3d"
+source = "git+https://github.com/erskingardner/openmls.git?rev=59e7d3b27a7e95237879dd5478de1fd90eff7ada#59e7d3b27a7e95237879dd5478de1fd90eff7ada"
 dependencies = [
  "serde",
  "tls_codec",
@@ -5550,7 +5550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,11 +35,11 @@ publish = false
 # Keep every companion crate on the same repository commit to prevent source skew.
 # Migration: once an upstream OpenMLS release contains this fix, replace all five
 # git entries together with one matching upstream release series and remove the fork pin.
-openmls = { git = "https://github.com/erskingardner/openmls.git", rev = "85990fd44634bd054f010f14dc4d8987c9adfb3d", features = ["extensions-draft"] }
-openmls_basic_credential = { git = "https://github.com/erskingardner/openmls.git", rev = "85990fd44634bd054f010f14dc4d8987c9adfb3d" }
-openmls_memory_storage = { git = "https://github.com/erskingardner/openmls.git", rev = "85990fd44634bd054f010f14dc4d8987c9adfb3d", features = ["extensions-draft"] }
-openmls_rust_crypto = { git = "https://github.com/erskingardner/openmls.git", rev = "85990fd44634bd054f010f14dc4d8987c9adfb3d" }
-openmls_traits = { git = "https://github.com/erskingardner/openmls.git", rev = "85990fd44634bd054f010f14dc4d8987c9adfb3d", features = ["extensions-draft"] }
+openmls = { git = "https://github.com/erskingardner/openmls.git", rev = "59e7d3b27a7e95237879dd5478de1fd90eff7ada", features = ["extensions-draft"] }
+openmls_basic_credential = { git = "https://github.com/erskingardner/openmls.git", rev = "59e7d3b27a7e95237879dd5478de1fd90eff7ada" }
+openmls_memory_storage = { git = "https://github.com/erskingardner/openmls.git", rev = "59e7d3b27a7e95237879dd5478de1fd90eff7ada", features = ["extensions-draft"] }
+openmls_rust_crypto = { git = "https://github.com/erskingardner/openmls.git", rev = "59e7d3b27a7e95237879dd5478de1fd90eff7ada" }
+openmls_traits = { git = "https://github.com/erskingardner/openmls.git", rev = "59e7d3b27a7e95237879dd5478de1fd90eff7ada", features = ["extensions-draft"] }
 tls_codec = "~0.5"
 
 # async

--- a/crates/cgka-engine/src/capabilities.rs
+++ b/crates/cgka-engine/src/capabilities.rs
@@ -25,7 +25,6 @@ pub(crate) fn leaf_capabilities(
     let mut ext_types: Vec<ExtensionType> = vec![
         ExtensionType::RequiredCapabilities,
         ExtensionType::AppDataDictionary,
-        ExtensionType::LastResort,
         crate::account_identity_proof::account_identity_proof_capability(),
     ];
     let mut proposal_types: Vec<ProposalType> = vec![ProposalType::AppDataUpdate];

--- a/crates/cgka-engine/src/key_package.rs
+++ b/crates/cgka-engine/src/key_package.rs
@@ -61,7 +61,8 @@ pub fn key_package_metadata(kp: &KeyPackage) -> Result<KeyPackageMetadata, Engin
 }
 
 /// Parse and validate a transported KeyPackage and report whether it carries
-/// the MLS last-resort extension.
+/// either the current last-resort application-data component or the legacy
+/// last-resort extension.
 pub fn is_last_resort_key_package(kp: &KeyPackage) -> Result<bool, EngineError> {
     let msg = MlsMessageIn::tls_deserialize_exact(kp.bytes())
         .map_err(|e| EngineError::Serialize(format!("key_package deserialize: {e:?}")))?;
@@ -124,8 +125,9 @@ impl<S: StorageProvider> Engine<S> {
     /// KeyPackage it must call this to prune the orphaned private bundle;
     /// otherwise retries against a failing publisher accumulate unused private
     /// key material indefinitely (mdk#160). The KeyPackages produced
-    /// here carry the last-resort extension, so OpenMLS never deletes them on
-    /// the welcome path — cleanup is entirely the caller's responsibility.
+    /// here carry the last-resort application-data component, so OpenMLS never
+    /// deletes them on the welcome path — cleanup is entirely the caller's
+    /// responsibility.
     ///
     /// Deleting a KeyPackage that is not present in storage is a no-op (the
     /// underlying `DELETE` matches zero rows), so this is safe to call

--- a/crates/cgka-engine/tests/application_data_wire.rs
+++ b/crates/cgka-engine/tests/application_data_wire.rs
@@ -1,0 +1,145 @@
+//! Wire-contract tests for the MLS application-data carriers Marmot uses.
+//!
+//! These tests deliberately sit at the MDK integration boundary. They pin the
+//! OpenMLS fork behavior that current-profile KeyPackages, LeafNodes,
+//! GroupContexts, and AppDataUpdate proposals rely on.
+
+use openmls::component::ComponentData;
+use openmls::extensions::{
+    AppDataDictionary, AppDataDictionaryExtension, Extension, ExtensionType, Extensions,
+};
+use openmls::group::GroupContext;
+use openmls::messages::proposals::{AppDataUpdateOperation, AppDataUpdateProposal, ProposalType};
+use openmls::prelude::{KeyPackage, LeafNode};
+use tls_codec::{Deserialize as _, Serialize as _, VLBytes};
+
+const OPAQUE_COMPONENT_ID: u16 = 0x9001;
+const OPAQUE_COMPONENT_BYTES: &[u8] = &[0xde, 0xad, 0xbe, 0xef];
+
+fn app_data_extension() -> Extension {
+    let mut dictionary = AppDataDictionary::new();
+    dictionary.insert(OPAQUE_COMPONENT_ID, OPAQUE_COMPONENT_BYTES.to_vec());
+    Extension::AppDataDictionary(AppDataDictionaryExtension::new(dictionary))
+}
+
+fn assert_opaque_component<T>(extensions: &Extensions<T>) {
+    let dictionary = extensions
+        .app_data_dictionary()
+        .expect("app_data_dictionary extension")
+        .dictionary();
+    assert_eq!(
+        dictionary.get(&OPAQUE_COMPONENT_ID),
+        Some(OPAQUE_COMPONENT_BYTES)
+    );
+}
+
+#[test]
+fn application_data_dictionary_roundtrips_in_every_extension_carrier_mdk_uses() {
+    let key_package = Extensions::<KeyPackage>::single(app_data_extension()).unwrap();
+    let decoded = Extensions::<KeyPackage>::tls_deserialize_exact(
+        key_package.tls_serialize_detached().unwrap(),
+    )
+    .unwrap();
+    assert_opaque_component(&decoded);
+
+    let leaf_node = Extensions::<LeafNode>::single(app_data_extension()).unwrap();
+    let decoded =
+        Extensions::<LeafNode>::tls_deserialize_exact(leaf_node.tls_serialize_detached().unwrap())
+            .unwrap();
+    assert_opaque_component(&decoded);
+
+    let group_context = Extensions::<GroupContext>::single(app_data_extension()).unwrap();
+    let decoded = Extensions::<GroupContext>::tls_deserialize_exact(
+        group_context.tls_serialize_detached().unwrap(),
+    )
+    .unwrap();
+    assert_opaque_component(&decoded);
+}
+
+#[test]
+fn application_data_dictionary_roundtrip_is_canonical_and_preserves_opaque_bytes() {
+    let entries = vec![
+        ComponentData::from_parts(0x0001, vec![0x01].into()),
+        ComponentData::from_parts(OPAQUE_COMPONENT_ID, OPAQUE_COMPONENT_BYTES.to_vec().into()),
+    ];
+    let encoded = entries.tls_serialize_detached().unwrap();
+    let dictionary = AppDataDictionary::tls_deserialize_exact(encoded.clone()).unwrap();
+
+    assert_eq!(
+        dictionary.get(&OPAQUE_COMPONENT_ID),
+        Some(OPAQUE_COMPONENT_BYTES)
+    );
+    assert_eq!(dictionary.tls_serialize_detached().unwrap(), encoded);
+}
+
+#[test]
+fn application_data_dictionary_rejects_duplicate_and_out_of_order_components() {
+    let duplicate = vec![
+        ComponentData::from_parts(0x0001, vec![0x01].into()),
+        ComponentData::from_parts(0x0001, vec![0x02].into()),
+    ]
+    .tls_serialize_detached()
+    .unwrap();
+    assert!(AppDataDictionary::tls_deserialize_exact(duplicate).is_err());
+
+    let out_of_order = vec![
+        ComponentData::from_parts(OPAQUE_COMPONENT_ID, vec![0x01].into()),
+        ComponentData::from_parts(0x0001, vec![0x02].into()),
+    ]
+    .tls_serialize_detached()
+    .unwrap();
+    assert!(AppDataDictionary::tls_deserialize_exact(out_of_order).is_err());
+}
+
+#[test]
+fn application_data_extension_rejects_malformed_length_framing() {
+    let Extension::AppDataDictionary(extension) = app_data_extension() else {
+        unreachable!()
+    };
+    let mut extension_data = extension.tls_serialize_detached().unwrap();
+    extension_data.push(0xff);
+
+    let mut malformed = ExtensionType::AppDataDictionary
+        .tls_serialize_detached()
+        .unwrap();
+    malformed.extend_from_slice(
+        &VLBytes::from(extension_data)
+            .tls_serialize_detached()
+            .unwrap(),
+    );
+
+    assert!(Extension::tls_deserialize_exact(malformed).is_err());
+
+    let mut truncated = app_data_extension().tls_serialize_detached().unwrap();
+    truncated.pop();
+    assert!(Extension::tls_deserialize_exact(truncated).is_err());
+}
+
+#[test]
+fn app_data_update_proposals_roundtrip_and_reject_malformed_operations() {
+    assert_eq!(u16::from(ProposalType::AppDataUpdate), 0x0008);
+
+    let update = AppDataUpdateProposal::update(OPAQUE_COMPONENT_ID, OPAQUE_COMPONENT_BYTES);
+    let update_bytes = update.tls_serialize_detached().unwrap();
+    let decoded = AppDataUpdateProposal::tls_deserialize_exact(update_bytes.clone()).unwrap();
+    assert_eq!(decoded.component_id(), OPAQUE_COMPONENT_ID);
+    assert!(matches!(
+        decoded.operation(),
+        AppDataUpdateOperation::Update(data) if data.as_slice() == OPAQUE_COMPONENT_BYTES
+    ));
+
+    let remove = AppDataUpdateProposal::remove(OPAQUE_COMPONENT_ID);
+    let decoded =
+        AppDataUpdateProposal::tls_deserialize_exact(remove.tls_serialize_detached().unwrap())
+            .unwrap();
+    assert_eq!(decoded.component_id(), OPAQUE_COMPONENT_ID);
+    assert_eq!(decoded.operation(), &AppDataUpdateOperation::Remove);
+
+    let mut unknown_operation = update_bytes.clone();
+    unknown_operation[2] = 0xff;
+    assert!(AppDataUpdateProposal::tls_deserialize_exact(unknown_operation).is_err());
+
+    let mut truncated = update_bytes;
+    truncated.pop();
+    assert!(AppDataUpdateProposal::tls_deserialize_exact(truncated).is_err());
+}

--- a/crates/cgka-engine/tests/application_data_wire.rs
+++ b/crates/cgka-engine/tests/application_data_wire.rs
@@ -1,8 +1,10 @@
-//! Wire-contract tests for the MLS application-data carriers Marmot uses.
+//! OpenMLS integration-contract tests for the MLS application-data carriers
+//! Marmot uses.
 //!
-//! These tests deliberately sit at the MDK integration boundary. They pin the
-//! OpenMLS fork behavior that current-profile KeyPackages, LeafNodes,
-//! GroupContexts, and AppDataUpdate proposals rely on.
+//! These direct codec tests pin the fork behavior that MDK's engine paths rely
+//! on. Engine-boundary coverage for KeyPackage application data lives in
+//! `group_creation.rs`; state-transition preservation coverage lives in
+//! `update_group_data.rs`.
 
 use openmls::component::ComponentData;
 use openmls::extensions::{
@@ -57,19 +59,26 @@ fn application_data_dictionary_roundtrips_in_every_extension_carrier_mdk_uses() 
 }
 
 #[test]
-fn application_data_dictionary_roundtrip_is_canonical_and_preserves_opaque_bytes() {
-    let entries = vec![
+fn application_data_dictionary_serializes_canonically_and_preserves_opaque_bytes() {
+    let mut dictionary = AppDataDictionary::new();
+    // Insert in descending component-id order. Canonical serialization must
+    // still order the wire entries by component id.
+    dictionary.insert(OPAQUE_COMPONENT_ID, OPAQUE_COMPONENT_BYTES.to_vec());
+    dictionary.insert(0x0001, vec![0x01]);
+    let encoded = dictionary.tls_serialize_detached().unwrap();
+    let expected = vec![
         ComponentData::from_parts(0x0001, vec![0x01].into()),
         ComponentData::from_parts(OPAQUE_COMPONENT_ID, OPAQUE_COMPONENT_BYTES.to_vec().into()),
-    ];
-    let encoded = entries.tls_serialize_detached().unwrap();
-    let dictionary = AppDataDictionary::tls_deserialize_exact(encoded.clone()).unwrap();
+    ]
+    .tls_serialize_detached()
+    .unwrap();
+    assert_eq!(encoded, expected);
 
+    let dictionary = AppDataDictionary::tls_deserialize_exact(encoded).unwrap();
     assert_eq!(
         dictionary.get(&OPAQUE_COMPONENT_ID),
         Some(OPAQUE_COMPONENT_BYTES)
     );
-    assert_eq!(dictionary.tls_serialize_detached().unwrap(), encoded);
 }
 
 #[test]
@@ -135,8 +144,11 @@ fn app_data_update_proposals_roundtrip_and_reject_malformed_operations() {
     assert_eq!(decoded.component_id(), OPAQUE_COMPONENT_ID);
     assert_eq!(decoded.operation(), &AppDataUpdateOperation::Remove);
 
-    let mut unknown_operation = update_bytes.clone();
-    unknown_operation[2] = 0xff;
+    // AppDataUpdateProposal starts with the explicit u16 component id followed
+    // by the operation discriminant. Construct that frame directly instead of
+    // mutating a positional byte in an otherwise-valid proposal.
+    let mut unknown_operation = OPAQUE_COMPONENT_ID.to_be_bytes().to_vec();
+    unknown_operation.push(0xff);
     assert!(AppDataUpdateProposal::tls_deserialize_exact(unknown_operation).is_err());
 
     let mut truncated = update_bytes;

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -933,11 +933,21 @@ async fn fresh_key_package_uses_draft10_last_resort_component() {
     );
 }
 
-#[test]
-fn malformed_last_resort_component_is_rejected_at_mdk_boundary() {
+#[tokio::test]
+async fn create_group_rejects_malformed_last_resort_component() {
+    let mut alice = build_client(b"alice", selfremove_registry());
     let key_package = key_package_with_malformed_last_resort_component(b"malformed-last-resort");
-    let error = is_last_resort_key_package(&key_package)
-        .expect_err("non-empty last-resort component data must be rejected");
+    let error = alice
+        .create_group(CreateGroupRequest {
+            name: "malformed-last-resort".into(),
+            description: String::new(),
+            members: vec![key_package],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .expect_err("create_group must reject non-empty last-resort component data");
     assert!(
         matches!(&error, EngineError::Backend(message) if message.contains("MalformedLastResortComponent")),
         "unexpected error: {error:?}"

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -30,6 +30,9 @@ use cgka_traits::transport::{
 };
 use cgka_traits::types::{MemberId, MessageId};
 use openmls::component::ComponentType;
+use openmls::extensions::{
+    AppDataDictionary, AppDataDictionaryExtension, Extension, LastResortExtension,
+};
 use openmls::prelude::{
     BasicCredential, Capabilities, CredentialWithKey, ExtensionType, Extensions,
     KeyPackage as MlsKeyPackage, Lifetime, MlsMessageBodyIn, MlsMessageIn, MlsMessageOut,
@@ -139,6 +142,88 @@ fn key_package_with_account_identity_proof_and_lifetime(
         .leaf_node_extensions(Extensions::single(proof_extension).unwrap())
         .key_package_lifetime(lifetime)
         .mark_as_last_resort()
+        .build(ciphersuite, &provider, &signer, credential_with_key)
+        .unwrap();
+    let mls_msg: MlsMessageOut = bundle.key_package().clone().into();
+    cgka_traits::engine::KeyPackage::new(mls_msg.tls_serialize_detached().unwrap())
+}
+
+fn key_package_with_malformed_last_resort_component(
+    identity_seed: &[u8],
+) -> cgka_traits::engine::KeyPackage {
+    let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let provider = openmls_rust_crypto::OpenMlsRustCrypto::default();
+    let signer = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
+    let credential_identity = pad32(identity_seed);
+    let credential = BasicCredential::new(credential_identity.clone());
+    let credential_with_key = CredentialWithKey {
+        credential: credential.into(),
+        signature_key: signer.public().into(),
+    };
+    let proof_extension = account_identity_proof_extension(
+        &credential_identity,
+        &signer.to_public_vec(),
+        ciphersuite,
+        ciphersuite.signature_algorithm(),
+        proof_signer(identity_seed).as_ref(),
+    )
+    .unwrap();
+    let mut dictionary = AppDataDictionary::new();
+    dictionary.insert(ComponentType::LastResortKeyPackage.into(), vec![0xff]);
+    let key_package_extension =
+        Extension::AppDataDictionary(AppDataDictionaryExtension::new(dictionary));
+    let bundle = MlsKeyPackage::builder()
+        .leaf_node_capabilities(Capabilities::new(
+            None,
+            Some(&[ciphersuite]),
+            Some(&[
+                ExtensionType::Unknown(ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE),
+                ExtensionType::AppDataDictionary,
+            ]),
+            None,
+            None,
+        ))
+        .leaf_node_extensions(Extensions::single(proof_extension).unwrap())
+        .key_package_extensions(Extensions::single(key_package_extension).unwrap())
+        .build(ciphersuite, &provider, &signer, credential_with_key)
+        .unwrap();
+    let mls_msg: MlsMessageOut = bundle.key_package().clone().into();
+    cgka_traits::engine::KeyPackage::new(mls_msg.tls_serialize_detached().unwrap())
+}
+
+fn legacy_last_resort_key_package(identity_seed: &[u8]) -> cgka_traits::engine::KeyPackage {
+    let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let provider = openmls_rust_crypto::OpenMlsRustCrypto::default();
+    let signer = SignatureKeyPair::new(ciphersuite.signature_algorithm()).unwrap();
+    let credential_identity = pad32(identity_seed);
+    let credential = BasicCredential::new(credential_identity.clone());
+    let credential_with_key = CredentialWithKey {
+        credential: credential.into(),
+        signature_key: signer.public().into(),
+    };
+    let proof_extension = account_identity_proof_extension(
+        &credential_identity,
+        &signer.to_public_vec(),
+        ciphersuite,
+        ciphersuite.signature_algorithm(),
+        proof_signer(identity_seed).as_ref(),
+    )
+    .unwrap();
+    let bundle = MlsKeyPackage::builder()
+        .leaf_node_capabilities(Capabilities::new(
+            None,
+            Some(&[ciphersuite]),
+            Some(&[
+                ExtensionType::Unknown(ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE),
+                ExtensionType::LastResort,
+            ]),
+            None,
+            None,
+        ))
+        .leaf_node_extensions(Extensions::single(proof_extension).unwrap())
+        .key_package_extensions(
+            Extensions::single(Extension::LastResort(LastResortExtension::new())).unwrap(),
+        )
         .build(ciphersuite, &provider, &signer, credential_with_key)
         .unwrap();
     let mls_msg: MlsMessageOut = bundle.key_package().clone().into();
@@ -819,6 +904,22 @@ async fn fresh_key_package_uses_draft10_last_resort_component() {
         !key_package.extensions().contains(ExtensionType::LastResort),
         "new KeyPackages must not use the legacy last_resort extension"
     );
+    assert!(
+        key_package
+            .leaf_node()
+            .capabilities()
+            .extensions()
+            .contains(&ExtensionType::AppDataDictionary),
+        "new KeyPackages must advertise the app_data_dictionary carrier"
+    );
+    assert!(
+        !key_package
+            .leaf_node()
+            .capabilities()
+            .extensions()
+            .contains(&ExtensionType::LastResort),
+        "last-resort is an application-data component, not an advertised extension capability"
+    );
     let dictionary = key_package
         .extensions()
         .app_data_dictionary()
@@ -829,6 +930,26 @@ async fn fresh_key_package_uses_draft10_last_resort_component() {
             .get(&ComponentType::LastResortKeyPackage.into()),
         Some(&[][..]),
         "draft-10 last-resort component 0x0004 must carry empty data"
+    );
+}
+
+#[test]
+fn malformed_last_resort_component_is_rejected_at_mdk_boundary() {
+    let key_package = key_package_with_malformed_last_resort_component(b"malformed-last-resort");
+    let error = is_last_resort_key_package(&key_package)
+        .expect_err("non-empty last-resort component data must be rejected");
+    assert!(
+        matches!(&error, EngineError::Backend(message) if message.contains("MalformedLastResortComponent")),
+        "unexpected error: {error:?}"
+    );
+}
+
+#[test]
+fn legacy_last_resort_extension_remains_decodable() {
+    let key_package = legacy_last_resort_key_package(b"legacy-last-resort");
+    assert!(
+        is_last_resort_key_package(&key_package)
+            .expect("legacy KeyPackage remains valid for compatibility")
     );
 }
 

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -320,6 +320,19 @@ fn build_with_routing(id: &[u8]) -> Engine<SqliteAccountStorage> {
         .unwrap()
 }
 
+fn build_with_opaque_component(id: &[u8], component_id: u16) -> Engine<SqliteAccountStorage> {
+    let mut components: Vec<_> = default_group_components().into_iter().collect();
+    components.push(component_id);
+    EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
+        .identity(pad32(id))
+        .account_identity_proof_signer(proof_signer(id))
+        .feature_registry(registry())
+        .supported_app_components(components)
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .unwrap()
+}
+
 /// #740 rotation regression: after a Nostr routing-component update commit is
 /// applied, the engine's `transport_group_id_index` must self-heal so inbound
 /// messages addressed to the NEW `nostr_group_id` still resolve to the group.
@@ -984,6 +997,70 @@ async fn admin_policy_update_listing_non_member_is_rejected() {
 }
 
 // ── Partial update ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn unrelated_update_preserves_opaque_app_component_for_all_members() {
+    const OPAQUE_COMPONENT_ID: u16 = 0xF301;
+    const OPAQUE_BYTES: &[u8] = &[0xde, 0xad, 0xbe, 0xef];
+
+    let mut alice = build_with_opaque_component(b"alice", OPAQUE_COMPONENT_ID);
+    let mut bob = build_with_opaque_component(b"bob", OPAQUE_COMPONENT_ID);
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (gid, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "original".into(),
+            description: "orig description".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![AppComponentData {
+                component_id: OPAQUE_COMPONENT_ID,
+                data: OPAQUE_BYTES.to_vec(),
+            }],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcomes.into_iter().next().unwrap())
+        .await
+        .unwrap();
+
+    let result = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: gid.clone(),
+            name: Some("renamed".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (commit, pending) = match result {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.ingest(TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: gid.as_slice().to_vec(),
+        },
+        ..commit
+    })
+    .await
+    .unwrap();
+    converge_buffered_commit(&mut bob, &gid);
+
+    assert_eq!(
+        alice.app_component(&gid, OPAQUE_COMPONENT_ID).unwrap(),
+        Some(OPAQUE_BYTES.to_vec())
+    );
+    assert_eq!(
+        bob.app_component(&gid, OPAQUE_COMPONENT_ID).unwrap(),
+        Some(OPAQUE_BYTES.to_vec())
+    );
+}
 
 #[tokio::test]
 async fn update_group_data_with_only_name_preserves_description() {

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -999,7 +999,7 @@ async fn admin_policy_update_listing_non_member_is_rejected() {
 // ── Partial update ──────────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn unrelated_update_preserves_opaque_app_component_for_all_members() {
+async fn unrelated_update_and_invite_preserve_opaque_app_component_for_all_members() {
     const OPAQUE_COMPONENT_ID: u16 = 0xF301;
     const OPAQUE_BYTES: &[u8] = &[0xde, 0xad, 0xbe, 0xef];
 
@@ -1060,6 +1060,49 @@ async fn unrelated_update_preserves_opaque_app_component_for_all_members() {
         bob.app_component(&gid, OPAQUE_COMPONENT_ID).unwrap(),
         Some(OPAQUE_BYTES.to_vec())
     );
+
+    // Exercise the distinct Add/Welcome transition after the unrelated
+    // profile update. The existing members and the new member must all retain
+    // the exact opaque bytes.
+    let mut carol = build_with_opaque_component(b"carol", OPAQUE_COMPONENT_ID);
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let invite = alice
+        .send(SendIntent::Invite {
+            group_id: gid.clone(),
+            key_packages: vec![carol_kp],
+        })
+        .await
+        .unwrap();
+    let (commit, pending, mut welcomes) = match invite {
+        SendResult::GroupEvolution {
+            msg,
+            pending,
+            welcomes,
+        } => (msg, pending, welcomes),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.ingest(TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: gid.as_slice().to_vec(),
+        },
+        ..commit
+    })
+    .await
+    .unwrap();
+    converge_buffered_commit(&mut bob, &gid);
+    carol
+        .join_welcome(welcomes.remove(0))
+        .await
+        .expect("new member joins from the invite Welcome");
+
+    for (name, engine) in [("alice", &alice), ("bob", &bob), ("carol", &carol)] {
+        assert_eq!(
+            engine.app_component(&gid, OPAQUE_COMPONENT_ID).unwrap(),
+            Some(OPAQUE_BYTES.to_vec()),
+            "{name} must retain the opaque component through Add/Welcome"
+        );
+    }
 }
 
 #[tokio::test]

--- a/docs/marmot-architecture/further-context/custom_extensions.md
+++ b/docs/marmot-architecture/further-context/custom_extensions.md
@@ -1,7 +1,7 @@
 ---
 title: "Custom Proposals & Extensions — When to Inherit vs Define"
 created: 2026-04-18
-updated: 2026-06-09
+updated: 2026-07-23
 tags: [marmot, mls, extensions, proposals, capabilities, design]
 status: exploration
 related:
@@ -531,9 +531,13 @@ Each MIP was read in full. For each, the analysis is based on what the MIP actua
 
 ### 6.1 MIP-00 — Credentials & KeyPackages
 
-**Current approach:** Uses standard MLS `BasicCredential` with Nostr pubkey in the identity field. Uses standard
-kind-30443 addressable Nostr events for KeyPackage distribution. MUST advertise `0xF2EE` (marmot_group_data) and
-`0x000a` (last_resort — standard MLS extension draft).
+**Historical MIP-00 approach:** Uses standard MLS `BasicCredential` with Nostr pubkey in the identity field and
+kind-30443 addressable Nostr events for KeyPackage distribution. The old profile advertised `0xF2EE`
+(`marmot_group_data`) and `0x000a` (`last_resort`).
+
+**Adopted current approach:** KeyPackages advertise the MLS `app_data_dictionary` carrier. Last-resort status is
+component `0x0004` with empty data inside KeyPackage application data; current encoders neither emit nor advertise the
+obsolete `0x000a` extension. Legacy decoding remains separate for compatibility.
 
 **Inherit vs Custom check:**
 
@@ -542,7 +546,8 @@ kind-30443 addressable Nostr events for KeyPackage distribution. MUST advertise 
 - KeyPackage event format: Marmot-specific (kind 30443, `d` tag, `i` tag, `mls_ciphersuite` tag, `mls_extensions` tag,
   `mls_proposals` tag, `app_components` tag). **Correct custom** — this is Nostr-layer event format, not
   MLS-layer; no standard exists.
-- `last_resort` extension: standard, inherited. **Correct.**
+- Historical `last_resort` extension: retained only on the legacy decode path. Current encoding uses application-data
+  component `0x0004`.
 - `KeyPackageRef` calculation: standard RFC 9420. **Correct to inherit.**
 
 **No issues.** MIP-00 is cleanly split: MLS-layer primitives are inherited; Nostr-layer event structure is Marmot-custom


### PR DESCRIPTION
## Summary

- pin the OpenMLS fork follow-up that rejects trailing bytes inside `app_data_dictionary` extension payloads
- stop advertising the obsolete last-resort extension on new LeafNodes while retaining legacy decoding
- keep current last-resort encoding pinned to KeyPackage application-data component `0x0004`
- add direct carrier-codec tripwires plus engine-boundary coverage for malformed KeyPackages and opaque-component preservation across update, Add, and Welcome

The draft-10 last-resort encoder itself arrived in #1063. This PR advances the OpenMLS pin to commit [`59e7d3b27a7e95237879dd5478de1fd90eff7ada`](https://github.com/erskingardner/openmls/commit/59e7d3b27a7e95237879dd5478de1fd90eff7ada) for the trailing-bytes framing fix, stops advertising the old extension, and pins the MDK integration contract around those behaviors.

Legacy extension decoding remains covered here. Persisted legacy-profile and legacy-group loadability are implemented and exercised in the immediately stacked #1067.

## Validation

- `cargo test -p cgka-engine --locked`
- `just fast-ci`
- OpenMLS targeted unit tests and clippy for the framing fix

Fixes #1047


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced handling of application-data components across KeyPackage, leaf, and group workflows.
  - Opaque application-data components are preserved during unrelated group updates, including after adding new members.

- **Bug Fixes**
  - Improved validation rejects malformed, duplicate, unordered, or truncated application-data encodings.
  - Updated last-resort behavior: current capability advertisement avoids the legacy last-resort extension while still supporting legacy decoding.

- **Tests**
  - Added wire-contract and group/update integration coverage for application-data carriers, last-resort variants, and update/remove proposals.

- **Documentation**
  - Refreshed architecture notes clarifying current extension advertisement and legacy handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->