### PR TITLE
fix: validate kind-445 ingress tag shape

### DIFF
--- a/crates/marmot-app/src/relay_plane/tests.rs
+++ b/crates/marmot-app/src/relay_plane/tests.rs
@@ -951,20 +951,22 @@ async fn directory_live_event_rejected_after_subscription_removed() {
 }
 
 fn group_event(id_prefix: &str, transport_group_id: &[u8]) -> NostrTransportEvent {
-    // `to_transport_message` verifies the id against the event hash (#351), so
-    // the distinguishing prefix lives in the content and the id is computed
-    // from it — distinct `id_prefix` values still yield distinct event ids.
-    let mut event = NostrTransportEvent {
-        id: String::new(),
-        pubkey: "22".repeat(32),
-        created_at: 1_700_000_000,
-        kind: KIND_MARMOT_GROUP_MESSAGE,
-        tags: vec![vec!["h".into(), hex::encode(transport_group_id)]],
-        content: format!("encrypted {id_prefix}"),
-        sig: None,
-    };
-    event.id = event.computed_id();
-    event
+    // Stable runtime fixtures preserve duplicate-event ids while carrying the
+    // valid kind-445 signature required by the routing boundary.
+    static KEYS: std::sync::OnceLock<nostr::Keys> = std::sync::OnceLock::new();
+    let keys = KEYS.get_or_init(nostr::Keys::generate);
+    let signed = nostr::EventBuilder::new(
+        nostr::Kind::Custom(KIND_MARMOT_GROUP_MESSAGE as u16),
+        format!("encrypted {id_prefix}"),
+    )
+    .tags([nostr::Tag::custom(
+        nostr::TagKind::custom("h"),
+        [hex::encode(transport_group_id)],
+    )])
+    .custom_created_at(nostr::Timestamp::from_secs(1_700_000_000))
+    .sign_with_keys(keys)
+    .expect("sign kind-445 fixture");
+    NostrTransportEvent::from_nostr_event(&signed).expect("map signed kind-445 fixture")
 }
 
 #[test]

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -148,19 +148,19 @@ fn assert_profile_word_list(name: &str, words: &[&str]) {
     }
 }
 
-fn relay_delivery(marker: &str, pubkey: String) -> cgka_traits::TransportDelivery {
-    // `to_transport_message` verifies the id against the event hash (#351), so
-    // the distinguishing marker lives in the content and the id is computed.
-    let mut event = NostrTransportEvent {
-        id: String::new(),
-        pubkey,
-        created_at: 1,
-        kind: transport_nostr_peeler::KIND_MARMOT_GROUP_MESSAGE,
-        tags: vec![vec!["h".to_owned(), "aa".repeat(32)]],
-        content: format!("ciphertext {marker}"),
-        sig: None,
-    };
-    event.id = event.computed_id();
+fn relay_delivery(marker: &str, keys: &nostr::Keys) -> cgka_traits::TransportDelivery {
+    let signed = nostr::EventBuilder::new(
+        nostr::Kind::Custom(transport_nostr_peeler::KIND_MARMOT_GROUP_MESSAGE as u16),
+        format!("ciphertext {marker}"),
+    )
+    .tags([nostr::Tag::custom(
+        nostr::TagKind::custom("h"),
+        ["aa".repeat(32)],
+    )])
+    .custom_created_at(nostr::Timestamp::from_secs(1))
+    .sign_with_keys(keys)
+    .expect("sign kind-445 fixture");
+    let event = NostrTransportEvent::from_nostr_event(&signed).expect("map signed fixture");
     cgka_traits::TransportDelivery {
         account_id: MemberId::new(vec![0; 32]),
         group_id_hint: None,
@@ -1477,9 +1477,10 @@ fn ingest_applies_owner_signed_transitive_448_and_drops_spoof() {
 
 #[test]
 fn own_relay_echo_requires_known_event_id_not_just_pubkey() {
-    let local_pubkey = "11".repeat(32);
+    let local_keys = nostr::Keys::generate();
+    let local_pubkey = local_keys.public_key().to_hex();
 
-    let known_local_delivery = relay_delivery("known", local_pubkey.clone());
+    let known_local_delivery = relay_delivery("known", &local_keys);
     let known_event_ids = HashSet::from([hex::encode(known_local_delivery.message.id.as_slice())]);
     assert!(client::is_own_relay_echo(
         &known_local_delivery,
@@ -1487,7 +1488,7 @@ fn own_relay_echo_requires_known_event_id_not_just_pubkey() {
         &known_event_ids
     ));
 
-    let same_pubkey_new_event = relay_delivery("new-cross-device", local_pubkey.clone());
+    let same_pubkey_new_event = relay_delivery("new-cross-device", &local_keys);
     assert!(!client::is_own_relay_echo(
         &same_pubkey_new_event,
         &local_pubkey,
@@ -1498,7 +1499,8 @@ fn own_relay_echo_requires_known_event_id_not_just_pubkey() {
     // out of the transport boundary (the id is verified against the event
     // hash, #351); forge one directly to prove the echo check independently
     // requires the local pubkey.
-    let mut known_other_pubkey_delivery = relay_delivery("known", "44".repeat(32));
+    let other_keys = nostr::Keys::generate();
+    let mut known_other_pubkey_delivery = relay_delivery("known", &other_keys);
     known_other_pubkey_delivery.message.id = known_local_delivery.message.id.clone();
     assert!(!client::is_own_relay_echo(
         &known_other_pubkey_delivery,

--- a/crates/marmot-app/tests/malformed_445_drain.rs
+++ b/crates/marmot-app/tests/malformed_445_drain.rs
@@ -1,11 +1,11 @@
 //! Acceptance test for hostile-input resilience of the transport drain.
 //!
 //! Anyone can publish a kind-445 event to a group's cleartext routing tag
-//! without being a member, so structurally-invalid content — too short to
-//! carry the spec's `base64(nonce || ciphertext)` envelope — is ordinary
-//! hostile wire input, not an exceptional condition. It must classify as
-//! stale inside the engine and never surface as a sync failure: a peel error
-//! that propagates as `Err` aborts the whole catch-up drain, loses the sync
+//! without being a member, so an event carrying tags outside the exact
+//! `h`/optional-`expiration` shape is ordinary hostile wire input, not an
+//! exceptional condition. It must be rejected before engine delivery and
+//! never surface as a sync failure: an ingest error that aborts the whole
+//! catch-up drain loses the sync
 //! summary (and with it every `MessageReceived` event the drain had
 //! produced), skips the app-state save, and — because the garbage event
 //! remains unremembered — re-aborts every subsequent catch-up the relay
@@ -29,7 +29,7 @@ use nostr_sdk::prelude::{
     Timestamp as NostrTimestamp,
 };
 use transport_nostr_adapter::{NostrRelayClient, NostrSdkRelayClient};
-use transport_nostr_peeler::{NOSTR_GROUP_CONTENT_MIN_LEN, NostrTransportEvent};
+use transport_nostr_peeler::{NOSTR_GROUP_CONTENT_MIN_LEN, NostrPeelerError, NostrTransportEvent};
 
 async fn mock_relay() -> (MockRelay, String) {
     let relay = MockRelay::run().await.unwrap();
@@ -70,12 +70,9 @@ async fn wait_for_event<F>(
     .expect("runtime event")
 }
 
-/// Publish a kind-445 whose content is structurally too short to be a
-/// `base64(nonce || ciphertext)` envelope, with a fresh ephemeral (non-member)
-/// signing key — the peeler classifies it `Malformed` before any decryption
-/// attempt. Contrast `since_floor.rs`'s probe helper, which deliberately
-/// builds an envelope-*shaped* payload so it classifies `DecryptFailed`
-/// instead; this helper pins the other, structurally-invalid classification.
+/// Publish a signed kind-445 carrying a forbidden extra tag. The direct mapping
+/// assertion and the cold relay catch-up exercise the same fixture at both
+/// ingress seams; neither may deliver it to engine state.
 async fn publish_malformed_group_message_at(
     relay_url: &str,
     nostr_group_id_hex: &str,
@@ -85,15 +82,22 @@ async fn publish_malformed_group_message_at(
     assert!(short.len() < NOSTR_GROUP_CONTENT_MIN_LEN);
     let ephemeral = Keys::generate();
     let signed = EventBuilder::new(Kind::MlsGroupMessage, BASE64_STANDARD.encode(short))
-        .tags([Tag::custom(
-            TagKind::SingleLetter(SingleLetterTag::lowercase(Alphabet::H)),
-            [nostr_group_id_hex.to_owned()],
-        )])
+        .tags([
+            Tag::custom(
+                TagKind::SingleLetter(SingleLetterTag::lowercase(Alphabet::H)),
+                [nostr_group_id_hex.to_owned()],
+            ),
+            Tag::custom(TagKind::custom("encoding"), ["base64"]),
+        ])
         .custom_created_at(NostrTimestamp::from_secs(created_at))
         .sign_with_keys(&ephemeral)
         .expect("sign ephemeral kind-445 test event");
     let transport_event =
         NostrTransportEvent::from_nostr_event(&signed).expect("dto from signed event");
+    assert!(matches!(
+        transport_event.to_transport_message(),
+        Err(NostrPeelerError::Malformed(_))
+    ));
     let relay_client = NostrSdkRelayClient::new(NostrSdkClient::builder().build());
     relay_client
         .publish_event(
@@ -197,7 +201,7 @@ async fn malformed_group_message_does_not_starve_messages_behind_it() {
     assert_eq!(
         account_sync_failures(&runtime_bob_boot2),
         0,
-        "hostile wire input must classify as stale inside the engine, never \
+        "hostile wire input must be rejected before engine delivery, never \
          surface as a sync failure",
     );
     runtime_bob_boot2.shutdown().await;

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -14,7 +14,7 @@ use transport_nostr_adapter::{
     NostrPublishOutcome, NostrRelayClient, NostrRelayEvent, NostrSubscription,
     NostrTransportAdapter, RelayExportConsent, RelayIndex,
 };
-use transport_nostr_peeler::{KIND_MARMOT_GROUP_MESSAGE, NostrTransportEvent};
+use transport_nostr_peeler::{KIND_MARMOT_GROUP_MESSAGE, NostrPeelerError, NostrTransportEvent};
 
 const DEFAULT_CONCURRENT_SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -1862,19 +1862,92 @@ async fn sync_telemetry_tracks_only_live_subscriptions_across_churn() {
     assert_eq!(adapter.relay_sync().await.tracked_subscriptions, 0);
 }
 
+#[tokio::test]
+async fn tampered_kind_445_signature_fails_before_adapter_delivery() {
+    let adapter = NostrTransportAdapter::new(Arc::new(FakeRelayClient::default()));
+    let signed = nostr::EventBuilder::new(
+        nostr::Kind::Custom(KIND_MARMOT_GROUP_MESSAGE as u16),
+        "outer encrypted body",
+    )
+    .tags([nostr::Tag::custom(
+        nostr::TagKind::custom("h"),
+        [hex::encode([0x99; 32])],
+    )])
+    .sign_with_keys(&nostr::Keys::generate())
+    .expect("sign kind-445 fixture");
+    let mut event = NostrTransportEvent::from_nostr_event(&signed).unwrap();
+    event.sig = Some("00".repeat(64));
+
+    assert!(matches!(
+        event.to_transport_message(),
+        Err(NostrPeelerError::Malformed(_))
+    ));
+
+    let err = adapter
+        .handle_relay_event(NostrRelayEvent {
+            event,
+            endpoint: TransportEndpoint("wss://relay.example".into()),
+            subscription_id: Some("sub".into()),
+        })
+        .await
+        .expect_err("unauthenticated kind-445 must fail before delivery");
+
+    assert!(matches!(
+        err,
+        cgka_traits::TransportAdapterError::Backend(_)
+    ));
+}
+
+#[tokio::test]
+async fn direct_and_adapter_ingress_reject_extra_kind_445_tag_as_malformed() {
+    let adapter = NostrTransportAdapter::new(Arc::new(FakeRelayClient::default()));
+    let signed = nostr::EventBuilder::new(
+        nostr::Kind::Custom(KIND_MARMOT_GROUP_MESSAGE as u16),
+        "outer encrypted body extra-tag",
+    )
+    .tags([
+        nostr::Tag::custom(nostr::TagKind::custom("h"), [hex::encode([0x99; 32])]),
+        nostr::Tag::custom(nostr::TagKind::custom("encoding"), ["base64"]),
+    ])
+    .sign_with_keys(&nostr::Keys::generate())
+    .expect("sign malformed kind-445 fixture");
+    let event = NostrTransportEvent::from_nostr_event(&signed).unwrap();
+
+    assert!(matches!(
+        event.to_transport_message(),
+        Err(NostrPeelerError::Malformed(_))
+    ));
+
+    let err = adapter
+        .handle_relay_event(NostrRelayEvent {
+            event,
+            endpoint: TransportEndpoint("wss://relay.example".into()),
+            subscription_id: Some("sub".into()),
+        })
+        .await
+        .expect_err("extra kind-445 tags must fail closed at mapping");
+
+    assert!(matches!(
+        err,
+        cgka_traits::TransportAdapterError::Backend(_)
+    ));
+}
+
 fn group_event(id_byte: &str, transport_group_id: &[u8]) -> NostrTransportEvent {
-    // `to_transport_message` verifies the id against the event hash (#351), so
-    // the distinguishing byte lives in the content and the id is computed from
-    // it — distinct `id_byte` values still yield distinct event ids.
-    let mut event = NostrTransportEvent {
-        id: String::new(),
-        pubkey: "22".repeat(32),
-        created_at: 1_700_000_010,
-        kind: KIND_MARMOT_GROUP_MESSAGE,
-        tags: vec![vec!["h".into(), hex::encode(transport_group_id)]],
-        content: format!("outer encrypted body {id_byte}"),
-        sig: None,
-    };
-    event.id = event.computed_id();
-    event
+    // Stable fixtures preserve duplicate-event ids while carrying a valid
+    // kind-445 signature required by the authenticated routing boundary.
+    static KEYS: std::sync::OnceLock<nostr::Keys> = std::sync::OnceLock::new();
+    let keys = KEYS.get_or_init(nostr::Keys::generate);
+    let signed = nostr::EventBuilder::new(
+        nostr::Kind::Custom(KIND_MARMOT_GROUP_MESSAGE as u16),
+        format!("outer encrypted body {id_byte}"),
+    )
+    .tags([nostr::Tag::custom(
+        nostr::TagKind::custom("h"),
+        [hex::encode(transport_group_id)],
+    )])
+    .custom_created_at(nostr::Timestamp::from_secs(1_700_000_010))
+    .sign_with_keys(keys)
+    .expect("sign kind-445 fixture");
+    NostrTransportEvent::from_nostr_event(&signed).expect("map signed kind-445 fixture")
 }

--- a/crates/transport-nostr-peeler/AGENTS.md
+++ b/crates/transport-nostr-peeler/AGENTS.md
@@ -40,7 +40,8 @@ skips content validation is a contract violation, not a style choice.
 - **No self-reported identifier is trusted before verification.** `to_transport_message` verifies the event `id`
   against the recomputed NIP-01 event hash before it becomes `TransportMessage.id` (which keys routing metrics,
   telemetry, and the forensic `wire_id`); a mismatch fails closed on every ingest path, including telemetry-only
-  observation. Signature verification still happens at peel time.
+  observation. For kind 445 it also verifies the signature before reading routing tags, then the peeler repeats
+  signature and routing-shape verification as defense in depth. Gift-wrap signature verification remains at peel time.
 - **Loose first-match helpers (`tag_value`, `tag_values`) are for non-routing, genuinely multi-valued fields only**,
   and any such field must carry explicit count/length bounds. Do not reach for them when wiring up a new tag.
 

--- a/crates/transport-nostr-peeler/src/event.rs
+++ b/crates/transport-nostr-peeler/src/event.rs
@@ -1,6 +1,6 @@
 use crate::{
-    GROUP_TAG, KIND_MARMOT_GROUP_MESSAGE, KIND_NIP59_GIFT_WRAP, NOSTR_SOURCE, NostrPeelerError,
-    RECIPIENT_TAG,
+    EXPIRATION_TAG, GROUP_TAG, KIND_MARMOT_GROUP_MESSAGE, KIND_NIP59_GIFT_WRAP, NOSTR_SOURCE,
+    NostrPeelerError, RECIPIENT_TAG,
 };
 use cgka_traits::transport::{Timestamp, TransportEnvelope, TransportMessage, TransportSource};
 use cgka_traits::types::{MemberId, MessageId};
@@ -32,8 +32,10 @@ impl NostrTransportEvent {
     pub fn to_transport_message(&self) -> Result<TransportMessage, NostrPeelerError> {
         // #709/#351 — the resulting `TransportMessage.id` keys routing metrics,
         // telemetry, and the forensic `wire_id`, so bind it to the event hash
-        // here rather than trusting the self-reported id. Signature
-        // verification still happens at peel time.
+        // here rather than trusting the self-reported id. Kind-445 signature
+        // verification happens before reading its routing tags and is repeated
+        // by the peeler as defense in depth; gift-wrap verification stays at the
+        // welcome peel boundary.
         if !self.id.eq_ignore_ascii_case(&self.computed_id()) {
             return Err(NostrPeelerError::Malformed(
                 "event id does not match event hash".into(),
@@ -42,12 +44,16 @@ impl NostrTransportEvent {
         let id = MessageId::new(decode_hex_exact("event id", &self.id, 32)?);
         let envelope = match self.kind {
             KIND_MARMOT_GROUP_MESSAGE => {
-                let group_id = self.single_tag_value(GROUP_TAG)?;
+                // Kind-445 routing is attacker-visible and drives account/group
+                // delivery. Authenticate the complete outer event before reading
+                // its tags so unauthenticated input never reaches engine state.
+                self.to_verified_nostr_event()?;
+                let group_id = validate_kind_445_tag_shape(self)?;
                 TransportEnvelope::GroupMessage {
                     // The `h` tag is the hex of the 32-byte nostr_group_id
                     // (spec/transports/nostr.md); shorter/longer route ids are
                     // rejected, not passed through.
-                    transport_group_id: decode_hex_exact("group h tag", group_id, 32)?,
+                    transport_group_id: decode_lowercase_hex_exact("group h tag", group_id, 32)?,
                 }
             }
             KIND_NIP59_GIFT_WRAP => {
@@ -240,22 +246,218 @@ pub(crate) fn decode_hex_exact(
     Ok(bytes)
 }
 
+pub(crate) fn decode_lowercase_hex_exact(
+    label: &str,
+    value: &str,
+    expected_len: usize,
+) -> Result<Vec<u8>, NostrPeelerError> {
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_digit() || matches!(ch, 'a'..='f'))
+    {
+        return Err(NostrPeelerError::Malformed(format!(
+            "{label} must be lowercase hex"
+        )));
+    }
+    decode_hex_exact(label, value, expected_len)
+}
+
+fn validate_expiration_tag_value(value: &str) -> Result<(), NostrPeelerError> {
+    if value.is_empty() || !value.chars().all(|ch| ch.is_ascii_digit()) {
+        return Err(NostrPeelerError::Malformed(
+            "kind-445 expiration tag must be a unix timestamp decimal string".into(),
+        ));
+    }
+    value.parse::<u64>().map_err(|_| {
+        NostrPeelerError::Malformed(
+            "kind-445 expiration tag must be a unix timestamp decimal string".into(),
+        )
+    })?;
+    Ok(())
+}
+
+/// Enforce the exact kind-445 outer tag shape from `spec/transports/nostr.md`.
+///
+/// Exactly one `h` tag and at most one `expiration` tag are permitted; tag order
+/// is not specified. Returns the validated `h` tag value.
+pub(crate) fn validate_kind_445_tag_shape(
+    event: &NostrTransportEvent,
+) -> Result<&str, NostrPeelerError> {
+    let mut h_value: Option<&str> = None;
+    let mut expiration_seen = false;
+
+    for tag in &event.tags {
+        let name = tag
+            .first()
+            .map(String::as_str)
+            .ok_or_else(|| NostrPeelerError::Malformed("kind-445 tag has no name".into()))?;
+        match name {
+            GROUP_TAG => {
+                if tag.len() != 2 {
+                    return Err(NostrPeelerError::Malformed(
+                        "kind-445 h tag must have exactly one value".into(),
+                    ));
+                }
+                if h_value.is_some() {
+                    return Err(NostrPeelerError::Malformed(
+                        "Nostr event must contain exactly one h tag".into(),
+                    ));
+                }
+                h_value = Some(tag[1].as_str());
+            }
+            EXPIRATION_TAG => {
+                if tag.len() != 2 {
+                    return Err(NostrPeelerError::Malformed(
+                        "kind-445 expiration tag must have exactly one value".into(),
+                    ));
+                }
+                if expiration_seen {
+                    return Err(NostrPeelerError::Malformed(
+                        "Nostr event must contain at most one expiration tag".into(),
+                    ));
+                }
+                expiration_seen = true;
+                validate_expiration_tag_value(tag[1].as_str())?;
+            }
+            _ => {
+                return Err(NostrPeelerError::Malformed(
+                    "kind-445 event has an unsupported tag".into(),
+                ));
+            }
+        }
+    }
+
+    h_value.ok_or_else(|| NostrPeelerError::MissingTag(GROUP_TAG.into()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn signed_kind_445_event(tags: Vec<Vec<String>>, content: &str) -> NostrTransportEvent {
+        let tags = tags.into_iter().map(|tag| {
+            let mut fields = tag.into_iter();
+            let name = fields.next().expect("test tag has a name");
+            nostr::Tag::custom(nostr::TagKind::custom(name), fields)
+        });
+        let signed = nostr::EventBuilder::new(
+            nostr::Kind::Custom(KIND_MARMOT_GROUP_MESSAGE as u16),
+            content,
+        )
+        .tags(tags)
+        .sign_with_keys(&nostr::Keys::generate())
+        .expect("sign kind-445 test event");
+        NostrTransportEvent::from_nostr_event(&signed).expect("map signed test event")
+    }
+
+    #[test]
+    fn kind_445_tag_shape_table() {
+        let valid_h = "aa".repeat(32);
+        let cases: Vec<(&str, Vec<Vec<String>>, bool)> = vec![
+            ("missing h", vec![], false),
+            (
+                "duplicate h",
+                vec![
+                    vec!["h".into(), valid_h.clone()],
+                    vec!["h".into(), valid_h.clone()],
+                ],
+                false,
+            ),
+            (
+                "extra unknown tag",
+                vec![
+                    vec!["h".into(), valid_h.clone()],
+                    vec!["encoding".into(), "base64".into()],
+                ],
+                false,
+            ),
+            (
+                "h wrong arity (extra value)",
+                vec![vec!["h".into(), valid_h.clone(), "extra".into()]],
+                false,
+            ),
+            ("h valueless", vec![vec!["h".into()]], false),
+            (
+                "h uppercase hex",
+                vec![vec!["h".into(), "AA".repeat(32)]],
+                false,
+            ),
+            (
+                "h wrong length (raw MLS group id sized)",
+                vec![vec!["h".into(), "aa".repeat(16)]],
+                false,
+            ),
+            (
+                "expiration duplicate",
+                vec![
+                    vec!["h".into(), valid_h.clone()],
+                    vec!["expiration".into(), "1700000060".into()],
+                    vec!["expiration".into(), "1700000070".into()],
+                ],
+                false,
+            ),
+            (
+                "expiration wrong arity",
+                vec![vec!["h".into(), valid_h.clone()], vec!["expiration".into()]],
+                false,
+            ),
+            (
+                "expiration malformed timestamp",
+                vec![
+                    vec!["h".into(), valid_h.clone()],
+                    vec!["expiration".into(), "not-a-timestamp".into()],
+                ],
+                false,
+            ),
+            (
+                "valid h only",
+                vec![vec!["h".into(), valid_h.clone()]],
+                true,
+            ),
+            (
+                "valid expiration then h",
+                vec![
+                    vec!["expiration".into(), "1700000060".into()],
+                    vec!["h".into(), valid_h.clone()],
+                ],
+                true,
+            ),
+            (
+                "valid h then expiration",
+                vec![
+                    vec!["h".into(), valid_h.clone()],
+                    vec!["expiration".into(), "1700000060".into()],
+                ],
+                true,
+            ),
+        ];
+
+        for (name, tags, should_accept) in cases {
+            let event = signed_kind_445_event(tags, "encrypted body");
+            let result = event.to_transport_message();
+            assert_eq!(
+                result.is_ok(),
+                should_accept,
+                "case {name}: expected accept={should_accept}, got {result:?}"
+            );
+            if should_accept {
+                assert!(matches!(
+                    result.unwrap().envelope,
+                    TransportEnvelope::GroupMessage { .. }
+                ));
+            } else {
+                assert!(matches!(
+                    result,
+                    Err(NostrPeelerError::Malformed(_) | NostrPeelerError::MissingTag(_))
+                ));
+            }
+        }
+    }
+
     #[test]
     fn kind_445_event_maps_to_group_transport_message() {
-        let mut event = NostrTransportEvent {
-            id: String::new(),
-            pubkey: "22".repeat(32),
-            created_at: 1_700_000_000,
-            kind: KIND_MARMOT_GROUP_MESSAGE,
-            tags: vec![vec!["h".into(), "aa".repeat(32)]],
-            content: "encrypted body".into(),
-            sig: None,
-        };
-        event.id = event.computed_id();
+        let event =
+            signed_kind_445_event(vec![vec!["h".into(), "aa".repeat(32)]], "encrypted body");
 
         let msg = event.to_transport_message().expect("event maps");
 
@@ -263,7 +465,7 @@ mod tests {
             msg.id.as_slice(),
             hex::decode(&event.id).unwrap().as_slice()
         );
-        assert_eq!(msg.timestamp.0, 1_700_000_000);
+        assert_eq!(msg.timestamp.0, event.created_at);
         assert_eq!(msg.source.0, NOSTR_SOURCE);
         // The peeler does not extract `e` causal-dependency tags (kind 445 carries
         // none per transports/nostr.md).
@@ -384,16 +586,7 @@ mod tests {
         // The `h` tag is the hex of the 32-byte nostr_group_id
         // (spec/transports/nostr.md); a short route id must be rejected at the
         // boundary, not passed through into the transport envelope.
-        let mut event = NostrTransportEvent {
-            id: String::new(),
-            pubkey: "22".repeat(32),
-            created_at: 1_700_000_000,
-            kind: KIND_MARMOT_GROUP_MESSAGE,
-            tags: vec![vec!["h".into(), "aa55".into()]],
-            content: "encrypted body".into(),
-            sig: None,
-        };
-        event.id = event.computed_id();
+        let event = signed_kind_445_event(vec![vec!["h".into(), "aa55".into()]], "encrypted body");
 
         assert!(matches!(
             event.to_transport_message(),
@@ -421,16 +614,10 @@ mod tests {
             Err(NostrPeelerError::Malformed(_))
         ));
 
-        let mut group = NostrTransportEvent {
-            id: String::new(),
-            pubkey: "22".repeat(32),
-            created_at: 1_700_000_000,
-            kind: KIND_MARMOT_GROUP_MESSAGE,
-            tags: vec![vec!["h".into()], vec!["h".into(), "aa".repeat(32)]],
-            content: "encrypted body".into(),
-            sig: None,
-        };
-        group.id = group.computed_id();
+        let group = signed_kind_445_event(
+            vec![vec!["h".into()], vec!["h".into(), "aa".repeat(32)]],
+            "encrypted body",
+        );
         assert!(matches!(
             group.to_transport_message(),
             Err(NostrPeelerError::Malformed(_))

--- a/crates/transport-nostr-peeler/src/lib.rs
+++ b/crates/transport-nostr-peeler/src/lib.rs
@@ -44,4 +44,5 @@ pub const NOSTR_GROUP_KEY_LEN: usize = 32;
 pub const NOSTR_GROUP_CONTENT_MIN_LEN: usize = 12 + 16;
 
 pub(crate) const GROUP_TAG: &str = "h";
+pub(crate) const EXPIRATION_TAG: &str = "expiration";
 pub(crate) const RECIPIENT_TAG: &str = "p";

--- a/crates/transport-nostr-peeler/src/peeler.rs
+++ b/crates/transport-nostr-peeler/src/peeler.rs
@@ -1,9 +1,9 @@
 use crate::error::to_peeler_error;
-use crate::event::decode_hex_exact;
+use crate::event::{decode_hex_exact, decode_lowercase_hex_exact, validate_kind_445_tag_shape};
 use crate::{
-    DEFAULT_EXPORTER_LABEL, GROUP_TAG, KIND_MARMOT_GROUP_MESSAGE, KIND_MARMOT_WELCOME_RUMOR,
-    KIND_NIP59_GIFT_WRAP, NOSTR_GROUP_CONTENT_MIN_LEN, NOSTR_GROUP_KEY_LEN, NostrTransportEvent,
-    RECIPIENT_TAG,
+    DEFAULT_EXPORTER_LABEL, EXPIRATION_TAG, GROUP_TAG, KIND_MARMOT_GROUP_MESSAGE,
+    KIND_MARMOT_WELCOME_RUMOR, KIND_NIP59_GIFT_WRAP, NOSTR_GROUP_CONTENT_MIN_LEN,
+    NOSTR_GROUP_KEY_LEN, NostrTransportEvent, RECIPIENT_TAG,
 };
 use async_trait::async_trait;
 use cgka_traits::engine::WelcomeMetadata;
@@ -24,7 +24,6 @@ use std::sync::Arc;
 const NONCE_LEN: usize = 12;
 const WELCOME_SIGNER_CONTEXT: &str = "nostr_welcome_signer";
 const KEY_PACKAGE_EVENT_TAG: &str = "e";
-const EXPIRATION_TAG: &str = "expiration";
 const WELCOME_RELAYS_TAG: &str = "relays";
 /// Bound on the welcome rumor `relays` tag value count (#392). Parity with
 /// `MAX_RELAY_ENDPOINTS_PER_ROUTE` in `marmot-app`'s relay safety policy.
@@ -202,6 +201,11 @@ impl TransportPeeler for NostrMlsPeeler {
                 "expected kind {KIND_MARMOT_GROUP_MESSAGE}, got {}",
                 event.kind
             )));
+        }
+        if !event.id.eq_ignore_ascii_case(&event.computed_id()) {
+            return Err(PeelerError::Malformed(
+                "event id does not match event hash".into(),
+            ));
         }
         event.to_verified_nostr_event().map_err(to_peeler_error)?;
         ensure_group_routing_matches(&event, msg)?;
@@ -461,10 +465,9 @@ fn ensure_group_routing_matches(
     event: &NostrTransportEvent,
     msg: &TransportMessage,
 ) -> Result<(), PeelerError> {
-    let event_group_id = event
-        .single_tag_value(GROUP_TAG)
-        .map_err(to_peeler_error)
-        .and_then(|h| decode_hex_exact("group h tag", h, 32).map_err(to_peeler_error))?;
+    let h = validate_kind_445_tag_shape(event).map_err(to_peeler_error)?;
+    let event_group_id =
+        decode_lowercase_hex_exact("group h tag", h, 32).map_err(to_peeler_error)?;
     match &msg.envelope {
         TransportEnvelope::GroupMessage { transport_group_id }
             if *transport_group_id == event_group_id =>
@@ -515,7 +518,7 @@ fn map_nip59_error(err: nostr::nips::nip59::Error) -> PeelerError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DEFAULT_EXPORTER_LABEL, KIND_MARMOT_GROUP_MESSAGE};
+    use crate::{DEFAULT_EXPORTER_LABEL, KIND_MARMOT_GROUP_MESSAGE, NostrPeelerError};
     use cgka_traits::TransportEndpoint;
     use cgka_traits::group_context::GroupContextSnapshot;
     use cgka_traits::ingest::PeeledContent;
@@ -580,6 +583,185 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn group_peel_accepts_event_before_and_after_expiration_timestamp() {
+        let secret = vec![0x7a; NOSTR_GROUP_KEY_LEN];
+        let group_id = vec![0x99; 32];
+        let ctx = GroupContextSnapshot::new(
+            EpochId(9),
+            HashMap::from([(DEFAULT_EXPORTER_LABEL.to_string(), secret)]),
+            Some(group_id.clone()),
+        );
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock is after unix epoch")
+            .as_secs();
+
+        // Expiration is relay metadata only. Neither side of the local wall
+        // clock boundary may change event validity.
+        for (label, created_at, retention_seconds) in [
+            ("after expiration", now.saturating_sub(120), 60),
+            ("before expiration", now.saturating_add(60), 60),
+        ] {
+            let wrapped = NostrMlsPeeler::default()
+                .wrap_group_message_with_metadata(
+                    &EncryptedPayload {
+                        ciphertext: b"inner mls bytes".to_vec(),
+                        aad: vec![],
+                    },
+                    &ctx,
+                    &GroupMessageMetadata::application(created_at, Some(retention_seconds)),
+                )
+                .await
+                .unwrap_or_else(|err| panic!("{label}: wrap failed: {err}"));
+            let event =
+                NostrTransportEvent::from_transport_message(&wrapped).expect("payload parses");
+            assert!(event.tag_value(EXPIRATION_TAG).is_some(), "{label}");
+
+            let peeled = NostrMlsPeeler::default()
+                .peel_group_message(&wrapped, &ctx)
+                .await
+                .unwrap_or_else(|err| panic!("{label}: peel failed: {err}"));
+
+            assert_eq!(
+                peeled.content,
+                PeeledContent::MlsMessage {
+                    bytes: b"inner mls bytes".to_vec(),
+                },
+                "{label}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn kind_445_direct_and_peel_seams_reject_extra_tag_identically() {
+        let secret = vec![0x7a; NOSTR_GROUP_KEY_LEN];
+        let group_id = vec![0x99; 32];
+        let ctx = GroupContextSnapshot::new(
+            EpochId(9),
+            HashMap::from([(DEFAULT_EXPORTER_LABEL.to_string(), secret)]),
+            Some(group_id.clone()),
+        );
+        let wrapped = NostrMlsPeeler::default()
+            .wrap_group_message(
+                &EncryptedPayload {
+                    ciphertext: b"inner mls bytes".to_vec(),
+                    aad: vec![],
+                },
+                &ctx,
+            )
+            .await
+            .expect("wrap succeeds");
+        let valid = NostrTransportEvent::from_transport_message(&wrapped).unwrap();
+        let signed = EventBuilder::new(
+            Kind::Custom(KIND_MARMOT_GROUP_MESSAGE as u16),
+            valid.content.as_str(),
+        )
+        .tags([
+            Tag::custom(nostr::TagKind::custom(GROUP_TAG), [hex::encode(&group_id)]),
+            Tag::custom(nostr::TagKind::custom("encoding"), ["base64"]),
+        ])
+        .sign_with_keys(&Keys::generate())
+        .expect("sign malformed kind-445");
+        let event = NostrTransportEvent::from_nostr_event(&signed).unwrap();
+
+        assert!(matches!(
+            event.to_transport_message(),
+            Err(NostrPeelerError::Malformed(_))
+        ));
+
+        let msg = TransportMessage {
+            id: MessageId::new(hex::decode(&event.id).unwrap()),
+            payload: serde_json::to_vec(&event).unwrap(),
+            timestamp: cgka_traits::transport::Timestamp(event.created_at),
+            causal_deps: Vec::new(),
+            source: cgka_traits::transport::TransportSource(crate::NOSTR_SOURCE.into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: group_id,
+            },
+        };
+
+        assert!(matches!(
+            NostrMlsPeeler::default()
+                .peel_group_message(&msg, &ctx)
+                .await,
+            Err(PeelerError::Malformed(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn group_peel_rejects_tampered_event_id_before_decryption() {
+        let group_id = vec![0x99; 32];
+        let ctx = GroupContextSnapshot::new(
+            EpochId(9),
+            HashMap::from([(DEFAULT_EXPORTER_LABEL.to_string(), vec![0x7a; 32])]),
+            Some(group_id.clone()),
+        );
+        let wrapped = NostrMlsPeeler::default()
+            .wrap_group_message(
+                &EncryptedPayload {
+                    ciphertext: b"inner mls bytes".to_vec(),
+                    aad: vec![],
+                },
+                &ctx,
+            )
+            .await
+            .expect("wrap succeeds");
+        let mut event = NostrTransportEvent::from_transport_message(&wrapped).unwrap();
+        event.id = "33".repeat(32);
+        let msg = TransportMessage {
+            id: MessageId::new(hex::decode(event.computed_id()).unwrap()),
+            payload: serde_json::to_vec(&event).unwrap(),
+            timestamp: cgka_traits::transport::Timestamp(event.created_at),
+            causal_deps: Vec::new(),
+            source: cgka_traits::transport::TransportSource(crate::NOSTR_SOURCE.into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: group_id,
+            },
+        };
+
+        assert!(matches!(
+            NostrMlsPeeler::default()
+                .peel_group_message(&msg, &ctx)
+                .await,
+            Err(PeelerError::Malformed(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn group_peel_rejects_tampered_signature_before_decryption() {
+        let group_id = vec![0x99; 32];
+        let ctx = GroupContextSnapshot::new(
+            EpochId(9),
+            HashMap::from([(DEFAULT_EXPORTER_LABEL.to_string(), vec![0x7a; 32])]),
+            Some(group_id),
+        );
+        let wrapped = NostrMlsPeeler::default()
+            .wrap_group_message(
+                &EncryptedPayload {
+                    ciphertext: b"inner mls bytes".to_vec(),
+                    aad: vec![],
+                },
+                &ctx,
+            )
+            .await
+            .expect("wrap succeeds");
+        let mut event = NostrTransportEvent::from_transport_message(&wrapped).unwrap();
+        event.sig = Some("00".repeat(64));
+        assert!(matches!(
+            event.to_transport_message(),
+            Err(NostrPeelerError::Malformed(_))
+        ));
+        let tampered = raw_group_transport_message(&event, &[0x99; 32]);
+
+        assert!(matches!(
+            NostrMlsPeeler::default()
+                .peel_group_message(&tampered, &ctx)
+                .await,
+            Err(PeelerError::Malformed(_))
+        ));
+    }
+
+    #[tokio::test]
     async fn group_peel_rejects_unsigned_kind_445() {
         let secret = vec![0x7a; NOSTR_GROUP_KEY_LEN];
         let group_id = vec![0x99; 32];
@@ -601,7 +783,11 @@ mod tests {
             .expect("wrap succeeds");
         let mut event = NostrTransportEvent::from_transport_message(&wrapped).unwrap();
         event.sig = None;
-        let unsigned_msg = event.to_transport_message().unwrap();
+        assert!(matches!(
+            event.to_transport_message(),
+            Err(NostrPeelerError::Malformed(_))
+        ));
+        let unsigned_msg = raw_group_transport_message(&event, &[0x99; 32]);
 
         assert!(matches!(
             peeler.peel_group_message(&unsigned_msg, &ctx).await,
@@ -1275,6 +1461,22 @@ mod tests {
             .unwrap()
             .to_transport_message()
             .unwrap()
+    }
+
+    fn raw_group_transport_message(
+        event: &NostrTransportEvent,
+        transport_group_id: &[u8],
+    ) -> TransportMessage {
+        TransportMessage {
+            id: MessageId::new(hex::decode(event.computed_id()).expect("computed id is hex")),
+            payload: serde_json::to_vec(event).expect("serialize event fixture"),
+            timestamp: cgka_traits::transport::Timestamp(event.created_at),
+            causal_deps: Vec::new(),
+            source: cgka_traits::transport::TransportSource(crate::NOSTR_SOURCE.into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: transport_group_id.to_vec(),
+            },
+        }
     }
 
     fn sample_welcome_metadata() -> WelcomeMetadata {


### PR DESCRIPTION
Fixes #1007

## Summary
- authenticate kind-445 events before reading their cleartext routing metadata, while retaining peel-time verification as defense in depth
- enforce exactly one lowercase 32-byte `h` routing tag, at most one decimal `expiration` tag, no other tags, and strict tag arity
- validate `expiration` structurally without using it as a message-validity deadline
- add direct, adapter, peeler, and cold relay-runtime regressions for malformed tags, tampered identity/signature data, route-id confusion, strict content encoding, and before/after-expiration behavior

## Verification
- `just fast-ci`
- `cargo test -p transport-nostr-peeler --locked`
- `cargo test -p transport-nostr-adapter --locked`
- `cargo test -p transport-nostr-adapter --features sdk --locked`
- `cargo test -p marmot-app --locked`
- `cargo test -p marmot-app --test malformed_445_drain --locked`
- focused adapter and Marmot app relay-plane regression tests
- independent read-only Cursor review: passed, no blocking findings

## Sensitive paths
- `crates/transport-nostr-peeler/src/event.rs`
- `crates/transport-nostr-peeler/src/peeler.rs`
- Nostr adapter and Marmot app ingress/runtime regression paths

Sensitive ingress/authentication change. Manual merge approval required.
