### PR TITLE
fix: authorize inbound MLS proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,7 @@ dependencies = [
  "marmot-forensics",
  "nostr",
  "openmls",
+ "openmls_basic_credential",
  "openmls_rust_crypto",
  "openmls_traits",
  "proptest",

--- a/crates/cgka-conformance-simulator/Cargo.toml
+++ b/crates/cgka-conformance-simulator/Cargo.toml
@@ -34,6 +34,7 @@ sha2.workspace = true
 tempfile.workspace = true
 
 [dev-dependencies]
+openmls_basic_credential.workspace = true
 # Byte-level conformance vectors for the agent text stream QUIC feature pin
 # the transport crates' key derivation, AAD, and broker control bytes.
 transport-quic-stream.workspace = true

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -874,6 +874,16 @@ impl HarnessClient {
         self.default_group.clone().expect("group")
     }
 
+    /// Peeler snapshot for the client's default group.
+    pub fn group_context_snapshot(&self) -> Result<GroupContextSnapshot, EngineError> {
+        let gid = self.default_group.clone().expect("group");
+        let ctx = self.engine.group_context(&gid)?;
+        Ok(GroupContextSnapshot::from_context(
+            ctx.as_ref(),
+            &[transport_nostr_peeler::DEFAULT_EXPORTER_LABEL],
+        ))
+    }
+
     fn next_app_payload(&mut self, payload: Vec<u8>) -> Vec<u8> {
         let seq = self.app_event_counter;
         self.app_event_counter = self

--- a/crates/cgka-conformance-simulator/tests/canonicalization_contract.rs
+++ b/crates/cgka-conformance-simulator/tests/canonicalization_contract.rs
@@ -272,6 +272,7 @@ fn commit_edges_materialize_candidate_branches_before_selection() {
             message_id: "withheld-1".into(),
             kind: MessageKind::Commit,
             reason: DroppedMessageReason::InvalidAgainstCandidateState,
+            rejection_category: None,
         }]
     );
 }
@@ -394,16 +395,19 @@ fn proposals_are_accepted_only_when_consumed_by_canonical_commits() {
                 message_id: "losing-commit".into(),
                 kind: MessageKind::Commit,
                 reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: None,
             },
             DroppedMessage {
                 message_id: "losing-proposal".into(),
                 kind: MessageKind::Proposal,
                 reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: None,
             },
             DroppedMessage {
                 message_id: "pending-proposal".into(),
                 kind: MessageKind::Proposal,
                 reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: None,
             },
         ]
     );
@@ -448,11 +452,13 @@ fn materialized_candidates_drive_commit_and_proposal_dispositions() {
                 message_id: "losing-commit".into(),
                 kind: MessageKind::Commit,
                 reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: None,
             },
             DroppedMessage {
                 message_id: "losing-proposal".into(),
                 kind: MessageKind::Proposal,
                 reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: None,
             },
         ]
     );
@@ -514,6 +520,7 @@ fn commit_beyond_rollback_horizon_is_discarded() {
             message_id: "stale-commit".into(),
             kind: MessageKind::Commit,
             reason: DroppedMessageReason::BeyondRollbackHorizon,
+            rejection_category: None,
         }]
     );
 }

--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -19,9 +19,7 @@ use cgka_engine::provider::EngineOpenMlsProvider;
 use cgka_traits::capabilities::{
     Capability, CapabilityRequirement, Feature, GroupCapabilities, RequirementLevel,
 };
-use cgka_traits::engine::CgkaEngine;
 use cgka_traits::group::{Group, Member};
-use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::message::{MessageRecord, MessageState};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
@@ -33,7 +31,7 @@ use openmls::group::MlsGroup;
 use openmls::prelude::tls_codec::Serialize as _;
 use openmls_rust_crypto::RustCrypto;
 use openmls_traits::OpenMlsProvider;
-use transport_nostr_peeler::{DEFAULT_EXPORTER_LABEL, NostrMlsPeeler};
+use transport_nostr_peeler::NostrMlsPeeler;
 
 fn pad32(name: &[u8]) -> Vec<u8> {
     let mut out = vec![0u8; 32];
@@ -1618,13 +1616,7 @@ async fn harness_tick_rejects_unauthorized_standalone_proposal() {
     let proposal_bytes = proposal_out
         .tls_serialize_detached()
         .expect("serialize proposal");
-    let group_context = bob
-        .engine
-        .group_context(&group_id)
-        .expect("bob group context");
-    let snapshot =
-        GroupContextSnapshot::from_context(group_context.as_ref(), &[DEFAULT_EXPORTER_LABEL]);
-    drop(group_context);
+    let snapshot = bob.group_context_snapshot().expect("bob group context");
     let proposal = NostrMlsPeeler::new()
         .wrap_group_message(
             &EncryptedPayload {

--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -19,14 +19,21 @@ use cgka_engine::provider::EngineOpenMlsProvider;
 use cgka_traits::capabilities::{
     Capability, CapabilityRequirement, Feature, GroupCapabilities, RequirementLevel,
 };
+use cgka_traits::engine::CgkaEngine;
 use cgka_traits::group::{Group, Member};
+use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::message::{MessageRecord, MessageState};
-use cgka_traits::storage::{GroupStorage, MessageStorage, StorageProvider};
-use cgka_traits::transport::TransportMessage;
+use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::storage::{
+    AccountDeviceSignerStorage, GroupStorage, MessageStorage, StorageProvider,
+};
+use cgka_traits::transport::{EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use openmls::group::MlsGroup;
+use openmls::prelude::tls_codec::Serialize as _;
 use openmls_rust_crypto::RustCrypto;
 use openmls_traits::OpenMlsProvider;
+use transport_nostr_peeler::{DEFAULT_EXPORTER_LABEL, NostrMlsPeeler};
 
 fn pad32(name: &[u8]) -> Vec<u8> {
     let mut out = vec![0u8; 32];
@@ -1343,11 +1350,13 @@ fn openmls_disposition_persistence_maps_all_canonicalization_states() {
                 message_id: hex::encode(losing_commit_id.as_slice()),
                 kind: MessageKind::Commit,
                 reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: None,
             },
             DroppedMessage {
                 message_id: hex::encode(malformed_proposal_id.as_slice()),
                 kind: MessageKind::Proposal,
                 reason: DroppedMessageReason::Malformed,
+                rejection_category: None,
             },
         ],
         already_seen: vec![],
@@ -1456,4 +1465,198 @@ fn store_created_message(
             payload: serde_json::to_vec(msg).expect("transport serializes"),
         })
         .expect("message stored");
+}
+
+#[tokio::test]
+async fn harness_convergence_rejects_unauthorized_standalone_proposal() {
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut carol = ClientBuilder::new(pad32(b"carol"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+
+    let bob_kp = bob.fresh_key_package().await;
+    let carol_kp = carol.fresh_key_package().await;
+    let (group_id, pending) = alice
+        .create_group("proposal-auth-harness", vec![bob_kp, carol_kp], vec![])
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+    carol.tick().await;
+
+    let crypto = RustCrypto::default();
+    let provider = EngineOpenMlsProvider::<storage_sqlite::SqliteAccountStorage>::new(
+        &crypto,
+        bob.storage().mls_storage(),
+    );
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mut mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load bob group")
+        .expect("bob group present");
+    let member_id = bob.member_id();
+    let binding = bob
+        .storage()
+        .account_device_signer(&member_id)
+        .expect("signer lookup")
+        .expect("signer present");
+    let signer = openmls_basic_credential::SignatureKeyPair::read(
+        bob.storage().mls_storage(),
+        &binding.mls_signature_public_key,
+        cgka_engine::DEFAULT_CIPHERSUITE.signature_algorithm(),
+    )
+    .expect("signer read");
+    let credential = openmls::prelude::CredentialWithKey {
+        credential: openmls::prelude::BasicCredential::new(member_id.as_slice().to_vec()).into(),
+        signature_key: signer.public().into(),
+    };
+    let leaf_node_parameters = openmls::prelude::LeafNodeParameters::builder()
+        .with_credential_with_key(credential)
+        .build();
+    let (proposal_out, _) = mls_group
+        .propose_self_update(&provider, &signer, leaf_node_parameters)
+        .expect("bob builds standalone update at OpenMLS layer");
+    let proposal_bytes = proposal_out
+        .tls_serialize_detached()
+        .expect("serialize proposal");
+    let proposal = TransportMessage {
+        id: MessageId::new(proposal_bytes[..16].to_vec()),
+        payload: proposal_bytes,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: cgka_traits::transport::TransportSource("harness-update-proposal".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    };
+
+    let observations = replay_openmls_messages(carol.storage(), &group_id, &[proposal])
+        .expect("replay unauthorized proposal");
+    assert!(
+        observations.iter().any(|observation| matches!(
+            observation,
+            OpenMlsReplayObservation::ProposalRejected {
+                category: cgka_traits::ingest::ProposalRejectionCategory::AuthorizationFailed,
+                ..
+            }
+        )),
+        "replay must emit typed proposal rejection, got {observations:?}"
+    );
+
+    let carol_provider = EngineOpenMlsProvider::<storage_sqlite::SqliteAccountStorage>::new(
+        &crypto,
+        carol.storage().mls_storage(),
+    );
+    let carol_group = MlsGroup::load(carol_provider.storage(), &mls_gid)
+        .expect("load carol group")
+        .expect("carol group present");
+    assert!(
+        carol_group.pending_proposals().next().is_none(),
+        "harness storage must not retain unauthorized standalone proposal"
+    );
+}
+
+#[tokio::test]
+async fn harness_tick_rejects_unauthorized_standalone_proposal() {
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+    let mut carol = ClientBuilder::new(pad32(b"carol"))
+        .registry(selfremove_registry())
+        .attach(&bus);
+
+    let bob_kp = bob.fresh_key_package().await;
+    let carol_kp = carol.fresh_key_package().await;
+    let (group_id, pending) = alice
+        .create_group("proposal-auth-harness-tick", vec![bob_kp, carol_kp], vec![])
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+    carol.tick().await;
+
+    let crypto = RustCrypto::default();
+    let provider = EngineOpenMlsProvider::<storage_sqlite::SqliteAccountStorage>::new(
+        &crypto,
+        bob.storage().mls_storage(),
+    );
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mut mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load bob group")
+        .expect("bob group present");
+    let member_id = bob.member_id();
+    let binding = bob
+        .storage()
+        .account_device_signer(&member_id)
+        .expect("signer lookup")
+        .expect("signer present");
+    let signer = openmls_basic_credential::SignatureKeyPair::read(
+        bob.storage().mls_storage(),
+        &binding.mls_signature_public_key,
+        cgka_engine::DEFAULT_CIPHERSUITE.signature_algorithm(),
+    )
+    .expect("signer read");
+    let credential = openmls::prelude::CredentialWithKey {
+        credential: openmls::prelude::BasicCredential::new(member_id.as_slice().to_vec()).into(),
+        signature_key: signer.public().into(),
+    };
+    let leaf_node_parameters = openmls::prelude::LeafNodeParameters::builder()
+        .with_credential_with_key(credential)
+        .build();
+    let (proposal_out, _) = mls_group
+        .propose_self_update(&provider, &signer, leaf_node_parameters)
+        .expect("bob builds standalone update at OpenMLS layer");
+    let proposal_bytes = proposal_out
+        .tls_serialize_detached()
+        .expect("serialize proposal");
+    let group_context = bob
+        .engine
+        .group_context(&group_id)
+        .expect("bob group context");
+    let snapshot =
+        GroupContextSnapshot::from_context(group_context.as_ref(), &[DEFAULT_EXPORTER_LABEL]);
+    drop(group_context);
+    let proposal = NostrMlsPeeler::new()
+        .wrap_group_message(
+            &EncryptedPayload {
+                ciphertext: proposal_bytes,
+                aad: vec![],
+            },
+            &snapshot,
+        )
+        .await
+        .expect("wrap standalone proposal through production Nostr peeler");
+
+    bus.inject(carol.bus_id, proposal);
+    let outcomes = carol.tick().await;
+    assert!(
+        outcomes.iter().any(|outcome| matches!(
+            outcome,
+            Ok(cgka_traits::ingest::IngestOutcome::Rejected {
+                category: cgka_traits::ingest::ProposalRejectionCategory::AuthorizationFailed
+            })
+        )),
+        "harness tick must reject unauthorized standalone proposal, got {outcomes:?}"
+    );
+
+    let carol_provider = EngineOpenMlsProvider::<storage_sqlite::SqliteAccountStorage>::new(
+        &crypto,
+        carol.storage().mls_storage(),
+    );
+    let carol_group = MlsGroup::load(carol_provider.storage(), &mls_gid)
+        .expect("load carol group")
+        .expect("carol group present");
+    assert!(
+        carol_group.pending_proposals().next().is_none(),
+        "harness tick must not retain unauthorized standalone proposal"
+    );
 }

--- a/crates/cgka-engine/src/account_identity_proof.rs
+++ b/crates/cgka-engine/src/account_identity_proof.rs
@@ -245,7 +245,7 @@ pub(crate) fn validate_leaf_account_identity_proof_for_member(
 
 pub(crate) fn validate_staged_commit_account_identity_proofs(
     staged: &StagedCommit,
-    group: &MlsGroup,
+    _group: &MlsGroup,
     committer: &MemberId,
     ciphersuite: Ciphersuite,
 ) -> Result<Vec<MemberId>, EngineError> {
@@ -255,21 +255,6 @@ pub(crate) fn validate_staged_commit_account_identity_proofs(
         let leaf = add.add_proposal().key_package().leaf_node();
         validate_leaf_account_identity_proof(leaf, ciphersuite)?;
         added.push(crate::identity::validated_member_id_of_leaf(leaf)?);
-    }
-
-    for update in staged.update_proposals() {
-        let expected =
-            crate::identity::member_id_of_sender(update.sender(), group).ok_or_else(|| {
-                EngineError::InvalidAccountIdentityProof(
-                    "Update proposal has no authenticated member sender".into(),
-                )
-            })?;
-        validate_leaf_account_identity_proof_for_member(
-            update.update_proposal().leaf_node(),
-            ciphersuite,
-            &expected,
-            "Update proposal",
-        )?;
     }
 
     if let Some(update_path_leaf) = staged.update_path_leaf_node() {

--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -211,7 +211,6 @@ pub(crate) fn require_admin_for_staged_commit(
     sender: Option<&MemberId>,
     staged: &StagedCommit,
 ) -> Result<(), EngineError> {
-    reject_admin_self_remove_proposals(mls_group, group_id, staged)?;
     if !staged_commit_requires_admin(staged) {
         return Ok(());
     }
@@ -223,7 +222,7 @@ pub(crate) fn require_admin_for_staged_commit(
     require_admin(mls_group, group_id, sender)
 }
 
-fn credential_account_pubkey(cred: openmls::prelude::Credential) -> Option<[u8; 32]> {
+pub(crate) fn credential_account_pubkey(cred: openmls::prelude::Credential) -> Option<[u8; 32]> {
     let basic = BasicCredential::try_from(cred).ok()?;
     <[u8; 32]>::try_from(basic.identity()).ok()
 }
@@ -465,50 +464,6 @@ pub(crate) fn reject_admins_without_member_accounts(
     }
     if admins.iter().any(|admin| !member_accounts.contains(admin)) {
         return Err(EngineError::Other("admin key has no member leaf".into()));
-    }
-    Ok(())
-}
-
-fn reject_admin_self_remove_proposals(
-    mls_group: &MlsGroup,
-    group_id: &GroupId,
-    staged: &StagedCommit,
-) -> Result<(), EngineError> {
-    let admins = admins_of_group(mls_group)?;
-    if admins.is_empty() {
-        return Ok(());
-    }
-    for queued in staged.queued_proposals() {
-        if !matches!(queued.proposal(), Proposal::SelfRemove) {
-            continue;
-        }
-        // Resolve the sender's account pubkey on the SAME (length-based) basis
-        // the admin set is decoded on (`decode_admin_policy` /
-        // `credential_account_pubkey`), NOT the secp256k1-validating
-        // `identity::member_id_of_sender` (mdk#728 review). The admin set is not
-        // curve-validated, so a leaf whose 32-byte identity equals a listed
-        // admin key but fails secp256k1 validation would resolve to `None` under
-        // the validating chokepoint and SKIP this guard — letting that admin
-        // self-remove in violation of MIP-03. Matching the admin-set basis keeps
-        // both sides of the comparison comparable. Fail CLOSED: a `SelfRemove`
-        // whose sender cannot be resolved to a member account is rejected, never
-        // waved through (mirrors the Sm7 auto-committer / fork-recovery posture).
-        let sender_pubkey = match queued.sender() {
-            Sender::Member(leaf_idx) => mls_group
-                .member_at(*leaf_idx)
-                .and_then(|member| credential_account_pubkey(member.credential)),
-            _ => None,
-        };
-        let Some(sender_pubkey) = sender_pubkey else {
-            return Err(EngineError::AdminCannotSelfRemove {
-                group_id: group_id.clone(),
-            });
-        };
-        if admins.iter().any(|admin| admin == &sender_pubkey) {
-            return Err(EngineError::AdminCannotSelfRemove {
-                group_id: group_id.clone(),
-            });
-        }
     }
     Ok(())
 }

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -66,6 +66,7 @@ pub(crate) fn ingest_outcome_kind_str(outcome: &IngestOutcome) -> &'static str {
         IngestOutcome::Processed => "processed",
         IngestOutcome::Buffered { .. } => "buffered",
         IngestOutcome::Stale { .. } => "stale",
+        IngestOutcome::Rejected { .. } => "rejected",
     }
 }
 
@@ -80,6 +81,12 @@ pub(crate) fn stale_reason_str(reason: &StaleReason) -> &'static str {
         StaleReason::SelfEvicted => "self_evicted",
         StaleReason::Quarantined => "quarantined",
     }
+}
+
+pub(crate) fn proposal_rejection_category_tag(
+    category: cgka_traits::ingest::ProposalRejectionCategory,
+) -> &'static str {
+    crate::proposal_authorization::proposal_rejection_category_tag(category)
 }
 
 pub(crate) fn ingest_outcome_epoch(outcome: &IngestOutcome) -> Option<u64> {
@@ -434,6 +441,9 @@ pub(crate) fn ingest_outcome_event(
         outcome_kind: ingest_outcome_kind_str(outcome).to_string(),
         stale_reason: match outcome {
             IngestOutcome::Stale { reason } => Some(stale_reason_str(reason).to_string()),
+            IngestOutcome::Rejected { category } => {
+                Some(proposal_rejection_category_tag(*category).to_string())
+            }
             _ => None,
         },
         epoch: ingest_outcome_epoch(outcome),

--- a/crates/cgka-engine/src/canonicalization.rs
+++ b/crates/cgka-engine/src/canonicalization.rs
@@ -182,6 +182,7 @@ pub struct DroppedMessage {
     pub message_id: String,
     pub kind: MessageKind,
     pub reason: DroppedMessageReason,
+    pub rejection_category: Option<cgka_traits::ingest::ProposalRejectionCategory>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -831,6 +832,7 @@ fn drop_losing_materialized_candidate_commits(
                 message_id: message_id.clone(),
                 kind: MessageKind::Commit,
                 reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: None,
             });
         }
     }
@@ -922,6 +924,7 @@ fn dropped(message: &PeeledMessage, reason: DroppedMessageReason) -> DroppedMess
         message_id: message.message_id.clone(),
         kind: message.kind_name(),
         reason,
+        rejection_category: None,
     }
 }
 

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -479,6 +479,7 @@ impl<S: StorageProvider> Engine<S> {
         }
         self.emit_application_replay_events(group_id, &observations);
         self.emit_invalidated_app_events(group_id, &result)?;
+        self.emit_rejected_proposal_convergence_audits(group_id, &result);
         self.emit_rolled_back_commits(group_id, &result)?;
         self.emit_superseded_processed_commits(group_id, &result)?;
 
@@ -816,6 +817,27 @@ impl<S: StorageProvider> Engine<S> {
                 });
         }
         Ok(())
+    }
+
+    fn emit_rejected_proposal_convergence_audits(
+        &mut self,
+        group_id: &GroupId,
+        result: &CanonicalizationResult,
+    ) {
+        for dropped in &result.dropped_messages {
+            let Some(category) = dropped.rejection_category else {
+                continue;
+            };
+            let reason = crate::proposal_authorization::proposal_rejection_category_tag(category)
+                .to_string();
+            self.audit_group(
+                group_id,
+                marmot_forensics::AuditEventKind::Rejection {
+                    msg_id: dropped.message_id.clone(),
+                    reason,
+                },
+            );
+        }
     }
 
     /// Emit a [`GroupEvent::CommitRolledBack`] for every commit that this

--- a/crates/cgka-engine/src/key_package.rs
+++ b/crates/cgka-engine/src/key_package.rs
@@ -218,3 +218,14 @@ fn validate_key_package_lifetime_policy(key_package: &MlsKeyPackage) -> Result<(
     }
     Ok(())
 }
+
+/// Validate an Add proposal's KeyPackage credential and account-identity proof.
+pub(crate) fn validate_add_proposal_key_package(
+    add: &openmls::messages::proposals::AddProposal,
+    ciphersuite: openmls::prelude::Ciphersuite,
+) -> Result<(), EngineError> {
+    let leaf = add.key_package().leaf_node();
+    crate::identity::validated_member_id_of_leaf(leaf)?;
+    crate::account_identity_proof::validate_leaf_account_identity_proof(leaf, ciphersuite)?;
+    Ok(())
+}

--- a/crates/cgka-engine/src/lib.rs
+++ b/crates/cgka-engine/src/lib.rs
@@ -57,6 +57,7 @@ pub(crate) mod message_disposition;
 pub mod message_processor;
 pub mod openmls_projection;
 pub mod pending_commit_guard;
+pub mod proposal_authorization;
 pub mod provider;
 pub mod publish;
 pub mod snapshot_guard;

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -2,8 +2,9 @@
 //!
 //! Inbound messages are peeled, classified, stored, and either applied or
 //! buffered for convergence. Classifiable stale ingest cases return
-//! `Ok(IngestOutcome::Stale { .. })` with a typed `StaleReason`. `Err` is
-//! reserved for storage, peeler, serialization, and OpenMLS failures.
+//! `Ok(IngestOutcome::Stale { .. })`; terminal protocol admission failures
+//! return `Ok(IngestOutcome::Rejected { .. })`. `Err` is reserved for storage,
+//! peeler, serialization, and unclassified OpenMLS failures.
 
 use super::{content_dedup_id, route_wrapped_group_message};
 use crate::engine::{Engine, ScheduledSelfRemoveAutoCommit};
@@ -22,7 +23,7 @@ use cgka_traits::engine::{
     GroupStateInvalidationReason,
 };
 use cgka_traits::error::{EngineError, PeelerError};
-use cgka_traits::ingest::{IngestOutcome, PeeledContent, StaleReason};
+use cgka_traits::ingest::{IngestOutcome, PeeledContent, ProposalRejectionCategory, StaleReason};
 use cgka_traits::message::{MessageState, StoredMessagePayload};
 use cgka_traits::storage::{StorageError, StorageProvider};
 use cgka_traits::transport::{EncryptedPayload, TransportMessage};
@@ -54,6 +55,44 @@ enum ForkProbeError {
 }
 
 impl<S: StorageProvider> Engine<S> {
+    fn terminalize_rejected_proposal(
+        &mut self,
+        group_id: &GroupId,
+        msg_id: &MessageId,
+        raw_msg_id: &MessageId,
+        category: ProposalRejectionCategory,
+    ) -> Result<IngestOutcome, EngineError> {
+        let reason = crate::proposal_authorization::proposal_rejection_category_tag(category);
+        self.audit_group(
+            group_id,
+            marmot_forensics::AuditEventKind::Rejection {
+                msg_id: hex::encode(msg_id.as_slice()),
+                reason: reason.to_string(),
+            },
+        );
+        self.update_stored_message_state(msg_id, MessageState::Failed)?;
+        self.mark_raw_transport_message_failed_if_awaiting_retry(raw_msg_id, reason)?;
+        Ok(IngestOutcome::Rejected { category })
+    }
+
+    fn reject_staged_commit_proposals(
+        &mut self,
+        mls_group: &MlsGroup,
+        group_id: &GroupId,
+        msg_id: &MessageId,
+        raw_msg_id: &MessageId,
+        staged: &openmls::prelude::StagedCommit,
+    ) -> Result<Option<IngestOutcome>, EngineError> {
+        match crate::proposal_authorization::authorize_staged_commit_queued_proposals(
+            mls_group, group_id, staged,
+        ) {
+            crate::proposal_authorization::ProposalAuthorizationOutcome::Authorized => Ok(None),
+            crate::proposal_authorization::ProposalAuthorizationOutcome::Rejected(category) => Ok(
+                Some(self.terminalize_rejected_proposal(group_id, msg_id, raw_msg_id, category)?),
+            ),
+        }
+    }
+
     pub(crate) async fn ingest_welcome(
         &mut self,
         msg: &TransportMessage,
@@ -806,6 +845,19 @@ impl<S: StorageProvider> Engine<S> {
                     });
                 }
                 Err(e) => {
+                    if let Some(category) =
+                        crate::proposal_authorization::classify_process_message_error(
+                            &e,
+                            msg_content_type,
+                        )
+                    {
+                        return self.terminalize_rejected_proposal(
+                            &group_id,
+                            &msg.id,
+                            &raw_msg_id,
+                            category,
+                        );
+                    }
                     self.update_stored_message_state(&msg.id, MessageState::Retryable)?;
                     return Err(EngineError::Backend(format!("process_message: {e:?}")));
                 }
@@ -888,6 +940,15 @@ impl<S: StorageProvider> Engine<S> {
                 }
                 ProcessedMessageContent::StagedCommitMessage(staged) => {
                     let before = EpochId(mls_group.epoch().as_u64());
+                    if let Some(outcome) = self.reject_staged_commit_proposals(
+                        &mls_group,
+                        &group_id,
+                        &msg.id,
+                        &raw_msg_id,
+                        &staged,
+                    )? {
+                        return Ok(outcome);
+                    }
                     if let Err(err) = crate::app_components::require_admin_for_staged_commit(
                         &mls_group,
                         &group_id,
@@ -1206,6 +1267,25 @@ impl<S: StorageProvider> Engine<S> {
                     Ok(IngestOutcome::Processed)
                 }
                 ProcessedMessageContent::ProposalMessage(queued) => {
+                    match crate::proposal_authorization::authorize_queued_proposal(
+                        &mls_group,
+                        &group_id,
+                        &queued,
+                        crate::proposal_authorization::ProposalAuthorizationContext::Standalone,
+                    ) {
+                        crate::proposal_authorization::ProposalAuthorizationOutcome::Rejected(
+                            category,
+                        ) => {
+                            return self.terminalize_rejected_proposal(
+                                &group_id,
+                                &msg.id,
+                                &raw_msg_id,
+                                category,
+                            );
+                        }
+                        crate::proposal_authorization::ProposalAuthorizationOutcome::Authorized => {
+                        }
+                    }
                     // Ask the auto-committer policy whether we should commit
                     // this proposal. OpenMLS does not auto-enqueue processed
                     // proposals, so store it before attempting to commit the
@@ -1421,6 +1501,29 @@ impl<S: StorageProvider> Engine<S> {
         mls_group: &mut MlsGroup,
         queued: Box<QueuedProposal>,
     ) -> Result<bool, EngineError> {
+        if let crate::proposal_authorization::ProposalAuthorizationOutcome::Rejected(category) =
+            crate::proposal_authorization::authorize_queued_proposal(
+                mls_group,
+                group_id,
+                queued.as_ref(),
+                crate::proposal_authorization::ProposalAuthorizationContext::Standalone,
+            )
+        {
+            let reason = crate::proposal_authorization::proposal_rejection_category_tag(category);
+            self.audit_group(
+                group_id,
+                marmot_forensics::AuditEventKind::Rejection {
+                    msg_id: hex::encode(
+                        tls_codec::Serialize::tls_serialize_detached(
+                            queued.proposal_reference_ref(),
+                        )
+                        .unwrap_or_default(),
+                    ),
+                    reason: reason.to_string(),
+                },
+            );
+            return Ok(false);
+        }
         let decision_report = crate::auto_committer::decide_with_reason(mls_group, &queued);
         let decision_str = match &decision_report.decision {
             crate::auto_committer::AutoCommitDecision::Commit => "commit",
@@ -1836,6 +1939,14 @@ impl<S: StorageProvider> Engine<S> {
             .ok_or(ForkProbeError::InvalidCandidate)?;
         let priority = match processed.into_content() {
             ProcessedMessageContent::StagedCommitMessage(staged) => {
+                if crate::proposal_authorization::authorize_staged_commit_queued_proposals(
+                    &probe_group,
+                    group_id,
+                    staged.as_ref(),
+                ) != crate::proposal_authorization::ProposalAuthorizationOutcome::Authorized
+                {
+                    return Err(ForkProbeError::InvalidCandidate);
+                }
                 crate::app_components::require_admin_for_staged_commit(
                     &probe_group,
                     group_id,
@@ -2030,6 +2141,8 @@ fn convergence_ingest_outcome(
     epoch: EpochId,
 ) -> IngestOutcome {
     let message_id = hex::encode(msg.id.as_slice());
+    let content_message_id =
+        hex::encode(crate::message_processor::content_dedup_id(&msg.payload).as_slice());
 
     // Was this exact message classified by the canonicalize pass? Map
     // the disposition to a typed outcome so callers can log by category
@@ -2041,7 +2154,7 @@ fn convergence_ingest_outcome(
         .iter()
         .chain(&result.accepted_proposals)
         .chain(&result.accepted_app_messages)
-        .any(|accepted| accepted == &message_id);
+        .any(|accepted| accepted == &message_id || accepted == &content_message_id);
     if accepted && result.convergence_status == crate::canonicalization::ConvergenceStatus::Settled
     {
         return IngestOutcome::Processed;
@@ -2050,7 +2163,7 @@ fn convergence_ingest_outcome(
     if result
         .already_seen
         .iter()
-        .any(|seen| seen.message_id == message_id)
+        .any(|seen| seen.message_id == message_id || seen.message_id == content_message_id)
     {
         return IngestOutcome::Stale {
             reason: StaleReason::AlreadySeen,
@@ -2066,11 +2179,12 @@ fn convergence_ingest_outcome(
     // future epoch the local context can't yet peel. A subsequent
     // canonicalize pass that advances the MLS context will re-evaluate
     // it. Keep that case as Buffered.
-    if result
-        .dropped_messages
-        .iter()
-        .any(|dropped| dropped.message_id == message_id)
-    {
+    if let Some(dropped) = result.dropped_messages.iter().find(|dropped| {
+        dropped.message_id == message_id || dropped.message_id == content_message_id
+    }) {
+        if let Some(category) = dropped.rejection_category {
+            return IngestOutcome::Rejected { category };
+        }
         return IngestOutcome::Stale {
             reason: StaleReason::PeelFailed,
         };
@@ -2078,7 +2192,7 @@ fn convergence_ingest_outcome(
     if let Some(inv) = result
         .invalidated_app_messages
         .iter()
-        .find(|inv| inv.message_id == message_id)
+        .find(|inv| inv.message_id == message_id || inv.message_id == content_message_id)
     {
         use crate::canonicalization::InvalidatedAppMessageReason;
         match inv.reason {

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -845,6 +845,28 @@ impl<S: StorageProvider> Engine<S> {
                     });
                 }
                 Err(e) => {
+                    if msg_content_type == ContentType::Proposal
+                        && crate::proposal_authorization::is_parent_dependent_process_message_error(
+                            &e,
+                            msg_content_type,
+                        )
+                    {
+                        // The current state cannot prove this proposal invalid:
+                        // sender and membership-tag authentication can succeed
+                        // on a retained same-epoch fork. Let canonicalization
+                        // try every retained parent and keep the durable row
+                        // retryable if its parent commit has not arrived yet.
+                        let now_ms = self.convergence_now_ms();
+                        let result = self
+                            .converge_stored_openmls_messages(&group_id, now_ms)
+                            .map_err(|err| EngineError::Backend(format!("converge: {err}")))?;
+                        return Ok(convergence_ingest_outcome(
+                            &result,
+                            msg,
+                            group_id,
+                            current_epoch,
+                        ));
+                    }
                     if let Some(category) =
                         crate::proposal_authorization::classify_process_message_error(
                             &e,
@@ -1321,8 +1343,12 @@ impl<S: StorageProvider> Engine<S> {
                     Ok(IngestOutcome::Processed)
                 }
                 ProcessedMessageContent::ExternalJoinProposalMessage(_) => {
-                    self.update_stored_message_state(&msg.id, MessageState::Processed)?;
-                    Ok(IngestOutcome::Processed)
+                    return self.terminalize_rejected_proposal(
+                        &group_id,
+                        &msg.id,
+                        &raw_msg_id,
+                        crate::proposal_authorization::external_join_proposal_rejection_category(),
+                    );
                 }
                 ProcessedMessageContent::OwnPendingCommit
                 | ProcessedMessageContent::OwnPrivateMessage => {

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -4,9 +4,10 @@
 //! buffered for convergence. Outbound intents are checked against local epoch
 //! state and unresolved convergence inputs before any OpenMLS mutation.
 //!
-//! Classifiable stale ingest cases return
-//! `Ok(IngestOutcome::Stale { .. })` with a typed `StaleReason`. `Err` is
-//! reserved for storage, peeler, serialization, and OpenMLS failures.
+//! Classifiable stale ingest cases return `Ok(IngestOutcome::Stale { .. })`
+//! with a typed `StaleReason`; terminal protocol admission failures return
+//! `Ok(IngestOutcome::Rejected { .. })`. `Err` is reserved for storage, peeler,
+//! serialization, and unclassified OpenMLS failures.
 
 mod ingest;
 mod send;
@@ -106,8 +107,8 @@ struct DeferredPeelAttempts {
 }
 
 impl<S: StorageProvider> Engine<S> {
-    /// Inbound pipeline. Never panics; every classifiable stale case returns
-    /// a typed `StaleReason` inside `Ok(IngestOutcome::Stale { .. })`.
+    /// Inbound pipeline. Never panics; every classifiable stale or rejected case
+    /// returns a typed [`IngestOutcome`].
     pub(crate) async fn do_ingest(
         &mut self,
         msg: TransportMessage,
@@ -657,8 +658,8 @@ impl<S: StorageProvider> Engine<S> {
                     self.note_peel_deferred_row_retired(group_id, &record.id);
                     progressed += 1;
                 }
-                Ok(IngestOutcome::Stale { .. }) => {
-                    // Terminal stale classifications are still successful
+                Ok(IngestOutcome::Stale { .. } | IngestOutcome::Rejected { .. }) => {
+                    // Terminal stale/rejected classifications are still successful
                     // reclassifications of this raw deferred row. Retire it only
                     // while it is still awaiting retry: the reachable case is
                     // `SelfEvicted`, where re-ingesting the deferred row against a

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -796,13 +796,14 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
             .collect()
     };
 
+    let (preflight_drops, pending_messages) = preflight_current_epoch_pending_proposals(
+        storage,
+        group_id,
+        current_epoch,
+        pending_messages,
+    )?;
+
     if replay_start_epoch < current_epoch {
-        let (preflight_drops, pending_messages) = preflight_current_epoch_pending_proposals(
-            storage,
-            group_id,
-            current_epoch,
-            pending_messages,
-        )?;
         let mut result = canonicalize_stored_openmls_messages_from_retained_anchor(
             storage,
             group_id,
@@ -823,12 +824,6 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
         return Ok(result);
     }
 
-    let (preflight_drops, pending_messages) = preflight_current_epoch_pending_proposals(
-        storage,
-        group_id,
-        current_epoch,
-        pending_messages,
-    )?;
     let mut result = canonicalize_stored_openmls_messages_from_current(
         storage,
         group_id,
@@ -2233,6 +2228,16 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                 return Err(replay_error("process_message", err));
             }
             Err(err) if projection.kind == OpenMlsContentKind::Proposal => {
+                if crate::proposal_authorization::is_parent_dependent_process_message_error(
+                    &err,
+                    ContentType::Proposal,
+                ) {
+                    observations.push(OpenMlsReplayObservation::Ignored {
+                        message_id,
+                        kind: projection.kind,
+                    });
+                    continue;
+                }
                 if let Some(category) =
                     crate::proposal_authorization::classify_process_message_error(
                         &err,
@@ -2445,9 +2450,10 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                 }
             }
             ProcessedMessageContent::ExternalJoinProposalMessage(_) => {
-                observations.push(OpenMlsReplayObservation::Ignored {
+                observations.push(OpenMlsReplayObservation::ProposalRejected {
                     message_id,
-                    kind: projection.kind,
+                    category:
+                        crate::proposal_authorization::external_join_proposal_rejection_category(),
                 });
             }
             ProcessedMessageContent::OwnPendingCommit

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -206,8 +206,16 @@ impl ReplayBudget {
 #[derive(Clone, Debug)]
 enum CandidatePathProbeResult {
     Materialized(Option<OpenMlsMaterializedCandidate>),
-    UnauthorizedCommit { message_id: String },
-    InvalidCommit { message_id: String },
+    UnauthorizedCommit {
+        message_id: String,
+    },
+    UnauthorizedProposal {
+        message_id: String,
+        category: cgka_traits::ingest::ProposalRejectionCategory,
+    },
+    InvalidCommit {
+        message_id: String,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -251,6 +259,10 @@ pub enum OpenMlsReplayObservation {
         message_id: String,
         kind: OpenMlsContentKind,
     },
+    ProposalRejected {
+        message_id: String,
+        category: cgka_traits::ingest::ProposalRejectionCategory,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -269,8 +281,17 @@ pub enum OpenMlsProjectionError {
     MissingGroup,
     Snapshot(String),
     Replay(String),
-    UnauthorizedCommit { message_id: String },
-    InvalidCommit { message_id: String, reason: String },
+    UnauthorizedCommit {
+        message_id: String,
+    },
+    UnauthorizedProposal {
+        message_id: String,
+        category: cgka_traits::ingest::ProposalRejectionCategory,
+    },
+    InvalidCommit {
+        message_id: String,
+        reason: String,
+    },
     Serialize(String),
     Storage(String),
     InvalidPolicy(String),
@@ -295,6 +316,16 @@ impl std::fmt::Display for OpenMlsProjectionError {
             OpenMlsProjectionError::Replay(e) => write!(f, "OpenMLS replay failed: {e}"),
             OpenMlsProjectionError::UnauthorizedCommit { message_id } => {
                 write!(f, "unauthorized admin-gated commit: {message_id}")
+            }
+            OpenMlsProjectionError::UnauthorizedProposal {
+                message_id,
+                category,
+            } => {
+                write!(
+                    f,
+                    "unauthorized proposal {message_id}: {}",
+                    crate::proposal_authorization::proposal_rejection_category_tag(*category)
+                )
             }
             OpenMlsProjectionError::InvalidCommit { message_id, reason } => {
                 write!(f, "invalid commit {message_id}: {reason}")
@@ -708,6 +739,7 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
                             message_id: hex::encode(message.id.as_slice()),
                             kind: MessageKind::Commit,
                             reason: DroppedMessageReason::BeyondAnchor,
+                            rejection_category: None,
                         });
                     }
                     continue;
@@ -765,6 +797,12 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
     };
 
     if replay_start_epoch < current_epoch {
+        let (preflight_drops, pending_messages) = preflight_current_epoch_pending_proposals(
+            storage,
+            group_id,
+            current_epoch,
+            pending_messages,
+        )?;
         let mut result = canonicalize_stored_openmls_messages_from_retained_anchor(
             storage,
             group_id,
@@ -780,10 +818,17 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
                 own_commits,
             },
         )?;
+        append_dropped_messages(&mut result, preflight_drops);
         append_dropped_messages(&mut result, stale_commit_drops);
         return Ok(result);
     }
 
+    let (preflight_drops, pending_messages) = preflight_current_epoch_pending_proposals(
+        storage,
+        group_id,
+        current_epoch,
+        pending_messages,
+    )?;
     let mut result = canonicalize_stored_openmls_messages_from_current(
         storage,
         group_id,
@@ -798,7 +843,9 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
             replay_start_epoch,
             own_commits,
         },
+        current_epoch,
     )?;
+    append_dropped_messages(&mut result, preflight_drops);
     append_dropped_messages(&mut result, stale_commit_drops);
     Ok(result)
 }
@@ -820,6 +867,112 @@ fn append_dropped_messages(
     result.dropped_messages.sort();
 }
 
+fn preflight_current_epoch_pending_proposals<S: StorageProvider>(
+    storage: &S,
+    group_id: &GroupId,
+    current_epoch: u64,
+    pending_messages: Vec<TransportMessage>,
+) -> Result<(Vec<DroppedMessage>, Vec<TransportMessage>), OpenMlsProjectionError> {
+    let mut drops = Vec::new();
+    let mut retained = Vec::with_capacity(pending_messages.len());
+    for message in pending_messages {
+        let projection = project_mls_message(&message.payload)?;
+        if projection.kind != OpenMlsContentKind::Proposal {
+            retained.push(message);
+            continue;
+        }
+        let Some(source_epoch) = projection.source_epoch else {
+            retained.push(message);
+            continue;
+        };
+        if source_epoch != current_epoch {
+            retained.push(message);
+            continue;
+        }
+        let message_id = hex::encode(message.id.as_slice());
+        let observations =
+            replay_openmls_messages(storage, group_id, std::slice::from_ref(&message))?;
+        let rejected = observations
+            .iter()
+            .find_map(|observation| match observation {
+                OpenMlsReplayObservation::ProposalRejected {
+                    message_id: observed_id,
+                    category,
+                } if *observed_id == message_id => Some(*category),
+                _ => None,
+            });
+        if let Some(category) = rejected {
+            drops.push(DroppedMessage {
+                message_id,
+                kind: MessageKind::Proposal,
+                reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: Some(category),
+            });
+        } else {
+            retained.push(message);
+        }
+    }
+    Ok((drops, retained))
+}
+
+fn globally_rejected_historical_proposal_drops(
+    current_epoch: u64,
+    pending_messages: &[TransportMessage],
+    materialized: &[OpenMlsMaterializedCandidate],
+) -> Result<Vec<DroppedMessage>, OpenMlsProjectionError> {
+    let mut drops = Vec::new();
+    for message in pending_messages {
+        let projection = project_mls_message(&message.payload)?;
+        if projection.kind != OpenMlsContentKind::Proposal {
+            continue;
+        }
+        let Some(source_epoch) = projection.source_epoch else {
+            continue;
+        };
+        if source_epoch >= current_epoch {
+            continue;
+        }
+        let message_id = hex::encode(message.id.as_slice());
+        let mut stored_branches = BTreeSet::new();
+        let mut rejected_by_branch = BTreeMap::new();
+        for candidate in materialized {
+            for observation in &candidate.observations {
+                match observation {
+                    OpenMlsReplayObservation::ProposalStored {
+                        message_id: observed_id,
+                        ..
+                    } if *observed_id == message_id => {
+                        stored_branches.insert(candidate.branch_id.clone());
+                    }
+                    OpenMlsReplayObservation::ProposalRejected {
+                        message_id: observed_id,
+                        category,
+                    } if *observed_id == message_id => {
+                        rejected_by_branch.insert(candidate.branch_id.clone(), *category);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if !stored_branches.is_empty() {
+            continue;
+        }
+        if rejected_by_branch.is_empty() {
+            continue;
+        }
+        let Some(category) = rejected_by_branch.values().next().copied() else {
+            continue;
+        };
+        drops.push(DroppedMessage {
+            message_id,
+            kind: MessageKind::Proposal,
+            reason: DroppedMessageReason::InvalidAgainstCandidateState,
+            rejection_category: Some(category),
+        });
+    }
+    Ok(drops)
+}
+
 fn canonicalize_stored_openmls_messages_from_retained_anchor<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
@@ -833,7 +986,19 @@ fn canonicalize_stored_openmls_messages_from_retained_anchor<S: StorageProvider>
 
     let anchor_snapshot = retained_anchor_snapshot_name(work.replay_start_epoch);
     let result = match storage.rollback_group_to_snapshot(group_id, &anchor_snapshot) {
-        Ok(()) => canonicalize_stored_openmls_messages_from_current(storage, group_id, work),
+        Ok(()) => {
+            let current_epoch = storage
+                .get_group(group_id)
+                .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?
+                .epoch
+                .0;
+            canonicalize_stored_openmls_messages_from_current(
+                storage,
+                group_id,
+                work,
+                current_epoch,
+            )
+        }
         Err(StorageError::SnapshotMissing(_)) => Ok(missing_retained_anchor_result(
             work.state,
             work.outbound_intents,
@@ -910,6 +1075,7 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
     storage: &S,
     group_id: &GroupId,
     work: StoredOpenMlsCanonicalizationWork,
+    current_epoch: u64,
 ) -> Result<CanonicalizationResult, OpenMlsProjectionError> {
     let path_result = build_stored_openmls_candidate_paths(
         storage,
@@ -921,7 +1087,22 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
         &work.own_commits,
     )?;
 
-    let has_pending_apps = pending_messages_contain_application(&work.pending_messages)?;
+    let historical_drops = globally_rejected_historical_proposal_drops(
+        current_epoch,
+        &work.pending_messages,
+        &path_result.materialized,
+    )?;
+    let dropped_ids: BTreeSet<String> = historical_drops
+        .iter()
+        .map(|dropped| dropped.message_id.clone())
+        .collect();
+    let pending_messages: Vec<_> = work
+        .pending_messages
+        .into_iter()
+        .filter(|message| !dropped_ids.contains(&hex::encode(message.id.as_slice())))
+        .collect();
+
+    let has_pending_apps = pending_messages_contain_application(&pending_messages)?;
     let can_reuse_materialized = can_reuse_bfs_materialization(
         has_pending_apps,
         path_result.materialized.len(),
@@ -931,7 +1112,7 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
     let batch = OpenMlsCanonicalizationBatch {
         state: work.state,
         candidate_paths: path_result.candidate_paths,
-        pending_messages: work.pending_messages,
+        pending_messages,
         already_delivered_app_ids: work.already_delivered_app_ids,
         outbound_intents: work.outbound_intents,
         policy: work.policy,
@@ -945,6 +1126,7 @@ fn canonicalize_stored_openmls_messages_from_current<S: StorageProvider>(
         canonicalize_openmls_batch_prevalidated(storage, group_id, batch, &work.own_commits)?
     };
     append_dropped_messages(&mut result, path_result.invalid_commit_drops);
+    append_dropped_messages(&mut result, historical_drops);
     Ok(result)
 }
 
@@ -1071,6 +1253,19 @@ fn build_stored_openmls_candidate_paths<S: StorageProvider>(
                             message_id,
                             kind: MessageKind::Commit,
                             reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                            rejection_category: None,
+                        });
+                        continue;
+                    }
+                    CandidatePathProbeResult::UnauthorizedProposal {
+                        message_id,
+                        category,
+                    } => {
+                        invalid_commit_drops.push(DroppedMessage {
+                            message_id,
+                            kind: MessageKind::Commit,
+                            reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                            rejection_category: Some(category),
                         });
                         continue;
                     }
@@ -1079,6 +1274,7 @@ fn build_stored_openmls_candidate_paths<S: StorageProvider>(
                             message_id,
                             kind: MessageKind::Commit,
                             reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                            rejection_category: None,
                         });
                         continue;
                     }
@@ -1107,6 +1303,7 @@ fn build_stored_openmls_candidate_paths<S: StorageProvider>(
             message_id: message_id.clone(),
             kind: MessageKind::Commit,
             reason: DroppedMessageReason::InvalidAgainstCandidateState,
+            rejection_category: None,
         });
     }
 
@@ -1184,6 +1381,13 @@ fn probe_candidate_path<S: StorageProvider>(
         Err(OpenMlsProjectionError::UnauthorizedCommit { message_id }) => {
             Ok(CandidatePathProbeResult::UnauthorizedCommit { message_id })
         }
+        Err(OpenMlsProjectionError::UnauthorizedProposal {
+            message_id,
+            category,
+        }) => Ok(CandidatePathProbeResult::UnauthorizedProposal {
+            message_id,
+            category,
+        }),
         Err(OpenMlsProjectionError::InvalidCommit {
             message_id,
             reason: _,
@@ -1295,7 +1499,7 @@ pub fn persist_openmls_canonicalization_dispositions<S: StorageProvider>(
     for dropped in &result.dropped_messages {
         state_by_message_id.insert(
             dropped.message_id.clone(),
-            message_state_for_dropped_reason(dropped.reason),
+            message_state_for_dropped_message(dropped),
         );
     }
     // The epoch convergence settled on: the selected branch tip, or the
@@ -1634,6 +1838,13 @@ fn unresolved_commit_state(state: MessageState) -> bool {
         state,
         MessageState::Sent | MessageState::Created | MessageState::Retryable
     )
+}
+
+fn message_state_for_dropped_message(dropped: &DroppedMessage) -> MessageState {
+    if dropped.kind == MessageKind::Proposal && dropped.rejection_category.is_some() {
+        return MessageState::Failed;
+    }
+    message_state_for_dropped_reason(dropped.reason)
 }
 
 fn message_state_for_dropped_reason(reason: DroppedMessageReason) -> MessageState {
@@ -2007,6 +2218,35 @@ fn process_openmls_messages_inner<S: StorageProvider>(
             mls_group.process_message(&provider, protocol)
         } {
             Ok(processed) => processed,
+            Err(err) if projection.kind == OpenMlsContentKind::Commit => {
+                if let Some(category) =
+                    crate::proposal_authorization::classify_process_message_error(
+                        &err,
+                        ContentType::Commit,
+                    )
+                {
+                    return Err(OpenMlsProjectionError::UnauthorizedProposal {
+                        message_id,
+                        category,
+                    });
+                }
+                return Err(replay_error("process_message", err));
+            }
+            Err(err) if projection.kind == OpenMlsContentKind::Proposal => {
+                if let Some(category) =
+                    crate::proposal_authorization::classify_process_message_error(
+                        &err,
+                        ContentType::Proposal,
+                    )
+                {
+                    observations.push(OpenMlsReplayObservation::ProposalRejected {
+                        message_id,
+                        category,
+                    });
+                    continue;
+                }
+                return Err(replay_error("process_message", err));
+            }
             Err(err) if projection.kind == OpenMlsContentKind::Application => {
                 // App-message replay against a candidate state is best-
                 // effort: an app message that doesn't apply on this branch is
@@ -2040,6 +2280,23 @@ fn process_openmls_messages_inner<S: StorageProvider>(
 
         match processed.into_content() {
             ProcessedMessageContent::ProposalMessage(queued) => {
+                match crate::proposal_authorization::authorize_queued_proposal(
+                    &mls_group,
+                    group_id,
+                    &queued,
+                    crate::proposal_authorization::ProposalAuthorizationContext::Standalone,
+                ) {
+                    crate::proposal_authorization::ProposalAuthorizationOutcome::Authorized => {}
+                    crate::proposal_authorization::ProposalAuthorizationOutcome::Rejected(
+                        category,
+                    ) => {
+                        observations.push(OpenMlsReplayObservation::ProposalRejected {
+                            message_id,
+                            category,
+                        });
+                        continue;
+                    }
+                }
                 let proposal_ref = tls_hex(queued.proposal_reference_ref())?;
                 mls_group
                     .store_pending_proposal(provider.storage(), *queued)
@@ -2053,6 +2310,16 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                 });
             }
             ProcessedMessageContent::StagedCommitMessage(staged) => {
+                if let crate::proposal_authorization::ProposalAuthorizationOutcome::Rejected(
+                    category,
+                ) = crate::proposal_authorization::authorize_staged_commit_queued_proposals(
+                    &mls_group, group_id, &staged,
+                ) {
+                    return Err(OpenMlsProjectionError::UnauthorizedProposal {
+                        message_id,
+                        category,
+                    });
+                }
                 if let Err(err) = crate::app_components::require_admin_for_staged_commit(
                     &mls_group,
                     group_id,

--- a/crates/cgka-engine/src/proposal_authorization.rs
+++ b/crates/cgka-engine/src/proposal_authorization.rs
@@ -1,0 +1,348 @@
+//! Marmot semantic authorization for standalone and staged MLS proposals.
+//!
+//! OpenMLS validates wire syntax and signatures; this module enforces protocol-core
+//! rules from `group-messaging.md` and `member-departure.md` against the
+//! authenticated source-epoch / candidate-parent group state. Every inbound seam
+//! that can queue or commit proposals must call these helpers before mutating
+//! pending proposal state.
+
+use cgka_traits::app_components::AppComponentData;
+use cgka_traits::ingest::ProposalRejectionCategory;
+use cgka_traits::types::GroupId;
+use openmls::framing::Sender;
+use openmls::group::{MlsGroup, ProcessMessageError, StageCommitError};
+use openmls::messages::proposals::{AppDataUpdateOperation, Proposal};
+use openmls::prelude::{
+    ContentType, ProposalOrRefType, ProposalValidationError, QueuedProposal, StagedCommit,
+    ValidationError,
+};
+
+use crate::app_components::{
+    admins_of_group, credential_account_pubkey, validate_app_component_remove,
+    validate_app_component_update,
+};
+use crate::capabilities::capabilities_of_key_package;
+use crate::capability_manager::{
+    required_capabilities_from_group, required_role_capabilities_from_group,
+};
+use crate::identity::member_id_of_sender;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProposalAuthorizationContext {
+    Standalone,
+    StagedCommit,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProposalAuthorizationOutcome {
+    Authorized,
+    Rejected(ProposalRejectionCategory),
+}
+
+pub(crate) fn proposal_rejection_category_tag(category: ProposalRejectionCategory) -> &'static str {
+    match category {
+        ProposalRejectionCategory::AuthorizationFailed => "authorization_failed",
+        ProposalRejectionCategory::UnsupportedProposal => "unsupported_proposal",
+        ProposalRejectionCategory::InvalidEncoding => "invalid_encoding",
+        ProposalRejectionCategory::InvalidSignature => "invalid_signature",
+        ProposalRejectionCategory::InvalidSelfRemove => "invalid_self_remove",
+    }
+}
+
+/// Authorize one queued proposal against `mls_group`'s current epoch state.
+pub(crate) fn authorize_queued_proposal(
+    mls_group: &MlsGroup,
+    _group_id: &GroupId,
+    queued: &QueuedProposal,
+    context: ProposalAuthorizationContext,
+) -> ProposalAuthorizationOutcome {
+    let ciphersuite = mls_group.ciphersuite();
+    let sender_member = member_id_of_sender(queued.sender(), mls_group);
+    let sender_account = sender_account_pubkey(mls_group, queued.sender());
+    let admins = match admins_of_group(mls_group) {
+        Ok(admins) => admins,
+        Err(_) => {
+            return ProposalAuthorizationOutcome::Rejected(
+                ProposalRejectionCategory::InvalidEncoding,
+            );
+        }
+    };
+    if admins.is_empty() {
+        // Current-profile groups require admin-policy state; absence is fail-closed
+        // at this profile-policy seam (no permissive legacy fallback).
+        return ProposalAuthorizationOutcome::Rejected(ProposalRejectionCategory::InvalidEncoding);
+    }
+    let sender_is_admin = sender_account
+        .as_ref()
+        .is_some_and(|pk| admins.iter().any(|admin| admin == pk));
+
+    match queued.proposal() {
+        Proposal::SelfRemove => {
+            authorize_self_remove_proposal(queued.sender(), sender_account, &admins)
+        }
+        Proposal::AppDataUpdate(update) => {
+            if !sender_is_admin {
+                return ProposalAuthorizationOutcome::Rejected(
+                    ProposalRejectionCategory::AuthorizationFailed,
+                );
+            }
+            match update.operation() {
+                AppDataUpdateOperation::Update(data) => {
+                    let component = AppComponentData {
+                        component_id: update.component_id(),
+                        data: data.as_slice().to_vec(),
+                    };
+                    if validate_app_component_update(&component).is_err() {
+                        return ProposalAuthorizationOutcome::Rejected(
+                            ProposalRejectionCategory::InvalidEncoding,
+                        );
+                    }
+                }
+                AppDataUpdateOperation::Remove => {
+                    if validate_app_component_remove(mls_group, update.component_id()).is_err() {
+                        return ProposalAuthorizationOutcome::Rejected(
+                            ProposalRejectionCategory::InvalidEncoding,
+                        );
+                    }
+                }
+            }
+            ProposalAuthorizationOutcome::Authorized
+        }
+        Proposal::Add(add) => {
+            if !sender_is_admin {
+                return ProposalAuthorizationOutcome::Rejected(
+                    ProposalRejectionCategory::AuthorizationFailed,
+                );
+            }
+            let advertised = capabilities_of_key_package(add.key_package());
+            let missing_required =
+                required_capabilities_from_group(mls_group).missing_from(&advertised);
+            let missing_roles =
+                required_role_capabilities_from_group(mls_group).missing_from(&advertised);
+            if !missing_required.is_empty() || !missing_roles.is_empty() {
+                return ProposalAuthorizationOutcome::Rejected(
+                    ProposalRejectionCategory::UnsupportedProposal,
+                );
+            }
+            if crate::key_package::validate_add_proposal_key_package(add, ciphersuite).is_err() {
+                return ProposalAuthorizationOutcome::Rejected(
+                    ProposalRejectionCategory::InvalidEncoding,
+                );
+            }
+            ProposalAuthorizationOutcome::Authorized
+        }
+        Proposal::Update(update) => match context {
+            ProposalAuthorizationContext::Standalone => {
+                if sender_is_admin {
+                    ProposalAuthorizationOutcome::Rejected(
+                        ProposalRejectionCategory::UnsupportedProposal,
+                    )
+                } else {
+                    ProposalAuthorizationOutcome::Rejected(
+                        ProposalRejectionCategory::AuthorizationFailed,
+                    )
+                }
+            }
+            ProposalAuthorizationContext::StagedCommit => {
+                // A by-reference Update originated as a standalone proposal, so
+                // it remains subject to the standalone sender rule when a later
+                // Commit consumes it. This is the commit-time revalidation seam
+                // for proposals retained before the current policy was applied.
+                if queued.proposal_or_ref_type() == ProposalOrRefType::Reference && !sender_is_admin
+                {
+                    return ProposalAuthorizationOutcome::Rejected(
+                        ProposalRejectionCategory::AuthorizationFailed,
+                    );
+                }
+                let Some(sender_member) = sender_member.as_ref() else {
+                    return ProposalAuthorizationOutcome::Rejected(
+                        ProposalRejectionCategory::InvalidSignature,
+                    );
+                };
+                if crate::account_identity_proof::validate_leaf_account_identity_proof_for_member(
+                    update.leaf_node(),
+                    ciphersuite,
+                    sender_member,
+                    "Update proposal",
+                )
+                .is_err()
+                {
+                    return ProposalAuthorizationOutcome::Rejected(
+                        ProposalRejectionCategory::InvalidEncoding,
+                    );
+                }
+                ProposalAuthorizationOutcome::Authorized
+            }
+        },
+        Proposal::Remove(_) | Proposal::GroupContextExtensions(_) => {
+            if !sender_is_admin {
+                ProposalAuthorizationOutcome::Rejected(
+                    ProposalRejectionCategory::AuthorizationFailed,
+                )
+            } else {
+                ProposalAuthorizationOutcome::Authorized
+            }
+        }
+        Proposal::PreSharedKey(_)
+        | Proposal::ReInit(_)
+        | Proposal::ExternalInit(_)
+        | Proposal::AppEphemeral(_)
+        | Proposal::Custom(_) => {
+            if sender_is_admin {
+                // v1 protocol core does not define admin standalone shapes for these
+                // proposal types; fail closed rather than admit by omission.
+                ProposalAuthorizationOutcome::Rejected(
+                    ProposalRejectionCategory::UnsupportedProposal,
+                )
+            } else {
+                ProposalAuthorizationOutcome::Rejected(
+                    ProposalRejectionCategory::AuthorizationFailed,
+                )
+            }
+        }
+    }
+}
+
+/// Revalidate every by-reference and by-value proposal consumed by a staged commit.
+pub(crate) fn authorize_staged_commit_queued_proposals(
+    mls_group: &MlsGroup,
+    group_id: &GroupId,
+    staged: &StagedCommit,
+) -> ProposalAuthorizationOutcome {
+    for queued in staged.queued_proposals() {
+        let outcome = authorize_queued_proposal(
+            mls_group,
+            group_id,
+            queued,
+            ProposalAuthorizationContext::StagedCommit,
+        );
+        if outcome != ProposalAuthorizationOutcome::Authorized {
+            return outcome;
+        }
+    }
+    ProposalAuthorizationOutcome::Authorized
+}
+
+/// Map only proposal-specific OpenMLS processing failures into the stable
+/// rejection taxonomy. Unrelated commit/path failures remain ordinary engine
+/// errors so callers do not mislabel them as rejected proposals.
+pub(crate) fn classify_process_message_error<StorageError>(
+    err: &ProcessMessageError<StorageError>,
+    content_type: ContentType,
+) -> Option<ProposalRejectionCategory> {
+    match (content_type, err) {
+        (ContentType::Proposal, ProcessMessageError::UnsupportedProposalType) => {
+            Some(ProposalRejectionCategory::UnsupportedProposal)
+        }
+        (ContentType::Proposal, ProcessMessageError::IncompatibleWireFormat) => {
+            Some(ProposalRejectionCategory::InvalidEncoding)
+        }
+        (ContentType::Proposal, ProcessMessageError::ValidationError(validation)) => {
+            match validation {
+                ValidationError::WrongEpoch => None,
+                ValidationError::UnknownMember
+                | ValidationError::MissingMembershipTag
+                | ValidationError::InvalidMembershipTag
+                | ValidationError::InvalidSignature
+                | ValidationError::UnauthorizedExternalSender
+                | ValidationError::NoExternalSendersExtension
+                | ValidationError::InvalidLeafNodeSignature
+                | ValidationError::InvalidSenderType => {
+                    Some(ProposalRejectionCategory::InvalidSignature)
+                }
+                _ => Some(ProposalRejectionCategory::InvalidEncoding),
+            }
+        }
+        // A commit-level WrongWireFormat is the OpenMLS error currently used
+        // when an inline AppDataUpdate payload fails validation. Keep all other
+        // message-level commit failures on the ordinary commit classification
+        // path; they are not evidence that a proposal failed Marmot semantics.
+        (
+            ContentType::Commit,
+            ProcessMessageError::ValidationError(ValidationError::WrongWireFormat),
+        ) => Some(ProposalRejectionCategory::InvalidEncoding),
+        (
+            ContentType::Commit,
+            ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+                validation,
+            )),
+        ) => Some(match validation {
+            ProposalValidationError::InsufficientCapabilities
+            | ProposalValidationError::UnsupportedProposalType => {
+                ProposalRejectionCategory::UnsupportedProposal
+            }
+            ProposalValidationError::UnknownMember
+            | ProposalValidationError::UpdateFromNonMember => {
+                ProposalRejectionCategory::InvalidSignature
+            }
+            _ => ProposalRejectionCategory::InvalidEncoding,
+        }),
+        (
+            ContentType::Commit,
+            ProcessMessageError::InvalidCommit(
+                StageCommitError::AppDataUpdateValidationError(_)
+                | StageCommitError::ApplyAppDataUpdateError(_)
+                | StageCommitError::GroupContextExtensionsProposalValidationError(_)
+                | StageCommitError::LeafNodeValidation(_),
+            ),
+        ) => Some(ProposalRejectionCategory::InvalidEncoding),
+        _ => None,
+    }
+}
+
+fn authorize_self_remove_proposal(
+    sender: &Sender,
+    sender_account: Option<[u8; 32]>,
+    admins: &[[u8; 32]],
+) -> ProposalAuthorizationOutcome {
+    let Sender::Member(_leaf_idx) = sender else {
+        return ProposalAuthorizationOutcome::Rejected(ProposalRejectionCategory::InvalidSignature);
+    };
+    // SelfRemove admin comparison uses the 32-byte BasicCredential identity on
+    // the same non-curve-validating basis as `decode_admin_policy` /
+    // `credential_account_pubkey`, NOT the secp256k1-validating
+    // `identity::member_id_of_sender` (mdk#728). The admin set is not
+    // curve-validated, so a leaf whose 32-byte identity equals a listed admin
+    // key but fails secp256k1 validation would resolve to `None` under the
+    // validating chokepoint and skip this guard. Matching the admin-set basis
+    // keeps both sides of the comparison comparable. Fail CLOSED: a SelfRemove
+    // whose sender cannot be resolved on that basis is rejected.
+    let Some(sender_pubkey) = sender_account else {
+        return ProposalAuthorizationOutcome::Rejected(
+            ProposalRejectionCategory::InvalidSelfRemove,
+        );
+    };
+    if admins.iter().any(|admin| admin == &sender_pubkey) {
+        return ProposalAuthorizationOutcome::Rejected(
+            ProposalRejectionCategory::InvalidSelfRemove,
+        );
+    }
+    ProposalAuthorizationOutcome::Authorized
+}
+
+fn sender_account_pubkey(mls_group: &MlsGroup, sender: &Sender) -> Option<[u8; 32]> {
+    match sender {
+        Sender::Member(leaf_idx) => mls_group
+            .member_at(*leaf_idx)
+            .and_then(|member| credential_account_pubkey(member.credential)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::proposal_rejection_category_tag;
+    use cgka_traits::ingest::ProposalRejectionCategory;
+
+    #[test]
+    fn rejection_category_tags_are_stable() {
+        assert_eq!(
+            proposal_rejection_category_tag(ProposalRejectionCategory::AuthorizationFailed),
+            "authorization_failed"
+        );
+        assert_eq!(
+            proposal_rejection_category_tag(ProposalRejectionCategory::UnsupportedProposal),
+            "unsupported_proposal"
+        );
+    }
+}

--- a/crates/cgka-engine/src/proposal_authorization.rs
+++ b/crates/cgka-engine/src/proposal_authorization.rs
@@ -223,6 +223,29 @@ pub(crate) fn authorize_staged_commit_queued_proposals(
     ProposalAuthorizationOutcome::Authorized
 }
 
+/// Membership-tag and sender-leaf authentication depend on the source-epoch
+/// group state. Failures here must be retried against retained fork parents
+/// before they may become terminal proposal rejections.
+pub(crate) fn is_parent_dependent_process_message_error<StorageError>(
+    err: &ProcessMessageError<StorageError>,
+    content_type: ContentType,
+) -> bool {
+    matches!(
+        (content_type, err),
+        (
+            ContentType::Proposal,
+            ProcessMessageError::ValidationError(
+                ValidationError::UnknownMember | ValidationError::InvalidMembershipTag
+            )
+        )
+    )
+}
+
+/// Marmot v1 does not admit standalone external-join proposals.
+pub(crate) fn external_join_proposal_rejection_category() -> ProposalRejectionCategory {
+    ProposalRejectionCategory::UnsupportedProposal
+}
+
 /// Map only proposal-specific OpenMLS processing failures into the stable
 /// rejection taxonomy. Unrelated commit/path failures remain ordinary engine
 /// errors so callers do not mislabel them as rejected proposals.
@@ -230,6 +253,9 @@ pub(crate) fn classify_process_message_error<StorageError>(
     err: &ProcessMessageError<StorageError>,
     content_type: ContentType,
 ) -> Option<ProposalRejectionCategory> {
+    if is_parent_dependent_process_message_error(err, content_type) {
+        return None;
+    }
     match (content_type, err) {
         (ContentType::Proposal, ProcessMessageError::UnsupportedProposalType) => {
             Some(ProposalRejectionCategory::UnsupportedProposal)
@@ -240,9 +266,7 @@ pub(crate) fn classify_process_message_error<StorageError>(
         (ContentType::Proposal, ProcessMessageError::ValidationError(validation)) => {
             match validation {
                 ValidationError::WrongEpoch => None,
-                ValidationError::UnknownMember
-                | ValidationError::MissingMembershipTag
-                | ValidationError::InvalidMembershipTag
+                ValidationError::MissingMembershipTag
                 | ValidationError::InvalidSignature
                 | ValidationError::UnauthorizedExternalSender
                 | ValidationError::NoExternalSendersExtension
@@ -343,6 +367,18 @@ mod tests {
         assert_eq!(
             proposal_rejection_category_tag(ProposalRejectionCategory::UnsupportedProposal),
             "unsupported_proposal"
+        );
+        assert_eq!(
+            proposal_rejection_category_tag(ProposalRejectionCategory::InvalidEncoding),
+            "invalid_encoding"
+        );
+        assert_eq!(
+            proposal_rejection_category_tag(ProposalRejectionCategory::InvalidSignature),
+            "invalid_signature"
+        );
+        assert_eq!(
+            proposal_rejection_category_tag(ProposalRejectionCategory::InvalidSelfRemove),
+            "invalid_self_remove"
         );
     }
 }

--- a/crates/cgka-engine/tests/audit_log.rs
+++ b/crates/cgka-engine/tests/audit_log.rs
@@ -11,6 +11,7 @@
 use async_trait::async_trait;
 use cgka_engine::EngineBuilder;
 use cgka_traits::CgkaEngine;
+use cgka_traits::StorageProvider;
 use cgka_traits::engine::{CreateGroupRequest, SendResult};
 use cgka_traits::error::PeelerError;
 use cgka_traits::group_context::GroupContextSnapshot;
@@ -24,6 +25,8 @@ use marmot_forensics::{
     AuditEvent, AuditEventContext, AuditEventKind, AuditHumanActionContext, AuditTransportContext,
     AuditTransportWire, JsonlRecorder,
 };
+use openmls::prelude::OpenMlsProvider;
+use openmls::prelude::tls_codec::Serialize as _;
 use storage_sqlite::SqliteAccountStorage;
 
 mod support;
@@ -400,6 +403,247 @@ async fn audit_log_records_transport_received_before_ingest_entry() {
             );
             assert_eq!(*payload_len, 4);
             assert_eq!(payload_digest.len(), 64, "payload_digest is a SHA-256 hex");
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[tokio::test]
+async fn audit_log_records_proposal_rejection_category_without_sensitive_fields() {
+    use cgka_engine::feature_registry::FeatureRegistry;
+    use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
+    use cgka_traits::engine::{CreateGroupRequest, SendResult};
+    use cgka_traits::ingest::{
+        IngestOutcome, PeeledContent, PeeledMessage, ProposalRejectionCategory,
+    };
+    use cgka_traits::storage::AccountDeviceSignerStorage;
+
+    struct PassThroughPeeler;
+
+    fn hash_id(bytes: &[u8]) -> MessageId {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut h = DefaultHasher::new();
+        bytes.hash(&mut h);
+        MessageId::new(h.finish().to_be_bytes().to_vec())
+    }
+
+    #[async_trait]
+    impl TransportPeeler for PassThroughPeeler {
+        async fn peel_group_message(
+            &self,
+            msg: &TransportMessage,
+            _ctx: &GroupContextSnapshot,
+        ) -> Result<PeeledMessage, PeelerError> {
+            Ok(PeeledMessage {
+                id: msg.id.clone(),
+                group_id: None,
+                sender: None,
+                content: PeeledContent::MlsMessage {
+                    bytes: msg.payload.clone(),
+                },
+                origin: msg.clone(),
+            })
+        }
+        async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+            Ok(PeeledMessage {
+                id: msg.id.clone(),
+                group_id: None,
+                sender: None,
+                content: PeeledContent::Welcome {
+                    bytes: msg.payload.clone(),
+                },
+                origin: msg.clone(),
+            })
+        }
+        async fn wrap_group_message(
+            &self,
+            payload: &EncryptedPayload,
+            _ctx: &GroupContextSnapshot,
+        ) -> Result<TransportMessage, PeelerError> {
+            Ok(TransportMessage {
+                id: hash_id(&payload.ciphertext),
+                payload: payload.ciphertext.clone(),
+                timestamp: Timestamp(0),
+                causal_deps: vec![],
+                source: TransportSource("audit-proposal-reject".into()),
+                envelope: TransportEnvelope::GroupMessage {
+                    transport_group_id: vec![],
+                },
+            })
+        }
+        async fn wrap_welcome(
+            &self,
+            payload: &EncryptedPayload,
+            recipient: &MemberId,
+        ) -> Result<TransportMessage, PeelerError> {
+            Ok(TransportMessage {
+                id: hash_id(&payload.ciphertext),
+                payload: payload.ciphertext.clone(),
+                timestamp: Timestamp(0),
+                causal_deps: vec![],
+                source: TransportSource("audit-proposal-reject".into()),
+                envelope: TransportEnvelope::Welcome {
+                    recipient: recipient.clone(),
+                },
+            })
+        }
+    }
+
+    fn registry() -> FeatureRegistry {
+        let mut r = FeatureRegistry::new();
+        r.register(
+            Feature("self-remove"),
+            CapabilityRequirement {
+                requires: Capability::Proposal(10),
+                level: RequirementLevel::Required,
+                description: "MIP-03",
+            },
+        );
+        r
+    }
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().join("audit-proposal-reject.jsonl");
+    let recorder = JsonlRecorder::open(&path, "audit-proposal-reject".to_string()).unwrap();
+
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let mut alice = EngineBuilder::new(storage.clone())
+        .identity(valid_identity(b"alice"))
+        .account_identity_proof_signer(proof_signer(b"alice"))
+        .feature_registry(registry())
+        .peeler(Box::new(PassThroughPeeler))
+        .build()
+        .unwrap();
+    let bob_storage = SqliteAccountStorage::in_memory().unwrap();
+    let mut bob = EngineBuilder::new(bob_storage.clone())
+        .identity(valid_identity(b"bob"))
+        .account_identity_proof_signer(proof_signer(b"bob"))
+        .feature_registry(registry())
+        .peeler(Box::new(PassThroughPeeler))
+        .build()
+        .unwrap();
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "audit-proposal-reject".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![Feature("self-remove")],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let welcome_for_bob = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            welcomes.remove(0)
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcome_for_bob).await.unwrap();
+
+    let crypto = openmls_rust_crypto::RustCrypto::default();
+    let provider = cgka_engine::provider::EngineOpenMlsProvider::<SqliteAccountStorage>::new(
+        &crypto,
+        bob_storage.mls_storage(),
+    );
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mut mls_group = openmls::group::MlsGroup::load(provider.storage(), &mls_gid)
+        .unwrap()
+        .unwrap();
+    let binding = bob_storage
+        .account_device_signer(&bob.self_id())
+        .unwrap()
+        .unwrap();
+    let signer = openmls_basic_credential::SignatureKeyPair::read(
+        bob_storage.mls_storage(),
+        &binding.mls_signature_public_key,
+        cgka_engine::DEFAULT_CIPHERSUITE.signature_algorithm(),
+    )
+    .unwrap();
+    let credential = openmls::prelude::CredentialWithKey {
+        credential: openmls::prelude::BasicCredential::new(bob.self_id().as_slice().to_vec())
+            .into(),
+        signature_key: signer.public().into(),
+    };
+    let leaf_node_parameters = openmls::prelude::LeafNodeParameters::builder()
+        .with_credential_with_key(credential)
+        .build();
+    let (proposal_out, _) = mls_group
+        .propose_self_update(&provider, &signer, leaf_node_parameters)
+        .unwrap();
+    let proposal_bytes = proposal_out.tls_serialize_detached().unwrap();
+    let proposal = TransportMessage {
+        id: MessageId::new(vec![0x42; 16]),
+        payload: proposal_bytes,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("audit-proposal-reject".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    };
+
+    let mut alice_audited = EngineBuilder::new(storage)
+        .identity(valid_identity(b"alice"))
+        .account_identity_proof_signer(proof_signer(b"alice"))
+        .feature_registry(registry())
+        .peeler(Box::new(PassThroughPeeler))
+        .recorder(Box::new(recorder))
+        .build()
+        .unwrap();
+    let outcome = alice_audited.ingest(proposal).await.unwrap();
+    assert!(matches!(
+        outcome,
+        IngestOutcome::Rejected {
+            category: ProposalRejectionCategory::AuthorizationFailed
+        }
+    ));
+    drop(alice_audited);
+
+    let contents = std::fs::read_to_string(&path).unwrap();
+    let events: Vec<AuditEvent> = contents
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    let rejection = events
+        .iter()
+        .find(|event| matches!(event.kind, AuditEventKind::Rejection { .. }))
+        .expect("Rejection audit event");
+    match &rejection.kind {
+        AuditEventKind::Rejection { reason, msg_id } => {
+            assert_eq!(reason, "authorization_failed");
+            assert_eq!(msg_id.len(), 64, "audit msg_id is SHA-256 hex of MLS bytes");
+            let rejection_kind_json = serde_json::to_string(&rejection.kind).unwrap();
+            assert!(
+                !rejection_kind_json.contains(&hex::encode(group_id.as_slice())),
+                "Rejection payload must not embed group id"
+            );
+            assert!(
+                !rejection_kind_json.contains(&hex::encode(bob.self_id().as_slice())),
+                "Rejection payload must not embed member id"
+            );
+        }
+        _ => unreachable!(),
+    }
+    let outcome_event = events
+        .iter()
+        .find(|event| matches!(event.kind, AuditEventKind::IngestOutcome { .. }))
+        .expect("IngestOutcome audit event");
+    match &outcome_event.kind {
+        AuditEventKind::IngestOutcome {
+            outcome_kind,
+            stale_reason,
+            ..
+        } => {
+            assert_eq!(outcome_kind, "rejected");
+            assert_eq!(stale_reason.as_deref(), Some("authorization_failed"));
         }
         _ => unreachable!(),
     }

--- a/crates/cgka-engine/tests/mip03_guards.rs
+++ b/crates/cgka-engine/tests/mip03_guards.rs
@@ -16,7 +16,9 @@ use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, Requ
 use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult};
 use cgka_traits::error::PeelerError;
 use cgka_traits::group_context::GroupContextSnapshot;
-use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage};
+use cgka_traits::ingest::{
+    IngestOutcome, PeeledContent, PeeledMessage, ProposalRejectionCategory, StaleReason,
+};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{AccountDeviceSignerStorage, StorageProvider};
 use cgka_traits::transport::{
@@ -483,11 +485,15 @@ async fn inbound_by_reference_update_rejects_account_identity_spoofing() {
 
     assert!(matches!(
         alice.ingest(spoofed_proposal.clone()).await.unwrap(),
-        IngestOutcome::Processed
+        IngestOutcome::Rejected {
+            category: ProposalRejectionCategory::AuthorizationFailed
+        }
     ));
     assert!(matches!(
         carol.ingest(spoofed_proposal.clone()).await.unwrap(),
-        IngestOutcome::Processed
+        IngestOutcome::Rejected {
+            category: ProposalRejectionCategory::AuthorizationFailed
+        }
     ));
 
     let before_epoch = carol.epoch(&group_id).expect("carol has group");
@@ -505,10 +511,10 @@ async fn inbound_by_reference_update_rejects_account_identity_spoofing() {
         matches!(
             outcome,
             IngestOutcome::Stale {
-                reason: cgka_traits::ingest::StaleReason::PeelFailed
+                reason: StaleReason::PeelFailed
             }
         ),
-        "terminally invalid by-reference Update commits should not remain buffered, got {outcome:?}"
+        "terminally invalid same-epoch by-reference commits should not remain buffered, got {outcome:?}"
     );
     let result = carol
         .converge_stored_openmls_messages(&group_id, 1_000_000)

--- a/crates/cgka-engine/tests/proposal_authorization.rs
+++ b/crates/cgka-engine/tests/proposal_authorization.rs
@@ -5,6 +5,8 @@
 //! auto-commit scheduling, or convergence replay.
 
 use async_trait::async_trait;
+use cgka_engine::canonicalization::CanonicalizationPolicy;
+use cgka_engine::convergence::ConvergencePolicy;
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::provider::EngineOpenMlsProvider;
 use cgka_engine::{DEFAULT_CIPHERSUITE, Engine, EngineBuilder};
@@ -15,6 +17,7 @@ use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{
     IngestOutcome, PeeledContent, PeeledMessage, ProposalRejectionCategory, StaleReason,
 };
+use cgka_traits::message::MessageState;
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{AccountDeviceSignerStorage, MessageStorage, StorageProvider};
 use cgka_traits::transport::{
@@ -23,11 +26,12 @@ use cgka_traits::transport::{
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use openmls::component::ComponentData;
 use openmls::group::MlsGroup;
+use openmls::messages::external_proposals::JoinProposal;
 use openmls::messages::proposals::{AppDataUpdateOperation, AppDataUpdateProposal, Proposal};
 use openmls::prelude::{BasicCredential, CredentialWithKey, LeafNodeParameters};
 use openmls_basic_credential::SignatureKeyPair;
-use openmls_rust_crypto::RustCrypto;
-use openmls_traits::OpenMlsProvider as _;
+use openmls_rust_crypto::{OpenMlsRustCrypto, RustCrypto};
+use openmls_traits::OpenMlsProvider;
 use storage_sqlite::SqliteAccountStorage;
 use tls_codec::{Deserialize as _, Serialize as _};
 
@@ -982,19 +986,13 @@ async fn rejected_proposal_does_not_block_or_alter_later_valid_commit() {
 }
 
 #[tokio::test]
-async fn tampered_standalone_proposal_returns_invalid_signature_rejection() {
+async fn invalid_external_join_signature_returns_invalid_signature_rejection() {
     let (mut alice, _alice_storage) = build_with_storage(b"alice");
-    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let (mut bob, _bob_storage) = build_with_storage(b"bob");
     let mut carol = build(b"carol");
     let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
-    let crypto = RustCrypto::default();
-    let mut proposal =
-        non_admin_self_update_proposal(&bob_storage, &crypto, &bob.self_id(), &group_id);
-    if let Some(byte) = proposal.payload.get_mut(32) {
-        *byte ^= 0xff;
-    } else {
-        proposal.payload.push(0xff);
-    }
+    let epoch = alice.epoch(&group_id).unwrap().0;
+    let proposal = external_join_proposal_with_signature(&group_id, epoch, false);
     let outcome = alice.ingest(proposal).await.unwrap();
     assert!(
         matches!(
@@ -1003,6 +1001,315 @@ async fn tampered_standalone_proposal_returns_invalid_signature_rejection() {
                 category: ProposalRejectionCategory::InvalidSignature
             }
         ),
-        "OpenMLS ValidationError on proposal must map to InvalidSignature, got {outcome:?}"
+        "cryptographic proposal-signature failure must map to InvalidSignature, got {outcome:?}"
+    );
+}
+
+fn evolution(msg: SendResult) -> (TransportMessage, cgka_traits::engine_state::PendingStateRef) {
+    match msg {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    }
+}
+
+fn proposal(msg: SendResult) -> TransportMessage {
+    match msg {
+        SendResult::Proposal { msg } => msg,
+        other => panic!("expected Proposal, got {other:?}"),
+    }
+}
+
+fn route(msg: TransportMessage, group_id: &GroupId) -> TransportMessage {
+    TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..msg
+    }
+}
+
+fn fresh_openmls_key_package(
+    identity: &[u8],
+    signer: &SignatureKeyPair,
+) -> openmls::prelude::KeyPackage {
+    let provider = OpenMlsRustCrypto::default();
+    let credential_with_key = CredentialWithKey {
+        credential: BasicCredential::new(pad32(identity)).into(),
+        signature_key: signer.public().into(),
+    };
+    openmls::key_packages::KeyPackage::builder()
+        .leaf_node_capabilities(openmls::prelude::Capabilities::default())
+        .build(DEFAULT_CIPHERSUITE, &provider, signer, credential_with_key)
+        .expect("build openmls key package")
+        .key_package()
+        .clone()
+}
+
+fn external_join_proposal(group_id: &GroupId, epoch: u64) -> TransportMessage {
+    external_join_proposal_with_signature(group_id, epoch, true)
+}
+
+fn external_join_proposal_with_signature(
+    group_id: &GroupId,
+    epoch: u64,
+    valid_signature: bool,
+) -> TransportMessage {
+    let key_package_signer = SignatureKeyPair::new(DEFAULT_CIPHERSUITE.signature_algorithm())
+        .expect("external join key package signer");
+    let other_signer = SignatureKeyPair::new(DEFAULT_CIPHERSUITE.signature_algorithm())
+        .expect("alternate external join signer");
+    let proposal_signer = if valid_signature {
+        &key_package_signer
+    } else {
+        &other_signer
+    };
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let proposal_out =
+        JoinProposal::new::<<OpenMlsRustCrypto as OpenMlsProvider>::StorageProvider>(
+            fresh_openmls_key_package(b"external-joiner", &key_package_signer),
+            mls_gid,
+            openmls::group::GroupEpoch::from(epoch),
+            proposal_signer,
+        )
+        .expect("build external join proposal");
+    let proposal_bytes = proposal_out
+        .tls_serialize_detached()
+        .expect("serialize external join proposal");
+    TransportMessage {
+        id: hash_id(&proposal_bytes),
+        payload: proposal_bytes,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("external-join-proposal".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    }
+}
+
+#[tokio::test]
+async fn direct_ingest_rejects_external_join_proposal() {
+    let (mut alice, _alice_storage) = build_with_storage(b"alice");
+    let (mut bob, _bob_storage) = build_with_storage(b"bob");
+    let mut carol = build(b"carol");
+    let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
+    let epoch = alice.epoch(&group_id).unwrap().0;
+    let proposal = external_join_proposal(&group_id, epoch);
+
+    let outcome = alice.ingest(proposal).await.unwrap();
+    assert!(
+        matches!(
+            outcome,
+            IngestOutcome::Rejected {
+                category: ProposalRejectionCategory::UnsupportedProposal
+            }
+        ),
+        "external join must be rejected before pending state, got {outcome:?}"
+    );
+    assert!(alice.drain_auto_publish().is_empty());
+
+    let crypto = RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, _alice_storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load alice group")
+        .expect("alice group present");
+    assert!(
+        mls_group.pending_proposals().next().is_none(),
+        "external join must not enter OpenMLS pending state"
+    );
+}
+
+#[tokio::test]
+async fn convergence_rejects_external_join_proposal_before_pending_store() {
+    let (mut alice, _alice_storage) = build_with_storage(b"alice");
+    let (mut bob, _bob_storage) = build_with_storage(b"bob");
+    let (mut carol, carol_storage) = build_with_storage(b"carol");
+    let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
+    let epoch = carol.epoch(&group_id).unwrap().0;
+    let proposal = external_join_proposal(&group_id, epoch);
+    let routed = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..proposal
+    };
+    let proposal_id = canonicalization_message_id(&routed);
+    let proposal_message_id = content_dedup_message_id(&routed);
+    carol
+        .buffer_openmls_convergence_message(&group_id, routed, 1_000)
+        .expect("buffer external join for convergence replay");
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("convergence run");
+    assert!(result.accepted_proposals.is_empty());
+    assert!(
+        result.dropped_messages.iter().any(|dropped| {
+            dropped.message_id == proposal_id
+                && dropped.kind == cgka_engine::canonicalization::MessageKind::Proposal
+                && dropped.reason
+                    == cgka_engine::canonicalization::DroppedMessageReason::InvalidAgainstCandidateState
+                && dropped.rejection_category
+                    == Some(ProposalRejectionCategory::UnsupportedProposal)
+        }),
+        "external join must be dropped through typed rejection: {:?}",
+        result.dropped_messages
+    );
+    let record = carol_storage
+        .get_message(&proposal_message_id)
+        .expect("durable proposal row");
+    assert_eq!(
+        record.state,
+        MessageState::Failed,
+        "rejected external join durable row must be terminal"
+    );
+}
+
+#[tokio::test]
+async fn parent_dependent_proposal_auth_deferred_until_retained_fork_replay() {
+    let (mut alice, _alice_storage) = build_with_storage(b"alice");
+    let (mut bob, _bob_storage) = build_with_storage(b"bob");
+    let (mut carol, carol_storage) = build_with_storage(b"carol");
+    let (mut david, _david_storage) = build_with_storage(b"david");
+    let (mut eve, _eve_storage) = build_with_storage(b"eve");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "parent-dependent-proposal".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![Feature("self-remove")],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcomes[0].clone()).await.unwrap();
+    carol.join_welcome(welcomes[1].clone()).await.unwrap();
+    carol.set_convergence_policy(CanonicalizationPolicy {
+        convergence: ConvergencePolicy {
+            max_rewind_commits: 1,
+            ..ConvergencePolicy::default()
+        },
+        ..CanonicalizationPolicy::default()
+    });
+
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let alice_invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david_kp],
+        })
+        .await
+        .unwrap();
+    let (alice_commit, alice_pending) = evolution(alice_invite);
+    alice.confirm_published(alice_pending).await.unwrap();
+    let alice_commit = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..alice_commit
+    };
+    carol
+        .buffer_openmls_convergence_message(&group_id, alice_commit.clone(), 1_000)
+        .expect("buffer alice branch commit");
+    carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("alice branch settles and retains epoch-1 anchor");
+    assert_eq!(carol.epoch(&group_id).unwrap().0, 2);
+
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let bob_invite = bob
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+        })
+        .await
+        .unwrap();
+    let (bob_commit, bob_pending, bob_welcomes) = match bob_invite {
+        SendResult::GroupEvolution {
+            msg,
+            pending,
+            welcomes,
+        } => (msg, pending, welcomes),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    bob.confirm_published(bob_pending).await.unwrap();
+    let bob_commit = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..bob_commit
+    };
+    let eve_welcome = bob_welcomes
+        .into_iter()
+        .find(|welcome| {
+            matches!(
+                &welcome.envelope,
+                TransportEnvelope::Welcome { recipient } if recipient == &eve.self_id()
+            )
+        })
+        .expect("bob welcome for eve");
+    eve.join_welcome(eve_welcome).await.unwrap();
+
+    let fork_proposal = route(
+        proposal(
+            eve.send(SendIntent::Leave {
+                group_id: group_id.clone(),
+            })
+            .await
+            .unwrap(),
+        ),
+        &group_id,
+    );
+    let proposal_message_id = content_dedup_message_id(&fork_proposal);
+    let proposal_id = canonicalization_message_id(&fork_proposal);
+
+    // The proposal deliberately arrives before the commit that creates its
+    // source-epoch parent. The current canonical state cannot authenticate it,
+    // but that is not proof of an invalid signature.
+    let ingest_outcome = carol.ingest(fork_proposal.clone()).await.unwrap();
+    assert!(
+        matches!(ingest_outcome, IngestOutcome::Buffered { .. }),
+        "parent-dependent auth must defer while its candidate parent is absent, got {ingest_outcome:?}"
+    );
+    let record = carol_storage
+        .get_message(&proposal_message_id)
+        .expect("proposal durable row");
+    assert_ne!(
+        record.state,
+        MessageState::Failed,
+        "proposal must stay retryable while its candidate parent is absent"
+    );
+
+    carol
+        .buffer_openmls_convergence_message(&group_id, bob_commit.clone(), 2_000)
+        .expect("buffer competing fork commit");
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("retained replay with alternate parent");
+    assert!(
+        !result.dropped_messages.iter().any(|dropped| {
+            dropped.message_id == proposal_id
+                && dropped.rejection_category == Some(ProposalRejectionCategory::InvalidSignature)
+        }),
+        "alternate-parent replay must not classify the proposal as an invalid signature: {:?}",
+        result.dropped_messages
+    );
+    let record = carol_storage
+        .get_message(&proposal_message_id)
+        .expect("proposal durable row");
+    assert_ne!(
+        record.state,
+        MessageState::Failed,
+        "proposal must stay retryable until retained fork replay authenticates a parent"
     );
 }

--- a/crates/cgka-engine/tests/proposal_authorization.rs
+++ b/crates/cgka-engine/tests/proposal_authorization.rs
@@ -1,0 +1,1008 @@
+//! Standalone MLS proposal authorization (mdk#1053).
+//!
+//! Non-admin members may send only SelfRemove as standalone proposals. Privileged
+//! or unsupported standalone proposals must be rejected before queueing,
+//! auto-commit scheduling, or convergence replay.
+
+use async_trait::async_trait;
+use cgka_engine::feature_registry::FeatureRegistry;
+use cgka_engine::provider::EngineOpenMlsProvider;
+use cgka_engine::{DEFAULT_CIPHERSUITE, Engine, EngineBuilder};
+use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
+use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult};
+use cgka_traits::error::PeelerError;
+use cgka_traits::group_context::GroupContextSnapshot;
+use cgka_traits::ingest::{
+    IngestOutcome, PeeledContent, PeeledMessage, ProposalRejectionCategory, StaleReason,
+};
+use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::storage::{AccountDeviceSignerStorage, MessageStorage, StorageProvider};
+use cgka_traits::transport::{
+    EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
+};
+use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
+use openmls::component::ComponentData;
+use openmls::group::MlsGroup;
+use openmls::messages::proposals::{AppDataUpdateOperation, AppDataUpdateProposal, Proposal};
+use openmls::prelude::{BasicCredential, CredentialWithKey, LeafNodeParameters};
+use openmls_basic_credential::SignatureKeyPair;
+use openmls_rust_crypto::RustCrypto;
+use openmls_traits::OpenMlsProvider as _;
+use storage_sqlite::SqliteAccountStorage;
+use tls_codec::{Deserialize as _, Serialize as _};
+
+mod support;
+use support::proof_signer;
+
+fn pad32(name: &[u8]) -> Vec<u8> {
+    use k256::schnorr::SigningKey;
+    use sha2::{Digest, Sha256};
+    let mut counter = 0u64;
+    loop {
+        let mut material = [0u8; 32];
+        let mut hasher = Sha256::new();
+        hasher.update(b"cgka-engine-test-identity-v1");
+        hasher.update(name);
+        hasher.update(counter.to_be_bytes());
+        material.copy_from_slice(&hasher.finalize());
+        if let Ok(sk) = SigningKey::from_bytes(&material) {
+            return sk.verifying_key().to_bytes().to_vec();
+        }
+        counter += 1;
+    }
+}
+
+struct MockPeeler;
+
+fn hash_id(b: &[u8]) -> MessageId {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut h = DefaultHasher::new();
+    b.hash(&mut h);
+    MessageId::new(h.finish().to_be_bytes().to_vec())
+}
+
+fn canonicalization_message_id(msg: &TransportMessage) -> String {
+    // Stored OpenMLS canonicalization keys messages by MLS payload digest, not
+    // by the transport envelope id used on the live ingest path.
+    use sha2::{Digest, Sha256};
+    hex::encode(Sha256::digest(&msg.payload))
+}
+
+fn content_dedup_message_id(msg: &TransportMessage) -> MessageId {
+    use sha2::{Digest, Sha256};
+    MessageId::new(Sha256::digest(&msg.payload).to_vec())
+}
+
+#[async_trait]
+impl TransportPeeler for MockPeeler {
+    async fn peel_group_message(
+        &self,
+        msg: &TransportMessage,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        Ok(PeeledMessage {
+            id: msg.id.clone(),
+            group_id: None,
+            sender: None,
+            content: PeeledContent::MlsMessage {
+                bytes: msg.payload.clone(),
+            },
+            origin: msg.clone(),
+        })
+    }
+    async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        Ok(PeeledMessage {
+            id: msg.id.clone(),
+            group_id: None,
+            sender: None,
+            content: PeeledContent::Welcome {
+                bytes: msg.payload.clone(),
+            },
+            origin: msg.clone(),
+        })
+    }
+    async fn wrap_group_message(
+        &self,
+        payload: &EncryptedPayload,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        Ok(TransportMessage {
+            id: hash_id(&payload.ciphertext),
+            payload: payload.ciphertext.clone(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("mock".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: vec![],
+            },
+        })
+    }
+    async fn wrap_welcome(
+        &self,
+        payload: &EncryptedPayload,
+        recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        Ok(TransportMessage {
+            id: hash_id(&payload.ciphertext),
+            payload: payload.ciphertext.clone(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("mock".into()),
+            envelope: TransportEnvelope::Welcome {
+                recipient: recipient.clone(),
+            },
+        })
+    }
+}
+
+fn registry() -> FeatureRegistry {
+    let mut r = FeatureRegistry::new();
+    r.register(
+        Feature("self-remove"),
+        CapabilityRequirement {
+            requires: Capability::Proposal(10),
+            level: RequirementLevel::Required,
+            description: "MIP-03",
+        },
+    );
+    r
+}
+
+fn build(id: &[u8]) -> impl CgkaEngine {
+    EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
+        .identity(pad32(id))
+        .account_identity_proof_signer(proof_signer(id))
+        .feature_registry(registry())
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .unwrap()
+}
+
+fn build_with_storage(id: &[u8]) -> (Engine<SqliteAccountStorage>, SqliteAccountStorage) {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let engine = EngineBuilder::new(storage.clone())
+        .identity(pad32(id))
+        .account_identity_proof_signer(proof_signer(id))
+        .feature_registry(registry())
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .unwrap();
+    (engine, storage)
+}
+
+fn load_group_and_signer<'a>(
+    storage: &'a SqliteAccountStorage,
+    crypto: &'a RustCrypto,
+    member: &MemberId,
+    group_id: &GroupId,
+) -> (MlsGroup, SignatureKeyPair) {
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(crypto, storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load group")
+        .expect("group present");
+    let binding = storage
+        .account_device_signer(member)
+        .expect("signer binding")
+        .expect("signer binding present");
+    let signer = SignatureKeyPair::read(
+        storage.mls_storage(),
+        &binding.mls_signature_public_key,
+        DEFAULT_CIPHERSUITE.signature_algorithm(),
+    )
+    .expect("signer present");
+    (mls_group, signer)
+}
+
+fn app_payload_for(engine: &Engine<SqliteAccountStorage>, content: &str) -> Vec<u8> {
+    use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
+    MarmotAppEvent::new(
+        hex::encode(engine.self_id().as_slice()),
+        1_700_000_000,
+        MARMOT_APP_EVENT_KIND_CHAT,
+        vec![],
+        content.to_string(),
+    )
+    .encode()
+    .expect("test app event encodes")
+}
+
+fn non_admin_self_update_proposal(
+    storage: &SqliteAccountStorage,
+    crypto: &RustCrypto,
+    sender: &MemberId,
+    group_id: &GroupId,
+) -> TransportMessage {
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(crypto, storage.mls_storage());
+    let (mut mls_group, signer) = load_group_and_signer(storage, crypto, sender, group_id);
+    let credential = CredentialWithKey {
+        credential: BasicCredential::new(sender.as_slice().to_vec()).into(),
+        signature_key: signer.public().into(),
+    };
+    let leaf_node_parameters = LeafNodeParameters::builder()
+        .with_credential_with_key(credential)
+        .build();
+    let (proposal_out, _proposal_ref) = mls_group
+        .propose_self_update(&provider, &signer, leaf_node_parameters)
+        .expect("non-admin can build self-update proposal at OpenMLS layer");
+    let proposal_bytes = proposal_out
+        .tls_serialize_detached()
+        .expect("serialize self-update proposal");
+
+    TransportMessage {
+        id: hash_id(&proposal_bytes),
+        payload: proposal_bytes,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("standalone-update-proposal".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    }
+}
+
+fn store_pending_proposal(
+    storage: &SqliteAccountStorage,
+    crypto: &RustCrypto,
+    member: &MemberId,
+    group_id: &GroupId,
+    proposal: &TransportMessage,
+) {
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(crypto, storage.mls_storage());
+    let (mut mls_group, _) = load_group_and_signer(storage, crypto, member, group_id);
+    let proposal_in = openmls::prelude::MlsMessageIn::tls_deserialize_exact(&proposal.payload)
+        .expect("deserialize standalone proposal");
+    let protocol: openmls::framing::ProtocolMessage = match proposal_in.extract() {
+        openmls::prelude::MlsMessageBodyIn::PrivateMessage(message) => message.into(),
+        openmls::prelude::MlsMessageBodyIn::PublicMessage(message) => message.into(),
+        other => panic!("expected proposal protocol message, got {other:?}"),
+    };
+    let processed = mls_group
+        .process_message(&provider, protocol)
+        .expect("process standalone proposal");
+    match processed.into_content() {
+        openmls::prelude::ProcessedMessageContent::ProposalMessage(queued) => mls_group
+            .store_pending_proposal(provider.storage(), *queued)
+            .expect("store pending proposal"),
+        other => panic!("expected proposal content, got {other:?}"),
+    }
+}
+
+fn commit_pending_proposals(
+    storage: &SqliteAccountStorage,
+    crypto: &RustCrypto,
+    committer: &MemberId,
+    group_id: &GroupId,
+) -> TransportMessage {
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(crypto, storage.mls_storage());
+    let (mut mls_group, signer) = load_group_and_signer(storage, crypto, committer, group_id);
+    let (commit_out, _, _) = mls_group
+        .commit_to_pending_proposals(&provider, &signer)
+        .expect("commit pending proposals");
+    let commit_bytes = commit_out
+        .tls_serialize_detached()
+        .expect("serialize by-reference commit");
+    TransportMessage {
+        id: hash_id(&commit_bytes),
+        payload: commit_bytes,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("by-reference-update-commit".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    }
+}
+
+#[tokio::test]
+async fn non_admin_standalone_update_proposal_is_rejected_at_ingest() {
+    // spec/protocol-core/group-messaging.md:57-59 — v1 allows only SelfRemove as
+    // a standalone proposal from non-admins. A by-reference Update proposal must
+    // not be accepted into pending state or schedule auto-commit work.
+    let (mut alice, _alice_storage) = build_with_storage(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let mut carol = build(b"carol");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "proposal-auth".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![Feature("self-remove")],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (welcome_for_bob, welcome_for_carol) = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            (welcomes.remove(0), welcomes.remove(0))
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcome_for_bob).await.unwrap();
+    carol.join_welcome(welcome_for_carol).await.unwrap();
+
+    let crypto = RustCrypto::default();
+    let proposal = non_admin_self_update_proposal(&bob_storage, &crypto, &bob.self_id(), &group_id);
+    let routed = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..proposal
+    };
+
+    let outcome = alice.ingest(routed.clone()).await.unwrap();
+    assert!(
+        matches!(
+            outcome,
+            IngestOutcome::Rejected {
+                category: ProposalRejectionCategory::AuthorizationFailed
+            }
+        ),
+        "privileged standalone Update must be rejected, got {outcome:?}"
+    );
+    assert!(
+        alice.drain_auto_publish().is_empty(),
+        "rejected proposal must not schedule auto-commit"
+    );
+    assert!(
+        carol.drain_auto_publish().is_empty(),
+        "rejected proposal must not schedule auto-commit on other members"
+    );
+
+    // Local outbound work must remain unblocked.
+    let app = alice
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(&alice, "still works"),
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(app, SendResult::ApplicationMessage { .. }),
+        "rejected inbound proposal must not block later local sends"
+    );
+
+    // OpenMLS pending proposal store must stay empty on the recipient.
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, _alice_storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load alice group")
+        .expect("alice group present");
+    assert!(
+        mls_group.pending_proposals().next().is_none(),
+        "rejected proposal must not enter OpenMLS pending state"
+    );
+
+    // Re-ingest after restart must not resurrect the proposal as pending.
+    let mut alice_restarted = EngineBuilder::new(_alice_storage.clone())
+        .identity(pad32(b"alice"))
+        .account_identity_proof_signer(proof_signer(b"alice"))
+        .feature_registry(registry())
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .unwrap();
+    let restart_outcome = alice_restarted.ingest(routed).await.unwrap();
+    assert!(
+        matches!(
+            restart_outcome,
+            IngestOutcome::Stale {
+                reason: StaleReason::AlreadySeen
+            } | IngestOutcome::Rejected {
+                category: ProposalRejectionCategory::AuthorizationFailed
+            }
+        ),
+        "restarted ingest must not hydrate rejected proposal, got {restart_outcome:?}"
+    );
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, _alice_storage.mls_storage());
+    let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("reload alice group")
+        .expect("alice group still present");
+    assert!(
+        mls_group.pending_proposals().next().is_none(),
+        "restart must not reintroduce rejected proposal into pending state"
+    );
+}
+
+async fn three_member_group(
+    alice: &mut Engine<SqliteAccountStorage>,
+    bob: &mut impl CgkaEngine,
+    carol: &mut impl CgkaEngine,
+) -> GroupId {
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "proposal-auth".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![Feature("self-remove")],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (welcome_for_bob, welcome_for_carol) = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            (welcomes.remove(0), welcomes.remove(0))
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcome_for_bob).await.unwrap();
+    carol.join_welcome(welcome_for_carol).await.unwrap();
+    group_id
+}
+
+#[tokio::test]
+async fn by_reference_non_admin_update_is_rejected_when_revalidated_at_commit() {
+    let (mut alice, alice_storage) = build_with_storage(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let (mut carol, carol_storage) = build_with_storage(b"carol");
+    let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
+    let crypto = RustCrypto::default();
+    let proposal = non_admin_self_update_proposal(&bob_storage, &crypto, &bob.self_id(), &group_id);
+
+    // Simulate a proposal retained before this authorization rule existed. Both
+    // the admin committer and recipient have the proposal needed to resolve the
+    // by-reference Commit. Commit-time revalidation must still reject Bob's
+    // admin-gated standalone Update proposal against the candidate parent.
+    store_pending_proposal(
+        &alice_storage,
+        &crypto,
+        &alice.self_id(),
+        &group_id,
+        &proposal,
+    );
+    store_pending_proposal(
+        &carol_storage,
+        &crypto,
+        &carol.self_id(),
+        &group_id,
+        &proposal,
+    );
+    let commit = commit_pending_proposals(&alice_storage, &crypto, &alice.self_id(), &group_id);
+    let before_epoch = carol.epoch(&group_id).expect("carol has group");
+
+    let outcome = carol.ingest(commit).await.unwrap();
+    assert!(
+        matches!(
+            outcome,
+            IngestOutcome::Rejected {
+                category: ProposalRejectionCategory::AuthorizationFailed
+            }
+        ),
+        "commit-time revalidation must reject non-admin by-reference Update, got {outcome:?}"
+    );
+    assert_eq!(carol.epoch(&group_id).unwrap(), before_epoch);
+}
+
+fn standalone_app_data_update_proposal(
+    storage: &SqliteAccountStorage,
+    crypto: &RustCrypto,
+    sender: &MemberId,
+    group_id: &GroupId,
+    component_id: cgka_traits::app_components::AppComponentId,
+    data: Vec<u8>,
+) -> TransportMessage {
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(crypto, storage.mls_storage());
+    let (mut mls_group, signer) = load_group_and_signer(storage, crypto, sender, group_id);
+    let (proposal_out, _) = mls_group
+        .propose_app_data_update(
+            &provider,
+            &signer,
+            component_id,
+            AppDataUpdateOperation::Update(data.into()),
+        )
+        .expect("build standalone AppDataUpdate proposal");
+    let proposal_bytes = proposal_out
+        .tls_serialize_detached()
+        .expect("serialize AppDataUpdate proposal");
+    TransportMessage {
+        id: hash_id(&proposal_bytes),
+        payload: proposal_bytes,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("standalone-app-data-update".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    }
+}
+
+#[tokio::test]
+async fn non_admin_standalone_app_data_update_is_rejected() {
+    let (mut alice, _alice_storage) = build_with_storage(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let mut carol = build(b"carol");
+    let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
+    let crypto = RustCrypto::default();
+    use cgka_traits::app_components::GROUP_PROFILE_COMPONENT_ID;
+    let proposal = standalone_app_data_update_proposal(
+        &bob_storage,
+        &crypto,
+        &bob.self_id(),
+        &group_id,
+        GROUP_PROFILE_COMPONENT_ID,
+        b"not-admin".to_vec(),
+    );
+    let routed = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..proposal
+    };
+    let outcome = alice.ingest(routed).await.unwrap();
+    assert!(matches!(
+        outcome,
+        IngestOutcome::Rejected {
+            category: ProposalRejectionCategory::AuthorizationFailed
+        }
+    ));
+}
+
+#[tokio::test]
+async fn admin_self_remove_standalone_is_rejected() {
+    let (mut alice, alice_storage) = build_with_storage(b"alice");
+    let (mut bob, _bob_storage) = build_with_storage(b"bob");
+    let (mut carol, _carol_storage) = build_with_storage(b"carol");
+    let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
+
+    let leave = alice
+        .send(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        leave,
+        cgka_traits::EngineError::AdminCannotSelfRemove { .. }
+    ));
+
+    // Build the proposal directly at the OpenMLS layer to exercise ingest auth.
+    let crypto = RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, alice_storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mut mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load")
+        .expect("present");
+    let binding = alice_storage
+        .account_device_signer(&alice.self_id())
+        .unwrap()
+        .unwrap();
+    let signer = SignatureKeyPair::read(
+        alice_storage.mls_storage(),
+        &binding.mls_signature_public_key,
+        DEFAULT_CIPHERSUITE.signature_algorithm(),
+    )
+    .unwrap();
+    let proposal_out = mls_group
+        .leave_group_via_self_remove(&provider, &signer)
+        .expect("admin can still build SelfRemove at OpenMLS layer");
+    let proposal_bytes = proposal_out.tls_serialize_detached().unwrap();
+    let routed = TransportMessage {
+        id: hash_id(&proposal_bytes),
+        payload: proposal_bytes,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("admin-self-remove".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    };
+
+    let outcome = carol.ingest(routed).await.unwrap();
+    assert!(matches!(
+        outcome,
+        IngestOutcome::Rejected {
+            category: ProposalRejectionCategory::InvalidSelfRemove
+        }
+    ));
+    assert!(carol.drain_auto_publish().is_empty());
+}
+
+#[tokio::test]
+async fn convergence_rejects_unauthorized_standalone_proposal_before_pending_store() {
+    let (mut alice, _alice_storage) = build_with_storage(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let (mut carol, carol_storage) = build_with_storage(b"carol");
+    let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
+    let crypto = RustCrypto::default();
+    let proposal = non_admin_self_update_proposal(&bob_storage, &crypto, &bob.self_id(), &group_id);
+    let routed = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..proposal
+    };
+    let proposal_id = canonicalization_message_id(&routed);
+    let proposal_message_id = content_dedup_message_id(&routed);
+    carol
+        .buffer_openmls_convergence_message(&group_id, routed, 1_000)
+        .expect("buffer unauthorized proposal for convergence replay");
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("convergence run");
+    assert!(result.accepted_proposals.is_empty());
+    assert!(
+        result.dropped_messages.iter().any(|dropped| {
+            dropped.message_id == proposal_id
+                && dropped.kind == cgka_engine::canonicalization::MessageKind::Proposal
+                && dropped.reason
+                    == cgka_engine::canonicalization::DroppedMessageReason::InvalidAgainstCandidateState
+                && dropped.rejection_category
+                    == Some(ProposalRejectionCategory::AuthorizationFailed)
+        }),
+        "rejected proposal must appear in dropped_messages: {:?}",
+        result.dropped_messages
+    );
+    let record = carol_storage
+        .get_message(&proposal_message_id)
+        .expect("durable proposal row");
+    assert_eq!(
+        record.state,
+        cgka_traits::message::MessageState::Failed,
+        "rejected proposal durable row must be terminal"
+    );
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, carol_storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load carol group")
+        .expect("carol group present");
+    assert!(
+        mls_group.pending_proposals().next().is_none(),
+        "convergence replay must not store unauthorized proposal"
+    );
+}
+
+#[tokio::test]
+async fn admin_standalone_update_is_unsupported() {
+    let (mut alice, alice_storage) = build_with_storage(b"alice");
+    let (mut bob, _bob_storage) = build_with_storage(b"bob");
+    let mut carol = build(b"carol");
+    let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
+    let crypto = RustCrypto::default();
+    let proposal =
+        non_admin_self_update_proposal(&alice_storage, &crypto, &alice.self_id(), &group_id);
+    let outcome = carol.ingest(proposal).await.unwrap();
+    assert!(matches!(
+        outcome,
+        IngestOutcome::Rejected {
+            category: ProposalRejectionCategory::UnsupportedProposal
+        }
+    ));
+}
+
+#[tokio::test]
+async fn admin_standalone_invalid_app_data_update_encoding_is_rejected() {
+    use cgka_traits::app_components::GROUP_PROFILE_COMPONENT_ID;
+
+    let (mut alice, alice_storage) = build_with_storage(b"alice");
+    let (mut bob, _bob_storage) = build_with_storage(b"bob");
+    let mut carol = build(b"carol");
+    let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
+    let crypto = RustCrypto::default();
+    let proposal = standalone_app_data_update_proposal(
+        &alice_storage,
+        &crypto,
+        &alice.self_id(),
+        &group_id,
+        GROUP_PROFILE_COMPONENT_ID,
+        vec![0xff, 0x00],
+    );
+    let outcome = carol.ingest(proposal).await.unwrap();
+    assert!(matches!(
+        outcome,
+        IngestOutcome::Rejected {
+            category: ProposalRejectionCategory::InvalidEncoding
+        }
+    ));
+}
+
+fn standalone_app_data_remove_proposal(
+    storage: &SqliteAccountStorage,
+    crypto: &RustCrypto,
+    sender: &MemberId,
+    group_id: &GroupId,
+    component_id: cgka_traits::app_components::AppComponentId,
+) -> TransportMessage {
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(crypto, storage.mls_storage());
+    let (mut mls_group, signer) = load_group_and_signer(storage, crypto, sender, group_id);
+    let (proposal_out, _) = mls_group
+        .propose_app_data_update(
+            &provider,
+            &signer,
+            component_id,
+            AppDataUpdateOperation::Remove,
+        )
+        .expect("build standalone AppDataUpdate remove proposal");
+    let proposal_bytes = proposal_out
+        .tls_serialize_detached()
+        .expect("serialize AppDataUpdate remove proposal");
+    TransportMessage {
+        id: hash_id(&proposal_bytes),
+        payload: proposal_bytes,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("standalone-app-data-remove".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    }
+}
+
+fn by_value_invalid_app_data_update_commit(
+    storage: &SqliteAccountStorage,
+    crypto: &RustCrypto,
+    committer: &MemberId,
+    group_id: &GroupId,
+    component_id: cgka_traits::app_components::AppComponentId,
+    data: Vec<u8>,
+) -> TransportMessage {
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(crypto, storage.mls_storage());
+    let (mut mls_group, signer) = load_group_and_signer(storage, crypto, committer, group_id);
+    let proposals = vec![Proposal::AppDataUpdate(Box::new(
+        AppDataUpdateProposal::update(component_id, data),
+    ))];
+    let mut builder = mls_group
+        .commit_builder()
+        .add_proposals(proposals)
+        .load_psks(provider.storage())
+        .expect("load psks");
+    let mut app_data = builder.app_data_dictionary_updater();
+    for proposal in builder.app_data_update_proposals() {
+        if let AppDataUpdateOperation::Update(bytes) = proposal.operation() {
+            app_data.set(ComponentData::from_parts(
+                proposal.component_id(),
+                bytes.clone(),
+            ));
+        }
+    }
+    builder.with_app_data_dictionary_updates(app_data.changes());
+    let commit_bundle = builder
+        .build(provider.rand(), provider.crypto(), &signer, |_| true)
+        .expect("build by-value invalid app-data commit")
+        .stage_commit(&provider)
+        .expect("stage by-value invalid app-data commit");
+    let (commit_out, _welcome_opt, _group_info) = commit_bundle.into_contents();
+    let commit_bytes = commit_out
+        .tls_serialize_detached()
+        .expect("serialize by-value invalid app-data commit");
+    TransportMessage {
+        id: hash_id(&commit_bytes),
+        payload: commit_bytes,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("by-value-invalid-commit".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    }
+}
+
+async fn bump_group_epoch(
+    alice: &mut Engine<SqliteAccountStorage>,
+    bob: &mut impl CgkaEngine,
+    carol: &mut impl CgkaEngine,
+    group_id: &GroupId,
+) -> EpochId {
+    let bump = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("epoch-bump".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (commit_msg, pending) = match bump {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    let routed = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..commit_msg
+    };
+    bob.ingest(routed.clone()).await.unwrap();
+    carol.ingest(routed).await.unwrap();
+    alice.epoch(group_id).expect("alice epoch after bump")
+}
+
+#[tokio::test]
+async fn admin_standalone_invalid_app_data_remove_is_rejected() {
+    use cgka_traits::app_components::APP_COMPONENTS_COMPONENT_ID;
+
+    let (mut alice, alice_storage) = build_with_storage(b"alice");
+    let (mut bob, _bob_storage) = build_with_storage(b"bob");
+    let mut carol = build(b"carol");
+    let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
+    let crypto = RustCrypto::default();
+    let proposal = standalone_app_data_remove_proposal(
+        &alice_storage,
+        &crypto,
+        &alice.self_id(),
+        &group_id,
+        APP_COMPONENTS_COMPONENT_ID,
+    );
+    let outcome = carol.ingest(proposal).await.unwrap();
+    assert!(matches!(
+        outcome,
+        IngestOutcome::Rejected {
+            category: ProposalRejectionCategory::InvalidEncoding
+        }
+    ));
+}
+
+#[tokio::test]
+async fn wrong_epoch_standalone_proposal_returns_already_at_epoch() {
+    let (mut alice, _alice_storage) = build_with_storage(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let mut carol = build(b"carol");
+    let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
+    let crypto = RustCrypto::default();
+    let stale_proposal =
+        non_admin_self_update_proposal(&bob_storage, &crypto, &bob.self_id(), &group_id);
+    let epoch_before = alice.epoch(&group_id).unwrap();
+    let epoch_after = bump_group_epoch(&mut alice, &mut bob, &mut carol, &group_id).await;
+    assert!(
+        epoch_after > epoch_before,
+        "epoch must advance for stale test"
+    );
+
+    let outcome = alice.ingest(stale_proposal).await.unwrap();
+    assert!(
+        matches!(
+            outcome,
+            IngestOutcome::Stale {
+                reason: StaleReason::AlreadyAtEpoch { .. }
+            }
+        ),
+        "wrong-epoch standalone proposal must be AlreadyAtEpoch, got {outcome:?}"
+    );
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, _alice_storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load alice group")
+        .expect("alice group present");
+    assert!(
+        mls_group.pending_proposals().next().is_none(),
+        "wrong-epoch proposal must not enter pending state"
+    );
+}
+
+#[tokio::test]
+async fn by_value_commit_with_invalid_proposal_is_rejected_before_merge() {
+    use cgka_traits::app_components::GROUP_PROFILE_COMPONENT_ID;
+
+    let (mut alice, alice_storage) = build_with_storage(b"alice");
+    let (mut bob, _bob_storage) = build_with_storage(b"bob");
+    let mut carol = build(b"carol");
+    let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
+    let crypto = RustCrypto::default();
+    let before_epoch = carol.epoch(&group_id).unwrap();
+    let commit = by_value_invalid_app_data_update_commit(
+        &alice_storage,
+        &crypto,
+        &alice.self_id(),
+        &group_id,
+        GROUP_PROFILE_COMPONENT_ID,
+        vec![0xff, 0x00],
+    );
+    let outcome = carol.ingest(commit).await.unwrap();
+    assert!(
+        matches!(
+            outcome,
+            IngestOutcome::Rejected {
+                category: ProposalRejectionCategory::InvalidEncoding
+            }
+        ),
+        "by-value commit with invalid proposal must reject before merge, got {outcome:?}"
+    );
+    assert_eq!(carol.epoch(&group_id).unwrap(), before_epoch);
+}
+
+#[tokio::test]
+async fn rejected_proposal_does_not_block_or_alter_later_valid_commit() {
+    let (mut alice, _alice_storage) = build_with_storage(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let (mut carol, _carol_storage) = build_with_storage(b"carol");
+    let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
+    let epoch_before = carol.epoch(&group_id).unwrap();
+    let crypto = RustCrypto::default();
+    let rejected = non_admin_self_update_proposal(&bob_storage, &crypto, &bob.self_id(), &group_id);
+    let reject_outcome = carol.ingest(rejected).await.unwrap();
+    assert!(matches!(
+        reject_outcome,
+        IngestOutcome::Rejected {
+            category: ProposalRejectionCategory::AuthorizationFailed
+        }
+    ));
+
+    let bump = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("after-reject".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (commit_msg, pending) = match bump {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    let routed = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..commit_msg
+    };
+    let valid_outcome = carol.ingest(routed).await.unwrap();
+    assert!(
+        matches!(
+            valid_outcome,
+            IngestOutcome::Processed | IngestOutcome::Buffered { .. }
+        ),
+        "valid commit after rejected proposal must apply, got {valid_outcome:?}"
+    );
+    if matches!(valid_outcome, IngestOutcome::Buffered { .. }) {
+        carol
+            .converge_stored_openmls_messages(&group_id, 1_000_000)
+            .expect("convergence must apply buffered commit");
+    }
+    assert!(
+        carol.epoch(&group_id).unwrap() > epoch_before,
+        "valid commit must advance epoch after prior proposal rejection"
+    );
+}
+
+#[tokio::test]
+async fn tampered_standalone_proposal_returns_invalid_signature_rejection() {
+    let (mut alice, _alice_storage) = build_with_storage(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let mut carol = build(b"carol");
+    let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
+    let crypto = RustCrypto::default();
+    let mut proposal =
+        non_admin_self_update_proposal(&bob_storage, &crypto, &bob.self_id(), &group_id);
+    if let Some(byte) = proposal.payload.get_mut(32) {
+        *byte ^= 0xff;
+    } else {
+        proposal.payload.push(0xff);
+    }
+    let outcome = alice.ingest(proposal).await.unwrap();
+    assert!(
+        matches!(
+            outcome,
+            IngestOutcome::Rejected {
+                category: ProposalRejectionCategory::InvalidSignature
+            }
+        ),
+        "OpenMLS ValidationError on proposal must map to InvalidSignature, got {outcome:?}"
+    );
+}

--- a/crates/cgka-engine/tests/proposal_authorization.rs
+++ b/crates/cgka-engine/tests/proposal_authorization.rs
@@ -1003,6 +1003,17 @@ async fn invalid_external_join_signature_returns_invalid_signature_rejection() {
         ),
         "cryptographic proposal-signature failure must map to InvalidSignature, got {outcome:?}"
     );
+    let crypto = RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, _alice_storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load alice group")
+        .expect("alice group present");
+    assert!(
+        mls_group.pending_proposals().next().is_none(),
+        "invalid-signature external join must not enter OpenMLS pending state"
+    );
 }
 
 fn evolution(msg: SendResult) -> (TransportMessage, cgka_traits::engine_state::PendingStateRef) {
@@ -1129,12 +1140,7 @@ async fn convergence_rejects_external_join_proposal_before_pending_store() {
     let group_id = three_member_group(&mut alice, &mut bob, &mut carol).await;
     let epoch = carol.epoch(&group_id).unwrap().0;
     let proposal = external_join_proposal(&group_id, epoch);
-    let routed = TransportMessage {
-        envelope: TransportEnvelope::GroupMessage {
-            transport_group_id: group_id.as_slice().to_vec(),
-        },
-        ..proposal
-    };
+    let routed = route(proposal, &group_id);
     let proposal_id = canonicalization_message_id(&routed);
     let proposal_message_id = content_dedup_message_id(&routed);
     carol
@@ -1212,12 +1218,7 @@ async fn parent_dependent_proposal_auth_deferred_until_retained_fork_replay() {
         .unwrap();
     let (alice_commit, alice_pending) = evolution(alice_invite);
     alice.confirm_published(alice_pending).await.unwrap();
-    let alice_commit = TransportMessage {
-        envelope: TransportEnvelope::GroupMessage {
-            transport_group_id: group_id.as_slice().to_vec(),
-        },
-        ..alice_commit
-    };
+    let alice_commit = route(alice_commit, &group_id);
     carol
         .buffer_openmls_convergence_message(&group_id, alice_commit.clone(), 1_000)
         .expect("buffer alice branch commit");
@@ -1243,12 +1244,7 @@ async fn parent_dependent_proposal_auth_deferred_until_retained_fork_replay() {
         other => panic!("expected GroupEvolution, got {other:?}"),
     };
     bob.confirm_published(bob_pending).await.unwrap();
-    let bob_commit = TransportMessage {
-        envelope: TransportEnvelope::GroupMessage {
-            transport_group_id: group_id.as_slice().to_vec(),
-        },
-        ..bob_commit
-    };
+    let bob_commit = route(bob_commit, &group_id);
     let eve_welcome = bob_welcomes
         .into_iter()
         .find(|welcome| {

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -763,6 +763,7 @@ fn ingest_outcome_kind(outcome: &IngestOutcome) -> &'static str {
         IngestOutcome::Processed => "processed",
         IngestOutcome::Buffered { .. } => "buffered",
         IngestOutcome::Stale { .. } => "stale",
+        IngestOutcome::Rejected { .. } => "rejected",
     }
 }
 

--- a/crates/traits/src/ingest.rs
+++ b/crates/traits/src/ingest.rs
@@ -22,6 +22,27 @@ pub enum IngestOutcome {
     /// Message was not applied. The variant names why — callers log by
     /// category rather than pattern-matching error strings.
     Stale { reason: StaleReason },
+    /// A standalone or by-reference MLS proposal failed Marmot semantic
+    /// authorization before entering pending state or scheduling auto-commit.
+    Rejected { category: ProposalRejectionCategory },
+}
+
+/// Protocol rejection category for a standalone or by-reference MLS proposal
+/// that failed Marmot semantic authorization (mdk#1053).
+///
+/// Tags align with `foundation/errors.md` input categories where applicable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum ProposalRejectionCategory {
+    /// Sender is not permitted to author this proposal in the source state.
+    AuthorizationFailed,
+    /// Standalone proposal type is not supported in the active profile.
+    UnsupportedProposal,
+    /// Proposal bytes or component payload failed encoding/validation rules.
+    InvalidEncoding,
+    /// Sender could not be attributed to a current member leaf.
+    InvalidSignature,
+    /// SelfRemove violates member-departure or admin-policy rules.
+    InvalidSelfRemove,
 }
 
 /// Why an inbound message was not processed.

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -76,7 +76,9 @@ pub use engine_state::{
 pub use error::{EngineError, PeelerError};
 pub use group::{Group, Member};
 pub use group_context::{GroupContext, GroupContextSnapshot, SecretBytes};
-pub use ingest::{IngestOutcome, PeeledContent, PeeledMessage, StaleReason};
+pub use ingest::{
+    IngestOutcome, PeeledContent, PeeledMessage, ProposalRejectionCategory, StaleReason,
+};
 pub use message::{MessageRecord, MessageState, OwnCommitConvergenceStamp, StoredMessagePayload};
 pub use peeler::{GroupMessageMetadata, GroupMessageMetadataError, TransportPeeler};
 pub use storage::{

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -397,6 +397,30 @@ fn snapshot_ingest_outcomes() {
             category: cgka_traits::ingest::ProposalRejectionCategory::AuthorizationFailed
         }
     );
+    insta::assert_json_snapshot!(
+        "ingest_outcome_rejected_unsupported_proposal",
+        IngestOutcome::Rejected {
+            category: cgka_traits::ingest::ProposalRejectionCategory::UnsupportedProposal
+        }
+    );
+    insta::assert_json_snapshot!(
+        "ingest_outcome_rejected_invalid_encoding",
+        IngestOutcome::Rejected {
+            category: cgka_traits::ingest::ProposalRejectionCategory::InvalidEncoding
+        }
+    );
+    insta::assert_json_snapshot!(
+        "ingest_outcome_rejected_invalid_signature",
+        IngestOutcome::Rejected {
+            category: cgka_traits::ingest::ProposalRejectionCategory::InvalidSignature
+        }
+    );
+    insta::assert_json_snapshot!(
+        "ingest_outcome_rejected_invalid_self_remove",
+        IngestOutcome::Rejected {
+            category: cgka_traits::ingest::ProposalRejectionCategory::InvalidSelfRemove
+        }
+    );
 }
 
 #[test]

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -391,6 +391,12 @@ fn snapshot_ingest_outcomes() {
             reason: StaleReason::Quarantined
         }
     );
+    insta::assert_json_snapshot!(
+        "ingest_outcome_rejected_authorization_failed",
+        IngestOutcome::Rejected {
+            category: cgka_traits::ingest::ProposalRejectionCategory::AuthorizationFailed
+        }
+    );
 }
 
 #[test]

--- a/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_authorization_failed.snap
+++ b/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_authorization_failed.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Rejected\n{\n    category:\n    cgka_traits::ingest::ProposalRejectionCategory::AuthorizationFailed\n}"
+---
+{
+  "Rejected": {
+    "category": "AuthorizationFailed"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_invalid_encoding.snap
+++ b/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_invalid_encoding.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Rejected\n{\n    category:\n    cgka_traits::ingest::ProposalRejectionCategory::InvalidEncoding\n}"
+---
+{
+  "Rejected": {
+    "category": "InvalidEncoding"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_invalid_self_remove.snap
+++ b/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_invalid_self_remove.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Rejected\n{\n    category:\n    cgka_traits::ingest::ProposalRejectionCategory::InvalidSelfRemove\n}"
+---
+{
+  "Rejected": {
+    "category": "InvalidSelfRemove"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_invalid_signature.snap
+++ b/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_invalid_signature.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Rejected\n{\n    category:\n    cgka_traits::ingest::ProposalRejectionCategory::InvalidSignature\n}"
+---
+{
+  "Rejected": {
+    "category": "InvalidSignature"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_unsupported_proposal.snap
+++ b/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_unsupported_proposal.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Rejected\n{\n    category:\n    cgka_traits::ingest::ProposalRejectionCategory::UnsupportedProposal\n}"
+---
+{
+  "Rejected": {
+    "category": "UnsupportedProposal"
+  }
+}


### PR DESCRIPTION
Fixes #1053

## Summary
- add a shared inbound proposal authorization layer before standalone proposals can reach live ingest, retained-state replay, or commit processing
- enforce sender/admin, account-identity proof, required-capability, app-component, and SelfRemove rules with typed rejection outcomes
- revalidate queued/by-reference proposals against the candidate parent before commit apply, including a regression for non-admin Update proposals
- persist terminal rejection state and emit privacy-safe rejection audit records without retaining rejected proposals in pending OpenMLS state
- extend the conformance harness to cover both raw replay and production Nostr-wrapped ingest paths

## Verification
- `cargo test -p cgka-engine --locked`
- `cargo test -p cgka-traits --locked`
- `cargo test -p cgka-session --locked`
- `cargo test -p cgka-conformance-simulator --locked`
- `just fast-ci`
- `git diff --check`

All passed.

## Sensitive paths
This changes MLS/CGKA authorization and group-state processing. Manual merge approval is required.

- `crates/cgka-engine/src/proposal_authorization.rs`
- `crates/cgka-engine/src/message_processor/ingest.rs`
- `crates/cgka-engine/src/openmls_projection.rs`
- `crates/cgka-engine/src/account_identity_proof.rs`
- `crates/cgka-engine/src/app_components.rs`
- `crates/cgka-engine/src/key_package.rs`
- `crates/cgka-engine/src/distributed_convergence.rs`
- `crates/cgka-engine/src/canonicalization.rs`
- `crates/traits/src/ingest.rs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed proposal rejection categories (authorization failures, unsupported proposals, invalid encoding/signatures, invalid self-removal).
  * Enforced semantic authorization for queued standalone and staged-commit proposals during ingest and commit-time revalidation.
  * Exposed richer rejection metadata in audit events and convergence outcomes.
  * Added a harness client helper to snapshot group context.

* **Bug Fixes**
  * Rejected proposals are now consistently terminalized, excluded from pending processing, and remain absent after restart.
  * Improved replay/canonicalization behavior and retry handling for rejected vs stale ingests.
  * Standardized rejected messaging classifications for diagnostics and tracing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->