### PR TITLE
Honor NIP-65 relay roles for KeyPackage routing

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -141,6 +141,9 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Fixed
 
+- `wn relays add/remove --type nip65` now round-trips the complete directional NIP-65 list instead of deleting
+  read-only relays or flattening existing role markers. Relay-list JSON adds `read_relays` and `write_relays` alongside
+  the existing write-target `relays` view.
 - Release builds now fail app startup with a clear error when `WN_DEV_SETTLEMENT_QUIESCENCE_MS` is set instead of
   allowing it to override the protocol-pinned convergence window. Debug builds retain the override for local
   development and integration tests.

--- a/crates/cli/src/commands/account.rs
+++ b/crates/cli/src/commands/account.rs
@@ -237,10 +237,14 @@ fn missing_relay_list_status(missing: Vec<MissingRelayListKind>) -> AccountRelay
         nip65: marmot_app::AccountRelayListState {
             kind: 10002,
             relays: Vec::new(),
+            read_relays: Vec::new(),
+            write_relays: Vec::new(),
         },
         inbox: marmot_app::AccountRelayListState {
             kind: 10050,
             relays: Vec::new(),
+            read_relays: Vec::new(),
+            write_relays: Vec::new(),
         },
     }
 }

--- a/crates/cli/src/commands/relays.rs
+++ b/crates/cli/src/commands/relays.rs
@@ -101,30 +101,40 @@ async fn update_relay_list(
                 &source_relays,
             )
         })?;
-    let mut relays = relays_for_type(&status, Some(&relay_type))?;
-    if add {
-        if !relays.contains(&url) {
-            relays.push(url.clone());
-        }
-    } else {
-        relays.retain(|relay| relay != &url);
-    }
-    relays.sort();
-    relays.dedup();
-    let publish_relays = relay_endpoints(relays.clone())?;
     let bootstrap = explicit_bootstrap
         .or_else(|| source_relays.first().map(|endpoint| endpoint.0.clone()))
-        .or_else(|| relays.first().cloned())
+        .or_else(|| {
+            relays_for_type(&status, Some(&relay_type))
+                .ok()
+                .and_then(|relays| relays.first().cloned())
+        })
         .ok_or(WnError::MissingRelay)?;
     let bootstrap_relays = vec![TransportEndpoint(bootstrap)];
-    let status = runtime
-        .publish_account_relay_list_kind(
-            &account.label,
-            &relay_type,
-            publish_relays,
-            bootstrap_relays,
-        )
-        .await?;
+    let status = if relay_type == "nip65" {
+        let (mut read_relays, mut write_relays) = nip65_relay_roles(&status.nip65);
+        update_relay_values(&mut read_relays, &url, add);
+        update_relay_values(&mut write_relays, &url, add);
+        runtime
+            .publish_account_nip65_relay_set(
+                &account.label,
+                relay_endpoints(read_relays)?,
+                relay_endpoints(write_relays)?,
+                bootstrap_relays,
+            )
+            .await?
+    } else {
+        let mut relays = relays_for_type(&status, Some(&relay_type))?;
+        update_relay_values(&mut relays, &url, add);
+        runtime
+            .publish_account_relay_list_kind(
+                &account.label,
+                &relay_type,
+                relay_endpoints(relays)?,
+                bootstrap_relays,
+            )
+            .await?
+    };
+    let relays = relays_for_type(&status, Some(&relay_type))?;
     Ok(CommandOutput {
         plain: relays.join("\n"),
         json: json!({
@@ -135,6 +145,25 @@ async fn update_relay_list(
             "relay_lists": relay_lists_json(status),
         }),
     })
+}
+
+fn nip65_relay_roles(state: &marmot_app::AccountRelayListState) -> (Vec<String>, Vec<String>) {
+    if state.read_relays.is_empty() && state.write_relays.is_empty() {
+        return (state.relays.clone(), state.relays.clone());
+    }
+    (state.read_relays.clone(), state.write_relays.clone())
+}
+
+fn update_relay_values(relays: &mut Vec<String>, url: &str, add: bool) {
+    if add {
+        if !relays.iter().any(|relay| relay == url) {
+            relays.push(url.to_owned());
+        }
+    } else {
+        relays.retain(|relay| relay != url);
+    }
+    relays.sort();
+    relays.dedup();
 }
 
 fn relays_for_type(
@@ -160,5 +189,42 @@ fn normalize_relay_type(value: &str) -> Result<String, WnError> {
         "nip65" => Ok("nip65".to_owned()),
         "inbox" => Ok("inbox".to_owned()),
         _ => Err(WnError::InvalidRelayType(value.to_owned())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use marmot_app::AccountRelayListState;
+
+    #[test]
+    fn nip65_update_preserves_unmodified_directional_relays() {
+        let state = AccountRelayListState {
+            kind: 10_002,
+            relays: vec!["wss://both.example".into(), "wss://write.example".into()],
+            read_relays: vec!["wss://both.example".into(), "wss://read.example".into()],
+            write_relays: vec!["wss://both.example".into(), "wss://write.example".into()],
+        };
+
+        let (mut read_relays, mut write_relays) = nip65_relay_roles(&state);
+        update_relay_values(&mut read_relays, "wss://new.example", true);
+        update_relay_values(&mut write_relays, "wss://new.example", true);
+
+        assert_eq!(
+            read_relays,
+            vec![
+                "wss://both.example",
+                "wss://new.example",
+                "wss://read.example",
+            ]
+        );
+        assert_eq!(
+            write_relays,
+            vec![
+                "wss://both.example",
+                "wss://new.example",
+                "wss://write.example",
+            ]
+        );
     }
 }

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -33,10 +33,8 @@ use crate::ids::{
     normalize_account_ids, npub_for_account_id, npub_for_account_id_lossy, parse_account_id_hex,
 };
 use crate::key_package_records::{
-    fill_missing_relay_lists_from_cached, fresh_or_cached_key_package,
-    fresh_relay_list_status_from_records, key_package_from_record,
+    fresh_or_cached_key_package, fresh_relay_list_status_from_records, key_package_from_record,
     latest_fresh_key_package_from_records, publish_endpoints_from_bootstrap, relay_list_queries,
-    relay_lists_have_any_relays,
 };
 use crate::relay_plane::{DirectoryEventQuery, DirectoryRelayEventRecord as RelayEventRecord};
 use crate::{
@@ -44,7 +42,7 @@ use crate::{
     DIRECTORY_FUTURE_CREATED_AT_CLEANUP_MARKER, DirectoryFreshness, FetchedKeyPackage,
     KIND_NOSTR_CONTACT_LIST, KIND_NOSTR_METADATA, MarmotApp, MissingRelayListKind, ReceivedMessage,
     SqlcipherDatabaseKind, USER_DIRECTORY_SEARCH_MAX_FRONTIER, USER_DIRECTORY_SEARCH_MAX_VISITED,
-    push_unique_strings, relays_from_relay_list_event, remove_sqlite_file_set,
+    push_unique_strings, relay_list_state_from_event, remove_sqlite_file_set,
 };
 
 impl MarmotApp {
@@ -92,18 +90,28 @@ impl MarmotApp {
             )
             .await
             .map_err(|e| AppError::RelayDirectory(format!("fetch relay lists: {e}")))?;
+        let observed_nip65 = records.iter().any(|record| {
+            record.event.pubkey == account_id_hex
+                && record.event.kind == KIND_NIP65_RELAY_LIST
+                && freshness.accepts(record)
+        });
+        let observed_inbox = records.iter().any(|record| {
+            record.event.pubkey == account_id_hex
+                && record.event.kind == KIND_MARMOT_INBOX_RELAY_LIST
+                && freshness.accepts(record)
+        });
         let selection = fresh_relay_list_status_from_records(&account_id_hex, records, freshness);
         let mut status = selection.value;
-        if selection.rejected_future || !relay_lists_have_any_relays(&status) {
+        if !observed_nip65 || !observed_inbox {
             let cached = self.account_relay_list_status_for_account_id(&account_id_hex)?;
-            if relay_lists_have_any_relays(&cached) {
-                if !relay_lists_have_any_relays(&status) {
-                    return Ok(cached);
-                }
-                if selection.rejected_future {
-                    fill_missing_relay_lists_from_cached(&mut status, &cached);
-                }
+            if !observed_nip65 {
+                status.nip65 = cached.nip65;
             }
+            if !observed_inbox {
+                status.inbox = cached.inbox;
+            }
+            push_unique_strings(&mut status.bootstrap_relays, cached.bootstrap_relays);
+            status.refresh();
         }
         if status.bootstrap_relays.is_empty() {
             status.bootstrap_relays = bootstrap_relays
@@ -870,16 +878,15 @@ impl MarmotApp {
         account_id_hex: &str,
         record: &RelayEventRecord,
     ) -> Result<(), AppError> {
-        let relays = relays_from_relay_list_event(&record.event);
-        if relays.is_empty() {
+        let Some(state) = relay_list_state_from_event(&record.event) else {
             return Ok(());
-        }
+        };
         let mut entry = self
             .directory_entry_for_account_id(account_id_hex)?
             .unwrap_or_else(|| self.empty_directory_record(account_id_hex));
         match record.event.kind {
-            KIND_NIP65_RELAY_LIST => entry.relay_lists.nip65.relays = relays,
-            KIND_MARMOT_INBOX_RELAY_LIST => entry.relay_lists.inbox.relays = relays,
+            KIND_NIP65_RELAY_LIST => entry.relay_lists.nip65 = state,
+            KIND_MARMOT_INBOX_RELAY_LIST => entry.relay_lists.inbox = state,
             _ => return Ok(()),
         }
         push_unique_strings(

--- a/crates/marmot-app/src/key_package_records.rs
+++ b/crates/marmot-app/src/key_package_records.rs
@@ -24,7 +24,7 @@ use crate::relay_plane::{DirectoryEventQuery, DirectoryRelayEventRecord as Relay
 use crate::{
     AccountKeyPackageRecord, AccountRelayListBootstrap, AccountRelayListStatus, DirectoryFreshness,
     DirectoryKeyPackage, DirectorySelection, FetchedKeyPackage, UserDirectoryRecord,
-    push_unique_strings, relays_from_relay_list_event, sort_directory_records,
+    push_unique_strings, relay_list_state_from_event, sort_directory_records,
 };
 
 pub(crate) fn relay_list_status_from_records(
@@ -37,13 +37,12 @@ pub(crate) fn relay_list_status_from_records(
         if record.event.pubkey != account_id_hex {
             continue;
         }
-        let relays = relays_from_relay_list_event(&record.event);
-        if relays.is_empty() {
+        let Some(state) = relay_list_state_from_event(&record.event) else {
             continue;
-        }
+        };
         match record.event.kind {
-            KIND_NIP65_RELAY_LIST => status.nip65.relays = relays,
-            KIND_MARMOT_INBOX_RELAY_LIST => status.inbox.relays = relays,
+            KIND_NIP65_RELAY_LIST => status.nip65 = state,
+            KIND_MARMOT_INBOX_RELAY_LIST => status.inbox = state,
             _ => continue,
         }
         push_unique_strings(
@@ -209,26 +208,6 @@ fn key_package_event_id_from_hex(event_id_hex: &str) -> Result<MessageId, AppErr
         )));
     }
     Ok(MessageId::new(bytes))
-}
-
-pub(crate) fn relay_lists_have_any_relays(status: &AccountRelayListStatus) -> bool {
-    !status.nip65.relays.is_empty() || !status.inbox.relays.is_empty()
-}
-
-pub(crate) fn fill_missing_relay_lists_from_cached(
-    status: &mut AccountRelayListStatus,
-    cached: &AccountRelayListStatus,
-) {
-    if status.nip65.relays.is_empty() {
-        status.nip65.relays = cached.nip65.relays.clone();
-    }
-    if status.inbox.relays.is_empty() {
-        status.inbox.relays = cached.inbox.relays.clone();
-    }
-    if status.bootstrap_relays.is_empty() {
-        status.bootstrap_relays = cached.bootstrap_relays.clone();
-    }
-    status.refresh();
 }
 
 pub(crate) fn fresh_or_cached_key_package(

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -58,7 +58,8 @@ use storage_sqlite::{
 use transport_nostr_adapter::{
     KIND_MARMOT_INBOX_RELAY_LIST, KIND_MARMOT_KEY_PACKAGE, KIND_NIP65_RELAY_LIST,
     NostrAccountRelayListKind, NostrAccountRelayListPublication, NostrKeyPackagePublication,
-    NostrKeyPackagePublisher, NostrRelayClient, NostrSdkRelayClient, parse_nip65_relay_set,
+    NostrKeyPackagePublisher, NostrNip65RelayListPublication, NostrNip65RelaySet, NostrRelayClient,
+    NostrSdkRelayClient, parse_nip65_relay_set,
 };
 use transport_nostr_peeler::{NostrMlsPeeler, NostrTransportEvent};
 
@@ -512,6 +513,18 @@ pub struct AccountRelayListState {
     /// unmarked and `write` entries, excluding `read`-only entries. For the
     /// Marmot inbox list this is the declared inbox relay set.
     pub relays: Vec<String>,
+    /// NIP-65 read-capable relays, including unmarked entries.
+    ///
+    /// Empty for non-NIP-65 lists and for cache records written before
+    /// directional roles were persisted.
+    #[serde(default)]
+    pub read_relays: Vec<String>,
+    /// NIP-65 write-capable relays, including unmarked entries.
+    ///
+    /// This is the explicit directional counterpart of the compatibility
+    /// `relays` field. Empty for non-NIP-65 lists and for legacy cache records.
+    #[serde(default)]
+    pub write_relays: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -547,10 +560,14 @@ impl AccountRelayListStatus {
             nip65: AccountRelayListState {
                 kind: KIND_NIP65_RELAY_LIST,
                 relays: Vec::new(),
+                read_relays: Vec::new(),
+                write_relays: Vec::new(),
             },
             inbox: AccountRelayListState {
                 kind: KIND_MARMOT_INBOX_RELAY_LIST,
                 relays: Vec::new(),
+                read_relays: Vec::new(),
+                write_relays: Vec::new(),
             },
         };
         status.refresh();
@@ -1231,8 +1248,27 @@ impl MarmotApp {
         .await
     }
 
+    /// Return every declared NIP-65 relay for backward-compatible list editing.
+    ///
+    /// Routing code must use `AccountRelayListStatus::nip65.relays`, which is
+    /// the write-capable subset. Returning the union here keeps the established
+    /// getter -> edit -> setter flow from deleting read-only entries.
     pub fn account_nip65_relays(&self, label: &str) -> Result<Vec<String>, AppError> {
-        Ok(self.account_relay_list_status(label)?.nip65.relays)
+        let state = self.account_relay_list_status(label)?.nip65;
+        let relay_set = nip65_relay_set_from_state(&state);
+        let mut relays = relay_set
+            .read_relays
+            .into_iter()
+            .map(|endpoint| endpoint.0)
+            .collect::<Vec<_>>();
+        push_unique_strings(
+            &mut relays,
+            relay_set
+                .write_relays
+                .into_iter()
+                .map(|endpoint| endpoint.0),
+        );
+        Ok(relays)
     }
 
     pub fn account_inbox_relays(&self, label: &str) -> Result<Vec<String>, AppError> {
@@ -1245,11 +1281,35 @@ impl MarmotApp {
         relays: Vec<TransportEndpoint>,
         bootstrap_relays: Vec<TransportEndpoint>,
     ) -> Result<AccountRelayListStatus, AppError> {
-        self.set_account_relay_list_kind(
+        let current = self.account_relay_list_status(label)?.nip65;
+        let relay_set = nip65_relay_set_preserving_roles(&current, relays);
+        self.publish_account_nip65_relay_set(
             label,
-            NostrAccountRelayListKind::Nip65,
-            relays,
+            relay_set.read_relays,
+            relay_set.write_relays,
             bootstrap_relays,
+        )
+        .await
+    }
+
+    /// Replace the account's NIP-65 list while preserving explicit relay
+    /// directions in the published kind-10002 event.
+    pub async fn publish_account_nip65_relay_set(
+        &self,
+        label: &str,
+        read_relays: Vec<TransportEndpoint>,
+        write_relays: Vec<TransportEndpoint>,
+        bootstrap_relays: Vec<TransportEndpoint>,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let relay_set = NostrNip65RelaySet {
+            read_relays: unique_transport_endpoints(read_relays),
+            write_relays: unique_transport_endpoints(write_relays),
+        };
+        self.publish_selected_account_relay_lists_with_nip65(
+            label,
+            AccountRelayListBootstrap::new(relay_set.write_relays.clone(), bootstrap_relays),
+            &[NostrAccountRelayListKind::Nip65],
+            Some(&relay_set),
         )
         .await
     }
@@ -1290,7 +1350,21 @@ impl MarmotApp {
         bootstrap: AccountRelayListBootstrap,
         list_kinds: &[NostrAccountRelayListKind],
     ) -> Result<AccountRelayListStatus, AppError> {
-        if bootstrap.default_relays.is_empty() {
+        self.publish_selected_account_relay_lists_with_nip65(label, bootstrap, list_kinds, None)
+            .await
+    }
+
+    async fn publish_selected_account_relay_lists_with_nip65(
+        &self,
+        label: &str,
+        bootstrap: AccountRelayListBootstrap,
+        list_kinds: &[NostrAccountRelayListKind],
+        nip65_relay_set: Option<&NostrNip65RelaySet>,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let has_directional_nip65_relays = nip65_relay_set.is_some_and(|relays| {
+            !relays.read_relays.is_empty() || !relays.write_relays.is_empty()
+        });
+        if bootstrap.default_relays.is_empty() && !has_directional_nip65_relays {
             return Err(AppError::MissingDefaultRelays);
         }
         let account = self.account_home().account(label)?;
@@ -1319,13 +1393,24 @@ impl MarmotApp {
         }
         let relay_client = self.relay_client_for_endpoints(signer.as_nostr_signer(), &endpoints);
         for list_kind in list_kinds {
-            let publication = NostrAccountRelayListPublication {
-                account_id: account_id.clone(),
-                list_kind: *list_kind,
-                relays: bootstrap.default_relays.clone(),
-                publish_endpoints: endpoints.clone(),
+            let event = if *list_kind == NostrAccountRelayListKind::Nip65
+                && let Some(relays) = nip65_relay_set
+            {
+                NostrNip65RelayListPublication {
+                    account_id: account_id.clone(),
+                    relays: relays.clone(),
+                    publish_endpoints: endpoints.clone(),
+                }
+                .to_event()?
+            } else {
+                NostrAccountRelayListPublication {
+                    account_id: account_id.clone(),
+                    list_kind: *list_kind,
+                    relays: bootstrap.default_relays.clone(),
+                    publish_endpoints: endpoints.clone(),
+                }
+                .to_event()?
             };
-            let event = publication.to_event()?;
             relay_client.publish_event(&endpoints, &event, 1).await?;
         }
         self.fetch_account_relay_list_status_for_account_id(&account_id_hex, endpoints)
@@ -3524,28 +3609,117 @@ fn sqlite_file_requires_key(path: &Path) -> bool {
         .is_err()
 }
 
+#[cfg(test)]
 fn relays_from_relay_list_event(event: &NostrTransportEvent) -> Vec<String> {
-    if event.kind == KIND_NIP65_RELAY_LIST {
-        return parse_nip65_relay_set(event)
-            .write_relays
-            .into_iter()
-            .map(|endpoint| endpoint.0)
-            .collect();
-    }
+    relay_list_state_from_event(event)
+        .map(|state| state.relays)
+        .unwrap_or_default()
+}
 
-    let tag_name = match event.kind {
-        KIND_MARMOT_INBOX_RELAY_LIST => "relay",
-        _ => return Vec::new(),
-    };
-    let mut relays = Vec::new();
-    for tag in &event.tags {
-        if tag.first().is_some_and(|name| name == tag_name)
-            && let Some(value) = tag.get(1).filter(|value| !value.trim().is_empty())
-        {
-            push_unique_strings(&mut relays, [value.clone()]);
+fn relay_list_state_from_event(event: &NostrTransportEvent) -> Option<AccountRelayListState> {
+    match event.kind {
+        KIND_NIP65_RELAY_LIST => {
+            let relay_set = parse_nip65_relay_set(event);
+            let read_relays = relay_set
+                .read_relays
+                .into_iter()
+                .map(|endpoint| endpoint.0)
+                .collect::<Vec<_>>();
+            let write_relays = relay_set
+                .write_relays
+                .into_iter()
+                .map(|endpoint| endpoint.0)
+                .collect::<Vec<_>>();
+            Some(AccountRelayListState {
+                kind: KIND_NIP65_RELAY_LIST,
+                relays: write_relays.clone(),
+                read_relays,
+                write_relays,
+            })
+        }
+        KIND_MARMOT_INBOX_RELAY_LIST => {
+            let mut relays = Vec::new();
+            for tag in &event.tags {
+                if tag.first().is_some_and(|name| name == "relay")
+                    && let Some(value) = tag.get(1).filter(|value| !value.trim().is_empty())
+                {
+                    push_unique_strings(&mut relays, [value.clone()]);
+                }
+            }
+            Some(AccountRelayListState {
+                kind: KIND_MARMOT_INBOX_RELAY_LIST,
+                relays,
+                read_relays: Vec::new(),
+                write_relays: Vec::new(),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn nip65_relay_set_from_state(state: &AccountRelayListState) -> NostrNip65RelaySet {
+    if state.read_relays.is_empty() && state.write_relays.is_empty() {
+        let legacy_relays = state
+            .relays
+            .iter()
+            .cloned()
+            .map(TransportEndpoint)
+            .collect::<Vec<_>>();
+        return NostrNip65RelaySet {
+            read_relays: legacy_relays.clone(),
+            write_relays: legacy_relays,
+        };
+    }
+    NostrNip65RelaySet {
+        read_relays: state
+            .read_relays
+            .iter()
+            .cloned()
+            .map(TransportEndpoint)
+            .collect(),
+        write_relays: state
+            .write_relays
+            .iter()
+            .cloned()
+            .map(TransportEndpoint)
+            .collect(),
+    }
+}
+
+fn nip65_relay_set_preserving_roles(
+    current: &AccountRelayListState,
+    requested_relays: Vec<TransportEndpoint>,
+) -> NostrNip65RelaySet {
+    let current = nip65_relay_set_from_state(current);
+    let mut next = NostrNip65RelaySet::default();
+    for endpoint in unique_transport_endpoints(requested_relays) {
+        let was_read = current.read_relays.contains(&endpoint);
+        let was_write = current.write_relays.contains(&endpoint);
+        if !was_read && !was_write {
+            next.read_relays.push(endpoint.clone());
+            next.write_relays.push(endpoint);
+            continue;
+        }
+        if was_read {
+            next.read_relays.push(endpoint.clone());
+        }
+        if was_write {
+            next.write_relays.push(endpoint);
         }
     }
-    relays
+    next
+}
+
+fn unique_transport_endpoints(
+    endpoints: impl IntoIterator<Item = TransportEndpoint>,
+) -> Vec<TransportEndpoint> {
+    let mut unique = Vec::new();
+    for endpoint in endpoints {
+        if !unique.contains(&endpoint) {
+            unique.push(endpoint);
+        }
+    }
+    unique
 }
 
 fn push_unique_strings(values: &mut Vec<String>, candidates: impl IntoIterator<Item = String>) {

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -58,7 +58,7 @@ use storage_sqlite::{
 use transport_nostr_adapter::{
     KIND_MARMOT_INBOX_RELAY_LIST, KIND_MARMOT_KEY_PACKAGE, KIND_NIP65_RELAY_LIST,
     NostrAccountRelayListKind, NostrAccountRelayListPublication, NostrKeyPackagePublication,
-    NostrKeyPackagePublisher, NostrRelayClient, NostrSdkRelayClient,
+    NostrKeyPackagePublisher, NostrRelayClient, NostrSdkRelayClient, parse_nip65_relay_set,
 };
 use transport_nostr_peeler::{NostrMlsPeeler, NostrTransportEvent};
 
@@ -506,6 +506,11 @@ impl MissingRelayListKind {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AccountRelayListState {
     pub kind: u64,
+    /// Direction-appropriate relay targets for this list.
+    ///
+    /// For NIP-65 kind 10002 this is specifically the write-capable set:
+    /// unmarked and `write` entries, excluding `read`-only entries. For the
+    /// Marmot inbox list this is the declared inbox relay set.
     pub relays: Vec<String>,
 }
 
@@ -3520,8 +3525,15 @@ fn sqlite_file_requires_key(path: &Path) -> bool {
 }
 
 fn relays_from_relay_list_event(event: &NostrTransportEvent) -> Vec<String> {
+    if event.kind == KIND_NIP65_RELAY_LIST {
+        return parse_nip65_relay_set(event)
+            .write_relays
+            .into_iter()
+            .map(|endpoint| endpoint.0)
+            .collect();
+    }
+
     let tag_name = match event.kind {
-        KIND_NIP65_RELAY_LIST => "r",
         KIND_MARMOT_INBOX_RELAY_LIST => "relay",
         _ => return Vec::new(),
     };

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -2335,6 +2335,25 @@ impl MarmotAppRuntime {
             .await
     }
 
+    pub async fn publish_account_nip65_relay_set(
+        &self,
+        account_ref: &str,
+        read_relays: Vec<TransportEndpoint>,
+        write_relays: Vec<TransportEndpoint>,
+        bootstrap_relays: Vec<TransportEndpoint>,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let account = self.accounts.resolve(account_ref)?;
+        self.accounts
+            .app
+            .publish_account_nip65_relay_set(
+                &account.label,
+                read_relays,
+                write_relays,
+                bootstrap_relays,
+            )
+            .await
+    }
+
     pub fn account_nip65_relays(&self, account_ref: &str) -> Result<Vec<String>, AppError> {
         let account = self.accounts.resolve(account_ref)?;
         self.accounts.app.account_nip65_relays(&account.label)

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -27,6 +27,34 @@ use crate::key_package_records::{
 use crate::messages::STREAM_ROUTE_QUIC;
 use crate::messages::{AppMessageIntent, build_inner_event};
 
+#[test]
+fn nip65_relay_list_targets_only_include_write_capable_entries() {
+    let event = NostrTransportEvent::new_unsigned(
+        "11".repeat(32),
+        KIND_NIP65_RELAY_LIST,
+        vec![
+            vec!["r".into(), "wss://both.example".into()],
+            vec!["r".into(), "wss://read-only.example".into(), "read".into()],
+            vec![
+                "r".into(),
+                "wss://write-only.example".into(),
+                "write".into(),
+            ],
+            vec!["r".into(), "wss://unknown.example".into(), "future".into()],
+            vec!["r".into(), "wss://both.example".into()],
+        ],
+        String::new(),
+    );
+
+    assert_eq!(
+        relays_from_relay_list_event(&event),
+        vec![
+            "wss://both.example".to_owned(),
+            "wss://write-only.example".to_owned(),
+        ]
+    );
+}
+
 #[derive(Clone, Debug)]
 struct TestExternalAccountSigner {
     keys: nostr::Keys,

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -21,8 +21,8 @@ use crate::directory::records::{
 };
 use crate::ids::npub_for_account_id_lossy;
 use crate::key_package_records::{
-    relay_list_queries, require_key_package_tag, require_multi_value_key_package_tag,
-    require_multi_value_key_package_tag_contains,
+    relay_list_queries, relay_list_status_from_records, require_key_package_tag,
+    require_multi_value_key_package_tag, require_multi_value_key_package_tag_contains,
 };
 use crate::messages::STREAM_ROUTE_QUIC;
 use crate::messages::{AppMessageIntent, build_inner_event};
@@ -51,6 +51,130 @@ fn nip65_relay_list_targets_only_include_write_capable_entries() {
         vec![
             "wss://both.example".to_owned(),
             "wss://write-only.example".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn newer_all_read_nip65_list_clears_stale_write_targets() {
+    let account_id = "11".repeat(32);
+    let mut older = NostrTransportEvent::new_unsigned(
+        account_id.clone(),
+        KIND_NIP65_RELAY_LIST,
+        vec![vec!["r".into(), "wss://stale-write.example".into()]],
+        String::new(),
+    );
+    older.created_at = 1;
+    older.id = "00".repeat(32);
+    let mut newer = NostrTransportEvent::new_unsigned(
+        account_id.clone(),
+        KIND_NIP65_RELAY_LIST,
+        vec![vec![
+            "r".into(),
+            "wss://read-only.example".into(),
+            "read".into(),
+        ]],
+        String::new(),
+    );
+    newer.created_at = 2;
+    newer.id = "11".repeat(32);
+
+    let status = relay_list_status_from_records(
+        &account_id,
+        vec![
+            crate::relay_plane::DirectoryRelayEventRecord {
+                endpoints: vec![TransportEndpoint("wss://source.example".into())],
+                event: newer,
+            },
+            crate::relay_plane::DirectoryRelayEventRecord {
+                endpoints: vec![TransportEndpoint("wss://source.example".into())],
+                event: older,
+            },
+        ],
+    );
+
+    assert!(status.nip65.relays.is_empty());
+    assert!(status.nip65.write_relays.is_empty());
+    assert_eq!(status.nip65.read_relays, vec!["wss://read-only.example"]);
+    assert_eq!(
+        status.missing,
+        vec![MissingRelayListKind::Nip65, MissingRelayListKind::Inbox]
+    );
+}
+
+#[test]
+fn ingesting_all_read_nip65_list_replaces_cached_write_targets() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let account_id = "22".repeat(32);
+    let record = |tags| crate::relay_plane::DirectoryRelayEventRecord {
+        endpoints: vec![TransportEndpoint("wss://source.example".into())],
+        event: NostrTransportEvent::new_unsigned(
+            account_id.clone(),
+            KIND_NIP65_RELAY_LIST,
+            tags,
+            String::new(),
+        ),
+    };
+
+    app.ingest_directory_relay_event(record(vec![vec![
+        "r".into(),
+        "wss://stale-write.example".into(),
+    ]]))
+    .unwrap();
+    app.ingest_directory_relay_event(record(vec![vec![
+        "r".into(),
+        "wss://read-only.example".into(),
+        "read".into(),
+    ]]))
+    .unwrap();
+
+    let cached = app
+        .directory_entry_for_account_id(&account_id)
+        .unwrap()
+        .expect("cached relay list");
+    assert!(cached.relay_lists.nip65.relays.is_empty());
+    assert!(cached.relay_lists.nip65.write_relays.is_empty());
+    assert_eq!(
+        cached.relay_lists.nip65.read_relays,
+        vec!["wss://read-only.example"]
+    );
+}
+
+#[test]
+fn nip65_setter_round_trip_preserves_existing_roles() {
+    let current = AccountRelayListState {
+        kind: KIND_NIP65_RELAY_LIST,
+        relays: vec!["wss://both.example".into(), "wss://write.example".into()],
+        read_relays: vec!["wss://both.example".into(), "wss://read.example".into()],
+        write_relays: vec!["wss://both.example".into(), "wss://write.example".into()],
+    };
+    let requested = vec![
+        TransportEndpoint("wss://both.example".into()),
+        TransportEndpoint("wss://read.example".into()),
+        TransportEndpoint("wss://write.example".into()),
+        TransportEndpoint("wss://new.example".into()),
+    ];
+
+    let next = nip65_relay_set_preserving_roles(&current, requested);
+
+    assert_eq!(
+        next.read_relays,
+        vec![
+            TransportEndpoint("wss://both.example".into()),
+            TransportEndpoint("wss://read.example".into()),
+            TransportEndpoint("wss://new.example".into()),
+        ]
+    );
+    assert_eq!(
+        next.write_relays,
+        vec![
+            TransportEndpoint("wss://both.example".into()),
+            TransportEndpoint("wss://write.example".into()),
+            TransportEndpoint("wss://new.example".into()),
         ]
     );
 }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -31,7 +31,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::time::{Duration, Instant, sleep, timeout};
-use transport_nostr_adapter::{KIND_MARMOT_KEY_PACKAGE, NostrRelayClient, NostrSdkRelayClient};
+use transport_nostr_adapter::{
+    KIND_MARMOT_KEY_PACKAGE, KIND_NIP65_RELAY_LIST, NostrRelayClient, NostrSdkRelayClient,
+};
 use transport_nostr_peeler::{NOSTR_GROUP_CONTENT_MIN_LEN, NostrTransportEvent};
 
 const AUDIT_TRACKER_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -4518,6 +4520,50 @@ async fn relay_app_public_methods_read_and_update_each_account_relay_list() {
 }
 
 #[tokio::test]
+async fn relay_app_nip65_getter_setter_round_trip_preserves_roles() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    home.create_account("alice").unwrap();
+    let (_seed, app, seed_url) = mock_app(&dir).await;
+    let read_only_url = "wss://read-only.example".to_owned();
+
+    let status = app
+        .publish_account_nip65_relay_set(
+            "alice",
+            vec![endpoint(&seed_url), endpoint(&read_only_url)],
+            vec![endpoint(&seed_url)],
+            vec![endpoint(&seed_url)],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        status.nip65.read_relays,
+        vec![seed_url.clone(), read_only_url.clone()]
+    );
+    assert_eq!(status.nip65.write_relays, vec![seed_url.clone()]);
+
+    let editable_relays = app.account_nip65_relays("alice").unwrap();
+    assert_eq!(
+        editable_relays,
+        vec![seed_url.clone(), read_only_url.clone()]
+    );
+    let status = app
+        .set_account_nip65_relays(
+            "alice",
+            editable_relays.into_iter().map(TransportEndpoint).collect(),
+            vec![endpoint(&seed_url)],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        status.nip65.read_relays,
+        vec![seed_url.clone(), read_only_url]
+    );
+    assert_eq!(status.nip65.write_relays, vec![seed_url]);
+}
+
+#[tokio::test]
 async fn relay_list_fetch_only_uses_requested_bootstrap_relays_without_cache() {
     let dir = tempfile::tempdir().unwrap();
     let home = AccountHome::open(dir.path());
@@ -4583,6 +4629,50 @@ async fn relay_list_empty_fetch_keeps_cached_lists() {
         .unwrap()
         .expect("cached directory entry");
     assert_eq!(directory_entry.relay_lists, cached);
+}
+
+#[tokio::test]
+async fn relay_list_all_read_fetch_clears_cached_write_targets() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    home.create_account("alice").unwrap();
+    let (_seed, app, seed_url) = mock_app(&dir).await;
+
+    let cached = app
+        .publish_account_relay_lists(
+            "alice",
+            AccountRelayListBootstrap::new(vec![endpoint(&seed_url)], vec![endpoint(&seed_url)]),
+        )
+        .await
+        .unwrap();
+    assert_eq!(cached.nip65.relays, vec![seed_url.clone()]);
+
+    publish_nostr_event_at(
+        &home,
+        "alice",
+        &seed_url,
+        KIND_NIP65_RELAY_LIST,
+        vec![vec![
+            "r".to_owned(),
+            "wss://read-only.example".to_owned(),
+            "read".to_owned(),
+        ]],
+        String::new(),
+        test_unix_now_seconds() + 1,
+    )
+    .await;
+
+    let account_id = home.account("alice").unwrap().account_id_hex;
+    let fetched = app
+        .fetch_account_relay_list_status_for_account_id(&account_id, vec![endpoint(&seed_url)])
+        .await
+        .unwrap();
+
+    assert!(fetched.nip65.relays.is_empty());
+    assert!(fetched.nip65.write_relays.is_empty());
+    assert_eq!(fetched.nip65.read_relays, vec!["wss://read-only.example"]);
+    assert_eq!(fetched.inbox, cached.inbox);
+    assert_eq!(fetched.missing, vec![MissingRelayListKind::Nip65]);
 }
 
 #[tokio::test]

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -77,7 +77,8 @@ pub use key_package::{
 };
 pub use relay_list::{
     KIND_MARMOT_INBOX_RELAY_LIST, KIND_NIP65_RELAY_LIST, NostrAccountRelayListKind,
-    NostrAccountRelayListPublication, NostrNip65RelaySet, parse_nip65_relay_set,
+    NostrAccountRelayListPublication, NostrNip65RelayListPublication, NostrNip65RelaySet,
+    parse_nip65_relay_set,
 };
 #[cfg(feature = "sdk")]
 pub use sdk_client::{

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -77,7 +77,7 @@ pub use key_package::{
 };
 pub use relay_list::{
     KIND_MARMOT_INBOX_RELAY_LIST, KIND_NIP65_RELAY_LIST, NostrAccountRelayListKind,
-    NostrAccountRelayListPublication,
+    NostrAccountRelayListPublication, NostrNip65RelaySet, parse_nip65_relay_set,
 };
 #[cfg(feature = "sdk")]
 pub use sdk_client::{

--- a/crates/transport-nostr-adapter/src/relay_list.rs
+++ b/crates/transport-nostr-adapter/src/relay_list.rs
@@ -7,6 +7,65 @@ pub const KIND_MARMOT_INBOX_RELAY_LIST: u64 = 10_050;
 const NIP65_RELAY_TAG: &str = "r";
 const MARMOT_RELAY_TAG: &str = "relay";
 
+/// Directional relay sets recovered from a NIP-65 kind-10002 event.
+///
+/// An unmarked `r` tag belongs to both sets. A `read`-marked tag belongs only
+/// to `read_relays`, and a `write`-marked tag belongs only to `write_relays`.
+/// Malformed tags and unknown markers are ignored. Repeated relay URLs are
+/// deduplicated independently in each direction while preserving first-seen
+/// order.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct NostrNip65RelaySet {
+    pub read_relays: Vec<TransportEndpoint>,
+    pub write_relays: Vec<TransportEndpoint>,
+}
+
+/// Parse the directional relay roles from a NIP-65 kind-10002 event.
+///
+/// This is intentionally a tolerant list parser: a hostile or future
+/// extension tag must not turn a different valid `r` entry into a relay
+/// target. Exact two-element tags are unmarked (read and write); exact
+/// three-element tags accept only the NIP-65 `read` and `write` markers.
+pub fn parse_nip65_relay_set(event: &NostrTransportEvent) -> NostrNip65RelaySet {
+    if event.kind != KIND_NIP65_RELAY_LIST {
+        return NostrNip65RelaySet::default();
+    }
+
+    let mut relays = NostrNip65RelaySet::default();
+    for tag in &event.tags {
+        let (relay, read, write) = match tag.as_slice() {
+            [name, relay] if name == NIP65_RELAY_TAG && !relay.trim().is_empty() => {
+                (relay, true, true)
+            }
+            [name, relay, marker]
+                if name == NIP65_RELAY_TAG && !relay.trim().is_empty() && marker == "read" =>
+            {
+                (relay, true, false)
+            }
+            [name, relay, marker]
+                if name == NIP65_RELAY_TAG && !relay.trim().is_empty() && marker == "write" =>
+            {
+                (relay, false, true)
+            }
+            _ => continue,
+        };
+
+        if read {
+            push_unique_endpoint(&mut relays.read_relays, relay);
+        }
+        if write {
+            push_unique_endpoint(&mut relays.write_relays, relay);
+        }
+    }
+    relays
+}
+
+fn push_unique_endpoint(endpoints: &mut Vec<TransportEndpoint>, relay: &str) {
+    if !endpoints.iter().any(|endpoint| endpoint.0 == relay) {
+        endpoints.push(TransportEndpoint(relay.to_owned()));
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NostrAccountRelayListKind {
     Nip65,
@@ -109,6 +168,63 @@ mod tests {
             event.tags[0],
             vec!["relay".to_string(), "wss://relay1.example".to_string()]
         );
+    }
+
+    #[test]
+    fn nip65_marker_matrix_is_directional_and_deduplicated() {
+        let event = NostrTransportEvent::new_unsigned(
+            "11".repeat(32),
+            KIND_NIP65_RELAY_LIST,
+            vec![
+                vec!["r".into(), "wss://both.example".into()],
+                vec!["r".into(), "wss://read.example".into(), "read".into()],
+                vec!["r".into(), "wss://write.example".into(), "write".into()],
+                vec!["r".into(), "wss://invalid.example".into(), "invalid".into()],
+                vec!["r".into(), "wss://both.example".into()],
+                vec!["r".into(), "wss://split.example".into(), "read".into()],
+                vec!["r".into(), "wss://split.example".into(), "write".into()],
+                vec![
+                    "r".into(),
+                    "wss://extra-field.example".into(),
+                    "write".into(),
+                    "extra".into(),
+                ],
+                vec!["r".into(), "".into()],
+                vec!["not-r".into(), "wss://wrong-tag.example".into()],
+            ],
+            String::new(),
+        );
+
+        let relays = parse_nip65_relay_set(&event);
+
+        assert_eq!(
+            relays.read_relays,
+            vec![
+                TransportEndpoint("wss://both.example".into()),
+                TransportEndpoint("wss://read.example".into()),
+                TransportEndpoint("wss://split.example".into()),
+            ]
+        );
+        assert_eq!(
+            relays.write_relays,
+            vec![
+                TransportEndpoint("wss://both.example".into()),
+                TransportEndpoint("wss://write.example".into()),
+                TransportEndpoint("wss://split.example".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn nip65_parser_ignores_other_event_kinds() {
+        let event = NostrTransportEvent::new_unsigned(
+            "11".repeat(32),
+            KIND_MARMOT_INBOX_RELAY_LIST,
+            vec![vec!["r".into(), "wss://relay.example".into()]],
+            String::new(),
+        );
+
+        assert_eq!(parse_nip65_relay_set(&event), NostrNip65RelaySet::default());
     }
 
     fn sample_publication(

--- a/crates/transport-nostr-adapter/src/relay_list.rs
+++ b/crates/transport-nostr-adapter/src/relay_list.rs
@@ -24,8 +24,9 @@ pub struct NostrNip65RelaySet {
 ///
 /// This is intentionally a tolerant list parser: a hostile or future
 /// extension tag must not turn a different valid `r` entry into a relay
-/// target. Exact two-element tags are unmarked (read and write); exact
-/// three-element tags accept only the NIP-65 `read` and `write` markers.
+/// target. Two-element tags are unmarked (read and write); longer tags accept
+/// only the NIP-65 `read` and `write` markers in the third position and ignore
+/// trailing extension values.
 pub fn parse_nip65_relay_set(event: &NostrTransportEvent) -> NostrNip65RelaySet {
     if event.kind != KIND_NIP65_RELAY_LIST {
         return NostrNip65RelaySet::default();
@@ -34,18 +35,19 @@ pub fn parse_nip65_relay_set(event: &NostrTransportEvent) -> NostrNip65RelaySet 
     let mut relays = NostrNip65RelaySet::default();
     for tag in &event.tags {
         let (relay, read, write) = match tag.as_slice() {
-            [name, relay] if name == NIP65_RELAY_TAG && !relay.trim().is_empty() => {
-                (relay, true, true)
-            }
-            [name, relay, marker]
-                if name == NIP65_RELAY_TAG && !relay.trim().is_empty() && marker == "read" =>
+            [name, relay, marker_and_extensions @ ..]
+                if name == NIP65_RELAY_TAG && !relay.trim().is_empty() =>
             {
-                (relay, true, false)
-            }
-            [name, relay, marker]
-                if name == NIP65_RELAY_TAG && !relay.trim().is_empty() && marker == "write" =>
-            {
-                (relay, false, true)
+                match marker_and_extensions.first().map(String::as_str) {
+                    None => (relay.trim(), true, true),
+                    Some(marker) if marker.eq_ignore_ascii_case("read") => {
+                        (relay.trim(), true, false)
+                    }
+                    Some(marker) if marker.eq_ignore_ascii_case("write") => {
+                        (relay.trim(), false, true)
+                    }
+                    Some(_) => continue,
+                }
             }
             _ => continue,
         };
@@ -61,6 +63,7 @@ pub fn parse_nip65_relay_set(event: &NostrTransportEvent) -> NostrNip65RelaySet 
 }
 
 fn push_unique_endpoint(endpoints: &mut Vec<TransportEndpoint>, relay: &str) {
+    let relay = relay.trim();
     if !endpoints.iter().any(|endpoint| endpoint.0 == relay) {
         endpoints.push(TransportEndpoint(relay.to_owned()));
     }
@@ -136,6 +139,69 @@ impl NostrAccountRelayListPublication {
     }
 }
 
+/// A role-preserving NIP-65 kind-10002 publication.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NostrNip65RelayListPublication {
+    pub account_id: MemberId,
+    pub relays: NostrNip65RelaySet,
+    pub publish_endpoints: Vec<TransportEndpoint>,
+}
+
+impl NostrNip65RelayListPublication {
+    pub fn to_event(&self) -> Result<NostrTransportEvent, TransportAdapterError> {
+        if self.account_id.as_slice().len() != 32 {
+            return Err(TransportAdapterError::Publish(
+                "account relay-list author must be a 32-byte Nostr pubkey".into(),
+            ));
+        }
+        if self.relays.read_relays.is_empty() && self.relays.write_relays.is_empty() {
+            return Err(TransportAdapterError::Publish(
+                "account relay-list relays must not be empty".into(),
+            ));
+        }
+        if self.publish_endpoints.is_empty() {
+            return Err(TransportAdapterError::Publish(
+                "account relay-list publish endpoints must not be empty".into(),
+            ));
+        }
+
+        let mut tags = Vec::new();
+        for endpoint in &self.relays.read_relays {
+            let write = self
+                .relays
+                .write_relays
+                .iter()
+                .any(|candidate| candidate == endpoint);
+            let mut tag = vec![NIP65_RELAY_TAG.into(), endpoint.0.clone()];
+            if !write {
+                tag.push("read".into());
+            }
+            tags.push(tag);
+        }
+        for endpoint in &self.relays.write_relays {
+            if self
+                .relays
+                .read_relays
+                .iter()
+                .any(|candidate| candidate == endpoint)
+            {
+                continue;
+            }
+            tags.push(vec![
+                NIP65_RELAY_TAG.into(),
+                endpoint.0.clone(),
+                "write".into(),
+            ]);
+        }
+        Ok(NostrTransportEvent::new_unsigned(
+            hex::encode(self.account_id.as_slice()),
+            KIND_NIP65_RELAY_LIST,
+            tags,
+            String::new(),
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -189,6 +255,9 @@ mod tests {
                     "write".into(),
                     "extra".into(),
                 ],
+                vec!["r".into(), "wss://uppercase.example".into(), "READ".into()],
+                vec!["r".into(), " wss://trimmed.example ".into()],
+                vec!["r".into(), "wss://trimmed.example".into()],
                 vec!["r".into(), "".into()],
                 vec!["not-r".into(), "wss://wrong-tag.example".into()],
             ],
@@ -203,6 +272,8 @@ mod tests {
                 TransportEndpoint("wss://both.example".into()),
                 TransportEndpoint("wss://read.example".into()),
                 TransportEndpoint("wss://split.example".into()),
+                TransportEndpoint("wss://uppercase.example".into()),
+                TransportEndpoint("wss://trimmed.example".into()),
             ]
         );
         assert_eq!(
@@ -211,6 +282,8 @@ mod tests {
                 TransportEndpoint("wss://both.example".into()),
                 TransportEndpoint("wss://write.example".into()),
                 TransportEndpoint("wss://split.example".into()),
+                TransportEndpoint("wss://extra-field.example".into()),
+                TransportEndpoint("wss://trimmed.example".into()),
             ]
         );
     }
@@ -225,6 +298,36 @@ mod tests {
         );
 
         assert_eq!(parse_nip65_relay_set(&event), NostrNip65RelaySet::default());
+    }
+
+    #[test]
+    fn nip65_publication_preserves_directional_roles() {
+        let publication = NostrNip65RelayListPublication {
+            account_id: MemberId::new(vec![0xA1; 32]),
+            relays: NostrNip65RelaySet {
+                read_relays: vec![
+                    TransportEndpoint("wss://both.example".into()),
+                    TransportEndpoint("wss://read.example".into()),
+                ],
+                write_relays: vec![
+                    TransportEndpoint("wss://both.example".into()),
+                    TransportEndpoint("wss://write.example".into()),
+                ],
+            },
+            publish_endpoints: vec![TransportEndpoint("wss://seed.example".into())],
+        };
+
+        let event = publication.to_event().unwrap();
+
+        assert_eq!(
+            event.tags,
+            vec![
+                vec!["r", "wss://both.example"],
+                vec!["r", "wss://read.example", "read"],
+                vec!["r", "wss://write.example", "write"],
+            ]
+        );
+        assert_eq!(parse_nip65_relay_set(&event), publication.relays);
     }
 
     fn sample_publication(


### PR DESCRIPTION
Part of #1057.

This separates NIP-65 marker semantics from the larger durable prior-route change:

- parses kind 10002 relay tags into distinct read- and write-capable sets
- treats unmarked entries as both read and write
- ignores malformed and unknown-marker entries
- merges duplicate relay roles deterministically
- uses only the write-capable set for Marmot KeyPackage fetch and publication routing

The existing account relay-list publication API emits unmarked entries, which remain valid for both directions.

Validation:
- cargo test -p transport-nostr-adapter
- cargo test -p marmot-app
- just fast-ci