### PR TITLE
Enforce kind 451 push owner proofs by group profile

### DIFF
--- a/crates/marmot-app/src/client/push.rs
+++ b/crates/marmot-app/src/client/push.rs
@@ -158,14 +158,15 @@ impl AppClient {
                 // resort.
                 continue;
             }
-            let event =
-                notifications::build_notification_gift_wrap(&server_pubkey_hex, &encrypted_tokens)
-                    .await?;
-            self.app
-                .relay_client_for_endpoints(nostr_signer.clone(), &endpoints)
-                .publish_event(&endpoints, &event, 1)
-                .await
-                .map_err(AppError::Transport)?;
+            for chunk in notifications::notification_trigger_chunks(&encrypted_tokens) {
+                let event =
+                    notifications::build_notification_gift_wrap(&server_pubkey_hex, chunk).await?;
+                self.app
+                    .relay_client_for_endpoints(nostr_signer.clone(), &endpoints)
+                    .publish_event(&endpoints, &event, 1)
+                    .await
+                    .map_err(AppError::Transport)?;
+            }
         }
         Ok(())
     }

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -513,21 +513,34 @@ impl AppClient {
                     // member set; owner signatures are then verified per record so
                     // a kind 448 may apply other members' records (offline-member
                     // bootstrap) without trusting the relaying sender.
-                    let ingest_result = self
-                        .runtime
-                        .members(&message.group_id)
-                        .map_err(AppError::from)
-                        .map(|members| {
-                            members
-                                .into_iter()
-                                .map(|member| hex::encode(member.id.as_slice()))
-                                .collect::<Vec<_>>()
+                    let ingest_result = group_metadata
+                        .as_ref()
+                        .map(|group| group.protocol_profile)
+                        .ok_or_else(|| {
+                            AppError::InvalidPushGossip(
+                                "group profile unavailable for push gossip".into(),
+                            )
                         })
-                        .and_then(|active_member_ids| {
+                        .and_then(|profile| {
+                            self.runtime
+                                .members(&message.group_id)
+                                .map_err(AppError::from)
+                                .map(|members| {
+                                    (
+                                        profile,
+                                        members
+                                            .into_iter()
+                                            .map(|member| hex::encode(member.id.as_slice()))
+                                            .collect::<Vec<_>>(),
+                                    )
+                                })
+                        })
+                        .and_then(|(profile, active_member_ids)| {
                             self.app.ingest_push_gossip_message(
                                 &self.state.label,
                                 &message,
                                 &active_member_ids,
+                                profile,
                             )
                         });
                     if let Err(err) = ingest_result {

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1823,7 +1823,7 @@ impl MarmotApp {
     /// Ingest inbound push-token gossip (kinds 447/448/449) into
     /// `group_push_tokens`. `active_member_ids` is the carrying group's current
     /// MLS member set; entries are owner-authenticated and bound to it by
-    /// [`notifications::verify_push_gossip`] before the spec's
+    /// [`notifications::verify_push_gossip_for_profile`] before the spec's
     /// `(owner_ts, record_digest)` ordering primitive and tombstones (enforced by
     /// the storage `apply_*` calls) decide what mutates state. Because authority
     /// comes from each record's `owner_sig`, a kind 448 may carry — and apply —
@@ -1833,6 +1833,7 @@ impl MarmotApp {
         account_ref: &str,
         message: &ReceivedMessage,
         active_member_ids: &[String],
+        profile: cgka_traits::group::ProtocolProfile,
     ) -> Result<(), AppError> {
         let account = self.account_home().account(account_ref)?;
         self.ensure_account_state(&account.label)?;
@@ -1840,7 +1841,12 @@ impl MarmotApp {
         let storage = self.account_storage(&account.label)?;
         let action =
             notifications::parse_push_gossip(message.kind, &group_id_hex, &message.plaintext)?;
-        let action = notifications::verify_push_gossip(action, &group_id_hex, active_member_ids);
+        let action = notifications::verify_push_gossip_for_profile(
+            action,
+            &group_id_hex,
+            active_member_ids,
+            profile,
+        );
         match action {
             notifications::PushGossipAction::Upsert(records) => {
                 for record in records {

--- a/crates/marmot-app/src/notifications.rs
+++ b/crates/marmot-app/src/notifications.rs
@@ -994,6 +994,10 @@ pub fn build_notification_rumor_content(tokens: &[Vec<u8>]) -> Result<String, Ap
     Ok(BASE64_STANDARD.encode(joined))
 }
 
+pub(crate) fn notification_trigger_chunks(tokens: &[Vec<u8>]) -> std::slice::Chunks<'_, Vec<u8>> {
+    tokens.chunks(PUSH_MAX_NOTIFICATION_TRIGGER_TOKENS)
+}
+
 pub async fn build_notification_gift_wrap(
     server_pubkey_hex: &str,
     tokens: &[Vec<u8>],

--- a/crates/marmot-app/src/notifications.rs
+++ b/crates/marmot-app/src/notifications.rs
@@ -28,6 +28,7 @@ use cgka_traits::app_event::{
     EVENT_REF_TAG, MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY, MARMOT_APP_EVENT_KIND_AGENT_OPERATION,
     MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_REACTION,
 };
+use cgka_traits::group::ProtocolProfile;
 
 use crate::messages::{PUBKEY_REF_TAG, inline_mention_pubkey_hexes, mention_pubkey_hex};
 use crate::{
@@ -44,6 +45,8 @@ pub const KIND_MARMOT_NOTIFICATION_SERVER_RELAYS: u64 = 10050;
 pub const PUSH_VERSION: &str = "marmot-push-v1";
 pub const PUSH_ENCRYPTED_TOKEN_LEN: usize = 1084;
 const PUSH_MAX_GOSSIP_ENTRIES: usize = 32;
+const PUSH_MAX_NOTIFICATION_TRIGGER_TOKENS: usize = 32;
+const PUSH_OWNER_TS_MAX_FUTURE_MS: i64 = 3_600_000;
 const PUSH_TOKEN_PLAINTEXT_LEN: usize = 1024;
 const PUSH_MAX_PROVIDER_TOKEN_LEN: usize = PUSH_TOKEN_PLAINTEXT_LEN - 3;
 const PUSH_CIPHERTEXT_LEN: usize = PUSH_TOKEN_PLAINTEXT_LEN + 16;
@@ -54,7 +57,8 @@ const PUSH_HKDF_INFO: &[u8] = b"marmot-push-token-encryption";
 /// distinct unpublished Nostr events so a signature cannot be cross-applied
 /// between them and external signers can produce the proof without raw digest
 /// access.
-const PUSH_OWNER_PROOF_EVENT_KIND: u16 = 450;
+const PUSH_OWNER_PROOF_EVENT_KIND: u16 = 451;
+const LEGACY_PUSH_OWNER_PROOF_EVENT_KIND: u16 = 450;
 const PUSH_RECORD_DOMAIN: &str = "marmot-push-token-record-v1";
 const PUSH_REMOVAL_DOMAIN: &str = "marmot-push-token-removal-v1";
 const NOTIFICATION_VERSION_TAG: &str = "v";
@@ -200,7 +204,7 @@ pub struct GroupPushTokenRecord {
     /// ordering primitive. Distinct from `updated_at_ms` (local receive time).
     pub owner_ts: i64,
     /// 64-byte BIP-340 Schnorr signature (128 lowercase hex) by `member_id_hex`
-    /// over the canonical `SignedRecord`. See `push_record_signing_digest`.
+    /// over the exact local-only kind-451 owner-proof event id.
     pub owner_sig: String,
     pub updated_at_ms: i64,
 }
@@ -662,7 +666,10 @@ struct PushOwnerProofEvent<'a> {
     encrypted_token: Option<&'a [u8]>,
 }
 
-fn push_owner_proof_event(input: PushOwnerProofEvent<'_>) -> Result<UnsignedEvent, AppError> {
+fn push_owner_proof_event(
+    input: PushOwnerProofEvent<'_>,
+    kind: u16,
+) -> Result<UnsignedEvent, AppError> {
     let member_pubkey = PublicKey::parse(input.member_id_hex)
         .map_err(|_| AppError::InvalidPushGossip("member id must be a Nostr pubkey".into()))?;
     let relay = normalized_relay_hint(input.relay_hint).unwrap_or("");
@@ -702,12 +709,10 @@ fn push_owner_proof_event(input: PushOwnerProofEvent<'_>) -> Result<UnsignedEven
         .encrypted_token
         .map(|token| BASE64_STANDARD.encode(token))
         .unwrap_or_default();
-    Ok(
-        EventBuilder::new(Kind::Custom(PUSH_OWNER_PROOF_EVENT_KIND), content)
-            .tags(tags)
-            .custom_created_at(Timestamp::zero())
-            .build(member_pubkey),
-    )
+    Ok(EventBuilder::new(Kind::Custom(kind), content)
+        .tags(tags)
+        .custom_created_at(Timestamp::zero())
+        .build(member_pubkey))
 }
 
 fn push_owner_sig_from_signed_event(
@@ -717,7 +722,13 @@ fn push_owner_sig_from_signed_event(
     let expected_id = expected
         .id
         .ok_or_else(|| AppError::Publish("push owner proof event id was not set".into()))?;
-    if signed.id != expected_id || signed.pubkey != expected.pubkey {
+    if signed.id != expected_id
+        || signed.pubkey != expected.pubkey
+        || signed.created_at != expected.created_at
+        || signed.kind != expected.kind
+        || signed.tags != expected.tags
+        || signed.content != expected.content
+    {
         return Err(AppError::Publish(
             "push owner proof signature does not match record".into(),
         ));
@@ -797,18 +808,25 @@ impl GroupPushTokenRecord {
     }
 
     fn owner_proof_event(&self) -> Result<UnsignedEvent, AppError> {
-        push_owner_proof_event(PushOwnerProofEvent {
-            domain: PUSH_RECORD_DOMAIN,
-            group_id_hex: &self.group_id_hex,
-            member_id_hex: &self.member_id_hex,
-            leaf_index: self.leaf_index,
-            platform: self.platform,
-            server_pubkey_hex: &self.server_pubkey_hex,
-            token_fingerprint: &self.token_fingerprint,
-            owner_ts: self.owner_ts,
-            relay_hint: self.relay_hint.as_deref(),
-            encrypted_token: Some(&self.encrypted_token),
-        })
+        self.owner_proof_event_with_kind(PUSH_OWNER_PROOF_EVENT_KIND)
+    }
+
+    fn owner_proof_event_with_kind(&self, kind: u16) -> Result<UnsignedEvent, AppError> {
+        push_owner_proof_event(
+            PushOwnerProofEvent {
+                domain: PUSH_RECORD_DOMAIN,
+                group_id_hex: &self.group_id_hex,
+                member_id_hex: &self.member_id_hex,
+                leaf_index: self.leaf_index,
+                platform: self.platform,
+                server_pubkey_hex: &self.server_pubkey_hex,
+                token_fingerprint: &self.token_fingerprint,
+                owner_ts: self.owner_ts,
+                relay_hint: self.relay_hint.as_deref(),
+                encrypted_token: Some(&self.encrypted_token),
+            },
+            kind,
+        )
     }
 
     /// Sign this record with the owner account `keys`, populating `owner_sig`.
@@ -836,15 +854,22 @@ impl GroupPushTokenRecord {
     }
 
     /// True when `owner_sig` is a valid Nostr signature by `member_id_hex`.
-    pub(crate) fn verify_owner_sig(&self) -> bool {
+    pub(crate) fn verify_owner_sig(&self, profile: ProtocolProfile) -> bool {
         if let Ok(proof_event) = self.owner_proof_event()
             && verify_push_owner_sig(proof_event, &self.owner_sig)
         {
             return true;
         }
-        // Legacy fallback (see verify_push_owner_sig_legacy): tokens signed by
-        // older clients, and rows already persisted before the event-shaped
-        // proof, carry a signature over SHA-256(SignedRecord), not the event id.
+        if profile == ProtocolProfile::Current {
+            return false;
+        }
+        if let Ok(proof_event) =
+            self.owner_proof_event_with_kind(LEGACY_PUSH_OWNER_PROOF_EVENT_KIND)
+            && verify_push_owner_sig(proof_event, &self.owner_sig)
+        {
+            return true;
+        }
+        // Verification-only raw legacy fallback for already-deployed groups.
         match self.signing_digest() {
             Ok(digest) => {
                 verify_push_owner_sig_legacy(digest, &self.member_id_hex, &self.owner_sig)
@@ -876,18 +901,29 @@ impl PushTokenRemovalRecord {
     }
 
     fn owner_proof_event(&self, group_id_hex: &str) -> Result<UnsignedEvent, AppError> {
-        push_owner_proof_event(PushOwnerProofEvent {
-            domain: PUSH_REMOVAL_DOMAIN,
-            group_id_hex,
-            member_id_hex: &self.member_id_hex,
-            leaf_index: self.leaf_index,
-            platform: self.platform,
-            server_pubkey_hex: &self.server_pubkey_hex,
-            token_fingerprint: &self.token_fingerprint,
-            owner_ts: self.owner_ts,
-            relay_hint: None,
-            encrypted_token: None,
-        })
+        self.owner_proof_event_with_kind(group_id_hex, PUSH_OWNER_PROOF_EVENT_KIND)
+    }
+
+    fn owner_proof_event_with_kind(
+        &self,
+        group_id_hex: &str,
+        kind: u16,
+    ) -> Result<UnsignedEvent, AppError> {
+        push_owner_proof_event(
+            PushOwnerProofEvent {
+                domain: PUSH_REMOVAL_DOMAIN,
+                group_id_hex,
+                member_id_hex: &self.member_id_hex,
+                leaf_index: self.leaf_index,
+                platform: self.platform,
+                server_pubkey_hex: &self.server_pubkey_hex,
+                token_fingerprint: &self.token_fingerprint,
+                owner_ts: self.owner_ts,
+                relay_hint: None,
+                encrypted_token: None,
+            },
+            kind,
+        )
     }
 
     #[cfg(test)]
@@ -915,15 +951,22 @@ impl PushTokenRemovalRecord {
         Ok(())
     }
 
-    pub(crate) fn verify_owner_sig(&self, group_id_hex: &str) -> bool {
+    pub(crate) fn verify_owner_sig(&self, group_id_hex: &str, profile: ProtocolProfile) -> bool {
         if let Ok(proof_event) = self.owner_proof_event(group_id_hex)
             && verify_push_owner_sig(proof_event, &self.owner_sig)
         {
             return true;
         }
-        // Legacy fallback (see verify_push_owner_sig_legacy): older clients, and
-        // rows already persisted before the event-shaped proof, signed over
-        // SHA-256(SignedRecord), not the event id.
+        if profile == ProtocolProfile::Current {
+            return false;
+        }
+        if let Ok(proof_event) =
+            self.owner_proof_event_with_kind(group_id_hex, LEGACY_PUSH_OWNER_PROOF_EVENT_KIND)
+            && verify_push_owner_sig(proof_event, &self.owner_sig)
+        {
+            return true;
+        }
+        // Verification-only raw legacy fallback for already-deployed groups.
         match self.signing_digest(group_id_hex) {
             Ok(digest) => {
                 verify_push_owner_sig_legacy(digest, &self.member_id_hex, &self.owner_sig)
@@ -935,6 +978,7 @@ impl PushTokenRemovalRecord {
 
 pub fn build_notification_rumor_content(tokens: &[Vec<u8>]) -> Result<String, AppError> {
     if tokens.is_empty()
+        || tokens.len() > PUSH_MAX_NOTIFICATION_TRIGGER_TOKENS
         || tokens
             .iter()
             .any(|token| token.len() != PUSH_ENCRYPTED_TOKEN_LEN)
@@ -1112,18 +1156,22 @@ where
 /// never poisons the batch — and a verified entry is applied no matter which
 /// member relayed it (kind 447 self-update or kind 448 transitive list response),
 /// which is what makes offline-member bootstrap safe.
-pub(crate) fn verify_push_gossip(
+pub(crate) fn verify_push_gossip_for_profile(
     action: PushGossipAction,
     group_id_hex: &str,
     active_members: &[String],
+    profile: ProtocolProfile,
 ) -> PushGossipAction {
     let active: HashSet<&str> = active_members.iter().map(String::as_str).collect();
+    let latest_valid_owner_ts = unix_now_ms().saturating_add(PUSH_OWNER_TS_MAX_FUTURE_MS);
     match action {
         PushGossipAction::Upsert(records) => PushGossipAction::Upsert(
             records
                 .into_iter()
                 .filter(|record| {
-                    active.contains(record.member_id_hex.as_str()) && record.verify_owner_sig()
+                    active.contains(record.member_id_hex.as_str())
+                        && (0..=latest_valid_owner_ts).contains(&record.owner_ts)
+                        && record.verify_owner_sig(profile)
                 })
                 .collect(),
         ),
@@ -1132,11 +1180,26 @@ pub(crate) fn verify_push_gossip(
                 .into_iter()
                 .filter(|removal| {
                     active.contains(removal.member_id_hex.as_str())
-                        && removal.verify_owner_sig(group_id_hex)
+                        && (0..=latest_valid_owner_ts).contains(&removal.owner_ts)
+                        && removal.verify_owner_sig(group_id_hex, profile)
                 })
                 .collect(),
         ),
     }
+}
+
+#[cfg(test)]
+fn verify_push_gossip(
+    action: PushGossipAction,
+    group_id_hex: &str,
+    active_members: &[String],
+) -> PushGossipAction {
+    verify_push_gossip_for_profile(
+        action,
+        group_id_hex,
+        active_members,
+        ProtocolProfile::Current,
+    )
 }
 
 impl PushTokenGossipEntry {

--- a/crates/marmot-app/src/notifications.rs
+++ b/crates/marmot-app/src/notifications.rs
@@ -203,8 +203,9 @@ pub struct GroupPushTokenRecord {
     /// Owner-signed millisecond stamp; the high half of the `(owner_ts, digest)`
     /// ordering primitive. Distinct from `updated_at_ms` (local receive time).
     pub owner_ts: i64,
-    /// 64-byte BIP-340 Schnorr signature (128 lowercase hex) by `member_id_hex`
-    /// over the exact local-only kind-451 owner-proof event id.
+    /// 64-byte BIP-340 Schnorr signature (128 lowercase hex) by `member_id_hex`.
+    /// Current producers sign the exact local-only kind-451 owner-proof event
+    /// id; legacy groups may retain kind-450 or raw-record-digest proofs.
     pub owner_sig: String,
     pub updated_at_ms: i64,
 }
@@ -722,6 +723,8 @@ fn push_owner_sig_from_signed_event(
     let expected_id = expected
         .id
         .ok_or_else(|| AppError::Publish("push owner proof event id was not set".into()))?;
+    // The id plus `verify` cryptographically binds these fields. Compare them
+    // explicitly as defense in depth at the external-signer trust boundary.
     if signed.id != expected_id
         || signed.pubkey != expected.pubkey
         || signed.created_at != expected.created_at

--- a/crates/marmot-app/src/notifications/tests.rs
+++ b/crates/marmot-app/src/notifications/tests.rs
@@ -223,7 +223,11 @@ async fn local_token_gossip_normalizes_relay_hint_before_signing_and_storage() {
         payload.tokens[0].relay_hint.as_deref(),
         Some("wss://relay.example")
     );
-    assert!(record.verify_owner_sig());
+    assert_eq!(
+        record.owner_proof_event().unwrap().kind,
+        Kind::Custom(PUSH_OWNER_PROOF_EVENT_KIND)
+    );
+    assert!(record.verify_owner_sig(ProtocolProfile::Current));
 }
 
 #[test]
@@ -232,6 +236,22 @@ fn kind_446_content_is_base64_concatenated_tokens_with_version_tag() {
     let content = build_notification_rumor_content(&[token.clone(), token.clone()]).unwrap();
     let decoded = BASE64_STANDARD.decode(content).unwrap();
     assert_eq!(decoded.len(), PUSH_ENCRYPTED_TOKEN_LEN * 2);
+}
+
+#[test]
+fn kind_446_content_is_bounded_to_32_encrypted_tokens() {
+    let token = vec![7_u8; PUSH_ENCRYPTED_TOKEN_LEN];
+    assert!(
+        build_notification_rumor_content(&vec![
+            token.clone();
+            PUSH_MAX_NOTIFICATION_TRIGGER_TOKENS
+        ])
+        .is_ok()
+    );
+    assert!(
+        build_notification_rumor_content(&vec![token; PUSH_MAX_NOTIFICATION_TRIGGER_TOKENS + 1])
+            .is_err()
+    );
 }
 
 #[tokio::test]
@@ -580,8 +600,13 @@ fn normalized_relay_hint_duplicates_are_deduplicated_before_verification_and_app
     };
 
     reset_owner_signature_verification_count();
-    app.ingest_push_gossip_message("alice", &message, std::slice::from_ref(&owner_id))
-        .unwrap();
+    app.ingest_push_gossip_message(
+        "alice",
+        &message,
+        std::slice::from_ref(&owner_id),
+        ProtocolProfile::Current,
+    )
+    .unwrap();
 
     assert_eq!(
         owner_signature_verification_count(),
@@ -690,8 +715,13 @@ fn mixed_entry_permutations_apply_the_same_valid_winner() {
         };
 
         reset_owner_signature_verification_count();
-        app.ingest_push_gossip_message("alice", &message, std::slice::from_ref(&owner_id))
-            .unwrap();
+        app.ingest_push_gossip_message(
+            "alice",
+            &message,
+            std::slice::from_ref(&owner_id),
+            ProtocolProfile::Current,
+        )
+        .unwrap();
         assert_eq!(
             owner_signature_verification_count(),
             2,
@@ -1320,6 +1350,227 @@ fn signed_removal_record(
     record
 }
 
+fn sign_token_record_with_event_kind(record: &mut GroupPushTokenRecord, keys: &Keys, kind: u16) {
+    let proof_event = record.owner_proof_event_with_kind(kind).unwrap();
+    let signed = proof_event.clone().sign_with_keys(keys).unwrap();
+    record.owner_sig = push_owner_sig_from_signed_event(&proof_event, signed).unwrap();
+}
+
+fn sign_removal_record_with_event_kind(
+    record: &mut PushTokenRemovalRecord,
+    group_id_hex: &str,
+    keys: &Keys,
+    kind: u16,
+) {
+    let proof_event = record
+        .owner_proof_event_with_kind(group_id_hex, kind)
+        .unwrap();
+    let signed = proof_event.clone().sign_with_keys(keys).unwrap();
+    record.owner_sig = push_owner_sig_from_signed_event(&proof_event, signed).unwrap();
+}
+
+fn sign_token_record_raw_legacy(record: &mut GroupPushTokenRecord, keys: &Keys) {
+    let message = Message::from_digest(record.signing_digest().unwrap());
+    record.owner_sig = hex::encode(
+        SECP256K1
+            .sign_schnorr_no_aux_rand(&message, keys.key_pair(SECP256K1))
+            .serialize(),
+    );
+}
+
+fn sign_removal_record_raw_legacy(
+    record: &mut PushTokenRemovalRecord,
+    group_id_hex: &str,
+    keys: &Keys,
+) {
+    let message = Message::from_digest(record.signing_digest(group_id_hex).unwrap());
+    record.owner_sig = hex::encode(
+        SECP256K1
+            .sign_schnorr_no_aux_rand(&message, keys.key_pair(SECP256K1))
+            .serialize(),
+    );
+}
+
+#[test]
+fn current_and_legacy_profiles_enforce_the_owner_proof_matrix() {
+    let keys = Keys::generate();
+    let group = "ee".repeat(16);
+    let server = "dd".repeat(32);
+    let member = keys.public_key().to_hex();
+
+    let current = signed_token_record(&keys, &group, 1, &server, 100);
+    for profile in [ProtocolProfile::Current, ProtocolProfile::Legacy] {
+        let verified = verify_push_gossip_for_profile(
+            PushGossipAction::Upsert(vec![current.clone()]),
+            &group,
+            std::slice::from_ref(&member),
+            profile,
+        );
+        assert!(
+            matches!(verified, PushGossipAction::Upsert(records) if records.len() == 1),
+            "kind-451 proof must be accepted for {profile:?}"
+        );
+    }
+
+    let mut transitional = current.clone();
+    sign_token_record_with_event_kind(&mut transitional, &keys, LEGACY_PUSH_OWNER_PROOF_EVENT_KIND);
+    let current_result = verify_push_gossip_for_profile(
+        PushGossipAction::Upsert(vec![transitional.clone()]),
+        &group,
+        std::slice::from_ref(&member),
+        ProtocolProfile::Current,
+    );
+    assert!(matches!(current_result, PushGossipAction::Upsert(records) if records.is_empty()));
+    let legacy_result = verify_push_gossip_for_profile(
+        PushGossipAction::Upsert(vec![transitional]),
+        &group,
+        std::slice::from_ref(&member),
+        ProtocolProfile::Legacy,
+    );
+    assert!(matches!(legacy_result, PushGossipAction::Upsert(records) if records.len() == 1));
+
+    let mut wrong_registry_kind = current.clone();
+    sign_token_record_with_event_kind(&mut wrong_registry_kind, &keys, 452);
+    for profile in [ProtocolProfile::Current, ProtocolProfile::Legacy] {
+        let result = verify_push_gossip_for_profile(
+            PushGossipAction::Upsert(vec![wrong_registry_kind.clone()]),
+            &group,
+            std::slice::from_ref(&member),
+            profile,
+        );
+        assert!(
+            matches!(result, PushGossipAction::Upsert(records) if records.is_empty()),
+            "kind-452 proof must be rejected for {profile:?}"
+        );
+    }
+
+    let mut raw = current;
+    sign_token_record_raw_legacy(&mut raw, &keys);
+    let current_result = verify_push_gossip_for_profile(
+        PushGossipAction::Upsert(vec![raw.clone()]),
+        &group,
+        std::slice::from_ref(&member),
+        ProtocolProfile::Current,
+    );
+    assert!(matches!(current_result, PushGossipAction::Upsert(records) if records.is_empty()));
+    let legacy_result = verify_push_gossip_for_profile(
+        PushGossipAction::Upsert(vec![raw]),
+        &group,
+        std::slice::from_ref(&member),
+        ProtocolProfile::Legacy,
+    );
+    assert!(matches!(legacy_result, PushGossipAction::Upsert(records) if records.len() == 1));
+}
+
+#[test]
+fn removal_owner_proofs_follow_the_same_profile_matrix() {
+    let keys = Keys::generate();
+    let group = "ee".repeat(16);
+    let server = "dd".repeat(32);
+    let member = keys.public_key().to_hex();
+    let current = signed_removal_record(&keys, &group, 1, &server, 100);
+
+    let mut transitional = current.clone();
+    sign_removal_record_with_event_kind(
+        &mut transitional,
+        &group,
+        &keys,
+        LEGACY_PUSH_OWNER_PROOF_EVENT_KIND,
+    );
+    let current_result = verify_push_gossip_for_profile(
+        PushGossipAction::Remove(vec![transitional.clone()]),
+        &group,
+        std::slice::from_ref(&member),
+        ProtocolProfile::Current,
+    );
+    assert!(matches!(current_result, PushGossipAction::Remove(records) if records.is_empty()));
+    let legacy_result = verify_push_gossip_for_profile(
+        PushGossipAction::Remove(vec![transitional]),
+        &group,
+        std::slice::from_ref(&member),
+        ProtocolProfile::Legacy,
+    );
+    assert!(matches!(legacy_result, PushGossipAction::Remove(records) if records.len() == 1));
+
+    let mut raw = current;
+    sign_removal_record_raw_legacy(&mut raw, &group, &keys);
+    let current_result = verify_push_gossip_for_profile(
+        PushGossipAction::Remove(vec![raw.clone()]),
+        &group,
+        std::slice::from_ref(&member),
+        ProtocolProfile::Current,
+    );
+    assert!(matches!(current_result, PushGossipAction::Remove(records) if records.is_empty()));
+    let legacy_result = verify_push_gossip_for_profile(
+        PushGossipAction::Remove(vec![raw]),
+        &group,
+        std::slice::from_ref(&member),
+        ProtocolProfile::Legacy,
+    );
+    assert!(matches!(legacy_result, PushGossipAction::Remove(records) if records.len() == 1));
+}
+
+#[test]
+fn removal_kind_451_vector_matches_the_adopted_spec() {
+    let mut secret = [0_u8; 32];
+    secret[31] = 3;
+    let keys = Keys::new(nostr::SecretKey::from_slice(&secret).unwrap());
+    let group_id_hex: String = (0_u8..32).map(|byte| format!("{byte:02x}")).collect();
+    let record = PushTokenRemovalRecord {
+        member_id_hex: keys.public_key().to_hex(),
+        leaf_index: 3,
+        platform: PushPlatform::Apns,
+        token_fingerprint: "sha256:000102030405060708090a0b".to_owned(),
+        server_pubkey_hex:
+            "2f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4"
+                .to_owned(),
+        owner_ts: 1_700_000_000_000,
+        owner_sig:
+            "04c3588a6533399aeaebb6c596fab896186dd0af1f9724f2926d984d2876490c76e1d149127e0fa697d7f19a0807aa373e942f0eb33edc63071567f274ce3bec"
+                .to_owned(),
+    };
+
+    let event = record.owner_proof_event(&group_id_hex).unwrap();
+    assert_eq!(event.kind, Kind::Custom(PUSH_OWNER_PROOF_EVENT_KIND));
+    assert_eq!(
+        event.id.expect("owner-proof event id is computed").to_hex(),
+        "be12f4d029d3cac4034251949d6c013ff18eae00870e199012c7a97e8960b7a2"
+    );
+    assert!(record.verify_owner_sig(&group_id_hex, ProtocolProfile::Current));
+}
+
+#[test]
+fn future_or_negative_owner_timestamps_are_rejected_before_signature_work() {
+    let keys = Keys::generate();
+    let group = "ee".repeat(16);
+    let server = "dd".repeat(32);
+    let member = keys.public_key().to_hex();
+    let too_future = unix_now_ms()
+        .saturating_add(PUSH_OWNER_TS_MAX_FUTURE_MS)
+        .saturating_add(60_000);
+    let future = signed_token_record(&keys, &group, 1, &server, too_future);
+    let negative = signed_token_record(&keys, &group, 2, &server, -1);
+    let future_removal = signed_removal_record(&keys, &group, 1, &server, too_future);
+    let negative_removal = signed_removal_record(&keys, &group, 2, &server, -1);
+
+    reset_owner_signature_verification_count();
+    let upserts = verify_push_gossip_for_profile(
+        PushGossipAction::Upsert(vec![future, negative]),
+        &group,
+        std::slice::from_ref(&member),
+        ProtocolProfile::Current,
+    );
+    let removals = verify_push_gossip_for_profile(
+        PushGossipAction::Remove(vec![future_removal, negative_removal]),
+        &group,
+        std::slice::from_ref(&member),
+        ProtocolProfile::Current,
+    );
+    assert!(matches!(upserts, PushGossipAction::Upsert(records) if records.is_empty()));
+    assert!(matches!(removals, PushGossipAction::Remove(records) if records.is_empty()));
+    assert_eq!(owner_signature_verification_count(), 0);
+}
+
 #[test]
 fn verify_keeps_owner_signed_self_update() {
     let keys = Keys::generate();
@@ -1446,7 +1697,7 @@ fn signed_record_survives_wire_round_trip_and_verifies() {
     match verified {
         PushGossipAction::Upsert(records) => {
             assert_eq!(records.len(), 1);
-            assert!(records[0].verify_owner_sig());
+            assert!(records[0].verify_owner_sig(ProtocolProfile::Current));
         }
         other => panic!("expected upsert, got {other:?}"),
     }

--- a/crates/marmot-app/src/notifications/tests.rs
+++ b/crates/marmot-app/src/notifications/tests.rs
@@ -254,6 +254,22 @@ fn kind_446_content_is_bounded_to_32_encrypted_tokens() {
     );
 }
 
+#[test]
+fn kind_446_trigger_chunks_split_33_encrypted_tokens() {
+    let tokens =
+        vec![vec![7_u8; PUSH_ENCRYPTED_TOKEN_LEN]; PUSH_MAX_NOTIFICATION_TRIGGER_TOKENS + 1];
+    let chunks = notification_trigger_chunks(&tokens).collect::<Vec<_>>();
+    assert_eq!(
+        chunks.iter().map(|chunk| chunk.len()).collect::<Vec<_>>(),
+        vec![PUSH_MAX_NOTIFICATION_TRIGGER_TOKENS, 1]
+    );
+    assert!(
+        chunks
+            .into_iter()
+            .all(|chunk| build_notification_rumor_content(chunk).is_ok())
+    );
+}
+
 #[tokio::test]
 async fn kind_446_rumor_only_carries_version_tag_and_no_routing_metadata() {
     use nostr::nips::nip59::UnwrappedGift;

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -1779,6 +1779,7 @@ fn ingest_applies_owner_signed_transitive_448_and_drops_spoof() {
         "alice",
         &message(honest, &relayer),
         &[owner_id.clone(), relayer.clone()],
+        cgka_traits::group::ProtocolProfile::Current,
     )
     .unwrap();
     let stored = app.group_push_tokens("alice", &group_id_hex).unwrap();
@@ -1794,6 +1795,7 @@ fn ingest_applies_owner_signed_transitive_448_and_drops_spoof() {
         "alice",
         &message(spoof, &relayer),
         &[owner_id.clone(), relayer, attacker.public_key().to_hex()],
+        cgka_traits::group::ProtocolProfile::Current,
     )
     .unwrap();
     let stored = app.group_push_tokens("alice", &group_id_hex).unwrap();


### PR DESCRIPTION
## Summary

- produce the adopted unpublished kind-451 event-shaped proof for push token records and removals
- bind inbound verification to the carrying group profile: current groups accept only kind 451; legacy groups additionally accept transitional kind 450 and deployed raw-digest proofs
- reject negative or more-than-one-hour-future owner timestamps before signature work, cap each kind-446 trigger at 32 encrypted tokens, and split larger per-server batches across valid triggers
- verify every field returned by an external event signer, while retaining the raw `SignedRecord` digest only for ordering and legacy verification
- pin the adopted kind-451 removal event ID/signature vector and profile acceptance matrix

## Normative source

Implemented against `marmot-protocol/marmot@dedeaf429a6f52a4f1c62f3e992be012dab61b7b` (`Specify push owner proof signing`).

## Validation

- `cargo test -p marmot-app`
- `cargo test -p marmot-uniffi`
- `just fast-ci`

`cargo doc -p marmot-app --no-deps` was also checked; it reaches only four pre-existing broken intra-doc links outside this diff.

Closes #1059