### PR TITLE
Enforce current-profile invariants on every resulting state

### DIFF
--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -57,6 +57,14 @@ These are the scenarios another implementation should be able to load from JSON 
 - Pressure: normal metadata commit path.
 - Expected: recipients advance one epoch and keep the same member set.
 
+### `current-profile-required-set/v1`
+
+- File: `vectors/current-profile-required-set.v1.json`
+- Setup: Alice creates a current-profile group with Bob and Bob joins from the founding Welcome.
+- Contract: GroupContext requires extension `0x0006`, proposal `0x0008`, and application components `0x8003` and
+  `0x8009`; `0x8003` has GroupContext state while `0x8009` is LeafNode-only.
+- Expected: both clients accept the profile, converge at epoch 1, and retain the two-member group.
+
 ### `admin-policy-update/v1`
 
 - File: `vectors/admin-policy-update.v1.json`

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -20,6 +20,7 @@ use cgka_traits::engine::{
 };
 use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::error::EngineError;
+use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{IngestOutcome, PeeledContent};
 use cgka_traits::peeler::TransportPeeler;
@@ -46,6 +47,7 @@ pub struct HarnessClient {
     identity: Vec<u8>,
     signer: nostr::Keys,
     registry: FeatureRegistry,
+    protocol_profile: ProtocolProfile,
     pending_events: Vec<GroupEvent>,
     /// Default MLS group id used by single-group scenarios. Set
     /// automatically after the first create/join.
@@ -60,6 +62,7 @@ pub struct ClientBuilder {
     identity: Vec<u8>,
     signer: nostr::Keys,
     registry: FeatureRegistry,
+    protocol_profile: ProtocolProfile,
     storage_mode: HarnessStorageMode,
 }
 
@@ -112,6 +115,7 @@ impl ClientBuilder {
             identity,
             signer,
             registry: FeatureRegistry::new(),
+            protocol_profile: ProtocolProfile::Legacy,
             storage_mode: HarnessStorageMode::from_env(),
         }
     }
@@ -126,6 +130,11 @@ impl ClientBuilder {
         self
     }
 
+    pub fn protocol_profile(mut self, profile: ProtocolProfile) -> Self {
+        self.protocol_profile = profile;
+        self
+    }
+
     pub fn attach(self, bus: &TransportBus) -> HarnessClient {
         let (storage, storage_dir) = self.storage_mode.open().expect("storage opens");
         let audit_capture = AuditCapture::default();
@@ -134,6 +143,7 @@ impl ClientBuilder {
             &self.identity,
             &self.signer,
             &self.registry,
+            self.protocol_profile,
             &audit_capture,
         );
         let bus_id = bus.attach(MemberId::new(self.identity.clone()));
@@ -146,6 +156,7 @@ impl ClientBuilder {
             identity: self.identity,
             signer: self.signer,
             registry: self.registry,
+            protocol_profile: self.protocol_profile,
             pending_events: Vec::new(),
             default_group: None,
             app_event_counter: 0,
@@ -163,6 +174,7 @@ fn build_harness_engine(
     identity: &[u8],
     signer: &nostr::Keys,
     registry: &FeatureRegistry,
+    protocol_profile: ProtocolProfile,
     audit_capture: &AuditCapture,
 ) -> Engine<SqliteAccountStorage> {
     let peeler = NostrMlsPeeler::new().with_welcome_signer(signer.clone());
@@ -171,6 +183,7 @@ fn build_harness_engine(
         .account_identity_proof_signer(Arc::new(NostrAccountIdentityProofSigner {
             keys: signer.clone(),
         }))
+        .protocol_profile(protocol_profile)
         .feature_registry(registry.clone())
         .supported_app_components(harness_supported_app_components())
         .peeler(Box::new(peeler))
@@ -226,10 +239,12 @@ fn key_package_with_harness_source(key_package: KeyPackage) -> KeyPackage {
     let mut hasher = Sha256::new();
     hasher.update(b"marmot-cgka-conformance-key-package-event-id-v1");
     hasher.update(key_package.bytes());
+    let protocol_profile = key_package.protocol_profile;
     KeyPackage::with_source_event_id(
         key_package.bytes().to_vec(),
         MessageId::new(hasher.finalize().to_vec()),
     )
+    .with_protocol_profile(protocol_profile)
 }
 
 #[derive(Clone)]
@@ -302,6 +317,7 @@ impl HarnessClient {
             &self.identity,
             &self.signer,
             &self.registry,
+            self.protocol_profile,
             &self.audit_capture,
         );
         engine

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -34,6 +34,7 @@ impl GeneratedScenarioCase {
             vector_version: "1".into(),
             conformance_version: conformance_version.into(),
             seed: Some(self.seed),
+            application_profile: None,
             scenario: self.scenario.clone(),
             expected_trace,
             expected_outcomes: self.expected_outcomes.clone(),

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -55,7 +55,7 @@ pub use scenario::{
     run_vector_fixture_report,
 };
 pub use vector::{
-    AppInvalidationObservation, ClientEventCounts, ClientObservation,
+    AppInvalidationObservation, ApplicationProfileContract, ClientEventCounts, ClientObservation,
     ConvergenceDecisionObservation, EpochChangeObservation, ExpectationFailure,
     ForkRecoveryObservation, PendingResolutionObservation, RecoveryOrderingKeyObservation,
     ScenarioAdminPolicyObservation, ScenarioErrorObservation, ScenarioTrace, TraceExpectation,

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -15,6 +15,7 @@ use cgka_traits::EngineError;
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::KeyPackage;
 use cgka_traits::engine_state::PendingStateRef;
+use cgka_traits::group::ProtocolProfile;
 use cgka_traits::types::MemberId;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
@@ -258,7 +259,7 @@ pub async fn run_scenario_report(
     spec: &ScenarioSpec,
     expected_trace: Option<ScenarioTrace>,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    run_scenario_report_inner(spec, expected_trace, vec![], None).await
+    run_scenario_report_inner(spec, expected_trace, vec![], None, ProtocolProfile::Legacy).await
 }
 
 pub async fn run_scenario_report_with_outcomes(
@@ -266,12 +267,33 @@ pub async fn run_scenario_report_with_outcomes(
     expected_trace: Option<ScenarioTrace>,
     expected_outcomes: Vec<TraceExpectation>,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    run_scenario_report_inner(spec, expected_trace, expected_outcomes, None).await
+    run_scenario_report_inner(
+        spec,
+        expected_trace,
+        expected_outcomes,
+        None,
+        ProtocolProfile::Legacy,
+    )
+    .await
 }
 
 pub async fn run_vector_fixture_report(
     fixture: &VectorFixture,
 ) -> Result<ScenarioReport, ScenarioRunError> {
+    let protocol_profile = match fixture
+        .application_profile
+        .as_ref()
+        .map(|profile| profile.name.as_str())
+    {
+        None | Some("legacy") => ProtocolProfile::Legacy,
+        Some("current") => ProtocolProfile::Current,
+        Some(name) => {
+            return Err(ScenarioRunError {
+                step_index: None,
+                message: format!("unsupported application profile {name}"),
+            });
+        }
+    };
     run_scenario_report_inner(
         &fixture.scenario,
         fixture.expected_trace.clone(),
@@ -282,6 +304,7 @@ pub async fn run_vector_fixture_report(
             conformance_version: fixture.conformance_version.clone(),
             seed: fixture.seed,
         }),
+        protocol_profile,
     )
     .await
 }
@@ -291,6 +314,7 @@ async fn run_scenario_report_inner(
     expected_trace: Option<ScenarioTrace>,
     expected_outcomes: Vec<TraceExpectation>,
     fixture: Option<VectorFixtureMetadata>,
+    protocol_profile: ProtocolProfile,
 ) -> Result<ScenarioReport, ScenarioRunError> {
     if spec.spec_version != "1" {
         return Err(ScenarioRunError {
@@ -309,6 +333,7 @@ async fn run_scenario_report_inner(
         }
         let client = ClientBuilder::new(pad32(label.as_bytes()))
             .registry(scenario_registry())
+            .protocol_profile(protocol_profile)
             .attach(&bus);
         clients.insert(label.clone(), client);
     }

--- a/crates/cgka-conformance-simulator/src/vector.rs
+++ b/crates/cgka-conformance-simulator/src/vector.rs
@@ -19,11 +19,26 @@ pub struct VectorFixture {
     pub vector_version: String,
     pub conformance_version: String,
     pub seed: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub application_profile: Option<ApplicationProfileContract>,
     pub scenario: ScenarioSpec,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expected_trace: Option<ScenarioTrace>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub expected_outcomes: Vec<TraceExpectation>,
+}
+
+/// Portable registry-level contract attached to scenarios that pin an
+/// application profile. Values use the specification's hexadecimal registry
+/// notation so fixtures remain implementation-neutral.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApplicationProfileContract {
+    pub name: String,
+    pub required_group_context_extensions: Vec<String>,
+    pub required_proposals: Vec<String>,
+    pub required_app_components: Vec<String>,
+    pub required_group_context_state_components: Vec<String>,
+    pub leaf_only_app_components: Vec<String>,
 }
 
 impl VectorFixture {

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -1096,6 +1096,7 @@ async fn vector_fixture_report_records_semantic_expectation_failures() {
         vector_version: "1".into(),
         conformance_version: env!("CARGO_PKG_VERSION").into(),
         seed: None,
+        application_profile: None,
         scenario: group_data_fork_recovery_spec(),
         expected_trace: None,
         expected_outcomes: vec![TraceExpectation::ClientState {
@@ -1700,9 +1701,11 @@ async fn canonical_vector_fixtures_match_generated_traces() {
         let fixture: VectorFixture =
             serde_json::from_str(&std::fs::read_to_string(&path).expect("fixture contents"))
                 .unwrap_or_else(|e| panic!("{fixture_name} parses: {e}"));
-        let observed_trace = run_scenario_spec(&fixture.scenario)
+        let observed_trace = run_vector_fixture_report(&fixture)
             .await
-            .expect("fixture scenario runs");
+            .expect("fixture scenario runs")
+            .observed_trace
+            .expect("successful fixture report has an observed trace");
         assert_vector_fixture_matches(fixture_name, &fixture, observed_trace);
     }
 }

--- a/crates/cgka-conformance-simulator/tests/vector_artifacts.rs
+++ b/crates/cgka-conformance-simulator/tests/vector_artifacts.rs
@@ -114,6 +114,25 @@ fn assert_even_hex(hex: &str, path: &Path) {
     );
 }
 
+#[test]
+fn current_profile_vector_pins_the_adopted_required_set() {
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("vectors/current-profile-required-set.v1.json");
+    let fixture: cgka_conformance_simulator::VectorFixture =
+        serde_json::from_str(&fs::read_to_string(&path).expect("profile fixture exists"))
+            .expect("profile fixture parses");
+    let profile = fixture
+        .application_profile
+        .expect("current profile contract is present");
+
+    assert_eq!(profile.name, "current");
+    assert_eq!(profile.required_group_context_extensions, ["0x0006"]);
+    assert_eq!(profile.required_proposals, ["0x0008"]);
+    assert_eq!(profile.required_app_components, ["0x8003", "0x8009"]);
+    assert_eq!(profile.required_group_context_state_components, ["0x8003"]);
+    assert_eq!(profile.leaf_only_app_components, ["0x8009"]);
+}
+
 /// The byte fixtures are portable cross-implementation vectors, so they MUST
 /// round-trip through the reference Marmot codec — not merely be well-formed hex
 /// (closes the gap that let the fixtures drift to a TLS layout the codec rejects).

--- a/crates/cgka-conformance-simulator/tests/vector_artifacts.rs
+++ b/crates/cgka-conformance-simulator/tests/vector_artifacts.rs
@@ -2,6 +2,11 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
 
+use cgka_engine::app_components::{
+    CURRENT_PROFILE_LEAF_ONLY_APP_COMPONENTS, CURRENT_PROFILE_REQUIRED_APP_COMPONENTS,
+    CURRENT_PROFILE_REQUIRED_GROUP_CONTEXT_EXTENSIONS,
+    CURRENT_PROFILE_REQUIRED_GROUP_CONTEXT_STATE_COMPONENTS, CURRENT_PROFILE_REQUIRED_PROPOSALS,
+};
 use serde_json::Value;
 
 #[test]
@@ -131,6 +136,42 @@ fn current_profile_vector_pins_the_adopted_required_set() {
     assert_eq!(profile.required_app_components, ["0x8003", "0x8009"]);
     assert_eq!(profile.required_group_context_state_components, ["0x8003"]);
     assert_eq!(profile.leaf_only_app_components, ["0x8009"]);
+
+    assert_eq!(
+        parse_registry_values(&profile.required_group_context_extensions),
+        CURRENT_PROFILE_REQUIRED_GROUP_CONTEXT_EXTENSIONS
+    );
+    assert_eq!(
+        parse_registry_values(&profile.required_proposals),
+        CURRENT_PROFILE_REQUIRED_PROPOSALS
+    );
+    assert_eq!(
+        parse_registry_values(&profile.required_app_components),
+        CURRENT_PROFILE_REQUIRED_APP_COMPONENTS
+    );
+    assert_eq!(
+        parse_registry_values(&profile.required_group_context_state_components),
+        CURRENT_PROFILE_REQUIRED_GROUP_CONTEXT_STATE_COMPONENTS
+    );
+    assert_eq!(
+        parse_registry_values(&profile.leaf_only_app_components),
+        CURRENT_PROFILE_LEAF_ONLY_APP_COMPONENTS
+    );
+}
+
+fn parse_registry_values(values: &[String]) -> Vec<u16> {
+    values
+        .iter()
+        .map(|value| {
+            u16::from_str_radix(
+                value
+                    .strip_prefix("0x")
+                    .expect("registry value has 0x prefix"),
+                16,
+            )
+            .expect("registry value fits in u16")
+        })
+        .collect()
 }
 
 /// The byte fixtures are portable cross-implementation vectors, so they MUST

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,0 +1,89 @@
+{
+  "scenario_name": "current-profile-required-set/v1",
+  "vector_version": "1",
+  "conformance_version": "0.9.5",
+  "seed": null,
+  "application_profile": {
+    "name": "current",
+    "required_group_context_extensions": [
+      "0x0006"
+    ],
+    "required_proposals": [
+      "0x0008"
+    ],
+    "required_app_components": [
+      "0x8003",
+      "0x8009"
+    ],
+    "required_group_context_state_components": [
+      "0x8003"
+    ],
+    "leaf_only_app_components": [
+      "0x8009"
+    ]
+  },
+  "scenario": {
+    "name": "current-profile-required-set/v1",
+    "spec_version": "1",
+    "clients": [
+      "alice",
+      "bob"
+    ],
+    "steps": [
+      {
+        "type": "create_group",
+        "creator": "alice",
+        "name": "current-profile",
+        "invitees": [
+          "bob"
+        ],
+        "required_features": [],
+        "pending": "create"
+      },
+      {
+        "type": "confirm_pending",
+        "client": "alice",
+        "pending": "create"
+      },
+      {
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob"
+        ]
+      },
+      {
+        "type": "observe",
+        "clients": [
+          "alice",
+          "bob"
+        ]
+      }
+    ]
+  },
+  "expected_outcomes": [
+    {
+      "type": "pending_resolution",
+      "step_index": 1,
+      "client": "alice",
+      "pending": "create",
+      "resolution": "confirmed"
+    },
+    {
+      "type": "client_state",
+      "client": "alice",
+      "epoch": 1,
+      "member_count": 2,
+      "received_payloads": []
+    },
+    {
+      "type": "client_state",
+      "client": "bob",
+      "epoch": 1,
+      "member_count": 2,
+      "received_payloads": []
+    }
+  ]
+}

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": "1",
-  "updated": "2026-07-06",
+  "updated": "2026-07-23",
   "purpose": "Inventory of current CGKA conformance artifacts and the next vectorization state for each one.",
   "entries": [
     {
@@ -63,6 +63,21 @@
         "stable member set across metadata update"
       ],
       "next": "Extend with explicit group profile state once ScenarioTrace carries component state."
+    },
+    {
+      "id": "current-profile-required-set/v1",
+      "kind": "scenario_vector",
+      "status": "portable",
+      "artifact": "current-profile-required-set.v1.json",
+      "coverage": [
+        "current application profile registry contract",
+        "required app_data_dictionary extension 0x0006",
+        "required app_data_update proposal 0x0008",
+        "mandatory admin-policy component 0x8003",
+        "mandatory LeafNode-only account-proof component 0x8009",
+        "creation and Welcome join under the current profile"
+      ],
+      "next": "Keep registry ids synchronized with the adopted application profile."
     },
     {
       "id": "admin-policy-update/v1",

--- a/crates/cgka-engine/README.md
+++ b/crates/cgka-engine/README.md
@@ -55,6 +55,19 @@ still agree after the world gets messy.
 
 See [`tests/AGENTS.md`](tests/AGENTS.md) for the test file map.
 
+## Promoting state-bearing app components
+
+`upgrade_group_capabilities` only promotes state-bearing app components whose
+optional state already exists in the GroupContext. Use two published commits:
+
+1. send `SendIntent::UpdateAppComponents` to install the optional component
+   state, then confirm that commit was published;
+2. call `upgrade_group_capabilities`, then publish and confirm its promotion
+   commit.
+
+The upgrade fails closed without staging a commit when required state is
+missing. MDK does not currently expose an atomic require-and-populate API.
+
 ## Reading order for a new contributor
 
 1. Target architecture: `../../docs/marmot-architecture/overview/target-architecture.md`

--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -24,6 +24,22 @@ use openmls::prelude::{
 use openmls::treesync::Node;
 use std::collections::{BTreeMap, BTreeSet};
 
+/// Registry-level contract enforced for every current-profile group state.
+///
+/// These values are public so portable conformance vectors can cross-check
+/// their implementation-neutral hexadecimal contract against the exact set the
+/// engine validator consumes.
+pub const CURRENT_PROFILE_REQUIRED_GROUP_CONTEXT_EXTENSIONS: [u16; 1] = [0x0006];
+pub const CURRENT_PROFILE_REQUIRED_PROPOSALS: [u16; 1] = [0x0008];
+pub const CURRENT_PROFILE_REQUIRED_APP_COMPONENTS: [AppComponentId; 2] = [
+    GROUP_ADMIN_POLICY_COMPONENT_ID,
+    ACCOUNT_IDENTITY_PROOF_COMPONENT_ID,
+];
+pub const CURRENT_PROFILE_REQUIRED_GROUP_CONTEXT_STATE_COMPONENTS: [AppComponentId; 1] =
+    [GROUP_ADMIN_POLICY_COMPONENT_ID];
+pub const CURRENT_PROFILE_LEAF_ONLY_APP_COMPONENTS: [AppComponentId; 1] =
+    [ACCOUNT_IDENTITY_PROOF_COMPONENT_ID];
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct InitialComponentState {
     pub(crate) name: String,
@@ -493,17 +509,25 @@ fn validate_current_profile_group_context(
             "invalid current-profile {context}: missing required_capabilities"
         ))
     })?;
-    if !required
-        .extension_types()
-        .contains(&ExtensionType::AppDataDictionary)
+    if !CURRENT_PROFILE_REQUIRED_GROUP_CONTEXT_EXTENSIONS
+        .iter()
+        .all(|extension_type| {
+            required
+                .extension_types()
+                .contains(&ExtensionType::from(*extension_type))
+        })
     {
         return Err(EngineError::Other(format!(
             "invalid current-profile {context}: app_data_dictionary is not a required extension"
         )));
     }
-    if !required
-        .proposal_types()
-        .contains(&ProposalType::AppDataUpdate)
+    if !CURRENT_PROFILE_REQUIRED_PROPOSALS
+        .iter()
+        .all(|proposal_type| {
+            required
+                .proposal_types()
+                .contains(&ProposalType::from(*proposal_type))
+        })
     {
         return Err(EngineError::Other(format!(
             "invalid current-profile {context}: app_data_update is not a required proposal"
@@ -516,10 +540,7 @@ fn validate_current_profile_group_context(
         ))
     })?;
     let required_components = required_app_components_of_extensions(extensions, context)?;
-    for mandatory in [
-        GROUP_ADMIN_POLICY_COMPONENT_ID,
-        ACCOUNT_IDENTITY_PROOF_COMPONENT_ID,
-    ] {
+    for mandatory in CURRENT_PROFILE_REQUIRED_APP_COMPONENTS {
         if !required_components.contains(mandatory) {
             return Err(EngineError::Other(format!(
                 "invalid current-profile {context}: missing mandatory component requirement \
@@ -527,13 +548,20 @@ fn validate_current_profile_group_context(
             )));
         }
     }
-    if dictionary
-        .dictionary()
-        .contains(&ACCOUNT_IDENTITY_PROOF_COMPONENT_ID)
-    {
-        return Err(EngineError::Other(format!(
-            "invalid current-profile {context}: leaf-only account proof appears in GroupContext"
-        )));
+    for component_id in CURRENT_PROFILE_LEAF_ONLY_APP_COMPONENTS {
+        if dictionary.dictionary().contains(&component_id) {
+            return Err(EngineError::Other(format!(
+                "invalid current-profile {context}: leaf-only account proof appears in GroupContext"
+            )));
+        }
+    }
+    for component_id in CURRENT_PROFILE_REQUIRED_GROUP_CONTEXT_STATE_COMPONENTS {
+        if !dictionary.dictionary().contains(&component_id) {
+            return Err(EngineError::Other(format!(
+                "invalid current-profile {context}: required component {component_id:#06x} \
+                 has no GroupContext state"
+            )));
+        }
     }
 
     for entry in dictionary.dictionary().entries() {
@@ -546,7 +574,7 @@ fn validate_current_profile_group_context(
         }
     }
     for component_id in &required_components.ids {
-        if *component_id == ACCOUNT_IDENTITY_PROOF_COMPONENT_ID {
+        if CURRENT_PROFILE_LEAF_ONLY_APP_COMPONENTS.contains(component_id) {
             continue;
         }
         if !is_known_group_component(*component_id) {
@@ -602,15 +630,20 @@ fn is_known_group_component(component_id: AppComponentId) -> bool {
     )
 }
 
-fn ratchet_tree_leaves(tree: openmls::treesync::RatchetTree) -> Result<Vec<LeafNode>, EngineError> {
+pub(crate) fn ratchet_tree_nodes(
+    tree: openmls::treesync::RatchetTree,
+) -> Result<Vec<Option<Node>>, EngineError> {
     // RatchetTree intentionally keeps its node vector private. Its stable
     // serde representation exposes the same public Node enum that MDK already
-    // uses for cold-path proof validation.
+    // uses for cold-path proof and capability validation.
     let value = serde_json::to_value(tree)
         .map_err(|error| EngineError::Backend(format!("export ratchet tree: {error}")))?;
-    let nodes: Vec<Option<Node>> = serde_json::from_value(value)
-        .map_err(|error| EngineError::Backend(format!("decode ratchet tree: {error}")))?;
-    Ok(nodes
+    serde_json::from_value(value)
+        .map_err(|error| EngineError::Backend(format!("decode ratchet tree: {error}")))
+}
+
+fn ratchet_tree_leaves(tree: openmls::treesync::RatchetTree) -> Result<Vec<LeafNode>, EngineError> {
+    Ok(ratchet_tree_nodes(tree)?
         .into_iter()
         .filter_map(|node| match node {
             Some(Node::LeafNode(leaf)) => Some(*leaf),
@@ -622,12 +655,8 @@ fn ratchet_tree_leaves(tree: openmls::treesync::RatchetTree) -> Result<Vec<LeafN
 fn indexed_ratchet_tree_leaves(
     tree: openmls::treesync::RatchetTree,
 ) -> Result<BTreeMap<u32, LeafNode>, EngineError> {
-    let value = serde_json::to_value(tree)
-        .map_err(|error| EngineError::Backend(format!("export ratchet tree: {error}")))?;
-    let nodes: Vec<Option<Node>> = serde_json::from_value(value)
-        .map_err(|error| EngineError::Backend(format!("decode ratchet tree: {error}")))?;
     let mut leaves = BTreeMap::new();
-    for (node_index, node) in nodes.into_iter().enumerate() {
+    for (node_index, node) in ratchet_tree_nodes(tree)?.into_iter().enumerate() {
         if let Some(Node::LeafNode(leaf)) = node {
             let leaf_index = u32::try_from(node_index / 2)
                 .map_err(|_| EngineError::Backend("ratchet tree index overflow".into()))?;

--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -13,11 +13,15 @@ use cgka_traits::app_components::{
 };
 use cgka_traits::engine::CommitOrderingPriority;
 use cgka_traits::error::EngineError;
+use cgka_traits::group::ProtocolProfile;
 use cgka_traits::types::{GroupId, MemberId};
-use openmls::extensions::{AppDataDictionary, AppDataDictionaryExtension, Extension};
-use openmls::group::{MlsGroup, StagedCommit};
-use openmls::messages::proposals::{AppDataUpdateOperation, Proposal};
-use openmls::prelude::{BasicCredential, LeafNode, Sender};
+use openmls::extensions::{AppDataDictionary, AppDataDictionaryExtension, Extension, Extensions};
+use openmls::group::{GroupContext, MlsGroup, StagedCommit};
+use openmls::messages::proposals::{AppDataUpdateOperation, AppDataUpdateProposal, Proposal};
+use openmls::prelude::{
+    BasicCredential, ExtensionType, LeafNode, LeafNodeIndex, ProposalType, Sender,
+};
+use openmls::treesync::Node;
 use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -343,9 +347,8 @@ pub(crate) fn validate_admin_leaf_coupling_for_staged_commit(
 /// Enforced rules, in order:
 /// 1. the `app_data_dictionary` extension itself may never be dropped;
 /// 2. the engine-owned `app_components` entry and the state entry of every
-///    component in the current epoch's required set may never be dropped
-///    (mirrors [`validate_app_component_remove`]: a component becomes
-///    droppable only after a prior commit removes it from the required list);
+///    component in the resulting epoch's required set may never be dropped;
+///    one Commit may atomically unrequire and remove an optional component;
 /// 3. every dictionary entry that changes relative to the current epoch —
 ///    added, rewritten, or removed — must match one of this commit's own
 ///    `AppDataUpdate` operations, whose payloads passed the component
@@ -365,12 +368,40 @@ pub(crate) fn validate_app_component_integrity_for_staged_commit(
     let current = current.map(|ext| ext.dictionary());
     let resulting = resulting.map(|ext| ext.dictionary());
 
-    let mut protected = required_app_components_of_group(mls_group)?.ids;
-    protected.insert(APP_COMPONENTS_COMPONENT_ID);
+    // Protect the RESULTING required set. This deliberately permits one
+    // authorized Commit to atomically unrequire and remove an optional
+    // component, while still rejecting a required entry that disappears.
+    let is_current = crate::account_identity_proof::protocol_profile_of_group(mls_group)?
+        == ProtocolProfile::Current;
+    let mut protected = if resulting
+        .and_then(|dictionary| dictionary.get(&APP_COMPONENTS_COMPONENT_ID))
+        .is_some()
+    {
+        required_app_components_of_extensions(
+            staged.group_context().extensions(),
+            "resulting GroupContext",
+        )?
+        .ids
+    } else if is_current {
+        return Err(EngineError::Other(
+            "commit is invalid: resulting GroupContext drops current-profile app_components".into(),
+        ));
+    } else {
+        BTreeSet::new()
+    };
+    if is_current
+        || current.is_some_and(|dictionary| dictionary.contains(&APP_COMPONENTS_COMPONENT_ID))
+    {
+        protected.insert(APP_COMPONENTS_COMPONENT_ID);
+    }
     for component_id in &protected {
-        let currently_present = current.is_some_and(|dict| dict.contains(component_id));
+        // The account proof is required by the GroupContext but its data is
+        // LeafNode-only. It must never appear as GroupContext state.
+        if *component_id == ACCOUNT_IDENTITY_PROOF_COMPONENT_ID {
+            continue;
+        }
         let still_present = resulting.is_some_and(|dict| dict.contains(component_id));
-        if currently_present && !still_present {
+        if !still_present {
             return Err(EngineError::Other(format!(
                 "commit is invalid: resulting GroupContext drops required app component \
                  {component_id:#06x}"
@@ -412,6 +443,272 @@ pub(crate) fn validate_app_component_integrity_for_staged_commit(
                 "commit is invalid: resulting GroupContext changes app component \
                  {component_id:#06x} outside an AppDataUpdate proposal"
             )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate the complete current application profile carried by an already
+/// materialized MLS group.
+///
+/// Legacy groups deliberately skip these current-profile requirements. Their
+/// deployed proof/component rules remain selected by their explicit profile.
+pub(crate) fn validate_current_profile_group_invariants(
+    group: &MlsGroup,
+) -> Result<(), EngineError> {
+    let profile = crate::account_identity_proof::protocol_profile_of_group(group)?;
+    if profile == ProtocolProfile::Legacy {
+        return Ok(());
+    }
+    let required_components =
+        validate_current_profile_group_context(group.extensions(), "group state")?;
+    let leaves = ratchet_tree_leaves(group.export_ratchet_tree())?;
+    validate_resulting_leaf_capabilities(leaves.iter(), group.extensions(), &required_components)
+}
+
+/// Validate current-profile invariants against the complete state a staged
+/// Commit would produce, before the Commit can mutate canonical group state.
+pub(crate) fn validate_current_profile_invariants_for_staged_commit(
+    group: &MlsGroup,
+    staged: &StagedCommit,
+    committer_index: LeafNodeIndex,
+) -> Result<(), EngineError> {
+    let profile = crate::account_identity_proof::protocol_profile_of_group(group)?;
+    if profile == ProtocolProfile::Legacy {
+        return Ok(());
+    }
+    let extensions = staged.group_context().extensions();
+    let required_components =
+        validate_current_profile_group_context(extensions, "resulting group state")?;
+    let leaves = conceptual_resulting_leaves(group, staged, committer_index)?;
+    validate_resulting_leaf_capabilities(leaves.iter(), extensions, &required_components)
+}
+
+fn validate_current_profile_group_context(
+    extensions: &Extensions<GroupContext>,
+    context: &str,
+) -> Result<AppComponentSet, EngineError> {
+    let required = extensions.required_capabilities().ok_or_else(|| {
+        EngineError::Other(format!(
+            "invalid current-profile {context}: missing required_capabilities"
+        ))
+    })?;
+    if !required
+        .extension_types()
+        .contains(&ExtensionType::AppDataDictionary)
+    {
+        return Err(EngineError::Other(format!(
+            "invalid current-profile {context}: app_data_dictionary is not a required extension"
+        )));
+    }
+    if !required
+        .proposal_types()
+        .contains(&ProposalType::AppDataUpdate)
+    {
+        return Err(EngineError::Other(format!(
+            "invalid current-profile {context}: app_data_update is not a required proposal"
+        )));
+    }
+
+    let dictionary = extensions.app_data_dictionary().ok_or_else(|| {
+        EngineError::Other(format!(
+            "invalid current-profile {context}: missing app_data_dictionary"
+        ))
+    })?;
+    let required_components = required_app_components_of_extensions(extensions, context)?;
+    for mandatory in [
+        GROUP_ADMIN_POLICY_COMPONENT_ID,
+        ACCOUNT_IDENTITY_PROOF_COMPONENT_ID,
+    ] {
+        if !required_components.contains(mandatory) {
+            return Err(EngineError::Other(format!(
+                "invalid current-profile {context}: missing mandatory component requirement \
+                 {mandatory:#06x}"
+            )));
+        }
+    }
+    if dictionary
+        .dictionary()
+        .contains(&ACCOUNT_IDENTITY_PROOF_COMPONENT_ID)
+    {
+        return Err(EngineError::Other(format!(
+            "invalid current-profile {context}: leaf-only account proof appears in GroupContext"
+        )));
+    }
+
+    for entry in dictionary.dictionary().entries() {
+        let component_id = entry.id();
+        if is_known_group_component(component_id) {
+            validate_app_component_update(&AppComponentData {
+                component_id,
+                data: entry.data().to_vec(),
+            })?;
+        }
+    }
+    for component_id in &required_components.ids {
+        if *component_id == ACCOUNT_IDENTITY_PROOF_COMPONENT_ID {
+            continue;
+        }
+        if !is_known_group_component(*component_id) {
+            return Err(EngineError::Other(format!(
+                "invalid current-profile {context}: unsupported required component \
+                 {component_id:#06x}"
+            )));
+        }
+        if !dictionary.dictionary().contains(component_id) {
+            return Err(EngineError::Other(format!(
+                "invalid current-profile {context}: required component {component_id:#06x} \
+                 has no GroupContext state"
+            )));
+        }
+    }
+    Ok(required_components)
+}
+
+fn required_app_components_of_extensions(
+    extensions: &Extensions<GroupContext>,
+    context: &str,
+) -> Result<AppComponentSet, EngineError> {
+    let dictionary = extensions.app_data_dictionary().ok_or_else(|| {
+        EngineError::Other(format!("invalid {context}: missing app_data_dictionary"))
+    })?;
+    let bytes = dictionary
+        .dictionary()
+        .get(&APP_COMPONENTS_COMPONENT_ID)
+        .ok_or_else(|| {
+            EngineError::Other(format!(
+                "invalid {context}: missing app_components requirement list"
+            ))
+        })?;
+    let ids = decode_components_list(bytes).map_err(|error| {
+        EngineError::Serialize(format!("invalid {context} app_components: {error}"))
+    })?;
+    Ok(AppComponentSet::from(ids))
+}
+
+fn is_known_group_component(component_id: AppComponentId) -> bool {
+    matches!(
+        component_id,
+        APP_COMPONENTS_COMPONENT_ID
+            | SAFE_AAD_COMPONENT_ID
+            | GROUP_PROFILE_COMPONENT_ID
+            | GROUP_BLOSSOM_IMAGE_COMPONENT_ID
+            | GROUP_ADMIN_POLICY_COMPONENT_ID
+            | NOSTR_ROUTING_COMPONENT_ID
+            | GROUP_MESSAGE_RETENTION_COMPONENT_ID
+            | AGENT_TEXT_STREAM_QUIC_COMPONENT_ID
+            | GROUP_AVATAR_URL_COMPONENT_ID
+            | GROUP_ENCRYPTED_MEDIA_COMPONENT_ID
+    )
+}
+
+fn ratchet_tree_leaves(tree: openmls::treesync::RatchetTree) -> Result<Vec<LeafNode>, EngineError> {
+    // RatchetTree intentionally keeps its node vector private. Its stable
+    // serde representation exposes the same public Node enum that MDK already
+    // uses for cold-path proof validation.
+    let value = serde_json::to_value(tree)
+        .map_err(|error| EngineError::Backend(format!("export ratchet tree: {error}")))?;
+    let nodes: Vec<Option<Node>> = serde_json::from_value(value)
+        .map_err(|error| EngineError::Backend(format!("decode ratchet tree: {error}")))?;
+    Ok(nodes
+        .into_iter()
+        .filter_map(|node| match node {
+            Some(Node::LeafNode(leaf)) => Some(*leaf),
+            _ => None,
+        })
+        .collect())
+}
+
+fn indexed_ratchet_tree_leaves(
+    tree: openmls::treesync::RatchetTree,
+) -> Result<BTreeMap<u32, LeafNode>, EngineError> {
+    let value = serde_json::to_value(tree)
+        .map_err(|error| EngineError::Backend(format!("export ratchet tree: {error}")))?;
+    let nodes: Vec<Option<Node>> = serde_json::from_value(value)
+        .map_err(|error| EngineError::Backend(format!("decode ratchet tree: {error}")))?;
+    let mut leaves = BTreeMap::new();
+    for (node_index, node) in nodes.into_iter().enumerate() {
+        if let Some(Node::LeafNode(leaf)) = node {
+            let leaf_index = u32::try_from(node_index / 2)
+                .map_err(|_| EngineError::Backend("ratchet tree index overflow".into()))?;
+            leaves.insert(leaf_index, *leaf);
+        }
+    }
+    Ok(leaves)
+}
+
+fn conceptual_resulting_leaves(
+    group: &MlsGroup,
+    staged: &StagedCommit,
+    committer_index: LeafNodeIndex,
+) -> Result<Vec<LeafNode>, EngineError> {
+    let mut leaves = indexed_ratchet_tree_leaves(group.export_ratchet_tree())?;
+    for remove in staged.remove_proposals() {
+        leaves.remove(&remove.remove_proposal().removed().u32());
+    }
+    for queued in staged.queued_proposals() {
+        if matches!(queued.proposal(), Proposal::SelfRemove)
+            && let Sender::Member(index) = queued.sender()
+        {
+            leaves.remove(&index.u32());
+        }
+    }
+    for update in staged.update_proposals() {
+        let Sender::Member(index) = update.sender() else {
+            return Err(EngineError::Other(
+                "invalid resulting group state: Update has no member sender".into(),
+            ));
+        };
+        leaves.insert(index.u32(), update.update_proposal().leaf_node().clone());
+    }
+    if let Some(path_leaf) = staged.update_path_leaf_node() {
+        leaves.insert(committer_index.u32(), path_leaf.clone());
+    }
+    let mut result = leaves.into_values().collect::<Vec<_>>();
+    result.extend(
+        staged
+            .add_proposals()
+            .map(|add| add.add_proposal().key_package().leaf_node().clone()),
+    );
+    Ok(result)
+}
+
+fn validate_resulting_leaf_capabilities<'a>(
+    leaves: impl Iterator<Item = &'a LeafNode>,
+    extensions: &Extensions<GroupContext>,
+    required_components: &AppComponentSet,
+) -> Result<(), EngineError> {
+    let required = extensions.required_capabilities().ok_or_else(|| {
+        EngineError::Other(
+            "invalid current-profile group state: missing required_capabilities".into(),
+        )
+    })?;
+    for leaf in leaves {
+        let capabilities = leaf.capabilities();
+        let supports_required = required
+            .extension_types()
+            .iter()
+            .all(|required| capabilities.extensions().contains(required))
+            && required
+                .proposal_types()
+                .iter()
+                .all(|required| capabilities.proposals().contains(required))
+            && required
+                .credential_types()
+                .iter()
+                .all(|required| capabilities.credentials().contains(required));
+        if !supports_required {
+            return Err(EngineError::Other(
+                "invalid current-profile resulting state: member lacks a required MLS capability"
+                    .into(),
+            ));
+        }
+        let advertised = app_components_of_leaf(leaf)?;
+        if !required_components.missing_from(&advertised).is_empty() {
+            return Err(EngineError::Other(
+                "invalid current-profile resulting state: member lacks a required app component"
+                    .into(),
+            ));
         }
     }
     Ok(())
@@ -731,8 +1028,71 @@ pub(crate) fn validate_app_component_update(
     }
 }
 
-pub(crate) fn validate_app_component_remove(
+/// Validate all AppDataUpdate operations in one Commit as a batch.
+///
+/// Removal legality is evaluated against the resulting `app_components`
+/// requirement list, not the parent epoch's list. That permits the spec's
+/// atomic "unrequire and remove" operation while still failing closed if the
+/// resulting epoch requires a component whose GroupContext data is removed.
+pub(crate) fn validate_app_data_update_batch<'a>(
     mls_group: &MlsGroup,
+    updates: impl IntoIterator<Item = &'a AppDataUpdateProposal>,
+) -> Result<(), EngineError> {
+    validate_app_data_update_batch_against(required_app_components_of_group(mls_group)?, updates)
+}
+
+fn validate_app_data_update_batch_against<'a>(
+    mut resulting_required: AppComponentSet,
+    updates: impl IntoIterator<Item = &'a AppDataUpdateProposal>,
+) -> Result<(), EngineError> {
+    let updates = updates.into_iter().collect::<Vec<_>>();
+    let mut seen = BTreeSet::new();
+
+    for update in &updates {
+        if !seen.insert(update.component_id()) {
+            return Err(EngineError::Other(format!(
+                "commit contains multiple AppDataUpdate operations for component {:#06x}",
+                update.component_id()
+            )));
+        }
+        if update.component_id() == APP_COMPONENTS_COMPONENT_ID {
+            match update.operation() {
+                AppDataUpdateOperation::Update(data) => {
+                    resulting_required = AppComponentSet::from(
+                        decode_components_list(data.as_slice()).map_err(|error| {
+                            EngineError::Serialize(format!(
+                                "invalid app_components component: {error}"
+                            ))
+                        })?,
+                    );
+                }
+                AppDataUpdateOperation::Remove => {
+                    return Err(EngineError::Other(
+                        "app_components component cannot be removed".into(),
+                    ));
+                }
+            }
+        }
+    }
+
+    for update in updates {
+        match update.operation() {
+            AppDataUpdateOperation::Update(data) => {
+                validate_app_component_update(&AppComponentData {
+                    component_id: update.component_id(),
+                    data: data.as_slice().to_vec(),
+                })?;
+            }
+            AppDataUpdateOperation::Remove => {
+                validate_app_component_remove_against(&resulting_required, update.component_id())?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_app_component_remove_against(
+    resulting_required: &AppComponentSet,
     component_id: AppComponentId,
 ) -> Result<(), EngineError> {
     if component_id == APP_COMPONENTS_COMPONENT_ID {
@@ -745,7 +1105,7 @@ pub(crate) fn validate_app_component_remove(
             "safe_aad group-component state is not supported yet".into(),
         ));
     }
-    if required_app_components_of_group(mls_group)?.contains(component_id) {
+    if resulting_required.contains(component_id) {
         return Err(EngineError::Other(
             "required Marmot app components cannot be removed".into(),
         ));
@@ -886,6 +1246,40 @@ fn decode_var_bytes(
 mod tests {
     use super::*;
     use cgka_traits::app_components::default_group_components;
+    use openmls::extensions::RequiredCapabilitiesExtension;
+
+    fn current_profile_extensions(
+        required_components: impl IntoIterator<Item = AppComponentId>,
+        include_admin_state: bool,
+        include_leaf_only_proof_state: bool,
+        required_extensions: &[ExtensionType],
+        required_proposals: &[ProposalType],
+    ) -> Extensions<GroupContext> {
+        let required_components = required_components.into_iter().collect();
+        let mut dictionary = AppDataDictionary::new();
+        dictionary.insert(
+            APP_COMPONENTS_COMPONENT_ID,
+            encode_components_list(&required_components),
+        );
+        if include_admin_state {
+            dictionary.insert(
+                GROUP_ADMIN_POLICY_COMPONENT_ID,
+                encode_admin_policy(&[[1; 32]]).unwrap(),
+            );
+        }
+        if include_leaf_only_proof_state {
+            dictionary.insert(ACCOUNT_IDENTITY_PROOF_COMPONENT_ID, vec![0; 104]);
+        }
+        Extensions::from_vec(vec![
+            Extension::RequiredCapabilities(RequiredCapabilitiesExtension::new(
+                required_extensions,
+                required_proposals,
+                &[],
+            )),
+            Extension::AppDataDictionary(AppDataDictionaryExtension::new(dictionary)),
+        ])
+        .unwrap()
+    }
 
     /// Build the group-creation `app_data_dictionary` for `required` with no
     /// initial component bytes, then assert that every entry the engine writes
@@ -1037,5 +1431,189 @@ mod tests {
         .unwrap_err();
 
         assert!(!error.to_string().contains(&hex::encode([0xA5; 32])));
+    }
+
+    #[test]
+    fn app_data_update_batch_rejects_duplicate_component_operations() {
+        let updates = [
+            AppDataUpdateProposal::update(GROUP_PROFILE_COMPONENT_ID, vec![0, 0]),
+            AppDataUpdateProposal::remove(GROUP_PROFILE_COMPONENT_ID),
+        ];
+
+        let error =
+            validate_app_data_update_batch_against(AppComponentSet::default(), updates.iter())
+                .expect_err("one operation per component id");
+
+        assert!(error.to_string().contains("multiple AppDataUpdate"));
+    }
+
+    #[test]
+    fn app_data_update_batch_allows_atomic_unrequire_and_remove() {
+        let initial = AppComponentSet::new([
+            GROUP_PROFILE_COMPONENT_ID,
+            GROUP_ADMIN_POLICY_COMPONENT_ID,
+            GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
+        ]);
+        let resulting = [GROUP_PROFILE_COMPONENT_ID, GROUP_ADMIN_POLICY_COMPONENT_ID]
+            .into_iter()
+            .collect();
+        let updates = [
+            AppDataUpdateProposal::update(
+                APP_COMPONENTS_COMPONENT_ID,
+                encode_components_list(&resulting),
+            ),
+            AppDataUpdateProposal::remove(GROUP_BLOSSOM_IMAGE_COMPONENT_ID),
+        ];
+
+        validate_app_data_update_batch_against(initial, updates.iter())
+            .expect("the component is optional in the resulting epoch");
+    }
+
+    #[test]
+    fn app_data_update_batch_rejects_removing_resulting_required_component() {
+        let initial = AppComponentSet::new([
+            GROUP_PROFILE_COMPONENT_ID,
+            GROUP_ADMIN_POLICY_COMPONENT_ID,
+            GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
+        ]);
+        let updates = [AppDataUpdateProposal::remove(
+            GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
+        )];
+
+        let error = validate_app_data_update_batch_against(initial, updates.iter())
+            .expect_err("required state must remain present");
+
+        assert!(error.to_string().contains("required Marmot app components"));
+    }
+
+    #[test]
+    fn current_profile_group_context_requires_the_complete_mandatory_set() {
+        struct Case {
+            label: &'static str,
+            components: Vec<AppComponentId>,
+            admin_state: bool,
+            proof_state: bool,
+            extensions: Vec<ExtensionType>,
+            proposals: Vec<ProposalType>,
+            expected_error: &'static str,
+        }
+        let mandatory = vec![
+            GROUP_ADMIN_POLICY_COMPONENT_ID,
+            ACCOUNT_IDENTITY_PROOF_COMPONENT_ID,
+        ];
+        let cases = [
+            Case {
+                label: "missing admin requirement",
+                components: vec![ACCOUNT_IDENTITY_PROOF_COMPONENT_ID],
+                admin_state: true,
+                proof_state: false,
+                extensions: vec![ExtensionType::AppDataDictionary],
+                proposals: vec![ProposalType::AppDataUpdate],
+                expected_error: "0x8003",
+            },
+            Case {
+                label: "missing proof requirement",
+                components: vec![GROUP_ADMIN_POLICY_COMPONENT_ID],
+                admin_state: true,
+                proof_state: false,
+                extensions: vec![ExtensionType::AppDataDictionary],
+                proposals: vec![ProposalType::AppDataUpdate],
+                expected_error: "0x8009",
+            },
+            Case {
+                label: "missing admin state",
+                components: mandatory.clone(),
+                admin_state: false,
+                proof_state: false,
+                extensions: vec![ExtensionType::AppDataDictionary],
+                proposals: vec![ProposalType::AppDataUpdate],
+                expected_error: "has no GroupContext state",
+            },
+            Case {
+                label: "proof incorrectly in GroupContext",
+                components: mandatory.clone(),
+                admin_state: true,
+                proof_state: true,
+                extensions: vec![ExtensionType::AppDataDictionary],
+                proposals: vec![ProposalType::AppDataUpdate],
+                expected_error: "leaf-only account proof",
+            },
+            Case {
+                label: "unknown required component",
+                components: vec![
+                    GROUP_ADMIN_POLICY_COMPONENT_ID,
+                    ACCOUNT_IDENTITY_PROOF_COMPONENT_ID,
+                    0xF301,
+                ],
+                admin_state: true,
+                proof_state: false,
+                extensions: vec![ExtensionType::AppDataDictionary],
+                proposals: vec![ProposalType::AppDataUpdate],
+                expected_error: "unsupported required component 0xf301",
+            },
+            Case {
+                label: "missing dictionary capability",
+                components: mandatory.clone(),
+                admin_state: true,
+                proof_state: false,
+                extensions: vec![],
+                proposals: vec![ProposalType::AppDataUpdate],
+                expected_error: "not a required extension",
+            },
+            Case {
+                label: "missing update capability",
+                components: mandatory,
+                admin_state: true,
+                proof_state: false,
+                extensions: vec![ExtensionType::AppDataDictionary],
+                proposals: vec![],
+                expected_error: "not a required proposal",
+            },
+        ];
+
+        for case in cases {
+            let extensions = current_profile_extensions(
+                case.components,
+                case.admin_state,
+                case.proof_state,
+                &case.extensions,
+                &case.proposals,
+            );
+            let error = validate_current_profile_group_context(&extensions, case.label)
+                .expect_err(case.label);
+            assert!(
+                error.to_string().contains(case.expected_error),
+                "{}: {error}",
+                case.label
+            );
+        }
+    }
+
+    #[test]
+    fn current_profile_group_context_preserves_unknown_optional_state() {
+        let mut extensions = current_profile_extensions(
+            [
+                GROUP_ADMIN_POLICY_COMPONENT_ID,
+                ACCOUNT_IDENTITY_PROOF_COMPONENT_ID,
+            ],
+            true,
+            false,
+            &[ExtensionType::AppDataDictionary],
+            &[ProposalType::AppDataUpdate],
+        );
+        let mut dictionary = extensions
+            .app_data_dictionary()
+            .unwrap()
+            .dictionary()
+            .clone();
+        dictionary.insert(0xF301, vec![0xde, 0xad, 0xbe, 0xef]);
+        extensions = Extensions::from_vec(vec![
+            Extension::RequiredCapabilities(extensions.required_capabilities().unwrap().clone()),
+            Extension::AppDataDictionary(AppDataDictionaryExtension::new(dictionary)),
+        ])
+        .unwrap();
+
+        validate_current_profile_group_context(&extensions, "test")
+            .expect("unknown optional component state is opaque");
     }
 }

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -816,6 +816,8 @@ impl<S: StorageProvider> Engine<S> {
         let wire_protocol_profile =
             crate::account_identity_proof::protocol_profile_of_group(&mls_group)
                 .map_err(|_| GroupHydrationQuarantineReason::MemberValidationFailed)?;
+        crate::app_components::validate_current_profile_group_invariants(&mls_group)
+            .map_err(|_| GroupHydrationQuarantineReason::MemberValidationFailed)?;
 
         // Member-credential + account-identity-proof validation runs one
         // BIP-340 schnorr verification per leaf. All of this state was already

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -282,13 +282,15 @@ impl<S: StorageProvider> Engine<S> {
         // crash or write fault cannot leave a partial, undiscoverable group.
         let mut mls_group = self.storage.with_transaction(|storage| {
             let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, storage.mls_storage());
-            MlsGroup::new(
+            let group = MlsGroup::new(
                 &provider,
                 &self.identity.signer,
                 &group_config,
                 self.identity.credential_with_key.clone(),
             )
-            .map_err(|e| EngineError::Backend(format!("group new: {e:?}")))
+            .map_err(|e| EngineError::Backend(format!("group new: {e:?}")))?;
+            crate::app_components::validate_current_profile_group_invariants(&group)?;
+            Ok::<MlsGroup, EngineError>(group)
         })?;
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
         let group_id = GroupId::new(mls_group.group_id().as_slice().to_vec());
@@ -334,6 +336,21 @@ impl<S: StorageProvider> Engine<S> {
                 &provider,
                 group_id.clone(),
             ));
+            let own_leaf_index = mls_group.own_leaf_index();
+            let staged = mls_group.pending_commit().ok_or_else(|| {
+                EngineError::Backend("founding add produced no pending commit".into())
+            })?;
+            crate::app_components::validate_current_profile_invariants_for_staged_commit(
+                &mls_group,
+                staged,
+                own_leaf_index,
+            )?;
+            crate::account_identity_proof::validate_staged_commit_account_identity_proofs(
+                staged,
+                &mls_group,
+                self.identity.self_id(),
+                self.ciphersuite,
+            )?;
             let bytes = welcome_out
                 .tls_serialize_detached()
                 .map_err(|e| EngineError::Serialize(format!("{e:?}")))?;
@@ -670,6 +687,8 @@ impl<S: StorageProvider> Engine<S> {
                 // joining.md:65).
                 let protocol_profile =
                     validate_member_credentials_and_account_proofs(&mls_group, self.ciphersuite)?;
+                crate::app_components::validate_current_profile_group_invariants(&mls_group)
+                    .map_err(|_| EngineError::InvalidWelcome)?;
 
                 // 5c. Reject active required capabilities this client cannot
                 // apply, including required agent-stream roles.

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -998,11 +998,7 @@ pub(crate) fn validate_member_credentials_and_account_proofs(
 ) -> Result<ProtocolProfile, EngineError> {
     validate_member_credentials(group)?;
     let protocol_profile = crate::account_identity_proof::protocol_profile_of_group(group)?;
-    let tree = group.export_ratchet_tree();
-    let value = serde_json::to_value(tree)
-        .map_err(|e| EngineError::Backend(format!("export ratchet tree: {e}")))?;
-    let nodes: Vec<Option<Node>> = serde_json::from_value(value)
-        .map_err(|e| EngineError::Backend(format!("decode exported ratchet tree: {e}")))?;
+    let nodes = crate::app_components::ratchet_tree_nodes(group.export_ratchet_tree())?;
     for node in nodes {
         if let Some(Node::LeafNode(leaf)) = node {
             let leaf_profile = crate::account_identity_proof::validate_leaf_account_identity_proof(

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -31,7 +31,7 @@ use openmls::framing::errors::{MessageDecryptionError, SecretTreeError};
 use openmls::group::{MlsGroup, MlsGroupStateError, ProcessMessageError};
 use openmls::prelude::{
     ContentType, MlsMessageBodyIn, MlsMessageIn, ProcessedMessageContent, Proposal,
-    ProtocolMessage, QueuedProposal, ValidationError,
+    ProtocolMessage, QueuedProposal, Sender, ValidationError,
 };
 use sha2::{Digest, Sha256};
 use tls_codec::{Deserialize as _, Serialize as _};
@@ -812,6 +812,10 @@ impl<S: StorageProvider> Engine<S> {
             };
 
             // Classify content.
+            let sender_leaf_index = match processed.sender() {
+                Sender::Member(index) => Some(*index),
+                _ => None,
+            };
             let sender_id = member_id_of_sender(processed.sender(), &mls_group);
             return match processed.into_content() {
                 ProcessedMessageContent::ApplicationMessage(bytes) => {
@@ -928,6 +932,12 @@ impl<S: StorageProvider> Engine<S> {
                             "commit has no authenticated member sender".into(),
                         ));
                     };
+                    let Some(committer_index) = sender_leaf_index else {
+                        self.update_stored_message_state(&msg.id, MessageState::Failed)?;
+                        return Err(EngineError::Backend(
+                            "commit has no authenticated member leaf".into(),
+                        ));
+                    };
                     let commit_priority =
                         crate::app_components::commit_ordering_priority_for_staged(&staged);
                     // foundation/identity.md: reject inbound commits that
@@ -946,6 +956,16 @@ impl<S: StorageProvider> Engine<S> {
                             return Err(err);
                         }
                     };
+                    if let Err(err) =
+                        crate::app_components::validate_current_profile_invariants_for_staged_commit(
+                            &mls_group,
+                            &staged,
+                            committer_index,
+                        )
+                    {
+                        self.update_stored_message_state(&msg.id, MessageState::Failed)?;
+                        return Err(err);
+                    }
                     // Classify departures before the merge consumes the staged
                     // commit and the leaving leaves disappear: a SelfRemove is a
                     // member leaving (attributed to themselves); a Remove is an
@@ -992,7 +1012,8 @@ impl<S: StorageProvider> Engine<S> {
                             .merge_staged_commit(&tx_provider, *staged)
                             .map_err(|e| {
                                 EngineError::Backend(format!("merge_staged_commit: {e:?}"))
-                            })
+                            })?;
+                        crate::app_components::validate_current_profile_group_invariants(&mls_group)
                     })?;
                     let after = EpochId(mls_group.epoch().as_u64());
                     let after_members = group_lifecycle::marmot_members(&mls_group);
@@ -1501,6 +1522,20 @@ impl<S: StorageProvider> Engine<S> {
         let (commit_out, _welcome_opt, _gi) = mls_group
             .commit_to_pending_proposals(&provider, &self.identity.signer)
             .map_err(|e| EngineError::Backend(format!("auto_commit: {e:?}")))?;
+        let staged_commit = mls_group
+            .pending_commit()
+            .ok_or_else(|| EngineError::Backend("auto-commit produced no pending commit".into()))?;
+        crate::app_components::validate_current_profile_invariants_for_staged_commit(
+            mls_group,
+            staged_commit,
+            mls_group.own_leaf_index(),
+        )?;
+        crate::account_identity_proof::validate_staged_commit_account_identity_proofs(
+            staged_commit,
+            mls_group,
+            self.identity.self_id(),
+            self.ciphersuite,
+        )?;
         let commit_bytes = commit_out
             .tls_serialize_detached()
             .map_err(|e| EngineError::Serialize(format!("{e:?}")))?;
@@ -1524,10 +1559,8 @@ impl<S: StorageProvider> Engine<S> {
         )?;
 
         let new_epoch = EpochId(pre_commit_epoch.0.saturating_add(1));
-        let commit_priority = mls_group
-            .pending_commit()
-            .map(crate::app_components::commit_ordering_priority_for_staged)
-            .ok_or_else(|| EngineError::Backend("auto-commit produced no pending commit".into()))?;
+        let commit_priority =
+            crate::app_components::commit_ordering_priority_for_staged(staged_commit);
         let pending_ref = self.epoch_manager.next_pending_ref();
         let staged =
             cgka_traits::engine_state::StagedCommitHandle::from_bytes(group_id.as_slice().to_vec());

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -168,6 +168,21 @@ impl<S: StorageProvider> Engine<S> {
         let (commit_out, welcome_out, _gi) = mls_group
             .add_members(&provider, &self.identity.signer, &parsed_kps)
             .map_err(|e| EngineError::Backend(format!("add_members: {e:?}")))?;
+        let own_leaf_index = mls_group.own_leaf_index();
+        let staged_commit = mls_group
+            .pending_commit()
+            .ok_or_else(|| EngineError::Backend("invite produced no pending commit".into()))?;
+        crate::app_components::validate_current_profile_invariants_for_staged_commit(
+            &mls_group,
+            staged_commit,
+            own_leaf_index,
+        )?;
+        crate::account_identity_proof::validate_staged_commit_account_identity_proofs(
+            staged_commit,
+            &mls_group,
+            self.identity.self_id(),
+            self.ciphersuite,
+        )?;
 
         let commit_bytes = commit_out
             .tls_serialize_detached()
@@ -474,6 +489,11 @@ impl<S: StorageProvider> Engine<S> {
             &mls_group,
             self.identity.self_id(),
             self.ciphersuite,
+        )?;
+        crate::app_components::validate_current_profile_invariants_for_staged_commit(
+            &mls_group,
+            staged_commit,
+            mls_group.own_leaf_index(),
         )?;
         let commit_priority =
             crate::app_components::commit_ordering_priority_for_staged(staged_commit);

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -9,7 +9,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::provider::EngineOpenMlsProvider;
-use cgka_traits::app_components::AppComponentData;
 use cgka_traits::engine::CommitOrderingPriority;
 use cgka_traits::group::Member;
 use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
@@ -23,7 +22,7 @@ use openmls::group::{
 use openmls::messages::proposals::AppDataUpdateOperation;
 use openmls::prelude::{
     BasicCredential, ContentType, MlsMessageBodyIn, MlsMessageIn, ProcessedMessage,
-    ProcessedMessageContent, ProtocolMessage,
+    ProcessedMessageContent, ProtocolMessage, Sender,
 };
 use openmls_rust_crypto::RustCrypto;
 use openmls_traits::OpenMlsProvider;
@@ -2036,6 +2035,10 @@ fn process_openmls_messages_inner<S: StorageProvider>(
             }
             Err(e) => return Err(replay_error("process_message", e)),
         };
+        let sender_leaf_index = match processed.sender() {
+            Sender::Member(index) => Some(*index),
+            _ => None,
+        };
         let sender_id = crate::identity::member_id_of_sender(processed.sender(), &mls_group);
 
         match processed.into_content() {
@@ -2093,6 +2096,11 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                         "commit has no authenticated member sender".into(),
                     ));
                 }
+                let Some(committer_index) = sender_leaf_index else {
+                    return Err(OpenMlsProjectionError::Replay(
+                        "commit has no authenticated member leaf".into(),
+                    ));
+                };
                 let priority = crate::app_components::commit_ordering_priority_for_staged(&staged);
                 let committer = sender_id
                     .as_ref()
@@ -2120,6 +2128,18 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                         reason: format!("invalid credential identity or account proof: {err}"),
                     });
                 }
+                if let Err(err) =
+                    crate::app_components::validate_current_profile_invariants_for_staged_commit(
+                        &mls_group,
+                        &staged,
+                        committer_index,
+                    )
+                {
+                    return Err(OpenMlsProjectionError::InvalidCommit {
+                        message_id,
+                        reason: format!("current-profile resulting state: {err}"),
+                    });
+                }
                 let resulting_epoch = mls_group.epoch().as_u64().saturating_add(1);
                 let mut consumed_proposal_refs = staged
                     .queued_proposals()
@@ -2127,7 +2147,7 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                     .collect::<Result<Vec<_>, _>>()?;
                 consumed_proposal_refs.sort();
                 observations.push(OpenMlsReplayObservation::CommitStaged {
-                    message_id,
+                    message_id: message_id.clone(),
                     source_epoch,
                     resulting_epoch,
                     priority,
@@ -2138,6 +2158,11 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                     .merge_staged_commit(&provider, *staged)
                     .map_err(|e| {
                         OpenMlsProjectionError::Replay(format!("merge_staged_commit: {e:?}"))
+                    })?;
+                crate::app_components::validate_current_profile_group_invariants(&mls_group)
+                    .map_err(|error| OpenMlsProjectionError::InvalidCommit {
+                        message_id,
+                        reason: format!("current-profile merged state: {error}"),
                     })?;
                 prefix_canonical =
                     prefix_canonical && own_commits.is_canonical(&projection.message_digest);
@@ -2285,30 +2310,18 @@ pub(crate) fn process_commit_with_app_data_updates<S: StorageProvider>(
         .app_data_update_proposals()
         .cloned()
         .collect::<Vec<_>>();
+    crate::app_components::validate_app_data_update_batch(mls_group, app_data_updates.iter())
+        .map_err(|_| ProcessMessageError::ValidationError(ValidationError::WrongWireFormat))?;
     let mut updater = mls_group.app_data_dictionary_updater();
     for update in app_data_updates {
         match update.operation() {
             AppDataUpdateOperation::Update(data) => {
-                crate::app_components::validate_app_component_update(&AppComponentData {
-                    component_id: update.component_id(),
-                    data: data.as_slice().to_vec(),
-                })
-                .map_err(|_| {
-                    ProcessMessageError::ValidationError(ValidationError::WrongWireFormat)
-                })?;
                 updater.set(ComponentData::from_parts(
                     update.component_id(),
                     data.clone(),
                 ));
             }
             AppDataUpdateOperation::Remove => {
-                crate::app_components::validate_app_component_remove(
-                    mls_group,
-                    update.component_id(),
-                )
-                .map_err(|_| {
-                    ProcessMessageError::ValidationError(ValidationError::WrongWireFormat)
-                })?;
                 updater.remove(&update.component_id());
             }
         }

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -122,6 +122,7 @@ impl<S: StorageProvider> Engine<S> {
                     mls_group
                         .merge_pending_commit(&tx_provider)
                         .map_err(|e| EngineError::Backend(format!("merge_pending: {e:?}")))?;
+                    crate::app_components::validate_current_profile_group_invariants(&mls_group)?;
                 }
 
                 // Now the MLS group is at the new epoch. Mirror the Marmot

--- a/crates/cgka-engine/src/update_group_data.rs
+++ b/crates/cgka-engine/src/update_group_data.rs
@@ -241,6 +241,11 @@ impl<S: StorageProvider> Engine<S> {
             self.identity.self_id(),
             self.ciphersuite,
         )?;
+        crate::app_components::validate_current_profile_invariants_for_staged_commit(
+            &mls_group,
+            staged_commit,
+            mls_group.own_leaf_index(),
+        )?;
         let commit_bytes = commit_out
             .tls_serialize_detached()
             .map_err(|e| EngineError::Serialize(format!("{e:?}")))?;
@@ -385,22 +390,16 @@ impl<S: StorageProvider> Engine<S> {
         proposals: Vec<Proposal>,
         context: &str,
     ) -> Result<MlsMessageOut, EngineError> {
-        // Mirror the receiver-side guard: a Remove of the negotiation
-        // component or a group-required component must fail at staging, not
-        // surface as a recipient-side rejection. Checked before the builder
-        // takes its mutable borrow of `mls_group`. No current caller produces
-        // a Remove (all send intents carry Update bytes); this keeps the
-        // shared helper in parity with the projection for future callers.
-        for proposal in &proposals {
-            if let Proposal::AppDataUpdate(update) = proposal
-                && matches!(update.operation(), AppDataUpdateOperation::Remove)
-            {
-                crate::app_components::validate_app_component_remove(
-                    mls_group,
-                    update.component_id(),
-                )?;
-            }
-        }
+        // Validate the proposal set as one operation. In particular, removal
+        // legality is based on the resulting requirement list so one Commit
+        // may atomically unrequire and remove an optional component.
+        crate::app_components::validate_app_data_update_batch(
+            mls_group,
+            proposals.iter().filter_map(|proposal| match proposal {
+                Proposal::AppDataUpdate(update) => Some(update.as_ref()),
+                _ => None,
+            }),
+        )?;
         let mut builder = mls_group
             .commit_builder()
             .propose_removals(removals)

--- a/crates/cgka-engine/src/upgrade.rs
+++ b/crates/cgka-engine/src/upgrade.rs
@@ -168,6 +168,15 @@ impl<S: StorageProvider> Engine<S> {
         // do NOT call `merge_pending_commit` here — the merge + Marmot
         // record's required capability update both defer to
         // `do_confirm_published` (which reads the post-merge group state).
+        crate::app_components::validate_app_data_update_batch(
+            &mls_group,
+            app_component_updates
+                .iter()
+                .filter_map(|proposal| match proposal {
+                    Proposal::AppDataUpdate(update) => Some(update.as_ref()),
+                    _ => None,
+                }),
+        )?;
         let mut commit_builder = mls_group.commit_builder();
         if let Some(new_extensions) = new_extensions {
             commit_builder = commit_builder
@@ -225,6 +234,11 @@ impl<S: StorageProvider> Engine<S> {
                 &mls_group,
                 self.identity.self_id(),
                 self.ciphersuite,
+            )?;
+            crate::app_components::validate_current_profile_invariants_for_staged_commit(
+                &mls_group,
+                staged_commit,
+                mls_group.own_leaf_index(),
             )?;
         }
         let commit_bytes = commit_out

--- a/crates/cgka-engine/tests/capabilities.rs
+++ b/crates/cgka-engine/tests/capabilities.rs
@@ -286,7 +286,7 @@ async fn group_creation_retains_non_negotiable_mandatory_components() {
 }
 
 #[tokio::test]
-async fn upgrade_group_capabilities_promotes_optional_app_component_to_required() {
+async fn upgrade_group_capabilities_rejects_app_component_without_group_state() {
     let mut supported = default_group_components();
     supported.insert(TEST_APP_COMPONENT);
     let mut alice = build_engine_with_registry_and_components(
@@ -332,21 +332,24 @@ async fn upgrade_group_capabilities_promotes_optional_app_component_to_required(
             .contains(TEST_APP_COMPONENT)
     );
 
-    let upgrade = alice.upgrade_group_capabilities(&group_id).await.unwrap();
-    let pending = match upgrade {
-        SendResult::GroupEvolution { pending, .. } => pending,
-        _ => unreachable!(),
-    };
-    alice.confirm_published(pending).await.unwrap();
+    let error = alice
+        .upgrade_group_capabilities(&group_id)
+        .await
+        .expect_err("a required GroupContext component must have resulting state");
+    assert!(
+        error
+            .to_string()
+            .contains("drops required app component 0x8101")
+    );
 
     assert!(matches!(
         alice
             .feature_status(&group_id, &Feature("test-app-component"))
             .unwrap(),
-        FeatureStatus::Available
+        FeatureStatus::Upgradeable
     ));
     assert!(
-        alice
+        !alice
             .group_record(&group_id)
             .unwrap()
             .required_capabilities

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -17,13 +17,17 @@ use cgka_engine::provider::EngineOpenMlsProvider;
 use cgka_engine::{Engine, EngineBuilder};
 use cgka_traits::EngineError;
 use cgka_traits::app_components::{
-    AppComponentData, GROUP_ADMIN_POLICY_COMPONENT_ID, GROUP_AVATAR_URL_COMPONENT_ID,
-    GROUP_MESSAGE_RETENTION_COMPONENT_ID, GroupAvatarUrlV1, NOSTR_ROUTING_COMPONENT_ID,
-    NostrRoutingV1, default_group_components, encode_group_avatar_url_v1, encode_nostr_routing_v1,
+    ACCOUNT_IDENTITY_PROOF_COMPONENT_ID, APP_COMPONENTS_COMPONENT_ID, AppComponentData,
+    GROUP_ADMIN_POLICY_COMPONENT_ID, GROUP_AVATAR_URL_COMPONENT_ID,
+    GROUP_BLOSSOM_IMAGE_COMPONENT_ID, GROUP_MESSAGE_RETENTION_COMPONENT_ID,
+    GROUP_PROFILE_COMPONENT_ID, GroupAvatarUrlV1, NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1,
+    default_group_components, encode_component_vectors, encode_components_list,
+    encode_group_avatar_url_v1, encode_nostr_routing_v1,
 };
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult};
 use cgka_traits::error::PeelerError;
+use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{PeeledContent, PeeledMessage};
 use cgka_traits::message::MessageState;
@@ -298,6 +302,49 @@ fn build_with_storage(id: &[u8]) -> (Engine<SqliteAccountStorage>, SqliteAccount
     (engine, storage)
 }
 
+fn build_current(id: &[u8]) -> Engine<SqliteAccountStorage> {
+    EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
+        .identity(pad32(id))
+        .account_identity_proof_signer(proof_signer(id))
+        .protocol_profile(ProtocolProfile::Current)
+        .feature_registry(registry())
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .unwrap()
+}
+
+fn build_current_with_storage(id: &[u8]) -> (Engine<SqliteAccountStorage>, SqliteAccountStorage) {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let engine = EngineBuilder::new(storage.clone())
+        .identity(pad32(id))
+        .account_identity_proof_signer(proof_signer(id))
+        .protocol_profile(ProtocolProfile::Current)
+        .feature_registry(registry())
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .unwrap();
+    (engine, storage)
+}
+
+fn build_with_storage_and_component(
+    id: &[u8],
+    component_id: u16,
+) -> (Engine<SqliteAccountStorage>, SqliteAccountStorage) {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let mut components: Vec<_> = default_group_components().into_iter().collect();
+    components.push(component_id);
+    let engine = EngineBuilder::new(storage.clone())
+        .identity(pad32(id))
+        .account_identity_proof_signer(proof_signer(id))
+        .protocol_profile(ProtocolProfile::Current)
+        .feature_registry(registry())
+        .supported_app_components(components)
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .unwrap();
+    (engine, storage)
+}
+
 fn converge_buffered_commit(engine: &mut Engine<SqliteAccountStorage>, group_id: &GroupId) {
     let result = engine
         .converge_stored_openmls_messages(group_id, 1_000_000)
@@ -326,6 +373,7 @@ fn build_with_opaque_component(id: &[u8], component_id: u16) -> Engine<SqliteAcc
     EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
         .identity(pad32(id))
         .account_identity_proof_signer(proof_signer(id))
+        .protocol_profile(ProtocolProfile::Current)
         .feature_registry(registry())
         .supported_app_components(components)
         .peeler(Box::new(MockPeeler))
@@ -443,6 +491,23 @@ fn malicious_app_component_commit(
     group_id: &GroupId,
     updates: Vec<AppComponentData>,
 ) -> TransportMessage {
+    raw_app_data_commit(
+        storage,
+        sender,
+        group_id,
+        updates
+            .into_iter()
+            .map(|update| AppDataUpdateProposal::update(update.component_id, update.data))
+            .collect(),
+    )
+}
+
+fn raw_app_data_commit(
+    storage: &SqliteAccountStorage,
+    sender: &MemberId,
+    group_id: &GroupId,
+    proposals: Vec<AppDataUpdateProposal>,
+) -> TransportMessage {
     let crypto = RustCrypto::default();
     let provider =
         EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, storage.mls_storage());
@@ -461,27 +526,27 @@ fn malicious_app_component_commit(
     )
     .expect("MLS signer exists");
 
-    let proposals = updates
-        .iter()
-        .map(|update| {
-            Proposal::AppDataUpdate(Box::new(AppDataUpdateProposal::update(
-                update.component_id,
-                update.data.clone(),
-            )))
-        })
-        .collect::<Vec<_>>();
     let mut builder = mls_group
         .commit_builder()
-        .add_proposals(proposals)
+        .add_proposals(
+            proposals
+                .into_iter()
+                .map(|proposal| Proposal::AppDataUpdate(Box::new(proposal))),
+        )
         .load_psks(provider.storage())
         .expect("load PSKs");
     let mut app_data = builder.app_data_dictionary_updater();
     for proposal in builder.app_data_update_proposals() {
-        if let AppDataUpdateOperation::Update(data) = proposal.operation() {
-            app_data.set(ComponentData::from_parts(
-                proposal.component_id(),
-                data.clone(),
-            ));
+        match proposal.operation() {
+            AppDataUpdateOperation::Update(data) => {
+                app_data.set(ComponentData::from_parts(
+                    proposal.component_id(),
+                    data.clone(),
+                ));
+            }
+            AppDataUpdateOperation::Remove => {
+                app_data.remove(&proposal.component_id());
+            }
         }
     }
     builder.with_app_data_dictionary_updates(app_data.changes());
@@ -932,6 +997,73 @@ async fn convergence_rejects_non_admin_admin_policy_update() {
 }
 
 #[tokio::test]
+async fn inbound_commit_cannot_unrequire_current_admin_policy() {
+    let (mut alice, alice_storage) = build_current_with_storage(b"alice");
+    let mut bob = build_current(b"bob");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (gid, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "mandatory-invariants".into(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcomes.into_iter().next().unwrap())
+        .await
+        .unwrap();
+
+    let malicious = raw_app_data_commit(
+        &alice_storage,
+        &alice.self_id(),
+        &gid,
+        vec![AppDataUpdateProposal::update(
+            APP_COMPONENTS_COMPONENT_ID,
+            encode_components_list(
+                &[
+                    GROUP_PROFILE_COMPONENT_ID,
+                    ACCOUNT_IDENTITY_PROOF_COMPONENT_ID,
+                ]
+                .into_iter()
+                .collect(),
+            ),
+        )],
+    );
+    bob.ingest(malicious.clone())
+        .await
+        .expect("commit is retained for convergence");
+    let result = bob
+        .converge_stored_openmls_messages(&gid, 1_000_000)
+        .expect("invalid commit receives a terminal disposition");
+
+    assert!(result.accepted_commits.is_empty());
+    assert!(result.dropped_messages.iter().any(|dropped| {
+        dropped.message_id == hex::encode(content_id(&malicious).as_slice())
+            && dropped.reason == DroppedMessageReason::InvalidAgainstCandidateState
+    }));
+    assert_eq!(bob.epoch(&gid).unwrap().0, 1);
+    assert!(
+        bob.group_record(&gid)
+            .unwrap()
+            .required_capabilities
+            .app_components
+            .contains(GROUP_ADMIN_POLICY_COMPONENT_ID)
+    );
+    assert_eq!(
+        bob.admin_pubkeys(&gid).unwrap(),
+        vec![<[u8; 32]>::try_from(pad32(b"alice")).unwrap()]
+    );
+}
+
+#[tokio::test]
 async fn non_admin_cannot_update_admin_policy_component() {
     let (_alice, mut bob, gid) = create_pair().await;
     let alice_id = pad32(b"alice");
@@ -1012,10 +1144,7 @@ async fn unrelated_update_and_invite_preserve_opaque_app_component_for_all_membe
             description: "orig description".into(),
             members: vec![bob_kp],
             required_features: vec![],
-            app_components: vec![AppComponentData {
-                component_id: OPAQUE_COMPONENT_ID,
-                data: OPAQUE_BYTES.to_vec(),
-            }],
+            app_components: vec![],
             initial_admins: vec![],
         })
         .await
@@ -1028,6 +1157,34 @@ async fn unrelated_update_and_invite_preserve_opaque_app_component_for_all_membe
     bob.join_welcome(welcomes.into_iter().next().unwrap())
         .await
         .unwrap();
+
+    // Add opaque state without listing it as required. Current-profile clients
+    // fail closed on unknown required components, but must preserve unknown
+    // OPTIONAL entries byte-for-byte across unrelated commits.
+    let result = alice
+        .send(SendIntent::UpdateAppComponents {
+            group_id: gid.clone(),
+            updates: vec![AppComponentData {
+                component_id: OPAQUE_COMPONENT_ID,
+                data: OPAQUE_BYTES.to_vec(),
+            }],
+        })
+        .await
+        .unwrap();
+    let (commit, pending) = match result {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.ingest(TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: gid.as_slice().to_vec(),
+        },
+        ..commit
+    })
+    .await
+    .unwrap();
+    converge_buffered_commit(&mut bob, &gid);
 
     let result = alice
         .send(SendIntent::UpdateGroupData {
@@ -1103,6 +1260,82 @@ async fn unrelated_update_and_invite_preserve_opaque_app_component_for_all_membe
             "{name} must retain the opaque component through Add/Welcome"
         );
     }
+}
+
+#[tokio::test]
+async fn inbound_commit_atomically_unrequires_and_removes_optional_component() {
+    let (mut alice, alice_storage) =
+        build_with_storage_and_component(b"alice", GROUP_BLOSSOM_IMAGE_COMPONENT_ID);
+    let mut bob = build_with_opaque_component(b"bob", GROUP_BLOSSOM_IMAGE_COMPONENT_ID);
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let absent_image = encode_component_vectors(&[&[], &[], &[], &[], &[]]);
+    let (gid, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "atomic-remove".into(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![AppComponentData {
+                component_id: GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
+                data: absent_image,
+            }],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcomes.into_iter().next().unwrap())
+        .await
+        .unwrap();
+
+    let resulting_required = [
+        GROUP_PROFILE_COMPONENT_ID,
+        GROUP_ADMIN_POLICY_COMPONENT_ID,
+        ACCOUNT_IDENTITY_PROOF_COMPONENT_ID,
+    ]
+    .into_iter()
+    .collect();
+    let commit = raw_app_data_commit(
+        &alice_storage,
+        &alice.self_id(),
+        &gid,
+        vec![
+            AppDataUpdateProposal::update(
+                APP_COMPONENTS_COMPONENT_ID,
+                encode_components_list(&resulting_required),
+            ),
+            AppDataUpdateProposal::remove(GROUP_BLOSSOM_IMAGE_COMPONENT_ID),
+        ],
+    );
+    bob.ingest(commit)
+        .await
+        .expect("atomic unrequire and remove is retained");
+    let result = bob
+        .converge_stored_openmls_messages(&gid, 1_000_000)
+        .expect("atomic unrequire and remove converges");
+    assert_eq!(
+        result.accepted_commits.len(),
+        1,
+        "atomic transition was rejected: {result:?}"
+    );
+
+    assert_eq!(bob.epoch(&gid).unwrap().0, 2);
+    assert_eq!(
+        bob.app_component(&gid, GROUP_BLOSSOM_IMAGE_COMPONENT_ID)
+            .unwrap(),
+        None
+    );
+    assert!(
+        !bob.group_record(&gid)
+            .unwrap()
+            .required_capabilities
+            .app_components
+            .contains(GROUP_BLOSSOM_IMAGE_COMPONENT_ID)
+    );
 }
 
 #[tokio::test]

--- a/crates/incident-replay/src/synth.rs
+++ b/crates/incident-replay/src/synth.rs
@@ -96,6 +96,7 @@ fn synthesize_group_data_fork(name: &str, winner: &str, loser: &str) -> VectorFi
         vector_version: "1".to_owned(),
         conformance_version: env!("CARGO_PKG_VERSION").to_owned(),
         seed: None,
+        application_profile: None,
         scenario: ScenarioSpec {
             name: name.to_owned(),
             spec_version: "1".to_owned(),
@@ -212,6 +213,7 @@ fn synthesize_membership_fork(name: &str, winner: &str, loser: &str) -> VectorFi
         vector_version: "1".to_owned(),
         conformance_version: env!("CARGO_PKG_VERSION").to_owned(),
         seed: None,
+        application_profile: None,
         scenario: ScenarioSpec {
             name: name.to_owned(),
             spec_version: "1".to_owned(),
@@ -344,6 +346,7 @@ fn convergence_fixture(
         vector_version: "1".to_owned(),
         conformance_version: env!("CARGO_PKG_VERSION").to_owned(),
         seed: None,
+        application_profile: None,
         scenario: ScenarioSpec {
             name: name.to_owned(),
             spec_version: "1".to_owned(),

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -705,6 +705,13 @@ pub trait CgkaEngine: Send + Sync {
     /// Upgrade the group to require every currently-upgradeable capability.
     /// Produces a `SendResult::GroupEvolution` whose commit updates
     /// `RequiredCapabilities`.
+    ///
+    /// A state-bearing app component must already have optional GroupContext
+    /// state before this method can promote it to required. Install and publish
+    /// that state first with [`SendIntent::UpdateAppComponents`], then call this
+    /// method and publish its second commit. Promotion fails closed without
+    /// staging a commit when the component state is absent; there is currently
+    /// no atomic require-and-populate API.
     async fn upgrade_group_capabilities(
         &mut self,
         group_id: &GroupId,


### PR DESCRIPTION
## Summary

- validate the complete current application profile at creation, founding Add, Welcome join, hydration, every local commit, direct inbound ingest, and convergence replay
- require `app_data_dictionary` / `AppDataUpdate`, mandatory components `0x8003` and `0x8009`, valid GroupContext state placement, and required capabilities on every resulting member leaf
- evaluate AppDataUpdate operations as a batch so duplicate component updates fail, mandatory state cannot be stripped, and an optional component can be atomically unrequired and removed
- preserve unknown optional component bytes across unrelated commits while failing closed on unknown required components
- add a profile-aware portable conformance vector; the harness now actually runs declared current-profile fixtures and preserves KeyPackage profile metadata

## Stack

- Depends on #1069 (`codex/issue-1048-proof-component`)
- Which depends on #1067 and #1066

## Note on issue wording

The adopted `app-components/README.md` permits multiple `AppDataUpdate` proposals in one Commit as long as there is at most one operation per component id. This implementation follows that normative rule, which is also required for an atomic `app_components` update plus removal of another component.

## Validation

- `cargo test -p cgka-engine -p cgka-conformance-simulator`
- `cargo test -p cgka-conformance-simulator canonical_vector_fixtures_match_generated_traces`
- `just fast-ci`

Fixes #1050


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Current protocol profile in simulator scenarios and vector fixtures.
  * Added conformance coverage for required extensions, proposals, and application components.
* **Bug Fixes**
  * Strengthened validation during group creation, joins, updates, commits, upgrades, and session loading.
  * Prevented invalid profile state, missing member capabilities, and unauthenticated commit senders from being accepted.
  * Enabled atomic removal of components when they are simultaneously made optional.
* **Documentation**
  * Clarified the steps required before promoting state-bearing components to required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->