### PR TITLE
Complete NIP-65 relay roles and durable prior group routes

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -174,6 +174,9 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Fixed
 
+- `wn relays add/remove --type nip65` now round-trips the complete directional NIP-65 list instead of deleting
+  read-only relays or flattening existing role markers. Relay-list JSON adds `read_relays` and `write_relays` alongside
+  the existing write-target `relays` view.
 - Release builds now fail app startup with a clear error when `WN_DEV_SETTLEMENT_QUIESCENCE_MS` is set instead of
   allowing it to override the protocol-pinned convergence window. Debug builds retain the override for local
   development and integration tests.

--- a/crates/cli/src/commands/account.rs
+++ b/crates/cli/src/commands/account.rs
@@ -237,10 +237,14 @@ fn missing_relay_list_status(missing: Vec<MissingRelayListKind>) -> AccountRelay
         nip65: marmot_app::AccountRelayListState {
             kind: 10002,
             relays: Vec::new(),
+            read_relays: Vec::new(),
+            write_relays: Vec::new(),
         },
         inbox: marmot_app::AccountRelayListState {
             kind: 10050,
             relays: Vec::new(),
+            read_relays: Vec::new(),
+            write_relays: Vec::new(),
         },
     }
 }

--- a/crates/cli/src/commands/relays.rs
+++ b/crates/cli/src/commands/relays.rs
@@ -101,30 +101,40 @@ async fn update_relay_list(
                 &source_relays,
             )
         })?;
-    let mut relays = relays_for_type(&status, Some(&relay_type))?;
-    if add {
-        if !relays.contains(&url) {
-            relays.push(url.clone());
-        }
-    } else {
-        relays.retain(|relay| relay != &url);
-    }
-    relays.sort();
-    relays.dedup();
-    let publish_relays = relay_endpoints(relays.clone())?;
     let bootstrap = explicit_bootstrap
         .or_else(|| source_relays.first().map(|endpoint| endpoint.0.clone()))
-        .or_else(|| relays.first().cloned())
+        .or_else(|| {
+            relays_for_type(&status, Some(&relay_type))
+                .ok()
+                .and_then(|relays| relays.first().cloned())
+        })
         .ok_or(WnError::MissingRelay)?;
     let bootstrap_relays = vec![TransportEndpoint(bootstrap)];
-    let status = runtime
-        .publish_account_relay_list_kind(
-            &account.label,
-            &relay_type,
-            publish_relays,
-            bootstrap_relays,
-        )
-        .await?;
+    let status = if relay_type == "nip65" {
+        let (mut read_relays, mut write_relays) = nip65_relay_roles(&status.nip65);
+        update_relay_values(&mut read_relays, &url, add);
+        update_relay_values(&mut write_relays, &url, add);
+        runtime
+            .publish_account_nip65_relay_set(
+                &account.label,
+                relay_endpoints(read_relays)?,
+                relay_endpoints(write_relays)?,
+                bootstrap_relays,
+            )
+            .await?
+    } else {
+        let mut relays = relays_for_type(&status, Some(&relay_type))?;
+        update_relay_values(&mut relays, &url, add);
+        runtime
+            .publish_account_relay_list_kind(
+                &account.label,
+                &relay_type,
+                relay_endpoints(relays)?,
+                bootstrap_relays,
+            )
+            .await?
+    };
+    let relays = relays_for_type(&status, Some(&relay_type))?;
     Ok(CommandOutput {
         plain: relays.join("\n"),
         json: json!({
@@ -135,6 +145,25 @@ async fn update_relay_list(
             "relay_lists": relay_lists_json(status),
         }),
     })
+}
+
+fn nip65_relay_roles(state: &marmot_app::AccountRelayListState) -> (Vec<String>, Vec<String>) {
+    if state.read_relays.is_empty() && state.write_relays.is_empty() {
+        return (state.relays.clone(), state.relays.clone());
+    }
+    (state.read_relays.clone(), state.write_relays.clone())
+}
+
+fn update_relay_values(relays: &mut Vec<String>, url: &str, add: bool) {
+    if add {
+        if !relays.iter().any(|relay| relay == url) {
+            relays.push(url.to_owned());
+        }
+    } else {
+        relays.retain(|relay| relay != url);
+    }
+    relays.sort();
+    relays.dedup();
 }
 
 fn relays_for_type(
@@ -160,5 +189,42 @@ fn normalize_relay_type(value: &str) -> Result<String, WnError> {
         "nip65" => Ok("nip65".to_owned()),
         "inbox" => Ok("inbox".to_owned()),
         _ => Err(WnError::InvalidRelayType(value.to_owned())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use marmot_app::AccountRelayListState;
+
+    #[test]
+    fn nip65_update_preserves_unmodified_directional_relays() {
+        let state = AccountRelayListState {
+            kind: 10_002,
+            relays: vec!["wss://both.example".into(), "wss://write.example".into()],
+            read_relays: vec!["wss://both.example".into(), "wss://read.example".into()],
+            write_relays: vec!["wss://both.example".into(), "wss://write.example".into()],
+        };
+
+        let (mut read_relays, mut write_relays) = nip65_relay_roles(&state);
+        update_relay_values(&mut read_relays, "wss://new.example", true);
+        update_relay_values(&mut write_relays, "wss://new.example", true);
+
+        assert_eq!(
+            read_relays,
+            vec![
+                "wss://both.example",
+                "wss://new.example",
+                "wss://read.example",
+            ]
+        );
+        assert_eq!(
+            write_relays,
+            vec![
+                "wss://both.example",
+                "wss://new.example",
+                "wss://write.example",
+            ]
+        );
     }
 }

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -2148,7 +2148,7 @@ impl AppClient {
                 tracing::warn!(
                     target: "marmot_app::client",
                     method = "refresh_group_routes",
-                    error_kind = "invalid_persisted_group_id",
+                    error_kind = "invalid_persisted_route_identifier",
                     "skipping malformed persisted group route",
                 );
                 continue;

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -2144,7 +2144,16 @@ impl AppClient {
     pub(crate) fn refresh_group_routes(&mut self) -> Result<bool, AppError> {
         let mut changed = false;
         for group in &mut self.state.groups {
-            let group_id = GroupId::new(hex::decode(&group.group_id_hex)?);
+            let Ok(group_id_bytes) = hex::decode(&group.group_id_hex) else {
+                tracing::warn!(
+                    target: "marmot_app::client",
+                    method = "refresh_group_routes",
+                    error_kind = "invalid_persisted_group_id",
+                    "skipping malformed persisted group route",
+                );
+                continue;
+            };
+            let group_id = GroupId::new(group_id_bytes);
             // Retention is epoch-derived, never process-uptime-derived. Do not
             // prune while convergence still has unresolved inputs: the
             // retained anchor is not settled yet, so conservatively keep every
@@ -2157,7 +2166,15 @@ impl AppClient {
             {
                 group.prune_prior_nostr_routes(group_record.epoch.0);
             }
-            let subscriptions = group.transport_subscriptions(&group_id)?;
+            let Ok(subscriptions) = group.transport_subscriptions(&group_id) else {
+                tracing::warn!(
+                    target: "marmot_app::client",
+                    method = "refresh_group_routes",
+                    error_kind = "invalid_persisted_group_route",
+                    "skipping malformed persisted group route",
+                );
+                continue;
+            };
             if self.routing.replace_group_routes(&group_id, subscriptions) {
                 changed = true;
             }

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -2139,20 +2139,26 @@ impl AppClient {
         }
     }
 
-    /// Upsert every group's current transport subscription into the routing
-    /// state, returning whether any route was added or modified. A modified
-    /// route means an in-place `nostr_group_id` / relay rotation on an existing
-    /// group (Finding 2) — `add_group` now replaces by `group_id` instead of
-    /// early-returning — so callers can trigger a single resync when routes
-    /// actually change rather than only on a membership-count change.
+    /// Reconcile every group's current and still-live prior transport
+    /// subscriptions, returning whether any installed route changed.
     pub(crate) fn refresh_group_routes(&mut self) -> Result<bool, AppError> {
         let mut changed = false;
-        for group in &self.state.groups {
+        for group in &mut self.state.groups {
             let group_id = GroupId::new(hex::decode(&group.group_id_hex)?);
-            if self
-                .routing
-                .add_group(group.nostr_routing.subscription(&group_id)?)
+            // Retention is epoch-derived, never process-uptime-derived. Do not
+            // prune while convergence still has unresolved inputs: the
+            // retained anchor is not settled yet, so conservatively keep every
+            // prior address until the next stable reconciliation.
+            if !self
+                .runtime
+                .has_pending_convergence_inputs(&group_id)
+                .unwrap_or(true)
+                && let Ok(group_record) = self.runtime.group_record(&group_id)
             {
+                group.prune_prior_nostr_routes(group_record.epoch.0);
+            }
+            let subscriptions = group.transport_subscriptions(&group_id)?;
+            if self.routing.replace_group_routes(&group_id, subscriptions) {
                 changed = true;
             }
         }

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -148,7 +148,6 @@ impl AppClient {
     pub(crate) fn add_group(&mut self, group_id: &GroupId) -> Result<(), AppError> {
         let group_metadata = self.runtime.group_record(group_id).ok();
         let nostr_routing = self.nostr_routing_for_group(group_id)?;
-        let subscription = nostr_routing.subscription(group_id)?;
         let projection = EventGroupProjection {
             nostr_routing,
             group_metadata: group_metadata.as_ref(),
@@ -165,7 +164,15 @@ impl AppClient {
             &projection,
             GroupConfirmationProjection::Accepted,
         );
-        self.routing.add_group(subscription);
+        let group_id_hex = hex::encode(group_id.as_slice());
+        let subscriptions = self
+            .state
+            .groups
+            .iter()
+            .find(|group| group.group_id_hex == group_id_hex)
+            .ok_or_else(|| AppError::UnknownGroup(group_id_hex))?
+            .transport_subscriptions(group_id)?;
+        self.routing.replace_group_routes(group_id, subscriptions);
         Ok(())
     }
 

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -251,8 +251,13 @@ impl AppClient {
     ) -> Result<SyncSummary, AppError> {
         let display_names = self.app.display_names_by_id()?;
         let mut summary = SyncSummary::default();
-        self.ingest_delivery(delivery, &display_names, &mut summary)
+        let routes_dirty = self
+            .ingest_delivery(delivery, &display_names, &mut summary)
             .await?;
+        let routes_changed = self.refresh_group_routes()?;
+        if routes_dirty || routes_changed {
+            self.sync_runtime_groups().await?;
+        }
         self.app.save_state(&self.state)?;
         Ok(summary)
     }
@@ -279,6 +284,7 @@ impl AppClient {
         let drain_started = std::time::Instant::now();
         let cursor_before_secs = self.state.last_transport_timestamp;
         let mut deliveries: u64 = 0;
+        let mut routes_dirty = false;
 
         loop {
             let wait = if first_wait {
@@ -302,11 +308,16 @@ impl AppClient {
                 continue;
             }
             remember_seen_event(&mut seen, &mut self.state, event_id);
-            self.ingest_delivery(delivery, &display_names, &mut summary)
+            routes_dirty |= self
+                .ingest_delivery(delivery, &display_names, &mut summary)
                 .await?;
             deliveries = deliveries.saturating_add(1);
         }
 
+        let routes_changed = self.refresh_group_routes()?;
+        if routes_dirty || routes_changed {
+            self.sync_runtime_groups().await?;
+        }
         self.record_sync_drain(
             drain_started.elapsed().as_millis() as u64,
             deliveries,
@@ -322,7 +333,7 @@ impl AppClient {
         delivery: cgka_traits::TransportDelivery,
         display_names: &HashMap<String, String>,
         summary: &mut SyncSummary,
-    ) -> Result<(), AppError> {
+    ) -> Result<bool, AppError> {
         let source_message_id_hex = hex::encode(delivery.message.id.as_slice());
         let outer_transport_at = delivery.message.timestamp.0;
         let source_received_at = delivery.received_at.0;
@@ -333,15 +344,16 @@ impl AppClient {
         self.remember_pending_convergence_effects(&effects.effects);
         self.remember_transport_cursor(outer_transport_at);
         self.detect_epoch_stall(group_id_hint, &source_message_id_hex, &effects.outcome);
-        self.observe_account_device_effects(
-            &effects.effects,
-            display_names,
-            summary,
-            &source_message_id_hex,
-            source_received_at,
-            Some(outer_transport_at),
-        )
-        .await?;
+        let routes_dirty = self
+            .observe_account_device_effects(
+                &effects.effects,
+                display_names,
+                summary,
+                &source_message_id_hex,
+                source_received_at,
+                Some(outer_transport_at),
+            )
+            .await?;
 
         // Publishing here is incidental work triggered by the inbound
         // delivery. A hard publish failure may roll that pending commit back,
@@ -358,7 +370,7 @@ impl AppClient {
                 "incidental auto-publish failed after inbound effects were projected"
             );
         }
-        Ok(())
+        Ok(routes_dirty)
     }
 
     /// Feed an undecryptable group delivery to the epoch-stall detector, arming a
@@ -444,15 +456,20 @@ impl AppClient {
         summary.projection_updates.extend(finalize_updates);
         let source_message_id_hex = String::new();
         let source_received_at = unix_now_seconds();
-        self.observe_account_device_effects(
-            &effects,
-            &display_names,
-            &mut summary,
-            &source_message_id_hex,
-            source_received_at,
-            None,
-        )
-        .await?;
+        let routes_dirty = self
+            .observe_account_device_effects(
+                &effects,
+                &display_names,
+                &mut summary,
+                &source_message_id_hex,
+                source_received_at,
+                None,
+            )
+            .await?;
+        let routes_changed = self.refresh_group_routes()?;
+        if routes_dirty || routes_changed {
+            self.sync_runtime_groups().await?;
+        }
         self.prune_plaintext_retention_for_group(group_id)?;
         self.app.save_state(&self.state)?;
         Ok(summary)
@@ -466,7 +483,7 @@ impl AppClient {
         source_message_id_hex: &str,
         source_received_at: u64,
         outer_transport_at: Option<u64>,
-    ) -> Result<(), AppError> {
+    ) -> Result<bool, AppError> {
         // MLS member ids in this design are the Nostr account pubkey hex, so a
         // membership change whose subject matches the local account id hex is
         // the local account leaving / being removed (or, for joins, returning).
@@ -671,17 +688,11 @@ impl AppClient {
                 .messages
                 .retain(|candidate| !gossip_message_ids.contains(&candidate.message_id_hex));
         }
-        // Reconcile current and still-live prior routes once after the batch
-        // drains; a membership-count change also forces the same single resync.
-        let routes_changed = self.refresh_group_routes()?;
-        if routes_dirty || routes_changed {
-            self.sync_runtime_groups().await?;
-        }
         // Synthesize durable kind-1210 system rows from authenticated state
         // changes (peer commits, auto-commits, and scheduled convergence).
         let system_updates = self.project_group_system_rows(&effects.events, source_received_at);
         summary.projection_updates.extend(system_updates);
-        Ok(())
+        Ok(routes_dirty)
     }
 
     /// Advance the persisted transport cursor from an inbound message —

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -55,6 +55,12 @@ impl AppClient {
     }
 
     pub async fn sync(&mut self) -> Result<SyncSummary, AppError> {
+        // Reconcile epoch-bounded prior routes before issuing the first relay
+        // subscriptions. This makes retirement deterministic even for a quiet
+        // group that has no new inbound events after restart.
+        if self.refresh_group_routes()? {
+            self.app.save_state(&self.state)?;
+        }
         let rebuild_since = self
             .relay_plane
             .subscription_rebuild_since(self.state.last_transport_timestamp);
@@ -118,8 +124,11 @@ impl AppClient {
             // Best-effort projection: a quarantined group is not live, so its
             // routing/metadata components may be unavailable. Skip projection
             // rather than propagate — the event must still reach subscribers.
-            let group_projection = event_group_id(event)
-                .and_then(|group_id| self.event_group_projection_best_effort(group_id));
+            let group_metadata =
+                event_group_id(event).and_then(|group_id| self.runtime.group_record(group_id).ok());
+            let group_projection = event_group_id(event).and_then(|group_id| {
+                self.event_group_projection_best_effort(group_id, group_metadata.as_ref())
+            });
             observe_event(
                 &mut self.state,
                 &display_names,
@@ -143,12 +152,9 @@ impl AppClient {
                 routes_dirty = true;
             }
         }
-        // #695 + rotation: reconcile transport routes once after the batch drains
-        // instead of per membership-changing event. refresh_group_routes upserts
-        // every group's current subscription — picking up a join's new route AND
-        // an in-place nostr_group_id / relay rotation on an existing group
-        // (Finding 2) — and reports whether anything changed; a membership count
-        // change (join/leave) also forces the single resync.
+        // Reconcile transport routes once after the batch drains instead of per
+        // membership-changing event. This installs a join's current route and
+        // retains any still-live address displaced by a routing rotation.
         let routes_changed = self.refresh_group_routes()?;
         if routes_dirty || routes_changed {
             self.sync_runtime_groups().await?;
@@ -161,14 +167,15 @@ impl AppClient {
     /// component lookup fails (e.g. the group is quarantined and not live).
     /// Used by the no-inbound drain path where a missing projection must not
     /// abort processing.
-    fn event_group_projection_best_effort(
+    fn event_group_projection_best_effort<'a>(
         &self,
         group_id: &cgka_traits::GroupId,
-    ) -> Option<EventGroupProjection<'static>> {
+        group_metadata: Option<&'a cgka_traits::group::Group>,
+    ) -> Option<EventGroupProjection<'a>> {
         let nostr_routing = self.nostr_routing_for_group(group_id).ok()?;
         Some(EventGroupProjection {
             nostr_routing,
-            group_metadata: None,
+            group_metadata,
             admin_policy: self
                 .runtime
                 .admin_pubkeys(group_id)
@@ -664,11 +671,8 @@ impl AppClient {
                 .messages
                 .retain(|candidate| !gossip_message_ids.contains(&candidate.message_id_hex));
         }
-        // #695 + rotation: reconcile transport routes once after the batch drains.
-        // refresh_group_routes upserts every group's current subscription (a
-        // join's new route AND an in-place nostr_group_id / relay rotation on an
-        // existing group, Finding 2) and reports whether anything changed; a
-        // membership count change (join/leave) also forces the single resync.
+        // Reconcile current and still-live prior routes once after the batch
+        // drains; a membership-count change also forces the same single resync.
         let routes_changed = self.refresh_group_routes()?;
         if routes_dirty || routes_changed {
             self.sync_runtime_groups().await?;

--- a/crates/marmot-app/src/conversions.rs
+++ b/crates/marmot-app/src/conversions.rs
@@ -23,7 +23,7 @@ use storage_sqlite::{
     AccountChatNotificationSettings, AccountGroupPushToken, AccountNotificationSettings,
     AccountPushRegistration, AccountStoredPushRegistration, StoredAccountGroup,
     StoredAccountGroupComponent, StoredAccountState, StoredAppEvent, StoredAppMessageRecord,
-    StoredAuditLogSettings, StoredRelayTelemetrySettings,
+    StoredAuditLogSettings, StoredNostrRoute, StoredRelayTelemetrySettings,
 };
 
 pub(crate) fn stored_state_from_account_state(state: &AccountState) -> StoredAccountState {
@@ -73,6 +73,16 @@ pub(crate) fn stored_group_from_app_group(group: &AppGroupRecord) -> StoredAccou
         self_membership: group.self_membership,
         welcomer_account_id_hex: group.welcomer_account_id_hex.clone(),
         via_welcome_message_id_hex: group.via_welcome_message_id_hex.clone(),
+        nostr_routing_last_epoch: group.nostr_routing_last_epoch,
+        prior_nostr_routes: group
+            .prior_nostr_routes
+            .iter()
+            .map(|route| StoredNostrRoute {
+                nostr_group_id_hex: route.nostr_group_id_hex.clone(),
+                relays: route.relays.clone(),
+                last_epoch: route.last_epoch,
+            })
+            .collect(),
         components: stored_components_from_app_group(group),
     }
 }
@@ -197,6 +207,16 @@ pub(crate) fn app_group_from_stored_group(
     group.self_membership = stored.self_membership;
     group.welcomer_account_id_hex = stored.welcomer_account_id_hex;
     group.via_welcome_message_id_hex = stored.via_welcome_message_id_hex;
+    group.nostr_routing_last_epoch = stored.nostr_routing_last_epoch;
+    group.prior_nostr_routes = stored
+        .prior_nostr_routes
+        .into_iter()
+        .map(|route| crate::AppPriorNostrRoute {
+            nostr_group_id_hex: route.nostr_group_id_hex,
+            relays: route.relays,
+            last_epoch: route.last_epoch,
+        })
+        .collect();
     Ok(group)
 }
 

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -33,10 +33,8 @@ use crate::ids::{
     normalize_account_ids, npub_for_account_id, npub_for_account_id_lossy, parse_account_id_hex,
 };
 use crate::key_package_records::{
-    fill_missing_relay_lists_from_cached, fresh_or_cached_key_package,
-    fresh_relay_list_status_from_records, key_package_from_record,
+    fresh_or_cached_key_package, fresh_relay_list_status_from_records, key_package_from_record,
     latest_fresh_key_package_from_records, publish_endpoints_from_bootstrap, relay_list_queries,
-    relay_lists_have_any_relays,
 };
 use crate::relay_plane::{DirectoryEventQuery, DirectoryRelayEventRecord as RelayEventRecord};
 use crate::{
@@ -44,7 +42,7 @@ use crate::{
     DIRECTORY_FUTURE_CREATED_AT_CLEANUP_MARKER, DirectoryFreshness, FetchedKeyPackage,
     KIND_NOSTR_CONTACT_LIST, KIND_NOSTR_METADATA, MarmotApp, MissingRelayListKind, ReceivedMessage,
     SqlcipherDatabaseKind, USER_DIRECTORY_SEARCH_MAX_FRONTIER, USER_DIRECTORY_SEARCH_MAX_VISITED,
-    push_unique_strings, relays_from_relay_list_event, remove_sqlite_file_set,
+    push_unique_strings, relay_list_state_from_event, remove_sqlite_file_set,
 };
 
 impl MarmotApp {
@@ -92,18 +90,28 @@ impl MarmotApp {
             )
             .await
             .map_err(|e| AppError::RelayDirectory(format!("fetch relay lists: {e}")))?;
+        let observed_nip65 = records.iter().any(|record| {
+            record.event.pubkey == account_id_hex
+                && record.event.kind == KIND_NIP65_RELAY_LIST
+                && freshness.accepts(record)
+        });
+        let observed_inbox = records.iter().any(|record| {
+            record.event.pubkey == account_id_hex
+                && record.event.kind == KIND_MARMOT_INBOX_RELAY_LIST
+                && freshness.accepts(record)
+        });
         let selection = fresh_relay_list_status_from_records(&account_id_hex, records, freshness);
         let mut status = selection.value;
-        if selection.rejected_future || !relay_lists_have_any_relays(&status) {
+        if !observed_nip65 || !observed_inbox {
             let cached = self.account_relay_list_status_for_account_id(&account_id_hex)?;
-            if relay_lists_have_any_relays(&cached) {
-                if !relay_lists_have_any_relays(&status) {
-                    return Ok(cached);
-                }
-                if selection.rejected_future {
-                    fill_missing_relay_lists_from_cached(&mut status, &cached);
-                }
+            if !observed_nip65 {
+                status.nip65 = cached.nip65;
             }
+            if !observed_inbox {
+                status.inbox = cached.inbox;
+            }
+            push_unique_strings(&mut status.bootstrap_relays, cached.bootstrap_relays);
+            status.refresh();
         }
         if status.bootstrap_relays.is_empty() {
             status.bootstrap_relays = bootstrap_relays
@@ -880,16 +888,15 @@ impl MarmotApp {
         account_id_hex: &str,
         record: &RelayEventRecord,
     ) -> Result<(), AppError> {
-        let relays = relays_from_relay_list_event(&record.event);
-        if relays.is_empty() {
+        let Some(state) = relay_list_state_from_event(&record.event) else {
             return Ok(());
-        }
+        };
         let mut entry = self
             .directory_entry_for_account_id(account_id_hex)?
             .unwrap_or_else(|| self.empty_directory_record(account_id_hex));
         match record.event.kind {
-            KIND_NIP65_RELAY_LIST => entry.relay_lists.nip65.relays = relays,
-            KIND_MARMOT_INBOX_RELAY_LIST => entry.relay_lists.inbox.relays = relays,
+            KIND_NIP65_RELAY_LIST => entry.relay_lists.nip65 = state,
+            KIND_MARMOT_INBOX_RELAY_LIST => entry.relay_lists.inbox = state,
             _ => return Ok(()),
         }
         push_unique_strings(

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -34,6 +34,11 @@ use serde::{Deserialize, Serialize};
 use crate::media::{EncryptedMediaVersion, media_imeta_tags_preserve_message};
 use crate::{AccountState, AppError, ReceivedMessage, SelfMembership, SendSummary, SyncSummary};
 
+/// Operational backstop for malformed or permanently unsettled routing
+/// histories. Normal stable pruning is much tighter because it follows the
+/// protocol's retained-epoch windows.
+const MAX_PRIOR_NOSTR_ROUTES: usize = 32;
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AppGroupRecord {
     pub group_id_hex: String,
@@ -477,12 +482,22 @@ impl AppGroupRecord {
                 .then_with(|| left.nostr_group_id_hex.cmp(&right.nostr_group_id_hex))
                 .then_with(|| left.relays.cmp(&right.relays))
         });
+        let overflow = self
+            .prior_nostr_routes
+            .len()
+            .saturating_sub(MAX_PRIOR_NOSTR_ROUTES);
+        if overflow > 0 {
+            self.prior_nostr_routes.drain(..overflow);
+        }
     }
 
     /// Retire prior routes only after every protocol retention window has
     /// advanced beyond the route's last epoch. Returns whether anything was
     /// retired.
     pub(crate) fn prune_prior_nostr_routes(&mut self, current_epoch: u64) -> bool {
+        // MDK currently runs the protocol-pinned convergence and application
+        // history depths. The only runtime override is settlement timing, so
+        // deriving these two depths from the canonical default is intentional.
         let policy = CanonicalizationPolicy::default();
         let retained_depth = policy
             .convergence
@@ -501,7 +516,15 @@ impl AppGroupRecord {
     ) -> Result<Vec<TransportGroupSubscription>, AppError> {
         let mut subscriptions = vec![self.nostr_routing.subscription(group_id)?];
         for route in &self.prior_nostr_routes {
-            subscriptions.push(route.subscription(group_id)?);
+            match route.subscription(group_id) {
+                Ok(subscription) => subscriptions.push(subscription),
+                Err(_) => tracing::warn!(
+                    target: "marmot_app::groups",
+                    method = "transport_subscriptions",
+                    error_kind = "invalid_prior_nostr_route",
+                    "skipping invalid prior Nostr route",
+                ),
+            }
         }
         Ok(subscriptions)
     }
@@ -743,6 +766,71 @@ mod prior_nostr_route_tests {
         );
         assert_eq!(record.nostr_routing_last_epoch, 6);
     }
+
+    #[test]
+    fn malformed_prior_route_does_not_discard_current_or_valid_history() {
+        let mut record = AppGroupRecord::new(
+            hex::encode([1u8; 16]),
+            routing(1, "wss://current.example"),
+            "group".to_owned(),
+            String::new(),
+            AppGroupImageInput::default(),
+            AppGroupAdminPolicyComponent::new(Vec::new()),
+            AppGroupMessageRetentionComponent::disabled(),
+        );
+        record.prior_nostr_routes = vec![
+            AppPriorNostrRoute {
+                nostr_group_id_hex: "not-hex".to_owned(),
+                relays: vec!["wss://invalid.example".to_owned()],
+                last_epoch: 1,
+            },
+            AppPriorNostrRoute {
+                nostr_group_id_hex: hex::encode([2u8; 32]),
+                relays: vec!["wss://prior.example".to_owned()],
+                last_epoch: 1,
+            },
+        ];
+
+        let subscriptions = record
+            .transport_subscriptions(&GroupId::new(vec![1; 16]))
+            .expect("the valid current route remains usable");
+
+        assert_eq!(subscriptions.len(), 2);
+        assert_eq!(subscriptions[0].transport_group_id, vec![1u8; 32]);
+        assert_eq!(subscriptions[1].transport_group_id, vec![2u8; 32]);
+    }
+
+    #[test]
+    fn unsettled_prior_route_history_has_a_fixed_operational_bound() {
+        let mut record = AppGroupRecord::new(
+            hex::encode([1u8; 16]),
+            routing(1, "wss://one.example"),
+            "group".to_owned(),
+            String::new(),
+            AppGroupImageInput::default(),
+            AppGroupAdminPolicyComponent::new(Vec::new()),
+            AppGroupMessageRetentionComponent::disabled(),
+        );
+
+        for epoch in 2..=34 {
+            let next_group = group(epoch);
+            record.refresh_from_group(&projection(
+                routing(epoch as u8, "wss://next.example"),
+                &next_group,
+            ));
+        }
+
+        assert_eq!(record.prior_nostr_routes.len(), MAX_PRIOR_NOSTR_ROUTES);
+        assert_eq!(
+            record
+                .prior_nostr_routes
+                .first()
+                .expect("bounded history remains non-empty")
+                .last_epoch,
+            2,
+            "the oldest route is evicted first"
+        );
+    }
 }
 
 impl AppGroupProfileComponent {
@@ -937,9 +1025,20 @@ impl AppGroupNostrRoutingComponent {
         &self,
         group_id: &GroupId,
     ) -> Result<TransportGroupSubscription, AppError> {
+        let transport_group_id = hex::decode(&self.nostr_group_id_hex)?;
+        if transport_group_id.len() != 32 {
+            return Err(AppError::InvalidNostrRouting(
+                "Nostr group id must be 32 bytes".into(),
+            ));
+        }
+        if self.relays.is_empty() {
+            return Err(AppError::InvalidNostrRouting(
+                "Nostr routing relays must not be empty".into(),
+            ));
+        }
         Ok(TransportGroupSubscription {
             group_id: group_id.clone(),
-            transport_group_id: hex::decode(&self.nostr_group_id_hex)?,
+            transport_group_id,
             endpoints: self.relays.iter().cloned().map(TransportEndpoint).collect(),
         })
     }

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use cgka_engine::canonicalization::CanonicalizationPolicy;
 use cgka_traits::agent_text_stream::{
     AGENT_TEXT_STREAM_QUIC_COMPONENT, AGENT_TEXT_STREAM_ROLE_FANOUT,
     AGENT_TEXT_STREAM_ROLE_RECEIVE, AGENT_TEXT_STREAM_ROLE_SEND, AgentTextStreamQuicPolicyV1,
@@ -41,6 +42,16 @@ pub struct AppGroupRecord {
     pub protocol_profile: AppProtocolProfile,
     pub endpoint: String,
     pub nostr_routing: AppGroupNostrRoutingComponent,
+    /// Highest epoch observed while the current routing address was active.
+    /// Kept separately so a rollback can retain the losing branch address for
+    /// its real epoch range instead of inferring from the new canonical tip.
+    #[serde(default)]
+    pub nostr_routing_last_epoch: u64,
+    /// Older authenticated routing addresses that still overlap at least one
+    /// retained-history window. These are local delivery history, not part of
+    /// the current signed component.
+    #[serde(default)]
+    pub prior_nostr_routes: Vec<AppPriorNostrRoute>,
     pub profile: AppGroupProfileComponent,
     pub image: AppGroupImageComponent,
     /// URL-based group avatar. When `present`, it takes precedence over `image`
@@ -279,6 +290,14 @@ pub struct AppGroupNostrRoutingComponent {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AppPriorNostrRoute {
+    pub nostr_group_id_hex: String,
+    pub relays: Vec<String>,
+    /// Last epoch known to have used this route.
+    pub last_epoch: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AppAgentTextStreamComponent {
     pub component_id: u16,
     pub component: String,
@@ -350,6 +369,8 @@ impl AppGroupRecord {
             protocol_profile: AppProtocolProfile::Legacy,
             endpoint,
             nostr_routing,
+            nostr_routing_last_epoch: 0,
+            prior_nostr_routes: Vec::new(),
             profile: AppGroupProfileComponent::new(profile_name, profile_description),
             image: AppGroupImageComponent::new(image),
             avatar_url: AppGroupAvatarUrlComponent::absent(),
@@ -394,14 +415,35 @@ impl AppGroupRecord {
         record.encrypted_media = encrypted_media;
         if let Some(group) = group {
             record.protocol_profile = group.protocol_profile.into();
+            record.nostr_routing_last_epoch = group.epoch.0;
         }
         record
     }
 
     pub(crate) fn refresh_from_group(&mut self, projection: &EventGroupProjection<'_>) {
         let nostr_routing = projection.nostr_routing.clone();
+        let route_changed = !same_nostr_route(&self.nostr_routing, &nostr_routing);
+        if route_changed {
+            let last_epoch = projection
+                .group_metadata
+                .map(|group| group.epoch.0.saturating_sub(1))
+                .unwrap_or_default()
+                .max(self.nostr_routing_last_epoch);
+            self.remember_prior_nostr_route(last_epoch);
+        }
         self.endpoint = nostr_routing.relays.first().cloned().unwrap_or_default();
         self.nostr_routing = nostr_routing;
+        self.nostr_routing_last_epoch = match (route_changed, projection.group_metadata) {
+            (true, Some(group)) => group.epoch.0,
+            (true, None) => 0,
+            (false, Some(group)) => self.nostr_routing_last_epoch.max(group.epoch.0),
+            (false, None) => self.nostr_routing_last_epoch,
+        };
+        let current = &self.nostr_routing;
+        self.prior_nostr_routes.retain(|route| {
+            route.nostr_group_id_hex != current.nostr_group_id_hex
+                || normalized_relays(&route.relays) != normalized_relays(&current.relays)
+        });
         self.admin_policy = projection.admin_policy.clone();
         self.message_retention = projection.message_retention.clone();
         self.agent_text_stream = projection.agent_text_stream.clone();
@@ -413,6 +455,55 @@ impl AppGroupRecord {
             self.profile =
                 AppGroupProfileComponent::new(group.name.clone(), group.description.clone());
         }
+    }
+
+    fn remember_prior_nostr_route(&mut self, last_epoch: u64) {
+        let relays = normalized_relays(&self.nostr_routing.relays);
+        if let Some(existing) = self.prior_nostr_routes.iter_mut().find(|route| {
+            route.nostr_group_id_hex == self.nostr_routing.nostr_group_id_hex
+                && normalized_relays(&route.relays) == relays
+        }) {
+            existing.last_epoch = existing.last_epoch.max(last_epoch);
+        } else {
+            self.prior_nostr_routes.push(AppPriorNostrRoute {
+                nostr_group_id_hex: self.nostr_routing.nostr_group_id_hex.clone(),
+                relays,
+                last_epoch,
+            });
+        }
+        self.prior_nostr_routes.sort_by(|left, right| {
+            left.last_epoch
+                .cmp(&right.last_epoch)
+                .then_with(|| left.nostr_group_id_hex.cmp(&right.nostr_group_id_hex))
+                .then_with(|| left.relays.cmp(&right.relays))
+        });
+    }
+
+    /// Retire prior routes only after every protocol retention window has
+    /// advanced beyond the route's last epoch. Returns whether anything was
+    /// retired.
+    pub(crate) fn prune_prior_nostr_routes(&mut self, current_epoch: u64) -> bool {
+        let policy = CanonicalizationPolicy::default();
+        let retained_depth = policy
+            .convergence
+            .max_rewind_commits
+            .max(policy.app_message_past_epoch_limit);
+        let oldest_live_epoch = current_epoch.saturating_sub(retained_depth);
+        let before = self.prior_nostr_routes.len();
+        self.prior_nostr_routes
+            .retain(|route| route.last_epoch >= oldest_live_epoch);
+        self.prior_nostr_routes.len() != before
+    }
+
+    pub(crate) fn transport_subscriptions(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Vec<TransportGroupSubscription>, AppError> {
+        let mut subscriptions = vec![self.nostr_routing.subscription(group_id)?];
+        for route in &self.prior_nostr_routes {
+            subscriptions.push(route.subscription(group_id)?);
+        }
+        Ok(subscriptions)
     }
 
     pub(crate) fn apply_confirmation_state(&mut self, state: GroupConfirmationProjection) {
@@ -445,6 +536,212 @@ impl AppGroupRecord {
                 self.welcomer_account_id_hex = welcomer_account_id_hex;
             }
         }
+    }
+}
+
+impl AppPriorNostrRoute {
+    fn subscription(&self, group_id: &GroupId) -> Result<TransportGroupSubscription, AppError> {
+        let transport_group_id = hex::decode(&self.nostr_group_id_hex)?;
+        if transport_group_id.len() != 32 {
+            return Err(AppError::InvalidNostrRouting(
+                "prior Nostr group id must be 32 bytes".into(),
+            ));
+        }
+        if self.relays.is_empty() {
+            return Err(AppError::InvalidNostrRouting(
+                "prior Nostr routing relays must not be empty".into(),
+            ));
+        }
+        Ok(TransportGroupSubscription {
+            group_id: group_id.clone(),
+            transport_group_id,
+            endpoints: self.relays.iter().cloned().map(TransportEndpoint).collect(),
+        })
+    }
+}
+
+fn same_nostr_route(
+    left: &AppGroupNostrRoutingComponent,
+    right: &AppGroupNostrRoutingComponent,
+) -> bool {
+    left.nostr_group_id_hex == right.nostr_group_id_hex
+        && normalized_relays(&left.relays) == normalized_relays(&right.relays)
+}
+
+fn normalized_relays(relays: &[String]) -> Vec<String> {
+    let mut relays = relays.to_vec();
+    relays.sort();
+    relays.dedup();
+    relays
+}
+
+#[cfg(test)]
+mod prior_nostr_route_tests {
+    use super::*;
+    use cgka_traits::capabilities::GroupCapabilities;
+    use cgka_traits::types::EpochId;
+
+    fn routing(id: u8, relay: &str) -> AppGroupNostrRoutingComponent {
+        AppGroupNostrRoutingComponent::new(NostrRoutingV1 {
+            nostr_group_id: [id; 32],
+            relays: vec![relay.to_owned()],
+        })
+        .unwrap()
+    }
+
+    fn group(epoch: u64) -> Group {
+        Group {
+            id: GroupId::new(vec![1; 16]),
+            name: "group".to_owned(),
+            description: String::new(),
+            epoch: EpochId(epoch),
+            members: Vec::new(),
+            required_capabilities: GroupCapabilities::default(),
+            protocol_profile: ProtocolProfile::Current,
+            removed: false,
+            join_epoch: EpochId(0),
+        }
+    }
+
+    fn projection<'a>(
+        nostr_routing: AppGroupNostrRoutingComponent,
+        group: &'a Group,
+    ) -> EventGroupProjection<'a> {
+        EventGroupProjection {
+            nostr_routing,
+            group_metadata: Some(group),
+            admin_policy: AppGroupAdminPolicyComponent::new(Vec::new()),
+            message_retention: AppGroupMessageRetentionComponent::disabled(),
+            agent_text_stream: AppAgentTextStreamComponent::disabled(),
+            avatar_url: AppGroupAvatarUrlComponent::absent(),
+            encrypted_media: AppGroupEncryptedMediaComponent::disabled(),
+            image: AppGroupImageInput::default(),
+        }
+    }
+
+    #[test]
+    fn rotation_retains_prior_route_until_both_epoch_windows_expire() {
+        let mut record = AppGroupRecord::new(
+            hex::encode([1u8; 16]),
+            routing(1, "wss://old.example"),
+            "group".to_owned(),
+            String::new(),
+            AppGroupImageInput::default(),
+            AppGroupAdminPolicyComponent::new(Vec::new()),
+            AppGroupMessageRetentionComponent::disabled(),
+        );
+        let at_epoch_six = group(6);
+
+        record.refresh_from_group(&projection(
+            routing(2, "wss://current.example"),
+            &at_epoch_six,
+        ));
+
+        assert_eq!(
+            record.prior_nostr_routes,
+            vec![AppPriorNostrRoute {
+                nostr_group_id_hex: hex::encode([1u8; 32]),
+                relays: vec!["wss://old.example".to_owned()],
+                last_epoch: 5,
+            }]
+        );
+        assert_eq!(
+            record
+                .transport_subscriptions(&GroupId::new(vec![1; 16]))
+                .unwrap()
+                .len(),
+            2
+        );
+
+        assert!(!record.prune_prior_nostr_routes(10));
+        assert!(record.prune_prior_nostr_routes(11));
+        assert!(record.prior_nostr_routes.is_empty());
+    }
+
+    #[test]
+    fn rotating_back_to_a_prior_address_deduplicates_history() {
+        let mut record = AppGroupRecord::new(
+            hex::encode([1u8; 16]),
+            routing(1, "wss://one.example"),
+            "group".to_owned(),
+            String::new(),
+            AppGroupImageInput::default(),
+            AppGroupAdminPolicyComponent::new(Vec::new()),
+            AppGroupMessageRetentionComponent::disabled(),
+        );
+        let epoch_two = group(2);
+        record.refresh_from_group(&projection(routing(2, "wss://two.example"), &epoch_two));
+        let epoch_three = group(3);
+        record.refresh_from_group(&projection(routing(1, "wss://one.example"), &epoch_three));
+
+        assert_eq!(record.prior_nostr_routes.len(), 1);
+        assert_eq!(
+            record.prior_nostr_routes[0].nostr_group_id_hex,
+            hex::encode([2u8; 32])
+        );
+    }
+
+    #[test]
+    fn relay_only_rotation_retains_the_prior_relay_set_for_the_same_id() {
+        let mut record = AppGroupRecord::new(
+            hex::encode([1u8; 16]),
+            routing(1, "wss://old.example"),
+            "group".to_owned(),
+            String::new(),
+            AppGroupImageInput::default(),
+            AppGroupAdminPolicyComponent::new(Vec::new()),
+            AppGroupMessageRetentionComponent::disabled(),
+        );
+        record.nostr_routing_last_epoch = 5;
+        let epoch_six = group(6);
+
+        record.refresh_from_group(&projection(routing(1, "wss://current.example"), &epoch_six));
+
+        assert_eq!(
+            record.prior_nostr_routes,
+            vec![AppPriorNostrRoute {
+                nostr_group_id_hex: hex::encode([1u8; 32]),
+                relays: vec!["wss://old.example".to_owned()],
+                last_epoch: 5,
+            }]
+        );
+        assert_eq!(
+            record
+                .transport_subscriptions(&GroupId::new(vec![1; 16]))
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn rollback_retains_losing_route_through_its_last_observed_epoch() {
+        let mut record = AppGroupRecord::new(
+            hex::encode([1u8; 16]),
+            routing(2, "wss://losing.example"),
+            "group".to_owned(),
+            String::new(),
+            AppGroupImageInput::default(),
+            AppGroupAdminPolicyComponent::new(Vec::new()),
+            AppGroupMessageRetentionComponent::disabled(),
+        );
+        record.nostr_routing_last_epoch = 10;
+        let rolled_back = group(6);
+
+        record.refresh_from_group(&projection(
+            routing(1, "wss://selected.example"),
+            &rolled_back,
+        ));
+
+        assert_eq!(
+            record.prior_nostr_routes,
+            vec![AppPriorNostrRoute {
+                nostr_group_id_hex: hex::encode([2u8; 32]),
+                relays: vec!["wss://losing.example".to_owned()],
+                last_epoch: 10,
+            }]
+        );
+        assert_eq!(record.nostr_routing_last_epoch, 6);
     }
 }
 

--- a/crates/marmot-app/src/key_package_records.rs
+++ b/crates/marmot-app/src/key_package_records.rs
@@ -25,7 +25,7 @@ use crate::relay_plane::{DirectoryEventQuery, DirectoryRelayEventRecord as Relay
 use crate::{
     AccountKeyPackageRecord, AccountRelayListBootstrap, AccountRelayListStatus, DirectoryFreshness,
     DirectoryKeyPackage, DirectorySelection, FetchedKeyPackage, UserDirectoryRecord,
-    push_unique_strings, relays_from_relay_list_event, sort_directory_records,
+    push_unique_strings, relay_list_state_from_event, sort_directory_records,
 };
 
 pub(crate) fn relay_list_status_from_records(
@@ -38,13 +38,12 @@ pub(crate) fn relay_list_status_from_records(
         if record.event.pubkey != account_id_hex {
             continue;
         }
-        let relays = relays_from_relay_list_event(&record.event);
-        if relays.is_empty() {
+        let Some(state) = relay_list_state_from_event(&record.event) else {
             continue;
-        }
+        };
         match record.event.kind {
-            KIND_NIP65_RELAY_LIST => status.nip65.relays = relays,
-            KIND_MARMOT_INBOX_RELAY_LIST => status.inbox.relays = relays,
+            KIND_NIP65_RELAY_LIST => status.nip65 = state,
+            KIND_MARMOT_INBOX_RELAY_LIST => status.inbox = state,
             _ => continue,
         }
         push_unique_strings(
@@ -225,26 +224,6 @@ fn key_package_event_id_from_hex(event_id_hex: &str) -> Result<MessageId, AppErr
         )));
     }
     Ok(MessageId::new(bytes))
-}
-
-pub(crate) fn relay_lists_have_any_relays(status: &AccountRelayListStatus) -> bool {
-    !status.nip65.relays.is_empty() || !status.inbox.relays.is_empty()
-}
-
-pub(crate) fn fill_missing_relay_lists_from_cached(
-    status: &mut AccountRelayListStatus,
-    cached: &AccountRelayListStatus,
-) {
-    if status.nip65.relays.is_empty() {
-        status.nip65.relays = cached.nip65.relays.clone();
-    }
-    if status.inbox.relays.is_empty() {
-        status.inbox.relays = cached.inbox.relays.clone();
-    }
-    if status.bootstrap_relays.is_empty() {
-        status.bootstrap_relays = cached.bootstrap_relays.clone();
-    }
-    status.refresh();
 }
 
 pub(crate) fn fresh_or_cached_key_package(

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -2253,8 +2253,25 @@ impl MarmotApp {
         let relay_lists = self.account_relay_list_status_for_account_id(&account.account_id_hex)?;
         let mut group_routes = Vec::new();
         for group in &state.groups {
-            let group_id = GroupId::new(hex::decode(&group.group_id_hex)?);
-            group_routes.extend(group.transport_subscriptions(&group_id)?);
+            let Ok(group_id_bytes) = hex::decode(&group.group_id_hex) else {
+                tracing::warn!(
+                    target: "marmot_app",
+                    method = "routing_for",
+                    error_kind = "invalid_persisted_group_id",
+                    "skipping malformed persisted group route",
+                );
+                continue;
+            };
+            let group_id = GroupId::new(group_id_bytes);
+            match group.transport_subscriptions(&group_id) {
+                Ok(subscriptions) => group_routes.extend(subscriptions),
+                Err(_) => tracing::warn!(
+                    target: "marmot_app",
+                    method = "routing_for",
+                    error_kind = "invalid_persisted_group_route",
+                    "skipping malformed persisted group route",
+                ),
+            }
         }
 
         Ok(AppTransportRouting::new(AppRoutingState {

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -61,7 +61,8 @@ use storage_sqlite::{
 use transport_nostr_adapter::{
     KIND_MARMOT_INBOX_RELAY_LIST, KIND_MARMOT_KEY_PACKAGE, KIND_NIP65_RELAY_LIST,
     NostrAccountRelayListKind, NostrAccountRelayListPublication, NostrKeyPackagePublication,
-    NostrKeyPackagePublisher, NostrRelayClient, NostrSdkRelayClient, parse_nip65_relay_set,
+    NostrKeyPackagePublisher, NostrNip65RelayListPublication, NostrNip65RelaySet, NostrRelayClient,
+    NostrSdkRelayClient, parse_nip65_relay_set,
 };
 use transport_nostr_peeler::{NostrMlsPeeler, NostrTransportEvent};
 
@@ -517,6 +518,18 @@ pub struct AccountRelayListState {
     /// unmarked and `write` entries, excluding `read`-only entries. For the
     /// Marmot inbox list this is the declared inbox relay set.
     pub relays: Vec<String>,
+    /// NIP-65 read-capable relays, including unmarked entries.
+    ///
+    /// Empty for non-NIP-65 lists and for cache records written before
+    /// directional roles were persisted.
+    #[serde(default)]
+    pub read_relays: Vec<String>,
+    /// NIP-65 write-capable relays, including unmarked entries.
+    ///
+    /// This is the explicit directional counterpart of the compatibility
+    /// `relays` field. Empty for non-NIP-65 lists and for legacy cache records.
+    #[serde(default)]
+    pub write_relays: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -552,10 +565,14 @@ impl AccountRelayListStatus {
             nip65: AccountRelayListState {
                 kind: KIND_NIP65_RELAY_LIST,
                 relays: Vec::new(),
+                read_relays: Vec::new(),
+                write_relays: Vec::new(),
             },
             inbox: AccountRelayListState {
                 kind: KIND_MARMOT_INBOX_RELAY_LIST,
                 relays: Vec::new(),
+                read_relays: Vec::new(),
+                write_relays: Vec::new(),
             },
         };
         status.refresh();
@@ -1304,8 +1321,27 @@ impl MarmotApp {
         .await
     }
 
+    /// Return every declared NIP-65 relay for backward-compatible list editing.
+    ///
+    /// Routing code must use `AccountRelayListStatus::nip65.relays`, which is
+    /// the write-capable subset. Returning the union here keeps the established
+    /// getter -> edit -> setter flow from deleting read-only entries.
     pub fn account_nip65_relays(&self, label: &str) -> Result<Vec<String>, AppError> {
-        Ok(self.account_relay_list_status(label)?.nip65.relays)
+        let state = self.account_relay_list_status(label)?.nip65;
+        let relay_set = nip65_relay_set_from_state(&state);
+        let mut relays = relay_set
+            .read_relays
+            .into_iter()
+            .map(|endpoint| endpoint.0)
+            .collect::<Vec<_>>();
+        push_unique_strings(
+            &mut relays,
+            relay_set
+                .write_relays
+                .into_iter()
+                .map(|endpoint| endpoint.0),
+        );
+        Ok(relays)
     }
 
     pub fn account_inbox_relays(&self, label: &str) -> Result<Vec<String>, AppError> {
@@ -1318,11 +1354,35 @@ impl MarmotApp {
         relays: Vec<TransportEndpoint>,
         bootstrap_relays: Vec<TransportEndpoint>,
     ) -> Result<AccountRelayListStatus, AppError> {
-        self.set_account_relay_list_kind(
+        let current = self.account_relay_list_status(label)?.nip65;
+        let relay_set = nip65_relay_set_preserving_roles(&current, relays);
+        self.publish_account_nip65_relay_set(
             label,
-            NostrAccountRelayListKind::Nip65,
-            relays,
+            relay_set.read_relays,
+            relay_set.write_relays,
             bootstrap_relays,
+        )
+        .await
+    }
+
+    /// Replace the account's NIP-65 list while preserving explicit relay
+    /// directions in the published kind-10002 event.
+    pub async fn publish_account_nip65_relay_set(
+        &self,
+        label: &str,
+        read_relays: Vec<TransportEndpoint>,
+        write_relays: Vec<TransportEndpoint>,
+        bootstrap_relays: Vec<TransportEndpoint>,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let relay_set = NostrNip65RelaySet {
+            read_relays: unique_transport_endpoints(read_relays),
+            write_relays: unique_transport_endpoints(write_relays),
+        };
+        self.publish_selected_account_relay_lists_with_nip65(
+            label,
+            AccountRelayListBootstrap::new(relay_set.write_relays.clone(), bootstrap_relays),
+            &[NostrAccountRelayListKind::Nip65],
+            Some(&relay_set),
         )
         .await
     }
@@ -1363,7 +1423,21 @@ impl MarmotApp {
         bootstrap: AccountRelayListBootstrap,
         list_kinds: &[NostrAccountRelayListKind],
     ) -> Result<AccountRelayListStatus, AppError> {
-        if bootstrap.default_relays.is_empty() {
+        self.publish_selected_account_relay_lists_with_nip65(label, bootstrap, list_kinds, None)
+            .await
+    }
+
+    async fn publish_selected_account_relay_lists_with_nip65(
+        &self,
+        label: &str,
+        bootstrap: AccountRelayListBootstrap,
+        list_kinds: &[NostrAccountRelayListKind],
+        nip65_relay_set: Option<&NostrNip65RelaySet>,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let has_directional_nip65_relays = nip65_relay_set.is_some_and(|relays| {
+            !relays.read_relays.is_empty() || !relays.write_relays.is_empty()
+        });
+        if bootstrap.default_relays.is_empty() && !has_directional_nip65_relays {
             return Err(AppError::MissingDefaultRelays);
         }
         let account = self.account_home().account(label)?;
@@ -1392,13 +1466,24 @@ impl MarmotApp {
         }
         let relay_client = self.relay_client_for_endpoints(signer.as_nostr_signer(), &endpoints);
         for list_kind in list_kinds {
-            let publication = NostrAccountRelayListPublication {
-                account_id: account_id.clone(),
-                list_kind: *list_kind,
-                relays: bootstrap.default_relays.clone(),
-                publish_endpoints: endpoints.clone(),
+            let event = if *list_kind == NostrAccountRelayListKind::Nip65
+                && let Some(relays) = nip65_relay_set
+            {
+                NostrNip65RelayListPublication {
+                    account_id: account_id.clone(),
+                    relays: relays.clone(),
+                    publish_endpoints: endpoints.clone(),
+                }
+                .to_event()?
+            } else {
+                NostrAccountRelayListPublication {
+                    account_id: account_id.clone(),
+                    list_kind: *list_kind,
+                    relays: bootstrap.default_relays.clone(),
+                    publish_endpoints: endpoints.clone(),
+                }
+                .to_event()?
             };
-            let event = publication.to_event()?;
             relay_client.publish_event(&endpoints, &event, 1).await?;
         }
         self.fetch_account_relay_list_status_for_account_id(&account_id_hex, endpoints)
@@ -3978,28 +4063,117 @@ fn sqlite_file_requires_key(path: &Path) -> bool {
         .is_err()
 }
 
+#[cfg(test)]
 fn relays_from_relay_list_event(event: &NostrTransportEvent) -> Vec<String> {
-    if event.kind == KIND_NIP65_RELAY_LIST {
-        return parse_nip65_relay_set(event)
-            .write_relays
-            .into_iter()
-            .map(|endpoint| endpoint.0)
-            .collect();
-    }
+    relay_list_state_from_event(event)
+        .map(|state| state.relays)
+        .unwrap_or_default()
+}
 
-    let tag_name = match event.kind {
-        KIND_MARMOT_INBOX_RELAY_LIST => "relay",
-        _ => return Vec::new(),
-    };
-    let mut relays = Vec::new();
-    for tag in &event.tags {
-        if tag.first().is_some_and(|name| name == tag_name)
-            && let Some(value) = tag.get(1).filter(|value| !value.trim().is_empty())
-        {
-            push_unique_strings(&mut relays, [value.clone()]);
+fn relay_list_state_from_event(event: &NostrTransportEvent) -> Option<AccountRelayListState> {
+    match event.kind {
+        KIND_NIP65_RELAY_LIST => {
+            let relay_set = parse_nip65_relay_set(event);
+            let read_relays = relay_set
+                .read_relays
+                .into_iter()
+                .map(|endpoint| endpoint.0)
+                .collect::<Vec<_>>();
+            let write_relays = relay_set
+                .write_relays
+                .into_iter()
+                .map(|endpoint| endpoint.0)
+                .collect::<Vec<_>>();
+            Some(AccountRelayListState {
+                kind: KIND_NIP65_RELAY_LIST,
+                relays: write_relays.clone(),
+                read_relays,
+                write_relays,
+            })
+        }
+        KIND_MARMOT_INBOX_RELAY_LIST => {
+            let mut relays = Vec::new();
+            for tag in &event.tags {
+                if tag.first().is_some_and(|name| name == "relay")
+                    && let Some(value) = tag.get(1).filter(|value| !value.trim().is_empty())
+                {
+                    push_unique_strings(&mut relays, [value.clone()]);
+                }
+            }
+            Some(AccountRelayListState {
+                kind: KIND_MARMOT_INBOX_RELAY_LIST,
+                relays,
+                read_relays: Vec::new(),
+                write_relays: Vec::new(),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn nip65_relay_set_from_state(state: &AccountRelayListState) -> NostrNip65RelaySet {
+    if state.read_relays.is_empty() && state.write_relays.is_empty() {
+        let legacy_relays = state
+            .relays
+            .iter()
+            .cloned()
+            .map(TransportEndpoint)
+            .collect::<Vec<_>>();
+        return NostrNip65RelaySet {
+            read_relays: legacy_relays.clone(),
+            write_relays: legacy_relays,
+        };
+    }
+    NostrNip65RelaySet {
+        read_relays: state
+            .read_relays
+            .iter()
+            .cloned()
+            .map(TransportEndpoint)
+            .collect(),
+        write_relays: state
+            .write_relays
+            .iter()
+            .cloned()
+            .map(TransportEndpoint)
+            .collect(),
+    }
+}
+
+fn nip65_relay_set_preserving_roles(
+    current: &AccountRelayListState,
+    requested_relays: Vec<TransportEndpoint>,
+) -> NostrNip65RelaySet {
+    let current = nip65_relay_set_from_state(current);
+    let mut next = NostrNip65RelaySet::default();
+    for endpoint in unique_transport_endpoints(requested_relays) {
+        let was_read = current.read_relays.contains(&endpoint);
+        let was_write = current.write_relays.contains(&endpoint);
+        if !was_read && !was_write {
+            next.read_relays.push(endpoint.clone());
+            next.write_relays.push(endpoint);
+            continue;
+        }
+        if was_read {
+            next.read_relays.push(endpoint.clone());
+        }
+        if was_write {
+            next.write_relays.push(endpoint);
         }
     }
-    relays
+    next
+}
+
+fn unique_transport_endpoints(
+    endpoints: impl IntoIterator<Item = TransportEndpoint>,
+) -> Vec<TransportEndpoint> {
+    let mut unique = Vec::new();
+    for endpoint in endpoints {
+        if !unique.contains(&endpoint) {
+            unique.push(endpoint);
+        }
+    }
+    unique
 }
 
 fn push_unique_strings(values: &mut Vec<String>, candidates: impl IntoIterator<Item = String>) {

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -137,7 +137,8 @@ pub use groups::{
     AppGroupAvatarUrlComponent, AppGroupEncryptedMediaComponent, AppGroupHydrationQuarantineReason,
     AppGroupImageComponent, AppGroupMemberRecord, AppGroupMessageRetentionComponent,
     AppGroupMlsState, AppGroupNostrRoutingComponent, AppGroupProfileComponent, AppGroupRecord,
-    AppGroupSystemEvent, AppProtocolProfile, AppQuarantinedGroup, group_system_event_from_message,
+    AppGroupSystemEvent, AppPriorNostrRoute, AppProtocolProfile, AppQuarantinedGroup,
+    group_system_event_from_message,
 };
 pub use ids::{
     account_id_hex_from_ref, nprofile_for_account_id, npub_for_account_id, validate_relay_urls,
@@ -2163,7 +2164,7 @@ impl MarmotApp {
         let mut group_routes = Vec::new();
         for group in &state.groups {
             let group_id = GroupId::new(hex::decode(&group.group_id_hex)?);
-            group_routes.push(group.nostr_routing.subscription(&group_id)?);
+            group_routes.extend(group.transport_subscriptions(&group_id)?);
         }
 
         Ok(AppTransportRouting::new(AppRoutingState {
@@ -3685,25 +3686,29 @@ impl AppTransportRouting {
         }
     }
 
-    /// Insert or replace the route for a group, returning whether the route set
-    /// changed. Replaces by `group_id` (rather than early-returning on a
-    /// duplicate) so an in-place `nostr_group_id` / relay rotation on an existing
-    /// group actually switches the subscription (Finding 2). Returns `false`
-    /// when the group's subscription is already present and identical.
-    fn add_group(&self, group: TransportGroupSubscription) -> bool {
+    /// Atomically replace every current/prior subscription for one group.
+    /// Returns whether the desired route set differs from the installed set.
+    fn replace_group_routes(
+        &self,
+        group_id: &GroupId,
+        mut routes: Vec<TransportGroupSubscription>,
+    ) -> bool {
         let mut state = self.write();
-        if let Some(existing) = state
+        let mut existing = state
             .group_routes
-            .iter_mut()
-            .find(|existing| existing.group_id == group.group_id)
-        {
-            if *existing == group {
-                return false;
-            }
-            *existing = group;
-            return true;
+            .iter()
+            .filter(|route| route.group_id == *group_id)
+            .cloned()
+            .collect::<Vec<_>>();
+        normalize_group_subscriptions(&mut existing);
+        normalize_group_subscriptions(&mut routes);
+        if existing == routes {
+            return false;
         }
-        state.group_routes.push(group);
+        state
+            .group_routes
+            .retain(|route| route.group_id != *group_id);
+        state.group_routes.extend(routes);
         true
     }
 
@@ -3726,6 +3731,19 @@ impl AppTransportRouting {
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
+}
+
+fn normalize_group_subscriptions(routes: &mut Vec<TransportGroupSubscription>) {
+    for route in routes.iter_mut() {
+        route.endpoints.sort();
+        route.endpoints.dedup();
+    }
+    routes.sort_by(|left, right| {
+        left.transport_group_id
+            .cmp(&right.transport_group_id)
+            .then_with(|| left.endpoints.cmp(&right.endpoints))
+    });
+    routes.dedup();
 }
 
 impl TransportRoutingPolicy for AppTransportRouting {

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -61,7 +61,7 @@ use storage_sqlite::{
 use transport_nostr_adapter::{
     KIND_MARMOT_INBOX_RELAY_LIST, KIND_MARMOT_KEY_PACKAGE, KIND_NIP65_RELAY_LIST,
     NostrAccountRelayListKind, NostrAccountRelayListPublication, NostrKeyPackagePublication,
-    NostrKeyPackagePublisher, NostrRelayClient, NostrSdkRelayClient,
+    NostrKeyPackagePublisher, NostrRelayClient, NostrSdkRelayClient, parse_nip65_relay_set,
 };
 use transport_nostr_peeler::{NostrMlsPeeler, NostrTransportEvent};
 
@@ -511,6 +511,11 @@ impl MissingRelayListKind {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AccountRelayListState {
     pub kind: u64,
+    /// Direction-appropriate relay targets for this list.
+    ///
+    /// For NIP-65 kind 10002 this is specifically the write-capable set:
+    /// unmarked and `write` entries, excluding `read`-only entries. For the
+    /// Marmot inbox list this is the declared inbox relay set.
     pub relays: Vec<String>,
 }
 
@@ -3974,8 +3979,15 @@ fn sqlite_file_requires_key(path: &Path) -> bool {
 }
 
 fn relays_from_relay_list_event(event: &NostrTransportEvent) -> Vec<String> {
+    if event.kind == KIND_NIP65_RELAY_LIST {
+        return parse_nip65_relay_set(event)
+            .write_relays
+            .into_iter()
+            .map(|endpoint| endpoint.0)
+            .collect();
+    }
+
     let tag_name = match event.kind {
-        KIND_NIP65_RELAY_LIST => "r",
         KIND_MARMOT_INBOX_RELAY_LIST => "relay",
         _ => return Vec::new(),
     };

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -2257,7 +2257,7 @@ impl MarmotApp {
                 tracing::warn!(
                     target: "marmot_app",
                     method = "routing_for",
-                    error_kind = "invalid_persisted_group_id",
+                    error_kind = "invalid_persisted_route_identifier",
                     "skipping malformed persisted group route",
                 );
                 continue;

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -2353,6 +2353,25 @@ impl MarmotAppRuntime {
             .await
     }
 
+    pub async fn publish_account_nip65_relay_set(
+        &self,
+        account_ref: &str,
+        read_relays: Vec<TransportEndpoint>,
+        write_relays: Vec<TransportEndpoint>,
+        bootstrap_relays: Vec<TransportEndpoint>,
+    ) -> Result<AccountRelayListStatus, AppError> {
+        let account = self.accounts.resolve(account_ref)?;
+        self.accounts
+            .app
+            .publish_account_nip65_relay_set(
+                &account.label,
+                read_relays,
+                write_relays,
+                bootstrap_relays,
+            )
+            .await
+    }
+
     pub fn account_nip65_relays(&self, account_ref: &str) -> Result<Vec<String>, AppError> {
         let account = self.accounts.resolve(account_ref)?;
         self.accounts.app.account_nip65_relays(&account.label)

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -21,7 +21,8 @@ use crate::directory::records::{
 };
 use crate::ids::npub_for_account_id_lossy;
 use crate::key_package_records::{
-    relay_list_queries, require_key_package_tag, require_multi_value_key_package_tag_matches,
+    relay_list_queries, relay_list_status_from_records, require_key_package_tag,
+    require_multi_value_key_package_tag_matches,
 };
 use crate::messages::STREAM_ROUTE_QUIC;
 use crate::messages::{AppMessageIntent, build_inner_event};
@@ -305,6 +306,130 @@ fn nip65_relay_list_targets_only_include_write_capable_entries() {
         vec![
             "wss://both.example".to_owned(),
             "wss://write-only.example".to_owned(),
+        ]
+    );
+}
+
+#[test]
+fn newer_all_read_nip65_list_clears_stale_write_targets() {
+    let account_id = "11".repeat(32);
+    let mut older = NostrTransportEvent::new_unsigned(
+        account_id.clone(),
+        KIND_NIP65_RELAY_LIST,
+        vec![vec!["r".into(), "wss://stale-write.example".into()]],
+        String::new(),
+    );
+    older.created_at = 1;
+    older.id = "00".repeat(32);
+    let mut newer = NostrTransportEvent::new_unsigned(
+        account_id.clone(),
+        KIND_NIP65_RELAY_LIST,
+        vec![vec![
+            "r".into(),
+            "wss://read-only.example".into(),
+            "read".into(),
+        ]],
+        String::new(),
+    );
+    newer.created_at = 2;
+    newer.id = "11".repeat(32);
+
+    let status = relay_list_status_from_records(
+        &account_id,
+        vec![
+            crate::relay_plane::DirectoryRelayEventRecord {
+                endpoints: vec![TransportEndpoint("wss://source.example".into())],
+                event: newer,
+            },
+            crate::relay_plane::DirectoryRelayEventRecord {
+                endpoints: vec![TransportEndpoint("wss://source.example".into())],
+                event: older,
+            },
+        ],
+    );
+
+    assert!(status.nip65.relays.is_empty());
+    assert!(status.nip65.write_relays.is_empty());
+    assert_eq!(status.nip65.read_relays, vec!["wss://read-only.example"]);
+    assert_eq!(
+        status.missing,
+        vec![MissingRelayListKind::Nip65, MissingRelayListKind::Inbox]
+    );
+}
+
+#[test]
+fn ingesting_all_read_nip65_list_replaces_cached_write_targets() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let account_id = "22".repeat(32);
+    let record = |tags| crate::relay_plane::DirectoryRelayEventRecord {
+        endpoints: vec![TransportEndpoint("wss://source.example".into())],
+        event: NostrTransportEvent::new_unsigned(
+            account_id.clone(),
+            KIND_NIP65_RELAY_LIST,
+            tags,
+            String::new(),
+        ),
+    };
+
+    app.ingest_directory_relay_event(record(vec![vec![
+        "r".into(),
+        "wss://stale-write.example".into(),
+    ]]))
+    .unwrap();
+    app.ingest_directory_relay_event(record(vec![vec![
+        "r".into(),
+        "wss://read-only.example".into(),
+        "read".into(),
+    ]]))
+    .unwrap();
+
+    let cached = app
+        .directory_entry_for_account_id(&account_id)
+        .unwrap()
+        .expect("cached relay list");
+    assert!(cached.relay_lists.nip65.relays.is_empty());
+    assert!(cached.relay_lists.nip65.write_relays.is_empty());
+    assert_eq!(
+        cached.relay_lists.nip65.read_relays,
+        vec!["wss://read-only.example"]
+    );
+}
+
+#[test]
+fn nip65_setter_round_trip_preserves_existing_roles() {
+    let current = AccountRelayListState {
+        kind: KIND_NIP65_RELAY_LIST,
+        relays: vec!["wss://both.example".into(), "wss://write.example".into()],
+        read_relays: vec!["wss://both.example".into(), "wss://read.example".into()],
+        write_relays: vec!["wss://both.example".into(), "wss://write.example".into()],
+    };
+    let requested = vec![
+        TransportEndpoint("wss://both.example".into()),
+        TransportEndpoint("wss://read.example".into()),
+        TransportEndpoint("wss://write.example".into()),
+        TransportEndpoint("wss://new.example".into()),
+    ];
+
+    let next = nip65_relay_set_preserving_roles(&current, requested);
+
+    assert_eq!(
+        next.read_relays,
+        vec![
+            TransportEndpoint("wss://both.example".into()),
+            TransportEndpoint("wss://read.example".into()),
+            TransportEndpoint("wss://new.example".into()),
+        ]
+    );
+    assert_eq!(
+        next.write_relays,
+        vec![
+            TransportEndpoint("wss://both.example".into()),
+            TransportEndpoint("wss://write.example".into()),
+            TransportEndpoint("wss://new.example".into()),
         ]
     );
 }

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -3118,3 +3118,43 @@ fn reopening_account_restores_current_and_prior_group_routes() {
         HashSet::from([vec![0x11; 32], vec![0x22; 32]])
     );
 }
+
+#[test]
+fn account_routing_skips_malformed_groups_without_discarding_valid_routes() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://account.example");
+    let valid = AppGroupRecord::new(
+        "aa".repeat(16),
+        AppGroupNostrRoutingComponent::new(
+            NostrRoutingV1::new([0x22; 32], vec!["wss://valid.example".to_owned()]).unwrap(),
+        )
+        .unwrap(),
+        "valid".to_owned(),
+        String::new(),
+        AppGroupImageInput::default(),
+        AppGroupAdminPolicyComponent::new(Vec::new()),
+        AppGroupMessageRetentionComponent::disabled(),
+    );
+    let mut malformed_group_id = valid.clone();
+    malformed_group_id.group_id_hex = "not-hex".to_owned();
+    let mut malformed_current_route = valid.clone();
+    malformed_current_route.group_id_hex = "bb".repeat(16);
+    malformed_current_route.nostr_routing.nostr_group_id_hex = "not-hex".to_owned();
+
+    let routes = app
+        .routing_for(&AccountState {
+            label: "alice".to_owned(),
+            seen_events: Vec::new(),
+            last_transport_timestamp: None,
+            groups: vec![malformed_group_id, malformed_current_route, valid],
+        })
+        .expect("malformed group rows do not prevent account routing")
+        .snapshot()
+        .group_routes;
+
+    assert_eq!(routes.len(), 1);
+    assert_eq!(routes[0].transport_group_id, vec![0x22; 32]);
+}

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -281,6 +281,34 @@ async fn member_key_package_falls_back_to_current_directory_for_local_account() 
     );
 }
 
+#[test]
+fn nip65_relay_list_targets_only_include_write_capable_entries() {
+    let event = NostrTransportEvent::new_unsigned(
+        "11".repeat(32),
+        KIND_NIP65_RELAY_LIST,
+        vec![
+            vec!["r".into(), "wss://both.example".into()],
+            vec!["r".into(), "wss://read-only.example".into(), "read".into()],
+            vec![
+                "r".into(),
+                "wss://write-only.example".into(),
+                "write".into(),
+            ],
+            vec!["r".into(), "wss://unknown.example".into(), "future".into()],
+            vec!["r".into(), "wss://both.example".into()],
+        ],
+        String::new(),
+    );
+
+    assert_eq!(
+        relays_from_relay_list_event(&event),
+        vec![
+            "wss://both.example".to_owned(),
+            "wss://write-only.example".to_owned(),
+        ]
+    );
+}
+
 #[derive(Clone, Debug)]
 struct TestExternalAccountSigner {
     keys: nostr::Keys,

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -2876,12 +2876,8 @@ fn group_state_invalidated_event_tombstones_origin_commit_system_rows() {
     );
 }
 
-// Finding 2: an in-place nostr_group_id / relay rotation on an existing group
-// must switch the transport subscription. `add_group` previously early-returned
-// on a duplicate group_id, so a rotated route never took effect; it now replaces
-// by group_id and reports whether the route set changed.
 #[test]
-fn transport_add_group_replaces_route_for_same_group_on_rotation() {
+fn transport_group_route_replacement_installs_current_and_prior_routes() {
     let routing = AppTransportRouting::new(AppRoutingState {
         local_inbox_endpoints: Vec::new(),
         key_package_endpoints: Vec::new(),
@@ -2895,19 +2891,15 @@ fn transport_add_group_replaces_route_for_same_group_on_rotation() {
         transport_group_id: vec![0x41; 32],
         endpoints: vec![TransportEndpoint("wss://x.example".to_owned())],
     };
-    // First insert of a new group route reports a change.
-    assert!(routing.add_group(sub_x.clone()));
-    // Re-adding the identical subscription is a no-op.
-    assert!(!routing.add_group(sub_x.clone()));
+    assert!(routing.replace_group_routes(&group_id, vec![sub_x.clone()]));
+    assert!(!routing.replace_group_routes(&group_id, vec![sub_x.clone()]));
 
-    // Rotation: same group_id, new transport_group_id + relay. Must replace the
-    // existing route, report a change, and NOT leave a duplicate for the group.
     let sub_y = TransportGroupSubscription {
         group_id: group_id.clone(),
         transport_group_id: vec![0x59; 32],
         endpoints: vec![TransportEndpoint("wss://y.example".to_owned())],
     };
-    assert!(routing.add_group(sub_y.clone()));
+    assert!(routing.replace_group_routes(&group_id, vec![sub_y.clone(), sub_x.clone()]));
 
     let snapshot = routing.snapshot();
     let routes: Vec<_> = snapshot
@@ -2915,6 +2907,61 @@ fn transport_add_group_replaces_route_for_same_group_on_rotation() {
         .iter()
         .filter(|route| route.group_id == group_id)
         .collect();
-    assert_eq!(routes.len(), 1, "rotation must replace, not duplicate");
-    assert_eq!(routes[0], &sub_y);
+    assert_eq!(routes.len(), 2);
+    assert!(routes.contains(&&sub_x));
+    assert!(routes.contains(&&sub_y));
+}
+
+#[test]
+fn reopening_account_restores_current_and_prior_group_routes() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://account.example");
+    let group_id_hex = "aa".repeat(16);
+    let mut group = AppGroupRecord::new(
+        group_id_hex.clone(),
+        AppGroupNostrRoutingComponent::new(
+            NostrRoutingV1::new([0x22; 32], vec!["wss://current.example".to_owned()]).unwrap(),
+        )
+        .unwrap(),
+        "routed".to_owned(),
+        String::new(),
+        AppGroupImageInput::default(),
+        AppGroupAdminPolicyComponent::new(Vec::new()),
+        AppGroupMessageRetentionComponent::disabled(),
+    );
+    group.prior_nostr_routes = vec![AppPriorNostrRoute {
+        nostr_group_id_hex: hex::encode([0x11; 32]),
+        relays: vec!["wss://prior.example".to_owned()],
+        last_epoch: 7,
+    }];
+    group.nostr_routing_last_epoch = 8;
+    app.save_state(&AccountState {
+        label: "alice".to_owned(),
+        seen_events: Vec::new(),
+        last_transport_timestamp: Some(1_800_000_000),
+        groups: vec![group],
+    })
+    .unwrap();
+    drop(app);
+
+    let reopened = MarmotApp::with_relay(dir.path(), "wss://account.example");
+    let state = reopened.load_state("alice").unwrap();
+    assert_eq!(state.groups[0].prior_nostr_routes[0].last_epoch, 7);
+    assert_eq!(state.groups[0].nostr_routing_last_epoch, 8);
+    let routes = reopened
+        .routing_for(&state)
+        .unwrap()
+        .snapshot()
+        .group_routes;
+    assert_eq!(routes.len(), 2);
+    assert_eq!(
+        routes
+            .iter()
+            .map(|route| route.transport_group_id.clone())
+            .collect::<HashSet<_>>(),
+        HashSet::from([vec![0x11; 32], vec![0x22; 32]])
+    );
 }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -32,7 +32,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::time::{Duration, Instant, sleep, timeout};
-use transport_nostr_adapter::{KIND_MARMOT_KEY_PACKAGE, NostrRelayClient, NostrSdkRelayClient};
+use transport_nostr_adapter::{
+    KIND_MARMOT_KEY_PACKAGE, KIND_NIP65_RELAY_LIST, NostrRelayClient, NostrSdkRelayClient,
+};
 use transport_nostr_peeler::{NOSTR_GROUP_CONTENT_MIN_LEN, NostrTransportEvent};
 
 const AUDIT_TRACKER_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -4538,6 +4540,50 @@ async fn relay_app_public_methods_read_and_update_each_account_relay_list() {
 }
 
 #[tokio::test]
+async fn relay_app_nip65_getter_setter_round_trip_preserves_roles() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    home.create_account("alice").unwrap();
+    let (_seed, app, seed_url) = mock_app(&dir).await;
+    let read_only_url = "wss://read-only.example".to_owned();
+
+    let status = app
+        .publish_account_nip65_relay_set(
+            "alice",
+            vec![endpoint(&seed_url), endpoint(&read_only_url)],
+            vec![endpoint(&seed_url)],
+            vec![endpoint(&seed_url)],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        status.nip65.read_relays,
+        vec![seed_url.clone(), read_only_url.clone()]
+    );
+    assert_eq!(status.nip65.write_relays, vec![seed_url.clone()]);
+
+    let editable_relays = app.account_nip65_relays("alice").unwrap();
+    assert_eq!(
+        editable_relays,
+        vec![seed_url.clone(), read_only_url.clone()]
+    );
+    let status = app
+        .set_account_nip65_relays(
+            "alice",
+            editable_relays.into_iter().map(TransportEndpoint).collect(),
+            vec![endpoint(&seed_url)],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        status.nip65.read_relays,
+        vec![seed_url.clone(), read_only_url]
+    );
+    assert_eq!(status.nip65.write_relays, vec![seed_url]);
+}
+
+#[tokio::test]
 async fn relay_list_fetch_only_uses_requested_bootstrap_relays_without_cache() {
     let dir = tempfile::tempdir().unwrap();
     let home = AccountHome::open(dir.path());
@@ -4603,6 +4649,50 @@ async fn relay_list_empty_fetch_keeps_cached_lists() {
         .unwrap()
         .expect("cached directory entry");
     assert_eq!(directory_entry.relay_lists, cached);
+}
+
+#[tokio::test]
+async fn relay_list_all_read_fetch_clears_cached_write_targets() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    home.create_account("alice").unwrap();
+    let (_seed, app, seed_url) = mock_app(&dir).await;
+
+    let cached = app
+        .publish_account_relay_lists(
+            "alice",
+            AccountRelayListBootstrap::new(vec![endpoint(&seed_url)], vec![endpoint(&seed_url)]),
+        )
+        .await
+        .unwrap();
+    assert_eq!(cached.nip65.relays, vec![seed_url.clone()]);
+
+    publish_nostr_event_at(
+        &home,
+        "alice",
+        &seed_url,
+        KIND_NIP65_RELAY_LIST,
+        vec![vec![
+            "r".to_owned(),
+            "wss://read-only.example".to_owned(),
+            "read".to_owned(),
+        ]],
+        String::new(),
+        test_unix_now_seconds() + 1,
+    )
+    .await;
+
+    let account_id = home.account("alice").unwrap().account_id_hex;
+    let fetched = app
+        .fetch_account_relay_list_status_for_account_id(&account_id, vec![endpoint(&seed_url)])
+        .await
+        .unwrap();
+
+    assert!(fetched.nip65.relays.is_empty());
+    assert!(fetched.nip65.write_relays.is_empty());
+    assert_eq!(fetched.nip65.read_relays, vec!["wss://read-only.example"]);
+    assert_eq!(fetched.inbox, cached.inbox);
+    assert_eq!(fetched.missing, vec![MissingRelayListKind::Nip65]);
 }
 
 #[tokio::test]

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -70,6 +70,10 @@ pub struct StoredAccountGroup {
     pub pending_confirmation: bool,
     pub welcomer_account_id_hex: Option<String>,
     pub via_welcome_message_id_hex: Option<String>,
+    pub nostr_routing_last_epoch: u64,
+    /// Authenticated Nostr routes that preceded the current group component
+    /// and still intersect a retained-history window.
+    pub prior_nostr_routes: Vec<StoredNostrRoute>,
     /// The local account's membership in this group. Read-only on this struct:
     /// it is loaded from `account_groups` but owned exclusively by
     /// [`SqliteAccountStorage::set_group_self_membership`], so the projection
@@ -77,6 +81,13 @@ pub struct StoredAccountGroup {
     /// membership change). New rows take the schema default `Member`.
     pub self_membership: SelfMembership,
     pub components: Vec<StoredAccountGroupComponent>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoredNostrRoute {
+    pub nostr_group_id_hex: String,
+    pub relays: Vec<String>,
+    pub last_epoch: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -257,6 +268,8 @@ struct RawStoredAccountGroup {
     pending_confirmation: bool,
     welcomer_account_id_hex: Option<String>,
     via_welcome_message_id_hex: Option<String>,
+    nostr_routing_last_epoch: i64,
+    prior_nostr_routes_json: String,
     self_membership: SelfMembership,
 }
 
@@ -313,7 +326,8 @@ impl SqliteAccountStorage {
                         image_hash_hex, image_key_hex, image_nonce_hex,
                         image_upload_key_hex, image_media_type, admin_keys_hex,
                         archived, pending_confirmation, welcomer_account_id_hex,
-                        via_welcome_message_id_hex, self_membership
+                        via_welcome_message_id_hex, nostr_routing_last_epoch,
+                        prior_nostr_routes_json, self_membership
                  FROM account_groups
                  ORDER BY updated_at, group_id_hex",
             )
@@ -335,7 +349,9 @@ impl SqliteAccountStorage {
                     pending_confirmation: row.get::<_, i64>(11)? != 0,
                     welcomer_account_id_hex: row.get(12)?,
                     via_welcome_message_id_hex: row.get(13)?,
-                    self_membership: SelfMembership::from_storage(&row.get::<_, String>(14)?),
+                    nostr_routing_last_epoch: row.get(14)?,
+                    prior_nostr_routes_json: row.get(15)?,
+                    self_membership: SelfMembership::from_storage(&row.get::<_, String>(16)?),
                 })
             })
             .storage()?
@@ -346,6 +362,8 @@ impl SqliteAccountStorage {
         let mut components_by_group = all_account_group_components(&conn)?;
         let mut groups = Vec::with_capacity(raw_groups.len());
         for raw in raw_groups {
+            let prior_nostr_routes = serde_json::from_str(&raw.prior_nostr_routes_json)
+                .map_err(|err| StorageError::Serialization(err.to_string()))?;
             let components = components_by_group
                 .remove(&raw.group_id_hex)
                 .unwrap_or_default();
@@ -364,6 +382,11 @@ impl SqliteAccountStorage {
                 pending_confirmation: raw.pending_confirmation,
                 welcomer_account_id_hex: raw.welcomer_account_id_hex,
                 via_welcome_message_id_hex: raw.via_welcome_message_id_hex,
+                nostr_routing_last_epoch: raw
+                    .nostr_routing_last_epoch
+                    .try_into()
+                    .unwrap_or_default(),
+                prior_nostr_routes,
                 self_membership: raw.self_membership,
                 components,
             });
@@ -490,15 +513,19 @@ impl SqliteAccountStorage {
             }
 
             for group in &state.groups {
+                let nostr_routing_last_epoch =
+                    i64::try_from(group.nostr_routing_last_epoch).unwrap_or(i64::MAX);
+                let prior_nostr_routes_json = serde_json::to_string(&group.prior_nostr_routes)
+                    .map_err(|err| StorageError::Serialization(err.to_string()))?;
                 conn.execute(
                     "INSERT INTO account_groups (
                         group_id_hex, endpoint, profile_name, profile_description,
                         image_hash_hex, image_key_hex, image_nonce_hex,
                         image_upload_key_hex, image_media_type, admin_keys_hex, archived,
                         pending_confirmation, welcomer_account_id_hex, via_welcome_message_id_hex,
-                        updated_at
+                        nostr_routing_last_epoch, prior_nostr_routes_json, updated_at
                      )
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
                      ON CONFLICT(group_id_hex) DO UPDATE SET
                         endpoint = excluded.endpoint,
                         profile_name = excluded.profile_name,
@@ -513,6 +540,8 @@ impl SqliteAccountStorage {
                         pending_confirmation = excluded.pending_confirmation,
                         welcomer_account_id_hex = excluded.welcomer_account_id_hex,
                         via_welcome_message_id_hex = excluded.via_welcome_message_id_hex,
+                        nostr_routing_last_epoch = excluded.nostr_routing_last_epoch,
+                        prior_nostr_routes_json = excluded.prior_nostr_routes_json,
                         updated_at = excluded.updated_at
                      WHERE account_groups.endpoint IS NOT excluded.endpoint
                         OR account_groups.profile_name IS NOT excluded.profile_name
@@ -526,7 +555,9 @@ impl SqliteAccountStorage {
                         OR account_groups.archived IS NOT excluded.archived
                         OR account_groups.pending_confirmation IS NOT excluded.pending_confirmation
                         OR account_groups.welcomer_account_id_hex IS NOT excluded.welcomer_account_id_hex
-                        OR account_groups.via_welcome_message_id_hex IS NOT excluded.via_welcome_message_id_hex",
+                        OR account_groups.via_welcome_message_id_hex IS NOT excluded.via_welcome_message_id_hex
+                        OR account_groups.nostr_routing_last_epoch IS NOT excluded.nostr_routing_last_epoch
+                        OR account_groups.prior_nostr_routes_json IS NOT excluded.prior_nostr_routes_json",
                     params![
                         &group.group_id_hex,
                         &group.endpoint,
@@ -542,6 +573,8 @@ impl SqliteAccountStorage {
                         bool_i64(group.pending_confirmation),
                         &group.welcomer_account_id_hex,
                         &group.via_welcome_message_id_hex,
+                        nostr_routing_last_epoch,
+                        prior_nostr_routes_json,
                         now_i64
                     ],
                 )

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -229,6 +229,8 @@ fn group(id: &str, name: &str) -> StoredAccountGroup {
         pending_confirmation: false,
         welcomer_account_id_hex: None,
         via_welcome_message_id_hex: None,
+        nostr_routing_last_epoch: 0,
+        prior_nostr_routes: Vec::new(),
         self_membership: SelfMembership::Member,
         components: vec![
             StoredAccountGroupComponent {
@@ -352,11 +354,18 @@ fn delete_event(
 #[test]
 fn account_projection_state_roundtrips_groups_components_and_seen_events() {
     let store = SqliteAccountStorage::in_memory().unwrap();
+    let mut stored_group = group("aa", "alpha");
+    stored_group.nostr_routing_last_epoch = 8;
+    stored_group.prior_nostr_routes = vec![StoredNostrRoute {
+        nostr_group_id_hex: "11".repeat(32),
+        relays: vec!["wss://prior.example".to_owned()],
+        last_epoch: 7,
+    }];
     let state = StoredAccountState {
         label: "alice".to_owned(),
         seen_events: vec!["old".to_owned(), "kept".to_owned()],
         last_transport_timestamp: Some(1_700_000_001),
-        groups: vec![group("aa", "alpha")],
+        groups: vec![stored_group],
     };
 
     store
@@ -369,6 +378,15 @@ fn account_projection_state_roundtrips_groups_components_and_seen_events() {
     assert_eq!(restored.groups[0].profile_name, "alpha");
     assert_eq!(restored.groups[0].components.len(), 2);
     assert_eq!(restored.groups[0].components[1].component_id, 0x8004);
+    assert_eq!(restored.groups[0].nostr_routing_last_epoch, 8);
+    assert_eq!(
+        restored.groups[0].prior_nostr_routes,
+        vec![StoredNostrRoute {
+            nostr_group_id_hex: "11".repeat(32),
+            relays: vec!["wss://prior.example".to_owned()],
+            last_epoch: 7,
+        }]
+    );
 }
 
 #[test]

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -32,6 +32,8 @@ fn group() -> StoredAccountGroup {
         pending_confirmation: false,
         welcomer_account_id_hex: None,
         via_welcome_message_id_hex: None,
+        nostr_routing_last_epoch: 0,
+        prior_nostr_routes: Vec::new(),
         self_membership: SelfMembership::Member,
         components: Vec::new(),
     }

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -22,7 +22,7 @@ pub use account_projection::{
     AccountChatNotificationSettings, AccountGroupPushToken, AccountNotificationSettings,
     AccountPushRegistration, AccountStoredPushRegistration, AppEventReplayCursor, SelfMembership,
     StoredAccountGroup, StoredAccountGroupComponent, StoredAccountState, StoredAppMessageQuery,
-    StoredAppMessageRecord, clamp_to_max_future_skew,
+    StoredAppMessageRecord, StoredNostrRoute, clamp_to_max_future_skew,
 };
 pub use chat_list::{
     AccountUnreadTotal, ChatListAvatar, ChatListMessagePreview, ChatListQuery, ChatListRow,

--- a/crates/storage-sqlite/src/message_drafts.rs
+++ b/crates/storage-sqlite/src/message_drafts.rs
@@ -540,6 +540,8 @@ mod tests {
             pending_confirmation: false,
             welcomer_account_id_hex: None,
             via_welcome_message_id_hex: None,
+            nostr_routing_last_epoch: 0,
+            prior_nostr_routes: Vec::new(),
             self_membership: SelfMembership::Member,
             components: vec![],
         }

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -56,6 +56,8 @@ mod migration_0027_app_event_moderation_grant;
 mod migration_0028_ingress_dedup;
 #[path = "migrations/0029_app_event_retention_decision.rs"]
 mod migration_0029_app_event_retention_decision;
+#[path = "migrations/0030_prior_nostr_routes.rs"]
+mod migration_0030_prior_nostr_routes;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -212,6 +214,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 29,
         name: "0029_app_event_retention_decision",
         apply: migration_0029_app_event_retention_decision::apply,
+    },
+    Migration {
+        version: 30,
+        name: "0030_prior_nostr_routes",
+        apply: migration_0030_prior_nostr_routes::apply,
     },
 ];
 
@@ -581,6 +588,38 @@ mod tests {
             )
             .unwrap();
         assert_eq!(legacy_membership, "member");
+    }
+
+    #[test]
+    fn prior_nostr_routes_migration_defaults_existing_groups_to_empty_history() {
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.pragma_update(None, "foreign_keys", true).unwrap();
+        run(&mut conn, &MIGRATIONS[..29]).unwrap();
+        conn.execute(
+            "INSERT INTO account_groups (group_id_hex, endpoint, updated_at)
+             VALUES ('11', 'relay', 1)",
+            [],
+        )
+        .unwrap();
+
+        run(&mut conn, MIGRATIONS).unwrap();
+
+        assert_eq!(
+            column_default(&conn, "account_groups", "prior_nostr_routes_json").as_deref(),
+            Some("'[]'")
+        );
+        assert_eq!(
+            column_default(&conn, "account_groups", "nostr_routing_last_epoch").as_deref(),
+            Some("0")
+        );
+        let history: String = conn
+            .query_row(
+                "SELECT prior_nostr_routes_json FROM account_groups WHERE group_id_hex = '11'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(history, "[]");
     }
 
     #[test]

--- a/crates/storage-sqlite/src/migrations/0030_prior_nostr_routes.rs
+++ b/crates/storage-sqlite/src/migrations/0030_prior_nostr_routes.rs
@@ -1,0 +1,16 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+ALTER TABLE account_groups
+ADD COLUMN nostr_routing_last_epoch INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE account_groups
+ADD COLUMN prior_nostr_routes_json TEXT NOT NULL DEFAULT '[]';
+"#,
+    )
+    .storage()
+}

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -77,7 +77,8 @@ pub use key_package::{
 };
 pub use relay_list::{
     KIND_MARMOT_INBOX_RELAY_LIST, KIND_NIP65_RELAY_LIST, NostrAccountRelayListKind,
-    NostrAccountRelayListPublication, NostrNip65RelaySet, parse_nip65_relay_set,
+    NostrAccountRelayListPublication, NostrNip65RelayListPublication, NostrNip65RelaySet,
+    parse_nip65_relay_set,
 };
 #[cfg(feature = "sdk")]
 pub use sdk_client::{

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -77,7 +77,7 @@ pub use key_package::{
 };
 pub use relay_list::{
     KIND_MARMOT_INBOX_RELAY_LIST, KIND_NIP65_RELAY_LIST, NostrAccountRelayListKind,
-    NostrAccountRelayListPublication,
+    NostrAccountRelayListPublication, NostrNip65RelaySet, parse_nip65_relay_set,
 };
 #[cfg(feature = "sdk")]
 pub use sdk_client::{

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -544,9 +544,10 @@ impl TransportAdapter for NostrTransportAdapter {
             activation.inbox_endpoints.clone(),
             inbox_since(activation.since),
         ));
-        let full_backfill_groups = groups_requiring_full_backfill(&activation.group_subscriptions);
+        let prior_route_keys = prior_group_route_keys(&account_id, &activation.group_subscriptions);
         for group in &activation.group_subscriptions {
-            let since = if full_backfill_groups.contains(&group.group_id) {
+            let route_key = group_subscription(&account_id, group, None).route_key();
+            let since = if prior_route_keys.contains(&route_key) {
                 None
             } else {
                 activation.since
@@ -1244,11 +1245,13 @@ fn diff_group_subscriptions(
         .iter()
         .map(|group| group_subscription(account_id, group, None))
         .collect::<Vec<_>>();
-    let full_backfill_groups = groups_requiring_full_backfill(desired);
+    let current_prior_keys = prior_group_route_keys(account_id, current);
+    let desired_prior_keys = prior_group_route_keys(account_id, desired);
     let desired_subscriptions = desired
         .iter()
         .map(|group| {
-            let since = if full_backfill_groups.contains(&group.group_id) {
+            let route_key = group_subscription(account_id, group, None).route_key();
+            let since = if desired_prior_keys.contains(&route_key) {
                 None
             } else {
                 since
@@ -1267,7 +1270,12 @@ fn diff_group_subscriptions(
 
     let to_add = desired_subscriptions
         .into_iter()
-        .filter(|subscription| !current_keys.contains(&subscription.route_key()))
+        .filter(|subscription| {
+            let route_key = subscription.route_key();
+            !current_keys.contains(&route_key)
+                || (desired_prior_keys.contains(&route_key)
+                    && !current_prior_keys.contains(&route_key))
+        })
         .collect();
     let to_remove = current_subscriptions
         .into_iter()
@@ -1277,22 +1285,22 @@ fn diff_group_subscriptions(
     (to_add, to_remove)
 }
 
-/// More than one subscription for one MLS group means the caller retained at
-/// least one prior routing address alongside the current address. A global
-/// account cursor cannot safely bound those subscriptions: a delayed event at
-/// the prior address can have a `created_at` older than that cursor. Backfill
-/// every retained address for the group and rely on authenticated event-id
-/// deduplication and the engine's retained-epoch bounds to discard repeats or
-/// stale traffic.
-fn groups_requiring_full_backfill(groups: &[TransportGroupSubscription]) -> HashSet<GroupId> {
-    let mut seen = HashSet::new();
-    let mut repeated = HashSet::new();
+/// Return route keys for retained prior addresses. App routing orders each
+/// group's current signed route first and its retained historical routes
+/// immediately afterward. Only those historical routes need an unbounded
+/// backfill; the current route keeps the account cursor.
+fn prior_group_route_keys(
+    account_id: &MemberId,
+    groups: &[TransportGroupSubscription],
+) -> HashSet<NostrSubscriptionRouteKey> {
+    let mut seen_groups = HashSet::new();
+    let mut prior_route_keys = HashSet::new();
     for group in groups {
-        if !seen.insert(group.group_id.clone()) {
-            repeated.insert(group.group_id.clone());
+        if !seen_groups.insert(group.group_id.clone()) {
+            prior_route_keys.insert(group_subscription(account_id, group, None).route_key());
         }
     }
-    repeated
+    prior_route_keys
 }
 
 fn normalized_endpoints(endpoints: &[TransportEndpoint]) -> Vec<TransportEndpoint> {

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -543,8 +543,14 @@ impl TransportAdapter for NostrTransportAdapter {
             activation.inbox_endpoints.clone(),
             inbox_since(activation.since),
         ));
+        let full_backfill_groups = groups_requiring_full_backfill(&activation.group_subscriptions);
         for group in &activation.group_subscriptions {
-            issued.push(group_subscription(&account_id, group, activation.since));
+            let since = if full_backfill_groups.contains(&group.group_id) {
+                None
+            } else {
+                activation.since
+            };
+            issued.push(group_subscription(&account_id, group, since));
         }
         // Register routing/telemetry state BEFORE the relay REQs go out: a
         // relay may stream stored events the moment it sees a subscription,
@@ -1237,9 +1243,17 @@ fn diff_group_subscriptions(
         .iter()
         .map(|group| group_subscription(account_id, group, None))
         .collect::<Vec<_>>();
+    let full_backfill_groups = groups_requiring_full_backfill(desired);
     let desired_subscriptions = desired
         .iter()
-        .map(|group| group_subscription(account_id, group, since))
+        .map(|group| {
+            let since = if full_backfill_groups.contains(&group.group_id) {
+                None
+            } else {
+                since
+            };
+            group_subscription(account_id, group, since)
+        })
         .collect::<Vec<_>>();
     let current_keys = current_subscriptions
         .iter()
@@ -1260,6 +1274,24 @@ fn diff_group_subscriptions(
         .collect();
 
     (to_add, to_remove)
+}
+
+/// More than one subscription for one MLS group means the caller retained at
+/// least one prior routing address alongside the current address. A global
+/// account cursor cannot safely bound those subscriptions: a delayed event at
+/// the prior address can have a `created_at` older than that cursor. Backfill
+/// every retained address for the group and rely on authenticated event-id
+/// deduplication and the engine's retained-epoch bounds to discard repeats or
+/// stale traffic.
+fn groups_requiring_full_backfill(groups: &[TransportGroupSubscription]) -> HashSet<GroupId> {
+    let mut seen = HashSet::new();
+    let mut repeated = HashSet::new();
+    for group in groups {
+        if !seen.insert(group.group_id.clone()) {
+            repeated.insert(group.group_id.clone());
+        }
+    }
+    repeated
 }
 
 fn normalized_endpoints(endpoints: &[TransportEndpoint]) -> Vec<TransportEndpoint> {

--- a/crates/transport-nostr-adapter/src/relay_list.rs
+++ b/crates/transport-nostr-adapter/src/relay_list.rs
@@ -7,6 +7,65 @@ pub const KIND_MARMOT_INBOX_RELAY_LIST: u64 = 10_050;
 const NIP65_RELAY_TAG: &str = "r";
 const MARMOT_RELAY_TAG: &str = "relay";
 
+/// Directional relay sets recovered from a NIP-65 kind-10002 event.
+///
+/// An unmarked `r` tag belongs to both sets. A `read`-marked tag belongs only
+/// to `read_relays`, and a `write`-marked tag belongs only to `write_relays`.
+/// Malformed tags and unknown markers are ignored. Repeated relay URLs are
+/// deduplicated independently in each direction while preserving first-seen
+/// order.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct NostrNip65RelaySet {
+    pub read_relays: Vec<TransportEndpoint>,
+    pub write_relays: Vec<TransportEndpoint>,
+}
+
+/// Parse the directional relay roles from a NIP-65 kind-10002 event.
+///
+/// This is intentionally a tolerant list parser: a hostile or future
+/// extension tag must not turn a different valid `r` entry into a relay
+/// target. Exact two-element tags are unmarked (read and write); exact
+/// three-element tags accept only the NIP-65 `read` and `write` markers.
+pub fn parse_nip65_relay_set(event: &NostrTransportEvent) -> NostrNip65RelaySet {
+    if event.kind != KIND_NIP65_RELAY_LIST {
+        return NostrNip65RelaySet::default();
+    }
+
+    let mut relays = NostrNip65RelaySet::default();
+    for tag in &event.tags {
+        let (relay, read, write) = match tag.as_slice() {
+            [name, relay] if name == NIP65_RELAY_TAG && !relay.trim().is_empty() => {
+                (relay, true, true)
+            }
+            [name, relay, marker]
+                if name == NIP65_RELAY_TAG && !relay.trim().is_empty() && marker == "read" =>
+            {
+                (relay, true, false)
+            }
+            [name, relay, marker]
+                if name == NIP65_RELAY_TAG && !relay.trim().is_empty() && marker == "write" =>
+            {
+                (relay, false, true)
+            }
+            _ => continue,
+        };
+
+        if read {
+            push_unique_endpoint(&mut relays.read_relays, relay);
+        }
+        if write {
+            push_unique_endpoint(&mut relays.write_relays, relay);
+        }
+    }
+    relays
+}
+
+fn push_unique_endpoint(endpoints: &mut Vec<TransportEndpoint>, relay: &str) {
+    if !endpoints.iter().any(|endpoint| endpoint.0 == relay) {
+        endpoints.push(TransportEndpoint(relay.to_owned()));
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NostrAccountRelayListKind {
     Nip65,
@@ -109,6 +168,63 @@ mod tests {
             event.tags[0],
             vec!["relay".to_string(), "wss://relay1.example".to_string()]
         );
+    }
+
+    #[test]
+    fn nip65_marker_matrix_is_directional_and_deduplicated() {
+        let event = NostrTransportEvent::new_unsigned(
+            "11".repeat(32),
+            KIND_NIP65_RELAY_LIST,
+            vec![
+                vec!["r".into(), "wss://both.example".into()],
+                vec!["r".into(), "wss://read.example".into(), "read".into()],
+                vec!["r".into(), "wss://write.example".into(), "write".into()],
+                vec!["r".into(), "wss://invalid.example".into(), "invalid".into()],
+                vec!["r".into(), "wss://both.example".into()],
+                vec!["r".into(), "wss://split.example".into(), "read".into()],
+                vec!["r".into(), "wss://split.example".into(), "write".into()],
+                vec![
+                    "r".into(),
+                    "wss://extra-field.example".into(),
+                    "write".into(),
+                    "extra".into(),
+                ],
+                vec!["r".into(), "".into()],
+                vec!["not-r".into(), "wss://wrong-tag.example".into()],
+            ],
+            String::new(),
+        );
+
+        let relays = parse_nip65_relay_set(&event);
+
+        assert_eq!(
+            relays.read_relays,
+            vec![
+                TransportEndpoint("wss://both.example".into()),
+                TransportEndpoint("wss://read.example".into()),
+                TransportEndpoint("wss://split.example".into()),
+            ]
+        );
+        assert_eq!(
+            relays.write_relays,
+            vec![
+                TransportEndpoint("wss://both.example".into()),
+                TransportEndpoint("wss://write.example".into()),
+                TransportEndpoint("wss://split.example".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn nip65_parser_ignores_other_event_kinds() {
+        let event = NostrTransportEvent::new_unsigned(
+            "11".repeat(32),
+            KIND_MARMOT_INBOX_RELAY_LIST,
+            vec![vec!["r".into(), "wss://relay.example".into()]],
+            String::new(),
+        );
+
+        assert_eq!(parse_nip65_relay_set(&event), NostrNip65RelaySet::default());
     }
 
     fn sample_publication(

--- a/crates/transport-nostr-adapter/src/relay_list.rs
+++ b/crates/transport-nostr-adapter/src/relay_list.rs
@@ -24,8 +24,9 @@ pub struct NostrNip65RelaySet {
 ///
 /// This is intentionally a tolerant list parser: a hostile or future
 /// extension tag must not turn a different valid `r` entry into a relay
-/// target. Exact two-element tags are unmarked (read and write); exact
-/// three-element tags accept only the NIP-65 `read` and `write` markers.
+/// target. Two-element tags are unmarked (read and write); longer tags accept
+/// only the NIP-65 `read` and `write` markers in the third position and ignore
+/// trailing extension values.
 pub fn parse_nip65_relay_set(event: &NostrTransportEvent) -> NostrNip65RelaySet {
     if event.kind != KIND_NIP65_RELAY_LIST {
         return NostrNip65RelaySet::default();
@@ -34,18 +35,19 @@ pub fn parse_nip65_relay_set(event: &NostrTransportEvent) -> NostrNip65RelaySet 
     let mut relays = NostrNip65RelaySet::default();
     for tag in &event.tags {
         let (relay, read, write) = match tag.as_slice() {
-            [name, relay] if name == NIP65_RELAY_TAG && !relay.trim().is_empty() => {
-                (relay, true, true)
-            }
-            [name, relay, marker]
-                if name == NIP65_RELAY_TAG && !relay.trim().is_empty() && marker == "read" =>
+            [name, relay, marker_and_extensions @ ..]
+                if name == NIP65_RELAY_TAG && !relay.trim().is_empty() =>
             {
-                (relay, true, false)
-            }
-            [name, relay, marker]
-                if name == NIP65_RELAY_TAG && !relay.trim().is_empty() && marker == "write" =>
-            {
-                (relay, false, true)
+                match marker_and_extensions.first().map(String::as_str) {
+                    None => (relay.trim(), true, true),
+                    Some(marker) if marker.eq_ignore_ascii_case("read") => {
+                        (relay.trim(), true, false)
+                    }
+                    Some(marker) if marker.eq_ignore_ascii_case("write") => {
+                        (relay.trim(), false, true)
+                    }
+                    Some(_) => continue,
+                }
             }
             _ => continue,
         };
@@ -61,6 +63,7 @@ pub fn parse_nip65_relay_set(event: &NostrTransportEvent) -> NostrNip65RelaySet 
 }
 
 fn push_unique_endpoint(endpoints: &mut Vec<TransportEndpoint>, relay: &str) {
+    let relay = relay.trim();
     if !endpoints.iter().any(|endpoint| endpoint.0 == relay) {
         endpoints.push(TransportEndpoint(relay.to_owned()));
     }
@@ -136,6 +139,69 @@ impl NostrAccountRelayListPublication {
     }
 }
 
+/// A role-preserving NIP-65 kind-10002 publication.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NostrNip65RelayListPublication {
+    pub account_id: MemberId,
+    pub relays: NostrNip65RelaySet,
+    pub publish_endpoints: Vec<TransportEndpoint>,
+}
+
+impl NostrNip65RelayListPublication {
+    pub fn to_event(&self) -> Result<NostrTransportEvent, TransportAdapterError> {
+        if self.account_id.as_slice().len() != 32 {
+            return Err(TransportAdapterError::Publish(
+                "account relay-list author must be a 32-byte Nostr pubkey".into(),
+            ));
+        }
+        if self.relays.read_relays.is_empty() && self.relays.write_relays.is_empty() {
+            return Err(TransportAdapterError::Publish(
+                "account relay-list relays must not be empty".into(),
+            ));
+        }
+        if self.publish_endpoints.is_empty() {
+            return Err(TransportAdapterError::Publish(
+                "account relay-list publish endpoints must not be empty".into(),
+            ));
+        }
+
+        let mut tags = Vec::new();
+        for endpoint in &self.relays.read_relays {
+            let write = self
+                .relays
+                .write_relays
+                .iter()
+                .any(|candidate| candidate == endpoint);
+            let mut tag = vec![NIP65_RELAY_TAG.into(), endpoint.0.clone()];
+            if !write {
+                tag.push("read".into());
+            }
+            tags.push(tag);
+        }
+        for endpoint in &self.relays.write_relays {
+            if self
+                .relays
+                .read_relays
+                .iter()
+                .any(|candidate| candidate == endpoint)
+            {
+                continue;
+            }
+            tags.push(vec![
+                NIP65_RELAY_TAG.into(),
+                endpoint.0.clone(),
+                "write".into(),
+            ]);
+        }
+        Ok(NostrTransportEvent::new_unsigned(
+            hex::encode(self.account_id.as_slice()),
+            KIND_NIP65_RELAY_LIST,
+            tags,
+            String::new(),
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -189,6 +255,9 @@ mod tests {
                     "write".into(),
                     "extra".into(),
                 ],
+                vec!["r".into(), "wss://uppercase.example".into(), "READ".into()],
+                vec!["r".into(), " wss://trimmed.example ".into()],
+                vec!["r".into(), "wss://trimmed.example".into()],
                 vec!["r".into(), "".into()],
                 vec!["not-r".into(), "wss://wrong-tag.example".into()],
             ],
@@ -203,6 +272,8 @@ mod tests {
                 TransportEndpoint("wss://both.example".into()),
                 TransportEndpoint("wss://read.example".into()),
                 TransportEndpoint("wss://split.example".into()),
+                TransportEndpoint("wss://uppercase.example".into()),
+                TransportEndpoint("wss://trimmed.example".into()),
             ]
         );
         assert_eq!(
@@ -211,6 +282,8 @@ mod tests {
                 TransportEndpoint("wss://both.example".into()),
                 TransportEndpoint("wss://write.example".into()),
                 TransportEndpoint("wss://split.example".into()),
+                TransportEndpoint("wss://extra-field.example".into()),
+                TransportEndpoint("wss://trimmed.example".into()),
             ]
         );
     }
@@ -225,6 +298,36 @@ mod tests {
         );
 
         assert_eq!(parse_nip65_relay_set(&event), NostrNip65RelaySet::default());
+    }
+
+    #[test]
+    fn nip65_publication_preserves_directional_roles() {
+        let publication = NostrNip65RelayListPublication {
+            account_id: MemberId::new(vec![0xA1; 32]),
+            relays: NostrNip65RelaySet {
+                read_relays: vec![
+                    TransportEndpoint("wss://both.example".into()),
+                    TransportEndpoint("wss://read.example".into()),
+                ],
+                write_relays: vec![
+                    TransportEndpoint("wss://both.example".into()),
+                    TransportEndpoint("wss://write.example".into()),
+                ],
+            },
+            publish_endpoints: vec![TransportEndpoint("wss://seed.example".into())],
+        };
+
+        let event = publication.to_event().unwrap();
+
+        assert_eq!(
+            event.tags,
+            vec![
+                vec!["r", "wss://both.example"],
+                vec!["r", "wss://read.example", "read"],
+                vec!["r", "wss://write.example", "write"],
+            ]
+        );
+        assert_eq!(parse_nip65_relay_set(&event), publication.relays);
     }
 
     fn sample_publication(

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -1087,6 +1087,78 @@ async fn synced_group_subscriptions_replace_old_routes() {
     );
 }
 
+#[tokio::test]
+async fn restart_with_retained_route_backfills_and_routes_delayed_old_event() {
+    let relay = Arc::new(FakeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let group_id = cgka_traits::GroupId::new(vec![0xB2; 16]);
+    let prior_transport_group_id = vec![0xC3; 32];
+    let current_transport_group_id = vec![0xD4; 32];
+    let prior_endpoint = TransportEndpoint("wss://prior.example".into());
+    let current_endpoint = TransportEndpoint("wss://current.example".into());
+
+    // A reopened account carries both the current and retained prior route.
+    // The global cursor is deliberately newer than the delayed event below;
+    // retained routes therefore must be subscribed without that cursor.
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![
+                TransportGroupSubscription {
+                    group_id: group_id.clone(),
+                    transport_group_id: current_transport_group_id,
+                    endpoints: vec![current_endpoint],
+                },
+                TransportGroupSubscription {
+                    group_id: group_id.clone(),
+                    transport_group_id: prior_transport_group_id.clone(),
+                    endpoints: vec![prior_endpoint.clone()],
+                },
+            ],
+            since: Some(Timestamp(1_800_000_000)),
+        })
+        .await
+        .expect("restart activation succeeds");
+
+    let group_subscriptions = relay
+        .subscriptions
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(|subscription| match subscription {
+            NostrSubscription::Group { since, .. } => Some(*since),
+            NostrSubscription::AccountInbox { .. } => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(group_subscriptions, vec![None, None]);
+
+    let delayed = group_event("12", &prior_transport_group_id);
+    assert!(
+        delayed.created_at < 1_800_000_000,
+        "fixture must predate the global restart cursor"
+    );
+    let delivered = adapter
+        .handle_relay_event(NostrRelayEvent {
+            endpoint: prior_endpoint,
+            subscription_id: Some("retained-prior-route".into()),
+            event: delayed,
+        })
+        .await
+        .expect("delayed prior-route event is accepted");
+    assert_eq!(delivered, 1);
+    assert_eq!(
+        adapter
+            .receive()
+            .await
+            .expect("receive succeeds")
+            .expect("delivery is present")
+            .group_id_hint,
+        Some(group_id)
+    );
+}
+
 // Regression for mdk#337: a failed relay unsubscribe must not fail the sync or
 // leave the routing index serving the old group set. The removal takes effect
 // in routing state immediately; the relay-side teardown is queued for retry.

--- a/crates/transport-nostr-adapter/tests/inbound_routing.rs
+++ b/crates/transport-nostr-adapter/tests/inbound_routing.rs
@@ -1100,7 +1100,8 @@ async fn restart_with_retained_route_backfills_and_routes_delayed_old_event() {
 
     // A reopened account carries both the current and retained prior route.
     // The global cursor is deliberately newer than the delayed event below;
-    // retained routes therefore must be subscribed without that cursor.
+    // the retained route therefore must be subscribed without that cursor,
+    // while the already-current route keeps the bounded restart cursor.
     adapter
         .activate_account(TransportAccountActivation {
             account_id: account_id.clone(),
@@ -1132,7 +1133,10 @@ async fn restart_with_retained_route_backfills_and_routes_delayed_old_event() {
             NostrSubscription::AccountInbox { .. } => None,
         })
         .collect::<Vec<_>>();
-    assert_eq!(group_subscriptions, vec![None, None]);
+    assert_eq!(
+        group_subscriptions,
+        vec![Some(Timestamp(1_800_000_000)), None]
+    );
 
     let delayed = group_event("12", &prior_transport_group_id);
     assert!(
@@ -1156,6 +1160,87 @@ async fn restart_with_retained_route_backfills_and_routes_delayed_old_event() {
             .expect("delivery is present")
             .group_id_hint,
         Some(group_id)
+    );
+}
+
+#[tokio::test]
+async fn rotating_current_route_reissues_the_displaced_route_for_full_backfill_once() {
+    let relay = Arc::new(FakeRelayClient::default());
+    let adapter = NostrTransportAdapter::new(relay.clone());
+    let account_id = MemberId::new(vec![0xA1; 32]);
+    let group_id = cgka_traits::GroupId::new(vec![0xB2; 16]);
+    let route_a = TransportGroupSubscription {
+        group_id: group_id.clone(),
+        transport_group_id: vec![0xC3; 32],
+        endpoints: vec![TransportEndpoint("wss://a.example".into())],
+    };
+    let route_b = TransportGroupSubscription {
+        group_id: group_id.clone(),
+        transport_group_id: vec![0xD4; 32],
+        endpoints: vec![TransportEndpoint("wss://b.example".into())],
+    };
+    let since = Some(Timestamp(1_800_000_000));
+
+    adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account_id.clone(),
+            inbox_endpoints: vec![TransportEndpoint("wss://inbox.example".into())],
+            group_subscriptions: vec![route_a.clone()],
+            since,
+        })
+        .await
+        .expect("initial activation succeeds");
+
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id: account_id.clone(),
+            group_subscriptions: vec![route_b.clone(), route_a.clone()],
+            since,
+        })
+        .await
+        .expect("route rotation sync succeeds");
+
+    let issued_after_rotation = relay
+        .subscriptions
+        .lock()
+        .unwrap()
+        .iter()
+        .skip(2)
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(
+        issued_after_rotation,
+        vec![
+            NostrSubscription::Group {
+                account_id: account_id.clone(),
+                group_id: group_id.clone(),
+                transport_group_id: route_b.transport_group_id.clone(),
+                endpoints: route_b.endpoints.clone(),
+                since,
+            },
+            NostrSubscription::Group {
+                account_id: account_id.clone(),
+                group_id: group_id.clone(),
+                transport_group_id: route_a.transport_group_id.clone(),
+                endpoints: route_a.endpoints.clone(),
+                since: None,
+            },
+        ],
+        "the new current route is bounded while the displaced route is reissued without a cursor"
+    );
+
+    adapter
+        .sync_account_groups(TransportGroupSync {
+            account_id,
+            group_subscriptions: vec![route_b, route_a],
+            since,
+        })
+        .await
+        .expect("unchanged retained-route sync succeeds");
+    assert_eq!(
+        relay.subscriptions.lock().unwrap().len(),
+        4,
+        "an already-retained route is not repeatedly reissued"
     );
 }
 


### PR DESCRIPTION
## Summary

- interpret NIP-65 relay markers as read/write capabilities and preserve those roles through runtime, CLI, and publication state
- persist authenticated prior Nostr routing addresses and the last epoch observed for the current route
- retain current and prior subscriptions until both protocol retained-history windows have advanced past them
- restore those subscriptions before restart sync, including a full prior-route backfill that cannot be clipped by the account-global Nostr cursor
- preserve the actual displaced-route epoch across rollback/fork recovery and deduplicate repeated route history

## Why

PR #1082 contained the reviewed NIP-65 marker half of #1057, but it was merged only into its stacked base rather than `master`. This PR carries those reviewed commits forward and completes the durable prior-route half of the adopted `marmot.transport.nostr.routing.v1` rotation rules.

Without durable prior routes, MDK discarded the prior signed group route after a routing update. Delayed or offline kind-445 events could then become unreachable, especially after restart when their `created_at` predates the account-global subscription cursor.

## Impact

Existing account databases gain migration `0030_prior_nostr_routes`. Legacy rows default to no history and epoch zero. Groups without a retained prior route keep the existing bounded `since` behavior; only groups carrying current-plus-prior routes perform the required full route backfill.

## Validation

- `just fast-ci`
- `cargo test -p storage-sqlite`
- `cargo test -p transport-nostr-adapter`
- `cargo test -p marmot-app`
- `cargo test -p wn-cli`

Closes #1057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Direction-preserving NIP-65 relay lists with separate read/write roles, including parser and publishing support.
  - Persisted group transport history to support prior-route delivery after restarts and routing changes.
  - Full group route reconciliation across current and retained subscriptions.

- **Bug Fixes**
  - Improved group projection behavior when runtime metadata isn’t available.
  - CLI relay add/remove for `nip65` now round-trips directional roles correctly.
  - Relay-list syncing now preserves read/write ordering and avoids unintended role flattening.
  - Restart behavior now backfills retained routes while still delivering delayed prior-route events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->