### PR TITLE
Authorize standalone proposals before queueing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,6 +861,7 @@ dependencies = [
  "marmot-forensics",
  "nostr",
  "openmls",
+ "openmls_basic_credential",
  "openmls_rust_crypto",
  "openmls_traits",
  "proptest",

--- a/crates/cgka-conformance-simulator/Cargo.toml
+++ b/crates/cgka-conformance-simulator/Cargo.toml
@@ -18,6 +18,7 @@ marmot-forensics.workspace = true
 storage-sqlite.workspace = true
 transport-nostr-peeler.workspace = true
 openmls.workspace = true
+openmls_basic_credential.workspace = true
 openmls_rust_crypto.workspace = true
 openmls_traits.workspace = true
 tls_codec.workspace = true

--- a/crates/cgka-conformance-simulator/tests/canonicalization_contract.rs
+++ b/crates/cgka-conformance-simulator/tests/canonicalization_contract.rs
@@ -272,6 +272,7 @@ fn commit_edges_materialize_candidate_branches_before_selection() {
             message_id: "withheld-1".into(),
             kind: MessageKind::Commit,
             reason: DroppedMessageReason::InvalidAgainstCandidateState,
+            rejection_category: None,
         }]
     );
 }
@@ -394,16 +395,19 @@ fn proposals_are_accepted_only_when_consumed_by_canonical_commits() {
                 message_id: "losing-commit".into(),
                 kind: MessageKind::Commit,
                 reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: None,
             },
             DroppedMessage {
                 message_id: "losing-proposal".into(),
                 kind: MessageKind::Proposal,
                 reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: None,
             },
             DroppedMessage {
                 message_id: "pending-proposal".into(),
                 kind: MessageKind::Proposal,
                 reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: None,
             },
         ]
     );
@@ -448,11 +452,13 @@ fn materialized_candidates_drive_commit_and_proposal_dispositions() {
                 message_id: "losing-commit".into(),
                 kind: MessageKind::Commit,
                 reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: None,
             },
             DroppedMessage {
                 message_id: "losing-proposal".into(),
                 kind: MessageKind::Proposal,
                 reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: None,
             },
         ]
     );
@@ -514,6 +520,7 @@ fn commit_beyond_rollback_horizon_is_discarded() {
             message_id: "stale-commit".into(),
             kind: MessageKind::Commit,
             reason: DroppedMessageReason::BeyondRollbackHorizon,
+            rejection_category: None,
         }]
     );
 }

--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -16,17 +16,32 @@ use cgka_conformance_simulator::openmls_projection::{
 use cgka_conformance_simulator::{ClientBuilder, HarnessClient, TransportBus};
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::provider::EngineOpenMlsProvider;
+use cgka_engine::{DEFAULT_CIPHERSUITE, openmls_projection::OpenMlsProjectionError};
+use cgka_traits::app_components::{GROUP_PROFILE_COMPONENT_ID, encode_component_vectors};
 use cgka_traits::capabilities::{
     Capability, CapabilityRequirement, Feature, GroupCapabilities, RequirementLevel,
 };
+use cgka_traits::engine::CgkaEngine;
+use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group::{Group, Member};
+use cgka_traits::group_context::GroupContextSnapshot;
+use cgka_traits::ingest::{IngestOutcome, ProposalRejectionCategory};
 use cgka_traits::message::{MessageRecord, MessageState};
-use cgka_traits::storage::{GroupStorage, MessageStorage, StorageProvider};
-use cgka_traits::transport::TransportMessage;
+use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::storage::{
+    AccountDeviceSignerStorage, GroupStorage, MessageStorage, StorageProvider,
+};
+use cgka_traits::transport::{
+    EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
+};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use openmls::group::MlsGroup;
+use openmls::messages::proposals::AppDataUpdateOperation;
+use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::RustCrypto;
 use openmls_traits::OpenMlsProvider;
+use sha2::{Digest, Sha256};
+use tls_codec::Serialize;
 
 fn pad32(name: &[u8]) -> Vec<u8> {
     let mut out = vec![0u8; 32];
@@ -96,6 +111,182 @@ async fn queued_commit_messages(
                 .is_ok_and(|projection| projection.kind == OpenMlsContentKind::Commit)
         })
         .collect()
+}
+
+fn raw_group_profile_update_proposal(
+    client: &HarnessClient,
+    group_id: &GroupId,
+) -> TransportMessage {
+    let crypto = RustCrypto::default();
+    let provider = EngineOpenMlsProvider::<storage_sqlite::SqliteAccountStorage>::new(
+        &crypto,
+        client.storage().mls_storage(),
+    );
+    let mls_group_id = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mut group = MlsGroup::load(provider.storage(), &mls_group_id)
+        .expect("load MLS group")
+        .expect("MLS group exists");
+    let binding = client
+        .storage()
+        .account_device_signer(&client.member_id())
+        .expect("load signer binding")
+        .expect("signer binding exists");
+    let signer = SignatureKeyPair::read(
+        client.storage().mls_storage(),
+        &binding.mls_signature_public_key,
+        DEFAULT_CIPHERSUITE.signature_algorithm(),
+    )
+    .expect("load MLS signer");
+    let (proposal, _) = group
+        .propose_app_data_update(
+            &provider,
+            &signer,
+            GROUP_PROFILE_COMPONENT_ID,
+            AppDataUpdateOperation::Update(
+                encode_component_vectors(&[b"renamed", b"description"]).into(),
+            ),
+        )
+        .expect("build valid group-profile proposal");
+    let payload = proposal
+        .tls_serialize_detached()
+        .expect("serialize proposal");
+    TransportMessage {
+        id: MessageId::new(Sha256::digest(&payload).to_vec()),
+        payload,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("openmls-proposal-vector".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    }
+}
+
+fn stored_pending_proposal_count(client: &HarnessClient, group_id: &GroupId) -> usize {
+    let crypto = RustCrypto::default();
+    let provider = EngineOpenMlsProvider::<storage_sqlite::SqliteAccountStorage>::new(
+        &crypto,
+        client.storage().mls_storage(),
+    );
+    let mls_group_id = openmls::group::GroupId::from_slice(group_id.as_slice());
+    MlsGroup::load(provider.storage(), &mls_group_id)
+        .expect("load MLS group")
+        .expect("MLS group exists")
+        .pending_proposals()
+        .count()
+}
+
+#[tokio::test]
+async fn proposal_authorization_vector_rejects_direct_and_nostr_wrapped_input() {
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice"))
+        .registry(selfremove_registry())
+        .protocol_profile(ProtocolProfile::Current)
+        .attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob"))
+        .registry(selfremove_registry())
+        .protocol_profile(ProtocolProfile::Current)
+        .attach(&bus);
+
+    let bob_kp = bob.fresh_key_package().await;
+    let (group_id, pending) = alice
+        .create_group_with_admins_maybe_pending(
+            "proposal-authorization-vector",
+            vec![bob_kp],
+            vec![],
+            vec![],
+        )
+        .await;
+    assert!(
+        pending.is_none(),
+        "current-profile founding creation is immediately stable"
+    );
+    bus.deliver_all();
+    let join_outcomes = bob.tick().await;
+    assert!(
+        join_outcomes.iter().all(Result::is_ok),
+        "bob joins current-profile group: {join_outcomes:?}"
+    );
+
+    // Bob is a member but not an admin. The proposal is MLS-valid and its
+    // component payload is well-formed, so authorization is the only reason it
+    // must be rejected.
+    let stable_epoch = alice.epoch();
+    let direct = raw_group_profile_update_proposal(&bob, &group_id);
+    let direct_rejection =
+        replay_openmls_messages(alice.storage(), &group_id, std::slice::from_ref(&direct))
+            .expect_err("direct OpenMLS replay rejects unauthorized proposal");
+    assert!(matches!(
+        direct_rejection,
+        OpenMlsProjectionError::RejectedProposal {
+            category: ProposalRejectionCategory::AuthorizationFailed,
+            ..
+        }
+    ));
+    assert_eq!(
+        alice.epoch(),
+        stable_epoch,
+        "direct replay rolls back without changing the live group"
+    );
+    assert_eq!(
+        stored_pending_proposal_count(&alice, &group_id),
+        0,
+        "direct replay cannot leave the rejected proposal pending"
+    );
+
+    // Exercise the production-shaped Nostr kind-445 seam with the same inner
+    // MLS proposal. It must terminate as Failed before pending storage or
+    // auto-commit scheduling.
+    let snapshot = {
+        let context = alice
+            .engine
+            .group_context(&group_id)
+            .expect("load group context");
+        GroupContextSnapshot::from_context(
+            context.as_ref(),
+            &[transport_nostr_peeler::DEFAULT_EXPORTER_LABEL],
+        )
+    };
+    let wrapped = transport_nostr_peeler::NostrMlsPeeler::default()
+        .wrap_group_message(
+            &EncryptedPayload {
+                ciphertext: direct.payload,
+                aad: vec![],
+            },
+            &snapshot,
+        )
+        .await
+        .expect("wrap proposal as Nostr group event");
+    bus.inject(alice.bus_id, wrapped.clone());
+    let outcomes = alice.tick_ingest_only().await;
+    assert!(
+        matches!(
+            outcomes.as_slice(),
+            [Ok(IngestOutcome::Rejected {
+                category: ProposalRejectionCategory::AuthorizationFailed
+            })]
+        ),
+        "wrapped unauthorized proposal is terminal: {outcomes:?}"
+    );
+    assert!(
+        alice
+            .storage()
+            .list_messages(&group_id, EpochId(0))
+            .expect("list durable group messages")
+            .iter()
+            .any(|record| record.state == MessageState::Failed),
+        "wrapped rejection leaves a terminal failed content record"
+    );
+    assert!(
+        alice.engine.drain_auto_publish().is_empty(),
+        "rejected proposal cannot schedule an auto-commit"
+    );
+    assert_eq!(
+        stored_pending_proposal_count(&alice, &group_id),
+        0,
+        "wrapped ingest cannot leave the rejected proposal pending"
+    );
+    assert_eq!(alice.epoch(), stable_epoch);
 }
 
 #[tokio::test]
@@ -1343,11 +1534,13 @@ fn openmls_disposition_persistence_maps_all_canonicalization_states() {
                 message_id: hex::encode(losing_commit_id.as_slice()),
                 kind: MessageKind::Commit,
                 reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: None,
             },
             DroppedMessage {
                 message_id: hex::encode(malformed_proposal_id.as_slice()),
                 kind: MessageKind::Proposal,
                 reason: DroppedMessageReason::Malformed,
+                rejection_category: None,
             },
         ],
         already_seen: vec![],

--- a/crates/cgka-engine/src/account_identity_proof.rs
+++ b/crates/cgka-engine/src/account_identity_proof.rs
@@ -35,7 +35,7 @@ use nostr::{
 };
 use openmls::extensions::{Extension, ExtensionType, Extensions, UnknownExtension};
 use openmls::group::{GroupContext as OpenMlsGroupContext, MlsGroup, StagedCommit};
-use openmls::prelude::{BasicCredential, LeafNode, SignatureScheme};
+use openmls::prelude::{BasicCredential, LeafNode, Proposal, QueuedProposal, SignatureScheme};
 use openmls_traits::types::Ciphersuite;
 
 /// Deployed legacy custom LeafNode proof extension.
@@ -603,6 +603,49 @@ pub(crate) fn validate_staged_commit_account_identity_proofs(
     }
 
     Ok(added)
+}
+
+/// Validate the account identity carried by a standalone Add or Update before
+/// the proposal is admitted to Marmot's durable pending set.
+///
+/// Commit validation performs the same checks again against the authenticated
+/// candidate parent. Keeping this proposal seam separate is intentional: a
+/// syntactically valid MLS proposal must not sit pending until a later Commit
+/// discovers that its leaf proof or profile is invalid.
+pub(crate) fn validate_standalone_proposal_account_identity_proof(
+    proposal: &QueuedProposal,
+    group: &MlsGroup,
+    ciphersuite: Ciphersuite,
+) -> Result<(), EngineError> {
+    let profile = protocol_profile_of_group(group)?;
+    match proposal.proposal() {
+        Proposal::Add(add) => {
+            let leaf = add.key_package().leaf_node();
+            ensure_profile(
+                validate_leaf_account_identity_proof(leaf, ciphersuite)?,
+                profile,
+                "standalone Add proposal",
+            )?;
+            crate::identity::validated_member_id_of_leaf(leaf)?;
+        }
+        Proposal::Update(update) => {
+            let expected = crate::identity::member_id_of_sender(proposal.sender(), group)
+                .ok_or_else(|| {
+                    EngineError::InvalidAccountIdentityProof(
+                        "standalone Update proposal has no authenticated member sender".into(),
+                    )
+                })?;
+            let update_profile = validate_leaf_account_identity_proof_for_member(
+                update.leaf_node(),
+                ciphersuite,
+                &expected,
+                "standalone Update proposal",
+            )?;
+            ensure_profile(update_profile, profile, "standalone Update proposal")?;
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 pub(crate) fn account_identity_proof_capability() -> ExtensionType {

--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -15,12 +15,16 @@ use cgka_traits::app_components::{
 use cgka_traits::engine::CommitOrderingPriority;
 use cgka_traits::error::EngineError;
 use cgka_traits::group::ProtocolProfile;
+use cgka_traits::ingest::ProposalRejectionCategory;
 use cgka_traits::types::{GroupId, MemberId};
 use openmls::extensions::{AppDataDictionary, AppDataDictionaryExtension, Extension, Extensions};
-use openmls::group::{GroupContext, MlsGroup, StagedCommit};
+use openmls::group::{
+    GroupContext, MlsGroup, ProcessMessageError, StageCommitError, StagedCommit, ValidationError,
+};
 use openmls::messages::proposals::{AppDataUpdateOperation, AppDataUpdateProposal, Proposal};
 use openmls::prelude::{
-    BasicCredential, ExtensionType, LeafNode, LeafNodeIndex, ProposalType, Sender,
+    BasicCredential, ContentType, ExtensionType, LeafNode, LeafNodeIndex, ProposalType,
+    ProposalValidationError, QueuedProposal, Sender,
 };
 use openmls::treesync::Node;
 use std::collections::{BTreeMap, BTreeSet};
@@ -249,6 +253,301 @@ pub(crate) fn require_admin_for_staged_commit(
         });
     };
     require_admin(mls_group, group_id, sender)
+}
+
+pub(crate) const fn proposal_rejection_category_tag(
+    category: ProposalRejectionCategory,
+) -> &'static str {
+    match category {
+        ProposalRejectionCategory::AuthorizationFailed => "authorization_failed",
+        ProposalRejectionCategory::UnsupportedProposal => "unsupported_proposal",
+        ProposalRejectionCategory::InvalidEncoding => "invalid_encoding",
+        ProposalRejectionCategory::InvalidSignature => "invalid_signature",
+        ProposalRejectionCategory::InvalidSelfRemove => "invalid_self_remove",
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct StandaloneProposalRejection {
+    pub(crate) category: ProposalRejectionCategory,
+}
+
+impl StandaloneProposalRejection {
+    const fn authorization(_reason: &'static str) -> Self {
+        Self {
+            category: ProposalRejectionCategory::AuthorizationFailed,
+        }
+    }
+
+    const fn invalid_self_remove(_reason: &'static str) -> Self {
+        Self {
+            category: ProposalRejectionCategory::InvalidSelfRemove,
+        }
+    }
+
+    const fn unsupported(_reason: &'static str) -> Self {
+        Self {
+            category: ProposalRejectionCategory::UnsupportedProposal,
+        }
+    }
+
+    const fn invalid(_reason: &'static str) -> Self {
+        Self {
+            category: ProposalRejectionCategory::InvalidEncoding,
+        }
+    }
+}
+
+/// Membership-tag and sender-leaf authentication depend on the source-epoch
+/// group state. A same-epoch proposal can therefore fail against the live
+/// branch but authenticate against a retained parent branch.
+pub(crate) fn is_parent_dependent_process_message_error<StorageError>(
+    error: &ProcessMessageError<StorageError>,
+    content_type: ContentType,
+) -> bool {
+    matches!(
+        (content_type, error),
+        (
+            ContentType::Proposal,
+            ProcessMessageError::ValidationError(
+                ValidationError::UnknownMember | ValidationError::InvalidMembershipTag
+            )
+        )
+    )
+}
+
+/// Map only proposal-specific MLS processing failures into the stable,
+/// privacy-safe rejection taxonomy. Unrelated commit and local-state failures
+/// remain retryable and therefore return `None`.
+pub(crate) fn classify_process_message_rejection<StorageError>(
+    error: &ProcessMessageError<StorageError>,
+    content_type: ContentType,
+) -> Option<ProposalRejectionCategory> {
+    if is_parent_dependent_process_message_error(error, content_type) {
+        return None;
+    }
+    match (content_type, error) {
+        (ContentType::Proposal, ProcessMessageError::UnsupportedProposalType) => {
+            Some(ProposalRejectionCategory::UnsupportedProposal)
+        }
+        (ContentType::Proposal, ProcessMessageError::IncompatibleWireFormat) => {
+            Some(ProposalRejectionCategory::InvalidEncoding)
+        }
+        (ContentType::Proposal, ProcessMessageError::ValidationError(validation)) => {
+            match validation {
+                ValidationError::WrongEpoch => None,
+                ValidationError::MissingMembershipTag
+                | ValidationError::InvalidSignature
+                | ValidationError::UnauthorizedExternalSender
+                | ValidationError::NoExternalSendersExtension
+                | ValidationError::InvalidLeafNodeSignature
+                | ValidationError::InvalidSenderType => {
+                    Some(ProposalRejectionCategory::InvalidSignature)
+                }
+                _ => Some(ProposalRejectionCategory::InvalidEncoding),
+            }
+        }
+        (
+            ContentType::Commit,
+            ProcessMessageError::ValidationError(ValidationError::WrongWireFormat),
+        ) => Some(ProposalRejectionCategory::InvalidEncoding),
+        (
+            ContentType::Commit,
+            ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+                validation,
+            )),
+        ) => Some(match validation {
+            ProposalValidationError::InsufficientCapabilities
+            | ProposalValidationError::UnsupportedProposalType => {
+                ProposalRejectionCategory::UnsupportedProposal
+            }
+            ProposalValidationError::UnknownMember
+            | ProposalValidationError::UpdateFromNonMember => {
+                ProposalRejectionCategory::InvalidSignature
+            }
+            _ => ProposalRejectionCategory::InvalidEncoding,
+        }),
+        (
+            ContentType::Commit,
+            ProcessMessageError::InvalidCommit(
+                StageCommitError::AppDataUpdateValidationError(_)
+                | StageCommitError::ApplyAppDataUpdateError(_)
+                | StageCommitError::GroupContextExtensionsProposalValidationError(_)
+                | StageCommitError::LeafNodeValidation(_),
+            ),
+        ) => Some(ProposalRejectionCategory::InvalidEncoding),
+        _ => None,
+    }
+}
+
+/// Authorize one authenticated proposal against its source-epoch group state.
+///
+/// This is shared by direct ingest, convergence replay, delayed SelfRemove
+/// replay, and staged-Commit validation. OpenMLS has already authenticated the
+/// sender and parsed the proposal before this function runs; this layer owns
+/// Marmot roles, component semantics, profile rules, and capability checks.
+pub(crate) fn authorize_standalone_proposal(
+    mls_group: &MlsGroup,
+    proposal: &QueuedProposal,
+) -> Result<(), StandaloneProposalRejection> {
+    authorize_proposal(mls_group, proposal, true)
+}
+
+fn authorize_proposal(
+    mls_group: &MlsGroup,
+    proposal: &QueuedProposal,
+    validate_app_data_payload: bool,
+) -> Result<(), StandaloneProposalRejection> {
+    let Sender::Member(sender_index) = proposal.sender() else {
+        return Err(StandaloneProposalRejection::authorization(
+            "proposal_sender_not_member",
+        ));
+    };
+    let Some(sender_member) = mls_group.member_at(*sender_index) else {
+        return Err(StandaloneProposalRejection::authorization(
+            "proposal_sender_not_current_member",
+        ));
+    };
+    let sender_id = crate::identity::validated_member_id(&sender_member.credential)
+        .map_err(|_| StandaloneProposalRejection::invalid("proposal_sender_identity_invalid"))?;
+    let profile = crate::account_identity_proof::protocol_profile_of_group(mls_group)
+        .map_err(|_| StandaloneProposalRejection::invalid("proposal_group_profile_invalid"))?;
+    let admins = admins_of_group(mls_group)
+        .map_err(|_| StandaloneProposalRejection::invalid("proposal_admin_policy_invalid"))?;
+    let sender_pubkey = admin_pubkey_from_member_id(&sender_id)
+        .map_err(|_| StandaloneProposalRejection::invalid("proposal_sender_identity_invalid"))?;
+    let sender_is_admin = admins.iter().any(|admin| admin == &sender_pubkey);
+
+    match proposal.proposal() {
+        Proposal::SelfRemove => {
+            if sender_is_admin {
+                return Err(StandaloneProposalRejection::invalid_self_remove(
+                    "self_remove_sender_is_active_admin",
+                ));
+            }
+        }
+        Proposal::AppDataUpdate(update) => {
+            if !sender_is_admin {
+                return Err(StandaloneProposalRejection::authorization(
+                    "app_data_update_sender_not_admin",
+                ));
+            }
+            if validate_app_data_payload {
+                validate_standalone_app_data_update(update).map_err(|_| {
+                    StandaloneProposalRejection::invalid("app_data_update_payload_invalid")
+                })?;
+            }
+        }
+        Proposal::GroupContextExtensions(update) => {
+            if !sender_is_admin {
+                return Err(StandaloneProposalRejection::authorization(
+                    "group_context_extensions_sender_not_admin",
+                ));
+            }
+            validate_group_context_extension_proposal(mls_group, profile, update.extensions())?;
+        }
+        Proposal::Add(_) | Proposal::Remove(_) => {
+            if !sender_is_admin {
+                return Err(StandaloneProposalRejection::authorization(
+                    "membership_proposal_sender_not_admin",
+                ));
+            }
+            validate_membership_proposal(mls_group, proposal)?;
+        }
+        Proposal::Update(_) => {
+            // The current profile's only non-admin standalone proposal is
+            // SelfRemove. Deployed legacy groups retain the ordinary MLS
+            // member self-update proposal flow.
+            if profile == ProtocolProfile::Current && !sender_is_admin {
+                return Err(StandaloneProposalRejection::authorization(
+                    "update_proposal_sender_not_admin",
+                ));
+            }
+            validate_membership_proposal(mls_group, proposal)?;
+        }
+        Proposal::PreSharedKey(_)
+        | Proposal::ReInit(_)
+        | Proposal::ExternalInit(_)
+        | Proposal::AppEphemeral(_)
+        | Proposal::Custom(_) => {
+            return Err(StandaloneProposalRejection::unsupported(
+                "standalone_proposal_type_unsupported",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Re-run proposal-sender authorization for every proposal carried by a
+/// staged Commit. By-reference proposals keep their original authenticated
+/// sender; by-value proposals are attributed to the committer by MLS.
+pub(crate) fn authorize_staged_commit_proposals(
+    mls_group: &MlsGroup,
+    staged: &StagedCommit,
+) -> Result<(), StandaloneProposalRejection> {
+    for proposal in staged.queued_proposals() {
+        authorize_proposal(mls_group, proposal, false)?;
+    }
+    validate_app_data_update_batch(
+        mls_group,
+        staged.queued_proposals().filter_map(|proposal| {
+            if let Proposal::AppDataUpdate(update) = proposal.proposal() {
+                Some(update.as_ref())
+            } else {
+                None
+            }
+        }),
+    )
+    .map_err(|_| StandaloneProposalRejection::invalid("app_data_update_payload_invalid"))?;
+    Ok(())
+}
+
+fn validate_membership_proposal(
+    mls_group: &MlsGroup,
+    proposal: &QueuedProposal,
+) -> Result<(), StandaloneProposalRejection> {
+    if let Proposal::Remove(remove) = proposal.proposal()
+        && mls_group.member_at(remove.removed()).is_none()
+    {
+        return Err(StandaloneProposalRejection::invalid(
+            "remove_target_not_current_member",
+        ));
+    }
+    crate::account_identity_proof::validate_standalone_proposal_account_identity_proof(
+        proposal,
+        mls_group,
+        mls_group.ciphersuite(),
+    )
+    .map_err(|_| StandaloneProposalRejection::invalid("proposal_account_proof_invalid"))
+}
+
+fn validate_group_context_extension_proposal(
+    mls_group: &MlsGroup,
+    profile: ProtocolProfile,
+    extensions: &Extensions<GroupContext>,
+) -> Result<(), StandaloneProposalRejection> {
+    let required_components = if profile == ProtocolProfile::Current {
+        validate_current_profile_group_context(extensions, "proposed group state").map_err(
+            |_| {
+                StandaloneProposalRejection::invalid(
+                    "group_context_extensions_current_profile_invalid",
+                )
+            },
+        )?
+    } else {
+        AppComponentSet::default()
+    };
+    let leaves = ratchet_tree_leaves(mls_group.export_ratchet_tree()).map_err(|_| {
+        StandaloneProposalRejection::invalid("group_context_extensions_tree_invalid")
+    })?;
+    validate_resulting_leaf_capabilities(leaves.iter(), extensions, &required_components).map_err(
+        |_| {
+            StandaloneProposalRejection::unsupported(
+                "group_context_extensions_not_supported_by_all_members",
+            )
+        },
+    )
 }
 
 fn credential_account_pubkey(cred: openmls::prelude::Credential) -> Option<[u8; 32]> {
@@ -1092,6 +1391,26 @@ pub(crate) fn validate_app_data_update_batch<'a>(
     validate_app_data_update_batch_against(required_app_components_of_group(mls_group)?, updates)
 }
 
+/// Validate the parts of an AppDataUpdate operation that are decidable before
+/// a Commit supplies the complete proposal batch.
+///
+/// A standalone removal can be valid only together with another proposal that
+/// un-requires the component in the same Commit. Therefore proposal admission
+/// checks the operation's intrinsic encoding/removability here and defers the
+/// resulting required-component rule to [`validate_app_data_update_batch`].
+fn validate_standalone_app_data_update(update: &AppDataUpdateProposal) -> Result<(), EngineError> {
+    match update.operation() {
+        AppDataUpdateOperation::Update(data) => validate_app_component_update(&AppComponentData {
+            component_id: update.component_id(),
+            data: data.as_slice().to_vec(),
+        }),
+        AppDataUpdateOperation::Remove => validate_app_component_remove_against(
+            &AppComponentSet::default(),
+            update.component_id(),
+        ),
+    }
+}
+
 fn validate_app_data_update_batch_against<'a>(
     mut resulting_required: AppComponentSet,
     updates: impl IntoIterator<Item = &'a AppDataUpdateProposal>,
@@ -1524,6 +1843,17 @@ mod tests {
 
         validate_app_data_update_batch_against(initial, updates.iter())
             .expect("the component is optional in the resulting epoch");
+    }
+
+    #[test]
+    fn standalone_app_data_remove_defers_batch_dependent_requirement_check() {
+        let optional_remove = AppDataUpdateProposal::remove(GROUP_BLOSSOM_IMAGE_COMPONENT_ID);
+        validate_standalone_app_data_update(&optional_remove)
+            .expect("a later commit may atomically unrequire and remove the component");
+
+        let intrinsic_remove = AppDataUpdateProposal::remove(APP_COMPONENTS_COMPONENT_ID);
+        validate_standalone_app_data_update(&intrinsic_remove)
+            .expect_err("app_components can never be removed");
     }
 
     #[test]

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -66,6 +66,7 @@ pub(crate) fn ingest_outcome_kind_str(outcome: &IngestOutcome) -> &'static str {
         IngestOutcome::Processed => "processed",
         IngestOutcome::Buffered { .. } => "buffered",
         IngestOutcome::Stale { .. } => "stale",
+        IngestOutcome::Rejected { .. } => "rejected",
     }
 }
 
@@ -436,6 +437,9 @@ pub(crate) fn ingest_outcome_event(
         outcome_kind: ingest_outcome_kind_str(outcome).to_string(),
         stale_reason: match outcome {
             IngestOutcome::Stale { reason } => Some(stale_reason_str(reason).to_string()),
+            IngestOutcome::Rejected { category } => {
+                Some(crate::app_components::proposal_rejection_category_tag(*category).to_string())
+            }
             _ => None,
         },
         epoch: ingest_outcome_epoch(outcome),

--- a/crates/cgka-engine/src/canonicalization.rs
+++ b/crates/cgka-engine/src/canonicalization.rs
@@ -182,6 +182,7 @@ pub struct DroppedMessage {
     pub message_id: String,
     pub kind: MessageKind,
     pub reason: DroppedMessageReason,
+    pub rejection_category: Option<cgka_traits::ingest::ProposalRejectionCategory>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -831,6 +832,7 @@ fn drop_losing_materialized_candidate_commits(
                 message_id: message_id.clone(),
                 kind: MessageKind::Commit,
                 reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                rejection_category: None,
             });
         }
     }
@@ -922,6 +924,7 @@ fn dropped(message: &PeeledMessage, reason: DroppedMessageReason) -> DroppedMess
         message_id: message.message_id.clone(),
         kind: message.kind_name(),
         reason,
+        rejection_category: None,
     }
 }
 

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -479,6 +479,7 @@ impl<S: StorageProvider> Engine<S> {
         }
         self.emit_application_replay_events(group_id, &observations);
         self.emit_invalidated_app_events(group_id, &result)?;
+        self.emit_rejected_proposal_convergence_audits(group_id, &result);
         self.emit_rolled_back_commits(group_id, &result)?;
         self.emit_superseded_processed_commits(group_id, &result)?;
 
@@ -816,6 +817,26 @@ impl<S: StorageProvider> Engine<S> {
                 });
         }
         Ok(())
+    }
+
+    fn emit_rejected_proposal_convergence_audits(
+        &mut self,
+        group_id: &GroupId,
+        result: &CanonicalizationResult,
+    ) {
+        for dropped in &result.dropped_messages {
+            let Some(category) = dropped.rejection_category else {
+                continue;
+            };
+            self.audit_group(
+                group_id,
+                marmot_forensics::AuditEventKind::Rejection {
+                    msg_id: dropped.message_id.clone(),
+                    reason: crate::app_components::proposal_rejection_category_tag(category)
+                        .to_string(),
+                },
+            );
+        }
     }
 
     /// Emit a [`GroupEvent::CommitRolledBack`] for every commit that this

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1181,6 +1181,7 @@ impl<S: StorageProvider> Engine<S> {
             };
             if let ProcessedMessageContent::ProposalMessage(queued) = processed.into_content()
                 && matches!(queued.proposal(), Proposal::SelfRemove)
+                && crate::app_components::authorize_standalone_proposal(mls_group, &queued).is_ok()
             {
                 return Ok(true);
             }

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -2,8 +2,9 @@
 //!
 //! Inbound messages are peeled, classified, stored, and either applied or
 //! buffered for convergence. Classifiable stale ingest cases return
-//! `Ok(IngestOutcome::Stale { .. })` with a typed `StaleReason`. `Err` is
-//! reserved for storage, peeler, serialization, and OpenMLS failures.
+//! `Ok(IngestOutcome::Stale { .. })`; authenticated protocol-admission
+//! failures return `Ok(IngestOutcome::Rejected { .. })`. `Err` is reserved for
+//! storage, peeler, serialization, and unclassified OpenMLS failures.
 
 use super::{content_dedup_id, route_wrapped_group_message};
 use crate::engine::{Engine, ScheduledSelfRemoveAutoCommit};
@@ -22,7 +23,7 @@ use cgka_traits::engine::{
     GroupStateInvalidationReason,
 };
 use cgka_traits::error::{EngineError, PeelerError};
-use cgka_traits::ingest::{IngestOutcome, PeeledContent, StaleReason};
+use cgka_traits::ingest::{IngestOutcome, PeeledContent, ProposalRejectionCategory, StaleReason};
 use cgka_traits::message::{MessageState, StoredMessagePayload};
 use cgka_traits::storage::{StorageError, StorageProvider};
 use cgka_traits::transport::{EncryptedPayload, TransportMessage};
@@ -54,6 +55,26 @@ enum ForkProbeError {
 }
 
 impl<S: StorageProvider> Engine<S> {
+    fn terminalize_rejected_proposal(
+        &mut self,
+        group_id: &GroupId,
+        msg_id: &MessageId,
+        raw_msg_id: &MessageId,
+        category: ProposalRejectionCategory,
+    ) -> Result<IngestOutcome, EngineError> {
+        let reason = crate::app_components::proposal_rejection_category_tag(category);
+        self.update_stored_message_state(msg_id, MessageState::Failed)?;
+        self.mark_raw_transport_message_failed_if_awaiting_retry(raw_msg_id, reason)?;
+        self.audit_group(
+            group_id,
+            marmot_forensics::AuditEventKind::Rejection {
+                msg_id: hex::encode(msg_id.as_slice()),
+                reason: reason.to_string(),
+            },
+        );
+        Ok(IngestOutcome::Rejected { category })
+    }
+
     pub(crate) async fn ingest_welcome(
         &mut self,
         msg: &TransportMessage,
@@ -806,6 +827,37 @@ impl<S: StorageProvider> Engine<S> {
                     });
                 }
                 Err(e) => {
+                    if crate::app_components::is_parent_dependent_process_message_error(
+                        &e,
+                        msg_content_type,
+                    ) {
+                        // Sender and membership-tag authentication can depend
+                        // on a retained same-epoch parent. Try every retained
+                        // branch before classifying the proposal as terminal.
+                        let now_ms = self.convergence_now_ms();
+                        let result = self
+                            .converge_stored_openmls_messages(&group_id, now_ms)
+                            .map_err(|error| EngineError::Backend(format!("converge: {error}")))?;
+                        return Ok(convergence_ingest_outcome(
+                            &result,
+                            msg,
+                            group_id,
+                            current_epoch,
+                        ));
+                    }
+                    if let Some(category) =
+                        crate::app_components::classify_process_message_rejection(
+                            &e,
+                            msg_content_type,
+                        )
+                    {
+                        return self.terminalize_rejected_proposal(
+                            &group_id,
+                            &msg.id,
+                            &raw_msg_id,
+                            category,
+                        );
+                    }
                     self.update_stored_message_state(&msg.id, MessageState::Retryable)?;
                     return Err(EngineError::Backend(format!("process_message: {e:?}")));
                 }
@@ -892,6 +944,16 @@ impl<S: StorageProvider> Engine<S> {
                 }
                 ProcessedMessageContent::StagedCommitMessage(staged) => {
                     let before = EpochId(mls_group.epoch().as_u64());
+                    if let Err(rejection) = crate::app_components::authorize_staged_commit_proposals(
+                        &mls_group, &staged,
+                    ) {
+                        return self.terminalize_rejected_proposal(
+                            &group_id,
+                            &msg.id,
+                            &raw_msg_id,
+                            rejection.category,
+                        );
+                    }
                     if let Err(err) = crate::app_components::require_admin_for_staged_commit(
                         &mls_group,
                         &group_id,
@@ -1226,6 +1288,16 @@ impl<S: StorageProvider> Engine<S> {
                     Ok(IngestOutcome::Processed)
                 }
                 ProcessedMessageContent::ProposalMessage(queued) => {
+                    if let Err(rejection) =
+                        crate::app_components::authorize_standalone_proposal(&mls_group, &queued)
+                    {
+                        return self.terminalize_rejected_proposal(
+                            &group_id,
+                            &msg.id,
+                            &raw_msg_id,
+                            rejection.category,
+                        );
+                    }
                     // Ask the auto-committer policy whether we should commit
                     // this proposal. OpenMLS does not auto-enqueue processed
                     // proposals, so store it before attempting to commit the
@@ -1260,10 +1332,13 @@ impl<S: StorageProvider> Engine<S> {
                     }
                     Ok(IngestOutcome::Processed)
                 }
-                ProcessedMessageContent::ExternalJoinProposalMessage(_) => {
-                    self.update_stored_message_state(&msg.id, MessageState::Processed)?;
-                    Ok(IngestOutcome::Processed)
-                }
+                ProcessedMessageContent::ExternalJoinProposalMessage(_) => self
+                    .terminalize_rejected_proposal(
+                        &group_id,
+                        &msg.id,
+                        &raw_msg_id,
+                        ProposalRejectionCategory::UnsupportedProposal,
+                    ),
                 ProcessedMessageContent::OwnPendingCommit
                 | ProcessedMessageContent::OwnPrivateMessage => {
                     // This normally returns through the durable sent-content
@@ -1424,6 +1499,23 @@ impl<S: StorageProvider> Engine<S> {
             };
             (mls_group, queued)
         };
+
+        if let Err(rejection) =
+            crate::app_components::authorize_standalone_proposal(&mls_group, &queued)
+        {
+            self.update_stored_message_state(&schedule.proposal_id, MessageState::Failed)?;
+            self.audit_group(
+                &schedule.group_id,
+                marmot_forensics::AuditEventKind::Rejection {
+                    msg_id: hex::encode(schedule.proposal_id.as_slice()),
+                    reason: crate::app_components::proposal_rejection_category_tag(
+                        rejection.category,
+                    )
+                    .to_string(),
+                },
+            );
+            return Ok(ScheduledAutoCommitReplay::NotApplicable);
+        }
 
         if self
             .stage_auto_commit_for_queued_proposal(&schedule.group_id, &mut mls_group, queued)
@@ -1868,6 +1960,11 @@ impl<S: StorageProvider> Engine<S> {
             .ok_or(ForkProbeError::InvalidCandidate)?;
         let priority = match processed.into_content() {
             ProcessedMessageContent::StagedCommitMessage(staged) => {
+                crate::app_components::authorize_staged_commit_proposals(
+                    &probe_group,
+                    staged.as_ref(),
+                )
+                .map_err(|_| ForkProbeError::InvalidCandidate)?;
                 crate::app_components::require_admin_for_staged_commit(
                     &probe_group,
                     group_id,
@@ -2062,6 +2159,7 @@ fn convergence_ingest_outcome(
     epoch: EpochId,
 ) -> IngestOutcome {
     let message_id = hex::encode(msg.id.as_slice());
+    let content_message_id = hex::encode(content_dedup_id(&msg.payload).as_slice());
 
     // Was this exact message classified by the canonicalize pass? Map
     // the disposition to a typed outcome so callers can log by category
@@ -2073,7 +2171,7 @@ fn convergence_ingest_outcome(
         .iter()
         .chain(&result.accepted_proposals)
         .chain(&result.accepted_app_messages)
-        .any(|accepted| accepted == &message_id);
+        .any(|accepted| accepted == &message_id || accepted == &content_message_id);
     if accepted && result.convergence_status == crate::canonicalization::ConvergenceStatus::Settled
     {
         return IngestOutcome::Processed;
@@ -2082,7 +2180,7 @@ fn convergence_ingest_outcome(
     if result
         .already_seen
         .iter()
-        .any(|seen| seen.message_id == message_id)
+        .any(|seen| seen.message_id == message_id || seen.message_id == content_message_id)
     {
         return IngestOutcome::Stale {
             reason: StaleReason::AlreadySeen,
@@ -2098,11 +2196,12 @@ fn convergence_ingest_outcome(
     // future epoch the local context can't yet peel. A subsequent
     // canonicalize pass that advances the MLS context will re-evaluate
     // it. Keep that case as Buffered.
-    if result
-        .dropped_messages
-        .iter()
-        .any(|dropped| dropped.message_id == message_id)
-    {
+    if let Some(dropped) = result.dropped_messages.iter().find(|dropped| {
+        dropped.message_id == message_id || dropped.message_id == content_message_id
+    }) {
+        if let Some(category) = dropped.rejection_category {
+            return IngestOutcome::Rejected { category };
+        }
         return IngestOutcome::Stale {
             reason: StaleReason::PeelFailed,
         };
@@ -2110,7 +2209,7 @@ fn convergence_ingest_outcome(
     if let Some(inv) = result
         .invalidated_app_messages
         .iter()
-        .find(|inv| inv.message_id == message_id)
+        .find(|inv| inv.message_id == message_id || inv.message_id == content_message_id)
     {
         use crate::canonicalization::InvalidatedAppMessageReason;
         match inv.reason {

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -659,7 +659,7 @@ impl<S: StorageProvider> Engine<S> {
                     self.note_peel_deferred_row_retired(group_id, &record.id);
                     progressed += 1;
                 }
-                Ok(IngestOutcome::Stale { .. }) => {
+                Ok(IngestOutcome::Stale { .. } | IngestOutcome::Rejected { .. }) => {
                     // Terminal stale classifications are still successful
                     // reclassifications of this raw deferred row. Retire it only
                     // while it is still awaiting retry: the reachable case is

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -205,8 +205,17 @@ impl ReplayBudget {
 #[derive(Clone, Debug)]
 enum CandidatePathProbeResult {
     Materialized(Option<OpenMlsMaterializedCandidate>),
-    UnauthorizedCommit { message_id: String },
-    InvalidCommit { message_id: String },
+    RejectedProposal {
+        message_id: String,
+        category: cgka_traits::ingest::ProposalRejectionCategory,
+    },
+    UnauthorizedCommit {
+        message_id: String,
+    },
+    InvalidCommit {
+        message_id: String,
+        rejection_category: Option<cgka_traits::ingest::ProposalRejectionCategory>,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -268,8 +277,18 @@ pub enum OpenMlsProjectionError {
     MissingGroup,
     Snapshot(String),
     Replay(String),
-    UnauthorizedCommit { message_id: String },
-    InvalidCommit { message_id: String, reason: String },
+    RejectedProposal {
+        message_id: String,
+        category: cgka_traits::ingest::ProposalRejectionCategory,
+    },
+    UnauthorizedCommit {
+        message_id: String,
+    },
+    InvalidCommit {
+        message_id: String,
+        reason: String,
+        rejection_category: Option<cgka_traits::ingest::ProposalRejectionCategory>,
+    },
     Serialize(String),
     Storage(String),
     InvalidPolicy(String),
@@ -292,10 +311,22 @@ impl std::fmt::Display for OpenMlsProjectionError {
             OpenMlsProjectionError::MissingGroup => write!(f, "MLS group not found"),
             OpenMlsProjectionError::Snapshot(e) => write!(f, "snapshot failed: {e}"),
             OpenMlsProjectionError::Replay(e) => write!(f, "OpenMLS replay failed: {e}"),
+            OpenMlsProjectionError::RejectedProposal {
+                message_id,
+                category,
+            } => {
+                write!(
+                    f,
+                    "rejected proposal {message_id}: {}",
+                    crate::app_components::proposal_rejection_category_tag(*category)
+                )
+            }
             OpenMlsProjectionError::UnauthorizedCommit { message_id } => {
                 write!(f, "unauthorized admin-gated commit: {message_id}")
             }
-            OpenMlsProjectionError::InvalidCommit { message_id, reason } => {
+            OpenMlsProjectionError::InvalidCommit {
+                message_id, reason, ..
+            } => {
                 write!(f, "invalid commit {message_id}: {reason}")
             }
             OpenMlsProjectionError::Serialize(e) => write!(f, "serialize failed: {e}"),
@@ -707,6 +738,7 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
                             message_id: hex::encode(message.id.as_slice()),
                             kind: MessageKind::Commit,
                             reason: DroppedMessageReason::BeyondAnchor,
+                            rejection_category: None,
                         });
                     }
                     continue;
@@ -807,11 +839,22 @@ fn append_dropped_messages(
     dropped_messages: Vec<DroppedMessage>,
 ) {
     for dropped in dropped_messages {
-        if result
-            .dropped_messages
-            .iter()
-            .any(|existing| existing.message_id == dropped.message_id)
+        if dropped.kind == MessageKind::Proposal
+            && result
+                .accepted_proposals
+                .iter()
+                .any(|accepted| accepted == &dropped.message_id)
         {
+            continue;
+        }
+        if let Some(existing) = result
+            .dropped_messages
+            .iter_mut()
+            .find(|existing| existing.message_id == dropped.message_id)
+        {
+            if existing.rejection_category.is_none() {
+                existing.rejection_category = dropped.rejection_category;
+            }
             continue;
         }
         result.dropped_messages.push(dropped);
@@ -1065,19 +1108,42 @@ fn build_stored_openmls_candidate_paths<S: StorageProvider>(
                         replay_rejected_commit_ids.insert(commit.message.id.to_string());
                         continue;
                     }
+                    CandidatePathProbeResult::RejectedProposal {
+                        message_id,
+                        category,
+                    } => {
+                        invalid_commit_drops.push(DroppedMessage {
+                            message_id,
+                            kind: MessageKind::Proposal,
+                            reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                            rejection_category: Some(category),
+                        });
+                        invalid_commit_drops.push(DroppedMessage {
+                            message_id: commit.message.id.to_string(),
+                            kind: MessageKind::Commit,
+                            reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                            rejection_category: None,
+                        });
+                        continue;
+                    }
                     CandidatePathProbeResult::UnauthorizedCommit { message_id } => {
                         invalid_commit_drops.push(DroppedMessage {
                             message_id,
                             kind: MessageKind::Commit,
                             reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                            rejection_category: None,
                         });
                         continue;
                     }
-                    CandidatePathProbeResult::InvalidCommit { message_id, .. } => {
+                    CandidatePathProbeResult::InvalidCommit {
+                        message_id,
+                        rejection_category,
+                    } => {
                         invalid_commit_drops.push(DroppedMessage {
                             message_id,
                             kind: MessageKind::Commit,
                             reason: DroppedMessageReason::InvalidAgainstCandidateState,
+                            rejection_category,
                         });
                         continue;
                     }
@@ -1106,6 +1172,7 @@ fn build_stored_openmls_candidate_paths<S: StorageProvider>(
             message_id: message_id.clone(),
             kind: MessageKind::Commit,
             reason: DroppedMessageReason::InvalidAgainstCandidateState,
+            rejection_category: None,
         });
     }
 
@@ -1180,13 +1247,24 @@ fn probe_candidate_path<S: StorageProvider>(
         budget,
     ) {
         Ok(mut candidates) => Ok(CandidatePathProbeResult::Materialized(candidates.pop())),
+        Err(OpenMlsProjectionError::RejectedProposal {
+            message_id,
+            category,
+        }) => Ok(CandidatePathProbeResult::RejectedProposal {
+            message_id,
+            category,
+        }),
         Err(OpenMlsProjectionError::UnauthorizedCommit { message_id }) => {
             Ok(CandidatePathProbeResult::UnauthorizedCommit { message_id })
         }
         Err(OpenMlsProjectionError::InvalidCommit {
             message_id,
             reason: _,
-        }) => Ok(CandidatePathProbeResult::InvalidCommit { message_id }),
+            rejection_category,
+        }) => Ok(CandidatePathProbeResult::InvalidCommit {
+            message_id,
+            rejection_category,
+        }),
         Err(OpenMlsProjectionError::Replay(_)) => Ok(CandidatePathProbeResult::Materialized(None)),
         Err(err) => Err(err),
     }
@@ -2006,6 +2084,32 @@ fn process_openmls_messages_inner<S: StorageProvider>(
             mls_group.process_message(&provider, protocol)
         } {
             Ok(processed) => processed,
+            Err(err) if projection.kind == OpenMlsContentKind::Commit => {
+                if let Some(category) = crate::app_components::classify_process_message_rejection(
+                    &err,
+                    ContentType::Commit,
+                ) {
+                    return Err(OpenMlsProjectionError::InvalidCommit {
+                        message_id,
+                        reason: crate::app_components::proposal_rejection_category_tag(category)
+                            .to_string(),
+                        rejection_category: Some(category),
+                    });
+                }
+                return Err(replay_error("process_message", err));
+            }
+            Err(err) if projection.kind == OpenMlsContentKind::Proposal => {
+                if let Some(category) = crate::app_components::classify_process_message_rejection(
+                    &err,
+                    ContentType::Proposal,
+                ) {
+                    return Err(OpenMlsProjectionError::RejectedProposal {
+                        message_id,
+                        category,
+                    });
+                }
+                return Err(replay_error("process_message", err));
+            }
             Err(err) if projection.kind == OpenMlsContentKind::Application => {
                 // App-message replay against a candidate state is best-
                 // effort: an app message that doesn't apply on this branch is
@@ -2043,6 +2147,14 @@ fn process_openmls_messages_inner<S: StorageProvider>(
 
         match processed.into_content() {
             ProcessedMessageContent::ProposalMessage(queued) => {
+                if let Err(rejection) =
+                    crate::app_components::authorize_standalone_proposal(&mls_group, &queued)
+                {
+                    return Err(OpenMlsProjectionError::RejectedProposal {
+                        message_id,
+                        category: rejection.category,
+                    });
+                }
                 let proposal_ref = tls_hex(queued.proposal_reference_ref())?;
                 mls_group
                     .store_pending_proposal(provider.storage(), *queued)
@@ -2056,6 +2168,18 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                 });
             }
             ProcessedMessageContent::StagedCommitMessage(staged) => {
+                if let Err(rejection) =
+                    crate::app_components::authorize_staged_commit_proposals(&mls_group, &staged)
+                {
+                    return Err(OpenMlsProjectionError::InvalidCommit {
+                        message_id,
+                        reason: crate::app_components::proposal_rejection_category_tag(
+                            rejection.category,
+                        )
+                        .to_string(),
+                        rejection_category: Some(rejection.category),
+                    });
+                }
                 if let Err(err) = crate::app_components::require_admin_for_staged_commit(
                     &mls_group,
                     group_id,
@@ -2079,6 +2203,7 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                     return Err(OpenMlsProjectionError::InvalidCommit {
                         message_id,
                         reason: format!("admin leaf coupling: {err}"),
+                        rejection_category: None,
                     });
                 }
                 if let Err(err) =
@@ -2089,6 +2214,7 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                     return Err(OpenMlsProjectionError::InvalidCommit {
                         message_id,
                         reason: format!("app component integrity: {err}"),
+                        rejection_category: None,
                     });
                 }
                 if sender_id.is_none() {
@@ -2126,6 +2252,7 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                     return Err(OpenMlsProjectionError::InvalidCommit {
                         message_id,
                         reason: format!("invalid credential identity or account proof: {err}"),
+                        rejection_category: None,
                     });
                 }
                 if let Err(err) =
@@ -2138,6 +2265,7 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                     return Err(OpenMlsProjectionError::InvalidCommit {
                         message_id,
                         reason: format!("current-profile resulting state: {err}"),
+                        rejection_category: None,
                     });
                 }
                 let resulting_epoch = mls_group.epoch().as_u64().saturating_add(1);
@@ -2163,6 +2291,7 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                     .map_err(|error| OpenMlsProjectionError::InvalidCommit {
                         message_id,
                         reason: format!("current-profile merged state: {error}"),
+                        rejection_category: None,
                     })?;
                 prefix_canonical =
                     prefix_canonical && own_commits.is_canonical(&projection.message_digest);

--- a/crates/cgka-engine/tests/mip03_guards.rs
+++ b/crates/cgka-engine/tests/mip03_guards.rs
@@ -8,31 +8,37 @@
 
 use async_trait::async_trait;
 use cgka_engine::app_components::staged_commit_requires_admin;
-use cgka_engine::canonicalization::DroppedMessageReason;
+use cgka_engine::canonicalization::{CanonicalizationPolicy, DroppedMessageReason};
+use cgka_engine::convergence::ConvergencePolicy;
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::provider::EngineOpenMlsProvider;
 use cgka_engine::{DEFAULT_CIPHERSUITE, Engine, EngineBuilder};
+use cgka_traits::app_components::{GROUP_PROFILE_COMPONENT_ID, encode_component_vectors};
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult};
 use cgka_traits::error::PeelerError;
+use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
-use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage};
+use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage, ProposalRejectionCategory};
+use cgka_traits::message::MessageState;
 use cgka_traits::peeler::TransportPeeler;
-use cgka_traits::storage::{AccountDeviceSignerStorage, StorageProvider};
+use cgka_traits::storage::{AccountDeviceSignerStorage, MessageStorage, StorageProvider};
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
 use cgka_traits::types::{GroupId, MemberId, MessageId};
 use openmls::group::MlsGroup;
-use openmls::messages::proposals::{PreSharedKeyProposal, Proposal};
+use openmls::messages::external_proposals::JoinProposal;
+use openmls::messages::proposals::{AppDataUpdateOperation, PreSharedKeyProposal, Proposal};
 use openmls::prelude::{
     BasicCredential, CredentialWithKey, LeafNodeParameters, MlsMessageBodyIn, MlsMessageIn,
-    ProcessedMessageContent,
+    MlsMessageOut, ProcessedMessageContent,
 };
 use openmls::schedule::PreSharedKeyId;
 use openmls_basic_credential::SignatureKeyPair;
-use openmls_rust_crypto::RustCrypto;
+use openmls_rust_crypto::{OpenMlsRustCrypto, RustCrypto};
 use openmls_traits::OpenMlsProvider as _;
+use sha2::Digest as _;
 use storage_sqlite::SqliteAccountStorage;
 use tls_codec::{Deserialize as _, Serialize as _};
 
@@ -175,6 +181,133 @@ fn build_with_storage(id: &[u8]) -> (Engine<SqliteAccountStorage>, SqliteAccount
     (engine, storage)
 }
 
+fn build_current_with_storage(id: &[u8]) -> (Engine<SqliteAccountStorage>, SqliteAccountStorage) {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let engine = EngineBuilder::new(storage.clone())
+        .identity(pad32(id))
+        .account_identity_proof_signer(proof_signer(id))
+        .protocol_profile(ProtocolProfile::Current)
+        .feature_registry(registry())
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .unwrap();
+    (engine, storage)
+}
+
+fn proposal_transport(
+    message: MlsMessageOut,
+    group_id: &GroupId,
+    source: &str,
+) -> TransportMessage {
+    let payload = message
+        .tls_serialize_detached()
+        .expect("serialize raw proposal");
+    TransportMessage {
+        id: hash_id(&payload),
+        payload,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource(source.into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    }
+}
+
+fn self_update_proposal(
+    storage: &SqliteAccountStorage,
+    crypto: &RustCrypto,
+    sender: &MemberId,
+    group_id: &GroupId,
+) -> TransportMessage {
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(crypto, storage.mls_storage());
+    let (mut group, signer) = load_group_and_signer(storage, crypto, sender, group_id);
+    let (message, _) = group
+        .propose_self_update(&provider, &signer, LeafNodeParameters::default())
+        .expect("build valid self-update proposal");
+    proposal_transport(message, group_id, "raw-self-update")
+}
+
+fn app_data_update_proposal(
+    storage: &SqliteAccountStorage,
+    crypto: &RustCrypto,
+    sender: &MemberId,
+    group_id: &GroupId,
+    data: Vec<u8>,
+) -> TransportMessage {
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(crypto, storage.mls_storage());
+    let (mut group, signer) = load_group_and_signer(storage, crypto, sender, group_id);
+    let (message, _) = group
+        .propose_app_data_update(
+            &provider,
+            &signer,
+            GROUP_PROFILE_COMPONENT_ID,
+            AppDataUpdateOperation::Update(data.into()),
+        )
+        .expect("build AppDataUpdate proposal");
+    proposal_transport(message, group_id, "raw-app-data-update")
+}
+
+fn unsupported_psk_proposal(
+    storage: &SqliteAccountStorage,
+    crypto: &RustCrypto,
+    sender: &MemberId,
+    group_id: &GroupId,
+) -> TransportMessage {
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(crypto, storage.mls_storage());
+    let (mut group, signer) = load_group_and_signer(storage, crypto, sender, group_id);
+    let psk_id = PreSharedKeyId::external(vec![9u8; 32], vec![0u8; 32]);
+    let (message, _) = group
+        .propose_pre_shared_key(&provider, &signer, psk_id)
+        .expect("build unsupported PSK proposal");
+    proposal_transport(message, group_id, "raw-psk")
+}
+
+fn raw_self_remove_proposal(
+    storage: &SqliteAccountStorage,
+    crypto: &RustCrypto,
+    sender: &MemberId,
+    group_id: &GroupId,
+) -> TransportMessage {
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(crypto, storage.mls_storage());
+    let (mut group, signer) = load_group_and_signer(storage, crypto, sender, group_id);
+    let message = group
+        .leave_group_via_self_remove(&provider, &signer)
+        .expect("build raw SelfRemove proposal");
+    proposal_transport(message, group_id, "raw-self-remove")
+}
+
+async fn establish_current_group(
+    creator: &mut Engine<SqliteAccountStorage>,
+    invitee: &mut Engine<SqliteAccountStorage>,
+    invitee_is_admin: bool,
+    name: &str,
+) -> GroupId {
+    let invitee_id = invitee.self_id();
+    let invitee_kp = invitee.fresh_key_package().await.unwrap();
+    let (group_id, create) = creator
+        .create_group(CreateGroupRequest {
+            name: name.into(),
+            description: String::new(),
+            members: vec![invitee_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: invitee_is_admin.then_some(invitee_id).into_iter().collect(),
+        })
+        .await
+        .unwrap();
+    let welcome = match create {
+        SendResult::FoundingGroupCreated { mut welcomes } => welcomes.remove(0),
+        other => panic!("expected FoundingGroupCreated, got {other:?}"),
+    };
+    invitee.join_welcome(welcome).await.unwrap();
+    group_id
+}
+
 /// Load the engine's underlying OpenMLS group + signer for `member` so a test
 /// can construct raw commits of arbitrary shape against the real group state.
 fn load_group_and_signer<'a>(
@@ -312,9 +445,39 @@ fn commit_pending_proposals(
     group_id: &GroupId,
     proposal: &TransportMessage,
 ) -> TransportMessage {
+    store_pending_proposal(storage, crypto, committer, group_id, proposal);
     let provider =
         EngineOpenMlsProvider::<SqliteAccountStorage>::new(crypto, storage.mls_storage());
     let (mut mls_group, signer) = load_group_and_signer(storage, crypto, committer, group_id);
+    let (commit_out, _welcome_opt, _group_info) = mls_group
+        .commit_to_pending_proposals(&provider, &signer)
+        .expect("committer can build by-reference update commit");
+    let commit_bytes = commit_out
+        .tls_serialize_detached()
+        .expect("serialize by-reference update commit");
+
+    TransportMessage {
+        id: hash_id(&commit_bytes),
+        payload: commit_bytes,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("raw-openmls-commit".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    }
+}
+
+fn store_pending_proposal(
+    storage: &SqliteAccountStorage,
+    crypto: &RustCrypto,
+    member: &MemberId,
+    group_id: &GroupId,
+    proposal: &TransportMessage,
+) {
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(crypto, storage.mls_storage());
+    let (mut mls_group, _) = load_group_and_signer(storage, crypto, member, group_id);
     // Re-process and store the by-reference proposal into the committer's live
     // OpenMLS proposal store so `commit_to_pending_proposals` can pick it up.
     //
@@ -344,19 +507,55 @@ fn commit_pending_proposals(
         }
         other => panic!("expected a proposal message, got {other:?}"),
     }
-    let (commit_out, _welcome_opt, _group_info) = mls_group
-        .commit_to_pending_proposals(&provider, &signer)
-        .expect("committer can build by-reference update commit");
-    let commit_bytes = commit_out
-        .tls_serialize_detached()
-        .expect("serialize by-reference update commit");
+}
 
+fn external_join_proposal_with_signature(
+    group_id: &GroupId,
+    epoch: u64,
+    valid_signature: bool,
+) -> TransportMessage {
+    let key_package_signer = SignatureKeyPair::new(DEFAULT_CIPHERSUITE.signature_algorithm())
+        .expect("external join key package signer");
+    let other_signer = SignatureKeyPair::new(DEFAULT_CIPHERSUITE.signature_algorithm())
+        .expect("alternate external join signer");
+    let proposal_signer = if valid_signature {
+        &key_package_signer
+    } else {
+        &other_signer
+    };
+    let credential_with_key = CredentialWithKey {
+        credential: BasicCredential::new(pad32(b"external-joiner")).into(),
+        signature_key: key_package_signer.public().into(),
+    };
+    let key_package = openmls::key_packages::KeyPackage::builder()
+        .leaf_node_capabilities(openmls::prelude::Capabilities::default())
+        .build(
+            DEFAULT_CIPHERSUITE,
+            &OpenMlsRustCrypto::default(),
+            &key_package_signer,
+            credential_with_key,
+        )
+        .expect("build external join key package")
+        .key_package()
+        .clone();
+    let proposal_out = JoinProposal::new::<
+        <OpenMlsRustCrypto as openmls_traits::OpenMlsProvider>::StorageProvider,
+    >(
+        key_package,
+        openmls::group::GroupId::from_slice(group_id.as_slice()),
+        openmls::group::GroupEpoch::from(epoch),
+        proposal_signer,
+    )
+    .expect("build external join proposal");
+    let proposal_bytes = proposal_out
+        .tls_serialize_detached()
+        .expect("serialize external join proposal");
     TransportMessage {
-        id: hash_id(&commit_bytes),
-        payload: commit_bytes,
+        id: hash_id(&proposal_bytes),
+        payload: proposal_bytes,
         timestamp: Timestamp(0),
         causal_deps: vec![],
-        source: TransportSource("raw-openmls-commit".into()),
+        source: TransportSource("external-join-proposal".into()),
         envelope: TransportEnvelope::GroupMessage {
             transport_group_id: group_id.as_slice().to_vec(),
         },
@@ -444,7 +643,7 @@ async fn inbound_by_reference_update_rejects_account_identity_spoofing() {
     // leaf against Bob's pre-merge account identity before applying the commit.
     let (mut alice, alice_storage) = build_with_storage(b"alice");
     let (mut bob, bob_storage) = build_with_storage(b"bob");
-    let (mut carol, _carol_storage) = build_with_storage(b"carol");
+    let (mut carol, carol_storage) = build_with_storage(b"carol");
     let bob_kp = bob.fresh_key_package().await.unwrap();
     let carol_kp = carol.fresh_key_package().await.unwrap();
 
@@ -480,15 +679,34 @@ async fn inbound_by_reference_update_rejects_account_identity_spoofing() {
         &alice.self_id(),
         &group_id,
     );
+    let rejected_proposal_id =
+        MessageId::new(sha2::Sha256::digest(&spoofed_proposal.payload).to_vec());
 
-    assert!(matches!(
+    for outcome in [
         alice.ingest(spoofed_proposal.clone()).await.unwrap(),
-        IngestOutcome::Processed
-    ));
-    assert!(matches!(
         carol.ingest(spoofed_proposal.clone()).await.unwrap(),
-        IngestOutcome::Processed
-    ));
+    ] {
+        assert!(
+            matches!(
+                outcome,
+                IngestOutcome::Rejected {
+                    category: ProposalRejectionCategory::InvalidEncoding
+                }
+            ),
+            "invalid standalone Update must be rejected before pending storage, got {outcome:?}"
+        );
+    }
+    assert_eq!(
+        carol_storage
+            .get_message(&rejected_proposal_id)
+            .expect("rejected proposal remains diagnosable")
+            .state,
+        cgka_traits::message::MessageState::Failed
+    );
+    assert!(
+        carol.drain_auto_publish().is_empty(),
+        "a rejected proposal cannot schedule auto-commit work"
+    );
 
     let before_epoch = carol.epoch(&group_id).expect("carol has group");
     let by_reference_commit = commit_pending_proposals(
@@ -525,6 +743,480 @@ async fn inbound_by_reference_update_rejects_account_identity_spoofing() {
         "spoofed by-reference Update must be terminally invalidated, got {result:?}"
     );
     assert_eq!(carol.epoch(&group_id).unwrap(), before_epoch);
+
+    // A rejected proposal is terminal durable input, not pending work that a
+    // restart can accidentally hydrate or schedule.
+    drop(carol);
+    let mut reopened = EngineBuilder::new(carol_storage.clone())
+        .identity(pad32(b"carol"))
+        .account_identity_proof_signer(proof_signer(b"carol"))
+        .feature_registry(registry())
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .unwrap();
+    reopened
+        .hydrate_stable_groups_from_storage()
+        .expect("reopen after rejected proposal");
+    assert!(reopened.drain_auto_publish().is_empty());
+    assert_eq!(
+        carol_storage
+            .get_message(&rejected_proposal_id)
+            .expect("rejected proposal remains failed after reopen")
+            .state,
+        cgka_traits::message::MessageState::Failed
+    );
+}
+
+#[tokio::test]
+async fn current_by_reference_non_admin_update_is_rejected_at_commit() {
+    let (mut alice, alice_storage) = build_current_with_storage(b"alice-by-ref-current");
+    let (mut bob, bob_storage) = build_current_with_storage(b"bob-by-ref-current");
+    let (mut carol, carol_storage) = build_current_with_storage(b"carol-by-ref-current");
+    let group_id =
+        establish_current_group(&mut alice, &mut bob, false, "current-by-reference").await;
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![carol_kp],
+        })
+        .await
+        .unwrap();
+    let (commit, pending, mut welcomes) = match invite {
+        SendResult::GroupEvolution {
+            msg,
+            pending,
+            welcomes,
+        } => (msg, pending, welcomes),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.ingest(commit).await.unwrap();
+    bob.converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("bob applies Carol's invite");
+    carol.join_welcome(welcomes.remove(0)).await.unwrap();
+
+    let crypto = RustCrypto::default();
+    let proposal = self_update_proposal(&bob_storage, &crypto, &bob.self_id(), &group_id);
+    store_pending_proposal(
+        &carol_storage,
+        &crypto,
+        &carol.self_id(),
+        &group_id,
+        &proposal,
+    );
+    let commit = commit_pending_proposals(
+        &alice_storage,
+        &crypto,
+        &alice.self_id(),
+        &group_id,
+        &proposal,
+    );
+    let before_epoch = carol.epoch(&group_id).expect("carol has current group");
+
+    let outcome = carol.ingest(commit).await.unwrap();
+    assert_eq!(
+        outcome,
+        IngestOutcome::Rejected {
+            category: ProposalRejectionCategory::AuthorizationFailed,
+        },
+        "commit-time revalidation must reject a non-admin by-reference Update"
+    );
+    assert_eq!(carol.epoch(&group_id).unwrap(), before_epoch);
+}
+
+#[tokio::test]
+async fn standalone_update_authorization_is_profile_specific() {
+    let (mut alice, _alice_storage) = build_current_with_storage(b"alice-current");
+    let (mut bob, bob_storage) = build_current_with_storage(b"bob-current");
+    let group_id =
+        establish_current_group(&mut alice, &mut bob, false, "current-proposal-policy").await;
+
+    let crypto = RustCrypto::default();
+    let current_update = self_update_proposal(&bob_storage, &crypto, &bob.self_id(), &group_id);
+    let outcome = alice.ingest(current_update).await.unwrap();
+    assert!(
+        matches!(
+            outcome,
+            IngestOutcome::Rejected {
+                category: ProposalRejectionCategory::AuthorizationFailed
+            }
+        ),
+        "current-profile non-admin standalone Update must be unauthorized, got {outcome:?}"
+    );
+    assert!(alice.drain_auto_publish().is_empty());
+
+    // Existing legacy groups keep the deployed ordinary MLS member-update
+    // proposal flow. This is deliberately not inferred from the new-engine
+    // default; it follows the group's independently classified wire profile.
+    let (mut legacy_alice, _legacy_alice_storage) = build_with_storage(b"alice-legacy");
+    let (mut legacy_bob, legacy_bob_storage) = build_with_storage(b"bob-legacy");
+    let legacy_bob_kp = legacy_bob.fresh_key_package().await.unwrap();
+    let (legacy_group_id, create) = legacy_alice
+        .create_group(CreateGroupRequest {
+            name: "legacy-proposal-policy".into(),
+            description: String::new(),
+            members: vec![legacy_bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let welcome = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            legacy_alice.confirm_published(pending).await.unwrap();
+            welcomes.remove(0)
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    legacy_bob.join_welcome(welcome).await.unwrap();
+    let legacy_update = self_update_proposal(
+        &legacy_bob_storage,
+        &crypto,
+        &legacy_bob.self_id(),
+        &legacy_group_id,
+    );
+    assert!(matches!(
+        legacy_alice.ingest(legacy_update).await.unwrap(),
+        IngestOutcome::Processed
+    ));
+}
+
+#[tokio::test]
+async fn standalone_proposal_gate_distinguishes_authorization_encoding_support_and_signature() {
+    use marmot_forensics::{AuditEvent, AuditEventKind, JsonlRecorder};
+
+    let audit_dir = tempfile::TempDir::new().unwrap();
+    let audit_path = audit_dir.path().join("proposal-rejections.jsonl");
+    let recorder = JsonlRecorder::open(&audit_path, "proposal-gate-test".to_string()).unwrap();
+    let alice_storage = SqliteAccountStorage::in_memory().unwrap();
+    let mut alice = EngineBuilder::new(alice_storage.clone())
+        .identity(pad32(b"alice-proposal-gate"))
+        .account_identity_proof_signer(proof_signer(b"alice-proposal-gate"))
+        .protocol_profile(ProtocolProfile::Current)
+        .feature_registry(registry())
+        .peeler(Box::new(MockPeeler))
+        .recorder(Box::new(recorder))
+        .build()
+        .unwrap();
+    let (mut bob, bob_storage) = build_current_with_storage(b"bob-proposal-gate");
+    let (mut carol, carol_storage) = build_current_with_storage(b"carol-proposal-gate");
+    let (mut dave, dave_storage) = build_current_with_storage(b"dave-proposal-gate");
+    let (mut frank, frank_storage) = build_current_with_storage(b"frank-proposal-gate");
+    let invalid_group =
+        establish_current_group(&mut alice, &mut bob, true, "invalid-component").await;
+    let unauthorized_group =
+        establish_current_group(&mut alice, &mut carol, false, "unauthorized-component").await;
+    let unsupported_group =
+        establish_current_group(&mut alice, &mut dave, false, "unsupported-proposal").await;
+    let self_remove_group =
+        establish_current_group(&mut alice, &mut frank, true, "invalid-self-remove").await;
+
+    let crypto = RustCrypto::default();
+    let invalid_component = app_data_update_proposal(
+        &bob_storage,
+        &crypto,
+        &bob.self_id(),
+        &invalid_group,
+        vec![0xff],
+    );
+    let unauthorized_component = app_data_update_proposal(
+        &carol_storage,
+        &crypto,
+        &carol.self_id(),
+        &unauthorized_group,
+        encode_component_vectors(&[b"new name", b"description"]),
+    );
+    let unsupported =
+        unsupported_psk_proposal(&dave_storage, &crypto, &dave.self_id(), &unsupported_group);
+    let invalid_signature = external_join_proposal_with_signature(
+        &unauthorized_group,
+        alice.epoch(&unauthorized_group).unwrap().0,
+        false,
+    );
+    let invalid_self_remove = raw_self_remove_proposal(
+        &frank_storage,
+        &crypto,
+        &frank.self_id(),
+        &self_remove_group,
+    );
+
+    for (proposal, expected_category) in [
+        (
+            invalid_component,
+            ProposalRejectionCategory::InvalidEncoding,
+        ),
+        (
+            unauthorized_component,
+            ProposalRejectionCategory::AuthorizationFailed,
+        ),
+        (unsupported, ProposalRejectionCategory::UnsupportedProposal),
+        (
+            invalid_signature,
+            ProposalRejectionCategory::InvalidSignature,
+        ),
+        (
+            invalid_self_remove,
+            ProposalRejectionCategory::InvalidSelfRemove,
+        ),
+    ] {
+        let outcome = alice.ingest(proposal).await.unwrap();
+        assert_eq!(
+            outcome,
+            IngestOutcome::Rejected {
+                category: expected_category,
+            },
+            "proposal rejection must be terminal, got {outcome:?}"
+        );
+    }
+    assert!(alice.drain_auto_publish().is_empty());
+
+    drop(alice);
+    let events: Vec<AuditEvent> = std::fs::read_to_string(&audit_path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    let rejection_classes = events
+        .iter()
+        .filter_map(|event| match &event.kind {
+            AuditEventKind::Rejection { reason, .. } => Some(reason.as_str()),
+            _ => None,
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+    for expected in [
+        "authorization_failed",
+        "invalid_encoding",
+        "unsupported_proposal",
+        "invalid_signature",
+        "invalid_self_remove",
+    ] {
+        assert!(
+            rejection_classes.contains(expected),
+            "missing privacy-safe rejection class {expected}: {rejection_classes:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn external_join_proposal_is_rejected_before_pending_state() {
+    let (mut alice, alice_storage) = build_with_storage(b"alice-external-join");
+    let mut bob = build(b"bob-external-join");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "external-join-rejection".into(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let pending = match create {
+        SendResult::GroupCreated { pending, .. } => pending,
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+
+    let proposal =
+        external_join_proposal_with_signature(&group_id, alice.epoch(&group_id).unwrap().0, true);
+    assert_eq!(
+        alice.ingest(proposal).await.unwrap(),
+        IngestOutcome::Rejected {
+            category: ProposalRejectionCategory::UnsupportedProposal,
+        }
+    );
+    assert!(alice.drain_auto_publish().is_empty());
+
+    let crypto = RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, alice_storage.mls_storage());
+    let mls_group = MlsGroup::load(
+        provider.storage(),
+        &openmls::group::GroupId::from_slice(group_id.as_slice()),
+    )
+    .expect("load group")
+    .expect("group present");
+    assert!(mls_group.pending_proposals().next().is_none());
+}
+
+#[tokio::test]
+async fn stale_standalone_proposal_never_schedules_or_reenters_pending_state() {
+    let (mut alice, _alice_storage) = build_current_with_storage(b"alice-stale-proposal");
+    let (mut bob, bob_storage) = build_current_with_storage(b"bob-stale-proposal");
+    let group_id = establish_current_group(&mut alice, &mut bob, false, "stale-proposal").await;
+    let crypto = RustCrypto::default();
+    let stale_self_remove =
+        raw_self_remove_proposal(&bob_storage, &crypto, &bob.self_id(), &group_id);
+
+    let update = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("advanced".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let pending = match update {
+        SendResult::GroupEvolution { pending, .. } => pending,
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+
+    let outcome = alice.ingest(stale_self_remove).await.unwrap();
+    assert!(
+        matches!(
+            outcome,
+            IngestOutcome::Stale {
+                reason: cgka_traits::ingest::StaleReason::AlreadyAtEpoch {
+                    current: cgka_traits::types::EpochId(2),
+                    msg_epoch: cgka_traits::types::EpochId(1),
+                }
+            }
+        ),
+        "wrong-epoch proposal should retain the stale distinction, got {outcome:?}"
+    );
+    assert!(alice.drain_auto_publish().is_empty());
+}
+
+#[tokio::test]
+async fn parent_dependent_proposal_waits_for_retained_fork_parent() {
+    let (mut alice, _alice_storage) = build_with_storage(b"alice-parent-dependent");
+    let (mut bob, _bob_storage) = build_with_storage(b"bob-parent-dependent");
+    let (mut carol, carol_storage) = build_with_storage(b"carol-parent-dependent");
+    let (mut david, _david_storage) = build_with_storage(b"david-parent-dependent");
+    let (mut eve, _eve_storage) = build_with_storage(b"eve-parent-dependent");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "parent-dependent-proposal".into(),
+            description: String::new(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![Feature("self-remove")],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcomes[0].clone()).await.unwrap();
+    carol.join_welcome(welcomes[1].clone()).await.unwrap();
+    carol.set_convergence_policy(CanonicalizationPolicy {
+        convergence: ConvergencePolicy {
+            max_rewind_commits: 1,
+            ..ConvergencePolicy::default()
+        },
+        ..CanonicalizationPolicy::default()
+    });
+
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let alice_invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david_kp],
+        })
+        .await
+        .unwrap();
+    let (alice_commit, alice_pending) = match alice_invite {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(alice_pending).await.unwrap();
+    carol
+        .buffer_openmls_convergence_message(&group_id, alice_commit, 1_000)
+        .expect("buffer alice branch commit");
+    carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("settle alice branch and retain the epoch-one anchor");
+    assert_eq!(carol.epoch(&group_id).unwrap().0, 2);
+
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let bob_invite = bob
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+        })
+        .await
+        .unwrap();
+    let (bob_commit, bob_pending, bob_welcomes) = match bob_invite {
+        SendResult::GroupEvolution {
+            msg,
+            pending,
+            welcomes,
+        } => (msg, pending, welcomes),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    bob.confirm_published(bob_pending).await.unwrap();
+    let eve_welcome = bob_welcomes
+        .into_iter()
+        .find(|welcome| {
+            matches!(
+                &welcome.envelope,
+                TransportEnvelope::Welcome { recipient } if recipient == &eve.self_id()
+            )
+        })
+        .expect("bob welcome for eve");
+    eve.join_welcome(eve_welcome).await.unwrap();
+
+    let fork_proposal = match eve
+        .send(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::Proposal { msg } => msg,
+        other => panic!("expected Proposal, got {other:?}"),
+    };
+    let proposal_message_id = MessageId::new(sha2::Sha256::digest(&fork_proposal.payload).to_vec());
+    let proposal_id = canonicalization_message_id(&fork_proposal);
+
+    let ingest_outcome = carol.ingest(fork_proposal).await.unwrap();
+    assert!(
+        matches!(ingest_outcome, IngestOutcome::Buffered { .. }),
+        "parent-dependent authentication must defer until the candidate parent arrives, got {ingest_outcome:?}"
+    );
+    assert_ne!(
+        carol_storage
+            .get_message(&proposal_message_id)
+            .expect("proposal durable row")
+            .state,
+        MessageState::Failed
+    );
+
+    carol
+        .buffer_openmls_convergence_message(&group_id, bob_commit, 2_000)
+        .expect("buffer competing fork commit");
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("replay with retained alternate parent");
+    assert!(
+        !result.dropped_messages.iter().any(|dropped| {
+            dropped.message_id == proposal_id
+                && dropped.rejection_category == Some(ProposalRejectionCategory::InvalidSignature)
+        }),
+        "alternate-parent replay must not misclassify the proposal signature: {:?}",
+        result.dropped_messages
+    );
+    assert_ne!(
+        carol_storage
+            .get_message(&proposal_message_id)
+            .expect("proposal durable row after replay")
+            .state,
+        MessageState::Failed
+    );
 }
 
 #[tokio::test]

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -785,6 +785,7 @@ fn ingest_outcome_kind(outcome: &IngestOutcome) -> &'static str {
         IngestOutcome::Processed => "processed",
         IngestOutcome::Buffered { .. } => "buffered",
         IngestOutcome::Stale { .. } => "stale",
+        IngestOutcome::Rejected { .. } => "rejected",
     }
 }
 

--- a/crates/traits/src/ingest.rs
+++ b/crates/traits/src/ingest.rs
@@ -22,6 +22,25 @@ pub enum IngestOutcome {
     /// Message was not applied. The variant names why — callers log by
     /// category rather than pattern-matching error strings.
     Stale { reason: StaleReason },
+    /// A standalone or commit-carried MLS proposal failed Marmot semantic
+    /// admission before it could enter pending state or affect group state.
+    Rejected { category: ProposalRejectionCategory },
+}
+
+/// Stable rejection taxonomy for authenticated MLS proposals that fail
+/// Marmot's semantic admission rules.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum ProposalRejectionCategory {
+    /// The authenticated sender is not authorized for this proposal.
+    AuthorizationFailed,
+    /// The active protocol profile does not admit this proposal type.
+    UnsupportedProposal,
+    /// Proposal bytes, component data, or resulting state are invalid.
+    InvalidEncoding,
+    /// The proposal cannot be authenticated to a valid current member.
+    InvalidSignature,
+    /// SelfRemove violates the active member-departure or admin rules.
+    InvalidSelfRemove,
 }
 
 /// Why an inbound message was not processed.

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -76,7 +76,9 @@ pub use engine_state::{
 pub use error::{EngineError, PeelerError};
 pub use group::{Group, Member};
 pub use group_context::{GroupContext, GroupContextSnapshot, SecretBytes};
-pub use ingest::{IngestOutcome, PeeledContent, PeeledMessage, StaleReason};
+pub use ingest::{
+    IngestOutcome, PeeledContent, PeeledMessage, ProposalRejectionCategory, StaleReason,
+};
 pub use message::{MessageRecord, MessageState, OwnCommitConvergenceStamp, StoredMessagePayload};
 pub use peeler::{GroupMessageMetadata, GroupMessageMetadataError, TransportPeeler};
 pub use storage::{

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -391,6 +391,36 @@ fn snapshot_ingest_outcomes() {
             reason: StaleReason::Quarantined
         }
     );
+    insta::assert_json_snapshot!(
+        "ingest_outcome_rejected_authorization_failed",
+        IngestOutcome::Rejected {
+            category: cgka_traits::ingest::ProposalRejectionCategory::AuthorizationFailed
+        }
+    );
+    insta::assert_json_snapshot!(
+        "ingest_outcome_rejected_unsupported_proposal",
+        IngestOutcome::Rejected {
+            category: cgka_traits::ingest::ProposalRejectionCategory::UnsupportedProposal
+        }
+    );
+    insta::assert_json_snapshot!(
+        "ingest_outcome_rejected_invalid_encoding",
+        IngestOutcome::Rejected {
+            category: cgka_traits::ingest::ProposalRejectionCategory::InvalidEncoding
+        }
+    );
+    insta::assert_json_snapshot!(
+        "ingest_outcome_rejected_invalid_signature",
+        IngestOutcome::Rejected {
+            category: cgka_traits::ingest::ProposalRejectionCategory::InvalidSignature
+        }
+    );
+    insta::assert_json_snapshot!(
+        "ingest_outcome_rejected_invalid_self_remove",
+        IngestOutcome::Rejected {
+            category: cgka_traits::ingest::ProposalRejectionCategory::InvalidSelfRemove
+        }
+    );
 }
 
 #[test]

--- a/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_authorization_failed.snap
+++ b/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_authorization_failed.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Rejected\n{\n    category:\n    cgka_traits::ingest::ProposalRejectionCategory::AuthorizationFailed\n}"
+---
+{
+  "Rejected": {
+    "category": "AuthorizationFailed"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_invalid_encoding.snap
+++ b/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_invalid_encoding.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Rejected\n{ category: cgka_traits::ingest::ProposalRejectionCategory::InvalidEncoding }"
+---
+{
+  "Rejected": {
+    "category": "InvalidEncoding"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_invalid_self_remove.snap
+++ b/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_invalid_self_remove.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Rejected\n{\n    category:\n    cgka_traits::ingest::ProposalRejectionCategory::InvalidSelfRemove\n}"
+---
+{
+  "Rejected": {
+    "category": "InvalidSelfRemove"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_invalid_signature.snap
+++ b/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_invalid_signature.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Rejected\n{ category: cgka_traits::ingest::ProposalRejectionCategory::InvalidSignature }"
+---
+{
+  "Rejected": {
+    "category": "InvalidSignature"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_unsupported_proposal.snap
+++ b/crates/traits/tests/snapshots/snapshots__ingest_outcome_rejected_unsupported_proposal.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Rejected\n{\n    category:\n    cgka_traits::ingest::ProposalRejectionCategory::UnsupportedProposal\n}"
+---
+{
+  "Rejected": {
+    "category": "UnsupportedProposal"
+  }
+}


### PR DESCRIPTION
## Summary

- authorize authenticated standalone proposals against their source-epoch Marmot profile, membership, admin policy, capabilities, component rules, and account identity proofs before durable pending storage
- expose stable typed rejection categories (`AuthorizationFailed`, `UnsupportedProposal`, `InvalidEncoding`, `InvalidSignature`, and `InvalidSelfRemove`) while keeping parent-dependent proposals eligible for retained-fork convergence
- re-run the same proposal policy for staged commits, delayed SelfRemove work, retained-history replay, candidate probing, and hydration so rejected proposals cannot affect a later commit
- preserve deployed legacy Update behavior while enforcing current-profile proposal roles, and emit canonical privacy-safe rejection categories
- add adversarial engine/restart coverage plus an executable conformance vector for raw OpenMLS and Nostr-wrapped inbound seams

## Stack

This PR is based on #1075 (`codex/issue-1052-media-v2`). Merge the stack in order.

## Validation

- `just fast-ci`
- `cargo test -p cgka-engine`
- `cargo test -p cgka-conformance-simulator`
- `cargo test -p cgka-engine --test mip03_guards`
- `cargo test -p cgka-conformance-simulator --test openmls_replay_probe proposal_authorization_vector_rejects_direct_and_nostr_wrapped_input`

Fixes #1053