### PR TITLE
Persist frozen outbound fanout lifecycle

### DIFF
--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -452,17 +452,37 @@ impl<S: StorageProvider> EngineBuilder<S> {
 impl<S: StorageProvider> Engine<S> {
     /// Persist a frozen transport fanout before or after one lifecycle edge.
     pub fn put_outbound_fanout(&self, fanout: &OutboundFanout) -> Result<(), EngineError> {
+        if let Some(group_id) = fanout.group_id() {
+            self.ensure_group_live(group_id)?;
+        }
         self.storage.put_outbound_fanout(fanout)?;
         Ok(())
     }
 
     /// Read all frozen fanouts in original staging order.
     pub fn outbound_fanouts(&self) -> Result<Vec<OutboundFanout>, EngineError> {
-        Ok(self.storage.list_outbound_fanouts()?)
+        Ok(self
+            .storage
+            .list_outbound_fanouts()?
+            .into_iter()
+            .filter(|fanout| {
+                fanout
+                    .group_id()
+                    .is_none_or(|group_id| !self.quarantined_groups.contains_key(group_id))
+            })
+            .collect())
     }
 
     /// Delete a terminal fanout after its outcome has been returned.
     pub fn delete_outbound_fanout(&self, message_id: &MessageId) -> Result<(), EngineError> {
+        if let Some(group_id) = self
+            .storage
+            .outbound_fanout(message_id)?
+            .as_ref()
+            .and_then(OutboundFanout::group_id)
+        {
+            self.ensure_group_live(group_id)?;
+        }
         self.storage.delete_outbound_fanout(message_id)?;
         Ok(())
     }
@@ -470,9 +490,12 @@ impl<S: StorageProvider> Engine<S> {
     /// Resolve the group owning a live pending reference without exposing
     /// epoch-manager internals across the session/runtime boundary.
     pub fn pending_group_id(&self, pending: PendingStateRef) -> Result<GroupId, EngineError> {
-        self.epoch_manager
+        let group_id = self
+            .epoch_manager
             .group_for_pending(pending)
-            .ok_or(EngineError::UnknownPending)
+            .ok_or(EngineError::UnknownPending)?;
+        self.ensure_group_live(&group_id)?;
+        Ok(group_id)
     }
 
     /// Confirm MLS and persist the matching fanout's terminal MLS edge in the
@@ -482,6 +505,10 @@ impl<S: StorageProvider> Engine<S> {
         pending: PendingStateRef,
         fanout: &mut OutboundFanout,
     ) -> Result<GroupEvent, EngineError> {
+        if let Some(group_id) = fanout.group_id() {
+            self.ensure_group_live(group_id)?;
+        }
+        self.pending_group_id(pending)?;
         self.do_confirm_published_with_fanout(pending, Some(fanout))
             .await
     }
@@ -493,6 +520,10 @@ impl<S: StorageProvider> Engine<S> {
         pending: PendingStateRef,
         fanout: &mut OutboundFanout,
     ) -> Result<(), EngineError> {
+        if let Some(group_id) = fanout.group_id() {
+            self.ensure_group_live(group_id)?;
+        }
+        self.pending_group_id(pending)?;
         self.do_publish_failed_with_fanout(pending, Some(fanout))
             .await
     }
@@ -985,25 +1016,13 @@ impl<S: StorageProvider> Engine<S> {
                 fanout.group_id() == Some(group_id)
                     && matches!(fanout.mls_state(), cgka_traits::FanoutMlsState::Pending(_))
             });
-        let mut restored_pending = false;
-        if mls_group.pending_commit().is_some()
+        let pending_recovery = if mls_group.pending_commit().is_some()
             && let Some(fanout) = durable_pending_fanout.as_ref()
         {
             let pending_ref = fanout
                 .pending_ref()
                 .expect("pending fanout state retains its pending ref");
             let prior_epoch = EpochId(mls_group.epoch().as_u64());
-            self.epoch_manager
-                .restore_pending(
-                    group_id.clone(),
-                    prior_epoch,
-                    EpochId(prior_epoch.0.saturating_add(1)),
-                    StagedCommitHandle::from_bytes(group_id.as_slice().to_vec()),
-                    pending_ref,
-                    crate::epoch_manager::PendingKind::GroupEvolution,
-                )
-                .map_err(|_| GroupHydrationQuarantineReason::PendingCommitRecoveryFailed)?;
-
             let stored = self
                 .storage
                 .get_message(fanout.message_id())
@@ -1027,9 +1046,8 @@ impl<S: StorageProvider> Engine<S> {
             let snapshot_name = newest_fork_snapshot(snapshots, &snapshot_prefix)
                 .map_err(|_| GroupHydrationQuarantineReason::PendingCommitRecoveryFailed)?
                 .ok_or(GroupHydrationQuarantineReason::PendingCommitRecoveryFailed)?;
-            self.fork_recovery.record_pending(
+            Some((
                 pending_ref,
-                group_id.clone(),
                 prior_epoch,
                 fanout.message_id().clone(),
                 CommitOrderingKey::from_commit_bytes(
@@ -1039,9 +1057,11 @@ impl<S: StorageProvider> Engine<S> {
                     commit_bytes,
                 ),
                 snapshot_name,
-            );
-            restored_pending = true;
-        }
+            ))
+        } else {
+            None
+        };
+        let restored_pending = pending_recovery.is_some();
 
         // A staged commit that survived process restart *may* mean the
         // application crashed mid-publish. Clear it (treat as
@@ -1103,36 +1123,9 @@ impl<S: StorageProvider> Engine<S> {
                 });
         }
 
-        if let Some(request) = self
+        let leave_request = self
             .leave_request_to_restore_on_hydrate(group_id, &mut mls_group, &group, &provider)
-            .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?
-        {
-            self.leave_requests.insert(group_id.clone(), request);
-            self.leaving_groups.insert(group_id.clone());
-        } else {
-            self.leave_requests.remove(group_id);
-            self.leaving_groups.remove(group_id);
-        }
-
-        // #740: the transport routing id was already indexed right after the
-        // MLS load above (kept pre-validation so quarantined groups resolve
-        // too); nothing on this path changes it.
-
-        if !restored_pending {
-            self.epoch_manager.set_stable(group_id.clone(), group.epoch);
-        }
-        self.audit_group(
-            group_id,
-            crate::audit_helpers::epoch_state_changed_event(
-                None,
-                "stable",
-                group.epoch,
-                "hydrate_stable_group",
-                None,
-                None,
-            ),
-        );
-        self.audit_group_context(group_id, "hydrate_stable_group");
+            .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
 
         // Startup must recreate the in-memory scheduling edge for durable
         // convergence work. Otherwise queued user sends and stored branch
@@ -1146,6 +1139,65 @@ impl<S: StorageProvider> Engine<S> {
         let has_convergence_inputs = self
             .has_pending_convergence_inputs(group_id)
             .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
+
+        // Do not expose any recovered pending state until every fallible
+        // hydration read and validation above has succeeded. If a later step
+        // quarantines the group, neither runtime fanout resumption nor direct
+        // pending access may observe a half-hydrated lifecycle.
+        if let Some((pending_ref, prior_epoch, message_id, ordering_key, snapshot_name)) =
+            pending_recovery
+        {
+            self.epoch_manager
+                .restore_pending(
+                    group_id.clone(),
+                    prior_epoch,
+                    EpochId(prior_epoch.0.saturating_add(1)),
+                    StagedCommitHandle::from_bytes(group_id.as_slice().to_vec()),
+                    pending_ref,
+                    crate::epoch_manager::PendingKind::GroupEvolution,
+                )
+                .map_err(|_| GroupHydrationQuarantineReason::PendingCommitRecoveryFailed)?;
+            self.fork_recovery.record_pending(
+                pending_ref,
+                group_id.clone(),
+                prior_epoch,
+                message_id,
+                ordering_key,
+                snapshot_name,
+            );
+        } else {
+            self.epoch_manager.set_stable(group_id.clone(), group.epoch);
+        }
+
+        if let Some(request) = leave_request {
+            self.leave_requests.insert(group_id.clone(), request);
+            self.leaving_groups.insert(group_id.clone());
+        } else {
+            self.leave_requests.remove(group_id);
+            self.leaving_groups.remove(group_id);
+        }
+
+        // #740: the transport routing id was already indexed right after the
+        // MLS load above (kept pre-validation so quarantined groups resolve
+        // too); nothing on this path changes it.
+
+        self.audit_group(
+            group_id,
+            crate::audit_helpers::epoch_state_changed_event(
+                None,
+                if restored_pending {
+                    "pending_publish"
+                } else {
+                    "stable"
+                },
+                group.epoch,
+                "hydrate_stable_group",
+                None,
+                None,
+            ),
+        );
+        self.audit_group_context(group_id, "hydrate_stable_group");
+
         if has_queued_intents || has_convergence_inputs {
             self.schedule_pending_convergence_group(group_id);
         }

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -12,13 +12,14 @@ use crate::bounded_id_set::{BoundedIdSet, DEDUP_CACHE_CAPACITY};
 use crate::feature_registry::FeatureRegistry;
 use crate::identity::Identity;
 use async_trait::async_trait;
+use cgka_traits::OutboundFanout;
 use cgka_traits::app_components::{AppComponentId, AppComponentSet, default_group_components};
 use cgka_traits::capabilities::{Feature, FeatureStatus, GroupCapabilities};
 use cgka_traits::engine::{
-    AutoPublish, CgkaEngine, CreateGroupRequest, GroupEvent, GroupHydrationQuarantineReason,
-    GroupStateChange, KeyPackage, SendIntent, SendResult,
+    AutoPublish, CgkaEngine, CommitOrderingKey, CreateGroupRequest, GroupEvent,
+    GroupHydrationQuarantineReason, GroupStateChange, KeyPackage, SendIntent, SendResult,
 };
-use cgka_traits::engine_state::PendingStateRef;
+use cgka_traits::engine_state::{PendingStateRef, StagedCommitHandle};
 use cgka_traits::error::EngineError;
 use cgka_traits::group::{Group, Member, ProtocolProfile};
 use cgka_traits::group_context::GroupContext;
@@ -65,6 +66,30 @@ pub(crate) fn hydration_quarantine_group_digest(group_id: &GroupId) -> String {
     hasher.update(b"marmot-hydration-quarantine-group/v1");
     hasher.update(group_id.as_slice());
     hex::encode(hasher.finalize())
+}
+
+fn newest_fork_snapshot(
+    names: impl IntoIterator<Item = String>,
+    prefix: &str,
+) -> Result<Option<String>, ()> {
+    let mut newest: Option<(u64, String)> = None;
+    for name in names {
+        let Some(suffix) = name.strip_prefix(prefix) else {
+            continue;
+        };
+        let (counter, digest) = suffix.split_once('-').ok_or(())?;
+        if digest.is_empty() {
+            return Err(());
+        }
+        let counter = counter.parse::<u64>().map_err(|_| ())?;
+        if newest
+            .as_ref()
+            .is_none_or(|(newest_counter, _)| counter > *newest_counter)
+        {
+            newest = Some((counter, name));
+        }
+    }
+    Ok(newest.map(|(_, name)| name))
 }
 
 /// OpenMLS-backed CGKA engine. Construct via [`EngineBuilder`].
@@ -425,6 +450,53 @@ impl<S: StorageProvider> EngineBuilder<S> {
 }
 
 impl<S: StorageProvider> Engine<S> {
+    /// Persist a frozen transport fanout before or after one lifecycle edge.
+    pub fn put_outbound_fanout(&self, fanout: &OutboundFanout) -> Result<(), EngineError> {
+        self.storage.put_outbound_fanout(fanout)?;
+        Ok(())
+    }
+
+    /// Read all frozen fanouts in original staging order.
+    pub fn outbound_fanouts(&self) -> Result<Vec<OutboundFanout>, EngineError> {
+        Ok(self.storage.list_outbound_fanouts()?)
+    }
+
+    /// Delete a terminal fanout after its outcome has been returned.
+    pub fn delete_outbound_fanout(&self, message_id: &MessageId) -> Result<(), EngineError> {
+        self.storage.delete_outbound_fanout(message_id)?;
+        Ok(())
+    }
+
+    /// Resolve the group owning a live pending reference without exposing
+    /// epoch-manager internals across the session/runtime boundary.
+    pub fn pending_group_id(&self, pending: PendingStateRef) -> Result<GroupId, EngineError> {
+        self.epoch_manager
+            .group_for_pending(pending)
+            .ok_or(EngineError::UnknownPending)
+    }
+
+    /// Confirm MLS and persist the matching fanout's terminal MLS edge in the
+    /// same backend transaction.
+    pub async fn confirm_published_fanout(
+        &mut self,
+        pending: PendingStateRef,
+        fanout: &mut OutboundFanout,
+    ) -> Result<GroupEvent, EngineError> {
+        self.do_confirm_published_with_fanout(pending, Some(fanout))
+            .await
+    }
+
+    /// Roll back MLS and persist the matching all-failed fanout edge in the
+    /// same backend transaction.
+    pub async fn publish_failed_fanout(
+        &mut self,
+        pending: PendingStateRef,
+        fanout: &mut OutboundFanout,
+    ) -> Result<(), EngineError> {
+        self.do_publish_failed_with_fanout(pending, Some(fanout))
+            .await
+    }
+
     pub async fn ingest_with_audit_context(
         &mut self,
         msg: TransportMessage,
@@ -904,6 +976,73 @@ impl<S: StorageProvider> Engine<S> {
             return Err(GroupHydrationQuarantineReason::MemberValidationFailed);
         }
 
+        let durable_pending_fanout = self
+            .storage
+            .list_outbound_fanouts_for_group(group_id)
+            .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?
+            .into_iter()
+            .find(|fanout| {
+                fanout.group_id() == Some(group_id)
+                    && matches!(fanout.mls_state(), cgka_traits::FanoutMlsState::Pending(_))
+            });
+        let mut restored_pending = false;
+        if mls_group.pending_commit().is_some()
+            && let Some(fanout) = durable_pending_fanout.as_ref()
+        {
+            let pending_ref = fanout
+                .pending_ref()
+                .expect("pending fanout state retains its pending ref");
+            let prior_epoch = EpochId(mls_group.epoch().as_u64());
+            self.epoch_manager
+                .restore_pending(
+                    group_id.clone(),
+                    prior_epoch,
+                    EpochId(prior_epoch.0.saturating_add(1)),
+                    StagedCommitHandle::from_bytes(group_id.as_slice().to_vec()),
+                    pending_ref,
+                    crate::epoch_manager::PendingKind::GroupEvolution,
+                )
+                .map_err(|_| GroupHydrationQuarantineReason::PendingCommitRecoveryFailed)?;
+
+            let stored = self
+                .storage
+                .get_message(fanout.message_id())
+                .map_err(|_| GroupHydrationQuarantineReason::PendingCommitRecoveryFailed)?;
+            let payload = StoredMessagePayload::decode(&stored.payload)
+                .map_err(|_| GroupHydrationQuarantineReason::PendingCommitRecoveryFailed)?;
+            let commit_bytes = payload
+                .as_openmls_wire()
+                .map(|message| message.payload.as_slice())
+                .ok_or(GroupHydrationQuarantineReason::PendingCommitRecoveryFailed)?;
+            let priority = crate::app_components::commit_ordering_priority_for_staged(
+                mls_group
+                    .pending_commit()
+                    .expect("pending commit presence checked above"),
+            );
+            let snapshot_prefix = format!("fork-{}-", prior_epoch.0);
+            let snapshots = self
+                .storage
+                .list_group_snapshots(group_id)
+                .map_err(|_| GroupHydrationQuarantineReason::PendingCommitRecoveryFailed)?;
+            let snapshot_name = newest_fork_snapshot(snapshots, &snapshot_prefix)
+                .map_err(|_| GroupHydrationQuarantineReason::PendingCommitRecoveryFailed)?
+                .ok_or(GroupHydrationQuarantineReason::PendingCommitRecoveryFailed)?;
+            self.fork_recovery.record_pending(
+                pending_ref,
+                group_id.clone(),
+                prior_epoch,
+                fanout.message_id().clone(),
+                CommitOrderingKey::from_commit_bytes(
+                    prior_epoch,
+                    priority,
+                    self.identity.self_id().clone(),
+                    commit_bytes,
+                ),
+                snapshot_name,
+            );
+            restored_pending = true;
+        }
+
         // A staged commit that survived process restart *may* mean the
         // application crashed mid-publish. Clear it (treat as
         // publish-failed) so the group is not permanently wedged, then
@@ -925,7 +1064,7 @@ impl<S: StorageProvider> Engine<S> {
                 )
             })
         });
-        if mls_group.pending_commit().is_some() && !staged_removes_member {
+        if mls_group.pending_commit().is_some() && !staged_removes_member && !restored_pending {
             // Clear the staged commit transactionally (preserves the #421
             // crash-safety fix): the MLS storage mutation must be atomic so a
             // crash mid-clear cannot leave torn group state.
@@ -979,7 +1118,9 @@ impl<S: StorageProvider> Engine<S> {
         // MLS load above (kept pre-validation so quarantined groups resolve
         // too); nothing on this path changes it.
 
-        self.epoch_manager.set_stable(group_id.clone(), group.epoch);
+        if !restored_pending {
+            self.epoch_manager.set_stable(group_id.clone(), group.epoch);
+        }
         self.audit_group(
             group_id,
             crate::audit_helpers::epoch_state_changed_event(
@@ -2087,5 +2228,31 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
 
     async fn delete_key_package(&mut self, key_package: &KeyPackage) -> Result<(), EngineError> {
         self.do_delete_key_package(key_package)
+    }
+}
+
+#[cfg(test)]
+mod frozen_fanout_recovery_tests {
+    use super::newest_fork_snapshot;
+
+    #[test]
+    fn recovery_snapshot_selection_compares_numeric_counters() {
+        let names = vec![
+            "fork-7-9-old".to_string(),
+            "fork-7-10-new".to_string(),
+            "fork-6-99-other-epoch".to_string(),
+        ];
+        assert_eq!(
+            newest_fork_snapshot(names, "fork-7-").unwrap().as_deref(),
+            Some("fork-7-10-new")
+        );
+    }
+
+    #[test]
+    fn recovery_snapshot_selection_rejects_malformed_matching_names() {
+        assert!(
+            newest_fork_snapshot(vec!["fork-7-not-a-counter-digest".to_string()], "fork-7-")
+                .is_err()
+        );
     }
 }

--- a/crates/cgka-engine/src/epoch_manager.rs
+++ b/crates/cgka-engine/src/epoch_manager.rs
@@ -164,6 +164,31 @@ impl EpochManager {
         Ok(())
     }
 
+    /// Recreate a pending-publish slot from its durable frozen fanout after a
+    /// process restart. The restored ref also advances the allocator so a new
+    /// pending operation cannot reuse it in this session.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn restore_pending(
+        &mut self,
+        group_id: GroupId,
+        pre_commit_epoch: EpochId,
+        new_epoch: EpochId,
+        pending: StagedCommitHandle,
+        pending_ref: PendingStateRef,
+        kind: PendingKind,
+    ) -> Result<(), EngineError> {
+        self.pending_counter = self.pending_counter.max(pending_ref.as_u64());
+        self.begin_pending(
+            group_id,
+            pre_commit_epoch,
+            new_epoch,
+            pending,
+            pending_ref,
+            kind,
+            None,
+        )
+    }
+
     /// Peek at which group a pending publish belongs to without consuming
     /// the entry. Used by `do_confirm_published` / `do_publish_failed` so
     /// the engine can load the MLS group BEFORE we burn the state-machine

--- a/crates/cgka-engine/src/fork_recovery.rs
+++ b/crates/cgka-engine/src/fork_recovery.rs
@@ -91,7 +91,7 @@ impl ForkRecoveryManager {
         Ok(name)
     }
 
-    fn record_pending(
+    pub(crate) fn record_pending(
         &mut self,
         pending: PendingStateRef,
         group_id: GroupId,
@@ -100,6 +100,13 @@ impl ForkRecoveryManager {
         ordering_key: CommitOrderingKey,
         snapshot_name: String,
     ) {
+        if let Some(counter) = snapshot_name
+            .strip_prefix("fork-")
+            .and_then(|suffix| suffix.split('-').nth(1))
+            .and_then(|counter| counter.parse::<u64>().ok())
+        {
+            self.snapshot_counter = self.snapshot_counter.max(counter);
+        }
         self.pending.insert(
             pending,
             CommitRecoveryRecord {

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -29,6 +29,7 @@
 
 use crate::engine::Engine;
 use crate::provider::EngineOpenMlsProvider;
+use cgka_traits::OutboundFanout;
 use cgka_traits::engine::GroupEvent;
 use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::error::EngineError;
@@ -43,6 +44,29 @@ impl<S: StorageProvider> Engine<S> {
         &mut self,
         pending: PendingStateRef,
     ) -> Result<GroupEvent, EngineError> {
+        self.do_confirm_published_with_fanout(pending, None).await
+    }
+
+    pub(crate) async fn do_confirm_published_with_fanout(
+        &mut self,
+        pending: PendingStateRef,
+        mut fanout: Option<&mut OutboundFanout>,
+    ) -> Result<GroupEvent, EngineError> {
+        let confirmed_fanout = fanout
+            .as_deref()
+            .map(|fanout| {
+                if fanout.pending_ref() != Some(pending) || fanout.outcome().accepted_targets == 0 {
+                    return Err(EngineError::Other(
+                        "fanout does not contain an accepted matching pending publish".into(),
+                    ));
+                }
+                let mut confirmed = fanout.clone();
+                confirmed.mark_mls_confirmed().map_err(|_| {
+                    EngineError::Other("fanout MLS confirmation transition failed".into())
+                })?;
+                Ok(confirmed)
+            })
+            .transpose()?;
         // Look up which group this pending belongs to without consuming the
         // entry — we need the MlsGroup load to succeed before we burn the
         // state-machine slot.
@@ -161,6 +185,9 @@ impl<S: StorageProvider> Engine<S> {
                 if let Some((_, intent_id)) = queued_intent.as_ref() {
                     storage.delete_queued_outbound_intent(intent_id)?;
                 }
+                if let Some(fanout) = confirmed_fanout.as_ref() {
+                    storage.put_outbound_fanout(fanout)?;
+                }
                 Ok(())
             })?;
 
@@ -178,6 +205,9 @@ impl<S: StorageProvider> Engine<S> {
         // backend) plus best-effort cleanup. Kind discriminates create (always
         // `GroupCreated`) from evolution (always `EpochChanged`).
         let (group_id, new_epoch) = self.epoch_manager.confirm_publish(pending)?;
+        if let (Some(fanout), Some(confirmed)) = (fanout.take(), confirmed_fanout) {
+            *fanout = confirmed;
+        }
         self.queued_intent_by_pending.remove(&pending);
         self.audit_with_context(
             Some(&group_id),
@@ -263,6 +293,14 @@ impl<S: StorageProvider> Engine<S> {
         &mut self,
         pending: PendingStateRef,
     ) -> Result<(), EngineError> {
+        self.do_publish_failed_with_fanout(pending, None).await
+    }
+
+    pub(crate) async fn do_publish_failed_with_fanout(
+        &mut self,
+        pending: PendingStateRef,
+        mut fanout: Option<&mut OutboundFanout>,
+    ) -> Result<(), EngineError> {
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
 
         let group_id = self
@@ -275,30 +313,53 @@ impl<S: StorageProvider> Engine<S> {
             .map_err(|e| EngineError::Backend(format!("load: {e:?}")))?
             .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
 
-        if mls_group.pending_commit().is_some() {
-            self.storage.with_transaction(|storage| {
-                let tx_provider =
-                    EngineOpenMlsProvider::<S>::new(&self.crypto, storage.mls_storage());
-                mls_group
-                    .clear_pending_commit(tx_provider.storage())
-                    .map_err(|e| EngineError::Backend(format!("clear_pending: {e:?}")))
-            })?;
-        }
+        let rolled_back_fanout = fanout
+            .as_deref()
+            .map(|fanout| {
+                let outcome = fanout.outcome();
+                if fanout.pending_ref() != Some(pending)
+                    || outcome.accepted_targets != 0
+                    || !outcome.fanout_complete
+                {
+                    return Err(EngineError::Other(
+                        "fanout is not a complete all-failed matching pending publish".into(),
+                    ));
+                }
+                let mut rolled_back = fanout.clone();
+                rolled_back.mark_mls_rolled_back().map_err(|_| {
+                    EngineError::Other("fanout MLS rollback transition failed".into())
+                })?;
+                Ok(rolled_back)
+            })
+            .transpose()?;
 
-        // Roll back the Marmot record's projected fields. The send paths
-        // wrote a projected `members` list (+ for upgrade, projected
-        // `required_capabilities`); after `clear_pending_commit` the MLS
-        // group is back to its pre-stage shape, so re-deriving from MLS
-        // restores the prior projection. The capability cache for newly-
-        // invited members stays — it's not visible via `members()` once
-        // we drop them from the Marmot record, and the next successful
-        // invite simply overwrites.
-        if let Ok(mut g) = self.storage.get_group(&group_id) {
-            g.epoch = EpochId(mls_group.epoch().as_u64());
-            g.members = crate::group_lifecycle::marmot_members(&mls_group);
-            g.required_capabilities = required_capabilities_from_group(&mls_group);
-            crate::group_lifecycle::mirror_app_components_into_record(&mls_group, &mut g);
-            self.storage.put_group(&g)?;
+        let has_pending_commit = mls_group.pending_commit().is_some();
+        self.storage
+            .with_transaction(|storage| -> Result<(), EngineError> {
+                if has_pending_commit {
+                    let tx_provider =
+                        EngineOpenMlsProvider::<S>::new(&self.crypto, storage.mls_storage());
+                    mls_group
+                        .clear_pending_commit(tx_provider.storage())
+                        .map_err(|e| EngineError::Backend(format!("clear_pending: {e:?}")))?;
+                }
+
+                // Re-derive the Marmot projection in the same durable unit as the
+                // MLS clear and fanout terminal state.
+                let mut g = storage.get_group(&group_id)?;
+                g.epoch = EpochId(mls_group.epoch().as_u64());
+                g.members = crate::group_lifecycle::marmot_members(&mls_group);
+                g.required_capabilities = required_capabilities_from_group(&mls_group);
+                crate::group_lifecycle::mirror_app_components_into_record(&mls_group, &mut g);
+                storage.put_group(&g)?;
+                if let Some(fanout) = rolled_back_fanout.as_ref() {
+                    storage.put_outbound_fanout(fanout)?;
+                }
+                Ok(())
+            })?;
+
+        if let (Some(fanout), Some(rolled_back)) = (fanout.take(), rolled_back_fanout) {
+            *fanout = rolled_back;
         }
 
         let kind = self

--- a/crates/cgka-engine/tests/auto_commit_atomicity.rs
+++ b/crates/cgka-engine/tests/auto_commit_atomicity.rs
@@ -30,9 +30,9 @@ use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
     ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage, LeaveRequest,
-    MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage, OutboundIntentStorage,
-    QueuedOutboundIntent, StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle,
-    WelcomeStorage,
+    LeaveRequestStorage, MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage,
+    OutboundIntentStorage, QueuedOutboundIntent, StorageError, StorageProvider, StorageResult,
+    StoredKeyPackageBundle, WelcomeStorage,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,

--- a/crates/cgka-engine/tests/auto_commit_atomicity.rs
+++ b/crates/cgka-engine/tests/auto_commit_atomicity.rs
@@ -16,6 +16,7 @@
 use async_trait::async_trait;
 use cgka_engine::EngineBuilder;
 use cgka_engine::feature_registry::FeatureRegistry;
+use cgka_traits::OutboundFanout;
 use cgka_traits::capabilities::{
     Capability, CapabilityRequirement, Feature, GroupCapabilities, RequirementLevel,
 };
@@ -29,7 +30,7 @@ use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
     ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage, LeaveRequest,
-    LeaveRequestStorage, MemberValidationCacheStorage, MessageStorage, OutboundIntentStorage,
+    MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage, OutboundIntentStorage,
     QueuedOutboundIntent, StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle,
     WelcomeStorage,
 };
@@ -247,6 +248,27 @@ impl OutboundIntentStorage for FaultStorage {
     }
     fn delete_queued_outbound_intent(&self, id: &MessageId) -> StorageResult<()> {
         self.inner.delete_queued_outbound_intent(id)
+    }
+}
+
+impl OutboundFanoutStorage for FaultStorage {
+    fn put_outbound_fanout(&self, fanout: &OutboundFanout) -> StorageResult<()> {
+        self.inner.put_outbound_fanout(fanout)
+    }
+    fn outbound_fanout(&self, id: &MessageId) -> StorageResult<Option<OutboundFanout>> {
+        self.inner.outbound_fanout(id)
+    }
+    fn list_outbound_fanouts(&self) -> StorageResult<Vec<OutboundFanout>> {
+        self.inner.list_outbound_fanouts()
+    }
+    fn list_outbound_fanouts_for_group(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Vec<OutboundFanout>> {
+        self.inner.list_outbound_fanouts_for_group(group_id)
+    }
+    fn delete_outbound_fanout(&self, id: &MessageId) -> StorageResult<()> {
+        self.inner.delete_outbound_fanout(id)
     }
 }
 

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -1,10 +1,9 @@
 use async_trait::async_trait;
 use cgka_engine::{Engine, EngineBuilder};
-use cgka_traits::Backend;
-use cgka_traits::OutboundFanout;
 use cgka_traits::capabilities::{CapabilityRequirement, Feature, GroupCapabilities};
 use cgka_traits::engine::{
-    CgkaEngine, CreateGroupRequest, GroupEvent, GroupHydrationQuarantineReason, SendResult,
+    CgkaEngine, CreateGroupRequest, GroupEvent, GroupHydrationQuarantineReason, SendIntent,
+    SendResult,
 };
 use cgka_traits::error::{EngineError, PeelerError};
 use cgka_traits::group::{Group, Member};
@@ -24,6 +23,9 @@ use cgka_traits::transport::{
 };
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use cgka_traits::welcome::PendingWelcome;
+use cgka_traits::{
+    Backend, OutboundFanout, TransportEndpoint, TransportPublishRequest, TransportPublishTarget,
+};
 use marmot_forensics::{AuditEvent, AuditEventKind, JsonlRecorder};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -337,6 +339,7 @@ async fn hydration_quarantines_first_bad_group_and_continues_to_later_healthy_gr
 struct FlakyGroupRecordStorage {
     inner: SqliteAccountStorage,
     fail_get_group: Arc<AtomicBool>,
+    fail_list_queued_outbound_intents: Arc<AtomicBool>,
 }
 
 impl FlakyGroupRecordStorage {
@@ -344,11 +347,17 @@ impl FlakyGroupRecordStorage {
         Self {
             inner,
             fail_get_group: Arc::new(AtomicBool::new(false)),
+            fail_list_queued_outbound_intents: Arc::new(AtomicBool::new(false)),
         }
     }
 
     fn set_fail_get_group(&self, fail: bool) {
         self.fail_get_group.store(fail, Ordering::SeqCst);
+    }
+
+    fn set_fail_list_queued_outbound_intents(&self, fail: bool) {
+        self.fail_list_queued_outbound_intents
+            .store(fail, Ordering::SeqCst);
     }
 }
 
@@ -415,6 +424,14 @@ impl OutboundIntentStorage for FlakyGroupRecordStorage {
         &self,
         group_id: &GroupId,
     ) -> StorageResult<Vec<QueuedOutboundIntent>> {
+        if self
+            .fail_list_queued_outbound_intents
+            .load(Ordering::SeqCst)
+        {
+            return Err(StorageError::Backend(
+                "injected queued-outbound-intent list failure".into(),
+            ));
+        }
         self.inner.list_queued_outbound_intents(group_id)
     }
     fn delete_queued_outbound_intent(&self, id: &MessageId) -> StorageResult<()> {
@@ -712,6 +729,128 @@ async fn retry_recovers_a_transiently_quarantined_group() {
         )),
         "recovery event missing or carried the wrong epoch (expected {group_epoch:?}): {events:?}"
     );
+}
+
+#[tokio::test]
+async fn pending_fanout_is_not_exposed_until_hydration_fully_succeeds() {
+    let storage = FlakyGroupRecordStorage::new(SqliteAccountStorage::in_memory().expect("storage"));
+    let mut initial = build_flaky_engine(storage.clone());
+    let group_id = create_confirmed_group_flaky(&mut initial).await;
+    let baseline_epoch = initial.epoch(&group_id).unwrap();
+    let staged = initial
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("pending fanout".into()),
+            description: None,
+        })
+        .await
+        .expect("stage update");
+    let (message, pending) = match staged {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected group evolution, got {other:?}"),
+    };
+    let transport_group_id = match &message.envelope {
+        TransportEnvelope::GroupMessage { transport_group_id } => transport_group_id.clone(),
+        other => panic!("expected group message, got {other:?}"),
+    };
+    let fanout = OutboundFanout::stage(
+        TransportPublishRequest {
+            account_id: initial.self_id(),
+            message,
+            target: TransportPublishTarget::Group {
+                group_id: group_id.clone(),
+                transport_group_id,
+                endpoints: vec![TransportEndpoint("wss://hydrate.example".into())],
+            },
+            required_acks: 1,
+        },
+        Some(pending),
+        Some(group_id.clone()),
+        0,
+    )
+    .expect("stage frozen fanout");
+    initial
+        .put_outbound_fanout(&fanout)
+        .expect("persist frozen fanout");
+    drop(initial);
+
+    // Fail after the durable pending candidate has been fully validated. The
+    // group is quarantined, but no pending lifecycle may escape into memory.
+    storage.set_fail_list_queued_outbound_intents(true);
+    let mut reopened = build_flaky_engine(storage.clone());
+    reopened
+        .hydrate_stable_groups_from_storage()
+        .expect("per-group failure is quarantined");
+    assert!(matches!(
+        reopened.quarantined_groups().as_slice(),
+        [(id, GroupHydrationQuarantineReason::GroupRecordLoadFailed)] if id == &group_id
+    ));
+    assert!(
+        reopened.outbound_fanouts().unwrap().is_empty(),
+        "runtime fanout resumption must hide quarantined groups"
+    );
+    assert_eq!(
+        storage.list_outbound_fanouts().unwrap().len(),
+        1,
+        "quarantine must retain the durable fanout for a later retry"
+    );
+    assert!(matches!(
+        reopened.put_outbound_fanout(&fanout),
+        Err(EngineError::UnknownGroup(id)) if id == group_id
+    ));
+    assert!(matches!(
+        reopened.delete_outbound_fanout(fanout.message_id()),
+        Err(EngineError::UnknownGroup(id)) if id == group_id
+    ));
+    let mut confirm_candidate = fanout.clone();
+    assert!(matches!(
+        reopened
+            .confirm_published_fanout(pending, &mut confirm_candidate)
+            .await,
+        Err(EngineError::UnknownGroup(id)) if id == group_id
+    ));
+    let mut rollback_candidate = fanout.clone();
+    assert!(matches!(
+        reopened
+            .publish_failed_fanout(pending, &mut rollback_candidate)
+            .await,
+        Err(EngineError::UnknownGroup(id)) if id == group_id
+    ));
+
+    // A clean retry restores the pending lifecycle exactly once. This would
+    // fail if the first hydration had already registered it before the later
+    // storage read failed.
+    storage.set_fail_list_queued_outbound_intents(false);
+    assert!(
+        reopened
+            .retry_hydrate_quarantined_group(&group_id)
+            .expect("retry hydration"),
+        "healthy retry must recover the quarantined group"
+    );
+    assert_eq!(reopened.pending_group_id(pending).unwrap(), group_id);
+    let mut recovered_fanout = reopened
+        .outbound_fanouts()
+        .unwrap()
+        .into_iter()
+        .next()
+        .expect("recovered durable fanout");
+    recovered_fanout
+        .mark_attempt_started(0)
+        .expect("start recovered attempt");
+    reopened
+        .put_outbound_fanout(&recovered_fanout)
+        .expect("persist recovered attempt");
+    recovered_fanout
+        .mark_target_failed(0)
+        .expect("fail recovered attempt");
+    reopened
+        .put_outbound_fanout(&recovered_fanout)
+        .expect("persist recovered failure");
+    reopened
+        .publish_failed_fanout(pending, &mut recovered_fanout)
+        .await
+        .expect("recovered pending can roll back");
+    assert_eq!(reopened.epoch(&group_id).unwrap(), baseline_epoch);
 }
 
 #[tokio::test]

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use cgka_engine::{Engine, EngineBuilder};
 use cgka_traits::Backend;
+use cgka_traits::OutboundFanout;
 use cgka_traits::capabilities::{CapabilityRequirement, Feature, GroupCapabilities};
 use cgka_traits::engine::{
     CgkaEngine, CreateGroupRequest, GroupEvent, GroupHydrationQuarantineReason, SendResult,
@@ -14,7 +15,7 @@ use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
     ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage, LeaveRequest,
-    LeaveRequestStorage, MemberValidationCacheStorage, MessageStorage, OutboundIntentStorage,
+    MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage, OutboundIntentStorage,
     QueuedOutboundIntent, StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle,
     WelcomeStorage,
 };
@@ -418,6 +419,27 @@ impl OutboundIntentStorage for FlakyGroupRecordStorage {
     }
     fn delete_queued_outbound_intent(&self, id: &MessageId) -> StorageResult<()> {
         self.inner.delete_queued_outbound_intent(id)
+    }
+}
+
+impl OutboundFanoutStorage for FlakyGroupRecordStorage {
+    fn put_outbound_fanout(&self, fanout: &OutboundFanout) -> StorageResult<()> {
+        self.inner.put_outbound_fanout(fanout)
+    }
+    fn outbound_fanout(&self, id: &MessageId) -> StorageResult<Option<OutboundFanout>> {
+        self.inner.outbound_fanout(id)
+    }
+    fn list_outbound_fanouts(&self) -> StorageResult<Vec<OutboundFanout>> {
+        self.inner.list_outbound_fanouts()
+    }
+    fn list_outbound_fanouts_for_group(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Vec<OutboundFanout>> {
+        self.inner.list_outbound_fanouts_for_group(group_id)
+    }
+    fn delete_outbound_fanout(&self, id: &MessageId) -> StorageResult<()> {
+        self.inner.delete_outbound_fanout(id)
     }
 }
 

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -15,9 +15,9 @@ use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
     ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage, LeaveRequest,
-    MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage, OutboundIntentStorage,
-    QueuedOutboundIntent, StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle,
-    WelcomeStorage,
+    LeaveRequestStorage, MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage,
+    OutboundIntentStorage, QueuedOutboundIntent, StorageError, StorageProvider, StorageResult,
+    StoredKeyPackageBundle, WelcomeStorage,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -18,6 +18,7 @@ use cgka_engine::canonicalization::CanonicalizationPolicy;
 use cgka_engine::convergence::ConvergencePolicy;
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_traits::EngineError;
+use cgka_traits::OutboundFanout;
 use cgka_traits::capabilities::GroupCapabilities;
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult};
@@ -30,7 +31,7 @@ use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
     ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage, LeaveRequest,
-    LeaveRequestStorage, MemberValidationCacheStorage, MessageStorage, OutboundIntentStorage,
+    MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage, OutboundIntentStorage,
     QueuedOutboundIntent, StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle,
     WelcomeStorage,
 };
@@ -881,6 +882,27 @@ impl OutboundIntentStorage for FaultStorage {
     }
     fn delete_queued_outbound_intent(&self, id: &MessageId) -> StorageResult<()> {
         self.inner.delete_queued_outbound_intent(id)
+    }
+}
+
+impl OutboundFanoutStorage for FaultStorage {
+    fn put_outbound_fanout(&self, fanout: &OutboundFanout) -> StorageResult<()> {
+        self.inner.put_outbound_fanout(fanout)
+    }
+    fn outbound_fanout(&self, id: &MessageId) -> StorageResult<Option<OutboundFanout>> {
+        self.inner.outbound_fanout(id)
+    }
+    fn list_outbound_fanouts(&self) -> StorageResult<Vec<OutboundFanout>> {
+        self.inner.list_outbound_fanouts()
+    }
+    fn list_outbound_fanouts_for_group(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Vec<OutboundFanout>> {
+        self.inner.list_outbound_fanouts_for_group(group_id)
+    }
+    fn delete_outbound_fanout(&self, id: &MessageId) -> StorageResult<()> {
+        self.inner.delete_outbound_fanout(id)
     }
 }
 

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -31,9 +31,9 @@ use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
     ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage, LeaveRequest,
-    MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage, OutboundIntentStorage,
-    QueuedOutboundIntent, StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle,
-    WelcomeStorage,
+    LeaveRequestStorage, MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage,
+    OutboundIntentStorage, QueuedOutboundIntent, StorageError, StorageProvider, StorageResult,
+    StoredKeyPackageBundle, WelcomeStorage,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -25,7 +25,7 @@ use cgka_traits::storage::StorageError;
 use cgka_traits::transport::TransportMessage;
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use cgka_traits::{
-    SecretBytes, TransportDelivery, TransportDeliveryPlane, TransportDeliverySource,
+    OutboundFanout, SecretBytes, TransportDelivery, TransportDeliveryPlane, TransportDeliverySource,
 };
 use marmot_forensics::{
     AuditEventContext, AuditEventKind, AuditTransportContext, AuditTransportWire, ForensicRecorder,
@@ -665,6 +665,22 @@ impl AccountDeviceSession {
         Ok(effects)
     }
 
+    pub async fn confirm_published_fanout(
+        &mut self,
+        pending: PendingStateRef,
+        fanout: &mut OutboundFanout,
+    ) -> SessionResult<SessionEffects> {
+        let event = self
+            .engine
+            .confirm_published_fanout(pending, fanout)
+            .await?;
+        let mut effects = self.collect_effects(vec![]);
+        if !effects.events.contains(&event) {
+            effects.events.insert(0, event);
+        }
+        Ok(effects)
+    }
+
     pub async fn publish_failed(
         &mut self,
         pending: PendingStateRef,
@@ -683,6 +699,15 @@ impl AccountDeviceSession {
         Ok(self.collect_effects(vec![]))
     }
 
+    pub async fn publish_failed_fanout(
+        &mut self,
+        pending: PendingStateRef,
+        fanout: &mut OutboundFanout,
+    ) -> SessionResult<SessionEffects> {
+        self.engine.publish_failed_fanout(pending, fanout).await?;
+        Ok(self.collect_effects(vec![]))
+    }
+
     pub fn drain(&mut self) -> SessionEffects {
         tracing::trace!(
             target: TRACE_TARGET,
@@ -694,6 +719,24 @@ impl AccountDeviceSession {
 
     pub fn epoch(&self, group_id: &GroupId) -> Result<EpochId, EngineError> {
         self.engine.epoch(group_id)
+    }
+
+    pub fn put_outbound_fanout(&self, fanout: &OutboundFanout) -> SessionResult<()> {
+        self.engine.put_outbound_fanout(fanout)?;
+        Ok(())
+    }
+
+    pub fn outbound_fanouts(&self) -> SessionResult<Vec<OutboundFanout>> {
+        Ok(self.engine.outbound_fanouts()?)
+    }
+
+    pub fn delete_outbound_fanout(&self, message_id: &MessageId) -> SessionResult<()> {
+        self.engine.delete_outbound_fanout(message_id)?;
+        Ok(())
+    }
+
+    pub fn pending_group_id(&self, pending: PendingStateRef) -> SessionResult<GroupId> {
+        Ok(self.engine.pending_group_id(pending)?)
     }
 
     pub fn members(&self, group_id: &GroupId) -> Result<Vec<Member>, EngineError> {

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -431,9 +431,9 @@ where
                     retention,
                 } => {
                     let reports_before = output.reports.len();
-                    let status = self
-                        .publish_one(msg, None, output, queue, context.clone())
-                        .await?;
+                    let status =
+                        Box::pin(self.publish_one(msg, None, output, queue, context.clone()))
+                            .await?;
                     if status.accepted_by_any_endpoint {
                         if let Some(message_id) = output
                             .reports
@@ -461,14 +461,20 @@ where
                     self.resolve_regenerated_queued_intent(queued_intent, status);
                 }
                 PublishWork::Proposal { msg, queued_intent } => {
-                    let status = self
-                        .publish_one(msg, None, output, queue, context.clone())
-                        .await?;
+                    let status =
+                        Box::pin(self.publish_one(msg, None, output, queue, context.clone()))
+                            .await?;
                     self.resolve_regenerated_queued_intent(queued_intent, status);
                 }
                 PublishWork::GroupCreated { welcomes, pending } => {
-                    self.publish_group_created(welcomes, pending, output, queue, context.clone())
-                        .await?;
+                    Box::pin(self.publish_group_created(
+                        welcomes,
+                        pending,
+                        output,
+                        queue,
+                        context.clone(),
+                    ))
+                    .await?;
                 }
                 PublishWork::FoundingGroupCreated { welcomes } => {
                     self.publish_founding_group_created(welcomes, output, queue, context.clone())
@@ -479,14 +485,14 @@ where
                     welcomes,
                     pending,
                 } => {
-                    self.publish_group_evolution(
+                    Box::pin(self.publish_group_evolution(
                         msg,
                         welcomes,
                         pending,
                         output,
                         queue,
                         context.clone(),
-                    )
+                    ))
                     .await?;
                 }
                 PublishWork::AutoPublish { msg, pending } => {
@@ -508,8 +514,7 @@ where
             if outcome.outstanding_targets > 0
                 || matches!(fanout.mls_state(), FanoutMlsState::Pending(_))
             {
-                self.drive_outbound_fanout(fanout, &mut output, &mut queue, None)
-                    .await?;
+                Box::pin(self.drive_outbound_fanout(fanout, &mut output, &mut queue, None)).await?;
             } else {
                 self.session.delete_outbound_fanout(fanout.message_id())?;
             }
@@ -630,8 +635,7 @@ where
             return Ok(());
         };
         debug_assert!(messages.next().is_none());
-        self.publish_one(message, Some(pending), output, queue, context)
-            .await?;
+        Box::pin(self.publish_one(message, Some(pending), output, queue, context)).await?;
         Ok(())
     }
 
@@ -651,9 +655,8 @@ where
             let recipient = welcome_recipient(&welcome);
             let welcome_id = welcome.id.clone();
             let failures_before = output.failures.len();
-            let status = self
-                .publish_one(welcome, None, output, queue, context.clone())
-                .await?;
+            let status =
+                Box::pin(self.publish_one(welcome, None, output, queue, context.clone())).await?;
             any_welcome_exposed |= status.accepted_by_any_endpoint;
             if status.met_required_acks {
                 delivered_welcome_ids.push(welcome_id);
@@ -745,18 +748,18 @@ where
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
     ) -> AccountResult<()> {
-        let commit_status = self
-            .publish_one(commit, Some(pending), output, queue, context.clone())
-            .await?;
+        let commit_status =
+            Box::pin(self.publish_one(commit, Some(pending), output, queue, context.clone()))
+                .await?;
         if commit_status.accepted_by_any_endpoint {
             let group_id = confirmed_group_id_from_events(&output.events);
             for welcome in welcomes {
                 let recipient = welcome_recipient(&welcome);
                 let welcome_id = welcome.id.clone();
                 let failures_before = output.failures.len();
-                let status = self
-                    .publish_one(welcome, None, output, queue, context.clone())
-                    .await?;
+                let status =
+                    Box::pin(self.publish_one(welcome, None, output, queue, context.clone()))
+                        .await?;
                 if status.met_required_acks {
                     self.mark_welcome_delivered_best_effort(&welcome_id);
                 } else {
@@ -797,9 +800,8 @@ where
         let mut output = AccountDeviceEffects::default();
         let mut queue = VecDeque::new();
         let failures_before = output.failures.len();
-        let status = self
-            .publish_one(message, None, &mut output, &mut queue, None)
-            .await?;
+        let status =
+            Box::pin(self.publish_one(message, None, &mut output, &mut queue, None)).await?;
         if status.met_required_acks {
             self.mark_welcome_delivered_best_effort(message_id);
         } else if let Some(recipient) = recipient {
@@ -917,8 +919,7 @@ where
                 0,
             )?;
             self.session.put_outbound_fanout(&fanout)?;
-            self.drive_outbound_fanout(fanout, output, queue, context)
-                .await
+            Box::pin(self.drive_outbound_fanout(fanout, output, queue, context)).await
         } else {
             self.publish_legacy_one(message, output, context).await
         }

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -16,8 +16,10 @@ use cgka_traits::group::{Group, Member};
 use cgka_traits::ingest::IngestOutcome;
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::{
-    EpochId, GroupId, MemberId, Timestamp, TransportAccountActivation, TransportAdapter,
-    TransportDelivery, TransportGroupSync, TransportPublishReport, TransportPublishRequest,
+    EpochId, FanoutMlsState, GroupId, MemberId, OutboundFanout, OutboundFanoutOutcome, Timestamp,
+    TransportAccountActivation, TransportAdapter, TransportDelivery, TransportEndpoint,
+    TransportEndpointFailure, TransportEndpointReceipt, TransportGroupSync, TransportPublishReport,
+    TransportPublishRequest, TransportPublishTarget,
 };
 use marmot_forensics::{
     AuditEventContext, AuditEventKind, AuditTransportWire, MessageArtifactKind, PublishRelayFailure,
@@ -374,7 +376,10 @@ where
     /// work the same way `ingest_delivery` does.
     pub async fn drain(&mut self) -> AccountResult<AccountDeviceEffects> {
         let effects = self.session.drain();
-        self.publish_session_effects(effects).await
+        let mut output = self.publish_session_effects(effects).await?;
+        let resumed = self.resume_outbound_fanouts().await?;
+        output.extend(resumed);
+        Ok(output)
     }
 
     pub async fn ingest_delivery(
@@ -405,7 +410,16 @@ where
         let mut output = AccountDeviceEffects::default();
         let mut queue = VecDeque::new();
         output.absorb_session_effects(effects, &mut queue);
+        self.publish_queue(&mut output, &mut queue, context).await?;
+        Ok(output)
+    }
 
+    async fn publish_queue(
+        &mut self,
+        output: &mut AccountDeviceEffects,
+        queue: &mut VecDeque<PublishWork>,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<()> {
         while let Some(work) = queue.pop_front() {
             match work {
                 PublishWork::ApplicationMessage {
@@ -417,7 +431,9 @@ where
                     retention,
                 } => {
                     let reports_before = output.reports.len();
-                    let status = self.publish_one(msg, &mut output, context.clone()).await?;
+                    let status = self
+                        .publish_one(msg, None, output, queue, context.clone())
+                        .await?;
                     if status.accepted_by_any_endpoint {
                         if let Some(message_id) = output
                             .reports
@@ -445,21 +461,17 @@ where
                     self.resolve_regenerated_queued_intent(queued_intent, status);
                 }
                 PublishWork::Proposal { msg, queued_intent } => {
-                    let status = self.publish_one(msg, &mut output, context.clone()).await?;
+                    let status = self
+                        .publish_one(msg, None, output, queue, context.clone())
+                        .await?;
                     self.resolve_regenerated_queued_intent(queued_intent, status);
                 }
                 PublishWork::GroupCreated { welcomes, pending } => {
-                    self.publish_group_created(
-                        welcomes,
-                        pending,
-                        &mut output,
-                        &mut queue,
-                        context.clone(),
-                    )
-                    .await?;
+                    self.publish_group_created(welcomes, pending, output, queue, context.clone())
+                        .await?;
                 }
                 PublishWork::FoundingGroupCreated { welcomes } => {
-                    self.publish_founding_group_created(welcomes, &mut output, context.clone())
+                    self.publish_founding_group_created(welcomes, output, queue, context.clone())
                         .await?;
                 }
                 PublishWork::GroupEvolution {
@@ -471,25 +483,38 @@ where
                         msg,
                         welcomes,
                         pending,
-                        &mut output,
-                        &mut queue,
+                        output,
+                        queue,
                         context.clone(),
                     )
                     .await?;
                 }
                 PublishWork::AutoPublish { msg, pending } => {
-                    self.publish_pending(
-                        vec![msg],
-                        pending,
-                        &mut output,
-                        &mut queue,
-                        context.clone(),
-                    )
-                    .await?;
+                    self.publish_pending(vec![msg], pending, output, queue, context.clone())
+                        .await?;
                 }
             }
         }
+        Ok(())
+    }
 
+    /// Resume every incomplete frozen fanout in original staging order.
+    pub async fn resume_outbound_fanouts(&mut self) -> AccountResult<AccountDeviceEffects> {
+        let fanouts = self.session.outbound_fanouts()?;
+        let mut output = AccountDeviceEffects::default();
+        let mut queue = VecDeque::new();
+        for fanout in fanouts {
+            let outcome = fanout.outcome();
+            if outcome.outstanding_targets > 0
+                || matches!(fanout.mls_state(), FanoutMlsState::Pending(_))
+            {
+                self.drive_outbound_fanout(fanout, &mut output, &mut queue, None)
+                    .await?;
+            } else {
+                self.session.delete_outbound_fanout(fanout.message_id())?;
+            }
+        }
+        self.publish_queue(&mut output, &mut queue, None).await?;
         Ok(output)
     }
 
@@ -560,6 +585,30 @@ where
         }
     }
 
+    async fn confirm_published_fanout_retrying(
+        &mut self,
+        pending: PendingStateRef,
+        fanout: &mut OutboundFanout,
+    ) -> AccountResult<SessionEffects> {
+        const MAX_CONFIRM_ATTEMPTS: u32 = 4;
+        let mut attempt = 0;
+        loop {
+            match self.session.confirm_published_fanout(pending, fanout).await {
+                Ok(effects) => return Ok(effects),
+                Err(e) if e.is_transient() && attempt + 1 < MAX_CONFIRM_ATTEMPTS => {
+                    attempt += 1;
+                    tracing::warn!(
+                        target: TRACE_TARGET,
+                        method = "confirm_published_fanout_retrying",
+                        attempt,
+                        "fanout confirm hit a transient backend lock; retrying"
+                    );
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+
     async fn publish_pending(
         &mut self,
         messages: Vec<TransportMessage>,
@@ -568,35 +617,21 @@ where
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
     ) -> AccountResult<()> {
-        // Mirror `publish_group_created`'s exposure-aware resolution
-        // (mdk#483): a message that any endpoint accepted has already
-        // propagated to peers, so rolling it back here would leave the sender's
-        // row falsely `local_publish_failed` while recipients have the message —
-        // a resend then produces a real in-group duplicate, and convergence
-        // retry is a no-op because the commit was rolled back. Treat unreached
-        // endpoints as recoverable: confirm/keep when at least one endpoint
-        // accepted, and roll back only when nothing was accepted at all.
-        let mut all_published = true;
-        let mut any_accepted = false;
-        for message in messages {
-            let status = self.publish_one(message, output, context.clone()).await?;
-            any_accepted |= status.accepted_by_any_endpoint;
-            all_published &= status.met_required_acks;
-        }
-
-        if all_published || any_accepted {
-            let effects = self.confirm_published_retrying(pending).await?;
-            output
-                .pending
-                .push(PendingResolution::Confirmed { pending });
-            output.absorb_session_effects(effects, queue);
-        } else {
+        // A pending MLS state has one frozen group-message artifact. Its first
+        // relay acknowledgement releases MLS inside `drive_outbound_fanout`;
+        // remaining targets continue as an independent durable obligation.
+        let mut messages = messages.into_iter();
+        let Some(message) = messages.next() else {
             let effects = self.session.publish_failed(pending).await?;
             output
                 .pending
                 .push(PendingResolution::RolledBack { pending });
             output.absorb_session_effects(effects, queue);
-        }
+            return Ok(());
+        };
+        debug_assert!(messages.next().is_none());
+        self.publish_one(message, Some(pending), output, queue, context)
+            .await?;
         Ok(())
     }
 
@@ -616,7 +651,9 @@ where
             let recipient = welcome_recipient(&welcome);
             let welcome_id = welcome.id.clone();
             let failures_before = output.failures.len();
-            let status = self.publish_one(welcome, output, context.clone()).await?;
+            let status = self
+                .publish_one(welcome, None, output, queue, context.clone())
+                .await?;
             any_welcome_exposed |= status.accepted_by_any_endpoint;
             if status.met_required_acks {
                 delivered_welcome_ids.push(welcome_id);
@@ -670,6 +707,7 @@ where
         &mut self,
         welcomes: Vec<TransportMessage>,
         output: &mut AccountDeviceEffects,
+        queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
     ) -> AccountResult<()> {
         let group_id = output.events.iter().find_map(|event| match event {
@@ -680,7 +718,9 @@ where
             let recipient = welcome_recipient(&welcome);
             let welcome_id = welcome.id.clone();
             let failures_before = output.failures.len();
-            let status = self.publish_one(welcome, output, context.clone()).await?;
+            let status = self
+                .publish_one(welcome, None, output, queue, context.clone())
+                .await?;
             if status.met_required_acks {
                 self.mark_welcome_delivered_best_effort(&welcome_id);
             } else if let Some(recipient) = recipient {
@@ -705,24 +745,18 @@ where
         queue: &mut VecDeque<PublishWork>,
         context: Option<AuditEventContext>,
     ) -> AccountResult<()> {
-        let commit_status = self.publish_one(commit, output, context.clone()).await?;
-        if commit_status.met_required_acks || commit_status.accepted_by_any_endpoint {
-            // A commit accepted by any endpoint is externally visible even when
-            // it missed the policy ack threshold. Rolling it back would diverge
-            // the sender from peers that ingest it, so treat unreached endpoints
-            // as recoverable and proceed with welcome publication.
-            let effects = self.confirm_published_retrying(pending).await?;
-            let group_id = confirmed_group_id(&effects);
-            output
-                .pending
-                .push(PendingResolution::Confirmed { pending });
-            output.absorb_session_effects(effects, queue);
-
+        let commit_status = self
+            .publish_one(commit, Some(pending), output, queue, context.clone())
+            .await?;
+        if commit_status.accepted_by_any_endpoint {
+            let group_id = confirmed_group_id_from_events(&output.events);
             for welcome in welcomes {
                 let recipient = welcome_recipient(&welcome);
                 let welcome_id = welcome.id.clone();
                 let failures_before = output.failures.len();
-                let status = self.publish_one(welcome, output, context.clone()).await?;
+                let status = self
+                    .publish_one(welcome, None, output, queue, context.clone())
+                    .await?;
                 if status.met_required_acks {
                     self.mark_welcome_delivered_best_effort(&welcome_id);
                 } else {
@@ -740,12 +774,6 @@ where
                     }
                 }
             }
-        } else {
-            let effects = self.session.publish_failed(pending).await?;
-            output
-                .pending
-                .push(PendingResolution::RolledBack { pending });
-            output.absorb_session_effects(effects, queue);
         }
         Ok(())
     }
@@ -767,8 +795,11 @@ where
         // `stored_sent_welcome` only returns welcome envelopes.
         let recipient = welcome_recipient(&message);
         let mut output = AccountDeviceEffects::default();
+        let mut queue = VecDeque::new();
         let failures_before = output.failures.len();
-        let status = self.publish_one(message, &mut output, None).await?;
+        let status = self
+            .publish_one(message, None, &mut output, &mut queue, None)
+            .await?;
         if status.met_required_acks {
             self.mark_welcome_delivered_best_effort(message_id);
         } else if let Some(recipient) = recipient {
@@ -845,6 +876,167 @@ where
     }
 
     async fn publish_one(
+        &mut self,
+        message: TransportMessage,
+        pending: Option<PendingStateRef>,
+        output: &mut AccountDeviceEffects,
+        queue: &mut VecDeque<PublishWork>,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<PublishStatus> {
+        if matches!(message.envelope, TransportEnvelope::GroupMessage { .. }) {
+            let target = match self.routing.publish_target(&message) {
+                Ok(target) => target,
+                Err(error) => {
+                    output.failures.push(PublishFailure {
+                        message_id: message.id,
+                        reason: error.to_string(),
+                    });
+                    if let Some(pending) = pending {
+                        let effects = self.session.publish_failed(pending).await?;
+                        output
+                            .pending
+                            .push(PendingResolution::RolledBack { pending });
+                        output.absorb_session_effects(effects, queue);
+                    }
+                    return Ok(PublishStatus::default());
+                }
+            };
+            let required_acks = self.routing.required_acks(&target);
+            let pending_group_id = pending
+                .map(|pending| self.session.pending_group_id(pending))
+                .transpose()?;
+            let fanout = OutboundFanout::stage(
+                TransportPublishRequest {
+                    account_id: self.session.self_id(),
+                    message,
+                    target,
+                    required_acks,
+                },
+                pending,
+                pending_group_id,
+                0,
+            )?;
+            self.session.put_outbound_fanout(&fanout)?;
+            self.drive_outbound_fanout(fanout, output, queue, context)
+                .await
+        } else {
+            self.publish_legacy_one(message, output, context).await
+        }
+    }
+
+    async fn drive_outbound_fanout(
+        &mut self,
+        mut fanout: OutboundFanout,
+        output: &mut AccountDeviceEffects,
+        queue: &mut VecDeque<PublishWork>,
+        context: Option<AuditEventContext>,
+    ) -> AccountResult<PublishStatus> {
+        self.resolve_outbound_fanout_mls(&mut fanout, output, queue)
+            .await?;
+        let endpoints = fanout.request().target.endpoints().to_vec();
+        for index in fanout.outstanding_target_indexes() {
+            let endpoint = endpoints[index].clone();
+            fanout.mark_attempt_started(index)?;
+            self.session.put_outbound_fanout(&fanout)?;
+
+            let attempt = TransportPublishRequest {
+                account_id: fanout.request().account_id.clone(),
+                message: fanout.request().message.clone(),
+                target: single_endpoint_target(&fanout.request().target, endpoint.clone()),
+                required_acks: 1,
+            };
+            let accepted = match self.adapter.publish(attempt).await {
+                Ok(report) => {
+                    report.message_id == *fanout.message_id()
+                        && report
+                            .accepted
+                            .iter()
+                            .any(|receipt| receipt.endpoint == endpoint)
+                }
+                Err(_) => false,
+            };
+            if accepted {
+                fanout.mark_target_accepted(index)?;
+            } else {
+                fanout.mark_target_failed(index)?;
+            }
+            self.session.put_outbound_fanout(&fanout)?;
+            self.resolve_outbound_fanout_mls(&mut fanout, output, queue)
+                .await?;
+        }
+
+        let report = frozen_fanout_report(&fanout);
+        let status = PublishStatus {
+            met_required_acks: report.met_required_acks(),
+            accepted_by_any_endpoint: report.accepted_count() > 0,
+        };
+        if !status.met_required_acks {
+            output.failures.push(PublishFailure {
+                message_id: report.message_id.clone(),
+                reason: "insufficient publish acknowledgements".into(),
+            });
+        }
+        // `EpochConfirmed` / `EpochRolledBack` records the MLS edge. This
+        // endpoint-free publish row records the separate terminal fanout edge;
+        // relay URLs stay solely in the encrypted fanout record and never enter
+        // this privacy-safe audit summary.
+        self.session.record_audit_event(
+            fanout.group_id(),
+            context,
+            AuditEventKind::PublishOutcome {
+                msg_id: hex::encode(report.message_id.as_slice()),
+                artifact_kind: None,
+                target_kind: "frozen_group_fanout".into(),
+                relay_url: None,
+                accepted_relay_urls: Vec::new(),
+                failed_relays: Vec::new(),
+                required_acks: report.required_acks as u64,
+                met_required_acks: status.met_required_acks,
+                transport: Some(publish_wire_metadata(&fanout.request().message)),
+            },
+        );
+        output.reports.push(report);
+        output.fanout.push(fanout.outcome());
+        if fanout.outcome().fanout_complete
+            && !matches!(fanout.mls_state(), FanoutMlsState::Pending(_))
+        {
+            self.session.delete_outbound_fanout(fanout.message_id())?;
+        }
+        Ok(status)
+    }
+
+    async fn resolve_outbound_fanout_mls(
+        &mut self,
+        fanout: &mut OutboundFanout,
+        output: &mut AccountDeviceEffects,
+        queue: &mut VecDeque<PublishWork>,
+    ) -> AccountResult<()> {
+        let outcome = fanout.outcome();
+        if outcome.mls_confirmation_required {
+            let pending = fanout
+                .pending_ref()
+                .expect("confirmation-required fanout retains pending ref");
+            let effects = self
+                .confirm_published_fanout_retrying(pending, fanout)
+                .await?;
+            output
+                .pending
+                .push(PendingResolution::Confirmed { pending });
+            output.absorb_session_effects(effects, queue);
+        } else if outcome.fanout_complete
+            && outcome.accepted_targets == 0
+            && let Some(pending) = fanout.pending_ref()
+        {
+            let effects = self.session.publish_failed_fanout(pending, fanout).await?;
+            output
+                .pending
+                .push(PendingResolution::RolledBack { pending });
+            output.absorb_session_effects(effects, queue);
+        }
+        Ok(())
+    }
+
+    async fn publish_legacy_one(
         &self,
         message: TransportMessage,
         output: &mut AccountDeviceEffects,
@@ -1002,6 +1194,57 @@ where
     }
 }
 
+fn single_endpoint_target(
+    target: &TransportPublishTarget,
+    endpoint: TransportEndpoint,
+) -> TransportPublishTarget {
+    match target {
+        TransportPublishTarget::Group {
+            group_id,
+            transport_group_id,
+            ..
+        } => TransportPublishTarget::Group {
+            group_id: group_id.clone(),
+            transport_group_id: transport_group_id.clone(),
+            endpoints: vec![endpoint],
+        },
+        TransportPublishTarget::Inbox { recipient, .. } => TransportPublishTarget::Inbox {
+            recipient: recipient.clone(),
+            endpoints: vec![endpoint],
+        },
+    }
+}
+
+fn frozen_fanout_report(fanout: &OutboundFanout) -> TransportPublishReport {
+    let endpoints = fanout.request().target.endpoints();
+    let mut accepted = Vec::new();
+    let mut failed = Vec::new();
+    for (endpoint, status) in endpoints.iter().zip(fanout.target_statuses()) {
+        match status {
+            cgka_traits::FanoutTargetStatus::Accepted => {
+                accepted.push(TransportEndpointReceipt {
+                    endpoint: endpoint.clone(),
+                    accepted_at: None,
+                });
+            }
+            cgka_traits::FanoutTargetStatus::Failed => {
+                failed.push(TransportEndpointFailure {
+                    endpoint: endpoint.clone(),
+                    reason: "publish attempt failed".into(),
+                });
+            }
+            cgka_traits::FanoutTargetStatus::NotAttempted
+            | cgka_traits::FanoutTargetStatus::Attempting => {}
+        }
+    }
+    TransportPublishReport {
+        message_id: fanout.message_id().clone(),
+        accepted,
+        failed,
+        required_acks: fanout.request().required_acks,
+    }
+}
+
 /// The welcome recipient carried in the message's transport envelope, if the
 /// message is a welcome.
 fn welcome_recipient(message: &TransportMessage) -> Option<MemberId> {
@@ -1021,7 +1264,11 @@ fn welcome_recipient(message: &TransportMessage) -> Option<MemberId> {
 /// best-effort preserves the existing `WelcomeDeliveryFailure::group_id`
 /// contract without re-reading the durable sent-welcome record.
 fn confirmed_group_id(effects: &SessionEffects) -> Option<GroupId> {
-    effects.events.iter().find_map(|event| match event {
+    confirmed_group_id_from_events(&effects.events)
+}
+
+fn confirmed_group_id_from_events(events: &[GroupEvent]) -> Option<GroupId> {
+    events.iter().rev().find_map(|event| match event {
         GroupEvent::GroupCreated { group_id } | GroupEvent::EpochChanged { group_id, .. } => {
             Some(group_id.clone())
         }
@@ -1054,6 +1301,8 @@ pub struct AccountDeviceEffects {
     pub queued: Vec<QueuedIntentRef>,
     pub pending_convergence: Vec<GroupId>,
     pub reports: Vec<TransportPublishReport>,
+    /// Privacy-safe summaries separate MLS release from target fanout completion.
+    pub fanout: Vec<OutboundFanoutOutcome>,
     pub failures: Vec<PublishFailure>,
     /// Application messages accepted by at least one transport endpoint,
     /// carrying source-state metadata captured by the exact MLS encryption
@@ -1077,6 +1326,17 @@ pub struct PublishedApplicationMessage {
 }
 
 impl AccountDeviceEffects {
+    fn extend(&mut self, other: Self) {
+        self.events.extend(other.events);
+        self.queued.extend(other.queued);
+        self.pending_convergence.extend(other.pending_convergence);
+        self.reports.extend(other.reports);
+        self.fanout.extend(other.fanout);
+        self.failures.extend(other.failures);
+        self.welcome_failures.extend(other.welcome_failures);
+        self.pending.extend(other.pending);
+    }
+
     fn absorb_session_effects(
         &mut self,
         effects: SessionEffects,

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -948,11 +948,11 @@ where
             };
             let accepted = match self.adapter.publish(attempt).await {
                 Ok(report) => {
-                    report.message_id == *fanout.message_id()
-                        && report
-                            .accepted
-                            .iter()
-                            .any(|receipt| receipt.endpoint == endpoint)
+                    fanout.record_published_message_id(report.message_id)?;
+                    report
+                        .accepted
+                        .iter()
+                        .any(|receipt| receipt.endpoint == endpoint)
                 }
                 Err(_) => false,
             };
@@ -1239,7 +1239,10 @@ fn frozen_fanout_report(fanout: &OutboundFanout) -> TransportPublishReport {
         }
     }
     TransportPublishReport {
-        message_id: fanout.message_id().clone(),
+        message_id: fanout
+            .published_message_id()
+            .unwrap_or_else(|| fanout.message_id())
+            .clone(),
         accepted,
         failed,
         required_acks: fanout.request().required_acks,

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -893,21 +893,24 @@ where
                         message_id: message.id,
                         reason: error.to_string(),
                     });
-                    if let Some(pending) = pending {
-                        let effects = self.session.publish_failed(pending).await?;
-                        output
-                            .pending
-                            .push(PendingResolution::RolledBack { pending });
-                        output.absorb_session_effects(effects, queue);
-                    }
+                    self.rollback_unstaged_pending(pending, output, queue)
+                        .await?;
                     return Ok(PublishStatus::default());
                 }
             };
             let required_acks = self.routing.required_acks(&target);
-            let pending_group_id = pending
+            let pending_group_id = match pending
                 .map(|pending| self.session.pending_group_id(pending))
-                .transpose()?;
-            let fanout = OutboundFanout::stage(
+                .transpose()
+            {
+                Ok(group_id) => group_id,
+                Err(error) => {
+                    self.rollback_unstaged_pending(pending, output, queue)
+                        .await?;
+                    return Err(error.into());
+                }
+            };
+            let fanout = match OutboundFanout::stage(
                 TransportPublishRequest {
                     account_id: self.session.self_id(),
                     message,
@@ -917,12 +920,39 @@ where
                 pending,
                 pending_group_id,
                 0,
-            )?;
-            self.session.put_outbound_fanout(&fanout)?;
+            ) {
+                Ok(fanout) => fanout,
+                Err(error) => {
+                    self.rollback_unstaged_pending(pending, output, queue)
+                        .await?;
+                    return Err(error.into());
+                }
+            };
+            if let Err(error) = self.session.put_outbound_fanout(&fanout) {
+                self.rollback_unstaged_pending(pending, output, queue)
+                    .await?;
+                return Err(error.into());
+            }
             Box::pin(self.drive_outbound_fanout(fanout, output, queue, context)).await
         } else {
             self.publish_legacy_one(message, output, context).await
         }
+    }
+
+    async fn rollback_unstaged_pending(
+        &mut self,
+        pending: Option<PendingStateRef>,
+        output: &mut AccountDeviceEffects,
+        queue: &mut VecDeque<PublishWork>,
+    ) -> AccountResult<()> {
+        if let Some(pending) = pending {
+            let effects = self.session.publish_failed(pending).await?;
+            output
+                .pending
+                .push(PendingResolution::RolledBack { pending });
+            output.absorb_session_effects(effects, queue);
+        }
+        Ok(())
     }
 
     async fn drive_outbound_fanout(
@@ -1337,6 +1367,8 @@ impl AccountDeviceEffects {
         self.reports.extend(other.reports);
         self.fanout.extend(other.fanout);
         self.failures.extend(other.failures);
+        self.published_app_messages
+            .extend(other.published_app_messages);
         self.welcome_failures.extend(other.welcome_failures);
         self.pending.extend(other.pending);
     }
@@ -1385,4 +1417,35 @@ pub struct WelcomeDeliveryFailure {
 pub enum PendingResolution {
     Confirmed { pending: PendingStateRef },
     RolledBack { pending: PendingStateRef },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn published_message(id: u8) -> PublishedApplicationMessage {
+        PublishedApplicationMessage {
+            group_id: GroupId::new(vec![id]),
+            app_event_id: format!("event-{id}"),
+            message_id: cgka_traits::MessageId::new(vec![id]),
+            source_epoch: EpochId(u64::from(id)),
+            retention: cgka_traits::app_event::AppMessageRetentionDecision::new(10, 0),
+        }
+    }
+
+    #[test]
+    fn extending_effects_preserves_published_application_messages() {
+        let first = published_message(1);
+        let second = published_message(2);
+        let mut combined = AccountDeviceEffects {
+            published_app_messages: vec![first.clone()],
+            ..AccountDeviceEffects::default()
+        };
+        combined.extend(AccountDeviceEffects {
+            published_app_messages: vec![second.clone()],
+            ..AccountDeviceEffects::default()
+        });
+
+        assert_eq!(combined.published_app_messages, vec![first, second]);
+    }
 }

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -23,7 +23,7 @@ use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
 use cgka_traits::{
-    EpochId, FanoutMlsState, FanoutTargetStatus, MemberId, MessageId, OutboundFanout,
+    EpochId, FanoutMlsState, FanoutTargetStatus, GroupId, MemberId, MessageId, OutboundFanout,
     TransportAccountActivation, TransportAdapter, TransportAdapterError, TransportDelivery,
     TransportDeliveryPlane, TransportDeliverySource, TransportEndpoint, TransportEndpointReceipt,
     TransportGroupSync, TransportPublishReport, TransportPublishRequest, TransportPublishTarget,
@@ -31,6 +31,7 @@ use cgka_traits::{
 use marmot_account::{
     AccountDeviceRuntime, AccountError, KeyPackagePublication, KeyPackagePublishError,
     KeyPackagePublisher, PendingResolution, PublishedApplicationMessage, StaticTransportRouting,
+    TransportRoutingError, TransportRoutingPolicy,
 };
 use storage_sqlite::{SqlCipherKey, SqliteAccountStorage};
 
@@ -357,6 +358,47 @@ impl TransportAdapter for RecordingAdapter {
 
     async fn receive(&self) -> Result<Option<TransportDelivery>, TransportAdapterError> {
         Ok(None)
+    }
+}
+
+#[derive(Clone)]
+struct MismatchedPendingGroupRouting {
+    wrong_group_id: GroupId,
+    endpoint: TransportEndpoint,
+}
+
+impl TransportRoutingPolicy for MismatchedPendingGroupRouting {
+    fn local_inbox_endpoints(&self) -> Vec<TransportEndpoint> {
+        vec![self.endpoint.clone()]
+    }
+
+    fn key_package_endpoints(&self) -> Vec<TransportEndpoint> {
+        vec![self.endpoint.clone()]
+    }
+
+    fn group_subscriptions(&self) -> Vec<cgka_traits::TransportGroupSubscription> {
+        Vec::new()
+    }
+
+    fn publish_target(
+        &self,
+        message: &TransportMessage,
+    ) -> Result<TransportPublishTarget, TransportRoutingError> {
+        let transport_group_id = match &message.envelope {
+            TransportEnvelope::GroupMessage { transport_group_id } => transport_group_id.clone(),
+            TransportEnvelope::Welcome { .. } => {
+                return Err(TransportRoutingError::MissingInboxRoute);
+            }
+        };
+        Ok(TransportPublishTarget::Group {
+            group_id: self.wrong_group_id.clone(),
+            transport_group_id,
+            endpoints: vec![self.endpoint.clone()],
+        })
+    }
+
+    fn required_acks(&self, _target: &TransportPublishTarget) -> usize {
+        1
     }
 }
 
@@ -1712,4 +1754,83 @@ async fn published_app_messages_carry_exact_source_state_and_adapter_identity() 
         proposal_effects.published_app_messages.is_empty(),
         "proposal reports must not be mislabeled as application publications"
     );
+}
+
+#[tokio::test]
+async fn fanout_staging_failure_rolls_back_pending_mls_state() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot fanout staging rollback key").unwrap();
+    let mut alice = session(
+        dir.path().join("alice-stage-rollback.sqlite"),
+        &key,
+        b"alice-stage-rollback",
+    );
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "before failed staging".into(),
+            description: String::new(),
+            members: vec![],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id.clone();
+    let create_pending = match &created.effects.publish[0] {
+        PublishWork::GroupCreated { pending, .. } => *pending,
+        other => panic!("expected GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(create_pending).await.unwrap();
+    let baseline_epoch = alice.epoch(&group_id).unwrap();
+
+    let adapter = RecordingAdapter::default();
+    let routing = MismatchedPendingGroupRouting {
+        wrong_group_id: GroupId::new(b"wrong-pending-group".to_vec()),
+        endpoint: TransportEndpoint("wss://stage-rollback.example".into()),
+    };
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        adapter.clone(),
+        routing,
+        RecordingKeyPackages::default(),
+    );
+
+    let error = runtime
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("must roll back".into()),
+            description: None,
+        })
+        .await
+        .expect_err("mismatched pending group must fail fanout staging");
+    assert!(matches!(
+        error,
+        AccountError::Transport(TransportAdapterError::PublishTargetMismatch { .. })
+    ));
+    assert!(
+        adapter.publishes().is_empty(),
+        "staging failure happens before any transport side effect"
+    );
+    assert_eq!(runtime.session().epoch(&group_id).unwrap(), baseline_epoch);
+    assert_eq!(
+        runtime.session().group_record(&group_id).unwrap().name,
+        "before failed staging",
+        "failed pre-publish staging must roll back the projected group update"
+    );
+
+    // A second commit can stage and reaches the same routing validation,
+    // proving the first pending state did not wedge the group.
+    assert!(matches!(
+        runtime
+            .send(SendIntent::UpdateGroupData {
+                group_id,
+                name: Some("second attempt".into()),
+                description: None,
+            })
+            .await,
+        Err(AccountError::Transport(
+            TransportAdapterError::PublishTargetMismatch { .. }
+        ))
+    ));
 }

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -1296,6 +1296,7 @@ async fn group_evolution_confirms_pending_when_commit_was_partially_exposed() {
 
     let adapter = RecordingAdapter::default();
     adapter.accept_next(1);
+    adapter.accept_next(0);
     let policy =
         StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())])
             .required_acks(2)
@@ -1352,13 +1353,17 @@ async fn group_evolution_confirms_pending_when_commit_was_partially_exposed() {
     );
 
     let publishes = adapter.publishes();
-    assert_eq!(publishes.len(), 2);
+    assert_eq!(publishes.len(), 3);
     assert!(matches!(
         publishes[0].message.envelope,
         TransportEnvelope::GroupMessage { .. }
     ));
     assert!(matches!(
         publishes[1].message.envelope,
+        TransportEnvelope::GroupMessage { .. }
+    ));
+    assert!(matches!(
+        publishes[2].message.envelope,
         TransportEnvelope::Welcome { .. }
     ));
 }
@@ -1522,6 +1527,7 @@ async fn auto_publish_confirms_pending_when_commit_was_partially_exposed() {
     // this back; the fix must confirm it.
     let adapter = RecordingAdapter::default();
     adapter.accept_only_next(1);
+    adapter.accept_next(0);
     let alice_id = alice.self_id();
     let policy =
         StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())])

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -18,20 +18,21 @@ use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{PeeledContent, PeeledMessage};
 use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::storage::OutboundFanoutStorage;
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
 use cgka_traits::{
-    EpochId, MemberId, MessageId, TransportAccountActivation, TransportAdapter,
-    TransportAdapterError, TransportDelivery, TransportDeliveryPlane, TransportDeliverySource,
-    TransportEndpoint, TransportEndpointReceipt, TransportGroupSync, TransportPublishReport,
-    TransportPublishRequest,
+    EpochId, FanoutMlsState, FanoutTargetStatus, MemberId, MessageId, OutboundFanout,
+    TransportAccountActivation, TransportAdapter, TransportAdapterError, TransportDelivery,
+    TransportDeliveryPlane, TransportDeliverySource, TransportEndpoint, TransportEndpointReceipt,
+    TransportGroupSync, TransportPublishReport, TransportPublishRequest, TransportPublishTarget,
 };
 use marmot_account::{
     AccountDeviceRuntime, AccountError, KeyPackagePublication, KeyPackagePublishError,
     KeyPackagePublisher, PendingResolution, PublishedApplicationMessage, StaticTransportRouting,
 };
-use storage_sqlite::SqlCipherKey;
+use storage_sqlite::{SqlCipherKey, SqliteAccountStorage};
 
 fn pad32(name: &[u8]) -> Vec<u8> {
     deterministic_nostr_keys(name)
@@ -246,6 +247,7 @@ struct RecordingAdapterInner {
     publishes: Mutex<Vec<TransportPublishRequest>>,
     accepted_counts: Mutex<VecDeque<usize>>,
     reported_message_ids: Mutex<VecDeque<MessageId>>,
+    timeout_pattern: Mutex<VecDeque<bool>>,
 }
 
 impl RecordingAdapter {
@@ -267,6 +269,10 @@ impl RecordingAdapter {
             .lock()
             .unwrap()
             .push_back(message_id);
+    }
+
+    fn timeout_pattern(&self, pattern: impl IntoIterator<Item = bool>) {
+        self.inner.timeout_pattern.lock().unwrap().extend(pattern);
     }
 
     fn activations(&self) -> Vec<TransportAccountActivation> {
@@ -308,6 +314,16 @@ impl TransportAdapter for RecordingAdapter {
         request: TransportPublishRequest,
     ) -> Result<TransportPublishReport, TransportAdapterError> {
         self.inner.publishes.lock().unwrap().push(request.clone());
+        if self
+            .inner
+            .timeout_pattern
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or(false)
+        {
+            return Err(TransportAdapterError::Publish("simulated timeout".into()));
+        }
         let accepted_count = self
             .inner
             .accepted_counts
@@ -343,6 +359,8 @@ impl TransportAdapter for RecordingAdapter {
         Ok(None)
     }
 }
+
+include!("runtime/frozen_fanout.rs");
 
 #[derive(Clone, Default)]
 struct RecordingKeyPackages {

--- a/crates/marmot-account/tests/runtime/frozen_fanout.rs
+++ b/crates/marmot-account/tests/runtime/frozen_fanout.rs
@@ -1,0 +1,447 @@
+
+#[derive(Clone, Default)]
+struct CrashAfterFirstAcceptanceAdapter {
+    publishes: Arc<Mutex<Vec<TransportPublishRequest>>>,
+}
+
+impl CrashAfterFirstAcceptanceAdapter {
+    fn publishes(&self) -> Vec<TransportPublishRequest> {
+        self.publishes.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl TransportAdapter for CrashAfterFirstAcceptanceAdapter {
+    async fn activate_account(
+        &self,
+        _activation: TransportAccountActivation,
+    ) -> Result<(), TransportAdapterError> {
+        Ok(())
+    }
+
+    async fn sync_account_groups(
+        &self,
+        _sync: TransportGroupSync,
+    ) -> Result<(), TransportAdapterError> {
+        Ok(())
+    }
+
+    async fn deactivate_account(
+        &self,
+        _account_id: &MemberId,
+    ) -> Result<(), TransportAdapterError> {
+        Ok(())
+    }
+
+    async fn publish(
+        &self,
+        request: TransportPublishRequest,
+    ) -> Result<TransportPublishReport, TransportAdapterError> {
+        let call = {
+            let mut publishes = self.publishes.lock().unwrap();
+            publishes.push(request.clone());
+            publishes.len()
+        };
+        assert_ne!(call, 2, "simulated process crash after the first relay ack");
+        Ok(TransportPublishReport {
+            message_id: request.message.id,
+            accepted: request
+                .target
+                .endpoints()
+                .iter()
+                .cloned()
+                .map(|endpoint| TransportEndpointReceipt {
+                    endpoint,
+                    accepted_at: None,
+                })
+                .collect(),
+            failed: Vec::new(),
+            required_acks: request.required_acks,
+        })
+    }
+
+    async fn receive(&self) -> Result<Option<TransportDelivery>, TransportAdapterError> {
+        Ok(None)
+    }
+}
+
+async fn assert_frozen_fanout_case(accept_at: Option<usize>, timeout_at: Option<usize>) {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot fanout matrix key").unwrap();
+    let mut alice = session(
+        dir.path().join("alice.sqlite"),
+        &key,
+        b"alice-fanout-matrix",
+    );
+    let mut bob = session(dir.path().join("bob.sqlite"), &key, b"bob-fanout-matrix");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "fanout matrix".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id.clone();
+    let create_pending = match &created.effects.publish[0] {
+        PublishWork::GroupCreated { pending, .. } => *pending,
+        other => panic!("expected GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(create_pending).await.unwrap();
+
+    let endpoints = vec![
+        TransportEndpoint("wss://fanout-one.example".into()),
+        TransportEndpoint("wss://fanout-two.example".into()),
+        TransportEndpoint("wss://fanout-three.example".into()),
+    ];
+    let adapter = RecordingAdapter::default();
+    adapter.timeout_pattern((0..endpoints.len()).map(|index| timeout_at == Some(index)));
+    for index in 0..endpoints.len() {
+        if timeout_at != Some(index) {
+            adapter.accept_next(usize::from(accept_at == Some(index)));
+        }
+    }
+    let policy = StaticTransportRouting::new(vec![TransportEndpoint("wss://inbox.example".into())])
+        .with_group_route(
+            group_id.clone(),
+            group_id.as_slice().to_vec(),
+            endpoints.clone(),
+        );
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        adapter.clone(),
+        policy,
+        RecordingKeyPackages::default(),
+    );
+
+    let effects = runtime
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("fanout result".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(adapter.publishes().len(), endpoints.len());
+    assert_eq!(effects.reports.len(), 1);
+    assert_eq!(effects.fanout.len(), 1);
+    assert!(effects.fanout[0].fanout_complete);
+    assert_eq!(effects.fanout[0].outstanding_targets, 0);
+    assert!(
+        runtime.session().outbound_fanouts().unwrap().is_empty(),
+        "terminal fanouts must be pruned after their outcome is surfaced"
+    );
+
+    if accept_at.is_some() {
+        assert!(effects.fanout[0].mls_confirmed);
+        assert_eq!(effects.fanout[0].accepted_targets, 1);
+        assert_eq!(runtime.session().epoch(&group_id).unwrap().0, 2);
+        assert!(matches!(
+            effects.pending.as_slice(),
+            [PendingResolution::Confirmed { .. }]
+        ));
+    } else {
+        assert!(!effects.fanout[0].mls_confirmed);
+        assert_eq!(effects.fanout[0].accepted_targets, 0);
+        assert_eq!(runtime.session().epoch(&group_id).unwrap().0, 1);
+        assert!(matches!(
+            effects.pending.as_slice(),
+            [PendingResolution::RolledBack { .. }]
+        ));
+    }
+
+    let privacy_safe = serde_json::to_string(&effects.fanout[0]).unwrap();
+    assert!(!privacy_safe.contains("wss://"));
+    let publish_count = adapter.publishes().len();
+    let duplicate_resume = runtime.resume_outbound_fanouts().await.unwrap();
+    assert!(duplicate_resume.reports.is_empty());
+    assert!(duplicate_resume.pending.is_empty());
+    assert_eq!(adapter.publishes().len(), publish_count);
+}
+
+#[tokio::test]
+async fn frozen_fanout_first_middle_last_ack_and_all_fail_are_terminal() {
+    for accept_at in [Some(0), Some(1), Some(2), None] {
+        assert_frozen_fanout_case(accept_at, None).await;
+    }
+}
+
+#[tokio::test]
+async fn frozen_fanout_mixed_ack_failure_and_timeout_still_completes() {
+    assert_frozen_fanout_case(Some(0), Some(1)).await;
+}
+
+async fn assert_frozen_fanout_restart_edge(send_before_ack_persist: bool) {
+    let dir = tempfile::tempdir().unwrap();
+    let alice_path = dir.path().join("alice-restart-edge.sqlite");
+    let key_text = "marmot fanout restart edge key";
+    let key = SqlCipherKey::new(key_text).unwrap();
+    let mut alice = session(&alice_path, &key, b"alice-fanout-restart-edge");
+    let mut bob = session(
+        dir.path().join("bob-restart-edge.sqlite"),
+        &key,
+        b"bob-fanout-restart-edge",
+    );
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "fanout restart edge".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id.clone();
+    let create_pending = match &created.effects.publish[0] {
+        PublishWork::GroupCreated { pending, .. } => *pending,
+        other => panic!("expected GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(create_pending).await.unwrap();
+
+    let staged = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("resume frozen bytes".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (message, pending) = match &staged.publish[0] {
+        PublishWork::GroupEvolution { msg, pending, .. } => (msg.clone(), *pending),
+        other => panic!("expected GroupEvolution publish work, got {other:?}"),
+    };
+    let transport_group_id = match &message.envelope {
+        TransportEnvelope::GroupMessage { transport_group_id } => transport_group_id.clone(),
+        other => panic!("expected group message, got {other:?}"),
+    };
+    let endpoints = vec![
+        TransportEndpoint("wss://restart-one.example".into()),
+        TransportEndpoint("wss://restart-two.example".into()),
+        TransportEndpoint("wss://restart-three.example".into()),
+    ];
+    let request = TransportPublishRequest {
+        account_id: alice.self_id(),
+        message: message.clone(),
+        target: TransportPublishTarget::Group {
+            group_id: group_id.clone(),
+            transport_group_id: transport_group_id.clone(),
+            endpoints: endpoints.clone(),
+        },
+        required_acks: 1,
+    };
+    let mut fanout =
+        OutboundFanout::stage(request.clone(), Some(pending), Some(group_id.clone()), 0).unwrap();
+    alice.put_outbound_fanout(&fanout).unwrap();
+
+    let adapter = RecordingAdapter::default();
+    if send_before_ack_persist {
+        fanout.mark_attempt_started(0).unwrap();
+        alice.put_outbound_fanout(&fanout).unwrap();
+        adapter
+            .publish(TransportPublishRequest {
+                account_id: request.account_id.clone(),
+                message: message.clone(),
+                target: TransportPublishTarget::Group {
+                    group_id: group_id.clone(),
+                    transport_group_id: transport_group_id.clone(),
+                    endpoints: vec![endpoints[0].clone()],
+                },
+                required_acks: 1,
+            })
+            .await
+            .unwrap();
+    }
+    let pre_restart_publish_count = adapter.publishes().len();
+    drop(alice);
+
+    let reopened = session(
+        &alice_path,
+        &SqlCipherKey::new(key_text).unwrap(),
+        b"alice-fanout-restart-edge",
+    );
+    let replacement_policy = StaticTransportRouting::new(vec![TransportEndpoint(
+        "wss://replacement-inbox.example".into(),
+    )])
+    .with_group_route(
+        group_id.clone(),
+        vec![0xEE; 32],
+        vec![TransportEndpoint("wss://replacement.example".into())],
+    );
+    let mut resumed = AccountDeviceRuntime::new(
+        reopened,
+        adapter.clone(),
+        replacement_policy,
+        RecordingKeyPackages::default(),
+    );
+    let effects = resumed.drain().await.unwrap();
+
+    assert!(effects.fanout[0].mls_confirmed);
+    assert!(effects.fanout[0].fanout_complete);
+    assert_eq!(resumed.session().epoch(&group_id).unwrap().0, 2);
+    let attempts = adapter.publishes();
+    let resumed_attempts = &attempts[pre_restart_publish_count..];
+    assert_eq!(resumed_attempts.len(), endpoints.len());
+    assert!(resumed_attempts.iter().all(|attempt| {
+        attempt.message.id == message.id && attempt.message.payload == message.payload
+    }));
+    assert_eq!(
+        resumed_attempts
+            .iter()
+            .flat_map(|attempt| attempt.target.endpoints())
+            .collect::<Vec<_>>(),
+        endpoints.iter().collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn frozen_fanout_resumes_after_intent_and_after_send_before_ack_persistence() {
+    assert_frozen_fanout_restart_edge(false).await;
+    assert_frozen_fanout_restart_edge(true).await;
+}
+
+#[tokio::test]
+async fn frozen_fanout_survives_crash_and_ignores_changed_routing_on_resume() {
+    let dir = tempfile::tempdir().unwrap();
+    let alice_path = dir.path().join("alice-frozen-fanout.sqlite");
+    let key_text = "marmot frozen fanout key";
+    let key = SqlCipherKey::new(key_text).unwrap();
+    let mut alice = session(&alice_path, &key, b"alice-frozen-fanout");
+    let mut bob = session(
+        dir.path().join("bob-frozen-fanout.sqlite"),
+        &key,
+        b"bob-frozen-fanout",
+    );
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let created = alice
+        .create_group(CreateGroupRequest {
+            name: "frozen fanout".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let group_id = created.group_id.clone();
+    let create_pending = match &created.effects.publish[0] {
+        PublishWork::GroupCreated { pending, .. } => *pending,
+        other => panic!("expected GroupCreated publish work, got {other:?}"),
+    };
+    alice.confirm_published(create_pending).await.unwrap();
+
+    let original_endpoints = vec![
+        TransportEndpoint("wss://original-one.example".into()),
+        TransportEndpoint("wss://original-two.example".into()),
+        TransportEndpoint("wss://original-three.example".into()),
+    ];
+    let crash_adapter = CrashAfterFirstAcceptanceAdapter::default();
+    let policy =
+        StaticTransportRouting::new(vec![TransportEndpoint("wss://alice-inbox.example".into())])
+            .with_group_route(
+                group_id.clone(),
+                group_id.as_slice().to_vec(),
+                original_endpoints.clone(),
+            );
+    let mut runtime = AccountDeviceRuntime::new(
+        alice,
+        crash_adapter.clone(),
+        policy,
+        RecordingKeyPackages::default(),
+    );
+    let crashed = tokio::spawn(async move {
+        runtime
+            .send(SendIntent::UpdateGroupData {
+                group_id,
+                name: Some("published before crash".into()),
+                description: None,
+            })
+            .await
+    })
+    .await;
+    assert!(crashed.unwrap_err().is_panic());
+
+    let first_attempts = crash_adapter.publishes();
+    assert_eq!(first_attempts.len(), 2);
+    assert_eq!(
+        first_attempts[0].target.endpoints(),
+        &original_endpoints[..1]
+    );
+    let frozen_id = first_attempts[0].message.id.clone();
+    let frozen_bytes = first_attempts[0].message.payload.clone();
+
+    {
+        let stored = SqliteAccountStorage::open_encrypted(
+            &alice_path,
+            &SqlCipherKey::new(key_text).unwrap(),
+        )
+        .unwrap();
+        let fanouts = stored.list_outbound_fanouts().unwrap();
+        assert_eq!(fanouts.len(), 1);
+        assert_eq!(fanouts[0].message_id(), &frozen_id);
+        assert_eq!(fanouts[0].request().message.payload, frozen_bytes);
+        assert_eq!(fanouts[0].request().target.endpoints(), original_endpoints);
+        assert_eq!(
+            fanouts[0].target_statuses(),
+            &[
+                FanoutTargetStatus::Accepted,
+                FanoutTargetStatus::Attempting,
+                FanoutTargetStatus::NotAttempted,
+            ]
+        );
+        assert_eq!(fanouts[0].mls_state(), FanoutMlsState::Confirmed);
+    }
+
+    let reopened = session(
+        &alice_path,
+        &SqlCipherKey::new(key_text).unwrap(),
+        b"alice-frozen-fanout",
+    );
+    let replacement_endpoints = vec![TransportEndpoint("wss://replacement.example".into())];
+    let resumed_adapter = RecordingAdapter::default();
+    let replacement_policy = StaticTransportRouting::new(vec![TransportEndpoint(
+        "wss://replacement-inbox.example".into(),
+    )])
+    .with_group_route(
+        created.group_id.clone(),
+        vec![0xEE; 32],
+        replacement_endpoints,
+    );
+    let mut resumed = AccountDeviceRuntime::new(
+        reopened,
+        resumed_adapter.clone(),
+        replacement_policy,
+        RecordingKeyPackages::default(),
+    );
+
+    let effects = resumed.resume_outbound_fanouts().await.unwrap();
+    assert_eq!(effects.reports.len(), 1);
+    assert_eq!(effects.fanout.len(), 1);
+    assert!(effects.fanout[0].mls_confirmed);
+    assert!(effects.fanout[0].fanout_complete);
+
+    let resumed_attempts = resumed_adapter.publishes();
+    assert_eq!(resumed_attempts.len(), 2);
+    assert_eq!(
+        resumed_attempts
+            .iter()
+            .flat_map(|request| request.target.endpoints())
+            .collect::<Vec<_>>(),
+        vec![&original_endpoints[1], &original_endpoints[2]]
+    );
+    assert!(resumed_attempts.iter().all(|request| {
+        request.message.id == frozen_id && request.message.payload == frozen_bytes
+    }));
+
+    let duplicate_resume = resumed.resume_outbound_fanouts().await.unwrap();
+    assert!(duplicate_resume.reports.is_empty());
+    assert_eq!(resumed_adapter.publishes().len(), 2);
+}

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -58,6 +58,8 @@ mod migration_0028_ingress_dedup;
 mod migration_0029_app_event_retention_decision;
 #[path = "migrations/0030_prior_nostr_routes.rs"]
 mod migration_0030_prior_nostr_routes;
+#[path = "migrations/0031_outbound_fanout.rs"]
+mod migration_0031_outbound_fanout;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -219,6 +221,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 30,
         name: "0030_prior_nostr_routes",
         apply: migration_0030_prior_nostr_routes::apply,
+    },
+    Migration {
+        version: 31,
+        name: "0031_outbound_fanout",
+        apply: migration_0031_outbound_fanout::apply,
     },
 ];
 

--- a/crates/storage-sqlite/src/migrations/0031_outbound_fanout.rs
+++ b/crates/storage-sqlite/src/migrations/0031_outbound_fanout.rs
@@ -1,0 +1,21 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE cgka_outbound_fanout (
+    insert_order INTEGER PRIMARY KEY AUTOINCREMENT,
+    message_id BLOB NOT NULL UNIQUE,
+    group_id BLOB,
+    record BLOB NOT NULL,
+    FOREIGN KEY(group_id) REFERENCES cgka_groups(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_cgka_outbound_fanout_group
+    ON cgka_outbound_fanout(group_id, insert_order);
+"#,
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/storage/outbound.rs
+++ b/crates/storage-sqlite/src/storage/outbound.rs
@@ -1,10 +1,11 @@
 use crate::connection::retry_on_busy;
 use crate::{SqliteAccountStorage, SqliteResultExt, created_at_to_i64, deserialize, serialize};
+use cgka_traits::OutboundFanout;
 use cgka_traits::storage::{
-    OutboundIntentStorage, QueuedOutboundIntent, StorageError, StorageResult,
+    OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent, StorageError, StorageResult,
 };
 use cgka_traits::types::{GroupId, MessageId};
-use rusqlite::params;
+use rusqlite::{OptionalExtension, params};
 
 impl OutboundIntentStorage for SqliteAccountStorage {
     fn put_queued_outbound_intent(&self, record: &QueuedOutboundIntent) -> StorageResult<()> {
@@ -84,11 +85,242 @@ impl OutboundIntentStorage for SqliteAccountStorage {
     }
 }
 
+impl OutboundFanoutStorage for SqliteAccountStorage {
+    fn put_outbound_fanout(&self, fanout: &OutboundFanout) -> StorageResult<()> {
+        let serialized = serialize(fanout)?;
+        let write = || {
+            let conn = self.lock()?;
+            let previous = conn
+                .query_row(
+                    "SELECT record FROM cgka_outbound_fanout WHERE message_id = ?1",
+                    params![fanout.message_id().as_slice()],
+                    |row| row.get::<_, Vec<u8>>(0),
+                )
+                .optional()
+                .storage()?
+                .map(|record| deserialize::<OutboundFanout>(&record))
+                .transpose()?;
+            if let Some(previous) = previous {
+                fanout.validate_successor_of(&previous).map_err(|_| {
+                    StorageError::Backend(
+                        "outbound fanout update would alter or regress durable state".into(),
+                    )
+                })?;
+            }
+            conn.execute(
+                "INSERT INTO cgka_outbound_fanout (message_id, group_id, record)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(message_id) DO UPDATE SET
+                    group_id = excluded.group_id,
+                    record = excluded.record",
+                params![
+                    fanout.message_id().as_slice(),
+                    fanout.group_id().map(GroupId::as_slice),
+                    serialized,
+                ],
+            )
+            .storage()?;
+            Ok(())
+        };
+        if self.connection.is_current_thread_transaction_owner() {
+            write()
+        } else {
+            retry_on_busy(write)
+        }
+    }
+
+    fn outbound_fanout(&self, message_id: &MessageId) -> StorageResult<Option<OutboundFanout>> {
+        let conn = self.lock()?;
+        let record = conn
+            .query_row(
+                "SELECT record FROM cgka_outbound_fanout WHERE message_id = ?1",
+                params![message_id.as_slice()],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .optional()
+            .storage()?;
+        record.map(|record| deserialize(&record)).transpose()
+    }
+
+    fn list_outbound_fanouts(&self) -> StorageResult<Vec<OutboundFanout>> {
+        let conn = self.lock()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT record FROM cgka_outbound_fanout
+                 ORDER BY insert_order",
+            )
+            .storage()?;
+        let records = stmt
+            .query_map([], |row| row.get::<_, Vec<u8>>(0))
+            .storage()?
+            .collect::<Result<Vec<_>, _>>()
+            .storage()?;
+        records.iter().map(|record| deserialize(record)).collect()
+    }
+
+    fn list_outbound_fanouts_for_group(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Vec<OutboundFanout>> {
+        let conn = self.lock()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT record FROM cgka_outbound_fanout
+                 WHERE group_id = ?1
+                 ORDER BY insert_order",
+            )
+            .storage()?;
+        let records = stmt
+            .query_map(params![group_id.as_slice()], |row| row.get::<_, Vec<u8>>(0))
+            .storage()?
+            .collect::<Result<Vec<_>, _>>()
+            .storage()?;
+        records.iter().map(|record| deserialize(record)).collect()
+    }
+
+    fn delete_outbound_fanout(&self, message_id: &MessageId) -> StorageResult<()> {
+        let delete = || {
+            self.lock()?
+                .execute(
+                    "DELETE FROM cgka_outbound_fanout WHERE message_id = ?1",
+                    params![message_id.as_slice()],
+                )
+                .storage()
+        };
+        if self.connection.is_current_thread_transaction_owner() {
+            delete()?;
+        } else {
+            retry_on_busy(delete)?;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::SqliteAccountStorage;
     use crate::storage::test_support::{gid, mid, sample_group, sample_queued_intent};
-    use cgka_traits::storage::{GroupStorage, OutboundIntentStorage};
+    use cgka_traits::engine_state::PendingStateRef;
+    use cgka_traits::storage::{GroupStorage, OutboundFanoutStorage, OutboundIntentStorage};
+    use cgka_traits::{
+        MemberId, OutboundFanout, Timestamp, TransportEndpoint, TransportEnvelope,
+        TransportMessage, TransportPublishRequest, TransportPublishTarget, TransportSource,
+    };
+
+    fn sample_fanout(id: u8) -> OutboundFanout {
+        OutboundFanout::stage(
+            TransportPublishRequest {
+                account_id: MemberId::new(vec![0xA1; 32]),
+                message: TransportMessage {
+                    id: mid(id),
+                    payload: vec![id; 64],
+                    timestamp: Timestamp(55),
+                    causal_deps: Vec::new(),
+                    source: TransportSource("marmot.transport.nostr".into()),
+                    envelope: TransportEnvelope::GroupMessage {
+                        transport_group_id: vec![0xC3; 32],
+                    },
+                },
+                target: TransportPublishTarget::Group {
+                    group_id: gid(1),
+                    transport_group_id: vec![0xC3; 32],
+                    endpoints: vec![
+                        TransportEndpoint("wss://one.example".into()),
+                        TransportEndpoint("wss://two.example".into()),
+                    ],
+                },
+                required_acks: 1,
+            },
+            Some(PendingStateRef::new(41)),
+            Some(gid(1)),
+            99,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn frozen_outbound_fanout_round_trips_and_updates_in_place() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        let mut fanout = sample_fanout(7);
+
+        store.put_outbound_fanout(&fanout).unwrap();
+        fanout.mark_attempt_started(0).unwrap();
+        store.put_outbound_fanout(&fanout).unwrap();
+        fanout.mark_target_accepted(0).unwrap();
+        store.put_outbound_fanout(&fanout).unwrap();
+
+        assert_eq!(
+            store.outbound_fanout(&mid(7)).unwrap(),
+            Some(fanout.clone())
+        );
+        assert_eq!(store.list_outbound_fanouts().unwrap(), vec![fanout.clone()]);
+        assert_eq!(
+            store.list_outbound_fanouts_for_group(&gid(1)).unwrap(),
+            vec![fanout]
+        );
+        assert!(
+            store
+                .list_outbound_fanouts_for_group(&gid(2))
+                .unwrap()
+                .is_empty()
+        );
+        store.delete_outbound_fanout(&mid(7)).unwrap();
+        assert!(store.list_outbound_fanouts().unwrap().is_empty());
+    }
+
+    #[test]
+    fn frozen_outbound_fanout_survives_reopen_with_exact_bytes_and_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fanout.sqlite");
+        let key = crate::SqlCipherKey::new("durable fanout key").unwrap();
+        let expected = sample_fanout(8);
+        {
+            let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+            store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+            store.put_outbound_fanout(&expected).unwrap();
+        }
+
+        let reopened = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        assert_eq!(reopened.outbound_fanout(&mid(8)).unwrap(), Some(expected));
+    }
+
+    #[test]
+    fn frozen_outbound_fanout_rejects_route_replacement_and_state_regression() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        let initial = sample_fanout(9);
+        store.put_outbound_fanout(&initial).unwrap();
+
+        let mut replacement_request = initial.request().clone();
+        replacement_request.target = TransportPublishTarget::Group {
+            group_id: gid(1),
+            transport_group_id: vec![0xC3; 32],
+            endpoints: vec![TransportEndpoint("wss://replacement.example".into())],
+        };
+        let replacement = OutboundFanout::stage(
+            replacement_request,
+            Some(PendingStateRef::new(41)),
+            Some(gid(1)),
+            99,
+        )
+        .unwrap();
+        assert!(store.put_outbound_fanout(&replacement).is_err());
+        assert_eq!(
+            store.outbound_fanout(&mid(9)).unwrap(),
+            Some(initial.clone())
+        );
+
+        let mut attempting = initial.clone();
+        attempting.mark_attempt_started(0).unwrap();
+        store.put_outbound_fanout(&attempting).unwrap();
+        let mut accepted = attempting.clone();
+        accepted.mark_target_accepted(0).unwrap();
+        store.put_outbound_fanout(&accepted).unwrap();
+
+        assert!(store.put_outbound_fanout(&attempting).is_err());
+        assert_eq!(store.outbound_fanout(&mid(9)).unwrap(), Some(accepted));
+    }
 
     #[test]
     fn queued_outbound_intents_are_group_scoped_and_ordered() {

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -83,13 +83,14 @@ pub use message::{MessageRecord, MessageState, OwnCommitConvergenceStamp, Stored
 pub use peeler::{GroupMessageMetadata, TransportPeeler};
 pub use storage::{
     CapabilityStorage, GroupStorage, LeaveRequest, LeaveRequestStorage, MessageStorage,
-    OutboundIntentStorage, QueuedOutboundIntent, StorageError, StorageProvider, StorageResult,
-    WelcomeStorage,
+    OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent, StorageError,
+    StorageProvider, StorageResult, WelcomeStorage,
 };
 pub use transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
 };
 pub use transport_adapter::{
+    FanoutMlsState, FanoutTargetStatus, OutboundFanout, OutboundFanoutOutcome,
     TransportAccountActivation, TransportAdapter, TransportAdapterError, TransportDelivery,
     TransportDeliveryPlane, TransportDeliverySource, TransportEndpoint, TransportEndpointFailure,
     TransportEndpointReceipt, TransportGroupSubscription, TransportGroupSync,

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -13,6 +13,7 @@ use crate::capabilities::{CapabilityRequirement, GroupCapabilities};
 use crate::engine::SendIntent;
 use crate::group::{Group, Member};
 use crate::message::{MessageRecord, MessageState};
+use crate::transport_adapter::OutboundFanout;
 use crate::types::{Backend, EpochId, GroupId, MemberId, MessageId};
 use crate::welcome::PendingWelcome;
 use openmls_traits::storage::{CURRENT_VERSION, StorageProvider as OpenMlsStorageProvider};
@@ -121,6 +122,29 @@ pub trait OutboundIntentStorage {
         group_id: &GroupId,
     ) -> StorageResult<Vec<QueuedOutboundIntent>>;
     fn delete_queued_outbound_intent(&self, id: &MessageId) -> StorageResult<()>;
+}
+
+// ── OutboundFanoutStorage ──────────────────────────────────────────────────
+
+/// Durable frozen transport fanouts, keyed by the signed message id.
+pub trait OutboundFanoutStorage {
+    fn put_outbound_fanout(&self, fanout: &OutboundFanout) -> StorageResult<()>;
+
+    fn outbound_fanout(&self, message_id: &MessageId) -> StorageResult<Option<OutboundFanout>>;
+
+    fn list_outbound_fanouts(&self) -> StorageResult<Vec<OutboundFanout>>;
+
+    /// Read fanouts for one MLS group in original staging order.
+    ///
+    /// Hydration uses this indexed lookup instead of scanning every account
+    /// fanout once per group.
+    fn list_outbound_fanouts_for_group(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Vec<OutboundFanout>>;
+
+    /// Remove a terminal fanout after its outcome has been surfaced.
+    fn delete_outbound_fanout(&self, message_id: &MessageId) -> StorageResult<()>;
 }
 
 // ── LeaveRequestStorage ────────────────────────────────────────────────────
@@ -270,6 +294,7 @@ pub trait StorageProvider:
     GroupStorage
     + MessageStorage
     + OutboundIntentStorage
+    + OutboundFanoutStorage
     + LeaveRequestStorage
     + WelcomeStorage
     + CapabilityStorage

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -8,6 +8,7 @@
 //! boundary and remains the source of truth for commit ordering, branch
 //! selection, and application-message validity.
 
+use crate::engine_state::PendingStateRef;
 use crate::transport::{Timestamp, TransportEnvelope, TransportMessage, TransportSource};
 use crate::types::{GroupId, MemberId, MessageId};
 use async_trait::async_trait;
@@ -161,6 +162,312 @@ impl TransportPublishRequest {
             }),
         }
     }
+}
+
+/// Durable first-attempt state for one endpoint in a frozen publish fanout.
+///
+/// `Attempting` is written before the external send. A process that restarts
+/// with an `Attempting` target treats it as outstanding and safely repeats the
+/// same already-signed event bytes. Terminal callbacks are idempotent: once a
+/// target is `Accepted` or `Failed`, later duplicate or contradictory results
+/// do not change it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FanoutTargetStatus {
+    NotAttempted,
+    Attempting,
+    Accepted,
+    Failed,
+}
+
+impl FanoutTargetStatus {
+    pub fn is_outstanding(self) -> bool {
+        matches!(self, Self::NotAttempted | Self::Attempting)
+    }
+
+    pub fn is_terminal(self) -> bool {
+        !self.is_outstanding()
+    }
+}
+
+/// MLS half of a durable publish obligation.
+///
+/// Standalone application messages/proposals use `NotApplicable`. A group
+/// evolution retains its opaque pending reference until the first endpoint
+/// accepts, then transitions once to `Confirmed`; an all-failed first-attempt
+/// fanout transitions once to `RolledBack`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "state", content = "pending")]
+pub enum FanoutMlsState {
+    NotApplicable,
+    Pending(PendingStateRef),
+    Confirmed,
+    RolledBack,
+}
+
+/// One durable transport fanout frozen before its first external side effect.
+///
+/// The request owns the exact serialized transport message and original target
+/// set. `target_statuses` is positionally aligned with
+/// `request.target.endpoints()`; construction is centralized in [`stage`] so a
+/// valid record can never have a different status count.
+///
+/// [`stage`]: Self::stage
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutboundFanout {
+    request: TransportPublishRequest,
+    group_id: Option<GroupId>,
+    target_statuses: Vec<FanoutTargetStatus>,
+    mls_state: FanoutMlsState,
+    created_at_ms: u64,
+}
+
+impl OutboundFanout {
+    pub fn stage(
+        request: TransportPublishRequest,
+        pending: Option<PendingStateRef>,
+        pending_group_id: Option<GroupId>,
+        created_at_ms: u64,
+    ) -> Result<Self, TransportAdapterError> {
+        request.validate_envelope_matches_target()?;
+        let target_group_id = match &request.target {
+            TransportPublishTarget::Group { group_id, .. } => Some(group_id.clone()),
+            TransportPublishTarget::Inbox { .. } => None,
+        };
+        if let (Some(target_group_id), Some(pending_group_id)) =
+            (&target_group_id, &pending_group_id)
+            && target_group_id != pending_group_id
+        {
+            return Err(TransportAdapterError::PublishTargetMismatch {
+                envelope: "pending_group".into(),
+                target: "group".into(),
+            });
+        }
+        let target_count = request.target.endpoints().len();
+        Ok(Self {
+            request,
+            group_id: target_group_id.or(pending_group_id),
+            target_statuses: vec![FanoutTargetStatus::NotAttempted; target_count],
+            mls_state: pending.map_or(FanoutMlsState::NotApplicable, FanoutMlsState::Pending),
+            created_at_ms,
+        })
+    }
+
+    pub fn request(&self) -> &TransportPublishRequest {
+        &self.request
+    }
+
+    pub fn message_id(&self) -> &MessageId {
+        &self.request.message.id
+    }
+
+    pub fn group_id(&self) -> Option<&GroupId> {
+        self.group_id.as_ref()
+    }
+
+    pub fn created_at_ms(&self) -> u64 {
+        self.created_at_ms
+    }
+
+    pub fn target_statuses(&self) -> &[FanoutTargetStatus] {
+        &self.target_statuses
+    }
+
+    pub fn target_status(&self, index: usize) -> Option<FanoutTargetStatus> {
+        self.target_statuses.get(index).copied()
+    }
+
+    pub fn pending_ref(&self) -> Option<PendingStateRef> {
+        match self.mls_state {
+            FanoutMlsState::Pending(pending) => Some(pending),
+            FanoutMlsState::NotApplicable
+            | FanoutMlsState::Confirmed
+            | FanoutMlsState::RolledBack => None,
+        }
+    }
+
+    pub fn mls_state(&self) -> FanoutMlsState {
+        self.mls_state
+    }
+
+    pub fn outstanding_target_indexes(&self) -> Vec<usize> {
+        self.target_statuses
+            .iter()
+            .enumerate()
+            .filter_map(|(index, status)| status.is_outstanding().then_some(index))
+            .collect()
+    }
+
+    /// Persist the send-before-side-effect edge for one target.
+    ///
+    /// Returns `true` only for the first `NotAttempted -> Attempting`
+    /// transition. Re-marking an `Attempting` target after restart is harmless;
+    /// terminal targets remain unchanged.
+    pub fn mark_attempt_started(&mut self, index: usize) -> Result<bool, TransportAdapterError> {
+        let status = self.target_status_mut(index)?;
+        match status {
+            FanoutTargetStatus::NotAttempted => {
+                *status = FanoutTargetStatus::Attempting;
+                Ok(true)
+            }
+            FanoutTargetStatus::Attempting
+            | FanoutTargetStatus::Accepted
+            | FanoutTargetStatus::Failed => Ok(false),
+        }
+    }
+
+    pub fn mark_target_accepted(&mut self, index: usize) -> Result<bool, TransportAdapterError> {
+        self.mark_target_terminal(index, FanoutTargetStatus::Accepted)
+    }
+
+    pub fn mark_target_failed(&mut self, index: usize) -> Result<bool, TransportAdapterError> {
+        self.mark_target_terminal(index, FanoutTargetStatus::Failed)
+    }
+
+    pub fn mark_mls_confirmed(&mut self) -> Result<bool, TransportAdapterError> {
+        match self.mls_state {
+            FanoutMlsState::Pending(_) => {
+                self.mls_state = FanoutMlsState::Confirmed;
+                Ok(true)
+            }
+            FanoutMlsState::Confirmed => Ok(false),
+            FanoutMlsState::NotApplicable | FanoutMlsState::RolledBack => Err(
+                TransportAdapterError::Other("fanout has no confirmable pending MLS state".into()),
+            ),
+        }
+    }
+
+    pub fn mark_mls_rolled_back(&mut self) -> Result<bool, TransportAdapterError> {
+        match self.mls_state {
+            FanoutMlsState::Pending(_) => {
+                self.mls_state = FanoutMlsState::RolledBack;
+                Ok(true)
+            }
+            FanoutMlsState::RolledBack => Ok(false),
+            FanoutMlsState::NotApplicable | FanoutMlsState::Confirmed => Err(
+                TransportAdapterError::Other("fanout has no rollbackable pending MLS state".into()),
+            ),
+        }
+    }
+
+    pub fn outcome(&self) -> OutboundFanoutOutcome {
+        let accepted_targets = self
+            .target_statuses
+            .iter()
+            .filter(|status| **status == FanoutTargetStatus::Accepted)
+            .count();
+        let failed_targets = self
+            .target_statuses
+            .iter()
+            .filter(|status| **status == FanoutTargetStatus::Failed)
+            .count();
+        let outstanding_targets = self
+            .target_statuses
+            .iter()
+            .filter(|status| status.is_outstanding())
+            .count();
+        OutboundFanoutOutcome {
+            message_id: self.request.message.id.clone(),
+            mls_confirmation_required: accepted_targets > 0
+                && matches!(self.mls_state, FanoutMlsState::Pending(_)),
+            mls_confirmed: self.mls_state == FanoutMlsState::Confirmed,
+            fanout_complete: outstanding_targets == 0,
+            accepted_targets,
+            failed_targets,
+            outstanding_targets,
+        }
+    }
+
+    /// Verify that `self` is a monotonic update of an already-durable fanout.
+    ///
+    /// The signed bytes, message id, frozen target set, policy and creation
+    /// time are immutable. Per-target and MLS states may only advance. Storage
+    /// implementations use this guard before replacing the serialized record,
+    /// so a stale callback or regenerated request cannot reopen terminal state
+    /// or silently substitute a new route.
+    pub fn validate_successor_of(&self, previous: &Self) -> Result<(), TransportAdapterError> {
+        let immutable_matches = self.request == previous.request
+            && self.group_id == previous.group_id
+            && self.created_at_ms == previous.created_at_ms
+            && self.target_statuses.len() == previous.target_statuses.len();
+        let targets_advance = immutable_matches
+            && self
+                .target_statuses
+                .iter()
+                .zip(&previous.target_statuses)
+                .all(|(next, prior)| target_status_advances(*prior, *next));
+        let mls_advances = mls_state_advances(previous.mls_state, self.mls_state);
+        if targets_advance && mls_advances {
+            Ok(())
+        } else {
+            Err(TransportAdapterError::Other(
+                "outbound fanout update is not monotonic".into(),
+            ))
+        }
+    }
+
+    fn target_status_mut(
+        &mut self,
+        index: usize,
+    ) -> Result<&mut FanoutTargetStatus, TransportAdapterError> {
+        self.target_statuses.get_mut(index).ok_or_else(|| {
+            TransportAdapterError::Other("fanout target index is out of bounds".into())
+        })
+    }
+
+    fn mark_target_terminal(
+        &mut self,
+        index: usize,
+        terminal: FanoutTargetStatus,
+    ) -> Result<bool, TransportAdapterError> {
+        debug_assert!(terminal.is_terminal());
+        let status = self.target_status_mut(index)?;
+        if status.is_terminal() {
+            return Ok(false);
+        }
+        *status = terminal;
+        Ok(true)
+    }
+}
+
+fn target_status_advances(prior: FanoutTargetStatus, next: FanoutTargetStatus) -> bool {
+    prior == next
+        || matches!(
+            (prior, next),
+            (
+                FanoutTargetStatus::NotAttempted,
+                FanoutTargetStatus::Attempting
+            ) | (
+                FanoutTargetStatus::Attempting,
+                FanoutTargetStatus::Accepted | FanoutTargetStatus::Failed
+            )
+        )
+}
+
+fn mls_state_advances(prior: FanoutMlsState, next: FanoutMlsState) -> bool {
+    prior == next
+        || matches!(
+            (prior, next),
+            (
+                FanoutMlsState::Pending(_),
+                FanoutMlsState::Confirmed | FanoutMlsState::RolledBack
+            )
+        )
+}
+
+/// Privacy-safe caller/audit summary for one frozen fanout.
+///
+/// Counts and lifecycle booleans are exposed separately; relay endpoints are
+/// deliberately absent.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutboundFanoutOutcome {
+    pub message_id: MessageId,
+    pub mls_confirmation_required: bool,
+    pub mls_confirmed: bool,
+    pub fanout_complete: bool,
+    pub accepted_targets: usize,
+    pub failed_targets: usize,
+    pub outstanding_targets: usize,
 }
 
 /// Successful endpoint-level publish acknowledgement.
@@ -344,6 +651,123 @@ fn envelope_label(envelope: &TransportEnvelope) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fanout_request() -> TransportPublishRequest {
+        TransportPublishRequest {
+            account_id: MemberId::new(vec![0xA1; 32]),
+            message: TransportMessage {
+                id: MessageId::new(vec![0xB2; 32]),
+                payload: b"exact signed event bytes".to_vec(),
+                timestamp: Timestamp(1_700_000_000),
+                causal_deps: Vec::new(),
+                source: TransportSource("marmot.transport.nostr".into()),
+                envelope: TransportEnvelope::GroupMessage {
+                    transport_group_id: vec![0xC3; 32],
+                },
+            },
+            target: TransportPublishTarget::Group {
+                group_id: GroupId::new(vec![0xD4; 16]),
+                transport_group_id: vec![0xC3; 32],
+                endpoints: vec![
+                    TransportEndpoint("wss://one.example".into()),
+                    TransportEndpoint("wss://two.example".into()),
+                    TransportEndpoint("wss://three.example".into()),
+                ],
+            },
+            required_acks: 2,
+        }
+    }
+
+    #[test]
+    fn frozen_fanout_first_ack_releases_mls_before_fanout_completes() {
+        let pending = crate::engine_state::PendingStateRef::new(9);
+        let mut fanout = OutboundFanout::stage(
+            fanout_request(),
+            Some(pending),
+            Some(GroupId::new(vec![0xD4; 16])),
+            55,
+        )
+        .unwrap();
+
+        fanout.mark_attempt_started(1).unwrap();
+        assert!(fanout.mark_target_accepted(1).unwrap());
+
+        let outcome = fanout.outcome();
+        assert!(outcome.mls_confirmation_required);
+        assert!(!outcome.mls_confirmed);
+        assert!(!outcome.fanout_complete);
+        assert_eq!(outcome.accepted_targets, 1);
+        assert_eq!(outcome.outstanding_targets, 2);
+        assert_eq!(fanout.pending_ref(), Some(pending));
+    }
+
+    #[test]
+    fn frozen_fanout_duplicate_and_late_callbacks_are_idempotent() {
+        let pending = crate::engine_state::PendingStateRef::new(9);
+        let mut fanout = OutboundFanout::stage(
+            fanout_request(),
+            Some(pending),
+            Some(GroupId::new(vec![0xD4; 16])),
+            55,
+        )
+        .unwrap();
+
+        fanout.mark_attempt_started(0).unwrap();
+        assert!(fanout.mark_target_accepted(0).unwrap());
+        fanout.mark_mls_confirmed().unwrap();
+
+        assert!(!fanout.mark_target_accepted(0).unwrap());
+        assert!(!fanout.mark_target_failed(0).unwrap());
+        assert!(fanout.outcome().mls_confirmed);
+        assert_eq!(fanout.outcome().accepted_targets, 1);
+    }
+
+    #[test]
+    fn frozen_fanout_all_fail_is_complete_without_mls_confirmation() {
+        let pending = crate::engine_state::PendingStateRef::new(9);
+        let mut fanout = OutboundFanout::stage(
+            fanout_request(),
+            Some(pending),
+            Some(GroupId::new(vec![0xD4; 16])),
+            55,
+        )
+        .unwrap();
+
+        for index in 0..3 {
+            fanout.mark_attempt_started(index).unwrap();
+            assert!(fanout.mark_target_failed(index).unwrap());
+        }
+
+        let outcome = fanout.outcome();
+        assert!(outcome.fanout_complete);
+        assert!(!outcome.mls_confirmation_required);
+        assert!(!outcome.mls_confirmed);
+        assert_eq!(outcome.failed_targets, 3);
+        assert_eq!(outcome.outstanding_targets, 0);
+    }
+
+    #[test]
+    fn frozen_fanout_round_trip_preserves_bytes_id_and_original_targets() {
+        let request = fanout_request();
+        let original_bytes = request.message.payload.clone();
+        let original_id = request.message.id.clone();
+        let original_targets = request.target.endpoints().to_vec();
+        let fanout = OutboundFanout::stage(
+            request,
+            Some(crate::engine_state::PendingStateRef::new(9)),
+            Some(GroupId::new(vec![0xD4; 16])),
+            55,
+        )
+        .unwrap();
+
+        let encoded = serde_json::to_vec(&fanout).unwrap();
+        let restored: OutboundFanout = serde_json::from_slice(&encoded).unwrap();
+
+        assert_eq!(restored.request().message.payload, original_bytes);
+        assert_eq!(restored.request().message.id, original_id);
+        assert_eq!(restored.request().target.endpoints(), original_targets);
+        assert_eq!(restored.outstanding_target_indexes(), vec![0, 1, 2]);
+    }
 
     fn report(accepted: usize, failed: usize, required_acks: usize) -> TransportPublishReport {
         TransportPublishReport {

--- a/crates/traits/src/transport_adapter.rs
+++ b/crates/traits/src/transport_adapter.rs
@@ -217,6 +217,8 @@ pub enum FanoutMlsState {
 pub struct OutboundFanout {
     request: TransportPublishRequest,
     group_id: Option<GroupId>,
+    #[serde(default)]
+    published_message_id: Option<MessageId>,
     target_statuses: Vec<FanoutTargetStatus>,
     mls_state: FanoutMlsState,
     created_at_ms: u64,
@@ -247,6 +249,7 @@ impl OutboundFanout {
         Ok(Self {
             request,
             group_id: target_group_id.or(pending_group_id),
+            published_message_id: None,
             target_statuses: vec![FanoutTargetStatus::NotAttempted; target_count],
             mls_state: pending.map_or(FanoutMlsState::NotApplicable, FanoutMlsState::Pending),
             created_at_ms,
@@ -259,6 +262,14 @@ impl OutboundFanout {
 
     pub fn message_id(&self) -> &MessageId {
         &self.request.message.id
+    }
+
+    /// Transport-visible message id reported by the adapter.
+    ///
+    /// The frozen request remains keyed by the engine message id, while this
+    /// value captures the deterministic signed-event id exposed to apps.
+    pub fn published_message_id(&self) -> Option<&MessageId> {
+        self.published_message_id.as_ref()
     }
 
     pub fn group_id(&self) -> Option<&GroupId> {
@@ -324,6 +335,22 @@ impl OutboundFanout {
         self.mark_target_terminal(index, FanoutTargetStatus::Failed)
     }
 
+    pub fn record_published_message_id(
+        &mut self,
+        message_id: MessageId,
+    ) -> Result<bool, TransportAdapterError> {
+        match &self.published_message_id {
+            None => {
+                self.published_message_id = Some(message_id);
+                Ok(true)
+            }
+            Some(previous) if previous == &message_id => Ok(false),
+            Some(_) => Err(TransportAdapterError::Other(
+                "adapter changed the transport-visible id for a frozen fanout".into(),
+            )),
+        }
+    }
+
     pub fn mark_mls_confirmed(&mut self) -> Result<bool, TransportAdapterError> {
         match self.mls_state {
             FanoutMlsState::Pending(_) => {
@@ -367,7 +394,10 @@ impl OutboundFanout {
             .filter(|status| status.is_outstanding())
             .count();
         OutboundFanoutOutcome {
-            message_id: self.request.message.id.clone(),
+            message_id: self
+                .published_message_id
+                .clone()
+                .unwrap_or_else(|| self.request.message.id.clone()),
             mls_confirmation_required: accepted_targets > 0
                 && matches!(self.mls_state, FanoutMlsState::Pending(_)),
             mls_confirmed: self.mls_state == FanoutMlsState::Confirmed,
@@ -390,7 +420,14 @@ impl OutboundFanout {
             && self.group_id == previous.group_id
             && self.created_at_ms == previous.created_at_ms
             && self.target_statuses.len() == previous.target_statuses.len();
+        let published_id_advances =
+            match (&previous.published_message_id, &self.published_message_id) {
+                (None, _) => true,
+                (Some(previous), Some(next)) => previous == next,
+                (Some(_), None) => false,
+            };
         let targets_advance = immutable_matches
+            && published_id_advances
             && self
                 .target_statuses
                 .iter()


### PR DESCRIPTION
## Summary

- persist the exact outbound group-message request, frozen relay set, and per-relay first-attempt state before publishing
- release MLS pending state on the first acknowledgement while continuing every remaining first attempt
- resume incomplete fanouts after restart with the original bytes, event identity, and targets
- expose MLS-confirmed and fanout-complete outcomes without relay URLs
- prune terminal fanouts and use an indexed per-group hydration lookup
- recover pending commits with numeric fork-snapshot ordering and reject malformed matching snapshots

This is the current-`master` replacement for the closed draft #1083. KeyPackage relay deletion is intentionally outside this PR.

## Validation

- `just fast-ci`
- `cargo test -p cgka-traits -p storage-sqlite -p cgka-engine -p cgka-session -p marmot-account`
- `cargo test -p storage-sqlite storage::outbound`
- `cargo test -p cgka-engine frozen_fanout_recovery_tests`
- `cargo test -p marmot-account --test runtime`

Fixes #1020


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable outbound fanout tracking for group message delivery, including per-target progress and delivery outcomes.
  * Added support for resuming incomplete fanouts after app restarts or interruptions.
  * Added publish confirmation and rollback handling for completed and failed fanouts.
  * Added fanout results to account effects for improved delivery visibility.

* **Bug Fixes**
  * Prevented invalid delivery-state regressions and duplicate snapshot identifiers.
  * Improved recovery of pending group changes during session reopening.

* **Tests**
  * Added coverage for retries, timeouts, crashes, persistence, and fanout recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->