### PR TITLE
fix: serialize matching idempotent sends

### DIFF
--- a/crates/agent-connector/AGENTS.md
+++ b/crates/agent-connector/AGENTS.md
@@ -42,8 +42,9 @@ several files in the same crate); methods shared across those files are `pub(cra
 - `src/stream_session.rs` — `StreamSessionStore`/`ActiveStreamSession`, the persisted
   `SendIdempotencyStore` (`$MARMOT_HOME/dev/send-idempotency.json`, 1024-entry FIFO,
   versioned SHA-256 request fingerprints, `stream_finalize_v2:` keys for durable finalized sends,
-  crash-safe atomic writes), and the
-  `DebugFinalSendStore` recorder.
+  crash-safe atomic writes, plus bounded same-key/same-fingerprint in-flight gates whose followers
+  reuse a leader's successful result or receive `send_in_progress` when the gate wait expires), and
+  the `DebugFinalSendStore` recorder.
 - `src/media_temp.rs` — TTL sweep of decrypted inbound media temp dirs under
   `$TMPDIR/marmot-media/`.
 - `src/quic.rs` — QUIC broker candidate parsing, address resolution, and trust selection.

--- a/crates/agent-connector/src/error.rs
+++ b/crates/agent-connector/src/error.rs
@@ -30,6 +30,8 @@ pub enum ConnectorError {
     InvalidProfileName(&'static str),
     #[error("connector operation timed out: {0}")]
     OperationTimedOut(&'static str),
+    #[error("matching send is still in progress")]
+    SendInProgress,
     #[error("outbound media path denied: {0}")]
     MediaPathDenied(&'static str),
     #[error("stream id is already reserved")]
@@ -57,6 +59,7 @@ impl ConnectorError {
             Self::Stream(_) => "stream_error",
             Self::InvalidProfileName(_) => "invalid_profile_name",
             Self::OperationTimedOut(_) => "operation_timed_out",
+            Self::SendInProgress => "send_in_progress",
             Self::MediaPathDenied(_) => "media_path_denied",
             Self::StreamIdInUse => "stream_id_in_use",
             Self::StreamCapabilityDenied => "stream_capability_denied",
@@ -75,6 +78,9 @@ impl ConnectorError {
             Self::Stream(_) => "agent stream request failed",
             Self::InvalidProfileName(_) => "invalid profile name",
             Self::OperationTimedOut(_) => "connector operation timed out",
+            Self::SendInProgress => {
+                "matching send is still in progress; retry with the same idempotency key"
+            }
             Self::MediaPathDenied(_) => "media path is not allowed",
             Self::StreamIdInUse => "stream id is already in use",
             Self::StreamCapabilityDenied => "stream capability is not authorized",

--- a/crates/agent-connector/src/messaging.rs
+++ b/crates/agent-connector/src/messaging.rs
@@ -12,6 +12,7 @@ use marmot_app::{
 
 use crate::AgentConnector;
 use crate::error::ConnectorError;
+use crate::stream_session::SendIdempotencyAcquisition;
 use crate::validation::normalize_hex;
 
 /// Current schema version for persisted `send_final` request fingerprints.
@@ -120,14 +121,18 @@ impl AgentConnector {
             reply_to_message_id_hex.as_deref(),
         );
 
-        // Idempotent durable send: if this key already committed a matching send,
-        // return the original message ids without re-sending so a retry after a
-        // post-write timeout cannot double-post an unrecallable message.
-        if let Some(key) = idempotency_key.as_deref()
-            && let Some(message_ids_hex) = self.idempotency.get(key, &fingerprint)
-        {
-            return Ok(AgentControlResponse::FinalSent { message_ids_hex });
-        }
+        // Reserve matching requests before the first await so concurrent
+        // same-key retries cannot both miss the cache and both durably send.
+        let idempotency = if let Some(key) = idempotency_key {
+            match self.idempotency.acquire(&key, &fingerprint).await? {
+                SendIdempotencyAcquisition::Completed(message_ids_hex) => {
+                    return Ok(AgentControlResponse::FinalSent { message_ids_hex });
+                }
+                SendIdempotencyAcquisition::Leader(reservation) => Some((key, reservation)),
+            }
+        } else {
+            None
+        };
 
         let account = self.local_account_for_account_id(account_id_hex)?;
         let group_id = GroupId::new(hex::decode(&group_id_hex)?);
@@ -143,7 +148,7 @@ impl AgentConnector {
         // Record only after a successful send so a failed send remains retryable.
         // A key already bound to a different fingerprint is left untouched (first
         // write wins), so this send simply proceeds without caching.
-        if let Some(key) = idempotency_key {
+        if let Some((key, _reservation)) = idempotency {
             self.idempotency
                 .record(key, fingerprint, summary.message_ids.clone());
         }

--- a/crates/agent-connector/src/messaging.rs
+++ b/crates/agent-connector/src/messaging.rs
@@ -110,6 +110,11 @@ impl AgentConnector {
             );
         }
 
+        // Reject unknown accounts and malformed group ids before a request can
+        // wait on or reserve an in-flight send gate.
+        let account = self.local_account_for_account_id(account_id_hex)?;
+        let group_id = GroupId::new(hex::decode(&group_id_hex)?);
+
         // Server-derived request fingerprint: a reused idempotency key only short-
         // circuits when the request it identifies is the same one. A reused key
         // carrying a different request body is a cache miss, so dedup can never
@@ -134,8 +139,6 @@ impl AgentConnector {
             None
         };
 
-        let account = self.local_account_for_account_id(account_id_hex)?;
-        let group_id = GroupId::new(hex::decode(&group_id_hex)?);
         let summary = if let Some(target_message_id) = reply_to_message_id_hex {
             self.runtime
                 .reply_to_message(&account.label, &group_id, &target_message_id, &text)
@@ -148,9 +151,11 @@ impl AgentConnector {
         // Record only after a successful send so a failed send remains retryable.
         // A key already bound to a different fingerprint is left untouched (first
         // write wins), so this send simply proceeds without caching.
-        if let Some((key, _reservation)) = idempotency {
+        if let Some((key, reservation)) = idempotency {
+            let message_ids = summary.message_ids.clone();
             self.idempotency
-                .record(key, fingerprint, summary.message_ids.clone());
+                .record(key, fingerprint, message_ids.clone());
+            reservation.complete(message_ids);
         }
         Ok(AgentControlResponse::FinalSent {
             message_ids_hex: summary.message_ids,

--- a/crates/agent-connector/src/stream.rs
+++ b/crates/agent-connector/src/stream.rs
@@ -19,8 +19,8 @@ use crate::quic::{
     resolve_quic_candidate_addr,
 };
 use crate::stream_session::{
-    ActiveStreamSession, FinalizedStream, StreamBeginReceipt, StreamBeginReservation,
-    normalize_stream_capability,
+    ActiveStreamSession, FinalizedStream, SendIdempotencyAcquisition, SendIdempotencyLeader,
+    StreamBeginReceipt, StreamBeginReservation, normalize_stream_capability,
 };
 use crate::validation::{normalize_hex, transcript_hash_from_hex, unix_now_seconds};
 use crate::{
@@ -95,6 +95,7 @@ fn stream_finalize_idempotency_key(key: &str) -> String {
 struct StreamFinalizeIdempotency {
     key: String,
     fingerprint: String,
+    _reservation: SendIdempotencyLeader,
 }
 
 impl AgentConnector {
@@ -364,14 +365,25 @@ impl AgentConnector {
             .map(str::trim)
             .filter(|key| !key.is_empty())
             .map(stream_finalize_idempotency_key);
-        if let Some(key) = idempotency_key.as_deref()
-            && let Some(message_ids_hex) = self.idempotency.get(key, &fingerprint)
-        {
-            return Ok(AgentControlResponse::StreamFinalized {
-                stream_id_hex,
-                message_ids_hex,
-            });
-        }
+        let idempotency = if let Some(key) = idempotency_key {
+            match self.idempotency.acquire(&key, &fingerprint).await? {
+                SendIdempotencyAcquisition::Completed(message_ids_hex) => {
+                    return Ok(AgentControlResponse::StreamFinalized {
+                        stream_id_hex,
+                        message_ids_hex,
+                    });
+                }
+                SendIdempotencyAcquisition::Leader(reservation) => {
+                    Some(StreamFinalizeIdempotency {
+                        key,
+                        fingerprint,
+                        _reservation: reservation,
+                    })
+                }
+            }
+        } else {
+            None
+        };
         // Clone (not remove) the session: the final text/hash/chunk-count
         // expectation is validated inside the compose task, atomically with
         // its teardown. On mismatch the session stays registered and the
@@ -401,7 +413,7 @@ impl AgentConnector {
                     final_text,
                     transcript_hash,
                     chunk_count,
-                    idempotency_key.map(|key| StreamFinalizeIdempotency { key, fingerprint }),
+                    idempotency,
                 )
                 .await;
         }
@@ -470,7 +482,7 @@ impl AgentConnector {
             final_text,
             transcript_hash,
             chunk_count,
-            idempotency_key.map(|key| StreamFinalizeIdempotency { key, fingerprint }),
+            idempotency,
         )
         .await
     }

--- a/crates/agent-connector/src/stream.rs
+++ b/crates/agent-connector/src/stream.rs
@@ -95,7 +95,7 @@ fn stream_finalize_idempotency_key(key: &str) -> String {
 struct StreamFinalizeIdempotency {
     key: String,
     fingerprint: String,
-    _reservation: SendIdempotencyLeader,
+    reservation: SendIdempotencyLeader,
 }
 
 impl AgentConnector {
@@ -365,6 +365,20 @@ impl AgentConnector {
             .map(str::trim)
             .filter(|key| !key.is_empty())
             .map(stream_finalize_idempotency_key);
+        // Preserve the post-success retry path after its stream session has
+        // been removed, but reject a cache miss with an invalid capability
+        // before it can wait on or reserve an in-flight send gate.
+        if let Some(key) = idempotency_key.as_deref()
+            && let Some(message_ids_hex) = self.idempotency.get(key, &fingerprint)
+        {
+            return Ok(AgentControlResponse::StreamFinalized {
+                stream_id_hex,
+                message_ids_hex,
+            });
+        }
+        let session = self
+            .streams
+            .get_authorized(&stream_id_hex, &stream_capability)?;
         let idempotency = if let Some(key) = idempotency_key {
             match self.idempotency.acquire(&key, &fingerprint).await? {
                 SendIdempotencyAcquisition::Completed(message_ids_hex) => {
@@ -377,7 +391,7 @@ impl AgentConnector {
                     Some(StreamFinalizeIdempotency {
                         key,
                         fingerprint,
-                        _reservation: reservation,
+                        reservation,
                     })
                 }
             }
@@ -388,10 +402,6 @@ impl AgentConnector {
         // expectation is validated inside the compose task, atomically with
         // its teardown. On mismatch the session stays registered and the
         // compose task keeps running, so finalize is retryable (#366).
-        let session = self
-            .streams
-            .get_authorized(&stream_id_hex, &stream_capability)?;
-
         // Retry fast-path: a prior finalize already validated the transcript and
         // the compose task exited, but the durable finish below failed. The
         // compose task is gone, so re-attempt the durable finish directly from
@@ -516,11 +526,13 @@ impl AgentConnector {
             )
             .await?;
         if let Some(idempotency) = idempotency {
+            let message_ids = summary.message_ids.clone();
             self.idempotency.record(
                 idempotency.key,
                 idempotency.fingerprint,
-                summary.message_ids.clone(),
+                message_ids.clone(),
             );
+            idempotency.reservation.complete(message_ids);
         }
         // Durable final published: it is now safe to drop the session.
         let _ = self.streams.remove_if_same(stream_id_hex, session);

--- a/crates/agent-connector/src/stream_session.rs
+++ b/crates/agent-connector/src/stream_session.rs
@@ -53,8 +53,12 @@ pub(crate) const SEND_IDEMPOTENCY_FILE: &str = "dev/send-idempotency.json";
 const SEND_IDEMPOTENCY_FILE_VERSION: u8 = 1;
 
 type SendIdempotencyGateKey = (String, String);
-type SendIdempotencyGate = tokio::sync::Mutex<()>;
 type SendIdempotencyGates = Arc<Mutex<HashMap<SendIdempotencyGateKey, Weak<SendIdempotencyGate>>>>;
+
+struct SendIdempotencyGate {
+    lock: Arc<tokio::sync::Mutex<()>>,
+    completed: Mutex<Option<Vec<String>>>,
+}
 
 /// Bounded FIFO map from a client-supplied idempotency key to a server-derived
 /// request fingerprint plus the durable message ids produced by the first
@@ -86,6 +90,17 @@ pub(crate) enum SendIdempotencyAcquisition {
 
 pub(crate) struct SendIdempotencyLeader {
     _guard: OwnedMutexGuard<()>,
+    gate: Arc<SendIdempotencyGate>,
+}
+
+impl SendIdempotencyLeader {
+    /// Publish the leader's successful result to callers that were already
+    /// waiting on this in-process gate. This remains transient so a sequential
+    /// reuse of a key with a different fingerprint keeps its legacy cache-miss
+    /// behavior.
+    pub(crate) fn complete(&self, message_ids: Vec<String>) {
+        *crate::lock_recover(&self.gate.completed) = Some(message_ids);
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -132,13 +147,25 @@ impl SendIdempotencyStore {
             .map(|(_, ids)| ids.clone())
     }
 
+    #[cfg(test)]
+    pub(crate) fn in_flight_participant_count(&self, key: &str, fingerprint: &str) -> usize {
+        crate::lock_recover(&self.in_flight)
+            .get(&(key.to_owned(), fingerprint.to_owned()))
+            .map_or(0, Weak::strong_count)
+    }
+
     /// Serialize matching in-flight sends before their first external side
-    /// effect. A follower rechecks the committed cache after the leader exits;
-    /// if the leader failed, the follower becomes the next leader and may retry.
+    /// effect. A follower rechecks the committed cache and the transient gate
+    /// result after the leader exits; if the leader failed, the follower becomes
+    /// the next leader and may retry.
     ///
     /// The gate includes the fingerprint so the existing behavior for a reused
     /// key with a different request body remains a cache miss rather than
-    /// blocking behind or reusing an unrelated send.
+    /// blocking behind or reusing an unrelated send. A leader intentionally
+    /// holds its gate across the external send and result recording. Those
+    /// operations are not cancelled here because cancellation cannot prove that
+    /// an unrecallable send did not land; a follower instead receives
+    /// [`ConnectorError::SendInProgress`] after the bounded gate wait.
     pub(crate) async fn acquire(
         &self,
         key: &str,
@@ -155,20 +182,30 @@ impl SendIdempotencyStore {
             if let Some(gate) = in_flight.get(&gate_key).and_then(Weak::upgrade) {
                 gate
             } else {
-                let gate = Arc::new(tokio::sync::Mutex::new(()));
+                let gate = Arc::new(SendIdempotencyGate {
+                    lock: Arc::new(tokio::sync::Mutex::new(())),
+                    completed: Mutex::new(None),
+                });
                 in_flight.insert(gate_key, Arc::downgrade(&gate));
                 gate
             }
         };
-        let guard =
-            crate::with_control_operation_timeout("send_idempotency_wait", gate.lock_owned())
-                .await?;
+        let guard = crate::with_control_operation_timeout(
+            "send_idempotency_wait",
+            Arc::clone(&gate.lock).lock_owned(),
+        )
+        .await
+        .map_err(|_| ConnectorError::SendInProgress)?;
 
         if let Some(message_ids) = self.get(key, fingerprint) {
             return Ok(SendIdempotencyAcquisition::Completed(message_ids));
         }
+        if let Some(message_ids) = crate::lock_recover(&gate.completed).clone() {
+            return Ok(SendIdempotencyAcquisition::Completed(message_ids));
+        }
         Ok(SendIdempotencyAcquisition::Leader(SendIdempotencyLeader {
             _guard: guard,
+            gate,
         }))
     }
 

--- a/crates/agent-connector/src/stream_session.rs
+++ b/crates/agent-connector/src/stream_session.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::{ErrorKind, Write};
 use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use agent_control::AgentControlDebugFinalSend;
@@ -13,7 +13,7 @@ use cgka_traits::GroupId;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;
-use tokio::sync::watch;
+use tokio::sync::{OwnedMutexGuard, watch};
 
 use crate::error::ConnectorError;
 use crate::validation::normalize_hex;
@@ -52,6 +52,10 @@ pub(crate) const SEND_IDEMPOTENCY_FILE: &str = "dev/send-idempotency.json";
 /// On-disk schema version for [`SEND_IDEMPOTENCY_FILE`].
 const SEND_IDEMPOTENCY_FILE_VERSION: u8 = 1;
 
+type SendIdempotencyGateKey = (String, String);
+type SendIdempotencyGate = tokio::sync::Mutex<()>;
+type SendIdempotencyGates = Arc<Mutex<HashMap<SendIdempotencyGateKey, Weak<SendIdempotencyGate>>>>;
+
 /// Bounded FIFO map from a client-supplied idempotency key to a server-derived
 /// request fingerprint plus the durable message ids produced by the first
 /// successful `send_final` for that key.
@@ -72,6 +76,16 @@ pub(crate) struct SendIdempotencyStore {
     path: PathBuf,
     lock: Arc<Mutex<()>>,
     inner: Arc<Mutex<SendIdempotencyInner>>,
+    in_flight: SendIdempotencyGates,
+}
+
+pub(crate) enum SendIdempotencyAcquisition {
+    Completed(Vec<String>),
+    Leader(SendIdempotencyLeader),
+}
+
+pub(crate) struct SendIdempotencyLeader {
+    _guard: OwnedMutexGuard<()>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -101,6 +115,7 @@ impl SendIdempotencyStore {
             path: home.join(SEND_IDEMPOTENCY_FILE),
             lock: Arc::new(Mutex::new(())),
             inner: Arc::new(Mutex::new(SendIdempotencyInner::default())),
+            in_flight: Arc::new(Mutex::new(HashMap::new())),
         };
         store.load_from_disk();
         store
@@ -115,6 +130,46 @@ impl SendIdempotencyStore {
             .get(key)
             .filter(|(recorded, _)| constant_time_eq(recorded.as_bytes(), fingerprint.as_bytes()))
             .map(|(_, ids)| ids.clone())
+    }
+
+    /// Serialize matching in-flight sends before their first external side
+    /// effect. A follower rechecks the committed cache after the leader exits;
+    /// if the leader failed, the follower becomes the next leader and may retry.
+    ///
+    /// The gate includes the fingerprint so the existing behavior for a reused
+    /// key with a different request body remains a cache miss rather than
+    /// blocking behind or reusing an unrelated send.
+    pub(crate) async fn acquire(
+        &self,
+        key: &str,
+        fingerprint: &str,
+    ) -> Result<SendIdempotencyAcquisition, ConnectorError> {
+        if let Some(message_ids) = self.get(key, fingerprint) {
+            return Ok(SendIdempotencyAcquisition::Completed(message_ids));
+        }
+
+        let gate_key = (key.to_owned(), fingerprint.to_owned());
+        let gate = {
+            let mut in_flight = crate::lock_recover(&self.in_flight);
+            in_flight.retain(|_, gate| gate.strong_count() > 0);
+            if let Some(gate) = in_flight.get(&gate_key).and_then(Weak::upgrade) {
+                gate
+            } else {
+                let gate = Arc::new(tokio::sync::Mutex::new(()));
+                in_flight.insert(gate_key, Arc::downgrade(&gate));
+                gate
+            }
+        };
+        let guard =
+            crate::with_control_operation_timeout("send_idempotency_wait", gate.lock_owned())
+                .await?;
+
+        if let Some(message_ids) = self.get(key, fingerprint) {
+            return Ok(SendIdempotencyAcquisition::Completed(message_ids));
+        }
+        Ok(SendIdempotencyAcquisition::Leader(SendIdempotencyLeader {
+            _guard: guard,
+        }))
     }
 
     /// Record the request `fingerprint` and durable message ids produced for

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -62,6 +62,16 @@ async fn control_operation_timeout_bounds_a_stalled_whole_operation() {
     assert!(started.elapsed() < Duration::from_secs(1));
 }
 
+#[test]
+fn send_in_progress_has_a_distinct_retry_contract() {
+    let error = crate::ConnectorError::SendInProgress;
+    assert_eq!(error.code(), "send_in_progress");
+    assert_eq!(
+        error.client_message(),
+        "matching send is still in progress; retry with the same idempotency key"
+    );
+}
+
 #[tokio::test]
 async fn control_frame_write_timeout_includes_flush() {
     struct FlushStallingWriter;
@@ -2698,20 +2708,44 @@ async fn connector_finalize_retries_durable_finish_without_compose_task() {
         "a rejected retry must not drop the session"
     );
 
-    // A matching retry completes the durable publish from the frozen transcript
-    // — the compose task was aborted above, so this proves it is not consulted —
-    // and only then removes the session.
-    let finalized = connector
-        .stream_finalize_response(
-            &stream_id_hex,
-            &stream_capability,
-            "frozen final".to_owned(),
-            &hex::encode(transcript_hash),
-            1,
-            Some("frozen-finalize".to_owned()),
-        )
-        .await
-        .expect("frozen-transcript retry finalizes without the compose task");
+    // Two matching retries race the durable publish from the frozen transcript.
+    // The compose task was aborted above, so the leader cannot consult it; the
+    // follower must reuse the leader's result instead of publishing again.
+    let transcript_hash_hex = hex::encode(transcript_hash);
+    let start = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let first_start = std::sync::Arc::clone(&start);
+    let second_start = std::sync::Arc::clone(&start);
+    let first_finalize = async {
+        first_start.wait().await;
+        connector
+            .stream_finalize_response(
+                &stream_id_hex,
+                &stream_capability,
+                "frozen final".to_owned(),
+                &transcript_hash_hex,
+                1,
+                Some("frozen-finalize".to_owned()),
+            )
+            .await
+    };
+    let second_finalize = async {
+        second_start.wait().await;
+        connector
+            .stream_finalize_response(
+                &stream_id_hex,
+                &stream_capability,
+                "frozen final".to_owned(),
+                &transcript_hash_hex,
+                1,
+                Some("frozen-finalize".to_owned()),
+            )
+            .await
+    };
+    let (first_result, second_result) = tokio::join!(first_finalize, second_finalize);
+    let finalized =
+        first_result.expect("first frozen-transcript retry finalizes without the compose task");
+    let concurrent_retry =
+        second_result.expect("concurrent frozen-transcript retry reuses the leader result");
     let AgentControlResponse::StreamFinalized {
         message_ids_hex, ..
     } = finalized
@@ -2720,6 +2754,17 @@ async fn connector_finalize_retries_durable_finish_without_compose_task() {
     };
     assert_eq!(message_ids_hex.len(), 1);
     assert!(!message_ids_hex[0].is_empty());
+    let AgentControlResponse::StreamFinalized {
+        message_ids_hex: concurrent_ids,
+        ..
+    } = concurrent_retry
+    else {
+        panic!("expected concurrent stream finalized response");
+    };
+    assert_eq!(
+        concurrent_ids, message_ids_hex,
+        "a concurrent stream finalize must reuse the leader message ids"
+    );
     assert!(
         connector.streams.get(&stream_id_norm).is_err(),
         "a successful durable finish must remove the session"
@@ -3731,7 +3776,7 @@ async fn replay_missed_inbound_recovers_dropped_messages_and_dedups() {
 }
 
 #[tokio::test]
-async fn send_final_with_repeated_idempotency_key_dedups_without_second_send() {
+async fn concurrent_send_final_with_repeated_idempotency_key_sends_once() {
     // GAP-06: a retry that reuses the same idempotency key must return the
     // ORIGINAL durable message ids without re-sending, so a post-write-timeout
     // retry can never double-post an unrecallable encrypted message. Observable
@@ -3772,42 +3817,52 @@ async fn send_final_with_repeated_idempotency_key_dedups_without_second_send() {
     connector.runtime.catch_up_accounts().await.unwrap();
 
     let key = "retry-key-1".to_owned();
+    let start = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let first_start = std::sync::Arc::clone(&start);
+    let second_start = std::sync::Arc::clone(&start);
+    let first_send = async {
+        first_start.wait().await;
+        connector
+            .send_final_response(
+                &agent.account.account_id_hex,
+                &group_id_hex.to_uppercase(),
+                "idempotent reply".to_owned(),
+                None,
+                Some(key.clone()),
+            )
+            .await
+    };
+    let second_send = async {
+        second_start.wait().await;
+        connector
+            .send_final_response(
+                &agent.account.account_id_hex,
+                &group_id_hex,
+                "idempotent reply".to_owned(),
+                None,
+                Some(key.clone()),
+            )
+            .await
+    };
+    let (first_result, second_result) = tokio::join!(first_send, second_send);
+
     let AgentControlResponse::FinalSent {
         message_ids_hex: first_ids,
-    } = connector
-        .send_final_response(
-            &agent.account.account_id_hex,
-            &group_id_hex.to_uppercase(),
-            "idempotent reply".to_owned(),
-            None,
-            Some(key.clone()),
-        )
-        .await
-        .unwrap()
+    } = first_result.unwrap()
     else {
         panic!("expected first send to return FinalSent");
     };
     assert!(!first_ids.is_empty(), "a real send returns message ids");
 
-    // Second call with the SAME key returns the cached ids verbatim.
     let AgentControlResponse::FinalSent {
         message_ids_hex: second_ids,
-    } = connector
-        .send_final_response(
-            &agent.account.account_id_hex,
-            &group_id_hex,
-            "idempotent reply".to_owned(),
-            None,
-            Some(key),
-        )
-        .await
-        .unwrap()
+    } = second_result.unwrap()
     else {
-        panic!("expected second send to return cached FinalSent");
+        panic!("expected concurrent retry to return FinalSent");
     };
     assert_eq!(
         second_ids, first_ids,
-        "a repeated idempotency key must return the original ids across equivalent hex casing"
+        "a concurrent retry must return the leader ids across equivalent hex casing"
     );
 
     // Observable proof there was no second underlying send: exactly one copy of
@@ -3861,6 +3916,20 @@ fn send_idempotency_store_returns_recorded_ids_for_a_key() {
     );
 }
 
+async fn wait_for_idempotency_follower(
+    store: &crate::stream_session::SendIdempotencyStore,
+    key: &str,
+    fingerprint: &str,
+) {
+    timeout(Duration::from_secs(1), async {
+        while store.in_flight_participant_count(key, fingerprint) < 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the follower must join the leader's in-flight gate");
+}
+
 #[tokio::test]
 async fn send_idempotency_store_same_request_waits_for_leader_result() {
     use crate::stream_session::{SendIdempotencyAcquisition, SendIdempotencyStore};
@@ -3879,11 +3948,8 @@ async fn send_idempotency_store_same_request_waits_for_leader_result() {
             .await
             .unwrap()
     });
-    tokio::task::yield_now().await;
-    assert!(
-        !follower.is_finished(),
-        "a matching follower must wait instead of issuing another send"
-    );
+    wait_for_idempotency_follower(&store, "same-key", "same-fingerprint").await;
+    assert!(!follower.is_finished());
 
     let ids = vec!["aa".repeat(32)];
     store.record(
@@ -3891,6 +3957,7 @@ async fn send_idempotency_store_same_request_waits_for_leader_result() {
         "same-fingerprint".to_owned(),
         ids.clone(),
     );
+    leader.complete(ids.clone());
     drop(leader);
 
     match follower.await.unwrap() {
@@ -3923,7 +3990,8 @@ async fn send_idempotency_store_failed_leader_leaves_request_retryable() {
             .await
             .unwrap()
     });
-    tokio::task::yield_now().await;
+    wait_for_idempotency_follower(&store, "retry-key", "retry-fingerprint").await;
+    assert!(!follower.is_finished());
     drop(leader);
 
     match follower.await.unwrap() {
@@ -3932,6 +4000,67 @@ async fn send_idempotency_store_failed_leader_leaves_request_retryable() {
             panic!("a failed leader has no committed result")
         }
     }
+}
+
+#[tokio::test]
+async fn concurrent_new_fingerprint_reuses_transient_leader_result() {
+    use crate::stream_session::{SendIdempotencyAcquisition, SendIdempotencyStore};
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SendIdempotencyStore::new(dir.path());
+    store.record(
+        "shared-key".to_owned(),
+        "first-fingerprint".to_owned(),
+        vec!["aa".repeat(32)],
+    );
+    let leader = match store
+        .acquire("shared-key", "second-fingerprint")
+        .await
+        .unwrap()
+    {
+        SendIdempotencyAcquisition::Leader(leader) => leader,
+        SendIdempotencyAcquisition::Completed(_) => {
+            panic!("a new request body must remain a cache miss")
+        }
+    };
+
+    let follower_store = store.clone();
+    let follower = tokio::spawn(async move {
+        follower_store
+            .acquire("shared-key", "second-fingerprint")
+            .await
+            .unwrap()
+    });
+    wait_for_idempotency_follower(&store, "shared-key", "second-fingerprint").await;
+    assert!(!follower.is_finished());
+
+    let ids = vec!["bb".repeat(32)];
+    store.record(
+        "shared-key".to_owned(),
+        "second-fingerprint".to_owned(),
+        ids.clone(),
+    );
+    assert_eq!(
+        store.get("shared-key", "second-fingerprint"),
+        None,
+        "the original durable key binding remains first-write-wins"
+    );
+    leader.complete(ids.clone());
+    drop(leader);
+
+    match follower.await.unwrap() {
+        SendIdempotencyAcquisition::Completed(recorded) => assert_eq!(recorded, ids),
+        SendIdempotencyAcquisition::Leader(_) => {
+            panic!("a concurrent follower must reuse the transient leader result")
+        }
+    }
+    assert!(matches!(
+        store
+            .acquire("shared-key", "second-fingerprint")
+            .await
+            .unwrap(),
+        SendIdempotencyAcquisition::Leader(_)
+    ));
 }
 
 #[tokio::test]

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -3861,6 +3861,103 @@ fn send_idempotency_store_returns_recorded_ids_for_a_key() {
     );
 }
 
+#[tokio::test]
+async fn send_idempotency_store_same_request_waits_for_leader_result() {
+    use crate::stream_session::{SendIdempotencyAcquisition, SendIdempotencyStore};
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SendIdempotencyStore::new(dir.path());
+    let leader = match store.acquire("same-key", "same-fingerprint").await.unwrap() {
+        SendIdempotencyAcquisition::Leader(leader) => leader,
+        SendIdempotencyAcquisition::Completed(_) => panic!("first caller must lead"),
+    };
+
+    let follower_store = store.clone();
+    let follower = tokio::spawn(async move {
+        follower_store
+            .acquire("same-key", "same-fingerprint")
+            .await
+            .unwrap()
+    });
+    tokio::task::yield_now().await;
+    assert!(
+        !follower.is_finished(),
+        "a matching follower must wait instead of issuing another send"
+    );
+
+    let ids = vec!["aa".repeat(32)];
+    store.record(
+        "same-key".to_owned(),
+        "same-fingerprint".to_owned(),
+        ids.clone(),
+    );
+    drop(leader);
+
+    match follower.await.unwrap() {
+        SendIdempotencyAcquisition::Completed(recorded) => assert_eq!(recorded, ids),
+        SendIdempotencyAcquisition::Leader(_) => {
+            panic!("a follower must reuse the leader's committed result")
+        }
+    }
+}
+
+#[tokio::test]
+async fn send_idempotency_store_failed_leader_leaves_request_retryable() {
+    use crate::stream_session::{SendIdempotencyAcquisition, SendIdempotencyStore};
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SendIdempotencyStore::new(dir.path());
+    let leader = match store
+        .acquire("retry-key", "retry-fingerprint")
+        .await
+        .unwrap()
+    {
+        SendIdempotencyAcquisition::Leader(leader) => leader,
+        SendIdempotencyAcquisition::Completed(_) => panic!("first caller must lead"),
+    };
+
+    let follower_store = store.clone();
+    let follower = tokio::spawn(async move {
+        follower_store
+            .acquire("retry-key", "retry-fingerprint")
+            .await
+            .unwrap()
+    });
+    tokio::task::yield_now().await;
+    drop(leader);
+
+    match follower.await.unwrap() {
+        SendIdempotencyAcquisition::Leader(_) => {}
+        SendIdempotencyAcquisition::Completed(_) => {
+            panic!("a failed leader has no committed result")
+        }
+    }
+}
+
+#[tokio::test]
+async fn send_idempotency_store_different_fingerprint_remains_a_cache_miss() {
+    use crate::stream_session::{SendIdempotencyAcquisition, SendIdempotencyStore};
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = SendIdempotencyStore::new(dir.path());
+    store.record(
+        "shared-key".to_owned(),
+        "first-fingerprint".to_owned(),
+        vec!["aa".repeat(32)],
+    );
+
+    match store
+        .acquire("shared-key", "different-fingerprint")
+        .await
+        .unwrap()
+    {
+        SendIdempotencyAcquisition::Leader(_) => {}
+        SendIdempotencyAcquisition::Completed(_) => {
+            panic!("different request bodies must not reuse unrelated message ids")
+        }
+    }
+}
+
 #[test]
 fn send_idempotency_persist_preserves_existing_socket_directory_mode() {
     use crate::stream_session::SendIdempotencyStore;


### PR DESCRIPTION
## Summary
- serialize only matching key-and-fingerprint sends before the first external effect
- let concurrent followers reuse the leader committed message IDs
- release failed leaders so the next caller can retry
- preserve existing cache-miss behavior for different request fingerprints

## Scope
This intentionally fixes only #1039. It adds no delivery-status protocol, Hermes or OpenCode changes, or cross-restart logical-delivery contract. #1088 remains open pending upstream Hermes issue NousResearch/hermes-agent#70694 and a durable delivery design.

## Verification
- cargo test -p agent-connector: 116 passed
- just fast-ci: passed

Fixes #1039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate message sends when requests with the same idempotency key arrive concurrently.
  - Concurrent matching requests now reuse the original successful result instead of triggering another send.
  - Added clearer handling when a matching request is still processing, including a `send_in_progress` error and guidance to retry with the same idempotency key.
  - Improved retry behavior for finalized responses, preserving message results and preventing duplicate durable publishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->