### PR TITLE
feat: implement current founding Add and Welcome lifecycle

### DIFF
--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -60,10 +60,12 @@ These are the scenarios another implementation should be able to load from JSON 
 ### `current-profile-required-set/v1`
 
 - File: `vectors/current-profile-required-set.v1.json`
-- Setup: Alice creates a current-profile group with Bob and Bob joins from the founding Welcome.
+- Setup: Alice creates a current-profile group with Bob, Bob joins from the founding Welcome, and Bob sends the
+  group’s first application message.
 - Contract: GroupContext requires extension `0x0006`, proposal `0x0008`, and application components `0x8003` and
   `0x8009`; `0x8003` has GroupContext state while `0x8009` is LeafNode-only.
-- Expected: both clients accept the profile, converge at epoch 1, and retain the two-member group.
+- Expected: creation is canonical at epoch 1 without publishing or confirming an ordinary founding commit; both
+  clients retain the two-member group, and Alice receives Bob’s first application message.
 
 ### `admin-policy-update/v1`
 

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -387,6 +387,43 @@ impl HarnessClient {
         required_features: Vec<cgka_traits::capabilities::Feature>,
         initial_admins: Vec<MemberId>,
     ) -> Result<(GroupId, PendingStateRef), EngineError> {
+        let (group_id, pending) = self
+            .try_create_group_with_admins_maybe_pending(
+                name,
+                invitees,
+                required_features,
+                initial_admins,
+            )
+            .await?;
+        pending.map(|pending| (group_id, pending)).ok_or_else(|| {
+            EngineError::Other("current founding creation has no pending state".into())
+        })
+    }
+
+    pub async fn create_group_with_admins_maybe_pending(
+        &mut self,
+        name: &str,
+        invitees: Vec<KeyPackage>,
+        required_features: Vec<cgka_traits::capabilities::Feature>,
+        initial_admins: Vec<MemberId>,
+    ) -> (GroupId, Option<PendingStateRef>) {
+        self.try_create_group_with_admins_maybe_pending(
+            name,
+            invitees,
+            required_features,
+            initial_admins,
+        )
+        .await
+        .expect("create_group")
+    }
+
+    async fn try_create_group_with_admins_maybe_pending(
+        &mut self,
+        name: &str,
+        invitees: Vec<KeyPackage>,
+        required_features: Vec<cgka_traits::capabilities::Feature>,
+        initial_admins: Vec<MemberId>,
+    ) -> Result<(GroupId, Option<PendingStateRef>), EngineError> {
         let res = self
             .engine
             .create_group(CreateGroupRequest {
@@ -399,10 +436,11 @@ impl HarnessClient {
             })
             .await?;
         let (gid, pending, welcomes) = match res {
-            (gid, SendResult::GroupCreated { pending, welcomes }) => (gid, pending, welcomes),
+            (gid, SendResult::GroupCreated { pending, welcomes }) => (gid, Some(pending), welcomes),
+            (gid, SendResult::FoundingGroupCreated { welcomes }) => (gid, None, welcomes),
             (_, other) => {
                 return Err(EngineError::Other(format!(
-                    "expected GroupCreated, got {other:?}"
+                    "expected group creation result, got {other:?}"
                 )));
             }
         };
@@ -410,6 +448,9 @@ impl HarnessClient {
             self.bus.send(self.bus_id, w);
         }
         self.default_group = Some(gid.clone());
+        if pending.is_none() {
+            self.capture_engine_events();
+        }
         Ok((gid, pending))
     }
 
@@ -822,6 +863,12 @@ impl HarnessClient {
                     self.bus.send(self.bus_id, welcome);
                 }
                 self.engine.confirm_published(pending).await?;
+                self.capture_engine_events();
+            }
+            SendResult::FoundingGroupCreated { welcomes } => {
+                for welcome in welcomes {
+                    self.bus.send(self.bus_id, welcome);
+                }
                 self.capture_engine_events();
             }
             SendResult::Queued { .. } => {}

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -364,9 +364,16 @@ async fn run_scenario_report_inner(
                     required_features_from_names(required_features, step_index)?;
                 let creator = client_mut(&mut clients, creator, step_index)?;
                 let (_group_id, pending_ref) = creator
-                    .create_group_with_admins(name, key_packages, required_features, initial_admins)
+                    .create_group_with_admins_maybe_pending(
+                        name,
+                        key_packages,
+                        required_features,
+                        initial_admins,
+                    )
                     .await;
-                insert_pending(&mut pending_refs, pending, pending_ref, step_index)?;
+                if let Some(pending_ref) = pending_ref {
+                    insert_pending(&mut pending_refs, pending, pending_ref, step_index)?;
+                }
             }
             ScenarioStep::InviteMembers {
                 inviter,

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -41,9 +41,18 @@
         "pending": "create"
       },
       {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
+        "type": "deliver_all"
+      },
+      {
+        "type": "tick",
+        "clients": [
+          "bob"
+        ]
+      },
+      {
+        "type": "send_app_message",
+        "sender": "bob",
+        "payload": "bob:first-current-message"
       },
       {
         "type": "deliver_all"
@@ -51,6 +60,7 @@
       {
         "type": "tick",
         "clients": [
+          "alice",
           "bob"
         ]
       },
@@ -65,18 +75,13 @@
   },
   "expected_outcomes": [
     {
-      "type": "pending_resolution",
-      "step_index": 1,
-      "client": "alice",
-      "pending": "create",
-      "resolution": "confirmed"
-    },
-    {
       "type": "client_state",
       "client": "alice",
       "epoch": 1,
       "member_count": 2,
-      "received_payloads": []
+      "received_payloads": [
+        "bob:first-current-message"
+      ]
     },
     {
       "type": "client_state",

--- a/crates/cgka-conformance-simulator/vectors/manifest.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/manifest.v1.json
@@ -75,7 +75,8 @@
         "required app_data_update proposal 0x0008",
         "mandatory admin-policy component 0x8003",
         "mandatory LeafNode-only account-proof component 0x8009",
-        "creation and Welcome join under the current profile"
+        "canonical founding creation without ordinary commit publication",
+        "Welcome join and invitee first application message under the current profile"
       ],
       "next": "Keep registry ids synchronized with the adopted application profile."
     },

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -160,10 +160,12 @@ These are the load-bearing departures from the original plan. Each is also docum
    mechanical churn with zero functional value. Site: `crates/traits/src/storage.rs` (`StorageProvider` aggregate with
    `type Mls` / `fn mls_storage`).
 
-2. **`SendResult::GroupCreated { welcomes, pending }` is its own variant.** `GroupEvolution` carries a
-   `msg: TransportMessage` that has no consumer at create-time (every other initial member arrives via welcome with
-   post-commit state). Splitting the variant also eliminates a welcome-before-commit `AlreadyAtEpoch` bounce at
-   creation. Site: `crates/traits/src/engine.rs::SendResult`.
+2. **Founding creation never invents a group-message publication.** Current-profile creation returns
+   `SendResult::FoundingGroupCreated { welcomes }`: the epoch-0 group and optional founding Add are already canonical,
+   and each Welcome is an independent delivery obligation. The temporary explicit-legacy path retains
+   `SendResult::GroupCreated { welcomes, pending }`. Neither variant carries a `msg: TransportMessage`, because every
+   initial invitee arrives through a Welcome containing the post-Add state. Site:
+   `crates/traits/src/engine.rs::SendResult`.
 
 3. **`CreateGroupRequest::initial_admins: Vec<MemberId>`.** Bootstraps multi-admin groups so admins can subsequently
    self-remove (MIP-03 §149's "not the last admin" constraint). Creator is implicitly an admin; `initial_admins` adds
@@ -301,11 +303,13 @@ Admin-policy and routing-component updates are deliberately out of scope. Tests 
 
 ### Done — Task 4.13 publish-before-apply (2026-04-25)
 
-`do_create_group` / `do_send_invite` / `do_upgrade_group_capabilities` / auto-commit stage their commits and defer merge
-until `CgkaEngine::confirm_published`. `CgkaEngine::publish_failed` discards via `MlsGroup::clear_pending_commit` +
-Marmot re-derive from the still-unmerged group. The Marmot record holds _projected post-merge_ `members` so `members()`
-and `feature_status` reflect the pending group evolution during `PendingPublish`. See `tests/publish_lifecycle.rs` and
-`tests/invite_leave.rs` for the contract.
+`do_send_invite` / `do_upgrade_group_capabilities` / auto-commit stage their commits and defer merge until
+`CgkaEngine::confirm_published`. `CgkaEngine::publish_failed` discards via `MlsGroup::clear_pending_commit` + Marmot
+re-derive from the still-unmerged group. Current-profile `do_create_group` is the founding exception: it atomically
+makes epoch 0 and the optional founding Add canonical locally, publishes no ordinary group commit, and persists each
+Welcome as independent retryable work. The temporary explicit-legacy create path retains the older pending behavior.
+For pending evolutions, the Marmot record holds _projected post-merge_ `members` so `members()` and `feature_status`
+reflect the pending change. See `tests/publish_lifecycle.rs`, `tests/group_creation.rs`, and `tests/invite_leave.rs`.
 
 OpenMLS 0.8.1 surface used: `MlsGroup::pending_commit() -> Option<&StagedCommit>` (`mod.rs:353`),
 `StagedCommit::export_secret` (`staged_commit.rs:778`, identical signature to `MlsGroup::export_secret`),

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -132,7 +132,9 @@ pub(crate) fn send_result_kind_str(result: &SendResult) -> &'static str {
         SendResult::Queued { .. } => "queued",
         SendResult::Proposal { .. } => "proposal",
         SendResult::GroupEvolution { .. } => "group_evolution",
-        SendResult::GroupCreated { .. } => "group_created",
+        SendResult::GroupCreated { .. } | SendResult::FoundingGroupCreated { .. } => {
+            "group_created"
+        }
     }
 }
 
@@ -531,7 +533,8 @@ pub(crate) fn send_outbound_messages(result: &SendResult) -> Vec<OutboundMessage
                     .map(|w| outbound(w, MessageArtifactKind::Welcome)),
             );
         }
-        SendResult::GroupCreated { welcomes, .. } => {
+        SendResult::GroupCreated { welcomes, .. }
+        | SendResult::FoundingGroupCreated { welcomes } => {
             messages.extend(
                 welcomes
                     .iter()

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -609,7 +609,9 @@ impl<S: StorageProvider> Engine<S> {
             }
             SendResult::Proposal { msg } => Some((msg, MessageArtifactKind::Proposal)),
             SendResult::GroupEvolution { msg, .. } => Some((msg, MessageArtifactKind::Commit)),
-            SendResult::GroupCreated { .. } | SendResult::Queued { .. } => None,
+            SendResult::GroupCreated { .. }
+            | SendResult::FoundingGroupCreated { .. }
+            | SendResult::Queued { .. } => None,
         };
         if let Some((msg, artifact_kind)) = main {
             let self_id = self.identity.self_id();
@@ -643,7 +645,8 @@ impl<S: StorageProvider> Engine<S> {
 
         let welcomes = match result {
             SendResult::GroupEvolution { welcomes, .. }
-            | SendResult::GroupCreated { welcomes, .. } => welcomes.as_slice(),
+            | SendResult::GroupCreated { welcomes, .. }
+            | SendResult::FoundingGroupCreated { welcomes } => welcomes.as_slice(),
             _ => [].as_slice(),
         };
         for welcome in welcomes {

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1553,11 +1553,11 @@ impl<S: StorageProvider> Engine<S> {
 
     /// Return the stored outbound welcome for `id` along with its group.
     ///
-    /// Wrapped welcomes are persisted at wrap time as `Sent` raw-transport
-    /// records, so a welcome whose publish failed after the commit was already
-    /// confirmed can be re-delivered from storage without re-committing
-    /// (mdk#352). Errors if the id does not resolve to a sent raw-transport
-    /// welcome record.
+    /// New wrapped welcomes are persisted at wrap time as delivery-aware
+    /// `OutboundWelcome` records. Historical `Sent` raw-transport Welcome
+    /// records remain directly re-deliverable by a known id for compatibility,
+    /// but are not rediscovered as outstanding after an upgrade because older
+    /// versions did not persist acknowledgement completion (mdk#352).
     pub fn stored_sent_welcome(
         &self,
         id: &MessageId,
@@ -1570,15 +1570,82 @@ impl<S: StorageProvider> Engine<S> {
         }
         let payload = StoredMessagePayload::decode(&record.payload)
             .map_err(|e| EngineError::Backend(format!("stored payload decode: {e}")))?;
-        let message = payload.as_raw_transport().ok_or_else(|| {
-            EngineError::Backend("stored message is not a raw transport record".into())
-        })?;
+        let message = payload
+            .as_outbound_welcome()
+            .or_else(|| payload.as_raw_transport())
+            .ok_or_else(|| {
+                EngineError::Backend(
+                    "stored message is not an outbound Welcome transport record".into(),
+                )
+            })?;
         if !matches!(message.envelope, TransportEnvelope::Welcome { .. }) {
             return Err(EngineError::Backend(
                 "stored message is not a welcome".into(),
             ));
         }
         Ok((record.group_id.clone(), message.clone()))
+    }
+
+    /// Return every retained outbound Welcome whose delivery policy has not
+    /// yet been acknowledged.
+    ///
+    /// Founding creation persists delivery-aware `OutboundWelcome` records in
+    /// the same transaction that makes the group canonical. This scan is
+    /// therefore the authoritative cold-restart recovery index even if a
+    /// higher-layer pending-delivery projection was not written before process
+    /// termination. Historical raw `Sent` Welcome rows are deliberately
+    /// excluded because their acknowledgement state is unknowable.
+    pub fn outstanding_sent_welcomes(
+        &self,
+    ) -> Result<Vec<(GroupId, TransportMessage)>, EngineError> {
+        let mut welcomes = Vec::new();
+        for group_id in self.storage.list_groups()? {
+            for record in self.storage.list_messages(&group_id, EpochId(0))? {
+                if record.state != MessageState::Sent {
+                    continue;
+                }
+                let Ok(payload) = StoredMessagePayload::decode(&record.payload) else {
+                    continue;
+                };
+                let Some(message) = payload.as_outbound_welcome() else {
+                    continue;
+                };
+                if matches!(message.envelope, TransportEnvelope::Welcome { .. }) {
+                    welcomes.push((group_id.clone(), message.clone()));
+                }
+            }
+        }
+        Ok(welcomes)
+    }
+
+    /// IDs of every delivery-aware outbound Welcome retained by this engine,
+    /// including completed obligations.
+    ///
+    /// Higher layers use this to distinguish their founding-Welcome projection
+    /// rows from older pending-delivery rows that are intentionally backed by
+    /// historical raw `Sent` payloads.
+    pub fn tracked_outbound_welcome_ids(&self) -> Result<Vec<MessageId>, EngineError> {
+        let mut ids = Vec::new();
+        for group_id in self.storage.list_groups()? {
+            for record in self.storage.list_messages(&group_id, EpochId(0))? {
+                let Ok(payload) = StoredMessagePayload::decode(&record.payload) else {
+                    continue;
+                };
+                if payload.as_outbound_welcome().is_some() {
+                    ids.push(record.id);
+                }
+            }
+        }
+        Ok(ids)
+    }
+
+    /// Mark one retained outbound Welcome's independent delivery obligation
+    /// complete. The canonical group lifecycle is unaffected.
+    pub fn mark_sent_welcome_delivered(&self, id: &MessageId) -> Result<(), EngineError> {
+        // Validate the exact retained artifact before using `Processed` as its
+        // terminal delivery state.
+        let _ = self.stored_sent_welcome(id)?;
+        self.update_stored_message_state(id, MessageState::Processed)
     }
 
     /// Return the current Marmot admin policy keys mirrored from signed MLS

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1563,6 +1563,7 @@ impl<S: StorageProvider> Engine<S> {
         id: &MessageId,
     ) -> Result<(GroupId, TransportMessage), EngineError> {
         let record = self.storage.get_message(id)?;
+        self.ensure_group_live(&record.group_id)?;
         if record.state != MessageState::Sent {
             return Err(EngineError::Backend(
                 "stored message is not an outbound sent record".into(),
@@ -1600,6 +1601,9 @@ impl<S: StorageProvider> Engine<S> {
     ) -> Result<Vec<(GroupId, TransportMessage)>, EngineError> {
         let mut welcomes = Vec::new();
         for group_id in self.storage.list_groups()? {
+            if self.ensure_group_live(&group_id).is_err() {
+                continue;
+            }
             for record in self.storage.list_messages(&group_id, EpochId(0))? {
                 if record.state != MessageState::Sent {
                     continue;
@@ -1627,6 +1631,9 @@ impl<S: StorageProvider> Engine<S> {
     pub fn tracked_outbound_welcome_ids(&self) -> Result<Vec<MessageId>, EngineError> {
         let mut ids = Vec::new();
         for group_id in self.storage.list_groups()? {
+            if self.ensure_group_live(&group_id).is_err() {
+                continue;
+            }
             for record in self.storage.list_messages(&group_id, EpochId(0))? {
                 let Ok(payload) = StoredMessagePayload::decode(&record.payload) else {
                     continue;

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -556,7 +556,7 @@ impl<S: StorageProvider> Engine<S> {
                         storage.put_group(&canonical_record)?;
 
                         for welcome in &welcomes {
-                            let payload = StoredMessagePayload::raw_transport(welcome.clone())
+                            let payload = StoredMessagePayload::outbound_welcome(welcome.clone())
                                 .encode()
                                 .map_err(|error| {
                                     EngineError::Serialize(format!(
@@ -597,6 +597,10 @@ impl<S: StorageProvider> Engine<S> {
             }
 
             for welcome in &welcomes {
+                // `Sent` deliberately means "durable outbound obligation",
+                // not "transport delivery completed". Account orchestration
+                // moves an acknowledged Welcome to `Processed`; until then it
+                // remains discoverable after a crash for independent retry.
                 self.sent_message_ids.insert(welcome.id.clone());
                 self.audit_group(
                     &group_id,
@@ -867,10 +871,21 @@ impl<S: StorageProvider> Engine<S> {
                 );
 
                 let local_state_is_stale = match storage.get_group(&group_id) {
-                    Ok(group) => !group
-                        .members
-                        .iter()
-                        .any(|member| &member.id == self.identity.self_id()),
+                    Ok(group) => {
+                        if group
+                            .members
+                            .iter()
+                            .any(|member| &member.id == self.identity.self_id())
+                        {
+                            // A distinct transport/content id does not make a
+                            // second normal Welcome for an already-active group
+                            // a rejoin. Reject before OpenMLS staging and let
+                            // the surrounding transaction restore KeyPackage
+                            // consumption and every tentative write.
+                            return Err(EngineError::WelcomeAlreadyProcessed);
+                        }
+                        true
+                    }
                     Err(cgka_traits::storage::StorageError::NotFound) => false,
                     Err(error) => return Err(EngineError::Storage(error)),
                 };

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -1,14 +1,12 @@
 //! Group lifecycle — `create_group`, `join_welcome`, etc.
 //!
-//! `do_create_group` uses publish-before-apply: it stages an add-members
-//! commit, wraps welcomes from the staged group, enters `PendingPublish`,
-//! and returns. `Engine::do_confirm_published` merges the MLS commit and
-//! updates Marmot records after the application reports transport success.
-//! `publish_failed` clears the staged commit and rewinds to `Stable`.
-//!
-//! For SOLO create (no invitees) there is no pending commit — the engine
-//! still issues a `PendingStateRef` so the API shape is uniform, but
-//! confirm/fail are state-machine-only no-ops MLS-side.
+//! Current-profile `do_create_group` follows the founding exception to normal
+//! publish-before-apply: epoch 0 and its optional founding Add are made
+//! canonical locally, no ordinary group message is emitted, and the returned
+//! Welcomes are independent delivery obligations. Explicit legacy-profile
+//! creation retains the older staged/pending lifecycle until strict cutover.
+
+use std::collections::BTreeSet;
 
 use crate::capabilities::{
     capabilities_of_key_package, extension_from_group_capabilities, leaf_capabilities,
@@ -27,7 +25,7 @@ use cgka_traits::engine::{CreateGroupRequest, KeyPackage, SendResult, WelcomeMet
 use cgka_traits::error::EngineError;
 use cgka_traits::group::{Group, Member, ProtocolProfile};
 use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
-use cgka_traits::storage::StorageProvider;
+use cgka_traits::storage::{StorageError, StorageProvider};
 use cgka_traits::transport::{EncryptedPayload, TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use marmot_forensics::AuditEventKind;
@@ -37,6 +35,7 @@ use openmls::prelude::{
     MlsMessageIn, WelcomeError,
 };
 use openmls::treesync::Node;
+use openmls_traits::OpenMlsProvider as _;
 use openmls_traits::types::Ciphersuite;
 use sha2::{Digest, Sha256};
 use tls_codec::{Deserialize as _, Serialize as _};
@@ -99,6 +98,70 @@ pub(crate) const ENCRYPTED_MEDIA_EXPORTER_SNAPSHOT_KEY: &str =
     cgka_traits::app_components::GROUP_ENCRYPTED_MEDIA_EXPORTER_CACHE_KEY;
 pub(crate) const AGENT_TEXT_STREAM_EXPORTER_SNAPSHOT_KEY: &str =
     cgka_traits::agent_text_stream::AGENT_TEXT_STREAM_EXPORTER_CACHE_KEY;
+
+/// Deletes a not-yet-canonical current-profile group if creation returns early
+/// or the async future is cancelled after OpenMLS first persists it.
+///
+/// The final creation transaction disarms this immediately after atomically
+/// merging the optional founding Add, writing the Marmot group record, and
+/// retaining every wrapped Welcome. Until then no caller has received the
+/// group id and no transport work has escaped.
+struct NewGroupCleanupGuard<S: StorageProvider> {
+    storage: *const S,
+    group_id: GroupId,
+    armed: bool,
+}
+
+// SAFETY: `S` is `Send + Sync`; the pointer is dereferenced only from Drop
+// while the guarded `&mut Engine` future (and therefore its storage) is alive.
+unsafe impl<S: StorageProvider> Send for NewGroupCleanupGuard<S> {}
+
+impl<S: StorageProvider> NewGroupCleanupGuard<S> {
+    fn arm(storage: &S, group_id: GroupId) -> Self {
+        Self {
+            storage: storage as *const S,
+            group_id,
+            armed: true,
+        }
+    }
+
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl<S: StorageProvider> Drop for NewGroupCleanupGuard<S> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // SAFETY: see the `Send` justification above.
+        let storage = unsafe { &*self.storage };
+        let mls_gid = openmls::group::GroupId::from_slice(self.group_id.as_slice());
+        let cleanup = storage.with_transaction(|storage| {
+            let crypto = openmls_rust_crypto::RustCrypto::default();
+            let provider = EngineOpenMlsProvider::<S>::new(&crypto, storage.mls_storage());
+            if let Some(mut group) = MlsGroup::load(provider.storage(), &mls_gid)
+                .map_err(|error| StorageError::Backend(format!("load new group: {error:?}")))?
+            {
+                group.delete(provider.storage()).map_err(|error| {
+                    StorageError::Backend(format!("delete new group: {error:?}"))
+                })?;
+            }
+            match storage.delete_group(&self.group_id) {
+                Ok(()) | Err(StorageError::NotFound) => Ok(()),
+                Err(error) => Err(error),
+            }
+        });
+        if cleanup.is_err() {
+            tracing::warn!(
+                target: "cgka_engine::group_lifecycle",
+                method = "new_group_cleanup",
+                "could not remove incomplete current-profile group"
+            );
+        }
+    }
+}
 
 impl<S: StorageProvider> Engine<S> {
     /// Implementation of `CgkaEngine::create_group`.
@@ -294,6 +357,8 @@ impl<S: StorageProvider> Engine<S> {
         })?;
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
         let group_id = GroupId::new(mls_group.group_id().as_slice().to_vec());
+        let mut new_group_guard = (self.new_protocol_profile == ProtocolProfile::Current)
+            .then(|| NewGroupCleanupGuard::arm(&self.storage, group_id.clone()));
 
         // Admin-leaf coupling at creation (mdk#737): every admin key MUST
         // correspond to a member of the initial group (creator + invitees).
@@ -331,11 +396,13 @@ impl<S: StorageProvider> Engine<S> {
             let (_commit_out, welcome_out, _group_info) = mls_group
                 .add_members(&provider, &self.identity.signer, &parsed_kps)
                 .map_err(|e| EngineError::Backend(format!("add_members: {e:?}")))?;
-            pending_commit_guard = Some(PendingCommitCleanupGuard::arm(
-                &self.storage,
-                &provider,
-                group_id.clone(),
-            ));
+            if self.new_protocol_profile == ProtocolProfile::Legacy {
+                pending_commit_guard = Some(PendingCommitCleanupGuard::arm(
+                    &self.storage,
+                    &provider,
+                    group_id.clone(),
+                ));
+            }
             let own_leaf_index = mls_group.own_leaf_index();
             let staged = mls_group.pending_commit().ok_or_else(|| {
                 EngineError::Backend("founding add produced no pending commit".into())
@@ -380,16 +447,17 @@ impl<S: StorageProvider> Engine<S> {
             removed: false,
             join_epoch: EpochId(mls_group.epoch().as_u64()),
         };
-        self.storage.put_group(&group_record)?;
-        // #740: index this group's transport routing id for O(1) inbound
-        // resolution (see `Engine::transport_group_id_index`). Best-effort: a
-        // routing-read failure only forfeits the fast path (inbound would fall
-        // through to the unknown-group disposition), never fails creation.
-        if let Ok(transport_group_id) =
-            crate::app_components::transport_group_id_of_group(&mls_group)
-        {
-            self.transport_group_id_index
-                .insert(transport_group_id, group_id.clone());
+        if self.new_protocol_profile == ProtocolProfile::Legacy {
+            self.storage.put_group(&group_record)?;
+            // #740: index this group's transport routing id for O(1) inbound
+            // resolution (see `Engine::transport_group_id_index`). Best-effort:
+            // a routing-read failure only forfeits the fast path.
+            if let Ok(transport_group_id) =
+                crate::app_components::transport_group_id_of_group(&mls_group)
+            {
+                self.transport_group_id_index
+                    .insert(transport_group_id, group_id.clone());
+            }
         }
 
         // 5. Wrap welcomes via the peeler.
@@ -425,9 +493,154 @@ impl<S: StorageProvider> Engine<S> {
                     self.peeler.wrap_welcome(&payload, &recipient).await
                 }
                 .map_err(EngineError::Peeler)?;
-                self.record_sent_message(&wrapped, &group_id, EpochId(0))?;
+                if self.new_protocol_profile == ProtocolProfile::Legacy {
+                    self.record_sent_message(&wrapped, &group_id, EpochId(0))?;
+                }
                 welcomes.push(wrapped);
             }
+        }
+
+        if self.new_protocol_profile == ProtocolProfile::Current {
+            let unique_welcome_ids = welcomes
+                .iter()
+                .map(|welcome| welcome.id.as_slice().to_vec())
+                .collect::<BTreeSet<_>>();
+            if welcomes.len() != parsed_kps.len() || unique_welcome_ids.len() != parsed_kps.len() {
+                return Err(EngineError::Backend(
+                    "founding creation did not produce one distinct Welcome per invitee".into(),
+                ));
+            }
+            // Founding creation has an empty group-message publication
+            // obligation. Atomically make the optional Add canonical together
+            // with the Marmot projection and durable Welcome artifacts before
+            // any caller can attempt transport delivery.
+            let canonical_epoch =
+                self.storage
+                    .with_transaction(|storage| -> Result<EpochId, EngineError> {
+                        if mls_group.pending_commit().is_some() {
+                            // The capability cache validates every added leaf
+                            // against the persisted group's protocol profile.
+                            // Seed the projected record inside this same
+                            // transaction before inspecting the staged Add;
+                            // it is overwritten with the canonical epoch and
+                            // roster after the merge below.
+                            storage.put_group(&group_record)?;
+                            {
+                                let staged = mls_group.pending_commit().ok_or_else(|| {
+                                    EngineError::Backend(
+                                        "founding add lost its pending commit".into(),
+                                    )
+                                })?;
+                                crate::capability_manager::cache_from_staged_commit(
+                                    storage, &group_id, staged,
+                                )?;
+                            }
+                            let tx_provider = EngineOpenMlsProvider::<S>::new(
+                                &self.crypto,
+                                storage.mls_storage(),
+                            );
+                            mls_group
+                                .merge_pending_commit(&tx_provider)
+                                .map_err(|error| {
+                                    EngineError::Backend(format!("merge founding add: {error:?}"))
+                                })?;
+                            crate::app_components::validate_current_profile_group_invariants(
+                                &mls_group,
+                            )?;
+                        }
+
+                        let canonical_epoch = EpochId(mls_group.epoch().as_u64());
+                        let mut canonical_record = group_record.clone();
+                        canonical_record.epoch = canonical_epoch;
+                        canonical_record.members = marmot_members(&mls_group);
+                        storage.put_group(&canonical_record)?;
+
+                        for welcome in &welcomes {
+                            let payload = StoredMessagePayload::raw_transport(welcome.clone())
+                                .encode()
+                                .map_err(|error| {
+                                    EngineError::Serialize(format!(
+                                        "encode founding Welcome: {error:?}"
+                                    ))
+                                })?;
+                            storage.put_message(&MessageRecord {
+                                id: welcome.id.clone(),
+                                group_id: group_id.clone(),
+                                epoch: canonical_epoch,
+                                state: MessageState::Sent,
+                                payload,
+                            })?;
+                        }
+                        crate::capability_manager::cache_from_key_packages(
+                            storage,
+                            &group_id,
+                            &parsed_kps,
+                        )?;
+                        crate::capability_manager::cache_self_capabilities(
+                            storage,
+                            &group_id,
+                            &mls_group,
+                            self.identity.self_id(),
+                            self.ciphersuite,
+                        )?;
+                        Ok(canonical_epoch)
+                    })?;
+
+            // The durable creation transaction is complete. From here on,
+            // failure must not delete or roll back the canonical group.
+            new_group_guard
+                .take()
+                .expect("current creation arms cleanup")
+                .disarm();
+            if let Some(guard) = pending_commit_guard.take() {
+                guard.disarm();
+            }
+
+            for welcome in &welcomes {
+                self.sent_message_ids.insert(welcome.id.clone());
+                self.audit_group(
+                    &group_id,
+                    crate::audit_helpers::message_state_transition_event(
+                        hex::encode(welcome.id.as_slice()),
+                        None,
+                        MessageState::Sent,
+                        Some(canonical_epoch),
+                        "founding_welcome_persisted",
+                    ),
+                );
+            }
+            if let Ok(transport_group_id) =
+                crate::app_components::transport_group_id_of_group(&mls_group)
+            {
+                self.transport_group_id_index
+                    .insert(transport_group_id, group_id.clone());
+            }
+            self.epoch_manager
+                .set_stable(group_id.clone(), canonical_epoch);
+            self.audit_group(
+                &group_id,
+                crate::audit_helpers::epoch_state_changed_event(
+                    None,
+                    "stable",
+                    canonical_epoch,
+                    "founding_create",
+                    None,
+                    None,
+                ),
+            );
+            self.events_buf
+                .push_back(cgka_traits::engine::GroupEvent::GroupCreated {
+                    group_id: group_id.clone(),
+                });
+            if let Err(error) = self.retain_current_epoch_snapshot_for_group(&group_id) {
+                tracing::warn!(
+                    target: "cgka_engine::group_lifecycle",
+                    method = "do_create_group",
+                    transient = error.is_transient(),
+                    "deferred founding snapshot retention"
+                );
+            }
+            return Ok((group_id, SendResult::FoundingGroupCreated { welcomes }));
         }
 
         crate::capability_manager::cache_from_key_packages(&self.storage, &group_id, &parsed_kps)?;

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -273,7 +273,9 @@ impl<S: StorageProvider> Engine<S> {
                     self.queued_intent_by_pending
                         .insert(*pending, (record.group_id.clone(), record.id.clone()));
                 }
-                SendResult::GroupCreated { .. } | SendResult::Queued { .. } => {}
+                SendResult::GroupCreated { .. }
+                | SendResult::FoundingGroupCreated { .. }
+                | SendResult::Queued { .. } => {}
             }
             drained.push(result);
             if pauses_for_pending_publish {

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -224,7 +224,21 @@ impl<S: StorageProvider> Engine<S> {
         state: MessageState,
     ) -> Result<(), EngineError> {
         match self.storage.get_group(group_id) {
-            Ok(_) => self.persist_transport_message(msg, group_id, epoch, state),
+            Ok(_) => {
+                // An own transport echo must not erase the delivery-aware
+                // payload flavor of a retained outbound Welcome. The row is
+                // already durable when its id enters `sent_message_ids`.
+                if self
+                    .storage
+                    .get_message(&msg.id)
+                    .ok()
+                    .and_then(|record| StoredMessagePayload::decode(&record.payload).ok())
+                    .is_some_and(|payload| payload.as_outbound_welcome().is_some())
+                {
+                    return Ok(());
+                }
+                self.persist_transport_message(msg, group_id, epoch, state)
+            }
             Err(StorageError::NotFound) => Ok(()),
             Err(e) => Err(EngineError::Storage(e)),
         }

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -409,7 +409,8 @@ pub(crate) fn stamp_processed_own_commit_record<S: StorageProvider>(
         }
         // Raw-transport rows never enter the OpenMLS candidate graph; a plain
         // state update preserves their shape.
-        other @ StoredMessagePayload::RawTransport(_) => other,
+        other @ (StoredMessagePayload::RawTransport(_)
+        | StoredMessagePayload::OutboundWelcome(_)) => other,
     };
     record.state = MessageState::Processed;
     record.payload = payload

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -21,11 +21,11 @@
 //! 4. Hand off to `EpochManager::rollback_publish` for the state-machine
 //!    bookkeeping.
 //!
-//! ### Solo `create_group`
-//! Solo create has no pending commit (no `add_members` was called). Both
-//! confirm + fail are state-machine-only — confirm transitions to Stable
-//! at epoch 0, fail rewinds to Stable at epoch 0 (no-op MLS-side, but the
-//! group record stays around).
+//! ### Founding `create_group`
+//! Current-profile founding creation is completed atomically in
+//! `group_lifecycle::do_create_group` and never enters these confirm/fail
+//! paths. The temporary explicit-legacy path still does: a solo legacy create
+//! has no pending commit, so confirm + fail are state-machine-only at epoch 0.
 
 use crate::engine::Engine;
 use crate::provider::EngineOpenMlsProvider;

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -496,8 +496,10 @@ impl TransportPeeler for MockPeeler {
         payload: &EncryptedPayload,
         recipient: &MemberId,
     ) -> Result<TransportMessage, PeelerError> {
+        let mut id_material = payload.ciphertext.clone();
+        id_material.extend_from_slice(recipient.as_slice());
         Ok(TransportMessage {
-            id: hash_id(&payload.ciphertext),
+            id: hash_id(&id_material),
             payload: payload.ciphertext.clone(),
             timestamp: Timestamp(0),
             causal_deps: vec![],
@@ -956,15 +958,14 @@ async fn current_group_persists_profile_and_rejects_legacy_key_packages() {
         })
         .await
         .unwrap();
-    let (welcome, pending) = match result {
-        SendResult::GroupCreated {
-            mut welcomes,
-            pending,
-        } => (welcomes.remove(0), pending),
-        other => panic!("expected GroupCreated, got {other:?}"),
+    let welcome = match result {
+        SendResult::FoundingGroupCreated { mut welcomes } => welcomes.remove(0),
+        other => panic!("expected FoundingGroupCreated, got {other:?}"),
     };
-    alice.confirm_published(pending).await.unwrap();
+    let welcome_id = welcome.id.clone();
     let group = alice.group_record(&group_id).unwrap();
+    assert_eq!(group.epoch, cgka_traits::types::EpochId(1));
+    assert_eq!(group.members.len(), 2);
     assert_eq!(group.protocol_profile, ProtocolProfile::Current);
     assert!(
         group
@@ -978,11 +979,27 @@ async fn current_group_persists_profile_and_rejects_legacy_key_packages() {
             .extensions
             .contains(&ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE)
     );
+    let duplicate_welcome = welcome.clone();
     let joined = bob.join_welcome(welcome).await.unwrap();
     assert_eq!(
         bob.group_record(&joined).unwrap().protocol_profile,
         ProtocolProfile::Current
     );
+    let duplicate_error = bob
+        .join_welcome(duplicate_welcome)
+        .await
+        .expect_err("a duplicate founding Welcome must not mutate joined state");
+    assert!(matches!(
+        duplicate_error,
+        EngineError::WelcomeAlreadyProcessed
+    ));
+    assert_eq!(bob.epoch(&joined).unwrap(), cgka_traits::types::EpochId(1));
+    assert_eq!(bob.members(&joined).unwrap().len(), 2);
+    assert!(matches!(
+        alice.drain_events().as_slice(),
+        [cgka_traits::engine::GroupEvent::GroupCreated { group_id: created }]
+            if created == &group_id
+    ));
 
     let legacy_kp = legacy_carol.fresh_key_package().await.unwrap();
     let error = alice
@@ -1003,10 +1020,52 @@ async fn current_group_persists_profile_and_rejects_legacy_key_packages() {
         .build()
         .unwrap();
     reopened.hydrate_stable_groups_from_storage().unwrap();
-    assert_eq!(
-        reopened.group_record(&group_id).unwrap().protocol_profile,
-        ProtocolProfile::Current
-    );
+    let reopened_group = reopened.group_record(&group_id).unwrap();
+    assert_eq!(reopened_group.protocol_profile, ProtocolProfile::Current);
+    assert_eq!(reopened_group.epoch, cgka_traits::types::EpochId(1));
+    assert_eq!(reopened_group.members.len(), 2);
+    let (stored_group, stored_welcome) = reopened.stored_sent_welcome(&welcome_id).unwrap();
+    assert_eq!(stored_group, group_id);
+    assert_eq!(stored_welcome.id, welcome_id);
+}
+
+#[tokio::test]
+async fn current_solo_group_is_canonical_at_epoch_zero_without_confirmation() {
+    let mut alice = build_current_client(b"alice-current-solo");
+
+    let (group_id, result) = alice
+        .create_group(CreateGroupRequest {
+            name: "solo".into(),
+            description: "canonical immediately".into(),
+            members: vec![],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        result,
+        SendResult::FoundingGroupCreated { ref welcomes } if welcomes.is_empty()
+    ));
+    let group = alice.group_record(&group_id).unwrap();
+    assert_eq!(group.epoch, cgka_traits::types::EpochId(0));
+    assert_eq!(group.members.len(), 1);
+    assert!(matches!(
+        alice.drain_events().as_slice(),
+        [cgka_traits::engine::GroupEvent::GroupCreated { group_id: created }]
+            if created == &group_id
+    ));
+
+    let sent = alice
+        .send(cgka_traits::engine::SendIntent::AppMessage {
+            group_id,
+            payload: app_payload_for(&alice, "usable immediately"),
+        })
+        .await
+        .expect("canonical solo group accepts work without confirm_published");
+    assert!(matches!(sent, SendResult::ApplicationMessage { .. }));
 }
 
 #[tokio::test]
@@ -1090,11 +1149,10 @@ async fn group_commit_cannot_change_or_mix_the_protocol_profile() {
         })
         .await
         .unwrap();
-    let pending = match result {
-        SendResult::GroupCreated { pending, .. } => pending,
-        other => panic!("expected GroupCreated, got {other:?}"),
-    };
-    current.confirm_published(pending).await.unwrap();
+    assert!(matches!(
+        result,
+        SendResult::FoundingGroupCreated { ref welcomes } if welcomes.is_empty()
+    ));
     let drop_current_proof = AppComponentData {
         component_id: cgka_traits::app_components::APP_COMPONENTS_COMPONENT_ID,
         data: encode_components_list(&default_group_components()),

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -26,8 +26,9 @@ use cgka_traits::error::PeelerError;
 use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{PeeledContent, PeeledMessage};
+use cgka_traits::message::StoredMessagePayload;
 use cgka_traits::peeler::TransportPeeler;
-use cgka_traits::storage::StorageProvider;
+use cgka_traits::storage::{MessageStorage, StorageProvider};
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
@@ -432,6 +433,7 @@ fn pad32(name: &[u8]) -> Vec<u8> {
 #[derive(Default)]
 struct MockPeeler {
     welcome_sender: Option<MemberId>,
+    collide_welcome_ids: bool,
 }
 
 fn hash_id(bytes: &[u8]) -> MessageId {
@@ -499,7 +501,11 @@ impl TransportPeeler for MockPeeler {
         let mut id_material = payload.ciphertext.clone();
         id_material.extend_from_slice(recipient.as_slice());
         Ok(TransportMessage {
-            id: hash_id(&id_material),
+            id: if self.collide_welcome_ids {
+                MessageId::new(b"colliding-founding-welcome-id".to_vec())
+            } else {
+                hash_id(&id_material)
+            },
             payload: payload.ciphertext.clone(),
             timestamp: Timestamp(0),
             causal_deps: vec![],
@@ -568,6 +574,7 @@ fn build_client_with_welcome_sender(
         .feature_registry(registry)
         .peeler(Box::new(MockPeeler {
             welcome_sender: Some(welcome_sender),
+            collide_welcome_ids: false,
         }))
         .build()
         .expect("build engine")
@@ -963,6 +970,15 @@ async fn current_group_persists_profile_and_rejects_legacy_key_packages() {
         other => panic!("expected FoundingGroupCreated, got {other:?}"),
     };
     let welcome_id = welcome.id.clone();
+    let stored = storage.get_message(&welcome_id).unwrap();
+    assert!(
+        StoredMessagePayload::decode(&stored.payload)
+            .unwrap()
+            .as_outbound_welcome()
+            .is_some(),
+        "new outbound Welcomes must carry an explicit recoverable-delivery tag"
+    );
+    assert_eq!(alice.outstanding_sent_welcomes().unwrap().len(), 1);
     let group = alice.group_record(&group_id).unwrap();
     assert_eq!(group.epoch, cgka_traits::types::EpochId(1));
     assert_eq!(group.members.len(), 2);
@@ -979,7 +995,8 @@ async fn current_group_persists_profile_and_rejects_legacy_key_packages() {
             .extensions
             .contains(&ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE)
     );
-    let duplicate_welcome = welcome.clone();
+    let mut duplicate_welcome = welcome.clone();
+    duplicate_welcome.id = MessageId::new(b"distinct-transport-id-same-welcome".to_vec());
     let joined = bob.join_welcome(welcome).await.unwrap();
     assert_eq!(
         bob.group_record(&joined).unwrap().protocol_profile,
@@ -995,6 +1012,7 @@ async fn current_group_persists_profile_and_rejects_legacy_key_packages() {
     ));
     assert_eq!(bob.epoch(&joined).unwrap(), cgka_traits::types::EpochId(1));
     assert_eq!(bob.members(&joined).unwrap().len(), 2);
+
     assert!(matches!(
         alice.drain_events().as_slice(),
         [cgka_traits::engine::GroupEvent::GroupCreated { group_id: created }]
@@ -1012,6 +1030,20 @@ async fn current_group_persists_profile_and_rejects_legacy_key_packages() {
     assert!(matches!(error, EngineError::InvalidAccountIdentityProof(_)));
 
     drop(alice);
+
+    // Upgrade compatibility: historical versions stored outbound Welcomes as
+    // raw `Sent` rows but did not persist their acknowledgement completion.
+    // A known id remains re-deliverable, while cold-restart discovery must not
+    // resurrect such an old row after it may already have reached its recipient.
+    let mut historical = storage.get_message(&welcome_id).unwrap();
+    let message = StoredMessagePayload::decode(&historical.payload)
+        .unwrap()
+        .into_message();
+    historical.payload = StoredMessagePayload::raw_transport(message)
+        .encode()
+        .unwrap();
+    storage.put_message(&historical).unwrap();
+
     let mut reopened = EngineBuilder::new(storage)
         .identity(pad32(b"alice-current-group"))
         .account_identity_proof_signer(proof_signer(b"alice-current-group"))
@@ -1024,9 +1056,53 @@ async fn current_group_persists_profile_and_rejects_legacy_key_packages() {
     assert_eq!(reopened_group.protocol_profile, ProtocolProfile::Current);
     assert_eq!(reopened_group.epoch, cgka_traits::types::EpochId(1));
     assert_eq!(reopened_group.members.len(), 2);
+    assert!(
+        reopened.outstanding_sent_welcomes().unwrap().is_empty(),
+        "historical raw Sent Welcomes have unknown ack state and must not be rediscovered"
+    );
     let (stored_group, stored_welcome) = reopened.stored_sent_welcome(&welcome_id).unwrap();
     assert_eq!(stored_group, group_id);
     assert_eq!(stored_welcome.id, welcome_id);
+}
+
+#[tokio::test]
+async fn current_group_rejects_colliding_founding_welcome_ids_atomically() {
+    let mut alice = EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
+        .identity(pad32(b"alice-colliding-welcomes"))
+        .account_identity_proof_signer(proof_signer(b"alice-colliding-welcomes"))
+        .protocol_profile(ProtocolProfile::Current)
+        .peeler(Box::new(MockPeeler {
+            welcome_sender: None,
+            collide_welcome_ids: true,
+        }))
+        .build()
+        .unwrap();
+    let mut bob = build_current_client(b"bob-colliding-welcomes");
+    let mut carol = build_current_client(b"carol-colliding-welcomes");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+
+    let error = alice
+        .create_group(CreateGroupRequest {
+            name: "colliding founding welcomes".into(),
+            description: String::new(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .expect_err("two invitees must not share a Welcome delivery id");
+
+    assert!(matches!(
+        error,
+        EngineError::Backend(ref message)
+            if message == "founding creation did not produce one distinct Welcome per invitee"
+    ));
+    assert!(
+        alice.live_group_ids().unwrap().is_empty(),
+        "the failed founding transaction must leave no live group"
+    );
 }
 
 #[tokio::test]

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -521,6 +521,90 @@ fn build_flaky_engine(storage: FlakyGroupRecordStorage) -> Engine<FlakyGroupReco
         .expect("build flaky engine")
 }
 
+fn build_current_flaky_engine(
+    storage: FlakyGroupRecordStorage,
+    name: &[u8],
+) -> Engine<FlakyGroupRecordStorage> {
+    EngineBuilder::new(storage)
+        .identity(pad32(name))
+        .account_identity_proof_signer(proof_signer(name))
+        .protocol_profile(cgka_traits::group::ProtocolProfile::Current)
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .expect("build current-profile flaky engine")
+}
+
+fn build_current_named_client(name: &[u8]) -> Engine<SqliteAccountStorage> {
+    EngineBuilder::new(SqliteAccountStorage::in_memory().expect("storage"))
+        .identity(pad32(name))
+        .account_identity_proof_signer(proof_signer(name))
+        .protocol_profile(cgka_traits::group::ProtocolProfile::Current)
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .expect("build current-profile client")
+}
+
+#[tokio::test]
+async fn welcome_delivery_accessors_hide_quarantined_groups() {
+    let storage = FlakyGroupRecordStorage::new(SqliteAccountStorage::in_memory().expect("storage"));
+    let mut alice = build_current_flaky_engine(storage.clone(), b"alice-quarantined-welcome");
+    let mut bob = build_current_named_client(b"bob-quarantined-welcome");
+    let bob_key_package = bob.fresh_key_package().await.expect("bob key package");
+    let (group_id, result) = alice
+        .create_group(CreateGroupRequest {
+            name: "quarantined welcome".into(),
+            description: String::new(),
+            members: vec![bob_key_package],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .expect("create current-profile group");
+    let welcome_id = match result {
+        SendResult::FoundingGroupCreated { welcomes } => {
+            welcomes.into_iter().next().expect("founding Welcome").id
+        }
+        other => panic!("expected founding group creation, got {other:?}"),
+    };
+    assert_eq!(alice.outstanding_sent_welcomes().unwrap().len(), 1);
+    drop(alice);
+
+    storage.set_fail_get_group(true);
+    let mut engine = build_current_flaky_engine(storage.clone(), b"alice-quarantined-welcome");
+    engine
+        .hydrate_stable_groups_from_storage()
+        .expect("unreadable group is quarantined");
+    assert_eq!(
+        engine.quarantined_groups(),
+        vec![(
+            group_id.clone(),
+            GroupHydrationQuarantineReason::GroupRecordLoadFailed
+        )]
+    );
+
+    // Make the underlying record readable again without retrying hydration.
+    // The quarantine gate, rather than the transient storage failure, must
+    // continue to hide every delivery accessor until explicit recovery.
+    storage.set_fail_get_group(false);
+    assert!(matches!(
+        engine.stored_sent_welcome(&welcome_id),
+        Err(EngineError::UnknownGroup(id)) if id == group_id
+    ));
+    assert!(matches!(
+        engine.mark_sent_welcome_delivered(&welcome_id),
+        Err(EngineError::UnknownGroup(id)) if id == group_id
+    ));
+    assert!(
+        engine.outstanding_sent_welcomes().unwrap().is_empty(),
+        "quarantined groups must not contribute outstanding Welcome work"
+    );
+    assert!(
+        engine.tracked_outbound_welcome_ids().unwrap().is_empty(),
+        "quarantined groups must not contribute tracked Welcome ids"
+    );
+}
+
 async fn create_confirmed_group_flaky(engine: &mut Engine<FlakyGroupRecordStorage>) -> GroupId {
     let (group_id, send_result) = engine
         .create_group(CreateGroupRequest {

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -1012,11 +1012,10 @@ async fn inbound_commit_cannot_unrequire_current_admin_policy() {
         })
         .await
         .unwrap();
-    let (pending, welcomes) = match create {
-        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
-        other => panic!("expected GroupCreated, got {other:?}"),
+    let welcomes = match create {
+        SendResult::FoundingGroupCreated { welcomes } => welcomes,
+        other => panic!("expected FoundingGroupCreated, got {other:?}"),
     };
-    alice.confirm_published(pending).await.unwrap();
     bob.join_welcome(welcomes.into_iter().next().unwrap())
         .await
         .unwrap();
@@ -1149,11 +1148,10 @@ async fn unrelated_update_and_invite_preserve_opaque_app_component_for_all_membe
         })
         .await
         .unwrap();
-    let (pending, welcomes) = match create {
-        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
-        other => panic!("expected GroupCreated, got {other:?}"),
+    let welcomes = match create {
+        SendResult::FoundingGroupCreated { welcomes } => welcomes,
+        other => panic!("expected FoundingGroupCreated, got {other:?}"),
     };
-    alice.confirm_published(pending).await.unwrap();
     bob.join_welcome(welcomes.into_iter().next().unwrap())
         .await
         .unwrap();
@@ -1283,11 +1281,10 @@ async fn inbound_commit_atomically_unrequires_and_removes_optional_component() {
         })
         .await
         .unwrap();
-    let (pending, welcomes) = match create {
-        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
-        other => panic!("expected GroupCreated, got {other:?}"),
+    let welcomes = match create {
+        SendResult::FoundingGroupCreated { welcomes } => welcomes,
+        other => panic!("expected FoundingGroupCreated, got {other:?}"),
     };
-    alice.confirm_published(pending).await.unwrap();
     bob.join_welcome(welcomes.into_iter().next().unwrap())
         .await
         .unwrap();

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -180,6 +180,9 @@ pub enum PublishWork {
         welcomes: Vec<TransportMessage>,
         pending: PendingStateRef,
     },
+    FoundingGroupCreated {
+        welcomes: Vec<TransportMessage>,
+    },
     AutoPublish {
         msg: TransportMessage,
         pending: PendingStateRef,
@@ -710,6 +713,9 @@ impl AccountDeviceSession {
                 SendResult::GroupCreated { welcomes, pending } => effects
                     .publish
                     .push(PublishWork::GroupCreated { welcomes, pending }),
+                SendResult::FoundingGroupCreated { welcomes } => effects
+                    .publish
+                    .push(PublishWork::FoundingGroupCreated { welcomes }),
                 SendResult::Queued {
                     group_id,
                     intent_id,
@@ -764,7 +770,9 @@ fn send_result_kind(result: &SendResult) -> &'static str {
         SendResult::Queued { .. } => "queued",
         SendResult::Proposal { .. } => "proposal",
         SendResult::GroupEvolution { .. } => "group_evolution",
-        SendResult::GroupCreated { .. } => "group_created",
+        SendResult::GroupCreated { .. } | SendResult::FoundingGroupCreated { .. } => {
+            "group_created"
+        }
     }
 }
 

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -299,6 +299,24 @@ impl AccountDeviceSession {
         Ok(self.engine.stored_sent_welcome(id)?)
     }
 
+    /// Retained outbound Welcomes that have not yet met their independent
+    /// delivery policy. This is derived from the engine's transactional
+    /// message store, so it survives a crash before app projection writes.
+    pub fn outstanding_sent_welcomes(&self) -> SessionResult<Vec<(GroupId, TransportMessage)>> {
+        Ok(self.engine.outstanding_sent_welcomes()?)
+    }
+
+    /// IDs of delivery-aware outbound Welcomes, including completed ones.
+    pub fn tracked_outbound_welcome_ids(&self) -> SessionResult<Vec<MessageId>> {
+        Ok(self.engine.tracked_outbound_welcome_ids()?)
+    }
+
+    /// Complete one retained outbound Welcome delivery obligation after the
+    /// transport reports the required acknowledgements.
+    pub fn mark_sent_welcome_delivered(&self, id: &MessageId) -> SessionResult<()> {
+        Ok(self.engine.mark_sent_welcome_delivered(id)?)
+    }
+
     /// Stored groups that failed session-open hydration and were skipped
     /// (mdk#151 / #417), paired with their coarse quarantine reason.
     /// Backs the application's per-group recovery surface (mdk#426).

--- a/crates/cgka-session/tests/session_lifecycle.rs
+++ b/crates/cgka-session/tests/session_lifecycle.rs
@@ -9,6 +9,7 @@ use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{CreateGroupRequest, GroupEvent, SendIntent};
 use cgka_traits::error::{EngineError, PeelerError};
+use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{PeeledContent, PeeledMessage};
 use cgka_traits::peeler::TransportPeeler;
@@ -120,8 +121,10 @@ impl TransportPeeler for MockPeeler {
         payload: &EncryptedPayload,
         recipient: &MemberId,
     ) -> Result<TransportMessage, PeelerError> {
+        let mut id_material = payload.ciphertext.clone();
+        id_material.extend_from_slice(recipient.as_slice());
         Ok(TransportMessage {
-            id: hash_id(&payload.ciphertext),
+            id: hash_id(&id_material),
             payload: payload.ciphertext.clone(),
             timestamp: Timestamp(0),
             causal_deps: vec![],
@@ -248,6 +251,84 @@ async fn session_reopens_encrypted_sqlite_group_state() {
     assert_eq!(reopened.epoch(&created.group_id).unwrap(), EpochId(1));
     assert_eq!(reopened.members(&created.group_id).unwrap().len(), 2);
     assert_eq!(reopened.own_leaf_index(&created.group_id).unwrap(), 0);
+}
+
+#[tokio::test]
+async fn current_founding_creation_is_immediately_stable_and_survives_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let alice_path = dir.path().join("alice-current.sqlite");
+    let bob_path = dir.path().join("bob-current.sqlite");
+    let key = SqlCipherKey::new("session current founding key").unwrap();
+    let mut alice = AccountDeviceSession::open(
+        config(&alice_path, &key, b"alice-current").protocol_profile(ProtocolProfile::Current),
+    )
+    .unwrap();
+    let mut bob = AccountDeviceSession::open(
+        config(&bob_path, &key, b"bob-current").protocol_profile(ProtocolProfile::Current),
+    )
+    .unwrap();
+
+    let bob_key_package = bob.fresh_key_package().await.unwrap();
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "current-founding".into(),
+            description: String::new(),
+            members: vec![bob_key_package],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let welcome = match created.effects.publish.as_slice() {
+        [PublishWork::FoundingGroupCreated { welcomes }] if welcomes.len() == 1 => {
+            welcomes[0].clone()
+        }
+        other => panic!("expected one founding Welcome and no pending commit, got {other:?}"),
+    };
+    assert_eq!(
+        created.effects.events,
+        vec![GroupEvent::GroupCreated {
+            group_id: created.group_id.clone()
+        }]
+    );
+    assert_eq!(alice.epoch(&created.group_id).unwrap(), EpochId(1));
+    assert_eq!(alice.members(&created.group_id).unwrap().len(), 2);
+    assert_eq!(
+        alice.stored_sent_welcome(&welcome.id).unwrap().0,
+        created.group_id
+    );
+
+    bob.ingest(welcome).await.unwrap();
+    let sent = bob
+        .send(SendIntent::AppMessage {
+            group_id: created.group_id.clone(),
+            payload: app_payload_for(&bob, b"invitee first message"),
+        })
+        .await
+        .unwrap();
+    let message = match sent.publish.as_slice() {
+        [PublishWork::ApplicationMessage { msg, .. }] => route(msg.clone(), &created.group_id),
+        other => panic!("expected invitee application publish work, got {other:?}"),
+    };
+    let received = alice.ingest(message).await.unwrap();
+    assert_eq!(
+        received.effects.events,
+        vec![GroupEvent::MessageReceived {
+            group_id: created.group_id.clone(),
+            epoch: EpochId(1),
+            sender: bob.self_id(),
+            payload: app_payload_for(&bob, b"invitee first message"),
+        }]
+    );
+
+    drop(alice);
+    let reopened = AccountDeviceSession::open(
+        config(&alice_path, &key, b"alice-current").protocol_profile(ProtocolProfile::Current),
+    )
+    .unwrap();
+    assert_eq!(reopened.epoch(&created.group_id).unwrap(), EpochId(1));
+    assert_eq!(reopened.members(&created.group_id).unwrap().len(), 2);
 }
 
 #[tokio::test]

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -547,13 +547,16 @@ where
         let mut all_published = true;
         let mut any_welcome_exposed = false;
         let mut welcome_failures = Vec::new();
+        let mut delivered_welcome_ids = Vec::new();
         for welcome in welcomes {
             let recipient = welcome_recipient(&welcome);
             let welcome_id = welcome.id.clone();
             let failures_before = output.failures.len();
             let status = self.publish_one(welcome, output, context.clone()).await?;
             any_welcome_exposed |= status.accepted_by_any_endpoint;
-            if !status.met_required_acks {
+            if status.met_required_acks {
+                delivered_welcome_ids.push(welcome_id);
+            } else {
                 if let Some(recipient) = recipient {
                     welcome_failures.push(self.welcome_delivery_failure(
                         welcome_id,
@@ -577,6 +580,9 @@ where
                 .pending
                 .push(PendingResolution::Confirmed { pending });
             output.absorb_session_effects(effects, queue);
+            for message_id in &delivered_welcome_ids {
+                self.mark_welcome_delivered_best_effort(message_id);
+            }
             for failure in &mut welcome_failures {
                 if failure.group_id.is_none() {
                     failure.group_id = group_id.clone();
@@ -611,9 +617,9 @@ where
             let welcome_id = welcome.id.clone();
             let failures_before = output.failures.len();
             let status = self.publish_one(welcome, output, context.clone()).await?;
-            if !status.met_required_acks
-                && let Some(recipient) = recipient
-            {
+            if status.met_required_acks {
+                self.mark_welcome_delivered_best_effort(&welcome_id);
+            } else if let Some(recipient) = recipient {
                 output.welcome_failures.push(self.welcome_delivery_failure(
                     welcome_id,
                     recipient,
@@ -653,7 +659,9 @@ where
                 let welcome_id = welcome.id.clone();
                 let failures_before = output.failures.len();
                 let status = self.publish_one(welcome, output, context.clone()).await?;
-                if !status.met_required_acks {
+                if status.met_required_acks {
+                    self.mark_welcome_delivered_best_effort(&welcome_id);
+                } else {
                     // The commit is already confirmed, so this member's join
                     // hinges on re-delivering exactly this welcome.
                     if let Some(recipient) = recipient {
@@ -697,9 +705,9 @@ where
         let mut output = AccountDeviceEffects::default();
         let failures_before = output.failures.len();
         let status = self.publish_one(message, &mut output, None).await?;
-        if !status.met_required_acks
-            && let Some(recipient) = recipient
-        {
+        if status.met_required_acks {
+            self.mark_welcome_delivered_best_effort(message_id);
+        } else if let Some(recipient) = recipient {
             let failure = self.welcome_delivery_failure(
                 message_id.clone(),
                 recipient,
@@ -710,6 +718,39 @@ where
             output.welcome_failures.push(failure);
         }
         Ok(output)
+    }
+
+    /// Retained outbound Welcome obligations that have not met their
+    /// acknowledgement policy. Unlike app projections, this list is rooted in
+    /// the engine transaction that made the corresponding group state
+    /// canonical, so non-app callers and cold restarts can recover it.
+    pub fn outstanding_welcome_deliveries(
+        &self,
+    ) -> AccountResult<Vec<(GroupId, TransportMessage)>> {
+        Ok(self.session.outstanding_sent_welcomes()?)
+    }
+
+    /// IDs of delivery-aware outbound Welcomes, including completed ones.
+    ///
+    /// This lets app projections clear a completed founding intent without
+    /// disturbing older pending-delivery rows whose engine payloads predate
+    /// delivery-aware tagging.
+    pub fn tracked_outbound_welcome_ids(&self) -> AccountResult<Vec<cgka_traits::MessageId>> {
+        Ok(self.session.tracked_outbound_welcome_ids()?)
+    }
+
+    /// Delivery is already externally visible when this runs. A local state
+    /// write failure must therefore leave the Welcome conservatively retryable
+    /// rather than turn canonical creation/evolution into a false hard error.
+    fn mark_welcome_delivered_best_effort(&self, message_id: &cgka_traits::MessageId) {
+        if let Err(error) = self.session.mark_sent_welcome_delivered(message_id) {
+            tracing::warn!(
+                target: TRACE_TARGET,
+                method = "mark_welcome_delivered_best_effort",
+                transient = error.is_transient(),
+                "acknowledged Welcome remains conservatively retryable"
+            );
+        }
     }
 
     /// Build the structured re-delivery record for a welcome that just failed

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -262,13 +262,40 @@ where
         context: AuditEventContext,
     ) -> AccountResult<(GroupId, AccountDeviceEffects)> {
         let CreateGroupEffects { group_id, effects } = self
-            .session
-            .create_group_with_audit_context(request, context.clone())
+            .prepare_create_group_with_audit_context(request, context.clone())
             .await?;
         let effects = self
-            .publish_session_effects_with_audit_context(effects, Some(context))
+            .publish_prepared_session_effects_with_audit_context(effects, context)
             .await?;
         Ok((group_id, effects))
+    }
+
+    /// Prepare group creation without performing transport side effects.
+    ///
+    /// The application runtime uses this seam to durably record every
+    /// current-profile founding Welcome obligation before the first publish
+    /// attempt. Callers must subsequently pass the returned effects to
+    /// [`Self::publish_prepared_session_effects_with_audit_context`].
+    pub async fn prepare_create_group_with_audit_context(
+        &mut self,
+        request: CreateGroupRequest,
+        context: AuditEventContext,
+    ) -> AccountResult<CreateGroupEffects> {
+        Ok(self
+            .session
+            .create_group_with_audit_context(request, context)
+            .await?)
+    }
+
+    /// Publish effects returned by
+    /// [`Self::prepare_create_group_with_audit_context`].
+    pub async fn publish_prepared_session_effects_with_audit_context(
+        &mut self,
+        effects: SessionEffects,
+        context: AuditEventContext,
+    ) -> AccountResult<AccountDeviceEffects> {
+        self.publish_session_effects_with_audit_context(effects, Some(context))
+            .await
     }
 
     pub async fn send(&mut self, intent: SendIntent) -> AccountResult<AccountDeviceEffects> {
@@ -366,6 +393,10 @@ where
                         context.clone(),
                     )
                     .await?;
+                }
+                PublishWork::FoundingGroupCreated { welcomes } => {
+                    self.publish_founding_group_created(welcomes, &mut output, context.clone())
+                        .await?;
                 }
                 PublishWork::GroupEvolution {
                     msg,
@@ -551,9 +582,9 @@ where
                     failure.group_id = group_id.clone();
                 }
             }
-            // Only a confirmed create leaves welcomes worth re-delivering; a
-            // rolled-back create discards the whole evolution, welcomes
-            // included.
+            // Only a confirmed legacy create leaves welcomes worth
+            // re-delivering; a rolled-back create discards the whole
+            // evolution, welcomes included.
             output.welcome_failures.extend(welcome_failures);
         } else {
             let effects = self.session.publish_failed(pending).await?;
@@ -561,6 +592,36 @@ where
                 .pending
                 .push(PendingResolution::RolledBack { pending });
             output.absorb_session_effects(effects, queue);
+        }
+        Ok(())
+    }
+
+    async fn publish_founding_group_created(
+        &mut self,
+        welcomes: Vec<TransportMessage>,
+        output: &mut AccountDeviceEffects,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<()> {
+        let group_id = output.events.iter().find_map(|event| match event {
+            GroupEvent::GroupCreated { group_id } => Some(group_id.clone()),
+            _ => None,
+        });
+        for welcome in welcomes {
+            let recipient = welcome_recipient(&welcome);
+            let welcome_id = welcome.id.clone();
+            let failures_before = output.failures.len();
+            let status = self.publish_one(welcome, output, context.clone()).await?;
+            if !status.met_required_acks
+                && let Some(recipient) = recipient
+            {
+                output.welcome_failures.push(self.welcome_delivery_failure(
+                    welcome_id,
+                    recipient,
+                    group_id.clone(),
+                    output,
+                    failures_before,
+                ));
+            }
         }
         Ok(())
     }

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -10,6 +10,7 @@ use cgka_session::{AccountDeviceSession, PublishWork, SessionConfig};
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{CreateGroupRequest, GroupEvent, SendIntent};
 use cgka_traits::error::PeelerError;
+use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{PeeledContent, PeeledMessage};
 use cgka_traits::peeler::TransportPeeler;
@@ -135,8 +136,10 @@ impl TransportPeeler for MockPeeler {
         payload: &EncryptedPayload,
         recipient: &MemberId,
     ) -> Result<TransportMessage, PeelerError> {
+        let mut id_material = payload.ciphertext.clone();
+        id_material.extend_from_slice(recipient.as_slice());
         Ok(TransportMessage {
-            id: hash_id(&payload.ciphertext),
+            id: hash_id(&id_material),
             payload: payload.ciphertext.clone(),
             timestamp: Timestamp(0),
             causal_deps: vec![],
@@ -154,6 +157,25 @@ fn session(
     identity: &[u8],
 ) -> AccountDeviceSession {
     session_with_registry(path, key, identity, FeatureRegistry::new())
+}
+
+fn current_session(
+    path: impl Into<std::path::PathBuf>,
+    key: &SqlCipherKey,
+    identity: &[u8],
+) -> AccountDeviceSession {
+    let keys = deterministic_nostr_keys(identity);
+    AccountDeviceSession::open(
+        SessionConfig::new(
+            path,
+            SqlCipherKey::new(key.as_secret_str()).unwrap(),
+            pad32(identity),
+            Box::new(MockPeeler),
+        )
+        .account_identity_proof_signer(Arc::new(NostrAccountIdentityProofSigner { keys }))
+        .protocol_profile(ProtocolProfile::Current),
+    )
+    .unwrap()
 }
 
 fn session_with_registry(
@@ -780,6 +802,133 @@ async fn create_group_stops_welcome_publish_after_unexposed_failure() {
     assert_eq!(runtime.session().epoch(&group_id).unwrap().0, 0);
     assert_eq!(runtime.session().members(&group_id).unwrap().len(), 1);
     assert_eq!(adapter.publishes().len(), 1);
+}
+
+#[tokio::test]
+async fn current_founding_create_keeps_group_when_every_welcome_delivery_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot current founding delivery key").unwrap();
+    let mut bob_session = current_session(dir.path().join("bob.sqlite"), &key, b"bob-current");
+    let mut carol_session =
+        current_session(dir.path().join("carol.sqlite"), &key, b"carol-current");
+    let bob_kp = bob_session.fresh_key_package().await.unwrap();
+    let carol_kp = carol_session.fresh_key_package().await.unwrap();
+    let bob_id = bob_session.self_id();
+    let carol_id = carol_session.self_id();
+    let alice_path = dir.path().join("alice.sqlite");
+    let session = current_session(&alice_path, &key, b"alice-current");
+    let adapter = RecordingAdapter::default();
+    adapter.accept_next(0);
+    adapter.accept_next(0);
+    let policy =
+        StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())])
+            .with_inbox_route(
+                bob_id.clone(),
+                vec![TransportEndpoint("wss://bob-inbox.example".into())],
+            )
+            .with_inbox_route(
+                carol_id.clone(),
+                vec![TransportEndpoint("wss://carol-inbox.example".into())],
+            );
+    let mut runtime = AccountDeviceRuntime::new(
+        session,
+        adapter.clone(),
+        policy,
+        RecordingKeyPackages::default(),
+    );
+
+    let (group_id, effects) = runtime
+        .create_group(CreateGroupRequest {
+            name: "canonical current founding".into(),
+            description: String::new(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        effects.pending.is_empty(),
+        "founding creation has no transport-gated pending commit"
+    );
+    assert!(matches!(
+        effects.events.as_slice(),
+        [GroupEvent::GroupCreated { group_id: created }] if created == &group_id
+    ));
+    assert_eq!(effects.reports.len(), 2);
+    assert_eq!(effects.failures.len(), 2);
+    assert_eq!(effects.welcome_failures.len(), 2);
+    assert_eq!(adapter.publishes().len(), 2);
+    assert!(
+        adapter
+            .publishes()
+            .iter()
+            .all(|request| matches!(request.message.envelope, TransportEnvelope::Welcome { .. })),
+        "founding creation must not publish an ordinary group commit"
+    );
+    assert_eq!(runtime.session().epoch(&group_id).unwrap().0, 1);
+    assert_eq!(runtime.session().members(&group_id).unwrap().len(), 3);
+
+    let mut failed_recipients = effects
+        .welcome_failures
+        .iter()
+        .map(|failure| failure.recipient.clone())
+        .collect::<Vec<_>>();
+    failed_recipients.sort_by(|a, b| a.as_slice().cmp(b.as_slice()));
+    let mut expected_recipients = vec![bob_id.clone(), carol_id.clone()];
+    expected_recipients.sort_by(|a, b| a.as_slice().cmp(b.as_slice()));
+    assert_eq!(failed_recipients, expected_recipients);
+    assert_ne!(
+        effects.welcome_failures[0].message_id, effects.welcome_failures[1].message_id,
+        "each invitee has an independent durable Welcome artifact"
+    );
+    for failure in &effects.welcome_failures {
+        assert_eq!(failure.group_id, Some(group_id.clone()));
+        let (stored_group, stored_welcome) = runtime
+            .session()
+            .stored_sent_welcome(&failure.message_id)
+            .unwrap();
+        assert_eq!(stored_group, group_id);
+        assert_eq!(stored_welcome.id, failure.message_id);
+    }
+
+    // Restart before retrying exactly one stored Welcome. It succeeds without
+    // merging or publishing another commit, and leaves the other failed
+    // delivery independently addressable by its own message id.
+    drop(runtime);
+    let restarted_adapter = RecordingAdapter::default();
+    let restarted_policy =
+        StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())])
+            .with_inbox_route(
+                bob_id,
+                vec![TransportEndpoint("wss://bob-inbox.example".into())],
+            )
+            .with_inbox_route(
+                carol_id,
+                vec![TransportEndpoint("wss://carol-inbox.example".into())],
+            );
+    let mut runtime = AccountDeviceRuntime::new(
+        current_session(&alice_path, &key, b"alice-current"),
+        restarted_adapter.clone(),
+        restarted_policy,
+        RecordingKeyPackages::default(),
+    );
+    let retried = runtime
+        .redeliver_welcome(&effects.welcome_failures[0].message_id)
+        .await
+        .unwrap();
+    assert!(retried.failures.is_empty());
+    assert!(retried.welcome_failures.is_empty());
+    assert_eq!(retried.reports.len(), 1);
+    assert_eq!(adapter.publishes().len(), 2);
+    assert_eq!(restarted_adapter.publishes().len(), 1);
+    assert_eq!(
+        restarted_adapter.publishes()[0].message.id,
+        effects.welcome_failures[0].message_id
+    );
+    assert_eq!(runtime.session().epoch(&group_id).unwrap().0, 1);
 }
 
 #[tokio::test]

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -805,6 +805,76 @@ async fn create_group_stops_welcome_publish_after_unexposed_failure() {
 }
 
 #[tokio::test]
+async fn current_founding_welcomes_survive_restart_before_publication() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot current founding prepare crash key").unwrap();
+    let mut bob_session =
+        current_session(dir.path().join("bob-prepare.sqlite"), &key, b"bob-prepare");
+    let mut carol_session = current_session(
+        dir.path().join("carol-prepare.sqlite"),
+        &key,
+        b"carol-prepare",
+    );
+    let bob_kp = bob_session.fresh_key_package().await.unwrap();
+    let carol_kp = carol_session.fresh_key_package().await.unwrap();
+    let alice_path = dir.path().join("alice-prepare.sqlite");
+    let session = current_session(&alice_path, &key, b"alice-prepare");
+    let adapter = RecordingAdapter::default();
+    let policy =
+        StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session,
+        adapter,
+        policy.clone(),
+        RecordingKeyPackages::default(),
+    );
+
+    let prepared = runtime
+        .session_mut()
+        .create_group(CreateGroupRequest {
+            name: "prepared current founding".into(),
+            description: String::new(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let expected_ids = match &prepared.effects.publish[..] {
+        [PublishWork::FoundingGroupCreated { welcomes }] => welcomes
+            .iter()
+            .map(|welcome| welcome.id.clone())
+            .collect::<Vec<_>>(),
+        other => panic!("expected founding Welcome work, got {other:?}"),
+    };
+    assert_eq!(expected_ids.len(), 2);
+    drop(runtime);
+
+    let restarted = AccountDeviceRuntime::new(
+        current_session(&alice_path, &key, b"alice-prepare"),
+        RecordingAdapter::default(),
+        policy,
+        RecordingKeyPackages::default(),
+    );
+    let mut recovered_ids = restarted
+        .outstanding_welcome_deliveries()
+        .unwrap()
+        .into_iter()
+        .map(|(_, welcome)| welcome.id)
+        .collect::<Vec<_>>();
+    recovered_ids.sort_by(|a, b| a.as_slice().cmp(b.as_slice()));
+    let mut expected_ids = expected_ids;
+    expected_ids.sort_by(|a, b| a.as_slice().cmp(b.as_slice()));
+    assert_eq!(recovered_ids, expected_ids);
+    assert_eq!(
+        restarted.session().epoch(&prepared.group_id).unwrap().0,
+        1,
+        "recovery discovers delivery work without creating or merging the group again"
+    );
+}
+
+#[tokio::test]
 async fn current_founding_create_keeps_group_when_every_welcome_delivery_fails() {
     let dir = tempfile::tempdir().unwrap();
     let key = SqlCipherKey::new("marmot current founding delivery key").unwrap();
@@ -893,6 +963,11 @@ async fn current_founding_create_keeps_group_when_every_welcome_delivery_fails()
         assert_eq!(stored_group, group_id);
         assert_eq!(stored_welcome.id, failure.message_id);
     }
+    assert_eq!(
+        runtime.outstanding_welcome_deliveries().unwrap().len(),
+        2,
+        "both failed founding Welcomes remain discoverable without in-process failure handles"
+    );
 
     // Restart before retrying exactly one stored Welcome. It succeeds without
     // merging or publishing another commit, and leaves the other failed
@@ -927,6 +1002,12 @@ async fn current_founding_create_keeps_group_when_every_welcome_delivery_fails()
     assert_eq!(
         restarted_adapter.publishes()[0].message.id,
         effects.welcome_failures[0].message_id
+    );
+    let outstanding_after_retry = runtime.outstanding_welcome_deliveries().unwrap();
+    assert_eq!(outstanding_after_retry.len(), 1);
+    assert_eq!(
+        outstanding_after_retry[0].1.id,
+        effects.welcome_failures[1].message_id
     );
     assert_eq!(runtime.session().epoch(&group_id).unwrap().0, 1);
 }

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use cgka_engine::key_package::is_last_resort_key_package;
+use cgka_session::PublishWork;
 use cgka_traits::agent_text_stream::{
     AGENT_TEXT_STREAM_EXPORTER_CACHE_KEY, AgentTextStreamQuicPolicyV1,
 };
@@ -17,6 +18,7 @@ use cgka_traits::app_event::{
     EVENT_REF_TAG, MARMOT_APP_EVENT_KIND_REACTION, MarmotAppEvent as MarmotInnerEvent,
 };
 use cgka_traits::engine::{CreateGroupRequest, KeyPackage, SendIntent};
+use cgka_traits::transport::TransportEnvelope;
 use cgka_traits::{GroupId, SecretBytes};
 use marmot_forensics::AuditEventContext;
 
@@ -260,9 +262,9 @@ impl AppClient {
             Some(member_refs.len() as u64),
         );
 
-        let (group_id, effects) = self
+        let prepared = self
             .runtime
-            .create_group_with_audit_context(
+            .prepare_create_group_with_audit_context(
                 CreateGroupRequest {
                     name: name.to_owned(),
                     description: String::new(),
@@ -274,6 +276,21 @@ impl AppClient {
                 audit_context.clone(),
             )
             .await?;
+        let group_id = prepared.group_id;
+        // Current-profile founding creation is already canonical before
+        // transport delivery. Persist every exact Welcome obligation before
+        // the first external side effect, so a crash between recipients
+        // cannot lose the still-undelivered work or induce a second group.
+        let founding_welcome_intents =
+            self.record_founding_welcome_delivery_intents(&group_id, &prepared.effects)?;
+        let effects = self
+            .runtime
+            .publish_prepared_session_effects_with_audit_context(
+                prepared.effects,
+                audit_context.clone(),
+            )
+            .await?;
+        self.clear_delivered_founding_welcome_intents(&founding_welcome_intents, &effects)?;
         fail_if_publish_failed(&effects)?;
         self.record_welcome_delivery_failures(&hex::encode(group_id.as_slice()), &effects)?;
         self.record_human_action_succeeded(&group_id, &audit_context, &effects);
@@ -2084,6 +2101,67 @@ impl AppClient {
                     recipient_hex,
                     recorded_at,
                 });
+        }
+        Ok(())
+    }
+
+    /// Record current-profile founding Welcome delivery intent before any
+    /// transport publish. Returns the message ids so successful deliveries can
+    /// be cleared after the account runtime reports their acknowledgements.
+    fn record_founding_welcome_delivery_intents(
+        &mut self,
+        group_id: &GroupId,
+        effects: &cgka_session::SessionEffects,
+    ) -> Result<Vec<String>, AppError> {
+        let group_id_hex = hex::encode(group_id.as_slice());
+        let recorded_at = unix_now_seconds();
+        let storage = self.app.account_storage(&self.state.label)?;
+        let mut message_ids = Vec::new();
+        for work in &effects.publish {
+            let PublishWork::FoundingGroupCreated { welcomes } = work else {
+                continue;
+            };
+            for welcome in welcomes {
+                let TransportEnvelope::Welcome { recipient } = &welcome.envelope else {
+                    return Err(AppError::Publish(
+                        "founding delivery artifact was not a Welcome".into(),
+                    ));
+                };
+                let message_id_hex = hex::encode(welcome.id.as_slice());
+                storage.record_pending_welcome_delivery(
+                    &message_id_hex,
+                    &group_id_hex,
+                    &hex::encode(recipient.as_slice()),
+                    recorded_at,
+                )?;
+                message_ids.push(message_id_hex);
+            }
+        }
+        Ok(message_ids)
+    }
+
+    /// Clear only intent rows whose exact Welcome met its acknowledgement
+    /// policy. Failed or unattempted rows stay durable for re-delivery.
+    fn clear_delivered_founding_welcome_intents(
+        &mut self,
+        message_ids: &[String],
+        effects: &marmot_account::AccountDeviceEffects,
+    ) -> Result<(), AppError> {
+        if message_ids.is_empty() {
+            return Ok(());
+        }
+        let storage = self.app.account_storage(&self.state.label)?;
+        for message_id_hex in message_ids {
+            let delivered = effects.reports.iter().any(|report| {
+                hex::encode(report.message_id.as_slice()) == *message_id_hex
+                    && report.met_required_acks()
+            }) && !effects
+                .welcome_failures
+                .iter()
+                .any(|failure| hex::encode(failure.message_id.as_slice()) == *message_id_hex);
+            if delivered {
+                storage.clear_pending_welcome_delivery(message_id_hex)?;
+            }
         }
         Ok(())
     }

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -227,6 +227,12 @@ impl AppClient {
         Ok(self.runtime.publish_fresh_key_package().await?)
     }
 
+    /// Create a locally canonical group and attempt each founding Welcome.
+    ///
+    /// `Ok(group_id)` reports group creation, not blanket invitation success.
+    /// Any Welcome that misses its acknowledgement policy is reported through
+    /// `WelcomeDeliveryPending` and remains listed by
+    /// [`Self::pending_welcome_deliveries`] for explicit re-delivery.
     pub async fn create_group(
         &mut self,
         name: &str,
@@ -2166,6 +2172,60 @@ impl AppClient {
         Ok(())
     }
 
+    /// Reconcile the app-facing repair index from the engine's authoritative
+    /// retained Welcome obligations.
+    ///
+    /// The engine persists founding Welcomes in the same transaction that
+    /// makes the group canonical. This closes the crash window between
+    /// `prepare_create_group` returning and the app recording its convenience
+    /// index: a cold restart can rebuild missing rows without re-creating the
+    /// group or re-consuming KeyPackages.
+    fn reconcile_pending_welcome_delivery_index(&self) -> Result<(), AppError> {
+        let outstanding = self.runtime.outstanding_welcome_deliveries()?;
+        let tracked_ids = self
+            .runtime
+            .tracked_outbound_welcome_ids()?
+            .into_iter()
+            .map(|id| hex::encode(id.as_slice()))
+            .collect::<HashSet<_>>();
+        let storage = self.app.account_storage(&self.state.label)?;
+        let existing = storage.list_pending_welcome_deliveries()?;
+        let outstanding_ids = outstanding
+            .iter()
+            .map(|(_, welcome)| hex::encode(welcome.id.as_slice()))
+            .collect::<HashSet<_>>();
+
+        for record in &existing {
+            if tracked_ids.contains(&record.message_id_hex)
+                && !outstanding_ids.contains(&record.message_id_hex)
+            {
+                storage.clear_pending_welcome_delivery(&record.message_id_hex)?;
+            }
+        }
+
+        let existing_ids = existing
+            .into_iter()
+            .map(|record| record.message_id_hex)
+            .collect::<HashSet<_>>();
+        let recorded_at = unix_now_seconds();
+        for (group_id, welcome) in outstanding {
+            let TransportEnvelope::Welcome { recipient } = welcome.envelope else {
+                continue;
+            };
+            let message_id_hex = hex::encode(welcome.id.as_slice());
+            if existing_ids.contains(&message_id_hex) {
+                continue;
+            }
+            storage.record_pending_welcome_delivery(
+                &message_id_hex,
+                &hex::encode(group_id.as_slice()),
+                &hex::encode(recipient.as_slice()),
+                recorded_at,
+            )?;
+        }
+        Ok(())
+    }
+
     /// Drain the welcomes queued for re-delivery during the last create/invite,
     /// for the runtime worker to broadcast as `WelcomeDeliveryPending` events
     /// (mdk#352).
@@ -2177,6 +2237,7 @@ impl AppClient {
     /// first. Each entry's `message_id_hex` is the handle for
     /// [`AppClient::redeliver_welcome`].
     pub fn pending_welcome_deliveries(&self) -> Result<Vec<PendingWelcomeDelivery>, AppError> {
+        self.reconcile_pending_welcome_delivery_index()?;
         Ok(self
             .app
             .account_storage(&self.state.label)?

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -84,6 +84,30 @@ pub struct AppClient {
     pub(crate) epoch_backfill_pending: bool,
 }
 
+/// Cross the point-of-no-return for current-profile group creation without
+/// allowing repairable follow-up work to turn a canonical group into an
+/// apparent create failure. Returning `Err` after that boundary encourages a
+/// caller to retry and create a second group. The engine's retained outbound
+/// Welcome index and account-open reconciliation repair any missed projection
+/// work.
+fn recover_post_canonical_result<T: Default>(
+    method: &'static str,
+    result: Result<T, AppError>,
+) -> T {
+    match result {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!(
+                target: "marmot_app::client",
+                method,
+                error_kind = error.privacy_safe_kind(),
+                "canonical group creation outpaced repairable follow-up work"
+            );
+            T::default()
+        }
+    }
+}
+
 /// A point-in-time copy of the live session's read-only group projections
 /// (`members`, `group_mls_state`, `quarantined_groups`).
 ///
@@ -287,18 +311,32 @@ impl AppClient {
         // transport delivery. Persist every exact Welcome obligation before
         // the first external side effect, so a crash between recipients
         // cannot lose the still-undelivered work or induce a second group.
-        let founding_welcome_intents =
-            self.record_founding_welcome_delivery_intents(&group_id, &prepared.effects)?;
-        let effects = self
-            .runtime
-            .publish_prepared_session_effects_with_audit_context(
-                prepared.effects,
-                audit_context.clone(),
-            )
-            .await?;
-        self.clear_delivered_founding_welcome_intents(&founding_welcome_intents, &effects)?;
-        fail_if_publish_failed(&effects)?;
-        self.record_welcome_delivery_failures(&hex::encode(group_id.as_slice()), &effects)?;
+        let founding_welcome_intents = recover_post_canonical_result(
+            "record_founding_welcome_delivery_intents",
+            self.record_founding_welcome_delivery_intents(&group_id, &prepared.effects),
+        );
+        let effects = recover_post_canonical_result(
+            "publish_prepared_founding_group",
+            self.runtime
+                .publish_prepared_session_effects_with_audit_context(
+                    prepared.effects,
+                    audit_context.clone(),
+                )
+                .await
+                .map_err(AppError::from),
+        );
+        recover_post_canonical_result(
+            "clear_delivered_founding_welcome_intents",
+            self.clear_delivered_founding_welcome_intents(&founding_welcome_intents, &effects),
+        );
+        recover_post_canonical_result(
+            "classify_founding_welcome_publish",
+            fail_if_publish_failed(&effects),
+        );
+        recover_post_canonical_result(
+            "record_founding_welcome_delivery_failures",
+            self.record_welcome_delivery_failures(&hex::encode(group_id.as_slice()), &effects),
+        );
         self.record_human_action_succeeded(&group_id, &audit_context, &effects);
         self.remember_published_reports(&effects);
         // The engine group is already published and confirmed. Projection,
@@ -2302,6 +2340,24 @@ fn local_account_removed_from_roster(
     !members
         .iter()
         .any(|member| hex::encode(member.id.as_slice()).eq_ignore_ascii_case(local_account_id_hex))
+}
+
+#[cfg(test)]
+mod post_canonical_create_tests {
+    use super::recover_post_canonical_result;
+    use crate::AppError;
+
+    #[test]
+    fn post_canonical_failures_default_instead_of_escaping() {
+        let recovered: Vec<String> = recover_post_canonical_result(
+            "test_post_canonical_failure",
+            Err(AppError::Publish("injected failure".into())),
+        );
+        assert!(recovered.is_empty());
+
+        let successful: u8 = recover_post_canonical_result("test_post_canonical_success", Ok(7));
+        assert_eq!(successful, 7);
+    }
 }
 
 #[cfg(test)]

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -1226,6 +1226,10 @@ pub(crate) fn add_group(
 ///   operation is live at its new epoch; unreached endpoints are recoverable
 ///   "ghost member" conditions. Keep the local projection (caller still runs
 ///   `add_group` / `save_state`) and surface a soft warning only.
+/// - a canonical founding create has an immediate `GroupCreated` event and no
+///   pending resolution. If every flat publish failure is paired with a
+///   structured Welcome failure, the group itself succeeded and only its
+///   independently retryable Welcome deliveries remain outstanding.
 /// - failures with no pending resolution at all (e.g. a plain application
 ///   message or proposal publish that never landed): hard error, as before.
 pub(crate) fn fail_if_publish_failed(
@@ -1255,6 +1259,27 @@ pub(crate) fn fail_if_publish_failed(
             failures = effects.failures.len(),
             "publish reached insufficient endpoints but pending state confirmed; \
              treating unreached endpoints as recoverable and keeping local projection"
+        );
+        return Ok(());
+    }
+
+    let canonical_create_with_only_welcome_failures = effects
+        .events
+        .iter()
+        .any(|event| matches!(event, GroupEvent::GroupCreated { .. }))
+        && !effects.welcome_failures.is_empty()
+        && effects.failures.iter().all(|failure| {
+            effects
+                .welcome_failures
+                .iter()
+                .any(|welcome| welcome.message_id == failure.message_id)
+        });
+    if canonical_create_with_only_welcome_failures {
+        tracing::warn!(
+            target: "marmot_app",
+            method = "fail_if_publish_failed",
+            failures = effects.failures.len(),
+            "founding group is canonical but one or more Welcome deliveries remain pending"
         );
         return Ok(());
     }
@@ -1531,9 +1556,11 @@ mod inner_tag_tests {
 #[cfg(test)]
 mod fail_if_publish_failed_tests {
     use super::*;
-    use cgka_traits::MessageId;
     use cgka_traits::engine_state::PendingStateRef;
-    use marmot_account::{AccountDeviceEffects, PendingResolution, PublishFailure};
+    use cgka_traits::{GroupId, MemberId, MessageId};
+    use marmot_account::{
+        AccountDeviceEffects, PendingResolution, PublishFailure, WelcomeDeliveryFailure,
+    };
 
     fn failure(reason: &str) -> PublishFailure {
         PublishFailure {
@@ -1594,6 +1621,47 @@ mod fail_if_publish_failed_tests {
         effects.failures.push(failure("relay rejected"));
         let err = fail_if_publish_failed(&effects).unwrap_err();
         assert!(matches!(err, AppError::Publish(_)));
+    }
+
+    #[test]
+    fn canonical_founding_create_with_only_welcome_failures_is_soft_pass() {
+        let mut effects = AccountDeviceEffects::default();
+        let publish_failure = failure("welcome inbox unavailable");
+        effects.failures.push(publish_failure.clone());
+        effects.events.push(GroupEvent::GroupCreated {
+            group_id: GroupId::new(vec![0xcd; 16]),
+        });
+        effects.welcome_failures.push(WelcomeDeliveryFailure {
+            message_id: publish_failure.message_id,
+            recipient: MemberId::new(vec![0xef; 32]),
+            group_id: Some(GroupId::new(vec![0xcd; 16])),
+            reason: publish_failure.reason,
+        });
+
+        assert!(
+            fail_if_publish_failed(&effects).is_ok(),
+            "canonical group creation must not be reported as failed solely because a Welcome is pending"
+        );
+    }
+
+    #[test]
+    fn group_created_event_does_not_soften_an_unrelated_publish_failure() {
+        let mut effects = AccountDeviceEffects::default();
+        effects.failures.push(failure("unrelated publish failed"));
+        effects.events.push(GroupEvent::GroupCreated {
+            group_id: GroupId::new(vec![0xcd; 16]),
+        });
+        effects.welcome_failures.push(WelcomeDeliveryFailure {
+            message_id: MessageId::new(vec![0x11; 32]),
+            recipient: MemberId::new(vec![0xef; 32]),
+            group_id: Some(GroupId::new(vec![0xcd; 16])),
+            reason: "different Welcome".into(),
+        });
+
+        assert!(matches!(
+            fail_if_publish_failed(&effects),
+            Err(AppError::Publish(_))
+        ));
     }
 
     // A mixed resolution where any pending rolled back must hard-fail even if

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -40,6 +40,9 @@ impl AccountManager {
         }
     }
 
+    /// Create the group and return its canonical id. Invitation delivery is
+    /// reported independently through `WelcomeDeliveryPending` events and
+    /// `pending_welcome_deliveries`.
     pub async fn create_group(
         &self,
         account_ref: &str,

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -1040,6 +1040,10 @@ impl MarmotAppRuntime {
         }
     }
 
+    /// Create a locally canonical group. A successful return does not imply
+    /// every invitation Welcome was delivered; subscribe for
+    /// [`MarmotAppEvent::WelcomeDeliveryPending`] or query
+    /// [`Self::pending_welcome_deliveries`] before presenting invite success.
     pub async fn create_group(
         &self,
         account_ref: &str,

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -210,7 +210,10 @@ impl Marmot {
     // -----------------------------------------------------------------------
 
     /// Create a new MLS group with `name` and the given members. Members are
-    /// referenced by `npub` or hex account id. Returns the group id as hex.
+    /// referenced by `npub` or hex account id. Returns the locally canonical
+    /// group id as hex; this does not imply every Welcome reached its
+    /// recipient. Hosts must observe `WelcomeDeliveryPending` events before
+    /// presenting invitation success.
     pub async fn create_group(
         &self,
         account_ref: String,

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -211,9 +211,11 @@ impl Marmot {
 
     /// Create a new MLS group with `name` and the given members. Members are
     /// referenced by `npub` or hex account id. Returns the locally canonical
-    /// group id as hex; this does not imply every Welcome reached its
-    /// recipient. Hosts must observe `WelcomeDeliveryPending` events before
-    /// presenting invitation success.
+    /// group id as hex; this confirms local canonicalization, not Welcome
+    /// delivery. `WelcomeDeliveryPending` is a delivery-failure signal, not an
+    /// acknowledgement. Hosts should subscribe before creation and/or query
+    /// `pending_welcome_deliveries` afterward before presenting invitation
+    /// success.
     pub async fn create_group(
         &self,
         account_ref: String,

--- a/crates/traits/README.md
+++ b/crates/traits/README.md
@@ -16,7 +16,7 @@ between engine, peeler, storage, and caller imports from here.
 - `EpochState`, `WelcomeState`, `IngestOutcome`, `StaleReason`, `EngineError` — the typed state-machine + error
   vocabulary.
 - `MessageRecord`, `MessageState`, `StoredMessagePayload` — durable message state plus the typed envelope that
-  distinguishes raw transport bytes from peeled OpenMLS wire bytes.
+  distinguishes raw transport bytes, delivery-aware outbound Welcomes, and peeled OpenMLS wire bytes.
 - All cross-boundary value types: `TransportMessage`, `TransportEnvelope`, `TransportAccountActivation`,
   `TransportPublishRequest`, `TransportDelivery`, `PeeledMessage`, `EncryptedPayload`, `SendIntent`, `SendResult`,
   `AutoPublish`, `GroupEvent`, `PendingStateRef`, `MessageId`, `GroupId`, `MemberId`, `EpochId`, `Group`, `Member`.

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -182,15 +182,20 @@ pub enum SendResult {
         welcomes: Vec<TransportMessage>,
         pending: PendingStateRef,
     },
-    /// Initial group creation. Only `welcomes` need publishing — there's no
-    /// pre-existing member to consume a commit, so the founding client
-    /// doesn't emit one. The application calls
-    /// [`CgkaEngine::confirm_published`] once every welcome is handed off
-    /// to the transport.
+    /// Legacy-profile initial group creation. Only `welcomes` need publishing;
+    /// the founding commit is staged until the caller resolves `pending`.
+    /// Retained temporarily for explicit legacy-profile compatibility until
+    /// strict creation cutover removes this path.
     GroupCreated {
         welcomes: Vec<TransportMessage>,
         pending: PendingStateRef,
     },
+    /// Current-profile founding creation. The epoch-0 group and its optional
+    /// founding Add are already canonical when this result is returned. No
+    /// normal group message or pending publish handle exists; each Welcome is
+    /// an independent delivery obligation whose failure cannot roll back the
+    /// group.
+    FoundingGroupCreated { welcomes: Vec<TransportMessage> },
 }
 
 /// Group evolution produced as a side effect of inbound processing.
@@ -626,7 +631,7 @@ pub trait CgkaEngine: Send + Sync {
     /// endpoint. The durable intent remains intact until confirmation.
     fn retry_queued_outbound_intent(&mut self, group_id: &GroupId);
 
-    /// Confirm that a [`SendResult::GroupEvolution`] (or
+    /// Confirm that a [`SendResult::GroupEvolution`] (or legacy-profile
     /// [`SendResult::GroupCreated`]) was successfully published to the
     /// transport. The engine applies the staged commit to local MLS state,
     /// updates Marmot bookkeeping + capability cache, and emits
@@ -646,12 +651,12 @@ pub trait CgkaEngine: Send + Sync {
         pending: PendingStateRef,
     ) -> Result<GroupEvent, EngineError>;
 
-    /// Report that a [`SendResult::GroupEvolution`] (or
-    /// [`SendResult::GroupCreated`]) failed to publish. The engine
-    /// discards the staged commit (`MlsGroup::clear_pending_commit`),
-    /// rewinds Marmot/cache state to its pre-stage shape, and transitions
-    /// back to `Stable` at the prior epoch. The group is immediately
-    /// usable for a fresh `send`.
+    /// Report that a [`SendResult::GroupEvolution`] (or legacy-profile
+    /// [`SendResult::GroupCreated`]) failed to publish. The engine discards
+    /// the staged commit
+    /// (`MlsGroup::clear_pending_commit`), rewinds Marmot/cache state to its
+    /// pre-stage shape, and transitions back to `Stable` at the prior epoch.
+    /// The group is immediately usable for a fresh `send`.
     ///
     /// **Errors.** `UnknownPending` if the ref has already been confirmed,
     /// rolled back, or was never issued.
@@ -660,8 +665,13 @@ pub trait CgkaEngine: Send + Sync {
     // ── Lifecycle ───────────────────────────────────────────────────────────
 
     /// Create a new group with the named members (via their KeyPackages) and
-    /// the requested required features. Returns the new `GroupId` and a
-    /// `SendResult::GroupEvolution` carrying the initial welcomes.
+    /// the requested required features.
+    ///
+    /// Current-profile creation returns
+    /// [`SendResult::FoundingGroupCreated`]: the group is already canonical
+    /// locally and the result carries only independently deliverable
+    /// Welcomes. Explicit legacy-profile creation temporarily returns
+    /// [`SendResult::GroupCreated`] with its older pending lifecycle.
     ///
     /// **Validation.** Every invitee's KeyPackage must advertise the union of
     /// capabilities required by `required_features`. On mismatch, returns

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -194,7 +194,8 @@ pub enum SendResult {
     /// founding Add are already canonical when this result is returned. No
     /// normal group message or pending publish handle exists; each Welcome is
     /// an independent delivery obligation whose failure cannot roll back the
-    /// group.
+    /// group. This result alone does not imply any Welcome was delivered:
+    /// callers must publish and acknowledge every entry independently.
     FoundingGroupCreated { welcomes: Vec<TransportMessage> },
 }
 

--- a/crates/traits/src/message.rs
+++ b/crates/traits/src/message.rs
@@ -39,6 +39,11 @@ pub struct OwnCommitConvergenceStamp {
 ///
 /// - `RawTransport`: original transport-wrapped message. Used when peeling is
 ///   deferred or the engine needs to retry with a different epoch context.
+/// - `OutboundWelcome`: a locally produced Welcome retained until its
+///   independent transport acknowledgement policy is satisfied. Keeping this
+///   distinct from historical `RawTransport` `Sent` rows lets cold-restart
+///   recovery find only delivery obligations created by versions that track
+///   their completion.
 /// - `OpenMlsWire`: transport metadata plus payload replaced with peeled MLS
 ///   wire bytes. Only this variant and `OwnCommitWire` are eligible for
 ///   OpenMLS projection and convergence replay.
@@ -50,6 +55,7 @@ pub struct OwnCommitConvergenceStamp {
 #[serde(tag = "kind", content = "message", rename_all = "snake_case")]
 pub enum StoredMessagePayload {
     RawTransport(TransportMessage),
+    OutboundWelcome(TransportMessage),
     OpenMlsWire(TransportMessage),
     OwnCommitWire {
         message: TransportMessage,
@@ -60,6 +66,10 @@ pub enum StoredMessagePayload {
 impl StoredMessagePayload {
     pub fn raw_transport(message: TransportMessage) -> Self {
         Self::RawTransport(message)
+    }
+
+    pub fn outbound_welcome(message: TransportMessage) -> Self {
+        Self::OutboundWelcome(message)
     }
 
     pub fn openmls_wire(message: TransportMessage) -> Self {
@@ -87,13 +97,20 @@ impl StoredMessagePayload {
     pub fn as_raw_transport(&self) -> Option<&TransportMessage> {
         match self {
             Self::RawTransport(message) => Some(message),
-            Self::OpenMlsWire(_) | Self::OwnCommitWire { .. } => None,
+            Self::OutboundWelcome(_) | Self::OpenMlsWire(_) | Self::OwnCommitWire { .. } => None,
+        }
+    }
+
+    pub fn as_outbound_welcome(&self) -> Option<&TransportMessage> {
+        match self {
+            Self::OutboundWelcome(message) => Some(message),
+            Self::RawTransport(_) | Self::OpenMlsWire(_) | Self::OwnCommitWire { .. } => None,
         }
     }
 
     pub fn as_openmls_wire(&self) -> Option<&TransportMessage> {
         match self {
-            Self::RawTransport(_) => None,
+            Self::RawTransport(_) | Self::OutboundWelcome(_) => None,
             Self::OpenMlsWire(message) | Self::OwnCommitWire { message, .. } => Some(message),
         }
     }
@@ -102,7 +119,7 @@ impl StoredMessagePayload {
     /// published-and-confirmed commit.
     pub fn own_commit_stamp(&self) -> Option<&OwnCommitConvergenceStamp> {
         match self {
-            Self::RawTransport(_) | Self::OpenMlsWire(_) => None,
+            Self::RawTransport(_) | Self::OutboundWelcome(_) | Self::OpenMlsWire(_) => None,
             Self::OwnCommitWire { stamp, .. } => Some(stamp),
         }
     }
@@ -110,6 +127,7 @@ impl StoredMessagePayload {
     pub fn into_message(self) -> TransportMessage {
         match self {
             Self::RawTransport(message)
+            | Self::OutboundWelcome(message)
             | Self::OpenMlsWire(message)
             | Self::OwnCommitWire { message, .. } => message,
         }
@@ -129,6 +147,7 @@ pub struct MessageRecord {
 ///
 /// Transitions:
 ///   `Sent` → `Sent` (outbound message recorded for durable own-echo checks)
+///   `Sent` → `Processed` (a retained outbound Welcome met its delivery policy)
 ///   `Created` → `Processed` (happy path after successful ingest)
 ///   `Created` → `Failed` (terminal error — no retry)
 ///   `Created` → `Retryable` (transient error — can be re-tried later)
@@ -143,7 +162,8 @@ pub enum MessageState {
     Sent,
     /// Stored but not yet processed.
     Created,
-    /// Successfully applied to the group state.
+    /// Successfully applied to the group state, or a retained outbound
+    /// Welcome whose independent delivery obligation completed.
     Processed,
     /// Terminal failure — do not retry.
     Failed,

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -238,11 +238,19 @@ fn stored_message_payload_distinguishes_raw_and_openmls_wire() {
         payload: vec![0xAB, 0xCD],
         ..raw.clone()
     };
+    let outbound_welcome = TransportMessage {
+        envelope: TransportEnvelope::Welcome {
+            recipient: MemberId::new(vec![0xDD; 32]),
+        },
+        ..raw.clone()
+    };
 
     let raw_payload = StoredMessagePayload::raw_transport(raw.clone());
+    let outbound_welcome_payload = StoredMessagePayload::outbound_welcome(outbound_welcome.clone());
     let openmls_payload = StoredMessagePayload::openmls_wire(openmls.clone());
 
     insta::assert_json_snapshot!("stored_payload_raw_transport", raw_payload);
+    insta::assert_json_snapshot!("stored_payload_outbound_welcome", outbound_welcome_payload);
     insta::assert_json_snapshot!("stored_payload_openmls_wire", openmls_payload);
 
     assert_eq!(
@@ -251,6 +259,18 @@ fn stored_message_payload_distinguishes_raw_and_openmls_wire() {
             .as_raw_transport()
             .unwrap()
             .payload,
+        vec![1, 2, 3]
+    );
+    assert_eq!(
+        StoredMessagePayload::decode(
+            &StoredMessagePayload::outbound_welcome(outbound_welcome)
+                .encode()
+                .unwrap()
+        )
+        .unwrap()
+        .as_outbound_welcome()
+        .unwrap()
+        .payload,
         vec![1, 2, 3]
     );
     assert_eq!(

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -223,7 +223,7 @@ fn snapshot_transport_adapter_boundary_types() {
 }
 
 #[test]
-fn stored_message_payload_distinguishes_raw_and_openmls_wire() {
+fn stored_message_payload_distinguishes_raw_outbound_welcome_and_openmls_wire() {
     let raw = TransportMessage {
         id: mid(),
         payload: vec![1, 2, 3],

--- a/crates/traits/tests/snapshots/snapshots__stored_payload_outbound_welcome.snap
+++ b/crates/traits/tests/snapshots/snapshots__stored_payload_outbound_welcome.snap
@@ -1,0 +1,61 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: outbound_welcome_payload
+---
+{
+  "kind": "outbound_welcome",
+  "message": {
+    "id": [
+      187,
+      187,
+      187,
+      187
+    ],
+    "payload": [
+      1,
+      2,
+      3
+    ],
+    "timestamp": 1717171717,
+    "causal_deps": [],
+    "source": "nostr",
+    "envelope": {
+      "Welcome": {
+        "recipient": [
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221,
+          221
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- make current-profile group creation canonical locally at epoch 0 (solo) or epoch 1 (one founding Add), without publishing an ordinary founding commit
- persist and publish one distinct Welcome per invitee as independent, retryable delivery work; failed delivery cannot roll back or suppress the other Welcomes
- record founding Welcome intent before app-layer transport side effects and retain failed/unattempted work across restart
- preserve the explicit legacy pending-create path until the strict cutover PR
- extend engine, session, account/runtime, app, and portable conformance coverage through the invitee’s first application message

## Validation

- `just fast-ci`
- `cargo test -p cgka-engine -p cgka-session -p marmot-account -p cgka-conformance-simulator` (the three stale current-profile assertions found in the first run were updated; their targeted suite then passed)
- `cargo test -p cgka-engine --test update_group_data`
- `cargo test -p cgka-session -p marmot-account`
- `cargo test -p marmot-app`
- `cargo test -p cgka-conformance-simulator canonical_vector_fixtures_match_generated_traces -- --nocapture`

Fixes #1051


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Current-profile founding group creation is now canonical immediately (no pending confirmation step).
  * Founding Welcome delivery is tracked as retained outbound work, supporting independent retry after failures or restarts.
  * Added APIs and runtime/app queries for outstanding and tracked Welcome deliveries.
* **Bug Fixes**
  * Fixed handling/auditing of founding-creation outcomes across engine/session/publishing so expectations and recipient classification match.
  * Improved preservation of already-stored retained Welcome payloads to prevent overwrites.
* **Documentation**
  * Clarified founding vs legacy creation and “delivery pending” semantics.
* **Tests**
  * Expanded conformance vectors and added restart/redelivery regression tests for current founding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
