### PR TITLE
Prefer encrypted Blossom for negotiated group images

### DIFF
--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -51,6 +51,7 @@ pub(crate) struct InitialComponentState {
     pub(crate) description: String,
     pub(crate) admins: Vec<[u8; 32]>,
     pub(crate) app_components: Vec<AppComponentData>,
+    pub(crate) optional_app_components: Vec<AppComponentData>,
 }
 
 pub(crate) fn leaf_app_components_extension(
@@ -134,6 +135,15 @@ pub(crate) fn app_data_dictionary_extension_for_group(
         if required.contains(component.component_id) {
             dict.insert(component.component_id, component.data.clone());
         }
+    }
+    for component in &initial.optional_app_components {
+        if !seen_initial.insert(component.component_id) {
+            return Err(EngineError::Other(
+                "group creation request contains duplicate app components".into(),
+            ));
+        }
+        validate_initial_app_component(component)?;
+        dict.insert(component.component_id, component.data.clone());
     }
     Ok(Extension::AppDataDictionary(
         AppDataDictionaryExtension::new(dict),
@@ -1668,6 +1678,7 @@ mod tests {
             description: "desc".to_string(),
             admins: vec![[7u8; 32]],
             app_components: Vec::new(),
+            optional_app_components: Vec::new(),
         };
         let ext = app_data_dictionary_extension_for_group(&required, &initial)
             .expect("creation dictionary should build");
@@ -1752,6 +1763,7 @@ mod tests {
             description: "desc".to_string(),
             admins: vec![[7u8; 32]],
             app_components: Vec::new(),
+            optional_app_components: Vec::new(),
         };
 
         let ext = app_data_dictionary_extension_for_group(&required, &initial)

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -547,6 +547,16 @@ impl<S: StorageProvider> Engine<S> {
         req: CreateGroupRequest,
         context: Option<AuditEventContext>,
     ) -> Result<(GroupId, SendResult), EngineError> {
+        self.create_group_with_optional_app_components_and_audit_context(req, Vec::new(), context)
+            .await
+    }
+
+    pub async fn create_group_with_optional_app_components_and_audit_context(
+        &mut self,
+        req: CreateGroupRequest,
+        optional_app_components: Vec<cgka_traits::app_components::AppComponentData>,
+        context: Option<AuditEventContext>,
+    ) -> Result<(GroupId, SendResult), EngineError> {
         let operation_id = self.next_audit_operation_id();
         let mut context = context.unwrap_or_default();
         context.operation_id = Some(operation_id);
@@ -557,12 +567,13 @@ impl<S: StorageProvider> Engine<S> {
             AuditEventKind::CreateGroupEntry {
                 member_count: req.members.len() as u64,
                 required_feature_count: req.required_features.len() as u64,
-                app_component_count: req.app_components.len() as u64,
+                app_component_count: (req.app_components.len() + optional_app_components.len())
+                    as u64,
                 initial_admin_count: req.initial_admins.len() as u64,
             },
         );
         self.current_audit_context = Some(context.clone());
-        let result = self.do_create_group(req).await;
+        let result = self.do_create_group(req, optional_app_components).await;
         match &result {
             Ok((group_id, send_result)) => {
                 let mut outcome_context = context.clone();
@@ -1850,6 +1861,19 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
         req: CreateGroupRequest,
     ) -> Result<(GroupId, SendResult), EngineError> {
         self.create_group_with_audit_context(req, None).await
+    }
+
+    async fn create_group_with_optional_app_components(
+        &mut self,
+        req: CreateGroupRequest,
+        optional_app_components: Vec<cgka_traits::app_components::AppComponentData>,
+    ) -> Result<(GroupId, SendResult), EngineError> {
+        self.create_group_with_optional_app_components_and_audit_context(
+            req,
+            optional_app_components,
+            None,
+        )
+        .await
     }
 
     async fn join_welcome(

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -1128,27 +1128,20 @@ impl<S: StorageProvider> Engine<S> {
         &self,
         key_packages: &[cgka_traits::engine::KeyPackage],
     ) -> Result<GroupCapabilities, EngineError> {
-        if key_packages.is_empty() {
-            return Ok(leaf_capabilities_as_marmot(
-                &self.registry,
-                self.ciphersuite,
-                &self.supported_app_components,
-                self.new_protocol_profile,
-            ));
-        }
-        let mut it = key_packages.iter();
-        let first_input = it.next().unwrap();
-        let first_profile = first_input.protocol_profile;
-        let first = self.parse_key_package(first_input)?;
-        let mut acc = capabilities_of_key_package(&first);
-        for kp in it {
-            let parsed = self.parse_key_package(kp)?;
-            if kp.protocol_profile != first_profile {
+        let mut acc = leaf_capabilities_as_marmot(
+            &self.registry,
+            self.ciphersuite,
+            &self.supported_app_components,
+            self.new_protocol_profile,
+        );
+        for kp in key_packages {
+            if kp.protocol_profile != self.new_protocol_profile {
                 return Err(EngineError::InvalidAccountIdentityProof(
-                    "cannot compute constructable capabilities across mixed-profile KeyPackages"
+                    "cannot compute constructable capabilities across mixed-profile founding members"
                         .into(),
                 ));
             }
+            let parsed = self.parse_key_package(kp)?;
             let other = capabilities_of_key_package(&parsed);
             acc = GroupCapabilities {
                 proposals: acc

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -170,6 +170,7 @@ impl<S: StorageProvider> Engine<S> {
     pub(crate) async fn do_create_group(
         &mut self,
         req: CreateGroupRequest,
+        optional_app_components: Vec<cgka_traits::app_components::AppComponentData>,
     ) -> Result<(GroupId, SendResult), EngineError> {
         // 1. Validate invitees against required capabilities.
         let active_transports: [TransportKind; 0] = []; // engine-layer: no transports
@@ -202,6 +203,24 @@ impl<S: StorageProvider> Engine<S> {
             return Err(EngineError::MissingRequiredCapabilities {
                 required: Box::new(required_caps.clone()),
                 had: Box::new(had),
+            });
+        }
+        let optional_ids = AppComponentSet::new(
+            optional_app_components
+                .iter()
+                .map(|component| component.component_id),
+        );
+        let self_optional_missing = optional_ids.missing_from(&self_supported_components);
+        if !self_optional_missing.is_empty() {
+            return Err(EngineError::MissingRequiredCapabilities {
+                required: Box::new(GroupCapabilities {
+                    app_components: optional_ids,
+                    ..GroupCapabilities::default()
+                }),
+                had: Box::new(GroupCapabilities {
+                    app_components: self_supported_components.clone(),
+                    ..GroupCapabilities::default()
+                }),
             });
         }
 
@@ -322,6 +341,7 @@ impl<S: StorageProvider> Engine<S> {
                 description: req.description.clone(),
                 admins: admin_set,
                 app_components: req.app_components.clone(),
+                optional_app_components,
             },
         )?;
 

--- a/crates/cgka-engine/tests/capabilities.rs
+++ b/crates/cgka-engine/tests/capabilities.rs
@@ -6,7 +6,8 @@ use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::{Engine, EngineBuilder};
 use cgka_traits::EngineError;
 use cgka_traits::app_components::{
-    GROUP_ADMIN_POLICY_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID, default_group_components,
+    AppComponentData, GROUP_ADMIN_POLICY_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID,
+    default_group_components,
 };
 use cgka_traits::capabilities::{
     Capability, CapabilityRequirement, Feature, FeatureStatus, RequirementLevel,
@@ -286,6 +287,46 @@ async fn group_creation_retains_non_negotiable_mandatory_components() {
             .required_capabilities
             .app_components
             .contains(TEST_APP_COMPONENT)
+    );
+}
+
+#[tokio::test]
+async fn optional_initial_component_state_is_not_a_membership_requirement() {
+    let mut alice_supported = default_group_components();
+    alice_supported.insert(TEST_APP_COMPONENT);
+    let mut alice = build_engine_with_components(b"alice", alice_supported);
+    let mut bob = build_engine_with_components(b"bob", default_group_components());
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let state = vec![0x01, 0x02, 0x03];
+
+    let (group_id, _) = alice
+        .create_group_with_optional_app_components(
+            CreateGroupRequest {
+                name: "optional-state".into(),
+                description: String::new(),
+                members: vec![bob_kp],
+                required_features: vec![],
+                app_components: vec![],
+                initial_admins: vec![],
+            },
+            vec![AppComponentData {
+                component_id: TEST_APP_COMPONENT,
+                data: state.clone(),
+            }],
+        )
+        .await
+        .expect("an invitee need not support optional initial state");
+
+    let group = alice.group_record(&group_id).unwrap();
+    assert!(
+        !group
+            .required_capabilities
+            .app_components
+            .contains(TEST_APP_COMPONENT)
+    );
+    assert_eq!(
+        alice.app_component(&group_id, TEST_APP_COMPONENT).unwrap(),
+        Some(state)
     );
 }
 

--- a/crates/cgka-engine/tests/capabilities.rs
+++ b/crates/cgka-engine/tests/capabilities.rs
@@ -291,6 +291,24 @@ async fn group_creation_retains_non_negotiable_mandatory_components() {
 }
 
 #[tokio::test]
+async fn constructable_capabilities_include_creator_support() {
+    let alice = build_engine_with_components(b"alice", default_group_components());
+    let mut bob_supported = default_group_components();
+    bob_supported.insert(TEST_APP_COMPONENT);
+    let mut bob = build_engine_with_components(b"bob", bob_supported);
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let constructable = alice
+        .constructable_capabilities(std::slice::from_ref(&bob_kp))
+        .unwrap();
+
+    assert!(
+        !constructable.app_components.contains(TEST_APP_COMPONENT),
+        "an invitee cannot make a component constructable when the creator lacks support"
+    );
+}
+
+#[tokio::test]
 async fn optional_initial_component_state_is_not_a_membership_requirement() {
     let mut alice_supported = default_group_components();
     alice_supported.insert(TEST_APP_COMPONENT);
@@ -327,6 +345,67 @@ async fn optional_initial_component_state_is_not_a_membership_requirement() {
     assert_eq!(
         alice.app_component(&group_id, TEST_APP_COMPONENT).unwrap(),
         Some(state)
+    );
+}
+
+#[tokio::test]
+async fn optional_initial_component_state_requires_creator_support() {
+    let mut alice = build_engine_with_components(b"alice", default_group_components());
+
+    let error = alice
+        .create_group_with_optional_app_components(
+            CreateGroupRequest {
+                name: "unsupported-optional-state".into(),
+                description: String::new(),
+                members: vec![],
+                required_features: vec![],
+                app_components: vec![],
+                initial_admins: vec![],
+            },
+            vec![AppComponentData {
+                component_id: TEST_APP_COMPONENT,
+                data: vec![0x01],
+            }],
+        )
+        .await
+        .expect_err("the creator must support optional initial component state");
+
+    assert!(
+        matches!(error, EngineError::MissingRequiredCapabilities { .. }),
+        "expected MissingRequiredCapabilities, got {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn group_creation_rejects_component_duplicated_across_required_and_optional_state() {
+    let mut supported = default_group_components();
+    supported.insert(TEST_APP_COMPONENT);
+    let mut alice = build_engine_with_components(b"alice", supported);
+
+    let error = alice
+        .create_group_with_optional_app_components(
+            CreateGroupRequest {
+                name: "duplicate-component-state".into(),
+                description: String::new(),
+                members: vec![],
+                required_features: vec![],
+                app_components: vec![AppComponentData {
+                    component_id: TEST_APP_COMPONENT,
+                    data: vec![0x01],
+                }],
+                initial_admins: vec![],
+            },
+            vec![AppComponentData {
+                component_id: TEST_APP_COMPONENT,
+                data: vec![0x02],
+            }],
+        )
+        .await
+        .expect_err("a component cannot appear in both initial-state lists");
+
+    assert!(
+        matches!(error, EngineError::Other(ref message) if message == "group creation request contains duplicate app components"),
+        "expected duplicate-component rejection, got {error:?}"
     );
 }
 

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -455,6 +455,13 @@ impl AccountDeviceSession {
             .current_safe_export_epoch(group_id, component_id)
     }
 
+    pub fn constructable_capabilities(
+        &self,
+        key_packages: &[KeyPackage],
+    ) -> Result<cgka_traits::capabilities::GroupCapabilities, EngineError> {
+        self.engine.constructable_capabilities(key_packages)
+    }
+
     pub async fn create_group(
         &mut self,
         req: CreateGroupRequest,
@@ -482,6 +489,16 @@ impl AccountDeviceSession {
         req: CreateGroupRequest,
         context: AuditEventContext,
     ) -> SessionResult<CreateGroupEffects> {
+        self.create_group_with_optional_app_components_and_audit_context(req, Vec::new(), context)
+            .await
+    }
+
+    pub async fn create_group_with_optional_app_components_and_audit_context(
+        &mut self,
+        req: CreateGroupRequest,
+        optional_app_components: Vec<cgka_traits::app_components::AppComponentData>,
+        context: AuditEventContext,
+    ) -> SessionResult<CreateGroupEffects> {
         tracing::debug!(
             target: TRACE_TARGET,
             method = "create_group_with_audit_context",
@@ -492,7 +509,11 @@ impl AccountDeviceSession {
         );
         let (group_id, result) = self
             .engine
-            .create_group_with_audit_context(req, Some(context))
+            .create_group_with_optional_app_components_and_audit_context(
+                req,
+                optional_app_components,
+                Some(context),
+            )
             .await?;
         tracing::debug!(
             target: TRACE_TARGET,

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -260,6 +260,13 @@ where
         Ok((group_id, effects))
     }
 
+    pub fn constructable_capabilities(
+        &self,
+        key_packages: &[cgka_traits::engine::KeyPackage],
+    ) -> AccountResult<cgka_traits::capabilities::GroupCapabilities> {
+        Ok(self.session.constructable_capabilities(key_packages)?)
+    }
+
     pub async fn create_group_with_audit_context(
         &mut self,
         request: CreateGroupRequest,
@@ -285,9 +292,27 @@ where
         request: CreateGroupRequest,
         context: AuditEventContext,
     ) -> AccountResult<CreateGroupEffects> {
+        self.prepare_create_group_with_optional_app_components_and_audit_context(
+            request,
+            Vec::new(),
+            context,
+        )
+        .await
+    }
+
+    pub async fn prepare_create_group_with_optional_app_components_and_audit_context(
+        &mut self,
+        request: CreateGroupRequest,
+        optional_app_components: Vec<cgka_traits::app_components::AppComponentData>,
+        context: AuditEventContext,
+    ) -> AccountResult<CreateGroupEffects> {
         Ok(self
             .session
-            .create_group_with_audit_context(request, context)
+            .create_group_with_optional_app_components_and_audit_context(
+                request,
+                optional_app_components,
+                context,
+            )
             .await?)
     }
 

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -324,13 +324,7 @@ impl AppClient {
                 Some(GROUP_BLOSSOM_IMAGE_COMPONENT_ID) => {
                     let upload =
                         upload_group_image(&image.plaintext, &image.media_type, None).await?;
-                    let input = AppGroupImageInput {
-                        image_hash_hex: upload.image_hash_hex,
-                        image_key_hex: upload.image_key_hex,
-                        image_nonce_hex: upload.image_nonce_hex,
-                        image_upload_key_hex: upload.image_upload_key_hex,
-                        media_type: Some(upload.media_type),
-                    };
+                    let input = AppGroupImageInput::from(upload);
                     optional_app_components.push(AppComponentData {
                         component_id: GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
                         data: hex::decode(AppGroupImageComponent::new(input).data_hex)?,
@@ -1670,13 +1664,7 @@ impl AppClient {
             AppGroupImageInput::default()
         } else {
             let upload = upload_group_image(&plaintext, media_type, None).await?;
-            AppGroupImageInput {
-                image_hash_hex: upload.image_hash_hex,
-                image_key_hex: upload.image_key_hex,
-                image_nonce_hex: upload.image_nonce_hex,
-                image_upload_key_hex: upload.image_upload_key_hex,
-                media_type: Some(upload.media_type),
-            }
+            AppGroupImageInput::from(upload)
         };
         let data = hex::decode(AppGroupImageComponent::new(input).data_hex)?;
         let effects = self

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -17,6 +17,7 @@ use cgka_traits::app_components::{
 use cgka_traits::app_event::{
     EVENT_REF_TAG, MARMOT_APP_EVENT_KIND_REACTION, MarmotAppEvent as MarmotInnerEvent,
 };
+use cgka_traits::capabilities::GroupCapabilities;
 use cgka_traits::engine::{CreateGroupRequest, KeyPackage, SendIntent};
 use cgka_traits::group::ProtocolProfile;
 use cgka_traits::transport::TransportEnvelope;
@@ -41,10 +42,11 @@ use crate::{
     AppError, AppGroupAdminPolicyComponent, AppGroupAvatarUrlComponent,
     AppGroupEncryptedMediaComponent, AppGroupImageComponent, AppGroupImageInput,
     AppGroupMemberRecord, AppGroupMessageRetentionComponent, AppGroupMlsState, AppGroupRecord,
-    AppMessageQuery, AppPerformanceTelemetry, AppQuarantinedGroup, AppRuntime, AppTransportRouting,
-    GroupInviteDeclineResult, MarmotApp, MarmotRelayPlane, MarmotRelayPlaneAccountAdapter,
-    MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest, MediaUploadResult,
-    PendingWelcomeDelivery, SelfMembership, SendSummary, remember_seen_event, unix_now_seconds,
+    AppInitialGroupImage, AppMessageQuery, AppPerformanceTelemetry, AppQuarantinedGroup,
+    AppRuntime, AppTransportRouting, GroupInviteDeclineResult, MarmotApp, MarmotRelayPlane,
+    MarmotRelayPlaneAccountAdapter, MediaAttachmentReference, MediaDownloadResult,
+    MediaUploadRequest, MediaUploadResult, PendingWelcomeDelivery, SelfMembership, SendSummary,
+    remember_seen_event, unix_now_seconds,
 };
 
 mod audit;
@@ -235,6 +237,9 @@ impl AppClient {
                 let reusable_current = match key_package_metadata(&key_package) {
                     Ok(metadata) if metadata.protocol_profile == ProtocolProfile::Current => {
                         is_last_resort_key_package(&key_package).unwrap_or(false)
+                            && self
+                                .app
+                                .key_package_metadata_matches_current_support(&metadata)
                     }
                     // Strict cutover replaces legacy or malformed cached
                     // packages instead of republishing them.
@@ -278,6 +283,16 @@ impl AppClient {
         name: &str,
         member_refs: &[&str],
     ) -> Result<GroupId, AppError> {
+        self.create_group_with_initial_image(name, member_refs, None)
+            .await
+    }
+
+    pub async fn create_group_with_initial_image(
+        &mut self,
+        name: &str,
+        member_refs: &[&str],
+        initial_image: Option<AppInitialGroupImage>,
+    ) -> Result<GroupId, AppError> {
         validate_group_profile(name, "")?;
         let mut members = Vec::with_capacity(member_refs.len());
         for member in member_refs {
@@ -299,20 +314,64 @@ impl AppClient {
         let encrypted_media = self.encrypted_media_component_for_new_group()?;
         let encrypted_media_component_id = encrypted_media.component_id;
         app_components.push(encrypted_media);
+        let constructable = self.runtime.constructable_capabilities(&members)?;
+        let mut optional_app_components = Vec::new();
+        if let Some(image) = initial_image {
+            match preferred_initial_group_image_component(
+                &constructable,
+                image.source_url.is_some(),
+            ) {
+                Some(GROUP_BLOSSOM_IMAGE_COMPONENT_ID) => {
+                    let upload =
+                        upload_group_image(&image.plaintext, &image.media_type, None).await?;
+                    let input = AppGroupImageInput {
+                        image_hash_hex: upload.image_hash_hex,
+                        image_key_hex: upload.image_key_hex,
+                        image_nonce_hex: upload.image_nonce_hex,
+                        image_upload_key_hex: upload.image_upload_key_hex,
+                        media_type: Some(upload.media_type),
+                    };
+                    optional_app_components.push(AppComponentData {
+                        component_id: GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
+                        data: hex::decode(AppGroupImageComponent::new(input).data_hex)?,
+                    });
+                }
+                Some(GROUP_AVATAR_URL_COMPONENT_ID) => {
+                    if let Some(url) = image.source_url {
+                        optional_app_components.push(
+                            AppGroupAvatarUrlComponent::new(url, image.dim, image.thumbhash)?
+                                .to_app_component_data()?,
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+        let mut touched_components = vec![
+            NOSTR_ROUTING_COMPONENT_ID,
+            AGENT_TEXT_STREAM_QUIC_COMPONENT_ID,
+            encrypted_media_component_id,
+        ];
+        touched_components.extend(
+            optional_app_components
+                .iter()
+                .map(|component| component.component_id),
+        );
+        let changed_fields = if optional_app_components.is_empty() {
+            vec!["name", "members"]
+        } else {
+            vec!["name", "members", "image"]
+        };
         let audit_context = Self::local_human_action_context(
             "create_group",
-            vec!["name", "members"],
-            vec![
-                NOSTR_ROUTING_COMPONENT_ID,
-                AGENT_TEXT_STREAM_QUIC_COMPONENT_ID,
-                encrypted_media_component_id,
-            ],
+            changed_fields,
+            touched_components,
             Some(member_refs.len() as u64),
         );
 
         let prepared = self
             .runtime
-            .prepare_create_group_with_audit_context(
+            .prepare_create_group_with_optional_app_components_and_audit_context(
                 CreateGroupRequest {
                     name: name.to_owned(),
                     description: String::new(),
@@ -321,6 +380,7 @@ impl AppClient {
                     app_components,
                     initial_admins: Vec::new(),
                 },
+                optional_app_components,
                 audit_context.clone(),
             )
             .await?;
@@ -2417,6 +2477,26 @@ impl AppClient {
     }
 }
 
+fn preferred_initial_group_image_component(
+    constructable: &GroupCapabilities,
+    has_source_url: bool,
+) -> Option<u16> {
+    if constructable
+        .app_components
+        .contains(GROUP_BLOSSOM_IMAGE_COMPONENT_ID)
+    {
+        Some(GROUP_BLOSSOM_IMAGE_COMPONENT_ID)
+    } else if has_source_url
+        && constructable
+            .app_components
+            .contains(GROUP_AVATAR_URL_COMPONENT_ID)
+    {
+        Some(GROUP_AVATAR_URL_COMPONENT_ID)
+    } else {
+        None
+    }
+}
+
 /// Whether the local account (`local_account_id_hex`) is absent from a group's
 /// engine roster — the backfill's suppression decision. MLS member ids in this
 /// design are the Nostr account pubkey hex, so an account is "still a member"
@@ -2435,8 +2515,40 @@ fn local_account_removed_from_roster(
 
 #[cfg(test)]
 mod post_canonical_create_tests {
-    use super::recover_post_canonical_result;
+    use super::{preferred_initial_group_image_component, recover_post_canonical_result};
     use crate::AppError;
+    use cgka_traits::app_components::{
+        GROUP_AVATAR_URL_COMPONENT_ID, GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
+    };
+    use cgka_traits::capabilities::GroupCapabilities;
+
+    #[test]
+    fn founding_image_prefers_blossom_then_url_then_none() {
+        let mut capabilities = GroupCapabilities::default();
+        capabilities
+            .app_components
+            .insert(GROUP_AVATAR_URL_COMPONENT_ID);
+        capabilities
+            .app_components
+            .insert(GROUP_BLOSSOM_IMAGE_COMPONENT_ID);
+        assert_eq!(
+            preferred_initial_group_image_component(&capabilities, true),
+            Some(GROUP_BLOSSOM_IMAGE_COMPONENT_ID)
+        );
+
+        capabilities
+            .app_components
+            .ids
+            .remove(&GROUP_BLOSSOM_IMAGE_COMPONENT_ID);
+        assert_eq!(
+            preferred_initial_group_image_component(&capabilities, true),
+            Some(GROUP_AVATAR_URL_COMPONENT_ID)
+        );
+        assert_eq!(
+            preferred_initial_group_image_component(&capabilities, false),
+            None
+        );
+    }
 
     #[test]
     fn post_canonical_failures_default_instead_of_escaping() {

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -39,6 +39,33 @@ use crate::{AccountState, AppError, ReceivedMessage, SelfMembership, SendSummary
 /// protocol's retained-epoch windows.
 const MAX_PRIOR_NOSTR_ROUTES: usize = 32;
 
+/// Initial group-image input for encrypted-Blossom-first creation.
+///
+/// The host owns discovery and download. MDK receives the decoded image bytes,
+/// prefers encrypting and uploading them to Blossom, and uses `source_url`
+/// only as a negotiated fallback when a founding member does not advertise the
+/// encrypted Blossom image component.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AppInitialGroupImage {
+    pub plaintext: Vec<u8>,
+    pub media_type: String,
+    pub source_url: Option<String>,
+    pub dim: Option<String>,
+    pub thumbhash: Option<String>,
+}
+
+impl std::fmt::Debug for AppInitialGroupImage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppInitialGroupImage")
+            .field("plaintext_len", &self.plaintext.len())
+            .field("media_type", &self.media_type)
+            .field("has_source_url", &self.source_url.is_some())
+            .field("dim", &self.dim)
+            .field("thumbhash", &self.thumbhash)
+            .finish()
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AppGroupRecord {
     pub group_id_hex: String,

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -138,7 +138,8 @@ pub use groups::{
     AppGroupAvatarUrlComponent, AppGroupEncryptedMediaComponent, AppGroupHydrationQuarantineReason,
     AppGroupImageComponent, AppGroupMemberRecord, AppGroupMessageRetentionComponent,
     AppGroupMlsState, AppGroupNostrRoutingComponent, AppGroupProfileComponent, AppGroupRecord,
-    AppGroupSystemEvent, AppPriorNostrRoute, AppProtocolProfile, AppQuarantinedGroup,
+    AppGroupSystemEvent, AppInitialGroupImage, AppPriorNostrRoute, AppProtocolProfile,
+    AppQuarantinedGroup,
     group_system_event_from_message,
 };
 pub use ids::{
@@ -1154,7 +1155,9 @@ impl MarmotApp {
                 .ok()
                 .and_then(|key_package| key_package_metadata(&key_package).ok())
                 .is_some_and(|metadata| {
-                    metadata.protocol_profile == cgka_traits::group::ProtocolProfile::Current
+                    client
+                        .app
+                        .key_package_metadata_matches_current_support(&metadata)
                 });
             if cached_current {
                 client
@@ -1180,7 +1183,9 @@ impl MarmotApp {
                     .ok()
                     .and_then(|key_package| key_package_metadata(&key_package).ok())
                     .is_some_and(|metadata| {
-                        metadata.protocol_profile == cgka_traits::group::ProtocolProfile::Current
+                        client
+                            .app
+                            .key_package_metadata_matches_current_support(&metadata)
                     })
                 {
                     client
@@ -2343,7 +2348,7 @@ impl MarmotApp {
         .ok()
         .and_then(|key_package| key_package_metadata(&key_package).ok())
         .is_some_and(|metadata| {
-            metadata.protocol_profile == cgka_traits::group::ProtocolProfile::Current
+            self.key_package_metadata_matches_current_support(&metadata)
                 && metadata.credential_identity_hex == record.account_id_hex
         });
         if is_current {
@@ -2458,10 +2463,13 @@ impl MarmotApp {
         for record in records {
             let event_id = record.event.id.clone();
             let endpoints = record.endpoints.clone();
-            let profile = key_package_from_record(record)
+            let is_current = key_package_from_record(record)
                 .ok()
-                .map(|fetched| fetched.key_package.protocol_profile);
-            if profile == Some(cgka_traits::group::ProtocolProfile::Current) {
+                .and_then(|fetched| key_package_metadata(&fetched.key_package).ok())
+                .is_some_and(|metadata| {
+                    self.key_package_metadata_matches_current_support(&metadata)
+                });
+            if is_current {
                 continue;
             }
             if !self.mark_key_package_cutover_replacement_pending(label) {
@@ -2496,13 +2504,13 @@ impl MarmotApp {
     fn key_package_cutover_replacement_pending_path(&self, label: &str) -> PathBuf {
         self.key_package_cache_dir()
             .join(KEY_PACKAGE_DIR)
-            .join(format!("{label}.strict-cutover-replacement-pending"))
+            .join(format!("{label}.capability-refresh-v1-replacement-pending"))
     }
 
     fn key_package_cutover_scan_complete_path(&self, label: &str) -> PathBuf {
         self.key_package_cache_dir()
             .join(KEY_PACKAGE_DIR)
-            .join(format!("{label}.strict-cutover-relay-scan-complete"))
+            .join(format!("{label}.capability-refresh-v1-relay-scan-complete"))
     }
 
     fn key_package_cutover_replacement_pending(&self, label: &str) -> bool {
@@ -3679,14 +3687,28 @@ impl MarmotApp {
 
     fn supported_app_component_ids(&self) -> Vec<u16> {
         let mut components = default_group_components();
+        components.insert(GROUP_BLOSSOM_IMAGE_COMPONENT_ID);
         components.insert(NOSTR_ROUTING_COMPONENT_ID);
+        components.insert(GROUP_MESSAGE_RETENTION_COMPONENT_ID);
         components.insert(AGENT_TEXT_STREAM_QUIC_COMPONENT_ID);
+        components.insert(GROUP_AVATAR_URL_COMPONENT_ID);
         // Existing legacy groups continue to require V1, while fresh
         // current-profile groups require V2. Advertising both is support, not
         // negotiation: each group's required component id selects exactly one.
         components.insert(GROUP_ENCRYPTED_MEDIA_V1_COMPONENT_ID);
         components.insert(GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID);
         components.into_iter().collect()
+    }
+
+    fn key_package_metadata_matches_current_support(
+        &self,
+        metadata: &cgka_engine::key_package::KeyPackageMetadata,
+    ) -> bool {
+        metadata.protocol_profile == cgka_traits::group::ProtocolProfile::Current
+            && self
+                .supported_app_component_ids()
+                .iter()
+                .all(|component_id| metadata.app_components.contains(component_id))
     }
 
     fn new_nostr_routing(&self) -> Result<NostrRoutingV1, AppError> {

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -139,8 +139,7 @@ pub use groups::{
     AppGroupImageComponent, AppGroupMemberRecord, AppGroupMessageRetentionComponent,
     AppGroupMlsState, AppGroupNostrRoutingComponent, AppGroupProfileComponent, AppGroupRecord,
     AppGroupSystemEvent, AppInitialGroupImage, AppPriorNostrRoute, AppProtocolProfile,
-    AppQuarantinedGroup,
-    group_system_event_from_message,
+    AppQuarantinedGroup, group_system_event_from_message,
 };
 pub use ids::{
     account_id_hex_from_ref, nprofile_for_account_id, npub_for_account_id, validate_relay_urls,

--- a/crates/marmot-app/src/media/group_image.rs
+++ b/crates/marmot-app/src/media/group_image.rs
@@ -8,7 +8,7 @@ use zeroize::Zeroizing;
 use super::DEFAULT_BLOSSOM_SERVER_URL;
 use super::blossom::{blossom_blob_url, fetch_blossom_blob, upload_blossom_blob};
 use super::canonical_media_type;
-use crate::AppError;
+use crate::{AppError, AppGroupImageInput};
 
 const GROUP_IMAGE_VERSION: &str = "marmot-group-image-v1";
 
@@ -30,6 +30,18 @@ pub(crate) struct GroupImageUpload {
     pub(crate) image_nonce_hex: String,
     pub(crate) image_upload_key_hex: String,
     pub(crate) media_type: String,
+}
+
+impl From<GroupImageUpload> for AppGroupImageInput {
+    fn from(upload: GroupImageUpload) -> Self {
+        Self {
+            image_hash_hex: upload.image_hash_hex,
+            image_key_hex: upload.image_key_hex,
+            image_nonce_hex: upload.image_nonce_hex,
+            image_upload_key_hex: upload.image_upload_key_hex,
+            media_type: Some(upload.media_type),
+        }
+    }
 }
 
 fn group_image_aad(media_type: &str) -> Vec<u8> {

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -24,10 +24,11 @@ use crate::{
     ACCOUNT_WORKER_RECONNECT_BASE_DELAY, ACCOUNT_WORKER_RECONNECT_JITTER_MAX_MS,
     ACCOUNT_WORKER_RECONNECT_MAX_DELAY, APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT,
     AgentTextStreamFinishRequest, AppBlobEndpoint, AppClient, AppError, AppGroupMemberRecord,
-    AppGroupMlsState, AppGroupRecord, AppProjectionUpdate, AppQuarantinedGroup,
-    GroupInviteDeclineResult, MarmotApp, MarmotRelayPlane, MediaAttachmentReference,
-    MediaDownloadResult, MediaUploadRequest, MediaUploadResult, PendingWelcomeDelivery,
-    PushRegistration, ReceivedMessage, SecureDeleteExpiredResult, SendSummary, SyncSummary,
+    AppGroupMlsState, AppGroupRecord, AppInitialGroupImage, AppProjectionUpdate,
+    AppQuarantinedGroup, GroupInviteDeclineResult, MarmotApp, MarmotRelayPlane,
+    MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest, MediaUploadResult,
+    PendingWelcomeDelivery, PushRegistration, ReceivedMessage, SecureDeleteExpiredResult,
+    SendSummary, SyncSummary,
 };
 use cgka_traits::app_event::MarmotAppEvent as MarmotInnerEvent;
 
@@ -93,6 +94,7 @@ pub(crate) enum AccountWorkerCommand {
         name: String,
         members: Vec<String>,
         description: Option<String>,
+        initial_image: Option<AppInitialGroupImage>,
         respond: oneshot::Sender<Result<GroupId, AppError>>,
     },
     Members {
@@ -712,11 +714,14 @@ async fn handle_account_worker_command(
             name,
             members,
             description,
+            initial_image,
             respond,
         } => {
             let result = async {
                 let member_refs = members.iter().map(String::as_str).collect::<Vec<_>>();
-                let group_id = client.create_group(&name, &member_refs).await?;
+                let group_id = client
+                    .create_group_with_initial_image(&name, &member_refs, initial_image)
+                    .await?;
                 if description.is_some() {
                     client
                         .update_group_profile(&group_id, None, description.as_deref())

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -50,6 +50,18 @@ impl AccountManager {
         members: &[String],
         description: Option<String>,
     ) -> Result<GroupId, AppError> {
+        self.create_group_with_initial_image(account_ref, name, members, description, None)
+            .await
+    }
+
+    pub async fn create_group_with_initial_image(
+        &self,
+        account_ref: &str,
+        name: &str,
+        members: &[String],
+        description: Option<String>,
+        initial_image: Option<crate::AppInitialGroupImage>,
+    ) -> Result<GroupId, AppError> {
         let command = self.worker_commands(account_ref).await?;
         let (respond, response) = oneshot::channel();
         command
@@ -57,6 +69,7 @@ impl AccountManager {
                 name: name.to_owned(),
                 members: members.to_vec(),
                 description,
+                initial_image,
                 respond,
             })
             .await

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -1056,6 +1056,19 @@ impl MarmotAppRuntime {
             .await
     }
 
+    pub async fn create_group_with_initial_image(
+        &self,
+        account_ref: &str,
+        name: &str,
+        members: &[String],
+        description: Option<String>,
+        initial_image: Option<crate::AppInitialGroupImage>,
+    ) -> Result<GroupId, AppError> {
+        self.accounts
+            .create_group_with_initial_image(account_ref, name, members, description, initial_image)
+            .await
+    }
+
     pub async fn group_members(
         &self,
         account_ref: &str,

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -187,7 +187,8 @@ async fn fresh_key_package_for_account(
         Box::new(NostrMlsPeeler::new().with_welcome_signer(signer.as_nostr_signer())),
     )
     .account_identity_proof_signer(signer.as_proof_signer())
-    .feature_registry(app_feature_registry());
+    .feature_registry(app_feature_registry())
+    .supported_app_components(app.supported_app_component_ids());
     if legacy {
         config = config.legacy_compatibility_profile();
     }
@@ -1645,13 +1646,27 @@ fn encrypted_media_v2_round_trips_through_account_projection() {
     assert_eq!(restored.encrypted_media, group.encrypted_media);
 }
 
-#[test]
-fn key_package_capabilities_advertise_both_frozen_v1_and_current_v2_support() {
+#[tokio::test]
+async fn key_package_capabilities_advertise_every_supported_group_component() {
     let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    let account = home.create_account("component-advertisement").unwrap();
     let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
     let supported = app.supported_app_component_ids();
+    assert!(supported.contains(&GROUP_BLOSSOM_IMAGE_COMPONENT_ID));
+    assert!(supported.contains(&GROUP_MESSAGE_RETENTION_COMPONENT_ID));
+    assert!(supported.contains(&GROUP_AVATAR_URL_COMPONENT_ID));
     assert!(supported.contains(&GROUP_ENCRYPTED_MEDIA_V1_COMPONENT_ID));
     assert!(supported.contains(&GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID));
+
+    let key_package = fresh_key_package_for_account(&app, &account, false).await;
+    let metadata = cgka_engine::key_package::key_package_metadata(&key_package).unwrap();
+    for component_id in supported {
+        assert!(
+            metadata.app_components.contains(&component_id),
+            "generated KeyPackage omitted supported component {component_id:#06x}"
+        );
+    }
 }
 
 #[test]

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -17,6 +17,27 @@ use crate::conversions::{
 };
 use crate::errors::MarmotKitError;
 
+#[derive(Clone, uniffi::Record)]
+pub struct InitialGroupImageFfi {
+    pub plaintext: Vec<u8>,
+    pub media_type: String,
+    pub source_url: Option<String>,
+    pub dim: Option<String>,
+    pub thumbhash: Option<String>,
+}
+
+impl std::fmt::Debug for InitialGroupImageFfi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InitialGroupImageFfi")
+            .field("plaintext_len", &self.plaintext.len())
+            .field("media_type", &self.media_type)
+            .field("has_source_url", &self.source_url.is_some())
+            .field("dim", &self.dim)
+            .field("thumbhash", &self.thumbhash)
+            .finish()
+    }
+}
+
 pub(crate) async fn group_details_for(
     kit: &Marmot,
     account_ref: &str,
@@ -226,6 +247,37 @@ impl Marmot {
         let group_id = self
             .runtime
             .create_group(&account_ref, &name, &member_refs, description)
+            .await?;
+        Ok(hex::encode(group_id.as_slice()))
+    }
+
+    /// Create a group with an optional initial avatar. MDK prefers an
+    /// encrypted Blossom image and uses `source_url` only when the founding
+    /// members do not all support that component but do support URL avatars.
+    pub async fn create_group_with_initial_image(
+        &self,
+        account_ref: String,
+        name: String,
+        member_refs: Vec<String>,
+        description: Option<String>,
+        initial_image: Option<InitialGroupImageFfi>,
+    ) -> Result<String, MarmotKitError> {
+        let initial_image = initial_image.map(|image| marmot_app::AppInitialGroupImage {
+            plaintext: image.plaintext,
+            media_type: image.media_type,
+            source_url: image.source_url,
+            dim: image.dim,
+            thumbhash: image.thumbhash,
+        });
+        let group_id = self
+            .runtime
+            .create_group_with_initial_image(
+                &account_ref,
+                &name,
+                &member_refs,
+                description,
+                initial_image,
+            )
             .await?;
         Ok(hex::encode(group_id.as_slice()))
     }

--- a/crates/marmot-uniffi/src/commands/mod.rs
+++ b/crates/marmot-uniffi/src/commands/mod.rs
@@ -22,4 +22,5 @@ mod relay;
 mod subscription;
 mod timeline;
 
+pub use group::InitialGroupImageFfi;
 pub use media::parse_media_imeta_tag;

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -42,7 +42,7 @@ pub use markdown::{
 
 uniffi::setup_scaffolding!();
 
-pub use commands::parse_media_imeta_tag;
+pub use commands::{InitialGroupImageFfi, parse_media_imeta_tag};
 pub use conversions::{
     AppBlobEndpointFfi, AppGroupEncryptedMediaComponentFfi, AuditDataModeFfi,
     AuditLogDeleteResultFfi, AuditLogFileFfi, AuditLogSettingsFfi, AuditLogTrackerConfigFfi,

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -698,6 +698,25 @@ pub trait CgkaEngine: Send + Sync {
         req: CreateGroupRequest,
     ) -> Result<(GroupId, SendResult), EngineError>;
 
+    /// Create a group with additional initial GroupContext component state
+    /// that is deliberately not added to the group's required-component list.
+    ///
+    /// Optional state is useful for progressive presentation features such as
+    /// group avatars: capable members can render it, while the state does not
+    /// become a permanent membership gate.
+    async fn create_group_with_optional_app_components(
+        &mut self,
+        req: CreateGroupRequest,
+        optional_app_components: Vec<AppComponentData>,
+    ) -> Result<(GroupId, SendResult), EngineError> {
+        if optional_app_components.is_empty() {
+            return self.create_group(req).await;
+        }
+        Err(EngineError::Other(
+            "this engine does not support optional initial app-component state".into(),
+        ))
+    }
+
     /// Accept a welcome addressed to the local identity.
     ///
     /// **Errors.** Returns `Peeler(...)` if the welcome was not addressed to

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -734,7 +734,8 @@ pub trait CgkaEngine: Send + Sync {
     ) -> Result<FeatureStatus, EngineError>;
 
     /// Capabilities that would result from constructing a group with the
-    /// given members (intersection of every invitee's advertised caps).
+    /// given members (intersection of the creator's and every invitee's
+    /// advertised caps).
     fn constructable_capabilities(
         &self,
         key_packages: &[KeyPackage],


### PR DESCRIPTION
## What changed

- Advertise every group component implemented by `marmot-app`, including encrypted Blossom images, URL avatars, and message retention.
- Refresh cached and relay KeyPackages that are current-profile but under-advertise the app's supported components.
- Add an engine/session/account creation seam for initial GroupContext component state that remains optional instead of becoming a membership requirement.
- Add encrypted-Blossom-first image negotiation during group creation: use Blossom when all founding members support it, fall back to a source URL when they only support URL avatars, and otherwise create the group without an avatar.
- Add additive runtime and UniFFI APIs for hosts to supply downloaded image bytes, media type, and an optional source-URL fallback.
- Redact plaintext bytes and source URLs from Debug output.

## Why

The app implemented both group-image components but did not advertise either one in generated KeyPackages. Its creation request also treated every supplied component state as required, which would make an optional avatar feature a permanent membership gate. This separates support advertisement, optional state, and group requirements while keeping encrypted Blossom as the preferred application behavior.

## Client impact

Existing `create_group` calls remain source-compatible. Clients that want an initial image can adopt the new `create_group_with_initial_image` API and provide already-downloaded bytes; web discovery and download remain host responsibilities.

The capability-refresh marker intentionally causes a one-time relay rescan and replacement of under-advertised KeyPackages after upgrade. Client rollouts should account for the resulting KeyPackage publication traffic and may be staged where relay capacity warrants it.

## Client adoption checklist

- [ ] Update to the MarmotKit/MDK release containing this change and regenerate Swift/Kotlin UniFFI bindings.
- [ ] In the create-group UI, let the host search for or select an image and download it before calling MDK.
- [ ] Pass the downloaded bytes, media type, source URL, and optional render hints through `create_group_with_initial_image`.
- [ ] Continue using the existing `create_group` API when no initial image is selected.
- [ ] For existing-group avatar changes, make `update_group_image` the normal path: download the selected web image, then pass its bytes to MDK. Retain URL-avatar support for interoperability.
- [ ] Render both image-component projections and apply the protocol precedence rule when both are present: the URL avatar wins.
- [ ] Ensure normal account startup and KeyPackage publication run after adoption so under-advertised cached KeyPackages are automatically replaced.
- [ ] Surface image download and Blossom upload failures before presenting group creation as successful. A Blossom upload failure aborts creation; it does not silently fall back to the URL.
- [ ] Verify the negotiated outcomes in client tests: encrypted Blossom when universally supported, URL fallback when Blossom is unavailable but URL avatars are supported, and no avatar without blocking group creation when neither is universal.

MDK owns encryption, Blossom upload, and founding-member negotiation. Web discovery, image download, cropping/resizing, MIME selection, licensing, and content moderation remain host responsibilities.

## Validation

- `just fast-ci`
- Full `cargo test -p marmot-app` suite
- `cargo test -p marmot-uniffi`
- `cargo test -p cgka-session`
- `cargo test -p marmot-account`
- Focused engine capability and app negotiation regression tests
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create groups with an optional initial image, supporting encrypted image data, avatar URLs, and image metadata.
  * Added public APIs for supplying initial group images across application and UniFFI interfaces.
  * Optional initial components can be included without becoming membership requirements.

* **Bug Fixes**
  * Improved capability validation to reject unsupported optional components early.
  * Key packages now accurately reflect supported components and are refreshed when capabilities change.

* **Tests**
  * Added coverage for initial image selection, capability matching, and optional component behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->