### PR TITLE
Omit unrepresentable Nostr expiration hints

### DIFF
--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -80,7 +80,7 @@ pub use ingest::{
     IngestOutcome, PeeledContent, PeeledMessage, ProposalRejectionCategory, StaleReason,
 };
 pub use message::{MessageRecord, MessageState, OwnCommitConvergenceStamp, StoredMessagePayload};
-pub use peeler::{GroupMessageMetadata, GroupMessageMetadataError, TransportPeeler};
+pub use peeler::{GroupMessageMetadata, TransportPeeler};
 pub use storage::{
     CapabilityStorage, GroupStorage, LeaveRequest, LeaveRequestStorage, MessageStorage,
     OutboundIntentStorage, QueuedOutboundIntent, StorageError, StorageProvider, StorageResult,

--- a/crates/traits/src/peeler.rs
+++ b/crates/traits/src/peeler.rs
@@ -79,10 +79,10 @@ impl GroupMessageMetadata {
         if *retention_seconds == 0 {
             return Ok(None);
         }
-        inner_created_at
-            .checked_add(*retention_seconds)
-            .map(Some)
-            .ok_or(GroupMessageMetadataError::ExpirationTimestampOverflow)
+        // Expiration is only a transport hint. If the sum is not
+        // representable, the hint is undefined and must be omitted without
+        // rejecting the otherwise-valid application message.
+        Ok(inner_created_at.checked_add(*retention_seconds))
     }
 }
 

--- a/crates/traits/src/peeler.rs
+++ b/crates/traits/src/peeler.rs
@@ -65,30 +65,25 @@ impl GroupMessageMetadata {
     }
 
     /// Compute the transport-level expiration timestamp, if any.
-    pub fn expiration_timestamp(&self) -> Result<Option<u64>, GroupMessageMetadataError> {
+    pub fn expiration_timestamp(&self) -> Option<u64> {
         let Self::Application {
             inner_created_at,
             retention_seconds,
         } = self
         else {
-            return Ok(None);
+            return None;
         };
         let Some(retention_seconds) = retention_seconds else {
-            return Ok(None);
+            return None;
         };
         if *retention_seconds == 0 {
-            return Ok(None);
+            return None;
         }
         // Expiration is only a transport hint. If the sum is not
         // representable, the hint is undefined and must be omitted without
         // rejecting the otherwise-valid application message.
-        Ok(inner_created_at.checked_add(*retention_seconds))
+        inner_created_at.checked_add(*retention_seconds)
     }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum GroupMessageMetadataError {
-    ExpirationTimestampOverflow,
 }
 
 /// Unwrap and rewrap transport-layer envelopes. A single peeler typically

--- a/crates/transport-nostr-peeler/src/peeler.rs
+++ b/crates/transport-nostr-peeler/src/peeler.rs
@@ -841,14 +841,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn group_wrap_rejects_overflowing_expiration_metadata() {
+    async fn group_wrap_omits_unrepresentable_expiration_metadata() {
         let ctx = GroupContextSnapshot::new(
             EpochId(9),
             HashMap::from([(DEFAULT_EXPORTER_LABEL.to_string(), vec![0x7a; 32])]),
             Some(vec![0x99; 32]),
         );
 
-        let err = NostrMlsPeeler::default()
+        let wrapped = NostrMlsPeeler::default()
             .wrap_group_message_with_metadata(
                 &EncryptedPayload {
                     ciphertext: b"inner mls bytes".to_vec(),
@@ -858,9 +858,11 @@ mod tests {
                 &GroupMessageMetadata::application(u64::MAX, Some(1)),
             )
             .await
-            .expect_err("overflow should fail closed");
+            .expect("an optional expiration overflow does not reject the message");
 
-        assert!(matches!(err, PeelerError::WrapFailed(_)));
+        let event = NostrTransportEvent::from_transport_message(&wrapped).expect("payload parses");
+        assert_eq!(event.created_at, u64::MAX);
+        assert_eq!(event.tag_value(EXPIRATION_TAG), None);
     }
 
     #[tokio::test]

--- a/crates/transport-nostr-peeler/src/peeler.rs
+++ b/crates/transport-nostr-peeler/src/peeler.rs
@@ -145,14 +145,7 @@ impl NostrMlsPeeler {
             nostr::TagKind::custom(GROUP_TAG),
             [hex::encode(group_id)],
         )];
-        if let Some(expiration) = metadata
-            .map(|metadata| metadata.expiration_timestamp())
-            .transpose()
-            .map_err(|err| {
-                PeelerError::WrapFailed(format!("invalid group-message metadata: {err:?}"))
-            })?
-            .flatten()
-        {
+        if let Some(expiration) = metadata.and_then(GroupMessageMetadata::expiration_timestamp) {
             tags.push(Tag::custom(
                 nostr::TagKind::custom(EXPIRATION_TAG),
                 [expiration.to_string()],


### PR DESCRIPTION
## Summary

- keep transport expiration metadata optional when `message_timestamp + retention_seconds` overflows
- omit the Nostr `expiration` tag instead of rejecting an otherwise valid outbound message
- replace the fail-closed regression test with coverage for a successfully wrapped event without the hint
- simplify the now-infallible metadata helper to return `Option<u64>` directly, removing the unreachable error type and dead wrapper error path

## API note

`GroupMessageMetadata::expiration_timestamp` now returns `Option<u64>` instead of `Result<Option<u64>, GroupMessageMetadataError>`, and the unreachable public `GroupMessageMetadataError` type is removed.

## Validation

- `cargo test -p cgka-traits -p transport-nostr-peeler`
- `just fast-ci`

Closes #1070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group messages with unrepresentable expiration times are now wrapped successfully instead of failing.
  * Expiration hints are omitted when they cannot be represented, preventing invalid expiration data from interrupting message processing.
  * Updated behavior ensures wrapped events remain valid for maximum timestamp values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->