### PR TITLE
fix(engine): batch eligible SelfRemove proposals

### DIFF
--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -197,6 +197,15 @@ These are real simulator scenarios that are still tied to Rust harness details.
 - Expected: Alice, Bob, and Carol reach epoch 2, and Bob is removed from the active group.
 - Reason: the direct harness asserts the auto-commit path and member state.
 
+### `openmls_probe_exposes_deterministic_multi_selfremove_batch`
+
+- Setup: Alice creates a four-member group. Bob and Carol publish SelfRemove proposals, with the higher proposal digest
+  deliberately delivered first; Dave retains the proposal and commit bytes as an observer.
+- Expected: Alice emits one SelfRemove-only commit whose consumed proposal references map to both proposal digests in
+  ascending digest order. Alice and Dave finish at epoch 2 with both leavers absent.
+- Reason: the OpenMLS replay probe exposes the selected batch and its canonical proposal-digest ordering instead of
+  asserting only the final member count.
+
 ### `deliberate_fork_via_harness`
 
 - Setup: Alice and Bob concurrently invite different new members while a partition hides each branch.

--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use cgka_conformance_simulator::canonicalization::{
     CanonicalizationError, CanonicalizationInput, CanonicalizationPolicy, CanonicalizationResult,
@@ -180,6 +180,131 @@ async fn openmls_probe_replays_consumed_proposal_without_mutating_live_state() {
         "carol should still process the real proposal and commit after probe: {carol_outcomes:?}"
     );
     assert_eq!(carol.epoch().0, 2);
+}
+
+#[tokio::test]
+async fn openmls_probe_exposes_deterministic_multi_selfremove_batch() {
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice-batch"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob-batch"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut carol = ClientBuilder::new(pad32(b"carol-batch"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut dave = ClientBuilder::new(pad32(b"dave-batch"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+
+    let bob_kp = bob.fresh_key_package().await;
+    let carol_kp = carol.fresh_key_package().await;
+    let dave_kp = dave.fresh_key_package().await;
+    let (group_id, pending) = alice
+        .create_group(
+            "openmls-multi-selfremove-batch",
+            vec![bob_kp, carol_kp, dave_kp],
+            vec![],
+        )
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+    carol.tick().await;
+    dave.tick().await;
+
+    let bob_proposal = bob.leave_capture().await;
+    let carol_proposal = carol.leave_capture().await;
+    let bob_proposal = openmls_projection_message(&dave, &bob_proposal).await;
+    let carol_proposal = openmls_projection_message(&dave, &carol_proposal).await;
+    let bob_digest = project_mls_message(&bob_proposal.payload)
+        .expect("bob proposal projects")
+        .message_digest;
+    let carol_digest = project_mls_message(&carol_proposal.payload)
+        .expect("carol proposal projects")
+        .message_digest;
+
+    // Deliver the higher digest first. Arrival order is deliberately the
+    // opposite of the canonical local-commit order.
+    if bob_digest < carol_digest {
+        assert!(bus.reorder_queued(&[1, 0]));
+    }
+    bus.deliver_all();
+    let alice_outcomes = alice.tick().await;
+    assert!(
+        alice_outcomes.iter().all(Result::is_ok),
+        "alice should batch both SelfRemove proposals: {alice_outcomes:?}"
+    );
+
+    let commit_msg = queued_commit_messages(&dave, &bus)
+        .await
+        .into_iter()
+        .next()
+        .expect("alice auto-published one batched commit");
+    assert_projected_kind(&commit_msg, OpenMlsContentKind::Commit, 1);
+
+    let observations = replay_openmls_messages(
+        dave.storage(),
+        &group_id,
+        &[bob_proposal.clone(), carol_proposal.clone(), commit_msg],
+    )
+    .expect("batched SelfRemove replay succeeds");
+
+    let digest_by_message_id = BTreeMap::from([
+        (hex::encode(bob_proposal.id.as_slice()), bob_digest),
+        (hex::encode(carol_proposal.id.as_slice()), carol_digest),
+    ]);
+    let mut digest_by_proposal_ref = BTreeMap::new();
+    let mut consumed_refs = None;
+    for observation in observations {
+        match observation {
+            OpenMlsReplayObservation::ProposalStored {
+                message_id,
+                proposal_ref,
+                ..
+            } => {
+                let digest = digest_by_message_id
+                    .get(&message_id)
+                    .copied()
+                    .expect("proposal observation names one frozen input");
+                digest_by_proposal_ref.insert(proposal_ref, digest);
+            }
+            OpenMlsReplayObservation::CommitStaged {
+                consumed_proposal_refs,
+                ..
+            } => consumed_refs = Some(consumed_proposal_refs),
+            _ => {}
+        }
+    }
+
+    let consumed_digests: Vec<_> = consumed_refs
+        .expect("batch commit staged during replay")
+        .iter()
+        .map(|proposal_ref| {
+            digest_by_proposal_ref
+                .get(proposal_ref)
+                .copied()
+                .expect("consumed reference maps to a frozen proposal digest")
+        })
+        .collect();
+    let mut expected_digests = vec![bob_digest, carol_digest];
+    expected_digests.sort();
+    assert_eq!(
+        consumed_digests, expected_digests,
+        "selected batch must expose both proposal digests in canonical order"
+    );
+    assert_eq!(alice.epoch().0, 2);
+    assert_eq!(alice.members().len(), 2);
+
+    bus.deliver_all();
+    let dave_outcomes = dave.tick().await;
+    assert!(
+        dave_outcomes.iter().all(Result::is_ok),
+        "observer should apply the batched commit: {dave_outcomes:?}"
+    );
+    assert_eq!(dave.epoch().0, 2, "final epoch must be deterministic");
+    assert_eq!(dave.members().len(), 2);
 }
 
 #[tokio::test]

--- a/crates/cgka-engine/src/auto_committer.rs
+++ b/crates/cgka-engine/src/auto_committer.rs
@@ -20,13 +20,16 @@
 //! the application calls `publish_failed` with the pending ref and the engine
 //! clears the staged commit.
 
+use std::collections::BTreeMap;
+
 use openmls::framing::Sender;
 use openmls::group::MlsGroup;
 use openmls::prelude::{LeafNodeIndex, Proposal, QueuedProposal};
 
 /// Decision returned by the policy.
 pub(crate) enum AutoCommitDecision {
-    /// This client should commit the named proposal.
+    /// This client should include the eligible proposal in the next frozen
+    /// SelfRemove batch.
     Commit,
     /// We are not allowed to commit this proposal.
     Observe,
@@ -159,7 +162,63 @@ fn pubkey_at_leaf_index(
     PubkeyResult::Ok(out)
 }
 
+/// Resolve a frozen set of eligible SelfRemove candidates without consulting
+/// arrival order or local identity. At most one proposal may represent each
+/// leaving leaf; the lower SHA-256 proposal digest wins that slot. Selected
+/// proposals are returned in digest order so OpenMLS insertion order is stable.
+pub(crate) fn select_self_remove_batch<T>(
+    candidates: impl IntoIterator<Item = (LeafNodeIndex, [u8; 32], T)>,
+) -> Vec<T> {
+    let mut selected_by_leaver: BTreeMap<LeafNodeIndex, ([u8; 32], T)> = BTreeMap::new();
+    for (leaver, digest, candidate) in candidates {
+        let replace = selected_by_leaver
+            .get(&leaver)
+            .is_none_or(|(selected_digest, _)| digest < *selected_digest);
+        if replace {
+            selected_by_leaver.insert(leaver, (digest, candidate));
+        }
+    }
+
+    let mut selected: Vec<_> = selected_by_leaver.into_values().collect();
+    selected.sort_by_key(|(digest, _)| *digest);
+    selected
+        .into_iter()
+        .map(|(_, candidate)| candidate)
+        .collect()
+}
+
 // The commit-staging work happens in `message_processor::ingest_group_message`
 // directly so the freshly processed proposal can be stored and committed on
 // the same OpenMLS group instance. Applying the staged commit still waits for
 // `confirm_published`.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn self_remove_batch_selection_is_permutation_invariant() {
+        let candidates = [
+            (LeafNodeIndex::new(1), [9; 32], "bob-high"),
+            (LeafNodeIndex::new(2), [4; 32], "carol"),
+            (LeafNodeIndex::new(1), [2; 32], "bob-low"),
+        ];
+        let permutations = [
+            [0, 1, 2],
+            [0, 2, 1],
+            [1, 0, 2],
+            [1, 2, 0],
+            [2, 0, 1],
+            [2, 1, 0],
+        ];
+
+        for permutation in permutations {
+            let input = permutation.map(|index| candidates[index]);
+            assert_eq!(
+                select_self_remove_batch(input),
+                vec!["bob-low", "carol"],
+                "arrival order {permutation:?} changed the selected batch"
+            );
+        }
+    }
+}

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -142,10 +142,12 @@ pub struct Engine<S: StorageProvider> {
     /// further outbound group traffic while a leave request is outstanding.
     pub(crate) leaving_groups: HashSet<GroupId>,
 
-    /// Delayed SelfRemove auto-commit attempts keyed by the standalone
-    /// proposal's content-derived message id. These are re-checked against live
-    /// storage before staging so unrelated commits can invalidate them without
-    /// producing a commit storm.
+    /// Delayed SelfRemove auto-commit candidates keyed by the standalone
+    /// proposal's content-derived message id. The first due candidate freezes
+    /// all currently eligible proposals for the same group/epoch into one
+    /// deterministic batch; every candidate is re-checked against live storage
+    /// before staging so unrelated commits can invalidate it without producing
+    /// a commit storm.
     pub(crate) scheduled_self_remove_auto_commits:
         HashMap<MessageId, ScheduledSelfRemoveAutoCommit>,
 
@@ -935,6 +937,13 @@ impl<S: StorageProvider> Engine<S> {
             ),
         );
         self.audit_group_context(group_id, "hydrate_stable_group");
+
+        self.restore_self_remove_auto_commit_schedules_for_group(
+            group_id,
+            group.epoch,
+            self.convergence_now_ms(),
+        )
+        .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
 
         // Startup must recreate the in-memory scheduling edge for durable
         // convergence work. Otherwise queued user sends and stored branch

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -9,7 +9,7 @@ use super::{content_dedup_id, route_wrapped_group_message};
 use crate::engine::{Engine, ScheduledSelfRemoveAutoCommit};
 use crate::fork_recovery::ForkResolution;
 use crate::group_lifecycle::{self};
-use crate::identity::{member_id_at_leaf, member_id_of_sender};
+use crate::identity::member_id_of_sender;
 use crate::openmls_projection::{
     OpenMlsContentKind, process_commit_with_app_data_updates, project_mls_message,
     retained_anchor_epoch_from_snapshot_name,
@@ -27,6 +27,7 @@ use cgka_traits::message::{MessageState, StoredMessagePayload};
 use cgka_traits::storage::{StorageError, StorageProvider};
 use cgka_traits::transport::{EncryptedPayload, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
+use openmls::framing::Sender;
 use openmls::framing::errors::{MessageDecryptionError, SecretTreeError};
 use openmls::group::{MlsGroup, MlsGroupStateError, ProcessMessageError};
 use openmls::prelude::{
@@ -1301,7 +1302,13 @@ impl<S: StorageProvider> Engine<S> {
                 .scheduled_self_remove_auto_commits
                 .values()
                 .filter(|scheduled| &scheduled.group_id == group_id)
-                .min_by_key(|scheduled| scheduled.due_at_ms)
+                .min_by(|left, right| {
+                    left.due_at_ms.cmp(&right.due_at_ms).then_with(|| {
+                        left.proposal_id
+                            .as_slice()
+                            .cmp(right.proposal_id.as_slice())
+                    })
+                })
                 .cloned()
             else {
                 return Ok(false);
@@ -1311,12 +1318,51 @@ impl<S: StorageProvider> Engine<S> {
                 return Ok(false);
             }
 
-            self.scheduled_self_remove_auto_commits
-                .remove(&schedule.proposal_id);
-            match self
-                .replay_scheduled_self_remove_auto_commit(schedule)
-                .await?
-            {
+            // Freeze every proposal already scheduled for this group/epoch when
+            // the first jitter expires. Later arrivals belong to a later pass;
+            // due time, map iteration order, and local identity never choose the
+            // contents of this batch.
+            let mut batch: Vec<_> = self
+                .scheduled_self_remove_auto_commits
+                .values()
+                .filter(|scheduled| {
+                    scheduled.group_id == schedule.group_id
+                        && scheduled.source_epoch == schedule.source_epoch
+                })
+                .cloned()
+                .collect();
+            batch.sort_by(|left, right| {
+                left.proposal_id
+                    .as_slice()
+                    .cmp(right.proposal_id.as_slice())
+            });
+            for scheduled in &batch {
+                self.scheduled_self_remove_auto_commits
+                    .remove(&scheduled.proposal_id);
+            }
+
+            let replay = self
+                .replay_scheduled_self_remove_auto_commit_batch(
+                    schedule.group_id.clone(),
+                    schedule.source_epoch,
+                    batch,
+                )
+                .await;
+            let replay = match replay {
+                Ok(replay) => replay,
+                Err(error) => {
+                    // Staging guards have unwound partial OpenMLS state. Re-arm
+                    // from durable proposal rows so a transient failure does not
+                    // strand the frozen batch until process restart.
+                    let _ = self.restore_self_remove_auto_commit_schedules_for_group(
+                        &schedule.group_id,
+                        schedule.source_epoch,
+                        now_ms,
+                    );
+                    return Err(error);
+                }
+            };
+            match replay {
                 ScheduledAutoCommitReplay::Staged => {
                     self.drop_self_remove_auto_commit_schedules_for_group(group_id);
                     return Ok(true);
@@ -1326,58 +1372,25 @@ impl<S: StorageProvider> Engine<S> {
         }
     }
 
-    async fn replay_scheduled_self_remove_auto_commit(
+    async fn replay_scheduled_self_remove_auto_commit_batch(
         &mut self,
-        schedule: ScheduledSelfRemoveAutoCommit,
+        group_id: GroupId,
+        source_epoch: EpochId,
+        schedules: Vec<ScheduledSelfRemoveAutoCommit>,
     ) -> Result<ScheduledAutoCommitReplay, EngineError> {
-        let group = match self.storage.get_group(&schedule.group_id) {
+        let group = match self.storage.get_group(&group_id) {
             Ok(group) => group,
             Err(StorageError::NotFound) => return Ok(ScheduledAutoCommitReplay::NotApplicable),
             Err(err) => return Err(EngineError::Storage(err)),
         };
-        if group.epoch != schedule.source_epoch {
+        if group.epoch != source_epoch {
             return Ok(ScheduledAutoCommitReplay::NotApplicable);
         }
 
-        let record = match self.storage.get_message(&schedule.proposal_id) {
-            Ok(record) => record,
-            Err(StorageError::NotFound) => return Ok(ScheduledAutoCommitReplay::NotApplicable),
-            Err(err) => return Err(EngineError::Storage(err)),
-        };
-        if !matches!(
-            record.state,
-            MessageState::Created | MessageState::Retryable
-        ) {
-            return Ok(ScheduledAutoCommitReplay::NotApplicable);
-        }
-
-        let Ok(stored_payload) = StoredMessagePayload::decode(&record.payload) else {
-            return Ok(ScheduledAutoCommitReplay::NotApplicable);
-        };
-        let Some(message) = stored_payload.as_openmls_wire() else {
-            return Ok(ScheduledAutoCommitReplay::NotApplicable);
-        };
-        let Ok(projection) = project_mls_message(&message.payload) else {
-            return Ok(ScheduledAutoCommitReplay::NotApplicable);
-        };
-        if projection.kind != OpenMlsContentKind::Proposal
-            || projection.source_epoch != Some(schedule.source_epoch.0)
-        {
-            return Ok(ScheduledAutoCommitReplay::NotApplicable);
-        }
-
-        let msg_in = MlsMessageIn::tls_deserialize_exact(message.payload.as_slice())
-            .map_err(|e| EngineError::Serialize(format!("message deserialize: {e:?}")))?;
-        let proto: ProtocolMessage = match msg_in.extract() {
-            MlsMessageBodyIn::PrivateMessage(p) => p.into(),
-            MlsMessageBodyIn::PublicMessage(p) => p.into(),
-            _ => return Ok(ScheduledAutoCommitReplay::NotApplicable),
-        };
-
-        let (mut mls_group, queued) = {
+        let (mut mls_group, replayed) = {
             let provider =
                 EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
-            let mls_gid = openmls::group::GroupId::from_slice(schedule.group_id.as_slice());
+            let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
             let mut mls_group = MlsGroup::load(
                 <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(
                     &provider,
@@ -1385,28 +1398,101 @@ impl<S: StorageProvider> Engine<S> {
                 &mls_gid,
             )
             .map_err(|e| EngineError::Backend(format!("load auto-commit replay: {e:?}")))?
-            .ok_or_else(|| EngineError::UnknownGroup(schedule.group_id.clone()))?;
-            if EpochId(mls_group.epoch().as_u64()) != schedule.source_epoch {
+            .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+            if EpochId(mls_group.epoch().as_u64()) != source_epoch {
                 return Ok(ScheduledAutoCommitReplay::NotApplicable);
             }
 
-            let processed = match mls_group.process_message(&provider, proto) {
-                Ok(processed) => processed,
-                Err(_) => return Ok(ScheduledAutoCommitReplay::NotApplicable),
-            };
-            let queued = match processed.into_content() {
-                ProcessedMessageContent::ProposalMessage(queued)
-                    if matches!(queued.proposal(), Proposal::SelfRemove) =>
-                {
-                    queued
+            let mut replayed = Vec::new();
+            for schedule in schedules {
+                let record = match self.storage.get_message(&schedule.proposal_id) {
+                    Ok(record) => record,
+                    Err(StorageError::NotFound) => continue,
+                    Err(err) => return Err(EngineError::Storage(err)),
+                };
+                if !matches!(
+                    record.state,
+                    MessageState::Created | MessageState::Retryable
+                ) {
+                    continue;
                 }
-                _ => return Ok(ScheduledAutoCommitReplay::NotApplicable),
-            };
-            (mls_group, queued)
+                let Ok(stored_payload) = StoredMessagePayload::decode(&record.payload) else {
+                    continue;
+                };
+                let Some(message) = stored_payload.as_openmls_wire() else {
+                    continue;
+                };
+                let Ok(projection) = project_mls_message(&message.payload) else {
+                    continue;
+                };
+                if projection.kind != OpenMlsContentKind::Proposal
+                    || projection.source_epoch != Some(source_epoch.0)
+                {
+                    continue;
+                }
+                let Ok(msg_in) = MlsMessageIn::tls_deserialize_exact(message.payload.as_slice())
+                else {
+                    continue;
+                };
+                let proto: ProtocolMessage = match msg_in.extract() {
+                    MlsMessageBodyIn::PrivateMessage(private) => private.into(),
+                    MlsMessageBodyIn::PublicMessage(public) => public.into(),
+                    _ => continue,
+                };
+                let Ok(processed) = mls_group.process_message(&provider, proto) else {
+                    continue;
+                };
+                let ProcessedMessageContent::ProposalMessage(queued) = processed.into_content()
+                else {
+                    continue;
+                };
+                if !matches!(queued.proposal(), Proposal::SelfRemove) {
+                    continue;
+                }
+                let digest: [u8; 32] = Sha256::digest(&message.payload).into();
+                replayed.push((digest, queued));
+            }
+            (mls_group, replayed)
         };
 
+        // Re-check authorization against the same candidate-parent state used
+        // to stage the batch, then deterministically retain the lowest proposal
+        // digest for each leaving leaf. Finally order the selected proposals by
+        // that digest before they enter OpenMLS's insertion-ordered store.
+        let mut eligible = Vec::new();
+        for (digest, queued) in replayed {
+            let decision_report = crate::auto_committer::decide_with_reason(&mls_group, &queued);
+            let decision_str = match &decision_report.decision {
+                crate::auto_committer::AutoCommitDecision::Commit => "commit",
+                crate::auto_committer::AutoCommitDecision::Observe => "observe",
+            };
+            self.audit_group(
+                &group_id,
+                marmot_forensics::AuditEventKind::AutoCommitDecision {
+                    proposal_kind: crate::audit_helpers::proposal_kind_str(queued.proposal())
+                        .to_string(),
+                    decision: decision_str.to_string(),
+                    reason: Some(decision_report.reason.to_string()),
+                },
+            );
+            if !matches!(
+                decision_report.decision,
+                crate::auto_committer::AutoCommitDecision::Commit
+            ) {
+                continue;
+            }
+            let Sender::Member(leaver) = queued.sender() else {
+                continue;
+            };
+            eligible.push((*leaver, digest, *queued));
+        }
+        let selected = crate::auto_committer::select_self_remove_batch(eligible);
+        if selected.is_empty() {
+            return Ok(ScheduledAutoCommitReplay::NotApplicable);
+        }
+
         if self
-            .stage_auto_commit_for_queued_proposal(&schedule.group_id, &mut mls_group, queued)
+            .stage_auto_commit_for_queued_proposals(&group_id, &mut mls_group, selected)
             .await?
         {
             Ok(ScheduledAutoCommitReplay::Staged)
@@ -1415,79 +1501,86 @@ impl<S: StorageProvider> Engine<S> {
         }
     }
 
-    async fn stage_auto_commit_for_queued_proposal(
+    async fn stage_auto_commit_for_queued_proposals(
         &mut self,
         group_id: &GroupId,
         mls_group: &mut MlsGroup,
-        queued: Box<QueuedProposal>,
+        queued_proposals: Vec<QueuedProposal>,
     ) -> Result<bool, EngineError> {
-        let decision_report = crate::auto_committer::decide_with_reason(mls_group, &queued);
-        let decision_str = match &decision_report.decision {
-            crate::auto_committer::AutoCommitDecision::Commit => "commit",
-            crate::auto_committer::AutoCommitDecision::Observe => "observe",
-        };
-        self.audit_group(
-            group_id,
-            marmot_forensics::AuditEventKind::AutoCommitDecision {
-                proposal_kind: crate::audit_helpers::proposal_kind_str(queued.proposal())
-                    .to_string(),
-                decision: decision_str.to_string(),
-                reason: Some(decision_report.reason.to_string()),
-            },
-        );
-        if !matches!(
-            decision_report.decision,
-            crate::auto_committer::AutoCommitDecision::Commit
-        ) {
+        if queued_proposals.is_empty()
+            || queued_proposals
+                .iter()
+                .any(|queued| !matches!(queued.proposal(), Proposal::SelfRemove))
+        {
             return Ok(false);
         }
-
-        let auto_removed: Vec<MemberId> = match queued.proposal() {
-            Proposal::Remove(r) => member_id_at_leaf(mls_group, r.removed())
-                .into_iter()
-                .collect(),
-            Proposal::SelfRemove => member_id_of_sender(queued.sender(), mls_group)
-                .into_iter()
-                .collect(),
-            _ => Vec::new(),
-        };
-        let auto_is_self_remove = matches!(queued.proposal(), Proposal::SelfRemove);
-        let auto_proposer = member_id_of_sender(queued.sender(), mls_group);
-        let auto_proposal_kind =
-            crate::audit_helpers::proposal_kind_str(queued.proposal()).to_string();
 
         let is_stable = self
             .epoch_manager
             .state(group_id)
-            .is_none_or(|s| s.is_stable());
+            .is_none_or(|state| state.is_stable());
         if !is_stable {
             self.audit_group(
                 group_id,
                 marmot_forensics::AuditEventKind::AutoCommitDecision {
-                    proposal_kind: auto_proposal_kind,
+                    proposal_kind: "self_remove".to_string(),
                     decision: "observe".to_string(),
                     reason: Some("group_not_stable".to_string()),
                 },
             );
-            self.schedule_pending_convergence_group(group_id);
+            self.restore_self_remove_auto_commit_schedules_for_group(
+                group_id,
+                EpochId(mls_group.epoch().as_u64()),
+                self.convergence_now_ms(),
+            )?;
+            return Ok(false);
+        }
+
+        // `commit_to_pending_proposals` consumes the whole insertion-ordered
+        // live store. Keep SelfRemove batches closed: unrelated work remains in
+        // durable message records and must never be mixed into this commit.
+        if mls_group.has_pending_proposals() {
+            self.audit_group(
+                group_id,
+                marmot_forensics::AuditEventKind::AutoCommitDecision {
+                    proposal_kind: "self_remove".to_string(),
+                    decision: "observe".to_string(),
+                    reason: Some("unrelated_pending_proposals".to_string()),
+                },
+            );
+            self.restore_self_remove_auto_commit_schedules_for_group(
+                group_id,
+                EpochId(mls_group.epoch().as_u64()),
+                self.convergence_now_ms(),
+            )?;
+            return Ok(false);
+        }
+
+        let auto_removed: Vec<MemberId> = queued_proposals
+            .iter()
+            .filter_map(|queued| member_id_of_sender(queued.sender(), mls_group))
+            .collect();
+        if auto_removed.len() != queued_proposals.len() {
             return Ok(false);
         }
 
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
-        let stored_proposal_ref = queued.proposal_reference_ref().clone();
-        mls_group
-            .store_pending_proposal(
-                <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(
-                    &provider,
-                ),
-                *queued,
-            )
-            .map_err(|e| EngineError::Backend(format!("store_pending: {e:?}")))?;
-
-        let pre_commit_epoch = EpochId(mls_group.epoch().as_u64());
         let mut pending_commit_guard =
             PendingCommitCleanupGuard::arm(&self.storage, &provider, group_id.clone());
-        pending_commit_guard.set_stored_proposal_ref(stored_proposal_ref);
+        for queued in queued_proposals {
+            let stored_proposal_ref = queued.proposal_reference_ref().clone();
+            mls_group
+                .store_pending_proposal(
+                    <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(
+                        &provider,
+                    ),
+                    queued,
+                )
+                .map_err(|e| EngineError::Backend(format!("store_pending: {e:?}")))?;
+            pending_commit_guard.set_stored_proposal_ref(stored_proposal_ref);
+        }
+
+        let pre_commit_epoch = EpochId(mls_group.epoch().as_u64());
         let recovery_snapshot =
             self.fork_recovery
                 .create_snapshot(&self.storage, group_id, pre_commit_epoch)?;
@@ -1499,9 +1592,33 @@ impl<S: StorageProvider> Engine<S> {
             "pre_auto_commit",
         );
         let pre_commit_ctx = group_lifecycle::build_group_context_snapshot(mls_group, &provider)?;
-        let (commit_out, _welcome_opt, _gi) = mls_group
+        let (commit_out, _welcome_opt, _group_info) = mls_group
             .commit_to_pending_proposals(&provider, &self.identity.signer)
             .map_err(|e| EngineError::Backend(format!("auto_commit: {e:?}")))?;
+
+        // Re-check the complete resulting transition before exposing pending
+        // state: committer/leaver separation, active-admin depletion,
+        // admin/leaf coupling, and app-component integrity are one atomic gate.
+        let staged_commit = mls_group
+            .pending_commit()
+            .ok_or_else(|| EngineError::Backend("auto-commit produced no pending commit".into()))?;
+        crate::app_components::require_admin_for_staged_commit(
+            mls_group,
+            group_id,
+            Some(self.identity.self_id()),
+            staged_commit,
+        )?;
+        crate::app_components::validate_admin_leaf_coupling_for_staged_commit(
+            mls_group,
+            group_id,
+            staged_commit,
+        )?;
+        crate::app_components::validate_app_component_integrity_for_staged_commit(
+            mls_group,
+            group_id,
+            staged_commit,
+        )?;
+
         let commit_bytes = commit_out
             .tls_serialize_detached()
             .map_err(|e| EngineError::Serialize(format!("{e:?}")))?;
@@ -1523,6 +1640,7 @@ impl<S: StorageProvider> Engine<S> {
             group_id,
             pre_commit_epoch,
         )?;
+        pending_commit_guard.set_stored_commit_id(wrapped.id.clone());
 
         let new_epoch = EpochId(pre_commit_epoch.0.saturating_add(1));
         let commit_priority = mls_group
@@ -1567,7 +1685,7 @@ impl<S: StorageProvider> Engine<S> {
             if self.epoch_manager.rollback_publish(pending_ref).is_err() {
                 tracing::warn!(
                     target: "cgka_engine::message_processor",
-                    method = "stage_auto_commit_for_queued_proposal",
+                    method = "stage_auto_commit_for_queued_proposals",
                     "state-machine rollback failed after group record projection failure"
                 );
             }
@@ -1598,23 +1716,10 @@ impl<S: StorageProvider> Engine<S> {
             recovery_snapshot,
         );
         let auto_changes = auto_removed
-            .iter()
-            .cloned()
-            .map(|member| {
-                let (change, actor) = if auto_is_self_remove {
-                    (
-                        GroupStateChange::MemberLeft {
-                            member: member.clone(),
-                        },
-                        Some(member),
-                    )
-                } else {
-                    (
-                        GroupStateChange::MemberRemoved { member },
-                        auto_proposer.clone(),
-                    )
-                };
-                crate::engine::PendingGroupStateChange { actor, change }
+            .into_iter()
+            .map(|member| crate::engine::PendingGroupStateChange {
+                actor: Some(member.clone()),
+                change: GroupStateChange::MemberLeft { member },
             })
             .collect();
         self.pending_state_changes.insert(pending_ref, auto_changes);

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -356,6 +356,41 @@ impl<S: StorageProvider> Engine<S> {
         Ok(())
     }
 
+    /// Rebuild the in-memory jitter edge from durable current-epoch proposal
+    /// rows. The proposal bytes and source epoch are the source of truth; the
+    /// eventual replay performs full MLS, SelfRemove, and authorization checks.
+    /// A staged removal commit projects the group record to the next epoch, so
+    /// its already-consumed source-epoch proposals are excluded after restart.
+    pub(crate) fn restore_self_remove_auto_commit_schedules_for_group(
+        &mut self,
+        group_id: &GroupId,
+        source_epoch: EpochId,
+        now_ms: u64,
+    ) -> Result<(), EngineError> {
+        let records = self.storage.list_messages(group_id, source_epoch)?;
+        for record in records {
+            if record.epoch != source_epoch
+                || !matches!(
+                    record.state,
+                    MessageState::Created | MessageState::Retryable
+                )
+            {
+                continue;
+            }
+            let Some((_message, projection)) = decode_openmls_wire_projection(&record.payload)
+            else {
+                continue;
+            };
+            if projection.kind != OpenMlsContentKind::Proposal
+                || projection.source_epoch != Some(source_epoch.0)
+            {
+                continue;
+            }
+            self.schedule_self_remove_auto_commit(group_id, &record.id, source_epoch, now_ms)?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn drop_self_remove_auto_commit_schedules_for_group(&mut self, group_id: &GroupId) {
         self.scheduled_self_remove_auto_commits
             .retain(|_, scheduled| &scheduled.group_id != group_id);

--- a/crates/cgka-engine/src/pending_commit_guard.rs
+++ b/crates/cgka-engine/src/pending_commit_guard.rs
@@ -28,8 +28,9 @@
 //! worse than the bounded snapshot leak this guard exists to prevent.
 
 use crate::provider::EngineOpenMlsProvider;
+use cgka_traits::message::MessageState;
 use cgka_traits::storage::{StorageError, StorageProvider};
-use cgka_traits::types::GroupId;
+use cgka_traits::types::{GroupId, MessageId};
 use openmls::ciphersuite::hash_ref::ProposalRef;
 use openmls::group::{MlsGroup, RemoveProposalError};
 use openmls_traits::OpenMlsProvider as _;
@@ -54,10 +55,14 @@ pub(crate) struct PendingCommitCleanupGuard<S: StorageProvider> {
     // caller created one. `None` for paths that stage a commit without a
     // snapshot (e.g. group creation).
     snapshot_name: Option<String>,
-    // Proposal this staging attempt stored via `store_pending_proposal`, to
-    // remove from the OpenMLS proposal store on Drop. `None` for the send
-    // paths, which commit proposals they did not store themselves.
-    stored_proposal_ref: Option<ProposalRef>,
+    // Proposals this staging attempt stored via `store_pending_proposal`, to
+    // remove from the OpenMLS proposal store on Drop. Empty for send paths,
+    // which commit proposals they did not store themselves.
+    stored_proposal_refs: Vec<ProposalRef>,
+    // Outbound commit row created by this staging attempt. Early-return cleanup
+    // marks it failed so durable convergence never selects an unpublished
+    // commit after restart.
+    stored_commit_id: Option<MessageId>,
     armed: bool,
 }
 
@@ -77,7 +82,8 @@ impl<S: StorageProvider> PendingCommitCleanupGuard<S> {
             mls_storage: provider.storage() as *const S::Mls,
             group_id,
             snapshot_name: None,
-            stored_proposal_ref: None,
+            stored_proposal_refs: Vec::new(),
+            stored_commit_id: None,
             armed: true,
         }
     }
@@ -89,13 +95,16 @@ impl<S: StorageProvider> PendingCommitCleanupGuard<S> {
         self.snapshot_name = Some(snapshot_name);
     }
 
-    /// Attach the reference of a proposal the guarded path stored via
-    /// `store_pending_proposal`, so `Drop` restores the proposal store to its
-    /// pre-attempt state. A stale stored proposal is not benign residue:
-    /// OpenMLS 0.8.1 panics when a later `remove_members` commit filters a
-    /// leftover SelfRemove proposal against a Remove for the same leaf.
+    /// Attach one proposal reference stored by the guarded path. Call this
+    /// immediately after each successful `store_pending_proposal` so partial
+    /// batch storage is unwound if a later proposal or staging step fails.
     pub(crate) fn set_stored_proposal_ref(&mut self, proposal_ref: ProposalRef) {
-        self.stored_proposal_ref = Some(proposal_ref);
+        self.stored_proposal_refs.push(proposal_ref);
+    }
+
+    /// Attach the durable outbound commit row written by the guarded path.
+    pub(crate) fn set_stored_commit_id(&mut self, commit_id: MessageId) {
+        self.stored_commit_id = Some(commit_id);
     }
 
     /// The staged commit (and its snapshot) is now tracked by `EpochManager`
@@ -150,50 +159,52 @@ impl<S: StorageProvider> Drop for PendingCommitCleanupGuard<S> {
         };
         let pending_commit_cleared = match loaded_group.as_mut() {
             Some(mls_group) => {
-                if mls_group.pending_commit().is_none() {
-                    true
-                } else {
-                    let clear_result: Result<(), StorageError> =
-                        storage.with_transaction(|storage| {
+                // Clear the staged commit and every proposal this attempt
+                // inserted as one storage unit. A partial batch cleanup would
+                // leave OpenMLS with a mixed proposal store on retry.
+                let cleanup_result: Result<(), StorageError> =
+                    storage.with_transaction(|storage| {
+                        if mls_group.pending_commit().is_some() {
                             mls_group
                                 .clear_pending_commit(storage.mls_storage())
-                                .map_err(|e| StorageError::Backend(format!("clear_pending: {e:?}")))
-                        });
-                    match clear_result {
-                        Ok(()) => true,
-                        Err(_e) => {
-                            tracing::warn!(
-                                target: TRACE_TARGET,
-                                method = "drop",
-                                "pending commit guard could not clear staged commit"
-                            );
-                            false
+                                .map_err(|e| {
+                                    StorageError::Backend(format!("clear_pending: {e:?}"))
+                                })?;
                         }
+                        for proposal_ref in &self.stored_proposal_refs {
+                            match mls_group
+                                .remove_pending_proposal(storage.mls_storage(), proposal_ref)
+                            {
+                                Ok(()) | Err(RemoveProposalError::ProposalNotFound) => {}
+                                Err(e) => {
+                                    return Err(StorageError::Backend(format!(
+                                        "remove_pending_proposal: {e:?}"
+                                    )));
+                                }
+                            }
+                        }
+                        if let Some(commit_id) = self.stored_commit_id.as_ref() {
+                            match storage.update_message_state(commit_id, MessageState::Failed) {
+                                Ok(()) | Err(StorageError::NotFound) => {}
+                                Err(error) => return Err(error),
+                            }
+                        }
+                        Ok(())
+                    });
+                match cleanup_result {
+                    Ok(()) => true,
+                    Err(_e) => {
+                        tracing::warn!(
+                            target: TRACE_TARGET,
+                            method = "drop",
+                            "pending commit guard could not clear staged commit and stored proposals"
+                        );
+                        false
                     }
                 }
             }
             None => false,
         };
-
-        // Restore the proposal store to its pre-attempt state when this path
-        // stored the proposal itself. Best-effort and independent of the
-        // snapshot decision below: a proposal that is already gone is benign
-        // (`clear_pending_commit` does not remove stored proposals, but a
-        // concurrent merge would have consumed it).
-        if let (Some(mls_group), Some(proposal_ref)) =
-            (loaded_group.as_mut(), self.stored_proposal_ref.as_ref())
-        {
-            match mls_group.remove_pending_proposal(mls_storage, proposal_ref) {
-                Ok(()) | Err(RemoveProposalError::ProposalNotFound) => {}
-                Err(_e) => {
-                    tracing::warn!(
-                        target: TRACE_TARGET,
-                        method = "drop",
-                        "pending commit guard could not remove stored proposal"
-                    );
-                }
-            }
-        }
 
         // Release the pre-commit fork-recovery snapshot only after confirming
         // the staged pending commit is gone, mirroring

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -277,13 +277,50 @@ impl<S: StorageProvider> Engine<S> {
             .map_err(|e| EngineError::Backend(format!("load: {e:?}")))?
             .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
 
+        let retry_self_remove_batch = mls_group.pending_commit().is_some_and(|commit| {
+            let mut proposals = commit.queued_proposals().peekable();
+            proposals.peek().is_some()
+                && proposals.all(|proposal| {
+                    matches!(proposal.proposal(), openmls::prelude::Proposal::SelfRemove)
+                })
+        });
+        let failed_self_remove_commit = retry_self_remove_batch
+            .then(|| self.peek_pending_commit_for_recovery(pending))
+            .flatten();
+        let retry_proposal_refs = if retry_self_remove_batch {
+            mls_group
+                .pending_commit()
+                .into_iter()
+                .flat_map(|commit| commit.queued_proposals())
+                .map(|proposal| proposal.proposal_reference_ref().clone())
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
         if mls_group.pending_commit().is_some() {
             self.storage.with_transaction(|storage| {
                 let tx_provider =
                     EngineOpenMlsProvider::<S>::new(&self.crypto, storage.mls_storage());
                 mls_group
                     .clear_pending_commit(tx_provider.storage())
-                    .map_err(|e| EngineError::Backend(format!("clear_pending: {e:?}")))
+                    .map_err(|error| EngineError::Backend(format!("clear_pending: {error:?}")))?;
+                for proposal_ref in &retry_proposal_refs {
+                    match mls_group.remove_pending_proposal(tx_provider.storage(), proposal_ref) {
+                        Ok(()) | Err(openmls::group::RemoveProposalError::ProposalNotFound) => {}
+                        Err(error) => {
+                            return Err(EngineError::Backend(format!(
+                                "remove retry proposal: {error:?}"
+                            )));
+                        }
+                    }
+                }
+                if let Some(commit_id) = failed_self_remove_commit.as_ref() {
+                    match storage.update_message_state(commit_id, MessageState::Failed) {
+                        Ok(()) | Err(cgka_traits::storage::StorageError::NotFound) => {}
+                        Err(error) => return Err(EngineError::Storage(error)),
+                    }
+                }
+                Ok(())
             })?;
         }
 
@@ -332,6 +369,13 @@ impl<S: StorageProvider> Engine<S> {
             ),
         );
         self.pending_state_changes.remove(&pending);
+        if retry_self_remove_batch {
+            self.restore_self_remove_auto_commit_schedules_for_group(
+                &group_id,
+                prior_epoch,
+                self.convergence_now_ms(),
+            )?;
+        }
         if let Some((queued_group_id, _)) = self.queued_intent_by_pending.remove(&pending) {
             self.schedule_pending_convergence_group(&queued_group_id);
         }

--- a/crates/cgka-engine/tests/auto_commit_atomicity.rs
+++ b/crates/cgka-engine/tests/auto_commit_atomicity.rs
@@ -1,6 +1,6 @@
 //! Auto-commit staging atomicity (mdk#333).
 //!
-//! `stage_auto_commit_for_queued_proposal` projects the post-merge group
+//! `stage_auto_commit_for_queued_proposals` projects the post-merge group
 //! record (epoch N+1, leaver dropped) as part of staging. If any fallible
 //! staging step fails after durable state has advanced, the record must not
 //! be left torn — epoch/membership disagreeing with the MLS group and the
@@ -540,24 +540,17 @@ async fn auto_commit_record_write_failure_leaves_no_torn_group_record() {
     );
 
     // The group stays fully usable: the state machine rewound to Stable, the
-    // staged OpenMLS commit was cleared, AND the stored SelfRemove proposal
-    // was removed from the proposal store (left behind, OpenMLS 0.8.1 panics
-    // when this remove_members filters it against the Remove for bob's
-    // leaf). A fresh commit stages, confirms, and lands. (The failed attempt
-    // consumed bob's scheduled auto-commit — schedule removal precedes
-    // replay by design — so the admin completes the removal explicitly.)
-    let evolution = alice
-        .send(SendIntent::RemoveMembers {
-            group_id: group_id.clone(),
-            members: vec![bob_member_id.clone()],
-        })
+    // staged OpenMLS commit was cleared, and every proposal-store insertion was
+    // removed. The durable SelfRemove row re-arms the same batch, which stages,
+    // confirms, and lands on the next convergence pass.
+    tokio::time::sleep(std::time::Duration::from_millis(75)).await;
+    alice.advance_convergence(&group_id).await.unwrap();
+    let mut retried = alice.drain_auto_publish();
+    assert_eq!(retried.len(), 1, "failed batch must re-arm exactly once");
+    alice
+        .confirm_published(retried.remove(0).pending)
         .await
         .unwrap();
-    let pending = match evolution {
-        SendResult::GroupEvolution { pending, .. } => pending,
-        other => panic!("expected GroupEvolution, got {other:?}"),
-    };
-    alice.confirm_published(pending).await.unwrap();
     let record = handle.get_group(&group_id).unwrap();
     assert_eq!(record.epoch, EpochId(2));
     assert_eq!(record.members.len(), 2);

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -13,15 +13,16 @@ use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, KeyPackage, SendIntent
 use cgka_traits::error::PeelerError;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage, StaleReason};
+use cgka_traits::message::MessageState;
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
-    AccountDeviceSignerStorage, GroupStorage, LeaveRequestStorage, OutboundIntentStorage,
-    StorageProvider,
+    AccountDeviceSignerStorage, GroupStorage, LeaveRequestStorage, MessageStorage,
+    OutboundIntentStorage, StorageProvider,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
-use cgka_traits::types::{GroupId, MemberId, MessageId};
+use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use openmls::component::ComponentData;
 use openmls::group::MlsGroup;
 use openmls::messages::proposals::{AppDataUpdateOperation, AppDataUpdateProposal, Proposal};
@@ -1895,6 +1896,206 @@ async fn selfremove_full_flow_with_auto_commit() {
 }
 
 #[tokio::test]
+async fn selfremove_auto_commit_batches_all_eligible_leavers() {
+    let (mut alice, alice_storage) = build_with_storage(b"alice-batch");
+    let mut bob = build_client(b"bob-batch");
+    let mut carol = build_client(b"carol-batch");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "selfremove-batch".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (welcome_for_bob, welcome_for_carol) = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            (welcomes.remove(0), welcomes.remove(0))
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcome_for_bob).await.unwrap();
+    carol.join_welcome(welcome_for_carol).await.unwrap();
+
+    let bob_leave = match bob
+        .send(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::Proposal { msg } => msg,
+        other => panic!("expected bob SelfRemove proposal, got {other:?}"),
+    };
+    let carol_leave = match carol
+        .send(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::Proposal { msg } => msg,
+        other => panic!("expected carol SelfRemove proposal, got {other:?}"),
+    };
+
+    for proposal in [carol_leave, bob_leave] {
+        let outcome = alice
+            .ingest(TransportMessage {
+                envelope: TransportEnvelope::GroupMessage {
+                    transport_group_id: group_id.as_slice().to_vec(),
+                },
+                ..proposal
+            })
+            .await
+            .unwrap();
+        assert!(matches!(outcome, IngestOutcome::Processed));
+    }
+
+    advance_selfremove_auto_commit(&mut alice, &group_id).await;
+    assert_eq!(
+        alice.drain_auto_publish().len(),
+        1,
+        "one eligible frozen batch must produce one commit"
+    );
+    let projected_members = alice.members(&group_id).unwrap();
+    assert_eq!(
+        projected_members.len(),
+        1,
+        "the staged batch must project both leavers out; got {projected_members:?}"
+    );
+    assert_eq!(projected_members[0].id, alice.self_id());
+
+    let crypto = RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, alice_storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load alice group")
+        .expect("alice group present");
+    let staged = mls_group
+        .pending_commit()
+        .expect("alice staged a SelfRemove batch commit");
+    let queued: Vec<_> = staged.queued_proposals().collect();
+    assert_eq!(queued.len(), 2, "the commit must reference both proposals");
+    assert!(
+        queued
+            .iter()
+            .all(|queued| matches!(queued.proposal(), Proposal::SelfRemove)),
+        "the batch commit must contain only SelfRemove proposals"
+    );
+}
+
+#[tokio::test]
+async fn selfremove_batch_schedule_survives_engine_rebuild() {
+    let (mut alice, alice_storage) = build_with_storage(b"alice-batch-restart");
+    let mut bob = build_client(b"bob-batch-restart");
+    let mut carol = build_client(b"carol-batch-restart");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "selfremove-batch-restart".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (welcome_for_bob, welcome_for_carol) = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            (welcomes.remove(0), welcomes.remove(0))
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcome_for_bob).await.unwrap();
+    carol.join_welcome(welcome_for_carol).await.unwrap();
+
+    let bob_leave = match bob
+        .send(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::Proposal { msg } => msg,
+        other => panic!("expected bob SelfRemove proposal, got {other:?}"),
+    };
+    let carol_leave = match carol
+        .send(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::Proposal { msg } => msg,
+        other => panic!("expected carol SelfRemove proposal, got {other:?}"),
+    };
+    for proposal in [bob_leave, carol_leave] {
+        alice
+            .ingest(TransportMessage {
+                envelope: TransportEnvelope::GroupMessage {
+                    transport_group_id: group_id.as_slice().to_vec(),
+                },
+                ..proposal
+            })
+            .await
+            .unwrap();
+    }
+    assert!(alice.drain_auto_publish().is_empty());
+
+    drop(alice);
+    let mut alice = build_client_on_storage(b"alice-batch-restart", alice_storage.clone());
+    alice.hydrate_stable_groups_from_storage().unwrap();
+    advance_selfremove_auto_commit(&mut alice, &group_id).await;
+
+    assert_eq!(
+        alice.drain_auto_publish().len(),
+        1,
+        "restart must restore one durable batch schedule"
+    );
+    let projected_members = alice.members(&group_id).unwrap();
+    assert_eq!(
+        projected_members.len(),
+        1,
+        "restored batch must still remove both leavers; got {projected_members:?}"
+    );
+    assert_eq!(projected_members[0].id, alice.self_id());
+
+    // Crash again after the batch has been staged but before its pending handle
+    // is resolved. The durable projected epoch prevents hydration from
+    // scheduling either source-epoch proposal again, so no duplicate commit is
+    // prepared on the reopened engine.
+    drop(alice);
+    let mut alice = build_client_on_storage(b"alice-batch-restart", alice_storage);
+    alice.hydrate_stable_groups_from_storage().unwrap();
+    assert!(alice.drain_auto_publish().is_empty());
+    advance_selfremove_auto_commit(&mut alice, &group_id).await;
+    assert!(
+        alice.drain_auto_publish().is_empty(),
+        "restart with a staged batch must not produce a duplicate commit"
+    );
+    assert_eq!(alice.epoch(&group_id).unwrap(), EpochId(2));
+    assert_eq!(alice.members(&group_id).unwrap().len(), 1);
+}
+
+#[tokio::test]
 async fn selfremove_leaving_gate_survives_engine_rebuild() {
     let mut alice = build_client(b"alice");
     let (mut bob, bob_storage) = build_with_storage(b"bob");
@@ -2232,7 +2433,7 @@ async fn leave_requires_stable_epoch_state() {
 
 #[tokio::test]
 async fn selfremove_auto_commit_publish_failed_rolls_back_projection() {
-    let mut alice = build_client(b"alice");
+    let (mut alice, alice_storage) = build_with_storage(b"alice");
     let mut bob = build_client(b"bob");
     let mut carol = build_client(b"carol");
     let bob_kp = bob.fresh_key_package().await.unwrap();
@@ -2290,12 +2491,43 @@ async fn selfremove_auto_commit_publish_failed_rolls_back_projection() {
     alice.publish_failed(auto.remove(0).pending).await.unwrap();
 
     assert_eq!(alice.epoch(&group_id).unwrap().0, 1);
+    let proposal_states: Vec<_> = alice_storage
+        .list_messages(&group_id, EpochId(1))
+        .unwrap()
+        .into_iter()
+        .map(|record| record.state)
+        .collect();
+    assert!(
+        proposal_states
+            .iter()
+            .any(|state| matches!(state, MessageState::Created | MessageState::Retryable)),
+        "publish_failed must leave durable proposal rows retryable; got {proposal_states:?}"
+    );
     let members = alice.members(&group_id).unwrap();
     assert_eq!(members.len(), 3, "publish_failed should restore bob");
+    let crypto = RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, alice_storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        mls_group.pending_proposals().count(),
+        0,
+        "publish_failed must restore an empty live proposal store"
+    );
     let events = alice.drain_events();
     assert!(
         !emits_departure_of(&events, &bob.self_id()),
         "failed auto-publish must not emit a departure; got {events:?}"
+    );
+
+    advance_selfremove_auto_commit(&mut alice, &group_id).await;
+    assert_eq!(
+        alice.drain_auto_publish().len(),
+        1,
+        "durable SelfRemove proposals must be retried after publish failure"
     );
 }
 


### PR DESCRIPTION
## Summary
- freeze all currently scheduled SelfRemove proposals for one group/epoch and select the lowest SHA-256 MLSMessage digest per leaving leaf
- stage the selected proposals in canonical digest order as one SelfRemove-only publish-before-apply commit
- restore durable scheduling after restart or publish failure, with atomic pending-commit/proposal cleanup and no duplicate commit after a staged restart
- cover permutation invariance, multi-leaver batching, restart/idempotence, atomic failure recovery, and OpenMLS conformance digest ordering

## Test plan
- `cargo test -p cgka-engine --locked`
- `cargo test -p cgka-conformance-simulator --locked`
- `just fast-ci`

## Dependency context
- #1053, #806, and #1027 remain separate open dependency work; this change uses the current authorization and convergence scheduling seams without duplicating them.

Fixes #1054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Self-removal requests are now combined into a single deterministic update when multiple members leave at once.
  - Batched changes preserve a consistent ordering regardless of message arrival order.
  - Scheduled self-removal processing resumes correctly after an engine restart.

- **Bug Fixes**
  - Improved recovery after publishing failures, preventing duplicate updates and preserving retry behavior.
  - Strengthened cleanup and rollback handling when batched membership changes cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->