### PR TITLE
fix(storage): persist semantic chat-list ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -852,7 +852,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "hex",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "libc",
  "tempfile",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-conformance-simulator",
  "serde",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3176,7 +3176,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "fs-private",
  "serde",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5435,7 +5435,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6029,7 +6029,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6065,7 +6065,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6085,7 +6085,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7140,7 +7140,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7171,7 +7171,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "agent-control",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.5"
+version = "0.9.6"
 license = "MIT"
 publish = false
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1308,6 +1308,8 @@ mod tests {
             "first_unread_message_id_hex": "m0",
             "last_read_message_id_hex": "r1",
             "last_read_timeline_at": 1_700_000_000_u64,
+            "conversation_created_at": 1_699_999_000_u64,
+            "activity_sort_at": 1_700_000_050_u64,
             "updated_at": 1_700_000_060_u64,
             "self_membership": "Member"
         }))

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -1024,6 +1024,8 @@ fn chat_list_test_row(group_id_hex: &str, title: &str) -> ChatListRow {
         first_unread_message_id_hex: None,
         last_read_message_id_hex: None,
         last_read_timeline_at: None,
+        conversation_created_at: 0,
+        activity_sort_at: 0,
         updated_at: 0,
         self_membership: crate::SelfMembership::Member,
     }

--- a/crates/marmot-uniffi/src/conversions/chat_list.rs
+++ b/crates/marmot-uniffi/src/conversions/chat_list.rs
@@ -92,6 +92,8 @@ pub struct ChatListRowFfi {
     pub first_unread_message_id_hex: Option<String>,
     pub last_read_message_id_hex: Option<String>,
     pub last_read_timeline_at: Option<u64>,
+    pub conversation_created_at: u64,
+    pub activity_sort_at: u64,
     pub updated_at: u64,
     /// Whether the local account is still a member of this group, and if not,
     /// whether it left voluntarily or was removed.
@@ -116,6 +118,8 @@ impl From<ChatListRow> for ChatListRowFfi {
             first_unread_message_id_hex: value.first_unread_message_id_hex,
             last_read_message_id_hex: value.last_read_message_id_hex,
             last_read_timeline_at: value.last_read_timeline_at,
+            conversation_created_at: value.conversation_created_at,
+            activity_sort_at: value.activity_sort_at,
             updated_at: value.updated_at,
             self_membership: value.self_membership.into(),
         }
@@ -187,6 +191,35 @@ impl From<marmot_app::ChatListUpdateTrigger> for ChatListUpdateTriggerFfi {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn chat_list_row_exports_semantic_timestamps() {
+        let ffi = ChatListRowFfi::from(ChatListRow {
+            group_id_hex: "11".to_owned(),
+            archived: false,
+            pending_confirmation: false,
+            title: "Marmot Lab".to_owned(),
+            group_name: "Marmot Lab".to_owned(),
+            avatar_url: None,
+            avatar: None,
+            last_message: None,
+            unread_count: 0,
+            has_unread: false,
+            unread_mention_count: 0,
+            has_unread_mention: false,
+            first_unread_message_id_hex: None,
+            last_read_message_id_hex: None,
+            last_read_timeline_at: None,
+            conversation_created_at: 100,
+            activity_sort_at: 200,
+            updated_at: 300,
+            self_membership: marmot_app::SelfMembership::Member,
+        });
+
+        assert_eq!(ffi.conversation_created_at, 100);
+        assert_eq!(ffi.activity_sort_at, 200);
+        assert_eq!(ffi.updated_at, 300);
+    }
 
     #[test]
     fn chat_list_avatar_debug_redacts_key_material() {

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -479,9 +479,9 @@ impl SqliteAccountStorage {
                         image_hash_hex, image_key_hex, image_nonce_hex,
                         image_upload_key_hex, image_media_type, admin_keys_hex, archived,
                         pending_confirmation, welcomer_account_id_hex, via_welcome_message_id_hex,
-                        updated_at
+                        conversation_created_at, updated_at
                      )
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?15)
                      ON CONFLICT(group_id_hex) DO UPDATE SET
                         endpoint = excluded.endpoint,
                         profile_name = excluded.profile_name,

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -90,6 +90,11 @@ pub struct ChatListRow {
     pub first_unread_message_id_hex: Option<String>,
     pub last_read_message_id_hex: Option<String>,
     pub last_read_timeline_at: Option<u64>,
+    /// Immutable local observation time for the conversation's creation.
+    pub conversation_created_at: u64,
+    /// Durable user-visible activity anchor. Projection maintenance never
+    /// advances this value.
+    pub activity_sort_at: u64,
     pub updated_at: u64,
     /// The local account's membership in this group (active member, left, or
     /// removed). Denormalized from `account_groups.self_membership`.
@@ -104,6 +109,7 @@ struct AccountGroupRow {
     profile_name: String,
     avatar_url: Option<String>,
     avatar: Option<ChatListAvatar>,
+    conversation_created_at: u64,
     self_membership: SelfMembership,
 }
 
@@ -297,11 +303,22 @@ fn rebuild_all_chat_list_rows_tx(
     local_account_id_hex: &str,
     mention_classifier: &MentionClassifier<'_>,
 ) -> StorageResult<()> {
-    tx.execute("DELETE FROM chat_list_rows", []).storage()?;
     let groups = account_groups_tx(tx)?;
     for group in groups {
         rebuild_chat_list_row_for_group_tx(tx, local_account_id_hex, group, mention_classifier)?;
     }
+    // Upsert in place so durable activity anchors survive a projection rebuild
+    // after their preview rows have been securely pruned. Remove only true
+    // orphans; normal account-group deletion already cascades this table.
+    tx.execute(
+        "DELETE FROM chat_list_rows
+         WHERE NOT EXISTS (
+             SELECT 1 FROM account_groups AS ag
+             WHERE ag.group_id_hex = chat_list_rows.group_id_hex
+         )",
+        [],
+    )
+    .storage()?;
     // #750: a full rebuild recomputes every mention count, so the projection is
     // current — advance the marker so warm-up completeness checks skip the
     // per-group recompute.
@@ -417,6 +434,7 @@ fn chat_list_projection_complete_tx(
                         WHEN 'removed' THEN 'removed'
                         ELSE 'member'
                       END
+                   OR row.conversation_created_at IS NOT ag.conversation_created_at
                    OR row.updated_at < COALESCE(avatar_url.updated_at, 0)
                    OR row.updated_at < ag.updated_at
              )",
@@ -505,6 +523,15 @@ fn chat_list_projection_complete_tx(
                         ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
                         LIMIT 1
                      ), 0)
+                   OR row.activity_sort_at < COALESCE((
+                        SELECT mt.timeline_at
+                        FROM message_timeline AS mt
+                        WHERE mt.group_id_hex = ag.group_id_hex
+                          AND mt.kind = ?1
+                          AND mt.invalidation_status IS NULL
+                        ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
+                        LIMIT 1
+                     ), ag.conversation_created_at)
              )",
         params![u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
     )? {
@@ -577,6 +604,16 @@ fn rebuild_chat_list_row_for_group_tx(
         read_state.as_ref(),
         mention_classifier,
     )?;
+    let activity_sort_at = latest
+        .as_ref()
+        .map(|message| message.timeline_at)
+        .into_iter()
+        .chain(
+            read_state
+                .as_ref()
+                .and_then(|state| state.last_read_timeline_at),
+        )
+        .fold(group.conversation_created_at, u64::max);
     let now = unix_now_seconds();
     tx.execute(
         "INSERT INTO chat_list_rows (
@@ -587,12 +624,13 @@ fn rebuild_chat_list_row_for_group_tx(
             last_message_id_hex, last_message_sender, last_message_preview,
             last_message_kind, last_message_timeline_at, last_message_deleted,
             unread_count, unread_mention_count, first_unread_message_id_hex,
-            last_read_message_id_hex, last_read_timeline_at, updated_at,
-            self_membership
+            last_read_message_id_hex, last_read_timeline_at,
+            conversation_created_at, activity_sort_at, updated_at, self_membership
          )
          VALUES (
             ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
-            ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24
+            ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20,
+            ?21, ?22, ?23, ?24, ?25, ?26
          )
          ON CONFLICT(group_id_hex) DO UPDATE SET
             archived = excluded.archived,
@@ -616,6 +654,8 @@ fn rebuild_chat_list_row_for_group_tx(
             first_unread_message_id_hex = excluded.first_unread_message_id_hex,
             last_read_message_id_hex = excluded.last_read_message_id_hex,
             last_read_timeline_at = excluded.last_read_timeline_at,
+            conversation_created_at = excluded.conversation_created_at,
+            activity_sort_at = MAX(chat_list_rows.activity_sort_at, excluded.activity_sort_at),
             updated_at = excluded.updated_at,
             self_membership = excluded.self_membership",
         params![
@@ -671,6 +711,8 @@ fn rebuild_chat_list_row_for_group_tx(
                     .as_ref()
                     .and_then(|state| state.last_read_timeline_at)
             )?,
+            u64_to_i64(group.conversation_created_at)?,
+            u64_to_i64(activity_sort_at)?,
             u64_to_i64(now)?,
             group.self_membership.as_str(),
         ],
@@ -772,7 +814,7 @@ fn account_groups_tx(tx: &Connection) -> StorageResult<Vec<AccountGroupRow>> {
             "SELECT ag.group_id_hex, ag.archived, ag.pending_confirmation, ag.profile_name,
                     image_hash_hex, image_key_hex, image_nonce_hex,
                     image_upload_key_hex, image_media_type, avatar_url.component_data_hex,
-                    ag.self_membership
+                    ag.conversation_created_at, ag.self_membership
              FROM account_groups AS ag
              LEFT JOIN account_group_app_components AS avatar_url
                 ON avatar_url.group_id_hex = ag.group_id_hex
@@ -793,7 +835,7 @@ fn account_group_tx(tx: &Connection, group_id_hex: &str) -> StorageResult<Option
         "SELECT ag.group_id_hex, ag.archived, ag.pending_confirmation, ag.profile_name,
                 image_hash_hex, image_key_hex, image_nonce_hex,
                 image_upload_key_hex, image_media_type, avatar_url.component_data_hex,
-                ag.self_membership
+                ag.conversation_created_at, ag.self_membership
          FROM account_groups AS ag
          LEFT JOIN account_group_app_components AS avatar_url
             ON avatar_url.group_id_hex = ag.group_id_hex
@@ -813,7 +855,8 @@ fn account_group_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AccountGr
     let image_upload_key_hex: String = row.get(7)?;
     let media_type: Option<String> = row.get(8)?;
     let avatar_url_component_hex: Option<String> = row.get(9)?;
-    let self_membership: String = row.get(10)?;
+    let conversation_created_at = row.get::<_, i64>(10)?.try_into().unwrap_or_default();
+    let self_membership: String = row.get(11)?;
     let has_avatar = !image_hash_hex.is_empty()
         || !image_key_hex.is_empty()
         || !image_nonce_hex.is_empty()
@@ -832,6 +875,7 @@ fn account_group_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AccountGr
             image_upload_key_hex,
             media_type,
         }),
+        conversation_created_at,
         self_membership: SelfMembership::from_storage(&self_membership),
     })
 }
@@ -919,9 +963,10 @@ fn chat_list_rows_tx(tx: &Connection, query: ChatListQuery) -> StorageResult<Vec
                 last_message_kind, last_message_timeline_at, last_message_deleted,
                 unread_count, unread_mention_count, first_unread_message_id_hex,
                 last_read_message_id_hex,
-                last_read_timeline_at, updated_at, self_membership
+                last_read_timeline_at, conversation_created_at, activity_sort_at,
+                updated_at, self_membership
          FROM chat_list_rows
-         ORDER BY last_message_timeline_at DESC, group_id_hex"
+         ORDER BY activity_sort_at DESC, group_id_hex"
     } else {
         "SELECT group_id_hex, archived, pending_confirmation, title, group_name,
                 avatar_url,
@@ -931,10 +976,11 @@ fn chat_list_rows_tx(tx: &Connection, query: ChatListQuery) -> StorageResult<Vec
                 last_message_kind, last_message_timeline_at, last_message_deleted,
                 unread_count, unread_mention_count, first_unread_message_id_hex,
                 last_read_message_id_hex,
-                last_read_timeline_at, updated_at, self_membership
+                last_read_timeline_at, conversation_created_at, activity_sort_at,
+                updated_at, self_membership
          FROM chat_list_rows
          WHERE archived = 0
-         ORDER BY last_message_timeline_at DESC, group_id_hex"
+         ORDER BY activity_sort_at DESC, group_id_hex"
     };
     let mut stmt = tx.prepare(sql).storage()?;
     stmt.query_map([], chat_list_row_from_row)
@@ -953,7 +999,8 @@ fn chat_list_row_tx(tx: &Connection, group_id_hex: &str) -> StorageResult<Option
                 last_message_kind, last_message_timeline_at, last_message_deleted,
                 unread_count, unread_mention_count, first_unread_message_id_hex,
                 last_read_message_id_hex,
-                last_read_timeline_at, updated_at, self_membership
+                last_read_timeline_at, conversation_created_at, activity_sort_at,
+                updated_at, self_membership
          FROM chat_list_rows
          WHERE group_id_hex = ?1",
         params![group_id_hex],
@@ -1025,8 +1072,10 @@ fn chat_list_row_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChatListR
         last_read_timeline_at: row
             .get::<_, Option<i64>>(21)?
             .and_then(|value| value.try_into().ok()),
-        updated_at: row.get::<_, i64>(22)?.try_into().unwrap_or_default(),
-        self_membership: SelfMembership::from_storage(&row.get::<_, String>(23)?),
+        conversation_created_at: row.get::<_, i64>(22)?.try_into().unwrap_or_default(),
+        activity_sort_at: row.get::<_, i64>(23)?.try_into().unwrap_or_default(),
+        updated_at: row.get::<_, i64>(24)?.try_into().unwrap_or_default(),
+        self_membership: SelfMembership::from_storage(&row.get::<_, String>(25)?),
     })
 }
 

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -135,6 +135,92 @@ fn avatar_url_component(url: &str) -> StoredAccountGroupComponent {
 }
 
 #[test]
+fn never_messaged_rows_sort_by_creation_then_group_id_across_rebuilds() {
+    let second_group = StoredAccountGroup {
+        group_id_hex: "22".to_owned(),
+        profile_name: "Second".to_owned(),
+        ..group()
+    };
+    let tied_group = StoredAccountGroup {
+        group_id_hex: "33".to_owned(),
+        profile_name: "Tied".to_owned(),
+        ..group()
+    };
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                groups: vec![group(), second_group, tied_group],
+                ..StoredAccountState::default()
+            },
+            256,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+    {
+        let conn = store.lock().unwrap();
+        conn.execute(
+            "UPDATE account_groups
+             SET conversation_created_at = CASE group_id_hex
+                 WHEN ?1 THEN 100
+                 WHEN ?2 THEN 200
+                 WHEN ?3 THEN 100
+             END",
+            params![GROUP, "22", "33"],
+        )
+        .unwrap();
+    }
+
+    store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    let before = store
+        .chat_list_rows(crate::ChatListQuery::default())
+        .unwrap();
+    assert_eq!(
+        before
+            .iter()
+            .map(|row| row.group_id_hex.as_str())
+            .collect::<Vec<_>>(),
+        vec!["22", GROUP, "33"]
+    );
+    assert_eq!(before[0].conversation_created_at, 200);
+    assert_eq!(before[0].activity_sort_at, 200);
+    assert_eq!(before[1].conversation_created_at, 100);
+    assert_eq!(before[1].activity_sort_at, 100);
+
+    let semantic_before = before
+        .iter()
+        .map(|row| {
+            (
+                row.group_id_hex.clone(),
+                row.conversation_created_at,
+                row.activity_sort_at,
+            )
+        })
+        .collect::<Vec<_>>();
+    {
+        let conn = store.lock().unwrap();
+        conn.execute("UPDATE chat_list_rows SET updated_at = 4000000000", [])
+            .unwrap();
+    }
+    store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    let after = store
+        .chat_list_rows(crate::ChatListQuery::default())
+        .unwrap();
+    let semantic_after = after
+        .iter()
+        .map(|row| {
+            (
+                row.group_id_hex.clone(),
+                row.conversation_created_at,
+                row.activity_sort_at,
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(semantic_after, semantic_before);
+}
+
+#[test]
 fn initialize_chat_read_state_returns_none_for_unknown_group() {
     let store = setup_store();
 
@@ -143,6 +229,101 @@ fn initialize_chat_read_state_returns_none_for_unknown_group() {
         .unwrap();
 
     assert_eq!(row, None);
+}
+
+#[test]
+fn visible_activity_survives_read_metadata_membership_and_secure_prune_updates() {
+    for mark_read in [false, true] {
+        let store = setup_store();
+        {
+            let conn = store.lock().unwrap();
+            conn.execute(
+                "UPDATE account_groups SET conversation_created_at = 5 WHERE group_id_hex = ?1",
+                params![GROUP],
+            )
+            .unwrap();
+        }
+        store
+            .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+            .unwrap();
+        store
+            .record_app_event(&chat("visible", REMOTE, 100, "semantic activity"))
+            .unwrap();
+        let mut row = store
+            .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+            .unwrap()
+            .expect("chat row");
+        assert_eq!(row.conversation_created_at, 5);
+        assert_eq!(row.activity_sort_at, 100);
+        assert_eq!(row.unread_count, 1);
+
+        if mark_read {
+            row = store
+                .mark_timeline_message_read(LOCAL, GROUP, "visible", &no_mentions)
+                .unwrap()
+                .expect("chat row");
+            assert_eq!(row.unread_count, 0);
+            assert_eq!(row.activity_sort_at, 100);
+        }
+
+        let mut renamed = group();
+        renamed.profile_name = "Renamed Lab".to_owned();
+        renamed
+            .components
+            .push(avatar_url_component("https://cdn.example.com/new.png"));
+        store
+            .save_account_projection_state(
+                &StoredAccountState {
+                    label: "alice".to_owned(),
+                    groups: vec![renamed],
+                    ..StoredAccountState::default()
+                },
+                256,
+                MAX_FUTURE_SKEW_SECS,
+            )
+            .unwrap();
+        store
+            .set_group_self_membership(GROUP, SelfMembership::Removed)
+            .unwrap();
+        row = store
+            .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+            .unwrap()
+            .expect("chat row");
+        assert_eq!(row.conversation_created_at, 5);
+        assert_eq!(row.activity_sort_at, 100);
+
+        store.secure_prune_app_events_before(GROUP, 101).unwrap();
+        row = store.chat_list_row(GROUP).unwrap().expect("chat row");
+        assert_eq!(row.last_message, None);
+        assert_eq!(row.unread_count, u64::from(!mark_read));
+        assert_eq!(row.activity_sort_at, 100);
+
+        if mark_read {
+            // A read cursor is durable source history: even if projection repair
+            // must recreate the row after pruning, it recovers the last visible
+            // activity rather than falling back to conversation creation.
+            let conn = store.lock().unwrap();
+            conn.execute(
+                "DELETE FROM chat_list_rows WHERE group_id_hex = ?1",
+                params![GROUP],
+            )
+            .unwrap();
+        }
+        store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+        row = store.chat_list_row(GROUP).unwrap().expect("chat row");
+        assert_eq!(row.last_message, None);
+        assert_eq!(row.conversation_created_at, 5);
+        assert_eq!(row.activity_sort_at, 100);
+
+        store
+            .record_app_event(&chat("new-visible", REMOTE, 200, "new activity"))
+            .unwrap();
+        row = store
+            .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+            .unwrap()
+            .expect("chat row");
+        assert_eq!(row.activity_sort_at, 200);
+    }
 }
 
 #[test]

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -54,6 +54,8 @@ mod migration_0026_message_drafts;
 mod migration_0027_app_event_moderation_grant;
 #[path = "migrations/0028_ingress_dedup.rs"]
 mod migration_0028_ingress_dedup;
+#[path = "migrations/0029_chat_list_semantic_timestamps.rs"]
+mod migration_0029_chat_list_semantic_timestamps;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -205,6 +207,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 28,
         name: "0028_ingress_dedup",
         apply: migration_0028_ingress_dedup::apply,
+    },
+    Migration {
+        version: 29,
+        name: "0029_chat_list_semantic_timestamps",
+        apply: migration_0029_chat_list_semantic_timestamps::apply,
     },
 ];
 
@@ -409,6 +416,113 @@ mod tests {
     fn initial_schema_migration_is_recorded() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         assert_eq!(applied_migrations(&store), expected_migrations());
+    }
+
+    #[test]
+    fn chat_list_semantic_timestamps_backfill_from_durable_history() {
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.pragma_update(None, "foreign_keys", true).unwrap();
+        run(&mut conn, &MIGRATIONS[..28]).unwrap();
+        conn.execute(
+            "INSERT INTO account_groups (group_id_hex, endpoint, updated_at)
+             VALUES ('never-messaged', 'relay', 100),
+                    ('active', 'relay', 200),
+                    ('pruned-read', 'relay', 300)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO app_events (
+                group_id_hex, message_id_hex, direction, sender, plaintext, kind,
+                tags_json, recorded_at, received_at
+             ) VALUES ('active', 'origin', 'received', 'sender', 'origin', 9, '[]', 140, 140)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message_timeline (
+                group_id_hex, message_id_hex, direction, sender, plaintext, kind,
+                tags_json, timeline_at, received_at, reactions_json
+             ) VALUES ('active', 'latest', 'received', 'sender', 'latest', 9, '[]', 150, 150, '[]')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message_timeline (
+                group_id_hex, message_id_hex, direction, sender, plaintext, kind,
+                tags_json, timeline_at, received_at, reactions_json, invalidation_status
+             ) VALUES (
+                'active', 'invalidated', 'received', 'sender', 'losing branch',
+                9, '[]', 160, 160, '[]', 'LosingBranch'
+             )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO conversation_read_state (
+                group_id_hex, last_read_message_id_hex, last_read_timeline_at,
+                initialized_at, updated_at
+             ) VALUES ('pruned-read', 'pruned-message', 350, 0, 400)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message_timeline (
+                group_id_hex, message_id_hex, direction, sender, plaintext, kind,
+                tags_json, timeline_at, received_at, reactions_json
+             ) VALUES (
+                'pruned-read', 'older-survivor', 'received', 'sender', 'older',
+                9, '[]', 310, 310, '[]'
+             )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO chat_list_rows (group_id_hex, updated_at)
+             VALUES ('never-messaged', 500), ('active', 500), ('pruned-read', 500)",
+            [],
+        )
+        .unwrap();
+
+        run(&mut conn, MIGRATIONS).unwrap();
+
+        let rows = conn
+            .prepare(
+                "SELECT group_id_hex, conversation_created_at, activity_sort_at
+                 FROM chat_list_rows ORDER BY group_id_hex",
+            )
+            .unwrap()
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                ("active".to_owned(), 140, 150),
+                ("never-messaged".to_owned(), 100, 100),
+                ("pruned-read".to_owned(), 300, 350),
+            ]
+        );
+
+        run(&mut conn, MIGRATIONS).unwrap();
+        let after_second_run: Vec<(String, i64, i64)> = conn
+            .prepare(
+                "SELECT group_id_hex, conversation_created_at, activity_sort_at
+                 FROM chat_list_rows ORDER BY group_id_hex",
+            )
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(after_second_run, rows);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/migrations/0029_chat_list_semantic_timestamps.rs
+++ b/crates/storage-sqlite/src/migrations/0029_chat_list_semantic_timestamps.rs
@@ -1,0 +1,108 @@
+//! Add durable semantic timestamps for chat-list ordering (#1086).
+//!
+//! `conversation_created_at` is anchored once on the durable account-group row.
+//! Existing rows use the earliest retained app-event time when available, capped
+//! by the group's persisted first/last projection timestamp; never-messaged rows
+//! use that persisted group timestamp. `activity_sort_at` starts at the latest
+//! visible chat timeline time, then falls back to the durable read cursor and
+//! finally conversation creation. No migration wall clock participates.
+
+use crate::{SqliteResultExt, u64_to_i64};
+use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
+use cgka_traits::storage::StorageResult;
+use rusqlite::{Transaction, params};
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+ALTER TABLE account_groups
+    ADD COLUMN conversation_created_at INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE chat_list_rows
+    ADD COLUMN conversation_created_at INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE chat_list_rows
+    ADD COLUMN activity_sort_at INTEGER NOT NULL DEFAULT 0;
+"#,
+    )
+    .storage()?;
+
+    tx.execute(
+        "UPDATE account_groups AS ag
+         SET conversation_created_at = CASE
+             WHEN (
+                 SELECT MIN(events.recorded_at)
+                 FROM app_events AS events
+                 WHERE events.group_id_hex = ag.group_id_hex
+             ) IS NULL THEN ag.updated_at
+             WHEN ag.updated_at = 0 THEN (
+                 SELECT MIN(events.recorded_at)
+                 FROM app_events AS events
+                 WHERE events.group_id_hex = ag.group_id_hex
+             )
+             ELSE MIN(
+                 ag.updated_at,
+                 (
+                     SELECT MIN(events.recorded_at)
+                     FROM app_events AS events
+                     WHERE events.group_id_hex = ag.group_id_hex
+                 )
+             )
+         END",
+        [],
+    )
+    .storage()?;
+
+    tx.execute(
+        "UPDATE chat_list_rows AS row
+         SET conversation_created_at = COALESCE(
+                 (
+                     SELECT ag.conversation_created_at
+                     FROM account_groups AS ag
+                     WHERE ag.group_id_hex = row.group_id_hex
+                 ),
+                 0
+             ),
+             activity_sort_at = MAX(
+                 COALESCE(
+                     (
+                         SELECT timeline.timeline_at
+                         FROM message_timeline AS timeline
+                         WHERE timeline.group_id_hex = row.group_id_hex
+                           AND timeline.kind = ?1
+                           AND timeline.invalidation_status IS NULL
+                         ORDER BY timeline.timeline_at DESC, timeline.message_id_hex DESC
+                         LIMIT 1
+                     ),
+                     0
+                 ),
+                 COALESCE(
+                     (
+                         SELECT read_state.last_read_timeline_at
+                         FROM conversation_read_state AS read_state
+                         WHERE read_state.group_id_hex = row.group_id_hex
+                     ),
+                     0
+                 ),
+                 COALESCE(
+                     (
+                         SELECT ag.conversation_created_at
+                         FROM account_groups AS ag
+                         WHERE ag.group_id_hex = row.group_id_hex
+                     ),
+                     0
+                 )
+             )",
+        params![u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
+    )
+    .storage()?;
+
+    tx.execute_batch(
+        r#"
+DROP INDEX IF EXISTS idx_chat_list_rows_archived_order;
+CREATE INDEX idx_chat_list_rows_archived_activity_order
+    ON chat_list_rows (archived, activity_sort_at DESC, group_id_hex);
+"#,
+    )
+    .storage()?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- persist immutable `conversation_created_at` and durable `activity_sort_at` values in the chat-list projection
- backfill both fields deterministically from account-group, visible timeline, and read-cursor history without migration wall-clock time
- preserve semantic activity across projection rebuilds, metadata/read/membership updates, and secure pruning
- order chat rows by semantic activity plus stable group ID and expose both timestamps through UniFFI
- bump the workspace version to 0.9.6 for the UniFFI record change

## Test plan

- `cargo test -p storage-sqlite`
- `cargo test -p marmot-uniffi --locked`
- `cargo test -p marmot-app --locked`
- `RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --locked`
- `RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --exclude cgka-conformance-simulator --doc --locked`

Fixes #1086


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat lists now retain conversation creation times and durable activity timestamps.
  - Chat ordering is more consistent, including for conversations with no messages.
  - Chat list data exports now include conversation creation and activity timestamps.
- **Bug Fixes**
  - Rebuilding or pruning chat-list projections no longer causes conversations to unexpectedly change order.
  - Existing databases automatically backfill the new timestamp data during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->