### PR TITLE
Enforce exact kind-445 ingress shape

### DIFF
--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -593,6 +593,8 @@ pub(crate) fn engine_error_detail(err: &EngineError) -> Option<String> {
 pub(crate) fn peeler_error_kind(err: &PeelerError) -> &'static str {
     match err {
         PeelerError::Malformed(_) => "malformed",
+        PeelerError::InvalidSignature => "invalid_signature",
+        PeelerError::WrongRecipient => "wrong_recipient",
         PeelerError::DecryptFailed => "decrypt_failed",
         PeelerError::StaleEpoch { .. } => "stale_epoch",
         PeelerError::MissingContext { .. } => "missing_context",

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -57,6 +57,8 @@ pub(crate) fn terminal_welcome_error(error: &EngineError) -> bool {
         error,
         EngineError::Peeler(cgka_traits::error::PeelerError::DecryptFailed)
             | EngineError::Peeler(cgka_traits::error::PeelerError::Malformed(_))
+            | EngineError::Peeler(cgka_traits::error::PeelerError::InvalidSignature)
+            | EngineError::Peeler(cgka_traits::error::PeelerError::WrongRecipient)
             | EngineError::Serialize(_)
             | EngineError::InvalidWelcome
             | EngineError::InvalidCredentialIdentity(_)

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -244,6 +244,12 @@ impl<S: StorageProvider> Engine<S> {
                     Err(PeelerError::Malformed(_)) => {
                         marmot_forensics::PeelerOutcomeKind::Malformed
                     }
+                    Err(PeelerError::InvalidSignature) => {
+                        marmot_forensics::PeelerOutcomeKind::InvalidSignature
+                    }
+                    Err(PeelerError::WrongRecipient) => {
+                        marmot_forensics::PeelerOutcomeKind::WrongRecipient
+                    }
                     Err(_) => marmot_forensics::PeelerOutcomeKind::Other,
                 };
                 self.audit_group(
@@ -281,18 +287,22 @@ impl<S: StorageProvider> Engine<S> {
                     {
                         Ok(recovered) => recovered,
                         // Defense-in-depth for the public TransportPeeler
-                        // contract: a `Malformed` verdict raised only by the
-                        // snapshot fallback is terminal on this seam too — never
-                        // an aborted drain (mdk#707). Not reachable via the
-                        // production Nostr peeler (its Malformed detection is
-                        // deterministic in the message bytes, so the direct peel
-                        // catches it first); MissingContext / storage errors keep
-                        // propagating as genuine engine faults.
-                        Err(EngineError::Peeler(PeelerError::Malformed(_))) => {
-                            return self.malformed_terminal_stale(
+                        // contract: a malformed or invalid-signature verdict
+                        // raised only by the snapshot fallback is terminal on
+                        // this seam too — never an aborted drain (mdk#707). Not
+                        // reachable via the production Nostr peeler (both
+                        // checks are deterministic in the message bytes, so
+                        // the direct peel catches them first); MissingContext /
+                        // storage errors keep propagating as genuine engine
+                        // faults.
+                        Err(EngineError::Peeler(
+                            PeelerError::Malformed(_) | PeelerError::InvalidSignature,
+                        )) => {
+                            return self.terminal_peel_rejection_stale(
                                 &raw_msg_id,
                                 &msg.id,
                                 "malformed_payload_snapshot_fallback",
+                                StaleReason::PeelFailed,
                             );
                         }
                         Err(e) => return Err(e),
@@ -378,18 +388,22 @@ impl<S: StorageProvider> Engine<S> {
                     {
                         Ok(recovered) => recovered,
                         // Defense-in-depth for the public TransportPeeler
-                        // contract: a `Malformed` verdict raised only by the
-                        // snapshot fallback is terminal on this seam too — never
-                        // an aborted drain (mdk#707). Not reachable via the
-                        // production Nostr peeler (its Malformed detection is
-                        // deterministic in the message bytes, so the direct peel
-                        // catches it first); MissingContext / storage errors keep
-                        // propagating as genuine engine faults.
-                        Err(EngineError::Peeler(PeelerError::Malformed(_))) => {
-                            return self.malformed_terminal_stale(
+                        // contract: a malformed or invalid-signature verdict
+                        // raised only by the snapshot fallback is terminal on
+                        // this seam too — never an aborted drain (mdk#707). Not
+                        // reachable via the production Nostr peeler (both
+                        // checks are deterministic in the message bytes, so
+                        // the direct peel catches them first); MissingContext /
+                        // storage errors keep propagating as genuine engine
+                        // faults.
+                        Err(EngineError::Peeler(
+                            PeelerError::Malformed(_) | PeelerError::InvalidSignature,
+                        )) => {
+                            return self.terminal_peel_rejection_stale(
                                 &raw_msg_id,
                                 &msg.id,
                                 "malformed_payload_snapshot_fallback",
+                                StaleReason::PeelFailed,
                             );
                         }
                         Err(e) => return Err(e),
@@ -438,22 +452,37 @@ impl<S: StorageProvider> Engine<S> {
                         });
                     }
                 }
-                Err(PeelerError::Malformed(_)) => {
-                    // Structurally-invalid content is ordinary hostile input:
-                    // anyone can publish to the cleartext routing tag without
-                    // group membership, and no epoch context can ever peel it.
-                    // Terminal — propagating an error here would abort the
-                    // caller's whole transport drain on one garbage event,
-                    // starving every message queued behind it. Dropped
-                    // unpersisted for the same reason as the mdk#339 flood
-                    // cap: transport ids are attacker-controllable, so durable
-                    // rows keyed by them would grow without bound. Retire the
-                    // raw deferred row if this arrived via the retry
-                    // lifecycle; a no-op on the direct path.
-                    return self.malformed_terminal_stale(
+                Err(rejection @ (PeelerError::Malformed(_) | PeelerError::InvalidSignature)) => {
+                    // Structurally-invalid or unauthenticated content is
+                    // ordinary hostile input: anyone can publish to the
+                    // cleartext routing tag without group membership, and no
+                    // epoch context can ever make it valid. Terminal —
+                    // propagating an error here would abort the caller's whole
+                    // transport drain on one garbage event, starving every
+                    // message queued behind it. Dropped unpersisted for the
+                    // same reason as the mdk#339 flood cap: transport ids are
+                    // attacker-controllable, so durable rows keyed by them
+                    // would grow without bound. Retire the raw deferred row if
+                    // this arrived via the retry lifecycle; a no-op on the
+                    // direct path.
+                    let reason = if matches!(rejection, PeelerError::InvalidSignature) {
+                        "invalid_signature"
+                    } else {
+                        "malformed_payload"
+                    };
+                    return self.terminal_peel_rejection_stale(
                         &raw_msg_id,
                         &msg.id,
-                        "malformed_payload",
+                        reason,
+                        StaleReason::PeelFailed,
+                    );
+                }
+                Err(PeelerError::WrongRecipient) => {
+                    return self.terminal_peel_rejection_stale(
+                        &raw_msg_id,
+                        &msg.id,
+                        "wrong_recipient",
+                        StaleReason::NotForThisClient,
                     );
                 }
                 Err(e) => return Err(EngineError::Peeler(e)),
@@ -1714,22 +1743,24 @@ impl<S: StorageProvider> Engine<S> {
         Ok(())
     }
 
-    /// Terminal disposition for a peel that resolved to `Malformed`: retire the
-    /// awaiting-retry raw transport row (a no-op on the direct path, where no
-    /// deferred row exists), mark the id seen so a redelivery short-circuits,
-    /// and classify the input `Stale { PeelFailed }`. Shared by the direct peel
-    /// and both snapshot-fallback seams so the terminal behavior has a single
+    /// Terminal disposition for malformed, unauthenticated, or misaddressed
+    /// transport input: retire the awaiting-retry raw transport row (a no-op on
+    /// the direct path, where no deferred row exists), mark the id seen so a
+    /// redelivery short-circuits, and classify the input with the supplied
+    /// typed stale reason. Shared by the direct peel and both
+    /// snapshot-fallback seams so the terminal behavior has a single
     /// definition — a guard living on one seam only is a bug (mdk#707).
-    fn malformed_terminal_stale(
+    fn terminal_peel_rejection_stale(
         &mut self,
         raw_msg_id: &MessageId,
         msg_id: &MessageId,
         reason: &'static str,
+        stale_reason: StaleReason,
     ) -> Result<IngestOutcome, EngineError> {
         self.mark_raw_transport_message_failed_if_awaiting_retry(raw_msg_id, reason)?;
         self.seen_message_ids.insert(msg_id.clone());
         Ok(IngestOutcome::Stale {
-            reason: StaleReason::PeelFailed,
+            reason: stale_reason,
         })
     }
 

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -305,6 +305,14 @@ impl<S: StorageProvider> Engine<S> {
                                 StaleReason::PeelFailed,
                             );
                         }
+                        Err(EngineError::Peeler(PeelerError::WrongRecipient)) => {
+                            return self.terminal_peel_rejection_stale(
+                                &raw_msg_id,
+                                &msg.id,
+                                "wrong_recipient_snapshot_fallback",
+                                StaleReason::NotForThisClient,
+                            );
+                        }
                         Err(e) => return Err(e),
                     };
                     if let Some(recovery) = recovered {
@@ -404,6 +412,14 @@ impl<S: StorageProvider> Engine<S> {
                                 &msg.id,
                                 "malformed_payload_snapshot_fallback",
                                 StaleReason::PeelFailed,
+                            );
+                        }
+                        Err(EngineError::Peeler(PeelerError::WrongRecipient)) => {
+                            return self.terminal_peel_rejection_stale(
+                                &raw_msg_id,
+                                &msg.id,
+                                "wrong_recipient_snapshot_fallback",
+                                StaleReason::NotForThisClient,
                             );
                         }
                         Err(e) => return Err(e),

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -86,6 +86,12 @@ impl<S: StorageProvider> Engine<S> {
                     reason: StaleReason::AlreadySeen,
                 })
             }
+            Err(EngineError::Peeler(PeelerError::WrongRecipient)) => {
+                self.storage.put_ingress_dedup_marker(&msg.id)?;
+                Ok(IngestOutcome::Stale {
+                    reason: StaleReason::NotForThisClient,
+                })
+            }
             Err(error) if group_lifecycle::terminal_welcome_error(&error) => {
                 self.storage.put_ingress_dedup_marker(&msg.id)?;
                 Ok(IngestOutcome::Stale {

--- a/crates/cgka-engine/tests/ingest.rs
+++ b/crates/cgka-engine/tests/ingest.rs
@@ -324,6 +324,9 @@ impl TransportPeeler for BoundaryRejectionPeeler {
     }
 
     async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        if msg.payload == BOUNDARY_REJECTION_PAYLOAD {
+            return Err(self.rejection.peeler_error());
+        }
         MockPeeler.peel_welcome(msg).await
     }
 
@@ -1051,6 +1054,49 @@ async fn wrong_transport_recipient_is_typed_terminal_input() {
         StaleReason::NotForThisClient,
     )
     .await;
+}
+
+#[tokio::test]
+async fn wrong_transport_welcome_recipient_is_typed_terminal_input() {
+    let mut engine = build_client_with_peeler(
+        b"welcome-wrong-recipient",
+        Box::new(BoundaryRejectionPeeler {
+            rejection: BoundaryRejection::WrongRecipient,
+            path: BoundaryRejectionPath::Direct,
+        }),
+    );
+    let rejected = TransportMessage {
+        id: hash_id(b"wrong transport welcome recipient"),
+        payload: BOUNDARY_REJECTION_PAYLOAD.to_vec(),
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("mock".into()),
+        envelope: TransportEnvelope::Welcome {
+            recipient: engine.self_id(),
+        },
+    };
+
+    let outcome = engine
+        .ingest(rejected.clone())
+        .await
+        .expect("wrong-recipient welcome is terminal input, not a drain failure");
+    assert_eq!(
+        outcome,
+        IngestOutcome::Stale {
+            reason: StaleReason::NotForThisClient
+        }
+    );
+
+    let duplicate = engine
+        .ingest(rejected)
+        .await
+        .expect("redelivery short-circuits after wrong-recipient welcome");
+    assert_eq!(
+        duplicate,
+        IngestOutcome::Stale {
+            reason: StaleReason::AlreadySeen
+        }
+    );
 }
 
 #[tokio::test]

--- a/crates/cgka-engine/tests/ingest.rs
+++ b/crates/cgka-engine/tests/ingest.rs
@@ -65,7 +65,34 @@ enum BoundaryRejection {
     InvalidSignature,
     WrongRecipient,
 }
-struct BoundaryRejectionPeeler(BoundaryRejection);
+#[derive(Clone, Copy)]
+enum InitialPeelFailure {
+    DecryptFailed,
+    StaleEpoch,
+}
+#[derive(Clone, Copy)]
+enum BoundaryRejectionPath {
+    Direct,
+    SnapshotFallback {
+        live_epoch: u64,
+        initial_failure: InitialPeelFailure,
+    },
+}
+struct BoundaryRejectionPeeler {
+    rejection: BoundaryRejection,
+    path: BoundaryRejectionPath,
+}
+
+const BOUNDARY_REJECTION_PAYLOAD: &[u8] = b"typed-boundary-rejection-payload";
+
+impl BoundaryRejection {
+    fn peeler_error(self) -> PeelerError {
+        match self {
+            Self::InvalidSignature => PeelerError::InvalidSignature,
+            Self::WrongRecipient => PeelerError::WrongRecipient,
+        }
+    }
+}
 
 impl FailOncePeeler {
     fn new() -> Self {
@@ -273,13 +300,27 @@ impl TransportPeeler for MalformedShortPayloadPeeler {
 impl TransportPeeler for BoundaryRejectionPeeler {
     async fn peel_group_message(
         &self,
-        _msg: &TransportMessage,
-        _ctx: &GroupContextSnapshot,
+        msg: &TransportMessage,
+        ctx: &GroupContextSnapshot,
     ) -> Result<PeeledMessage, PeelerError> {
-        Err(match self.0 {
-            BoundaryRejection::InvalidSignature => PeelerError::InvalidSignature,
-            BoundaryRejection::WrongRecipient => PeelerError::WrongRecipient,
-        })
+        if msg.payload != BOUNDARY_REJECTION_PAYLOAD {
+            return MockPeeler.peel_group_message(msg, ctx).await;
+        }
+
+        match self.path {
+            BoundaryRejectionPath::Direct => Err(self.rejection.peeler_error()),
+            BoundaryRejectionPath::SnapshotFallback {
+                live_epoch,
+                initial_failure,
+            } if ctx.epoch().0 >= live_epoch => Err(match initial_failure {
+                InitialPeelFailure::DecryptFailed => PeelerError::DecryptFailed,
+                InitialPeelFailure::StaleEpoch => PeelerError::StaleEpoch {
+                    message_epoch: EpochId(live_epoch.saturating_sub(1)),
+                    context_epoch: ctx.epoch(),
+                },
+            }),
+            BoundaryRejectionPath::SnapshotFallback { .. } => Err(self.rejection.peeler_error()),
+        }
     }
 
     async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
@@ -833,7 +874,10 @@ async fn assert_typed_terminal_transport_rejection(
     let mut alice = build_client(b"alice-terminal-rejection");
     let mut bob = build_client_with_peeler(
         b"bob-terminal-rejection",
-        Box::new(BoundaryRejectionPeeler(rejection)),
+        Box::new(BoundaryRejectionPeeler {
+            rejection,
+            path: BoundaryRejectionPath::Direct,
+        }),
     );
     let bob_kp = bob.fresh_key_package().await.unwrap();
 
@@ -860,7 +904,7 @@ async fn assert_typed_terminal_transport_rejection(
 
     let rejected = TransportMessage {
         id: hash_id(b"terminal transport rejection"),
-        payload: vec![0; STRUCTURAL_MIN_PAYLOAD_LEN],
+        payload: BOUNDARY_REJECTION_PAYLOAD.to_vec(),
         timestamp: Timestamp(0),
         causal_deps: vec![],
         source: TransportSource("mock".into()),
@@ -891,6 +935,106 @@ async fn assert_typed_terminal_transport_rejection(
     ));
 }
 
+async fn assert_snapshot_fallback_terminal_transport_rejection(
+    rejection: BoundaryRejection,
+    initial_failure: InitialPeelFailure,
+    expected_reason: StaleReason,
+) {
+    let mut alice = build_client(b"alice-snapshot-boundary-rejection");
+    let live_epoch = 2u64;
+    let mut bob = build_client_with_peeler(
+        b"bob-snapshot-boundary-rejection",
+        Box::new(BoundaryRejectionPeeler {
+            rejection,
+            path: BoundaryRejectionPath::SnapshotFallback {
+                live_epoch,
+                initial_failure,
+            },
+        }),
+    );
+    let mut carol = build_client(b"carol-snapshot-boundary-rejection");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let (group_id, result) = alice
+        .create_group(CreateGroupRequest {
+            name: String::new(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, bob_welcome) = match result {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => (pending, welcomes.remove(0)),
+        other => panic!("expected group create, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(bob_welcome).await.unwrap();
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let invite = match alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![carol_kp],
+        })
+        .await
+        .unwrap()
+    {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            alice.confirm_published(pending).await.unwrap();
+            TransportMessage {
+                envelope: TransportEnvelope::GroupMessage {
+                    transport_group_id: group_id.as_slice().to_vec(),
+                },
+                ..msg
+            }
+        }
+        other => panic!("expected invite commit, got {other:?}"),
+    };
+    bob.buffer_openmls_convergence_message(&group_id, invite, 1_000)
+        .expect("invite commit buffered");
+    bob.converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("invite commit applies and retains the pre-commit anchor");
+    assert_eq!(bob.epoch(&group_id).unwrap(), EpochId(live_epoch));
+
+    let rejected = TransportMessage {
+        id: hash_id(b"snapshot fallback terminal transport rejection"),
+        payload: BOUNDARY_REJECTION_PAYLOAD.to_vec(),
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("mock".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    };
+    let outcome = bob
+        .ingest(rejected.clone())
+        .await
+        .expect("snapshot-fallback boundary rejection is terminal, not a drain failure");
+    assert_eq!(
+        outcome,
+        IngestOutcome::Stale {
+            reason: expected_reason
+        }
+    );
+
+    let duplicate = bob
+        .ingest(rejected)
+        .await
+        .expect("redelivery short-circuits after snapshot-fallback rejection");
+    assert_eq!(
+        duplicate,
+        IngestOutcome::Stale {
+            reason: StaleReason::AlreadySeen
+        }
+    );
+}
+
 #[tokio::test]
 async fn invalid_transport_signature_is_typed_terminal_input() {
     assert_typed_terminal_transport_rejection(
@@ -904,6 +1048,26 @@ async fn invalid_transport_signature_is_typed_terminal_input() {
 async fn wrong_transport_recipient_is_typed_terminal_input() {
     assert_typed_terminal_transport_rejection(
         BoundaryRejection::WrongRecipient,
+        StaleReason::NotForThisClient,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn invalid_transport_signature_after_decrypt_failed_fallback_is_terminal() {
+    assert_snapshot_fallback_terminal_transport_rejection(
+        BoundaryRejection::InvalidSignature,
+        InitialPeelFailure::DecryptFailed,
+        StaleReason::PeelFailed,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn wrong_transport_recipient_after_stale_epoch_fallback_is_terminal() {
+    assert_snapshot_fallback_terminal_transport_rejection(
+        BoundaryRejection::WrongRecipient,
+        InitialPeelFailure::StaleEpoch,
         StaleReason::NotForThisClient,
     )
     .await;

--- a/crates/cgka-engine/tests/ingest.rs
+++ b/crates/cgka-engine/tests/ingest.rs
@@ -60,6 +60,12 @@ struct FailOncePeeler {
 /// as `Malformed` before any decryption attempt.
 const STRUCTURAL_MIN_PAYLOAD_LEN: usize = 28;
 struct MalformedShortPayloadPeeler;
+#[derive(Clone, Copy)]
+enum BoundaryRejection {
+    InvalidSignature,
+    WrongRecipient,
+}
+struct BoundaryRejectionPeeler(BoundaryRejection);
 
 impl FailOncePeeler {
     fn new() -> Self {
@@ -240,6 +246,40 @@ impl TransportPeeler for MalformedShortPayloadPeeler {
             ));
         }
         MockPeeler.peel_group_message(msg, ctx).await
+    }
+
+    async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        MockPeeler.peel_welcome(msg).await
+    }
+
+    async fn wrap_group_message(
+        &self,
+        payload: &EncryptedPayload,
+        ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        MockPeeler.wrap_group_message(payload, ctx).await
+    }
+
+    async fn wrap_welcome(
+        &self,
+        payload: &EncryptedPayload,
+        recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        MockPeeler.wrap_welcome(payload, recipient).await
+    }
+}
+
+#[async_trait]
+impl TransportPeeler for BoundaryRejectionPeeler {
+    async fn peel_group_message(
+        &self,
+        _msg: &TransportMessage,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        Err(match self.0 {
+            BoundaryRejection::InvalidSignature => PeelerError::InvalidSignature,
+            BoundaryRejection::WrongRecipient => PeelerError::WrongRecipient,
+        })
     }
 
     async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
@@ -784,6 +824,89 @@ async fn malformed_group_message_is_stale_and_does_not_wedge_ingest() {
         ),
         "expected the message behind the garbage to still deliver, got {events:?}"
     );
+}
+
+async fn assert_typed_terminal_transport_rejection(
+    rejection: BoundaryRejection,
+    expected_reason: StaleReason,
+) {
+    let mut alice = build_client(b"alice-terminal-rejection");
+    let mut bob = build_client_with_peeler(
+        b"bob-terminal-rejection",
+        Box::new(BoundaryRejectionPeeler(rejection)),
+    );
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let (group_id, result) = alice
+        .create_group(CreateGroupRequest {
+            name: String::new(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, bob_welcome) = match result {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => (pending, welcomes.remove(0)),
+        other => panic!("expected group create, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(bob_welcome).await.unwrap();
+
+    let rejected = TransportMessage {
+        id: hash_id(b"terminal transport rejection"),
+        payload: vec![0; STRUCTURAL_MIN_PAYLOAD_LEN],
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("mock".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    };
+    let outcome = bob
+        .ingest(rejected.clone())
+        .await
+        .expect("boundary rejection is terminal input, not a drain failure");
+    assert_eq!(
+        outcome,
+        IngestOutcome::Stale {
+            reason: expected_reason
+        }
+    );
+
+    let duplicate = bob
+        .ingest(rejected)
+        .await
+        .expect("redelivery short-circuits after terminal rejection");
+    assert!(matches!(
+        duplicate,
+        IngestOutcome::Stale {
+            reason: StaleReason::AlreadySeen
+        }
+    ));
+}
+
+#[tokio::test]
+async fn invalid_transport_signature_is_typed_terminal_input() {
+    assert_typed_terminal_transport_rejection(
+        BoundaryRejection::InvalidSignature,
+        StaleReason::PeelFailed,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn wrong_transport_recipient_is_typed_terminal_input() {
+    assert_typed_terminal_transport_rejection(
+        BoundaryRejection::WrongRecipient,
+        StaleReason::NotForThisClient,
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/crates/marmot-app/src/relay_plane/tests.rs
+++ b/crates/marmot-app/src/relay_plane/tests.rs
@@ -8,7 +8,7 @@ use cgka_traits::{
 };
 use tokio::sync::Notify;
 use transport_nostr_adapter::{NostrRelayEvent, NostrSubscription};
-use transport_nostr_peeler::{KIND_MARMOT_GROUP_MESSAGE, NOSTR_SOURCE};
+use transport_nostr_peeler::{KIND_MARMOT_GROUP_MESSAGE, NOSTR_SOURCE, NostrPeelerError};
 
 use crate::config::{RelayTelemetryResource, RelayTelemetryRuntimeConfig};
 
@@ -773,6 +773,35 @@ async fn shared_group_event_is_delivered_to_each_matching_account_receiver() {
     assert_eq!(bob_delivery.group_id_hint, Some(group_id));
     assert_eq!(alice_delivery.source.plane, TransportDeliveryPlane::Group);
     assert_eq!(bob_delivery.source.plane, TransportDeliveryPlane::Group);
+}
+
+#[tokio::test]
+async fn direct_and_runtime_kind_445_shape_rejection_are_both_malformed() {
+    let transport_group_id = vec![0xD4; 32];
+    let mut event = group_event("extra-tag", &transport_group_id);
+    event.tags.push(vec!["e".into(), "11".repeat(32)]);
+    event.id = event.computed_id();
+
+    assert!(matches!(
+        event.to_transport_message(),
+        Err(NostrPeelerError::Malformed(_))
+    ));
+
+    let relay = Arc::new(RecordingRelayClient::default());
+    let relay_plane = MarmotRelayPlane::new(Some(Duration::from_secs(30)), relay);
+    let runtime_error = relay_plane
+        .handle_relay_event_for_test(NostrRelayEvent {
+            endpoint: TransportEndpoint("wss://relay.example".into()),
+            subscription_id: Some("group-sub".into()),
+            event,
+        })
+        .await
+        .expect_err("runtime seam must reject the same malformed fixture");
+
+    assert!(
+        matches!(runtime_error, TransportAdapterError::InvalidInboundEncoding),
+        "runtime rejection must preserve the malformed classification"
+    );
 }
 
 #[tokio::test]

--- a/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
+++ b/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
@@ -693,7 +693,15 @@
       }
     },
     "peelerOutcomeKind": {
-      "enum": ["success", "decrypt_failed", "stale_epoch", "malformed", "other"]
+      "enum": [
+        "success",
+        "decrypt_failed",
+        "stale_epoch",
+        "malformed",
+        "invalid_signature",
+        "wrong_recipient",
+        "other"
+      ]
     },
     "jsonScalar": {
       "type": ["string", "number", "integer", "boolean", "null"]

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -1108,6 +1108,8 @@ pub enum PeelerOutcomeKind {
     DecryptFailed,
     StaleEpoch,
     Malformed,
+    InvalidSignature,
+    WrongRecipient,
     Other,
 }
 

--- a/crates/traits/src/error.rs
+++ b/crates/traits/src/error.rs
@@ -142,6 +142,18 @@ pub enum PeelerError {
     #[error("malformed transport payload: {0}")]
     Malformed(String),
 
+    /// A required outer transport signature or signed-event id failed
+    /// authentication. Kept distinct from malformed byte encoding so callers
+    /// can report the adopted `invalid_signature` category without parsing
+    /// error strings.
+    #[error("invalid transport signature")]
+    InvalidSignature,
+
+    /// The outer transport object names a routing id or recipient that does
+    /// not match the transport envelope presented to the engine.
+    #[error("transport input is addressed to another recipient")]
+    WrongRecipient,
+
     #[error("decrypt failed (likely stale or wrong-epoch exporter secret)")]
     DecryptFailed,
 

--- a/crates/traits/src/ingest.rs
+++ b/crates/traits/src/ingest.rs
@@ -36,7 +36,8 @@ pub enum StaleReason {
         current: EpochId,
         msg_epoch: EpochId,
     },
-    /// A welcome addressed to a member other than ourselves.
+    /// Input addressed to another member, or whose signed transport routing
+    /// metadata conflicts with the envelope presented to the engine.
     NotForThisClient,
     /// No local group matches this message's routing.
     UnknownGroup,

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -270,6 +270,18 @@ pub enum TransportAdapterError {
     #[error("account not active")]
     AccountNotActive(MemberId),
 
+    /// An inbound transport object failed its transport-specific syntax or
+    /// exact-shape validation. Carries no attacker-controlled detail so it is
+    /// safe to classify in runtime telemetry.
+    #[error("invalid inbound transport encoding")]
+    InvalidInboundEncoding,
+
+    /// An inbound signed transport object reported an id that did not match
+    /// its signed fields. Full signature verification remains at the peeler
+    /// boundary, before decryption.
+    #[error("invalid inbound transport signature")]
+    InvalidInboundSignature,
+
     #[error("publish target does not match message envelope: envelope={envelope}, target={target}")]
     PublishTargetMismatch { envelope: String, target: String },
 

--- a/crates/traits/tests/error_display.rs
+++ b/crates/traits/tests/error_display.rs
@@ -1,5 +1,5 @@
 use cgka_traits::app_event::MarmotAppEventError;
-use cgka_traits::error::EngineError;
+use cgka_traits::error::{EngineError, PeelerError};
 use cgka_traits::transport_adapter::TransportAdapterError;
 use cgka_traits::types::{EpochId, GroupId, MemberId};
 
@@ -58,6 +58,26 @@ fn transport_adapter_error_display_passes_reasons_through_verbatim() {
     assert_eq!(err.to_string(), "publish failed: connect relay failed");
     let err = TransportAdapterError::Subscription("add relay failed".to_owned());
     assert_eq!(err.to_string(), "subscription failed: add relay failed");
+}
+
+#[test]
+fn typed_inbound_rejection_display_is_fixed_and_privacy_safe() {
+    assert_eq!(
+        PeelerError::InvalidSignature.to_string(),
+        "invalid transport signature"
+    );
+    assert_eq!(
+        PeelerError::WrongRecipient.to_string(),
+        "transport input is addressed to another recipient"
+    );
+    assert_eq!(
+        TransportAdapterError::InvalidInboundEncoding.to_string(),
+        "invalid inbound transport encoding"
+    );
+    assert_eq!(
+        TransportAdapterError::InvalidInboundSignature.to_string(),
+        "invalid inbound transport signature"
+    );
 }
 
 #[test]

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -27,7 +27,18 @@ use nostr::RelayUrl;
 use sha2::{Digest, Sha256};
 use tokio::sync::{Mutex, RwLock, mpsc};
 use tokio::task::JoinSet;
-use transport_nostr_peeler::{KIND_NIP59_GIFT_WRAP, NOSTR_SOURCE, NostrTransportEvent};
+use transport_nostr_peeler::{
+    KIND_NIP59_GIFT_WRAP, NOSTR_SOURCE, NostrPeelerError, NostrTransportEvent,
+};
+
+fn map_inbound_event_error(error: NostrPeelerError) -> TransportAdapterError {
+    match error {
+        NostrPeelerError::InvalidSignature => TransportAdapterError::InvalidInboundSignature,
+        NostrPeelerError::Malformed(_)
+        | NostrPeelerError::UnsupportedKind(_)
+        | NostrPeelerError::MissingTag(_) => TransportAdapterError::InvalidInboundEncoding,
+    }
+}
 
 /// Build forensic wire metadata for an inbound relay event. The
 /// `transport_group_id` is read from the peeler-mapped envelope (the canonical
@@ -417,7 +428,7 @@ impl NostrTransportAdapter {
         let message = relay_event
             .event
             .to_transport_message()
-            .map_err(|e| TransportAdapterError::Backend(format!("Nostr event mapping: {e}")))?;
+            .map_err(map_inbound_event_error)?;
         let received_at = Timestamp(unix_now_seconds());
         let routes = {
             let state = self.state.read().await;

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -891,7 +891,7 @@ async fn forged_event_id_fails_closed_on_delivery_and_telemetry_paths() {
     let mut forged = group_event("11", &transport_group_id);
     forged.id = "77".repeat(32);
 
-    adapter
+    let error = adapter
         .handle_relay_event(NostrRelayEvent {
             endpoint: endpoint.clone(),
             subscription_id: Some("group-sub".into()),
@@ -899,6 +899,10 @@ async fn forged_event_id_fails_closed_on_delivery_and_telemetry_paths() {
         })
         .await
         .expect_err("forged id must not map to a delivery");
+    assert!(matches!(
+        error,
+        cgka_traits::TransportAdapterError::InvalidInboundSignature
+    ));
 
     adapter
         .observe_relay_event(NostrRelayEvent {
@@ -911,6 +915,39 @@ async fn forged_event_id_fails_closed_on_delivery_and_telemetry_paths() {
     let spread = adapter.delivery_spread().await;
     assert_eq!(spread.observed, 0, "forged id must not enter telemetry");
     assert_eq!(spread.spread.sample_count(), 0);
+    assert_eq!(spread.per_relay.len(), 0);
+}
+
+#[tokio::test]
+async fn non_exact_kind_445_shape_is_typed_invalid_encoding() {
+    let relay = Arc::new(FakeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay);
+    let mut event = group_event("extra-tag", &[0xC3; 32]);
+    event.tags.push(vec!["e".into(), "11".repeat(32)]);
+    event.id = event.computed_id();
+
+    let error = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: TransportEndpoint("wss://group.example".into()),
+            subscription_id: Some("group-sub".into()),
+            event: event.clone(),
+        })
+        .await
+        .expect_err("extra kind-445 tag must fail before routing");
+    assert!(matches!(
+        error,
+        cgka_traits::TransportAdapterError::InvalidInboundEncoding
+    ));
+
+    adapter
+        .observe_relay_event(NostrRelayEvent {
+            endpoint: TransportEndpoint("wss://group.example".into()),
+            subscription_id: Some("group-sub".into()),
+            event,
+        })
+        .await;
+    let spread = adapter.delivery_spread().await;
+    assert_eq!(spread.observed, 0);
     assert_eq!(spread.per_relay.len(), 0);
 }
 

--- a/crates/transport-nostr-peeler/src/error.rs
+++ b/crates/transport-nostr-peeler/src/error.rs
@@ -6,6 +6,8 @@ use cgka_traits::error::PeelerError;
 pub enum NostrPeelerError {
     #[error("malformed Nostr event: {0}")]
     Malformed(String),
+    #[error("invalid Nostr event signature")]
+    InvalidSignature,
     #[error("unsupported Nostr kind: {0}")]
     UnsupportedKind(u64),
     #[error("missing required Nostr tag: {0}")]
@@ -15,6 +17,7 @@ pub enum NostrPeelerError {
 pub(crate) fn to_peeler_error(err: NostrPeelerError) -> PeelerError {
     match err {
         NostrPeelerError::Malformed(msg) => PeelerError::Malformed(msg),
+        NostrPeelerError::InvalidSignature => PeelerError::InvalidSignature,
         NostrPeelerError::UnsupportedKind(kind) => {
             PeelerError::Malformed(format!("unsupported Nostr kind: {kind}"))
         }

--- a/crates/transport-nostr-peeler/src/event.rs
+++ b/crates/transport-nostr-peeler/src/event.rs
@@ -1,6 +1,6 @@
 use crate::{
-    GROUP_TAG, KIND_MARMOT_GROUP_MESSAGE, KIND_NIP59_GIFT_WRAP, NOSTR_SOURCE, NostrPeelerError,
-    RECIPIENT_TAG,
+    EXPIRATION_TAG, GROUP_TAG, KIND_MARMOT_GROUP_MESSAGE, KIND_NIP59_GIFT_WRAP, NOSTR_SOURCE,
+    NostrPeelerError, RECIPIENT_TAG,
 };
 use cgka_traits::transport::{Timestamp, TransportEnvelope, TransportMessage, TransportSource};
 use cgka_traits::types::{MemberId, MessageId};
@@ -35,21 +35,13 @@ impl NostrTransportEvent {
         // here rather than trusting the self-reported id. Signature
         // verification still happens at peel time.
         if !self.id.eq_ignore_ascii_case(&self.computed_id()) {
-            return Err(NostrPeelerError::Malformed(
-                "event id does not match event hash".into(),
-            ));
+            return Err(NostrPeelerError::InvalidSignature);
         }
         let id = MessageId::new(decode_hex_exact("event id", &self.id, 32)?);
         let envelope = match self.kind {
-            KIND_MARMOT_GROUP_MESSAGE => {
-                let group_id = self.single_tag_value(GROUP_TAG)?;
-                TransportEnvelope::GroupMessage {
-                    // The `h` tag is the hex of the 32-byte nostr_group_id
-                    // (spec/transports/nostr.md); shorter/longer route ids are
-                    // rejected, not passed through.
-                    transport_group_id: decode_hex_exact("group h tag", group_id, 32)?,
-                }
-            }
+            KIND_MARMOT_GROUP_MESSAGE => TransportEnvelope::GroupMessage {
+                transport_group_id: self.kind_445_transport_group_id()?,
+            },
             KIND_NIP59_GIFT_WRAP => {
                 let recipient = self.single_tag_value(RECIPIENT_TAG)?;
                 TransportEnvelope::Welcome {
@@ -71,6 +63,79 @@ impl NostrTransportEvent {
             source: TransportSource(NOSTR_SOURCE.into()),
             envelope,
         })
+    }
+
+    /// Validate the adopted exact kind-445 tag shape and return its Nostr
+    /// routing id.
+    ///
+    /// A Marmot group event carries exactly one `["h", <lowercase 32-byte
+    /// hex>]` tag and optionally one NIP-40
+    /// `["expiration", <unsigned Unix timestamp>]` tag. No other tags or
+    /// additional tag elements are permitted. Tag order is not significant.
+    ///
+    /// Expiration is relay-facing deletion metadata only. This validates its
+    /// syntax but deliberately does not compare it to the local wall clock.
+    pub(crate) fn kind_445_transport_group_id(&self) -> Result<Vec<u8>, NostrPeelerError> {
+        let mut transport_group_id = None;
+        let mut saw_expiration = false;
+
+        for tag in &self.tags {
+            let Some(name) = tag.first().map(String::as_str) else {
+                return Err(NostrPeelerError::Malformed(
+                    "kind-445 tag must contain exactly a name and value".into(),
+                ));
+            };
+            match name {
+                GROUP_TAG => {
+                    if transport_group_id.is_some() {
+                        return Err(NostrPeelerError::Malformed(
+                            "kind-445 event must contain exactly one h tag".into(),
+                        ));
+                    }
+                    let [_, value] = tag.as_slice() else {
+                        return Err(NostrPeelerError::Malformed(
+                            "kind-445 h tag must contain exactly a name and value".into(),
+                        ));
+                    };
+                    if value.len() != 64
+                        || !value
+                            .bytes()
+                            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+                    {
+                        return Err(NostrPeelerError::Malformed(
+                            "kind-445 h tag must be 32 bytes of lowercase hex".into(),
+                        ));
+                    }
+                    transport_group_id = Some(decode_hex_exact("kind-445 h tag", value, 32)?);
+                }
+                EXPIRATION_TAG => {
+                    if saw_expiration {
+                        return Err(NostrPeelerError::Malformed(
+                            "kind-445 event must contain at most one expiration tag".into(),
+                        ));
+                    }
+                    saw_expiration = true;
+                    let [_, value] = tag.as_slice() else {
+                        return Err(NostrPeelerError::Malformed(
+                            "kind-445 expiration tag must contain exactly a name and value".into(),
+                        ));
+                    };
+                    value.parse::<u64>().map_err(|_| {
+                        NostrPeelerError::Malformed(
+                            "kind-445 expiration tag must contain an unsigned Unix timestamp"
+                                .into(),
+                        )
+                    })?;
+                }
+                _ => {
+                    return Err(NostrPeelerError::Malformed(
+                        "kind-445 event contains a tag other than h or expiration".into(),
+                    ));
+                }
+            }
+        }
+
+        transport_group_id.ok_or_else(|| NostrPeelerError::MissingTag(GROUP_TAG.to_owned()))
     }
 
     /// Parse the Nostr DTO carried as a [`TransportMessage`] payload.
@@ -98,10 +163,11 @@ impl NostrTransportEvent {
 
     /// Convert this DTO into a signed, verified Nostr SDK event.
     pub fn to_verified_nostr_event(&self) -> Result<Event, NostrPeelerError> {
-        if self.sig.is_none() {
-            return Err(NostrPeelerError::Malformed(
-                "signed Nostr event is missing sig".into(),
-            ));
+        let Some(signature) = self.sig.as_deref() else {
+            return Err(NostrPeelerError::InvalidSignature);
+        };
+        if decode_hex_exact("event signature", signature, 64).is_err() {
+            return Err(NostrPeelerError::InvalidSignature);
         }
         let event = Event::from_json(
             serde_json::to_vec(self)
@@ -110,7 +176,7 @@ impl NostrTransportEvent {
         .map_err(|e| NostrPeelerError::Malformed(format!("Nostr event parse: {e}")))?;
         event
             .verify()
-            .map_err(|e| NostrPeelerError::Malformed(format!("Nostr event verification: {e}")))?;
+            .map_err(|_| NostrPeelerError::InvalidSignature)?;
         Ok(event)
     }
 
@@ -280,6 +346,117 @@ mod tests {
         );
     }
 
+    #[test]
+    fn kind_445_exact_tag_shape_table() {
+        let route = "aa".repeat(32);
+        let valid = |tags: Vec<Vec<String>>| {
+            let mut event = NostrTransportEvent {
+                id: String::new(),
+                pubkey: "22".repeat(32),
+                created_at: 1_700_000_000,
+                kind: KIND_MARMOT_GROUP_MESSAGE,
+                tags,
+                content: "encrypted body".into(),
+                sig: None,
+            };
+            event.id = event.computed_id();
+            event
+        };
+
+        for tags in [
+            vec![vec!["h".into(), route.clone()]],
+            vec![
+                vec!["h".into(), route.clone()],
+                vec!["expiration".into(), "1700000060".into()],
+            ],
+            // Tag order is not significant for the adopted kind-445 shape.
+            vec![
+                vec!["expiration".into(), "1".into()],
+                vec!["h".into(), route.clone()],
+            ],
+        ] {
+            valid(tags)
+                .to_transport_message()
+                .expect("valid exact kind-445 tag shape");
+        }
+
+        let malformed = [
+            ("missing h", vec![]),
+            (
+                "duplicate h",
+                vec![
+                    vec!["h".into(), route.clone()],
+                    vec!["h".into(), route.clone()],
+                ],
+            ),
+            (
+                "unknown tag",
+                vec![
+                    vec!["h".into(), route.clone()],
+                    vec!["e".into(), "11".repeat(32)],
+                ],
+            ),
+            ("empty tag", vec![vec![], vec!["h".into(), route.clone()]]),
+            ("h missing value", vec![vec!["h".into()]]),
+            (
+                "h marker or extra value",
+                vec![vec!["h".into(), route.clone(), "root".into()]],
+            ),
+            (
+                "uppercase h encoding",
+                vec![vec!["h".into(), "AA".repeat(32)]],
+            ),
+            ("short h encoding", vec![vec!["h".into(), "aa".repeat(31)]]),
+            (
+                "non-hex h encoding",
+                vec![vec!["h".into(), "gg".repeat(32)]],
+            ),
+            (
+                "duplicate expiration",
+                vec![
+                    vec!["h".into(), route.clone()],
+                    vec!["expiration".into(), "1".into()],
+                    vec!["expiration".into(), "2".into()],
+                ],
+            ),
+            (
+                "expiration missing value",
+                vec![vec!["h".into(), route.clone()], vec!["expiration".into()]],
+            ),
+            (
+                "expiration marker or extra value",
+                vec![
+                    vec!["h".into(), route.clone()],
+                    vec!["expiration".into(), "1".into(), "relay".into()],
+                ],
+            ),
+            (
+                "invalid expiration",
+                vec![
+                    vec!["h".into(), route],
+                    vec!["expiration".into(), "-1".into()],
+                ],
+            ),
+            (
+                "overflowing expiration",
+                vec![
+                    vec!["h".into(), "aa".repeat(32)],
+                    vec!["expiration".into(), "18446744073709551616".into()],
+                ],
+            ),
+        ];
+
+        for (name, tags) in malformed {
+            assert!(
+                matches!(
+                    valid(tags).to_transport_message(),
+                    Err(NostrPeelerError::Malformed(_) | NostrPeelerError::MissingTag(_))
+                ),
+                "{name} should be rejected"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn signed_kind_1059_event_maps_to_welcome_transport_message() {
         let sender =
@@ -351,7 +528,7 @@ mod tests {
 
         assert!(matches!(
             event.to_transport_message(),
-            Err(NostrPeelerError::Malformed(_))
+            Err(NostrPeelerError::InvalidSignature)
         ));
     }
 

--- a/crates/transport-nostr-peeler/src/lib.rs
+++ b/crates/transport-nostr-peeler/src/lib.rs
@@ -44,4 +44,5 @@ pub const NOSTR_GROUP_KEY_LEN: usize = 32;
 pub const NOSTR_GROUP_CONTENT_MIN_LEN: usize = 12 + 16;
 
 pub(crate) const GROUP_TAG: &str = "h";
+pub(crate) const EXPIRATION_TAG: &str = "expiration";
 pub(crate) const RECIPIENT_TAG: &str = "p";

--- a/crates/transport-nostr-peeler/src/peeler.rs
+++ b/crates/transport-nostr-peeler/src/peeler.rs
@@ -488,9 +488,7 @@ fn ensure_welcome_routing_matches(
         TransportEnvelope::Welcome { recipient } if recipient.as_slice() == event_recipient => {
             Ok(())
         }
-        TransportEnvelope::Welcome { .. } => Err(PeelerError::Malformed(
-            "event p tag does not match transport envelope".into(),
-        )),
+        TransportEnvelope::Welcome { .. } => Err(PeelerError::WrongRecipient),
         TransportEnvelope::GroupMessage { .. } => Err(PeelerError::Malformed(
             "welcome peeler received group envelope".into(),
         )),
@@ -1104,7 +1102,7 @@ mod tests {
             .await
             .expect_err("mismatched route should not peel");
 
-        assert!(matches!(err, PeelerError::Malformed(_)));
+        assert!(matches!(err, PeelerError::WrongRecipient));
     }
 
     #[tokio::test]

--- a/crates/transport-nostr-peeler/src/peeler.rs
+++ b/crates/transport-nostr-peeler/src/peeler.rs
@@ -1,9 +1,9 @@
 use crate::error::to_peeler_error;
 use crate::event::decode_hex_exact;
 use crate::{
-    DEFAULT_EXPORTER_LABEL, GROUP_TAG, KIND_MARMOT_GROUP_MESSAGE, KIND_MARMOT_WELCOME_RUMOR,
-    KIND_NIP59_GIFT_WRAP, NOSTR_GROUP_CONTENT_MIN_LEN, NOSTR_GROUP_KEY_LEN, NostrTransportEvent,
-    RECIPIENT_TAG,
+    DEFAULT_EXPORTER_LABEL, EXPIRATION_TAG, GROUP_TAG, KIND_MARMOT_GROUP_MESSAGE,
+    KIND_MARMOT_WELCOME_RUMOR, KIND_NIP59_GIFT_WRAP, NOSTR_GROUP_CONTENT_MIN_LEN,
+    NOSTR_GROUP_KEY_LEN, NostrTransportEvent, RECIPIENT_TAG,
 };
 use async_trait::async_trait;
 use cgka_traits::engine::WelcomeMetadata;
@@ -24,7 +24,6 @@ use std::sync::Arc;
 const NONCE_LEN: usize = 12;
 const WELCOME_SIGNER_CONTEXT: &str = "nostr_welcome_signer";
 const KEY_PACKAGE_EVENT_TAG: &str = "e";
-const EXPIRATION_TAG: &str = "expiration";
 const WELCOME_RELAYS_TAG: &str = "relays";
 /// Bound on the welcome rumor `relays` tag value count (#392). Parity with
 /// `MAX_RELAY_ENDPOINTS_PER_ROUTE` in `marmot-app`'s relay safety policy.
@@ -462,18 +461,15 @@ fn ensure_group_routing_matches(
     msg: &TransportMessage,
 ) -> Result<(), PeelerError> {
     let event_group_id = event
-        .single_tag_value(GROUP_TAG)
-        .map_err(to_peeler_error)
-        .and_then(|h| decode_hex_exact("group h tag", h, 32).map_err(to_peeler_error))?;
+        .kind_445_transport_group_id()
+        .map_err(to_peeler_error)?;
     match &msg.envelope {
         TransportEnvelope::GroupMessage { transport_group_id }
             if *transport_group_id == event_group_id =>
         {
             Ok(())
         }
-        TransportEnvelope::GroupMessage { .. } => Err(PeelerError::Malformed(
-            "event h tag does not match transport envelope".into(),
-        )),
+        TransportEnvelope::GroupMessage { .. } => Err(PeelerError::WrongRecipient),
         TransportEnvelope::Welcome { .. } => Err(PeelerError::Malformed(
             "group peeler received welcome envelope".into(),
         )),
@@ -605,8 +601,106 @@ mod tests {
 
         assert!(matches!(
             peeler.peel_group_message(&unsigned_msg, &ctx).await,
-            Err(PeelerError::Malformed(_))
+            Err(PeelerError::InvalidSignature)
         ));
+    }
+
+    #[tokio::test]
+    async fn group_peel_rejects_tampered_signature_before_decryption() {
+        let group_id = vec![0x99; 32];
+        let wrap_ctx = GroupContextSnapshot::new(
+            EpochId(9),
+            HashMap::from([(
+                DEFAULT_EXPORTER_LABEL.to_string(),
+                vec![0x7a; NOSTR_GROUP_KEY_LEN],
+            )]),
+            Some(group_id.clone()),
+        );
+        let wrong_secret_ctx = GroupContextSnapshot::new(
+            EpochId(9),
+            HashMap::from([(
+                DEFAULT_EXPORTER_LABEL.to_string(),
+                vec![0x7b; NOSTR_GROUP_KEY_LEN],
+            )]),
+            Some(group_id.clone()),
+        );
+        let peeler = NostrMlsPeeler::default();
+        let wrapped = peeler
+            .wrap_group_message(
+                &EncryptedPayload {
+                    ciphertext: b"inner mls bytes".to_vec(),
+                    aad: vec![],
+                },
+                &wrap_ctx,
+            )
+            .await
+            .expect("wrap succeeds");
+        let unrelated = peeler
+            .wrap_group_message(
+                &EncryptedPayload {
+                    ciphertext: b"unrelated inner bytes".to_vec(),
+                    aad: vec![],
+                },
+                &wrap_ctx,
+            )
+            .await
+            .expect("second wrap succeeds");
+        let mut tampered_event =
+            NostrTransportEvent::from_transport_message(&wrapped).expect("payload parses");
+        tampered_event.sig = NostrTransportEvent::from_transport_message(&unrelated)
+            .expect("unrelated payload parses")
+            .sig;
+        let tampered = tampered_event
+            .to_transport_message()
+            .expect("id and outer route still map");
+
+        let err = peeler
+            .peel_group_message(&tampered, &wrong_secret_ctx)
+            .await
+            .expect_err("tampered signature must fail before decryption");
+
+        assert!(matches!(err, PeelerError::InvalidSignature));
+    }
+
+    #[tokio::test]
+    async fn group_peel_rejects_extra_tag_before_decryption() {
+        let group_id = vec![0x99; 32];
+        let signed = EventBuilder::new(
+            Kind::Custom(KIND_MARMOT_GROUP_MESSAGE as u16),
+            BASE64_STANDARD.encode([0u8; NOSTR_GROUP_CONTENT_MIN_LEN]),
+        )
+        .tags([
+            Tag::custom(nostr::TagKind::custom(GROUP_TAG), [hex::encode(&group_id)]),
+            Tag::custom(nostr::TagKind::custom("e"), ["11".repeat(32)]),
+        ])
+        .sign_with_keys(&Keys::generate())
+        .expect("sign structurally invalid kind-445");
+        let event = NostrTransportEvent::from_nostr_event(&signed).expect("map signed event");
+        let msg = TransportMessage {
+            id: cgka_traits::types::MessageId::new(hex::decode(&event.id).expect("event id hex")),
+            payload: serde_json::to_vec(&event).expect("serialize event"),
+            timestamp: cgka_traits::transport::Timestamp(event.created_at),
+            causal_deps: vec![],
+            source: cgka_traits::transport::TransportSource(crate::NOSTR_SOURCE.into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: group_id.clone(),
+            },
+        };
+        let wrong_secret_ctx = GroupContextSnapshot::new(
+            EpochId(9),
+            HashMap::from([(
+                DEFAULT_EXPORTER_LABEL.to_string(),
+                vec![0x7b; NOSTR_GROUP_KEY_LEN],
+            )]),
+            Some(group_id),
+        );
+
+        let err = NostrMlsPeeler::default()
+            .peel_group_message(&msg, &wrong_secret_ctx)
+            .await
+            .expect_err("extra tag must fail before ciphertext decryption");
+
+        assert!(matches!(err, PeelerError::Malformed(_)));
     }
 
     #[tokio::test]
@@ -654,6 +748,41 @@ mod tests {
         assert_eq!(event.tag_value("h"), Some(expected_group_id.as_str()));
         assert_eq!(event.tag_value(EXPIRATION_TAG), Some("1700000060"));
         assert_eq!(event.tag_values(EXPIRATION_TAG).len(), 1);
+    }
+
+    #[tokio::test]
+    async fn group_peel_accepts_valid_events_before_and_after_expiration() {
+        let group_id = vec![0x99; 32];
+        let ctx = GroupContextSnapshot::new(
+            EpochId(9),
+            HashMap::from([(DEFAULT_EXPORTER_LABEL.to_string(), vec![0x7a; 32])]),
+            Some(group_id),
+        );
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        for (label, created_at, retention_seconds) in
+            [("already expired", 1, 1), ("not yet expired", now, 3_600)]
+        {
+            let wrapped = NostrMlsPeeler::default()
+                .wrap_group_message_with_metadata(
+                    &EncryptedPayload {
+                        ciphertext: b"inner mls bytes".to_vec(),
+                        aad: vec![],
+                    },
+                    &ctx,
+                    &GroupMessageMetadata::application(created_at, Some(retention_seconds)),
+                )
+                .await
+                .expect("wrap succeeds");
+
+            NostrMlsPeeler::default()
+                .peel_group_message(&wrapped, &ctx)
+                .await
+                .unwrap_or_else(|err| panic!("{label} event should peel: {err}"));
+        }
     }
 
     #[tokio::test]
@@ -865,7 +994,7 @@ mod tests {
             .await
             .expect_err("mismatched route should not peel");
 
-        assert!(matches!(err, PeelerError::Malformed(_)));
+        assert!(matches!(err, PeelerError::WrongRecipient));
     }
 
     #[tokio::test]
@@ -1035,7 +1164,7 @@ mod tests {
             .await
             .expect_err("peeling verifies the signed gift wrap");
 
-        assert!(matches!(err, PeelerError::Malformed(_)));
+        assert!(matches!(err, PeelerError::InvalidSignature));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- enforce the adopted exact kind-445 tag shape: one lowercase 32-byte `h`, optional syntactically valid NIP-40 `expiration`, and no other tags or extra tag elements
- validate the same shape at DTO mapping and peeler boundaries while treating expiration only as relay metadata, never a wall-clock validity rule
- add typed privacy-safe invalid-encoding, invalid-signature, and wrong-recipient outcomes; keep hostile terminal input from wedging transport drains
- cover direct, adapter, engine, and app runtime seams, including tampered IDs/signatures, routing-id confusion, and pre/post-expiration delivery

## Validation

- `cargo test -p cgka-traits`
- `cargo test -p transport-nostr-peeler`
- `cargo test -p transport-nostr-adapter`
- `cargo test -p cgka-engine`
- `cargo test -p marmot-app`
- `just fast-ci`

Fixes #1007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reject invalid-signature and wrong-recipient messages earlier with correct typed stale outcomes, preventing further processing/telemetry.
  * Strengthened Nostr transport validation (including strict kind-445 tag shape and optional expiration handling).
  * Ensure repeated rejected messages reliably short-circuit to the “already seen” stale state.

* **Improvements**
  * Added privacy-safe typed inbound rejection categories and expanded audit-log peeler outcome kinds: `invalid_signature` and `wrong_recipient`.

* **Tests**
  * Expanded ingest and relay boundary tests to cover direct and snapshot-fallback typed terminal rejections, including Welcome-envelope wrong-recipient cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->