### PR TITLE
fix: retire encrypted media secrets with retained messages

### DIFF
--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1446,10 +1446,31 @@ impl AppClient {
                 .iter()
                 .map(|attachment| attachment.reference.clone())
                 .collect();
-            result.sent = Some(
-                self.send_media_attachments(group_id, attachments, caption)
-                    .await?,
-            );
+            let summary = self
+                .send_media_attachments(group_id, attachments, caption)
+                .await?;
+            // The post-publish projection now durably references this source
+            // epoch. Persist again so a prior final-reference retirement cannot
+            // suppress the secret needed by the newly retained message.
+            if self
+                .remember_encrypted_media_epoch_secret(
+                    group_id,
+                    source_epoch,
+                    media_secret.as_ref(),
+                )
+                .is_err()
+            {
+                // Publication already succeeded. Do not report a false send
+                // failure that could make the caller publish a duplicate; the
+                // normal current-epoch cache pass can retry this durable write.
+                tracing::warn!(
+                    target: "marmot_app::media",
+                    method = "upload_media",
+                    error_code = "encrypted_media_secret_cache_skipped",
+                    "failed to cache encrypted media source epoch secret after publish",
+                );
+            }
+            result.sent = Some(summary);
         }
         Ok(result)
     }
@@ -1900,6 +1921,16 @@ impl AppClient {
         group_id: &GroupId,
         source_epoch: u64,
     ) -> Result<SecretBytes, AppError> {
+        let group_id_hex = hex::encode(group_id.as_slice());
+        if !self
+            .app
+            .account_storage(&self.state.label)?
+            .encrypted_media_epoch_secret_may_be_served(&group_id_hex, source_epoch)?
+        {
+            return Err(AppError::InvalidEncryptedMedia(format!(
+                "encrypted media secret retired for epoch {source_epoch}"
+            )));
+        }
         if let Some(secret) = self.cached_encrypted_media_epoch_secret(group_id, source_epoch)? {
             return Ok(SecretBytes::new(secret));
         }
@@ -1908,13 +1939,17 @@ impl AppClient {
             GROUP_ENCRYPTED_MEDIA_EXPORTER_CACHE_KEY,
             32,
         )?;
-        self.remember_encrypted_media_epoch_secret(group_id, epoch.0, secret.as_ref())?;
-        if epoch.0 != source_epoch {
-            return Err(AppError::InvalidEncryptedMedia(format!(
-                "missing encrypted media secret for epoch {source_epoch}"
-            )));
+        if epoch.0 == source_epoch {
+            self.remember_encrypted_media_epoch_secret(group_id, epoch.0, secret.as_ref())?;
+            if let Some(secret) =
+                self.cached_encrypted_media_epoch_secret(group_id, source_epoch)?
+            {
+                return Ok(SecretBytes::new(secret));
+            }
         }
-        Ok(secret)
+        Err(AppError::InvalidEncryptedMedia(format!(
+            "missing encrypted media secret for epoch {source_epoch}"
+        )))
     }
 
     fn remember_current_encrypted_media_secret(&self, group_id: &GroupId) -> Result<(), AppError> {

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -539,22 +539,11 @@ impl AppClient {
                     gossip_message_ids.insert(message.message_id_hex.clone());
                     continue;
                 }
-                if message.kind == MARMOT_APP_EVENT_KIND_CHAT
+                let retains_encrypted_media = message.kind == MARMOT_APP_EVENT_KIND_CHAT
                     && media_imeta_tags_are_valid(
                         &message.tags,
                         self.app.allow_loopback_blob_endpoints(),
-                    )
-                    && self
-                        .remember_current_encrypted_media_secret(&message.group_id)
-                        .is_err()
-                {
-                    tracing::warn!(
-                        target: "marmot_app::media",
-                        method = "ingest_delivery",
-                        error_code = "encrypted_media_secret_cache_skipped",
-                        "failed to cache encrypted media source epoch secret",
                     );
-                }
                 self.app.remember_directory_message_sender(&message)?;
                 // Evaluated against the signed MLS group state while the
                 // delete's epoch context is live, then persisted with the
@@ -581,6 +570,23 @@ impl AppClient {
                     &message_projection,
                     message.received_at,
                 )?;
+                // Persist the reference first. A source epoch whose previous
+                // final reference was retired may be re-used by a later message;
+                // the durable reference is what authorizes restoring its secret.
+                // Doing this before the next delivery also preserves the source
+                // epoch when the same sync batch advances the group afterwards.
+                if retains_encrypted_media
+                    && self
+                        .remember_current_encrypted_media_secret(&message.group_id)
+                        .is_err()
+                {
+                    tracing::warn!(
+                        target: "marmot_app::media",
+                        method = "ingest_delivery",
+                        error_code = "encrypted_media_secret_cache_skipped",
+                        "failed to cache encrypted media source epoch secret",
+                    );
+                }
                 summary.projection_updates.push(projection_update);
                 self.prune_plaintext_retention_for_group(&message.group_id)?;
             }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -4250,6 +4250,106 @@ async fn encrypted_media_upload_sends_ciphertext_and_download_decrypts_plaintext
 }
 
 #[tokio::test]
+async fn retained_media_rehydrates_a_retired_current_epoch_before_the_group_advances() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    home.create_account("alice").unwrap();
+    home.create_account("bob").unwrap();
+
+    let (_relay, app, _url) = mock_app(&dir).await;
+    let blossom = mock_blossom().await;
+    let mut bob = app.client("bob").await.unwrap();
+    bob.publish_key_package().await.unwrap();
+
+    let mut alice = app.client("alice").await.unwrap();
+    let group_id = alice
+        .create_group("retired media epoch", &["bob"])
+        .await
+        .unwrap();
+    bob.sync().await.unwrap();
+    alice.update_message_retention(&group_id, 2).await.unwrap();
+    bob.sync().await.unwrap();
+
+    let expired = alice
+        .upload_media(
+            &group_id,
+            MediaUploadRequest {
+                attachments: vec![MediaUploadAttachmentRequest {
+                    file_name: "expired.txt".to_owned(),
+                    media_type: "text/plain".to_owned(),
+                    plaintext: b"expired media".to_vec(),
+                    dim: None,
+                    thumbhash: None,
+                }],
+                caption: None,
+                send: true,
+                blossom_server: Some(blossom.url.clone()),
+            },
+        )
+        .await
+        .unwrap();
+    let expired_reference = expired.attachments[0].reference.clone();
+    let expired_source_epoch = expired_reference.source_epoch;
+    bob.sync().await.unwrap();
+
+    sleep(Duration::from_secs(3)).await;
+    let pruned = bob
+        .secure_delete_expired_plaintext_for_group(&group_id)
+        .unwrap();
+    assert!(pruned.pruned_messages > 0);
+    assert!(
+        bob.download_media(&group_id, expired_reference.clone())
+            .await
+            .is_err(),
+        "a retired source epoch must not be re-derived from live MLS state"
+    );
+    drop(bob);
+    let mut bob = app.client("bob").await.unwrap();
+    assert!(
+        bob.download_media(&group_id, expired_reference)
+            .await
+            .is_err(),
+        "a retired source epoch must stay unavailable after restart"
+    );
+
+    let retained_plaintext = b"retained after epoch retirement".to_vec();
+    let retained = alice
+        .upload_media(
+            &group_id,
+            MediaUploadRequest {
+                attachments: vec![MediaUploadAttachmentRequest {
+                    file_name: "retained.txt".to_owned(),
+                    media_type: "text/plain".to_owned(),
+                    plaintext: retained_plaintext.clone(),
+                    dim: None,
+                    thumbhash: None,
+                }],
+                caption: None,
+                send: true,
+                blossom_server: Some(blossom.url.clone()),
+            },
+        )
+        .await
+        .unwrap();
+    let retained_reference = retained.attachments[0].reference.clone();
+    assert_eq!(
+        retained_reference.source_epoch, expired_source_epoch,
+        "the retained message must reuse the retired epoch for this regression"
+    );
+    alice
+        .update_group_profile(&group_id, Some("advanced after media"), None)
+        .await
+        .unwrap();
+
+    bob.sync().await.unwrap();
+    let download = bob
+        .download_media(&group_id, retained_reference)
+        .await
+        .expect("retained media must preserve its source-epoch secret across the next commit");
+    assert_eq!(download.plaintext, retained_plaintext);
+}
+
+#[tokio::test]
 async fn encrypted_media_endpoint_updates_are_full_replacement_and_admin_only() {
     let dir = tempfile::tempdir().unwrap();
     let home = AccountHome::open(dir.path());

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -1,5 +1,6 @@
 use crate::{
-    SqliteAccountStorage, SqliteResultExt, bool_i64, connection::retry_on_busy, tags_from_json,
+    SqliteAccountStorage, SqliteResultExt, bool_i64, connection::retry_on_busy,
+    encrypted_media_secrets::retire_all_encrypted_media_secrets_for_group_tx, tags_from_json,
     unix_now_ms, unix_now_seconds, unix_now_seconds_i64, usize_to_i64,
 };
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -544,9 +545,12 @@ impl SqliteAccountStorage {
     /// local delete/wipe UX: it drops the chat-list/account projection, plaintext
     /// app events, timeline rows, agent-stream start projection rows, cached
     /// encrypted-media epoch secrets, and group push-token rows keyed by
-    /// `group_id_hex`. `seen_events` and protocol/MLS tables are intentionally
-    /// left intact so old relay deliveries stay suppressed while a future fresh
-    /// group message can re-create the app projection.
+    /// `group_id_hex`. A metadata-only media-secret retirement barrier remains
+    /// because protocol/MLS state is intentionally retained; without it that
+    /// state could immediately rederive wiped key bytes. `seen_events` and
+    /// protocol/MLS tables are left intact so old relay deliveries stay
+    /// suppressed while a future fresh group message can re-create the app
+    /// projection.
     pub fn delete_local_group_data(&self, group_id_hex: &str) -> StorageResult<bool> {
         if group_id_hex.trim().is_empty() {
             return Err(StorageError::Backend(
@@ -556,7 +560,7 @@ impl SqliteAccountStorage {
 
         self.connection.with_transaction(|| -> StorageResult<bool> {
             let conn = self.lock()?;
-            let mut deleted = 0usize;
+            let mut deleted = retire_all_encrypted_media_secrets_for_group_tx(&conn, group_id_hex)?;
             for table in [
                 "app_events",
                 "message_timeline",
@@ -567,6 +571,7 @@ impl SqliteAccountStorage {
                 "group_push_tokens",
                 "group_push_token_tombstones",
                 "chat_notification_settings",
+                "encrypted_media_epoch_secret_references",
                 "encrypted_media_epoch_secrets",
                 "account_groups",
             ] {
@@ -742,6 +747,14 @@ impl SqliteAccountStorage {
                 (Err(err), Err(_)) => Err(err),
             }
         })?;
+        if outcome.pruned_media_epoch_secrets > 0 {
+            tracing::debug!(
+                target: "storage_sqlite::retention",
+                method = "secure_prune_app_events_before",
+                pruned_media_epoch_secrets = outcome.pruned_media_epoch_secrets,
+                "retired encrypted-media epoch secrets after final retained references expired"
+            );
+        }
         if outcome.pruned_messages > 0 {
             let conn = self.lock()?;
             if let Err(error) = checkpoint_wal_truncate_after_secure_prune(&conn) {

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -1365,9 +1365,10 @@ fn delete_local_group_data_removes_app_local_rows_without_touching_protocol_stat
     store
         .save_account_projection_state(&state, 16, MAX_FUTURE_SKEW_SECS)
         .unwrap();
-    store
-        .record_app_event(&app_event("msg-aa", "aa", 10))
-        .unwrap();
+    let mut group_a_message = app_event("msg-aa", "aa", 10);
+    group_a_message.source_epoch = Some(7);
+    group_a_message.tags = vec![vec!["imeta".to_owned(), "v encrypted-media-v1".to_owned()]];
+    store.record_app_event(&group_a_message).unwrap();
     store
         .record_app_event(&agent_stream_start_event(
             "stream-aa",
@@ -1385,6 +1386,16 @@ fn delete_local_group_data_removes_app_local_rows_without_touching_protocol_stat
     store
         .remember_encrypted_media_epoch_secret("bb", 0x8008, 7, &[4, 5, 6])
         .unwrap();
+    store
+        .lock()
+        .unwrap()
+        .execute(
+            "INSERT INTO encrypted_media_epoch_secret_retirement_watermarks (
+                 group_id_hex, retired_through_epoch, retired_at_unix_seconds
+             ) VALUES ('aa', 6, 10)",
+            [],
+        )
+        .unwrap();
     insert_group_push_token(&store, "aa", "member-aa");
     insert_group_push_token(&store, "bb", "member-bb");
     // Tombstones on a distinct leaf so they don't collide with the live rows
@@ -1400,6 +1411,14 @@ fn delete_local_group_data_removes_app_local_rows_without_touching_protocol_stat
     insert_protocol_group_marker(&store, &[0xaa]);
 
     assert!(store.delete_local_group_data("aa").unwrap());
+    store
+        .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[9, 9, 9])
+        .unwrap();
+    assert_eq!(
+        store.encrypted_media_epoch_secret("aa", 0x8008, 7).unwrap(),
+        None,
+        "local group deletion must prevent retained MLS state from rehydrating wiped secrets"
+    );
 
     for table in [
         "account_groups",
@@ -1411,10 +1430,20 @@ fn delete_local_group_data_removes_app_local_rows_without_touching_protocol_stat
         "chat_list_rows",
         "group_push_tokens",
         "group_push_token_tombstones",
+        "encrypted_media_epoch_secret_references",
         "encrypted_media_epoch_secrets",
     ] {
         assert_eq!(group_row_count(&store, table, "aa"), 0, "{table}");
     }
+    assert_eq!(
+        group_row_count(
+            &store,
+            "encrypted_media_epoch_secret_retirement_watermarks",
+            "aa",
+        ),
+        1,
+        "the retirement barrier outlives the local group projection"
+    );
     for table in [
         "account_groups",
         "account_group_app_components",

--- a/crates/storage-sqlite/src/encrypted_media_secrets.rs
+++ b/crates/storage-sqlite/src/encrypted_media_secrets.rs
@@ -1,6 +1,14 @@
-use crate::{SqliteAccountStorage, SqliteResultExt, u64_to_i64, unix_now_seconds_i64};
+use std::collections::BTreeSet;
+
+use crate::{
+    SqliteAccountStorage, SqliteResultExt, StoredAppEvent, u64_to_i64, unix_now_seconds_i64,
+};
+use cgka_traits::app_components::{
+    ENCRYPTED_MEDIA_FORMAT_V1, ENCRYPTED_MEDIA_FORMAT_V2, GROUP_ENCRYPTED_MEDIA_COMPONENT_ID,
+    GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID,
+};
 use cgka_traits::storage::{StorageError, StorageResult};
-use rusqlite::{OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, params};
 
 impl SqliteAccountStorage {
     pub fn remember_encrypted_media_epoch_secret(
@@ -28,11 +36,42 @@ INSERT INTO encrypted_media_epoch_secrets (
     component_id,
     source_epoch,
     secret,
-    created_at_unix_seconds
-) VALUES (?1, ?2, ?3, ?4, ?5)
+    created_at_unix_seconds,
+    retention_managed
+)
+SELECT
+    ?1, ?2, ?3, ?4, ?5,
+    EXISTS (
+        SELECT 1
+        FROM encrypted_media_epoch_secret_references
+        WHERE group_id_hex = ?1
+          AND source_epoch = ?3
+    )
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM encrypted_media_epoch_secret_retirement_watermarks
+    WHERE group_id_hex = ?1
+      AND retired_through_epoch >= ?3
+) OR EXISTS (
+    SELECT 1
+    FROM encrypted_media_epoch_secret_references
+    WHERE group_id_hex = ?1
+      AND source_epoch = ?3
+)
 ON CONFLICT(group_id_hex, component_id, source_epoch) DO UPDATE SET
     secret = excluded.secret,
-    created_at_unix_seconds = excluded.created_at_unix_seconds
+    created_at_unix_seconds = excluded.created_at_unix_seconds,
+    retention_managed = CASE
+        WHEN excluded.retention_managed = 1 THEN 1
+        ELSE encrypted_media_epoch_secrets.retention_managed
+    END
+WHERE excluded.retention_managed = 1
+   OR NOT EXISTS (
+       SELECT 1
+       FROM encrypted_media_epoch_secret_retirement_watermarks
+       WHERE group_id_hex = excluded.group_id_hex
+         AND retired_through_epoch >= excluded.source_epoch
+   )
 "#,
                 params![
                     group_id_hex,
@@ -60,6 +99,20 @@ FROM encrypted_media_epoch_secrets
 WHERE group_id_hex = ?1
   AND component_id = ?2
   AND source_epoch = ?3
+  AND (
+      EXISTS (
+          SELECT 1
+          FROM encrypted_media_epoch_secret_references AS refs
+          WHERE refs.group_id_hex = encrypted_media_epoch_secrets.group_id_hex
+            AND refs.source_epoch = encrypted_media_epoch_secrets.source_epoch
+      )
+      OR NOT EXISTS (
+          SELECT 1
+          FROM encrypted_media_epoch_secret_retirement_watermarks AS watermarks
+          WHERE watermarks.group_id_hex = encrypted_media_epoch_secrets.group_id_hex
+            AND watermarks.retired_through_epoch >= encrypted_media_epoch_secrets.source_epoch
+      )
+  )
 "#,
                 params![
                     group_id_hex,
@@ -71,41 +124,746 @@ WHERE group_id_hex = ?1
             .optional()
             .storage()
     }
+
+    /// Whether the epoch secret may be returned to a media caller. Epochs that
+    /// have never been retired remain usable for freshly uploaded, not-yet-sent
+    /// media. Once the final retained reference retires an epoch, only a new
+    /// durable reference can make that epoch usable again.
+    pub fn encrypted_media_epoch_secret_may_be_served(
+        &self,
+        group_id_hex: &str,
+        source_epoch: u64,
+    ) -> StorageResult<bool> {
+        Ok(self
+            .lock()?
+            .query_row(
+                "SELECT
+                     EXISTS (
+                         SELECT 1
+                         FROM encrypted_media_epoch_secret_references
+                         WHERE group_id_hex = ?1
+                           AND source_epoch = ?2
+                     )
+                     OR NOT EXISTS (
+                         SELECT 1
+                         FROM encrypted_media_epoch_secret_retirement_watermarks
+                         WHERE group_id_hex = ?1
+                           AND retired_through_epoch >= ?2
+                     )",
+                params![group_id_hex, u64_to_i64(source_epoch)?],
+                |row| row.get::<_, i64>(0),
+            )
+            .storage()?
+            != 0)
+    }
+}
+
+pub(crate) fn encrypted_media_component_ids(tags: &[Vec<String>]) -> BTreeSet<u16> {
+    let mut component_ids = BTreeSet::new();
+    for tag in tags
+        .iter()
+        .filter(|tag| tag.first().is_some_and(|name| name == "imeta"))
+    {
+        for field in tag.iter().skip(1) {
+            match field.strip_prefix("v ") {
+                Some(ENCRYPTED_MEDIA_FORMAT_V1) => {
+                    component_ids.insert(GROUP_ENCRYPTED_MEDIA_COMPONENT_ID);
+                }
+                Some(ENCRYPTED_MEDIA_FORMAT_V2) => {
+                    component_ids.insert(GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID);
+                }
+                _ => {}
+            }
+        }
+    }
+    component_ids
+}
+
+/// Replace one retained message's versioned media-secret references. This runs
+/// inside the same transaction as the owning `app_events` upsert, so a restart
+/// observes either the old event/reference set or the new one, never a torn mix.
+pub(crate) fn replace_encrypted_media_secret_references_tx(
+    tx: &Connection,
+    event: &StoredAppEvent,
+) -> StorageResult<()> {
+    let retiring_epochs = encrypted_media_secret_reference_epochs_for_message_tx(
+        tx,
+        &event.group_id_hex,
+        &event.message_id_hex,
+    )?;
+    tx.execute(
+        "DELETE FROM encrypted_media_epoch_secret_references
+         WHERE group_id_hex = ?1 AND message_id_hex = ?2",
+        params![&event.group_id_hex, &event.message_id_hex],
+    )
+    .storage()?;
+
+    if let Some(source_epoch) = event.source_epoch {
+        let source_epoch = u64_to_i64(source_epoch)?;
+        for component_id in encrypted_media_component_ids(&event.tags) {
+            tx.execute(
+                "INSERT INTO encrypted_media_epoch_secret_references (
+                     group_id_hex, message_id_hex, component_id, source_epoch
+                 ) VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    &event.group_id_hex,
+                    &event.message_id_hex,
+                    i64::from(component_id),
+                    source_epoch,
+                ],
+            )
+            .storage()?;
+            tx.execute(
+                "UPDATE encrypted_media_epoch_secrets
+                 SET retention_managed = 1
+                 WHERE group_id_hex = ?1
+                   AND source_epoch = ?2",
+                params![&event.group_id_hex, source_epoch],
+            )
+            .storage()?;
+        }
+    }
+
+    retire_unreferenced_encrypted_media_secret_epochs_tx(
+        tx,
+        &event.group_id_hex,
+        &retiring_epochs,
+    )?;
+    Ok(())
+}
+
+fn encrypted_media_secret_reference_epochs_for_message_tx(
+    tx: &Connection,
+    group_id_hex: &str,
+    message_id_hex: &str,
+) -> StorageResult<BTreeSet<i64>> {
+    let mut statement = tx
+        .prepare(
+            "SELECT DISTINCT source_epoch
+             FROM encrypted_media_epoch_secret_references
+             WHERE group_id_hex = ?1 AND message_id_hex = ?2",
+        )
+        .storage()?;
+    statement
+        .query_map(params![group_id_hex, message_id_hex], |row| row.get(0))
+        .storage()?
+        .collect::<Result<BTreeSet<_>, _>>()
+        .storage()
+}
+
+/// Retire candidate exporter epochs that no retained V1 or V2 message still
+/// references. The retirement watermark is independent of key-row existence,
+/// so a later cache hydration cannot resurrect an epoch pruned before its key
+/// was ever persisted. V1 and V2 share the same MLS exporter value; their
+/// references therefore protect every cached component row for the epoch.
+pub(crate) fn retire_unreferenced_encrypted_media_secret_epochs_tx(
+    tx: &Connection,
+    group_id_hex: &str,
+    candidate_epochs: &BTreeSet<i64>,
+) -> StorageResult<usize> {
+    let mut deleted = 0usize;
+    for source_epoch in candidate_epochs {
+        let referenced = tx
+            .query_row(
+                "SELECT EXISTS (
+                     SELECT 1
+                     FROM encrypted_media_epoch_secret_references
+                     WHERE group_id_hex = ?1 AND source_epoch = ?2
+                 )",
+                params![group_id_hex, source_epoch],
+                |row| row.get::<_, i64>(0),
+            )
+            .storage()?
+            != 0;
+        if referenced {
+            continue;
+        }
+
+        tx.execute(
+            "INSERT INTO encrypted_media_epoch_secret_retirement_watermarks (
+                 group_id_hex, retired_through_epoch, retired_at_unix_seconds
+             ) VALUES (?1, ?2, ?3)
+             ON CONFLICT(group_id_hex) DO UPDATE SET
+                 retired_through_epoch = max(
+                     encrypted_media_epoch_secret_retirement_watermarks.retired_through_epoch,
+                     excluded.retired_through_epoch
+                 ),
+                 retired_at_unix_seconds = excluded.retired_at_unix_seconds",
+            params![group_id_hex, source_epoch, unix_now_seconds_i64()],
+        )
+        .storage()?;
+        tx.execute(
+            "UPDATE encrypted_media_epoch_secrets
+             SET secret = zeroblob(length(secret))
+             WHERE retention_managed = 1
+               AND group_id_hex = ?1
+               AND source_epoch = ?2",
+            params![group_id_hex, source_epoch],
+        )
+        .storage()?;
+        deleted = deleted.saturating_add(
+            tx.execute(
+                "DELETE FROM encrypted_media_epoch_secrets
+                 WHERE retention_managed = 1
+                   AND group_id_hex = ?1
+                   AND source_epoch = ?2",
+                params![group_id_hex, source_epoch],
+            )
+            .storage()?,
+        );
+    }
+    Ok(deleted)
+}
+
+/// Securely wipe every cached exporter value for a locally deleted group and
+/// leave a group-wide barrier. MLS state intentionally survives local app-data
+/// deletion, so the barrier prevents that retained state from immediately
+/// rehydrating wiped epochs; a newly retained media reference still authorizes
+/// its exact source epoch.
+pub(crate) fn retire_all_encrypted_media_secrets_for_group_tx(
+    tx: &Connection,
+    group_id_hex: &str,
+) -> StorageResult<usize> {
+    let has_group_data = tx
+        .query_row(
+            "SELECT
+                 EXISTS (SELECT 1 FROM account_groups WHERE group_id_hex = ?1)
+                 OR EXISTS (SELECT 1 FROM app_events WHERE group_id_hex = ?1)
+                 OR EXISTS (
+                     SELECT 1 FROM encrypted_media_epoch_secrets WHERE group_id_hex = ?1
+                 )
+                 OR EXISTS (
+                     SELECT 1 FROM encrypted_media_epoch_secret_references
+                     WHERE group_id_hex = ?1
+                 )",
+            params![group_id_hex],
+            |row| row.get::<_, i64>(0),
+        )
+        .storage()?
+        != 0;
+    if !has_group_data {
+        return Ok(0);
+    }
+
+    tx.execute(
+        "INSERT INTO encrypted_media_epoch_secret_retirement_watermarks (
+             group_id_hex, retired_through_epoch, retired_at_unix_seconds
+         ) VALUES (?1, ?2, ?3)
+         ON CONFLICT(group_id_hex) DO UPDATE SET
+             retired_through_epoch = excluded.retired_through_epoch,
+             retired_at_unix_seconds = excluded.retired_at_unix_seconds",
+        params![group_id_hex, i64::MAX, unix_now_seconds_i64()],
+    )
+    .storage()?;
+    tx.execute(
+        "UPDATE encrypted_media_epoch_secrets
+         SET secret = zeroblob(length(secret))
+         WHERE group_id_hex = ?1",
+        params![group_id_hex],
+    )
+    .storage()?;
+    tx.execute(
+        "DELETE FROM encrypted_media_epoch_secrets WHERE group_id_hex = ?1",
+        params![group_id_hex],
+    )
+    .storage()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::StoredAppEvent;
+    use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
+
+    fn media_event(id: &str, recorded_at: u64, source_epoch: u64) -> StoredAppEvent {
+        media_event_with_versions(id, recorded_at, source_epoch, &[ENCRYPTED_MEDIA_FORMAT_V1])
+    }
+
+    fn media_event_with_versions(
+        id: &str,
+        recorded_at: u64,
+        source_epoch: u64,
+        versions: &[&str],
+    ) -> StoredAppEvent {
+        StoredAppEvent {
+            group_id_hex: "aa".to_owned(),
+            message_id_hex: id.to_owned(),
+            source_message_id_hex: Some(format!("source-{id}")),
+            source_epoch: Some(source_epoch),
+            direction: "received".to_owned(),
+            sender: "sender".to_owned(),
+            plaintext: String::new(),
+            kind: MARMOT_APP_EVENT_KIND_CHAT,
+            tags: versions
+                .iter()
+                .map(|version| {
+                    vec![
+                        "imeta".to_owned(),
+                        format!("v {version}"),
+                        format!("ciphertext_sha256 {}", "ab".repeat(32)),
+                    ]
+                })
+                .collect(),
+            recorded_at,
+            received_at: recorded_at,
+            origin_commit_id: None,
+            moderation_grant: false,
+        }
+    }
+
+    fn secret_is_referenced(
+        store: &SqliteAccountStorage,
+        group_id_hex: &str,
+        component_id: u16,
+        source_epoch: u64,
+    ) -> bool {
+        store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT EXISTS (
+                     SELECT 1
+                     FROM encrypted_media_epoch_secret_references
+                     WHERE group_id_hex = ?1
+                       AND component_id = ?2
+                       AND source_epoch = ?3
+                 )",
+                params![
+                    group_id_hex,
+                    i64::from(component_id),
+                    u64_to_i64(source_epoch).unwrap()
+                ],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap()
+            != 0
+    }
 
     #[test]
     fn encrypted_media_epoch_secret_round_trips_and_replaces() {
         let store = SqliteAccountStorage::in_memory().unwrap();
-        let group_id_hex = "ab".repeat(32);
+        let group_id_hex = "aa";
+        store
+            .record_app_event(&media_event("retained", 10, 7))
+            .unwrap();
         assert_eq!(
             store
-                .encrypted_media_epoch_secret(&group_id_hex, 0x8008, 7)
+                .encrypted_media_epoch_secret(group_id_hex, 0x8008, 7)
                 .unwrap(),
             None
         );
 
         store
-            .remember_encrypted_media_epoch_secret(&group_id_hex, 0x8008, 7, &[1, 2, 3])
+            .remember_encrypted_media_epoch_secret(group_id_hex, 0x8008, 7, &[1, 2, 3])
             .unwrap();
         assert_eq!(
             store
-                .encrypted_media_epoch_secret(&group_id_hex, 0x8008, 7)
+                .encrypted_media_epoch_secret(group_id_hex, 0x8008, 7)
                 .unwrap(),
             Some(vec![1, 2, 3])
         );
 
         store
-            .remember_encrypted_media_epoch_secret(&group_id_hex, 0x8008, 7, &[4, 5, 6])
+            .remember_encrypted_media_epoch_secret(group_id_hex, 0x8008, 7, &[4, 5, 6])
             .unwrap();
         assert_eq!(
             store
-                .encrypted_media_epoch_secret(&group_id_hex, 0x8008, 7)
+                .encrypted_media_epoch_secret(group_id_hex, 0x8008, 7)
                 .unwrap(),
             Some(vec![4, 5, 6])
         );
+    }
+
+    #[test]
+    fn unreferenced_non_retired_cached_secret_can_be_served() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[1, 2, 3])
+            .unwrap();
+
+        assert_eq!(
+            store.encrypted_media_epoch_secret("aa", 0x8008, 7).unwrap(),
+            Some(vec![1, 2, 3])
+        );
+        let durable_rows: i64 = store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT count(*) FROM encrypted_media_epoch_secrets",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            durable_rows, 1,
+            "pre-cached secrets remain for delayed messages"
+        );
+    }
+
+    #[test]
+    fn final_retained_media_message_prune_deletes_its_epoch_secret() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[1, 2, 3])
+            .unwrap();
+        store.record_app_event(&media_event("old", 10, 7)).unwrap();
+
+        let outcome = store.secure_prune_app_events_before("aa", 11).unwrap();
+        assert_eq!(outcome.pruned_messages, 1);
+        assert_eq!(outcome.pruned_media_epoch_secrets, 1);
+        assert_eq!(
+            store.encrypted_media_epoch_secret("aa", 0x8008, 7).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn duplicate_attachments_create_one_epoch_secret_reference() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[1, 2, 3])
+            .unwrap();
+        let duplicate = media_event_with_versions(
+            "duplicate",
+            10,
+            7,
+            &[ENCRYPTED_MEDIA_FORMAT_V1, ENCRYPTED_MEDIA_FORMAT_V1],
+        );
+
+        store.record_app_event(&duplicate).unwrap();
+
+        let references: i64 = store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT count(*) FROM encrypted_media_epoch_secret_references
+                 WHERE group_id_hex = 'aa' AND message_id_hex = 'duplicate'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(references, 1);
+    }
+
+    #[test]
+    fn shared_epoch_secret_survives_partial_sweep_until_final_reference() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[1, 2, 3])
+            .unwrap();
+        store.record_app_event(&media_event("old", 10, 7)).unwrap();
+        store.record_app_event(&media_event("new", 20, 7)).unwrap();
+
+        let partial = store.secure_prune_app_events_before("aa", 15).unwrap();
+        assert_eq!(partial.pruned_messages, 1);
+        assert_eq!(partial.pruned_media_epoch_secrets, 0);
+        assert!(secret_is_referenced(&store, "aa", 0x8008, 7));
+        assert_eq!(
+            store.encrypted_media_epoch_secret("aa", 0x8008, 7).unwrap(),
+            Some(vec![1, 2, 3])
+        );
+
+        let final_sweep = store.secure_prune_app_events_before("aa", 21).unwrap();
+        assert_eq!(final_sweep.pruned_messages, 1);
+        assert_eq!(final_sweep.pruned_media_epoch_secrets, 1);
+        assert_eq!(
+            store.encrypted_media_epoch_secret("aa", 0x8008, 7).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn media_v2_reference_is_tracked_under_its_distinct_component_id() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .remember_encrypted_media_epoch_secret(
+                "aa",
+                GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID,
+                7,
+                &[4, 5, 6],
+            )
+            .unwrap();
+        store
+            .record_app_event(&media_event_with_versions(
+                "v2",
+                10,
+                7,
+                &[ENCRYPTED_MEDIA_FORMAT_V2],
+            ))
+            .unwrap();
+
+        assert!(secret_is_referenced(
+            &store,
+            "aa",
+            GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID,
+            7,
+        ));
+        assert!(!secret_is_referenced(
+            &store,
+            "aa",
+            GROUP_ENCRYPTED_MEDIA_COMPONENT_ID,
+            7,
+        ));
+        let outcome = store.secure_prune_app_events_before("aa", 11).unwrap();
+        assert_eq!(outcome.pruned_media_epoch_secrets, 1);
+        assert_eq!(
+            store
+                .encrypted_media_epoch_secret("aa", GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID, 7,)
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn retired_secret_cannot_be_rehydrated_without_a_new_retained_reference() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[1, 2, 3])
+            .unwrap();
+        store.record_app_event(&media_event("old", 10, 7)).unwrap();
+        store.secure_prune_app_events_before("aa", 11).unwrap();
+
+        store
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[9, 9, 9])
+            .unwrap();
+        assert!(
+            !store
+                .encrypted_media_epoch_secret_may_be_served("aa", 7)
+                .unwrap()
+        );
+        assert_eq!(
+            store.encrypted_media_epoch_secret("aa", 0x8008, 7).unwrap(),
+            None,
+            "eager current-epoch caching must not resurrect a retired secret"
+        );
+
+        store.record_app_event(&media_event("late", 20, 7)).unwrap();
+        assert!(
+            store
+                .encrypted_media_epoch_secret_may_be_served("aa", 7)
+                .unwrap()
+        );
+        store
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[9, 9, 9])
+            .unwrap();
+        assert_eq!(
+            store.encrypted_media_epoch_secret("aa", 0x8008, 7).unwrap(),
+            Some(vec![9, 9, 9]),
+            "a newly retained sibling makes the source epoch usable again"
+        );
+    }
+
+    #[test]
+    fn retirement_watermark_is_bounded_and_advances_monotonically() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[1, 2, 3])
+            .unwrap();
+        store
+            .record_app_event(&media_event("seven", 10, 7))
+            .unwrap();
+        store.secure_prune_app_events_before("aa", 11).unwrap();
+
+        store
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 6, &[6])
+            .unwrap();
+        store
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 8, &[8])
+            .unwrap();
+        let durable_epochs = |store: &SqliteAccountStorage| {
+            let conn = store.lock().unwrap();
+            let mut statement = conn
+                .prepare(
+                    "SELECT source_epoch FROM encrypted_media_epoch_secrets
+                     ORDER BY source_epoch",
+                )
+                .unwrap();
+            statement
+                .query_map([], |row| row.get::<_, i64>(0))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+        };
+        assert_eq!(durable_epochs(&store), vec![8]);
+
+        store
+            .record_app_event(&media_event("eight", 20, 8))
+            .unwrap();
+        store.secure_prune_app_events_before("aa", 21).unwrap();
+        let watermark: (i64, i64) = store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT count(*), max(retired_through_epoch)
+                 FROM encrypted_media_epoch_secret_retirement_watermarks",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(watermark, (1, 8));
+    }
+
+    #[test]
+    fn retired_secret_stays_unavailable_after_restart() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("media-retirement.sqlite");
+        let store = SqliteAccountStorage::from_connection_with_options(
+            rusqlite::Connection::open(&path).unwrap(),
+            crate::SqliteStorageOptions::default(),
+        )
+        .unwrap();
+        store
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[1, 2, 3])
+            .unwrap();
+        store.record_app_event(&media_event("old", 10, 7)).unwrap();
+        store.secure_prune_app_events_before("aa", 11).unwrap();
+        drop(store);
+
+        let reopened = SqliteAccountStorage::from_connection_with_options(
+            rusqlite::Connection::open(&path).unwrap(),
+            crate::SqliteStorageOptions::default(),
+        )
+        .unwrap();
+        reopened
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[9, 9, 9])
+            .unwrap();
+        assert_eq!(
+            reopened
+                .encrypted_media_epoch_secret("aa", 0x8008, 7)
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn reference_without_cached_secret_still_retires_across_restart() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory
+            .path()
+            .join("media-reference-only-retirement.sqlite");
+        let store = SqliteAccountStorage::from_connection_with_options(
+            rusqlite::Connection::open(&path).unwrap(),
+            crate::SqliteStorageOptions::default(),
+        )
+        .unwrap();
+        store
+            .record_app_event(&media_event("reference-only", 10, 7))
+            .unwrap();
+        store.secure_prune_app_events_before("aa", 11).unwrap();
+        store
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[1, 2, 3])
+            .unwrap();
+        assert_eq!(
+            store.encrypted_media_epoch_secret("aa", 0x8008, 7).unwrap(),
+            None,
+            "retirement must not depend on a key row existing at prune time"
+        );
+        drop(store);
+
+        let reopened = SqliteAccountStorage::from_connection_with_options(
+            rusqlite::Connection::open(&path).unwrap(),
+            crate::SqliteStorageOptions::default(),
+        )
+        .unwrap();
+        reopened
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[4, 5, 6])
+            .unwrap();
+        assert_eq!(
+            reopened
+                .encrypted_media_epoch_secret("aa", 0x8008, 7)
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn v1_and_v2_references_share_one_exporter_secret_lifetime() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .remember_encrypted_media_epoch_secret(
+                "aa",
+                GROUP_ENCRYPTED_MEDIA_COMPONENT_ID,
+                7,
+                &[1, 2, 3],
+            )
+            .unwrap();
+        store
+            .record_app_event(&media_event_with_versions(
+                "v1-old",
+                10,
+                7,
+                &[ENCRYPTED_MEDIA_FORMAT_V1],
+            ))
+            .unwrap();
+        store
+            .record_app_event(&media_event_with_versions(
+                "v2-new",
+                20,
+                7,
+                &[ENCRYPTED_MEDIA_FORMAT_V2],
+            ))
+            .unwrap();
+
+        let partial = store.secure_prune_app_events_before("aa", 15).unwrap();
+        assert_eq!(partial.pruned_messages, 1);
+        assert_eq!(partial.pruned_media_epoch_secrets, 0);
+        assert_eq!(
+            store
+                .encrypted_media_epoch_secret("aa", GROUP_ENCRYPTED_MEDIA_COMPONENT_ID, 7)
+                .unwrap(),
+            Some(vec![1, 2, 3]),
+            "a retained V2 sibling needs the same source-epoch exporter secret"
+        );
+
+        let final_sweep = store.secure_prune_app_events_before("aa", 21).unwrap();
+        assert_eq!(final_sweep.pruned_messages, 1);
+        assert_eq!(final_sweep.pruned_media_epoch_secrets, 1);
+        assert_eq!(
+            store
+                .encrypted_media_epoch_secret("aa", GROUP_ENCRYPTED_MEDIA_COMPONENT_ID, 7)
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn prune_failure_rolls_back_message_reference_secret_and_retirement() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store
+            .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[1, 2, 3])
+            .unwrap();
+        store.record_app_event(&media_event("old", 10, 7)).unwrap();
+        store
+            .lock()
+            .unwrap()
+            .execute_batch(
+                "CREATE TEMP TRIGGER abort_media_secret_delete
+                 BEFORE DELETE ON encrypted_media_epoch_secrets
+                 BEGIN
+                    SELECT RAISE(ABORT, 'abort media secret delete');
+                 END;",
+            )
+            .unwrap();
+
+        let error = store
+            .secure_prune_app_events_before("aa", 11)
+            .expect_err("secret-delete failure must abort the whole prune");
+        assert!(format!("{error}").contains("abort media secret delete"));
+        assert_eq!(store.app_message_count().unwrap(), 1);
+        assert!(secret_is_referenced(&store, "aa", 0x8008, 7));
+        assert_eq!(
+            store.encrypted_media_epoch_secret("aa", 0x8008, 7).unwrap(),
+            Some(vec![1, 2, 3])
+        );
+        let retirement_watermarks: i64 = store
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT count(*) FROM encrypted_media_epoch_secret_retirement_watermarks",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retirement_watermarks, 0);
     }
 }

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -54,6 +54,8 @@ mod migration_0026_message_drafts;
 mod migration_0027_app_event_moderation_grant;
 #[path = "migrations/0028_ingress_dedup.rs"]
 mod migration_0028_ingress_dedup;
+#[path = "migrations/0029_encrypted_media_secret_references.rs"]
+mod migration_0029_encrypted_media_secret_references;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -205,6 +207,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 28,
         name: "0028_ingress_dedup",
         apply: migration_0028_ingress_dedup::apply,
+    },
+    Migration {
+        version: 29,
+        name: "0029_encrypted_media_secret_references",
+        apply: migration_0029_encrypted_media_secret_references::apply,
     },
 ];
 
@@ -409,6 +416,63 @@ mod tests {
     fn initial_schema_migration_is_recorded() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         assert_eq!(applied_migrations(&store), expected_migrations());
+    }
+
+    #[test]
+    fn media_secret_reference_migration_backfills_known_rows_conservatively() {
+        let mut connection = rusqlite::Connection::open_in_memory().unwrap();
+        connection
+            .pragma_update(None, "foreign_keys", true)
+            .unwrap();
+        run(&mut connection, &MIGRATIONS[..28]).unwrap();
+        let media_tags =
+            serde_json::to_string(&[vec!["imeta".to_owned(), "v encrypted-media-v1".to_owned()]])
+                .unwrap();
+        connection
+            .execute(
+                "INSERT INTO app_events (
+                     group_id_hex, message_id_hex, source_message_id_hex, source_epoch,
+                     direction, sender, plaintext, kind, tags_json, recorded_at, received_at
+                 ) VALUES ('aa', 'media', 'source-media', 7, 'received', 'sender', '', 9, ?1, 10, 10)",
+                params![media_tags],
+            )
+            .unwrap();
+        for (epoch, secret) in [(7_i64, vec![1_u8, 2, 3]), (8, vec![4_u8, 5, 6])] {
+            connection
+                .execute(
+                    "INSERT INTO encrypted_media_epoch_secrets (
+                         group_id_hex, component_id, source_epoch, secret,
+                         created_at_unix_seconds
+                     ) VALUES ('aa', 32776, ?1, ?2, 10)",
+                    params![epoch, secret],
+                )
+                .unwrap();
+        }
+
+        run(&mut connection, MIGRATIONS).unwrap();
+
+        let references: i64 = connection
+            .query_row(
+                "SELECT count(*) FROM encrypted_media_epoch_secret_references
+                 WHERE group_id_hex = 'aa' AND message_id_hex = 'media'
+                   AND component_id = 32776 AND source_epoch = 7",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(references, 1);
+        let managed = connection
+            .prepare(
+                "SELECT source_epoch, retention_managed
+                 FROM encrypted_media_epoch_secrets
+                 ORDER BY source_epoch",
+            )
+            .unwrap()
+            .query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(managed, vec![(7, 1), (8, 0)]);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/migrations/0029_encrypted_media_secret_references.rs
+++ b/crates/storage-sqlite/src/migrations/0029_encrypted_media_secret_references.rs
@@ -1,0 +1,106 @@
+use crate::{
+    SqliteResultExt, encrypted_media_secrets::encrypted_media_component_ids, tags_from_json,
+};
+use cgka_traits::storage::StorageResult;
+use rusqlite::{Transaction, params};
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+ALTER TABLE encrypted_media_epoch_secrets
+    ADD COLUMN retention_managed INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE encrypted_media_epoch_secret_references (
+    group_id_hex TEXT NOT NULL,
+    message_id_hex TEXT NOT NULL,
+    component_id INTEGER NOT NULL,
+    source_epoch INTEGER NOT NULL,
+    PRIMARY KEY (group_id_hex, message_id_hex, component_id, source_epoch),
+    FOREIGN KEY (group_id_hex, message_id_hex)
+        REFERENCES app_events (group_id_hex, message_id_hex) ON DELETE CASCADE
+);
+CREATE INDEX idx_media_secret_references_secret
+    ON encrypted_media_epoch_secret_references (
+        group_id_hex, source_epoch, component_id, message_id_hex
+    );
+
+-- A bounded retirement watermark prevents eager current-epoch caching from
+-- rehydrating key bytes after the final retained source-message reference was
+-- deleted. Rows are metadata only; they contain no key material.
+CREATE TABLE encrypted_media_epoch_secret_retirement_watermarks (
+    group_id_hex TEXT PRIMARY KEY,
+    retired_through_epoch INTEGER NOT NULL CHECK(retired_through_epoch >= 0),
+    retired_at_unix_seconds INTEGER NOT NULL CHECK(retired_at_unix_seconds >= 0)
+) WITHOUT ROWID;
+"#,
+    )
+    .storage()?;
+
+    backfill_references(tx)?;
+    tx.execute(
+        "UPDATE encrypted_media_epoch_secrets AS secrets
+         SET retention_managed = 1
+         WHERE EXISTS (
+             SELECT 1
+             FROM encrypted_media_epoch_secret_references AS refs
+             WHERE refs.group_id_hex = secrets.group_id_hex
+               AND refs.source_epoch = secrets.source_epoch
+         )",
+        [],
+    )
+    .storage()?;
+    Ok(())
+}
+
+/// Backfill only references that can be proved from retained app-event rows.
+/// Existing secrets without a recoverable retained reference deliberately keep
+/// `retention_managed = 0`: a migration cannot distinguish stale material from a
+/// secret cached in advance for delayed source-epoch delivery, so later message
+/// sweeps must not guess destructively.
+fn backfill_references(tx: &Transaction<'_>) -> StorageResult<()> {
+    let mut statement = tx
+        .prepare(
+            "SELECT group_id_hex, message_id_hex, source_epoch, tags_json
+             FROM app_events
+             WHERE source_epoch IS NOT NULL",
+        )
+        .storage()?;
+    let events = statement
+        .query_map([], |row| {
+            let tags = tags_from_json(row.get::<_, String>(3)?).map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    3,
+                    rusqlite::types::Type::Text,
+                    Box::new(error),
+                )
+            })?;
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                tags,
+            ))
+        })
+        .storage()?
+        .collect::<Result<Vec<_>, _>>()
+        .storage()?;
+    drop(statement);
+
+    for (group_id_hex, message_id_hex, source_epoch, tags) in events {
+        for component_id in encrypted_media_component_ids(&tags) {
+            tx.execute(
+                "INSERT OR IGNORE INTO encrypted_media_epoch_secret_references (
+                     group_id_hex, message_id_hex, component_id, source_epoch
+                 ) VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    group_id_hex,
+                    message_id_hex,
+                    i64::from(component_id),
+                    source_epoch,
+                ],
+            )
+            .storage()?;
+        }
+    }
+    Ok(())
+}

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -1,8 +1,12 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use crate::{
-    SqliteAccountStorage, SqliteResultExt, optional_u64_to_i64, tags_from_json, u64_to_i64,
-    unix_now_seconds,
+    SqliteAccountStorage, SqliteResultExt,
+    encrypted_media_secrets::{
+        encrypted_media_component_ids, replace_encrypted_media_secret_references_tx,
+        retire_unreferenced_encrypted_media_secret_epochs_tx,
+    },
+    optional_u64_to_i64, tags_from_json, u64_to_i64, unix_now_seconds,
 };
 use cgka_traits::app_event::{
     EVENT_REF_TAG, MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY, MARMOT_APP_EVENT_KIND_AGENT_OPERATION,
@@ -185,6 +189,9 @@ pub struct TimelineProjectionUpdate {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SecurePruneAppEventsResult {
     pub pruned_messages: usize,
+    /// Number of versioned encrypted-media epoch secrets whose final retained
+    /// source-message reference was removed in this transaction.
+    pub pruned_media_epoch_secrets: usize,
     /// Sorted set of encrypted-media blob ids referenced by pruned messages.
     /// Callers should treat this as an unordered purge set.
     pub media_ciphertext_sha256: Vec<String>,
@@ -250,6 +257,7 @@ struct RawAppEvent {
 struct PrunedAppEvent {
     message_id_hex: String,
     kind: u64,
+    source_epoch: Option<u64>,
     tags: Vec<Vec<String>>,
 }
 
@@ -403,6 +411,7 @@ impl SqliteAccountStorage {
                 ],
             )
             .storage()?;
+            replace_encrypted_media_secret_references_tx(&conn, event)?;
             upsert_message_modifier_edges_tx(&conn, event)?;
             if can_incrementally_project {
                 for message_id in &affected_message_ids {
@@ -780,9 +789,15 @@ pub(crate) fn secure_prune_app_events_before_tx(
     let mut pruned_message_ids = BTreeSet::new();
     let mut affected_message_ids = BTreeSet::new();
     let mut media_ciphertext_sha256 = BTreeSet::new();
+    let mut retiring_media_epochs = BTreeSet::new();
     for event in &pruned_events {
         pruned_message_ids.insert(event.message_id_hex.clone());
         collect_media_ciphertext_hashes(&event.tags, &mut media_ciphertext_sha256);
+        if !encrypted_media_component_ids(&event.tags).is_empty()
+            && let Some(source_epoch) = event.source_epoch
+        {
+            retiring_media_epochs.insert(u64_to_i64(source_epoch)?);
+        }
         affected_message_ids.extend(affected_timeline_message_ids_for_pruned_event_tx(
             tx,
             group_id_hex,
@@ -807,6 +822,11 @@ pub(crate) fn secure_prune_app_events_before_tx(
             params![group_id_hex, u64_to_i64(cutoff_recorded_at)?],
         )
         .storage()?;
+    let pruned_media_epoch_secrets = retire_unreferenced_encrypted_media_secret_epochs_tx(
+        tx,
+        group_id_hex,
+        &retiring_media_epochs,
+    )?;
 
     delete_timeline_projection_rows_by_ids_tx(tx, group_id_hex, &pruned_message_ids)?;
     affected_message_ids.retain(|message_id| !pruned_message_ids.contains(message_id));
@@ -817,6 +837,7 @@ pub(crate) fn secure_prune_app_events_before_tx(
 
     Ok(SecurePruneAppEventsResult {
         pruned_messages: pruned,
+        pruned_media_epoch_secrets,
         media_ciphertext_sha256: media_ciphertext_sha256.into_iter().collect(),
     })
 }
@@ -1337,7 +1358,7 @@ fn app_events_before_cutoff_tx(
 ) -> StorageResult<Vec<PrunedAppEvent>> {
     let mut stmt = tx
         .prepare(
-            "SELECT message_id_hex, kind, tags_json
+            "SELECT message_id_hex, kind, source_epoch, tags_json
              FROM app_events
              WHERE group_id_hex = ?1
                AND recorded_at < ?2
@@ -1347,9 +1368,9 @@ fn app_events_before_cutoff_tx(
     stmt.query_map(
         params![group_id_hex, u64_to_i64(cutoff_recorded_at)?],
         |row| {
-            let tags = tags_from_json(row.get::<_, String>(2)?).map_err(|err| {
+            let tags = tags_from_json(row.get::<_, String>(3)?).map_err(|err| {
                 rusqlite::Error::FromSqlConversionFailure(
-                    2,
+                    3,
                     rusqlite::types::Type::Text,
                     Box::new(err),
                 )
@@ -1357,6 +1378,9 @@ fn app_events_before_cutoff_tx(
             Ok(PrunedAppEvent {
                 message_id_hex: row.get(0)?,
                 kind: row.get::<_, i64>(1)?.try_into().unwrap_or_default(),
+                source_epoch: row
+                    .get::<_, Option<i64>>(2)?
+                    .and_then(|value| value.try_into().ok()),
                 tags,
             })
         },

--- a/crates/traits/src/app_components/mod.rs
+++ b/crates/traits/src/app_components/mod.rs
@@ -63,7 +63,11 @@ pub const NOSTR_ROUTING_COMPONENT_ID: AppComponentId = 0x8004;
 pub const GROUP_MESSAGE_RETENTION_COMPONENT_ID: AppComponentId = 0x8005;
 pub const AGENT_TEXT_STREAM_QUIC_COMPONENT_ID: AppComponentId = 0x8006;
 pub const GROUP_AVATAR_URL_COMPONENT_ID: AppComponentId = 0x8007;
+/// Frozen encrypted-media v1 component id. Kept under its original public name
+/// for compatibility; current-profile Media V2 uses [`GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID`].
 pub const GROUP_ENCRYPTED_MEDIA_COMPONENT_ID: AppComponentId = 0x8008;
+/// Current encrypted-media v2 component id.
+pub const GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID: AppComponentId = 0x800b;
 /// Lookup key for the encrypted-media secret in the
 /// [`crate::group_context::GroupContextSnapshot`] secrets map. This is an
 /// internal cache key, NOT the MLS exporter label/context: the secret is derived
@@ -79,7 +83,9 @@ pub const GROUP_MESSAGE_RETENTION_COMPONENT: &str = "marmot.group.message-retent
 pub const AGENT_TEXT_STREAM_QUIC_COMPONENT: &str = "marmot.group.agent-text-stream.quic.v1";
 pub const GROUP_AVATAR_URL_COMPONENT: &str = "marmot.group.avatar-url.v1";
 pub const GROUP_ENCRYPTED_MEDIA_COMPONENT: &str = "marmot.group.encrypted-media.v1";
+pub const GROUP_ENCRYPTED_MEDIA_V2_COMPONENT: &str = "marmot.group.encrypted-media.v2";
 pub const ENCRYPTED_MEDIA_FORMAT_V1: &str = "encrypted-media-v1";
+pub const ENCRYPTED_MEDIA_FORMAT_V2: &str = "encrypted-media-v2";
 pub const BLOSSOM_LOCATOR_KIND_V1: &str = "blossom-v1";
 
 /// Maximum encoded length of a group avatar URL, in bytes.


### PR DESCRIPTION
## Summary

- track version-aware retained-message references for each encrypted-media exporter epoch
- retire key rows and persist anti-rehydration watermarks in the same SQLite transaction as final-reference pruning
- keep V1/V2 references coherent around their shared MLS exporter secret, including duplicate, partial-sweep, restart, and local-group-delete cases
- gate runtime hydration after durable retirement and recache only after a newly retained reference is durable
- preserve publish success when the post-publish cache retry fails, avoiding duplicate sends

## Dependency

Depends on #1068 (`#1055`) for source-epoch-pinned retention deadlines. Both branches currently add migration 0029, so this draft must be rebased and this migration renumbered after #1068 lands.

The V2 reference identity is recorded now; V2 runtime behavior remains owned by #1052.

## Test plan

- `cargo test -p storage-sqlite --locked` (250 passed)
- `cargo test -p cgka-traits --locked` (101 passed across unit/integration/snapshot suites)
- `cargo test -p marmot-app media --locked` (46 unit + 4 relay media tests passed)
- `cargo test -p marmot-app --test relay_runtime retained_media_rehydrates_a_retired_current_epoch_before_the_group_advances --locked -- --exact`
- `just fast-ci`

Fixes #1056
