### PR TITLE
Expose checked Media V1/V2 imeta APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -852,7 +852,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "hex",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "libc",
  "tempfile",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-conformance-simulator",
  "serde",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "fs-private",
  "serde",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5435,7 +5435,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6029,7 +6029,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6065,7 +6065,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6085,7 +6085,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7140,7 +7140,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7171,7 +7171,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "agent-control",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.5"
+version = "0.9.6"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.5",
+  "conformance_version": "0.9.6",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/src/commands/media.rs
+++ b/crates/cli/src/commands/media.rs
@@ -1,6 +1,5 @@
 //! `media` command namespace handlers and media-attachment helpers.
 
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use cgka_traits::GroupId;
@@ -105,7 +104,11 @@ pub(crate) async fn media_command_with_runtime(
                     limit: None,
                 },
             )?;
-            let reference = media_attachment_for_hash(messages, &file_hash_hex)?;
+            let reference = media_attachment_for_hash(
+                messages,
+                &file_hash_hex,
+                app.allow_loopback_blob_endpoints(),
+            )?;
             let output_path = media_output_path(output, &reference.file_name);
             let download = runtime
                 .download_media(&account.account_id_hex, &group_id, reference.clone())
@@ -135,7 +138,7 @@ pub(crate) async fn media_command_with_runtime(
                     limit: None,
                 },
             )?;
-            let media = media_records_json(messages)?;
+            let media = media_records_json(messages, app.allow_loopback_blob_endpoints())?;
             Ok(CommandOutput {
                 plain: if media.is_empty() {
                     "no media".to_owned()
@@ -157,13 +160,17 @@ pub(crate) async fn media_command_with_runtime(
     }
 }
 
-fn media_records_json(messages: Vec<AppMessageRecord>) -> Result<Vec<Value>, WnError> {
+fn media_records_json(
+    messages: Vec<AppMessageRecord>,
+    allow_loopback_http: bool,
+) -> Result<Vec<Value>, WnError> {
     let mut records = Vec::new();
     for message in messages {
         let caption = (!message.plaintext.is_empty()).then(|| message.plaintext.clone());
-        for (attachment_index, reference) in media_attachments_from_message(&message)?
-            .into_iter()
-            .enumerate()
+        for (attachment_index, reference) in
+            media_attachments_from_message(&message, allow_loopback_http)?
+                .into_iter()
+                .enumerate()
         {
             records.push(json!({
                 "message_id": message.message_id_hex,
@@ -235,9 +242,10 @@ fn send_summary_json(summary: marmot_app::SendSummary) -> Value {
 fn media_attachment_for_hash(
     messages: Vec<AppMessageRecord>,
     file_hash_hex: &str,
+    allow_loopback_http: bool,
 ) -> Result<MediaAttachmentReference, WnError> {
     for message in messages {
-        for reference in media_attachments_from_message(&message)? {
+        for reference in media_attachments_from_message(&message, allow_loopback_http)? {
             if reference.plaintext_sha256 == file_hash_hex {
                 return Ok(reference);
             }
@@ -248,59 +256,25 @@ fn media_attachment_for_hash(
 
 fn media_attachments_from_message(
     message: &AppMessageRecord,
+    allow_loopback_http: bool,
 ) -> Result<Vec<MediaAttachmentReference>, WnError> {
     message
         .tags
         .iter()
         .filter(|tag| tag.first().map(String::as_str) == Some("imeta"))
-        .map(|tag| media_attachment_from_imeta_tag(tag, message.source_epoch))
+        .map(|tag| media_attachment_from_imeta_tag(tag, message.source_epoch, allow_loopback_http))
         .collect()
 }
 
 fn media_attachment_from_imeta_tag(
     tag: &[String],
     source_epoch: Option<u64>,
+    allow_loopback_http: bool,
 ) -> Result<MediaAttachmentReference, WnError> {
-    let mut locators = Vec::new();
-    let mut fields = HashMap::new();
-    for field in tag.iter().skip(1) {
-        if field.starts_with("blurhash ") {
-            return Err(WnError::InvalidMediaAttachment("blurhash".to_owned()));
-        }
-        if let Some(rest) = field.strip_prefix("locator ") {
-            let (kind, value) = rest
-                .split_once(' ')
-                .ok_or_else(|| WnError::InvalidMediaAttachment("locator".to_owned()))?;
-            locators.push(MediaLocator {
-                kind: kind.to_owned(),
-                value: value.to_owned(),
-            });
-            continue;
-        }
-        if let Some((key, value)) = field.split_once(' ') {
-            fields.insert(key.to_owned(), value.to_owned());
-        }
-    }
-    let required = |key: &'static str| {
-        fields
-            .get(key)
-            .cloned()
-            .filter(|value| !value.trim().is_empty())
-            .ok_or(WnError::InvalidMediaAttachment(key.to_owned()))
-    };
-    Ok(MediaAttachmentReference {
-        locators,
-        ciphertext_sha256: required("ciphertext_sha256")?,
-        plaintext_sha256: required("plaintext_sha256")?,
-        nonce_hex: required("nonce")?,
-        file_name: required("filename")?,
-        media_type: required("m")?,
-        version: required("v")?,
-        source_epoch: source_epoch
-            .ok_or_else(|| WnError::InvalidMediaAttachment("source_epoch".to_owned()))?,
-        dim: fields.get("dim").cloned(),
-        thumbhash: fields.get("thumbhash").cloned(),
-    })
+    let source_epoch =
+        source_epoch.ok_or_else(|| WnError::InvalidMediaAttachment("source_epoch".to_owned()))?;
+    marmot_app::media_attachment_from_imeta_tag(tag, Some(source_epoch), allow_loopback_http)
+        .map_err(|error| WnError::InvalidMediaAttachment(error.to_string()))
 }
 
 fn normalize_sha256_hex(value: &str) -> Result<String, WnError> {

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1410,6 +1410,26 @@ impl AppClient {
         Ok(summary)
     }
 
+    /// Build one outbound encrypted-media `imeta` tag using the target
+    /// group's actual profile-selected media version and locator policy.
+    ///
+    /// This is the checked bridge used by host apps for optimistic message
+    /// records. It deliberately performs no publish.
+    pub async fn build_media_imeta_tag(
+        &mut self,
+        group_id: &GroupId,
+        reference: &MediaAttachmentReference,
+    ) -> Result<Vec<String>, AppError> {
+        self.ensure_group(group_id)?;
+        self.sync_runtime_groups().await?;
+        let policy = self.encrypted_media_policy_for_group(group_id)?;
+        reference.build_imeta_tag(
+            policy.version,
+            &policy.allowed_locator_kinds,
+            self.app.allow_loopback_blob_endpoints(),
+        )
+    }
+
     pub async fn upload_media(
         &mut self,
         group_id: &GroupId,

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -887,7 +887,13 @@ impl MarmotApp {
     /// Whether this build may act on loopback-HTTP blob endpoints (dev/test
     /// only). Production builds return `false` and skip such endpoints in the
     /// upload/download act paths.
-    pub(crate) fn allow_loopback_blob_endpoints(&self) -> bool {
+    /// Whether this runtime was explicitly configured to act on cleartext
+    /// loopback blob endpoints for development or testing.
+    ///
+    /// Consumers that parse stored V1 media references outside the account
+    /// worker must pass this same policy to the shared media parser so
+    /// reference validation and the eventual fetch path cannot disagree.
+    pub fn allow_loopback_blob_endpoints(&self) -> bool {
         self.config.allow_loopback_blob_endpoints
     }
 

--- a/crates/marmot-app/src/media/mod.rs
+++ b/crates/marmot-app/src/media/mod.rs
@@ -211,6 +211,24 @@ impl MediaAttachmentReference {
         Ok(())
     }
 
+    /// Build the exact authenticated `imeta` tag for this reference after
+    /// validating it against the target group's selected media version and
+    /// locator policy.
+    ///
+    /// Host-facing callers must use this checked builder instead of formatting
+    /// `imeta` fields themselves. In particular, the `version` carried by the
+    /// reference cannot be used to smuggle a V1 reference into a V2 group (or
+    /// vice versa).
+    pub fn build_imeta_tag(
+        &self,
+        expected_version: EncryptedMediaVersion,
+        allowed_locator_kinds: &[String],
+        allow_loopback_http: bool,
+    ) -> Result<Vec<String>, AppError> {
+        self.validate_outbound(expected_version, allowed_locator_kinds, allow_loopback_http)?;
+        Ok(self.imeta_tag())
+    }
+
     pub(crate) fn imeta_tag(&self) -> Vec<String> {
         let mut tag = vec!["imeta".to_owned(), format!("v {}", self.version)];
         tag.extend(
@@ -225,14 +243,13 @@ impl MediaAttachmentReference {
             format!("m {}", self.media_type),
             format!("filename {}", self.file_name),
         ]);
-        if let Some(dim) = self.dim.as_deref().filter(|value| !value.trim().is_empty()) {
+        // Optional wire fields are emitted whenever they are present. `Some("")`
+        // and `None` are distinct authenticated inputs; omitting a present-empty
+        // value would make build -> parse lossy.
+        if let Some(dim) = self.dim.as_deref() {
             tag.push(format!("dim {}", dim));
         }
-        if let Some(thumbhash) = self
-            .thumbhash
-            .as_deref()
-            .filter(|value| !value.trim().is_empty())
-        {
+        if let Some(thumbhash) = self.thumbhash.as_deref() {
             tag.push(format!("thumbhash {}", thumbhash));
         }
         tag

--- a/crates/marmot-app/src/media/tests.rs
+++ b/crates/marmot-app/src/media/tests.rs
@@ -103,6 +103,39 @@ fn outbound_media_never_crosses_group_version() {
         v2.validate_outbound(EncryptedMediaVersion::V1, &allowed, false)
             .is_err()
     );
+    assert!(
+        v1.build_imeta_tag(EncryptedMediaVersion::V2, &allowed, false)
+            .is_err()
+    );
+    assert!(
+        v2.build_imeta_tag(EncryptedMediaVersion::V1, &allowed, false)
+            .is_err()
+    );
+}
+
+#[test]
+fn checked_imeta_builder_preserves_version_and_present_empty_optional_fields() {
+    let allowed = [BLOSSOM_LOCATOR_KIND_V1.to_owned()];
+    let v1 = media_attachment_from_imeta_tag(&valid_imeta_tag(), Some(1), false).unwrap();
+    let v1_tag = v1
+        .build_imeta_tag(EncryptedMediaVersion::V1, &allowed, false)
+        .unwrap();
+    assert!(v1_tag.iter().any(|field| field == "v encrypted-media-v1"));
+
+    let mut v2 = media_attachment_from_imeta_tag(&valid_v2_imeta_tag(), Some(2), false).unwrap();
+    v2.dim = Some(String::new());
+    v2.thumbhash = Some(" ".to_owned());
+    let v2_tag = v2
+        .build_imeta_tag(EncryptedMediaVersion::V2, &allowed, false)
+        .unwrap();
+    assert!(v2_tag.iter().any(|field| field == "v encrypted-media-v2"));
+    assert!(v2_tag.iter().any(|field| field == "dim "));
+    assert!(v2_tag.iter().any(|field| field == "thumbhash  "));
+
+    let round_trip = media_attachment_from_imeta_tag(&v2_tag, Some(2), false).unwrap();
+    assert_eq!(round_trip.version, ENCRYPTED_MEDIA_FORMAT_V2);
+    assert_eq!(round_trip.dim.as_deref(), Some(""));
+    assert_eq!(round_trip.thumbhash.as_deref(), Some(" "));
 }
 
 #[test]

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -209,6 +209,11 @@ pub(crate) enum AccountWorkerCommand {
         intent: AppMessageIntent,
         respond: oneshot::Sender<Result<SendSummary, AppError>>,
     },
+    BuildMediaImetaTag {
+        group_id: GroupId,
+        reference: MediaAttachmentReference,
+        respond: oneshot::Sender<Result<Vec<String>, AppError>>,
+    },
     UploadMedia {
         group_id: GroupId,
         request: MediaUploadRequest,
@@ -1124,6 +1129,14 @@ async fn handle_account_worker_command(
                 send_started_at.elapsed(),
                 result.is_ok(),
             );
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::BuildMediaImetaTag {
+            group_id,
+            reference,
+            respond,
+        } => {
+            let result = client.build_media_imeta_tag(&group_id, &reference).await;
             let _ = respond.send(result);
         }
         AccountWorkerCommand::UploadMedia {

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -868,6 +868,25 @@ impl AccountManager {
         Ok(result)
     }
 
+    pub(crate) async fn build_media_imeta_tag(
+        &self,
+        account_ref: &str,
+        group_id: &GroupId,
+        reference: MediaAttachmentReference,
+    ) -> Result<Vec<String>, AppError> {
+        let command = self.worker_commands(account_ref).await?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::BuildMediaImetaTag {
+                group_id: group_id.clone(),
+                reference,
+                respond,
+            })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        account_worker_response(response).await
+    }
+
     pub(crate) async fn download_media(
         &self,
         account_ref: &str,

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -1806,6 +1806,20 @@ impl MarmotAppRuntime {
             .await
     }
 
+    /// Build an authenticated `imeta` tag for an optimistic host-side record
+    /// without publishing it. The account worker derives the target group's
+    /// media profile and rejects a reference from the other media version.
+    pub async fn build_media_imeta_tag(
+        &self,
+        account_ref: &str,
+        group_id: &GroupId,
+        reference: MediaAttachmentReference,
+    ) -> Result<Vec<String>, AppError> {
+        self.accounts
+            .build_media_imeta_tag(account_ref, group_id, reference)
+            .await
+    }
+
     pub async fn download_media(
         &self,
         account_ref: &str,

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -4100,6 +4100,23 @@ async fn encrypted_media_upload_sends_ciphertext_and_download_decrypts_plaintext
     );
     assert!(upload.sent.as_ref().is_some_and(|sent| sent.published > 0));
 
+    let optimistic_tag = alice
+        .build_media_imeta_tag(&group_id, &reference)
+        .await
+        .expect("legacy group accepts its V1 upload reference");
+    assert!(
+        optimistic_tag
+            .iter()
+            .any(|field| field == "v encrypted-media-v1")
+    );
+    let mut wrong_version = reference.clone();
+    wrong_version.version = "encrypted-media-v2".to_owned();
+    let mismatch = alice
+        .build_media_imeta_tag(&group_id, &wrong_version)
+        .await
+        .expect_err("legacy group must reject a V2 optimistic reference");
+    assert!(mismatch.to_string().contains("requires encrypted-media-v1"));
+
     let stored = blossom
         .blob(&reference.ciphertext_sha256)
         .await

--- a/crates/marmot-uniffi/src/commands/media.rs
+++ b/crates/marmot-uniffi/src/commands/media.rs
@@ -5,12 +5,47 @@ use marmot_app::AppMessageQuery;
 use crate::Marmot;
 use crate::conversions::{
     MediaAttachmentReferenceFfi, MediaDownloadResultFfi, MediaRecordFfi, MediaUploadRequestFfi,
-    MediaUploadResultFfi, SendSummaryFfi, group_id_from_hex, media_records_ffi,
+    MediaUploadResultFfi, MessageTagFfi, SendSummaryFfi, group_id_from_hex, media_records_ffi,
 };
 use crate::errors::MarmotKitError;
 
+/// Parse one authenticated encrypted-media `imeta` tag using MDK's frozen V1
+/// or current V2 validation rules.
+///
+/// `source_epoch` is required because it is MLS metadata rather than an
+/// `imeta` field and is needed to download the attachment later.
+#[uniffi::export]
+pub fn parse_media_imeta_tag(
+    tag: MessageTagFfi,
+    source_epoch: u64,
+) -> Result<MediaAttachmentReferenceFfi, MarmotKitError> {
+    marmot_app::media_attachment_from_imeta_tag(&tag.values, Some(source_epoch), false)
+        .map(Into::into)
+        .map_err(media_reference_error)
+}
+
 #[uniffi::export(async_runtime = "tokio")]
 impl Marmot {
+    /// Build one outbound encrypted-media `imeta` tag without publishing it.
+    ///
+    /// The account worker derives the target group's actual media profile and
+    /// rejects a V1 reference for a V2 group (or a V2 reference for a legacy
+    /// V1 group).
+    pub async fn build_media_imeta_tag(
+        &self,
+        account_ref: String,
+        group_id_hex: String,
+        reference: MediaAttachmentReferenceFfi,
+    ) -> Result<MessageTagFfi, MarmotKitError> {
+        let group_id = group_id_from_hex(&group_id_hex)?;
+        let values = self
+            .runtime
+            .build_media_imeta_tag(&account_ref, &group_id, reference.into())
+            .await
+            .map_err(media_reference_error)?;
+        Ok(MessageTagFfi { values })
+    }
+
     /// Send already-uploaded encrypted media attachments as a kind-9 chat
     /// carrying ordered NIP-92 `imeta` tags.
     pub async fn send_media_attachments(
@@ -96,5 +131,15 @@ impl Marmot {
             },
         )?;
         Ok(media_records_ffi(records))
+    }
+}
+
+fn media_reference_error(error: marmot_app::AppError) -> MarmotKitError {
+    match error {
+        marmot_app::AppError::InvalidAppMessagePayload(details)
+        | marmot_app::AppError::InvalidEncryptedMedia(details) => {
+            MarmotKitError::InvalidMediaReference { details }
+        }
+        other => other.into(),
     }
 }

--- a/crates/marmot-uniffi/src/commands/mod.rs
+++ b/crates/marmot-uniffi/src/commands/mod.rs
@@ -21,3 +21,5 @@ mod push;
 mod relay;
 mod subscription;
 mod timeline;
+
+pub use media::parse_media_imeta_tag;

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -13,6 +13,10 @@ pub enum MarmotKitError {
     /// Host-supplied draft attachment metadata is malformed.
     #[error("invalid message draft: {details}")]
     InvalidMessageDraft { details: String },
+    /// Host-supplied encrypted-media metadata is malformed or does not match
+    /// the target group's selected media profile.
+    #[error("invalid media reference: {details}")]
+    InvalidMediaReference { details: String },
     #[error("invalid hex: {details}")]
     InvalidHex { details: String },
     #[error("invalid nostr identity: {details}")]

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -42,6 +42,7 @@ pub use markdown::{
 
 uniffi::setup_scaffolding!();
 
+pub use commands::parse_media_imeta_tag;
 pub use conversions::{
     AppBlobEndpointFfi, AppGroupEncryptedMediaComponentFfi, AuditDataModeFfi,
     AuditLogDeleteResultFfi, AuditLogFileFfi, AuditLogSettingsFfi, AuditLogTrackerConfigFfi,
@@ -53,12 +54,12 @@ pub use conversions::{
     MediaDownloadResultFfi, MediaLocatorFfi, MediaRecordFfi, MediaUploadAttachmentRequestFfi,
     MediaUploadAttachmentResultFfi, MediaUploadRequestFfi, MediaUploadResultFfi,
     MessageDraftAttachmentFfi, MessageDraftAttachmentSummaryFfi, MessageDraftFfi,
-    MessageDraftSummaryFfi, NotificationCollectionStatusFfi, NotificationSettingsFfi,
-    NotificationTrafficClassFfi, NotificationTriggerFfi, NotificationUpdateFfi,
-    NotificationUserFfi, NotificationWakeSourceFfi, PushPlatformFfi, PushRegistrationFfi,
-    RelayTelemetryResourceFfi, RelayTelemetryRuntimeConfigFfi, RelayTelemetrySettingsFfi,
-    RuntimeProjectionUpdateFfi, SecureDeleteExpiredResultFfi, TimelineMessageChangeFfi,
-    TimelineMessageQueryFfi, TimelineMessageRecordFfi, TimelinePageFfi,
+    MessageDraftSummaryFfi, MessageTagFfi, NotificationCollectionStatusFfi,
+    NotificationSettingsFfi, NotificationTrafficClassFfi, NotificationTriggerFfi,
+    NotificationUpdateFfi, NotificationUserFfi, NotificationWakeSourceFfi, PushPlatformFfi,
+    PushRegistrationFfi, RelayTelemetryResourceFfi, RelayTelemetryRuntimeConfigFfi,
+    RelayTelemetrySettingsFfi, RuntimeProjectionUpdateFfi, SecureDeleteExpiredResultFfi,
+    TimelineMessageChangeFfi, TimelineMessageQueryFfi, TimelineMessageRecordFfi, TimelinePageFfi,
     TimelineProjectionUpdateFfi, TimelineReactionEmojiFfi, TimelineReactionSummaryFfi,
     TimelineRemoveReasonFfi, TimelineSubscriptionUpdateFfi, TimelineUpdateTriggerFfi,
     TimelineUserReactionFfi,

--- a/crates/marmot-uniffi/tests/smoke.rs
+++ b/crates/marmot-uniffi/tests/smoke.rs
@@ -15,7 +15,8 @@ use marmot_uniffi::{
     AuditDataModeFfi, AuditLogSettingsFfi, AuditLogTrackerConfigFfi, AuditLogUploadSourceFfi,
     CursorPersistenceFfi, Marmot, MarmotKitError, MediaAttachmentReferenceFfi, MediaLocatorFfi,
     MediaUploadAttachmentRequestFfi, MediaUploadRequestFfi, MessageDraftAttachmentFfi,
-    NotificationWakeSourceFfi, PushPlatformFfi, RelayTelemetrySettingsFfi, TimelineMessageQueryFfi,
+    MessageTagFfi, NotificationWakeSourceFfi, PushPlatformFfi, RelayTelemetrySettingsFfi,
+    TimelineMessageQueryFfi, parse_media_imeta_tag,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -403,16 +404,54 @@ async fn media_binding_records_are_public_and_methods_validate_group_hex() {
     assert!(format!("{send_error}").contains("invalid hex"));
 
     let singular_send_error = kit
-        .send_media_reference("alice".into(), "not-hex".into(), reference, None)
+        .send_media_reference("alice".into(), "not-hex".into(), reference.clone(), None)
         .await
         .expect_err("singular compatibility helper should validate group hex");
     assert!(format!("{singular_send_error}").contains("invalid hex"));
+
+    let build_error = kit
+        .build_media_imeta_tag("alice".into(), "not-hex".into(), reference.clone())
+        .await
+        .expect_err("optimistic tag builder should validate group hex");
+    assert!(format!("{build_error}").contains("invalid hex"));
 
     let upload_error = kit
         .upload_media("alice".into(), "not-hex".into(), request)
         .await
         .expect_err("invalid group hex should fail before upload");
     assert!(format!("{upload_error}").contains("invalid hex"));
+
+    let tag = MessageTagFfi {
+        values: vec![
+            "imeta".into(),
+            "v encrypted-media-v1".into(),
+            format!(
+                "locator blossom-v1 https://blossom.example/{}",
+                "01".repeat(32)
+            ),
+            format!("ciphertext_sha256 {}", "01".repeat(32)),
+            format!("plaintext_sha256 {}", "02".repeat(32)),
+            format!("nonce {}", "03".repeat(12)),
+            "m text/plain".into(),
+            "filename note.txt".into(),
+        ],
+    };
+    let parsed = parse_media_imeta_tag(tag.clone(), 7).expect("valid V1 tag");
+    assert_eq!(parsed.version, marmot_uniffi::EncryptedMediaVersionFfi::V1);
+    assert_eq!(parsed.source_epoch, 7);
+
+    let mut v2 = tag;
+    v2.values[1] = "v encrypted-media-v2".into();
+    let parsed = parse_media_imeta_tag(v2.clone(), 8).expect("valid V2 tag");
+    assert_eq!(parsed.version, marmot_uniffi::EncryptedMediaVersionFfi::V2);
+    assert_eq!(parsed.source_epoch, 8);
+
+    v2.values[6] = "m Text/Plain".into();
+    let invalid = parse_media_imeta_tag(v2, 8).expect_err("noncanonical V2 type must fail");
+    assert!(matches!(
+        invalid,
+        MarmotKitError::InvalidMediaReference { .. }
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Completes the public binding boundary for encrypted Media V1/V2 on top of #1075.

- add an async, group-aware `build_media_imeta_tag` API that derives the target group's actual media version and locator policy before emitting a tag
- add a strict `parse_media_imeta_tag` FFI API that returns the typed wire version and complete download/display reference
- return `InvalidMediaReference` as a typed Swift/Kotlin error for malformed, noncanonical, or cross-profile input
- preserve present-empty optional `dim`/`thumbhash` fields instead of collapsing them to absence
- remove the CLI's duplicate hand-written `imeta` parser and use the same Rust parser and loopback policy as the runtime
- bump the workspace to 0.9.6 for the public UniFFI surface change

This is additive for existing media send/upload/download/list callers. Legacy groups continue to build V1 references; current groups build V2 references. A reference from the wrong version is rejected before optimistic metadata is produced.

## Normative sources

Adopted by marmot-protocol/marmot#408 at `625f8aae8096a17c6b11fde08ec8c2d582568619`:

- `features/encrypted-media-v1.md`
- `features/encrypted-media.md`
- `app-components/group-encrypted-media-v1.md`
- `app-components/group-encrypted-media-v2.md`

## Stack

- Base: #1075 (`codex/issue-1052-media-v2`)
- This PR does not depend on #1078 or #1079.

## Verification

- `cargo test -p marmot-uniffi` (63 unit + 22 smoke)
- `cargo test -p marmot-app` (373 unit plus all integration suites, including 70 relay-runtime tests)
- `cargo test -p wn-cli` (375 unit + 86 end-to-end)
- `just fast-ci`
- `./crates/marmot-uniffi/xcframework.sh`
  - host dylib, iOS device, iOS simulator, generated Swift, and XCFramework succeeded
- `./crates/marmot-uniffi/kotlin-bindings.sh`
  - generated Kotlin plus arm64-v8a, armeabi-v7a, x86, and x86_64 JNI libraries succeeded

Generated binding artifacts remain ignored per `crates/marmot-uniffi/AGENTS.md`; both generated surfaces were inspected for the builder, parser, and typed error.

Closes #955
