### PR TITLE
fix(engine): pin convergence policy to the adopted v1 baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,9 @@ jobs:
       - name: Run clippy with all features
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
-  # Ordinary cargo/nextest keeps debug_assertions, so the
-  # `#[cfg(not(debug_assertions))]` convergence-policy pin (mdk#970) is
-  # otherwise unexecuted. This job rebuilds the focused binary with
-  # assertions disabled and runs the production reject path.
+  # The broader integration matrix explicitly enables test-policy-overrides.
+  # This focused default-feature job proves ordinary debug/release consumers
+  # reject every non-v1 convergence policy (mdk#970).
   convergence-policy-pin:
     name: Convergence policy pin (release assertions)
     runs-on: ubuntu-latest
@@ -132,9 +131,9 @@ jobs:
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      - name: Run release-mode convergence policy pin tests
+      - name: Run default-build convergence policy pin tests
         # Keep in sync with `just test-convergence-policy-pin`.
-        run: RUSTFLAGS='-C debug-assertions=off' cargo test -p cgka-engine --test convergence_policy_pin --locked
+        run: cargo test -p cgka-engine --test convergence_policy_pin --locked
 
   rust-test:
     name: Rust tests (${{ matrix.partition }}/4)
@@ -170,7 +169,7 @@ jobs:
         # The subprocess-heavy `wn-cli::cli` suite runs in its own
         # `cli-e2e` job so its fan-out never starves these fast unit tests
         # (issue #103). `relay_runtime` keeps its own serial job.
-        run: cargo nextest run --workspace --exclude cgka-conformance-simulator --locked --profile ci --partition count:${{ matrix.partition }}/4 -E 'not (package(marmot-app) & binary(relay_runtime)) and not (package(wn-cli) & binary(cli))'
+        run: cargo nextest run --workspace --exclude cgka-conformance-simulator --features wn-cli/test-policy-overrides --locked --profile ci --partition count:${{ matrix.partition }}/4 -E 'not (package(marmot-app) & binary(relay_runtime)) and not (package(wn-cli) & binary(cli))'
 
       - name: Run doctests
         if: matrix.partition == 1
@@ -207,7 +206,7 @@ jobs:
         # test-group and the `ci` profile adds retries + a hung-test backstop.
         # The real-relay test self-skips here; it has its own `Relay CLI E2E`
         # job with a docker relay stack.
-        run: cargo nextest run -p wn-cli --test cli --locked --profile ci
+        run: cargo nextest run -p wn-cli --test cli --features test-policy-overrides --locked --profile ci
 
   relay-runtime:
     name: Relay runtime tests
@@ -233,7 +232,7 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run relay runtime tests serially
-        run: cargo test -p marmot-app --test relay_runtime --locked -- --test-threads=1
+        run: cargo test -p marmot-app --test relay_runtime --features test-policy-overrides --locked -- --test-threads=1
 
   relay-e2e:
     name: Relay CLI E2E
@@ -272,7 +271,7 @@ jobs:
       - name: Run real relay CLI E2E
         env:
           MDK_E2E_REQUIRE_RELAYS: "1"
-        run: cargo nextest run -p wn-cli --test cli --locked --profile ci -E 'test(=real_local_relays_deliver_cli_messages_over_sdk_path)'
+        run: cargo nextest run -p wn-cli --test cli --features test-policy-overrides --locked --profile ci -E 'test(=real_local_relays_deliver_cli_messages_over_sdk_path)'
 
       - name: Dump local relay logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,37 @@ jobs:
       - name: Run clippy with all features
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
+  # Ordinary cargo/nextest keeps debug_assertions, so the
+  # `#[cfg(not(debug_assertions))]` convergence-policy pin (mdk#970) is
+  # otherwise unexecuted. This job rebuilds the focused binary with
+  # assertions disabled and runs the production reject path.
+  convergence-policy-pin:
+    name: Convergence policy pin (release assertions)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: |
+          set -euo pipefail
+          toolchain="$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)"
+          rustup toolchain install "$toolchain" --profile minimal
+          rustup default "$toolchain"
+          rustc --version
+          cargo --version
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Run release-mode convergence policy pin tests
+        # Keep in sync with `just test-convergence-policy-pin`.
+        run: RUSTFLAGS='-C debug-assertions=off' cargo test -p cgka-engine --test convergence_policy_pin --locked
+
   rust-test:
     name: Rust tests (${{ matrix.partition }}/4)
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -290,8 +290,14 @@ dead-code-audit:
 naming-gate:
     ./scripts/check_legacy_naming.sh
 
-# Fast local pre-push gate: mechanical/static checks only. GitHub CI runs the
-# full `just ci` suite (including the workspace test matrix).
-fast-ci: fmt-check naming-gate check clippy
+# Prove the release-mode convergence policy pin (mdk#970). Ordinary
+# `cargo test` keeps debug_assertions, so the `#[cfg(not(debug_assertions))]`
+# reject path is otherwise unexecuted; this recipe disables them.
+test-convergence-policy-pin:
+    RUSTFLAGS='-C debug-assertions=off' cargo test -p cgka-engine --test convergence_policy_pin --locked
 
-ci: fmt-check naming-gate check clippy test
+# Fast local pre-push gate: mechanical/static checks plus the release pin proof.
+# GitHub CI runs the full `just ci` suite (including the workspace test matrix).
+fast-ci: fmt-check naming-gate check clippy test-convergence-policy-pin
+
+ci: fmt-check naming-gate check clippy test-convergence-policy-pin test

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,7 @@
 set shell := ["bash", "-cu"]
 
 otlp-features := "marmot-app/otlp-export,marmot-uniffi/otlp-export,wn-cli/otlp-export"
+test-features := "wn-cli/test-policy-overrides"
 
 default:
     @just --list
@@ -38,11 +39,11 @@ clippy-otlp:
 test: test-default test-otlp
 
 test-default:
-    cargo nextest run --workspace
+    cargo nextest run --workspace --features {{test-features}}
     cargo test --workspace --doc
 
 test-otlp:
-    cargo nextest run --workspace --features {{otlp-features}}
+    cargo nextest run --workspace --features {{otlp-features}},{{test-features}}
 
 relay-up:
     docker compose up -d
@@ -233,9 +234,9 @@ e2e-test test="":
     #!/usr/bin/env bash
     set -euo pipefail
     if [ -z "{{test}}" ]; then
-        MDK_E2E_REQUIRE_RELAYS=1 cargo nextest run -p wn-cli --test cli -E 'test(=real_local_relays_deliver_cli_messages_over_sdk_path)'
+        MDK_E2E_REQUIRE_RELAYS=1 cargo nextest run -p wn-cli --test cli --features test-policy-overrides -E 'test(=real_local_relays_deliver_cli_messages_over_sdk_path)'
     else
-        MDK_E2E_REQUIRE_RELAYS=1 cargo nextest run -p wn-cli --test cli "{{test}}"
+        MDK_E2E_REQUIRE_RELAYS=1 cargo nextest run -p wn-cli --test cli --features test-policy-overrides "{{test}}"
     fi
 
 conformance:
@@ -290,11 +291,10 @@ dead-code-audit:
 naming-gate:
     ./scripts/check_legacy_naming.sh
 
-# Prove the release-mode convergence policy pin (mdk#970). Ordinary
-# `cargo test` keeps debug_assertions, so the `#[cfg(not(debug_assertions))]`
-# reject path is otherwise unexecuted; this recipe disables them.
+# Prove the normal-build convergence policy pin (mdk#970). The broader test
+# matrix explicitly enables test-policy-overrides; this target must not.
 test-convergence-policy-pin:
-    RUSTFLAGS='-C debug-assertions=off' cargo test -p cgka-engine --test convergence_policy_pin --locked
+    cargo test -p cgka-engine --test convergence_policy_pin --locked
 
 # Fast local pre-push gate: mechanical/static checks plus the release pin proof.
 # GitHub CI runs the full `just ci` suite (including the workspace test matrix).

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -733,8 +733,12 @@ impl HarnessClient {
     }
 
     /// Override the engine-wide convergence policy (quiescence window, etc.).
+    ///
+    /// Debug/test harness escape hatch; release builds reject non-v1 policies.
     pub fn set_convergence_policy(&mut self, policy: CanonicalizationPolicy) {
-        self.engine.set_convergence_policy(policy);
+        self.engine
+            .set_convergence_policy(policy)
+            .expect("convergence policy accepted");
     }
 
     /// Run the same convergence entry point the app uses after a scheduled

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -6,6 +6,12 @@ license.workspace = true
 publish.workspace = true
 description = "OpenMLS-backed CGKA engine implementation."
 
+[features]
+default = []
+# Explicit escape hatch for engine/session integration tests that need custom
+# settlement or rewind policies. Production/app consumers must not enable it.
+test-policy-overrides = []
+
 [dependencies]
 cgka-traits.workspace = true
 openmls.workspace = true

--- a/crates/cgka-engine/src/canonicalization.rs
+++ b/crates/cgka-engine/src/canonicalization.rs
@@ -97,15 +97,15 @@ impl CanonicalizationPolicy {
     /// Same acceptance contract as engine setters and session open (mdk#970).
     ///
     /// Always enforces the witness-override bound and app-window alignment.
-    /// Release builds also require the pinned v1 baseline; debug harnesses may
-    /// override for settlement/rewind probes.
+    /// Normal builds also require the pinned v1 baseline. Only test harnesses
+    /// built with the explicit `test-policy-overrides` feature may override it.
     pub fn ensure_acceptable(
         &self,
         max_past_epochs: usize,
     ) -> Result<(), CanonicalizationPolicyError> {
         self.validate()?;
         self.ensure_app_window_matches(max_past_epochs)?;
-        #[cfg(not(debug_assertions))]
+        #[cfg(not(feature = "test-policy-overrides"))]
         if !self.is_pinned_v1() {
             return Err(CanonicalizationPolicyError::NotPinnedV1);
         }

--- a/crates/cgka-engine/src/canonicalization.rs
+++ b/crates/cgka-engine/src/canonicalization.rs
@@ -93,6 +93,24 @@ impl CanonicalizationPolicy {
         }
         Ok(())
     }
+
+    /// Same acceptance contract as engine setters and session open (mdk#970).
+    ///
+    /// Always enforces the witness-override bound and app-window alignment.
+    /// Release builds also require the pinned v1 baseline; debug harnesses may
+    /// override for settlement/rewind probes.
+    pub fn ensure_acceptable(
+        &self,
+        max_past_epochs: usize,
+    ) -> Result<(), CanonicalizationPolicyError> {
+        self.validate()?;
+        self.ensure_app_window_matches(max_past_epochs)?;
+        #[cfg(not(debug_assertions))]
+        if !self.is_pinned_v1() {
+            return Err(CanonicalizationPolicyError::NotPinnedV1);
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1060,6 +1078,26 @@ mod witness_window_tests {
                 app_message_past_epoch_limit: V1_APP_MESSAGE_PAST_EPOCH_LIMIT,
                 max_past_epochs: 1,
             })
+        );
+    }
+
+    #[test]
+    fn ensure_acceptable_requires_app_window_alignment() {
+        let policy = CanonicalizationPolicy {
+            app_message_past_epoch_limit: 1,
+            ..CanonicalizationPolicy::default()
+        };
+        assert_eq!(
+            policy.ensure_acceptable(V1_APP_MESSAGE_PAST_EPOCH_LIMIT as usize),
+            Err(CanonicalizationPolicyError::AppWindowMismatch {
+                app_message_past_epoch_limit: 1,
+                max_past_epochs: V1_APP_MESSAGE_PAST_EPOCH_LIMIT,
+            })
+        );
+        assert!(
+            CanonicalizationPolicy::default()
+                .ensure_acceptable(V1_APP_MESSAGE_PAST_EPOCH_LIMIT as usize)
+                .is_ok()
         );
     }
 

--- a/crates/cgka-engine/src/canonicalization.rs
+++ b/crates/cgka-engine/src/canonicalization.rs
@@ -7,11 +7,19 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::convergence::{
-    AppWitness, BranchCandidate, BranchSelectionTrace, ConvergencePolicy, is_branch_eligible,
-    select_canonical_branch, select_canonical_branch_traced,
+    AppWitness, BranchCandidate, BranchSelectionTrace, ConvergencePolicy, ConvergencePolicyError,
+    is_branch_eligible, select_canonical_branch, select_canonical_branch_traced,
 };
 use cgka_traits::engine::CommitOrderingPriority;
 use serde::{Deserialize, Serialize};
+
+/// Adopted v1 app-message past-epoch delivery/decrypt window.
+///
+/// Must stay equal to [`crate::wire_format::DEFAULT_MAX_PAST_EPOCHS`] — the MLS
+/// past-epoch window — so witness and delivery horizons cannot diverge.
+pub const V1_APP_MESSAGE_PAST_EPOCH_LIMIT: u64 = 5;
+/// Adopted v1 settlement quiescence window, in milliseconds.
+pub const V1_SETTLEMENT_QUIESCENCE_MS: u64 = 1_000;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CanonicalizationPolicy {
@@ -24,17 +32,66 @@ impl Default for CanonicalizationPolicy {
     fn default() -> Self {
         Self {
             convergence: ConvergencePolicy::default(),
-            app_message_past_epoch_limit: 5,
-            settlement_quiescence_ms: 1_000,
+            app_message_past_epoch_limit: V1_APP_MESSAGE_PAST_EPOCH_LIMIT,
+            settlement_quiescence_ms: V1_SETTLEMENT_QUIESCENCE_MS,
         }
     }
+}
+
+/// Validation errors for a [`CanonicalizationPolicy`].
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum CanonicalizationPolicyError {
+    #[error(transparent)]
+    Convergence(#[from] ConvergencePolicyError),
+    /// Policy differs from the adopted v1 baseline. Until a negotiation mechanism
+    /// exists behind a required capability, every client MUST use exactly those
+    /// pinned constants — not a local preference or per-group override.
+    #[error("convergence policy must equal the pinned v1 baseline")]
+    NotPinnedV1,
+    /// App-message window disagrees with the engine's MLS `max_past_epochs`.
+    #[error(
+        "app_message_past_epoch_limit ({app_message_past_epoch_limit}) must equal \
+         engine max_past_epochs ({max_past_epochs})"
+    )]
+    AppWindowMismatch {
+        app_message_past_epoch_limit: u64,
+        max_past_epochs: u64,
+    },
 }
 
 impl CanonicalizationPolicy {
     /// Validate the nested convergence policy bounds. See
     /// [`ConvergencePolicy::validate`](crate::convergence::ConvergencePolicy::validate).
-    pub fn validate(&self) -> Result<(), crate::convergence::ConvergencePolicyError> {
+    pub fn validate(&self) -> Result<(), ConvergencePolicyError> {
         self.convergence.validate()
+    }
+
+    /// Exact equality with the adopted convergence-policy v1 constants.
+    pub fn is_pinned_v1(&self) -> bool {
+        self == &Self::default()
+    }
+
+    /// Fail closed unless this policy is exactly the adopted v1 baseline.
+    pub fn ensure_pinned_v1(&self) -> Result<(), CanonicalizationPolicyError> {
+        self.validate()?;
+        if !self.is_pinned_v1() {
+            return Err(CanonicalizationPolicyError::NotPinnedV1);
+        }
+        Ok(())
+    }
+
+    /// Keep the app-message delivery window aligned with MLS past-epoch decryptability.
+    pub fn ensure_app_window_matches(
+        &self,
+        max_past_epochs: usize,
+    ) -> Result<(), CanonicalizationPolicyError> {
+        if self.app_message_past_epoch_limit != max_past_epochs as u64 {
+            return Err(CanonicalizationPolicyError::AppWindowMismatch {
+                app_message_past_epoch_limit: self.app_message_past_epoch_limit,
+                max_past_epochs: max_past_epochs as u64,
+            });
+        }
+        Ok(())
     }
 }
 
@@ -961,18 +1018,48 @@ mod witness_window_tests {
 
     #[test]
     fn v1_default_policy_constants_are_pinned() {
+        use crate::convergence::{
+            V1_MAX_REWIND_COMMITS, V1_MAX_WITNESS_OVERRIDE_DEPTH, V1_WITNESS_QUORUM_EPOCHS,
+            V1_WITNESS_QUORUM_SENDERS_PER_EPOCH,
+        };
         assert_eq!(
             CanonicalizationPolicy::default(),
             CanonicalizationPolicy {
                 convergence: ConvergencePolicy {
-                    max_rewind_commits: 5,
-                    witness_quorum_senders_per_epoch: 2,
-                    witness_quorum_epochs: 1,
-                    max_witness_override_depth: 1,
+                    max_rewind_commits: V1_MAX_REWIND_COMMITS,
+                    witness_quorum_senders_per_epoch: V1_WITNESS_QUORUM_SENDERS_PER_EPOCH,
+                    witness_quorum_epochs: V1_WITNESS_QUORUM_EPOCHS,
+                    max_witness_override_depth: V1_MAX_WITNESS_OVERRIDE_DEPTH,
                 },
-                app_message_past_epoch_limit: 5,
-                settlement_quiescence_ms: 1_000,
+                app_message_past_epoch_limit: V1_APP_MESSAGE_PAST_EPOCH_LIMIT,
+                settlement_quiescence_ms: V1_SETTLEMENT_QUIESCENCE_MS,
             }
+        );
+        assert!(CanonicalizationPolicy::default().ensure_pinned_v1().is_ok());
+        assert_eq!(
+            CanonicalizationPolicy {
+                settlement_quiescence_ms: 0,
+                ..CanonicalizationPolicy::default()
+            }
+            .ensure_pinned_v1(),
+            Err(CanonicalizationPolicyError::NotPinnedV1)
+        );
+    }
+
+    #[test]
+    fn app_message_window_must_match_engine_max_past_epochs() {
+        let policy = CanonicalizationPolicy::default();
+        assert!(
+            policy
+                .ensure_app_window_matches(V1_APP_MESSAGE_PAST_EPOCH_LIMIT as usize)
+                .is_ok()
+        );
+        assert_eq!(
+            policy.ensure_app_window_matches(1),
+            Err(CanonicalizationPolicyError::AppWindowMismatch {
+                app_message_past_epoch_limit: V1_APP_MESSAGE_PAST_EPOCH_LIMIT,
+                max_past_epochs: 1,
+            })
         );
     }
 

--- a/crates/cgka-engine/src/convergence.rs
+++ b/crates/cgka-engine/src/convergence.rs
@@ -10,6 +10,15 @@ use std::collections::{BTreeMap, BTreeSet};
 use cgka_traits::engine::CommitOrderingPriority;
 use serde::{Deserialize, Serialize};
 
+/// Adopted convergence-policy v1 rewind horizon (protocol-core/convergence.md).
+pub const V1_MAX_REWIND_COMMITS: u64 = 5;
+/// Adopted v1 distinct-sender count required for witness quorum in an epoch.
+pub const V1_WITNESS_QUORUM_SENDERS_PER_EPOCH: usize = 2;
+/// Adopted v1 number of branch epochs that must meet witness quorum.
+pub const V1_WITNESS_QUORUM_EPOCHS: usize = 1;
+/// Adopted v1 bound on the witness-quorum effective-depth boost.
+pub const V1_MAX_WITNESS_OVERRIDE_DEPTH: u64 = 1;
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConvergencePolicy {
     pub max_rewind_commits: u64,
@@ -21,10 +30,10 @@ pub struct ConvergencePolicy {
 impl Default for ConvergencePolicy {
     fn default() -> Self {
         Self {
-            max_rewind_commits: 5,
-            witness_quorum_senders_per_epoch: 2,
-            witness_quorum_epochs: 1,
-            max_witness_override_depth: 1,
+            max_rewind_commits: V1_MAX_REWIND_COMMITS,
+            witness_quorum_senders_per_epoch: V1_WITNESS_QUORUM_SENDERS_PER_EPOCH,
+            witness_quorum_epochs: V1_WITNESS_QUORUM_EPOCHS,
+            max_witness_override_depth: V1_MAX_WITNESS_OVERRIDE_DEPTH,
         }
     }
 }

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -79,20 +79,33 @@ fn convergence_run_context(run_id: &str, phase: ConvergencePhase) -> AuditEventC
 type ReorgComponentSnapshot = (Vec<[u8; 32]>, [Option<Vec<u8>>; 2], Option<u64>);
 
 impl<S: StorageProvider> Engine<S> {
-    pub fn set_convergence_policy(&mut self, policy: CanonicalizationPolicy) {
+    /// Install the process-wide convergence policy.
+    ///
+    /// Release builds accept only the pinned v1 baseline. Debug/test builds may
+    /// override for harnesses (instant settlement, rewind probes), but still
+    /// require the witness-override bound and
+    /// `app_message_past_epoch_limit == max_past_epochs`.
+    pub fn set_convergence_policy(
+        &mut self,
+        policy: CanonicalizationPolicy,
+    ) -> Result<(), OpenMlsProjectionError> {
+        self.accept_convergence_policy(&policy)?;
         self.convergence_policy = policy;
         self.audit_engine_context();
+        Ok(())
     }
 
+    /// Persist a per-group convergence policy.
+    ///
+    /// Same acceptance rules as [`Self::set_convergence_policy`]. Under v1 the
+    /// policy is not group-negotiated; release builds reject any non-baseline
+    /// value so a stored override cannot fork honest clients.
     pub fn set_group_convergence_policy(
         &mut self,
         group_id: &GroupId,
         policy: CanonicalizationPolicy,
     ) -> Result<(), OpenMlsProjectionError> {
-        // Fail fast: never persist a policy that violates the witness-override bound.
-        policy
-            .validate()
-            .map_err(|e| OpenMlsProjectionError::InvalidPolicy(e.to_string()))?;
+        self.accept_convergence_policy(&policy)?;
         self.storage
             .put_convergence_policy(group_id, &encode_convergence_policy(&policy)?)
             .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
@@ -107,6 +120,28 @@ impl<S: StorageProvider> Engine<S> {
                 context,
             },
         );
+        Ok(())
+    }
+
+    /// Fail closed before a policy can drive branch selection or be persisted.
+    fn accept_convergence_policy(
+        &self,
+        policy: &CanonicalizationPolicy,
+    ) -> Result<(), OpenMlsProjectionError> {
+        policy
+            .validate()
+            .map_err(|e| OpenMlsProjectionError::InvalidPolicy(e.to_string()))?;
+        policy
+            .ensure_app_window_matches(self.max_past_epochs)
+            .map_err(|e| OpenMlsProjectionError::InvalidPolicy(e.to_string()))?;
+        // Release builds may only run the pinned v1 baseline. Debug harnesses may
+        // override for deterministic settlement / rewind-horizon probes (mdk#970).
+        #[cfg(not(debug_assertions))]
+        if !policy.is_pinned_v1() {
+            return Err(OpenMlsProjectionError::InvalidPolicy(
+                crate::canonicalization::CanonicalizationPolicyError::NotPinnedV1.to_string(),
+            ));
+        }
         Ok(())
     }
 
@@ -145,12 +180,12 @@ impl<S: StorageProvider> Engine<S> {
             // `set_convergence_policy` fails closed at read rather than driving
             // branch selection.
             let policy = self.convergence_policy.clone();
-            policy
-                .validate()
-                .map_err(|e| OpenMlsProjectionError::InvalidPolicy(e.to_string()))?;
+            self.accept_convergence_policy(&policy)?;
             return Ok(policy);
         };
-        decode_convergence_policy(&policy_bytes)
+        let policy = decode_convergence_policy(&policy_bytes)?;
+        self.accept_convergence_policy(&policy)?;
+        Ok(policy)
     }
 
     pub(crate) fn retain_current_epoch_snapshot_for_group(

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -255,12 +255,38 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         now_ms: u64,
     ) -> Result<CanonicalizationResult, OpenMlsProjectionError> {
+        // A hydration-quarantined group is frozen until explicit repair: no
+        // canonicalization pass may read or mutate its state, and no
+        // set_stable may re-activate it out of band (mdk#364). Check this
+        // before syncing a durable Unrecoverable halt into memory so the
+        // quarantine path cannot mutate `epoch_manager`. Report a blocked run
+        // and leave everything untouched; retained inputs replay once repair
+        // clears the quarantine (hydration then restores any durable halt).
+        if self.quarantined_reason(group_id).is_some() {
+            let epoch = self
+                .epoch_manager
+                .epoch(group_id)
+                .map(|e| e.0)
+                .unwrap_or_default();
+            self.audit_group(
+                group_id,
+                marmot_forensics::AuditEventKind::ConvergenceRunState {
+                    phase: ConvergencePhase::Blocked,
+                    current_tip_epoch: Some(epoch),
+                    retained_anchor_horizon: None,
+                    reason: Some("group_quarantined".to_string()),
+                    error_kind: None,
+                },
+            );
+            return Ok(quarantined_result(epoch));
+        }
+
         // A group that has already entered `Unrecoverable` MUST stop applying
         // group-state changes until a verified repair path
         // (spec/protocol-core/group-state.md:50-51,65). Report the halt and
-        // leave canonical state untouched. Sync from the durable marker first
-        // so a restart (or a path that skipped hydration) cannot skip the halt
-        // (mdk#971).
+        // leave canonical state untouched. Sync from the durable marker so a
+        // restart (or a path that skipped hydration) cannot skip the halt
+        // (mdk#971). Only reached for non-quarantined groups.
         if self
             .sync_unrecoverable_halt_from_storage(group_id)
             .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?
@@ -281,30 +307,6 @@ impl<S: StorageProvider> Engine<S> {
                 },
             );
             return Ok(unrecoverable_result(epoch));
-        }
-
-        // A hydration-quarantined group is frozen until explicit repair: no
-        // canonicalization pass may read or mutate its state, and no
-        // set_stable may re-activate it out of band (mdk#364). Report a
-        // blocked run and leave everything untouched; retained inputs replay
-        // once repair clears the quarantine.
-        if self.quarantined_reason(group_id).is_some() {
-            let epoch = self
-                .epoch_manager
-                .epoch(group_id)
-                .map(|e| e.0)
-                .unwrap_or_default();
-            self.audit_group(
-                group_id,
-                marmot_forensics::AuditEventKind::ConvergenceRunState {
-                    phase: ConvergencePhase::Blocked,
-                    current_tip_epoch: Some(epoch),
-                    retained_anchor_horizon: None,
-                    reason: Some("group_quarantined".to_string()),
-                    error_kind: None,
-                },
-            );
-            return Ok(quarantined_result(epoch));
         }
 
         let previous_group = self

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -129,20 +129,8 @@ impl<S: StorageProvider> Engine<S> {
         policy: &CanonicalizationPolicy,
     ) -> Result<(), OpenMlsProjectionError> {
         policy
-            .validate()
-            .map_err(|e| OpenMlsProjectionError::InvalidPolicy(e.to_string()))?;
-        policy
-            .ensure_app_window_matches(self.max_past_epochs)
-            .map_err(|e| OpenMlsProjectionError::InvalidPolicy(e.to_string()))?;
-        // Release builds may only run the pinned v1 baseline. Debug harnesses may
-        // override for deterministic settlement / rewind-horizon probes (mdk#970).
-        #[cfg(not(debug_assertions))]
-        if !policy.is_pinned_v1() {
-            return Err(OpenMlsProjectionError::InvalidPolicy(
-                crate::canonicalization::CanonicalizationPolicyError::NotPinnedV1.to_string(),
-            ));
-        }
-        Ok(())
+            .ensure_acceptable(self.max_past_epochs)
+            .map_err(|e| OpenMlsProjectionError::InvalidPolicy(e.to_string()))
     }
 
     /// Hex-encoded `seen_message_ids` snapshot for the convergence

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -81,9 +81,9 @@ type ReorgComponentSnapshot = (Vec<[u8; 32]>, [Option<Vec<u8>>; 2], Option<u64>)
 impl<S: StorageProvider> Engine<S> {
     /// Install the process-wide convergence policy.
     ///
-    /// Release builds accept only the pinned v1 baseline. Debug/test builds may
-    /// override for harnesses (instant settlement, rewind probes), but still
-    /// require the witness-override bound and
+    /// Normal builds accept only the pinned v1 baseline. Test harnesses built
+    /// with `test-policy-overrides` may override it for instant settlement and
+    /// rewind probes, but still require the witness-override bound and
     /// `app_message_past_epoch_limit == max_past_epochs`.
     pub fn set_convergence_policy(
         &mut self,
@@ -98,7 +98,7 @@ impl<S: StorageProvider> Engine<S> {
     /// Persist a per-group convergence policy.
     ///
     /// Same acceptance rules as [`Self::set_convergence_policy`]. Under v1 the
-    /// policy is not group-negotiated; release builds reject any non-baseline
+    /// policy is not group-negotiated; normal builds reject any non-baseline
     /// value so a stored override cannot fork honest clients.
     pub fn set_group_convergence_policy(
         &mut self,

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -155,7 +155,10 @@ impl<S: StorageProvider> Engine<S> {
         snapshot
     }
 
-    pub(crate) fn convergence_policy_for_group(
+    /// Load and accept the group's convergence policy without the live-group
+    /// gate. Used by hydration while a group is still quarantined (it must
+    /// inspect pending convergence work before clearing quarantine).
+    pub(crate) fn convergence_policy_for_group_ungated(
         &self,
         group_id: &GroupId,
     ) -> Result<CanonicalizationPolicy, OpenMlsProjectionError> {
@@ -176,13 +179,37 @@ impl<S: StorageProvider> Engine<S> {
         Ok(policy)
     }
 
+    pub(crate) fn convergence_policy_for_group(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<CanonicalizationPolicy, OpenMlsProjectionError> {
+        // Quarantined groups are hidden from every live surface (mdk#364): do
+        // not read or return a default/stored policy that could drive rewind
+        // retention or branch selection.
+        self.ensure_group_live(group_id).map_err(|e| match e {
+            cgka_traits::error::EngineError::UnknownGroup(_) => {
+                OpenMlsProjectionError::MissingGroup
+            }
+            other => OpenMlsProjectionError::Storage(format!("{other}")),
+        })?;
+        self.convergence_policy_for_group_ungated(group_id)
+    }
+
     pub(crate) fn retain_current_epoch_snapshot_for_group(
         &self,
         group_id: &GroupId,
     ) -> Result<(), cgka_traits::error::EngineError> {
-        let policy = self.convergence_policy_for_group(group_id).map_err(|e| {
-            cgka_traits::error::EngineError::Backend(format!("load convergence policy: {e}"))
-        })?;
+        let policy = self
+            .convergence_policy_for_group(group_id)
+            .map_err(|e| match e {
+                // `convergence_policy_for_group` maps quarantine to MissingGroup.
+                OpenMlsProjectionError::MissingGroup => {
+                    cgka_traits::error::EngineError::UnknownGroup(group_id.clone())
+                }
+                other => cgka_traits::error::EngineError::Backend(format!(
+                    "load convergence policy: {other}"
+                )),
+            })?;
         retain_current_group_epoch_snapshot(
             &self.storage,
             group_id,

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -389,6 +389,15 @@ impl<S: StorageProvider> EngineBuilder<S> {
                 required: u16::from(DEFAULT_CIPHERSUITE),
             });
         }
+        // Release builds keep the MLS past-epoch window pinned to the v1
+        // app-message horizon. Debug harnesses may shrink it for decrypt-window
+        // probes (mdk#970).
+        #[cfg(not(debug_assertions))]
+        if self.max_past_epochs != crate::wire_format::DEFAULT_MAX_PAST_EPOCHS {
+            return Err(EngineError::Other(
+                "max_past_epochs must equal the pinned v1 app-message window".into(),
+            ));
+        }
         let identity_bytes = self
             .identity_bytes
             .ok_or_else(|| EngineError::Other("identity bytes are required".into()))?;
@@ -433,7 +442,13 @@ impl<S: StorageProvider> EngineBuilder<S> {
             pending_convergence_groups: HashSet::new(),
             queued_intent_by_message: HashMap::new(),
             queued_intent_by_pending: HashMap::new(),
-            convergence_policy: crate::canonicalization::CanonicalizationPolicy::default(),
+            // Keep the in-memory app-message window aligned with MLS
+            // `max_past_epochs` from construction so the two knobs cannot drift
+            // before the first `set_convergence_policy` call.
+            convergence_policy: crate::canonicalization::CanonicalizationPolicy {
+                app_message_past_epoch_limit: self.max_past_epochs as u64,
+                ..crate::canonicalization::CanonicalizationPolicy::default()
+            },
             last_convergence_relevant_input_ms: HashMap::new(),
             convergence_clock_started_at: Instant::now(),
             engine_metrics: crate::engine_metrics::EngineMetrics::default(),

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -389,10 +389,10 @@ impl<S: StorageProvider> EngineBuilder<S> {
                 required: u16::from(DEFAULT_CIPHERSUITE),
             });
         }
-        // Release builds keep the MLS past-epoch window pinned to the v1
-        // app-message horizon. Debug harnesses may shrink it for decrypt-window
-        // probes (mdk#970).
-        #[cfg(not(debug_assertions))]
+        // Normal builds keep the MLS past-epoch window pinned to the v1
+        // app-message horizon. Only explicit test harness builds may shrink it
+        // for decrypt-window probes (mdk#970).
+        #[cfg(not(feature = "test-policy-overrides"))]
         if self.max_past_epochs != crate::wire_format::DEFAULT_MAX_PAST_EPOCHS {
             return Err(EngineError::Other(
                 "max_past_epochs must equal the pinned v1 app-message window".into(),

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -482,8 +482,12 @@ impl<S: StorageProvider> Engine<S> {
         // it gates again correctly once the tip advances into `[anchor, ceiling]`.
         let (anchor, ceiling) = match self.storage.get_group(group_id) {
             Ok(group) => {
+                // Ungated: hydration calls this while the group is still
+                // quarantined to decide whether to schedule post-repair
+                // convergence. Live send/convergence paths already gate via
+                // `ensure_group_live` before reaching here.
                 let policy = self
-                    .convergence_policy_for_group(group_id)
+                    .convergence_policy_for_group_ungated(group_id)
                     .map_err(|e| EngineError::Backend(format!("load convergence policy: {e}")))?;
                 let rewind = policy.convergence.max_rewind_commits;
                 (

--- a/crates/cgka-engine/src/wire_format.rs
+++ b/crates/cgka-engine/src/wire_format.rs
@@ -35,7 +35,11 @@ pub use openmls::group::PURE_PLAINTEXT_WIRE_FORMAT_POLICY;
 /// Default number of past MLS epochs retained for delayed application
 /// messages. This is intentionally small because it trades away some forward
 /// secrecy for delivery robustness.
-pub const DEFAULT_MAX_PAST_EPOCHS: usize = 5;
+///
+/// Pinned to the adopted convergence-policy v1 app-message window so MLS
+/// decryptability and witness/delivery horizons cannot diverge.
+pub const DEFAULT_MAX_PAST_EPOCHS: usize =
+    crate::canonicalization::V1_APP_MESSAGE_PAST_EPOCH_LIMIT as usize;
 
 /// Grep marker: every release checklist item that audits "are we still
 /// shipping pure-plaintext MLS?" should find this. Do NOT remove without

--- a/crates/cgka-engine/tests/AGENTS.md
+++ b/crates/cgka-engine/tests/AGENTS.md
@@ -52,9 +52,9 @@ backend on the same rail.
   - **Owns:** Stored-message convergence, stale classification, and retained-anchor behavior
 
 - **File:** `convergence_policy_pin.rs`
-  - **Owns:** Release-mode pinned v1 policy reject path (mdk#970). Ordinary `cargo test` keeps
-    `debug_assertions`; run `just test-convergence-policy-pin` (also in `just fast-ci` / CI) so the
-    `#[cfg(not(debug_assertions))]` engine gate is actually executed.
+  - **Owns:** Default-build pinned v1 policy rejection (mdk#970). Run
+    `just test-convergence-policy-pin` without `test-policy-overrides`; the broader integration
+    matrix enables that feature explicitly for settlement/rewind fixtures.
 
 - **File:** `mip03_guards.rs`
   - **Owns:** Phase 4.9 — committer-MUST-NOT-be-leaver, admin-not-last, admin-self-remove

--- a/crates/cgka-engine/tests/AGENTS.md
+++ b/crates/cgka-engine/tests/AGENTS.md
@@ -51,6 +51,11 @@ backend on the same rail.
 - **File:** `distributed_convergence.rs`
   - **Owns:** Stored-message convergence, stale classification, and retained-anchor behavior
 
+- **File:** `convergence_policy_pin.rs`
+  - **Owns:** Release-mode pinned v1 policy reject path (mdk#970). Ordinary `cargo test` keeps
+    `debug_assertions`; run `just test-convergence-policy-pin` (also in `just fast-ci` / CI) so the
+    `#[cfg(not(debug_assertions))]` engine gate is actually executed.
+
 - **File:** `mip03_guards.rs`
   - **Owns:** Phase 4.9 — committer-MUST-NOT-be-leaver, admin-not-last, admin-self-remove
 

--- a/crates/cgka-engine/tests/convergence_policy_pin.rs
+++ b/crates/cgka-engine/tests/convergence_policy_pin.rs
@@ -1,0 +1,142 @@
+//! Release-mode convergence policy pin proofs (mdk#970).
+//!
+//! Normal `cargo test` keeps `debug_assertions`, so the
+//! `#[cfg(not(debug_assertions))]` reject path inside
+//! `CanonicalizationPolicy::ensure_acceptable` / engine setters is never
+//! executed by the regular suite. Run this file with assertions disabled:
+//!
+//! ```sh
+//! just test-convergence-policy-pin
+//! ```
+//!
+//! CI and `just fast-ci` / `just ci` invoke that recipe so the production gate
+//! cannot rot unnoticed.
+
+use async_trait::async_trait;
+use cgka_engine::canonicalization::CanonicalizationPolicy;
+use cgka_engine::{DEFAULT_MAX_PAST_EPOCHS, EngineBuilder};
+use cgka_traits::error::PeelerError;
+use cgka_traits::group_context::GroupContextSnapshot;
+use cgka_traits::ingest::PeeledMessage;
+use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::transport::{EncryptedPayload, TransportMessage};
+use cgka_traits::types::MemberId;
+use storage_sqlite::SqliteAccountStorage;
+
+#[cfg(not(debug_assertions))]
+use cgka_engine::openmls_projection::OpenMlsProjectionError;
+#[cfg(not(debug_assertions))]
+use cgka_traits::error::EngineError;
+
+mod support;
+use support::proof_signer;
+
+fn valid_identity(seed: &[u8]) -> Vec<u8> {
+    use k256::schnorr::SigningKey;
+    use sha2::{Digest, Sha256};
+    let mut counter = 0u64;
+    loop {
+        let mut material = [0u8; 32];
+        let mut hasher = Sha256::new();
+        hasher.update(b"cgka-engine-test-identity-v1");
+        hasher.update(seed);
+        hasher.update(counter.to_be_bytes());
+        material.copy_from_slice(&hasher.finalize());
+        if let Ok(sk) = SigningKey::from_bytes(&material) {
+            return sk.verifying_key().to_bytes().to_vec();
+        }
+        counter += 1;
+    }
+}
+
+struct StubPeeler;
+
+#[async_trait]
+impl TransportPeeler for StubPeeler {
+    async fn peel_group_message(
+        &self,
+        _msg: &TransportMessage,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        Err(PeelerError::Backend("test peeler".into()))
+    }
+
+    async fn peel_welcome(&self, _msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        Err(PeelerError::Backend("test peeler".into()))
+    }
+
+    async fn wrap_group_message(
+        &self,
+        _payload: &EncryptedPayload,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        Err(PeelerError::Backend("test peeler".into()))
+    }
+
+    async fn wrap_welcome(
+        &self,
+        _payload: &EncryptedPayload,
+        _recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        Err(PeelerError::Backend("test peeler".into()))
+    }
+}
+
+fn build_engine() -> cgka_engine::Engine<SqliteAccountStorage> {
+    EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
+        .identity(valid_identity(b"pin-policy"))
+        .account_identity_proof_signer(proof_signer(b"pin-policy"))
+        .peeler(Box::new(StubPeeler))
+        .build()
+        .expect("pinned default engine builds")
+}
+
+#[test]
+fn ensure_acceptable_accepts_pinned_v1_baseline() {
+    CanonicalizationPolicy::default()
+        .ensure_acceptable(DEFAULT_MAX_PAST_EPOCHS)
+        .expect("pinned v1 baseline must be acceptable");
+}
+
+#[test]
+fn set_convergence_policy_accepts_pinned_v1_baseline() {
+    let mut engine = build_engine();
+    engine
+        .set_convergence_policy(CanonicalizationPolicy::default())
+        .expect("pinned v1 baseline must be accepted");
+}
+
+// Compiled only when assertions are off so ordinary `cargo test` / nextest do
+// not see an empty reject path. `just test-convergence-policy-pin` rebuilds
+// this binary with `RUSTFLAGS=-C debug-assertions=off`.
+#[cfg(not(debug_assertions))]
+#[test]
+fn release_mode_set_convergence_policy_rejects_non_pinned() {
+    let mut engine = build_engine();
+    let err = engine
+        .set_convergence_policy(CanonicalizationPolicy {
+            settlement_quiescence_ms: 0,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect_err("release builds must reject non-v1 policies");
+    assert!(
+        matches!(err, OpenMlsProjectionError::InvalidPolicy(_)),
+        "expected InvalidPolicy, got {err:?}"
+    );
+}
+
+#[cfg(not(debug_assertions))]
+#[test]
+fn release_mode_builder_rejects_non_default_max_past_epochs() {
+    let result = EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
+        .identity(valid_identity(b"pin-policy-epochs"))
+        .account_identity_proof_signer(proof_signer(b"pin-policy-epochs"))
+        .peeler(Box::new(StubPeeler))
+        .max_past_epochs(1)
+        .build();
+    match result {
+        Err(EngineError::Other(_)) => {}
+        Ok(_) => panic!("release builds must pin max_past_epochs to v1"),
+        Err(err) => panic!("expected EngineError::Other, got {err:?}"),
+    }
+}

--- a/crates/cgka-engine/tests/convergence_policy_pin.rs
+++ b/crates/cgka-engine/tests/convergence_policy_pin.rs
@@ -1,20 +1,22 @@
-//! Release-mode convergence policy pin proofs (mdk#970).
+//! Default-build convergence policy pin proofs (mdk#970).
 //!
-//! Normal `cargo test` keeps `debug_assertions`, so the
-//! `#[cfg(not(debug_assertions))]` reject path inside
-//! `CanonicalizationPolicy::ensure_acceptable` / engine setters is never
-//! executed by the regular suite. Run this file with assertions disabled:
+//! This target deliberately runs without the `test-policy-overrides` feature,
+//! proving that ordinary debug and release consumers both reject non-v1 policy:
 //!
 //! ```sh
 //! just test-convergence-policy-pin
 //! ```
 //!
-//! CI and `just fast-ci` / `just ci` invoke that recipe so the production gate
-//! cannot rot unnoticed.
+//! CI and `just fast-ci` / `just ci` invoke that recipe separately from the
+//! feature-enabled integration-test matrix.
 
 use async_trait::async_trait;
 use cgka_engine::canonicalization::CanonicalizationPolicy;
+#[cfg(not(feature = "test-policy-overrides"))]
+use cgka_engine::openmls_projection::OpenMlsProjectionError;
 use cgka_engine::{DEFAULT_MAX_PAST_EPOCHS, EngineBuilder};
+#[cfg(not(feature = "test-policy-overrides"))]
+use cgka_traits::error::EngineError;
 use cgka_traits::error::PeelerError;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::PeeledMessage;
@@ -22,11 +24,6 @@ use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::transport::{EncryptedPayload, TransportMessage};
 use cgka_traits::types::MemberId;
 use storage_sqlite::SqliteAccountStorage;
-
-#[cfg(not(debug_assertions))]
-use cgka_engine::openmls_projection::OpenMlsProjectionError;
-#[cfg(not(debug_assertions))]
-use cgka_traits::error::EngineError;
 
 mod support;
 use support::proof_signer;
@@ -106,28 +103,25 @@ fn set_convergence_policy_accepts_pinned_v1_baseline() {
         .expect("pinned v1 baseline must be accepted");
 }
 
-// Compiled only when assertions are off so ordinary `cargo test` / nextest do
-// not see an empty reject path. `just test-convergence-policy-pin` rebuilds
-// this binary with `RUSTFLAGS=-C debug-assertions=off`.
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "test-policy-overrides"))]
 #[test]
-fn release_mode_set_convergence_policy_rejects_non_pinned() {
+fn default_build_set_convergence_policy_rejects_non_pinned() {
     let mut engine = build_engine();
     let err = engine
         .set_convergence_policy(CanonicalizationPolicy {
             settlement_quiescence_ms: 0,
             ..CanonicalizationPolicy::default()
         })
-        .expect_err("release builds must reject non-v1 policies");
+        .expect_err("normal builds must reject non-v1 policies");
     assert!(
         matches!(err, OpenMlsProjectionError::InvalidPolicy(_)),
         "expected InvalidPolicy, got {err:?}"
     );
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "test-policy-overrides"))]
 #[test]
-fn release_mode_builder_rejects_non_default_max_past_epochs() {
+fn default_build_builder_rejects_non_default_max_past_epochs() {
     let result = EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
         .identity(valid_identity(b"pin-policy-epochs"))
         .account_identity_proof_signer(proof_signer(b"pin-policy-epochs"))
@@ -136,7 +130,7 @@ fn release_mode_builder_rejects_non_default_max_past_epochs() {
         .build();
     match result {
         Err(EngineError::Other(_)) => {}
-        Ok(_) => panic!("release builds must pin max_past_epochs to v1"),
+        Ok(_) => panic!("normal builds must pin max_past_epochs to v1"),
         Err(err) => panic!("expected EngineError::Other, got {err:?}"),
     }
 }

--- a/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
+++ b/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
@@ -191,10 +191,12 @@ fn build_counting_client(
         .peeler(Box::new(peeler.clone()))
         .build()
         .unwrap();
-    engine.set_convergence_policy(CanonicalizationPolicy {
-        settlement_quiescence_ms: 0,
-        ..CanonicalizationPolicy::default()
-    });
+    engine
+        .set_convergence_policy(CanonicalizationPolicy {
+            settlement_quiescence_ms: 0,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
     (engine, storage, peeler)
 }
 

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -5642,32 +5642,22 @@ fn set_convergence_policy_accepts_pinned_v1_baseline() {
 }
 
 #[test]
-fn release_builds_reject_non_pinned_convergence_policy() {
-    // Mirror the CLI/dev-override gate: release code paths must refuse anything
-    // other than the pinned v1 baseline (mdk#970).
+fn non_pinned_policy_fails_ensure_pinned_v1_helper() {
+    // Pure helper coverage. The engine reject arm under
+    // `#[cfg(not(debug_assertions))]` is proven by
+    // `just test-convergence-policy-pin` (tests/convergence_policy_pin.rs).
     let policy = CanonicalizationPolicy {
         settlement_quiescence_ms: 0,
         ..CanonicalizationPolicy::default()
     };
-    if cfg!(debug_assertions) {
-        assert!(
-            !policy.is_pinned_v1(),
-            "fixture must differ from the pinned baseline"
-        );
-        assert_eq!(
-            policy.ensure_pinned_v1(),
-            Err(cgka_engine::canonicalization::CanonicalizationPolicyError::NotPinnedV1)
-        );
-    } else {
-        let (mut alice, _storage) = build_client(b"alice");
-        let err = alice
-            .set_convergence_policy(policy)
-            .expect_err("release builds must reject non-v1 policies");
-        assert!(
-            matches!(err, OpenMlsProjectionError::InvalidPolicy(_)),
-            "expected InvalidPolicy, got {err:?}"
-        );
-    }
+    assert!(
+        !policy.is_pinned_v1(),
+        "fixture must differ from the pinned baseline"
+    );
+    assert_eq!(
+        policy.ensure_pinned_v1(),
+        Err(cgka_engine::canonicalization::CanonicalizationPolicyError::NotPinnedV1)
+    );
 }
 
 #[tokio::test]

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -1321,13 +1321,15 @@ async fn superseded_self_removal_clears_removed_marker_and_restores_send() {
         .join_welcome(welcome_for(&welcomes, b"carol"))
         .await
         .unwrap();
-    carol.set_convergence_policy(CanonicalizationPolicy {
-        convergence: ConvergencePolicy {
-            max_rewind_commits: 1,
-            ..ConvergencePolicy::default()
-        },
-        ..CanonicalizationPolicy::default()
-    });
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            convergence: ConvergencePolicy {
+                max_rewind_commits: 1,
+                ..ConvergencePolicy::default()
+            },
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
     carol.drain_events();
 
     // Same-epoch fork by the two admins: one removes Carol, the other renames
@@ -2120,13 +2122,15 @@ async fn engine_replays_late_same_epoch_commit_from_retained_anchor() {
         .join_welcome(welcome_for(&welcomes, b"carol"))
         .await
         .unwrap();
-    carol.set_convergence_policy(CanonicalizationPolicy {
-        convergence: ConvergencePolicy {
-            max_rewind_commits: 1,
-            ..ConvergencePolicy::default()
-        },
-        ..CanonicalizationPolicy::default()
-    });
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            convergence: ConvergencePolicy {
+                max_rewind_commits: 1,
+                ..ConvergencePolicy::default()
+            },
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
 
     let david_kp = david.fresh_key_package().await.unwrap();
     let alice_invite = alice
@@ -2226,13 +2230,15 @@ async fn engine_ingest_buffers_late_same_epoch_commit_within_rewind_horizon() {
         .join_welcome(welcome_for(&welcomes, b"carol"))
         .await
         .unwrap();
-    carol.set_convergence_policy(CanonicalizationPolicy {
-        convergence: ConvergencePolicy {
-            max_rewind_commits: 1,
-            ..ConvergencePolicy::default()
-        },
-        ..CanonicalizationPolicy::default()
-    });
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            convergence: ConvergencePolicy {
+                max_rewind_commits: 1,
+                ..ConvergencePolicy::default()
+            },
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
 
     let david_kp = david.fresh_key_package().await.unwrap();
     let alice_invite = alice
@@ -2332,13 +2338,15 @@ async fn engine_metrics_count_post_settle_reorg_from_late_same_epoch_commit() {
         .join_welcome(welcome_for(&welcomes, b"carol"))
         .await
         .unwrap();
-    carol.set_convergence_policy(CanonicalizationPolicy {
-        convergence: ConvergencePolicy {
-            max_rewind_commits: 1,
-            ..ConvergencePolicy::default()
-        },
-        ..CanonicalizationPolicy::default()
-    });
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            convergence: ConvergencePolicy {
+                max_rewind_commits: 1,
+                ..ConvergencePolicy::default()
+            },
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
 
     // Carol settles on Alice's commit (epoch 1 -> 2) and retains the epoch-1
     // anchor. This is the first settle for the group: not a reorg.
@@ -2575,13 +2583,15 @@ async fn engine_reports_missing_retained_anchor_without_mutating_late_commit() {
         .join_welcome(welcome_for(&welcomes, b"carol"))
         .await
         .unwrap();
-    carol.set_convergence_policy(CanonicalizationPolicy {
-        convergence: ConvergencePolicy {
-            max_rewind_commits: 1,
-            ..ConvergencePolicy::default()
-        },
-        ..CanonicalizationPolicy::default()
-    });
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            convergence: ConvergencePolicy {
+                max_rewind_commits: 1,
+                ..ConvergencePolicy::default()
+            },
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
 
     let david_kp = david.fresh_key_package().await.unwrap();
     let alice_invite = alice
@@ -2705,13 +2715,15 @@ async fn engine_prunes_retained_anchor_snapshots_to_rewind_horizon() {
         .join_welcome(welcome_for(&welcomes, b"carol"))
         .await
         .unwrap();
-    carol.set_convergence_policy(CanonicalizationPolicy {
-        convergence: ConvergencePolicy {
-            max_rewind_commits: 1,
-            ..ConvergencePolicy::default()
-        },
-        ..CanonicalizationPolicy::default()
-    });
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            convergence: ConvergencePolicy {
+                max_rewind_commits: 1,
+                ..ConvergencePolicy::default()
+            },
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
 
     let david_kp = david.fresh_key_package().await.unwrap();
     let invite_david = alice
@@ -2795,13 +2807,15 @@ async fn engine_invalidates_commit_older_than_retained_anchor() {
         .join_welcome(welcome_for(&welcomes, b"carol"))
         .await
         .unwrap();
-    carol.set_convergence_policy(CanonicalizationPolicy {
-        convergence: ConvergencePolicy {
-            max_rewind_commits: 1,
-            ..ConvergencePolicy::default()
-        },
-        ..CanonicalizationPolicy::default()
-    });
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            convergence: ConvergencePolicy {
+                max_rewind_commits: 1,
+                ..ConvergencePolicy::default()
+            },
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
 
     let frank_kp = frank.fresh_key_package().await.unwrap();
     let bob_invite = bob
@@ -4301,13 +4315,15 @@ async fn far_future_convergence_input_beyond_ceiling_does_not_gate_sends() {
         .unwrap();
     // Tight horizon so a small real epoch is already "far future": with the tip
     // at epoch 1 and `max_rewind_commits = 1`, the ceiling is epoch 2.
-    carol.set_convergence_policy(CanonicalizationPolicy {
-        convergence: ConvergencePolicy {
-            max_rewind_commits: 1,
-            ..ConvergencePolicy::default()
-        },
-        ..CanonicalizationPolicy::default()
-    });
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            convergence: ConvergencePolicy {
+                max_rewind_commits: 1,
+                ..ConvergencePolicy::default()
+            },
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
     carol.drain_events();
     assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
 
@@ -4687,10 +4703,12 @@ async fn send_preflight_retries_deferred_peels_after_convergence_apply() {
         MessageState::PeelDeferred
     );
 
-    carol.set_convergence_policy(CanonicalizationPolicy {
-        settlement_quiescence_ms: 0,
-        ..CanonicalizationPolicy::default()
-    });
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            settlement_quiescence_ms: 0,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
     let sent = carol
         .send(SendIntent::AppMessage {
             group_id: group_id.clone(),
@@ -4801,10 +4819,12 @@ async fn deferred_row_terminally_rejected_after_peel_leaves_the_deferred_queue()
         .ingest(commit_to_epoch2)
         .await
         .expect("commit buffered");
-    carol.set_convergence_policy(CanonicalizationPolicy {
-        settlement_quiescence_ms: 0,
-        ..CanonicalizationPolicy::default()
-    });
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            settlement_quiescence_ms: 0,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
     carol
         .converge_and_drain_queued_outbound_intents(&group_id, 1_000_000)
         .await
@@ -4855,8 +4875,11 @@ async fn send_preflight_terminally_retires_deferred_app_message_outside_past_epo
         .unwrap();
     bob.set_convergence_policy(CanonicalizationPolicy {
         settlement_quiescence_ms: 0,
+        // Keep the app window aligned with bob's MLS `max_past_epochs = 1`.
+        app_message_past_epoch_limit: 1,
         ..CanonicalizationPolicy::default()
-    });
+    })
+    .expect("convergence policy accepted");
 
     let old_app = send_app(&mut alice, &group_id, b"outside past window".to_vec()).await;
 
@@ -5080,7 +5103,9 @@ async fn trait_advance_convergence_drains_queued_outbound_intent() {
         settlement_quiescence_ms: 0,
         ..CanonicalizationPolicy::default()
     };
-    carol.set_convergence_policy(policy);
+    carol
+        .set_convergence_policy(policy)
+        .expect("convergence policy accepted");
 
     let mut engine: Box<dyn CgkaEngine> = Box::new(carol);
     let drained = engine.advance_convergence(&group_id).await.unwrap();
@@ -5591,6 +5616,58 @@ fn set_group_convergence_policy_rejects_witness_override_exceeding_rewind() {
         matches!(err, OpenMlsProjectionError::InvalidPolicy(_)),
         "expected InvalidPolicy, got {err:?}"
     );
+}
+
+#[test]
+fn set_convergence_policy_rejects_app_window_mismatch() {
+    let (mut alice, _storage) = build_client(b"alice");
+    let err = alice
+        .set_convergence_policy(CanonicalizationPolicy {
+            app_message_past_epoch_limit: 1,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect_err("app window must match engine max_past_epochs");
+    assert!(
+        matches!(err, OpenMlsProjectionError::InvalidPolicy(_)),
+        "expected InvalidPolicy, got {err:?}"
+    );
+}
+
+#[test]
+fn set_convergence_policy_accepts_pinned_v1_baseline() {
+    let (mut alice, _storage) = build_client(b"alice");
+    alice
+        .set_convergence_policy(CanonicalizationPolicy::default())
+        .expect("pinned v1 baseline must be accepted");
+}
+
+#[test]
+fn release_builds_reject_non_pinned_convergence_policy() {
+    // Mirror the CLI/dev-override gate: release code paths must refuse anything
+    // other than the pinned v1 baseline (mdk#970).
+    let policy = CanonicalizationPolicy {
+        settlement_quiescence_ms: 0,
+        ..CanonicalizationPolicy::default()
+    };
+    if cfg!(debug_assertions) {
+        assert!(
+            !policy.is_pinned_v1(),
+            "fixture must differ from the pinned baseline"
+        );
+        assert_eq!(
+            policy.ensure_pinned_v1(),
+            Err(cgka_engine::canonicalization::CanonicalizationPolicyError::NotPinnedV1)
+        );
+    } else {
+        let (mut alice, _storage) = build_client(b"alice");
+        let err = alice
+            .set_convergence_policy(policy)
+            .expect_err("release builds must reject non-v1 policies");
+        assert!(
+            matches!(err, OpenMlsProjectionError::InvalidPolicy(_)),
+            "expected InvalidPolicy, got {err:?}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -2772,13 +2772,15 @@ async fn unrecoverable_halt_survives_engine_restart_until_verified_repair() {
         .join_welcome(welcome_for(&welcomes, b"carol"))
         .await
         .unwrap();
-    carol.set_convergence_policy(CanonicalizationPolicy {
-        convergence: ConvergencePolicy {
-            max_rewind_commits: 1,
-            ..ConvergencePolicy::default()
-        },
-        ..CanonicalizationPolicy::default()
-    });
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            convergence: ConvergencePolicy {
+                max_rewind_commits: 1,
+                ..ConvergencePolicy::default()
+            },
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
 
     let david_kp = david.fresh_key_package().await.unwrap();
     let alice_invite = alice

--- a/crates/cgka-engine/tests/mip03_guards.rs
+++ b/crates/cgka-engine/tests/mip03_guards.rs
@@ -1115,13 +1115,15 @@ async fn parent_dependent_proposal_waits_for_retained_fork_parent() {
     alice.confirm_published(pending).await.unwrap();
     bob.join_welcome(welcomes[0].clone()).await.unwrap();
     carol.join_welcome(welcomes[1].clone()).await.unwrap();
-    carol.set_convergence_policy(CanonicalizationPolicy {
-        convergence: ConvergencePolicy {
-            max_rewind_commits: 1,
-            ..ConvergencePolicy::default()
-        },
-        ..CanonicalizationPolicy::default()
-    });
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            convergence: ConvergencePolicy {
+                max_rewind_commits: 1,
+                ..ConvergencePolicy::default()
+            },
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
 
     let david_kp = david.fresh_key_package().await.unwrap();
     let alice_invite = alice

--- a/crates/cgka-session/Cargo.toml
+++ b/crates/cgka-session/Cargo.toml
@@ -5,6 +5,10 @@ edition.workspace = true
 license.workspace = true
 publish.workspace = true
 
+[features]
+default = []
+test-policy-overrides = ["cgka-engine/test-policy-overrides"]
+
 [dependencies]
 cgka-engine.workspace = true
 cgka-traits.workspace = true

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -239,6 +239,14 @@ impl AccountDeviceSession {
             )
             .into());
         }
+        // Fail closed before opening storage or hydrating: a rejected release
+        // policy must not retire key packages or mutate durable group state
+        // (mdk#970 / PR review). Session construction always uses the default
+        // MLS past-epoch window, so validate against that same horizon here.
+        config
+            .convergence_policy
+            .ensure_acceptable(cgka_engine::DEFAULT_MAX_PAST_EPOCHS)
+            .map_err(|e| EngineError::Other(format!("convergence policy: {e}")))?;
         tracing::debug!(
             target: TRACE_TARGET,
             method = "open",

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -148,6 +148,10 @@ impl SessionConfig {
         self
     }
 
+    /// Set the session convergence policy.
+    ///
+    /// Production hosts MUST leave the default (pinned v1). Non-baseline values
+    /// are accepted only in debug/test builds; release `open` rejects them.
     pub fn convergence_policy(mut self, policy: CanonicalizationPolicy) -> Self {
         self.convergence_policy = policy;
         self
@@ -286,7 +290,9 @@ impl AccountDeviceSession {
             );
         }
         engine.hydrate_stable_groups_from_storage()?;
-        engine.set_convergence_policy(config.convergence_policy);
+        engine
+            .set_convergence_policy(config.convergence_policy)
+            .map_err(|e| EngineError::Other(format!("convergence policy: {e}")))?;
         engine.audit_recorder_health();
         tracing::debug!(
             target: TRACE_TARGET,
@@ -751,13 +757,18 @@ impl AccountDeviceSession {
         self.engine.self_id()
     }
 
-    pub fn set_convergence_policy(&mut self, policy: CanonicalizationPolicy) {
+    pub fn set_convergence_policy(
+        &mut self,
+        policy: CanonicalizationPolicy,
+    ) -> Result<(), EngineError> {
         tracing::debug!(
             target: TRACE_TARGET,
             method = "set_convergence_policy",
             "updating convergence policy"
         );
-        self.engine.set_convergence_policy(policy);
+        self.engine
+            .set_convergence_policy(policy)
+            .map_err(|e| EngineError::Other(format!("convergence policy: {e}")))
     }
 
     pub fn record_audit_event(

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -151,7 +151,7 @@ impl SessionConfig {
     /// Set the session convergence policy.
     ///
     /// Production hosts MUST leave the default (pinned v1). Non-baseline values
-    /// are accepted only in debug/test builds; release `open` rejects them.
+    /// are accepted only by explicit `test-policy-overrides` harness builds.
     pub fn convergence_policy(mut self, policy: CanonicalizationPolicy) -> Self {
         self.convergence_policy = policy;
         self

--- a/crates/cgka-session/tests/nostr_stack.rs
+++ b/crates/cgka-session/tests/nostr_stack.rs
@@ -190,10 +190,12 @@ async fn duplicate_group_relay_delivery_is_idempotent_at_session_boundary() {
     )
     .await;
     stack.sync_group(&bob, &created.group_id).await;
-    bob.session.set_convergence_policy(CanonicalizationPolicy {
-        settlement_quiescence_ms: 0,
-        ..CanonicalizationPolicy::default()
-    });
+    bob.session
+        .set_convergence_policy(CanonicalizationPolicy {
+            settlement_quiescence_ms: 0,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
 
     let app_message = send_app_message(&mut alice, &created.group_id, b"dedupe me").await;
     let report = stack
@@ -347,10 +349,12 @@ async fn invite_group_evolution_publishes_commit_and_welcome_through_stack() {
         .await
         .expect("commit delivery should reach bob");
     assert!(matches!(bob_commit.outcome, IngestOutcome::Buffered { .. }));
-    bob.session.set_convergence_policy(CanonicalizationPolicy {
-        settlement_quiescence_ms: 0,
-        ..CanonicalizationPolicy::default()
-    });
+    bob.session
+        .set_convergence_policy(CanonicalizationPolicy {
+            settlement_quiescence_ms: 0,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
     bob.session
         .advance_convergence(&created.group_id)
         .await

--- a/crates/cgka-session/tests/nostr_stack_chaos.rs
+++ b/crates/cgka-session/tests/nostr_stack_chaos.rs
@@ -57,10 +57,12 @@ async fn invite_lifecycle_chaos_handles_wrong_routes_replays_and_welcome_before_
         .confirm_published(invite.pending)
         .await
         .unwrap();
-    bob.session.set_convergence_policy(CanonicalizationPolicy {
-        settlement_quiescence_ms: 0,
-        ..CanonicalizationPolicy::default()
-    });
+    bob.session
+        .set_convergence_policy(CanonicalizationPolicy {
+            settlement_quiescence_ms: 0,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
 
     let commit_event = stack.take_next_published();
     let welcome_event = stack.take_next_published();
@@ -175,10 +177,12 @@ async fn invite_lifecycle_chaos_handles_commit_before_welcome_and_shared_replay(
     let group_id = created.group_id.clone();
     publish_confirm_and_deliver_welcome(&stack, &mut alice, &mut bob, created).await;
     stack.sync_group(&bob, &group_id).await;
-    bob.session.set_convergence_policy(CanonicalizationPolicy {
-        settlement_quiescence_ms: 0,
-        ..CanonicalizationPolicy::default()
-    });
+    bob.session
+        .set_convergence_policy(CanonicalizationPolicy {
+            settlement_quiescence_ms: 0,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
 
     let invite = invite_carol(&mut alice, &mut carol, &group_id).await;
     let commit_report = stack

--- a/crates/cgka-session/tests/session_lifecycle.rs
+++ b/crates/cgka-session/tests/session_lifecycle.rs
@@ -810,3 +810,33 @@ async fn session_advance_convergence_releases_queued_outbound_work() {
     );
     assert!(advanced.queued.is_empty());
 }
+
+#[test]
+fn open_rejects_invalid_convergence_policy_before_storage_open() {
+    // mdk#970 / PR review: policy must fail closed before durable open work.
+    // A mismatched app window is rejected in every build; use a path that does
+    // not exist so a late failure would be a storage error rather than policy.
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("never-created.sqlite");
+    assert!(!missing.exists(), "fixture path must not exist before open");
+    let key = SqlCipherKey::new("policy reject key").unwrap();
+    let result = AccountDeviceSession::open(
+        config(&missing, &key, b"policy-reject").convergence_policy(CanonicalizationPolicy {
+            app_message_past_epoch_limit: 1,
+            ..CanonicalizationPolicy::default()
+        }),
+    );
+    let err = match result {
+        Err(err) => err,
+        Ok(_) => panic!("invalid policy must fail before storage open"),
+    };
+    let message = err.to_string();
+    assert!(
+        message.contains("convergence policy"),
+        "expected policy error, got {message}"
+    );
+    assert!(
+        !missing.exists(),
+        "rejected open must not create the database file"
+    );
+}

--- a/crates/cgka-session/tests/session_lifecycle.rs
+++ b/crates/cgka-session/tests/session_lifecycle.rs
@@ -663,7 +663,8 @@ async fn session_advance_convergence_surfaces_auto_selfremove_reproposal() {
     bob.set_convergence_policy(CanonicalizationPolicy {
         settlement_quiescence_ms: 0,
         ..CanonicalizationPolicy::default()
-    });
+    })
+    .expect("convergence policy accepted");
     let advanced = bob.advance_convergence(&created.group_id).await.unwrap();
     assert!(
         advanced
@@ -755,10 +756,12 @@ async fn session_advance_convergence_releases_queued_outbound_work() {
     // early, and the message published instead of queuing (issue #296).
     // A large explicit window makes the queue path deterministic regardless of
     // scheduling jitter; the reset to 0 below deterministically releases it.
-    carol.set_convergence_policy(CanonicalizationPolicy {
-        settlement_quiescence_ms: 3_600_000,
-        ..CanonicalizationPolicy::default()
-    });
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            settlement_quiescence_ms: 3_600_000,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
     let queued_payload = app_payload_for(&carol, b"queued by session");
     let queued_app_event_id = cgka_traits::MarmotAppEvent::decode(&queued_payload)
         .expect("queued app event decodes")
@@ -774,10 +777,12 @@ async fn session_advance_convergence_releases_queued_outbound_work() {
     assert!(queued.publish.is_empty());
     let queued_intent = queued.queued[0].clone();
 
-    carol.set_convergence_policy(CanonicalizationPolicy {
-        settlement_quiescence_ms: 0,
-        ..CanonicalizationPolicy::default()
-    });
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            settlement_quiescence_ms: 0,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect("convergence policy accepted");
     let advanced = carol.advance_convergence(&created.group_id).await.unwrap();
 
     assert_eq!(carol.epoch(&created.group_id).unwrap(), EpochId(2));

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 [features]
 default = []
 otlp-export = ["marmot-app/otlp-export"]
+test-policy-overrides = ["marmot-app/test-policy-overrides"]
 
 [[bin]]
 name = "wn"

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -52,7 +52,7 @@ pub(crate) enum WnError {
     #[error("invalid secret store: {0}")]
     InvalidSecretStore(String),
     #[error(
-        "WN_DEV_SETTLEMENT_QUIESCENCE_MS is only available in debug builds; unset it when running a release binary"
+        "WN_DEV_SETTLEMENT_QUIESCENCE_MS requires a test-policy-overrides build; unset it in normal binaries"
     )]
     DevSettlementOverrideInRelease,
     #[error("stream text is required")]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1057,10 +1057,8 @@ fn app_for(
     let mut config = MarmotAppConfig::default()
         .with_allow_loopback_blob_endpoints(wn_allow_loopback_blob_endpoints())
         .with_allow_loopback_relay_endpoints(wn_allow_loopback_relays());
-    // Dev/test only: WN_DEV_SETTLEMENT_QUIESCENCE_MS overrides the pinned
-    // convergence settlement window (e.g. `0` for instant settlement in
-    // integration tests). Production installs leave it unset and use the pinned
-    // default.
+    // Explicit test builds only: WN_DEV_SETTLEMENT_QUIESCENCE_MS overrides the
+    // pinned convergence settlement window (e.g. `0` for integration tests).
     if let Some(ms) = wn_dev_settlement_quiescence_ms()? {
         config = config.with_dev_settlement_quiescence_ms(ms);
     }
@@ -1103,7 +1101,7 @@ fn resolve_dev_settlement_quiescence_ms(
 
 fn wn_dev_settlement_quiescence_ms() -> Result<Option<u64>, WnError> {
     let value = std::env::var("WN_DEV_SETTLEMENT_QUIESCENCE_MS").ok();
-    resolve_dev_settlement_quiescence_ms(value.as_deref(), cfg!(debug_assertions))
+    resolve_dev_settlement_quiescence_ms(value.as_deref(), cfg!(feature = "test-policy-overrides"))
 }
 
 fn open_account_home(
@@ -1411,7 +1409,7 @@ mod tests {
     }
 
     #[test]
-    fn dev_settlement_override_is_available_in_debug_builds() {
+    fn dev_settlement_override_is_available_in_explicit_test_builds() {
         assert_eq!(
             resolve_dev_settlement_quiescence_ms(Some("0"), true).unwrap(),
             Some(0)
@@ -1419,9 +1417,9 @@ mod tests {
     }
 
     #[test]
-    fn dev_settlement_override_is_rejected_in_release_builds() {
+    fn dev_settlement_override_is_rejected_without_test_feature() {
         let error =
-            resolve_dev_settlement_quiescence_ms(Some("0"), false).expect_err("release rejection");
+            resolve_dev_settlement_quiescence_ms(Some("0"), false).expect_err("feature rejection");
         assert!(matches!(&error, WnError::DevSettlementOverrideInRelease));
         assert_eq!(
             super::wn_error_json(&error)["code"],

--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -271,9 +271,10 @@ fn wn(home: &std::path::Path) -> Command {
     // CLI tests connect to an in-process `MockRelay` at loopback, which is the
     // dev/test scenario the loopback-relay gate is for.
     command.env("WN_ALLOW_LOOPBACK_RELAYS", "1");
-    // Instant convergence settlement so multi-client tests do not wait on the
-    // pinned 1000 ms quiescence window (dev/test only).
-    command.env("WN_DEV_SETTLEMENT_QUIESCENCE_MS", "0");
+    // Feature-gated instant settlement for the explicit test build only.
+    if cfg!(feature = "test-policy-overrides") {
+        command.env("WN_DEV_SETTLEMENT_QUIESCENCE_MS", "0");
+    }
     command
 }
 

--- a/crates/marmot-app/Cargo.toml
+++ b/crates/marmot-app/Cargo.toml
@@ -7,6 +7,11 @@ publish.workspace = true
 
 [features]
 default = []
+# Test-only convergence timing/rewind overrides. Never enable in app artifacts.
+test-policy-overrides = [
+    "cgka-engine/test-policy-overrides",
+    "cgka-session/test-policy-overrides",
+]
 # Opt-in relay-telemetry OTLP exporter wire encoding and HTTP push. The
 # privacy-critical mapping and opt-in gate stay in the default build; this
 # feature only adds the OTLP protobuf dependencies and the push transport.

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -73,9 +73,9 @@ pub struct MarmotAppConfig {
     pub allow_loopback_relay_endpoints: bool,
     /// Dev/test override for the convergence settlement quiescence window, in
     /// milliseconds. `None` (the default) uses the protocol-pinned value
-    /// (`settlement_quiescence_ms = 1000`). Honored only under `debug_assertions`;
-    /// release builds ignore it so hosts cannot fork the pinned v1 baseline
-    /// (mdk#970). Test harnesses set `Some(0)` for deterministic settlement.
+    /// (`settlement_quiescence_ms = 1000`). Honored only when the explicit
+    /// `test-policy-overrides` feature is enabled; normal debug and release
+    /// builds ignore it so hosts cannot fork the pinned v1 baseline (mdk#970).
     pub dev_settlement_quiescence_ms: Option<u64>,
 }
 
@@ -145,8 +145,8 @@ impl MarmotAppConfig {
     }
 
     /// Dev/test override for the convergence settlement quiescence window (ms).
-    /// Off by default (the protocol-pinned `1000` ms is used). Release builds
-    /// ignore this field; test harnesses set `0` for instant settlement.
+    /// Off by default (the protocol-pinned `1000` ms is used). Normal builds
+    /// ignore this field; explicit test harnesses set `0` for instant settlement.
     pub fn with_dev_settlement_quiescence_ms(mut self, ms: u64) -> Self {
         self.dev_settlement_quiescence_ms = Some(ms);
         self

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -73,9 +73,9 @@ pub struct MarmotAppConfig {
     pub allow_loopback_relay_endpoints: bool,
     /// Dev/test override for the convergence settlement quiescence window, in
     /// milliseconds. `None` (the default) uses the protocol-pinned value
-    /// (`settlement_quiescence_ms = 1000`); a client MUST NOT ship a non-default
-    /// value (spec/implementation-model.md, "Convergence Policy Overrides").
-    /// Test harnesses set `Some(0)` for deterministic, instant settlement.
+    /// (`settlement_quiescence_ms = 1000`). Honored only under `debug_assertions`;
+    /// release builds ignore it so hosts cannot fork the pinned v1 baseline
+    /// (mdk#970). Test harnesses set `Some(0)` for deterministic settlement.
     pub dev_settlement_quiescence_ms: Option<u64>,
 }
 
@@ -145,8 +145,8 @@ impl MarmotAppConfig {
     }
 
     /// Dev/test override for the convergence settlement quiescence window (ms).
-    /// Off by default (the protocol-pinned `1000` ms is used); production builds
-    /// must leave this unset. Test harnesses set `0` for instant settlement.
+    /// Off by default (the protocol-pinned `1000` ms is used). Release builds
+    /// ignore this field; test harnesses set `0` for instant settlement.
     pub fn with_dev_settlement_quiescence_ms(mut self, ms: u64) -> Self {
         self.dev_settlement_quiescence_ms = Some(ms);
         self

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -989,11 +989,11 @@ impl MarmotApp {
         mut config: MarmotAppConfig,
     ) -> Self {
         // These relay-only constructors are dev/test entry points (production
-        // opens through `with_relays_and_account_home*`). Default them to instant
-        // convergence settlement so multi-client tests are deterministic and do
-        // not wait on the pinned 1000 ms quiescence window; a caller may still
-        // set an explicit value.
-        if config.dev_settlement_quiescence_ms.is_none() {
+        // opens through `with_relays_and_account_home*`). In debug builds, default
+        // them to instant settlement so multi-client tests are deterministic and
+        // do not wait on the pinned 1000 ms quiescence window. Release builds
+        // keep the protocol-pinned window (mdk#970).
+        if cfg!(debug_assertions) && config.dev_settlement_quiescence_ms.is_none() {
             config.dev_settlement_quiescence_ms = Some(0);
         }
         let root = root.as_ref().to_path_buf();
@@ -2368,13 +2368,21 @@ impl MarmotApp {
         .feature_registry(app_feature_registry())
         .supported_app_components(self.supported_app_component_ids());
         // Production uses the protocol-pinned convergence policy (SessionConfig's
-        // default). Only a dev/test override changes it — never shipped (see
-        // spec/implementation-model.md, "Convergence Policy Overrides").
+        // default). Only a debug/test override may change it — release builds
+        // ignore the knob so a host misconfig cannot fork honest clients (mdk#970).
         if let Some(ms) = self.config.dev_settlement_quiescence_ms {
-            session_config = session_config.convergence_policy(CanonicalizationPolicy {
-                settlement_quiescence_ms: ms,
-                ..CanonicalizationPolicy::default()
-            });
+            if cfg!(debug_assertions) {
+                session_config = session_config.convergence_policy(CanonicalizationPolicy {
+                    settlement_quiescence_ms: ms,
+                    ..CanonicalizationPolicy::default()
+                });
+            } else {
+                tracing::warn!(
+                    target: "marmot_app",
+                    method = "open_account",
+                    "ignoring dev_settlement_quiescence_ms in release build; pinned v1 policy required"
+                );
+            }
         }
         let audit_log_enabled = match self.audit_log_settings() {
             Ok(settings) => settings.enabled,

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -989,11 +989,11 @@ impl MarmotApp {
         mut config: MarmotAppConfig,
     ) -> Self {
         // These relay-only constructors are dev/test entry points (production
-        // opens through `with_relays_and_account_home*`). In debug builds, default
-        // them to instant settlement so multi-client tests are deterministic and
-        // do not wait on the pinned 1000 ms quiescence window. Release builds
-        // keep the protocol-pinned window (mdk#970).
-        if cfg!(debug_assertions) && config.dev_settlement_quiescence_ms.is_none() {
+        // opens through `with_relays_and_account_home*`). Explicit test-policy
+        // builds default them to instant settlement so multi-client tests are
+        // deterministic. Normal debug and release builds keep the pinned window.
+        if cfg!(feature = "test-policy-overrides") && config.dev_settlement_quiescence_ms.is_none()
+        {
             config.dev_settlement_quiescence_ms = Some(0);
         }
         let root = root.as_ref().to_path_buf();
@@ -2368,10 +2368,10 @@ impl MarmotApp {
         .feature_registry(app_feature_registry())
         .supported_app_components(self.supported_app_component_ids());
         // Production uses the protocol-pinned convergence policy (SessionConfig's
-        // default). Only a debug/test override may change it — release builds
-        // ignore the knob so a host misconfig cannot fork honest clients (mdk#970).
+        // default). Only an explicit test-policy build may change it; normal
+        // debug and release builds ignore the knob (mdk#970).
         if let Some(ms) = self.config.dev_settlement_quiescence_ms {
-            if cfg!(debug_assertions) {
+            if cfg!(feature = "test-policy-overrides") {
                 session_config = session_config.convergence_policy(CanonicalizationPolicy {
                     settlement_quiescence_ms: ms,
                     ..CanonicalizationPolicy::default()
@@ -2380,7 +2380,7 @@ impl MarmotApp {
                 tracing::warn!(
                     target: "marmot_app",
                     method = "open_account",
-                    "ignoring dev_settlement_quiescence_ms in release build; pinned v1 policy required"
+                    "ignoring dev_settlement_quiescence_ms without test-policy-overrides; pinned v1 policy required"
                 );
             }
         }

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -1660,12 +1660,16 @@ impl ScheduledConvergence {
 }
 
 fn convergence_settlement_delay(app: &MarmotApp) -> Duration {
-    Duration::from_millis(
+    // Release builds always schedule against the pinned v1 quiescence window
+    // (mdk#970); the dev override is debug/test-only.
+    let quiescence_ms = if cfg!(debug_assertions) {
         app.config
             .dev_settlement_quiescence_ms
             .unwrap_or(DEFAULT_CONVERGENCE_SETTLEMENT_QUIESCENCE_MS)
-            .saturating_add(CONVERGENCE_SETTLEMENT_SCHEDULE_MARGIN_MS),
-    )
+    } else {
+        DEFAULT_CONVERGENCE_SETTLEMENT_QUIESCENCE_MS
+    };
+    Duration::from_millis(quiescence_ms.saturating_add(CONVERGENCE_SETTLEMENT_SCHEDULE_MARGIN_MS))
 }
 
 fn retry_delay_for_attempt(attempt: u32) -> Duration {

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -1543,7 +1543,6 @@ impl Drop for ScheduledPushRegistrationRetry {
     }
 }
 
-const DEFAULT_CONVERGENCE_SETTLEMENT_QUIESCENCE_MS: u64 = 1_000;
 /// Extra delay beyond the engine quiescence window before the first scheduled
 /// convergence tick fires. Avoids off-by-one-ms races where the timer fires
 /// while `ConvergenceStatus` is still `Syncing` (mdk#494).
@@ -1665,9 +1664,9 @@ fn convergence_settlement_delay(app: &MarmotApp) -> Duration {
     let quiescence_ms = if cfg!(debug_assertions) {
         app.config
             .dev_settlement_quiescence_ms
-            .unwrap_or(DEFAULT_CONVERGENCE_SETTLEMENT_QUIESCENCE_MS)
+            .unwrap_or(cgka_engine::canonicalization::V1_SETTLEMENT_QUIESCENCE_MS)
     } else {
-        DEFAULT_CONVERGENCE_SETTLEMENT_QUIESCENCE_MS
+        cgka_engine::canonicalization::V1_SETTLEMENT_QUIESCENCE_MS
     };
     Duration::from_millis(quiescence_ms.saturating_add(CONVERGENCE_SETTLEMENT_SCHEDULE_MARGIN_MS))
 }

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -1659,9 +1659,9 @@ impl ScheduledConvergence {
 }
 
 fn convergence_settlement_delay(app: &MarmotApp) -> Duration {
-    // Release builds always schedule against the pinned v1 quiescence window
-    // (mdk#970); the dev override is debug/test-only.
-    let quiescence_ms = if cfg!(debug_assertions) {
+    // Normal builds always schedule against the pinned v1 quiescence window
+    // (mdk#970); the override exists only in explicit test-policy builds.
+    let quiescence_ms = if cfg!(feature = "test-policy-overrides") {
         app.config
             .dev_settlement_quiescence_ms
             .unwrap_or(cgka_engine::canonicalization::V1_SETTLEMENT_QUIESCENCE_MS)

--- a/docs/marmot-architecture/overview/whitenoise-integration-map.md
+++ b/docs/marmot-architecture/overview/whitenoise-integration-map.md
@@ -1,7 +1,7 @@
 ---
 title: "whitenoise-rs Integration Map"
 created: 2026-05-11
-updated: 2026-06-07
+updated: 2026-07-24
 tags: [marmot, overview, cgka, integration, whitenoise]
 status: working-note
 ---
@@ -49,7 +49,7 @@ whitenoise-rs should keep owning:
 | Drain side effects | `drain()` |
 | Inspect basic group state | `epoch(&GroupId)`, `members(&GroupId)` |
 | Get local member id | `self_id()` |
-| Tune convergence policy | `set_convergence_policy(CanonicalizationPolicy)` |
+| Convergence policy | Pinned v1 baseline only (`CanonicalizationPolicy::default()`). Hosts MUST NOT tune it; debug harnesses may override under `debug_assertions`. |
 
 `marmot-account` adds a first coordinator shell:
 

--- a/docs/marmot-architecture/overview/whitenoise-integration-map.md
+++ b/docs/marmot-architecture/overview/whitenoise-integration-map.md
@@ -49,7 +49,7 @@ whitenoise-rs should keep owning:
 | Drain side effects | `drain()` |
 | Inspect basic group state | `epoch(&GroupId)`, `members(&GroupId)` |
 | Get local member id | `self_id()` |
-| Convergence policy | Pinned v1 baseline only (`CanonicalizationPolicy::default()`). Hosts MUST NOT tune it; debug harnesses may override under `debug_assertions`. |
+| Convergence policy | Pinned v1 baseline only (`CanonicalizationPolicy::default()`). Hosts MUST NOT tune it; dedicated harness builds may enable `test-policy-overrides`. |
 
 `marmot-account` adds a first coordinator shell:
 


### PR DESCRIPTION
## Summary
- Close security review M1 / #970: release builds accept only the pinned convergence-policy v1 constants, so hosts cannot locally (or per-group) tune branch selection and permanently fork honest clients.
- Keep debug/test overrides for settlement/rewind harnesses, but require `app_message_past_epoch_limit == max_past_epochs` and ignore `dev_settlement_quiescence_ms` in release app/runtime paths.
- Add named v1 constants, pin MLS `DEFAULT_MAX_PAST_EPOCHS` to the app-message window, and cover acceptance/rejection with unit + integration tests.

## Test plan
- [x] `cargo test -p cgka-engine --lib -- canonicalization::witness_window_tests`
- [x] `cargo test -p cgka-engine --test distributed_convergence -- set_convergence_policy_* release_builds_reject*`
- [x] `cargo test -p cgka-engine --test distributed_convergence --test deferred_peel_lifecycle --test mip03_guards --test fork_detection`
- [x] `cargo test -p cgka-session --test session_lifecycle -- session_advance_convergence`
- [x] `cargo check -p cgka-engine -p cgka-session -p marmot-app --release`
- [x] `just fast-ci`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release-grade convergence-policy validation is now enforced against the pinned v1 baseline, including app-message past-epoch window alignment.
  * Policy updates now report failures explicitly instead of silently succeeding.
* **Bug Fixes**
  * Release builds reject non-baseline convergence settings and ignore development-only settlement overrides.
* **Documentation**
  * Updated configuration and architecture guidance to clarify convergence-policy/settlement tuning is debug/test-only.
* **Tests & CI**
  * Added a release-mode “convergence-policy pin” test and wired it into CI/Justfile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->