### PR TITLE
fix: deduplicate logical final deliveries

### DIFF
--- a/crates/agent-connector/src/bootstrap.rs
+++ b/crates/agent-connector/src/bootstrap.rs
@@ -467,6 +467,7 @@ fn response_type_name(response: &AgentControlResponse) -> &'static str {
         AgentControlResponse::KeyPackagePublished { .. } => "key_package_published",
         AgentControlResponse::ProfilePublished { .. } => "profile_published",
         AgentControlResponse::FinalSent { .. } => "final_sent",
+        AgentControlResponse::DeliveryStatus { .. } => "delivery_status",
         AgentControlResponse::AppEventSent { .. } => "app_event_sent",
         AgentControlResponse::Allowlist { .. } => "allowlist",
         AgentControlResponse::GroupInfo { .. } => "group_info",

--- a/crates/agent-connector/src/connection.rs
+++ b/crates/agent-connector/src/connection.rs
@@ -222,6 +222,9 @@ impl AgentConnector {
                 )
                 .await
             }
+            AgentControlRequest::DeliveryStatus { idempotency_key } => {
+                Ok(self.delivery_status_response(&idempotency_key))
+            }
             AgentControlRequest::DeleteMessage {
                 account_id_hex,
                 group_id_hex,

--- a/crates/agent-connector/src/error.rs
+++ b/crates/agent-connector/src/error.rs
@@ -40,6 +40,8 @@ pub enum ConnectorError {
     InvalidStreamBeginRequestId,
     #[error("stream begin request id was reused with different inputs")]
     StreamBeginRequestConflict,
+    #[error("idempotency key was reused with different inputs")]
+    IdempotencyKeyConflict,
 }
 
 impl ConnectorError {
@@ -62,6 +64,7 @@ impl ConnectorError {
             Self::StreamCapabilityDenied => "stream_capability_denied",
             Self::InvalidStreamBeginRequestId => "invalid_stream_begin_request_id",
             Self::StreamBeginRequestConflict => "stream_begin_request_conflict",
+            Self::IdempotencyKeyConflict => "idempotency_key_conflict",
         }
     }
 
@@ -82,6 +85,7 @@ impl ConnectorError {
             Self::StreamBeginRequestConflict => {
                 "stream begin request id was reused with different inputs"
             }
+            Self::IdempotencyKeyConflict => "idempotency key was reused with different inputs",
             Self::Io(_) => "connector I/O failed",
             Self::AccountHome(_) | Self::App(_) => "connector request failed",
         }

--- a/crates/agent-connector/src/messaging.rs
+++ b/crates/agent-connector/src/messaging.rs
@@ -1,8 +1,8 @@
 //! Final-message sends, agent activity/operation/group-system events, and debug send recording.
 
 use agent_control::{
-    AgentControlDebugFinalSend, AgentControlEvent, AgentControlMediaRef, AgentControlMediaUpload,
-    AgentControlResponse,
+    AgentControlDebugFinalSend, AgentControlDeliveryStatus, AgentControlEvent,
+    AgentControlMediaRef, AgentControlMediaUpload, AgentControlResponse,
 };
 use cgka_traits::GroupId;
 use marmot_app::{
@@ -12,10 +12,12 @@ use marmot_app::{
 
 use crate::AgentConnector;
 use crate::error::ConnectorError;
+use crate::stream_session::{SendIdempotencyAcquisition, SendIdempotencyStatus};
 use crate::validation::normalize_hex;
 
 /// Current schema version for persisted `send_final` request fingerprints.
 pub(crate) const SEND_FINAL_FINGERPRINT_VERSION: u8 = 1;
+pub(crate) const LOGICAL_FINAL_IDEMPOTENCY_PREFIX: &str = "marmot_logical_final_v1:";
 
 /// Server-derived fingerprint of a `send_final` request: a versioned SHA-256 digest
 /// over the destination (account + group), message text, and optional reply target.
@@ -91,6 +93,20 @@ pub(crate) fn media_ref_to_reference(media: AgentControlMediaRef) -> MediaAttach
 }
 
 impl AgentConnector {
+    pub(crate) fn delivery_status_response(&self, idempotency_key: &str) -> AgentControlResponse {
+        let (status, message_ids_hex) = match self.idempotency.status(idempotency_key.trim()) {
+            SendIdempotencyStatus::Unknown => (AgentControlDeliveryStatus::Unknown, Vec::new()),
+            SendIdempotencyStatus::Pending => (AgentControlDeliveryStatus::Pending, Vec::new()),
+            SendIdempotencyStatus::Committed(message_ids_hex) => {
+                (AgentControlDeliveryStatus::Committed, message_ids_hex)
+            }
+        };
+        AgentControlResponse::DeliveryStatus {
+            status,
+            message_ids_hex,
+        }
+    }
+
     pub(crate) async fn send_final_response(
         &self,
         account_id_hex: &str,
@@ -100,33 +116,51 @@ impl AgentConnector {
         idempotency_key: Option<String>,
     ) -> Result<AgentControlResponse, ConnectorError> {
         let group_id_hex = normalize_hex(group_id_hex)?;
+        let idempotency_key = idempotency_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|key| !key.is_empty())
+            .map(str::to_owned);
+        // Server-derived request fingerprint: one idempotency key names exactly
+        // one logical final. Reusing it with different inputs is rejected before
+        // any send, so dedup cannot return unrelated ids or publish two bodies.
+        let fingerprint = send_final_fingerprint(
+            &account_id_hex.to_ascii_lowercase(),
+            &group_id_hex,
+            &text,
+            reply_to_message_id_hex
+                .as_deref()
+                .map(str::to_ascii_lowercase)
+                .as_deref(),
+        );
+
+        // Reserve before the first await. Same-key followers wait for the leader
+        // and return its committed ids; a failed/cancelled leader drops its guard,
+        // wakes followers, and leaves the key retryable.
+        let reservation = if let Some(key) = idempotency_key.as_deref() {
+            match self.idempotency.acquire(key, &fingerprint).await? {
+                SendIdempotencyAcquisition::Completed(message_ids_hex) => {
+                    return Ok(AgentControlResponse::FinalSent { message_ids_hex });
+                }
+                SendIdempotencyAcquisition::Leader(guard) => Some(guard),
+            }
+        } else {
+            None
+        };
+
         if self.debug_controls {
-            return self.debug_record_final_send_response(
+            let response = self.debug_record_final_send_response(
                 account_id_hex,
                 &group_id_hex,
                 text,
                 reply_to_message_id_hex,
-            );
-        }
-
-        // Server-derived request fingerprint: a reused idempotency key only short-
-        // circuits when the request it identifies is the same one. A reused key
-        // carrying a different request body is a cache miss, so dedup can never
-        // return ids belonging to an unrelated send.
-        let fingerprint = send_final_fingerprint(
-            account_id_hex,
-            &group_id_hex,
-            &text,
-            reply_to_message_id_hex.as_deref(),
-        );
-
-        // Idempotent durable send: if this key already committed a matching send,
-        // return the original message ids without re-sending so a retry after a
-        // post-write timeout cannot double-post an unrecallable message.
-        if let Some(key) = idempotency_key.as_deref()
-            && let Some(message_ids_hex) = self.idempotency.get(key, &fingerprint)
-        {
-            return Ok(AgentControlResponse::FinalSent { message_ids_hex });
+            )?;
+            if let (Some(reservation), AgentControlResponse::FinalSent { message_ids_hex }) =
+                (reservation, &response)
+            {
+                reservation.complete(message_ids_hex.clone());
+            }
+            return Ok(response);
         }
 
         let account = self.local_account_for_account_id(account_id_hex)?;
@@ -140,12 +174,8 @@ impl AgentConnector {
                 .send_message(&account.label, &group_id, text.into_bytes())
                 .await?
         };
-        // Record only after a successful send so a failed send remains retryable.
-        // A key already bound to a different fingerprint is left untouched (first
-        // write wins), so this send simply proceeds without caching.
-        if let Some(key) = idempotency_key {
-            self.idempotency
-                .record(key, fingerprint, summary.message_ids.clone());
+        if let Some(reservation) = reservation {
+            reservation.complete(summary.message_ids.clone());
         }
         Ok(AgentControlResponse::FinalSent {
             message_ids_hex: summary.message_ids,

--- a/crates/agent-connector/src/stream.rs
+++ b/crates/agent-connector/src/stream.rs
@@ -14,13 +14,15 @@ use tokio::sync::{mpsc, oneshot};
 use transport_quic_broker::OpenBrokerTextPublisher;
 
 use crate::error::ConnectorError;
+use crate::messaging::{LOGICAL_FINAL_IDEMPOTENCY_PREFIX, send_final_fingerprint};
 use crate::quic::{
     broker_trust_for_candidate, first_quic_candidate, parse_quic_candidate,
     resolve_quic_candidate_addr,
 };
 use crate::stream_session::{
-    ActiveStreamSession, FinalizedStream, StreamBeginReceipt, StreamBeginReservation,
-    normalize_stream_capability,
+    ActiveStreamSession, FinalizedStream, SendIdempotencyAcquisition,
+    SendIdempotencyReservationGuard, SendIdempotencyStatus, StreamBeginReceipt,
+    StreamBeginReservation, normalize_stream_capability,
 };
 use crate::validation::{normalize_hex, transcript_hash_from_hex, unix_now_seconds};
 use crate::{
@@ -90,11 +92,6 @@ fn begun_response(receipt: StreamBeginReceipt) -> AgentControlResponse {
 
 fn stream_finalize_idempotency_key(key: &str) -> String {
     format!("stream_finalize_v2:{key}")
-}
-
-struct StreamFinalizeIdempotency {
-    key: String,
-    fingerprint: String,
 }
 
 impl AgentConnector {
@@ -248,6 +245,7 @@ impl AgentConnector {
             stream_id_hex.clone(),
             ActiveStreamSession {
                 account_label: account.label,
+                account_id_hex: account.account_id_hex,
                 group_id,
                 stream_id,
                 stream_capability,
@@ -352,33 +350,84 @@ impl AgentConnector {
         let stream_id_hex = normalize_hex(stream_id_hex)?;
         let stream_capability = normalize_stream_capability(stream_capability)?;
         let transcript_hash = transcript_hash_from_hex(transcript_hash_hex)?;
-        let fingerprint = stream_finalize_fingerprint(
-            &stream_id_hex,
-            &stream_capability,
-            &final_text,
-            &transcript_hash,
-            chunk_count,
-        );
         let idempotency_key = idempotency_key
             .as_deref()
             .map(str::trim)
             .filter(|key| !key.is_empty())
-            .map(stream_finalize_idempotency_key);
-        if let Some(key) = idempotency_key.as_deref()
-            && let Some(message_ids_hex) = self.idempotency.get(key, &fingerprint)
+            .map(str::to_owned);
+        let legacy_idempotency = if let Some(client_key) = idempotency_key
+            .as_deref()
+            .filter(|key| !key.starts_with(LOGICAL_FINAL_IDEMPOTENCY_PREFIX))
         {
-            return Ok(AgentControlResponse::StreamFinalized {
-                stream_id_hex,
-                message_ids_hex,
-            });
-        }
+            let key = stream_finalize_idempotency_key(client_key);
+            let fingerprint = stream_finalize_fingerprint(
+                &stream_id_hex,
+                &stream_capability,
+                &final_text,
+                &transcript_hash,
+                chunk_count,
+            );
+            match self.idempotency.acquire(&key, &fingerprint).await? {
+                SendIdempotencyAcquisition::Completed(message_ids_hex) => {
+                    return Ok(AgentControlResponse::StreamFinalized {
+                        stream_id_hex,
+                        message_ids_hex,
+                    });
+                }
+                SendIdempotencyAcquisition::Leader(reservation) => Some(reservation),
+            }
+        } else {
+            None
+        };
         // Clone (not remove) the session: the final text/hash/chunk-count
         // expectation is validated inside the compose task, atomically with
         // its teardown. On mismatch the session stays registered and the
         // compose task keeps running, so finalize is retryable (#366).
-        let session = self
+        let session = match self
             .streams
-            .get_authorized(&stream_id_hex, &stream_capability)?;
+            .get_authorized(&stream_id_hex, &stream_capability)
+        {
+            Ok(session) => session,
+            Err(err) => {
+                // A successful finalize removes its stream session before the
+                // control response is written. A same-key retry after a lost
+                // acknowledgement can therefore recover from the committed
+                // logical result even though the capability no longer resolves.
+                if let Some(key) = idempotency_key
+                    .as_deref()
+                    .filter(|key| key.starts_with(LOGICAL_FINAL_IDEMPOTENCY_PREFIX))
+                    && let SendIdempotencyStatus::Committed(message_ids_hex) =
+                        self.idempotency.status(key)
+                {
+                    return Ok(AgentControlResponse::StreamFinalized {
+                        stream_id_hex,
+                        message_ids_hex,
+                    });
+                }
+                return Err(err);
+            }
+        };
+        let idempotency = if let Some(client_key) =
+            idempotency_key.filter(|key| key.starts_with(LOGICAL_FINAL_IDEMPOTENCY_PREFIX))
+        {
+            let fingerprint = send_final_fingerprint(
+                &session.account_id_hex,
+                &hex::encode(session.group_id.as_slice()),
+                &final_text,
+                Some(&session.start_message_id_hex),
+            );
+            match self.idempotency.acquire(&client_key, &fingerprint).await? {
+                SendIdempotencyAcquisition::Completed(message_ids_hex) => {
+                    return Ok(AgentControlResponse::StreamFinalized {
+                        stream_id_hex,
+                        message_ids_hex,
+                    });
+                }
+                SendIdempotencyAcquisition::Leader(reservation) => Some(reservation),
+            }
+        } else {
+            legacy_idempotency
+        };
 
         // Retry fast-path: a prior finalize already validated the transcript and
         // the compose task exited, but the durable finish below failed. The
@@ -401,7 +450,7 @@ impl AgentConnector {
                     final_text,
                     transcript_hash,
                     chunk_count,
-                    idempotency_key.map(|key| StreamFinalizeIdempotency { key, fingerprint }),
+                    idempotency,
                 )
                 .await;
         }
@@ -470,7 +519,7 @@ impl AgentConnector {
             final_text,
             transcript_hash,
             chunk_count,
-            idempotency_key.map(|key| StreamFinalizeIdempotency { key, fingerprint }),
+            idempotency,
         )
         .await
     }
@@ -486,7 +535,7 @@ impl AgentConnector {
         final_text: String,
         transcript_hash: [u8; 32],
         chunk_count: u64,
-        idempotency: Option<StreamFinalizeIdempotency>,
+        idempotency: Option<SendIdempotencyReservationGuard>,
     ) -> Result<AgentControlResponse, ConnectorError> {
         let (_payload, summary) = self
             .runtime
@@ -504,11 +553,7 @@ impl AgentConnector {
             )
             .await?;
         if let Some(idempotency) = idempotency {
-            self.idempotency.record(
-                idempotency.key,
-                idempotency.fingerprint,
-                summary.message_ids.clone(),
-            );
+            idempotency.complete(summary.message_ids.clone());
         }
         // Durable final published: it is now safe to drop the session.
         let _ = self.streams.remove_if_same(stream_id_hex, session);

--- a/crates/agent-connector/src/stream_session.rs
+++ b/crates/agent-connector/src/stream_session.rs
@@ -58,11 +58,10 @@ const SEND_IDEMPOTENCY_FILE_VERSION: u8 = 1;
 ///
 /// A retry that reuses the same key AND matches the recorded fingerprint returns
 /// the cached ids without re-sending, so a retry after a post-write timeout cannot
-/// double-post an unrecallable encrypted message. A reused key whose fingerprint
-/// differs (a different request body under the same key) is treated as a cache
-/// miss, so it can never return ids belonging to an unrelated send. Keys are
-/// evicted oldest-first once the capacity is reached and the eviction is mirrored
-/// to disk.
+/// double-post an unrecallable encrypted message. Reusing a key with a different
+/// fingerprint is rejected so one logical delivery identity cannot name two
+/// request bodies. Keys are evicted oldest-first once the capacity is reached and
+/// the eviction is mirrored to disk.
 ///
 /// Records are persisted under [`SEND_IDEMPOTENCY_FILE`] with crash-safe atomic
 /// renames so a connector restart can still dedup a bounded retry window. The
@@ -93,6 +92,54 @@ struct SendIdempotencyInner {
     order: std::collections::VecDeque<String>,
     seen: HashMap<String, (String, Vec<String>)>,
     recorded_at: HashMap<String, u64>,
+    in_flight: HashMap<String, InFlightSendIdempotency>,
+}
+
+struct InFlightSendIdempotency {
+    fingerprint: String,
+    completion: watch::Sender<bool>,
+}
+
+pub(crate) enum SendIdempotencyReservation {
+    Completed(Vec<String>),
+    Wait(watch::Receiver<bool>),
+    Leader(SendIdempotencyReservationGuard),
+}
+
+pub(crate) enum SendIdempotencyAcquisition {
+    Completed(Vec<String>),
+    Leader(SendIdempotencyReservationGuard),
+}
+
+pub(crate) enum SendIdempotencyStatus {
+    Unknown,
+    Pending,
+    Committed(Vec<String>),
+}
+
+pub(crate) struct SendIdempotencyReservationGuard {
+    store: SendIdempotencyStore,
+    key: String,
+    fingerprint: String,
+    active: bool,
+}
+
+impl SendIdempotencyReservationGuard {
+    pub(crate) fn complete(mut self, message_ids: Vec<String>) {
+        let completed = self
+            .store
+            .complete_reservation(&self.key, &self.fingerprint, message_ids);
+        debug_assert!(completed, "active send reservation must still exist");
+        self.active = !completed;
+    }
+}
+
+impl Drop for SendIdempotencyReservationGuard {
+    fn drop(&mut self) {
+        if self.active {
+            self.store.release_reservation(&self.key, &self.fingerprint);
+        }
+    }
 }
 
 impl SendIdempotencyStore {
@@ -109,6 +156,7 @@ impl SendIdempotencyStore {
     /// The message ids recorded for `key` by an earlier successful send, but only
     /// when the recorded request `fingerprint` matches. A key hit with a different
     /// fingerprint returns `None` (treated as a cache miss).
+    #[cfg(test)]
     pub(crate) fn get(&self, key: &str, fingerprint: &str) -> Option<Vec<String>> {
         crate::lock_recover(&self.inner)
             .seen
@@ -117,30 +165,140 @@ impl SendIdempotencyStore {
             .map(|(_, ids)| ids.clone())
     }
 
+    pub(crate) fn reserve(
+        &self,
+        key: &str,
+        fingerprint: &str,
+    ) -> Result<SendIdempotencyReservation, ConnectorError> {
+        let mut inner = crate::lock_recover(&self.inner);
+        if let Some((recorded, message_ids)) = inner.seen.get(key) {
+            if !constant_time_eq(recorded.as_bytes(), fingerprint.as_bytes()) {
+                return Err(ConnectorError::IdempotencyKeyConflict);
+            }
+            return Ok(SendIdempotencyReservation::Completed(message_ids.clone()));
+        }
+        if let Some(in_flight) = inner.in_flight.get(key) {
+            if !constant_time_eq(in_flight.fingerprint.as_bytes(), fingerprint.as_bytes()) {
+                return Err(ConnectorError::IdempotencyKeyConflict);
+            }
+            return Ok(SendIdempotencyReservation::Wait(
+                in_flight.completion.subscribe(),
+            ));
+        }
+
+        let (completion, _receiver) = watch::channel(false);
+        inner.in_flight.insert(
+            key.to_owned(),
+            InFlightSendIdempotency {
+                fingerprint: fingerprint.to_owned(),
+                completion,
+            },
+        );
+        Ok(SendIdempotencyReservation::Leader(
+            SendIdempotencyReservationGuard {
+                store: self.clone(),
+                key: key.to_owned(),
+                fingerprint: fingerprint.to_owned(),
+                active: true,
+            },
+        ))
+    }
+
+    pub(crate) async fn acquire(
+        &self,
+        key: &str,
+        fingerprint: &str,
+    ) -> Result<SendIdempotencyAcquisition, ConnectorError> {
+        loop {
+            match self.reserve(key, fingerprint)? {
+                SendIdempotencyReservation::Completed(message_ids) => {
+                    return Ok(SendIdempotencyAcquisition::Completed(message_ids));
+                }
+                SendIdempotencyReservation::Wait(mut completion) => {
+                    if !*completion.borrow() {
+                        let _ = completion.changed().await;
+                    }
+                }
+                SendIdempotencyReservation::Leader(guard) => {
+                    return Ok(SendIdempotencyAcquisition::Leader(guard));
+                }
+            }
+        }
+    }
+
+    pub(crate) fn status(&self, key: &str) -> SendIdempotencyStatus {
+        let inner = crate::lock_recover(&self.inner);
+        if let Some((_, message_ids)) = inner.seen.get(key) {
+            return SendIdempotencyStatus::Committed(message_ids.clone());
+        }
+        if inner.in_flight.contains_key(key) {
+            return SendIdempotencyStatus::Pending;
+        }
+        SendIdempotencyStatus::Unknown
+    }
+
+    fn complete_reservation(&self, key: &str, fingerprint: &str, message_ids: Vec<String>) -> bool {
+        let completion = {
+            let mut inner = crate::lock_recover(&self.inner);
+            let matches = inner.in_flight.get(key).is_some_and(|in_flight| {
+                constant_time_eq(in_flight.fingerprint.as_bytes(), fingerprint.as_bytes())
+            });
+            if !matches {
+                return false;
+            }
+            let completion = inner
+                .in_flight
+                .remove(key)
+                .expect("checked in-flight reservation")
+                .completion;
+            insert_committed(
+                &mut inner,
+                key.to_owned(),
+                fingerprint.to_owned(),
+                message_ids,
+            );
+            completion
+        };
+        let _ = completion.send(true);
+        self.persist_off_hot_path();
+        true
+    }
+
+    fn release_reservation(&self, key: &str, fingerprint: &str) {
+        let completion = {
+            let mut inner = crate::lock_recover(&self.inner);
+            let matches = inner.in_flight.get(key).is_some_and(|in_flight| {
+                constant_time_eq(in_flight.fingerprint.as_bytes(), fingerprint.as_bytes())
+            });
+            if !matches {
+                return;
+            }
+            inner
+                .in_flight
+                .remove(key)
+                .expect("checked in-flight reservation")
+                .completion
+        };
+        let _ = completion.send(true);
+    }
+
     /// Record the request `fingerprint` and durable message ids produced for
     /// `key`. A repeat record for an existing key keeps the original entry (the
     /// first successful send wins); otherwise the key is appended and the oldest
     /// is evicted once at capacity.
+    #[cfg(test)]
     pub(crate) fn record(&self, key: String, fingerprint: String, message_ids: Vec<String>) {
         let should_persist = {
             let mut inner = crate::lock_recover(&self.inner);
-            if inner.seen.contains_key(&key) {
-                return;
-            }
-            if inner.order.len() >= SEND_IDEMPOTENCY_CAPACITY
-                && let Some(evicted) = inner.order.pop_front()
-            {
-                inner.seen.remove(&evicted);
-                inner.recorded_at.remove(&evicted);
-            }
-            inner.seen.insert(key.clone(), (fingerprint, message_ids));
-            inner.recorded_at.insert(key.clone(), unix_timestamp_secs());
-            inner.order.push_back(key);
-            true
+            insert_committed(&mut inner, key, fingerprint, message_ids)
         };
         if !should_persist {
             return;
         }
+        self.persist_off_hot_path();
+    }
+
+    fn persist_off_hot_path(&self) {
         // #691: persist OFF the async send hot path. The in-memory entry recorded
         // above already enforces first-write-wins for the lifetime of this process,
         // so the (fs + double-fsync) disk write does not need to block the caller.
@@ -274,6 +432,27 @@ impl SendIdempotencyStore {
     }
 }
 
+fn insert_committed(
+    inner: &mut SendIdempotencyInner,
+    key: String,
+    fingerprint: String,
+    message_ids: Vec<String>,
+) -> bool {
+    if inner.seen.contains_key(&key) {
+        return false;
+    }
+    if inner.order.len() >= SEND_IDEMPOTENCY_CAPACITY
+        && let Some(evicted) = inner.order.pop_front()
+    {
+        inner.seen.remove(&evicted);
+        inner.recorded_at.remove(&evicted);
+    }
+    inner.seen.insert(key.clone(), (fingerprint, message_ids));
+    inner.recorded_at.insert(key.clone(), unix_timestamp_secs());
+    inner.order.push_back(key);
+    true
+}
+
 fn inner_from_persisted(entries: Vec<PersistedSendIdempotencyEntry>) -> SendIdempotencyInner {
     let mut inner = SendIdempotencyInner::default();
     for entry in entries {
@@ -387,6 +566,7 @@ impl Drop for StreamBeginReservationGuard {
 #[derive(Clone)]
 pub(crate) struct ActiveStreamSession {
     pub(crate) account_label: String,
+    pub(crate) account_id_hex: String,
     pub(crate) group_id: GroupId,
     pub(crate) stream_id: Vec<u8>,
     pub(crate) stream_capability: [u8; 32],

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -496,6 +496,7 @@ async fn stream_session_sweeper_aborts_idle_session_and_keeps_active_one() {
         "aa".to_owned(),
         ActiveStreamSession {
             account_label: "agent".to_owned(),
+            account_id_hex: "11".repeat(32),
             group_id: GroupId::new(vec![1]),
             stream_id: vec![0xaa],
             stream_capability: [0x77; 32],
@@ -516,6 +517,7 @@ async fn stream_session_sweeper_aborts_idle_session_and_keeps_active_one() {
         "bb".to_owned(),
         ActiveStreamSession {
             account_label: "agent".to_owned(),
+            account_id_hex: "11".repeat(32),
             group_id: GroupId::new(vec![2]),
             stream_id: vec![0xbb],
             stream_capability: [0x77; 32],
@@ -571,6 +573,7 @@ async fn stream_session_sweep_spares_finalized_session_despite_idle() {
         "aa".to_owned(),
         ActiveStreamSession {
             account_label: "agent".to_owned(),
+            account_id_hex: "11".repeat(32),
             group_id: GroupId::new(vec![1]),
             stream_id: vec![0xaa],
             stream_capability: [0x77; 32],
@@ -1446,6 +1449,7 @@ async fn stream_session_store_resolves_non_canonical_stream_id() {
         canonical_stream_id_hex.clone(),
         ActiveStreamSession {
             account_label: "agent".to_owned(),
+            account_id_hex: "11".repeat(32),
             group_id: GroupId::new(vec![1]),
             stream_id: vec![0xaa, 0xbb],
             stream_capability: [0x77; 32],
@@ -1605,6 +1609,7 @@ async fn stream_session_sweep_does_not_force_abort_when_cancel_already_queued() 
         "aa".to_owned(),
         ActiveStreamSession {
             account_label: "agent".to_owned(),
+            account_id_hex: "11".repeat(32),
             group_id: GroupId::new(vec![1]),
             stream_id: vec![0xaa],
             stream_capability: [0x77; 32],
@@ -2399,6 +2404,27 @@ async fn connector_socket_composes_and_finalizes_stream() {
             (AGENT_TEXT_STREAM_RECORD_STATUS, "thinking"),
         ],
     );
+    let logical_final_key = format!(
+        "{}test-delivery",
+        crate::messaging::LOGICAL_FINAL_IDEMPOTENCY_PREFIX
+    );
+    let unknown = serve_control_request_once(
+        &connector,
+        &listener,
+        &socket,
+        "req-delivery-status-unknown",
+        AgentControlRequest::DeliveryStatus {
+            idempotency_key: logical_final_key.clone(),
+        },
+    )
+    .await;
+    assert_eq!(
+        unknown.payload,
+        AgentControlResponse::DeliveryStatus {
+            status: agent_control::AgentControlDeliveryStatus::Unknown,
+            message_ids_hex: Vec::new(),
+        }
+    );
     let finalized = serve_control_request_once(
         &connector,
         &listener,
@@ -2406,11 +2432,11 @@ async fn connector_socket_composes_and_finalizes_stream() {
         "req-stream-finalize",
         AgentControlRequest::StreamFinalize {
             stream_id_hex: stream_id_hex.clone(),
-            stream_capability,
+            stream_capability: stream_capability.clone(),
             final_text: "hello stream".to_owned(),
-            transcript_hash_hex,
+            transcript_hash_hex: transcript_hash_hex.clone(),
             chunk_count: 2,
-            idempotency_key: None,
+            idempotency_key: Some(logical_final_key.clone()),
         },
     )
     .await;
@@ -2424,6 +2450,149 @@ async fn connector_socket_composes_and_finalizes_stream() {
     assert_eq!(finalized_stream_id_hex, stream_id_hex);
     assert_eq!(message_ids_hex.len(), 1);
     assert!(!message_ids_hex[0].is_empty());
+
+    let committed = serve_control_request_once(
+        &connector,
+        &listener,
+        &socket,
+        "req-delivery-status-committed",
+        AgentControlRequest::DeliveryStatus {
+            idempotency_key: logical_final_key.clone(),
+        },
+    )
+    .await;
+    assert_eq!(
+        committed.payload,
+        AgentControlResponse::DeliveryStatus {
+            status: agent_control::AgentControlDeliveryStatus::Committed,
+            message_ids_hex: message_ids_hex.clone(),
+        }
+    );
+
+    // If the finalize committed but its acknowledgement was lost, an exact
+    // replay arrives after the stream session has been removed. Recover the
+    // committed result from the logical-final reservation without another send.
+    let replayed_finalize = serve_control_request_once(
+        &connector,
+        &listener,
+        &socket,
+        "req-stream-finalize-replay",
+        AgentControlRequest::StreamFinalize {
+            stream_id_hex: stream_id_hex.clone(),
+            stream_capability: stream_capability.clone(),
+            final_text: "hello stream".to_owned(),
+            transcript_hash_hex,
+            chunk_count: 2,
+            idempotency_key: Some(logical_final_key.clone()),
+        },
+    )
+    .await;
+    assert_eq!(
+        replayed_finalize.payload,
+        AgentControlResponse::StreamFinalized {
+            stream_id_hex: stream_id_hex.clone(),
+            message_ids_hex: message_ids_hex.clone(),
+        },
+        "an exact finalize replay must recover the committed result"
+    );
+
+    // A reconstructed client must not bind the already-committed logical key to
+    // a new live stream. While the original session is gone (so an exact retry
+    // can recover below), an active replacement session provides enough context
+    // to detect its different stream-start parent and reject the key conflict.
+    let replacement_stream_id_hex = hex::encode([0x99; 32]);
+    let replacement_begun = serve_control_request_once(
+        &connector,
+        &listener,
+        &socket,
+        "req-replacement-stream-begin",
+        AgentControlRequest::StreamBegin {
+            account_id_hex: agent.account.account_id_hex.clone(),
+            group_id_hex: group_id_hex.clone(),
+            stream_id_hex: Some(replacement_stream_id_hex.clone()),
+            parent_message_id_hex: Some(parent_message_id_hex),
+            quic_candidates: vec!["quic://127.0.0.1:9".to_owned()],
+        },
+    )
+    .await;
+    let AgentControlResponse::StreamBegun {
+        stream_capability: replacement_capability,
+        start_message_id_hex: replacement_start_message_id_hex,
+        ..
+    } = replacement_begun.payload
+    else {
+        panic!("expected replacement stream begun response");
+    };
+    let replacement_append = serve_control_request_once(
+        &connector,
+        &listener,
+        &socket,
+        "req-replacement-stream-append",
+        AgentControlRequest::StreamAppend {
+            stream_id_hex: replacement_stream_id_hex.clone(),
+            stream_capability: replacement_capability.clone(),
+            append_text: "hello stream".to_owned(),
+        },
+    )
+    .await;
+    assert_eq!(replacement_append.payload, AgentControlResponse::Ack);
+    let replacement_transcript_hash = expected_stream_transcript_hash(
+        &replacement_stream_id_hex,
+        &replacement_start_message_id_hex,
+        &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, "hello stream")],
+    );
+    let conflicting_finalize = serve_control_request_once(
+        &connector,
+        &listener,
+        &socket,
+        "req-replacement-stream-finalize",
+        AgentControlRequest::StreamFinalize {
+            stream_id_hex: replacement_stream_id_hex.clone(),
+            stream_capability: replacement_capability.clone(),
+            final_text: "hello stream".to_owned(),
+            transcript_hash_hex: replacement_transcript_hash,
+            chunk_count: 1,
+            idempotency_key: Some(logical_final_key.clone()),
+        },
+    )
+    .await;
+    let AgentControlResponse::Error { code, .. } = conflicting_finalize.payload else {
+        panic!("expected logical final idempotency conflict");
+    };
+    assert_eq!(code, "idempotency_key_conflict");
+    let replacement_cancel = serve_control_request_once(
+        &connector,
+        &listener,
+        &socket,
+        "req-replacement-stream-cancel",
+        AgentControlRequest::StreamCancel {
+            stream_id_hex: replacement_stream_id_hex,
+            stream_capability: replacement_capability,
+            reason: Some("test cleanup".to_owned()),
+        },
+    )
+    .await;
+    assert_eq!(replacement_cancel.payload, AgentControlResponse::Ack);
+
+    let direct_retry = serve_control_request_once(
+        &connector,
+        &listener,
+        &socket,
+        "req-direct-final-retry",
+        AgentControlRequest::SendFinal {
+            account_id_hex: agent.account.account_id_hex.to_uppercase(),
+            group_id_hex: group_id_hex.clone(),
+            text: "hello stream".to_owned(),
+            reply_to_message_id_hex: Some(start_message_id_hex.to_uppercase()),
+            idempotency_key: Some(logical_final_key),
+        },
+    )
+    .await;
+    assert_eq!(
+        direct_retry.payload,
+        AgentControlResponse::FinalSent { message_ids_hex },
+        "direct fallback must reuse the committed stream-final result"
+    );
 }
 
 /// Regression for #366: a finalize whose expectation does not match the
@@ -3780,7 +3949,7 @@ async fn send_final_with_repeated_idempotency_key_dedups_without_second_send() {
             &group_id_hex.to_uppercase(),
             "idempotent reply".to_owned(),
             None,
-            Some(key.clone()),
+            Some(format!("  {key}  ")),
         )
         .await
         .unwrap()
@@ -3807,7 +3976,7 @@ async fn send_final_with_repeated_idempotency_key_dedups_without_second_send() {
     };
     assert_eq!(
         second_ids, first_ids,
-        "a repeated idempotency key must return the original ids across equivalent hex casing"
+        "a repeated idempotency key must return the original ids across equivalent hex casing and surrounding whitespace"
     );
 
     // Observable proof there was no second underlying send: exactly one copy of
@@ -3827,6 +3996,155 @@ async fn send_final_with_repeated_idempotency_key_dedups_without_second_send() {
         .filter(|m| m.plaintext == "idempotent reply")
         .count();
     assert_eq!(copies, 1, "a deduped retry must not re-post the message");
+}
+
+#[tokio::test]
+async fn concurrent_send_final_with_same_key_awaits_one_committed_send() {
+    let dir = tempfile::tempdir().unwrap();
+    let relay = MockRelay::run().await.unwrap();
+    let relay_url = relay.url().await.to_string();
+    let app = MarmotApp::with_relay(dir.path(), relay_url.clone());
+    let setup_runtime = MarmotAppRuntime::new(app);
+    let setup = AccountSetupRequest {
+        default_relays: vec![crate::validation::endpoint(&relay_url)],
+        bootstrap_relays: vec![crate::validation::endpoint(&relay_url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let agent = setup_runtime.create_identity(setup.clone()).await.unwrap();
+    let human = setup_runtime.create_identity(setup).await.unwrap();
+    let group_id = setup_runtime
+        .create_group(
+            &agent.account.account_id_hex,
+            "agent concurrent idempotent send",
+            std::slice::from_ref(&human.account.account_id_hex),
+            None,
+        )
+        .await
+        .unwrap();
+    setup_runtime.shutdown().await;
+    let group_id_hex = hex::encode(group_id.as_slice());
+
+    let connector = AgentConnector::open(test_config(
+        dir.path(),
+        dir.path().join("dev").join("wn-agent.sock"),
+        vec![relay_url],
+        false,
+        false,
+    ))
+    .unwrap();
+    connector.runtime.catch_up_accounts().await.unwrap();
+
+    let key = "concurrent-retry-key".to_owned();
+    let first = connector.send_final_response(
+        &agent.account.account_id_hex,
+        &group_id_hex,
+        "one logical reply".to_owned(),
+        None,
+        Some(key.clone()),
+    );
+    let second = connector.send_final_response(
+        &agent.account.account_id_hex,
+        &group_id_hex,
+        "one logical reply".to_owned(),
+        None,
+        Some(key),
+    );
+    let (first, second) = tokio::join!(first, second);
+
+    let AgentControlResponse::FinalSent {
+        message_ids_hex: first_ids,
+    } = first.unwrap()
+    else {
+        panic!("expected first concurrent send to return FinalSent");
+    };
+    let AgentControlResponse::FinalSent {
+        message_ids_hex: second_ids,
+    } = second.unwrap()
+    else {
+        panic!("expected second concurrent send to return FinalSent");
+    };
+    assert_eq!(
+        second_ids, first_ids,
+        "same-key followers return the leader ids"
+    );
+
+    let stored = connector
+        .runtime
+        .messages_with_query(
+            &agent.account.account_id_hex,
+            crate::AppMessageQuery {
+                group_id_hex: Some(group_id_hex),
+                limit: None,
+            },
+        )
+        .unwrap();
+    let copies = stored
+        .iter()
+        .filter(|message| message.plaintext == "one logical reply")
+        .count();
+    assert_eq!(
+        copies, 1,
+        "concurrent same-key requests must produce one durable message"
+    );
+}
+
+#[tokio::test]
+async fn send_idempotency_store_same_key_follower_waits_for_leader_result() {
+    use crate::stream_session::{
+        SendIdempotencyReservation, SendIdempotencyStatus, SendIdempotencyStore,
+    };
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SendIdempotencyStore::new(dir.path());
+    assert!(matches!(
+        store.status("logical-key"),
+        SendIdempotencyStatus::Unknown
+    ));
+    let leader = match store.reserve("logical-key", "fingerprint").unwrap() {
+        SendIdempotencyReservation::Leader(leader) => leader,
+        _ => panic!("first caller must lead the send"),
+    };
+    let mut completion = match store.reserve("logical-key", "fingerprint").unwrap() {
+        SendIdempotencyReservation::Wait(completion) => completion,
+        _ => panic!("same-key concurrent caller must wait"),
+    };
+    assert!(matches!(
+        store.status("logical-key"),
+        SendIdempotencyStatus::Pending
+    ));
+
+    let ids = vec!["aa".repeat(32)];
+    leader.complete(ids.clone());
+    if !*completion.borrow() {
+        completion.changed().await.unwrap();
+    }
+
+    match store.reserve("logical-key", "fingerprint").unwrap() {
+        SendIdempotencyReservation::Completed(recorded) => assert_eq!(recorded, ids),
+        _ => panic!("follower retry must receive the leader result"),
+    }
+    assert!(matches!(
+        store.status("logical-key"),
+        SendIdempotencyStatus::Committed(recorded) if recorded == ids
+    ));
+
+    let failed_leader = match store.reserve("retryable-key", "fingerprint").unwrap() {
+        SendIdempotencyReservation::Leader(leader) => leader,
+        _ => panic!("new key must elect a leader"),
+    };
+    let mut failed_follower = match store.reserve("retryable-key", "fingerprint").unwrap() {
+        SendIdempotencyReservation::Wait(completion) => completion,
+        _ => panic!("same-key caller must wait while the leader is active"),
+    };
+    drop(failed_leader);
+    if !*failed_follower.borrow() {
+        failed_follower.changed().await.unwrap();
+    }
+    assert!(matches!(
+        store.reserve("retryable-key", "fingerprint").unwrap(),
+        SendIdempotencyReservation::Leader(_)
+    ));
 }
 
 #[test]

--- a/crates/agent-connector/src/validation.rs
+++ b/crates/agent-connector/src/validation.rs
@@ -103,6 +103,7 @@ pub(crate) fn agent_control_request_type(request: &AgentControlRequest) -> &'sta
     match request {
         AgentControlRequest::SubscribeInbound { .. } => "subscribe_inbound",
         AgentControlRequest::SendFinal { .. } => "send_final",
+        AgentControlRequest::DeliveryStatus { .. } => "delivery_status",
         AgentControlRequest::DeleteMessage { .. } => "delete_message",
         AgentControlRequest::StreamBegin { .. } => "stream_begin",
         AgentControlRequest::StreamAppend { .. } => "stream_append",

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -83,6 +83,12 @@ pub enum AgentControlRequest {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         idempotency_key: Option<String>,
     },
+    /// Query the connector-local result of an idempotent logical final send.
+    /// Used after timeout/connection loss to distinguish committed, pending,
+    /// and safe-to-fallback unknown outcomes.
+    DeliveryStatus {
+        idempotency_key: String,
+    },
     DeleteMessage {
         account_id_hex: String,
         group_id_hex: String,
@@ -260,6 +266,14 @@ pub struct AgentControlMediaRef {
     pub thumbhash: Option<String>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentControlDeliveryStatus {
+    Unknown,
+    Pending,
+    Committed,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentControlResponse {
@@ -284,6 +298,10 @@ pub enum AgentControlResponse {
         display_name: Option<String>,
     },
     FinalSent {
+        message_ids_hex: Vec<String>,
+    },
+    DeliveryStatus {
+        status: AgentControlDeliveryStatus,
         message_ids_hex: Vec<String>,
     },
     AppEventSent {
@@ -512,9 +530,9 @@ mod tests {
     use tokio::io::BufReader;
 
     use crate::{
-        AgentControlEnvelope, AgentControlError, AgentControlEvent, AgentControlRequest,
-        AgentControlResponse, MAX_AGENT_CONTROL_FRAME_BYTES, decode_envelope, encode_frame,
-        read_envelope, read_frame, write_frame,
+        AgentControlDeliveryStatus, AgentControlEnvelope, AgentControlError, AgentControlEvent,
+        AgentControlRequest, AgentControlResponse, MAX_AGENT_CONTROL_FRAME_BYTES, decode_envelope,
+        encode_frame, read_envelope, read_frame, write_frame,
     };
 
     #[test]
@@ -619,6 +637,23 @@ mod tests {
         assert_eq!(value["idempotency_key"], "key-1");
         let round_tripped: AgentControlRequest = serde_json::from_value(value).unwrap();
         assert_eq!(round_tripped, with);
+    }
+
+    #[test]
+    fn delivery_status_response_uses_stable_status_strings() {
+        for (status, expected) in [
+            (AgentControlDeliveryStatus::Unknown, "unknown"),
+            (AgentControlDeliveryStatus::Pending, "pending"),
+            (AgentControlDeliveryStatus::Committed, "committed"),
+        ] {
+            let value = serde_json::to_value(AgentControlResponse::DeliveryStatus {
+                status,
+                message_ids_hex: Vec::new(),
+            })
+            .unwrap();
+            assert_eq!(value["type"], "delivery_status");
+            assert_eq!(value["status"], expected);
+        }
     }
 
     #[test]
@@ -839,6 +874,12 @@ mod tests {
                     idempotency_key: None,
                 },
                 "send_final",
+            ),
+            (
+                AgentControlRequest::DeliveryStatus {
+                    idempotency_key: "logical-final-1".to_owned(),
+                },
+                "delivery_status",
             ),
             (
                 AgentControlRequest::DeleteMessage {

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -345,6 +345,20 @@ directory with `--media-allowed-root`; without one, path sends fail closed.
   the Marmot group id and `user_id` set to the sender account id.
 - Hermes progressive edits open at most one live preview per chat at a time. A
   newer preview cancels the previous stream for that chat.
+- When Hermes supplies `metadata.logical_delivery_id`, the adapter preserves it
+  across progressive preview finalization, retries, and direct fallback. The
+  value must be stable when the same logical delivery is reconstructed or
+  retried, and unique for separate turns even when their text is identical.
+  Until Hermes provides that metadata, the adapter can only keep a generated
+  identity stable within one in-process send/finalize attempt. Message text is
+  never a delivery identity.
+- The adapter hashes that identity with the destination into an opaque, stable
+  final idempotency key. A stream finalize and its direct-send fallback
+  deliberately share one final key and the stream-start parent. Stream-begin
+  receipts are deliberately not derived from the logical identity: each begin
+  scopes a fresh request id to its own bounded retries, so a reconstructed
+  adapter never replays a begin for a stream whose local transcript it no longer
+  holds.
 - Durable message text is exactly what Hermes hands the adapter. The adapter
   never merges, splices, or reconstructs text across sends; fragmented or
   duplicated finals must be fixed in Hermes message segmentation.
@@ -352,7 +366,9 @@ directory with `--media-allowed-root`; without one, path sends fail closed.
   stream-final `kind: 9` when the final text is an append-only extension of the
   streamed text. There is no duplicate plain `send_final` for the same text.
 - Otherwise the preview is cancelled and the final goes out verbatim as one
-  plain `send_final`.
+  plain `send_final`. After an outcome-unknown finalize, the adapter first asks
+  `delivery_status` whether that logical final is pending or already committed;
+  it only falls back when the connector reports `unknown`.
 - Status records are included in the stream transcript hash and chunk count.
 
 Run the shim tests with:

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -53,6 +53,7 @@ TOOL_EVENT_PREFIX = "\x1fMARMOT_TOOL_EVENT:"
 SEND_FINAL_RETRY_BACKOFF_S = (0.1, 0.3)
 STREAM_BEGIN_RETRY_BACKOFF_S = (0.1, 0.3)
 STREAM_FINALIZE_RETRY_BACKOFF_S = (0.1, 0.3)
+LOGICAL_FINAL_IDEMPOTENCY_PREFIX = "marmot_logical_final_v1:"
 DEFAULT_STREAMING_CURSOR = "\u2589"
 _DEFAULT_READ_TIMEOUT = object()
 MAX_TOOL_PROGRESS_MESSAGES = 512
@@ -251,6 +252,64 @@ class _RecentKeys:
         self._keys[key] = None
         while len(self._keys) > self.max_size:
             self._keys.popitem(last=False)
+
+
+def _logical_delivery_id(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Return Hermes' stable per-delivery identity, when the gateway supplied it."""
+    if not isinstance(metadata, dict):
+        return None
+    value = str(metadata.get("logical_delivery_id") or "").strip()
+    return value or None
+
+
+def _opaque_delivery_key(prefix: str, *parts: Optional[str]) -> str:
+    """Derive a deterministic, log-safe transport key without exposing Hermes ids."""
+    preimage = json.dumps(
+        [prefix, *[str(part or "") for part in parts]],
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return f"{prefix}{hashlib.sha256(preimage).hexdigest()}"
+
+
+def _redaction_safe_ref(value: Optional[str]) -> str:
+    if not value:
+        return "none"
+    return hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:12]
+
+
+def _log_delivery_attempt(
+    *,
+    logical_delivery_key: Optional[str],
+    stream_id_hex: Optional[str],
+    operation_role: str,
+    attempt: int,
+    outcome: str,
+) -> None:
+    log = logger.debug if outcome == "started" else logger.info
+    log(
+        "Marmot delivery attempt",
+        extra={
+            "logical_delivery_ref": _redaction_safe_ref(logical_delivery_key),
+            "stream_ref": _redaction_safe_ref(stream_id_hex),
+            "operation_role": operation_role,
+            "attempt": attempt,
+            "outcome": outcome,
+        },
+    )
+
+
+def _logical_final_idempotency_key(
+    logical_delivery_id: str,
+    account_id_hex: str,
+    group_id_hex: str,
+) -> str:
+    return _opaque_delivery_key(
+        LOGICAL_FINAL_IDEMPOTENCY_PREFIX,
+        logical_delivery_id,
+        account_id_hex,
+        group_id_hex,
+    )
 
 
 class SentMessageTargetCache:
@@ -1062,6 +1121,14 @@ class MarmotAgentControlClient:
             }
         )
 
+    async def delivery_status(self, idempotency_key: str) -> Dict[str, Any]:
+        return await self.request(
+            {
+                "type": "delivery_status",
+                "idempotency_key": str(idempotency_key or "").strip(),
+            }
+        )
+
     async def stream_cancel(
         self,
         stream_id_hex: str,
@@ -1269,6 +1336,7 @@ class MarmotLiveStream:
         stream_capability: str,
         start_message_id_hex: str,
         chunk_bytes: int,
+        finalize_idempotency_key: Optional[str] = None,
     ):
         self.client = client
         self.account_id_hex = account_id_hex
@@ -1282,7 +1350,11 @@ class MarmotLiveStream:
             start_message_id_hex,
             chunk_bytes=chunk_bytes,
         )
-        self.finalize_idempotency_key = uuid.uuid4().hex
+        self.finalize_idempotency_key = finalize_idempotency_key or _logical_final_idempotency_key(
+            uuid.uuid4().hex,
+            account_id_hex,
+            group_id_hex,
+        )
         self.finalized = False
 
     @classmethod
@@ -1296,6 +1368,7 @@ class MarmotLiveStream:
         chunk_bytes: int,
         stream_id_hex: Optional[str] = None,
         parent_message_id_hex: Optional[str] = None,
+        logical_delivery_id: Optional[str] = None,
     ) -> "MarmotLiveStream":
         begin_options: Dict[str, Any] = {
             "stream_id_hex": stream_id_hex,
@@ -1303,9 +1376,26 @@ class MarmotLiveStream:
         }
         if parent_message_id_hex is not None:
             begin_options["parent_message_id_hex"] = parent_message_id_hex
+        delivery_id = str(logical_delivery_id or uuid.uuid4().hex)
+        # This request id is stable only across the bounded retries below. Reusing
+        # it after adapter reconstruction would return a stale stream-begin receipt
+        # without restoring the client-side transcript, so a replay could append
+        # the same preview text twice or target an already-finalized stream.
         begin_request_id = uuid.uuid4().hex
+        finalize_idempotency_key = _logical_final_idempotency_key(
+            delivery_id,
+            account_id_hex,
+            group_id_hex,
+        )
         response: Optional[Dict[str, Any]] = None
         for attempt in range(len(STREAM_BEGIN_RETRY_BACKOFF_S) + 1):
+            _log_delivery_attempt(
+                logical_delivery_key=finalize_idempotency_key,
+                stream_id_hex=stream_id_hex,
+                operation_role="stream_begin",
+                attempt=attempt + 1,
+                outcome="started",
+            )
             try:
                 response = await client.stream_begin(
                     account_id_hex,
@@ -1313,9 +1403,24 @@ class MarmotLiveStream:
                     request_id=begin_request_id,
                     **begin_options,
                 )
+                _log_delivery_attempt(
+                    logical_delivery_key=finalize_idempotency_key,
+                    stream_id_hex=str(response.get("stream_id_hex") or stream_id_hex or ""),
+                    operation_role="stream_begin",
+                    attempt=attempt + 1,
+                    outcome="committed",
+                )
                 break
             except Exception as exc:
-                if attempt < len(STREAM_BEGIN_RETRY_BACKOFF_S) and is_retryable(exc):
+                retryable = is_retryable(exc)
+                _log_delivery_attempt(
+                    logical_delivery_key=finalize_idempotency_key,
+                    stream_id_hex=stream_id_hex,
+                    operation_role="stream_begin",
+                    attempt=attempt + 1,
+                    outcome="retryable_failure" if retryable else "rejected",
+                )
+                if attempt < len(STREAM_BEGIN_RETRY_BACKOFF_S) and retryable:
                     await asyncio.sleep(STREAM_BEGIN_RETRY_BACKOFF_S[attempt])
                     continue
                 raise
@@ -1336,6 +1441,7 @@ class MarmotLiveStream:
                 chunk_bytes,
                 response.get("policy_max_plaintext_frame_len"),
             ),
+            finalize_idempotency_key=finalize_idempotency_key,
         )
 
     async def append_replacement(self, next_text: str) -> None:
@@ -1358,6 +1464,13 @@ class MarmotLiveStream:
         await self.append_replacement(final_text)
         response: Optional[Dict[str, Any]] = None
         for attempt in range(len(STREAM_FINALIZE_RETRY_BACKOFF_S) + 1):
+            _log_delivery_attempt(
+                logical_delivery_key=self.finalize_idempotency_key,
+                stream_id_hex=self.stream_id_hex,
+                operation_role="stream_finalize",
+                attempt=attempt + 1,
+                outcome="started",
+            )
             try:
                 response = await self.client.stream_finalize(
                     self.stream_id_hex,
@@ -1367,9 +1480,24 @@ class MarmotLiveStream:
                     self.transcript.chunk_count,
                     idempotency_key=self.finalize_idempotency_key,
                 )
+                _log_delivery_attempt(
+                    logical_delivery_key=self.finalize_idempotency_key,
+                    stream_id_hex=self.stream_id_hex,
+                    operation_role="stream_finalize",
+                    attempt=attempt + 1,
+                    outcome="committed",
+                )
                 break
             except Exception as exc:
-                if attempt < len(STREAM_FINALIZE_RETRY_BACKOFF_S) and is_retryable(exc):
+                retryable = is_retryable(exc)
+                _log_delivery_attempt(
+                    logical_delivery_key=self.finalize_idempotency_key,
+                    stream_id_hex=self.stream_id_hex,
+                    operation_role="stream_finalize",
+                    attempt=attempt + 1,
+                    outcome="retryable_failure" if retryable else "rejected",
+                )
+                if attempt < len(STREAM_FINALIZE_RETRY_BACKOFF_S) and retryable:
                     logger.debug(
                         "Marmot stream_finalize failed; retrying (attempt %d): %s",
                         attempt + 1,
@@ -1536,6 +1664,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         self._capture_loop()
         chat_id = _normalize_hex(chat_id, "chat_id")
         visible_content = self._strip_streaming_cursor(content)
+        logical_delivery_id = _logical_delivery_id(metadata)
 
         tool_events = _tool_events_from_progress_text(visible_content)
         if tool_events:
@@ -1553,6 +1682,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                 stream = await self._begin_live_stream(
                     chat_id,
                     parent_message_id_hex=_optional_hex(reply_to),
+                    logical_delivery_id=logical_delivery_id,
                 )
                 await stream.append_replacement(visible_content)
                 message_id = _stream_message_id(stream.stream_id_hex)
@@ -1566,6 +1696,26 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         stream = self._last_chat_stream.get(chat_id)
         if stream is not None and not stream.finalized:
             message_id = _stream_message_id(stream.stream_id_hex)
+            if logical_delivery_id is not None:
+                account_id = await self._ensure_account_id()
+                expected_key = _logical_final_idempotency_key(
+                    logical_delivery_id,
+                    account_id,
+                    chat_id,
+                )
+                if expected_key != stream.finalize_idempotency_key:
+                    await self._cancel_stream(
+                        chat_id,
+                        message_id,
+                        stream,
+                        "logical delivery was superseded",
+                    )
+                    return await self._send_final_direct(
+                        chat_id,
+                        visible_content,
+                        reply_to_message_id_hex=_optional_hex(reply_to),
+                        logical_delivery_id=logical_delivery_id,
+                    )
             try:
                 # The final text is authoritative. Finalize the live preview only
                 # when the final is an exact append-only extension of the streamed
@@ -1583,23 +1733,29 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                     visible_content,
                     message_id=message_id,
                     reason="final text was not append-only",
-                    reply_to_message_id_hex=_optional_hex(reply_to),
                 )
             except Exception as exc:
                 logger.debug("Marmot live-preview finalize failed: %s", exc)
+                if is_retryable(exc):
+                    return await self._reconcile_ambiguous_stream_final(
+                        chat_id,
+                        stream,
+                        visible_content,
+                        message_id=message_id,
+                    )
                 return await self._abandon_preview_and_send_final(
                     chat_id,
                     stream,
                     visible_content,
                     message_id=message_id,
                     reason="finalize_error",
-                    reply_to_message_id_hex=_optional_hex(reply_to),
                 )
 
         return await self._send_final_direct(
             chat_id,
             visible_content,
             reply_to_message_id_hex=_optional_hex(reply_to),
+            logical_delivery_id=logical_delivery_id,
         )
 
     async def edit_message(
@@ -1654,6 +1810,13 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("Marmot live-preview edit failed: %s", exc)
             if finalize:
+                if is_retryable(exc):
+                    return await self._reconcile_ambiguous_stream_final(
+                        chat_id,
+                        stream,
+                        visible_content,
+                        message_id=message_id,
+                    )
                 return await self._abandon_preview_and_send_final(
                     chat_id,
                     stream,
@@ -1774,6 +1937,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                         or metadata.get("reply_to_message_id_hex")
                         or _TURN_PARENT_MESSAGE_ID_HEX.get()
                     ),
+                    logical_delivery_id=_logical_delivery_id(metadata),
                 )
                 self._draft_streams[key] = stream
                 self._last_chat_stream[chat_id] = stream
@@ -1797,15 +1961,19 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         message_id: Optional[str] = None,
     ) -> SendResult:
         response = await stream.finalize(final_text)
-        if message_id:
-            self._active_streams.pop(message_id, None)
-        self._forget_stream(chat_id, stream)
         try:
             result = self._result_from_stream_finalize(response)
         except Exception as exc:
             logger.debug("Marmot stream finalize response rejected: %s", exc)
-            await self._cancel_stream(chat_id, message_id, stream, "finalize rejected")
-            return await self._send_final_direct(chat_id, final_text)
+            return await self._reconcile_ambiguous_stream_final(
+                chat_id,
+                stream,
+                final_text,
+                message_id=message_id,
+            )
+        if message_id:
+            self._active_streams.pop(message_id, None)
+        self._forget_stream(chat_id, stream)
         account_id = await self._ensure_account_id()
         self._sent_targets.record_all(
             tuple(response.get("message_ids_hex") or ()),
@@ -1813,6 +1981,95 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             group_id_hex=chat_id,
         )
         return result
+
+    async def _reconcile_ambiguous_stream_final(
+        self,
+        chat_id: str,
+        stream: MarmotLiveStream,
+        final_text: str,
+        *,
+        message_id: Optional[str],
+    ) -> SendResult:
+        """Resolve an outcome-unknown finalize before any direct fallback."""
+        _log_delivery_attempt(
+            logical_delivery_key=stream.finalize_idempotency_key,
+            stream_id_hex=stream.stream_id_hex,
+            operation_role="delivery_status",
+            attempt=1,
+            outcome="started",
+        )
+        try:
+            response = await self.client.delivery_status(stream.finalize_idempotency_key)
+        except Exception as exc:
+            _log_delivery_attempt(
+                logical_delivery_key=stream.finalize_idempotency_key,
+                stream_id_hex=stream.stream_id_hex,
+                operation_role="delivery_status",
+                attempt=1,
+                outcome="failed",
+            )
+            logger.debug("Marmot final-delivery reconciliation failed: %s", exc)
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+        if response.get("type") != "delivery_status":
+            _log_delivery_attempt(
+                logical_delivery_key=stream.finalize_idempotency_key,
+                stream_id_hex=stream.stream_id_hex,
+                operation_role="delivery_status",
+                attempt=1,
+                outcome="invalid",
+            )
+            return SendResult(
+                success=False,
+                error="Marmot final-delivery reconciliation returned an unexpected response",
+                retryable=True,
+            )
+        status = str(response.get("status") or "")
+        _log_delivery_attempt(
+            logical_delivery_key=stream.finalize_idempotency_key,
+            stream_id_hex=stream.stream_id_hex,
+            operation_role="delivery_status",
+            attempt=1,
+            outcome=status or "invalid",
+        )
+        if status == "committed":
+            message_ids = tuple(response.get("message_ids_hex") or ())
+            if not message_ids:
+                return SendResult(
+                    success=False,
+                    error="Marmot committed delivery status returned no message ids",
+                    retryable=True,
+                )
+            if message_id:
+                self._active_streams.pop(message_id, None)
+            self._forget_stream(chat_id, stream)
+            account_id = await self._ensure_account_id()
+            self._sent_targets.record_all(
+                message_ids,
+                account_id_hex=account_id,
+                group_id_hex=chat_id,
+            )
+            return SendResult(
+                success=True,
+                message_id=message_ids[-1],
+                raw_response=response,
+                continuation_message_ids=message_ids[:-1],
+            )
+        if status == "unknown":
+            return await self._abandon_preview_and_send_final(
+                chat_id,
+                stream,
+                final_text,
+                message_id=message_id,
+                reason="finalize_outcome_reconciled_unknown",
+            )
+        # A pending leader may still commit. Keep the preview/session handle and
+        # let Hermes retry this logical delivery with the same stable identity.
+        return SendResult(
+            success=False,
+            error="Marmot final delivery is still pending",
+            retryable=True,
+        )
 
     @staticmethod
     def _result_from_stream_finalize(response: Dict[str, Any]) -> SendResult:
@@ -1839,13 +2096,17 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         *,
         message_id: Optional[str] = None,
         reason: str,
-        reply_to_message_id_hex: Optional[str] = None,
     ) -> SendResult:
         await self._cancel_stream(chat_id, message_id, stream, reason)
         return await self._send_final_direct(
             chat_id,
             final_text,
-            reply_to_message_id_hex=reply_to_message_id_hex,
+            # A direct fallback is still the final node of the same causal
+            # stream chain. The stream-start already points at the prompt, so
+            # the fallback must point at the start rather than skipping it.
+            reply_to_message_id_hex=stream.start_message_id_hex,
+            idempotency_key=stream.finalize_idempotency_key,
+            stream_id_hex=stream.stream_id_hex,
         )
 
     async def _send_final_direct(
@@ -1854,17 +2115,32 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         content: str,
         *,
         reply_to_message_id_hex: Optional[str] = None,
+        logical_delivery_id: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+        stream_id_hex: Optional[str] = None,
     ) -> SendResult:
         # One idempotency key for every attempt of THIS durable reply: a retry
         # after a post-write timeout reuses the key so the connector dedups
         # instead of double-posting an unrecallable encrypted message. Bounded
         # retries with a tiny backoff cover the transient/timeout window;
         # non-retryable errors fail fast. Mirrors OpenClaw dispatch.ts.
-        idempotency_key = uuid.uuid4().hex
+        account_id = await self._ensure_account_id()
+        if idempotency_key is None:
+            idempotency_key = _logical_final_idempotency_key(
+                logical_delivery_id or uuid.uuid4().hex,
+                account_id,
+                chat_id,
+            )
         last_exc: BaseException | None = None
         for attempt in range(len(SEND_FINAL_RETRY_BACKOFF_S) + 1):
+            _log_delivery_attempt(
+                logical_delivery_key=idempotency_key,
+                stream_id_hex=stream_id_hex,
+                operation_role="direct_final",
+                attempt=attempt + 1,
+                outcome="started",
+            )
             try:
-                account_id = await self._ensure_account_id()
                 response = await self.client.send_final(
                     account_id,
                     chat_id,
@@ -1879,6 +2155,13 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                     account_id_hex=account_id,
                     group_id_hex=chat_id,
                 )
+                _log_delivery_attempt(
+                    logical_delivery_key=idempotency_key,
+                    stream_id_hex=stream_id_hex,
+                    operation_role="direct_final",
+                    attempt=attempt + 1,
+                    outcome="committed",
+                )
                 return SendResult(
                     success=True,
                     message_id=message_id,
@@ -1887,7 +2170,15 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                 )
             except Exception as exc:
                 last_exc = exc
-                if attempt < len(SEND_FINAL_RETRY_BACKOFF_S) and is_retryable(exc):
+                retryable = is_retryable(exc)
+                _log_delivery_attempt(
+                    logical_delivery_key=idempotency_key,
+                    stream_id_hex=stream_id_hex,
+                    operation_role="direct_final",
+                    attempt=attempt + 1,
+                    outcome="retryable_failure" if retryable else "rejected",
+                )
+                if attempt < len(SEND_FINAL_RETRY_BACKOFF_S) and retryable:
                     logger.debug(
                         "Marmot send_final failed; retrying (attempt %d): %s",
                         attempt + 1,
@@ -2138,6 +2429,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         chat_id: str,
         *,
         parent_message_id_hex: Optional[str] = None,
+        logical_delivery_id: Optional[str] = None,
     ) -> MarmotLiveStream:
         account_id = await self._ensure_account_id()
         return await MarmotLiveStream.begin(
@@ -2145,6 +2437,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             account_id_hex=account_id,
             group_id_hex=chat_id,
             parent_message_id_hex=parent_message_id_hex,
+            logical_delivery_id=logical_delivery_id,
             quic_candidates=self.quic_candidates,
             chunk_bytes=self.stream_chunk_bytes,
         )

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -232,6 +232,35 @@ class AgentControlClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("idempotency_key", requests[1])
         self.assertNotIn("idempotency_key", requests[2])
 
+    async def test_delivery_status_queries_the_logical_idempotency_key(self):
+        requests = []
+
+        async def handler(reader, writer):
+            request = await read_json_line(reader)
+            requests.append(request)
+            await write_json_line(
+                writer,
+                {
+                    "marmot_agent_control": "marmot.agent-control.v2",
+                    "id": request["id"],
+                    "type": "delivery_status",
+                    "status": "committed",
+                    "message_ids_hex": ["aa"],
+                },
+            )
+            writer.close()
+
+        await self.start_server(handler)
+        client = self.adapter.MarmotAgentControlClient(self.socket_path)
+        response = await client.delivery_status("marmot_logical_final_v1:abc")
+
+        self.assertEqual(response["status"], "committed")
+        self.assertEqual(requests[0]["type"], "delivery_status")
+        self.assertEqual(
+            requests[0]["idempotency_key"],
+            "marmot_logical_final_v1:abc",
+        )
+
     async def test_stream_begin_includes_parent_message_id_only_when_supplied(self):
         requests = []
 
@@ -2099,7 +2128,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(fake_client.stream_cancels, [("55" * 32, "final text was not append-only")])
         self.assertEqual(
             fake_client.final_sends,
-            [("11" * 32, "22" * 32, "Based on my search", None)],
+            [("11" * 32, "22" * 32, "Based on my search", "66" * 32)],
         )
 
 
@@ -2798,6 +2827,27 @@ class FinalizeFallbackTests(unittest.IsolatedAsyncioTestCase):
         self.adapter_module = load_adapter_module()
         self.config_cls = sys.modules["gateway.config"].PlatformConfig
 
+    def test_delivery_attempt_log_fields_are_redaction_safe(self):
+        logical_id = "private-logical-delivery-id"
+        stream_id = "ab" * 32
+        with unittest.mock.patch.object(self.adapter_module.logger, "info") as info:
+            self.adapter_module._log_delivery_attempt(
+                logical_delivery_key=logical_id,
+                stream_id_hex=stream_id,
+                operation_role="stream_finalize",
+                attempt=2,
+                outcome="committed",
+            )
+
+        extra = info.call_args.kwargs["extra"]
+        self.assertEqual(extra["operation_role"], "stream_finalize")
+        self.assertEqual(extra["attempt"], 2)
+        self.assertEqual(extra["outcome"], "committed")
+        self.assertEqual(len(extra["logical_delivery_ref"]), 12)
+        self.assertEqual(len(extra["stream_ref"]), 12)
+        self.assertNotIn(logical_id, str(extra))
+        self.assertNotIn(stream_id, str(extra))
+
     async def test_stream_begin_retries_with_the_same_request_id(self):
         adapter_module = self.adapter_module
 
@@ -2965,6 +3015,324 @@ class FinalizeFallbackTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(fake_client.final_sends), 1)
         self.assertEqual(fake_client.final_sends[0][2], "hello world")
         self.assertTrue(fake_client.stream_cancels)
+
+    async def test_logical_delivery_id_is_stable_across_reconstruction_but_not_same_text_turns(self):
+        calls = []
+
+        class FakeClient:
+            async def send_final(
+                self,
+                account_id_hex,
+                group_id_hex,
+                text,
+                reply_to_message_id_hex=None,
+                idempotency_key=None,
+            ):
+                calls.append((text, idempotency_key))
+                return {
+                    "type": "final_sent",
+                    "message_ids_hex": [f"{len(calls):064x}"],
+                }
+
+        for logical_delivery_id in ("delivery-a", "delivery-a", "delivery-b"):
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(extra={"account_id_hex": "11" * 32}),
+                client=FakeClient(),
+            )
+            result = await adapter.send(
+                "22" * 32,
+                "same text",
+                metadata={"logical_delivery_id": logical_delivery_id},
+            )
+            self.assertTrue(result.success)
+
+        first_key = calls[0][1]
+        self.assertEqual(calls[1][1], first_key)
+        self.assertNotEqual(calls[2][1], first_key)
+        self.assertTrue(first_key.startswith("marmot_logical_final_v1:"))
+        self.assertNotIn("delivery-a", first_key)
+
+    async def test_reconstructed_preview_starts_a_fresh_stream_begin_operation(self):
+        request_ids = []
+
+        class FakeClient:
+            async def stream_begin(
+                self,
+                account_id_hex,
+                group_id_hex,
+                *,
+                stream_id_hex=None,
+                parent_message_id_hex=None,
+                quic_candidates=(),
+                request_id=None,
+            ):
+                request_ids.append(request_id)
+                return {
+                    "type": "stream_begun",
+                    "stream_id_hex": "55" * 32,
+                    "stream_capability": "33" * 32,
+                    "start_message_id_hex": "66" * 32,
+                    "quic_candidates": list(quic_candidates),
+                }
+
+            async def stream_append(self, stream_id_hex, stream_capability, append_text):
+                return {"type": "ack"}
+
+        for _ in range(2):
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": "11" * 32,
+                        "quic_candidates": ["quic://127.0.0.1:4433"],
+                    }
+                ),
+                client=FakeClient(),
+            )
+            preview = await adapter.send(
+                "22" * 32,
+                "hello\u2589",
+                reply_to="44" * 32,
+                metadata={"logical_delivery_id": "delivery-a"},
+            )
+            self.assertTrue(preview.success)
+
+        self.assertEqual(len(request_ids), 2)
+        self.assertNotEqual(
+            request_ids[1],
+            request_ids[0],
+            "a reconstructed adapter has no transcript state for an old stream",
+        )
+
+    async def test_ambiguous_finalize_fallback_reuses_logical_key_and_stream_parent(self):
+        adapter_module = self.adapter_module
+
+        class FakeClient:
+            def __init__(self):
+                self.finalize_keys = []
+                self.final_sends = []
+                self.stream_cancels = []
+                self.status_keys = []
+
+            async def stream_begin(
+                self,
+                account_id_hex,
+                group_id_hex,
+                *,
+                stream_id_hex=None,
+                parent_message_id_hex=None,
+                quic_candidates=(),
+                request_id=None,
+            ):
+                return {
+                    "type": "stream_begun",
+                    "stream_id_hex": "55" * 32,
+                    "stream_capability": "33" * 32,
+                    "start_message_id_hex": "66" * 32,
+                    "quic_candidates": list(quic_candidates),
+                }
+
+            async def stream_append(self, stream_id_hex, stream_capability, append_text):
+                return {"type": "ack"}
+
+            async def stream_finalize(
+                self,
+                stream_id_hex,
+                stream_capability,
+                final_text,
+                transcript_hash_hex,
+                chunk_count,
+                idempotency_key=None,
+            ):
+                self.finalize_keys.append(idempotency_key)
+                raise adapter_module.AgentControlError(
+                    "response acknowledgement was lost",
+                    code="timeout",
+                    retryable=True,
+                )
+
+            async def stream_cancel(self, stream_id_hex, stream_capability, reason=None):
+                self.stream_cancels.append((stream_id_hex, reason))
+                return {"type": "ack"}
+
+            async def delivery_status(self, idempotency_key):
+                self.status_keys.append(idempotency_key)
+                return {
+                    "type": "delivery_status",
+                    "status": "unknown",
+                    "message_ids_hex": [],
+                }
+
+            async def send_final(
+                self,
+                account_id_hex,
+                group_id_hex,
+                text,
+                reply_to_message_id_hex=None,
+                idempotency_key=None,
+            ):
+                self.final_sends.append(
+                    (text, reply_to_message_id_hex, idempotency_key)
+                )
+                return {"type": "final_sent", "message_ids_hex": ["77" * 32]}
+
+        fake_client = FakeClient()
+        adapter = adapter_module.MarmotPlatformAdapter(
+            self.config_cls(
+                extra={
+                    "account_id_hex": "11" * 32,
+                    "quic_candidates": ["quic://127.0.0.1:4433"],
+                }
+            ),
+            client=fake_client,
+        )
+        metadata = {"logical_delivery_id": "delivery-a"}
+
+        preview = await adapter.send(
+            "22" * 32,
+            "hello\u2589",
+            reply_to="44" * 32,
+            metadata=metadata,
+        )
+        with unittest.mock.patch.object(adapter_module, "STREAM_FINALIZE_RETRY_BACKOFF_S", ()):
+            final = await adapter.send(
+                "22" * 32,
+                "hello world",
+                reply_to="44" * 32,
+                metadata=metadata,
+            )
+
+        self.assertTrue(preview.success)
+        self.assertTrue(final.success)
+        self.assertEqual(len(fake_client.finalize_keys), 1)
+        self.assertEqual(fake_client.status_keys, fake_client.finalize_keys)
+        self.assertEqual(len(fake_client.final_sends), 1)
+        self.assertEqual(fake_client.final_sends[0][2], fake_client.finalize_keys[0])
+        self.assertEqual(
+            fake_client.final_sends[0][1],
+            "66" * 32,
+            "fallback final must remain causally after the stream start",
+        )
+        self.assertTrue(fake_client.stream_cancels)
+
+    async def test_lost_finalize_ack_waits_while_pending_then_reconciles_committed(self):
+        adapter_module = self.adapter_module
+
+        class FakeClient:
+            def __init__(self):
+                self.finalize_keys = []
+                self.final_sends = []
+                self.stream_cancels = []
+                self.status_keys = []
+                self.delivery_status_value = "pending"
+
+            async def stream_begin(
+                self,
+                account_id_hex,
+                group_id_hex,
+                *,
+                stream_id_hex=None,
+                parent_message_id_hex=None,
+                quic_candidates=(),
+                request_id=None,
+            ):
+                return {
+                    "type": "stream_begun",
+                    "stream_id_hex": "55" * 32,
+                    "stream_capability": "33" * 32,
+                    "start_message_id_hex": "66" * 32,
+                    "quic_candidates": list(quic_candidates),
+                }
+
+            async def stream_append(self, stream_id_hex, stream_capability, append_text):
+                return {"type": "ack"}
+
+            async def stream_finalize(
+                self,
+                stream_id_hex,
+                stream_capability,
+                final_text,
+                transcript_hash_hex,
+                chunk_count,
+                idempotency_key=None,
+            ):
+                self.finalize_keys.append(idempotency_key)
+                raise adapter_module.AgentControlError(
+                    "response acknowledgement was lost",
+                    code="timeout",
+                    retryable=True,
+                )
+
+            async def delivery_status(self, idempotency_key):
+                self.status_keys.append(idempotency_key)
+                return {
+                    "type": "delivery_status",
+                    "status": self.delivery_status_value,
+                    "message_ids_hex": (
+                        ["77" * 32]
+                        if self.delivery_status_value == "committed"
+                        else []
+                    ),
+                }
+
+            async def stream_cancel(self, stream_id_hex, stream_capability, reason=None):
+                self.stream_cancels.append((stream_id_hex, reason))
+                return {"type": "ack"}
+
+            async def send_final(
+                self,
+                account_id_hex,
+                group_id_hex,
+                text,
+                reply_to_message_id_hex=None,
+                idempotency_key=None,
+            ):
+                self.final_sends.append(idempotency_key)
+                return {"type": "final_sent", "message_ids_hex": ["88" * 32]}
+
+        fake_client = FakeClient()
+        adapter = adapter_module.MarmotPlatformAdapter(
+            self.config_cls(
+                extra={
+                    "account_id_hex": "11" * 32,
+                    "quic_candidates": ["quic://127.0.0.1:4433"],
+                }
+            ),
+            client=fake_client,
+        )
+        metadata = {"logical_delivery_id": "delivery-a"}
+
+        preview = await adapter.send(
+            "22" * 32,
+            "hello\u2589",
+            reply_to="44" * 32,
+            metadata=metadata,
+        )
+        with unittest.mock.patch.object(adapter_module, "STREAM_FINALIZE_RETRY_BACKOFF_S", ()):
+            pending = await adapter.send(
+                "22" * 32,
+                "hello world",
+                reply_to="44" * 32,
+                metadata=metadata,
+            )
+            self.assertFalse(pending.success)
+            self.assertTrue(pending.retryable)
+            self.assertEqual(fake_client.final_sends, [])
+            self.assertEqual(fake_client.stream_cancels, [])
+
+            fake_client.delivery_status_value = "committed"
+            final = await adapter.send(
+                "22" * 32,
+                "hello world",
+                reply_to="44" * 32,
+                metadata=metadata,
+            )
+
+        self.assertTrue(preview.success)
+        self.assertTrue(final.success)
+        self.assertEqual(final.message_id, "77" * 32)
+        self.assertEqual(fake_client.status_keys, fake_client.finalize_keys)
+        self.assertEqual(fake_client.final_sends, [])
+        self.assertEqual(fake_client.stream_cancels, [])
 
 
 class MediaSupportTests(unittest.IsolatedAsyncioTestCase):

--- a/integrations/opencode/marmot/src/control.rs
+++ b/integrations/opencode/marmot/src/control.rs
@@ -303,6 +303,7 @@ fn response_name(response: &AgentControlResponse) -> &'static str {
         AgentControlResponse::KeyPackagePublished { .. } => "key_package_published",
         AgentControlResponse::ProfilePublished { .. } => "profile_published",
         AgentControlResponse::FinalSent { .. } => "final_sent",
+        AgentControlResponse::DeliveryStatus { .. } => "delivery_status",
         AgentControlResponse::AppEventSent { .. } => "app_event_sent",
         AgentControlResponse::Allowlist { .. } => "allowlist",
         AgentControlResponse::GroupInfo { .. } => "group_info",


### PR DESCRIPTION
## Summary

- derive a stable opaque logical-final idempotency key when Hermes supplies `metadata.logical_delivery_id`
- reuse that key across stream finalization, bounded retries, delivery-status reconciliation, and direct fallback
- make connector final sends single-flight so concurrent same-key callers share one committed result
- preserve the stream-start parent when a direct fallback is necessary
- keep stream-begin request IDs stable only inside one retry loop so reconstructed adapters cannot reuse stale transcript state
- reject an already-committed logical key when a new active stream tries to bind different final inputs
- add privacy-safe attempt correlation and regression coverage for lost acknowledgements, fallback, same-text turns, concurrency, reconstruction, and key conflicts

## Scope and dependency

This lands the MDK/connector half of #1088. The end-to-end reconstruction guarantee remains dependent on [NousResearch/hermes-agent#70694](https://github.com/NousResearch/hermes-agent/issues/70694), because current Hermes does not yet provide `logical_delivery_id` at the platform-adapter boundary. Without that metadata, the adapter generates an identity that is stable only within one in-process send/finalize attempt. For that reason this PR references, but does not close, #1088.

The connector single-flight reservation fully fixes #1039.

## Verification

- `python3 -m unittest discover -s integrations/hermes/marmot/tests -v` — 98 passed
- `cargo test -p agent-control` — 14 passed
- `cargo test -p agent-connector` — 115 passed
- `cargo test -p wn-opencode` — 48 passed, 1 process-spawning e2e test ignored by default
- `just fast-ci` — passed workspace fmt, naming, all-target checks, OTLP checks, and clippy

Fixes #1039
Refs #1088


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added delivery-status checks for tracking whether a message is unknown, pending, or committed.
  * Added stable logical delivery identifiers for reliable retries across previews, finalization, and direct sends.

* **Bug Fixes**
  * Prevented duplicate message delivery when concurrent or repeated requests use the same idempotency key.
  * Improved recovery after uncertain stream-finalization results by checking delivery status before falling back.
  * Added clear errors when an idempotency key is reused with different message content.
  * Preserved reply threading during final-send fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
