### PR TITLE
fix(media): close Media V1/V2 FFI acceptance gaps

### DIFF
--- a/crates/cli/src/commands/media.rs
+++ b/crates/cli/src/commands/media.rs
@@ -138,7 +138,7 @@ pub(crate) async fn media_command_with_runtime(
                     limit: None,
                 },
             )?;
-            let media = media_records_json(messages, app.allow_loopback_blob_endpoints())?;
+            let media = media_records_json(messages, app.allow_loopback_blob_endpoints());
             Ok(CommandOutput {
                 plain: if media.is_empty() {
                     "no media".to_owned()
@@ -160,15 +160,12 @@ pub(crate) async fn media_command_with_runtime(
     }
 }
 
-fn media_records_json(
-    messages: Vec<AppMessageRecord>,
-    allow_loopback_http: bool,
-) -> Result<Vec<Value>, WnError> {
+fn media_records_json(messages: Vec<AppMessageRecord>, allow_loopback_http: bool) -> Vec<Value> {
     let mut records = Vec::new();
     for message in messages {
         let caption = (!message.plaintext.is_empty()).then(|| message.plaintext.clone());
         for (attachment_index, reference) in
-            media_attachments_from_message(&message, allow_loopback_http)?
+            media_attachments_from_message(&message, allow_loopback_http)
                 .into_iter()
                 .enumerate()
         {
@@ -195,7 +192,7 @@ fn media_records_json(
             }));
         }
     }
-    Ok(records)
+    records
 }
 
 fn media_upload_attachment_json(attachment: &marmot_app::MediaUploadAttachmentResult) -> Value {
@@ -245,7 +242,7 @@ fn media_attachment_for_hash(
     allow_loopback_http: bool,
 ) -> Result<MediaAttachmentReference, WnError> {
     for message in messages {
-        for reference in media_attachments_from_message(&message, allow_loopback_http)? {
+        for reference in media_attachments_from_message(&message, allow_loopback_http) {
             if reference.plaintext_sha256 == file_hash_hex {
                 return Ok(reference);
             }
@@ -257,12 +254,17 @@ fn media_attachment_for_hash(
 fn media_attachments_from_message(
     message: &AppMessageRecord,
     allow_loopback_http: bool,
-) -> Result<Vec<MediaAttachmentReference>, WnError> {
+) -> Vec<MediaAttachmentReference> {
+    // Rejection is attachment-local: a malformed sibling must not abort list or
+    // download before a later valid reference is considered. Match the UniFFI
+    // `list_media` / timeline projection path, which uses `filter_map`.
     message
         .tags
         .iter()
         .filter(|tag| tag.first().map(String::as_str) == Some("imeta"))
-        .map(|tag| media_attachment_from_imeta_tag(tag, message.source_epoch, allow_loopback_http))
+        .filter_map(|tag| {
+            media_attachment_from_imeta_tag(tag, message.source_epoch, allow_loopback_http).ok()
+        })
         .collect()
 }
 
@@ -329,5 +331,131 @@ fn guess_media_type(path: &Path) -> &'static str {
         Some("txt") => "text/plain",
         Some("pdf") => "application/pdf",
         _ => "application/octet-stream",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shared golden imeta fixtures also drive marmot-app and marmot-uniffi
+    /// agreement tests.
+    fn shared_media_fixture_cases(file: &str) -> Vec<Value> {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../fixtures/encrypted-media")
+            .join(file);
+        let doc: Value = serde_json::from_str(
+            &std::fs::read_to_string(&path)
+                .unwrap_or_else(|err| panic!("read media fixture {}: {err}", path.display())),
+        )
+        .expect("media fixture file is valid JSON");
+        doc["cases"].as_array().expect("fixture cases").clone()
+    }
+
+    /// The CLI resolves inbound `imeta` tags through the same Rust parser as
+    /// app-core and the bindings; this locks the agreement on the shared
+    /// fixtures so a divergent CLI-side wrapper (the pre-#1080 hand-written
+    /// parser regressing) fails loudly.
+    #[test]
+    fn cli_media_validation_agrees_with_shared_golden_fixtures() {
+        for file in ["imeta-v1.json", "imeta-v2.json"] {
+            for case in shared_media_fixture_cases(file) {
+                let name = case["name"].as_str().expect("fixture case name");
+                let tag: Vec<String> = case["tag"]
+                    .as_array()
+                    .expect("fixture tag")
+                    .iter()
+                    .map(|field| field.as_str().expect("fixture tag field").to_owned())
+                    .collect();
+                let source_epoch = case["source_epoch"].as_u64().expect("fixture source_epoch");
+                let valid = case["valid"].as_bool().expect("fixture valid flag");
+                let result = media_attachment_from_imeta_tag(&tag, Some(source_epoch), false);
+                match result {
+                    Ok(reference) => {
+                        assert!(valid, "{file}/{name}: CLI accepted a rejection fixture");
+                        let expected = &case["expected"];
+                        assert_eq!(
+                            reference.version,
+                            expected["version"].as_str().unwrap(),
+                            "{file}/{name} version"
+                        );
+                        assert_eq!(
+                            reference.source_epoch, source_epoch,
+                            "{file}/{name} source_epoch"
+                        );
+                    }
+                    Err(err) => {
+                        assert!(
+                            !valid,
+                            "{file}/{name}: CLI rejected a golden fixture: {err}"
+                        );
+                        let needle = case["error_contains"].as_str().expect("error_contains");
+                        assert!(
+                            err.to_string().contains(needle),
+                            "{file}/{name} error must mention {needle:?}, got: {err}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn sample_message(tags: Vec<Vec<String>>) -> AppMessageRecord {
+        AppMessageRecord {
+            message_id_hex: "aa".repeat(32),
+            direction: "incoming".to_owned(),
+            group_id_hex: "bb".repeat(32),
+            sender: "alice".to_owned(),
+            plaintext: "caption".to_owned(),
+            kind: 9,
+            tags,
+            source_epoch: Some(7),
+            retention: None,
+            recorded_at: 10,
+            received_at: 11,
+            insert_order: 0,
+        }
+    }
+
+    fn valid_cli_imeta_tag(byte: u8, file_name: &str) -> Vec<String> {
+        vec![
+            "imeta".to_owned(),
+            "v encrypted-media-v1".to_owned(),
+            format!(
+                "locator blossom-v1 https://media.example/{}.bin",
+                hex::encode([byte; 32])
+            ),
+            format!("ciphertext_sha256 {}", hex::encode([byte; 32])),
+            format!(
+                "plaintext_sha256 {}",
+                hex::encode([byte.wrapping_add(1); 32])
+            ),
+            format!("nonce {}", hex::encode([byte; 12])),
+            "m image/png".to_owned(),
+            format!("filename {file_name}"),
+        ]
+    }
+
+    #[test]
+    fn cli_media_list_keeps_valid_siblings_when_one_imeta_is_malformed() {
+        let malformed = vec!["imeta".to_owned(), "v encrypted-media-v1".to_owned()];
+        let message = sample_message(vec![
+            valid_cli_imeta_tag(0x11, "ok.png"),
+            malformed,
+            valid_cli_imeta_tag(0x22, "also-ok.png"),
+        ]);
+
+        let references = media_attachments_from_message(&message, false);
+        assert_eq!(
+            references
+                .iter()
+                .map(|reference| reference.file_name.as_str())
+                .collect::<Vec<_>>(),
+            ["ok.png", "also-ok.png"]
+        );
+
+        let later = media_attachment_for_hash(vec![message], &hex::encode([0x23; 32]), false)
+            .expect("download lookup must reach the later valid sibling");
+        assert_eq!(later.file_name, "also-ok.png");
     }
 }

--- a/crates/marmot-app/src/media/mod.rs
+++ b/crates/marmot-app/src/media/mod.rs
@@ -201,6 +201,18 @@ impl MediaAttachmentReference {
                 expected_version.as_str()
             )));
         }
+        // Ingest still accepts noncanonical V1 `m` values for legacy wire
+        // compatibility, but the checked outbound builder must emit the
+        // canonical stored form exactly (same rule V2 already enforces in
+        // `validate`).
+        if expected_version == EncryptedMediaVersion::V1 {
+            let canonical = canonical_media_type_v1(&self.media_type)?;
+            if canonical != self.media_type {
+                return Err(AppError::InvalidAppMessagePayload(
+                    "media type is not canonical for encrypted-media-v1".into(),
+                ));
+            }
+        }
         for locator in &self.locators {
             if !locator_kind_allowed(&locator.kind, allowed_locator_kinds) {
                 return Err(AppError::InvalidEncryptedMedia(

--- a/crates/marmot-app/src/media/tests.rs
+++ b/crates/marmot-app/src/media/tests.rs
@@ -114,6 +114,25 @@ fn outbound_media_never_crosses_group_version() {
 }
 
 #[test]
+fn checked_v1_builder_rejects_noncanonical_media_type_while_ingest_stays_tolerant() {
+    let mut noncanonical = valid_imeta_tag();
+    noncanonical[6] = "m Image/JPG; charset=utf-8".to_owned();
+    let reference = media_attachment_from_imeta_tag(&noncanonical, Some(1), false)
+        .expect("legacy V1 ingest still accepts a noncanonical m field");
+    assert_eq!(reference.media_type, "Image/JPG; charset=utf-8");
+
+    let allowed = [BLOSSOM_LOCATOR_KIND_V1.to_owned()];
+    let err = reference
+        .build_imeta_tag(EncryptedMediaVersion::V1, &allowed, false)
+        .expect_err("checked outbound V1 builder must reject noncanonical m");
+    assert!(
+        err.to_string()
+            .contains("media type is not canonical for encrypted-media-v1"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
 fn checked_imeta_builder_preserves_version_and_present_empty_optional_fields() {
     let allowed = [BLOSSOM_LOCATOR_KIND_V1.to_owned()];
     let v1 = media_attachment_from_imeta_tag(&valid_imeta_tag(), Some(1), false).unwrap();
@@ -1168,4 +1187,141 @@ async fn limited_body_reader_rejects_chunked_body_over_cap() {
     let err = read_limited_blossom_body(response, 5).await.unwrap_err();
 
     assert!(err.to_string().contains("download exceeds 5 bytes"));
+}
+
+/// Load the shared golden imeta fixture file used by marmot-app, marmot-uniffi,
+/// and wn-cli agreement tests.
+fn shared_media_fixture_cases(file: &str) -> Vec<serde_json::Value> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../fixtures/encrypted-media")
+        .join(file);
+    let doc: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("read media fixture {}: {err}", path.display())),
+    )
+    .expect("media fixture file is valid JSON");
+    doc["cases"].as_array().expect("fixture cases").clone()
+}
+
+fn fixture_tag(case: &serde_json::Value) -> Vec<String> {
+    case["tag"]
+        .as_array()
+        .expect("fixture tag")
+        .iter()
+        .map(|field| field.as_str().expect("fixture tag field").to_owned())
+        .collect()
+}
+
+/// `null`/absent means the optional wire field is absent; `""` (or any string)
+/// means it is present with exactly that value. The distinction is part of the
+/// fixture contract because build -> parse must not collapse it.
+fn fixture_optional(value: &serde_json::Value, key: &str) -> Option<String> {
+    match &value[key] {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(text) => Some(text.clone()),
+        other => panic!("fixture optional field {key} must be null or string, got {other}"),
+    }
+}
+
+fn assert_shared_media_fixture_file(file: &str) {
+    let cases = shared_media_fixture_cases(file);
+    assert!(!cases.is_empty(), "{file} must contain cases");
+    for case in cases {
+        let name = case["name"].as_str().expect("fixture case name");
+        let tag = fixture_tag(&case);
+        let source_epoch = case["source_epoch"].as_u64().expect("fixture source_epoch");
+        let result = media_attachment_from_imeta_tag(&tag, Some(source_epoch), false);
+        if case["valid"].as_bool().expect("fixture valid flag") {
+            let reference = result
+                .unwrap_or_else(|err| panic!("{file}/{name} must parse as a valid tag: {err}"));
+            let expected = &case["expected"];
+            assert_eq!(
+                reference.version,
+                expected["version"].as_str().unwrap(),
+                "{file}/{name} version"
+            );
+            let expected_locators: Vec<MediaLocator> = expected["locators"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|locator| MediaLocator {
+                    kind: locator["kind"].as_str().unwrap().to_owned(),
+                    value: locator["value"].as_str().unwrap().to_owned(),
+                })
+                .collect();
+            assert_eq!(
+                reference.locators, expected_locators,
+                "{file}/{name} locators"
+            );
+            assert_eq!(
+                reference.ciphertext_sha256,
+                expected["ciphertext_sha256"].as_str().unwrap(),
+                "{file}/{name} ciphertext_sha256"
+            );
+            assert_eq!(
+                reference.plaintext_sha256,
+                expected["plaintext_sha256"].as_str().unwrap(),
+                "{file}/{name} plaintext_sha256"
+            );
+            assert_eq!(
+                reference.nonce_hex,
+                expected["nonce_hex"].as_str().unwrap(),
+                "{file}/{name} nonce_hex"
+            );
+            assert_eq!(
+                reference.media_type,
+                expected["media_type"].as_str().unwrap(),
+                "{file}/{name} media_type"
+            );
+            assert_eq!(
+                reference.file_name,
+                expected["file_name"].as_str().unwrap(),
+                "{file}/{name} file_name"
+            );
+            assert_eq!(
+                reference.source_epoch, source_epoch,
+                "{file}/{name} source_epoch"
+            );
+            assert_eq!(
+                reference.dim,
+                fixture_optional(expected, "dim"),
+                "{file}/{name} dim absent-vs-present-empty"
+            );
+            assert_eq!(
+                reference.thumbhash,
+                fixture_optional(expected, "thumbhash"),
+                "{file}/{name} thumbhash absent-vs-present-empty"
+            );
+            // Exact wire round-trip through the checked outbound builder: the
+            // group-version gate and locator policy accept the reference, and
+            // the rebuilt tag is byte-identical to the golden fixture.
+            let version = EncryptedMediaVersion::parse(&reference.version).unwrap();
+            let allowed: Vec<String> = reference
+                .locators
+                .iter()
+                .map(|locator| locator.kind.clone())
+                .collect();
+            let rebuilt = reference
+                .build_imeta_tag(version, &allowed, false)
+                .unwrap_or_else(|err| panic!("{file}/{name} must rebuild: {err}"));
+            assert_eq!(rebuilt, tag, "{file}/{name} exact round-trip");
+        } else {
+            let err = result.expect_err(&format!("{file}/{name} must be rejected"));
+            let needle = case["error_contains"].as_str().expect("error_contains");
+            assert!(
+                err.to_string().contains(needle),
+                "{file}/{name} error must mention {needle:?}, got: {err}"
+            );
+        }
+    }
+}
+
+#[test]
+fn shared_golden_v1_fixtures_parse_validate_and_round_trip_exactly() {
+    assert_shared_media_fixture_file("imeta-v1.json");
+}
+
+#[test]
+fn shared_golden_v2_fixtures_parse_validate_and_round_trip_exactly() {
+    assert_shared_media_fixture_file("imeta-v2.json");
 }

--- a/crates/marmot-uniffi/src/commands/media.rs
+++ b/crates/marmot-uniffi/src/commands/media.rs
@@ -64,7 +64,8 @@ impl Marmot {
                 attachments.into_iter().map(Into::into).collect(),
                 caption,
             )
-            .await?;
+            .await
+            .map_err(media_reference_error)?;
         Ok(summary.into())
     }
 
@@ -94,8 +95,9 @@ impl Marmot {
         let upload = self
             .runtime
             .upload_media(&account_ref, &group_id, request.into())
-            .await?;
-        Ok(upload.try_into()?)
+            .await
+            .map_err(media_reference_error)?;
+        upload.try_into().map_err(media_reference_error)
     }
 
     /// Fetch an encrypted media blob and decrypt it using the group's
@@ -110,7 +112,8 @@ impl Marmot {
         let download = self
             .runtime
             .download_media(&account_ref, &group_id, reference.into())
-            .await?;
+            .await
+            .map_err(media_reference_error)?;
         Ok(download.into())
     }
 

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -164,6 +164,10 @@ impl From<AppError> for MarmotKitError {
             },
             AppError::UnknownGroup(group_id_hex) => Self::UnknownGroup { group_id_hex },
             AppError::InvalidMessageDraft(details) => Self::InvalidMessageDraft { details },
+            // Encrypted-media validation failures are always media-boundary
+            // errors; map them to the typed variant so send/upload/download
+            // agree with build/parse even when a call site uses `?`/`From`.
+            AppError::InvalidEncryptedMedia(details) => Self::InvalidMediaReference { details },
             AppError::Hex(err) => Self::InvalidHex {
                 details: err.to_string(),
             },
@@ -256,6 +260,22 @@ mod tests {
                 );
             }
             other => panic!("expected AccountCatchUp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_encrypted_media_crosses_ffi_as_typed_media_reference() {
+        let app_err =
+            AppError::InvalidEncryptedMedia("group requires encrypted-media-v2 references".into());
+        let ffi: MarmotKitError = app_err.into();
+        match ffi {
+            MarmotKitError::InvalidMediaReference { details } => {
+                assert!(
+                    details.contains("encrypted-media-v2"),
+                    "typed InvalidMediaReference should carry the media detail, got: {details}"
+                );
+            }
+            other => panic!("expected InvalidMediaReference, got {other:?}"),
         }
     }
 

--- a/crates/marmot-uniffi/tests/media_fixtures.rs
+++ b/crates/marmot-uniffi/tests/media_fixtures.rs
@@ -1,0 +1,181 @@
+//! Shared golden imeta fixture agreement across the UniFFI media boundary.
+//!
+//! The same fixture files drive marmot-app's parser tests and wn-cli's
+//! validation test, so every Rust layer reaches identical verdicts for
+//! identical wire input. This suite proves the FFI boundary specifically:
+//!
+//! - `parse_media_imeta_tag` returns the typed wire version and the complete
+//!   reference for golden V1 and V2 fixtures independently;
+//! - absent (`null`) versus present-empty (`""`) optional fields survive the
+//!   FFI conversion unchanged;
+//! - malformed, noncanonical, and unknown-version tags surface as the typed
+//!   `MarmotKitError::InvalidMediaReference` error, never a panic;
+//! - converting the FFI record back to the app-layer reference and rebuilding
+//!   through the checked outbound builder reproduces the fixture tag exactly,
+//!   so the conversion drops no field.
+
+use marmot_app::{EncryptedMediaVersion, MediaAttachmentReference};
+use marmot_uniffi::{
+    EncryptedMediaVersionFfi, MarmotKitError, MessageTagFfi, parse_media_imeta_tag,
+};
+
+fn fixture_cases(file: &str) -> Vec<serde_json::Value> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../fixtures/encrypted-media")
+        .join(file);
+    let doc: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("read media fixture {}: {err}", path.display())),
+    )
+    .expect("media fixture file is valid JSON");
+    doc["cases"].as_array().expect("fixture cases").clone()
+}
+
+fn fixture_tag(case: &serde_json::Value) -> Vec<String> {
+    case["tag"]
+        .as_array()
+        .expect("fixture tag")
+        .iter()
+        .map(|field| field.as_str().expect("fixture tag field").to_owned())
+        .collect()
+}
+
+/// `null`/absent means the optional wire field is absent; a string (including
+/// `""`) means present with exactly that value.
+fn fixture_optional(value: &serde_json::Value, key: &str) -> Option<String> {
+    match &value[key] {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(text) => Some(text.clone()),
+        other => panic!("fixture optional field {key} must be null or string, got {other}"),
+    }
+}
+
+fn expected_version_ffi(expected: &serde_json::Value) -> EncryptedMediaVersionFfi {
+    match expected["version"].as_str().unwrap() {
+        "encrypted-media-v1" => EncryptedMediaVersionFfi::V1,
+        "encrypted-media-v2" => EncryptedMediaVersionFfi::V2,
+        other => panic!("fixture version {other} is not a supported FFI version"),
+    }
+}
+
+fn assert_fixture_file(file: &str) {
+    let cases = fixture_cases(file);
+    assert!(!cases.is_empty(), "{file} must contain cases");
+    for case in cases {
+        let name = case["name"].as_str().expect("fixture case name");
+        let tag = fixture_tag(&case);
+        let source_epoch = case["source_epoch"].as_u64().expect("fixture source_epoch");
+        let result = parse_media_imeta_tag(
+            MessageTagFfi {
+                values: tag.clone(),
+            },
+            source_epoch,
+        );
+        if case["valid"].as_bool().expect("fixture valid flag") {
+            let reference =
+                result.unwrap_or_else(|err| panic!("{file}/{name} must parse over FFI: {err}"));
+            let expected = &case["expected"];
+            assert_eq!(
+                reference.version,
+                expected_version_ffi(expected),
+                "{file}/{name} typed wire version"
+            );
+            assert_eq!(
+                reference.locators.len(),
+                expected["locators"].as_array().unwrap().len(),
+                "{file}/{name} locator count"
+            );
+            for (locator, expected_locator) in reference
+                .locators
+                .iter()
+                .zip(expected["locators"].as_array().unwrap())
+            {
+                assert_eq!(
+                    locator.kind,
+                    expected_locator["kind"].as_str().unwrap(),
+                    "{file}/{name} locator kind"
+                );
+                assert_eq!(
+                    locator.value,
+                    expected_locator["value"].as_str().unwrap(),
+                    "{file}/{name} locator value"
+                );
+            }
+            assert_eq!(
+                reference.ciphertext_sha256,
+                expected["ciphertext_sha256"].as_str().unwrap(),
+                "{file}/{name} ciphertext_sha256"
+            );
+            assert_eq!(
+                reference.plaintext_sha256,
+                expected["plaintext_sha256"].as_str().unwrap(),
+                "{file}/{name} plaintext_sha256"
+            );
+            assert_eq!(
+                reference.nonce_hex,
+                expected["nonce_hex"].as_str().unwrap(),
+                "{file}/{name} nonce_hex"
+            );
+            assert_eq!(
+                reference.media_type,
+                expected["media_type"].as_str().unwrap(),
+                "{file}/{name} media_type"
+            );
+            assert_eq!(
+                reference.file_name,
+                expected["file_name"].as_str().unwrap(),
+                "{file}/{name} file_name"
+            );
+            assert_eq!(
+                reference.source_epoch, source_epoch,
+                "{file}/{name} source_epoch"
+            );
+            assert_eq!(
+                reference.dim,
+                fixture_optional(expected, "dim"),
+                "{file}/{name} dim absent-vs-present-empty"
+            );
+            assert_eq!(
+                reference.thumbhash,
+                fixture_optional(expected, "thumbhash"),
+                "{file}/{name} thumbhash absent-vs-present-empty"
+            );
+            // Convert the FFI record back to the app-layer reference and rebuild
+            // the wire tag through the checked outbound builder: byte-identical
+            // output proves the FFI conversion dropped nothing.
+            let app_reference = MediaAttachmentReference::from(reference);
+            let version = EncryptedMediaVersion::parse(&app_reference.version).unwrap();
+            let allowed: Vec<String> = app_reference
+                .locators
+                .iter()
+                .map(|locator| locator.kind.clone())
+                .collect();
+            let rebuilt = app_reference
+                .build_imeta_tag(version, &allowed, false)
+                .unwrap_or_else(|err| panic!("{file}/{name} must rebuild after FFI: {err}"));
+            assert_eq!(rebuilt, tag, "{file}/{name} exact round-trip through FFI");
+        } else {
+            let err = result.expect_err(&format!("{file}/{name} must be rejected over FFI"));
+            let needle = case["error_contains"].as_str().expect("error_contains");
+            match &err {
+                MarmotKitError::InvalidMediaReference { details } => assert!(
+                    details.contains(needle),
+                    "{file}/{name} typed error must mention {needle:?}, got: {details}"
+                ),
+                other => panic!(
+                    "{file}/{name} must surface as typed InvalidMediaReference, got {other:?}"
+                ),
+            }
+        }
+    }
+}
+
+#[test]
+fn shared_golden_v1_fixtures_cross_ffi_with_typed_version_and_errors() {
+    assert_fixture_file("imeta-v1.json");
+}
+
+#[test]
+fn shared_golden_v2_fixtures_cross_ffi_with_typed_version_and_errors() {
+    assert_fixture_file("imeta-v2.json");
+}

--- a/fixtures/encrypted-media/imeta-v1.json
+++ b/fixtures/encrypted-media/imeta-v1.json
@@ -1,0 +1,216 @@
+{
+  "schema": "mdk-encrypted-media-imeta-fixture/v1",
+  "description": "Golden and rejection imeta fixtures for encrypted-media-v1. Shared by marmot-app, marmot-uniffi, and wn-cli tests so every layer agrees on validation verdicts and exact wire round-trips. `expected.dim`/`expected.thumbhash` distinguish absent (null) from present-empty (\"\").",
+  "media_version": "encrypted-media-v1",
+  "cases": [
+    {
+      "name": "golden-image-full",
+      "source_epoch": 7,
+      "valid": true,
+      "tag": [
+        "imeta",
+        "v encrypted-media-v1",
+        "locator blossom-v1 https://media.example/1111111111111111111111111111111111111111111111111111111111111111.bin",
+        "ciphertext_sha256 1111111111111111111111111111111111111111111111111111111111111111",
+        "plaintext_sha256 2222222222222222222222222222222222222222222222222222222222222222",
+        "nonce 333333333333333333333333",
+        "m image/png",
+        "filename diagram.png",
+        "dim 800x600",
+        "thumbhash 1QcSHQRnh493V4dIh4eXh1h4kJUI"
+      ],
+      "expected": {
+        "version": "encrypted-media-v1",
+        "locators": [
+          {
+            "kind": "blossom-v1",
+            "value": "https://media.example/1111111111111111111111111111111111111111111111111111111111111111.bin"
+          }
+        ],
+        "ciphertext_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+        "plaintext_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+        "nonce_hex": "333333333333333333333333",
+        "media_type": "image/png",
+        "file_name": "diagram.png",
+        "dim": "800x600",
+        "thumbhash": "1QcSHQRnh493V4dIh4eXh1h4kJUI"
+      }
+    },
+    {
+      "name": "golden-document-minimal",
+      "source_epoch": 42,
+      "valid": true,
+      "tag": [
+        "imeta",
+        "v encrypted-media-v1",
+        "locator blossom-v1 https://media.example/4444444444444444444444444444444444444444444444444444444444444444.bin",
+        "ciphertext_sha256 4444444444444444444444444444444444444444444444444444444444444444",
+        "plaintext_sha256 5555555555555555555555555555555555555555555555555555555555555555",
+        "nonce 666666666666666666666666",
+        "m application/pdf",
+        "filename brief.pdf"
+      ],
+      "expected": {
+        "version": "encrypted-media-v1",
+        "locators": [
+          {
+            "kind": "blossom-v1",
+            "value": "https://media.example/4444444444444444444444444444444444444444444444444444444444444444.bin"
+          }
+        ],
+        "ciphertext_sha256": "4444444444444444444444444444444444444444444444444444444444444444",
+        "plaintext_sha256": "5555555555555555555555555555555555555555555555555555555555555555",
+        "nonce_hex": "666666666666666666666666",
+        "media_type": "application/pdf",
+        "file_name": "brief.pdf",
+        "dim": null,
+        "thumbhash": null
+      }
+    },
+    {
+      "name": "golden-present-empty-dim",
+      "source_epoch": 7,
+      "valid": true,
+      "tag": [
+        "imeta",
+        "v encrypted-media-v1",
+        "locator blossom-v1 https://media.example/1111111111111111111111111111111111111111111111111111111111111111.bin",
+        "ciphertext_sha256 1111111111111111111111111111111111111111111111111111111111111111",
+        "plaintext_sha256 2222222222222222222222222222222222222222222222222222222222222222",
+        "nonce 333333333333333333333333",
+        "m image/png",
+        "filename diagram.png",
+        "dim "
+      ],
+      "expected": {
+        "version": "encrypted-media-v1",
+        "locators": [
+          {
+            "kind": "blossom-v1",
+            "value": "https://media.example/1111111111111111111111111111111111111111111111111111111111111111.bin"
+          }
+        ],
+        "ciphertext_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+        "plaintext_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+        "nonce_hex": "333333333333333333333333",
+        "media_type": "image/png",
+        "file_name": "diagram.png",
+        "dim": "",
+        "thumbhash": null
+      }
+    },
+    {
+      "name": "rejects-missing-nonce",
+      "source_epoch": 7,
+      "valid": false,
+      "error_contains": "nonce",
+      "tag": [
+        "imeta",
+        "v encrypted-media-v1",
+        "locator blossom-v1 https://media.example/1111111111111111111111111111111111111111111111111111111111111111.bin",
+        "ciphertext_sha256 1111111111111111111111111111111111111111111111111111111111111111",
+        "plaintext_sha256 2222222222222222222222222222222222222222222222222222222222222222",
+        "m image/png",
+        "filename diagram.png"
+      ]
+    },
+    {
+      "name": "rejects-duplicate-media-type",
+      "source_epoch": 7,
+      "valid": false,
+      "error_contains": "exactly one m",
+      "tag": [
+        "imeta",
+        "v encrypted-media-v1",
+        "locator blossom-v1 https://media.example/1111111111111111111111111111111111111111111111111111111111111111.bin",
+        "ciphertext_sha256 1111111111111111111111111111111111111111111111111111111111111111",
+        "plaintext_sha256 2222222222222222222222222222222222222222222222222222222222222222",
+        "nonce 333333333333333333333333",
+        "m image/png",
+        "filename diagram.png",
+        "m image/jpeg"
+      ]
+    },
+    {
+      "name": "rejects-blurhash-field",
+      "source_epoch": 7,
+      "valid": false,
+      "error_contains": "thumbhash",
+      "tag": [
+        "imeta",
+        "v encrypted-media-v1",
+        "locator blossom-v1 https://media.example/1111111111111111111111111111111111111111111111111111111111111111.bin",
+        "ciphertext_sha256 1111111111111111111111111111111111111111111111111111111111111111",
+        "plaintext_sha256 2222222222222222222222222222222222222222222222222222222222222222",
+        "nonce 333333333333333333333333",
+        "m image/png",
+        "filename diagram.png",
+        "blurhash LEHV6nWB2yk8pyo0adR*.7kCMdnj"
+      ]
+    },
+    {
+      "name": "rejects-blossom-locator-hash-mismatch",
+      "source_epoch": 7,
+      "valid": false,
+      "error_contains": "locator",
+      "tag": [
+        "imeta",
+        "v encrypted-media-v1",
+        "locator blossom-v1 https://media.example/7777777777777777777777777777777777777777777777777777777777777777.bin",
+        "ciphertext_sha256 1111111111111111111111111111111111111111111111111111111111111111",
+        "plaintext_sha256 2222222222222222222222222222222222222222222222222222222222222222",
+        "nonce 333333333333333333333333",
+        "m image/png",
+        "filename diagram.png"
+      ]
+    },
+    {
+      "name": "rejects-unknown-version",
+      "source_epoch": 7,
+      "valid": false,
+      "error_contains": "version",
+      "tag": [
+        "imeta",
+        "v encrypted-media-v3",
+        "locator blossom-v1 https://media.example/1111111111111111111111111111111111111111111111111111111111111111.bin",
+        "ciphertext_sha256 1111111111111111111111111111111111111111111111111111111111111111",
+        "plaintext_sha256 2222222222222222222222222222222222222222222222222222222222222222",
+        "nonce 333333333333333333333333",
+        "m image/png",
+        "filename diagram.png"
+      ]
+    },
+    {
+      "name": "rejects-whitespace-only-filename",
+      "source_epoch": 7,
+      "valid": false,
+      "error_contains": "file name",
+      "tag": [
+        "imeta",
+        "v encrypted-media-v1",
+        "locator blossom-v1 https://media.example/1111111111111111111111111111111111111111111111111111111111111111.bin",
+        "ciphertext_sha256 1111111111111111111111111111111111111111111111111111111111111111",
+        "plaintext_sha256 2222222222222222222222222222222222222222222222222222222222222222",
+        "nonce 333333333333333333333333",
+        "m image/png",
+        "filename  "
+      ]
+    },
+    {
+      "name": "rejects-short-nonce",
+      "source_epoch": 7,
+      "valid": false,
+      "error_contains": "nonce",
+      "tag": [
+        "imeta",
+        "v encrypted-media-v1",
+        "locator blossom-v1 https://media.example/1111111111111111111111111111111111111111111111111111111111111111.bin",
+        "ciphertext_sha256 1111111111111111111111111111111111111111111111111111111111111111",
+        "plaintext_sha256 2222222222222222222222222222222222222222222222222222222222222222",
+        "nonce 3333333333333333",
+        "m image/png",
+        "filename diagram.png"
+      ]
+    }
+  ]
+}

--- a/fixtures/encrypted-media/imeta-v2.json
+++ b/fixtures/encrypted-media/imeta-v2.json
@@ -1,0 +1,250 @@
+{
+  "schema": "mdk-encrypted-media-imeta-fixture/v1",
+  "description": "Golden and rejection imeta fixtures for encrypted-media-v2. Shared by marmot-app, marmot-uniffi, and wn-cli tests so every layer agrees on validation verdicts and exact wire round-trips. `expected.dim`/`expected.thumbhash` distinguish absent (null) from present-empty (\"\").",
+  "media_version": "encrypted-media-v2",
+  "cases": [
+    {
+      "name": "golden-image-full",
+      "source_epoch": 9,
+      "valid": true,
+      "tag": [
+        "imeta",
+        "v encrypted-media-v2",
+        "locator blossom-v1 https://media.example/abababababababababababababababababababababababababababababababab.bin",
+        "ciphertext_sha256 abababababababababababababababababababababababababababababababab",
+        "plaintext_sha256 cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "nonce efefefefefefefefefefefef",
+        "m image/jpeg",
+        "filename photo.jpg",
+        "dim 1920x1080",
+        "thumbhash 1QcSHQRnh493V4dIh4eXh1h4kJUI"
+      ],
+      "expected": {
+        "version": "encrypted-media-v2",
+        "locators": [
+          {
+            "kind": "blossom-v1",
+            "value": "https://media.example/abababababababababababababababababababababababababababababababab.bin"
+          }
+        ],
+        "ciphertext_sha256": "abababababababababababababababababababababababababababababababab",
+        "plaintext_sha256": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "nonce_hex": "efefefefefefefefefefefef",
+        "media_type": "image/jpeg",
+        "file_name": "photo.jpg",
+        "dim": "1920x1080",
+        "thumbhash": "1QcSHQRnh493V4dIh4eXh1h4kJUI"
+      }
+    },
+    {
+      "name": "golden-audio-minimal",
+      "source_epoch": 3,
+      "valid": true,
+      "tag": [
+        "imeta",
+        "v encrypted-media-v2",
+        "locator blossom-v1 https://media.example/1212121212121212121212121212121212121212121212121212121212121212.bin",
+        "ciphertext_sha256 1212121212121212121212121212121212121212121212121212121212121212",
+        "plaintext_sha256 3434343434343434343434343434343434343434343434343434343434343434",
+        "nonce 565656565656565656565656",
+        "m audio/ogg",
+        "filename voice.ogg"
+      ],
+      "expected": {
+        "version": "encrypted-media-v2",
+        "locators": [
+          {
+            "kind": "blossom-v1",
+            "value": "https://media.example/1212121212121212121212121212121212121212121212121212121212121212.bin"
+          }
+        ],
+        "ciphertext_sha256": "1212121212121212121212121212121212121212121212121212121212121212",
+        "plaintext_sha256": "3434343434343434343434343434343434343434343434343434343434343434",
+        "nonce_hex": "565656565656565656565656",
+        "media_type": "audio/ogg",
+        "file_name": "voice.ogg",
+        "dim": null,
+        "thumbhash": null
+      }
+    },
+    {
+      "name": "golden-multi-locator",
+      "source_epoch": 12,
+      "valid": true,
+      "tag": [
+        "imeta",
+        "v encrypted-media-v2",
+        "locator blossom-v1 https://media.example/abababababababababababababababababababababababababababababababab.bin",
+        "locator mirror-v9 https://mirror.example/blob",
+        "ciphertext_sha256 abababababababababababababababababababababababababababababababab",
+        "plaintext_sha256 cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "nonce efefefefefefefefefefefef",
+        "m video/mp4",
+        "filename clip.mp4"
+      ],
+      "expected": {
+        "version": "encrypted-media-v2",
+        "locators": [
+          {
+            "kind": "blossom-v1",
+            "value": "https://media.example/abababababababababababababababababababababababababababababababab.bin"
+          },
+          {
+            "kind": "mirror-v9",
+            "value": "https://mirror.example/blob"
+          }
+        ],
+        "ciphertext_sha256": "abababababababababababababababababababababababababababababababab",
+        "plaintext_sha256": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "nonce_hex": "efefefefefefefefefefefef",
+        "media_type": "video/mp4",
+        "file_name": "clip.mp4",
+        "dim": null,
+        "thumbhash": null
+      }
+    },
+    {
+      "name": "golden-present-empty-dim",
+      "source_epoch": 5,
+      "valid": true,
+      "tag": [
+        "imeta",
+        "v encrypted-media-v2",
+        "locator blossom-v1 https://media.example/abababababababababababababababababababababababababababababababab.bin",
+        "ciphertext_sha256 abababababababababababababababababababababababababababababababab",
+        "plaintext_sha256 cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "nonce efefefefefefefefefefefef",
+        "m image/jpeg",
+        "filename photo.jpg",
+        "dim "
+      ],
+      "expected": {
+        "version": "encrypted-media-v2",
+        "locators": [
+          {
+            "kind": "blossom-v1",
+            "value": "https://media.example/abababababababababababababababababababababababababababababababab.bin"
+          }
+        ],
+        "ciphertext_sha256": "abababababababababababababababababababababababababababababababab",
+        "plaintext_sha256": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "nonce_hex": "efefefefefefefefefefefef",
+        "media_type": "image/jpeg",
+        "file_name": "photo.jpg",
+        "dim": "",
+        "thumbhash": null
+      }
+    },
+    {
+      "name": "golden-exact-space-filename",
+      "source_epoch": 5,
+      "valid": true,
+      "tag": [
+        "imeta",
+        "v encrypted-media-v2",
+        "locator blossom-v1 https://media.example/abababababababababababababababababababababababababababababababab.bin",
+        "ciphertext_sha256 abababababababababababababababababababababababababababababababab",
+        "plaintext_sha256 cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "nonce efefefefefefefefefefefef",
+        "m image/jpeg",
+        "filename  "
+      ],
+      "expected": {
+        "version": "encrypted-media-v2",
+        "locators": [
+          {
+            "kind": "blossom-v1",
+            "value": "https://media.example/abababababababababababababababababababababababababababababababab.bin"
+          }
+        ],
+        "ciphertext_sha256": "abababababababababababababababababababababababababababababababab",
+        "plaintext_sha256": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "nonce_hex": "efefefefefefefefefefefef",
+        "media_type": "image/jpeg",
+        "file_name": " ",
+        "dim": null,
+        "thumbhash": null
+      }
+    },
+    {
+      "name": "rejects-noncanonical-media-type",
+      "source_epoch": 9,
+      "valid": false,
+      "error_contains": "canonical",
+      "tag": [
+        "imeta",
+        "v encrypted-media-v2",
+        "locator blossom-v1 https://media.example/abababababababababababababababababababababababababababababababab.bin",
+        "ciphertext_sha256 abababababababababababababababababababababababababababababababab",
+        "plaintext_sha256 cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "nonce efefefefefefefefefefefef",
+        "m Image/JPG",
+        "filename photo.jpg"
+      ]
+    },
+    {
+      "name": "rejects-overlong-filename",
+      "source_epoch": 9,
+      "valid": false,
+      "error_contains": "file name",
+      "tag": [
+        "imeta",
+        "v encrypted-media-v2",
+        "locator blossom-v1 https://media.example/abababababababababababababababababababababababababababababababab.bin",
+        "ciphertext_sha256 abababababababababababababababababababababababababababababababab",
+        "plaintext_sha256 cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "nonce efefefefefefefefefefefef",
+        "m image/jpeg",
+        "filename aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      ]
+    },
+    {
+      "name": "rejects-nul-in-filename",
+      "source_epoch": 9,
+      "valid": false,
+      "error_contains": "file name",
+      "tag": [
+        "imeta",
+        "v encrypted-media-v2",
+        "locator blossom-v1 https://media.example/abababababababababababababababababababababababababababababababab.bin",
+        "ciphertext_sha256 abababababababababababababababababababababababababababababababab",
+        "plaintext_sha256 cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "nonce efefefefefefefefefefefef",
+        "m image/jpeg",
+        "filename bad\u0000name.jpg"
+      ]
+    },
+    {
+      "name": "rejects-duplicate-plaintext-hash",
+      "source_epoch": 9,
+      "valid": false,
+      "error_contains": "exactly one plaintext_sha256",
+      "tag": [
+        "imeta",
+        "v encrypted-media-v2",
+        "locator blossom-v1 https://media.example/abababababababababababababababababababababababababababababababab.bin",
+        "ciphertext_sha256 abababababababababababababababababababababababababababababababab",
+        "plaintext_sha256 cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "nonce efefefefefefefefefefefef",
+        "m image/jpeg",
+        "filename photo.jpg",
+        "plaintext_sha256 3434343434343434343434343434343434343434343434343434343434343434"
+      ]
+    },
+    {
+      "name": "rejects-missing-version",
+      "source_epoch": 9,
+      "valid": false,
+      "error_contains": "missing v",
+      "tag": [
+        "imeta",
+        "locator blossom-v1 https://media.example/abababababababababababababababababababababababababababababababab.bin",
+        "ciphertext_sha256 abababababababababababababababababababababababababababababababab",
+        "plaintext_sha256 cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd",
+        "nonce efefefefefefefefefefefef",
+        "m image/jpeg",
+        "filename photo.jpg"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Keep CLI listing attachment-local, surface typed media errors on send/upload/download, reject noncanonical outbound V1 media types, and lock shared golden fixtures across app/CLI/UniFFI.

fixes #955 