### PR TITLE
Feat/tui media fidelity

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -316,6 +316,21 @@ versioning through the workspace version in the root `Cargo.toml`.
   (`unread_count`, `has_unread`, `last_message`, `last_read_message_id_hex`, `last_read_timeline_at`).
 ### Fixed
 
+- TUI: main-view keyboard accelerators now fire only on a plain keypress and ignore `Ctrl`/`Alt` chords. Previously
+  `Ctrl-U` in the message pane matched the bare `u` (unreact) accelerator and published an unconfirmed reaction
+  removal, and `Ctrl-Q` quit through the bare `q` accelerator. The whole accelerator family (`r`/`u`/`d`/`R`/`o`/`i`
+  and `g`/`G` in the message pane, `q`/`A`/`s`/`p`/`h`/`I` and `j`/`k` list navigation elsewhere) is now guarded, while
+  `Ctrl-U` stays the composer kill-line and `Ctrl-C` still quits. `Shift` is still tolerated, so the uppercase
+  accelerators keep working under the kitty keyboard protocol. No JSON response shapes changed.
+- TUI: logging out now reports the outcome faithfully when the follow-up account-list reload fails. Previously a reload
+  failure after a successful, irreversible wipe was reported with an `error:` prefix while the removed account and its
+  stale subscriptions lingered on screen. The logout is now reported as done and the status names `/refresh` to retry
+  the reload; a failure of the wipe itself is still reported as an error. No JSON response shapes changed.
+- TUI: a message-interaction command typed with a leading space now shows the armed-interaction hint and can be
+  cleared with `Esc`, matching how it submits. `parse_slash_command` already trims the composer text, so `/react`,
+  `/reply`, and `/delete` submit even with surrounding whitespace; the armed hint and the `Esc` escape hatch now trim
+  the same way instead of treating a space-prefixed command as an invisible, un-clearable armed state. Plain text with
+  a leading space is still a hand-typed draft and is preserved by `Esc`. No JSON response shapes changed.
 - `wn relays add/remove --type nip65` now round-trips the complete directional NIP-65 list instead of deleting
   read-only relays or flattening existing role markers. Relay-list JSON adds `read_relays` and `write_relays` alongside
   the existing write-target `relays` view.

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -109,6 +109,33 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Changed
 
+- TUI polish bundle: `Esc` on the main view is now spatial back (Composer → Messages → Chats, a no-op from Chats)
+  after the armed-interaction clear, and never destroys a hand-typed draft. The messages-pane row highlight renders
+  when that pane holds focus or while an interaction is armed — arming `/react`/`/reply`/`/delete` moves focus to the
+  composer, but the target row stays lit so you can see what the action is aimed at; a flick-through preview (focus on
+  the chat list with nothing armed) still shows no stray highlight. The chat sidebar shrinks to at
+  most a third of the width on narrow terminals (was a fixed 36 columns). Color roles are split: cyan for
+  chrome/labels/focused borders/selected markers, green reserved strictly for your own messages and the
+  daemon-connection dot; the unread badge stays yellow. The login screen centers its brand/menu block as a focused
+  card.
+- TUI: loading and empty states are now centered and color-coded — yellow while a load is in flight
+  (`loading messages...`, `searching...`, and the group-detail/profile/relay-health screen loads), dark gray when
+  genuinely empty (`no chats yet`, `no messages yet`). The messages pane distinguishes its three cases: no chat loaded
+  ("select a chat to start messaging"), a load in flight, and a loaded-but-empty chat.
+- TUI: popups are now sized to their content in cells and centered exactly, instead of always covering 70% of the
+  screen — a short confirmation is a small box, not a full panel. Confirmation bodies render yellow, the irreversible
+  typed-token logout body renders red, the title shows as a cyan-bold ` Title ` on the cyan border, and the hint row is
+  centered at the bottom. Every popup's key/paste modality and purpose is unchanged (styling and geometry only); the
+  image viewer keeps its aspect-fit 80%×80% card.
+- TUI: the hints bar now renders each key as a keycap (bold white text on a dark-gray block) followed by a dim label,
+  instead of one uniform gray string. The armed-interaction hint keeps its priority over the keymap while a
+  `/react`/`/reply`/`/delete` prefill is held, and boxes its `Enter`/`Esc` key references the same way. Popup hint rows
+  color the bracketed `[key]` cyan with a gray description.
+- TUI: the bottom status bar is now a full-width bar with a green ● / red ○ daemon-connection dot, the account display
+  name styled distinctly from its shortened npub, gray `│` separators, and hide-when-zero badges — the unread count
+  (yellow) only shows when nonzero instead of a permanent `0 unread`. Our last-action/error status segment is kept as a
+  trailing bar segment, truncated to fit. Existing redactions (terminal-safe account label and status, no relay URLs)
+  are unchanged.
 - TUI: user-initiated actions no longer freeze the interface for a `wn` subprocess round-trip. Sending a message,
   replying, reacting/unreacting, deleting, opening a chat, searching users, opening group detail, and listing invites
   now run on a dedicated background worker and fold their result back into the view on the next frame, so typing,

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -173,7 +173,12 @@ versioning through the workspace version in the root `Cargo.toml`.
   decode, so neither the inline preview nor any retained copy ever holds an unbounded camera-photo pixel buffer.
   Separately, viewer pixels are retained in memory only: at most four viewer copies are kept (oldest evicted first,
   worst case ~47 MB), so the decrypted download artifact is still removed right after decode and nothing is written
-  back to disk. The Lanczos3 downscale runs synchronously on the render thread and is cached per target size, so
+  back to disk. That ~47 MB bounds the viewer pool only. The inline image maps are decode-capped per image but not
+  bounded in aggregate: every image scrolled past keeps one decode-capped protocol (at most ~11.8 MB) alive for the
+  life of the session, so the session ceiling is ~47 MB plus that per-image cost times the images ever rendered, not
+  ~47 MB flat. LRU-bounding that inline retention needs re-download support (status un-tracking plus re-entrant
+  downloads) and is a deliberate follow-up, not this change. The Lanczos3 downscale runs synchronously on the render
+  thread and is cached per target size, so
   scrolling never re-resizes; changing the terminal width does re-resize every visible image on that one frame, an
   accepted cost of the sharper preview. Halfblock-only terminals, and evicted images, keep the cell-exact viewer popup.
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -31,6 +31,34 @@ versioning through the workspace version in the root `Cargo.toml`.
   pending flag without waiting for an unrelated refresh. `chats list --json` /
   `chat_list_row` rows gain a matching `leave_requested_at_ms` field; no other
   JSON response shapes changed.
+- TUI: the daemon auto-starts at launch when it is down and the TUI holds a relay source to give it (the
+  `--discovery-relays`/`--default-account-relays` passthrough flags, a global `--relay`, or `WN_RELAY`) — exactly as
+  `/daemon start` would, but off the event loop, since `wn daemon start` blocks up to five seconds on its readiness
+  poll. The status line shows `starting daemon...` and then the outcome, the status-bar dot flips green when the start
+  lands, and the daemon-backed live subscriptions attach without any manual action. Without a relay source no start is
+  attempted (it would fail requiring a relay URL): one honest status says so and the login/main flow continues degraded
+  exactly as before. Deliberate divergence from the retired reference client, which killed its auto-started daemon on
+  exit: the TUI never stops the daemon, because other `wn` commands share it — stop it explicitly with `/daemon stop`.
+- TUI: `f`/`x` on a highlighted user-search result follow/unfollow that user directly — the same key letters as the
+  Profile screen's `f`/`x`, but acting directly on the highlighted result (Profile's go through popups) instead of a
+  round-trip through the Profile screen with a pasted pubkey. Both run
+  `follows add`/`follows remove` on the background worker with in-flight feedback, and the outcome folds into a
+  per-row `[following]` badge. Rows an account already follows are badged up front from a `follows list` snapshot (one
+  local directory read per search, not a `follows check` per row). A fold whose search screen was left, whose acting
+  account was switched, or whose user is no longer among the results is dropped rather than badging the wrong row; the
+  results-focus hints line and the help card name the new keys.
+- TUI: inbound media renders inline in the message pane. Image attachments are downloaded and decoded off the event
+  loop (a worker thread runs `wn media download <group> <plaintext-hash> --output <cache path>` and the `image`
+  decode, delivering the result over an `mpsc` channel drained on tick) and drawn via `ratatui-image` as cell-exact
+  half-block glyphs (`▀` colored cells) on any image-capable terminal. The fidelity choice is deliberate: half-blocks
+  are ordinary colored cells rather than a native pixel image (iTerm2/Kitty/Sixel), so an image is bounded strictly to
+  its reserved block and can never overdraw a neighboring message or leave a terminal-side artifact behind on scroll.
+  Placeholders walk `[img name]` -> `[downloading name...]` -> `[loading name...]` -> the image, or
+  `[name failed: err]`, and stay `[img name]` on a terminal with no image capability. `o` opens the selected message's
+  image full-size in a dismiss-on-any-key viewer, drawn with the terminal's native pixel protocol when it has one and
+  the same cell-exact rendering otherwise. Decrypted media is held in memory only; the downloaded artifact is removed
+  right after decode rather than cached on disk. No JSON response shapes changed (the existing `media download --json`
+  `output_path` is passed via `--output`).
 
 ### Changed
 
@@ -43,72 +71,6 @@ versioning through the workspace version in the root `Cargo.toml`.
   leaves cannot race past a caller-side precheck and lose the reason. Forensic
   audit records and conformance observations for this case change from
   `invalid_transition` to `leave_already_requested`.
-
-### Security
-
-- `wn-agent import-identity` keeps secret material out of argv, environment,
-  output, and bootstrap/config artifacts; rejects symlinked, shared, or
-  non-regular credential files; verifies the expected public identity before
-  persistence; and makes duplicate or interrupted imports recoverable.
-
-### Fixed
-
-- TUI chat ordering now follows the durable `activity_sort_at` anchor exposed on
-  `chats list`/`subscribe`/`mark-read` rows (and timeline `chat_list_row`
-  updates) instead of re-sorting by `last_message.timeline_at`, so all-pruned
-  chats keep their storage position. Equal-activity rows tie-break on ascending
-  `group_id`, matching storage.
-
-## [0.9.7] - 2026-07-26
-
-### Fixed
-
-- Agent text-stream QUIC starts now accept zero broker candidates for durable
-  final-message fallback, validate complete candidate values against the
-  adopted 512-byte authority rules, preserve ordered candidate failover, and
-  durably reserve encrypted publisher sequences so repeated `stream send`,
-  reconnect, or daemon reuse cannot restart at sequence 1 for one start.
-  Zero-candidate daemon compose returns a `streaming` payload with
-  `candidate: ""` for TUI and script consumers instead of failing the start.
-- KeyPackage deletion during sign-out, wipe, and explicit deletion now uses one
-  scoped, account-bound relay connection set for the complete batch instead of
-  cold-connecting a throwaway client for every deletion event. Relay
-  acknowledgement and local-cache removal remain tracked per event.
-- The Hermes plugin now maps explicitly non-final assistant commentary to
-  durable kind-1201 agent activity while retaining kind-9 delivery for final
-  answers and compatibility with Hermes versions that do not yet provide
-  delivery metadata.
-
-### Security
-
-- Updated `quinn-proto` and `crossbeam-epoch` to patched releases, clearing the
-  active RustSec vulnerabilities in the QUIC and OpenMLS dependency paths.
-  Also removed the remaining unsoundness and yanked-package findings without
-  adding audit ignores; unmaintained-only dependencies remain tracked in
-  issue #1116.
-
-## [0.9.6] - 2026-07-26
-
-### Added
-
-- MarmotKit now exposes account-signed public profile-image uploads to Blossom,
-  with validated raster content and returned HTTPS URLs.
-- MarmotKit profile metadata now includes an optional `banner` field while
-  preserving the existing banner when partial updates omit it.
-
-### Fixed
-
-- `keys list` now reports every durably device-owned KeyPackage, including
-  retained private material, and merges relay visibility without losing
-  distinct relay event ids.
-- MarmotKit key-package ownership now reflects durable, Welcome-usable private
-  material across manual publication, automatic maintenance, and runtime
-  restarts; matching relay events merge with their local record.
-
-## [0.9.5] - 2026-07-25
-
-### Changed
-
 - TUI polish bundle: `Esc` on the main view is now spatial back (Composer → Messages → Chats, a no-op from Chats)
   after the armed-interaction clear, and never destroys a hand-typed draft. The messages-pane row highlight renders
   when that pane holds focus or while an interaction is armed — arming `/react`/`/reply`/`/delete` moves focus to the
@@ -162,7 +124,6 @@ versioning through the workspace version in the root `Cargo.toml`.
   sending to, whether it was opened or previewed. `Enter` is unchanged — it opens the highlighted chat and moves focus
   to the message pane, cancelling any pending preview; opening the chat already settled in the pane is a focus move
   only (no redundant reload). No JSON response shapes changed.
-
 - TUI: inline images are no longer pixelated, and `o` now shows the actual image on pixel-capable terminals. Inline
   previews stay cell-exact half-blocks but downscale through a proper resampling filter (Lanczos3) instead of
   `ratatui-image`'s nearest-neighbor default, so the 8-row preview reads as a legible thumbnail. On a terminal whose
@@ -181,6 +142,99 @@ versioning through the workspace version in the root `Cargo.toml`.
   thread and is cached per target size, so
   scrolling never re-resizes; changing the terminal width does re-resize every visible image on that one frame, an
   accepted cost of the sharper preview. Halfblock-only terminals, and evicted images, keep the cell-exact viewer popup.
+- TUI: unread badges are now runtime-backed instead of counted in the TUI. Each chat row's badge and the status
+  bar's `{u} unread` total derive from the `chats list` projection (`unread_count`), so they survive a TUI restart;
+  the TUI-local unread tally and its plain-`messages subscribe`-feed counting are gone (that feed now serves only
+  QUIC stream previews). Chat rows gained a wn-tui-style last-message preview line (sender plus truncated text, dark
+  gray; group-system rows render their summary, deleted rows a tombstone), and the chat list orders by last activity
+  (`last_message.timeline_at` descending; equal-activity chats keep the `chats list` order). Opening a chat clears
+  its badge immediately by calling `chats mark-read` and folding the returned projection (a failed mark-read leaves
+  the badge untouched and surfaces on the status line — never zeroed locally). Live badge/preview deltas for the open
+  chat ride the `messages timeline subscribe` feed's `chat_list_row`; for other chats the TUI consumes
+  `notifications subscribe` and, on a NewMessage for a non-selected chat, does one debounced `chats list` re-read per
+  tick (notification events deduplicated by `notification_key`), run on the background worker rather than the event
+  loop. Group-invite notifications surface as a status-line notice. Background re-lists and reorders keep the
+  highlighted chat selected by group id. No JSON response shapes changed.
+
+### Security
+
+- `wn-agent import-identity` keeps secret material out of argv, environment,
+  output, and bootstrap/config artifacts; rejects symlinked, shared, or
+  non-regular credential files; verifies the expected public identity before
+  persistence; and makes duplicate or interrupted imports recoverable.
+
+### Fixed
+
+- TUI chat ordering now follows the durable `activity_sort_at` anchor exposed on
+  `chats list`/`subscribe`/`mark-read` rows (and timeline `chat_list_row`
+  updates) instead of re-sorting by `last_message.timeline_at`, so all-pruned
+  chats keep their storage position. Equal-activity rows tie-break on ascending
+  `group_id`, matching storage.
+- TUI: main-view keyboard accelerators now fire only on a plain keypress and ignore `Ctrl`/`Alt` chords. Previously
+  `Ctrl-U` in the message pane matched the bare `u` (unreact) accelerator and published an unconfirmed reaction
+  removal, and `Ctrl-Q` quit through the bare `q` accelerator. The whole accelerator family (`r`/`u`/`d`/`R`/`o`/`i`
+  and `g`/`G` in the message pane, `q`/`A`/`s`/`p`/`h`/`I` and `j`/`k` list navigation elsewhere) is now guarded, while
+  `Ctrl-U` stays the composer kill-line and `Ctrl-C` still quits. `Shift` is still tolerated, so the uppercase
+  accelerators keep working under the kitty keyboard protocol. No JSON response shapes changed.
+- TUI: logging out now reports the outcome faithfully when the follow-up account-list reload fails. Previously a reload
+  failure after a successful, irreversible wipe was reported with an `error:` prefix while the removed account and its
+  stale subscriptions lingered on screen. The logout is now reported as done and the status names `/refresh` to retry
+  the reload; a failure of the wipe itself is still reported as an error. No JSON response shapes changed.
+- TUI: a message-interaction command typed with a leading space now shows the armed-interaction hint and can be
+  cleared with `Esc`, matching how it submits. `parse_slash_command` already trims the composer text, so `/react`,
+  `/reply`, and `/delete` submit even with surrounding whitespace; the armed hint and the `Esc` escape hatch now trim
+  the same way instead of treating a space-prefixed command as an invisible, un-clearable armed state. Plain text with
+  a leading space is still a hand-typed draft and is preserved by `Esc`. No JSON response shapes changed.
+
+## [0.9.7] - 2026-07-26
+
+### Fixed
+
+- Agent text-stream QUIC starts now accept zero broker candidates for durable
+  final-message fallback, validate complete candidate values against the
+  adopted 512-byte authority rules, preserve ordered candidate failover, and
+  durably reserve encrypted publisher sequences so repeated `stream send`,
+  reconnect, or daemon reuse cannot restart at sequence 1 for one start.
+  Zero-candidate daemon compose returns a `streaming` payload with
+  `candidate: ""` for TUI and script consumers instead of failing the start.
+- KeyPackage deletion during sign-out, wipe, and explicit deletion now uses one
+  scoped, account-bound relay connection set for the complete batch instead of
+  cold-connecting a throwaway client for every deletion event. Relay
+  acknowledgement and local-cache removal remain tracked per event.
+- The Hermes plugin now maps explicitly non-final assistant commentary to
+  durable kind-1201 agent activity while retaining kind-9 delivery for final
+  answers and compatibility with Hermes versions that do not yet provide
+  delivery metadata.
+
+### Security
+
+- Updated `quinn-proto` and `crossbeam-epoch` to patched releases, clearing the
+  active RustSec vulnerabilities in the QUIC and OpenMLS dependency paths.
+  Also removed the remaining unsoundness and yanked-package findings without
+  adding audit ignores; unmaintained-only dependencies remain tracked in
+  issue #1116.
+
+## [0.9.6] - 2026-07-26
+
+### Added
+
+- MarmotKit now exposes account-signed public profile-image uploads to Blossom,
+  with validated raster content and returned HTTPS URLs.
+- MarmotKit profile metadata now includes an optional `banner` field while
+  preserving the existing banner when partial updates omit it.
+
+### Fixed
+
+- `keys list` now reports every durably device-owned KeyPackage, including
+  retained private material, and merges relay visibility without losing
+  distinct relay event ids.
+- MarmotKit key-package ownership now reflects durable, Welcome-usable private
+  material across manual publication, automatic maintenance, and runtime
+  restarts; matching relay events merge with their local record.
+
+## [0.9.5] - 2026-07-25
+
+### Changed
 
 - TUI: `a` on a user-search result now picks which chat the found user is added to. It opens a group picker over the
   loaded chats list (`j`/`k` move, `Enter` picks, `Esc` closes without side effects), one row per chat in the list's
@@ -268,9 +322,9 @@ versioning through the workspace version in the root `Cargo.toml`.
   the badge untouched and surfaces on the status line — never zeroed locally). Live badge/preview deltas for the open
   chat ride the `messages timeline subscribe` feed's `chat_list_row`; for other chats the TUI consumes
   `notifications subscribe` and, on a NewMessage for a non-selected chat, does one debounced `chats list` re-read per
-  tick (notification events deduplicated by `notification_key`), run on the background worker rather than the event
-  loop. Group-invite notifications surface as a status-line notice. Background re-lists and reorders keep the
-  highlighted chat selected by group id. No JSON response shapes changed.
+  tick (notification events deduplicated by `notification_key`). Group-invite notifications surface as a status-line
+  notice. Background re-lists and reorders keep the highlighted chat selected by group id. No JSON response shapes
+  changed.
 
 ### Added
 
@@ -281,22 +335,6 @@ versioning through the workspace version in the root `Cargo.toml`.
   commands expose the lifecycle. New groups are periodically enrolled by default; existing groups remain manual-only.
   Successful application-send JSON now includes `maintenance_disposition` without blocking sends while post-join
   rotation is pending. ([#1103](https://github.com/marmot-protocol/mdk/pull/1103))
-- TUI: the daemon auto-starts at launch when it is down and the TUI holds a relay source to give it (the
-  `--discovery-relays`/`--default-account-relays` passthrough flags, a global `--relay`, or `WN_RELAY`) — exactly as
-  `/daemon start` would, but off the event loop, since `wn daemon start` blocks up to five seconds on its readiness
-  poll. The status line shows `starting daemon...` and then the outcome, the status-bar dot flips green when the start
-  lands, and the daemon-backed live subscriptions attach without any manual action. Without a relay source no start is
-  attempted (it would fail requiring a relay URL): one honest status says so and the login/main flow continues degraded
-  exactly as before. Deliberate divergence from the retired reference client, which killed its auto-started daemon on
-  exit: the TUI never stops the daemon, because other `wn` commands share it — stop it explicitly with `/daemon stop`.
-- TUI: `f`/`x` on a highlighted user-search result follow/unfollow that user directly — the same key letters as the
-  Profile screen's `f`/`x`, but acting directly on the highlighted result (Profile's go through popups) instead of a
-  round-trip through the Profile screen with a pasted pubkey. Both run
-  `follows add`/`follows remove` on the background worker with in-flight feedback, and the outcome folds into a
-  per-row `[following]` badge. Rows an account already follows are badged up front from a `follows list` snapshot (one
-  local directory read per search, not a `follows check` per row). A fold whose search screen was left, whose acting
-  account was switched, or whose user is no longer among the results is dropped rather than badging the wrong row; the
-  results-focus hints line and the help card name the new keys.
 - TUI: `/logout` removes the currently selected account. `wn logout` is destructive — it permanently erases the
   account's local data (messages, group membership, and MLS state) from this device and, for a local-signing account,
   deletes its signing key too — so the confirmation scales to the consequence. A local-signing logout is irreversible,
@@ -316,10 +354,9 @@ versioning through the workspace version in the root `Cargo.toml`.
   its reserved block and can never overdraw a neighboring message or leave a terminal-side artifact behind on scroll.
   Placeholders walk `[img name]` -> `[downloading name...]` -> `[loading name...]` -> the image, or
   `[name failed: err]`, and stay `[img name]` on a terminal with no image capability. `o` opens the selected message's
-  image full-size in a dismiss-on-any-key viewer, drawn with the terminal's native pixel protocol when it has one and
-  the same cell-exact rendering otherwise. Decrypted media is held in memory only; the downloaded artifact is removed
-  right after decode rather than cached on disk. No JSON response shapes changed (the existing `media download --json`
-  `output_path` is passed via `--output`).
+  image full-size (same cell-exact rendering) in a dismiss-on-any-key viewer. Decrypted files cache under the TUI home
+  in `tui-media-cache/`. No JSON response shapes changed (the existing `media download --json` `output_path` is passed
+  via `--output`).
 - TUI: message interactions on the selected message. New `/react [emoji]` (default `+`), `/unreact`, `/delete`, and
   `/retry <event-id>` slash commands call the real `messages react|unreact|delete|retry` commands; keyboard
   accelerators `r` (prefills `/react` followed by a space), `u` (removes your reaction immediately), and `d`
@@ -365,21 +402,6 @@ versioning through the workspace version in the root `Cargo.toml`.
   (`unread_count`, `has_unread`, `last_message`, `last_read_message_id_hex`, `last_read_timeline_at`).
 ### Fixed
 
-- TUI: main-view keyboard accelerators now fire only on a plain keypress and ignore `Ctrl`/`Alt` chords. Previously
-  `Ctrl-U` in the message pane matched the bare `u` (unreact) accelerator and published an unconfirmed reaction
-  removal, and `Ctrl-Q` quit through the bare `q` accelerator. The whole accelerator family (`r`/`u`/`d`/`R`/`o`/`i`
-  and `g`/`G` in the message pane, `q`/`A`/`s`/`p`/`h`/`I` and `j`/`k` list navigation elsewhere) is now guarded, while
-  `Ctrl-U` stays the composer kill-line and `Ctrl-C` still quits. `Shift` is still tolerated, so the uppercase
-  accelerators keep working under the kitty keyboard protocol. No JSON response shapes changed.
-- TUI: logging out now reports the outcome faithfully when the follow-up account-list reload fails. Previously a reload
-  failure after a successful, irreversible wipe was reported with an `error:` prefix while the removed account and its
-  stale subscriptions lingered on screen. The logout is now reported as done and the status names `/refresh` to retry
-  the reload; a failure of the wipe itself is still reported as an error. No JSON response shapes changed.
-- TUI: a message-interaction command typed with a leading space now shows the armed-interaction hint and can be
-  cleared with `Esc`, matching how it submits. `parse_slash_command` already trims the composer text, so `/react`,
-  `/reply`, and `/delete` submit even with surrounding whitespace; the armed hint and the `Esc` escape hatch now trim
-  the same way instead of treating a space-prefixed command as an invisible, un-clearable armed state. Plain text with
-  a leading space is still a hand-typed draft and is preserved by `Esc`. No JSON response shapes changed.
 - `wn relays add/remove --type nip65` now round-trips the complete directional NIP-65 list instead of deleting
   read-only relays or flattening existing role markers. Relay-list JSON adds `read_relays` and `write_relays` alongside
   the existing write-target `relays` view.

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -311,9 +311,10 @@ versioning through the workspace version in the root `Cargo.toml`.
   its reserved block and can never overdraw a neighboring message or leave a terminal-side artifact behind on scroll.
   Placeholders walk `[img name]` -> `[downloading name...]` -> `[loading name...]` -> the image, or
   `[name failed: err]`, and stay `[img name]` on a terminal with no image capability. `o` opens the selected message's
-  image full-size (same cell-exact rendering) in a dismiss-on-any-key viewer. Decrypted files cache under the TUI home
-  in `tui-media-cache/`. No JSON response shapes changed (the existing `media download --json` `output_path` is passed
-  via `--output`).
+  image full-size in a dismiss-on-any-key viewer, drawn with the terminal's native pixel protocol when it has one and
+  the same cell-exact rendering otherwise. Decrypted media is held in memory only; the downloaded artifact is removed
+  right after decode rather than cached on disk. No JSON response shapes changed (the existing `media download --json`
+  `output_path` is passed via `--output`).
 - TUI: message interactions on the selected message. New `/react [emoji]` (default `+`), `/unreact`, `/delete`, and
   `/retry <event-id>` slash commands call the real `messages react|unreact|delete|retry` commands; keyboard
   accelerators `r` (prefills `/react` followed by a space), `u` (removes your reaction immediately), and `d`

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -276,6 +276,22 @@ versioning through the workspace version in the root `Cargo.toml`.
   commands expose the lifecycle. New groups are periodically enrolled by default; existing groups remain manual-only.
   Successful application-send JSON now includes `maintenance_disposition` without blocking sends while post-join
   rotation is pending. ([#1103](https://github.com/marmot-protocol/mdk/pull/1103))
+- TUI: the daemon auto-starts at launch when it is down and the TUI holds a relay source to give it (the
+  `--discovery-relays`/`--default-account-relays` passthrough flags, a global `--relay`, or `WN_RELAY`) — exactly as
+  `/daemon start` would, but off the event loop, since `wn daemon start` blocks up to five seconds on its readiness
+  poll. The status line shows `starting daemon...` and then the outcome, the status-bar dot flips green when the start
+  lands, and the daemon-backed live subscriptions attach without any manual action. Without a relay source no start is
+  attempted (it would fail requiring a relay URL): one honest status says so and the login/main flow continues degraded
+  exactly as before. Deliberate divergence from the retired reference client, which killed its auto-started daemon on
+  exit: the TUI never stops the daemon, because other `wn` commands share it — stop it explicitly with `/daemon stop`.
+- TUI: `f`/`x` on a highlighted user-search result follow/unfollow that user directly — the same key letters as the
+  Profile screen's `f`/`x`, but acting directly on the highlighted result (Profile's go through popups) instead of a
+  round-trip through the Profile screen with a pasted pubkey. Both run
+  `follows add`/`follows remove` on the background worker with in-flight feedback, and the outcome folds into a
+  per-row `[following]` badge. Rows an account already follows are badged up front from a `follows list` snapshot (one
+  local directory read per search, not a `follows check` per row). A fold whose search screen was left, whose acting
+  account was switched, or whose user is no longer among the results is dropped rather than badging the wrong row; the
+  results-focus hints line and the help card name the new keys.
 - TUI: `/logout` removes the currently selected account. `wn logout` is destructive — it permanently erases the
   account's local data (messages, group membership, and MLS state) from this device and, for a local-signing account,
   deletes its signing key too — so the confirmation scales to the consequence. A local-signing logout is irreversible,

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -109,6 +109,20 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Changed
 
+- TUI: inline images are no longer pixelated, and `o` now shows the actual image on pixel-capable terminals. Inline
+  previews stay cell-exact half-blocks but downscale through a proper resampling filter (Lanczos3) instead of
+  `ratatui-image`'s nearest-neighbor default, so the 8-row preview reads as a legible thumbnail. On a terminal whose
+  startup capability query reported a real pixel protocol, the `o` full-size viewer draws the image with that native
+  protocol (inside an iTerm2 session the misdetected kitty answer is overridden to iTerm2's own inline-image
+  protocol); every popup close now forces a full terminal clear and repaint so a terminal-side image can never linger
+  after dismissal. Decoded images are capped to a 2100x1400 fit box at decode time — a general memory bound on every
+  decode, so neither the inline preview nor any retained copy ever holds an unbounded camera-photo pixel buffer.
+  Separately, viewer pixels are retained in memory only: at most four viewer copies are kept (oldest evicted first,
+  worst case ~47 MB), so the decrypted download artifact is still removed right after decode and nothing is written
+  back to disk. The Lanczos3 downscale runs synchronously on the render thread and is cached per target size, so
+  scrolling never re-resizes; changing the terminal width does re-resize every visible image on that one frame, an
+  accepted cost of the sharper preview. Halfblock-only terminals, and evicted images, keep the cell-exact viewer popup.
+
 - TUI: `a` on a user-search result now picks which chat the found user is added to. It opens a group picker over the
   loaded chats list (`j`/`k` move, `Enter` picks, `Esc` closes without side effects), one row per chat in the list's
   order with the open chat preselected when one is loaded; `Enter` then opens the same confirm popup that guards the

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -109,6 +109,33 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ### Changed
 
+- TUI: user-initiated actions no longer freeze the interface for a `wn` subprocess round-trip. Sending a message,
+  replying, reacting/unreacting, deleting, opening a chat, searching users, opening group detail, and listing invites
+  now run on a dedicated background worker and fold their result back into the view on the next frame, so typing,
+  scrolling, and input stay responsive while the command runs. The ambient chat-list re-read that a notification for a
+  non-selected chat triggers runs on that same worker (behind any queued mutations, so a re-read reflects a send that
+  preceded it), so a notification burst never blocks key handling either. Each shows honest in-flight feedback
+  (`sending...`, `loading chat...`, `searching...`, `loading invites...`, `loading group detail...`, and a
+  `loading chat...` placeholder in the message pane) and reports the outcome when it lands. User-initiated mutations
+  keep their submission order (a single worker drains a FIFO queue), optimistic send rows keep their by-id upsert
+  semantics, and a result whose target the user has already moved past — an open-chat load for a chat they left, a
+  search whose query changed, an invites list or a chat re-list whose account changed — is dropped instead of
+  clobbering the current view. A same-chat reload merges its page by id rather than replacing, so a live subscription
+  insert during the load window survives. Failures are still caught to the status line and never tear down the session.
+  Genuinely modal or rare flows (login/create-identity, logout, daemon start/stop, popup submits such as
+  rename/add-member/follow, profile, relay health, and stream compose) stay synchronous. No JSON response shapes
+  changed.
+- TUI: `j`/`k` in the chat list now live-previews the highlighted conversation while focus stays on the list
+  (flick-through browsing). The preview is debounced to ~150ms of quiet after the last movement, so racing through the
+  list loads only the chat you settle on rather than one load per row; a preview superseded by further movement is
+  dropped, and it marks the previewed chat read the same way opening it does (it is on screen — matching the reference
+  client's select-clears-unread precedent). The composer's send target follows the previewed chat (WYSIWYG), and the
+  messages-pane title now names the loaded chat (terminal-safe, shortened, falling back to "Messages"), keeping the
+  `[N older | M newer]` overflow annotation alongside — so the pane always shows which conversation you are reading and
+  sending to, whether it was opened or previewed. `Enter` is unchanged — it opens the highlighted chat and moves focus
+  to the message pane, cancelling any pending preview; opening the chat already settled in the pane is a focus move
+  only (no redundant reload). No JSON response shapes changed.
+
 - TUI: inline images are no longer pixelated, and `o` now shows the actual image on pixel-capable terminals. Inline
   previews stay cell-exact half-blocks but downscale through a proper resampling filter (Lanczos3) instead of
   `ratatui-image`'s nearest-neighbor default, so the 8-row preview reads as a legible thumbnail. On a terminal whose
@@ -209,9 +236,9 @@ versioning through the workspace version in the root `Cargo.toml`.
   the badge untouched and surfaces on the status line — never zeroed locally). Live badge/preview deltas for the open
   chat ride the `messages timeline subscribe` feed's `chat_list_row`; for other chats the TUI consumes
   `notifications subscribe` and, on a NewMessage for a non-selected chat, does one debounced `chats list` re-read per
-  tick (notification events deduplicated by `notification_key`). Group-invite notifications surface as a status-line
-  notice. Background re-lists and reorders keep the highlighted chat selected by group id. No JSON response shapes
-  changed.
+  tick (notification events deduplicated by `notification_key`), run on the background worker rather than the event
+  loop. Group-invite notifications surface as a status-line notice. Background re-lists and reorders keep the
+  highlighted chat selected by group id. No JSON response shapes changed.
 
 ### Added
 

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -539,6 +539,16 @@ When a daemon is running for the same home, TUI child commands use the daemon so
 state. While the daemon is running, the TUI attaches to daemon-backed runtime subscriptions for live message, chat, and
 group-state changes, and refreshes snapshots when the composer is idle.
 
+When the daemon is not running at launch, the TUI auto-starts it — exactly as `/daemon start` would — provided it
+holds a relay source to give it: the passthrough flags above, a global `--relay`, or `WN_RELAY`. The start runs off
+the event loop (`wn daemon start` waits on a readiness poll), so the status line shows `starting daemon...` and then
+the outcome, and the status-bar dot flips green when it lands. Without any relay source no start is attempted — it
+would only fail requiring a relay URL — and one status says so; the login/main flow continues degraded. To fix it,
+restart `wn tui` with `--discovery-relays`/`--default-account-relays` (or `WN_RELAY`); `/daemon start` in-session reads
+the same relay sources and would fail identically. Unlike the retired reference client, which killed its auto-started
+daemon on exit, the TUI never stops the daemon when it quits:
+other `wn` commands share it. Stop it explicitly with `/daemon stop` or `wn daemon stop`.
+
 User-initiated commands — sending a message, replying, reacting/unreacting, deleting, opening a chat, searching users,
 opening group detail, and listing invites — run on a background worker so a `wn` round-trip never freezes typing,
 scrolling, or input. The ambient chat-list re-read that a notification for a non-selected chat triggers runs on that
@@ -660,7 +670,12 @@ query (so `j`/`k` are literal text) and `Enter` runs the search; once there are 
 starts a new chat with them (a text popup names it, then `group create`), and `a` adds them to an existing chat: a
 group picker lists your chats (`j`/`k` move, `Enter` picks, `Esc` closes without side effects), preselecting the open
 chat when one is loaded, and `Enter` opens the confirm popup that guards the add (`groups add-members`), naming both
-the user and the chosen chat. With no chats a status notice explains and points at `c`. `i` returns to the query, and
+the user and the chosen chat. With no chats a status notice explains and points at `c`. `f` follows the highlighted
+result (`follows add`) and `x` unfollows them (`follows remove`) — the same key letters as the Profile screen's
+`f`/`x`, but acting directly on the highlighted result (Profile's go through popups). Both run on the background
+worker with in-flight feedback and fold into a per-row
+`[following]` badge; rows you already follow are badged up front from a `follows list` snapshot taken with each
+search. `i` returns to the query, and
 `Esc` returns to the main view. Result rows show the display name/name, a shortened npub, and the `matched_field · match_quality · radius`
 attribution the search returns.
 

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -589,17 +589,23 @@ Main view controls:
   `messages send --group <loaded-group> --reply-to <selected-message-id> <text>`, keeping `--reply-to` before the
   text as the guard requires. `o` opens the selected message's downloaded image full-size in a dismiss-on-any-key
   viewer (see "Inbound media" below).
-- Inbound media: an image attachment renders inline in the message pane as cell-exact half-block glyphs (`▀` colored
-  cells) on any image-capable terminal. The rendering is deliberately cell-exact rather than a native pixel image
+- Inbound media: an image attachment renders inline in the message pane as a filtered half-block preview — cell-exact
+  `▀` colored cells, downscaled with a proper resampling filter (Lanczos3) so the small preview stays legible — on any
+  image-capable terminal. The inline rendering is deliberately cell-exact rather than a native pixel image
   (iTerm2/Kitty/Sixel): half-blocks are ordinary colored cells bounded strictly to the reserved block, so an image can
   never overdraw a neighboring message or leave a terminal-side artifact behind when you scroll. Each image is
   downloaded and decoded in the background — never blocking the event loop — and its placeholder walks `[img name]` ->
   `[downloading name...]` -> `[loading name...]` -> the inline image, or `[name failed: err]` on error. A terminal
   with no image capability keeps the `[img name]` placeholder (and non-image attachments always show `[file name]`).
-  The `o` full-size viewer uses the same cell-exact rendering. Each image is decrypted to a private
-  `tui-media-cache/` directory under the TUI home, decoded into memory, and the decrypted file is then removed right
-  away — the viewer draws the in-memory image, so nothing reads the file again and no decrypted media is left at rest.
-  Any files a prior crashed session left behind are swept from that directory at startup.
+  The `o` full-size viewer shows the actual image with the terminal's native pixel protocol when the startup
+  capability query found one (in an iTerm2 session it uses iTerm2's own inline-image protocol), and closing the
+  viewer — like closing any popup — forces a full terminal repaint so nothing lingers on screen. Viewer pixels are
+  kept in a small in-memory pool (the most recent images, oldest evicted first); on terminals without a pixel
+  protocol, or for an evicted image, the viewer falls back to the same cell-exact half-block rendering. Each image is
+  decrypted to a private `tui-media-cache/` directory under the TUI home, decoded into memory, and the decrypted file
+  is then removed right away — inline preview and full-size viewer both draw from memory, so nothing reads the file
+  again and no decrypted media is left at rest. Any files a prior crashed session left behind are swept from that
+  directory at startup.
 - Composer: full cursor editing — `Left`/`Right`/`Home`/`End` move the cursor, `Backspace`/`Delete` remove a
   character, `Ctrl-U` clears the whole composer (a readline kill-line that empties it whatever it holds — armed prefill
   or hand-typed draft), and mid-string edits keep multi-byte characters intact. `Enter` submits; there is no keyboard

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -539,6 +539,15 @@ When a daemon is running for the same home, TUI child commands use the daemon so
 state. While the daemon is running, the TUI attaches to daemon-backed runtime subscriptions for live message, chat, and
 group-state changes, and refreshes snapshots when the composer is idle.
 
+User-initiated commands — sending a message, replying, reacting/unreacting, deleting, opening a chat, searching users,
+opening group detail, and listing invites — run on a background worker so a `wn` round-trip never freezes typing,
+scrolling, or input. The ambient chat-list re-read that a notification for a non-selected chat triggers runs on that
+same worker, so a burst of notifications never blocks key handling either. Each shows in-flight feedback (`sending...`,
+`loading chat...`, `searching...`) and folds its result in on the next frame; user-initiated mutations keep their
+submission order, and a load whose target you have already moved past is dropped rather than overwriting the current
+view. Modal or rare flows (login, logout, daemon start/stop, and popup submits such as rename or follow) stay
+synchronous.
+
 Login screen controls:
 
 - Menu (no accounts): `c` create a new identity, `l` log in with an nsec, `q` quit.
@@ -549,7 +558,13 @@ Login screen controls:
 Main view controls:
 
 - `Tab`/`BackTab`: cycle the chat list, messages, and composer.
-- Chats: `j`/`k` or arrows move the selection; `Enter` opens the chat and focuses the messages pane; `g` opens the
+- Chats: `j`/`k` or arrows move the selection; moving it also live-previews the highlighted chat in the message pane
+  after a brief pause (~150ms of quiet), with focus staying on the list, so flicking through with `j`/`k` loads only
+  the chat you settle on. The messages-pane title names the loaded chat (falling back to "Messages"), and the composer
+  sends to that same chat, so the pane always shows which conversation you are reading and sending to — whether it was
+  opened or previewed. `Enter` opens the highlighted chat and moves focus to the messages pane (cancelling any pending
+  preview; opening the chat already shown is just a focus move); a previewed chat is marked read the same way opening
+  it is. `g` opens the
   group-detail screen for the selected chat; `s` opens user search; `p` opens your profile; `h` opens the relay-health
   screen; `I` opens the pending-invites picker; `A` reopens the
   account picker. Each row shows an unread badge (bold name plus `(N)`) and a dark-gray last-message preview (sender

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -71,6 +71,14 @@ pub(crate) struct TuiApp {
     /// The one open modal, or none. While set it captures every key (routed at
     /// the top of `handle_key`) and overlays whatever screen is showing.
     pub(crate) popup: Option<Popup>,
+    /// Set when a popup is torn down; `run()` consumes it and clears the whole
+    /// terminal before the next draw. Ratatui otherwise erases a closed popup
+    /// by diffing cells, which cannot reach a pixel-protocol image stored
+    /// terminal-side (iTerm2 does not self-erase when its cells are
+    /// overwritten), so the viewer popup needs the full clear — and it is
+    /// applied uniformly to every popup close, which is rare and cheap, so no
+    /// close path has to know what the popup drew.
+    pub(crate) pending_full_repaint: bool,
     /// Group-detail screen state, loaded on entry and dropped on exit. Present
     /// only while `screen == Screen::GroupDetail`.
     pub(crate) group_detail: Option<GroupDetailView>,
@@ -124,6 +132,7 @@ impl TuiApp {
             streaming: None,
             status: "loading accounts".to_owned(),
             popup: None,
+            pending_full_repaint: false,
             group_detail: None,
             user_search: None,
             profile_view: None,
@@ -158,6 +167,13 @@ impl TuiApp {
             while self.running {
                 dirty |= self.tick();
                 if dirty {
+                    // A closed popup may have drawn a pixel-protocol image that
+                    // lives terminal-side, beyond the cell diff's reach; the
+                    // scheduled full clear wipes it and the draw below repaints
+                    // every cell.
+                    if std::mem::take(&mut self.pending_full_repaint) {
+                        terminal.clear()?;
+                    }
                     terminal.draw(|frame| self.render(frame))?;
                     dirty = false;
                 }
@@ -624,6 +640,11 @@ impl TuiApp {
         });
         match ready {
             Some((name, hash)) => {
+                // Build the native pixel-protocol viewer where the terminal has
+                // one and the pixels are still retained; on `false` the popup
+                // falls back to drawing the shared cell-exact halfblock
+                // protocol, so the viewer opens either way.
+                self.media.build_viewer_protocol(&hash);
                 self.popup = Some(Popup::Image {
                     title: format!("Image: {name}"),
                     hash,
@@ -1092,10 +1113,13 @@ impl TuiApp {
         };
         match popup_key(popup, key.code) {
             PopupAction::None => {}
-            PopupAction::Dismiss => self.popup = None,
+            PopupAction::Dismiss => self.close_popup(),
             // A multi-step flow: the reducer resolved the next popup (the group
             // picker's Enter opens the add-user confirm). No CLI call yet.
-            PopupAction::Open(next) => self.popup = Some(next),
+            PopupAction::Open(next) => {
+                self.close_popup();
+                self.popup = Some(next);
+            }
             PopupAction::Submit(submit) => {
                 // The invites picker stays open across actions so one
                 // accept/decline does not lose the user's place: capture the
@@ -1110,7 +1134,7 @@ impl TuiApp {
                     }) => Some(*selected),
                     _ => None,
                 };
-                self.popup = None;
+                self.close_popup();
                 if let Err(err) = self.run_popup_submit(submit) {
                     self.status = format!("error: {err}");
                 }
@@ -1122,6 +1146,16 @@ impl TuiApp {
             }
         }
         Ok(())
+    }
+
+    /// Tear down the open popup: drop the viewer's on-demand native protocol
+    /// (a no-op for non-image popups) and schedule the full clear+repaint that
+    /// `run()` applies before the next draw. Every popup close funnels through
+    /// here so a terminal-side pixel image can never outlive its popup.
+    fn close_popup(&mut self) {
+        self.popup = None;
+        self.media.drop_viewer_protocol();
+        self.pending_full_repaint = true;
     }
 
     fn run_popup_submit(&mut self, submit: PopupSubmit) -> TuiResult<()> {

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -865,13 +865,18 @@ impl TuiApp {
 
     /// Fire the debounced flick-through preview: load the highlighted chat's
     /// timeline while focus stays on the chat list. A no-op unless the chat list
-    /// has focus and the highlight names a chat the pane is not already showing.
-    /// The load is tagged with its group id (via `begin_timeline_load`), so a
-    /// preview superseded by further movement is dropped at fold time, and it
-    /// marks the previewed chat read exactly as opening it does — the chat is on
-    /// screen, so viewing-is-reading applies.
+    /// is actually what the user is looking at — the main screen, no popup, and
+    /// the chat list focused — and the highlight names a chat the pane is not
+    /// already showing. Focus alone is not enough: none of the `open_*` screens
+    /// change `self.focus`, and the help popup is reachable from `Focus::Chats`,
+    /// so a preview fired there would reload the pane and mark a chat read behind
+    /// a modal or on another screen (the read marker is forward-only, so that is
+    /// not recoverable). The load is tagged with its group id (via
+    /// `begin_timeline_load`), so a preview superseded by further movement is
+    /// dropped at fold time, and it marks the previewed chat read exactly as
+    /// opening it does — the chat is on screen, so viewing-is-reading applies.
     fn fire_flick_preview(&mut self) {
-        if self.focus != Focus::Chats {
+        if self.screen != Screen::Main || self.popup.is_some() || self.focus != Focus::Chats {
             return;
         }
         let Some(account_id) = self

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -122,6 +122,21 @@ pub(crate) struct TuiApp {
     pub(crate) effects: EffectRunner,
 }
 
+/// True when a keypress carries no Ctrl/Alt modifier, so a bare accelerator (a
+/// letter that fires an action on its own) may fire. Shift is deliberately
+/// tolerated: the uppercase accelerators (`G`/`R`/`A`/`I`/`P`/`L`) arrive with
+/// SHIFT under the kitty keyboard protocol, so an `is_empty()` modifier check
+/// would silently break them if enhancement flags are ever negotiated. Excluding
+/// only Ctrl/Alt lets chords like Ctrl-U (composer kill-line), Ctrl-Q, and
+/// Ctrl-C reach their own handlers — or fall through harmlessly — instead of
+/// being swallowed by the modifier-insensitive accelerator that shares the
+/// letter. Centralizing the policy in one predicate keeps every accelerator arm
+/// consistent and states the intent ("plain keypress") at each call site.
+fn plain(key: KeyEvent) -> bool {
+    !key.modifiers
+        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+}
+
 impl TuiApp {
     pub(crate) fn new(cli: Cli) -> TuiResult<Self> {
         let client = WnClient::from_cli(&cli)?;
@@ -477,7 +492,9 @@ impl TuiApp {
             KeyCode::Char('?') if self.focus != Focus::Composer => {
                 self.popup = Some(Popup::help());
             }
-            KeyCode::Char('q') if self.focus != Focus::Composer && self.input.is_empty() => {
+            KeyCode::Char('q')
+                if self.focus != Focus::Composer && self.input.is_empty() && plain(key) =>
+            {
                 self.running = false;
             }
             KeyCode::Tab => self.focus = self.focus.next(),
@@ -497,83 +514,83 @@ impl TuiApp {
             }
             // Reopen the account picker from the chat list (the accounts pane is
             // gone; `A` is its replacement entry point).
-            KeyCode::Char('A') if self.focus == Focus::Chats => {
+            KeyCode::Char('A') if self.focus == Focus::Chats && plain(key) => {
                 self.open_account_picker();
             }
             // Group detail and invites are entered from the chat list.
-            KeyCode::Char('g') if self.focus == Focus::Chats => {
+            KeyCode::Char('g') if self.focus == Focus::Chats && plain(key) => {
                 if let Err(err) = self.open_group_detail() {
                     self.status = format!("error: {err}");
                 }
             }
-            KeyCode::Char('I') if self.focus == Focus::Chats => {
+            KeyCode::Char('I') if self.focus == Focus::Chats && plain(key) => {
                 if let Err(err) = self.open_invites() {
                     self.status = format!("error: {err}");
                 }
             }
             // Full-view screens entered from the chat list (Phase 5b).
-            KeyCode::Char('s') if self.focus == Focus::Chats => {
+            KeyCode::Char('s') if self.focus == Focus::Chats && plain(key) => {
                 self.open_user_search(None);
             }
-            KeyCode::Char('p') if self.focus == Focus::Chats => {
+            KeyCode::Char('p') if self.focus == Focus::Chats && plain(key) => {
                 if let Err(err) = self.open_profile() {
                     self.status = format!("error: {err}");
                 }
             }
-            KeyCode::Char('h') if self.focus == Focus::Chats => {
+            KeyCode::Char('h') if self.focus == Focus::Chats && plain(key) => {
                 if let Err(err) = self.open_relay_health() {
                     self.status = format!("error: {err}");
                 }
             }
             // Messages pane: the message-offset scroll model. `k`/Up and PageUp
             // may reach the oldest loaded row and page in older history.
-            KeyCode::Up | KeyCode::Char('k') if self.focus == Focus::Messages => {
+            KeyCode::Up | KeyCode::Char('k') if self.focus == Focus::Messages && plain(key) => {
                 self.messages_select_up();
             }
-            KeyCode::Down | KeyCode::Char('j') if self.focus == Focus::Messages => {
+            KeyCode::Down | KeyCode::Char('j') if self.focus == Focus::Messages && plain(key) => {
                 self.timeline_scroll.select_down(self.timeline.len());
             }
             KeyCode::PageUp if self.focus == Focus::Messages => self.messages_page_up(),
             KeyCode::PageDown if self.focus == Focus::Messages => {
                 self.timeline_scroll.page_down(self.timeline.len());
             }
-            KeyCode::End | KeyCode::Char('G') if self.focus == Focus::Messages => {
+            KeyCode::End | KeyCode::Char('G') if self.focus == Focus::Messages && plain(key) => {
                 self.timeline_scroll.jump_newest(self.timeline.len());
             }
-            KeyCode::Home | KeyCode::Char('g') if self.focus == Focus::Messages => {
+            KeyCode::Home | KeyCode::Char('g') if self.focus == Focus::Messages && plain(key) => {
                 self.messages_jump_oldest();
             }
-            KeyCode::Char('i') | KeyCode::Enter if self.focus == Focus::Messages => {
+            KeyCode::Char('i') | KeyCode::Enter if self.focus == Focus::Messages && plain(key) => {
                 self.focus = Focus::Composer;
             }
             // Message-interaction accelerators (Messages focus, popups are Phase 5).
             // `r` and `d` prefill a slash command in the composer so Enter is the
             // visible action; `u` removes your own reaction immediately (no input).
-            KeyCode::Char('r') if self.focus == Focus::Messages => {
+            KeyCode::Char('r') if self.focus == Focus::Messages && plain(key) => {
                 self.prefill_composer("/react ");
             }
-            KeyCode::Char('u') if self.focus == Focus::Messages => {
+            KeyCode::Char('u') if self.focus == Focus::Messages && plain(key) => {
                 if let Err(err) = self.unreact_selected_message() {
                     self.status = format!("error: {err}");
                 }
             }
-            KeyCode::Char('d') if self.focus == Focus::Messages => {
+            KeyCode::Char('d') if self.focus == Focus::Messages && plain(key) => {
                 self.prefill_composer("/delete");
             }
             // `R` prefills `/reply ` (draft-protected, like `r`/`d`) and names the
             // reply target on the status line; the target resolves at submit.
-            KeyCode::Char('R') if self.focus == Focus::Messages => {
+            KeyCode::Char('R') if self.focus == Focus::Messages && plain(key) => {
                 self.begin_reply();
             }
             // Open the selected message's downloaded image full-size.
-            KeyCode::Char('o') if self.focus == Focus::Messages => {
+            KeyCode::Char('o') if self.focus == Focus::Messages && plain(key) => {
                 self.open_selected_image_viewer();
             }
             // Chat list navigation.
-            KeyCode::Up | KeyCode::Char('k') if self.focus != Focus::Composer => {
+            KeyCode::Up | KeyCode::Char('k') if self.focus != Focus::Composer && plain(key) => {
                 self.move_selection(-1);
             }
-            KeyCode::Down | KeyCode::Char('j') if self.focus != Focus::Composer => {
+            KeyCode::Down | KeyCode::Char('j') if self.focus != Focus::Composer && plain(key) => {
                 self.move_selection(1);
             }
             KeyCode::Enter => {
@@ -686,6 +703,14 @@ impl TuiApp {
     /// on disk is decrypted plaintext with no reader; clearing it keeps decrypted
     /// media from lingering at rest. Best-effort and non-recursive; see
     /// `sweep_media_cache_dir`.
+    ///
+    /// A concurrent session that shares this `--home` sweeps the same directory,
+    /// so this startup sweep can unlink another live session's in-flight download.
+    /// That is harmless and self-healing: the affected image renders as
+    /// `[<name> failed: ...]` and re-downloads next session, and the
+    /// decrypted-plaintext-at-rest guarantee still holds (an artifact is only ever
+    /// removed, never exposed). Cross-process locking would be over-engineering for
+    /// a rare race that already recovers on its own.
     pub(crate) fn sweep_media_cache(&self) {
         sweep_media_cache_dir(&self.media_cache_dir());
     }

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -120,6 +120,13 @@ pub(crate) struct TuiApp {
     /// send/react/open-chat/search/etc. from freezing the render loop for a
     /// subprocess round-trip.
     pub(crate) effects: EffectRunner,
+    /// Receiver for the launch daemon auto-start's outcome, delivered from its
+    /// own one-shot thread and drained on `tick`. Auto-start deliberately does
+    /// not ride the shared FIFO `effects` worker: its `wn daemon start` blocks up
+    /// to five seconds on a readiness poll and has no ordering dependency with
+    /// user effects, so queueing it there would stall the first user action
+    /// behind it. `None` until auto-start spawns, and again once its result folds.
+    pub(crate) daemon_autostart: Option<Receiver<Result<Value, String>>>,
 }
 
 /// True when a keypress carries no Ctrl/Alt modifier, so a bare accelerator (a
@@ -186,6 +193,7 @@ impl TuiApp {
             profile_view: None,
             relay_health: None,
             media: MediaState::new(),
+            daemon_autostart: None,
         })
     }
 
@@ -211,6 +219,10 @@ impl TuiApp {
         let result = (|| -> TuiResult<()> {
             let _ = self.refresh_daemon_status();
             self.start()?;
+            // After the startup routing so the auto-start status is what the
+            // first frame shows, and so its enqueued effect runs behind any
+            // initial loads instead of delaying them on the FIFO worker.
+            self.autostart_daemon_if_needed(std::env::var("WN_RELAY").ok());
             let mut dirty = true;
             while self.running {
                 dirty |= self.tick();
@@ -311,6 +323,9 @@ impl TuiApp {
         // subprocess and decode run on worker threads; this only folds results.
         changed |= self.media.drain();
         changed |= self.ensure_media_downloads();
+        // Fold the launch daemon auto-start's outcome if its one-shot thread has
+        // reported (it runs off the shared effect worker, so it drains here).
+        changed |= self.drain_daemon_autostart();
         // Fold every effect that finished off-loop since the last tick, exactly
         // as the synchronous handler folded its `run_json` return.
         let completed = self.effects.drain();
@@ -387,6 +402,71 @@ impl TuiApp {
             }
         }
         changed
+    }
+
+    /// Launch daemon auto-start: when the daemon is down and the TUI holds a
+    /// relay source to give it, start it exactly as `/daemon start` would — but
+    /// on its own one-shot thread, because `wn daemon start` blocks up to five
+    /// seconds on its readiness poll. It runs off the shared FIFO effect worker
+    /// deliberately: it has no ordering dependency with user effects, so queueing
+    /// it there would stall the first user action behind that five-second poll.
+    /// The thread mirrors the media worker — spawn, run the subprocess, deliver
+    /// the outcome over a channel drained on `tick`. Without a relay source the
+    /// start would only fail with `missing_relay_url`, so one honest status is
+    /// surfaced instead (no attempt, no retry loop) and the login/main flow
+    /// continues degraded. With a daemon already running this is a no-op (today's
+    /// behavior). Deliberate divergence from the retired reference client, which
+    /// killed its auto-started daemon on exit: ours outlives the TUI, because
+    /// other `wn` commands share it. `env_relay` is the caller's `WN_RELAY` read,
+    /// injected so the relay-source decision stays pure and testable.
+    pub(crate) fn autostart_daemon_if_needed(&mut self, env_relay: Option<String>) {
+        if self.daemon.running {
+            return;
+        }
+        if daemon_start_has_relay_source(
+            self.client.relay.as_deref(),
+            &self.client.discovery_relays,
+            &self.client.default_account_relays,
+            env_relay.as_deref(),
+        ) {
+            let client = self.client.clone();
+            let (tx, rx) = mpsc::channel();
+            thread::spawn(move || {
+                let args =
+                    daemon_start_args(&client.discovery_relays, &client.default_account_relays);
+                let result = client.run_json(None, &args).map_err(|err| err.to_string());
+                // The receiver is dropped only at shutdown; a failed send there
+                // simply means the app is gone and the result is moot.
+                let _ = tx.send(result);
+            });
+            self.daemon_autostart = Some(rx);
+            self.status = STARTING_DAEMON_STATUS.to_owned();
+        } else {
+            self.status = DAEMON_AUTOSTART_NO_RELAYS_STATUS.to_owned();
+        }
+    }
+
+    /// Fold the launch daemon auto-start's outcome once its thread reports, then
+    /// clear the one-shot channel. Returns whether anything changed, so `tick`
+    /// can mark the frame dirty. `Disconnected` (the thread panicked before
+    /// sending, which the panic-free subprocess path makes unreachable) just
+    /// clears the channel and leaves the degraded status in place.
+    fn drain_daemon_autostart(&mut self) -> bool {
+        let Some(rx) = self.daemon_autostart.as_ref() else {
+            return false;
+        };
+        match rx.try_recv() {
+            Ok(result) => {
+                self.daemon_autostart = None;
+                self.fold_daemon_start(result);
+                true
+            }
+            Err(TryRecvError::Empty) => false,
+            Err(TryRecvError::Disconnected) => {
+                self.daemon_autostart = None;
+                true
+            }
+        }
     }
 
     /// Route the opening screen from the loaded account list: no accounts opens
@@ -1642,8 +1722,12 @@ impl TuiApp {
     }
 
     /// Results-focus keys: `j`/`k` navigate (with `k` at the top returning to the
-    /// query), `Enter` opens the profile card, `c` starts a chat, `a` picks a chat
-    /// to add the user to, and `i`/`/` return to the query.
+    /// query), `Enter` opens the profile card, `f`/`x` follow/unfollow the
+    /// highlighted result (the same key letters as the Profile screen's, but
+    /// acting directly on the highlighted result — Profile's `f`/`x` go through
+    /// popups; `Tab` would collide with the muscle memory of pane cycling on
+    /// Main), `c` starts a chat, `a` picks a chat to add the user to, and `i`/`/`
+    /// return to the query.
     fn handle_user_search_results_key(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Up | KeyCode::Char('k') => {
@@ -1665,6 +1749,8 @@ impl TuiApp {
                     self.status = format!("error: {err}");
                 }
             }
+            KeyCode::Char('f') => self.follow_search_result(),
+            KeyCode::Char('x') => self.unfollow_search_result(),
             KeyCode::Char('c') => self.open_new_chat_with_user_popup(),
             KeyCode::Char('a') => self.open_add_user_to_chat_popup(),
             KeyCode::Char('i') | KeyCode::Char('/') => {

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -59,6 +59,27 @@ pub(crate) struct TuiApp {
     /// zero count leaves it clear. Cleared before the call and re-armed on error
     /// like `pending_chat_relist`, so a failure retries next tick, not forever.
     pub(crate) pending_mark_read: bool,
+    /// The group id of the most recently requested open-chat / flick-through
+    /// timeline load. A `LoadTimeline` result is folded only while its group
+    /// still matches this (the subscription-style stale guard); a later open
+    /// supersedes an earlier one that has not landed yet. `None` when the pane
+    /// is settled.
+    pub(crate) loading_chat: Option<String>,
+    /// The query of the most recently requested user search, or `None` when no
+    /// search is outstanding. A `UserSearch` result is folded only while its
+    /// query still matches (the same stale guard as `loading_chat`).
+    pub(crate) searching_users: Option<String>,
+    /// The group id of the group-detail load in flight, or `None`. A
+    /// `LoadGroupDetail` result is folded only while it still matches.
+    pub(crate) loading_group_detail: Option<String>,
+    /// Whether an invites-list load is in flight, gating a duplicate enqueue and
+    /// signalling the fold to open the picker.
+    pub(crate) loading_invites: bool,
+    /// Ticks remaining before the highlighted chat is previewed (flick-through),
+    /// or `None` when no preview is pending. Set to `FLICK_PREVIEW_DEBOUNCE_TICKS`
+    /// on each chat-list selection move and counted down each tick, so rapid j/k
+    /// coalesces to one load of the chat the user settles on.
+    pub(crate) flick_countdown: Option<u32>,
     /// Notification `notification_key`s already handled, so the runtime feed's
     /// duplicated emissions do not re-trigger a re-list or a repeated invite
     /// notice. FIFO-bounded to the recent event window, not unbounded.
@@ -94,13 +115,20 @@ pub(crate) struct TuiApp {
     /// Inbound-media state (Phase 6): terminal image capability, per-hash
     /// download/decode status, and the decoded protocols the renderer draws.
     pub(crate) media: MediaState,
+    /// Runs user-initiated `wn` mutations and loads off the event loop, in FIFO
+    /// order, delivering results back for folding on `tick`. This is what keeps
+    /// send/react/open-chat/search/etc. from freezing the render loop for a
+    /// subprocess round-trip.
+    pub(crate) effects: EffectRunner,
 }
 
 impl TuiApp {
     pub(crate) fn new(cli: Cli) -> TuiResult<Self> {
         let client = WnClient::from_cli(&cli)?;
+        let effects = EffectRunner::spawn(client.clone());
         Ok(Self {
             client,
+            effects,
             initial_account: cli.account.clone(),
             running: true,
             screen: Screen::Login(LoginMode::Menu),
@@ -125,6 +153,11 @@ impl TuiApp {
             notification_subscription: None,
             pending_chat_relist: false,
             pending_mark_read: false,
+            loading_chat: None,
+            searching_users: None,
+            loading_group_detail: None,
+            loading_invites: false,
+            flick_countdown: None,
             seen_notification_keys: SeenNotificationKeys::new(),
             daemon: DaemonView::default(),
             group_diagnostics: None,
@@ -263,6 +296,15 @@ impl TuiApp {
         // subprocess and decode run on worker threads; this only folds results.
         changed |= self.media.drain();
         changed |= self.ensure_media_downloads();
+        // Fold every effect that finished off-loop since the last tick, exactly
+        // as the synchronous handler folded its `run_json` return.
+        let completed = self.effects.drain();
+        if !completed.is_empty() {
+            for done in completed {
+                self.apply_effect_done(done);
+            }
+            changed = true;
+        }
         // Debounce: notification drains coalesce every NewMessage for a
         // non-loaded chat since the last tick into this one pending flag, so at
         // most one background `chats list` re-read runs per tick. Cleared before
@@ -272,9 +314,22 @@ impl TuiApp {
         // tick cadence is the hot-loop ceiling by construction).
         if self.pending_chat_relist {
             self.pending_chat_relist = false;
-            if let Err(err) = self.relist_chats() {
-                self.pending_chat_relist = true;
-                self.set_drain_status(format!("chat re-list failed: {err}"));
+            // Route the re-read through the effect worker rather than shelling out
+            // on the key-handling thread: a `chats list` subprocess inside `tick`
+            // would freeze typing. FIFO behind any queued mutations is fine (and
+            // even desirable — the mutation lands before the re-read reflects it).
+            // Only a local signing account has chats to list; a non-signing or
+            // absent selection simply queues nothing. The fold re-arms this flag on
+            // failure, so a transient error retries next tick instead of dropping
+            // the batch.
+            if let Some(account) = self
+                .selected_account_row()
+                .filter(|account| account.local_signing)
+            {
+                self.effects.enqueue(Effect::Relist {
+                    account: account.account_id.clone(),
+                    include_archived: self.show_archived_chats,
+                });
             }
             changed = true;
         }
@@ -287,10 +342,25 @@ impl TuiApp {
             if let (Some(account_id), Some(group_id)) = (
                 self.messages_account_id.clone(),
                 self.messages_group_id.clone(),
-            ) && let Err(err) = self.mark_selected_chat_read(&account_id, &group_id)
-            {
-                self.pending_mark_read = true;
-                self.set_drain_status(format!("mark-read failed: {err}"));
+            ) {
+                self.effects.enqueue(Effect::MarkRead {
+                    account: account_id,
+                    group: group_id,
+                });
+            }
+            changed = true;
+        }
+        // Flick-through debounce: count down the ticks since the last chat-list
+        // move and fire one preview load when the movement quiets, so racing
+        // through the list with j/k coalesces to a single load of the settled-on
+        // chat. `fire_flick_preview` and `begin_timeline_load` clear the counter.
+        if let Some(remaining) = self.flick_countdown {
+            let next = remaining.saturating_sub(1);
+            if next == 0 {
+                self.flick_countdown = None;
+                self.fire_flick_preview();
+            } else {
+                self.flick_countdown = Some(next);
             }
             changed = true;
         }
@@ -663,12 +733,46 @@ impl TuiApp {
     pub(crate) fn move_selection(&mut self, delta: isize) {
         match self.focus {
             Focus::Chats => {
+                let before = self.selected_chat;
                 self.selected_chat = move_index(self.selected_chat, self.chats.len(), delta);
+                if self.selected_chat != before {
+                    // Flick-through: schedule a debounced preview of the newly
+                    // highlighted chat. Focus stays on the chat list; the load
+                    // fires only after the movement quiets (see `tick`).
+                    self.flick_countdown = Some(FLICK_PREVIEW_DEBOUNCE_TICKS);
+                }
             }
             // The messages pane owns its own selection through `timeline_scroll`;
             // it is driven directly in `handle_key`, not through `move_selection`.
             Focus::Messages | Focus::Composer => {}
         }
+    }
+
+    /// Fire the debounced flick-through preview: load the highlighted chat's
+    /// timeline while focus stays on the chat list. A no-op unless the chat list
+    /// has focus and the highlight names a chat the pane is not already showing.
+    /// The load is tagged with its group id (via `begin_timeline_load`), so a
+    /// preview superseded by further movement is dropped at fold time, and it
+    /// marks the previewed chat read exactly as opening it does — the chat is on
+    /// screen, so viewing-is-reading applies.
+    fn fire_flick_preview(&mut self) {
+        if self.focus != Focus::Chats {
+            return;
+        }
+        let Some(account_id) = self
+            .selected_account_row()
+            .filter(|account| account.local_signing)
+            .map(|account| account.account_id.clone())
+        else {
+            return;
+        };
+        let Some(group_id) = self.selected_chat_row().map(|chat| chat.group_id.clone()) else {
+            return;
+        };
+        if self.messages_group_id.as_deref() == Some(group_id.as_str()) {
+            return;
+        }
+        self.begin_timeline_load(account_id, group_id);
     }
 
     /// Move the account-picker highlight (login/account-select screen only).
@@ -718,7 +822,19 @@ impl TuiApp {
             // Opening a chat also moves focus to the messages pane so the reader
             // can immediately scroll the conversation.
             Focus::Chats => {
-                self.refresh_messages()?;
+                // Opening the chat already loaded and settled in the pane — Enter
+                // after a settled flick preview of the same chat — is a focus move
+                // only. Reloading would re-enqueue a redundant timeline load and a
+                // second mark-read for a pane that already shows this chat (its
+                // live subscription keeps it current). A load still in flight, a
+                // different highlighted chat, or an empty pane still (re)loads.
+                let already_settled = self.loading_chat.is_none()
+                    && self.messages_group_id.is_some()
+                    && self.selected_chat_row().map(|chat| chat.group_id.as_str())
+                        == self.messages_group_id.as_deref();
+                if !already_settled {
+                    self.refresh_messages()?;
+                }
                 self.focus = Focus::Messages;
                 Ok(())
             }
@@ -1198,6 +1314,10 @@ impl TuiApp {
     /// same submit reached from elsewhere (e.g. group detail) is unaffected.
     fn reveal_chat_from_search(&mut self) {
         if self.screen == Screen::UserSearch {
+            // Drop any in-flight search so a late fold cannot repopulate the search
+            // view after we have moved on to the revealed chat (the same stale-fold
+            // guard `leave_screen` applies on `Esc`).
+            self.searching_users = None;
             self.user_search = None;
             self.screen = Screen::Main;
             self.focus = Focus::Chats;
@@ -1238,6 +1358,16 @@ impl TuiApp {
 
     pub(crate) fn leave_group_detail(&mut self) {
         self.group_detail = None;
+        // Clearing the load anchor drops any group-detail result still in flight,
+        // so a late load cannot repopulate the view after the screen is left.
+        self.loading_group_detail = None;
+        // Leaving mid-load would otherwise strand the "loading group detail..."
+        // status (the fold that clears it is now dropped). Reset it, guarded so a
+        // meaningful status a caller sets afterward (accept-invite, leave-group) is
+        // never clobbered.
+        if self.status == LOADING_GROUP_DETAIL_STATUS {
+            self.status = String::new();
+        }
         self.screen = Screen::Main;
         self.focus = Focus::Chats;
     }
@@ -1409,6 +1539,14 @@ impl TuiApp {
     /// the search/profile/relay-health `Esc` handlers (their data is a one-shot
     /// load with no per-view subscription to tear down).
     pub(crate) fn leave_screen(&mut self) {
+        // A user search may still be in flight. Clearing its anchor drops the
+        // stale result at fold time (mirroring `leave_group_detail`'s
+        // `loading_group_detail` clear), so reopening the search screen never
+        // inherits the abandoned query's results, and resets the "searching..."
+        // status the abandoned load would otherwise strand on the status line.
+        if self.searching_users.take().is_some() {
+            self.status = String::new();
+        }
         self.user_search = None;
         self.profile_view = None;
         self.relay_health = None;

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -508,6 +508,16 @@ impl TuiApp {
             KeyCode::Esc if is_armed_interaction(self.input.value()) => {
                 self.input.clear();
             }
+            // Otherwise Esc is spatial back: Composer -> Messages -> Chats, and a
+            // no-op from Chats. It never clears a hand-typed draft (only an armed
+            // interaction clears, handled above), so leaving the composer keeps the
+            // draft intact for when focus returns.
+            KeyCode::Esc => {
+                self.focus = match self.focus {
+                    Focus::Composer => Focus::Messages,
+                    Focus::Messages | Focus::Chats => Focus::Chats,
+                };
+            }
             KeyCode::Char('/') if self.focus != Focus::Composer => {
                 self.focus = Focus::Composer;
                 self.input.insert('/');

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -1387,8 +1387,10 @@ impl TuiApp {
     /// Tear down the open popup: drop the viewer's on-demand native protocol
     /// (a no-op for non-image popups) and schedule the full clear+repaint that
     /// `run()` applies before the next draw. Every popup close funnels through
-    /// here so a terminal-side pixel image can never outlive its popup.
-    fn close_popup(&mut self) {
+    /// here so a terminal-side pixel image can never outlive its popup —
+    /// including a popup replaced by a fold (see `fold_invites`), not only one
+    /// dismissed by a key.
+    pub(crate) fn close_popup(&mut self) {
         self.popup = None;
         self.media.drop_viewer_protocol();
         self.pending_full_repaint = true;

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -461,19 +461,22 @@ impl TuiApp {
         }
     }
 
-    /// Wait for the launch daemon auto-start's one-shot thread to report and fold
-    /// its outcome, for end-to-end tests over a fake `wn`. Panics if no auto-start
-    /// is in flight or the thread stalls.
+    /// Wait for the launch daemon auto-start's one-shot thread to report, and
+    /// hand the outcome back unfolded, for end-to-end tests over a fake `wn`.
+    /// Folding is the caller's explicit next step (`fold_daemon_start`): the
+    /// fold re-ensures the daemon-backed subscriptions, which spawns further
+    /// `wn` children against the same fake, so a test that inspects the fake's
+    /// recorded argv must read it between the receive and the fold — once the
+    /// result is in hand the `daemon start` child has exited and nothing else
+    /// has run yet. Panics if no auto-start is in flight or the thread stalls.
     #[cfg(test)]
-    pub(crate) fn settle_daemon_autostart(&mut self) {
+    pub(crate) fn recv_daemon_autostart(&mut self) -> Result<Value, String> {
         let rx = self
             .daemon_autostart
             .take()
             .expect("a daemon auto-start is in flight");
-        let result = rx
-            .recv_timeout(Duration::from_secs(5))
-            .expect("daemon auto-start produced a result");
-        self.fold_daemon_start(result);
+        rx.recv_timeout(Duration::from_secs(5))
+            .expect("daemon auto-start produced a result")
     }
 
     /// Send the composer text off the event loop. The optimistic row folds in

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -246,100 +246,292 @@ pub(crate) fn spawn_subscription_reader(
     Ok(rx)
 }
 
-impl TuiApp {
-    pub(crate) fn send_message(&mut self, text: String) -> TuiResult<()> {
-        let account_id = self.message_account_id()?;
-        let group_id = self.message_group_id()?;
-        // Use the documented plural `messages` surface, matching the react /
-        // unreact / delete / retry interactions (`message` is a hidden alias).
-        let args = vec!["messages", "send", &group_id, &text];
-        let result = self.client.run_json(Some(&account_id), &args)?;
-        let status = publish_status("sent message", &result);
-        if let Some(message_id) = result
-            .get("message_ids")
-            .and_then(Value::as_array)
-            .and_then(|ids| ids.first())
-            .and_then(Value::as_str)
-        {
-            // Optimistic row; the timeline projection event upserts over it by id
-            // once the send lands in the materialized view.
-            let now = unix_now_seconds();
-            let row = TimelineRow {
-                message_id: message_id.to_owned(),
-                direction: "sent".to_owned(),
-                from: account_id,
-                from_display_name: None,
-                plaintext: text.clone(),
-                display_text: text,
-                timeline_at: now,
-                received_at: now,
-                deleted: false,
-                reactions: Vec::new(),
-                reply: None,
-                attachments: Vec::new(),
-            };
-            if let TimelineFoldOutcome::Inserted(index) =
-                apply_timeline_change(&mut self.timeline, TimelineChange::Upsert(Box::new(row)))
-            {
-                self.timeline_scroll.on_insert(index, self.timeline.len());
+/// A completed effect handed back from the worker to the event loop: the effect
+/// that ran (so the fold knows how to interpret it) plus, in order, every call's
+/// parsed result — or the first error encountered.
+pub(crate) struct EffectDone {
+    pub(crate) effect: Effect,
+    pub(crate) result: Result<Vec<Value>, String>,
+}
+
+/// Runs queued [`Effect`]s on one dedicated worker thread, so a user-initiated
+/// `wn` round-trip never blocks the render loop and queued mutations run in FIFO
+/// order — a single thread draining a single channel preserves submission order
+/// end to end. Results return over a second channel drained on `tick`, mirroring
+/// the media pipeline and the subscription readers.
+///
+/// Supervision is deliberately omitted. If the worker thread ever panicked it
+/// would drop `done_tx`; `drain` would then see `Disconnected`, and any in-flight
+/// status (`sending...`, `loading chat...`, …) would be stranded with no fold to
+/// clear it — there is no restart. That is acceptable because the realistic panic
+/// surface here is empty: an effect is just `run_json`, which returns a `Result`
+/// (spawn/IO/JSON failures are values, not panics) reduced to a message string,
+/// and `parse_json_output` is panic-free (lossy UTF-8 decode, checked JSON parse,
+/// no indexing or unwraps). Reaching a panic would take an allocation abort, by
+/// which point the whole process is already lost.
+///
+/// A `wn` child still running when the app quits is left to finish: dropping the
+/// app drops `tx`, so the worker exits after its current effect, but that child
+/// is not killed. A send completing just after quit is acceptable (the work
+/// reached the relay); a read (a load) merely wastes the moment it takes to
+/// exit. Neither warrants tracking and reaping children across shutdown.
+pub(crate) struct EffectRunner {
+    tx: mpsc::Sender<Effect>,
+    rx: Receiver<EffectDone>,
+}
+
+impl EffectRunner {
+    pub(crate) fn spawn(client: WnClient) -> Self {
+        let (tx, effect_rx) = mpsc::channel::<Effect>();
+        let (done_tx, rx) = mpsc::channel::<EffectDone>();
+        thread::spawn(move || {
+            // `recv` returns `Err` once the app drops its `tx` (shutdown), so the
+            // worker exits cleanly. Effects run strictly one at a time in the
+            // order received.
+            while let Ok(effect) = effect_rx.recv() {
+                let result = run_effect(&client, &effect);
+                if done_tx.send(EffectDone { effect, result }).is_err() {
+                    return;
+                }
             }
-        } else {
-            self.refresh_messages()?;
+        });
+        Self { tx, rx }
+    }
+
+    /// Queue an effect to run off the event loop. The send only fails if the
+    /// worker is gone, which happens only at shutdown; a dropped effect then
+    /// simply never folds, which is correct while tearing down.
+    pub(crate) fn enqueue(&self, effect: Effect) {
+        let _ = self.tx.send(effect);
+    }
+
+    /// Drain every effect that finished since the last tick, for folding now.
+    pub(crate) fn drain(&self) -> Vec<EffectDone> {
+        let mut done = Vec::new();
+        // `try_recv` yields `Empty` when caught up and `Disconnected` only if the
+        // worker died; either ends the drain. The worker holds `done_tx` for the
+        // app's lifetime, so `Disconnected` is a shutdown-only edge.
+        while let Ok(item) = self.rx.try_recv() {
+            done.push(item);
         }
-        self.status = status;
+        done
+    }
+
+    #[cfg(test)]
+    pub(crate) fn recv_timeout(&self, timeout: Duration) -> Option<EffectDone> {
+        self.rx.recv_timeout(timeout).ok()
+    }
+}
+
+/// Run every call an effect expands to, in order, short-circuiting on the first
+/// error (mirroring the `?` chaining the synchronous handlers used). Worker
+/// thread only. The error is reduced to a message string at this boundary; the
+/// folds only ever surface it on the status line.
+fn run_effect(client: &WnClient, effect: &Effect) -> Result<Vec<Value>, String> {
+    let mut values = Vec::new();
+    for call in effect.calls() {
+        match client.run_json(Some(&call.account), &call.args) {
+            Ok(value) => values.push(value),
+            Err(err) => return Err(err.to_string()),
+        }
+    }
+    Ok(values)
+}
+
+/// Reduce a single-call effect's outcome to its one result value. A successful
+/// effect with no calls yields `Null` (defensive; every effect has at least one
+/// call today).
+fn single_effect_value(result: Result<Vec<Value>, String>) -> Result<Value, String> {
+    result.map(|mut values| values.pop().unwrap_or(Value::Null))
+}
+
+impl TuiApp {
+    /// Fold a completed effect back into state, exactly as the synchronous
+    /// handler folded its `run_json` return. A failure lands on the status line
+    /// and never tears down the session (the caught-error invariant).
+    pub(crate) fn apply_effect_done(&mut self, done: EffectDone) {
+        let EffectDone { effect, result } = done;
+        match effect {
+            Effect::SendMessage {
+                account,
+                group,
+                text,
+            } => {
+                self.fold_optimistic_send(account, group, text, None, "sent message", result);
+            }
+            Effect::SendReply {
+                account,
+                group,
+                reply_to,
+                text,
+            } => {
+                self.fold_optimistic_send(
+                    account,
+                    group,
+                    text,
+                    Some(reply_to),
+                    "sent reply",
+                    result,
+                );
+            }
+            Effect::React { emoji, .. } => {
+                self.fold_status_effect(result, format!("reacted {emoji}"));
+            }
+            Effect::Unreact { .. } => {
+                self.fold_status_effect(result, "removed reaction".to_owned());
+            }
+            Effect::Delete { .. } => {
+                self.fold_status_effect(result, "deleted message".to_owned());
+            }
+            Effect::LoadTimeline { account, group } => {
+                self.fold_load_timeline(account, group, result);
+            }
+            Effect::MarkRead { group, .. } => {
+                self.fold_mark_read(group, result);
+            }
+            Effect::GroupDiagnostics { group, .. } => {
+                self.fold_group_diagnostics(group, result);
+            }
+            Effect::UserSearch { query, .. } => {
+                self.fold_user_search(query, result);
+            }
+            Effect::LoadGroupDetail { account, group } => {
+                self.fold_group_detail(account, group, result);
+            }
+            Effect::LoadInvites { account } => {
+                self.fold_invites(account, result);
+            }
+            Effect::Relist { account, .. } => {
+                self.fold_relist(account, result);
+            }
+        }
+    }
+
+    /// Fold an effect whose only visible outcome is a status line: report
+    /// `success` on `Ok`, or the caught error otherwise.
+    fn fold_status_effect(&mut self, result: Result<Vec<Value>, String>, success: String) {
+        self.status = match result {
+            Ok(_) => success,
+            Err(err) => format!("error: {err}"),
+        };
+    }
+
+    #[cfg(test)]
+    pub(crate) fn apply_effect_done_for_test(&mut self, done: EffectDone) {
+        self.apply_effect_done(done);
+    }
+
+    /// Wait for `count` queued effects to finish on the worker and fold each,
+    /// for end-to-end tests over a fake `wn`. Panics if the worker stalls.
+    #[cfg(test)]
+    pub(crate) fn settle_effects(&mut self, count: usize) {
+        for _ in 0..count {
+            let done = self
+                .effects
+                .recv_timeout(Duration::from_secs(5))
+                .expect("effect worker produced a result");
+            self.apply_effect_done(done);
+        }
+    }
+
+    /// Send the composer text off the event loop. The optimistic row folds in
+    /// when the send lands (the timeline projection upserts over it by id once it
+    /// reaches the materialized view), so nothing blocks the render loop.
+    pub(crate) fn send_message(&mut self, text: String) -> TuiResult<()> {
+        let effect = self.resolve_send_message(text)?;
+        self.effects.enqueue(effect);
+        self.status = "sending...".to_owned();
         Ok(())
     }
 
-    /// Send the composer text as a reply to the selected message
-    /// (`messages send --group <g> --reply-to <id> <text>`). The `--reply-to`
-    /// flag goes before the trailing text: the CLI send guard treats a
-    /// `--reply-to` that lands after the text as literal message text and rejects
-    /// it (`reply_to_after_message_text`). The target resolves here, at submit,
-    /// with the same clear error the other interactions use when nothing is
-    /// selected. No list refetch: mirrors `send_message`'s optimistic row, which
-    /// the timeline projection upserts over by id once the reply lands.
+    /// Resolve (without running) the send effect. Uses the documented plural
+    /// `messages send` surface, matching react/unreact/delete/retry.
+    pub(crate) fn resolve_send_message(&self, text: String) -> TuiResult<Effect> {
+        Ok(Effect::SendMessage {
+            account: self.message_account_id()?,
+            group: self.message_group_id()?,
+            text,
+        })
+    }
+
+    /// Send the composer text as a reply to the selected message, off the event
+    /// loop. The target resolves at submit with the same clear error the other
+    /// interactions use when nothing is selected; the optimistic reply row folds
+    /// in when the reply lands.
     pub(crate) fn send_reply(&mut self, text: String) -> TuiResult<()> {
-        let account_id = self.message_account_id()?;
-        let group_id = self.message_group_id()?;
-        let reply_to = self.selected_timeline_message_id()?;
-        let args = reply_send_args(&group_id, &reply_to, &text);
-        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-        let result = self.client.run_json(Some(&account_id), &arg_refs)?;
-        let status = publish_status("sent reply", &result);
-        if let Some(message_id) = result
-            .get("message_ids")
-            .and_then(Value::as_array)
-            .and_then(|ids| ids.first())
-            .and_then(Value::as_str)
-        {
-            let now = unix_now_seconds();
-            let row = TimelineRow {
-                message_id: message_id.to_owned(),
-                direction: "sent".to_owned(),
-                from: account_id,
-                from_display_name: None,
-                plaintext: text.clone(),
-                display_text: text,
-                timeline_at: now,
-                received_at: now,
-                deleted: false,
-                reactions: Vec::new(),
-                reply: Some(TimelineReply {
-                    reply_to_message_id: reply_to,
-                    preview: None,
-                }),
-                attachments: Vec::new(),
-            };
-            if let TimelineFoldOutcome::Inserted(index) =
-                apply_timeline_change(&mut self.timeline, TimelineChange::Upsert(Box::new(row)))
-            {
-                self.timeline_scroll.on_insert(index, self.timeline.len());
+        let effect = self.resolve_reply(text)?;
+        self.effects.enqueue(effect);
+        self.status = "sending reply...".to_owned();
+        Ok(())
+    }
+
+    pub(crate) fn resolve_reply(&self, text: String) -> TuiResult<Effect> {
+        Ok(Effect::SendReply {
+            account: self.message_account_id()?,
+            group: self.message_group_id()?,
+            reply_to: self.selected_timeline_message_id()?,
+            text,
+        })
+    }
+
+    /// Fold a completed send/reply, exactly as the synchronous path did: report
+    /// the publish status and, while the pane still shows the target chat, insert
+    /// the optimistic row the timeline projection later upserts over by id. A row
+    /// for a chat the user has since left is dropped (the send still happened;
+    /// its group feed surfaces it on return). With no returned id, reload the
+    /// page like the synchronous path did.
+    fn fold_optimistic_send(
+        &mut self,
+        account: String,
+        group: String,
+        text: String,
+        reply_to: Option<String>,
+        action: &str,
+        result: Result<Vec<Value>, String>,
+    ) {
+        let result = match single_effect_value(result) {
+            Ok(value) => value,
+            Err(err) => {
+                self.status = format!("error: {err}");
+                return;
             }
-        } else {
-            self.refresh_messages()?;
+        };
+        let status = publish_status(action, &result);
+        if self.messages_group_id.as_deref() == Some(group.as_str()) {
+            if let Some(message_id) = result
+                .get("message_ids")
+                .and_then(Value::as_array)
+                .and_then(|ids| ids.first())
+                .and_then(Value::as_str)
+            {
+                let now = unix_now_seconds();
+                let row = TimelineRow {
+                    message_id: message_id.to_owned(),
+                    direction: "sent".to_owned(),
+                    from: account,
+                    from_display_name: None,
+                    plaintext: text.clone(),
+                    display_text: text,
+                    timeline_at: now,
+                    received_at: now,
+                    deleted: false,
+                    reactions: Vec::new(),
+                    reply: reply_to.map(|reply_to_message_id| TimelineReply {
+                        reply_to_message_id,
+                        preview: None,
+                    }),
+                    attachments: Vec::new(),
+                };
+                if let TimelineFoldOutcome::Inserted(index) =
+                    apply_timeline_change(&mut self.timeline, TimelineChange::Upsert(Box::new(row)))
+                {
+                    self.timeline_scroll.on_insert(index, self.timeline.len());
+                }
+            } else {
+                let _ = self.refresh_messages();
+            }
         }
         self.status = status;
-        Ok(())
     }
 
     /// The message id of the currently selected timeline row. Errors when the
@@ -352,42 +544,57 @@ impl TuiApp {
         Ok(self.timeline[index].message_id.clone())
     }
 
-    /// React to the selected message (`messages react <group> <id> [emoji]`). No
-    /// list refetch: the timeline projection subscription folds the reaction in
-    /// both directions, so success only updates the status line.
+    /// React to the selected message (`messages react <group> <id> [emoji]`). The
+    /// subprocess runs off the event loop; the timeline projection subscription
+    /// folds the reaction in both directions, so the fold only updates status.
     pub(crate) fn react_to_selected_message(&mut self, emoji: String) -> TuiResult<()> {
-        let account_id = self.message_account_id()?;
-        let group_id = self.message_group_id()?;
-        let message_id = self.selected_timeline_message_id()?;
-        self.client.run_json(
-            Some(&account_id),
-            &["messages", "react", &group_id, &message_id, &emoji],
-        )?;
-        self.status = format!("reacted {emoji}");
+        let effect = self.resolve_react(emoji)?;
+        self.effects.enqueue(effect);
+        self.status = "reacting...".to_owned();
         Ok(())
+    }
+
+    /// Resolve (without running) the react effect for the selected row.
+    pub(crate) fn resolve_react(&self, emoji: String) -> TuiResult<Effect> {
+        Ok(Effect::React {
+            account: self.message_account_id()?,
+            group: self.message_group_id()?,
+            message_id: self.selected_timeline_message_id()?,
+            emoji,
+        })
     }
 
     /// Remove your own reaction from the selected message
-    /// (`messages unreact <group> <id>`). No list refetch (see `react_to_...`).
+    /// (`messages unreact <group> <id>`), off the event loop (see `react_...`).
     pub(crate) fn unreact_selected_message(&mut self) -> TuiResult<()> {
-        let account_id = self.message_account_id()?;
-        let group_id = self.message_group_id()?;
-        let message_id = self.selected_timeline_message_id()?;
-        self.client.run_json(
-            Some(&account_id),
-            &["messages", "unreact", &group_id, &message_id],
-        )?;
-        self.status = "removed reaction".to_owned();
+        let effect = self.resolve_unreact()?;
+        self.effects.enqueue(effect);
+        self.status = "removing reaction...".to_owned();
         Ok(())
     }
 
-    /// Delete the selected message (`messages delete <group> <id>`). Delete only
-    /// makes sense for your own messages; the row's `direction` makes the check
-    /// trivial, so a clear status-line error fires early instead of a CLI
-    /// rejection. No list refetch: the projection tombstones the row.
+    pub(crate) fn resolve_unreact(&self) -> TuiResult<Effect> {
+        Ok(Effect::Unreact {
+            account: self.message_account_id()?,
+            group: self.message_group_id()?,
+            message_id: self.selected_timeline_message_id()?,
+        })
+    }
+
+    /// Delete the selected message (`messages delete <group> <id>`) off the event
+    /// loop. Delete only makes sense for your own messages; the ownership check
+    /// runs at resolve time, so a clear status-line error fires before anything
+    /// is queued. No list refetch: the projection tombstones the row.
     pub(crate) fn delete_selected_message(&mut self) -> TuiResult<()> {
-        let account_id = self.message_account_id()?;
-        let group_id = self.message_group_id()?;
+        let effect = self.resolve_delete()?;
+        self.effects.enqueue(effect);
+        self.status = "deleting...".to_owned();
+        Ok(())
+    }
+
+    pub(crate) fn resolve_delete(&self) -> TuiResult<Effect> {
+        let account = self.message_account_id()?;
+        let group = self.message_group_id()?;
         let index = self
             .timeline_scroll
             .resolved_selection(self.timeline.len())
@@ -401,13 +608,11 @@ impl TuiApp {
                 "can only delete your own messages".to_owned(),
             ));
         }
-        let message_id = self.timeline[index].message_id.clone();
-        self.client.run_json(
-            Some(&account_id),
-            &["messages", "delete", &group_id, &message_id],
-        )?;
-        self.status = "deleted message".to_owned();
-        Ok(())
+        Ok(Effect::Delete {
+            account,
+            group,
+            message_id: self.timeline[index].message_id.clone(),
+        })
     }
 
     /// Retry a failed outbound event (`messages retry <group> <event-id>`). The
@@ -743,29 +948,54 @@ impl TuiApp {
         self.group_detail = None;
         self.load_group_detail(&group_id)?;
         self.screen = Screen::GroupDetail;
-        self.status = "group detail".to_owned();
+        // Honest in-flight feedback while the four-call load runs off-loop; the
+        // fold clears it on settle.
+        self.status = LOADING_GROUP_DETAIL_STATUS.to_owned();
         Ok(())
     }
 
-    /// Load (or reload) the group-detail view: members with admin badges from
-    /// `groups members` + `groups admins`, relay hints from `groups relays`, and
-    /// name/description from `groups show`. The member selection is preserved and
-    /// clamped across reloads so a membership change never jumps the cursor.
+    /// Load (or reload) the group-detail view off the event loop: members with
+    /// admin badges (`groups members` + `groups admins`), relay hints
+    /// (`groups relays`), and name/description (`groups show`). The member
+    /// selection is preserved and clamped across reloads so a membership change
+    /// never jumps the cursor.
     pub(crate) fn load_group_detail(&mut self, group_id: &str) -> TuiResult<()> {
         let account_id = self.require_selected_local_account()?;
-        let members_result = self
-            .client
-            .run_json(Some(&account_id), &["groups", "members", group_id])?;
-        let admins_result = self
-            .client
-            .run_json(Some(&account_id), &["groups", "admins", group_id])?;
-        let relays_result = self
-            .client
-            .run_json(Some(&account_id), &["groups", "relays", group_id])?;
-        let show_result = self
-            .client
-            .run_json(Some(&account_id), &["groups", "show", group_id])?;
-        let (name, description) = parse_group_profile(&show_result).unwrap_or_else(|| {
+        self.loading_group_detail = Some(group_id.to_owned());
+        self.effects.enqueue(Effect::LoadGroupDetail {
+            account: account_id,
+            group: group_id.to_owned(),
+        });
+        Ok(())
+    }
+
+    /// Fold a completed group-detail load. Dropped if a newer open superseded it
+    /// or the screen was left (`loading_group_detail` is cleared on leave, and
+    /// reloads of the same group keep it set so each reload still folds). The
+    /// four results arrive in `calls()` order: members, admins, relays, show.
+    fn fold_group_detail(
+        &mut self,
+        account: String,
+        group: String,
+        result: Result<Vec<Value>, String>,
+    ) {
+        if self.loading_group_detail.as_deref() != Some(group.as_str())
+            || !matches!(self.screen, Screen::GroupDetail)
+        {
+            return;
+        }
+        let results = match result {
+            Ok(values) => values,
+            Err(err) => {
+                self.status = format!("error: {err}");
+                return;
+            }
+        };
+        let [members_result, admins_result, relays_result, show_result] = results.as_slice() else {
+            self.status = "group detail load returned unexpected results".to_owned();
+            return;
+        };
+        let (name, description) = parse_group_profile(show_result).unwrap_or_else(|| {
             (
                 self.selected_chat_row()
                     .map(|chat| chat.name.clone())
@@ -773,22 +1003,27 @@ impl TuiApp {
                 String::new(),
             )
         });
-        let members = parse_group_members(&members_result);
-        let admins = parse_group_admins(&admins_result);
-        let relays = parse_group_relays(&relays_result);
+        let members = parse_group_members(members_result);
+        let admins = parse_group_admins(admins_result);
+        let relays = parse_group_relays(relays_result);
         let previous = self.group_detail.as_ref().map_or(0, |view| view.selected);
         let mut view = build_group_detail(
-            group_id,
+            &group,
             &name,
             &description,
             &members,
             &admins,
             &relays,
-            &account_id,
+            &account,
         );
         view.selected = previous.min(view.members.len().saturating_sub(1));
         self.group_detail = Some(view);
-        Ok(())
+        // Clear the in-flight status now the load settled, but only if it is still
+        // showing: a reload triggered by a mutation (rename/add/remove/promote)
+        // has already set its own confirmation, which must not be clobbered.
+        if self.status == LOADING_GROUP_DETAIL_STATUS {
+            self.status = "group detail".to_owned();
+        }
     }
 
     fn reload_group_detail_if_active(&mut self, group_id: &str) -> TuiResult<()> {
@@ -883,20 +1118,55 @@ impl TuiApp {
         Ok(())
     }
 
-    /// Open the pending-invites list picker (`groups invites`). An empty result
-    /// shows an info card rather than an empty picker.
+    /// Open the pending-invites list picker (`groups invites`) off the event
+    /// loop; the picker (or an empty-state info card) opens when the list lands.
+    /// A load already in flight is not re-queued.
     pub(crate) fn open_invites(&mut self) -> TuiResult<()> {
         let account_id = self.require_selected_local_account()?;
-        let result = self
-            .client
-            .run_json(Some(&account_id), &["groups", "invites"])?;
+        if self.loading_invites {
+            return Ok(());
+        }
+        self.loading_invites = true;
+        self.status = "loading invites...".to_owned();
+        self.effects.enqueue(Effect::LoadInvites {
+            account: account_id,
+        });
+        Ok(())
+    }
+
+    /// Fold the pending-invites list into the invites picker (an empty result
+    /// shows an info card rather than an empty picker). The picker is not
+    /// screen-scoped (it is reachable from both the main view and group detail),
+    /// but it is anchored to the enqueuing account: a result whose account no
+    /// longer matches the selection is dropped rather than opening a picker of a
+    /// switched-away account's invites.
+    fn fold_invites(&mut self, account: String, result: Result<Vec<Value>, String>) {
+        if !self.loading_invites {
+            return;
+        }
+        self.loading_invites = false;
+        if self
+            .selected_account_row()
+            .map(|selected| selected.account_id.as_str())
+            != Some(account.as_str())
+        {
+            return;
+        }
+        let result = match single_effect_value(result) {
+            Ok(value) => value,
+            Err(err) => {
+                self.status = format!("error: {err}");
+                return;
+            }
+        };
         let items = parse_invite_items(&result);
+        let count = items.len();
         self.popup = Some(if items.is_empty() {
             Popup::info("Invites", "No pending invites.")
         } else {
             Popup::invites(items, 0)
         });
-        Ok(())
+        self.status = format!("{count} pending invite(s)");
     }
 
     /// After an accept/decline from the invites picker, re-read the pending
@@ -964,8 +1234,8 @@ impl TuiApp {
         }
     }
 
-    /// Run the one-shot `users search <query>` at the default radius and fold the
-    /// results into the view. An empty query is a no-op with a status hint.
+    /// Run the one-shot `users search <query>` off the event loop; the results
+    /// fold into the view when they land. An empty query is a no-op with a hint.
     pub(crate) fn run_user_search(&mut self) -> TuiResult<()> {
         let account_id = self.require_selected_local_account()?;
         let query = self
@@ -977,9 +1247,33 @@ impl TuiApp {
             self.status = "type a query, then Enter to search".to_owned();
             return Ok(());
         }
-        let result = self
-            .client
-            .run_json(Some(&account_id), &["users", "search", &query])?;
+        self.searching_users = Some(query.clone());
+        self.status = "searching...".to_owned();
+        self.effects.enqueue(Effect::UserSearch {
+            account: account_id,
+            query,
+        });
+        Ok(())
+    }
+
+    /// Fold a completed user search into the view, dropping a result whose query
+    /// no longer matches the pending search (a newer query superseded it) or
+    /// whose screen has been left.
+    fn fold_user_search(&mut self, query: String, result: Result<Vec<Value>, String>) {
+        if self.searching_users.as_deref() != Some(query.as_str()) {
+            return;
+        }
+        self.searching_users = None;
+        if self.user_search.is_none() {
+            return;
+        }
+        let result = match single_effect_value(result) {
+            Ok(value) => value,
+            Err(err) => {
+                self.status = format!("error: {err}");
+                return;
+            }
+        };
         let results = parse_user_search_results(&result);
         let count = results.len();
         if let Some(view) = self.user_search.as_mut() {
@@ -992,7 +1286,6 @@ impl TuiApp {
             view.selected = 0;
         }
         self.status = format!("found {count} user(s)");
-        Ok(())
     }
 
     /// Open the dismiss-on-any-key profile card for the selected search result
@@ -1518,117 +1811,204 @@ impl TuiApp {
         self.refresh_messages()
     }
 
+    /// Load (or reload) the selected chat's timeline off the event loop. Resolves
+    /// the selected account/group synchronously (a clear error if either is
+    /// missing) and hands the load to the effect worker; the page, subscriptions,
+    /// mark-read, and diagnostics are folded in when the result lands.
     pub(crate) fn refresh_messages(&mut self) -> TuiResult<()> {
         let account_id = self.require_selected_local_account()?;
         let group_id = self.require_selected_group()?;
-        let args = vec![
-            "messages".to_owned(),
-            "timeline".to_owned(),
-            "list".to_owned(),
-            "--group".to_owned(),
-            group_id.clone(),
-            "--limit".to_owned(),
-            TUI_TIMELINE_PAGE_SIZE.to_string(),
-        ];
-        let result = self.client.run_json(Some(&account_id), &args)?;
-        self.timeline = parse_timeline_page(&result);
-        self.timeline_scroll = TimelineScroll {
-            has_more_before: timeline_page_has_more_before(&result),
-            ..TimelineScroll::default()
+        self.begin_timeline_load(account_id, group_id);
+        Ok(())
+    }
+
+    /// Reset the pane to a loading state (only when switching to a different
+    /// group, so a same-chat reload never flashes empty), tag the pending target
+    /// for the stale guard, and queue the timeline load.
+    pub(crate) fn begin_timeline_load(&mut self, account_id: String, group_id: String) {
+        // Any explicit or fired load supersedes a pending flick-through preview.
+        self.flick_countdown = None;
+        if self.messages_group_id.as_deref() != Some(group_id.as_str()) {
+            // Drop the prior chat's pane and its per-group subscriptions so their
+            // drains cannot pollute the pane while the new chat loads.
+            self.clear_timeline_pane();
+            self.messages_group_id = None;
+            self.group_state_subscription = None;
+            self.group_diagnostics = None;
+        }
+        self.loading_chat = Some(group_id.clone());
+        self.status = "loading chat...".to_owned();
+        self.effects.enqueue(Effect::LoadTimeline {
+            account: account_id,
+            group: group_id,
+        });
+    }
+
+    /// Fold a completed timeline load into the pane, exactly as the synchronous
+    /// path did after its `run_json` returned — but dropping a result whose group
+    /// no longer matches the pending target (a newer open superseded it).
+    fn fold_load_timeline(
+        &mut self,
+        account: String,
+        group: String,
+        result: Result<Vec<Value>, String>,
+    ) {
+        if self.loading_chat.as_deref() != Some(group.as_str()) {
+            return;
+        }
+        let result = match single_effect_value(result) {
+            Ok(value) => value,
+            Err(err) => {
+                self.loading_chat = None;
+                self.status = format!("error: {err}");
+                return;
+            }
         };
-        self.messages_account_id = Some(account_id.clone());
-        self.messages_group_id = Some(group_id.clone());
+        if self.messages_group_id.as_deref() == Some(group.as_str()) {
+            // Same-chat reload: the pane and its timeline subscription stayed live
+            // (a different-chat open clears them and reloads fresh, so a stale
+            // fold there is harmless). A subscription insert may have landed
+            // between enqueue and now; merging the page in by id — the same
+            // idempotent upsert-by-id fold the subscription and history paging
+            // use — keeps those live rows instead of erasing them with a full
+            // replace, and preserves the existing scroll/pin (the pane was never
+            // reset). A genuinely new page row shifts the scroll exactly as a live
+            // insert would; a row already present is an idempotent update.
+            for row in parse_timeline_page(&result) {
+                if let TimelineFoldOutcome::Inserted(index) =
+                    apply_timeline_change(&mut self.timeline, TimelineChange::Upsert(Box::new(row)))
+                {
+                    self.timeline_scroll.on_insert(index, self.timeline.len());
+                }
+            }
+        } else {
+            // Different-chat open: the pane was cleared on enqueue, so replace it
+            // with the fresh page and reset the scroll to the pinned default.
+            self.timeline = parse_timeline_page(&result);
+            self.timeline_scroll = TimelineScroll {
+                has_more_before: timeline_page_has_more_before(&result),
+                ..TimelineScroll::default()
+            };
+        }
+        self.messages_account_id = Some(account.clone());
+        self.messages_group_id = Some(group.clone());
+        self.loading_chat = None;
         // Establish all three subscriptions regardless of any one's outcome. The
         // timeline feed drives the pane's live updates and its `ensure_*` also
         // kills a stale prior-group child, so a failed plain feed must not skip
         // it. Each error surfaces on the status line; the user sees the first by
         // precedence (message, then timeline, then group state).
         let message_subscription_error = self
-            .ensure_message_subscription(&account_id)
+            .ensure_message_subscription(&account)
             .err()
             .map(|err| format!("message subscription failed: {err}"));
         let timeline_subscription_error = self
-            .ensure_timeline_subscription(&account_id, &group_id)
+            .ensure_timeline_subscription(&account, &group)
             .err()
             .map(|err| format!("timeline subscription failed: {err}"));
         let group_state_subscription_error = self
-            .ensure_group_state_subscription(&account_id, &group_id)
+            .ensure_group_state_subscription(&account, &group)
             .err()
             .map(|err| format!("group state subscription failed: {err}"));
         if self.daemon.running && group_state_subscription_error.is_none() {
             if self
                 .group_diagnostics
                 .as_ref()
-                .is_none_or(|diagnostics| diagnostics.group_id != group_id)
+                .is_none_or(|diagnostics| diagnostics.group_id != group)
             {
-                self.group_diagnostics = Some(GroupDiagnostics::unavailable(
-                    &group_id,
-                    "loading group state",
-                ));
+                self.group_diagnostics =
+                    Some(GroupDiagnostics::unavailable(&group, "loading group state"));
             }
         } else {
-            self.refresh_group_diagnostics(&account_id, &group_id);
+            // No daemon (or its state feed failed): fetch diagnostics off-loop.
+            self.effects.enqueue(Effect::GroupDiagnostics {
+                account: account.clone(),
+                group: group.clone(),
+            });
         }
-        // Opening a chat clears its badge immediately: mark it read and fold the
+        // Opening a chat clears its badge: mark it read off-loop and fold the
         // returned projection into the row rather than waiting for a push (the
-        // chats feed does not emit one after a local mark-read). A failure leaves
-        // the badge untouched — never zeroed locally — and surfaces on the status
-        // line behind any subscription error.
-        let mark_read_error = self
-            .mark_selected_chat_read(&account_id, &group_id)
-            .err()
-            .map(|err| format!("mark-read failed: {err}"));
+        // chats feed does not emit one after a local mark-read).
+        self.effects.enqueue(Effect::MarkRead { account, group });
         self.status = message_subscription_error
             .or(timeline_subscription_error)
             .or(group_state_subscription_error)
-            .or(mark_read_error)
             .unwrap_or_else(|| format!("loaded {} message(s)", self.timeline.len()));
-        Ok(())
     }
 
-    /// Mark the loaded chat read up to its newest message and fold the refreshed
-    /// projection into its row, clearing the badge without waiting for a push.
-    /// The runtime read marker is forward-only, so re-marking is idempotent. On
-    /// failure the badge is left honest (never zeroed locally) and the error is
-    /// returned for the status line.
-    pub(crate) fn mark_selected_chat_read(
-        &mut self,
-        account_id: &str,
-        group_id: &str,
-    ) -> TuiResult<()> {
-        let result = self
-            .client
-            .run_json(Some(account_id), &["chats", "mark-read", group_id])?;
-        fold_chat_projection(
-            &mut self.chats,
-            &mut self.selected_chat,
-            group_id,
-            parse_chat_projection(&result),
-        );
-        Ok(())
+    /// Fold a completed mark-read: apply the returned projection to the chat's
+    /// row, clearing the badge. The runtime read marker is forward-only, so
+    /// re-marking is idempotent. On failure the badge is left honest (never
+    /// zeroed locally) and the mark-read is re-armed for the next tick.
+    fn fold_mark_read(&mut self, group: String, result: Result<Vec<Value>, String>) {
+        match single_effect_value(result) {
+            Ok(value) => {
+                fold_chat_projection(
+                    &mut self.chats,
+                    &mut self.selected_chat,
+                    &group,
+                    parse_chat_projection(&value),
+                );
+            }
+            Err(err) => {
+                self.pending_mark_read = true;
+                self.set_drain_status(format!("mark-read failed: {err}"));
+            }
+        }
     }
 
-    /// Background chats re-list for ambient state: re-read `chats list` and
-    /// refresh each row's projection (unread + last-message) while preserving the
+    /// Fold group diagnostics for the loaded chat (the no-daemon fallback),
+    /// dropping the result if the pane has since moved to another group.
+    fn fold_group_diagnostics(&mut self, group: String, result: Result<Vec<Value>, String>) {
+        if self.messages_group_id.as_deref() != Some(group.as_str()) {
+            return;
+        }
+        self.group_diagnostics = Some(match single_effect_value(result) {
+            Ok(value) => parse_group_diagnostics(&value).unwrap_or_else(|| {
+                GroupDiagnostics::unavailable(
+                    &group,
+                    "groups show did not return group diagnostics",
+                )
+            }),
+            Err(err) => GroupDiagnostics::unavailable(&group, err),
+        });
+    }
+
+    /// Fold a completed background chats re-list (the debounced response to a
+    /// notification for a non-selected chat). Refreshes each row's projection
+    /// (unread + last-message) and re-orders by activity while preserving the
     /// messages pane, its subscriptions, and the highlighted chat by group id.
     /// Unlike `refresh_chats` this never reloads the timeline or resets
-    /// subscriptions; it is the debounced response to a notification for a
-    /// non-selected chat. Silent on success (ambient), so it never clobbers the
-    /// status line.
-    pub(crate) fn relist_chats(&mut self) -> TuiResult<()> {
-        let Some(account) = self.selected_account_row().cloned() else {
-            return Ok(());
+    /// subscriptions, and it is silent on success (ambient) so it never clobbers
+    /// the status line.
+    fn fold_relist(&mut self, account: String, result: Result<Vec<Value>, String>) {
+        // Anchor to the enqueuing account: if the selection changed while the
+        // re-list was in flight, its rows belong to a different account — dropping
+        // them here keeps the fold from clobbering the now-selected account's chats
+        // with a stale account's list.
+        if self
+            .selected_account_row()
+            .map(|account| account.account_id.as_str())
+            != Some(account.as_str())
+        {
+            return;
+        }
+        let value = match single_effect_value(result) {
+            Ok(value) => value,
+            Err(err) => {
+                // Re-arm like the synchronous path did so a transient failure
+                // retries next tick instead of dropping the batch.
+                self.pending_chat_relist = true;
+                self.set_drain_status(format!("chat re-list failed: {err}"));
+                return;
+            }
         };
-        if !account.local_signing {
-            return Ok(());
-        }
+        // Capture the selected chat BEFORE replacing the list, then reselect it by
+        // group id after resorting. A naive resort-preserving-selection helper here
+        // would read the old index into the freshly parsed (unsorted) list and jump
+        // the highlight onto a different chat.
         let previous_group_id = self.selected_chat_row().map(|chat| chat.group_id.clone());
-        let mut args = vec!["chats".to_owned(), "list".to_owned()];
-        if self.show_archived_chats {
-            args.push("--include-archived".to_owned());
-        }
-        let result = self.client.run_json(Some(&account.account_id), &args)?;
-        self.chats = result
+        self.chats = value
             .get("chats")
             .and_then(Value::as_array)
             .map(|chats| chats.iter().filter_map(parse_chat).collect())
@@ -1636,7 +2016,6 @@ impl TuiApp {
         sort_chats_by_activity(&mut self.chats);
         self.selected_chat = selected_chat_index(&self.chats, previous_group_id.as_deref())
             .unwrap_or_else(|| self.selected_chat.min(self.chats.len().saturating_sub(1)));
-        Ok(())
     }
 
     /// Fetch and prepend the previous history page. Runs synchronously like every
@@ -1687,23 +2066,6 @@ impl TuiApp {
         self.timeline_scroll.loading_older = false;
         self.status = format!("loaded {prepended} older message(s)");
         Ok(())
-    }
-
-    pub(crate) fn refresh_group_diagnostics(&mut self, account_id: &str, group_id: &str) {
-        self.group_diagnostics = Some(
-            match self
-                .client
-                .run_json(Some(account_id), &["groups", "show", group_id])
-            {
-                Ok(result) => parse_group_diagnostics(&result).unwrap_or_else(|| {
-                    GroupDiagnostics::unavailable(
-                        group_id,
-                        "groups show did not return group diagnostics",
-                    )
-                }),
-                Err(err) => GroupDiagnostics::unavailable(group_id, err.to_string()),
-            },
-        );
     }
 
     pub(crate) fn ensure_chat_subscription(&mut self, account_id: &str) -> TuiResult<()> {

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -1112,9 +1112,21 @@ impl TuiApp {
     /// leaving the TUI pointed at a removed account or a stale subscription (the
     /// account-switch and empty-account clearing both live in that refresh path).
     pub(crate) fn logout_account(&mut self, account_id: &str, npub: &str) -> TuiResult<()> {
+        // The wipe is irreversible; its own failure still propagates (nothing was
+        // removed, so `error:` is the honest report). But once it succeeds, the
+        // account is gone whatever the follow-up reload does — reporting a reload
+        // failure as `error:` would mask a completed wipe and leave the removed
+        // account and its stale subscriptions on screen. So report the logout
+        // unconditionally and fold a reload failure into the same status, naming
+        // `/refresh` as the retry.
         self.client.run_json(None, &["logout", account_id])?;
-        self.refresh_or_return_to_login()?;
-        self.status = format!("logged out {}", shorten(&terminal_safe_text(npub), 18));
+        let logged_out = format!("logged out {}", shorten(&terminal_safe_text(npub), 18));
+        self.status = match self.refresh_or_return_to_login() {
+            Ok(()) => logged_out,
+            Err(err) => {
+                format!("{logged_out}; account list reload failed ({err}) — /refresh to retry")
+            }
+        };
         Ok(())
     }
 

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -2046,6 +2046,24 @@ impl TuiApp {
         result: Result<Vec<Value>, String>,
     ) {
         if self.loading_chat.as_deref() != Some(group.as_str()) {
+            // A newer load (an explicit open or a fired preview) already claimed
+            // the pane; leave `loading_chat` pointing at that pending target so
+            // this stale fold cannot cancel it.
+            return;
+        }
+        // Anchor to the enqueuing account, the same guard `fold_relist`,
+        // `fold_invites`, and `fold_follow_update` apply: `refresh_chats` has
+        // early returns (no selection, public-only, no chats) that clear the pane
+        // without a superseding load, so a switched-away account's in-flight load
+        // would otherwise repopulate the pane under the new account. Nothing will
+        // supersede it, so clear the anchor too or `empty_messages_notice` keeps
+        // showing `loading messages...` for a group the user has left.
+        if self
+            .selected_account_row()
+            .map(|row| row.account_id.as_str())
+            != Some(account.as_str())
+        {
+            self.loading_chat = None;
             return;
         }
         let result = match single_effect_value(result) {

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -1192,11 +1192,12 @@ impl TuiApp {
     }
 
     /// Fold the pending-invites list into the invites picker (an empty result
-    /// shows an info card rather than an empty picker). The picker is not
-    /// screen-scoped (it is reachable from both the main view and group detail),
-    /// but it is anchored to the enqueuing account: a result whose account no
-    /// longer matches the selection is dropped rather than opening a picker of a
-    /// switched-away account's invites.
+    /// shows an info card rather than an empty picker). The fold is dropped
+    /// unless the selection still matches the enqueuing account and the current
+    /// screen is one the picker is reachable from (the main view or group
+    /// detail, via their `I` bindings) — a result that lands after an account
+    /// switch or after the user left for another screen never pops a picker of a
+    /// switched-away account's invites or over a screen it cannot be opened from.
     fn fold_invites(&mut self, account: String, result: Result<Vec<Value>, String>) {
         if !self.loading_invites {
             return;
@@ -1209,6 +1210,13 @@ impl TuiApp {
         {
             return;
         }
+        // The picker is reachable only from the main view and group detail (the
+        // `I` bindings). A result that lands after the user left for another
+        // screen (e.g. `I` then `p`) must drop rather than pop over a screen the
+        // picker cannot be opened from.
+        if !matches!(self.screen, Screen::Main | Screen::GroupDetail) {
+            return;
+        }
         let result = match single_effect_value(result) {
             Ok(value) => value,
             Err(err) => {
@@ -1218,6 +1226,11 @@ impl TuiApp {
         };
         let items = parse_invite_items(&result);
         let count = items.len();
+        // Route the replacement through the close funnel so a pixel image drawn
+        // by an image popup this picker supersedes cannot outlive it: `close_popup`
+        // drops the viewer's native protocol and schedules the full clear+repaint
+        // ratatui's cell diff cannot do for a terminal-side image.
+        self.close_popup();
         self.popup = Some(if items.is_empty() {
             Popup::info("Invites", "No pending invites.")
         } else {

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -323,16 +323,27 @@ impl EffectRunner {
     }
 }
 
-/// Run every call an effect expands to, in order, short-circuiting on the first
-/// error (mirroring the `?` chaining the synchronous handlers used). Worker
-/// thread only. The error is reduced to a message string at this boundary; the
-/// folds only ever surface it on the status line.
+/// Run every call an effect expands to, in order. A required call's failure
+/// short-circuits the effect with the error (mirroring the `?` chaining the
+/// synchronous handlers used). A trailing best-effort enrichment call's failure
+/// instead stops the run and returns the required results already gathered, so
+/// the fold degrades gracefully — a `users search` whose `follows list` badge
+/// read failed still folds its results, unbadged, rather than being discarded as
+/// an error. Worker thread only. The error is reduced to a message string at this
+/// boundary; the folds only ever surface it on the status line.
 fn run_effect(client: &WnClient, effect: &Effect) -> Result<Vec<Value>, String> {
+    let calls = effect.calls();
+    let required = calls.len() - effect.best_effort_trailing_calls();
     let mut values = Vec::new();
-    for call in effect.calls() {
-        match client.run_json(Some(&call.account), &call.args) {
+    for (index, call) in calls.into_iter().enumerate() {
+        match client.run_json(call.account.as_deref(), &call.args) {
             Ok(value) => values.push(value),
-            Err(err) => return Err(err.to_string()),
+            Err(err) if index < required => return Err(err.to_string()),
+            // A trailing best-effort call failed. Every remaining call is also
+            // best-effort (they are trailing by construction), so stop here: the
+            // fold treats the missing enrichment value exactly as an older
+            // single-value result — no badges — instead of surfacing an error.
+            Err(_) => break,
         }
     }
     Ok(values)
@@ -404,6 +415,22 @@ impl TuiApp {
             Effect::Relist { account, .. } => {
                 self.fold_relist(account, result);
             }
+            Effect::FollowUser {
+                account,
+                pubkey,
+                label,
+                ..
+            } => {
+                self.fold_follow_update(account, pubkey, label, true, result);
+            }
+            Effect::UnfollowUser {
+                account,
+                pubkey,
+                label,
+                ..
+            } => {
+                self.fold_follow_update(account, pubkey, label, false, result);
+            }
         }
     }
 
@@ -432,6 +459,21 @@ impl TuiApp {
                 .expect("effect worker produced a result");
             self.apply_effect_done(done);
         }
+    }
+
+    /// Wait for the launch daemon auto-start's one-shot thread to report and fold
+    /// its outcome, for end-to-end tests over a fake `wn`. Panics if no auto-start
+    /// is in flight or the thread stalls.
+    #[cfg(test)]
+    pub(crate) fn settle_daemon_autostart(&mut self) {
+        let rx = self
+            .daemon_autostart
+            .take()
+            .expect("a daemon auto-start is in flight");
+        let result = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("daemon auto-start produced a result");
+        self.fold_daemon_start(result);
     }
 
     /// Send the composer text off the event loop. The optimistic row folds in
@@ -1279,14 +1321,21 @@ impl TuiApp {
         if self.user_search.is_none() {
             return;
         }
-        let result = match single_effect_value(result) {
-            Ok(value) => value,
+        let values = match result {
+            Ok(values) => values,
             Err(err) => {
                 self.status = format!("error: {err}");
                 return;
             }
         };
-        let results = parse_user_search_results(&result);
+        let mut results = parse_user_search_results(values.first().unwrap_or(&Value::Null));
+        // The effect's second call is the local `follows list` snapshot; badge
+        // every row's follow state from it. Tolerant to a missing value like
+        // every parse (an older single-value result simply carries no badges).
+        let follows = follows_pubkey_set(values.get(1).unwrap_or(&Value::Null));
+        for row in &mut results {
+            row.following = follows.contains(&row.pubkey);
+        }
         let count = results.len();
         if let Some(view) = self.user_search.as_mut() {
             view.focus = if results.is_empty() {
@@ -1298,6 +1347,101 @@ impl TuiApp {
             view.selected = 0;
         }
         self.status = format!("found {count} user(s)");
+    }
+
+    /// Follow the highlighted search result (`f`) off the event loop; the fold
+    /// badges the row when the publish lands.
+    pub(crate) fn follow_search_result(&mut self) {
+        self.update_search_follow(true);
+    }
+
+    /// Unfollow the highlighted search result (`x`); mirrors `f`.
+    pub(crate) fn unfollow_search_result(&mut self) {
+        self.update_search_follow(false);
+    }
+
+    /// Queue the follow/unfollow effect for the highlighted result. `follows
+    /// add`/`remove` are idempotent, so the explicit pair stays correct even if
+    /// the row's badge is momentarily stale — unlike a toggle, which would
+    /// invert the intent. No selected result is a silent no-op (the key only
+    /// renders meaningful in results focus).
+    fn update_search_follow(&mut self, follow: bool) {
+        let Some(row) = self
+            .user_search
+            .as_ref()
+            .and_then(UserSearchView::selected_result)
+        else {
+            return;
+        };
+        let pubkey = row.pubkey.clone();
+        let label = row.display_label();
+        let account = match self.require_selected_local_account() {
+            Ok(account) => account,
+            Err(err) => {
+                self.status = format!("error: {err}");
+                return;
+            }
+        };
+        let relay = self.client.account_setup_relay();
+        self.status = if follow {
+            format!("following {label}...")
+        } else {
+            format!("unfollowing {label}...")
+        };
+        let effect = if follow {
+            Effect::FollowUser {
+                account,
+                pubkey,
+                label,
+                relay,
+            }
+        } else {
+            Effect::UnfollowUser {
+                account,
+                pubkey,
+                label,
+                relay,
+            }
+        };
+        self.effects.enqueue(effect);
+    }
+
+    /// Fold a search-screen follow/unfollow: report the outcome, then badge the
+    /// acted-on row. The mutation's status is unconditional (the publish
+    /// happened, like a react or delete), but the badge fold is anchored — the
+    /// search view must still exist (leaving destroys it) and the selected
+    /// account must still be the acting one; the row is keyed by pubkey, so a
+    /// newer query's results only pick up the badge where that user is
+    /// genuinely still on screen.
+    fn fold_follow_update(
+        &mut self,
+        account: String,
+        pubkey: String,
+        label: String,
+        following: bool,
+        result: Result<Vec<Value>, String>,
+    ) {
+        if let Err(err) = single_effect_value(result) {
+            self.status = format!("error: {err}");
+            return;
+        }
+        self.status = if following {
+            format!("followed {label}")
+        } else {
+            format!("unfollowed {label}")
+        };
+        if self
+            .selected_account_row()
+            .map(|row| row.account_id.as_str())
+            != Some(account.as_str())
+        {
+            return;
+        }
+        if let Some(view) = self.user_search.as_mut() {
+            for row in view.results.iter_mut().filter(|row| row.pubkey == pubkey) {
+                row.following = following;
+            }
+        }
     }
 
     /// Open the dismiss-on-any-key profile card for the selected search result
@@ -1677,14 +1821,52 @@ impl TuiApp {
         Ok(())
     }
 
-    pub(crate) fn refresh_daemon_status(&mut self) -> TuiResult<()> {
-        let result = self.client.run_json(None, &["daemon", "status"])?;
-        self.daemon = parse_daemon_view(&result);
+    /// Adopt a daemon status/start result: parse the view and (re)attach the
+    /// daemon-backed subscriptions for the current selection. Shared by the
+    /// status refresh, the synchronous `/daemon start`, and the launch
+    /// auto-start fold, so every path that learns the daemon came up reflects
+    /// it the same way — including the status-bar dot, which reads
+    /// `daemon.running` each frame.
+    fn adopt_daemon_view(&mut self, result: &Value) {
+        self.daemon = parse_daemon_view(result);
         self.ensure_selected_chat_subscription();
         self.ensure_selected_message_subscription();
         self.ensure_selected_group_state_subscription();
         self.ensure_selected_timeline_subscription();
         self.ensure_selected_notification_subscription();
+    }
+
+    /// Fold the launch daemon auto-start's outcome: adopt the started daemon or
+    /// surface the failure on the status line. Either way the session stays up.
+    ///
+    /// The status write is guarded on the `starting daemon...` sentinel the
+    /// auto-start set (the same idiom the group-detail load uses). Because it runs
+    /// off the event loop, a user action may have queued a newer status (e.g.
+    /// `sending...`) meanwhile; that must survive. Only overwrite while the
+    /// sentinel is still showing, and otherwise let the status-bar dot — which
+    /// reads `daemon.running` each frame — tell the story. The daemon view is
+    /// always adopted regardless, so the dot and the subscriptions reflect the
+    /// start either way; checking the sentinel after the adopt also preserves a
+    /// genuine subscription-failure status the adopt may have surfaced.
+    pub(crate) fn fold_daemon_start(&mut self, result: Result<Value, String>) {
+        match result {
+            Ok(value) => {
+                self.adopt_daemon_view(&value);
+                if self.status == STARTING_DAEMON_STATUS {
+                    self.status = daemon_status_sentence(&self.daemon);
+                }
+            }
+            Err(err) => {
+                if self.status == STARTING_DAEMON_STATUS {
+                    self.status = format!("daemon start failed: {err}");
+                }
+            }
+        }
+    }
+
+    pub(crate) fn refresh_daemon_status(&mut self) -> TuiResult<()> {
+        let result = self.client.run_json(None, &["daemon", "status"])?;
+        self.adopt_daemon_view(&result);
         Ok(())
     }
 
@@ -1694,12 +1876,7 @@ impl TuiApp {
             &self.client.default_account_relays,
         );
         let result = self.client.run_json(None, &args)?;
-        self.daemon = parse_daemon_view(&result);
-        self.ensure_selected_chat_subscription();
-        self.ensure_selected_message_subscription();
-        self.ensure_selected_group_state_subscription();
-        self.ensure_selected_timeline_subscription();
-        self.ensure_selected_notification_subscription();
+        self.adopt_daemon_view(&result);
         self.status = daemon_status_sentence(&self.daemon);
         Ok(())
     }

--- a/crates/cli/src/tui/media.rs
+++ b/crates/cli/src/tui/media.rs
@@ -115,6 +115,15 @@ pub(crate) struct MediaState {
     /// and dropped when it closes. Keyed by hash so a stale popup for another
     /// image can never draw it.
     viewer_protocol: Option<(String, StatefulProtocol)>,
+    /// Per-hash download/decode status and inline half-block protocol for every
+    /// image rendered this session. Both are insert-only: each entry is
+    /// decode-capped (the protocol holds at most a ~11.8 MB decoded image plus
+    /// its encoded payload), but neither map is pruned on chat switch or
+    /// scrollback trim, so inline retention is unbounded in aggregate across a
+    /// session — only the per-image cost is capped, not the total. Bounding it
+    /// needs re-download support (status un-tracking plus re-entrant downloads),
+    /// a deliberate follow-up, so the `MEDIA_VIEWER_RETAINED_IMAGES` ~47 MB bound
+    /// covers the viewer pool only.
     statuses: HashMap<String, MediaStatus>,
     protocols: HashMap<String, StatefulProtocol>,
     tx: Sender<MediaLoad>,

--- a/crates/cli/src/tui/media.rs
+++ b/crates/cli/src/tui/media.rs
@@ -19,6 +19,57 @@ use image::DynamicImage;
 use ratatui_image::picker::cap_parser::QueryStdioOptions;
 use ratatui_image::picker::{Picker, ProtocolType};
 use ratatui_image::protocol::StatefulProtocol;
+use ratatui_image::{FilterType, Resize, StatefulImage};
+
+/// The one resize policy every media `StatefulImage` render passes to
+/// `ratatui-image` — the inline timeline block and the image-viewer popup both
+/// route through here. `Resize::Fit(None)` would fall back to
+/// `FilterType::Nearest`, which downscales by sparse sampling: on a photo shrunk
+/// to a terminal-sized target the surviving samples read as pixelated noise.
+/// Lanczos3 computes proper windowed averages instead, so the small render stays
+/// a legible preview. Cost is bounded: the resize runs once per (image,
+/// target-size) pair (`ratatui-image` re-encodes only when the target area
+/// changes) and a Lanczos3 pass at terminal-sized targets is tens of
+/// milliseconds.
+pub(crate) fn media_image_resize() -> Resize {
+    Resize::Fit(Some(FilterType::Lanczos3))
+}
+
+/// The configured `StatefulImage` widget every media render site draws with —
+/// the inline timeline blocks and both viewer-popup paths — so the resize
+/// policy above cannot be bypassed by constructing a widget ad hoc.
+pub(crate) fn media_image_widget() -> StatefulImage<StatefulProtocol> {
+    StatefulImage::new().resize(media_image_resize())
+}
+
+/// Decode-time bound on a decoded image's pixel area, sized to the largest
+/// plausible terminal display target. A fullscreen retina terminal is roughly
+/// 200+ columns by 50+ rows at font cells up to ~(14, 30) physical pixels —
+/// about 2800x1650 window pixels — and the image-viewer popup shows at most 80%
+/// of that (~2240x1320). The 2100x1400 box covers that for both orientations
+/// (`Resize::Fit` never upscales, so a retained copy only needs to match the
+/// largest area it can ever be displayed at). Everything larger is downscaled on
+/// the worker thread; at RGBA8 a capped image costs at most
+/// 2100 x 1400 x 4 bytes = ~11.8 MB, where an unbounded 48 MP camera photo
+/// would cost ~190 MB.
+const MEDIA_DECODED_MAX_WIDTH: u32 = 2100;
+const MEDIA_DECODED_MAX_HEIGHT: u32 = 1400;
+
+/// Downscale `image` to fit inside the decode-time cap box, preserving aspect;
+/// images already inside the box pass through untouched (`DynamicImage::resize`
+/// would upscale them, costing memory for no fidelity). Runs on the worker
+/// thread, never the event loop: a Lanczos3 pass over a large camera photo can
+/// take hundreds of milliseconds.
+pub(crate) fn cap_decoded_image(image: DynamicImage) -> DynamicImage {
+    if image.width() <= MEDIA_DECODED_MAX_WIDTH && image.height() <= MEDIA_DECODED_MAX_HEIGHT {
+        return image;
+    }
+    image.resize(
+        MEDIA_DECODED_MAX_WIDTH,
+        MEDIA_DECODED_MAX_HEIGHT,
+        FilterType::Lanczos3,
+    )
+}
 
 /// A worker-thread result delivered back to the event loop. `Downloaded` is the
 /// `downloading -> loading` ladder step (the subprocess finished, the decode is
@@ -45,6 +96,25 @@ pub(crate) struct MediaState {
     /// `None` until capability detection runs, and after it if the terminal has
     /// no image protocol. `None` means placeholders forever, no downloads.
     picker: Option<Picker>,
+    /// The pixel-protocol picker the startup query reported, kept only when the
+    /// terminal actually has one (the query never reaches a pixel protocol
+    /// without a real font size). The inline picker above is always forced to
+    /// halfblocks; this one exists solely so the full-size viewer popup can
+    /// draw the terminal's native image protocol.
+    viewer_picker: Option<Picker>,
+    /// Decoded pixels retained for the viewer popup, per hash, on every
+    /// image-capable terminal — pixel or halfblock-only. They seed the popup's
+    /// own dedicated protocol (native on a pixel terminal, a fresh halfblock
+    /// instance otherwise), so the popup never draws, and so never re-resizes,
+    /// the shared inline protocol. Images are decode-capped, so each entry costs
+    /// at most ~11.8 MB, and the map is bounded by eviction.
+    viewer_images: HashMap<String, DynamicImage>,
+    /// Insertion order of `viewer_images` for oldest-first eviction.
+    viewer_order: VecDeque<String>,
+    /// The one on-demand viewer protocol, built when the viewer popup opens
+    /// and dropped when it closes. Keyed by hash so a stale popup for another
+    /// image can never draw it.
+    viewer_protocol: Option<(String, StatefulProtocol)>,
     statuses: HashMap<String, MediaStatus>,
     protocols: HashMap<String, StatefulProtocol>,
     tx: Sender<MediaLoad>,
@@ -62,6 +132,10 @@ impl MediaState {
         let (tx, rx) = mpsc::channel();
         Self {
             picker: None,
+            viewer_picker: None,
+            viewer_images: HashMap::new(),
+            viewer_order: VecDeque::new(),
+            viewer_protocol: None,
             statuses: HashMap::new(),
             protocols: HashMap::new(),
             tx,
@@ -72,15 +146,16 @@ impl MediaState {
     /// Detect the terminal's image capability once, querying stdio. Called after
     /// raw-mode init and before the event loop owns stdin. A non-tty query fails
     /// fast; the shorter timeout bounds a tty that never answers. On any query
-    /// failure the picker stays `None` (placeholders only). The query is kept only
-    /// as the "is this an image-capable terminal" gate: the reported protocol is
-    /// discarded and replaced with the cell-exact halfblocks protocol by
-    /// `adopt_picker`, so the earlier iTerm2/Kitty misdetection no longer matters.
+    /// failure the picker stays `None` (placeholders only). The inline renderer
+    /// uses the query only as the "is this an image-capable terminal" gate — the
+    /// reported protocol is normalized to cell-exact halfblocks by
+    /// `adopt_picker` — while a reported pixel protocol is remembered separately
+    /// for the full-size viewer popup.
     pub(crate) fn detect_capability(&mut self) {
         let mut options = QueryStdioOptions::default();
         options.timeout = Duration::from_millis(500);
         if let Ok(picker) = Picker::from_query_stdio_with_options(options) {
-            self.adopt_picker(picker);
+            self.adopt_picker(picker, iterm2_session());
         }
     }
 
@@ -170,9 +245,19 @@ impl MediaState {
             }
             MediaLoad::Decoded { hash, image } => match self.picker.as_ref() {
                 Some(picker) => {
-                    let protocol = picker.new_resize_protocol(*image);
+                    let image = *image;
+                    // Keep a copy for the viewer popup before the inline protocol
+                    // consumes the decode. Retained on every image-capable
+                    // terminal (not only pixel ones): the popup builds its own
+                    // dedicated protocol from this copy, so drawing it at popup
+                    // size never disturbs the shared inline protocol's cached
+                    // size. Bounded by eviction, so the extra copies stay
+                    // memory-safe.
+                    let viewer_copy = image.clone();
+                    let protocol = picker.new_resize_protocol(image);
                     self.protocols.insert(hash.clone(), protocol);
-                    self.statuses.insert(hash, MediaStatus::Ready);
+                    self.statuses.insert(hash.clone(), MediaStatus::Ready);
+                    self.retain_viewer_image(hash, viewer_copy);
                 }
                 None => {
                     self.statuses
@@ -185,15 +270,87 @@ impl MediaState {
         }
     }
 
+    /// Retain a decode-capped copy of `hash`'s pixels for the viewer popup,
+    /// evicting oldest-first past `MEDIA_VIEWER_RETAINED_IMAGES`. Re-decoding a
+    /// hash refreshes its pixels in place without double-counting it in the
+    /// eviction order (the reducer folds duplicates idempotently).
+    fn retain_viewer_image(&mut self, hash: String, image: DynamicImage) {
+        if !self.viewer_images.contains_key(&hash) {
+            self.viewer_order.push_back(hash.clone());
+        }
+        self.viewer_images.insert(hash, image);
+        while self.viewer_order.len() > MEDIA_VIEWER_RETAINED_IMAGES {
+            if let Some(evicted) = self.viewer_order.pop_front() {
+                self.viewer_images.remove(&evicted);
+            }
+        }
+    }
+
+    /// Build the popup's own dedicated protocol from the retained pixels for
+    /// `hash`, so the popup never draws — and so never re-resizes — the shared
+    /// inline `protocols[hash]`. Uses the terminal's native pixel picker when it
+    /// has one, otherwise a fresh halfblocks instance built from the inline
+    /// picker; either way this is a distinct instance from the inline protocol,
+    /// dropped when the popup closes.
+    ///
+    /// Returns whether one was built. It is `false` only when the pixels were
+    /// evicted from the bounded retention (viewing an image older than the
+    /// retention window); the popup then draws the shared inline protocol as a
+    /// last resort — the evicted image's pixels survive only inside that
+    /// protocol, and `ratatui-image` exposes no way to read them back out to
+    /// seed a distinct instance. Any previously built viewer protocol is dropped
+    /// either way.
+    pub(crate) fn build_viewer_protocol(&mut self, hash: &str) -> bool {
+        // Prefer the terminal's native pixel picker; fall back to the inline
+        // halfblocks picker so a halfblock-only terminal still gets a dedicated
+        // (distinct-from-inline) instance rather than reusing the inline one.
+        let picker = self.viewer_picker.as_ref().or(self.picker.as_ref());
+        self.viewer_protocol = match (picker, self.viewer_images.get(hash)) {
+            (Some(picker), Some(image)) => {
+                Some((hash.to_owned(), picker.new_resize_protocol(image.clone())))
+            }
+            _ => None,
+        };
+        self.viewer_protocol.is_some()
+    }
+
+    /// The on-demand viewer protocol for `hash`, if one was built for exactly
+    /// that hash and not yet dropped.
+    pub(crate) fn viewer_protocol_mut(&mut self, hash: &str) -> Option<&mut StatefulProtocol> {
+        self.viewer_protocol
+            .as_mut()
+            .filter(|(built_for, _)| built_for == hash)
+            .map(|(_, protocol)| protocol)
+    }
+
+    /// Drop the on-demand viewer protocol (the popup closed). Frees the
+    /// protocol's pixel copy and its encoded payload; the retained viewer image
+    /// stays so reopening the popup rebuilds it.
+    pub(crate) fn drop_viewer_protocol(&mut self) {
+        self.viewer_protocol = None;
+    }
+
     /// Inject a picker for headless tests, so the `Decoded` reducer path and the
     /// renderer run without a real terminal. Routes through the same `adopt_picker`
     /// chokepoint the runtime uses, so a test picker forced to a pixel protocol is
-    /// still normalized to cell-exact halfblocks (proving the invariant holds
-    /// whatever the terminal reports).
+    /// still normalized to cell-exact halfblocks for the inline renderer (proving
+    /// the invariant holds whatever the terminal reports). The iTerm2-session
+    /// hint is pinned off so tests behave the same inside and outside iTerm2;
+    /// `with_test_picker_in_iterm2_session` covers the hint itself.
     #[cfg(test)]
     pub(crate) fn with_test_picker(picker: Picker) -> Self {
         let mut state = Self::new();
-        state.adopt_picker(picker);
+        state.adopt_picker(picker, false);
+        state
+    }
+
+    /// As `with_test_picker`, but as if the process were running inside an
+    /// iTerm2 session (`ITERM_SESSION_ID` and friends), without touching the
+    /// test process's real environment.
+    #[cfg(test)]
+    pub(crate) fn with_test_picker_in_iterm2_session(picker: Picker) -> Self {
+        let mut state = Self::new();
+        state.adopt_picker(picker, true);
         state
     }
 
@@ -203,41 +360,62 @@ impl MediaState {
         self.apply(load);
     }
 
-    /// Adopt `picker` as the terminal image picker, normalizing it to the
+    /// Adopt `picker` as the terminal image picker: remember a reported pixel
+    /// protocol for the viewer popup, then normalize the inline picker to the
     /// cell-exact halfblocks protocol whatever the terminal reported. This is the
     /// single chokepoint through which any picker enters `MediaState` — both the
-    /// runtime capability query and the test hook store their picker here — so no
-    /// caller can install an un-normalized (pixel-protocol) picker.
+    /// runtime capability query and the test hooks store their picker here — so
+    /// no caller can install an un-normalized (pixel-protocol) picker for the
+    /// inline renderer.
     ///
-    /// The protocol chosen here governs *every* image render path: the inline
-    /// timeline blocks and the full-screen image viewer popup (`o`) both draw the
-    /// one shared `StatefulProtocol` built per hash from this picker. It must be
-    /// cell-exact for both:
+    /// Inline, images occupy a reserved block of cells *inside a scrolling
+    /// message list*. Halfblocks draws ordinary colored cells (`▀` with fg/bg),
+    /// bounded strictly to the reserved rect, so it never spills past the block
+    /// and is erased and redrawn correctly on scroll through ratatui's normal
+    /// cell diff. The pixel protocols (iTerm2/Kitty/Sixel) instead map the cell
+    /// rect to pixels via the terminal's detected font size and store the image
+    /// terminal-side behind `set_skip` cells. When font-size detection falls back
+    /// to the arbitrary `(10, 20)` default (`ratatui-image` first tries a
+    /// `TIOCGWINSZ` ioctl for the window pixel size and only reaches `(10, 20)`
+    /// when both the escape-sequence cell-size query and that ioctl fail), the
+    /// pixels overflow the reserved block and occlude the next message, and the
+    /// terminal-side image is left as an artifact a partial redraw cannot erase
+    /// on scroll. Halfblocks depends on no font size for containment (the font
+    /// size only tunes intermediate sampling detail), so it is robust in every
+    /// terminal.
     ///
-    /// - Inline, images occupy a reserved block of cells *inside a scrolling
-    ///   message list*. Halfblocks draws ordinary colored cells (`▀` with fg/bg),
-    ///   bounded strictly to the reserved rect, so it never spills past the block
-    ///   and is erased and redrawn correctly on scroll through ratatui's normal
-    ///   cell diff.
-    /// - The popup has no full clear on close: ratatui erases it by diffing cells.
-    ///   A pixel protocol stores its image terminal-side, out of that diff's reach,
-    ///   so it cannot be reliably erased and would linger after the popup is
-    ///   dismissed.
-    ///
-    /// The pixel protocols (iTerm2/Kitty/Sixel) map the cell rect to pixels via the
-    /// terminal's detected font size and store the image terminal-side behind
-    /// `set_skip` cells. When font-size detection falls back to the arbitrary
-    /// `(10, 20)` default (`ratatui-image` first tries a `TIOCGWINSZ` ioctl for the
-    /// window pixel size and only reaches `(10, 20)` when both the escape-sequence
-    /// cell-size query and that ioctl fail), the pixels overflow the reserved block
-    /// and occlude the next message, and the terminal-side image is left as an
-    /// artifact a partial redraw cannot erase on scroll. Halfblocks depends on no
-    /// font size for containment (the font size only tunes intermediate sampling
-    /// detail), so it is robust in every terminal.
-    fn adopt_picker(&mut self, mut picker: Picker) {
+    /// A *reported* pixel protocol is still real capability, and the modal viewer
+    /// popup is a safe place to use it (its close path forces a full terminal
+    /// repaint, which is what a scrolling inline block cannot afford per frame).
+    /// So before the halfblocks normalization, a non-halfblocks picker is cloned
+    /// into `viewer_picker`. `ratatui-image` only reports a pixel protocol
+    /// together with a queried (or `TIOCGWINSZ`-derived) font size — the
+    /// `(10, 20)` fallback path always reports halfblocks — so a retained viewer
+    /// picker always carries a real font size. Inside an iTerm2 session the
+    /// query is answered kitty-style and misdetected as Kitty (the reason the
+    /// inline forcing exists at all), so `iterm2_session` overrides the viewer
+    /// protocol to iTerm2's own.
+    fn adopt_picker(&mut self, mut picker: Picker, iterm2_session: bool) {
+        if picker.protocol_type() != ProtocolType::Halfblocks {
+            let mut viewer_picker = picker.clone();
+            if iterm2_session {
+                viewer_picker.set_protocol_type(ProtocolType::Iterm2);
+            }
+            self.viewer_picker = Some(viewer_picker);
+        }
         picker.set_protocol_type(ProtocolType::Halfblocks);
         self.picker = Some(picker);
     }
+}
+
+/// Whether this process is running inside an iTerm2 session, per the same
+/// environment markers `ratatui-image` itself trusts as iTerm2 hints
+/// (`ITERM_SESSION_ID`, `LC_TERMINAL`, `TERM_PROGRAM`). Used only to pick the
+/// viewer popup's protocol; inline rendering never depends on it.
+fn iterm2_session() -> bool {
+    std::env::var("ITERM_SESSION_ID").is_ok_and(|value| !value.is_empty())
+        || std::env::var("LC_TERMINAL").is_ok_and(|value| value.contains("iTerm"))
+        || std::env::var("TERM_PROGRAM").is_ok_and(|value| value.contains("iTerm"))
 }
 
 /// Run a media download and decode on a worker thread, delivering the outcome
@@ -259,7 +437,7 @@ pub(crate) fn spawn_media_download(
             Ok(_) => {
                 // Advance to the decoding ladder step, then decode off-loop.
                 let _ = tx.send(MediaLoad::Downloaded { hash: hash.clone() });
-                let decoded = decode_image(&output_path);
+                let decoded = decode_image(&output_path).map(cap_decoded_image);
                 // Whether decode produced an in-memory image or an error, the file
                 // has no remaining reader; remove the decrypted plaintext artifact
                 // before signalling completion so it never lingers at rest.

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -97,6 +97,22 @@ const MESSAGES_TITLE_NAME_LIMIT: usize = 32;
 /// confirmation) is never clobbered.
 const LOADING_GROUP_DETAIL_STATUS: &str = "loading group detail...";
 
+/// The in-flight status shown while the launch daemon auto-start runs off the
+/// event loop, in the same in-flight vocabulary. The fold replaces it with the
+/// started daemon's status sentence, or with the failure.
+const STARTING_DAEMON_STATUS: &str = "starting daemon...";
+
+/// The single honest status when the daemon is down at launch and the TUI holds
+/// no relay source to start it with (`wn daemon start` would fail with
+/// `missing_relay_url`). Surfaced once — no start attempt, no retry loop — and
+/// the login/main flow continues degraded exactly as today. It points only at
+/// the actionable path: relaunching `wn tui` with relay flags (or `WN_RELAY`).
+/// It deliberately does not suggest `/daemon start`, which reads the very same
+/// relay sources (launch flags / `WN_RELAY`) and would fail identically, so it
+/// is no help in-session.
+const DAEMON_AUTOSTART_NO_RELAYS_STATUS: &str = "daemon not running and no relays configured; \
+restart wn tui with --discovery-relays/--default-account-relays (or WN_RELAY)";
+
 pub(crate) async fn run_tui(cli: Cli) -> CliOutput {
     match TuiApp::new(cli).and_then(|mut app| app.run()) {
         Ok(()) => CliOutput {

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -66,12 +66,20 @@ const MEDIA_IMAGE_ROWS: u16 = 8;
 /// images) would spike process/thread pressure. The remainder stay untracked
 /// and are slotted on later ticks as running downloads complete.
 const MEDIA_MAX_IN_FLIGHT: usize = 3;
-/// How many decoded images stay retained in memory for the full-size viewer on
-/// pixel-capable terminals. Each retained copy is decode-capped (at most
-/// ~11.8 MB RGBA), so four bound the viewer's worst-case footprint at ~47 MB
-/// while comfortably covering the freshest arrivals (`MEDIA_MAX_IN_FLIGHT`
-/// admits three at a time). Opening an evicted image's viewer falls back to
-/// the cell-exact halfblock popup.
+/// How many decoded images stay retained in memory for the full-size viewer, on
+/// every image-capable terminal — pixel or halfblock-only. A halfblock terminal
+/// still needs its own dedicated popup instance (drawing at popup size must not
+/// re-resize the shared inline protocol), so it carries the same pool a pixel
+/// terminal does. Each retained copy is decode-capped (at most ~11.8 MB RGBA),
+/// so four bound the viewer pool's worst-case footprint at ~47 MB while
+/// comfortably covering the freshest arrivals (`MEDIA_MAX_IN_FLIGHT` admits
+/// three at a time). Opening an evicted image's viewer falls back to the
+/// cell-exact halfblock popup. This ~47 MB bounds the viewer pool only: the
+/// inline `protocols`/`statuses` maps (see `media.rs`) retain one decode-capped
+/// entry per image ever scrolled past for the life of the session, so only the
+/// per-image decode cost is bounded, never the aggregate. LRU-bounding that
+/// inline retention needs re-download support (status un-tracking plus
+/// re-entrant downloads) and is a deliberate follow-up, not this change.
 const MEDIA_VIEWER_RETAINED_IMAGES: usize = 4;
 const TUI_LIVE_STREAM_PREVIEW_LIMIT: usize = 128;
 /// Cap on the notification-key dedup set. Dedup only needs to cover the recent

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -37,6 +37,12 @@ pub(crate) use view::*;
 
 type TuiResult<T> = Result<T, TuiError>;
 const UI_EVENT_WAIT: Duration = Duration::from_millis(50);
+/// Ticks of quiet after the last chat-list selection move before the highlighted
+/// chat is previewed (flick-through). At the ~50ms tick cadence this is ~150ms,
+/// so racing through the list with j/k coalesces to a single load of the chat
+/// the user settles on instead of one load per row. Each move resets the count;
+/// the tick loop counts it down (no separate timer).
+const FLICK_PREVIEW_DEBOUNCE_TICKS: u32 = 3;
 const STREAM_APPEND_FLUSH_INTERVAL: Duration = Duration::from_millis(125);
 const FOCUS_ACCENT: Color = Color::Green;
 const ACCOUNT_ACCENT: Color = Color::White;
@@ -74,6 +80,19 @@ const TUI_LIVE_STREAM_TEXT_LIMIT: usize = 64 * 1024;
 /// truncation. The List widget clips overflow too; this keeps a stored preview
 /// tidy and bounded independent of the panel width.
 const TUI_CHAT_PREVIEW_LIMIT: usize = 48;
+
+/// Max chars of the loaded chat's name in the messages-pane title before
+/// trailing-ellipsis truncation, leaving room for the `[N older | M newer]`
+/// overflow annotation alongside it. The panel border clips overflow too; this
+/// keeps the title tidy and bounded independent of the pane width.
+const MESSAGES_TITLE_NAME_LIMIT: usize = 32;
+
+/// The in-flight status shown while a group-detail load runs off the event loop,
+/// matching the `sending...`/`loading chat...`/`searching...` in-flight
+/// vocabulary. The fold clears it on settle, and leaving mid-load resets it, both
+/// guarded on this exact value so a more relevant status (e.g. a mutation's
+/// confirmation) is never clobbered.
+const LOADING_GROUP_DETAIL_STATUS: &str = "loading group detail...";
 
 pub(crate) async fn run_tui(cli: Cli) -> CliOutput {
     match TuiApp::new(cli).and_then(|mut app| app.run()) {

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -57,6 +57,13 @@ const MEDIA_IMAGE_ROWS: u16 = 8;
 /// images) would spike process/thread pressure. The remainder stay untracked
 /// and are slotted on later ticks as running downloads complete.
 const MEDIA_MAX_IN_FLIGHT: usize = 3;
+/// How many decoded images stay retained in memory for the full-size viewer on
+/// pixel-capable terminals. Each retained copy is decode-capped (at most
+/// ~11.8 MB RGBA), so four bound the viewer's worst-case footprint at ~47 MB
+/// while comfortably covering the freshest arrivals (`MEDIA_MAX_IN_FLIGHT`
+/// admits three at a time). Opening an evicted image's viewer falls back to
+/// the cell-exact halfblock popup.
+const MEDIA_VIEWER_RETAINED_IMAGES: usize = 4;
 const TUI_LIVE_STREAM_PREVIEW_LIMIT: usize = 128;
 /// Cap on the notification-key dedup set. Dedup only needs to cover the recent
 /// event window (the runtime feed emits duplicates close together), so the set

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -44,7 +44,10 @@ const UI_EVENT_WAIT: Duration = Duration::from_millis(50);
 /// the tick loop counts it down (no separate timer).
 const FLICK_PREVIEW_DEBOUNCE_TICKS: u32 = 3;
 const STREAM_APPEND_FLUSH_INTERVAL: Duration = Duration::from_millis(125);
-const FOCUS_ACCENT: Color = Color::Green;
+/// Chrome accent: focused borders, labels, prompts, and selected markers. Cyan
+/// in the color-role split — green is reserved strictly for self (own messages)
+/// and the daemon-connection dot.
+const FOCUS_ACCENT: Color = Color::Cyan;
 const ACCOUNT_ACCENT: Color = Color::White;
 const DEFAULT_STREAM_CANDIDATE: &str = crate::DEFAULT_PRODUCTION_QUIC_BROKER_CANDIDATE;
 const SLASH_SUGGESTION_LIMIT: usize = 8;

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -1912,9 +1912,14 @@ const ARMED_INTERACTIONS: &[ArmedInteraction] = &[
 /// The armed interaction the composer text begins with, if any: `input` is the
 /// command exactly (`/delete`) or the command followed by whitespace (`/react `,
 /// `/reply hello`). Matching on the whole command word (not a bare prefix) keeps
-/// `/refresh` and `/reactor` from counting. Shared by the persistent armed hint
-/// and the `Esc` escape hatch so they agree on what "armed" means.
+/// `/refresh` and `/reactor` from counting. Surrounding whitespace is trimmed
+/// first so this agrees with `parse_slash_command` (which also trims): a
+/// hand-typed leading space (" /react x") still submits as a reaction, so it
+/// must still read as armed here — otherwise the hint and the `Esc` escape hatch
+/// would silently disagree with what Enter sends. Shared by the persistent armed
+/// hint and the `Esc` escape hatch so they agree on what "armed" means.
 fn armed_interaction(input: &str) -> Option<&'static ArmedInteraction> {
+    let input = input.trim();
     ARMED_INTERACTIONS.iter().find(|armed| {
         input
             .strip_prefix(armed.command)

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -17,13 +17,13 @@ pub(crate) struct WnInvocation {
     pub(crate) stdin: Option<String>,
 }
 
-/// One `wn` call an [`Effect`] expands to: the account it runs under plus the
-/// argv. Distinct from [`WnInvocation`] (the account-less argv+stdin of the
-/// synchronous account-setup path) because every off-loop effect runs under a
-/// selected account and none of them feeds stdin.
+/// One `wn` call an [`Effect`] expands to: the account it runs under (`None`
+/// for the account-less daemon control call, which must work before any
+/// account exists) plus the argv. Distinct from [`WnInvocation`] (the argv+stdin
+/// of the synchronous account-setup path) because no effect feeds stdin.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct WnCall {
-    pub(crate) account: String,
+    pub(crate) account: Option<String>,
     pub(crate) args: Vec<String>,
 }
 
@@ -100,6 +100,24 @@ pub(crate) enum Effect {
         account: String,
         include_archived: bool,
     },
+    /// Follow the highlighted search result (`f`). `label` names the user on
+    /// the status line; `relay` is the setup relay `follows add` requires,
+    /// resolved at enqueue by the same only-when-no-global-`--relay` rule the
+    /// Profile screen's synchronous path uses. The fold badges the acted-on
+    /// row by pubkey, anchored to the surviving view and acting account.
+    FollowUser {
+        account: String,
+        pubkey: String,
+        label: String,
+        relay: Option<String>,
+    },
+    /// Unfollow the highlighted search result (`x`). Mirrors [`Self::FollowUser`].
+    UnfollowUser {
+        account: String,
+        pubkey: String,
+        label: String,
+        relay: Option<String>,
+    },
 }
 
 impl Effect {
@@ -113,7 +131,7 @@ impl Effect {
                 group,
                 text,
             } => vec![WnCall {
-                account: account.clone(),
+                account: Some(account.clone()),
                 args: vec![
                     "messages".to_owned(),
                     "send".to_owned(),
@@ -127,7 +145,7 @@ impl Effect {
                 reply_to,
                 text,
             } => vec![WnCall {
-                account: account.clone(),
+                account: Some(account.clone()),
                 args: reply_send_args(group, reply_to, text),
             }],
             Effect::React {
@@ -136,7 +154,7 @@ impl Effect {
                 message_id,
                 emoji,
             } => vec![WnCall {
-                account: account.clone(),
+                account: Some(account.clone()),
                 args: vec![
                     "messages".to_owned(),
                     "react".to_owned(),
@@ -150,7 +168,7 @@ impl Effect {
                 group,
                 message_id,
             } => vec![WnCall {
-                account: account.clone(),
+                account: Some(account.clone()),
                 args: vec![
                     "messages".to_owned(),
                     "unreact".to_owned(),
@@ -163,7 +181,7 @@ impl Effect {
                 group,
                 message_id,
             } => vec![WnCall {
-                account: account.clone(),
+                account: Some(account.clone()),
                 args: vec![
                     "messages".to_owned(),
                     "delete".to_owned(),
@@ -172,7 +190,7 @@ impl Effect {
                 ],
             }],
             Effect::LoadTimeline { account, group } => vec![WnCall {
-                account: account.clone(),
+                account: Some(account.clone()),
                 args: vec![
                     "messages".to_owned(),
                     "timeline".to_owned(),
@@ -184,37 +202,46 @@ impl Effect {
                 ],
             }],
             Effect::MarkRead { account, group } => vec![WnCall {
-                account: account.clone(),
+                account: Some(account.clone()),
                 args: vec!["chats".to_owned(), "mark-read".to_owned(), group.clone()],
             }],
             Effect::GroupDiagnostics { account, group } => vec![WnCall {
-                account: account.clone(),
+                account: Some(account.clone()),
                 args: vec!["groups".to_owned(), "show".to_owned(), group.clone()],
             }],
-            Effect::UserSearch { account, query } => vec![WnCall {
-                account: account.clone(),
-                args: vec!["users".to_owned(), "search".to_owned(), query.clone()],
-            }],
+            Effect::UserSearch { account, query } => vec![
+                WnCall {
+                    account: Some(account.clone()),
+                    args: vec!["users".to_owned(), "search".to_owned(), query.clone()],
+                },
+                // The local `follows list` directory read: one cheap call that
+                // badges every result row's follow state up front, instead of
+                // a `follows check` round-trip per row.
+                WnCall {
+                    account: Some(account.clone()),
+                    args: vec!["follows".to_owned(), "list".to_owned()],
+                },
+            ],
             Effect::LoadGroupDetail { account, group } => vec![
                 WnCall {
-                    account: account.clone(),
+                    account: Some(account.clone()),
                     args: vec!["groups".to_owned(), "members".to_owned(), group.clone()],
                 },
                 WnCall {
-                    account: account.clone(),
+                    account: Some(account.clone()),
                     args: vec!["groups".to_owned(), "admins".to_owned(), group.clone()],
                 },
                 WnCall {
-                    account: account.clone(),
+                    account: Some(account.clone()),
                     args: vec!["groups".to_owned(), "relays".to_owned(), group.clone()],
                 },
                 WnCall {
-                    account: account.clone(),
+                    account: Some(account.clone()),
                     args: vec!["groups".to_owned(), "show".to_owned(), group.clone()],
                 },
             ],
             Effect::LoadInvites { account } => vec![WnCall {
-                account: account.clone(),
+                account: Some(account.clone()),
                 args: vec!["groups".to_owned(), "invites".to_owned()],
             }],
             Effect::Relist {
@@ -226,12 +253,59 @@ impl Effect {
                     args.push("--include-archived".to_owned());
                 }
                 vec![WnCall {
-                    account: account.clone(),
+                    account: Some(account.clone()),
                     args,
                 }]
             }
+            Effect::FollowUser {
+                account,
+                pubkey,
+                relay,
+                ..
+            } => vec![WnCall {
+                account: Some(account.clone()),
+                args: follows_update_args("add", pubkey, relay.as_deref()),
+            }],
+            Effect::UnfollowUser {
+                account,
+                pubkey,
+                relay,
+                ..
+            } => vec![WnCall {
+                account: Some(account.clone()),
+                args: follows_update_args("remove", pubkey, relay.as_deref()),
+            }],
         }
     }
+
+    /// How many of this effect's trailing [`calls`](Self::calls) are best-effort
+    /// enrichment rather than required work. A required call's failure aborts the
+    /// effect with the error; a trailing best-effort call's failure instead yields
+    /// the required results already gathered, so the fold degrades gracefully
+    /// (it reads trailing enrichment values tolerantly). Zero unless an effect
+    /// opts a trailing call out here.
+    pub(crate) fn best_effort_trailing_calls(&self) -> usize {
+        match self {
+            // `[users search, follows list]`: the search is required, but the
+            // `follows list` only badges results with follow state. A badge-read
+            // failure must yield the search results with no badges, never discard
+            // a successful search as an error.
+            Effect::UserSearch { .. } => 1,
+            _ => 0,
+        }
+    }
+}
+
+/// Args for `follows add|remove <pubkey>`, with the command-local `--relay`
+/// those handlers require appended when the enqueue resolved one (absent when a
+/// global `--relay` already covers every child).
+fn follows_update_args(action: &str, pubkey: &str, relay: Option<&str>) -> Vec<String> {
+    let mut args = vec!["follows".to_owned(), action.to_owned(), pubkey.to_owned()];
+    if let Some(relay) = relay {
+        args.push("--relay".to_owned());
+        args.push(relay.to_owned());
+    }
+    args
 }
 
 /// Build the `wn` invocation for account setup. `setup_relay` supplies the
@@ -1008,7 +1082,7 @@ pub(crate) fn help_card_lines() -> Vec<String> {
         "On the selected message: r react (Enter sends +), u unreact, d delete, R reply.",
         "Composer: cursor editing (arrows/Home/End, Backspace/Delete); Enter sends.",
         "Group detail: j/k move; A add member; x remove; P promote; R rename; L leave.",
-        "User search: type + Enter searches; Enter opens a card; c chat; a add to a chat.",
+        "User search: type + Enter searches; Enter opens a card; c chat; a add to a chat; f follow; x unfollow.",
         "Profile: j/k move; Enter edits a field; f follow; x unfollow. Relay health: r refresh.",
         "Popups capture every key; Esc or the shown key closes them.",
         "",
@@ -1230,6 +1304,10 @@ pub(crate) struct UserSearchResultRow {
     pub(crate) matched_field: String,
     pub(crate) match_quality: String,
     pub(crate) radius: u8,
+    /// Whether the selected account follows this user. Not in the `users
+    /// search` JSON: seeded from the search effect's `follows list` snapshot
+    /// at fold time, then kept current by the `f`/`x` follow-effect folds.
+    pub(crate) following: bool,
 }
 
 impl UserSearchResultRow {
@@ -1305,7 +1383,24 @@ fn parse_user_search_result(value: &Value) -> Option<UserSearchResultRow> {
             .get("radius")
             .and_then(Value::as_u64)
             .unwrap_or_default() as u8,
+        following: false,
     })
+}
+
+/// The set of followed pubkeys (hex account ids) a `follows list` result
+/// carries, for badging search rows. Tolerant like every parse here: a missing
+/// or malformed value is an empty set.
+pub(crate) fn follows_pubkey_set(value: &Value) -> HashSet<String> {
+    value
+        .get("follows")
+        .and_then(Value::as_array)
+        .map(|follows| {
+            follows
+                .iter()
+                .filter_map(|follow| value_string(follow, "account_id"))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// The dismiss-on-any-key profile card body for a `users show` result. Picture
@@ -1664,7 +1759,9 @@ fn build_relay_health_rows(spread: &Value, sync: &Value) -> Vec<RelayHealthRow> 
 pub(crate) fn user_search_hint(focus: UserSearchFocus) -> &'static str {
     match focus {
         UserSearchFocus::Query => "type query  Enter search  Down results  Esc back",
-        UserSearchFocus::Results => "j/k move  Enter profile  c chat  a add  i query  Esc back",
+        UserSearchFocus::Results => {
+            "j/k move  Enter profile  f follow  x unfollow  c chat  a add  i query  Esc back"
+        }
     }
 }
 
@@ -4631,6 +4728,25 @@ pub(crate) fn composer_display_text(input: &str) -> String {
 /// flags. `wn daemon start` accepts comma-delimited `--discovery-relays` /
 /// `--default-account-relays`, so each non-empty list is joined and passed as
 /// the same flag the daemon exposes (flag passthrough, no JSON change).
+/// Whether a `daemon start` spawned by this TUI would have a relay to run with.
+/// Mirrors the exact sources `wn daemon start` accepts — the two passthrough
+/// flag lists, the global `--relay`, and the `WN_RELAY` environment fallback —
+/// so the launch auto-start never declines to start a daemon that would in
+/// fact have started, and never attempts one guaranteed to fail with
+/// `missing_relay_url`. The environment value arrives as a parameter so this
+/// stays pure; the caller reads `WN_RELAY` at the composition root.
+pub(crate) fn daemon_start_has_relay_source(
+    relay: Option<&str>,
+    discovery_relays: &[String],
+    default_account_relays: &[String],
+    env_relay: Option<&str>,
+) -> bool {
+    relay.is_some()
+        || !discovery_relays.is_empty()
+        || !default_account_relays.is_empty()
+        || env_relay.is_some_and(|relay| !relay.trim().is_empty())
+}
+
 pub(crate) fn daemon_start_args(
     discovery_relays: &[String],
     default_account_relays: &[String],

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -4728,25 +4728,6 @@ pub(crate) fn composer_display_text(input: &str) -> String {
 /// flags. `wn daemon start` accepts comma-delimited `--discovery-relays` /
 /// `--default-account-relays`, so each non-empty list is joined and passed as
 /// the same flag the daemon exposes (flag passthrough, no JSON change).
-/// Whether a `daemon start` spawned by this TUI would have a relay to run with.
-/// Mirrors the exact sources `wn daemon start` accepts — the two passthrough
-/// flag lists, the global `--relay`, and the `WN_RELAY` environment fallback —
-/// so the launch auto-start never declines to start a daemon that would in
-/// fact have started, and never attempts one guaranteed to fail with
-/// `missing_relay_url`. The environment value arrives as a parameter so this
-/// stays pure; the caller reads `WN_RELAY` at the composition root.
-pub(crate) fn daemon_start_has_relay_source(
-    relay: Option<&str>,
-    discovery_relays: &[String],
-    default_account_relays: &[String],
-    env_relay: Option<&str>,
-) -> bool {
-    relay.is_some()
-        || !discovery_relays.is_empty()
-        || !default_account_relays.is_empty()
-        || env_relay.is_some_and(|relay| !relay.trim().is_empty())
-}
-
 pub(crate) fn daemon_start_args(
     discovery_relays: &[String],
     default_account_relays: &[String],
@@ -4761,6 +4742,28 @@ pub(crate) fn daemon_start_args(
         args.push(default_account_relays.join(","));
     }
     args
+}
+
+/// Whether a `daemon start` spawned by this TUI would have a relay to run with.
+/// Mirrors the exact sources `wn daemon start` accepts — the two passthrough
+/// flag lists, the global `--relay`, and the `WN_RELAY` environment fallback —
+/// so the launch auto-start never declines to start a daemon that would in
+/// fact have started, and never attempts one guaranteed to fail with
+/// `missing_relay_url`. An empty or whitespace-only `--relay` or `WN_RELAY` is
+/// not a relay source — it would fail the start with `missing_relay_url`, the
+/// exact outcome this predicate exists to avoid. The environment value arrives
+/// as a parameter so this stays pure; the caller reads `WN_RELAY` at the
+/// composition root.
+pub(crate) fn daemon_start_has_relay_source(
+    relay: Option<&str>,
+    discovery_relays: &[String],
+    default_account_relays: &[String],
+    env_relay: Option<&str>,
+) -> bool {
+    relay.is_some_and(|relay| !relay.trim().is_empty())
+        || !discovery_relays.is_empty()
+        || !default_account_relays.is_empty()
+        || env_relay.is_some_and(|relay| !relay.trim().is_empty())
 }
 
 pub(crate) fn message_subscription_args() -> Vec<String> {

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -17,6 +17,223 @@ pub(crate) struct WnInvocation {
     pub(crate) stdin: Option<String>,
 }
 
+/// One `wn` call an [`Effect`] expands to: the account it runs under plus the
+/// argv. Distinct from [`WnInvocation`] (the account-less argv+stdin of the
+/// synchronous account-setup path) because every off-loop effect runs under a
+/// selected account and none of them feeds stdin.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct WnCall {
+    pub(crate) account: String,
+    pub(crate) args: Vec<String>,
+}
+
+/// A user-initiated `wn` operation resolved to a pure value and queued to run
+/// off the event loop. Separating *what to run* (this value, resolved from the
+/// key and current state) from *running it* (the worker) is the testing
+/// backbone: the resolve step and the argv mapping are asserted without ever
+/// spawning a subprocess, and the worker folds the result back on `tick`.
+///
+/// Each field the fold needs that is not carried by the `wn` result travels on
+/// the variant (the group id a load targets, the text an optimistic send row
+/// shows), so a completed effect can be folded exactly as the synchronous
+/// handler folded its `run_json` return.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum Effect {
+    /// Send a text message. The optimistic row the fold inserts uses `text` and
+    /// `account` (data the `wn` result does not echo back).
+    SendMessage {
+        account: String,
+        group: String,
+        text: String,
+    },
+    /// Send a reply to `reply_to`. Mirrors `SendMessage` plus the parent id the
+    /// optimistic reply row carries.
+    SendReply {
+        account: String,
+        group: String,
+        reply_to: String,
+        text: String,
+    },
+    React {
+        account: String,
+        group: String,
+        message_id: String,
+        emoji: String,
+    },
+    Unreact {
+        account: String,
+        group: String,
+        message_id: String,
+    },
+    Delete {
+        account: String,
+        group: String,
+        message_id: String,
+    },
+    /// Load (or reload) the materialized timeline page for a chat — the
+    /// open-chat / flick-through load. Stale results (a newer open superseded
+    /// this one) are dropped at fold time by comparing `group` to the pane's
+    /// pending target.
+    LoadTimeline { account: String, group: String },
+    /// Mark the loaded chat read up to its newest message and fold the returned
+    /// projection into its row, clearing the badge without waiting for a push.
+    MarkRead { account: String, group: String },
+    /// Load MLS group diagnostics for the loaded chat (the no-daemon fallback;
+    /// with a daemon the group-state subscription supplies these live).
+    GroupDiagnostics { account: String, group: String },
+    /// Run a one-shot user directory search. Stale results (a newer query, or a
+    /// left screen) are dropped at fold time by comparing `query` to the pending
+    /// search.
+    UserSearch { account: String, query: String },
+    /// Load the group-detail view: members, admins, relays, and profile (four
+    /// `wn` calls run in that order on the worker thread).
+    LoadGroupDetail { account: String, group: String },
+    /// Load the pending-invites list (`groups invites`) to open the invites
+    /// picker off the event loop.
+    LoadInvites { account: String },
+    /// Re-read the chat list for ambient state (the debounced response to a
+    /// notification for a non-selected chat). Runs off the event loop so a
+    /// notification burst never freezes key handling; the fold resorts and
+    /// preserves the highlighted chat by group id. Stale results (the selected
+    /// account changed while it was in flight) are dropped at fold time.
+    Relist {
+        account: String,
+        include_archived: bool,
+    },
+}
+
+impl Effect {
+    /// The `wn` call(s) this effect runs, in order. Almost every effect is a
+    /// single call; the group-detail load expands to several. Pure — the worker
+    /// executes the returned calls and tests assert them.
+    pub(crate) fn calls(&self) -> Vec<WnCall> {
+        match self {
+            Effect::SendMessage {
+                account,
+                group,
+                text,
+            } => vec![WnCall {
+                account: account.clone(),
+                args: vec![
+                    "messages".to_owned(),
+                    "send".to_owned(),
+                    group.clone(),
+                    text.clone(),
+                ],
+            }],
+            Effect::SendReply {
+                account,
+                group,
+                reply_to,
+                text,
+            } => vec![WnCall {
+                account: account.clone(),
+                args: reply_send_args(group, reply_to, text),
+            }],
+            Effect::React {
+                account,
+                group,
+                message_id,
+                emoji,
+            } => vec![WnCall {
+                account: account.clone(),
+                args: vec![
+                    "messages".to_owned(),
+                    "react".to_owned(),
+                    group.clone(),
+                    message_id.clone(),
+                    emoji.clone(),
+                ],
+            }],
+            Effect::Unreact {
+                account,
+                group,
+                message_id,
+            } => vec![WnCall {
+                account: account.clone(),
+                args: vec![
+                    "messages".to_owned(),
+                    "unreact".to_owned(),
+                    group.clone(),
+                    message_id.clone(),
+                ],
+            }],
+            Effect::Delete {
+                account,
+                group,
+                message_id,
+            } => vec![WnCall {
+                account: account.clone(),
+                args: vec![
+                    "messages".to_owned(),
+                    "delete".to_owned(),
+                    group.clone(),
+                    message_id.clone(),
+                ],
+            }],
+            Effect::LoadTimeline { account, group } => vec![WnCall {
+                account: account.clone(),
+                args: vec![
+                    "messages".to_owned(),
+                    "timeline".to_owned(),
+                    "list".to_owned(),
+                    "--group".to_owned(),
+                    group.clone(),
+                    "--limit".to_owned(),
+                    TUI_TIMELINE_PAGE_SIZE.to_string(),
+                ],
+            }],
+            Effect::MarkRead { account, group } => vec![WnCall {
+                account: account.clone(),
+                args: vec!["chats".to_owned(), "mark-read".to_owned(), group.clone()],
+            }],
+            Effect::GroupDiagnostics { account, group } => vec![WnCall {
+                account: account.clone(),
+                args: vec!["groups".to_owned(), "show".to_owned(), group.clone()],
+            }],
+            Effect::UserSearch { account, query } => vec![WnCall {
+                account: account.clone(),
+                args: vec!["users".to_owned(), "search".to_owned(), query.clone()],
+            }],
+            Effect::LoadGroupDetail { account, group } => vec![
+                WnCall {
+                    account: account.clone(),
+                    args: vec!["groups".to_owned(), "members".to_owned(), group.clone()],
+                },
+                WnCall {
+                    account: account.clone(),
+                    args: vec!["groups".to_owned(), "admins".to_owned(), group.clone()],
+                },
+                WnCall {
+                    account: account.clone(),
+                    args: vec!["groups".to_owned(), "relays".to_owned(), group.clone()],
+                },
+                WnCall {
+                    account: account.clone(),
+                    args: vec!["groups".to_owned(), "show".to_owned(), group.clone()],
+                },
+            ],
+            Effect::LoadInvites { account } => vec![WnCall {
+                account: account.clone(),
+                args: vec!["groups".to_owned(), "invites".to_owned()],
+            }],
+            Effect::Relist {
+                account,
+                include_archived,
+            } => {
+                let mut args = vec!["chats".to_owned(), "list".to_owned()];
+                if *include_archived {
+                    args.push("--include-archived".to_owned());
+                }
+                vec![WnCall {
+                    account: account.clone(),
+                    args,
+                }]
+            }
+        }
+    }
+}
+
 /// Build the `wn` invocation for account setup. `setup_relay` supplies the
 /// first-run relay to `create-identity` / `login` through the one relay flag
 /// those commands actually accept — the (global, for `create-identity`;

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -1827,23 +1827,95 @@ impl Input {
     }
 }
 
-/// The one-line status bar for the main view:
-/// `{account} · daemon {on|off} · {n} chats · {u} unread · {latest status}`.
-/// Untrusted fields (the account label and the status message) pass through
-/// `terminal_safe_text`, and the assembled line is shortened to `width`.
+/// The one-line bottom status bar as styled spans: a daemon-connection dot
+/// (green ● up / red ○ down), the account display name styled distinctly from
+/// its shortened npub (gray), gray `│` separators, the chat count, a
+/// hide-when-zero yellow unread badge, and our own last-action/error status
+/// segment truncated to fit the remaining width. The full-width DarkGray bar
+/// background is filled by the rendering `Paragraph`; the spans set only a
+/// foreground so the fill shows through. Untrusted fields (the account label
+/// and the status message) pass through `terminal_safe_text`.
+///
+/// Kept as our content over wn-tui's: the trailing status segment has no
+/// wn-tui equivalent and stays, and the pending-invites badge wn-tui showed is
+/// omitted because this TUI keeps no persistent pending-invites count (invites
+/// load on demand into a picker).
 pub(crate) fn status_bar_line(
-    account_label: &str,
+    display_name: Option<&str>,
+    npub: Option<&str>,
     daemon_running: bool,
     chats: usize,
     unread: usize,
     status: &str,
     width: usize,
-) -> String {
-    let account = shorten(&terminal_safe_text(account_label), 24);
-    let daemon = if daemon_running { "on" } else { "off" };
+) -> Line<'static> {
+    let sep = || Span::styled(" │ ", Style::default().fg(Color::Gray));
+    let (dot, dot_color) = if daemon_running {
+        ("●", Color::Green)
+    } else {
+        ("○", Color::Red)
+    };
+    let mut spans = vec![
+        Span::raw(" "),
+        Span::styled(dot, Style::default().fg(dot_color)),
+    ];
+
+    match (display_name.filter(|name| !name.trim().is_empty()), npub) {
+        (Some(name), Some(npub)) => {
+            spans.push(Span::styled(
+                format!(" {}", shorten(&terminal_safe_text(name), 24)),
+                Style::default().add_modifier(Modifier::BOLD),
+            ));
+            spans.push(Span::styled(
+                format!(" {}", shorten(&terminal_safe_text(npub), 20)),
+                Style::default().fg(Color::Gray),
+            ));
+        }
+        (None, Some(npub)) => spans.push(Span::raw(format!(
+            " {}",
+            shorten(&terminal_safe_text(npub), 24)
+        ))),
+        _ => spans.push(Span::styled(
+            " not logged in".to_owned(),
+            Style::default().fg(Color::Gray),
+        )),
+    }
+
+    spans.push(sep());
+    spans.push(Span::raw(format!("{chats} chats")));
+    if unread > 0 {
+        spans.push(sep());
+        spans.push(Span::styled(
+            format!("{unread} unread"),
+            Style::default().fg(Color::Yellow),
+        ));
+    }
+
     let status = terminal_safe_text(status);
-    let line = format!("{account} · daemon {daemon} · {chats} chats · {unread} unread · {status}");
-    shorten(&line, width)
+    if !status.is_empty() {
+        let used: usize = spans.iter().map(|span| span.content.chars().count()).sum();
+        // 3 covers the leading " │ " separator the status segment adds.
+        let remaining = width.saturating_sub(used + 3);
+        if remaining >= 4 {
+            spans.push(sep());
+            spans.push(Span::raw(truncate_status(&status, remaining)));
+        }
+    }
+    Line::from(spans)
+}
+
+/// Trailing-truncate a status segment to `max` chars, appending an ellipsis
+/// when clipped. Trailing (not middle) truncation reads better for prose than
+/// `shorten`'s id-shaped middle ellipsis.
+fn truncate_status(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_owned();
+    }
+    if max <= 3 {
+        return text.chars().take(max).collect();
+    }
+    let kept = text.chars().take(max - 3).collect::<String>();
+    format!("{kept}...")
 }
 
 /// The per-screen, per-focus hints line. Terse and kept in lockstep with the
@@ -1948,6 +2020,138 @@ pub(crate) fn armed_interaction_hint(input: &str, row: Option<&TimelineRow>) -> 
         "{} {target} — {}, Esc clears",
         armed.verb, armed.action
     ))
+}
+
+/// The chat-list sidebar width in cells: a fixed 36, but never more than a third
+/// of the available width, so a narrow terminal gives the conversation more room
+/// instead of a sidebar that crowds it out.
+pub(crate) fn sidebar_width(total_width: u16) -> u16 {
+    36.min(total_width / 3)
+}
+
+/// The centered notice shown in the messages pane when the timeline is empty,
+/// as `(text, color)`. Three distinct cases, keyed off the async load flag and
+/// whether a chat is loaded into the pane: an in-flight load is yellow
+/// ("loading messages..."); a settled pane with no chat loaded shows the
+/// dark-gray pick-a-chat prompt; a settled pane holding a chat with no messages
+/// is a genuinely empty (dark-gray) "no messages yet".
+pub(crate) fn empty_messages_notice(loading: bool, chat_loaded: bool) -> (&'static str, Color) {
+    if loading {
+        ("loading messages...", Color::Yellow)
+    } else if !chat_loaded {
+        ("select a chat to start messaging", Color::DarkGray)
+    } else {
+        ("no messages yet", Color::DarkGray)
+    }
+}
+
+/// A single keycap: the key text in a dark-gray-background block (bold white fg),
+/// space-padded so it reads as a raised cap. White-on-dark-gray stays legible on
+/// dark themes, where the previous black-on-dark-gray washed out. The bg is what
+/// distinguishes a key reference from its dim label.
+fn keycap_span(key: &str) -> Span<'static> {
+    Span::styled(
+        format!(" {key} "),
+        Style::default()
+            .fg(Color::White)
+            .bg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+/// A dim (dark-gray) hint label span with a leading space, so it sits a cell off
+/// the keycap that precedes it.
+fn hint_label_span(label: &str) -> Span<'static> {
+    Span::styled(format!(" {label}"), Style::default().fg(Color::DarkGray))
+}
+
+/// Whether a hint segment's leading token is a key press to box as a keycap
+/// (rather than prose to dim). A key is a single character, a slash-combo
+/// (`j/k`, `G/g`), or a capitalized key name (`Enter`, `Esc`, `Down`,
+/// `Ctrl-U`); a lowercase multi-char word (`type`) is prose. This keeps the one
+/// prose-leading hint (`type query`) from boxing the word "type" while every
+/// real key stays boxed.
+fn looks_like_key(token: &str) -> bool {
+    token.chars().count() == 1
+        || token.contains('/')
+        || token.starts_with(|ch: char| ch.is_uppercase())
+}
+
+/// Render a per-focus keymap hint string (`"j/k move  Enter open  ..."`) as
+/// keycap+label spans: each `"  "`-separated segment becomes a boxed keycap for
+/// its leading key token followed by a dim label. A segment whose leading token
+/// is prose (not a key) renders entirely dim. The hint strings are trusted
+/// static keymaps, so no terminal-safe filtering is needed.
+pub(crate) fn keymap_hint_spans(text: &str) -> Vec<Span<'static>> {
+    let mut spans = Vec::new();
+    for (index, segment) in text.split("  ").filter(|s| !s.is_empty()).enumerate() {
+        if index > 0 {
+            spans.push(Span::raw("  "));
+        }
+        match segment.split_once(' ') {
+            Some((key, label)) if looks_like_key(key) => {
+                spans.push(keycap_span(key));
+                spans.push(hint_label_span(label));
+            }
+            None if looks_like_key(segment) => spans.push(keycap_span(segment)),
+            _ => spans.push(Span::styled(
+                segment.to_owned(),
+                Style::default().fg(Color::DarkGray),
+            )),
+        }
+    }
+    spans
+}
+
+/// Render the persistent armed-interaction hint as spans: the prose stays dim,
+/// but the `Enter`/`Esc` key references are boxed as keycaps so the armed state
+/// styles its keys consistently with the keymap it replaces. The text is
+/// already terminal-safe (see `timeline_target_label`).
+pub(crate) fn armed_hint_spans(text: &str) -> Vec<Span<'static>> {
+    let mut spans = Vec::new();
+    for (index, word) in text.split(' ').enumerate() {
+        if index > 0 {
+            spans.push(Span::raw(" "));
+        }
+        if word == "Enter" || word == "Esc" {
+            spans.push(keycap_span(word));
+        } else {
+            spans.push(Span::styled(
+                word.to_owned(),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+    }
+    spans
+}
+
+/// Render a popup hint row (`"[Enter] submit  [Esc] cancel"`) as spans: the
+/// bracketed `[key]` token cyan, its description gray — the popup convention,
+/// distinct from the main-screen keycap blocks. Trusted static text.
+pub(crate) fn popup_hint_spans(text: &str) -> Vec<Span<'static>> {
+    let mut spans = Vec::new();
+    for (index, segment) in text.split("  ").filter(|s| !s.is_empty()).enumerate() {
+        if index > 0 {
+            spans.push(Span::raw("  "));
+        }
+        match segment.split_once(' ') {
+            Some((key, desc)) => {
+                spans.push(Span::styled(
+                    key.to_owned(),
+                    Style::default().fg(Color::Cyan),
+                ));
+                spans.push(Span::styled(
+                    format!(" {desc}"),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+            None => spans.push(Span::styled(
+                segment.to_owned(),
+                Style::default().fg(Color::Cyan),
+            )),
+        }
+    }
+    spans
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -873,7 +873,6 @@ fn logout_token_mismatch_is_a_noop_that_keeps_the_popup_open() {
 #[cfg(unix)]
 #[test]
 fn logout_success_then_refresh_failure_reports_logout_not_error() {
-    use std::os::unix::fs::PermissionsExt;
     // The wipe is irreversible and succeeds; only the follow-up account-list
     // reload fails. The status must report the logout as done and point at
     // `/refresh`, never masking a completed wipe behind `error:` while the
@@ -882,12 +881,7 @@ fn logout_success_then_refresh_failure_reports_logout_not_error() {
     let dir = tempfile::tempdir().expect("tempdir");
     let exe = dir.path().join("wn-json");
     let script = "#!/bin/sh\ncase \" $* \" in\n  *\" account list \"*)\ncat <<'JSON'\n{\"ok\":false,\"error\":{\"message\":\"relays unreachable\"}}\nJSON\n    ;;\n  *)\ncat <<'JSON'\n{\"ok\":true,\"result\":{}}\nJSON\n    ;;\nesac\n";
-    std::fs::write(&exe, script).expect("write fake wn");
-    let mut perms = std::fs::metadata(&exe)
-        .expect("fake wn metadata")
-        .permissions();
-    perms.set_mode(0o755);
-    std::fs::set_permissions(&exe, perms).expect("chmod fake wn");
+    write_fake_wn(&exe, script);
     let client = WnClient {
         exe,
         ..test_unused_client()
@@ -2398,6 +2392,49 @@ fn test_unused_client() -> WnClient {
     }
 }
 
+/// Write an executable fake `wn` script to `exe` without this process ever
+/// holding a write handle to the file it will later exec.
+///
+/// The test harness runs many write-then-exec fakes across threads at once. On
+/// Linux, if any thread has a file open for writing when another thread forks
+/// (which every subprocess spawn does under the hood), the forked child
+/// inherits that writable descriptor; an `execve` of the same file then fails
+/// with `ETXTBSY` ("text file busy") until the descriptor closes. Writing the
+/// body from a short-lived child shell keeps the writable descriptor out of
+/// this process's table entirely, so no spawn here can inherit it and the race
+/// cannot occur. `chmod` is path-based and opens nothing, so it stays in-process.
+#[cfg(unix)]
+fn write_fake_wn(exe: &std::path::Path, script: &str) {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    // `cat > "$1"` opens `exe` for writing inside the child shell, never here.
+    let mut writer = std::process::Command::new("/bin/sh")
+        .arg("-c")
+        .arg(r#"cat > "$1""#)
+        .arg("write_fake_wn") // $0: a label for diagnostics only
+        .arg(exe) // $1: the destination path
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn fake wn writer");
+    writer
+        .stdin
+        .take()
+        .expect("fake wn writer stdin")
+        .write_all(script.as_bytes())
+        .expect("write fake wn body");
+    assert!(
+        writer.wait().expect("await fake wn writer").success(),
+        "fake wn writer exited non-zero"
+    );
+
+    let mut permissions = std::fs::metadata(exe)
+        .expect("fake wn metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(exe, permissions).expect("chmod fake wn");
+}
+
 fn test_json_client(response: &str) -> (tempfile::TempDir, WnClient) {
     let tempdir = tempfile::tempdir().expect("tempdir");
     let exe = test_json_executable(tempdir.path(), response);
@@ -2420,8 +2457,6 @@ fn test_json_client(response: &str) -> (tempfile::TempDir, WnClient) {
 /// refreshed list shrinks (the fixed-response fake cannot model that).
 #[cfg(unix)]
 fn test_invites_seq_client(first: &str, rest: &str) -> (tempfile::TempDir, WnClient) {
-    use std::os::unix::fs::PermissionsExt;
-
     let tempdir = tempfile::tempdir().expect("tempdir");
     let counter = tempdir.path().join("invites-seen");
     let exe = tempdir.path().join("wn-json");
@@ -2429,12 +2464,7 @@ fn test_invites_seq_client(first: &str, rest: &str) -> (tempfile::TempDir, WnCli
         "#!/bin/sh\ncase \" $* \" in\n  *\" invites \"*)\n    if [ -f '{counter}' ]; then\ncat <<'JSON'\n{rest}\nJSON\n    else\n      : > '{counter}'\ncat <<'JSON'\n{first}\nJSON\n    fi\n    ;;\n  *)\ncat <<'JSON'\n{{\"ok\":true,\"result\":{{}}}}\nJSON\n    ;;\nesac\n",
         counter = counter.display(),
     );
-    std::fs::write(&exe, script).expect("write fake wn");
-    let mut permissions = std::fs::metadata(&exe)
-        .expect("fake wn metadata")
-        .permissions();
-    permissions.set_mode(0o755);
-    std::fs::set_permissions(&exe, permissions).expect("chmod fake wn");
+    write_fake_wn(&exe, &script);
     let client = WnClient {
         exe,
         home: None,
@@ -2450,16 +2480,11 @@ fn test_invites_seq_client(first: &str, rest: &str) -> (tempfile::TempDir, WnCli
 
 #[cfg(unix)]
 fn test_json_executable(dir: &std::path::Path, response: &str) -> PathBuf {
-    use std::os::unix::fs::PermissionsExt;
-
     let exe = dir.join("wn-json");
-    std::fs::write(&exe, format!("#!/bin/sh\ncat <<'JSON'\n{response}\nJSON\n"))
-        .expect("write fake wn");
-    let mut permissions = std::fs::metadata(&exe)
-        .expect("fake wn metadata")
-        .permissions();
-    permissions.set_mode(0o755);
-    std::fs::set_permissions(&exe, permissions).expect("chmod fake wn");
+    write_fake_wn(
+        &exe,
+        &format!("#!/bin/sh\ncat <<'JSON'\n{response}\nJSON\n"),
+    );
     exe
 }
 
@@ -2468,23 +2493,15 @@ fn test_json_executable(dir: &std::path::Path, response: &str) -> PathBuf {
 /// Returns the executable path and the args-file path.
 #[cfg(unix)]
 fn test_arg_recording_executable(dir: &std::path::Path, response: &str) -> (PathBuf, PathBuf) {
-    use std::os::unix::fs::PermissionsExt;
-
     let exe = dir.join("wn-json");
     let args_file = dir.join("recorded-args");
-    std::fs::write(
+    write_fake_wn(
         &exe,
-        format!(
+        &format!(
             "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\ncat <<'JSON'\n{response}\nJSON\n",
             args_file.display()
         ),
-    )
-    .expect("write fake wn");
-    let mut permissions = std::fs::metadata(&exe)
-        .expect("fake wn metadata")
-        .permissions();
-    permissions.set_mode(0o755);
-    std::fs::set_permissions(&exe, permissions).expect("chmod fake wn");
+    );
     (exe, args_file)
 }
 
@@ -2494,16 +2511,9 @@ fn test_arg_recording_executable(dir: &std::path::Path, response: &str) -> (Path
 /// pointed at the script.
 #[cfg(unix)]
 fn test_scripted_client(body: &str) -> (tempfile::TempDir, WnClient) {
-    use std::os::unix::fs::PermissionsExt;
-
     let tempdir = tempfile::tempdir().expect("tempdir");
     let exe = tempdir.path().join("wn-json");
-    std::fs::write(&exe, format!("#!/bin/sh\n{body}")).expect("write fake wn");
-    let mut permissions = std::fs::metadata(&exe)
-        .expect("fake wn metadata")
-        .permissions();
-    permissions.set_mode(0o755);
-    std::fs::set_permissions(&exe, permissions).expect("chmod fake wn");
+    write_fake_wn(&exe, &format!("#!/bin/sh\n{body}"));
     let client = WnClient {
         exe,
         ..test_unused_client()
@@ -9527,23 +9537,15 @@ fn composer_min_and_max_height_coexist_with_the_diagnostics_panel() {
 /// call) to a sidecar file, so a test can assert a multi-call flow's commands.
 #[cfg(unix)]
 fn test_appending_arg_executable(dir: &std::path::Path, response: &str) -> (PathBuf, PathBuf) {
-    use std::os::unix::fs::PermissionsExt;
-
     let exe = dir.join("wn-json");
     let args_file = dir.join("recorded-args");
-    std::fs::write(
+    write_fake_wn(
         &exe,
-        format!(
+        &format!(
             "#!/bin/sh\necho \"$*\" >> '{}'\ncat <<'JSON'\n{response}\nJSON\n",
             args_file.display()
         ),
-    )
-    .expect("write fake wn");
-    let mut permissions = std::fs::metadata(&exe)
-        .expect("fake wn metadata")
-        .permissions();
-    permissions.set_mode(0o755);
-    std::fs::set_permissions(&exe, permissions).expect("chmod fake wn");
+    );
     (exe, args_file)
 }
 

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -9724,6 +9724,63 @@ fn flick_j_schedules_a_debounced_preview_and_fires_after_the_quiet_window() {
     assert_eq!(app.focus, Focus::Chats, "focus never left the chat list");
 }
 
+#[test]
+fn flick_preview_does_not_fire_after_leaving_the_main_view() {
+    let account_id = "aa".repeat(32);
+    let group_b = "bb".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.daemon.running = false;
+    app.focus = Focus::Chats;
+    app.chats = vec![flick_chat(&"aa".repeat(32), "a"), flick_chat(&group_b, "b")];
+    app.selected_chat = 0;
+
+    app.handle_key(char_key('j')).expect("j");
+    assert_eq!(app.flick_countdown, Some(FLICK_PREVIEW_DEBOUNCE_TICKS));
+
+    // The user immediately opens the user-search screen.
+    app.open_user_search(None);
+    assert_eq!(app.screen, Screen::UserSearch);
+    assert_eq!(app.status, "user search");
+
+    for _ in 0..FLICK_PREVIEW_DEBOUNCE_TICKS {
+        app.tick();
+    }
+    assert!(
+        app.loading_chat.is_none(),
+        "flick preview fired while on the user-search screen"
+    );
+}
+
+#[test]
+fn flick_preview_does_not_fire_behind_an_open_popup() {
+    let account_id = "aa".repeat(32);
+    let group_b = "bb".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.daemon.running = false;
+    app.focus = Focus::Chats;
+    app.chats = vec![flick_chat(&"aa".repeat(32), "a"), flick_chat(&group_b, "b")];
+    app.selected_chat = 0;
+
+    app.handle_key(char_key('j')).expect("j");
+    assert_eq!(app.flick_countdown, Some(FLICK_PREVIEW_DEBOUNCE_TICKS));
+
+    // `?` opens the help card over the still-focused chat list (Screen::Main,
+    // Focus::Chats). The countdown keeps running behind the modal.
+    app.handle_key(char_key('?')).expect("?");
+    assert!(app.popup.is_some());
+    assert_eq!(app.screen, Screen::Main);
+    assert_eq!(app.focus, Focus::Chats);
+
+    for _ in 0..FLICK_PREVIEW_DEBOUNCE_TICKS {
+        app.tick();
+    }
+    assert!(
+        app.loading_chat.is_none(),
+        "flick preview fired behind the help popup, reloading the pane and \
+         marking a chat read behind the modal"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn rapid_flick_coalesces_to_one_load_of_the_final_selection() {

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -2265,8 +2265,10 @@ fn line_text(line: &Line<'_>) -> String {
 }
 
 fn test_tui_app(client: WnClient, account_id: &str) -> TuiApp {
+    let effects = EffectRunner::spawn(client.clone());
     TuiApp {
         client,
+        effects,
         initial_account: None,
         running: true,
         screen: Screen::Main,
@@ -2296,6 +2298,11 @@ fn test_tui_app(client: WnClient, account_id: &str) -> TuiApp {
         notification_subscription: None,
         pending_chat_relist: false,
         pending_mark_read: false,
+        loading_chat: None,
+        searching_users: None,
+        loading_group_detail: None,
+        loading_invites: false,
+        flick_countdown: None,
         seen_notification_keys: SeenNotificationKeys::new(),
         daemon: DaemonView {
             running: true,
@@ -3139,7 +3146,59 @@ fn tick_performs_the_pending_relist_exactly_once() {
     assert!(changed);
     assert!(
         !app.pending_chat_relist,
-        "tick runs the pending re-list once, then clears the debounce flag"
+        "tick queues the pending re-list once, then clears the debounce flag"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_notification_armed_relist_runs_off_loop_and_preserves_selection() {
+    let account_id = "aa".repeat(32);
+    let group_a = "aa".repeat(32);
+    let group_b = "bb".repeat(32);
+    // The re-read returns B as the most-active chat (a reorder): B first, A last.
+    let response = format!(
+        r#"{{"ok":true,"result":{{"chats":[{{"group_id":"{group_b}","profile":{{"name":"b"}},"last_message":{{"timeline_at":200,"plaintext":"hi","sender":"x"}}}},{{"group_id":"{group_a}","profile":{{"name":"a"}},"last_message":{{"timeline_at":100,"plaintext":"yo","sender":"x"}}}}]}}}}"#
+    );
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) = test_appending_arg_executable(tempdir.path(), &response);
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = test_tui_app(client, &account_id);
+    app.daemon = DaemonView::default(); // no live subscriptions to drain
+    // A is selected; a NewMessage for another chat armed a background re-list.
+    app.chats = vec![
+        projected_chat(&group_a, "a", 0, Some(100)),
+        projected_chat(&group_b, "b", 1, Some(50)),
+    ];
+    app.selected_chat = 0;
+    app.pending_chat_relist = true;
+
+    // tick queues the re-list off the event loop (it never runs `chats list` on the
+    // key-handling thread) and clears the debounce.
+    assert!(app.tick());
+    assert!(
+        !app.pending_chat_relist,
+        "the debounce clears when the re-list is queued"
+    );
+
+    // Folding the worker's result reorders the list but keeps A selected by id.
+    app.settle_effects(1);
+    let recorded = std::fs::read_to_string(&args_file).expect("recorded args");
+    assert!(
+        recorded.contains("chats list"),
+        "the re-read ran through the effect worker: {recorded:?}"
+    );
+    assert_eq!(
+        app.selected_chat_row().map(|chat| chat.group_id.as_str()),
+        Some(group_a.as_str()),
+        "the background reorder keeps the highlight on the chat the user selected"
+    );
+    assert_eq!(
+        app.selected_chat, 1,
+        "A is now second after B out-ranked it"
     );
 }
 
@@ -3213,14 +3272,12 @@ fn tick_marks_the_viewed_chat_read_once_and_clears_the_badge() {
     app.selected_chat = 0;
     app.pending_mark_read = true;
 
-    assert!(app.tick());
+    assert!(app.tick(), "tick queues the mark-read off-loop");
+    assert!(!app.pending_mark_read, "a queued mark-read clears the flag");
+    app.settle_effects(1);
     assert_eq!(
         app.chats[0].projection.unread_count, 0,
-        "tick folds the mark-read response and clears the viewed chat's badge"
-    );
-    assert!(
-        !app.pending_mark_read,
-        "a successful mark-read clears the flag"
+        "folding the mark-read response clears the viewed chat's badge"
     );
 
     // The folded projection is now zero, so a second tick re-arms nothing.
@@ -3236,7 +3293,11 @@ fn a_failed_relist_re_arms_for_the_next_tick() {
     app.daemon = DaemonView::default(); // no live subscriptions to drain
     app.pending_chat_relist = true;
 
+    // tick queues the re-list off-loop and clears the debounce; the failure lands
+    // when the worker's result folds.
     app.tick();
+    assert!(!app.pending_chat_relist, "the debounce clears on queue");
+    app.settle_effects(1);
 
     assert!(
         app.pending_chat_relist,
@@ -3261,6 +3322,8 @@ fn a_failed_mark_read_re_arms_for_the_next_tick() {
     app.pending_mark_read = true;
 
     app.tick();
+    // The mark-read runs off-loop; folding its failed result re-arms the flag.
+    app.settle_effects(1);
 
     assert!(
         app.pending_mark_read,
@@ -3296,10 +3359,13 @@ fn opening_a_chat_marks_it_read_and_clears_the_badge() {
     app.selected_chat = 0;
 
     app.refresh_messages().expect("refresh messages");
+    // The load runs off-loop and, with no daemon, queues diagnostics and a
+    // mark-read; folding all three clears the badge.
+    app.settle_effects(3);
 
     assert_eq!(
         app.chats[0].projection.unread_count, 0,
-        "opening a chat folds the mark-read response and clears the badge immediately"
+        "opening a chat folds the mark-read response and clears the badge"
     );
 }
 
@@ -3307,8 +3373,7 @@ fn opening_a_chat_marks_it_read_and_clears_the_badge() {
 fn mark_read_failure_keeps_the_badge_honest() {
     let account_id = "aa".repeat(32);
     let group_id = "bb".repeat(32);
-    let (_tempdir, client) = test_json_client(r#"{"ok":false,"error":{"message":"daemon gone"}}"#);
-    let mut app = test_tui_app(client, &account_id);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
     app.chats = vec![ChatRow {
         group_id: group_id.clone(),
         name: "general".to_owned(),
@@ -3321,15 +3386,28 @@ fn mark_read_failure_keeps_the_badge_honest() {
     }];
     app.selected_chat = 0;
 
-    let result = app.mark_selected_chat_read(&account_id, &group_id);
+    // A failed mark-read folds honestly: it never zeroes the badge locally and
+    // re-arms so the next tick retries.
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::MarkRead {
+            account: account_id,
+            group: group_id,
+        },
+        result: Err("daemon gone".to_owned()),
+    });
 
-    assert!(
-        result.is_err(),
-        "a failed mark-read is surfaced, not swallowed"
-    );
     assert_eq!(
         app.chats[0].projection.unread_count, 5,
         "a failed mark-read never zeroes the badge locally"
+    );
+    assert!(
+        app.pending_mark_read,
+        "a failed mark-read re-arms for the next tick"
+    );
+    assert!(
+        app.status.contains("mark-read failed"),
+        "the error still surfaces on the status line: {}",
+        app.status
     );
 }
 
@@ -5744,16 +5822,69 @@ fn pinned_view_follows_incoming_messages() {
 
 #[test]
 fn timeline_pane_title_reports_offscreen_row_counts() {
-    // Everything on screen: the plain title.
-    assert_eq!(timeline_pane_title(5, 0, 4), "Messages");
+    // Everything on screen: just the base title.
+    assert_eq!(timeline_pane_title("Ops", 5, 0, 4), "Ops");
     // Older rows above the view.
-    assert_eq!(timeline_pane_title(10, 3, 9), "Messages [3 older]");
+    assert_eq!(timeline_pane_title("Ops", 10, 3, 9), "Ops [3 older]");
     // Newer rows below the view.
-    assert_eq!(timeline_pane_title(10, 0, 6), "Messages [3 newer]");
+    assert_eq!(timeline_pane_title("Ops", 10, 0, 6), "Ops [3 newer]");
     // Both directions.
     assert_eq!(
-        timeline_pane_title(10, 2, 6),
-        "Messages [2 older | 3 newer]"
+        timeline_pane_title("Ops", 10, 2, 6),
+        "Ops [2 older | 3 newer]"
+    );
+    // With no loaded chat the base falls back to the plain "Messages".
+    assert_eq!(timeline_pane_title("Messages", 5, 0, 4), "Messages");
+}
+
+#[test]
+fn messages_pane_title_names_the_loaded_chat_not_the_highlighted_one() {
+    let account_id = "aa".repeat(32);
+    let group_b = "bb".repeat(32);
+    let group_c = "cc".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.daemon.running = false;
+    app.chats = vec![
+        projected_chat(&group_b, "BravoRoom", 0, Some(200)),
+        projected_chat(&group_c, "CharlieRoom", 0, Some(100)),
+    ];
+    // The pane shows B (opened or a settled preview), while the highlight has since
+    // moved to C. The title tracks the loaded pane (WYSIWYG), not the selection.
+    app.selected_chat = 1;
+    app.messages_account_id = Some(account_id.clone());
+    app.messages_group_id = Some(group_b.clone());
+    app.timeline = vec![timeline_row("m1", 200)];
+
+    // Row 0 is the top border of both panes; the only text there is the two pane
+    // titles ("Chats" left, the messages title right). Chat names appear as list
+    // items on later rows, so the loaded chat's name on row 0 can only be the
+    // messages-pane title.
+    let rows = rendered_rows(&mut app);
+    assert!(
+        rows[0].contains("BravoRoom"),
+        "the messages pane title names the loaded chat, got: {:?}",
+        rows[0]
+    );
+    assert!(
+        !rows[0].contains("CharlieRoom"),
+        "the title does not name the merely-highlighted chat, got: {:?}",
+        rows[0]
+    );
+}
+
+#[test]
+fn messages_pane_title_falls_back_to_messages_with_no_loaded_chat() {
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.daemon.running = false;
+    // No chat loaded into the pane.
+    app.messages_group_id = None;
+
+    let rows = rendered_rows(&mut app);
+    assert!(
+        rows[0].contains("Messages"),
+        "with nothing loaded the pane title is the plain \"Messages\", got: {:?}",
+        rows[0]
     );
 }
 
@@ -5908,6 +6039,8 @@ fn send_message_upserts_an_optimistic_timeline_row() {
 
     app.send_message("hello there".to_owned())
         .expect("send message");
+    // The send runs off-loop; folding it inserts the optimistic row.
+    app.settle_effects(1);
 
     assert_eq!(app.timeline.len(), 1);
     assert_eq!(app.timeline[0].message_id, "m1");
@@ -5940,6 +6073,8 @@ fn send_message_uses_the_documented_plural_messages_namespace() {
     app.messages_group_id = Some("bb".repeat(32));
 
     app.send_message("hello there".to_owned()).expect("send");
+    // The worker runs the send off-loop; wait for it before reading the argv.
+    app.settle_effects(1);
 
     let recorded = std::fs::read_to_string(&args_file).expect("recorded args");
     let args: Vec<&str> = recorded.lines().collect();
@@ -5971,6 +6106,8 @@ fn refresh_messages_loads_the_materialized_timeline_page() {
     app.selected_chat = 0;
 
     app.refresh_messages().expect("refresh messages");
+    // The load runs off-loop; folding it populates the pane.
+    app.settle_effects(1);
 
     assert_eq!(app.timeline.len(), 1);
     assert_eq!(app.timeline[0].message_id, "m1");
@@ -6227,6 +6364,36 @@ fn render_messages_wraps_long_lines_so_the_tail_is_visible() {
     assert!(
         rendered.contains("TAILMARKER"),
         "the wrapped tail of a long message must render, not truncate at the pane edge"
+    );
+}
+
+#[test]
+fn messages_pane_shows_loading_while_an_open_chat_load_is_in_flight() {
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.focus = Focus::Messages;
+    // An open-chat load is in flight and the pane has not yet folded any rows.
+    app.loading_chat = Some("bb".repeat(32));
+    assert!(app.timeline.is_empty());
+
+    let backend = ratatui::backend::TestBackend::new(100, 30);
+    let mut terminal = ratatui::Terminal::new(backend).expect("test terminal");
+    terminal.draw(|frame| app.render(frame)).expect("draw TUI");
+    let rendered = terminal
+        .backend()
+        .buffer()
+        .content()
+        .iter()
+        .map(|cell| cell.symbol())
+        .collect::<String>();
+
+    assert!(
+        rendered.contains("loading chat..."),
+        "an in-flight load shows honest feedback in the pane, not 'no messages'"
+    );
+    assert!(
+        !rendered.contains("no messages"),
+        "'no messages' is only shown once the load settles empty"
     );
 }
 
@@ -6687,8 +6854,10 @@ fn open_group_detail_loads_state_and_esc_returns_to_main() {
     app.selected_chat = 0;
 
     app.handle_key(char_key('g')).expect("g opens group detail");
-
     assert_eq!(app.screen, Screen::GroupDetail);
+    // The four-call load runs off-loop; folding it populates the view.
+    app.settle_effects(1);
+
     let view = app.group_detail.as_ref().expect("group detail loaded");
     assert_eq!(view.members.len(), 2);
     assert!(view.account_is_admin);
@@ -6916,6 +7085,7 @@ fn invites_picker_accept_closes_the_popup_once_the_last_invite_is_gone() {
     app.focus = Focus::Chats;
 
     app.handle_key(char_key('I')).expect("I opens invites");
+    app.settle_effects(1);
     assert!(matches!(app.popup, Some(Popup::Picker { .. })));
 
     app.handle_key(char_key('a')).expect("accept invite");
@@ -6941,6 +7111,7 @@ fn invites_picker_decline_closes_the_popup_once_the_last_invite_is_gone() {
     app.focus = Focus::Chats;
 
     app.handle_key(char_key('I')).expect("I opens invites");
+    app.settle_effects(1);
     app.handle_key(char_key('d')).expect("decline invite");
 
     assert!(app.popup.is_none());
@@ -6964,6 +7135,7 @@ fn invites_picker_stays_open_after_accepting_one_of_several() {
     app.focus = Focus::Chats;
 
     app.handle_key(char_key('I')).expect("I opens invites");
+    app.settle_effects(1);
     match &app.popup {
         Some(Popup::Picker { items, .. }) => assert_eq!(items.len(), 2, "two invites shown"),
         other => panic!("expected the invites picker, got {other:?}"),
@@ -7015,6 +7187,7 @@ fn accepting_an_invite_from_group_detail_returns_to_main() {
     });
 
     app.handle_key(char_key('I')).expect("I opens invites");
+    app.settle_effects(1);
     app.handle_key(char_key('a')).expect("accept invite");
 
     assert_eq!(
@@ -7037,6 +7210,7 @@ fn empty_invites_shows_an_info_card_not_a_picker() {
     app.focus = Focus::Chats;
 
     app.handle_key(char_key('I')).expect("I with no invites");
+    app.settle_effects(1);
 
     assert!(matches!(app.popup, Some(Popup::Card { .. })));
 }
@@ -7379,8 +7553,10 @@ fn enter_opens_the_chat_and_focuses_messages() {
     assert_eq!(
         app.focus,
         Focus::Messages,
-        "opening a chat moves focus to the messages pane"
+        "opening a chat moves focus to the messages pane immediately"
     );
+    // The timeline load runs off-loop; folding it settles the pane target.
+    app.settle_effects(1);
     assert_eq!(app.messages_group_id.as_deref(), Some(group_id.as_str()));
 }
 
@@ -8362,6 +8538,12 @@ fn messages_u_unreacts_immediately_without_prefilling_or_reloading() {
         "u acts immediately; it never focuses the composer"
     );
     assert!(app.input.is_empty(), "u does not prefill the composer");
+    assert_eq!(
+        app.status, "removing reaction...",
+        "the subprocess runs off-loop; the in-flight status is honest"
+    );
+
+    app.settle_effects(1);
     assert_eq!(app.status, "removed reaction");
     assert_eq!(
         app.timeline.len(),
@@ -8430,6 +8612,8 @@ fn delete_allows_own_message_arriving_via_the_received_path() {
 
     app.delete_selected_message()
         .expect("an own message on the received path renders as yours and is deletable");
+    assert_eq!(app.status, "deleting...", "in-flight feedback");
+    app.settle_effects(1);
     assert_eq!(app.status, "deleted message");
 }
 
@@ -8446,10 +8630,12 @@ fn own_message_interactions_do_not_reload_the_timeline() {
 
     app.react_to_selected_message("+".to_owned())
         .expect("react");
+    app.settle_effects(1);
     assert_eq!(app.status, "reacted +");
     assert_eq!(app.timeline.len(), 1, "react does not reload the list");
 
     app.delete_selected_message().expect("delete own");
+    app.settle_effects(1);
     assert_eq!(app.status, "deleted message");
     assert_eq!(
         app.timeline.len(),
@@ -8808,9 +8994,11 @@ fn user_search_runs_query_and_navigates_results() {
         app.handle_key(char_key(character)).expect("type query");
     }
     assert_eq!(app.user_search.as_ref().unwrap().query.value(), "ali");
-    // Enter runs the one-shot search and moves focus into the results.
+    // Enter runs the one-shot search off-loop; folding it moves focus into the
+    // results.
     app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
         .expect("run search");
+    app.settle_effects(1);
     {
         let view = app.user_search.as_ref().expect("search view");
         assert_eq!(view.results.len(), 2);
@@ -8836,10 +9024,469 @@ fn slash_users_query_runs_the_search_immediately() {
     );
     let mut app = test_tui_app(client, &"aa".repeat(32));
     app.open_user_search(Some("alice".to_owned()));
+    // The search runs off-loop; folding it populates the results.
+    app.settle_effects(1);
     let view = app.user_search.as_ref().expect("search view");
     assert_eq!(view.query.value(), "alice");
     assert_eq!(view.results.len(), 1);
     assert_eq!(view.focus, UserSearchFocus::Results);
+}
+
+fn flick_chat(group_id: &str, name: &str) -> ChatRow {
+    ChatRow {
+        group_id: group_id.to_owned(),
+        name: name.to_owned(),
+        archived: false,
+        projection: ChatProjection::default(),
+    }
+}
+
+#[test]
+fn flick_j_schedules_a_debounced_preview_and_fires_after_the_quiet_window() {
+    let account_id = "aa".repeat(32);
+    let group_b = "bb".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.daemon.running = false;
+    app.focus = Focus::Chats;
+    app.chats = vec![flick_chat(&"aa".repeat(32), "a"), flick_chat(&group_b, "b")];
+    app.selected_chat = 0;
+
+    app.handle_key(char_key('j'))
+        .expect("j highlights the next chat");
+    assert_eq!(app.selected_chat, 1, "highlight moved");
+    assert_eq!(
+        app.flick_countdown,
+        Some(FLICK_PREVIEW_DEBOUNCE_TICKS),
+        "a preview is scheduled but not fired"
+    );
+    assert_eq!(app.focus, Focus::Chats, "focus stays on the chat list");
+    assert!(app.loading_chat.is_none(), "nothing loads yet");
+
+    // Not enough quiet ticks yet.
+    for _ in 0..(FLICK_PREVIEW_DEBOUNCE_TICKS - 1) {
+        app.tick();
+    }
+    assert!(
+        app.loading_chat.is_none(),
+        "the debounce has not elapsed; no preview load"
+    );
+
+    // The tick that reaches zero fires the preview for the highlighted chat.
+    app.tick();
+    assert_eq!(app.flick_countdown, None, "the countdown cleared");
+    assert_eq!(
+        app.loading_chat.as_deref(),
+        Some(group_b.as_str()),
+        "the highlighted chat's timeline load fired"
+    );
+    assert_eq!(app.focus, Focus::Chats, "focus never left the chat list");
+}
+
+#[cfg(unix)]
+#[test]
+fn rapid_flick_coalesces_to_one_load_of_the_final_selection() {
+    let account_id = "aa".repeat(32);
+    let group_a = "aa".repeat(32);
+    let group_b = "bb".repeat(32);
+    let group_c = "cc".repeat(32);
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) =
+        test_appending_arg_executable(tempdir.path(), r#"{"ok":true,"result":{}}"#);
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = test_tui_app(client, &account_id);
+    app.daemon.running = false;
+    app.focus = Focus::Chats;
+    app.chats = vec![
+        flick_chat(&group_a, "a"),
+        flick_chat(&group_b, "b"),
+        flick_chat(&group_c, "c"),
+    ];
+    app.selected_chat = 0;
+
+    // Race through the list with no quiet ticks between presses: j (->b), j
+    // (->c), k (->b). The countdown resets on every move, so nothing fires yet.
+    app.handle_key(char_key('j')).expect("j");
+    app.handle_key(char_key('j')).expect("j");
+    app.handle_key(char_key('k')).expect("k");
+    assert_eq!(app.selected_chat, 1, "settled on the middle chat");
+    assert!(app.loading_chat.is_none(), "no premature load mid-race");
+
+    // Let the movement quiet: exactly one preview fires, for the final selection.
+    for _ in 0..FLICK_PREVIEW_DEBOUNCE_TICKS {
+        app.tick();
+    }
+    assert_eq!(app.loading_chat.as_deref(), Some(group_b.as_str()));
+    app.settle_effects(1);
+
+    let recorded = std::fs::read_to_string(&args_file).expect("recorded args");
+    let timeline_loads: Vec<&str> = recorded
+        .lines()
+        .filter(|line| line.contains("timeline list"))
+        .collect();
+    assert_eq!(
+        timeline_loads.len(),
+        1,
+        "rapid flicks coalesce to exactly one timeline load: {recorded:?}"
+    );
+    assert!(
+        timeline_loads[0].contains(&group_b),
+        "the single load targets the final selection (b): {:?}",
+        timeline_loads[0]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn enter_after_a_settled_same_chat_preview_is_a_focus_move_only() {
+    let account_id = "aa".repeat(32);
+    let group_a = "aa".repeat(32);
+    let group_b = "bb".repeat(32);
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) = test_appending_arg_executable(
+        tempdir.path(),
+        r#"{"ok":true,"result":{"messages":[],"has_more_before":false}}"#,
+    );
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = test_tui_app(client, &account_id);
+    app.daemon.running = false;
+    app.focus = Focus::Chats;
+    app.chats = vec![flick_chat(&group_a, "a"), flick_chat(&group_b, "b")];
+    app.selected_chat = 0;
+
+    // Flick to B and let the preview fire and settle onto the pane.
+    app.handle_key(char_key('j')).expect("j to b");
+    for _ in 0..FLICK_PREVIEW_DEBOUNCE_TICKS {
+        app.tick();
+    }
+    assert_eq!(app.loading_chat.as_deref(), Some(group_b.as_str()));
+    app.settle_effects(1); // fold the flick preview load
+    assert_eq!(app.messages_group_id.as_deref(), Some(group_b.as_str()));
+    assert!(app.loading_chat.is_none(), "the preview settled");
+
+    // Enter on the already-loaded, settled chat is a focus move only: it must not
+    // re-enqueue a redundant timeline load (nor a second mark-read).
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("enter");
+    assert_eq!(
+        app.focus,
+        Focus::Messages,
+        "Enter still moves focus to the message pane"
+    );
+    assert!(
+        app.loading_chat.is_none(),
+        "Enter on a settled same-chat preview enqueues no reload"
+    );
+
+    let recorded = std::fs::read_to_string(&args_file).expect("recorded args");
+    let timeline_loads: Vec<&str> = recorded
+        .lines()
+        .filter(|line| line.contains("timeline list"))
+        .collect();
+    assert_eq!(
+        timeline_loads.len(),
+        1,
+        "flick-then-open loads B exactly once, not twice: {recorded:?}"
+    );
+}
+
+#[test]
+fn enter_supersedes_a_pending_flick_preview() {
+    let account_id = "aa".repeat(32);
+    let group_b = "bb".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.daemon.running = false;
+    app.focus = Focus::Chats;
+    app.chats = vec![flick_chat(&"aa".repeat(32), "a"), flick_chat(&group_b, "b")];
+    app.selected_chat = 0;
+
+    app.handle_key(char_key('j'))
+        .expect("j schedules a preview");
+    assert!(app.flick_countdown.is_some());
+
+    // Enter opens the chat immediately and cancels the pending preview.
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("enter");
+    assert_eq!(
+        app.flick_countdown, None,
+        "the pending preview is cancelled"
+    );
+    assert_eq!(app.focus, Focus::Messages, "Enter moves focus to messages");
+    assert_eq!(app.loading_chat.as_deref(), Some(group_b.as_str()));
+}
+
+#[test]
+fn group_detail_load_maps_to_the_four_groups_calls_in_order() {
+    let effect = Effect::LoadGroupDetail {
+        account: "aa".repeat(32),
+        group: "gg".to_owned(),
+    };
+    let calls = effect.calls();
+    let subcommands: Vec<&str> = calls.iter().map(|call| call.args[1].as_str()).collect();
+    assert_eq!(
+        subcommands,
+        vec!["members", "admins", "relays", "show"],
+        "group detail reads members, admins, relays, then show — the fold's slice order"
+    );
+}
+
+#[test]
+fn a_stale_group_detail_load_after_leaving_is_dropped() {
+    let self_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &self_id);
+    // The user opened a group detail, then left before it landed.
+    app.screen = Screen::Main;
+    app.loading_group_detail = None;
+
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::LoadGroupDetail {
+            account: self_id.clone(),
+            group: "cc".repeat(32),
+        },
+        result: Ok(vec![
+            serde_json::json!({"members": [{"member_id": self_id, "npub": "npubself"}]}),
+            serde_json::json!({"admins": []}),
+            serde_json::json!({"relays": []}),
+            serde_json::json!({"profile": {"name": "Ops"}}),
+        ]),
+    });
+    assert!(
+        app.group_detail.is_none(),
+        "a group-detail result after leaving never repopulates the view"
+    );
+}
+
+#[test]
+fn open_group_detail_reports_loading_then_settles_on_fold() {
+    let self_id = "aa".repeat(32);
+    let group_id = "cc".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &self_id);
+    app.focus = Focus::Chats;
+    app.chats = vec![projected_chat(&group_id, "Ops", 0, Some(10))];
+    app.selected_chat = 0;
+
+    app.open_group_detail().expect("open group detail");
+    assert_eq!(
+        app.status, "loading group detail...",
+        "honest in-flight feedback while the four-call load runs off-loop"
+    );
+    assert_eq!(app.screen, Screen::GroupDetail);
+
+    // Folding the completed load clears the in-flight status.
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::LoadGroupDetail {
+            account: self_id.clone(),
+            group: group_id.clone(),
+        },
+        result: Ok(vec![
+            serde_json::json!({"members": [{"member_id": self_id, "npub": "npubself"}]}),
+            serde_json::json!({"admins": []}),
+            serde_json::json!({"relays": []}),
+            serde_json::json!({"profile": {"name": "Ops"}}),
+        ]),
+    });
+    assert_ne!(
+        app.status, "loading group detail...",
+        "the in-flight status is cleared once the load lands"
+    );
+    assert!(app.group_detail.is_some(), "the view populated");
+}
+
+#[test]
+fn invites_load_reports_loading_then_opens_the_picker() {
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+
+    app.open_invites().expect("kickoff");
+    assert_eq!(
+        app.status, "loading invites...",
+        "honest in-flight feedback"
+    );
+    assert!(app.loading_invites, "a load is in flight");
+    assert!(
+        app.popup.is_none(),
+        "the picker opens only when the list lands"
+    );
+
+    // A second press while one is in flight does not double-queue.
+    app.open_invites().expect("no double-queue");
+
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::LoadInvites {
+            account: account_id,
+        },
+        result: Ok(vec![serde_json::json!({
+            "invites": [{"group_id": "cc", "profile": {"name": "Ops"}, "pending_confirmation": true}]
+        })]),
+    });
+    assert!(!app.loading_invites, "the load settled");
+    assert!(
+        matches!(
+            app.popup,
+            Some(Popup::Picker {
+                purpose: PickerPurpose::Invites,
+                ..
+            })
+        ),
+        "the invites picker opened"
+    );
+}
+
+#[test]
+fn a_stale_invites_result_for_a_switched_account_is_dropped() {
+    let account_a = "aa".repeat(32);
+    let account_b = "bb".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_a);
+    app.accounts = vec![
+        AccountRow {
+            account_id: account_a.clone(),
+            npub: "npuba".to_owned(),
+            display_name: None,
+            local_signing: true,
+        },
+        AccountRow {
+            account_id: account_b.clone(),
+            npub: "npubb".to_owned(),
+            display_name: None,
+            local_signing: true,
+        },
+    ];
+    // A is selected and started an invites load; the user then switched to B
+    // before it landed.
+    app.selected_account = 0;
+    app.loading_invites = true;
+    app.selected_account = 1;
+
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::LoadInvites {
+            account: account_a.clone(),
+        },
+        result: Ok(vec![serde_json::json!({
+            "invites": [{"group_id": "cc", "profile": {"name": "Ops"}, "pending_confirmation": true}]
+        })]),
+    });
+
+    assert!(
+        app.popup.is_none(),
+        "an invites list for a since-switched account never opens a picker of the wrong account's invites"
+    );
+    assert!(
+        !app.loading_invites,
+        "the stale load clears the in-flight guard so a fresh open can proceed"
+    );
+}
+
+#[test]
+fn user_search_maps_to_the_users_search_argv() {
+    let effect = Effect::UserSearch {
+        account: "aa".repeat(32),
+        query: "alice".to_owned(),
+    };
+    assert_eq!(
+        effect.calls(),
+        vec![WnCall {
+            account: "aa".repeat(32),
+            args: vec!["users".to_owned(), "search".to_owned(), "alice".to_owned(),],
+        }]
+    );
+}
+
+#[test]
+fn a_stale_user_search_result_for_a_superseded_query_is_dropped() {
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::UserSearch;
+    let mut view = UserSearchView::default();
+    view.query.set_value("bob".to_owned());
+    app.user_search = Some(view);
+    // The pending search is for "bob"; an "alice" result is a superseded query.
+    app.searching_users = Some("bob".to_owned());
+
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::UserSearch {
+            account: account_id,
+            query: "alice".to_owned(),
+        },
+        result: Ok(vec![serde_json::json!({
+            "users": [{"account_id_hex":"aa","npub":"npubaa","radius":0,"matched_field":"name","match_quality":"exact"}]
+        })]),
+    });
+
+    assert!(
+        app.user_search.as_ref().unwrap().results.is_empty(),
+        "the superseded query's results never land"
+    );
+    assert_eq!(
+        app.searching_users.as_deref(),
+        Some("bob"),
+        "the pending search anchor is untouched by a stale result"
+    );
+}
+
+#[test]
+fn leaving_a_search_in_flight_drops_a_late_result_from_the_reopened_screen() {
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    // A search for "alice" is in flight on the search screen.
+    app.screen = Screen::UserSearch;
+    let mut view = UserSearchView::default();
+    view.query.set_value("alice".to_owned());
+    app.user_search = Some(view);
+    app.searching_users = Some("alice".to_owned());
+    app.status = "searching...".to_owned();
+
+    // The user leaves before it lands: the pending-search anchor is cleared so a
+    // late fold cannot pass the tag guard against a freshly reopened screen.
+    app.leave_screen();
+    assert!(
+        app.searching_users.is_none(),
+        "leaving clears the in-flight search anchor"
+    );
+
+    // The user reopens a fresh search screen without running a new query.
+    app.open_user_search(None);
+    assert!(app.user_search.as_ref().unwrap().results.is_empty());
+
+    // The abandoned "alice" search now completes; its result must not land in the
+    // fresh screen.
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::UserSearch {
+            account: account_id,
+            query: "alice".to_owned(),
+        },
+        result: Ok(vec![serde_json::json!({
+            "users": [{"account_id_hex":"aa","npub":"npubaa","radius":0,"matched_field":"name","match_quality":"exact"}]
+        })]),
+    });
+    assert!(
+        app.user_search.as_ref().unwrap().results.is_empty(),
+        "a search abandoned by leaving never repopulates a freshly reopened screen"
+    );
+}
+
+#[test]
+fn leaving_a_search_in_flight_clears_the_searching_status() {
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::UserSearch;
+    let mut view = UserSearchView::default();
+    view.query.set_value("alice".to_owned());
+    app.user_search = Some(view);
+    app.searching_users = Some("alice".to_owned());
+    app.status = "searching...".to_owned();
+
+    app.leave_screen();
+
+    assert!(
+        app.status.is_empty(),
+        "the stranded \"searching...\" status is cleared when leaving mid-search, got {:?}",
+        app.status
+    );
 }
 
 #[test]
@@ -9430,4 +10077,434 @@ fn group_picker_esc_closes_with_zero_side_effects() {
     assert!(app.user_search.is_some(), "the search view is intact");
     assert_eq!(app.chats.len(), 1, "chats untouched");
     assert_eq!(app.selected_chat, 0, "selection untouched");
+}
+
+// ---- Non-blocking effects: the dispatch-decision-as-value seam ----
+
+#[test]
+fn react_effect_maps_to_the_plural_messages_react_argv() {
+    // The pure argv mapping is asserted without spawning a subprocess: the
+    // effect resolves to exactly the call the worker will run.
+    let effect = Effect::React {
+        account: "aa".repeat(32),
+        group: "bb".repeat(32),
+        message_id: "m1".to_owned(),
+        emoji: "+".to_owned(),
+    };
+    assert_eq!(
+        effect.calls(),
+        vec![WnCall {
+            account: "aa".repeat(32),
+            args: vec![
+                "messages".to_owned(),
+                "react".to_owned(),
+                "bb".repeat(32),
+                "m1".to_owned(),
+                "+".to_owned(),
+            ],
+        }]
+    );
+}
+
+#[test]
+fn react_key_in_messages_focus_resolves_to_the_selected_rows_effect() {
+    // key + state -> invocation value, with no subprocess: the selected timeline
+    // row and the loaded group/account resolve into the effect the app enqueues.
+    let account_id = "aa".repeat(32);
+    let group_id = "bb".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.messages_account_id = Some(account_id.clone());
+    app.messages_group_id = Some(group_id.clone());
+    app.timeline = vec![timeline_row("m0", 0), timeline_row("m1", 10)];
+
+    let effect = app.resolve_react("+".to_owned()).expect("resolves");
+    assert_eq!(
+        effect,
+        Effect::React {
+            account: account_id,
+            group: group_id,
+            message_id: "m1".to_owned(),
+            emoji: "+".to_owned(),
+        },
+        "reacts to the newest (pinned-selected) row"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn queued_mutations_run_in_fifo_order_off_the_event_loop() {
+    // Two user-initiated mutations must reach `wn` in the order they were queued.
+    // A single worker thread draining one FIFO channel preserves that order; the
+    // appending fake records each argv line so the order is observable.
+    let account_id = "aa".repeat(32);
+    let group_id = "bb".repeat(32);
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) =
+        test_appending_arg_executable(tempdir.path(), r#"{"ok":true,"result":{}}"#);
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = test_tui_app(client, &account_id);
+    app.messages_account_id = Some(account_id.clone());
+    app.messages_group_id = Some(group_id.clone());
+    app.timeline = vec![timeline_row("m1", 10)];
+
+    app.react_to_selected_message("1".to_owned())
+        .expect("react 1");
+    app.react_to_selected_message("2".to_owned())
+        .expect("react 2");
+    app.settle_effects(2);
+
+    let recorded = std::fs::read_to_string(&args_file).expect("recorded args");
+    let react_lines: Vec<&str> = recorded
+        .lines()
+        .filter(|line| line.contains(" react "))
+        .collect();
+    assert_eq!(react_lines.len(), 2, "both reacts ran: {recorded:?}");
+    assert!(
+        react_lines[0].ends_with(" 1") && react_lines[1].ends_with(" 2"),
+        "queued reacts ran FIFO (emoji 1 then 2): {react_lines:?}"
+    );
+}
+
+#[test]
+fn react_reports_in_flight_then_final_status_via_the_fold() {
+    // The kickoff reports "reacting..." immediately (honest in-flight feedback);
+    // folding the worker result reports the final status. No timeline reload.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.messages_account_id = Some(account_id.clone());
+    app.messages_group_id = Some("bb".repeat(32));
+    app.timeline = vec![timeline_row("m1", 10)];
+
+    app.react_to_selected_message("+".to_owned())
+        .expect("react");
+    assert_eq!(app.status, "reacting...", "in-flight feedback is honest");
+
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::React {
+            account: account_id,
+            group: "bb".repeat(32),
+            message_id: "m1".to_owned(),
+            emoji: "+".to_owned(),
+        },
+        result: Ok(vec![serde_json::json!({})]),
+    });
+    assert_eq!(app.status, "reacted +");
+    assert_eq!(app.timeline.len(), 1, "react never reloads the timeline");
+}
+
+#[test]
+fn open_chat_load_maps_to_the_timeline_page_argv() {
+    let effect = Effect::LoadTimeline {
+        account: "aa".repeat(32),
+        group: "bb".repeat(32),
+    };
+    assert_eq!(
+        effect.calls(),
+        vec![WnCall {
+            account: "aa".repeat(32),
+            args: vec![
+                "messages".to_owned(),
+                "timeline".to_owned(),
+                "list".to_owned(),
+                "--group".to_owned(),
+                "bb".repeat(32),
+                "--limit".to_owned(),
+                TUI_TIMELINE_PAGE_SIZE.to_string(),
+            ],
+        }]
+    );
+}
+
+#[test]
+fn opening_a_chat_reports_loading_then_folds_the_timeline_page() {
+    let account_id = "aa".repeat(32);
+    let group_id = "bb".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.chats = vec![ChatRow {
+        group_id: group_id.clone(),
+        name: "general".to_owned(),
+        archived: false,
+        projection: ChatProjection::default(),
+    }];
+    app.selected_chat = 0;
+    // Daemon is off in this app, so the load stays a pure fold with no spawned
+    // subscription children.
+    app.daemon.running = false;
+
+    app.refresh_messages().expect("kickoff");
+    assert_eq!(app.status, "loading chat...", "honest in-flight feedback");
+    assert_eq!(app.loading_chat.as_deref(), Some(group_id.as_str()));
+    assert!(
+        app.timeline.is_empty(),
+        "rows arrive only when the load folds"
+    );
+
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::LoadTimeline {
+            account: account_id.clone(),
+            group: group_id.clone(),
+        },
+        result: Ok(vec![serde_json::json!({
+            "messages": [{
+                "message_id": "m1",
+                "direction": "received",
+                "from": "alice",
+                "plaintext": "hello",
+                "timeline_at": 100,
+                "received_at": 100
+            }],
+            "has_more_before": true
+        })]),
+    });
+
+    assert_eq!(app.timeline.len(), 1);
+    assert_eq!(app.timeline[0].message_id, "m1");
+    assert!(app.timeline_scroll.has_more_before);
+    assert!(app.timeline_scroll.is_pinned());
+    assert_eq!(app.messages_group_id.as_deref(), Some(group_id.as_str()));
+    assert_eq!(app.loading_chat, None, "the load is settled");
+    assert_eq!(app.status, "loaded 1 message(s)");
+}
+
+#[test]
+fn a_stale_open_chat_load_for_a_superseded_chat_is_dropped() {
+    // Open chat A, then open chat B before A's load lands. A's late result must
+    // not clobber the pane now targeting B.
+    let account_id = "aa".repeat(32);
+    let group_a = "aa".repeat(32);
+    let group_b = "bb".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.daemon.running = false;
+    app.chats = vec![
+        ChatRow {
+            group_id: group_a.clone(),
+            name: "a".to_owned(),
+            archived: false,
+            projection: ChatProjection::default(),
+        },
+        ChatRow {
+            group_id: group_b.clone(),
+            name: "b".to_owned(),
+            archived: false,
+            projection: ChatProjection::default(),
+        },
+    ];
+
+    app.selected_chat = 0;
+    app.refresh_messages().expect("open A");
+    app.selected_chat = 1;
+    app.refresh_messages().expect("open B");
+    assert_eq!(app.loading_chat.as_deref(), Some(group_b.as_str()));
+
+    // A's late result arrives after the user moved to B.
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::LoadTimeline {
+            account: account_id.clone(),
+            group: group_a.clone(),
+        },
+        result: Ok(vec![serde_json::json!({
+            "messages": [{"message_id":"stale","direction":"received","from":"x","plaintext":"old","timeline_at":1,"received_at":1}],
+            "has_more_before": false
+        })]),
+    });
+    assert!(
+        app.timeline.is_empty(),
+        "the superseded load is dropped; the pane still awaits B"
+    );
+    assert_ne!(
+        app.messages_group_id.as_deref(),
+        Some(group_a.as_str()),
+        "the pane never adopts the stale chat"
+    );
+    assert_eq!(app.loading_chat.as_deref(), Some(group_b.as_str()));
+
+    // B's result lands and is accepted.
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::LoadTimeline {
+            account: account_id,
+            group: group_b.clone(),
+        },
+        result: Ok(vec![serde_json::json!({
+            "messages": [{"message_id":"fresh","direction":"received","from":"x","plaintext":"new","timeline_at":9,"received_at":9}],
+            "has_more_before": false
+        })]),
+    });
+    assert_eq!(app.timeline.len(), 1);
+    assert_eq!(app.timeline[0].message_id, "fresh");
+    assert_eq!(app.messages_group_id.as_deref(), Some(group_b.as_str()));
+}
+
+#[test]
+fn same_chat_reload_merges_and_keeps_a_live_subscription_insert() {
+    let account_id = "aa".repeat(32);
+    let group_id = "bb".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.daemon.running = false;
+    // A chat is loaded and settled: the pane shows two messages and its group is
+    // the loaded target, so a same-chat reload keeps the pane and its live
+    // subscription (it never clears the pane like a different-chat open does).
+    app.messages_account_id = Some(account_id.clone());
+    app.messages_group_id = Some(group_id.clone());
+    app.timeline = vec![timeline_row("m1", 100), timeline_row("m2", 200)];
+    // A same-chat reload is in flight (its group matches the loaded pane).
+    app.loading_chat = Some(group_id.clone());
+
+    // Between enqueue and fold, the live timeline subscription folds in a newer
+    // message.
+    app.timeline.push(timeline_row("m3", 300));
+
+    // The reload page returns only what was materialized at enqueue time (m1, m2).
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::LoadTimeline {
+            account: account_id,
+            group: group_id.clone(),
+        },
+        result: Ok(vec![serde_json::json!({
+            "messages": [
+                {"message_id":"m1","direction":"received","from":"x","plaintext":"one","timeline_at":100,"received_at":100},
+                {"message_id":"m2","direction":"received","from":"x","plaintext":"two","timeline_at":200,"received_at":200}
+            ],
+            "has_more_before": false
+        })]),
+    });
+
+    assert_eq!(
+        timeline_ids(&app.timeline),
+        vec!["m1", "m2", "m3"],
+        "a same-chat reload merges the page by id instead of replacing, so a \
+         subscription insert during the load window survives"
+    );
+    assert!(app.loading_chat.is_none(), "the reload settled");
+    assert_eq!(app.messages_group_id.as_deref(), Some(group_id.as_str()));
+}
+
+#[test]
+fn send_maps_to_the_plural_messages_send_argv() {
+    let effect = Effect::SendMessage {
+        account: "aa".repeat(32),
+        group: "bb".repeat(32),
+        text: "hi".to_owned(),
+    };
+    assert_eq!(
+        effect.calls(),
+        vec![WnCall {
+            account: "aa".repeat(32),
+            args: vec![
+                "messages".to_owned(),
+                "send".to_owned(),
+                "bb".repeat(32),
+                "hi".to_owned(),
+            ],
+        }],
+        "send uses the documented plural `messages send`, not the singular alias"
+    );
+}
+
+#[test]
+fn sending_reports_in_flight_then_folds_an_optimistic_row() {
+    let account_id = "aa".repeat(32);
+    let group_id = "bb".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.messages_account_id = Some(account_id.clone());
+    app.messages_group_id = Some(group_id.clone());
+
+    app.send_message("hello there".to_owned()).expect("kickoff");
+    assert_eq!(app.status, "sending...", "in-flight feedback is honest");
+    assert!(
+        app.timeline.is_empty(),
+        "the row folds only when the send lands"
+    );
+
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::SendMessage {
+            account: account_id,
+            group: group_id,
+            text: "hello there".to_owned(),
+        },
+        result: Ok(vec![
+            serde_json::json!({"published": 1, "message_ids": ["m1"]}),
+        ]),
+    });
+
+    assert_eq!(app.timeline.len(), 1);
+    assert_eq!(app.timeline[0].message_id, "m1");
+    assert_eq!(app.timeline[0].direction, "sent");
+    assert_eq!(app.timeline[0].display_text, "hello there");
+    assert!(
+        app.timeline_scroll.is_pinned(),
+        "an own send keeps the view pinned to the bottom"
+    );
+}
+
+#[test]
+fn an_optimistic_send_row_for_a_chat_the_user_left_is_dropped() {
+    // The send still happened; folding its row into a pane now showing another
+    // chat would be wrong, so the fold drops it (the group's subscription shows
+    // it on return).
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.messages_group_id = Some("bb".repeat(32));
+
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::SendMessage {
+            account: account_id,
+            group: "cc".repeat(32),
+            text: "hello".to_owned(),
+        },
+        result: Ok(vec![
+            serde_json::json!({"published": 1, "message_ids": ["m1"]}),
+        ]),
+    });
+    assert!(
+        app.timeline.is_empty(),
+        "no optimistic row lands in the pane of a different chat"
+    );
+}
+
+#[test]
+fn reply_resolves_the_selected_target_and_folds_an_optimistic_reply() {
+    let account_id = "aa".repeat(32);
+    let group_id = "bb".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.messages_account_id = Some(account_id.clone());
+    app.messages_group_id = Some(group_id.clone());
+    app.timeline = vec![timeline_row("parent", 5)];
+
+    let effect = app.resolve_reply("re: hi".to_owned()).expect("resolves");
+    assert_eq!(
+        effect,
+        Effect::SendReply {
+            account: account_id.clone(),
+            group: group_id.clone(),
+            reply_to: "parent".to_owned(),
+            text: "re: hi".to_owned(),
+        },
+        "the reply targets the selected (pinned newest) row"
+    );
+
+    app.send_reply("re: hi".to_owned()).expect("kickoff");
+    assert_eq!(app.status, "sending reply...");
+    app.apply_effect_done_for_test(EffectDone {
+        effect,
+        result: Ok(vec![
+            serde_json::json!({"published": 1, "message_ids": ["r1"]}),
+        ]),
+    });
+    let reply_row = app
+        .timeline
+        .iter()
+        .find(|row| row.message_id == "r1")
+        .expect("the optimistic reply row folded in");
+    assert_eq!(reply_row.direction, "sent");
+    assert_eq!(
+        reply_row
+            .reply
+            .as_ref()
+            .map(|reply| reply.reply_to_message_id.as_str()),
+        Some("parent"),
+        "the optimistic reply carries its parent id"
+    );
 }

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -11837,6 +11837,14 @@ fn every_daemon_start_relay_source_counts_for_the_auto_start_decision() {
         !daemon_start_has_relay_source(None, &[], &[], Some("   ")),
         "a blank WN_RELAY is not a relay source"
     );
+    assert!(
+        !daemon_start_has_relay_source(Some("   "), &[], &[], None),
+        "a blank --relay is not a relay source (it would fail the start with missing_relay_url)"
+    );
+    assert!(
+        !daemon_start_has_relay_source(Some(""), &[], &[], None),
+        "an empty --relay is not a relay source"
+    );
 }
 
 // --- Follow/unfollow from user-search results ---

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -2381,6 +2381,7 @@ fn test_tui_app(client: WnClient, account_id: &str) -> TuiApp {
         profile_view: None,
         relay_health: None,
         media: MediaState::new(),
+        daemon_autostart: None,
     }
 }
 
@@ -2485,6 +2486,29 @@ fn test_arg_recording_executable(dir: &std::path::Path, response: &str) -> (Path
     permissions.set_mode(0o755);
     std::fs::set_permissions(&exe, permissions).expect("chmod fake wn");
     (exe, args_file)
+}
+
+/// A fake `wn` whose behavior is the literal `#!/bin/sh` script `body`, so a test
+/// can vary the response by subcommand (a `case " $* " in ... esac`) or add a
+/// `sleep` to model a slow call. Returns the tempdir (keep it alive) and a client
+/// pointed at the script.
+#[cfg(unix)]
+fn test_scripted_client(body: &str) -> (tempfile::TempDir, WnClient) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let exe = tempdir.path().join("wn-json");
+    std::fs::write(&exe, format!("#!/bin/sh\n{body}")).expect("write fake wn");
+    let mut permissions = std::fs::metadata(&exe)
+        .expect("fake wn metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&exe, permissions).expect("chmod fake wn");
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    (tempdir, client)
 }
 
 #[cfg(windows)]
@@ -6716,7 +6740,7 @@ fn hints_line_matches_the_keymap_per_screen_and_focus() {
     );
     assert_eq!(
         user_search_hint(UserSearchFocus::Results),
-        "j/k move  Enter profile  c chat  a add  i query  Esc back"
+        "j/k move  Enter profile  f follow  x unfollow  c chat  a add  i query  Esc back"
     );
     assert_eq!(
         hints_line(Screen::Main, Focus::Messages, true),
@@ -9991,17 +10015,203 @@ fn a_stale_invites_result_for_a_switched_account_is_dropped() {
 }
 
 #[test]
-fn user_search_maps_to_the_users_search_argv() {
+fn user_search_maps_to_the_users_search_argv_plus_a_follows_snapshot() {
+    // The second call is the local `follows list` directory read — one cheap
+    // call that lets every result row render an accurate follow badge, instead
+    // of a `follows check` per row.
     let effect = Effect::UserSearch {
         account: "aa".repeat(32),
         query: "alice".to_owned(),
     };
     assert_eq!(
         effect.calls(),
-        vec![WnCall {
-            account: "aa".repeat(32),
-            args: vec!["users".to_owned(), "search".to_owned(), "alice".to_owned(),],
-        }]
+        vec![
+            WnCall {
+                account: Some("aa".repeat(32)),
+                args: vec!["users".to_owned(), "search".to_owned(), "alice".to_owned()],
+            },
+            WnCall {
+                account: Some("aa".repeat(32)),
+                args: vec!["follows".to_owned(), "list".to_owned()],
+            },
+        ]
+    );
+}
+
+#[test]
+fn a_user_search_fold_badges_the_rows_the_account_already_follows() {
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::UserSearch;
+    app.user_search = Some(UserSearchView::default());
+    app.searching_users = Some("ali".to_owned());
+
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::UserSearch {
+            account: account_id,
+            query: "ali".to_owned(),
+        },
+        result: Ok(vec![
+            serde_json::json!({
+                "users": [
+                    {"account_id_hex": "bb".repeat(32), "npub": "npubbb", "radius": 1,
+                     "matched_field": "name", "match_quality": "prefix",
+                     "profile": {"display_name": "Alice"}},
+                    {"account_id_hex": "cc".repeat(32), "npub": "npubcc", "radius": 2,
+                     "matched_field": "name", "match_quality": "prefix",
+                     "profile": {"display_name": "Alina"}},
+                ]
+            }),
+            serde_json::json!({
+                "follows": [{"account_id": "bb".repeat(32), "npub": "npubbb"}]
+            }),
+        ]),
+    });
+
+    let view = app.user_search.as_ref().expect("search view");
+    assert!(
+        view.results[0].following,
+        "the followed result is badged from the snapshot"
+    );
+    assert!(
+        !view.results[1].following,
+        "an unfollowed result carries no badge"
+    );
+
+    let rendered = user_search_lines(view, false)
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        rendered.contains("[following]"),
+        "the badge renders on the followed row; got:\n{rendered}"
+    );
+    assert_eq!(
+        rendered.matches("[following]").count(),
+        1,
+        "only the followed row is badged; got:\n{rendered}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_failing_follows_snapshot_still_folds_the_search_results_without_badges() {
+    // The badge read is the effect's second call and is best-effort: a
+    // `follows list` failure that lands *after* a successful `users search`
+    // must still surface the results (with no badges), never discard the whole
+    // search as an error the way the old first-error short-circuit did.
+    let account_id = "aa".repeat(32);
+    let (_tempdir, client) = test_scripted_client(
+        "case \" $* \" in\n\
+         *' follows list '*)\n\
+         cat <<'JSON'\n{\"ok\":false,\"error\":{\"message\":\"relay unreachable\"}}\nJSON\n;;\n\
+         *' users search '*)\n\
+         cat <<'JSON'\n{\"ok\":true,\"result\":{\"users\":[\
+         {\"account_id_hex\":\"bb\",\"npub\":\"npubbb\",\"radius\":1,\"matched_field\":\"name\",\"match_quality\":\"prefix\",\"profile\":{\"display_name\":\"Alice\"}},\
+         {\"account_id_hex\":\"cc\",\"npub\":\"npubcc\",\"radius\":2,\"matched_field\":\"name\",\"match_quality\":\"prefix\",\"profile\":{\"display_name\":\"Alina\"}}\
+         ]}}\nJSON\n;;\n\
+         *)\ncat <<'JSON'\n{\"ok\":true,\"result\":{}}\nJSON\n;;\nesac\n",
+    );
+    let mut app = test_tui_app(client, &account_id);
+
+    app.open_user_search(Some("ali".to_owned()));
+    app.settle_effects(1);
+
+    let view = app.user_search.as_ref().expect("search view");
+    assert_eq!(view.results.len(), 2, "both search results still fold in");
+    assert!(
+        view.results.iter().all(|row| !row.following),
+        "a failed follows snapshot leaves every row unbadged"
+    );
+    assert_eq!(
+        app.status, "found 2 user(s)",
+        "the search succeeds; the best-effort badge failure is not surfaced as an error"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_failing_user_search_call_still_reports_as_an_error() {
+    // The search itself is the required first call: its failure must still land
+    // on the status line as an error (the best-effort tolerance covers only the
+    // trailing badge read).
+    let account_id = "aa".repeat(32);
+    let (_tempdir, client) = test_scripted_client(
+        "case \" $* \" in\n\
+         *' users search '*)\n\
+         cat <<'JSON'\n{\"ok\":false,\"error\":{\"message\":\"directory offline\"}}\nJSON\n;;\n\
+         *)\ncat <<'JSON'\n{\"ok\":true,\"result\":{}}\nJSON\n;;\nesac\n",
+    );
+    let mut app = test_tui_app(client, &account_id);
+
+    app.open_user_search(Some("ali".to_owned()));
+    app.settle_effects(1);
+
+    assert_eq!(app.status, "error: directory offline");
+    assert!(
+        app.user_search
+            .as_ref()
+            .expect("search view")
+            .results
+            .is_empty(),
+        "a failed search folds no results"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_re_search_after_following_badges_the_row_from_the_follows_snapshot() {
+    // Following a result (`f`) badges its row directly; a fresh re-search rebuilds
+    // the result rows from scratch, so their badge can only come from the
+    // `follows list` snapshot the search takes. This proves that snapshot reflects
+    // the just-made follow end to end. The fake `follows list` returns the user
+    // only once `follows add` has run (a marker beside the script), so the first
+    // search shows no badge and the re-search does.
+    let account_id = "aa".repeat(32);
+    let (_tempdir, client) = test_scripted_client(
+        "marker=\"$(dirname \"$0\")/followed\"\n\
+         case \" $* \" in\n\
+         *' follows add '*)\n\
+         : > \"$marker\"\n\
+         cat <<'JSON'\n{\"ok\":true,\"result\":{\"follows\":[{\"account_id\":\"bb\",\"npub\":\"npubbb\"}]}}\nJSON\n;;\n\
+         *' follows list '*)\n\
+         if [ -f \"$marker\" ]; then\n\
+         cat <<'JSON'\n{\"ok\":true,\"result\":{\"follows\":[{\"account_id\":\"bb\",\"npub\":\"npubbb\"}]}}\nJSON\n\
+         else\n\
+         cat <<'JSON'\n{\"ok\":true,\"result\":{\"follows\":[]}}\nJSON\n\
+         fi\n;;\n\
+         *' users search '*)\n\
+         cat <<'JSON'\n{\"ok\":true,\"result\":{\"users\":[\
+         {\"account_id_hex\":\"bb\",\"npub\":\"npubbb\",\"radius\":1,\"matched_field\":\"name\",\"match_quality\":\"prefix\",\"profile\":{\"display_name\":\"Bob\"}}\
+         ]}}\nJSON\n;;\n\
+         *)\ncat <<'JSON'\n{\"ok\":true,\"result\":{}}\nJSON\n;;\nesac\n",
+    );
+    let mut app = test_tui_app(client, &account_id);
+
+    app.open_user_search(Some("bob".to_owned()));
+    app.settle_effects(1);
+    assert!(
+        !app.user_search.as_ref().expect("search view").results[0].following,
+        "before following, the snapshot has no follow so the row is unbadged"
+    );
+
+    app.handle_key(char_key('f'))
+        .expect("f follows the highlighted result");
+    app.settle_effects(1);
+
+    // Re-run the same query: the results are rebuilt from scratch, so the badge
+    // below can only have come from the refreshed follows snapshot.
+    app.run_user_search().expect("re-search");
+    app.settle_effects(1);
+    assert!(
+        app.user_search.as_ref().expect("search view").results[0].following,
+        "the re-search badges the row from the follows snapshot that now lists the user"
     );
 }
 
@@ -10308,6 +10518,7 @@ fn user_search_frame_shows_query_and_results() {
             matched_field: "name".to_owned(),
             match_quality: "prefix".to_owned(),
             radius: 1,
+            following: false,
         }],
         focus: UserSearchFocus::Results,
         ..UserSearchView::default()
@@ -10493,6 +10704,7 @@ fn user_search_app_with_selected_result(client: WnClient) -> TuiApp {
             matched_field: "name".to_owned(),
             match_quality: "exact".to_owned(),
             radius: 0,
+            following: false,
         }],
         focus: UserSearchFocus::Results,
         ..UserSearchView::default()
@@ -10703,7 +10915,7 @@ fn react_effect_maps_to_the_plural_messages_react_argv() {
     assert_eq!(
         effect.calls(),
         vec![WnCall {
-            account: "aa".repeat(32),
+            account: Some("aa".repeat(32)),
             args: vec![
                 "messages".to_owned(),
                 "react".to_owned(),
@@ -10813,7 +11025,7 @@ fn open_chat_load_maps_to_the_timeline_page_argv() {
     assert_eq!(
         effect.calls(),
         vec![WnCall {
-            account: "aa".repeat(32),
+            account: Some("aa".repeat(32)),
             args: vec![
                 "messages".to_owned(),
                 "timeline".to_owned(),
@@ -11000,7 +11212,7 @@ fn send_maps_to_the_plural_messages_send_argv() {
     assert_eq!(
         effect.calls(),
         vec![WnCall {
-            account: "aa".repeat(32),
+            account: Some("aa".repeat(32)),
             args: vec![
                 "messages".to_owned(),
                 "send".to_owned(),
@@ -11115,5 +11327,495 @@ fn reply_resolves_the_selected_target_and_folds_an_optimistic_reply() {
             .map(|reply| reply.reply_to_message_id.as_str()),
         Some("parent"),
         "the optimistic reply carries its parent id"
+    );
+}
+
+// --- Daemon auto-start at launch ---
+//
+// `wn tui` needs a running daemon for group/invite flows and live feeds, and the
+// field-proven footgun is forgetting `/daemon start`. Launch auto-starts the
+// daemon off the event loop when it is down and the TUI holds a relay source to
+// give it; without one it surfaces a single honest status and continues
+// degraded. Deliberate divergence from the retired reference client: the daemon
+// is never killed on exit, because other `wn` commands share it.
+
+#[cfg(unix)]
+#[test]
+fn launch_with_no_daemon_and_relay_flags_auto_starts_the_daemon() {
+    let account_id = "aa".repeat(32);
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) = test_arg_recording_executable(
+        tempdir.path(),
+        r#"{"ok":true,"result":{"running":true,"pid":4242}}"#,
+    );
+    let client = WnClient {
+        exe,
+        discovery_relays: vec!["wss://d.example".to_owned()],
+        ..test_unused_client()
+    };
+    let mut app = test_tui_app(client, &account_id);
+    app.daemon = DaemonView::default();
+
+    app.autostart_daemon_if_needed(None);
+    assert_eq!(
+        app.status, STARTING_DAEMON_STATUS,
+        "the in-flight status shows before the outcome lands"
+    );
+    assert!(
+        app.daemon_autostart.is_some(),
+        "auto-start runs on its own one-shot thread, not the shared effect worker"
+    );
+
+    app.settle_daemon_autostart();
+    let recorded = std::fs::read_to_string(&args_file).expect("the fake wn ran");
+    let args: Vec<&str> = recorded.lines().collect();
+    assert!(
+        args.windows(2).any(|pair| pair == ["daemon", "start"]),
+        "auto-start spawns `daemon start`; got {args:?}"
+    );
+    assert!(
+        args.windows(2)
+            .any(|pair| pair == ["--discovery-relays", "wss://d.example"]),
+        "the TUI relay passthrough reaches the daemon-start child; got {args:?}"
+    );
+    assert!(
+        app.daemon.running,
+        "the fold adopts the started daemon, flipping the status-bar dot's data source"
+    );
+    assert_eq!(app.status, "daemon running");
+}
+
+#[cfg(unix)]
+#[test]
+fn the_launch_daemon_auto_start_does_not_stall_the_first_user_action() {
+    // The launch auto-start's `wn daemon start` blocks up to five seconds on its
+    // readiness poll, so it must run on its own thread, not the single FIFO
+    // effect worker. A user action enqueued right after it must fold without
+    // waiting behind the daemon start (here a ~300ms sleep stands in for the poll).
+    let account_id = "aa".repeat(32);
+    let (_tempdir, client) = test_scripted_client(
+        "case \" $* \" in\n\
+         *' daemon start '*)\n\
+         sleep 0.3\n\
+         cat <<'JSON'\n{\"ok\":true,\"result\":{\"running\":true,\"pid\":4242}}\nJSON\n;;\n\
+         *)\ncat <<'JSON'\n{\"ok\":true,\"result\":{}}\nJSON\n;;\nesac\n",
+    );
+    let client = WnClient {
+        discovery_relays: vec!["wss://d.example".to_owned()],
+        ..client
+    };
+    let mut app = test_tui_app(client, &account_id);
+    app.daemon = DaemonView::default();
+
+    // Warm the subprocess exec path first: the one-time cost of loading the
+    // shell/script into the page cache (~half a second cold, ~10ms after) would
+    // otherwise swamp the timing budget below and make it flaky. This settles a
+    // throwaway effect through the worker so every later spawn is warm.
+    app.effects.enqueue(Effect::MarkRead {
+        account: account_id.clone(),
+        group: "warmup".to_owned(),
+    });
+    assert!(
+        app.effects.recv_timeout(Duration::from_secs(5)).is_some(),
+        "warmup effect completes",
+    );
+
+    // Kick off the auto-start (its `daemon start` sleeps ~300ms), then queue a
+    // user effect right behind it. On the shared FIFO worker it would wait out
+    // the whole start; on its own thread the worker is free, so the user effect
+    // folds well inside the 200ms budget (warm spawns are ~10ms).
+    app.autostart_daemon_if_needed(None);
+    app.effects.enqueue(Effect::MarkRead {
+        account: account_id,
+        group: "g1".to_owned(),
+    });
+    assert!(
+        app.effects
+            .recv_timeout(Duration::from_millis(200))
+            .is_some(),
+        "a user effect enqueued during auto-start folds without waiting behind the ~300ms daemon start"
+    );
+}
+
+#[test]
+fn launch_with_no_daemon_and_no_relay_source_surfaces_one_honest_status() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.daemon = DaemonView::default();
+
+    app.autostart_daemon_if_needed(None);
+
+    assert_eq!(app.status, DAEMON_AUTOSTART_NO_RELAYS_STATUS);
+    // The status must point at the only path that actually gives the daemon a
+    // relay in this situation: relaunching `wn tui` with the relay flags (or
+    // WN_RELAY). It must not suggest `/daemon start`, which reads the very same
+    // relay sources and would fail identically -- non-actionable in-session.
+    assert!(DAEMON_AUTOSTART_NO_RELAYS_STATUS.contains("restart"));
+    assert!(DAEMON_AUTOSTART_NO_RELAYS_STATUS.contains("--discovery-relays"));
+    assert!(DAEMON_AUTOSTART_NO_RELAYS_STATUS.contains("--default-account-relays"));
+    assert!(DAEMON_AUTOSTART_NO_RELAYS_STATUS.contains("WN_RELAY"));
+    assert!(
+        !DAEMON_AUTOSTART_NO_RELAYS_STATUS.contains("/daemon start"),
+        "the no-relays status must not point at the non-actionable /daemon start"
+    );
+    assert!(
+        app.daemon_autostart.is_none(),
+        "no start thread spawns without a relay source"
+    );
+    assert!(
+        app.effects
+            .recv_timeout(Duration::from_millis(200))
+            .is_none(),
+        "no start attempt is queued on the effect worker either"
+    );
+    assert!(!app.daemon.running);
+    assert!(
+        app.running,
+        "the session continues degraded, exactly as today"
+    );
+}
+
+#[test]
+fn launch_with_a_running_daemon_never_attempts_an_auto_start() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    assert!(app.daemon.running, "precondition: the daemon is already up");
+    app.status = "2 chats".to_owned();
+
+    app.autostart_daemon_if_needed(None);
+
+    assert_eq!(app.status, "2 chats", "today's no-op behavior is preserved");
+    assert!(
+        app.daemon_autostart.is_none(),
+        "no redundant start thread spawns for an already-running daemon"
+    );
+    assert!(
+        app.effects
+            .recv_timeout(Duration::from_millis(200))
+            .is_none(),
+        "no redundant start attempt is queued"
+    );
+}
+
+#[test]
+fn a_failed_daemon_auto_start_reports_and_leaves_the_session_up() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.daemon = DaemonView::default();
+    // The in-flight sentinel the auto-start sets before its thread reports.
+    app.status = STARTING_DAEMON_STATUS.to_owned();
+
+    app.fold_daemon_start(Err("daemon did not become ready".to_owned()));
+
+    assert_eq!(
+        app.status,
+        "daemon start failed: daemon did not become ready"
+    );
+    assert!(
+        !app.daemon.running,
+        "a failed start never fakes a green dot"
+    );
+    assert!(
+        app.running,
+        "a failed auto-start never tears down the session"
+    );
+}
+
+#[test]
+fn a_daemon_auto_start_fold_keeps_a_users_in_flight_status() {
+    // The auto-start runs off-loop, so a user may have queued an action (setting
+    // e.g. "sending...") before its result folds. Adopting the started daemon
+    // must not clobber that in-flight status with "daemon running"; the daemon
+    // dot already tells that story. The status write is guarded on the
+    // "starting daemon..." sentinel it set, and only replaces that.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.daemon = DaemonView::default();
+    // Pre-attach the daemon-backed feeds so the re-adopt's subscription ensures
+    // short-circuit (they are idempotent) rather than trying — and failing — to
+    // spawn against the stub `wn`; that isolates the status guard under test.
+    app.chat_subscription = Some(test_chat_subscription(&account_id, false));
+    app.message_subscription = Some(test_message_subscription(&account_id));
+    app.notification_subscription = Some(test_notification_subscription(&account_id));
+    app.status = "sending...".to_owned();
+
+    app.fold_daemon_start(Ok(serde_json::json!({"running": true, "pid": 4242})));
+
+    assert_eq!(
+        app.status, "sending...",
+        "the user's in-flight status survives the auto-start fold"
+    );
+    assert!(
+        app.daemon.running,
+        "the daemon view is still adopted so the dot flips green"
+    );
+}
+
+#[test]
+fn a_daemon_auto_start_fold_replaces_its_own_in_flight_sentinel() {
+    // With no user action in between, the "starting daemon..." sentinel is still
+    // showing, so the fold replaces it with the outcome sentence.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.daemon = DaemonView::default();
+    // Pre-attach the feeds so the re-adopt's ensures short-circuit (see the
+    // in-flight-status test): isolates the sentinel replacement under test.
+    app.chat_subscription = Some(test_chat_subscription(&account_id, false));
+    app.message_subscription = Some(test_message_subscription(&account_id));
+    app.notification_subscription = Some(test_notification_subscription(&account_id));
+    app.status = STARTING_DAEMON_STATUS.to_owned();
+
+    app.fold_daemon_start(Ok(serde_json::json!({"running": true, "pid": 4242})));
+
+    assert_eq!(app.status, "daemon running");
+}
+
+#[test]
+fn a_daemon_auto_start_fold_re_adopts_manual_subscriptions_as_a_no_op() {
+    // A user who ran `/daemon start` manually is already attached to the
+    // daemon-backed feeds. The launch auto-start's late result then folds and
+    // re-adopts the daemon view, which re-runs the subscription ensures. Those
+    // must be idempotent: no feed is re-spawned (the fake `wn` here cannot spawn,
+    // so any re-spawn attempt would fail and taint the status), and the existing
+    // subscriptions are retained.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.chat_subscription = Some(test_chat_subscription(&account_id, false));
+    app.message_subscription = Some(test_message_subscription(&account_id));
+    app.notification_subscription = Some(test_notification_subscription(&account_id));
+    app.status = "daemon running".to_owned();
+
+    app.fold_daemon_start(Ok(serde_json::json!({"running": true, "pid": 4242})));
+
+    assert!(
+        app.chat_subscription.is_some()
+            && app.message_subscription.is_some()
+            && app.notification_subscription.is_some(),
+        "the already-attached subscriptions are retained across the re-adopt"
+    );
+    assert!(
+        !app.status.contains("subscription failed"),
+        "re-adopt is idempotent: no feed is re-spawned, got {:?}",
+        app.status
+    );
+    assert!(
+        app.daemon.running,
+        "the re-adopt keeps the daemon dot green"
+    );
+}
+
+#[test]
+fn every_daemon_start_relay_source_counts_for_the_auto_start_decision() {
+    // The exact sources `wn daemon start` accepts, mirrored so the TUI never
+    // declines to start a daemon that would in fact have started: the two
+    // passthrough flag lists, the global --relay, and the WN_RELAY fallback.
+    assert!(!daemon_start_has_relay_source(None, &[], &[], None));
+    assert!(daemon_start_has_relay_source(
+        None,
+        &["wss://d.example".to_owned()],
+        &[],
+        None
+    ));
+    assert!(daemon_start_has_relay_source(
+        None,
+        &[],
+        &["wss://a.example".to_owned()],
+        None
+    ));
+    assert!(daemon_start_has_relay_source(
+        Some("wss://r.example"),
+        &[],
+        &[],
+        None
+    ));
+    assert!(daemon_start_has_relay_source(
+        None,
+        &[],
+        &[],
+        Some("wss://env.example")
+    ));
+    assert!(
+        !daemon_start_has_relay_source(None, &[], &[], Some("   ")),
+        "a blank WN_RELAY is not a relay source"
+    );
+}
+
+// --- Follow/unfollow from user-search results ---
+//
+// The retired reference client followed the highlighted result directly from
+// the search screen; ours required leaving to the Profile screen with a pasted
+// pubkey. `f`/`x` mirror the Profile screen's existing follow/unfollow keys,
+// run through the effect worker, and fold into the per-row badge.
+
+#[test]
+fn follow_effects_map_to_the_follows_add_and_remove_argv() {
+    // The relay travels on the variant (resolved at enqueue from the same
+    // setup-relay rule the Profile screen's synchronous path uses), so `calls`
+    // stays pure and the add/remove child always has the relay it requires.
+    let follow = Effect::FollowUser {
+        account: "aa".repeat(32),
+        pubkey: "bb".repeat(32),
+        label: "Bob".to_owned(),
+        relay: Some("wss://setup.example".to_owned()),
+    };
+    assert_eq!(
+        follow.calls(),
+        vec![WnCall {
+            account: Some("aa".repeat(32)),
+            args: vec![
+                "follows".to_owned(),
+                "add".to_owned(),
+                "bb".repeat(32),
+                "--relay".to_owned(),
+                "wss://setup.example".to_owned(),
+            ],
+        }]
+    );
+    let unfollow = Effect::UnfollowUser {
+        account: "aa".repeat(32),
+        pubkey: "bb".repeat(32),
+        label: "Bob".to_owned(),
+        relay: None,
+    };
+    assert_eq!(
+        unfollow.calls(),
+        vec![WnCall {
+            account: Some("aa".repeat(32)),
+            // No --relay here: a global --relay already covers every child.
+            args: vec!["follows".to_owned(), "remove".to_owned(), "bb".repeat(32)],
+        }]
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn f_follows_the_highlighted_search_result_through_the_effect_worker() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) = test_arg_recording_executable(
+        tempdir.path(),
+        r#"{"ok":true,"result":{"follows":[{"account_id":"bb","npub":"npubbb"}]}}"#,
+    );
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = user_search_app_with_selected_result(client);
+
+    app.handle_key(char_key('f')).expect("f follows");
+    assert_eq!(
+        app.status, "following Bob...",
+        "the in-flight status shows before the publish lands"
+    );
+
+    app.settle_effects(1);
+    let recorded = std::fs::read_to_string(&args_file).expect("the fake wn ran");
+    let args: Vec<&str> = recorded.lines().collect();
+    assert!(
+        args.windows(3).any(|w| w == ["follows", "add", "bb"]),
+        "f runs `follows add` on the highlighted result; got {args:?}"
+    );
+    assert_eq!(app.status, "followed Bob");
+    assert!(
+        app.user_search.as_ref().expect("search view").results[0].following,
+        "the badge folds in when the publish lands"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn x_unfollows_the_highlighted_search_result_through_the_effect_worker() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) =
+        test_arg_recording_executable(tempdir.path(), r#"{"ok":true,"result":{"follows":[]}}"#);
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = user_search_app_with_selected_result(client);
+    if let Some(view) = app.user_search.as_mut() {
+        view.results[0].following = true;
+    }
+
+    app.handle_key(char_key('x')).expect("x unfollows");
+    assert_eq!(app.status, "unfollowing Bob...");
+
+    app.settle_effects(1);
+    let recorded = std::fs::read_to_string(&args_file).expect("the fake wn ran");
+    let args: Vec<&str> = recorded.lines().collect();
+    assert!(
+        args.windows(3).any(|w| w == ["follows", "remove", "bb"]),
+        "x runs `follows remove` on the highlighted result; got {args:?}"
+    );
+    assert_eq!(app.status, "unfollowed Bob");
+    assert!(
+        !app.user_search.as_ref().expect("search view").results[0].following,
+        "the badge clears when the removal lands"
+    );
+}
+
+#[test]
+fn a_stale_follow_fold_reports_but_never_badges_a_left_or_changed_search() {
+    // Left screen: the mutation outcome still surfaces (the publish happened),
+    // but there is no view to badge — and nothing crashes.
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::FollowUser {
+            account: "aa".repeat(32),
+            pubkey: "bb".to_owned(),
+            label: "Bob".to_owned(),
+            relay: None,
+        },
+        result: Ok(vec![serde_json::json!({"follows": []})]),
+    });
+    assert_eq!(app.status, "followed Bob");
+    assert!(app.user_search.is_none());
+
+    // Changed results: the fold is keyed by pubkey, so rows of a newer query
+    // that no longer include the acted-on user never pick up its badge.
+    let mut app = user_search_app_with_selected_result(test_unused_client());
+    if let Some(view) = app.user_search.as_mut() {
+        view.results[0].pubkey = "cc".to_owned();
+    }
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::FollowUser {
+            account: "aa".repeat(32),
+            pubkey: "bb".to_owned(),
+            label: "Bob".to_owned(),
+            relay: None,
+        },
+        result: Ok(vec![serde_json::json!({"follows": []})]),
+    });
+    assert!(
+        !app.user_search.as_ref().expect("search view").results[0].following,
+        "a different row never picks up a stale fold's badge"
+    );
+
+    // Switched account: the badge is account-scoped truth, so a fold from a
+    // since-switched account is dropped even if the same pubkey is on screen.
+    let mut app = user_search_app_with_selected_result(test_unused_client());
+    app.accounts[0].account_id = "dd".repeat(32);
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::FollowUser {
+            account: "aa".repeat(32),
+            pubkey: "bb".to_owned(),
+            label: "Bob".to_owned(),
+            relay: None,
+        },
+        result: Ok(vec![serde_json::json!({"follows": []})]),
+    });
+    assert!(
+        !app.user_search.as_ref().expect("search view").results[0].following,
+        "a fold from a since-switched account never badges the new account's view"
+    );
+}
+
+#[test]
+fn the_search_results_hints_and_help_card_name_the_follow_keys() {
+    let hint = user_search_hint(UserSearchFocus::Results);
+    assert!(
+        hint.contains("f follow  x unfollow"),
+        "the results-focus hints name the follow keys; got: {hint}"
+    );
+    let help = help_card_lines().join("\n");
+    assert!(
+        help.contains("f follow; x unfollow"),
+        "the help card names the search-screen follow keys; got: {help}"
     );
 }

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -11168,6 +11168,48 @@ fn a_stale_open_chat_load_for_a_superseded_chat_is_dropped() {
 }
 
 #[test]
+fn a_switched_away_accounts_timeline_fold_is_dropped() {
+    let account_a = "aa".repeat(32);
+    let group_a = "cc".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_a);
+    app.daemon.running = false;
+    app.chats = vec![flick_chat(&group_a, "a")];
+    app.selected_chat = 0;
+
+    app.begin_timeline_load(account_a.clone(), group_a.clone());
+
+    // Switch to a public-only account: refresh_chats takes its early return,
+    // clearing the pane without queueing a superseding load.
+    app.accounts.push(AccountRow {
+        account_id: "bb".repeat(32),
+        npub: "npub1bob".to_owned(),
+        display_name: None,
+        local_signing: false,
+    });
+    app.selected_account = 1;
+    app.refresh_chats().expect("refresh_chats");
+    assert!(app.messages_group_id.is_none());
+
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::LoadTimeline {
+            account: account_a.clone(),
+            group: group_a.clone(),
+        },
+        result: Ok(vec![serde_json::json!({"messages": []})]),
+    });
+    assert!(
+        app.messages_group_id.is_none(),
+        "a switched-away account's timeline fold repopulated the pane"
+    );
+    // The drop path clears the anchor so the pane's loading notice does not
+    // stick on a group the user has left (nothing supersedes this load).
+    assert!(
+        app.loading_chat.is_none(),
+        "the switched-away load left the loading anchor pointing at a left chat"
+    );
+}
+
+#[test]
 fn same_chat_reload_merges_and_keeps_a_live_subscription_insert() {
     let account_id = "aa".repeat(32);
     let group_id = "bb".repeat(32);

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -2491,6 +2491,13 @@ fn test_json_executable(dir: &std::path::Path, response: &str) -> PathBuf {
 /// A fake `wn` that records its argv (one arg per line) to a sidecar file and
 /// then prints `response`, so a test can assert which command was spawned.
 /// Returns the executable path and the args-file path.
+///
+/// Every invocation truncates and rewrites the recorder, so read it only at a
+/// point where the invocation under test is the last to have run. Beware
+/// actions whose fold spawns follow-up `wn` children (the daemon-adopt path
+/// re-ensures the live subscriptions): read the recorder before such a fold,
+/// or the children rewrite it out from under the assertion. For a flow that
+/// must observe several sequential calls, use `test_appending_arg_executable`.
 #[cfg(unix)]
 fn test_arg_recording_executable(dir: &std::path::Path, response: &str) -> (PathBuf, PathBuf) {
     let exe = dir.join("wn-json");
@@ -11368,7 +11375,14 @@ fn launch_with_no_daemon_and_relay_flags_auto_starts_the_daemon() {
         "auto-start runs on its own one-shot thread, not the shared effect worker"
     );
 
-    app.settle_daemon_autostart();
+    // Read the recorded argv after the result lands but before folding it: the
+    // received result proves the `daemon start` child ran to completion, and
+    // the fold below is what re-ensures the daemon-backed subscriptions —
+    // spawning further `wn` children against this same fake, each of which
+    // rewrites the truncating argv recorder. A read placed after the fold
+    // races those children (on a loaded CI box they win: the recorder held
+    // `messages subscribe` argv instead).
+    let result = app.recv_daemon_autostart();
     let recorded = std::fs::read_to_string(&args_file).expect("the fake wn ran");
     let args: Vec<&str> = recorded.lines().collect();
     assert!(
@@ -11380,6 +11394,8 @@ fn launch_with_no_daemon_and_relay_flags_auto_starts_the_daemon() {
             .any(|pair| pair == ["--discovery-relays", "wss://d.example"]),
         "the TUI relay passthrough reaches the daemon-start child; got {args:?}"
     );
+
+    app.fold_daemon_start(result);
     assert!(
         app.daemon.running,
         "the fold adopts the started daemon, flipping the status-bar dot's data source"

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -2306,6 +2306,7 @@ fn test_tui_app(client: WnClient, account_id: &str) -> TuiApp {
         streaming: None,
         status: String::new(),
         popup: None,
+        pending_full_repaint: false,
         group_detail: None,
         user_search: None,
         profile_view: None,
@@ -4384,6 +4385,27 @@ fn media_ready_image_with_picker(picker: ratatui_image::picker::Picker, hash: &s
     media
 }
 
+/// As `media_ready_image_with_picker`, but with a source large enough (in
+/// halfblock cells, font 10x20) that `Resize::Fit` must downscale it *differently*
+/// for the small inline block than for the full-size popup. A small source fits
+/// without upscaling and renders at one natural size in both, which would mask
+/// both a reused-protocol re-resize (item 1) and whether the popup card itself
+/// drew anything (item 2). 700x560 is ~70x28 cells: taller than the 8-row inline
+/// block and the ~21-row popup, so both downscale it and the popup image fills its
+/// card with glyphs.
+fn media_ready_large_varied_image(picker: ratatui_image::picker::Picker, hash: &str) -> MediaState {
+    let mut media = MediaState::with_test_picker(picker);
+    let mut buffer = image::RgbImage::new(700, 560);
+    for (x, y, pixel) in buffer.enumerate_pixels_mut() {
+        *pixel = image::Rgb([(x % 256) as u8, y.wrapping_mul(3) as u8, 200]);
+    }
+    media.apply_for_test(MediaLoad::Decoded {
+        hash: hash.to_owned(),
+        image: Box::new(image::DynamicImage::ImageRgb8(buffer)),
+    });
+    media
+}
+
 /// Each terminal row of a full frame render, top to bottom, as a string. Unlike
 /// `rendered_buffer` (which flattens the whole grid) this keeps row boundaries so
 /// a test can assert *where* content lands — e.g. that an image block never draws
@@ -4759,6 +4781,501 @@ fn inline_images_render_cell_exact_not_a_pixel_protocol() {
 }
 
 #[test]
+fn media_images_downscale_with_a_smoothing_filter_not_nearest() {
+    // The one `Resize` both media render sites (inline timeline block and the
+    // image-viewer popup) pass to `StatefulImage`. `Resize::Fit(None)` falls back
+    // to `FilterType::Nearest`, which downscales by sparse sampling — on a photo
+    // shrunk to a thumbnail that reads as pixelated noise (the field report).
+    // The seam must request a proper resampling filter instead.
+    let resize = media_image_resize();
+    assert!(
+        matches!(
+            resize,
+            ratatui_image::Resize::Fit(Some(ratatui_image::FilterType::Lanczos3))
+        ),
+        "media images must aspect-fit with Lanczos3 smoothing, got {resize:?}"
+    );
+}
+
+#[test]
+fn oversized_decodes_are_capped_to_the_screen_bound_preserving_aspect() {
+    // A decoded image is kept in memory for the rest of the session (the inline
+    // protocol retains it, and pixel-capable terminals retain a viewer copy), so
+    // an unbounded camera photo would cost its full pixel area forever. Anything
+    // beyond the largest plausible terminal display area is downscaled at decode
+    // time; smaller images pass through untouched.
+    let huge = image::DynamicImage::new_rgb8(4200, 2800);
+    let capped = cap_decoded_image(huge);
+    assert_eq!(
+        (capped.width(), capped.height()),
+        (2100, 1400),
+        "a 3:2 photo larger than the cap lands exactly on the cap box"
+    );
+
+    let portrait = image::DynamicImage::new_rgb8(1400, 4200);
+    let capped = cap_decoded_image(portrait);
+    assert!(
+        capped.width() <= 2100 && capped.height() <= 1400,
+        "portrait images fit inside the cap box too, got {}x{}",
+        capped.width(),
+        capped.height()
+    );
+    assert_eq!(
+        (capped.width() as f64 / capped.height() as f64 * 3.0).round(),
+        1.0,
+        "the 1:3 portrait aspect survives the cap"
+    );
+
+    let small = image::DynamicImage::new_rgb8(800, 600);
+    let untouched = cap_decoded_image(small);
+    assert_eq!(
+        (untouched.width(), untouched.height()),
+        (800, 600),
+        "images already inside the cap are never resized (Fit would upscale)"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn media_worker_delivers_oversized_images_already_capped() {
+    // The cap must run on the worker thread (off the 50ms event loop) before the
+    // decoded image is delivered, so no oversized pixel buffer ever crosses the
+    // channel or reaches the reducer.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let wn = test_json_executable(dir.path(), r#"{"ok":true}"#);
+    let output_path = dir.path().join("deadbeef");
+    let mut encoded = std::io::Cursor::new(Vec::new());
+    // Wider than the cap box but with a small pixel area, so the unoptimized
+    // test-build decode+resize stays well inside the worker harness timeout.
+    image::DynamicImage::new_rgb8(2150, 200)
+        .write_to(&mut encoded, image::ImageFormat::Png)
+        .expect("encode png");
+    std::fs::write(&output_path, encoded.into_inner()).expect("seed decrypted file");
+
+    let result = run_media_worker(&wn, output_path);
+
+    match result {
+        MediaLoad::Decoded { image, .. } => {
+            assert!(
+                image.width() <= 2100 && image.height() <= 1400,
+                "the worker caps before delivery, got {}x{}",
+                image.width(),
+                image.height()
+            );
+        }
+        _ => panic!("a valid image decodes"),
+    }
+}
+
+#[test]
+fn pixel_capable_terminal_builds_a_native_viewer_protocol_on_demand() {
+    // On a terminal whose startup query reported a pixel protocol, the inline
+    // timeline stays cell-exact halfblocks (the adopt chokepoint), but the
+    // full-size viewer popup can draw the real image: the queried pixel
+    // capability is remembered, decoded pixels are retained in memory, and a
+    // native-protocol instance is built on demand when the viewer opens.
+    let mut picker = ratatui_image::picker::Picker::halfblocks();
+    picker.set_protocol_type(ratatui_image::picker::ProtocolType::Kitty);
+    let mut media = media_ready_image_with_picker(picker, "cafebabe");
+
+    assert!(
+        media.build_viewer_protocol("cafebabe"),
+        "a pixel-capable terminal builds a native viewer protocol"
+    );
+    let protocol = media
+        .viewer_protocol_mut("cafebabe")
+        .expect("the built viewer protocol is drawable");
+    assert!(
+        matches!(
+            protocol.protocol_type(),
+            ratatui_image::protocol::StatefulProtocolType::Kitty(_)
+        ),
+        "the viewer draws the terminal's native pixel protocol, not halfblocks"
+    );
+}
+
+#[test]
+fn halfblock_only_terminal_builds_a_dedicated_halfblock_viewer_protocol() {
+    // Terminals whose query reported no pixel protocol still get a *dedicated*
+    // popup protocol — a fresh cell-exact halfblock instance built from the
+    // retained pixels — rather than reusing the shared inline protocol. It is a
+    // distinct instance, so drawing it at popup size never re-resizes the inline
+    // block's protocol.
+    let mut media = media_with_ready_image("cafebabe");
+    assert!(
+        media.build_viewer_protocol("cafebabe"),
+        "a halfblock-only terminal builds its own dedicated popup protocol"
+    );
+    let protocol = media
+        .viewer_protocol_mut("cafebabe")
+        .expect("the dedicated halfblock viewer protocol is drawable");
+    assert!(
+        matches!(
+            protocol.protocol_type(),
+            ratatui_image::protocol::StatefulProtocolType::Halfblocks(_)
+        ),
+        "the dedicated fallback popup protocol stays cell-exact halfblocks"
+    );
+}
+
+#[test]
+fn iterm2_session_viewer_protocol_is_iterm2_even_when_queried_as_kitty() {
+    // iTerm2 answers the startup capability query kitty-style and is misdetected
+    // as Kitty — the original reason inline rendering forces halfblocks. iTerm2's
+    // kitty-graphics support is not the real thing, so inside an iTerm2 session
+    // the viewer must use iTerm2's own inline-image protocol.
+    let mut picker = ratatui_image::picker::Picker::halfblocks();
+    picker.set_protocol_type(ratatui_image::picker::ProtocolType::Kitty);
+    let mut media = MediaState::with_test_picker_in_iterm2_session(picker);
+    media.apply_for_test(MediaLoad::Decoded {
+        hash: "cafebabe".to_owned(),
+        image: Box::new(image::DynamicImage::new_rgb8(40, 40)),
+    });
+
+    assert!(media.build_viewer_protocol("cafebabe"));
+    let protocol = media
+        .viewer_protocol_mut("cafebabe")
+        .expect("viewer protocol built");
+    assert!(
+        matches!(
+            protocol.protocol_type(),
+            ratatui_image::protocol::StatefulProtocolType::ITerm2(_)
+        ),
+        "an iTerm2 session viewer draws OSC 1337, not misdetected kitty graphics"
+    );
+}
+
+#[test]
+fn viewer_retention_evicts_oldest_and_falls_back_to_the_halfblock_popup() {
+    // Retained viewer pixels are bounded: decoding one image past the cap
+    // evicts the oldest. The evicted image's viewer degrades honestly — no
+    // native protocol, so the popup draws the shared halfblock protocol — while
+    // the newest images keep their crisp native viewer. Re-decoding a hash must
+    // refresh in place, not double-count it toward the cap.
+    let mut picker = ratatui_image::picker::Picker::halfblocks();
+    picker.set_protocol_type(ratatui_image::picker::ProtocolType::Kitty);
+    let mut media = MediaState::with_test_picker(picker);
+    let decode = |media: &mut MediaState, hash: &str| {
+        media.apply_for_test(MediaLoad::Decoded {
+            hash: hash.to_owned(),
+            image: Box::new(image::DynamicImage::new_rgb8(4, 4)),
+        });
+    };
+
+    for hash in ["h1", "h2", "h3", "h4"] {
+        decode(&mut media, hash);
+    }
+    decode(&mut media, "h2"); // refresh, not a new retention slot
+    assert!(
+        media.build_viewer_protocol("h1"),
+        "a duplicate decode must not evict anything"
+    );
+
+    decode(&mut media, "h5"); // one past the cap of 4: h1 is evicted
+    assert!(
+        !media.build_viewer_protocol("h1"),
+        "the oldest image is evicted and its viewer falls back to halfblocks"
+    );
+    assert!(media.is_ready("h1"), "the inline halfblock render survives");
+    for hash in ["h2", "h3", "h4", "h5"] {
+        assert!(
+            media.build_viewer_protocol(hash),
+            "{hash} stays retained for the native viewer"
+        );
+    }
+}
+
+/// A pixel-capable (iTerm2 session, kitty-misdetected) media state with one
+/// decoded, ready image, mirroring `media_with_ready_image` for the viewer path.
+fn iterm2_media_with_ready_image(hash: &str) -> MediaState {
+    let mut picker = ratatui_image::picker::Picker::halfblocks();
+    picker.set_protocol_type(ratatui_image::picker::ProtocolType::Kitty);
+    let mut media = MediaState::with_test_picker_in_iterm2_session(picker);
+    media.apply_for_test(MediaLoad::Decoded {
+        hash: hash.to_owned(),
+        image: Box::new(image::DynamicImage::new_rgb8(40, 40)),
+    });
+    media
+}
+
+#[test]
+fn o_opens_a_native_pixel_viewer_on_a_pixel_capable_terminal() {
+    // On a terminal with a real pixel protocol, `o` shows the actual image: the
+    // viewer popup draws a native-protocol instance (here iTerm2's OSC 1337
+    // inline image) instead of the low-resolution halfblock cells. The inline
+    // timeline behind it stays cell-exact (pinned elsewhere).
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Main;
+    app.focus = Focus::Messages;
+    let mut row = timeline_row("m", 0);
+    row.display_text = "look".to_owned();
+    row.attachments = vec![image_attachment("cafebabe")];
+    app.timeline = vec![row];
+    app.media = iterm2_media_with_ready_image("cafebabe");
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE))
+        .expect("open viewer");
+
+    assert!(
+        matches!(app.popup, Some(Popup::Image { .. })),
+        "o opens the image viewer popup"
+    );
+    assert!(
+        app.media.viewer_protocol_mut("cafebabe").is_some(),
+        "opening the viewer builds the native protocol on demand"
+    );
+    let rendered = rendered_buffer(&mut app);
+    assert!(
+        rendered.contains("1337"),
+        "the viewer popup draws the terminal's native pixel protocol"
+    );
+}
+
+#[test]
+fn o_falls_back_to_the_halfblock_viewer_without_a_pixel_protocol() {
+    // Halfblock-only terminal: `o` opens the viewer popup, which draws its own
+    // dedicated cell-exact halfblock protocol — never a pixel escape.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Main;
+    app.focus = Focus::Messages;
+    let mut row = timeline_row("m", 0);
+    row.display_text = "look".to_owned();
+    row.attachments = vec![image_attachment("cafebabe")];
+    app.timeline = vec![row];
+    app.media = media_with_ready_image("cafebabe");
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE))
+        .expect("open viewer");
+
+    assert!(
+        matches!(app.popup, Some(Popup::Image { .. })),
+        "o opens the image viewer popup"
+    );
+    assert!(
+        app.media.viewer_protocol_mut("cafebabe").is_some(),
+        "the popup builds its own dedicated halfblock protocol, not the inline one"
+    );
+    let rendered = rendered_buffer(&mut app);
+    assert!(
+        !rendered.contains("1337"),
+        "the fallback viewer never emits a pixel escape"
+    );
+    assert!(
+        rendered.contains('▀') || rendered.contains('▄'),
+        "the fallback viewer draws cell-exact halfblocks"
+    );
+}
+
+#[test]
+fn o_on_an_evicted_image_renders_the_halfblock_fallback_on_a_pixel_terminal() {
+    // review finding 6, driven end to end: on a pixel-capable terminal, opening
+    // `o` on an image whose retained viewer pixels were evicted (older than the
+    // retention cap) must still open the viewer and render — degrading honestly to
+    // the cell-exact halfblock protocol, never a pixel escape and never a blank
+    // card. The evicted image's pixels survive only inside the inline protocol, so
+    // that is what the popup draws as a last resort.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Main;
+    app.focus = Focus::Messages;
+    let mut row = timeline_row("m", 0);
+    row.display_text = "look".to_owned();
+    row.attachments = vec![image_attachment("h1")];
+    app.timeline = vec![row];
+
+    // Pixel-capable terminal (kitty). Decode h1 first as a large varied image so
+    // its inline halfblock protocol fills the popup card with glyphs; then four
+    // more decodes push h1 out of the bounded viewer-pixel retention (cap 4,
+    // oldest evicted first).
+    let mut picker = ratatui_image::picker::Picker::halfblocks();
+    picker.set_protocol_type(ratatui_image::picker::ProtocolType::Kitty);
+    app.media = media_ready_large_varied_image(picker, "h1");
+    for hash in ["h2", "h3", "h4", "h5"] {
+        app.media.apply_for_test(MediaLoad::Decoded {
+            hash: hash.to_owned(),
+            image: Box::new(image::DynamicImage::new_rgb8(4, 4)),
+        });
+    }
+    assert!(
+        app.media.is_ready("h1"),
+        "h1's inline render survives eviction"
+    );
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE))
+        .expect("open viewer");
+    assert!(
+        matches!(app.popup, Some(Popup::Image { .. })),
+        "o opens the viewer even for an evicted image"
+    );
+    assert!(
+        app.media.viewer_protocol_mut("h1").is_none(),
+        "the evicted image has no dedicated protocol — its pixels were evicted"
+    );
+
+    // On a 100x30 frame the popup card spans rows 3..27; its image area is rows
+    // 4..24. The inline preview behind it lives in the top ~9 rows, and the
+    // popup's `Clear` wipes everything under the card. So a halfblock glyph in the
+    // popup's interior band (rows 12..20) can only come from the popup drawing the
+    // image itself — not from the inline preview bleeding through the margins.
+    let rows = rendered_rows(&mut app);
+    let popup_interior = rows[12..=20].join("");
+    assert!(
+        popup_interior.contains('▀') || popup_interior.contains('▄'),
+        "the evicted fallback draws the cell-exact halfblock image inside the popup card:\n{}",
+        rows.join("\n")
+    );
+    assert!(
+        !rows.join("").contains("1337"),
+        "the evicted fallback never emits a pixel escape, even on a pixel terminal"
+    );
+}
+
+#[test]
+fn the_fallback_viewer_popup_does_not_re_resize_the_shared_inline_protocol() {
+    // The inline timeline draws `protocols[hash]` sized to its small reserved
+    // block. The viewer popup must draw its OWN dedicated protocol, never that
+    // shared inline one: reusing it would resize the inline protocol from its
+    // block size up to the ~80% popup area every frame, and the next inline frame
+    // would resize it straight back — two full Lanczos3 passes of a large source
+    // per frame, continuous jank while the popup is open.
+    //
+    // Observe it honestly through the protocol's own encode signal: after the
+    // inline block has encoded at its block size, opening and rendering the popup
+    // must not trigger a fresh resize/encode of the inline protocol.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Main;
+    app.focus = Focus::Messages;
+    let mut row = timeline_row("m", 0);
+    row.display_text = "look".to_owned();
+    row.attachments = vec![image_attachment("cafebabe")];
+    app.timeline = vec![row];
+    // Halfblock-only terminal: the popup fallback used to reuse the inline
+    // protocol here, so this is the case that thrashed. The source is large so it
+    // is downscaled to different sizes for the 8-row inline block and the ~21-row
+    // popup — a reused protocol would actually re-encode between them.
+    app.media =
+        media_ready_large_varied_image(ratatui_image::picker::Picker::halfblocks(), "cafebabe");
+
+    // First frame: the inline block encodes the shared protocol at its block size.
+    // Drain that encode result so a later `Some` means a *new* encode was forced.
+    let _ = rendered_buffer(&mut app);
+    let _ = app
+        .media
+        .protocol_mut("cafebabe")
+        .expect("the inline protocol exists after the first frame")
+        .last_encoding_result();
+
+    // Open the viewer popup and render it over the still-visible timeline.
+    app.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE))
+        .expect("open viewer");
+    assert!(
+        matches!(app.popup, Some(Popup::Image { .. })),
+        "o opens the viewer popup"
+    );
+    let _ = rendered_buffer(&mut app);
+
+    assert!(
+        app.media
+            .protocol_mut("cafebabe")
+            .expect("the inline protocol still exists")
+            .last_encoding_result()
+            .is_none(),
+        "the open viewer popup must not re-resize the shared inline protocol"
+    );
+}
+
+#[test]
+fn closing_the_image_viewer_forces_a_full_repaint_and_drops_the_native_protocol() {
+    // A pixel-protocol image lives terminal-side, out of reach of ratatui's
+    // cell diff (iTerm2 in particular does not self-erase when its cells are
+    // overwritten), so dismissing the viewer must schedule a full terminal
+    // clear+repaint — `run()` consumes this flag before the next draw — and
+    // drop the on-demand native protocol.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Main;
+    app.focus = Focus::Messages;
+    let mut row = timeline_row("m", 0);
+    row.display_text = "look".to_owned();
+    row.attachments = vec![image_attachment("cafebabe")];
+    app.timeline = vec![row];
+    app.media = iterm2_media_with_ready_image("cafebabe");
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE))
+        .expect("open viewer");
+    assert!(
+        !app.pending_full_repaint,
+        "opening the viewer needs no full repaint"
+    );
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE))
+        .expect("dismiss viewer");
+
+    assert!(app.popup.is_none(), "any key dismisses the viewer");
+    assert!(
+        app.pending_full_repaint,
+        "closing the viewer schedules the full clear+repaint"
+    );
+    assert!(
+        app.media.viewer_protocol_mut("cafebabe").is_none(),
+        "closing the viewer drops the native protocol"
+    );
+}
+
+#[test]
+fn every_popup_close_arm_forces_a_full_repaint() {
+    // All popup teardown funnels through the three non-`None` arms of
+    // `handle_popup_key` (dismiss, submit, open-next). The full repaint is
+    // uniform across them — a modal close is rare and a full repaint cheap, so
+    // no arm needs to know whether the popup it tears down drew a pixel image.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Main;
+
+    // Dismiss: Esc on the help card.
+    app.popup = Some(Popup::help());
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .expect("dismiss help");
+    assert!(app.popup.is_none());
+    assert!(app.pending_full_repaint, "dismiss forces a full repaint");
+
+    // Submit: Enter on a confirm popup (the CLI call fails onto the status
+    // line; the popup still closes).
+    app.pending_full_repaint = false;
+    app.popup = Some(Popup::confirm_add_user_to_chat("gid", "chat", "pk", "user"));
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("submit confirm");
+    assert!(app.popup.is_none());
+    assert!(app.pending_full_repaint, "submit forces a full repaint");
+
+    // Open-next: Enter on the add-user group picker replaces it with the
+    // confirm popup; the picker it tears down gets the same uniform treatment.
+    app.pending_full_repaint = false;
+    app.popup = Some(Popup::add_user_group_picker(
+        "pk".to_owned(),
+        "user".to_owned(),
+        vec![PickerItem {
+            id: "gid".to_owned(),
+            label: "chat".to_owned(),
+        }],
+        0,
+    ));
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("advance picker");
+    assert!(
+        matches!(app.popup, Some(Popup::Confirm { .. })),
+        "the picker advances to the confirm popup"
+    );
+    assert!(
+        app.pending_full_repaint,
+        "replacing a popup forces a full repaint too"
+    );
+}
+
+#[test]
 fn startup_media_sweep_removes_leftover_cache_files_but_keeps_the_dir() {
     // Decrypted-media artifacts are deleted right after decode, so any file still
     // in the cache dir is litter left by a crashed session — decrypted plaintext
@@ -4928,6 +5445,51 @@ fn media_worker_removes_the_decrypted_file_after_a_failed_decode() {
     assert!(
         !output_path.exists(),
         "the worker removes the decrypted artifact after a failed decode"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn viewer_retention_keeps_pixels_in_memory_only_never_on_disk() {
+    // The decrypted download artifact is removed right after decode (the
+    // security fix); the viewer's retained pixels must not undo that by
+    // parking plaintext back on disk. Drive the real worker end-to-end into a
+    // pixel-capable media state, build the native viewer protocol, and verify
+    // the cache directory holds nothing — the viewer draws from memory alone.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let wn = test_json_executable(dir.path(), r#"{"ok":true}"#);
+    let cache_dir = dir.path().join("media-cache");
+    std::fs::create_dir_all(&cache_dir).expect("cache dir");
+    let output_path = cache_dir.join("deadbeef");
+    seed_decodable_image(&output_path);
+
+    let result = run_media_worker(&wn, output_path.clone());
+
+    let mut picker = ratatui_image::picker::Picker::halfblocks();
+    picker.set_protocol_type(ratatui_image::picker::ProtocolType::Kitty);
+    let mut media = MediaState::with_test_picker(picker);
+    media.apply_for_test(result);
+    assert!(
+        media.is_ready("deadbeef"),
+        "the image decoded and folded in"
+    );
+    assert!(
+        media.build_viewer_protocol("deadbeef"),
+        "the native viewer builds from retained in-memory pixels"
+    );
+
+    assert!(
+        !output_path.exists(),
+        "the decrypted artifact is still removed after decode"
+    );
+    let leftover: Vec<_> = std::fs::read_dir(&cache_dir)
+        .expect("cache dir readable")
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name())
+        .collect();
+    assert!(
+        leftover.is_empty(),
+        "viewer retention writes nothing to disk; found {leftover:?}"
     );
 }
 

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -1208,7 +1208,8 @@ fn chat_row_line_shows_unread_count_in_bold() {
     assert_eq!(line_text(&line), "  Project Room (3)");
     assert!(line.spans[0].style.add_modifier.contains(Modifier::BOLD));
     assert!(line.spans[1].style.add_modifier.contains(Modifier::BOLD));
-    assert_eq!(line.spans[1].style.fg, Some(Color::Green));
+    // Chat-list labels are cyan (chrome), reserving green strictly for self.
+    assert_eq!(line.spans[1].style.fg, Some(Color::Cyan));
 }
 
 #[test]
@@ -1227,7 +1228,7 @@ fn chat_row_line_renders_the_unread_badge_yellow_and_bold() {
     assert_eq!(line_text(&line), "  Project Room (3)");
     let name = &line.spans[1];
     assert_eq!(name.content.as_ref(), "Project Room");
-    assert_eq!(name.style.fg, Some(Color::Green));
+    assert_eq!(name.style.fg, Some(Color::Cyan));
     assert!(name.style.add_modifier.contains(Modifier::BOLD));
     let badge = &line.spans[2];
     assert_eq!(badge.content.as_ref(), " (3)");
@@ -6536,12 +6537,12 @@ fn messages_pane_shows_loading_while_an_open_chat_load_is_in_flight() {
         .collect::<String>();
 
     assert!(
-        rendered.contains("loading chat..."),
-        "an in-flight load shows honest feedback in the pane, not 'no messages'"
+        rendered.contains("loading messages..."),
+        "an in-flight load shows honest feedback in the pane, not an empty notice"
     );
     assert!(
-        !rendered.contains("no messages"),
-        "'no messages' is only shown once the load settles empty"
+        !rendered.contains("no messages yet"),
+        "'no messages yet' is only shown once the load settles empty"
     );
 }
 
@@ -6592,27 +6593,106 @@ fn masked_secret_hides_every_character() {
 }
 
 #[test]
-fn status_bar_line_assembles_daemon_counts_and_status() {
-    assert_eq!(
-        status_bar_line("alice", true, 3, 5, "loaded 2 message(s)", 200),
-        "alice · daemon on · 3 chats · 5 unread · loaded 2 message(s)"
+fn status_bar_line_assembles_account_counts_and_status() {
+    let line = status_bar_line(
+        None,
+        Some("npub1alice"),
+        true,
+        3,
+        5,
+        "loaded 2 message(s)",
+        200,
     );
-    assert_eq!(
-        status_bar_line("bob", false, 0, 0, "", 200),
-        "bob · daemon off · 0 chats · 0 unread · "
+    let text = line_text(&line);
+    assert!(text.contains("npub1alice"), "account: {text:?}");
+    assert!(text.contains("3 chats"), "chats: {text:?}");
+    assert!(text.contains("5 unread"), "unread: {text:?}");
+    assert!(text.contains("loaded 2 message(s)"), "status: {text:?}");
+    // A width that fits the fixed segments but not the whole status truncates
+    // the status segment (trailing ellipsis) so the assembled line fits.
+    let narrow = status_bar_line(None, Some("npub1a"), true, 3, 0, "loaded slowly now", 30);
+    let narrow_text = line_text(&narrow);
+    assert!(
+        narrow_text.chars().count() <= 30,
+        "over width: {narrow_text:?}"
     );
-    // Narrow widths shorten the assembled line (middle ellipsis keeps head + tail).
-    let narrow = status_bar_line("alice", true, 3, 5, "loaded", 20);
-    assert!(narrow.chars().count() <= 20, "over width: {narrow:?}");
-    assert!(narrow.contains("..."), "expected truncation: {narrow:?}");
+    assert!(
+        narrow_text.contains("..."),
+        "expected truncation: {narrow_text:?}"
+    );
+    // A width too small for any status drops the segment rather than overflowing.
+    let tiny = status_bar_line(None, Some("npub1a"), true, 3, 0, "loaded", 20);
+    assert!(
+        !line_text(&tiny).contains("loaded"),
+        "dropped: {:?}",
+        line_text(&tiny)
+    );
+}
+
+#[test]
+fn status_bar_line_dot_reflects_daemon_state() {
+    fn dot(line: &Line<'_>) -> (String, Option<Color>) {
+        let span = line
+            .spans
+            .iter()
+            .find(|s| s.content == "●" || s.content == "○")
+            .expect("dot span");
+        (span.content.to_string(), span.style.fg)
+    }
+    let on = status_bar_line(None, Some("npub1a"), true, 0, 0, "", 200);
+    assert_eq!(dot(&on), ("●".to_owned(), Some(Color::Green)));
+    let off = status_bar_line(None, Some("npub1a"), false, 0, 0, "", 200);
+    assert_eq!(dot(&off), ("○".to_owned(), Some(Color::Red)));
+}
+
+#[test]
+fn status_bar_line_hides_zero_unread_and_shows_nonzero_yellow() {
+    let zero = status_bar_line(None, Some("npub1a"), true, 3, 0, "", 200);
+    assert!(
+        !line_text(&zero).contains("unread"),
+        "zero hidden: {:?}",
+        line_text(&zero)
+    );
+    let some = status_bar_line(None, Some("npub1a"), true, 3, 7, "", 200);
+    let badge = some
+        .spans
+        .iter()
+        .find(|s| s.content.contains("unread"))
+        .expect("unread badge");
+    assert_eq!(badge.content.as_ref(), "7 unread");
+    assert_eq!(badge.style.fg, Some(Color::Yellow));
+}
+
+#[test]
+fn status_bar_line_shows_display_name_distinct_from_npub() {
+    let line = status_bar_line(Some("Alice"), Some("npub1alice"), true, 0, 0, "", 200);
+    let text = line_text(&line);
+    assert!(text.contains("Alice"), "name: {text:?}");
+    assert!(text.contains("npub1alice"), "npub: {text:?}");
+    // The npub segment is styled gray, distinct from the name.
+    let npub_span = line
+        .spans
+        .iter()
+        .find(|s| s.content.contains("npub1alice"))
+        .expect("npub span");
+    assert_eq!(npub_span.style.fg, Some(Color::Gray));
 }
 
 #[test]
 fn status_bar_line_strips_control_sequences_from_untrusted_fields() {
-    assert_eq!(
-        status_bar_line("al\u{1b}[31mice", true, 1, 0, "ok\u{1b}[2J", 200),
-        "al[31mice · daemon on · 1 chats · 0 unread · ok[2J"
+    let line = status_bar_line(
+        None,
+        Some("al\u{1b}[31mice"),
+        true,
+        1,
+        0,
+        "ok\u{1b}[2J",
+        200,
     );
+    let text = line_text(&line);
+    assert!(text.contains("al[31mice"), "account stripped: {text:?}");
+    assert!(text.contains("ok[2J"), "status stripped: {text:?}");
+    assert!(!text.contains('\u{1b}'), "no escape: {text:?}");
 }
 
 #[test]
@@ -7671,6 +7751,29 @@ fn account_picker_l_opens_nsec_entry() {
 }
 
 #[test]
+fn account_picker_renders_without_panic_in_a_tiny_terminal() {
+    // Regression: with the account picker open, a terminal of height <= 3 shrinks
+    // the login body below the popup's 4-row floor. `rows.clamp(4, body.height)`
+    // panicked ("min > max") because the requested floor exceeded the available
+    // height. The rect must instead be built with a plain `max(4)` floor and left
+    // to `centered_cell_rect` to clamp down to the body.
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.accounts.push(AccountRow {
+        account_id: "bb".repeat(32),
+        npub: "npub1bob".to_owned(),
+        display_name: None,
+        local_signing: false,
+    });
+    app.screen = Screen::Login(LoginMode::AccountSelect);
+
+    let backend = ratatui::backend::TestBackend::new(50, 3);
+    let mut terminal = ratatui::Terminal::new(backend).expect("test terminal");
+    terminal
+        .draw(|frame| app.render(frame))
+        .expect("account picker must render without panicking in a 3-row terminal");
+}
+
+#[test]
 fn shift_a_reopens_the_account_picker_from_the_chat_list() {
     let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
     app.screen = Screen::Main;
@@ -7825,8 +7928,13 @@ fn main_frame_shows_chats_and_messages_with_bars_and_toggled_diagnostics() {
         !rendered.contains("Accounts"),
         "the accounts pane is gone from the main view"
     );
-    assert!(rendered.contains("g detail"), "chats hints line present");
-    assert!(rendered.contains("daemon"), "status bar present");
+    // The keymap hint renders keycaps (boxed keys) + dim labels; the `detail`
+    // label sits after the boxed `g` keycap.
+    assert!(rendered.contains("detail"), "chats hints line present");
+    assert!(
+        rendered.contains("loaded 1 message(s)"),
+        "status bar shows the latest status segment"
+    );
     assert!(
         !rendered.contains("Diagnostics"),
         "the diagnostics panel is off by default"
@@ -7859,7 +7967,7 @@ fn login_menu_frame_shows_options_and_hints() {
     assert!(rendered.contains("Create a new identity"));
     assert!(rendered.contains("Log in with an nsec"));
     assert!(
-        rendered.contains("c create identity"),
+        rendered.contains("create identity"),
         "login hints line present"
     );
 }
@@ -8035,8 +8143,8 @@ fn composer_grows_with_content_and_renders_the_cursor_cell() {
     );
     // The status bar still renders, so growth stole from the messages row, not the bars.
     assert!(
-        rendered.contains("daemon"),
-        "the status bar survives composer growth"
+        rendered.contains('●'),
+        "the status bar (connection dot) survives composer growth"
     );
     // The focused composer draws a black-on-white cursor cell.
     assert!(
@@ -8330,6 +8438,191 @@ fn messages_d_preserves_a_composer_draft_and_warns_instead_of_clobbering_it() {
 }
 
 #[test]
+fn keymap_hint_spans_box_keys_and_dim_labels() {
+    let spans = keymap_hint_spans("j/k move  Enter open");
+    // The keycap for `j/k`: white bold text on a dark-gray block, padded. White-on-
+    // dark-gray reads clearly on dark themes where black-on-dark-gray washed out.
+    let keycap = spans
+        .iter()
+        .find(|s| s.content.contains("j/k"))
+        .expect("j/k keycap");
+    assert_eq!(keycap.content.as_ref(), " j/k ");
+    assert_eq!(keycap.style.fg, Some(Color::White));
+    assert_eq!(keycap.style.bg, Some(Color::DarkGray));
+    assert!(keycap.style.add_modifier.contains(Modifier::BOLD));
+    // The label after it is dim, no keycap background.
+    let label = spans
+        .iter()
+        .find(|s| s.content.contains("move"))
+        .expect("move label");
+    assert_eq!(label.style.fg, Some(Color::DarkGray));
+    assert_eq!(label.style.bg, None);
+    // `Enter` is boxed like any other key.
+    assert!(
+        spans
+            .iter()
+            .any(|s| s.content.as_ref() == " Enter " && s.style.bg == Some(Color::DarkGray)),
+        "Enter keycap present"
+    );
+}
+
+#[test]
+fn keymap_hint_spans_leave_prose_leading_segment_unboxed() {
+    // `type query` is prose, not a key press — its first token must not be boxed.
+    let spans = keymap_hint_spans("type query  Enter search");
+    assert!(
+        !spans.iter().any(|s| s.content.as_ref() == " type "),
+        "the prose word `type` is not rendered as a keycap"
+    );
+    // The real key `Enter` is still boxed.
+    assert!(
+        spans
+            .iter()
+            .any(|s| s.content.as_ref() == " Enter " && s.style.bg == Some(Color::DarkGray)),
+        "Enter keycap present"
+    );
+}
+
+#[test]
+fn armed_hint_spans_box_only_enter_and_esc() {
+    let spans = armed_hint_spans("reacting to Alice — Enter sends the reaction, Esc clears");
+    let boxed = spans
+        .iter()
+        .filter(|s| s.style.bg == Some(Color::DarkGray))
+        .map(|s| s.content.trim().to_owned())
+        .collect::<Vec<_>>();
+    assert_eq!(boxed, vec!["Enter".to_owned(), "Esc".to_owned()]);
+    // The prose target still renders (dim), preserving the whole hint text.
+    let text = spans.iter().map(|s| s.content.as_ref()).collect::<String>();
+    assert!(text.contains("Alice"), "target preserved: {text:?}");
+}
+
+#[test]
+fn popup_hint_spans_color_bracket_keys_cyan_and_desc_gray() {
+    let spans = popup_hint_spans("[Enter] submit  [Esc] cancel");
+    let key = spans
+        .iter()
+        .find(|s| s.content.contains("[Enter]"))
+        .expect("[Enter] span");
+    assert_eq!(key.style.fg, Some(Color::Cyan));
+    let desc = spans
+        .iter()
+        .find(|s| s.content.contains("submit"))
+        .expect("submit desc");
+    assert_eq!(desc.style.fg, Some(Color::DarkGray));
+}
+
+#[test]
+fn empty_messages_notice_distinguishes_loading_no_chat_and_empty_chat() {
+    // In-flight load: yellow, regardless of whether a chat is already loaded.
+    assert_eq!(
+        empty_messages_notice(true, false),
+        ("loading messages...", Color::Yellow)
+    );
+    assert_eq!(
+        empty_messages_notice(true, true),
+        ("loading messages...", Color::Yellow)
+    );
+    // Settled, no chat loaded into the pane: the pick-a-chat prompt (dark gray).
+    assert_eq!(
+        empty_messages_notice(false, false),
+        ("select a chat to start messaging", Color::DarkGray)
+    );
+    // Settled, a chat is loaded but has no messages: genuinely empty (dark gray).
+    assert_eq!(
+        empty_messages_notice(false, true),
+        ("no messages yet", Color::DarkGray)
+    );
+}
+
+#[test]
+fn messages_pane_renders_the_three_empty_states() {
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Main;
+
+    // Loading a chat's timeline off the event loop.
+    app.loading_chat = Some("gg".repeat(32));
+    assert!(rendered_buffer(&mut app).contains("loading messages..."));
+
+    // Settled, no chat loaded.
+    app.loading_chat = None;
+    app.messages_group_id = None;
+    assert!(rendered_buffer(&mut app).contains("select a chat to start messaging"));
+
+    // Settled, a chat loaded but empty.
+    app.messages_group_id = Some("gg".repeat(32));
+    assert!(rendered_buffer(&mut app).contains("no messages yet"));
+
+    // Chats pane empty state.
+    assert!(rendered_buffer(&mut app).contains("no chats yet"));
+}
+
+#[test]
+fn popup_rect_sizes_a_short_confirm_to_content_and_centers() {
+    let popup = Popup::Confirm {
+        purpose: ConfirmPurpose::LeaveGroup {
+            group_id: "gg".repeat(32),
+        },
+        title: "Leave Group".to_owned(),
+        body: vec!["Leave ops-room?".to_owned()],
+    };
+    let area = Rect::new(0, 0, 100, 30);
+    let rect = popup_rect(&popup, area);
+    // Content-sized: 55 wide, snug height for one body line (not 70% of screen).
+    assert_eq!(rect.width, 55, "confirm width");
+    assert_eq!(
+        rect.height, 5,
+        "confirm height = body(1) + blank + hint + borders"
+    );
+    // Centered exactly.
+    assert_eq!(rect.x, (100 - 55) / 2);
+    assert_eq!(rect.y, (30 - 5) / 2);
+}
+
+#[test]
+fn popup_rect_clamps_to_a_small_area() {
+    let popup = Popup::info("Info", "hello");
+    let area = Rect::new(0, 0, 20, 4);
+    let rect = popup_rect(&popup, area);
+    assert!(rect.width <= 20, "width clamps: {}", rect.width);
+    assert!(rect.height <= 4, "height clamps: {}", rect.height);
+}
+
+#[test]
+fn popup_body_lines_color_confirm_yellow_and_logout_red() {
+    let confirm = Popup::Confirm {
+        purpose: ConfirmPurpose::LeaveGroup {
+            group_id: "gg".repeat(32),
+        },
+        title: "Leave Group".to_owned(),
+        body: vec!["Leave ops-room?".to_owned()],
+    };
+    let lines = popup_body_lines(&confirm);
+    assert_eq!(
+        lines[0].spans[0].style.fg,
+        Some(Color::Yellow),
+        "confirm body yellow"
+    );
+
+    let logout = Popup::Text {
+        purpose: TextPurpose::ConfirmLogout {
+            account_id: "aa".repeat(32),
+            npub: "npub1a".to_owned(),
+        },
+        title: "Log out".to_owned(),
+        body: vec!["This permanently destroys the signing key.".to_owned()],
+        input: Input::default(),
+    };
+    let lines = popup_body_lines(&logout);
+    assert_eq!(
+        lines[0].spans[0].style.fg,
+        Some(Color::Red),
+        "logout danger body red"
+    );
+}
+
+#[test]
 fn armed_interaction_hint_names_the_action_and_target() {
     // While the composer holds an interaction command, the hint tells the user
     // what Enter will do and to which message — the durable signal the field
@@ -8386,19 +8679,21 @@ fn render_hints_shows_the_persistent_armed_interaction_hint() {
     app.input.set_value("/react ");
 
     let armed = rendered_buffer(&mut app);
+    // The armed hint boxes `Enter`/`Esc` as keycaps, so the surrounding words are
+    // separate spans; assert on the prose fragments rather than exact spacing.
     assert!(
-        armed.contains("reacting to Alice") && armed.contains("Esc clears"),
+        armed.contains("reacting to Alice") && armed.contains("clears"),
         "armed hint must name the action and target, got: {armed:?}"
     );
     assert!(
-        !armed.contains("r react  u unreact"),
+        !armed.contains("unreact"),
         "the static messages keymap must be replaced while armed, got: {armed:?}"
     );
 
     app.input.clear();
     let idle = rendered_buffer(&mut app);
     assert!(
-        idle.contains("r react  u unreact"),
+        idle.contains("unreact"),
         "the static keymap returns once the composer is cleared, got: {idle:?}"
     );
 }
@@ -8458,6 +8753,121 @@ fn esc_preserves_a_hand_typed_draft() {
             "Esc must preserve a hand-typed draft, not destroy it"
         );
     }
+}
+
+#[test]
+fn sidebar_width_shrinks_on_narrow_terminals() {
+    // 5c: fixed 36 on a wide terminal, but never more than a third of the width so
+    // a narrow terminal gives the conversation more room.
+    assert_eq!(sidebar_width(120), 36, "wide: capped at 36");
+    assert_eq!(sidebar_width(108), 36, "108/3 == 36, still 36");
+    assert_eq!(sidebar_width(90), 30, "narrow: a third of 90");
+    assert_eq!(sidebar_width(30), 10, "very narrow: a third of 30");
+}
+
+#[test]
+fn esc_moves_focus_back_spatially_on_main() {
+    // 5a: Esc is spatial back on Main — Composer -> Messages -> Chats -> (no-op).
+    // A hand-typed draft is never destroyed; only the focus changes.
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::Main;
+    app.focus = Focus::Composer;
+    app.input.set_value("draft in progress");
+
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .expect("esc");
+    assert_eq!(app.focus, Focus::Messages, "Composer -> Messages");
+    assert_eq!(app.input.value(), "draft in progress", "draft preserved");
+
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .expect("esc");
+    assert_eq!(app.focus, Focus::Chats, "Messages -> Chats");
+
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .expect("esc");
+    assert_eq!(app.focus, Focus::Chats, "Chats -> no-op");
+    assert_eq!(
+        app.input.value(),
+        "draft in progress",
+        "draft still preserved"
+    );
+}
+
+/// Whether the rendered frame has any cell holding `ch` with the DarkGray
+/// selection-highlight background (used to detect the messages-pane row
+/// highlight, which only the message body carries).
+fn cell_with_char_has_darkgray_bg(app: &mut TuiApp, ch: char) -> bool {
+    let backend = ratatui::backend::TestBackend::new(100, 30);
+    let mut terminal = ratatui::Terminal::new(backend).expect("test terminal");
+    terminal.draw(|frame| app.render(frame)).expect("draw TUI");
+    terminal
+        .backend()
+        .buffer()
+        .content()
+        .iter()
+        .any(|cell| cell.symbol() == ch.to_string() && cell.bg == Color::DarkGray)
+}
+
+#[test]
+fn messages_highlight_renders_only_when_messages_focused() {
+    // 5b: the messages-pane row highlight is gated on focus, so a chat previewed
+    // while focus stays on the list (flick-through) shows no stray highlight.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Main;
+    app.messages_group_id = Some("gg".repeat(32));
+    let mut row = timeline_row("m0", 0);
+    row.display_text = "ZEBRAMSG".to_owned();
+    app.timeline = vec![row];
+
+    app.focus = Focus::Messages;
+    assert!(
+        cell_with_char_has_darkgray_bg(&mut app, 'Z'),
+        "the selected row is highlighted when the messages pane is focused"
+    );
+
+    app.focus = Focus::Chats;
+    assert!(
+        !cell_with_char_has_darkgray_bg(&mut app, 'Z'),
+        "no highlight on the message row when focus is elsewhere"
+    );
+}
+
+#[test]
+fn messages_highlight_stays_while_an_interaction_is_armed() {
+    // Arming r/d/R moves focus to the composer, but the highlighted row is the
+    // exact target of the pending action — it must keep its highlight while armed
+    // so the user can see what they are about to react to / delete / reply to.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Main;
+    app.messages_group_id = Some("gg".repeat(32));
+    let mut row = timeline_row("m0", 0);
+    row.display_text = "ZEBRAMSG".to_owned();
+    app.timeline = vec![row];
+
+    // `r` arms /react from the messages pane and moves focus to the composer.
+    app.focus = Focus::Messages;
+    app.handle_key(char_key('r')).expect("r arms /react");
+    assert_eq!(app.focus, Focus::Composer, "r moves focus to the composer");
+    assert!(
+        is_armed_interaction(app.input.value()),
+        "r leaves an armed /react in the composer, got {:?}",
+        app.input.value()
+    );
+    assert!(
+        cell_with_char_has_darkgray_bg(&mut app, 'Z'),
+        "the target row stays highlighted while an interaction is armed"
+    );
+
+    // Companion: focus on the chat list with nothing armed keeps the highlight
+    // hidden, so flick-through browsing shows no stray highlight.
+    app.input.clear();
+    app.focus = Focus::Chats;
+    assert!(
+        !cell_with_char_has_darkgray_bg(&mut app, 'Z'),
+        "no highlight when focus is elsewhere and nothing is armed"
+    );
 }
 
 #[test]
@@ -9078,7 +9488,7 @@ fn composer_min_and_max_height_coexist_with_the_diagnostics_panel() {
             "the diagnostics content renders alongside the composer"
         );
         assert!(
-            rendered.contains("daemon"),
+            rendered.contains('●'),
             "the status bar survives at composer height {expected_composer_rows}"
         );
     };

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -3260,8 +3260,11 @@ fn a_notification_armed_relist_runs_off_loop_and_preserves_selection() {
     let group_a = "aa".repeat(32);
     let group_b = "bb".repeat(32);
     // The re-read returns B as the most-active chat (a reorder): B first, A last.
+    // `activity_sort_at` is the durable ordering anchor the fold sorts by — a
+    // `last_message.timeline_at` alone leaves both rows at activity 0, where the
+    // ascending group-id tie-break would keep A first and the reorder never happens.
     let response = format!(
-        r#"{{"ok":true,"result":{{"chats":[{{"group_id":"{group_b}","profile":{{"name":"b"}},"last_message":{{"timeline_at":200,"plaintext":"hi","sender":"x"}}}},{{"group_id":"{group_a}","profile":{{"name":"a"}},"last_message":{{"timeline_at":100,"plaintext":"yo","sender":"x"}}}}]}}}}"#
+        r#"{{"ok":true,"result":{{"chats":[{{"group_id":"{group_b}","profile":{{"name":"b"}},"activity_sort_at":200,"last_message":{{"timeline_at":200,"plaintext":"hi","sender":"x"}}}},{{"group_id":"{group_a}","profile":{{"name":"a"}},"activity_sort_at":100,"last_message":{{"timeline_at":100,"plaintext":"yo","sender":"x"}}}}]}}}}"#
     );
     let tempdir = tempfile::tempdir().expect("tempdir");
     let (exe, args_file) = test_appending_arg_executable(tempdir.path(), &response);

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -870,6 +870,67 @@ fn logout_token_mismatch_is_a_noop_that_keeps_the_popup_open() {
     assert_eq!(app.accounts.len(), 1, "the account is untouched");
 }
 
+#[cfg(unix)]
+#[test]
+fn logout_success_then_refresh_failure_reports_logout_not_error() {
+    use std::os::unix::fs::PermissionsExt;
+    // The wipe is irreversible and succeeds; only the follow-up account-list
+    // reload fails. The status must report the logout as done and point at
+    // `/refresh`, never masking a completed wipe behind `error:` while the
+    // removed account lingers on screen.
+    let account_id = "aa".repeat(32);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let exe = dir.path().join("wn-json");
+    let script = "#!/bin/sh\ncase \" $* \" in\n  *\" account list \"*)\ncat <<'JSON'\n{\"ok\":false,\"error\":{\"message\":\"relays unreachable\"}}\nJSON\n    ;;\n  *)\ncat <<'JSON'\n{\"ok\":true,\"result\":{}}\nJSON\n    ;;\nesac\n";
+    std::fs::write(&exe, script).expect("write fake wn");
+    let mut perms = std::fs::metadata(&exe)
+        .expect("fake wn metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&exe, perms).expect("chmod fake wn");
+    let client = WnClient {
+        exe,
+        ..test_unused_client()
+    };
+    let mut app = test_tui_app(client, &account_id);
+    app.daemon.running = false;
+
+    app.logout_account(&account_id, "npub1alice")
+        .expect("a refresh failure after a successful wipe must not propagate");
+
+    assert!(
+        app.status.contains("logged out"),
+        "the completed wipe is reported: {:?}",
+        app.status
+    );
+    assert!(
+        app.status.contains("/refresh"),
+        "the status points at /refresh to retry the reload: {:?}",
+        app.status
+    );
+    assert!(
+        !app.status.starts_with("error:"),
+        "a completed wipe is never reported as an error: {:?}",
+        app.status
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn logout_success_with_successful_refresh_reports_only_the_logout() {
+    // The happy path is unchanged: a clean logout + reload reports just the
+    // logged-out account, with no reload-failure suffix.
+    let account_id = "aa".repeat(32);
+    let (_tempdir, client) = test_json_client(r#"{"ok":true,"result":{"accounts":[]}}"#);
+    let mut app = test_tui_app(client, &account_id);
+    app.daemon.running = false;
+
+    app.logout_account(&account_id, "npub1alice")
+        .expect("a clean logout succeeds");
+
+    assert_eq!(app.status, "logged out npub1alice");
+}
+
 #[test]
 fn slash_command_parser_handles_daemon_commands() {
     assert_eq!(
@@ -6335,6 +6396,93 @@ fn messages_pane_keys_drive_the_selection_and_composer_focus() {
 }
 
 #[test]
+fn ctrl_u_in_messages_focus_does_not_unreact() {
+    // Ctrl-U is the composer kill-line, never the Messages `u` (unreact)
+    // accelerator. The accelerator must fire only on a plain `u`, so Ctrl-U in
+    // the Messages pane is a no-op: it queues no `messages unreact` subprocess
+    // and leaves the status line untouched. A selected row is present so a fired
+    // unreact WOULD resolve and set "removing reaction..." — proving the no-op is
+    // real, not merely an unresolved-selection error.
+    let account_id = "aa".repeat(32);
+    let group_id = "bb".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.focus = Focus::Messages;
+    app.messages_account_id = Some(account_id.clone());
+    app.messages_group_id = Some(group_id);
+    app.timeline = vec![timeline_row("m1", 1)];
+    assert!(app.status.is_empty(), "precondition: status starts empty");
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL))
+        .expect("Ctrl-U handled");
+
+    assert!(
+        app.status.is_empty(),
+        "Ctrl-U in Messages must not fire unreact; status: {:?}",
+        app.status
+    );
+}
+
+#[test]
+fn ctrl_q_does_not_quit() {
+    // `q` quits only as a bare accelerator. Ctrl-Q is a chord that must not fall
+    // through the modifier-insensitive `q` arm and tear down the session.
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.focus = Focus::Chats;
+    assert!(app.input.is_empty(), "precondition: composer empty");
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL))
+        .expect("Ctrl-Q handled");
+
+    assert!(app.running, "Ctrl-Q must not quit the app");
+}
+
+#[test]
+fn plain_u_in_messages_focus_removes_the_reaction() {
+    // The guard on the `u` accelerator only rejects Ctrl/Alt: a plain `u` still
+    // fires the unreact and enqueues the `messages unreact` effect.
+    let account_id = "aa".repeat(32);
+    let group_id = "bb".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.focus = Focus::Messages;
+    app.messages_account_id = Some(account_id.clone());
+    app.messages_group_id = Some(group_id);
+    app.timeline = vec![timeline_row("m1", 1)];
+
+    app.handle_key(char_key('u')).expect("plain u handled");
+
+    assert_eq!(
+        app.status, "removing reaction...",
+        "a plain u still fires the unreact"
+    );
+}
+
+#[test]
+fn composer_ctrl_u_clears_the_input() {
+    // Ctrl-U in the composer is the readline kill-line and clears the field —
+    // the guard on the Messages accelerators must not shadow it.
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.focus = Focus::Composer;
+    app.input.set_value("/react 🔥");
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL))
+        .expect("Ctrl-U handled");
+
+    assert!(app.input.is_empty(), "Ctrl-U clears the composer");
+}
+
+#[test]
+fn plain_q_quits() {
+    // The plain-keypress guard tolerates Shift/no-modifier: a bare `q` outside
+    // the composer still quits.
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.focus = Focus::Chats;
+
+    app.handle_key(char_key('q')).expect("q handled");
+
+    assert!(!app.running, "a bare q quits the app");
+}
+
+#[test]
 fn render_messages_wraps_long_lines_so_the_tail_is_visible() {
     // The height model (`timeline_row_height`) measures with wrapping, so the
     // renderer must wrap too or long lines truncate at the pane edge and the
@@ -8310,6 +8458,57 @@ fn esc_preserves_a_hand_typed_draft() {
             "Esc must preserve a hand-typed draft, not destroy it"
         );
     }
+}
+
+#[test]
+fn a_leading_space_before_a_command_is_still_armed_and_esc_clears_it() {
+    // `parse_slash_command` trims, so a hand-typed leading space (" /react x")
+    // still submits as a reaction. The armed hint and the Esc escape hatch share
+    // `armed_interaction`, so they must agree with what submits: the hint shows
+    // and Esc clears the prefill rather than leaving the user with an invisible
+    // armed command.
+    assert!(
+        armed_interaction_hint(" /react x", None).is_some(),
+        "a leading space before /react is still an armed interaction"
+    );
+
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.focus = Focus::Composer;
+    app.input.set_value(" /react x");
+
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .expect("esc");
+
+    assert!(
+        app.input.is_empty(),
+        "Esc clears the armed interaction even with a leading space, left {:?}",
+        app.input.value()
+    );
+}
+
+#[test]
+fn a_leading_space_before_plain_text_is_not_armed_and_esc_preserves_it() {
+    // Trimming for command detection must not turn leading-space plain text into
+    // an armed command: " hello" is a hand-typed draft, so it shows no armed hint
+    // and Esc preserves it (the draft-protection rule).
+    assert_eq!(
+        armed_interaction_hint(" hello", None),
+        None,
+        "leading-space plain text is not an armed interaction"
+    );
+
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.focus = Focus::Composer;
+    app.input.set_value(" hello");
+
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .expect("esc");
+
+    assert_eq!(
+        app.input.value(),
+        " hello",
+        "Esc preserves a hand-typed draft with a leading space"
+    );
 }
 
 #[test]

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -10081,6 +10081,91 @@ fn a_stale_invites_result_for_a_switched_account_is_dropped() {
 }
 
 #[test]
+fn an_invites_fold_over_an_image_popup_reopens_through_the_close_funnel() {
+    // I from the chat list queues the invites load; the user Tabs to the pane
+    // and opens an image message. On a pixel terminal the viewer writes the
+    // image terminal-side, out of ratatui's cell-diff reach. When the invites
+    // result lands, replacing the popup by direct assignment would leave the
+    // pixel image on screen and the decoded viewer copy alive. The fold must
+    // funnel through close_popup: schedule the full clear+repaint and drop the
+    // native protocol before opening the picker.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Main;
+    app.focus = Focus::Messages;
+    let mut row = timeline_row("m", 0);
+    row.display_text = "look".to_owned();
+    row.attachments = vec![image_attachment("cafebabe")];
+    app.timeline = vec![row];
+    app.media = iterm2_media_with_ready_image("cafebabe");
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE))
+        .expect("open viewer");
+    assert!(matches!(app.popup, Some(Popup::Image { .. })));
+    assert!(app.media.viewer_protocol_mut("cafebabe").is_some());
+    assert!(!app.pending_full_repaint);
+
+    // The invites load (queued before the image was opened) now lands.
+    app.loading_invites = true;
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::LoadInvites {
+            account: account_id,
+        },
+        result: Ok(vec![serde_json::json!({
+            "invites": [{"group_id": "cc", "profile": {"name": "Ops"}, "pending_confirmation": true}]
+        })]),
+    });
+
+    assert!(
+        matches!(
+            app.popup,
+            Some(Popup::Picker {
+                purpose: PickerPurpose::Invites,
+                ..
+            })
+        ),
+        "the invites picker replaced the image popup"
+    );
+    assert!(
+        app.pending_full_repaint,
+        "replacing the image popup must schedule the full clear+repaint"
+    );
+    assert!(
+        app.media.viewer_protocol_mut("cafebabe").is_none(),
+        "replacing the image popup must drop the terminal-side viewer protocol"
+    );
+}
+
+#[test]
+fn an_invites_fold_while_on_the_profile_screen_does_not_open_the_picker() {
+    // I queues the invites load from the chat list; p then opens Profile before
+    // the result lands. The picker is reachable only from Main and group detail,
+    // so a late fold must drop rather than pop over an unrelated screen.
+    let account_id = "aa".repeat(32);
+    let mut app = test_tui_app(test_unused_client(), &account_id);
+    app.screen = Screen::Profile;
+    app.loading_invites = true;
+
+    app.apply_effect_done_for_test(EffectDone {
+        effect: Effect::LoadInvites {
+            account: account_id,
+        },
+        result: Ok(vec![serde_json::json!({
+            "invites": [{"group_id": "cc", "profile": {"name": "Ops"}, "pending_confirmation": true}]
+        })]),
+    });
+
+    assert!(
+        app.popup.is_none(),
+        "the invites picker popped over the profile screen"
+    );
+    assert!(
+        !app.loading_invites,
+        "the dropped load clears the in-flight guard"
+    );
+}
+
+#[test]
 fn user_search_maps_to_the_users_search_argv_plus_a_follows_snapshot() {
     // The second call is the local `follows list` directory read — one cheap
     // call that lets every result row render an accurate follow badge, instead

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -2,8 +2,6 @@
 
 use super::*;
 
-use ratatui_image::StatefulImage;
-
 pub(crate) fn daemon_status_sentence(daemon: &DaemonView) -> String {
     if !daemon.running {
         return "daemon not running".to_owned();
@@ -534,8 +532,14 @@ impl TuiApp {
     }
 
     /// Render the full-size image viewer popup: a centered card with a cyan
-    /// border, the decoded image aspect-fit inside, and a dismiss hint. Falls
-    /// back to a text card if the protocol is somehow gone.
+    /// border, the decoded image aspect-fit inside, and a dismiss hint. The popup
+    /// draws its own dedicated protocol (`viewer_protocol_mut`) — native on a
+    /// pixel-capable terminal, a fresh cell-exact halfblock instance on a
+    /// halfblock-only one — so it never re-resizes the shared inline protocol the
+    /// timeline draws. Only when that image's retained pixels were evicted (an
+    /// image older than the retention window) is there no dedicated instance; the
+    /// popup then draws the shared inline protocol as a last resort, since the
+    /// evicted pixels survive only there. If neither exists the card stays empty.
     fn render_image_popup(&mut self, frame: &mut Frame, title: &str, hash: &str) {
         let rect = centered_rect(80, 80, frame.area());
         frame.render_widget(Clear, rect);
@@ -558,8 +562,14 @@ impl TuiApp {
             height: 1,
             ..inner
         };
-        if let Some(protocol) = self.media.protocol_mut(hash) {
-            frame.render_stateful_widget(StatefulImage::new(), image_area, protocol);
+        if let Some(protocol) = self.media.viewer_protocol_mut(hash) {
+            // The popup's own dedicated instance (native or halfblock): drawing
+            // it at popup size never disturbs the shared inline protocol.
+            frame.render_stateful_widget(media_image_widget(), image_area, protocol);
+        } else if let Some(protocol) = self.media.protocol_mut(hash) {
+            // Evicted image only: its pixels survive solely inside the inline
+            // protocol, so the popup draws that as a last resort.
+            frame.render_stateful_widget(media_image_widget(), image_area, protocol);
         }
         frame.render_widget(
             Paragraph::new(Line::from(Span::styled(
@@ -930,7 +940,7 @@ impl TuiApp {
         // gave it the space; `StatefulImage` aspect-fits within the rect.
         for (hash, rect) in image_draws {
             if let Some(protocol) = self.media.protocol_mut(&hash) {
-                frame.render_stateful_widget(StatefulImage::new(), rect, protocol);
+                frame.render_stateful_widget(media_image_widget(), rect, protocol);
             }
         }
     }

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -142,17 +142,21 @@ pub(crate) fn stream_preview_line_pair(
     ])
 }
 
-/// The messages-pane title: plain "Messages" when pinned with everything on
-/// screen, otherwise annotated with the row counts above and below the viewport
-/// so the reader knows history or newer content is off-screen.
-pub(crate) fn timeline_pane_title(total: usize, first: usize, last: usize) -> String {
+/// The messages-pane title: the loaded chat's name (its `base`, or plain
+/// "Messages" when nothing is loaded) when pinned with everything on screen,
+/// otherwise annotated with the row counts above and below the viewport so the
+/// reader knows history or newer content is off-screen. Naming the loaded chat
+/// makes the pane target visible — the flick preview retargets the pane to a
+/// chat the highlight may have since moved past, so the title is the WYSIWYG cue
+/// for which conversation is shown.
+pub(crate) fn timeline_pane_title(base: &str, total: usize, first: usize, last: usize) -> String {
     let above = first;
     let below = total.saturating_sub(last + 1);
     match (above, below) {
-        (0, 0) => "Messages".to_owned(),
-        (above, 0) => format!("Messages [{above} older]"),
-        (0, below) => format!("Messages [{below} newer]"),
-        (above, below) => format!("Messages [{above} older | {below} newer]"),
+        (0, 0) => base.to_owned(),
+        (above, 0) => format!("{base} [{above} older]"),
+        (0, below) => format!("{base} [{below} newer]"),
+        (above, below) => format!("{base} [{above} older | {below} newer]"),
     }
 }
 
@@ -817,12 +821,32 @@ impl TuiApp {
         frame.render_stateful_widget(list, area, &mut state);
     }
 
+    /// The messages-pane title base: the loaded chat's terminal-safe, shortened
+    /// name, or the plain "Messages" when no chat is loaded (or its row is not in
+    /// the list). Keyed on the loaded pane target (`messages_group_id`), not the
+    /// highlighted selection, so it names the conversation actually on screen.
+    fn loaded_chat_title(&self) -> String {
+        self.messages_group_id
+            .as_deref()
+            .and_then(|group_id| self.chats.iter().find(|chat| chat.group_id == group_id))
+            .map(|chat| shorten(&terminal_safe_text(&chat.name), MESSAGES_TITLE_NAME_LIMIT))
+            .unwrap_or_else(|| "Messages".to_owned())
+    }
+
     pub(crate) fn render_messages(&mut self, frame: &mut Frame, area: Rect) {
         let focused = self.focus == Focus::Messages;
+        let base_title = self.loaded_chat_title();
         if self.timeline.is_empty() {
+            // Honest feedback while an open-chat / flick-through load is in flight
+            // off the event loop; "no messages" is only shown once it has settled.
+            let placeholder = if self.loading_chat.is_some() {
+                "loading chat..."
+            } else {
+                "no messages"
+            };
             frame.render_widget(
-                Paragraph::new(vec![Line::from("no messages")])
-                    .block(panel_block("Messages", focused)),
+                Paragraph::new(vec![Line::from(placeholder)])
+                    .block(panel_block(&base_title, focused)),
                 area,
             );
             return;
@@ -910,12 +934,12 @@ impl TuiApp {
                     cursor_y = cursor_y.saturating_add(heights[index]);
                 }
                 (
-                    timeline_pane_title(total, first, last),
+                    timeline_pane_title(&base_title, total, first, last),
                     lines,
                     Some((first, last)),
                 )
             }
-            None => ("Messages".to_owned(), Vec::new(), None),
+            None => (base_title.clone(), Vec::new(), None),
         };
         if bottom_block > 0 {
             lines.extend(preview_lines);

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -187,7 +187,7 @@ pub(crate) fn chat_row_line(chat: &ChatRow, selected: bool, unread_count: usize)
     let marker = if selected { ">" } else { " " };
     let archived = if chat.archived { " archived" } else { "" };
     let mut ambient_style = Style::default();
-    let mut label_style = row_label_style(selected, Color::Green);
+    let mut label_style = row_label_style(selected, Color::Cyan);
     if unread_count > 0 {
         ambient_style = ambient_style.add_modifier(Modifier::BOLD);
         label_style = label_style.add_modifier(Modifier::BOLD);
@@ -392,6 +392,103 @@ pub(crate) fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect 
             Constraint::Percentage((100 - percent_x) / 2),
         ])
         .split(vertical[1])[1]
+}
+
+/// The popup body content (everything above the pinned hint row): semantic-
+/// colored body lines, the embedded input cursor line for a text popup, or the
+/// picker rows. Untrusted body text and picker labels pass through
+/// `terminal_safe_text`. Confirm bodies render yellow ("are you sure?"); the
+/// typed-token logout body renders red (irreversible key destruction); other
+/// bodies keep the default foreground. The `Image` variant renders through
+/// `render_image_popup`, so it has no body here.
+pub(crate) fn popup_body_lines(popup: &Popup) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    match popup {
+        Popup::Text {
+            purpose,
+            body,
+            input,
+            ..
+        } => {
+            let style = if matches!(purpose, TextPurpose::ConfirmLogout { .. }) {
+                Style::default().fg(Color::Red)
+            } else {
+                Style::default()
+            };
+            lines.extend(
+                body.iter()
+                    .map(|line| Line::from(Span::styled(terminal_safe_text(line), style))),
+            );
+            lines.push(input_cursor_line("> ", input));
+        }
+        Popup::Confirm { body, .. } => lines.extend(body.iter().map(|line| {
+            Line::from(Span::styled(
+                terminal_safe_text(line),
+                Style::default().fg(Color::Yellow),
+            ))
+        })),
+        Popup::Card { body, .. } => {
+            lines.extend(body.iter().map(|line| Line::from(terminal_safe_text(line))))
+        }
+        Popup::Picker {
+            items, selected, ..
+        } => {
+            for (index, item) in items.iter().enumerate() {
+                let is_selected = index == *selected;
+                let marker = if is_selected { ">" } else { " " };
+                lines.push(Line::from(vec![
+                    Span::raw(format!("{marker} ")),
+                    Span::styled(
+                        shorten(&terminal_safe_text(&item.label), 40),
+                        row_label_style(is_selected, Color::Cyan),
+                    ),
+                ]));
+            }
+        }
+        // Rendered by `render_image_popup`, not here.
+        Popup::Image { .. } => {}
+    }
+    lines
+}
+
+/// The content-sized, exactly-centered rect for a popup: a per-variant width
+/// (text 50, confirm 55, card/info 70, picker 60) and a height snug to the
+/// measured (wrapped) body plus a blank gap, the hint row, and the two borders.
+/// Both dimensions clamp to the available area. The `Image` viewer is sized
+/// separately (`render_image_popup`), so it never reaches here.
+pub(crate) fn popup_rect(popup: &Popup, area: Rect) -> Rect {
+    let width = popup_width(popup).min(area.width);
+    let inner_width = width.saturating_sub(2).max(1);
+    let body_rows = Paragraph::new(popup_body_lines(popup))
+        .wrap(Wrap { trim: false })
+        .line_count(inner_width);
+    let body_rows = u16::try_from(body_rows).unwrap_or(u16::MAX);
+    // body + blank gap + hint row + top and bottom borders.
+    let height = body_rows.saturating_add(4);
+    centered_cell_rect(width, height, area)
+}
+
+/// The nominal (pre-clamp) popup width in cells, by variant.
+fn popup_width(popup: &Popup) -> u16 {
+    match popup {
+        Popup::Text { .. } => 50,
+        Popup::Confirm { .. } => 55,
+        Popup::Card { .. } => 70,
+        Popup::Picker { .. } => 60,
+        // Unused: the image viewer sizes itself; keep the match total.
+        Popup::Image { .. } => 70,
+    }
+}
+
+/// A rect of `width`×`height` cells centered in `area`, each dimension clamped
+/// to fit. Cell-based (unlike the percentage `centered_rect` the image viewer
+/// uses) so popups size to their content.
+pub(crate) fn centered_cell_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let w = width.min(area.width);
+    let h = height.min(area.height);
+    let x = area.x + area.width.saturating_sub(w) / 2;
+    let y = area.y + area.height.saturating_sub(h) / 2;
+    Rect::new(x, y, w, h)
 }
 
 /// Render `text` with a black-on-white cursor cell at char index `cursor` when
@@ -620,7 +717,10 @@ impl TuiApp {
 
         let body = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Length(36), Constraint::Min(24)])
+            .constraints([
+                Constraint::Length(sidebar_width(area.width)),
+                Constraint::Min(24),
+            ])
             .split(root[0]);
         self.render_chats(frame, body[0]);
         self.render_messages(frame, body[1]);
@@ -652,10 +752,29 @@ impl TuiApp {
                 Constraint::Length(1),
             ])
             .split(area);
+        // Center the brand/menu block within the body rather than letting it fill
+        // the whole pane — the login screen reads as a focused card, not a
+        // full-height panel.
+        let body = root[0];
+        let content = match mode {
+            LoginMode::Menu => centered_cell_rect(44, 9, body),
+            LoginMode::AccountSelect => {
+                let rows = u16::try_from(self.accounts.len().max(1))
+                    .unwrap_or(u16::MAX)
+                    .saturating_add(2);
+                // Floor the card at 4 rows (two borders + a row) but do not cap it
+                // here: `centered_cell_rect` clamps the height down to `body`, so a
+                // terminal shorter than the floor stays panic-free (a bare
+                // `clamp(4, body.height)` would assert `min > max` when the body is
+                // squeezed below 4 rows).
+                centered_cell_rect(50, rows.max(4), body)
+            }
+            LoginMode::NsecEntry => centered_cell_rect(54, 7, body),
+        };
         match mode {
-            LoginMode::Menu => self.render_login_menu(frame, root[0]),
-            LoginMode::AccountSelect => self.render_account_picker(frame, root[0]),
-            LoginMode::NsecEntry => self.render_nsec_entry(frame, root[0]),
+            LoginMode::Menu => self.render_login_menu(frame, content),
+            LoginMode::AccountSelect => self.render_account_picker(frame, content),
+            LoginMode::NsecEntry => self.render_nsec_entry(frame, content),
         }
         self.render_hints(frame, root[1]);
         self.render_status_bar(frame, root[2]);
@@ -754,61 +873,66 @@ impl TuiApp {
         // the main view, an armed interaction command in the composer replaces the
         // static keymap with a persistent "what Enter does, Esc clears" hint,
         // recomputed here each frame so it survives later status events.
-        let text = match (self.screen, self.user_search.as_ref()) {
-            (Screen::UserSearch, Some(view)) => user_search_hint(view.focus).to_owned(),
+        let spans = match (self.screen, self.user_search.as_ref()) {
+            (Screen::UserSearch, Some(view)) => keymap_hint_spans(user_search_hint(view.focus)),
             (Screen::Main, _) => {
-                armed_interaction_hint(self.input.value(), self.selected_timeline_row())
-                    .unwrap_or_else(|| {
-                        hints_line(self.screen, self.focus, self.entered_main).to_owned()
-                    })
+                match armed_interaction_hint(self.input.value(), self.selected_timeline_row()) {
+                    Some(armed) => armed_hint_spans(&armed),
+                    None => {
+                        keymap_hint_spans(hints_line(self.screen, self.focus, self.entered_main))
+                    }
+                }
             }
-            _ => hints_line(self.screen, self.focus, self.entered_main).to_owned(),
+            _ => keymap_hint_spans(hints_line(self.screen, self.focus, self.entered_main)),
         };
-        frame.render_widget(
-            Paragraph::new(Line::from(Span::styled(
-                text,
-                Style::default().fg(Color::DarkGray),
-            ))),
-            area,
-        );
+        frame.render_widget(Paragraph::new(Line::from(spans)), area);
     }
 
     fn render_status_bar(&self, frame: &mut Frame, area: Rect) {
-        let account_label = self
-            .selected_account_row()
-            .map(account_display_label)
-            .unwrap_or_else(|| "no account".to_owned());
-        let text = status_bar_line(
-            &account_label,
+        let account = self.selected_account_row();
+        let line = status_bar_line(
+            account.and_then(|account| account.display_name.as_deref()),
+            account.map(|account| account.npub.as_str()),
             self.daemon.running,
             self.chats.len(),
             total_unread(&self.chats),
             &self.status,
             area.width as usize,
         );
-        frame.render_widget(Paragraph::new(Line::from(text)), area);
+        // The DarkGray bar fill: the Paragraph base style covers the whole area,
+        // and the line's spans set only a foreground so the fill shows through.
+        frame.render_widget(
+            Paragraph::new(line).style(Style::default().bg(Color::DarkGray).fg(Color::White)),
+            area,
+        );
     }
 
     pub(crate) fn render_chats(&self, frame: &mut Frame, area: Rect) {
-        let items = if self.chats.is_empty() {
-            vec![ListItem::new("no chats")]
-        } else {
-            self.chats
-                .iter()
-                .enumerate()
-                .map(|(index, chat)| {
-                    let selected = index == self.selected_chat;
-                    // Unread badge and preview both come from the runtime-backed
-                    // projection now — no TUI-local counting.
-                    let mut lines =
-                        vec![chat_row_line(chat, selected, chat.projection.unread_count)];
-                    if let Some(preview) = chat_preview_line(chat) {
-                        lines.push(preview);
-                    }
-                    ListItem::new(lines).style(selected_style(selected))
-                })
-                .collect()
-        };
+        if self.chats.is_empty() {
+            // Chats load synchronously, so an empty list is genuinely empty (there
+            // is no in-flight frame to show a loading spinner for); a dark-gray,
+            // centered notice.
+            let block = panel_block("Chats", self.focus == Focus::Chats);
+            let inner = block.inner(area);
+            frame.render_widget(block, area);
+            render_centered_notice(frame, inner, "no chats yet", Color::DarkGray);
+            return;
+        }
+        let items: Vec<ListItem> = self
+            .chats
+            .iter()
+            .enumerate()
+            .map(|(index, chat)| {
+                let selected = index == self.selected_chat;
+                // Unread badge and preview both come from the runtime-backed
+                // projection now — no TUI-local counting.
+                let mut lines = vec![chat_row_line(chat, selected, chat.projection.unread_count)];
+                if let Some(preview) = chat_preview_line(chat) {
+                    lines.push(preview);
+                }
+                ListItem::new(lines).style(selected_style(selected))
+            })
+            .collect();
         let list = List::new(items).block(panel_block("Chats", self.focus == Focus::Chats));
         // Drive the list with a ListState synced to the selection so it always
         // scrolls the highlighted chat into view. Rows are 1-2 lines tall;
@@ -837,18 +961,18 @@ impl TuiApp {
         let focused = self.focus == Focus::Messages;
         let base_title = self.loaded_chat_title();
         if self.timeline.is_empty() {
-            // Honest feedback while an open-chat / flick-through load is in flight
-            // off the event loop; "no messages" is only shown once it has settled.
-            let placeholder = if self.loading_chat.is_some() {
-                "loading chat..."
-            } else {
-                "no messages"
-            };
-            frame.render_widget(
-                Paragraph::new(vec![Line::from(placeholder)])
-                    .block(panel_block(&base_title, focused)),
-                area,
+            // Three distinct, color-coded empty states: an in-flight load
+            // (yellow), the pick-a-chat prompt when nothing is loaded, and a
+            // genuinely empty loaded chat (both dark gray). Keyed off the async
+            // load flag and whether a chat is loaded into the pane.
+            let (text, color) = empty_messages_notice(
+                self.loading_chat.is_some(),
+                self.messages_group_id.is_some(),
             );
+            let block = panel_block(&base_title, focused);
+            let inner = block.inner(area);
+            frame.render_widget(block, area);
+            render_centered_notice(frame, inner, text, color);
             return;
         }
 
@@ -874,7 +998,18 @@ impl TuiApp {
         let heights =
             timeline_row_heights_media(&self.timeline, selected_account, inner_width, media);
         let total = self.timeline.len();
-        let selected = self.timeline_scroll.resolved_selection(total);
+        // The row highlight renders when the messages pane holds focus, or while an
+        // interaction is armed in the composer: r/d/R move focus to the composer,
+        // but the highlighted row is the exact target of the pending action, so it
+        // must stay lit while aimed at. A chat previewed with focus on the chat list
+        // and nothing armed (flick-through) shows no stray highlight — arming never
+        // leaves focus on Chats, so this cannot fight flick-through. Scroll/
+        // visibility are unaffected (they key off the offset, not this selection).
+        let selected = if focused || is_armed_interaction(self.input.value()) {
+            self.timeline_scroll.resolved_selection(total)
+        } else {
+            None
+        };
 
         // Ready images to draw over their reserved blocks, collected as owned
         // `(hash, rect)` so the immutable `self` borrows (media view, account) end
@@ -1006,55 +1141,39 @@ impl TuiApp {
         );
     }
 
-    /// Render the one open popup: a centered rect, `Clear` behind, cyan border,
-    /// the popup's title, its body (embedded input, confirm/card lines, or picker
-    /// rows), a blank spacer, and the bottom `[key] action` hint row.
+    /// Render the one open popup: a content-sized centered rect, `Clear` behind,
+    /// a cyan border with a cyan-bold ` Title ` heading, the popup body (embedded
+    /// input, semantic-colored confirm/card lines, or picker rows) at the top,
+    /// and the centered `[key] action` hint pinned to the bottom row.
     pub(crate) fn render_popup(&self, frame: &mut Frame, popup: &Popup, area: Rect) {
-        let rect = centered_rect(70, 70, area);
+        let rect = popup_rect(popup, area);
         frame.render_widget(Clear, rect);
-        let mut lines: Vec<Line<'static>> = Vec::new();
-        match popup {
-            Popup::Text { body, input, .. } => {
-                lines.extend(body.iter().map(|line| Line::from(terminal_safe_text(line))));
-                lines.push(input_cursor_line("> ", input));
-            }
-            Popup::Confirm { body, .. } | Popup::Card { body, .. } => {
-                lines.extend(body.iter().map(|line| Line::from(terminal_safe_text(line))))
-            }
-            Popup::Picker {
-                items, selected, ..
-            } => {
-                for (index, item) in items.iter().enumerate() {
-                    let is_selected = index == *selected;
-                    let marker = if is_selected { ">" } else { " " };
-                    let line = Line::from(vec![
-                        Span::raw(format!("{marker} ")),
-                        Span::styled(
-                            shorten(&terminal_safe_text(&item.label), 40),
-                            row_label_style(is_selected, Color::Green),
-                        ),
-                    ]);
-                    lines.push(line);
-                }
-            }
-            // Rendered by `render_image_popup`, not here; `render` routes it away.
-            Popup::Image { .. } => {}
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan))
+            .title(format!(" {} ", terminal_safe_text(popup.title())))
+            .title_style(
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            );
+        let inner = block.inner(rect);
+        frame.render_widget(block, rect);
+        if inner.width == 0 || inner.height == 0 {
+            return;
         }
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
-            popup_hint(popup),
-            Style::default().fg(Color::DarkGray),
-        )));
+        // Body fills the top; the hint is pinned to the last inner row, centered.
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(0), Constraint::Length(1)])
+            .split(inner);
         frame.render_widget(
-            Paragraph::new(lines)
-                .block(
-                    Block::default()
-                        .borders(Borders::ALL)
-                        .border_style(Style::default().fg(Color::Cyan))
-                        .title(terminal_safe_text(popup.title())),
-                )
-                .wrap(Wrap { trim: false }),
-            rect,
+            Paragraph::new(popup_body_lines(popup)).wrap(Wrap { trim: false }),
+            rows[0],
+        );
+        frame.render_widget(
+            Paragraph::new(Line::from(popup_hint_spans(popup_hint(popup)))).centered(),
+            rows[1],
         );
     }
 
@@ -1068,66 +1187,102 @@ impl TuiApp {
                 Constraint::Length(1),
             ])
             .split(area);
-        frame.render_widget(
-            Paragraph::new(group_detail_lines(self.group_detail.as_ref()))
-                .block(panel_block("Group Detail", true))
-                .wrap(Wrap { trim: false }),
-            root[0],
-        );
+        match self.group_detail.as_ref() {
+            Some(view) => frame.render_widget(
+                Paragraph::new(group_detail_lines(Some(view)))
+                    .block(panel_block("Group Detail", true))
+                    .wrap(Wrap { trim: false }),
+                root[0],
+            ),
+            None => {
+                render_loading_screen(frame, root[0], "Group Detail", "loading group detail...")
+            }
+        }
         self.render_hints(frame, root[1]);
         self.render_status_bar(frame, root[2]);
     }
 
     fn render_user_search(&self, frame: &mut Frame) {
         let root = screen_body_layout(frame.area());
-        let lines = self
-            .user_search
-            .as_ref()
-            .map(user_search_lines)
-            .unwrap_or_else(|| vec![Line::from("loading user search...")]);
-        frame.render_widget(
-            Paragraph::new(lines)
-                .block(panel_block("User Search", true))
-                .wrap(Wrap { trim: false }),
-            root[0],
-        );
+        match self.user_search.as_ref() {
+            Some(view) => frame.render_widget(
+                Paragraph::new(user_search_lines(view, self.searching_users.is_some()))
+                    .block(panel_block("User Search", true))
+                    .wrap(Wrap { trim: false }),
+                root[0],
+            ),
+            None => render_loading_screen(frame, root[0], "User Search", "loading user search..."),
+        }
         self.render_hints(frame, root[1]);
         self.render_status_bar(frame, root[2]);
     }
 
     fn render_profile(&self, frame: &mut Frame) {
         let root = screen_body_layout(frame.area());
-        let lines = self
-            .profile_view
-            .as_ref()
-            .map(profile_lines)
-            .unwrap_or_else(|| vec![Line::from("loading profile...")]);
-        frame.render_widget(
-            Paragraph::new(lines)
-                .block(panel_block("Profile", true))
-                .wrap(Wrap { trim: false }),
-            root[0],
-        );
+        match self.profile_view.as_ref() {
+            Some(view) => frame.render_widget(
+                Paragraph::new(profile_lines(view))
+                    .block(panel_block("Profile", true))
+                    .wrap(Wrap { trim: false }),
+                root[0],
+            ),
+            None => render_loading_screen(frame, root[0], "Profile", "loading profile..."),
+        }
         self.render_hints(frame, root[1]);
         self.render_status_bar(frame, root[2]);
     }
 
     fn render_relay_health(&self, frame: &mut Frame) {
         let root = screen_body_layout(frame.area());
-        let (lines, scroll) = match self.relay_health.as_ref() {
-            Some(view) => (relay_health_lines(&view.data), view.scroll),
-            None => (vec![Line::from("loading relay health...")], 0),
-        };
-        frame.render_widget(
-            Paragraph::new(lines)
-                .block(panel_block("Relay Health", true))
-                .wrap(Wrap { trim: false })
-                .scroll((scroll, 0)),
-            root[0],
-        );
+        match self.relay_health.as_ref() {
+            Some(view) => frame.render_widget(
+                Paragraph::new(relay_health_lines(&view.data))
+                    .block(panel_block("Relay Health", true))
+                    .wrap(Wrap { trim: false })
+                    .scroll((view.scroll, 0)),
+                root[0],
+            ),
+            None => {
+                render_loading_screen(frame, root[0], "Relay Health", "loading relay health...")
+            }
+        }
         self.render_hints(frame, root[1]);
         self.render_status_bar(frame, root[2]);
     }
+}
+
+/// Render a single-line notice horizontally centered on the vertical middle row
+/// of `inner`, in `color`. The shared treatment for every pane's loading/empty
+/// state (yellow while a load is in flight, dark gray when genuinely empty). The
+/// text is a trusted static notice.
+fn render_centered_notice(frame: &mut Frame, inner: Rect, text: &str, color: Color) {
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+    let row = Rect {
+        x: inner.x,
+        y: inner.y + inner.height / 2,
+        width: inner.width,
+        height: 1,
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            text.to_owned(),
+            Style::default().fg(color),
+        )))
+        .centered(),
+        row,
+    );
+}
+
+/// Render a full-view screen's panel with a centered yellow in-flight notice —
+/// the shared treatment for a Phase 5 screen whose one-shot load has not landed
+/// yet (its view is still `None`).
+fn render_loading_screen(frame: &mut Frame, area: Rect, title: &str, text: &str) {
+    let block = panel_block(title, true);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    render_centered_notice(frame, inner, text, Color::Yellow);
 }
 
 /// The shared full-view layout: a flexible body row over a one-line hints bar
@@ -1196,7 +1351,7 @@ pub(crate) fn group_detail_lines(view: Option<&GroupDetailView>) -> Vec<Line<'st
             Span::raw(format!("{marker} ")),
             Span::styled(
                 shorten(&terminal_safe_text(&member.npub), 28),
-                row_label_style(is_selected, Color::Green),
+                row_label_style(is_selected, Color::Cyan),
             ),
         ];
         if member.is_admin {
@@ -1219,7 +1374,7 @@ pub(crate) fn group_detail_lines(view: Option<&GroupDetailView>) -> Vec<Line<'st
 /// focus) then the result rows, each showing the display label, a shortened
 /// npub, and the `matched_field · match_quality · radius` attribution. Every
 /// name and npub passes through `terminal_safe_text`.
-pub(crate) fn user_search_lines(view: &UserSearchView) -> Vec<Line<'static>> {
+pub(crate) fn user_search_lines(view: &UserSearchView, searching: bool) -> Vec<Line<'static>> {
     let query_focused = view.focus == UserSearchFocus::Query;
     let mut lines = input_field_lines(
         &view.query.display(),
@@ -1229,10 +1384,14 @@ pub(crate) fn user_search_lines(view: &UserSearchView) -> Vec<Line<'static>> {
     );
     lines.push(Line::from(""));
     if view.results.is_empty() {
-        lines.push(Line::from(Span::styled(
-            "no results — type a query and press Enter",
-            Style::default().fg(Color::DarkGray),
-        )));
+        // Distinguish an in-flight search (yellow) from a settled empty result
+        // (dark gray), keyed off the async search flag.
+        let (text, color) = if searching {
+            ("searching...", Color::Yellow)
+        } else {
+            ("no results — type a query and press Enter", Color::DarkGray)
+        };
+        lines.push(Line::from(Span::styled(text, Style::default().fg(color))));
         return lines;
     }
     lines.push(Line::from(format!("Results ({})", view.results.len())));
@@ -1244,7 +1403,7 @@ pub(crate) fn user_search_lines(view: &UserSearchView) -> Vec<Line<'static>> {
             Span::raw(format!("{marker} ")),
             Span::styled(
                 shorten(&terminal_safe_text(&result.display_label()), 28),
-                row_label_style(is_selected, Color::Green),
+                row_label_style(is_selected, Color::Cyan),
             ),
             Span::styled(
                 format!("  {}", terminal_safe_text(&shorten(&result.npub, 18))),
@@ -1290,7 +1449,7 @@ pub(crate) fn profile_lines(view: &ProfileView) -> Vec<Line<'static>> {
             Span::raw(format!("{marker} ")),
             Span::styled(
                 format!("{}: ", field.label()),
-                row_label_style(is_selected, Color::Green),
+                row_label_style(is_selected, Color::Cyan),
             ),
             value_span,
         ]));
@@ -1304,7 +1463,7 @@ pub(crate) fn profile_lines(view: &ProfileView) -> Vec<Line<'static>> {
             Span::raw(format!("{marker} ")),
             Span::styled(
                 shorten(&terminal_safe_text(follow), 28),
-                row_label_style(is_selected, Color::Green),
+                row_label_style(is_selected, Color::Cyan),
             ),
         ]));
     }

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -1399,7 +1399,7 @@ pub(crate) fn user_search_lines(view: &UserSearchView, searching: bool) -> Vec<L
     for (index, result) in view.results.iter().enumerate() {
         let is_selected = results_focused && index == view.selected;
         let marker = if is_selected { ">" } else { " " };
-        lines.push(Line::from(vec![
+        let mut spans = vec![
             Span::raw(format!("{marker} ")),
             Span::styled(
                 shorten(&terminal_safe_text(&result.display_label()), 28),
@@ -1409,7 +1409,16 @@ pub(crate) fn user_search_lines(view: &UserSearchView, searching: bool) -> Vec<L
                 format!("  {}", terminal_safe_text(&shorten(&result.npub, 18))),
                 Style::default().fg(Color::DarkGray),
             ),
-        ]));
+        ];
+        if result.following {
+            // Passive state, styled like the row's other metadata (dark gray),
+            // not like attention (yellow) or chrome (cyan).
+            spans.push(Span::styled(
+                "  [following]",
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        lines.push(Line::from(spans));
         lines.push(Line::from(Span::styled(
             format!(
                 "    {} · {} · radius {}",

--- a/scripts/check_legacy_naming.sh
+++ b/scripts/check_legacy_naming.sh
@@ -25,6 +25,10 @@ report() {
     fail=1
 }
 
+# `.claude` is local agent tooling, not repo content: worktrees created under it
+# carry full repo checkouts that would re-trip this gate on their own copy of the
+# source. It is globbed out (alongside `.git`) rather than scanned.
+
 # One-word and two-word project-name forms, any case.
 if hits="$(rg --hidden --glob '!.git' --glob '!.claude' -n -i 'dark[- ]?matter' "${HISTORY_EXCLUDES[@]}" . 2>/dev/null)" && [ -n "$hits" ]; then
     report 'darkmatter / dark matter' "$hits"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TUI auto-starts the relay daemon on launch when relay sources are available, with live startup progress/status.
  * Added direct follow/unfollow (`f`/`x`) from highlighted user search results with immediate badge updates.
* **Improvements**
  * Chat previews and media rendering are more responsive, with centered, consistent loading/empty states and off-thread action handling (FIFO queueing, stale-result dropping).
  * Full-size inline images now use bounded, safer viewer behavior with improved teardown.
* **Bug Fixes**
  * Keyboard accelerators require plain keypresses; refined `Esc` navigation and command/draft trimming.
* **Documentation**
  * Updated CLI TUI docs and changelog to reflect new runtime/interaction semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->