### PR TITLE
Persist legacy/current protocol profiles

### DIFF
--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -1433,6 +1433,7 @@ fn dummy_group(group_id: GroupId) -> Group {
             credential: vec![1],
         }],
         required_capabilities: GroupCapabilities::default(),
+        protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
         removed: false,
         join_epoch: EpochId(0),
     }

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -23,7 +23,7 @@ use cgka_traits::app_components::{AppComponentSet, default_group_components};
 use cgka_traits::capabilities::{GroupCapabilities, TransportKind};
 use cgka_traits::engine::{CreateGroupRequest, KeyPackage, SendResult, WelcomeMetadata};
 use cgka_traits::error::EngineError;
-use cgka_traits::group::{Group, Member};
+use cgka_traits::group::{Group, Member, ProtocolProfile};
 use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
 use cgka_traits::storage::StorageProvider;
 use cgka_traits::transport::{EncryptedPayload, TransportEnvelope, TransportMessage};
@@ -340,6 +340,7 @@ impl<S: StorageProvider> Engine<S> {
             epoch: EpochId(mls_group.epoch().as_u64()),
             members: projected_members,
             required_capabilities: required_caps,
+            protocol_profile: ProtocolProfile::Legacy,
             removed: false,
             join_epoch: EpochId(mls_group.epoch().as_u64()),
         };
@@ -700,6 +701,7 @@ impl<S: StorageProvider> Engine<S> {
                     members: marmot_members(&mls_group),
                     required_capabilities:
                         crate::capability_manager::required_capabilities_from_group(&mls_group),
+                    protocol_profile: ProtocolProfile::Legacy,
                     removed: false,
                     join_epoch: EpochId(mls_group.epoch().as_u64()),
                 };

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -340,6 +340,10 @@ impl<S: StorageProvider> Engine<S> {
             epoch: EpochId(mls_group.epoch().as_u64()),
             members: projected_members,
             required_capabilities: required_caps,
+            // This persistence-only slice predates the strict application
+            // profile cutover, so creation is intentionally classified
+            // Legacy. The value does not describe the MLS application-data
+            // carrier, which is already app_data_dictionary.
             protocol_profile: ProtocolProfile::Legacy,
             removed: false,
             join_epoch: EpochId(mls_group.epoch().as_u64()),
@@ -701,6 +705,9 @@ impl<S: StorageProvider> Engine<S> {
                     members: marmot_members(&mls_group),
                     required_capabilities:
                         crate::capability_manager::required_capabilities_from_group(&mls_group),
+                    // Welcome state remains Legacy-classified until the
+                    // strict application-profile classifier lands. This does
+                    // not imply legacy MLS application-data encoding.
                     protocol_profile: ProtocolProfile::Legacy,
                     removed: false,
                     join_epoch: EpochId(mls_group.epoch().as_u64()),

--- a/crates/cgka-engine/src/key_package.rs
+++ b/crates/cgka-engine/src/key_package.rs
@@ -10,6 +10,7 @@ use crate::engine::Engine;
 use crate::provider::EngineOpenMlsProvider;
 use cgka_traits::engine::KeyPackage;
 use cgka_traits::error::EngineError;
+use cgka_traits::group::ProtocolProfile;
 use cgka_traits::storage::StorageProvider;
 use openmls::prelude::{
     Extensions, KeyPackage as MlsKeyPackage, KeyPackageVerifyError, MlsMessageBodyIn, MlsMessageIn,
@@ -51,6 +52,7 @@ pub fn key_package_metadata(kp: &KeyPackage) -> Result<KeyPackageMetadata, Engin
         key_package.leaf_node(),
         key_package.ciphersuite(),
     )?;
+    ensure_legacy_key_package_profile(kp)?;
     let key_package_ref = key_package
         .hash_ref(&crypto)
         .map_err(|e| EngineError::Backend(format!("key_package ref: {e:?}")))?;
@@ -83,6 +85,7 @@ pub fn is_last_resort_key_package(kp: &KeyPackage) -> Result<bool, EngineError> 
         key_package.leaf_node(),
         key_package.ciphersuite(),
     )?;
+    ensure_legacy_key_package_profile(kp)?;
     Ok(key_package.last_resort())
 }
 
@@ -183,8 +186,26 @@ impl<S: StorageProvider> Engine<S> {
             key_package.leaf_node(),
             self.ciphersuite,
         )?;
+        ensure_legacy_key_package_profile(kp)?;
         Ok(key_package)
     }
+}
+
+/// Bind the persisted wrapper classification to the only account-proof
+/// carrier this pre-cutover slice can validate.
+///
+/// The stacked current-profile implementation generalizes this check by
+/// deriving the profile from the decoded proof carrier. Keeping the check here
+/// prevents callers from relabeling legacy wire bytes as current in the
+/// meantime and then dispatching on unverified metadata.
+fn ensure_legacy_key_package_profile(key_package: &KeyPackage) -> Result<(), EngineError> {
+    if key_package.protocol_profile != ProtocolProfile::Legacy {
+        return Err(EngineError::InvalidAccountIdentityProof(format!(
+            "KeyPackage metadata says {:?}, but its decoded account proof is Legacy",
+            key_package.protocol_profile
+        )));
+    }
+    Ok(())
 }
 
 fn validate_key_package(

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -481,6 +481,7 @@ mod tests {
                 epoch: EpochId(3),
                 members: vec![],
                 required_capabilities: Default::default(),
+                protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
                 removed: false,
                 join_epoch: EpochId(0),
             })

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -21,6 +21,7 @@ use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendResult};
 use cgka_traits::error::PeelerError;
+use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{PeeledContent, PeeledMessage};
 use cgka_traits::peeler::TransportPeeler;
@@ -880,6 +881,38 @@ async fn fresh_key_package_roundtrips_bytes() {
     assert!(
         !kp.bytes().is_empty(),
         "key package bytes should be non-empty"
+    );
+}
+
+#[tokio::test]
+async fn create_group_rejects_relabelled_legacy_key_package_profile() {
+    let mut alice = build_client(b"alice-profile", selfremove_registry());
+    let mut bob = build_client(b"bob-profile", selfremove_registry());
+    let relabelled_key_package = bob
+        .fresh_key_package()
+        .await
+        .unwrap()
+        .with_protocol_profile(ProtocolProfile::Current);
+
+    let err = alice
+        .create_group(CreateGroupRequest {
+            name: "profile-mismatch".into(),
+            description: "".into(),
+            members: vec![relabelled_key_package],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .expect_err("legacy proof bytes must not be accepted as a Current-profile KeyPackage");
+
+    assert!(
+        matches!(
+            &err,
+            EngineError::InvalidAccountIdentityProof(message)
+                if message.contains("decoded account proof is Legacy")
+        ),
+        "unexpected error: {err:?}"
     );
 }
 

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -176,6 +176,7 @@ fn insert_marmot_group_without_openmls_state(
             members: Vec::new(),
             epoch: EpochId(epoch),
             required_capabilities: GroupCapabilities::default(),
+            protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
             removed: false,
             join_epoch: EpochId(0),
         })

--- a/crates/cgka-engine/tests/sqlite_storage.rs
+++ b/crates/cgka-engine/tests/sqlite_storage.rs
@@ -11,6 +11,7 @@ use cgka_engine::EngineBuilder;
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendResult};
 use cgka_traits::error::PeelerError;
+use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{PeeledContent, PeeledMessage};
 use cgka_traits::peeler::TransportPeeler;
@@ -176,5 +177,11 @@ async fn create_group_confirm_and_reopen_with_encrypted_sqlite_storage() {
     assert!(!file_bytes.starts_with(b"SQLite format 3\0"));
 
     let reopened = SqliteAccountStorage::open_encrypted(&alice_path, &key).unwrap();
-    assert_eq!(reopened.get_group(&group_id).unwrap().epoch, EpochId(1));
+    let reopened_group = reopened.get_group(&group_id).unwrap();
+    assert_eq!(reopened_group.epoch, EpochId(1));
+    assert_eq!(
+        reopened_group.protocol_profile,
+        ProtocolProfile::Legacy,
+        "the persisted application-profile classification must survive an engine reopen"
+    );
 }

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -1117,6 +1117,7 @@ async fn drain_surfaces_hydration_quarantine_without_inbound_delivery() {
                 members: Vec::new(),
                 epoch: EpochId(9),
                 required_capabilities: GroupCapabilities::default(),
+                protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
                 removed: false,
                 join_epoch: EpochId(0),
             })

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -878,6 +878,7 @@ mod delete_moderation_grant_tests {
                 })
                 .collect(),
             required_capabilities: Default::default(),
+            protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
             removed: false,
             join_epoch: EpochId(0),
         }

--- a/crates/storage-sqlite/src/storage/groups.rs
+++ b/crates/storage-sqlite/src/storage/groups.rs
@@ -79,6 +79,7 @@ mod tests {
         TestGroupState, gid, mid, sample_group, sample_message, sample_queued_intent,
     };
     use cgka_traits::capabilities::GroupCapabilities;
+    use cgka_traits::group::ProtocolProfile;
     use cgka_traits::storage::{
         CapabilityStorage, ConvergencePolicyStorage, GroupStorage, MessageStorage,
         OutboundIntentStorage, StorageError, StorageProvider,
@@ -89,9 +90,32 @@ mod tests {
     #[test]
     fn group_roundtrip_preserves_every_field() {
         let store = SqliteAccountStorage::in_memory().unwrap();
-        let group = sample_group(gid(1), 7, 3);
+        let mut group = sample_group(gid(1), 7, 3);
+        group.protocol_profile = ProtocolProfile::Current;
         store.put_group(&group).unwrap();
         assert_eq!(store.get_group(&group.id).unwrap(), group);
+    }
+
+    #[test]
+    fn pre_profile_group_record_reopens_as_legacy() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group = sample_group(gid(1), 7, 3);
+        let mut record = serde_json::to_value(&group).unwrap();
+        record.as_object_mut().unwrap().remove("protocol_profile");
+        let bytes = serde_json::to_vec(&record).unwrap();
+        store
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO cgka_groups (id, epoch, record) VALUES (?1, ?2, ?3)",
+                rusqlite::params![group.id.as_slice(), 7, bytes],
+            )
+            .unwrap();
+
+        let reopened = store.get_group(&group.id).unwrap();
+        assert_eq!(reopened.protocol_profile, ProtocolProfile::Legacy);
+        assert_eq!(reopened.name, group.name);
+        assert_eq!(reopened.members, group.members);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/storage/groups.rs
+++ b/crates/storage-sqlite/src/storage/groups.rs
@@ -113,9 +113,32 @@ mod tests {
             .unwrap();
 
         let reopened = store.get_group(&group.id).unwrap();
-        assert_eq!(reopened.protocol_profile, ProtocolProfile::Legacy);
-        assert_eq!(reopened.name, group.name);
-        assert_eq!(reopened.members, group.members);
+        assert_eq!(reopened, group);
+    }
+
+    #[test]
+    fn corrupt_present_group_profile_fails_closed() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group = sample_group(gid(1), 7, 3);
+        let mut record = serde_json::to_value(&group).unwrap();
+        record["protocol_profile"] = serde_json::json!("nope");
+        let bytes = serde_json::to_vec(&record).unwrap();
+        store
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO cgka_groups (id, epoch, record) VALUES (?1, ?2, ?3)",
+                rusqlite::params![group.id.as_slice(), 7, bytes],
+            )
+            .unwrap();
+
+        let error = store
+            .get_group(&group.id)
+            .expect_err("a present corrupt profile must not fall through the serde default");
+        assert!(
+            matches!(&error, StorageError::Serialization(message) if message.contains("unknown variant")),
+            "unexpected error: {error:?}"
+        );
     }
 
     #[test]

--- a/crates/storage-sqlite/src/storage/test_support.rs
+++ b/crates/storage-sqlite/src/storage/test_support.rs
@@ -1,6 +1,6 @@
 use cgka_traits::capabilities::GroupCapabilities;
 use cgka_traits::engine::SendIntent;
-use cgka_traits::group::{Group, Member};
+use cgka_traits::group::{Group, Member, ProtocolProfile};
 use cgka_traits::message::{MessageRecord, MessageState};
 use cgka_traits::storage::QueuedOutboundIntent;
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
@@ -38,6 +38,7 @@ pub(crate) fn sample_group(id: GroupId, epoch: u64, members: usize) -> Group {
             })
             .collect(),
         required_capabilities: GroupCapabilities::default(),
+        protocol_profile: ProtocolProfile::Legacy,
         removed: false,
         join_epoch: EpochId(0),
     }

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -60,9 +60,12 @@ pub struct KeyPackage {
     pub bytes: Vec<u8>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<KeyPackageSource>,
-    /// Persisted wire-compatibility profile. Raw KeyPackages constructed by
-    /// pre-classification callers default to legacy and must still be checked
-    /// against their decoded wire state by the engine.
+    /// Persisted application-profile classification asserted by the wrapper.
+    ///
+    /// Raw KeyPackages constructed before the strict cutover default to
+    /// legacy. The engine must verify this value against the decoded
+    /// account-proof carrier before any behavior branches on it; it is not a
+    /// statement about whether the MLS bytes use `app_data_dictionary`.
     #[serde(default)]
     pub protocol_profile: ProtocolProfile,
 }
@@ -96,7 +99,10 @@ impl KeyPackage {
 
 impl PartialEq for KeyPackage {
     fn eq(&self, other: &Self) -> bool {
-        self.bytes == other.bytes
+        // Transport provenance does not change KeyPackage identity, but the
+        // application-profile classification is security-relevant metadata
+        // and must not disappear from equality assertions or keyed sets.
+        self.bytes == other.bytes && self.protocol_profile == other.protocol_profile
     }
 }
 
@@ -105,6 +111,7 @@ impl Eq for KeyPackage {}
 impl Hash for KeyPackage {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.bytes.hash(state);
+        self.protocol_profile.hash(state);
     }
 }
 

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -21,7 +21,7 @@ use crate::app_components::{AppComponentData, AppComponentId};
 use crate::capabilities::{Feature, FeatureStatus, GroupCapabilities};
 use crate::engine_state::PendingStateRef;
 use crate::error::EngineError;
-use crate::group::Member;
+use crate::group::{Member, ProtocolProfile};
 use crate::group_context::{GroupContext, SecretBytes};
 use crate::ingest::IngestOutcome;
 use crate::transport::TransportMessage;
@@ -60,6 +60,11 @@ pub struct KeyPackage {
     pub bytes: Vec<u8>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<KeyPackageSource>,
+    /// Persisted wire-compatibility profile. Raw KeyPackages constructed by
+    /// pre-classification callers default to legacy and must still be checked
+    /// against their decoded wire state by the engine.
+    #[serde(default)]
+    pub protocol_profile: ProtocolProfile,
 }
 
 impl KeyPackage {
@@ -67,6 +72,7 @@ impl KeyPackage {
         Self {
             bytes,
             source: None,
+            protocol_profile: ProtocolProfile::Legacy,
         }
     }
 
@@ -74,7 +80,13 @@ impl KeyPackage {
         Self {
             bytes,
             source: Some(KeyPackageSource { event_id }),
+            protocol_profile: ProtocolProfile::Legacy,
         }
+    }
+
+    pub fn with_protocol_profile(mut self, protocol_profile: ProtocolProfile) -> Self {
+        self.protocol_profile = protocol_profile;
+        self
     }
 
     pub fn bytes(&self) -> &[u8] {

--- a/crates/traits/src/group.rs
+++ b/crates/traits/src/group.rs
@@ -9,12 +9,19 @@ use crate::capabilities::GroupCapabilities;
 use crate::types::{EpochId, GroupId, MemberId};
 use serde::{Deserialize, Serialize};
 
-/// Wire-compatibility profile governing every protocol decision for a group or
-/// KeyPackage.
+/// Marmot application-profile generation for a group or KeyPackage.
 ///
-/// Existing persisted records predate this field and therefore deserialize as
-/// [`ProtocolProfile::Legacy`]. Current-profile state is always explicit; code
-/// must not infer a hybrid profile independently for each component.
+/// This is the strict-cutover classification used for decisions that differ
+/// between the deployed legacy application profile and the adopted current
+/// profile, including the account-identity-proof carrier, encrypted-media
+/// component, and mixed-profile rejection. It does **not** identify which MLS
+/// extension carrier encodes application data: legacy-classified state may
+/// already use the current `app_data_dictionary` carrier.
+///
+/// Existing persisted records predate profile classification and therefore
+/// deserialize as [`ProtocolProfile::Legacy`]. Current-profile state is always
+/// explicit; code must not infer a hybrid profile independently for each
+/// application component.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProtocolProfile {
@@ -33,8 +40,9 @@ pub struct Group {
     pub epoch: EpochId,
     pub members: Vec<Member>,
     pub required_capabilities: GroupCapabilities,
-    /// Persisted wire-compatibility profile for this group. Records written
-    /// before profile classification existed are deterministically legacy.
+    /// Persisted application-profile generation for this group. Records
+    /// written before profile classification existed are deterministically
+    /// legacy, regardless of the MLS carrier used by their latest state.
     #[serde(default)]
     pub protocol_profile: ProtocolProfile,
     /// The local copy of this group is marked removed: retained canonical

--- a/crates/traits/src/group.rs
+++ b/crates/traits/src/group.rs
@@ -9,6 +9,20 @@ use crate::capabilities::GroupCapabilities;
 use crate::types::{EpochId, GroupId, MemberId};
 use serde::{Deserialize, Serialize};
 
+/// Wire-compatibility profile governing every protocol decision for a group or
+/// KeyPackage.
+///
+/// Existing persisted records predate this field and therefore deserialize as
+/// [`ProtocolProfile::Legacy`]. Current-profile state is always explicit; code
+/// must not infer a hybrid profile independently for each component.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProtocolProfile {
+    #[default]
+    Legacy,
+    Current,
+}
+
 /// A group, as storage sees it. Mirrors the engine's view of the group's
 /// metadata — not the MLS tree (OpenMLS owns that).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -19,6 +33,10 @@ pub struct Group {
     pub epoch: EpochId,
     pub members: Vec<Member>,
     pub required_capabilities: GroupCapabilities,
+    /// Persisted wire-compatibility profile for this group. Records written
+    /// before profile classification existed are deterministically legacy.
+    #[serde(default)]
+    pub protocol_profile: ProtocolProfile,
     /// The local copy of this group is marked removed: retained canonical
     /// state records the local member's own removal (spec
     /// `protocol-core/member-departure.md`, "Realizing removal"). The record

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -682,6 +682,37 @@ fn key_package_profile_is_persisted_and_old_records_default_to_legacy() {
     let reopened: KeyPackage =
         serde_json::from_slice(&serde_json::to_vec(&current).unwrap()).unwrap();
     assert_eq!(reopened.protocol_profile, ProtocolProfile::Current);
+
+    let invalid = serde_json::from_value::<KeyPackage>(serde_json::json!({
+        "bytes": [7, 8, 9],
+        "protocol_profile": "nope"
+    }))
+    .expect_err("a present corrupt profile must not fall through the serde default");
+    assert!(invalid.to_string().contains("unknown variant"));
+}
+
+#[test]
+fn key_package_equality_and_hash_include_protocol_profile_but_not_source() {
+    use std::collections::HashSet;
+
+    let legacy = KeyPackage::new(vec![1, 2, 3]);
+    let legacy_with_source =
+        KeyPackage::with_source_event_id(vec![1, 2, 3], MessageId::new(vec![4; 32]));
+    let current = KeyPackage::new(vec![1, 2, 3]).with_protocol_profile(ProtocolProfile::Current);
+
+    assert_eq!(
+        legacy, legacy_with_source,
+        "transport provenance must not change KeyPackage identity"
+    );
+    assert_ne!(
+        legacy, current,
+        "application-profile metadata must remain visible to equality"
+    );
+    assert_eq!(
+        HashSet::from([legacy, legacy_with_source, current]).len(),
+        2,
+        "hashing must use the same identity fields as equality"
+    );
 }
 
 #[test]

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -18,7 +18,7 @@ use cgka_traits::engine::{
     KeyPackage, SendIntent, SendResult,
 };
 use cgka_traits::engine_state::PendingStateRef;
-use cgka_traits::group::{Group, Member};
+use cgka_traits::group::{Group, Member, ProtocolProfile};
 use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage, StaleReason};
 use cgka_traits::message::StoredMessagePayload;
 use cgka_traits::transport::{
@@ -662,10 +662,26 @@ fn snapshot_group_and_member() {
                 credential: vec![],
             }],
             required_capabilities: GroupCapabilities::default(),
+            protocol_profile: ProtocolProfile::Current,
             removed: false,
             join_epoch: EpochId(2),
         }
     );
+}
+
+#[test]
+fn key_package_profile_is_persisted_and_old_records_default_to_legacy() {
+    let legacy: KeyPackage = serde_json::from_value(serde_json::json!({
+        "bytes": [1, 2, 3],
+        "source": null
+    }))
+    .unwrap();
+    assert_eq!(legacy.protocol_profile, ProtocolProfile::Legacy);
+
+    let current = KeyPackage::new(vec![4, 5, 6]).with_protocol_profile(ProtocolProfile::Current);
+    let reopened: KeyPackage =
+        serde_json::from_slice(&serde_json::to_vec(&current).unwrap()).unwrap();
+    assert_eq!(reopened.protocol_profile, ProtocolProfile::Current);
 }
 
 #[test]

--- a/crates/traits/tests/snapshots/snapshots__create_group_request.snap
+++ b/crates/traits/tests/snapshots/snapshots__create_group_request.snap
@@ -2,4 +2,4 @@
 source: crates/traits/tests/snapshots.rs
 expression: "format!(\"{:?}\", CreateGroupRequest\n{\n    name: \"demo\".into(), description: \"\".into(), members:\n    vec![KeyPackage::new(vec![0xEF; 4])], required_features:\n    vec![Feature(\"self-remove\")], app_components: vec![], initial_admins:\n    vec![],\n})"
 ---
-"CreateGroupRequest { name: \"demo\", description: \"\", members: [KeyPackage { bytes: [239, 239, 239, 239], source: None }], required_features: [Feature(\"self-remove\")], app_components: [], initial_admins: [] }"
+"CreateGroupRequest { name: \"demo\", description: \"\", members: [KeyPackage { bytes: [239, 239, 239, 239], source: None, protocol_profile: Legacy }], required_features: [Feature(\"self-remove\")], app_components: [], initial_admins: [] }"

--- a/crates/traits/tests/snapshots/snapshots__group.snap
+++ b/crates/traits/tests/snapshots/snapshots__group.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/traits/tests/snapshots.rs
-expression: "Group\n{\n    id: gid(), name: \"ops\".into(), description: \"for ops talk\".into(), epoch:\n    EpochId(3), members: vec![Member { id: mem_id(), credential: vec![], }],\n    required_capabilities: GroupCapabilities::default(), removed: false,\n    join_epoch: EpochId(2),\n}"
+expression: "Group\n{\n    id: gid(), name: \"ops\".into(), description: \"for ops talk\".into(), epoch:\n    EpochId(3), members: vec![Member { id: mem_id(), credential: vec![], }],\n    required_capabilities: GroupCapabilities::default(), protocol_profile:\n    ProtocolProfile::Current, removed: false, join_epoch: EpochId(2),\n}"
 ---
 {
   "id": [
@@ -31,6 +31,7 @@ expression: "Group\n{\n    id: gid(), name: \"ops\".into(), description: \"for o
       "ids": []
     }
   },
+  "protocol_profile": "current",
   "removed": false,
   "join_epoch": 2
 }

--- a/crates/traits/tests/snapshots/snapshots__intent_invite.snap
+++ b/crates/traits/tests/snapshots/snapshots__intent_invite.snap
@@ -17,7 +17,8 @@ expression: "SendIntent::Invite\n{ group_id: gid(), key_packages: vec![KeyPackag
           239,
           239,
           239
-        ]
+        ],
+        "protocol_profile": "legacy"
       }
     ]
   }


### PR DESCRIPTION
## Summary

- persist an explicit Marmot application `ProtocolProfile` on groups and KeyPackages
- default records written before profile classification to `Legacy`
- preserve explicit `Current` values across serialization and SQLite persistence
- classify the current create/join paths as legacy until the strict cutover lands
- bind KeyPackage wrapper metadata to the decoded legacy account-proof carrier so callers cannot relabel legacy wire bytes as current
- fail closed when a present stored profile has an unknown value
- include the security-relevant profile in KeyPackage equality and hashing while continuing to ignore transport provenance

`ProtocolProfile` is the strict-cutover application-profile generation. It governs differences such as the account-proof carrier, media component, and mixed-profile rejection; it does not identify the MLS application-data carrier. A legacy-classified group may already use `app_data_dictionary`.

This remains the first, deliberately narrow slice of #1048. The current account-proof component and creation-time strict cutover are implemented in the stacked follow-up. Higher-layer profile exposure and behavioral branching are likewise deferred to those profile-specific follow-ups rather than being added to this persistence slice.

## Stack

- #1066 is merged
- base branch: `master`
- next: #1069

## Validation

- `cargo test -p cgka-traits --test snapshots`
- `cargo test -p storage-sqlite corrupt_present_group_profile_fails_closed`
- `cargo test -p storage-sqlite pre_profile_group_record_reopens_as_legacy`
- `cargo test -p cgka-engine --test group_creation create_group_rejects_relabelled_legacy_key_package_profile -- --exact`
- `cargo test -p cgka-engine --test sqlite_storage`
- `just fast-ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added persisted protocol profile classification for groups and key packages, supporting both legacy and current variants.
  - Profile metadata is retained through storage round-trips and engine reopen scenarios.
  - Missing profile fields default deterministically to the legacy variant for backward compatibility.

- **Bug Fixes**
  - Enforces that transported key packages are tagged with the legacy protocol profile when required by account identity proofs.
  - Rejects relabeled legacy key packages with incorrect profile metadata and surfaces clear errors for unknown/invalid profile values.

- **Tests**
  - Expanded integration and storage test coverage to verify profile preservation, defaults, and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->