### PR TITLE
Persist Unrecoverable across restart until verified repair.

### DIFF
--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -1628,6 +1628,7 @@ fn dummy_group(group_id: GroupId) -> Group {
         required_capabilities: GroupCapabilities::default(),
         protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
         removed: false,
+        unrecoverable: false,
         join_epoch: EpochId(0),
     }
 }

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -235,8 +235,13 @@ impl<S: StorageProvider> Engine<S> {
         // A group that has already entered `Unrecoverable` MUST stop applying
         // group-state changes until a verified repair path
         // (spec/protocol-core/group-state.md:50-51,65). Report the halt and
-        // leave canonical state untouched.
-        if self.epoch_manager.is_unrecoverable(group_id) {
+        // leave canonical state untouched. Sync from the durable marker first
+        // so a restart (or a path that skipped hydration) cannot skip the halt
+        // (mdk#971).
+        if self
+            .sync_unrecoverable_halt_from_storage(group_id)
+            .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?
+        {
             let epoch = self
                 .epoch_manager
                 .epoch(group_id)
@@ -382,11 +387,23 @@ impl<S: StorageProvider> Engine<S> {
         // retained-history.md:30-31 — a required retained state missing inside
         // the rollback horizon MUST report `MissingRetainedAnchor`, leave
         // canonical group state unchanged, and move the group to
-        // `Unrecoverable`. Halt before applying anything.
+        // `Unrecoverable`. Halt before applying anything. Persist the marker
+        // on the group record so process restart cannot silently clear it
+        // (mdk#971).
         if result
             .errors
             .contains(&CanonicalizationError::MissingRetainedAnchor)
         {
+            let mut group = self
+                .storage
+                .get_group(group_id)
+                .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+            if !group.unrecoverable {
+                group.unrecoverable = true;
+                self.storage
+                    .put_group(&group)
+                    .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
+            }
             let previous_state = self
                 .epoch_manager
                 .state(group_id)

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1202,6 +1202,14 @@ impl<S: StorageProvider> Engine<S> {
             ),
         );
         self.audit_group_context(group_id, hydrate_reason);
+        if group.unrecoverable {
+            // The durable lifecycle marker is also an application-facing
+            // repair requirement. Re-emit it on every session open because the
+            // original transition event belonged to the prior process.
+            self.events_buf.push_back(GroupEvent::GroupUnrecoverable {
+                group_id: group_id.clone(),
+            });
+        }
 
         if has_queued_intents || has_convergence_inputs {
             self.schedule_pending_convergence_group(group_id);

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1144,7 +1144,15 @@ impl<S: StorageProvider> Engine<S> {
         // hydration read and validation above has succeeded. If a later step
         // quarantines the group, neither runtime fanout resumption nor direct
         // pending access may observe a half-hydrated lifecycle.
-        if let Some((pending_ref, prior_epoch, message_id, ordering_key, snapshot_name)) =
+        // mdk#971: a durable Unrecoverable halt must survive process restart.
+        // Do not restore PendingPublish or silently `set_stable` over an
+        // unrepaired base — keep ingest/convergence blocked until a verified
+        // repair path clears the marker.
+        let (hydrate_state, hydrate_reason) = if group.unrecoverable {
+            self.epoch_manager
+                .restore_unrecoverable(group_id.clone(), group.epoch);
+            ("unrecoverable", "hydrate_unrecoverable_group")
+        } else if let Some((pending_ref, prior_epoch, message_id, ordering_key, snapshot_name)) =
             pending_recovery
         {
             self.epoch_manager
@@ -1165,10 +1173,11 @@ impl<S: StorageProvider> Engine<S> {
                 ordering_key,
                 snapshot_name,
             );
+            ("pending_publish", "hydrate_stable_group")
         } else {
             self.epoch_manager.set_stable(group_id.clone(), group.epoch);
-        }
-
+            ("stable", "hydrate_stable_group")
+        };
         if let Some(request) = leave_request {
             self.leave_requests.insert(group_id.clone(), request);
             self.leaving_groups.insert(group_id.clone());
@@ -1185,18 +1194,14 @@ impl<S: StorageProvider> Engine<S> {
             group_id,
             crate::audit_helpers::epoch_state_changed_event(
                 None,
-                if restored_pending {
-                    "pending_publish"
-                } else {
-                    "stable"
-                },
+                hydrate_state,
                 group.epoch,
-                "hydrate_stable_group",
+                hydrate_reason,
                 None,
                 None,
             ),
         );
-        self.audit_group_context(group_id, "hydrate_stable_group");
+        self.audit_group_context(group_id, hydrate_reason);
 
         if has_queued_intents || has_convergence_inputs {
             self.schedule_pending_convergence_group(group_id);
@@ -1293,6 +1298,31 @@ impl<S: StorageProvider> Engine<S> {
             Err(StorageError::NotFound) => Ok(false),
             Err(err) => Err(EngineError::Storage(err)),
         }
+    }
+
+    /// Ensure a durable `Unrecoverable` halt is reflected in the in-memory
+    /// epoch map (mdk#971). Returns `true` when the group is halted. Used as
+    /// defense-in-depth on paths that may run before or without session-open
+    /// hydration so a persisted marker cannot be skipped by a bare
+    /// `set_stable` overwrite.
+    pub(crate) fn sync_unrecoverable_halt_from_storage(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<bool, EngineError> {
+        if self.epoch_manager.is_unrecoverable(group_id) {
+            return Ok(true);
+        }
+        let group = match self.storage.get_group(group_id) {
+            Ok(group) => group,
+            Err(StorageError::NotFound) => return Ok(false),
+            Err(err) => return Err(EngineError::Storage(err)),
+        };
+        if !group.unrecoverable {
+            return Ok(false);
+        }
+        self.epoch_manager
+            .restore_unrecoverable(group_id.clone(), group.epoch);
+        Ok(true)
     }
 
     /// Clear ONLY the live OpenMLS group state for `group_id`, leaving every

--- a/crates/cgka-engine/src/epoch_manager.rs
+++ b/crates/cgka-engine/src/epoch_manager.rs
@@ -105,7 +105,18 @@ impl EpochManager {
 
     /// Set a group's state to `Stable { epoch }`. Used by the join-welcome
     /// path (no prior state) and by the merge-to-stable path post-confirm.
+    ///
+    /// Refuses to overwrite `Unrecoverable`: the only legal exit is
+    /// [`Self::repair_to_stable`] after a verified repair path (mdk#971).
     pub(crate) fn set_stable(&mut self, group_id: GroupId, epoch: EpochId) {
+        if self.is_unrecoverable(&group_id) {
+            tracing::warn!(
+                target: "cgka_engine::epoch_manager",
+                method = "set_stable",
+                "refusing set_stable while Unrecoverable; verified repair must use repair_to_stable"
+            );
+            return;
+        }
         self.states.insert(group_id, EpochState::stable(epoch));
     }
 
@@ -335,6 +346,37 @@ impl EpochManager {
             .insert(group_id.clone(), prev.to_unrecoverable());
     }
 
+    /// Restore `Unrecoverable` at a known frozen epoch (session-open hydration
+    /// of a durable halt marker). Overwrites any prior in-memory state for the
+    /// group — the persisted marker is authoritative across restart (mdk#971).
+    pub(crate) fn restore_unrecoverable(&mut self, group_id: GroupId, last_stable_epoch: EpochId) {
+        self.states.insert(
+            group_id,
+            EpochState::stable(last_stable_epoch).to_unrecoverable(),
+        );
+    }
+
+    /// `Unrecoverable → Stable` after a verified repair path (authenticated
+    /// re-join welcome). The only legal exit from `Unrecoverable`.
+    pub(crate) fn repair_to_stable(
+        &mut self,
+        group_id: &GroupId,
+        epoch: EpochId,
+    ) -> Result<(), EngineError> {
+        // Atomic in the state map (mirrors Sm1): fallible transition before
+        // mutating so a non-Unrecoverable prev cannot orphan the entry.
+        let prev = self
+            .states
+            .get(group_id)
+            .cloned()
+            .unwrap_or_else(|| EpochState::stable(EpochId(0)).to_unrecoverable());
+        let new = prev
+            .repair_to_stable(epoch)
+            .map_err(EngineError::InvalidTransition)?;
+        self.states.insert(group_id.clone(), new);
+        Ok(())
+    }
+
     /// Whether the named group is currently `Unrecoverable`.
     pub(crate) fn is_unrecoverable(&self, group_id: &GroupId) -> bool {
         self.states
@@ -507,5 +549,45 @@ mod tests {
             em.we_committed_from(&group_id, EpochId(7)),
             "rollback must not clear the confirmed incumbent's committed_from entry"
         );
+    }
+
+    /// mdk#971: `set_stable` must not silently clear Unrecoverable.
+    #[test]
+    fn set_stable_refuses_while_unrecoverable() {
+        let mut em = EpochManager::new();
+        let group_id = gid();
+        em.set_stable(group_id.clone(), EpochId(4));
+        em.mark_unrecoverable(&group_id);
+        assert!(em.is_unrecoverable(&group_id));
+        em.set_stable(group_id.clone(), EpochId(9));
+        assert!(
+            em.is_unrecoverable(&group_id),
+            "set_stable must leave Unrecoverable intact"
+        );
+        assert_eq!(em.epoch(&group_id), Some(EpochId(4)));
+    }
+
+    /// mdk#971: verified repair is the only Unrecoverable exit.
+    #[test]
+    fn repair_to_stable_exits_unrecoverable() {
+        let mut em = EpochManager::new();
+        let group_id = gid();
+        em.restore_unrecoverable(group_id.clone(), EpochId(4));
+        assert!(em.is_unrecoverable(&group_id));
+        em.repair_to_stable(&group_id, EpochId(5))
+            .expect("repair_to_stable from Unrecoverable");
+        assert_eq!(em.state(&group_id).map(|s| s.name()), Some("Stable"));
+        assert_eq!(em.epoch(&group_id), Some(EpochId(5)));
+        assert!(!em.is_unrecoverable(&group_id));
+    }
+
+    #[test]
+    fn repair_to_stable_rejects_non_unrecoverable_without_orphaning() {
+        let mut em = EpochManager::new();
+        let group_id = gid();
+        em.set_stable(group_id.clone(), EpochId(3));
+        assert!(em.repair_to_stable(&group_id, EpochId(4)).is_err());
+        assert_eq!(em.state(&group_id).map(|s| s.name()), Some("Stable"));
+        assert_eq!(em.epoch(&group_id), Some(EpochId(3)));
     }
 }

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -876,7 +876,7 @@ impl<S: StorageProvider> Engine<S> {
         // live-state clearing, that store, every Marmot post-check, the
         // discoverable group record, capability cache, and both durable
         // Welcome dispositions in one transaction.
-        let (group_id, mls_group, welcome_sender_id) =
+        let (group_id, mls_group, welcome_sender_id, repaired_unrecoverable) =
             self.storage.with_transaction(|storage| {
                 let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, storage.mls_storage());
                 let processed = openmls::group::ProcessedWelcome::new_from_welcome(
@@ -893,25 +893,32 @@ impl<S: StorageProvider> Engine<S> {
                         .to_vec(),
                 );
 
-                let local_state_is_stale = match storage.get_group(&group_id) {
-                    Ok(group) => {
-                        if group
-                            .members
-                            .iter()
-                            .any(|member| &member.id == self.identity.self_id())
-                        {
-                            // A distinct transport/content id does not make a
-                            // second normal Welcome for an already-active group
-                            // a rejoin. Reject before OpenMLS staging and let
-                            // the surrounding transaction restore KeyPackage
-                            // consumption and every tentative write.
-                            return Err(EngineError::WelcomeAlreadyProcessed);
+                let (local_state_is_stale, repaired_unrecoverable) =
+                    match storage.get_group(&group_id) {
+                        Ok(group) => {
+                            let self_is_recorded_member = group
+                                .members
+                                .iter()
+                                .any(|member| &member.id == self.identity.self_id());
+                            if self_is_recorded_member && !group.unrecoverable {
+                                // A distinct transport/content id does not make a
+                                // second normal Welcome for an already-active group
+                                // a rejoin. Reject before OpenMLS staging and let
+                                // the surrounding transaction restore KeyPackage
+                                // consumption and every tentative write.
+                                return Err(EngineError::WelcomeAlreadyProcessed);
+                            }
+                            // Unrecoverable is the explicit exception: a fully
+                            // authenticated replacement Welcome is a protocol-defined
+                            // repair even though the frozen record still lists us as
+                            // a member. The surrounding transaction restores the old
+                            // OpenMLS state and KeyPackage on any later validation
+                            // failure, so clearing the live rows remains tentative.
+                            (true, group.unrecoverable)
                         }
-                        true
-                    }
-                    Err(cgka_traits::storage::StorageError::NotFound) => false,
-                    Err(error) => return Err(EngineError::Storage(error)),
-                };
+                        Err(cgka_traits::storage::StorageError::NotFound) => (false, false),
+                        Err(error) => return Err(EngineError::Storage(error)),
+                    };
                 if local_state_is_stale {
                     self.clear_live_openmls_group_on_storage(storage, &group_id)?;
                 }
@@ -1032,7 +1039,12 @@ impl<S: StorageProvider> Engine<S> {
                 storage.put_ingress_dedup_marker(&welcome_id)?;
                 storage.put_ingress_dedup_marker(&content_id)?;
 
-                Ok::<_, EngineError>((group_id, mls_group, welcome_sender_id))
+                Ok::<_, EngineError>((
+                    group_id,
+                    mls_group,
+                    welcome_sender_id,
+                    repaired_unrecoverable,
+                ))
             })?;
 
         // #740: index this joined group's transport routing id for O(1) inbound
@@ -1050,7 +1062,14 @@ impl<S: StorageProvider> Engine<S> {
         // blind `set_stable` overwrite (mdk#971). The group record written
         // above already clears the durable `unrecoverable` marker.
         let joined_epoch = EpochId(mls_group.epoch().as_u64());
-        let join_reason = if self.epoch_manager.is_unrecoverable(&group_id) {
+        let join_reason = if repaired_unrecoverable {
+            if !self.epoch_manager.is_unrecoverable(&group_id) {
+                // Direct join callers are not required to run session-open
+                // hydration first. Recreate the durable prior state so the
+                // explicit repair transition remains the only exit.
+                self.epoch_manager
+                    .restore_unrecoverable(group_id.clone(), joined_epoch);
+            }
             self.epoch_manager
                 .repair_to_stable(&group_id, joined_epoch)?;
             "join_welcome_repair"

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -467,6 +467,7 @@ impl<S: StorageProvider> Engine<S> {
             required_capabilities: required_caps,
             protocol_profile: self.new_protocol_profile,
             removed: false,
+            unrecoverable: false,
             join_epoch: EpochId(mls_group.epoch().as_u64()),
         };
         if self.new_protocol_profile == ProtocolProfile::Legacy {
@@ -1003,6 +1004,7 @@ impl<S: StorageProvider> Engine<S> {
                         crate::capability_manager::required_capabilities_from_group(&mls_group),
                     protocol_profile,
                     removed: false,
+                    unrecoverable: false,
                     join_epoch: EpochId(mls_group.epoch().as_u64()),
                 };
                 mirror_app_components_into_record(&mls_group, &mut group_record);
@@ -1043,21 +1045,32 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         // 7. State machine: Stable at the post-welcome epoch.
+        // An authenticated Welcome is a verified repair path: if the group was
+        // halted Unrecoverable, exit through `repair_to_stable` rather than a
+        // blind `set_stable` overwrite (mdk#971). The group record written
+        // above already clears the durable `unrecoverable` marker.
         let joined_epoch = EpochId(mls_group.epoch().as_u64());
-        self.epoch_manager
-            .set_stable(group_id.clone(), joined_epoch);
+        let join_reason = if self.epoch_manager.is_unrecoverable(&group_id) {
+            self.epoch_manager
+                .repair_to_stable(&group_id, joined_epoch)?;
+            "join_welcome_repair"
+        } else {
+            self.epoch_manager
+                .set_stable(group_id.clone(), joined_epoch);
+            "join_welcome"
+        };
         self.audit_group(
             &group_id,
             crate::audit_helpers::epoch_state_changed_event(
                 None,
                 "stable",
                 joined_epoch,
-                "join_welcome",
+                join_reason,
                 None,
                 None,
             ),
         );
-        self.audit_group_context(&group_id, "join_welcome");
+        self.audit_group_context(&group_id, join_reason);
 
         // 9. Emit event + register for in-process dedup.
         self.events_buf

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -184,6 +184,11 @@ impl<S: StorageProvider> Engine<S> {
             });
         }
 
+        // mdk#971: sync a durable Unrecoverable halt into memory before the
+        // can_ingest gate so a restart cannot accept group-state changes on an
+        // unrepaired base. Runs before the OpenMLS provider borrow below.
+        let _ = self.sync_unrecoverable_halt_from_storage(&group_id)?;
+
         let mut pending_recovery: Option<(
             EpochId,
             CommitOrderingKey,

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -221,6 +221,17 @@ impl<S: StorageProvider> Engine<S> {
                 },
             ));
         }
+        // mdk#971: durable Unrecoverable halt — sync into memory and refuse
+        // outbound work until a verified repair path clears the marker.
+        if self.sync_unrecoverable_halt_from_storage(&group_id)? {
+            return Err(EngineError::InvalidTransition(
+                cgka_traits::engine_state::InvalidTransition {
+                    from: "Unrecoverable",
+                    to: crate::audit_helpers::send_intent_kind_str(&intent),
+                    reason: "group is Unrecoverable pending verified repair",
+                },
+            ));
+        }
         if !matches!(intent, SendIntent::Leave { .. }) && self.has_leave_send_gate(&group_id)? {
             return Err(EngineError::InvalidTransition(
                 cgka_traits::engine_state::InvalidTransition {

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -256,6 +256,12 @@ impl<S: StorageProvider> Engine<S> {
         // Quarantined groups vanish from every live surface; convergence and
         // queued-intent drains must not touch their state (mdk#364).
         self.ensure_group_live(group_id)?;
+        // A drain can be invoked directly without session-open hydration.
+        // Synchronize the durable halt before convergence or queued work can
+        // run so restart never bypasses `Unrecoverable`.
+        if self.sync_unrecoverable_halt_from_storage(group_id)? {
+            return Ok(Vec::new());
+        }
         // Terminal: a removed copy must never publish, and the removed-copy
         // gate in `do_send_ready` would turn every queued record into a
         // permanent drain error that the app retries forever. Discard the

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -27,6 +27,7 @@ impl<S: StorageProvider> Engine<S> {
         &mut self,
         intent: SendIntent,
     ) -> Result<SendResult, EngineError> {
+        let group_id = super::send_intent_group_id(&intent).clone();
         // A local copy marked removed is terminal for outbound work: the spec
         // forbids preparing/publishing anything for it (member-departure.md,
         // "Realizing removal"), and the underlying OpenMLS state would only
@@ -34,12 +35,24 @@ impl<S: StorageProvider> Engine<S> {
         // here (not just `do_send`) so queued-intent drains hit the same
         // deterministic terminal error. Every intent kind is blocked,
         // including `Leave` — there is nothing left to leave.
-        if self.group_record_is_removed(super::send_intent_group_id(&intent))? {
+        if self.group_record_is_removed(&group_id)? {
             return Err(EngineError::InvalidTransition(
                 cgka_traits::engine_state::InvalidTransition {
                     from: "Removed",
                     to: crate::audit_helpers::send_intent_kind_str(&intent),
                     reason: "local group copy is marked removed (self-evicted)",
+                },
+            ));
+        }
+        // Queued drains call this method directly, bypassing `do_send`.
+        // Recheck the durable lifecycle marker here so no outbound work can
+        // escape an `Unrecoverable` halt after restart.
+        if self.sync_unrecoverable_halt_from_storage(&group_id)? {
+            return Err(EngineError::InvalidTransition(
+                cgka_traits::engine_state::InvalidTransition {
+                    from: "Unrecoverable",
+                    to: crate::audit_helpers::send_intent_kind_str(&intent),
+                    reason: "group is Unrecoverable pending verified repair",
                 },
             ));
         }

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -498,6 +498,7 @@ mod tests {
                 required_capabilities: Default::default(),
                 protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
                 removed: false,
+                unrecoverable: false,
                 join_epoch: EpochId(0),
             })
             .unwrap();

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -2678,6 +2678,154 @@ async fn engine_reports_missing_retained_anchor_without_mutating_late_commit() {
 }
 
 #[tokio::test]
+async fn unrecoverable_halt_survives_engine_restart_until_verified_repair() {
+    // mdk#971: Unrecoverable must persist across restart; hydration must not
+    // silently set_stable over an unrepaired base.
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+    let (mut eve, _eve_storage) = build_client(b"eve");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-unrecoverable-restart".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    carol.set_convergence_policy(CanonicalizationPolicy {
+        convergence: ConvergencePolicy {
+            max_rewind_commits: 1,
+            ..ConvergencePolicy::default()
+        },
+        ..CanonicalizationPolicy::default()
+    });
+
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let alice_invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david_kp],
+        })
+        .await
+        .unwrap();
+    let (alice_commit, _alice_pending) = evolution(alice_invite);
+    let alice_commit = route(alice_commit, &group_id);
+    carol
+        .buffer_openmls_convergence_message(&group_id, alice_commit, 1_000)
+        .expect("alice commit buffered");
+    carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("alice branch applies and retains epoch 1 anchor");
+    carol_storage
+        .release_group_snapshot(&group_id, "openmls-retained-anchor-1")
+        .expect("test removes retained anchor");
+
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let bob_invite = bob
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+        })
+        .await
+        .unwrap();
+    let (bob_commit, _bob_pending) = evolution(bob_invite);
+    let bob_commit = route(bob_commit, &group_id);
+    carol
+        .buffer_openmls_convergence_message(&group_id, bob_commit.clone(), 2_000)
+        .expect("late bob commit buffered");
+
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 3_000_000)
+        .expect("missing retained anchor is reported as a local result");
+    assert_eq!(
+        result.errors,
+        vec![CanonicalizationError::MissingRetainedAnchor]
+    );
+    assert!(
+        carol_storage.get_group(&group_id).unwrap().unrecoverable,
+        "MissingRetainedAnchor must persist Unrecoverable on the group record"
+    );
+    drop(carol);
+
+    let mut restarted = build_client_with_storage(b"carol", carol_storage.clone());
+    restarted
+        .hydrate_stable_groups_from_storage()
+        .expect("session-open hydration succeeds");
+    assert!(
+        carol_storage.get_group(&group_id).unwrap().unrecoverable,
+        "durable Unrecoverable marker must survive restart"
+    );
+
+    let after_restart = restarted
+        .converge_stored_openmls_messages(&group_id, 4_000_000)
+        .expect("convergence on a restarted unrecoverable group is a no-op result");
+    assert_eq!(
+        after_restart.errors,
+        vec![CanonicalizationError::MissingRetainedAnchor]
+    );
+    assert_eq!(after_restart.convergence_status, ConvergenceStatus::Blocked);
+    assert!(after_restart.selected_tip.is_none());
+    assert_eq!(restarted.epoch(&group_id).unwrap(), EpochId(2));
+    assert_message_state(&carol_storage, &bob_commit, MessageState::Created);
+    assert!(
+        !restarted
+            .members(&group_id)
+            .unwrap()
+            .iter()
+            .any(|member| member.id == eve.self_id())
+    );
+
+    let outcome = restarted
+        .ingest(bob_commit.clone())
+        .await
+        .expect("ingest does not error on a restarted unrecoverable group");
+    assert!(
+        matches!(
+            outcome,
+            IngestOutcome::Buffered { .. } | IngestOutcome::Stale { .. }
+        ),
+        "inbound must stay halted after restart; got {outcome:?}"
+    );
+    assert_eq!(restarted.epoch(&group_id).unwrap(), EpochId(2));
+
+    let send_err = restarted
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(&restarted, b"must not send while halted"),
+        })
+        .await
+        .expect_err("send must refuse Unrecoverable after restart");
+    assert!(
+        matches!(
+            send_err,
+            cgka_traits::error::EngineError::InvalidTransition(ref t)
+                if t.from == "Unrecoverable"
+        ),
+        "send must report Unrecoverable; got {send_err:?}"
+    );
+}
+
+#[tokio::test]
 async fn engine_prunes_retained_anchor_snapshots_to_rewind_horizon() {
     let (mut alice, _alice_storage) = build_client(b"alice");
     let (mut carol, carol_storage) = build_client(b"carol");

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -2678,6 +2678,56 @@ async fn engine_reports_missing_retained_anchor_without_mutating_late_commit() {
 }
 
 #[tokio::test]
+async fn durable_unrecoverable_halt_blocks_queued_drain_without_rehydration() {
+    let (mut alice, storage) = build_client(b"alice");
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "queued-unrecoverable".into(),
+            description: String::new(),
+            members: Vec::new(),
+            required_features: Vec::new(),
+            app_components: Vec::new(),
+            initial_admins: Vec::new(),
+        })
+        .await
+        .unwrap();
+    let pending = match create {
+        SendResult::GroupCreated { pending, .. } => pending,
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+
+    storage
+        .put_queued_outbound_intent(&QueuedOutboundIntent {
+            id: MessageId::new(b"queued-before-durable-halt".to_vec()),
+            group_id: group_id.clone(),
+            intent: SendIntent::AppMessage {
+                group_id: group_id.clone(),
+                payload: app_payload_for(&alice, b"must remain queued"),
+            },
+            created_at_ms: 1,
+        })
+        .unwrap();
+    let mut stored_group = storage.get_group(&group_id).unwrap();
+    stored_group.unrecoverable = true;
+    storage.put_group(&stored_group).unwrap();
+
+    let drained = alice
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_000_000)
+        .await
+        .expect("durable halt pauses queued drain");
+    assert!(drained.is_empty());
+    assert_eq!(
+        storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .len(),
+        1,
+        "halted queued work must remain available after verified repair"
+    );
+}
+
+#[tokio::test]
 async fn unrecoverable_halt_survives_engine_restart_until_verified_repair() {
     // mdk#971: Unrecoverable must persist across restart; hydration must not
     // silently set_stable over an unrepaired base.
@@ -2728,7 +2778,8 @@ async fn unrecoverable_halt_survives_engine_restart_until_verified_repair() {
         })
         .await
         .unwrap();
-    let (alice_commit, _alice_pending) = evolution(alice_invite);
+    let (alice_commit, alice_pending) = evolution(alice_invite);
+    alice.confirm_published(alice_pending).await.unwrap();
     let alice_commit = route(alice_commit, &group_id);
     carol
         .buffer_openmls_convergence_message(&group_id, alice_commit, 1_000)
@@ -2771,6 +2822,14 @@ async fn unrecoverable_halt_survives_engine_restart_until_verified_repair() {
     restarted
         .hydrate_stable_groups_from_storage()
         .expect("session-open hydration succeeds");
+    let hydration_events = restarted.drain_events();
+    assert!(
+        hydration_events.iter().any(|event| matches!(
+            event,
+            GroupEvent::GroupUnrecoverable { group_id: halted } if halted == &group_id
+        )),
+        "restart must re-surface the durable repair requirement; got {hydration_events:?}"
+    );
     assert!(
         carol_storage.get_group(&group_id).unwrap().unrecoverable,
         "durable Unrecoverable marker must survive restart"
@@ -2823,6 +2882,57 @@ async fn unrecoverable_halt_survives_engine_restart_until_verified_repair() {
         ),
         "send must report Unrecoverable; got {send_err:?}"
     );
+
+    // A verified replacement Welcome must be able to repair a frozen active
+    // record. Alice removes Carol from the live branch and re-adds her with a
+    // fresh KeyPackage; Carol intentionally never ingests the removal, so her
+    // frozen record still lists herself when the repair Welcome arrives.
+    let repair_kp = restarted.fresh_key_package().await.unwrap();
+    let remove = alice
+        .send(SendIntent::RemoveMembers {
+            group_id: group_id.clone(),
+            members: vec![restarted.self_id()],
+        })
+        .await
+        .unwrap();
+    let (_remove_commit, remove_pending) = evolution(remove);
+    alice.confirm_published(remove_pending).await.unwrap();
+    let readd = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![repair_kp],
+        })
+        .await
+        .unwrap();
+    let (repair_pending, repair_welcome) = match readd {
+        SendResult::GroupEvolution {
+            pending,
+            mut welcomes,
+            ..
+        } => (pending, welcomes.remove(0)),
+        other => panic!("expected repair GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(repair_pending).await.unwrap();
+    restarted
+        .join_welcome(repair_welcome)
+        .await
+        .expect("authenticated replacement Welcome repairs Unrecoverable");
+    assert!(
+        !carol_storage.get_group(&group_id).unwrap().unrecoverable,
+        "verified repair must clear the durable marker"
+    );
+    assert_eq!(
+        restarted.epoch(&group_id).unwrap(),
+        alice.epoch(&group_id).unwrap(),
+        "replacement Welcome must install the verified live state"
+    );
+    restarted
+        .send(SendIntent::AppMessage {
+            group_id,
+            payload: app_payload_for(&restarted, b"send resumes after verified repair"),
+        })
+        .await
+        .expect("verified repair returns the group to Stable");
 }
 
 #[tokio::test]

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -183,6 +183,7 @@ fn insert_marmot_group_without_openmls_state(
             required_capabilities: GroupCapabilities::default(),
             protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
             removed: false,
+            unrecoverable: false,
             join_epoch: EpochId(0),
         })
         .expect("insert marmot group record without openmls state");

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -1448,6 +1448,7 @@ async fn drain_surfaces_hydration_quarantine_without_inbound_delivery() {
                 required_capabilities: GroupCapabilities::default(),
                 protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
                 removed: false,
+                unrecoverable: false,
                 join_epoch: EpochId(0),
             })
             .unwrap();

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -500,6 +500,7 @@ impl AppClient {
             protocol_profile: group.protocol_profile.into(),
             epoch: group.epoch.0,
             member_count: group.members.len(),
+            unrecoverable: group.unrecoverable,
             required_app_components: group
                 .required_capabilities
                 .app_components

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -676,6 +676,7 @@ mod prior_nostr_route_tests {
             required_capabilities: GroupCapabilities::default(),
             protocol_profile: ProtocolProfile::Current,
             removed: false,
+            unrecoverable: false,
             join_epoch: EpochId(0),
         }
     }
@@ -1514,6 +1515,7 @@ mod delete_moderation_grant_tests {
             required_capabilities: Default::default(),
             protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
             removed: false,
+            unrecoverable: false,
             join_epoch: EpochId(0),
         }
     }

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -109,6 +109,11 @@ pub struct AppGroupRecord {
     /// whether it left voluntarily (`Left`) or was removed (`Removed`).
     #[serde(default)]
     pub self_membership: SelfMembership,
+    /// The engine has frozen this local group copy because it cannot safely
+    /// select canonical state from retained material. Sending and applying
+    /// group traffic remain blocked until a verified repair replaces it.
+    #[serde(default)]
+    pub unrecoverable: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub welcomer_account_id_hex: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -145,6 +150,8 @@ pub struct AppGroupMlsState {
     pub protocol_profile: AppProtocolProfile,
     pub epoch: u64,
     pub member_count: usize,
+    #[serde(default)]
+    pub unrecoverable: bool,
     pub required_app_components: Vec<u16>,
 }
 
@@ -441,6 +448,7 @@ impl AppGroupRecord {
             archived: false,
             pending_confirmation: false,
             self_membership: SelfMembership::Member,
+            unrecoverable: false,
             welcomer_account_id_hex: None,
             via_welcome_message_id_hex: None,
         }
@@ -476,6 +484,7 @@ impl AppGroupRecord {
         if let Some(group) = group {
             record.protocol_profile = group.protocol_profile.into();
             record.nostr_routing_last_epoch = group.epoch.0;
+            record.unrecoverable = group.unrecoverable;
         }
         record
     }
@@ -513,6 +522,7 @@ impl AppGroupRecord {
         self.profile = projection.profile.clone();
         if let Some(group) = projection.group_metadata {
             self.protocol_profile = group.protocol_profile.into();
+            self.unrecoverable = group.unrecoverable;
         }
     }
 
@@ -758,6 +768,27 @@ mod prior_nostr_route_tests {
             record.prior_nostr_routes[0].nostr_group_id_hex,
             hex::encode([2u8; 32])
         );
+    }
+
+    #[test]
+    fn refresh_projects_and_clears_unrecoverable_repair_requirement() {
+        let mut record = AppGroupRecord::new(
+            hex::encode([1u8; 16]),
+            routing(1, "wss://relay.example"),
+            "group".to_owned(),
+            String::new(),
+            AppGroupImageInput::default(),
+            AppGroupAdminPolicyComponent::new(Vec::new()),
+            AppGroupMessageRetentionComponent::disabled(),
+        );
+        let mut halted = group(6);
+        halted.unrecoverable = true;
+        record.refresh_from_group(&projection(routing(1, "wss://relay.example"), &halted));
+        assert!(record.unrecoverable);
+
+        let repaired = group(7);
+        record.refresh_from_group(&projection(routing(1, "wss://relay.example"), &repaired));
+        assert!(!record.unrecoverable);
     }
 
     #[test]

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -42,6 +42,8 @@ pub struct AppGroupRecordFfi {
     pub disappearing_message_secs: u64,
     pub archived: bool,
     pub pending_confirmation: bool,
+    /// Whether this local group copy is frozen pending verified repair.
+    pub unrecoverable: bool,
     /// Whether the local account is still a member of this group, and if not,
     /// whether it left voluntarily or was removed.
     pub self_membership: SelfMembershipFfi,
@@ -83,6 +85,7 @@ impl From<AppGroupRecord> for AppGroupRecordFfi {
             disappearing_message_secs,
             archived: value.archived,
             pending_confirmation: value.pending_confirmation,
+            unrecoverable: value.unrecoverable,
             self_membership: value.self_membership.into(),
             welcomer_account_id_hex: value.welcomer_account_id_hex,
             via_welcome_message_id_hex: value.via_welcome_message_id_hex,
@@ -371,6 +374,7 @@ pub struct AppGroupMlsStateFfi {
     pub protocol_profile: AppProtocolProfileFfi,
     pub epoch: u64,
     pub member_count: u32,
+    pub unrecoverable: bool,
     pub required_app_components: Vec<u16>,
 }
 
@@ -381,6 +385,7 @@ impl From<AppGroupMlsState> for AppGroupMlsStateFfi {
             protocol_profile: value.protocol_profile.into(),
             epoch: value.epoch,
             member_count: super::saturating_u32(value.member_count),
+            unrecoverable: value.unrecoverable,
             required_app_components: value.required_app_components,
         }
     }

--- a/crates/marmot-uniffi/src/conversions/mod.rs
+++ b/crates/marmot-uniffi/src/conversions/mod.rs
@@ -89,6 +89,7 @@ mod tests {
             disappearing_message_secs: 0,
             archived: false,
             pending_confirmation: false,
+            unrecoverable: false,
             self_membership: SelfMembershipFfi::Member,
             welcomer_account_id_hex: None,
             via_welcome_message_id_hex: None,

--- a/crates/storage-sqlite/src/storage/test_support.rs
+++ b/crates/storage-sqlite/src/storage/test_support.rs
@@ -40,6 +40,7 @@ pub(crate) fn sample_group(id: GroupId, epoch: u64, members: usize) -> Group {
         required_capabilities: GroupCapabilities::default(),
         protocol_profile: ProtocolProfile::Legacy,
         removed: false,
+        unrecoverable: false,
         join_epoch: EpochId(0),
     }
 }

--- a/crates/traits/src/group.rs
+++ b/crates/traits/src/group.rs
@@ -62,6 +62,17 @@ pub struct Group {
     /// persisted before this field existed.
     #[serde(default)]
     pub removed: bool,
+    /// Local copy cannot safely select a canonical branch from retained
+    /// material (e.g. `MissingRetainedAnchor` inside the rollback horizon).
+    /// Canonical state is frozen; the client MUST stop applying and ingesting
+    /// group-state changes until a verified repair path
+    /// (`spec/protocol-core/group-state.md:54-66`). Persisted so process
+    /// restart cannot silently clear the halt (mdk#971). Clears only through
+    /// an authenticated re-join welcome (or another verified repair that
+    /// rebuilds the group record). Defaults to `false` for records persisted
+    /// before this field existed.
+    #[serde(default)]
+    pub unrecoverable: bool,
     /// Epoch at which this device's membership began (welcome-join or group
     /// creation), refreshed on an authenticated re-join. Post-peel
     /// classification lower bound: an application message whose MLS epoch

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -719,6 +719,7 @@ fn snapshot_group_and_member() {
             required_capabilities: GroupCapabilities::default(),
             protocol_profile: ProtocolProfile::Current,
             removed: false,
+            unrecoverable: false,
             join_epoch: EpochId(2),
         }
     );
@@ -786,4 +787,22 @@ fn snapshot_create_group_request() {
             }
         )
     );
+}
+
+#[test]
+fn unrecoverable_defaults_false_for_old_records() {
+    let legacy: Group = serde_json::from_value(serde_json::json!({
+        "id": [1, 2, 3, 4],
+        "name": "ops",
+        "description": "",
+        "epoch": 1,
+        "members": [],
+        "required_capabilities": {
+            "proposals": [],
+            "extensions": [],
+            "app_components": { "ids": [] }
+        }
+    }))
+    .unwrap();
+    assert!(!legacy.unrecoverable);
 }

--- a/crates/traits/tests/snapshots/snapshots__group.snap
+++ b/crates/traits/tests/snapshots/snapshots__group.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/traits/tests/snapshots.rs
-expression: "Group\n{\n    id: gid(), name: \"ops\".into(), description: \"for ops talk\".into(), epoch:\n    EpochId(3), members: vec![Member { id: mem_id(), credential: vec![], }],\n    required_capabilities: GroupCapabilities::default(), protocol_profile:\n    ProtocolProfile::Current, removed: false, join_epoch: EpochId(2),\n}"
+expression: "Group\n{\n    id: gid(), name: \"ops\".into(), description: \"for ops talk\".into(), epoch:\n    EpochId(3), members: vec![Member { id: mem_id(), credential: vec![], }],\n    required_capabilities: GroupCapabilities::default(), protocol_profile:\n    ProtocolProfile::Current, removed: false, unrecoverable: false, join_epoch: EpochId(2),\n}"
 ---
 {
   "id": [
@@ -33,5 +33,6 @@ expression: "Group\n{\n    id: gid(), name: \"ops\".into(), description: \"for o
   },
   "protocol_profile": "current",
   "removed": false,
+  "unrecoverable": false,
   "join_epoch": 2
 }


### PR DESCRIPTION
MissingRetainedAnchor freezes a group in Unrecoverable, but that halt lived only in EpochManager memory so hydration's set_stable silently reactivated an unrepaired base after restart. Persist the marker on Group, restore it on hydrate, refuse set_stable overwrite, and exit only via repair_to_stable on an authenticated re-join. fixes #971.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unrecoverable group halts now persist across restarts and reliably block unsafe inbound and outbound activity.
  * Added verified repair handling to restore groups to a stable state after a successful rejoin.
  * Prevented stable-state updates from accidentally clearing an unrecoverable halt.
  * Existing records without the new status now default safely to recoverable.

* **Tests**
  * Added regression coverage for restart persistence, activity blocking, repair flows, and legacy record compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->