### PR TITLE
feat: add durable frozen convergence passes

### DIFF
--- a/crates/cgka-conformance-simulator/src/bus.rs
+++ b/crates/cgka-conformance-simulator/src/bus.rs
@@ -176,7 +176,7 @@ impl TransportBus {
     /// specific client's mailbox, bypassing the queue + delivery policy.
     /// This is the hook the proptest "true same-id replay" property uses
     /// to deliver an identical message twice and prove the engine's
-    /// `StaleReason::AlreadySeen` dedup fires.
+    /// the typed duplicate exclusion fires.
     pub fn inject(&self, client: ClientId, msg: TransportMessage) {
         let mut inner = self.inner.lock().unwrap();
         if let Some(mb) = inner.mailboxes.get_mut(&client) {

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -24,7 +24,7 @@ use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{IngestOutcome, PeeledContent};
 use cgka_traits::peeler::TransportPeeler;
-use cgka_traits::storage::{ConvergencePassStorage, MessageStorage};
+use cgka_traits::storage::{ConvergencePassStorage, MessageStorage, StorageProvider};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use cgka_traits::{ConvergenceCutoffCause, ConvergencePassPhase, DurableConvergencePass};
@@ -366,7 +366,8 @@ impl HarnessClient {
     }
 
     /// Restore a harness convergence checkpoint, including the pass row omitted
-    /// from the group epoch snapshot.
+    /// from the group epoch snapshot, then rebuild the engine over the restored
+    /// durable state.
     pub fn restore_convergence_checkpoint(&mut self, name: &str) {
         let (group_id, pass) = self
             .convergence_checkpoints
@@ -374,11 +375,12 @@ impl HarnessClient {
             .cloned()
             .expect("convergence checkpoint exists");
         self.storage
-            .rollback_group_to_snapshot(&group_id, name)
-            .expect("restore convergence group snapshot");
-        self.storage
-            .put_convergence_pass(&pass)
-            .expect("restore durable convergence pass");
+            .with_transaction(|storage| {
+                storage.rollback_group_to_snapshot(&group_id, name)?;
+                storage.put_convergence_pass(&pass)
+            })
+            .expect("atomically restore convergence checkpoint");
+        self.restart();
     }
 
     pub fn converge_stored_at(

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -7,7 +7,7 @@ use crate::bus::{ClientId, TransportBus};
 use cgka_engine::account_identity_proof::{
     AccountIdentityProofRequest, AccountIdentityProofSigner,
 };
-use cgka_engine::canonicalization::CanonicalizationPolicy;
+use cgka_engine::canonicalization::{CanonicalizationPolicy, CanonicalizationResult};
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::{Engine, EngineBuilder};
 use cgka_traits::app_components::{
@@ -24,8 +24,10 @@ use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
 use cgka_traits::ingest::{IngestOutcome, PeeledContent};
 use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::storage::{ConvergencePassStorage, MessageStorage};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
+use cgka_traits::{ConvergenceCutoffCause, ConvergencePassPhase, DurableConvergencePass};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -56,6 +58,7 @@ pub struct HarnessClient {
     /// Shared in-memory capture of the engine's forensic audit events, used to
     /// observe decisions no `GroupEvent` exposes (e.g. `convergence_decision`).
     audit_capture: AuditCapture,
+    convergence_checkpoints: HashMap<String, (GroupId, DurableConvergencePass)>,
 }
 
 pub struct ClientBuilder {
@@ -161,6 +164,7 @@ impl ClientBuilder {
             default_group: None,
             app_event_counter: 0,
             audit_capture,
+            convergence_checkpoints: HashMap::new(),
         }
     }
 }
@@ -327,6 +331,64 @@ impl HarnessClient {
             .expect("engine hydrates from storage");
         self.engine = engine;
         self.pending_events.clear();
+    }
+
+    /// Freeze the current durable pass at its quiescence boundary. This is a
+    /// harness-level restart fault operation; scenarios should not reach into
+    /// engine storage to manufacture the boundary themselves.
+    pub fn freeze_convergence_pass(&mut self, group_id: &GroupId) {
+        let mut pass = self
+            .storage
+            .convergence_pass(group_id)
+            .expect("load durable convergence pass")
+            .expect("durable convergence pass exists");
+        pass.phase = ConvergencePassPhase::Frozen;
+        pass.cutoff_cause = Some(ConvergenceCutoffCause::Quiescence);
+        pass.frozen_at_wall_ms = Some(pass.quiescence_deadline_wall_ms);
+        self.storage
+            .put_convergence_pass(&pass)
+            .expect("persist frozen convergence pass");
+    }
+
+    /// Snapshot group state and separately retain the pass row, which group
+    /// epoch snapshots intentionally exclude.
+    pub fn checkpoint_convergence(&mut self, group_id: &GroupId, name: &str) {
+        let pass = self
+            .storage
+            .convergence_pass(group_id)
+            .expect("load convergence pass for checkpoint")
+            .expect("checkpoint requires a convergence pass");
+        self.storage
+            .create_group_snapshot(group_id, name)
+            .expect("create convergence group snapshot");
+        self.convergence_checkpoints
+            .insert(name.to_owned(), (group_id.clone(), pass));
+    }
+
+    /// Restore a harness convergence checkpoint, including the pass row omitted
+    /// from the group epoch snapshot.
+    pub fn restore_convergence_checkpoint(&mut self, name: &str) {
+        let (group_id, pass) = self
+            .convergence_checkpoints
+            .get(name)
+            .cloned()
+            .expect("convergence checkpoint exists");
+        self.storage
+            .rollback_group_to_snapshot(&group_id, name)
+            .expect("restore convergence group snapshot");
+        self.storage
+            .put_convergence_pass(&pass)
+            .expect("restore durable convergence pass");
+    }
+
+    pub fn converge_stored_at(
+        &mut self,
+        group_id: &GroupId,
+        now_ms: u64,
+    ) -> CanonicalizationResult {
+        self.engine
+            .converge_stored_openmls_messages(group_id, now_ms)
+            .expect("stored convergence succeeds")
     }
 
     /// Drain the `convergence_decision` events the engine has emitted since the

--- a/crates/cgka-conformance-simulator/tests/canonicalization_contract.rs
+++ b/crates/cgka-conformance-simulator/tests/canonicalization_contract.rs
@@ -35,6 +35,7 @@ fn policy() -> CanonicalizationPolicy {
         },
         app_message_past_epoch_limit: 5,
         settlement_quiescence_ms: 1_000,
+        max_convergence_pass_ms: 5_000,
     }
 }
 

--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -63,10 +63,10 @@ fn selfremove_registry() -> FeatureRegistry {
     r
 }
 
-fn one_rewind_policy() -> CanonicalizationPolicy {
+fn base_test_policy() -> CanonicalizationPolicy {
     CanonicalizationPolicy {
         convergence: ConvergencePolicy {
-            max_rewind_commits: 1,
+            max_rewind_commits: 5,
             witness_quorum_senders_per_epoch: 2,
             witness_quorum_epochs: 1,
             max_witness_override_depth: 1,
@@ -74,6 +74,16 @@ fn one_rewind_policy() -> CanonicalizationPolicy {
         app_message_past_epoch_limit: 5,
         settlement_quiescence_ms: 1_000,
         max_convergence_pass_ms: 5_000,
+    }
+}
+
+fn one_rewind_policy() -> CanonicalizationPolicy {
+    CanonicalizationPolicy {
+        convergence: ConvergencePolicy {
+            max_rewind_commits: 1,
+            ..base_test_policy().convergence
+        },
+        ..base_test_policy()
     }
 }
 
@@ -456,17 +466,7 @@ async fn openmls_materializes_competing_commit_paths_from_same_anchor() {
             pending_messages: vec![],
             outbound_intents: vec![],
             candidate_branches: vec![],
-            policy: CanonicalizationPolicy {
-                convergence: ConvergencePolicy {
-                    max_rewind_commits: 5,
-                    witness_quorum_senders_per_epoch: 2,
-                    witness_quorum_epochs: 1,
-                    max_witness_override_depth: 1,
-                },
-                app_message_past_epoch_limit: 5,
-                settlement_quiescence_ms: 1_000,
-                max_convergence_pass_ms: 5_000,
-            },
+            policy: base_test_policy(),
             now_ms: 2_000,
         },
         candidates
@@ -563,17 +563,7 @@ async fn openmls_canonicalization_maps_consumed_proposal_refs_to_pending_proposa
             pending_messages: vec![proposal_msg.clone()],
             already_delivered_app_ids: BTreeSet::new(),
             outbound_intents: vec![],
-            policy: CanonicalizationPolicy {
-                convergence: ConvergencePolicy {
-                    max_rewind_commits: 5,
-                    witness_quorum_senders_per_epoch: 2,
-                    witness_quorum_epochs: 1,
-                    max_witness_override_depth: 1,
-                },
-                app_message_past_epoch_limit: 5,
-                settlement_quiescence_ms: 1_000,
-                max_convergence_pass_ms: 5_000,
-            },
+            policy: base_test_policy(),
             now_ms: 2_000,
         },
     )
@@ -680,17 +670,7 @@ async fn openmls_canonicalization_uses_app_messages_as_branch_witnesses() {
             pending_messages: vec![app_msg.clone()],
             already_delivered_app_ids: BTreeSet::new(),
             outbound_intents: vec![],
-            policy: CanonicalizationPolicy {
-                convergence: ConvergencePolicy {
-                    max_rewind_commits: 5,
-                    witness_quorum_senders_per_epoch: 2,
-                    witness_quorum_epochs: 1,
-                    max_witness_override_depth: 1,
-                },
-                app_message_past_epoch_limit: 5,
-                settlement_quiescence_ms: 1_000,
-                max_convergence_pass_ms: 5_000,
-            },
+            policy: base_test_policy(),
             now_ms: 2_000,
         },
     )
@@ -790,17 +770,7 @@ async fn stored_openmls_messages_reconstruct_canonicalization_batch() {
             seen_message_ids: BTreeSet::new(),
         },
         vec![],
-        CanonicalizationPolicy {
-            convergence: ConvergencePolicy {
-                max_rewind_commits: 5,
-                witness_quorum_senders_per_epoch: 2,
-                witness_quorum_epochs: 1,
-                max_witness_override_depth: 1,
-            },
-            app_message_past_epoch_limit: 5,
-            settlement_quiescence_ms: 1_000,
-            max_convergence_pass_ms: 5_000,
-        },
+        base_test_policy(),
         2_000,
     )
     .expect("stored OpenMLS canonicalization succeeds");
@@ -897,17 +867,7 @@ async fn stored_openmls_canonicalization_persists_message_dispositions() {
             seen_message_ids: BTreeSet::new(),
         },
         vec![],
-        CanonicalizationPolicy {
-            convergence: ConvergencePolicy {
-                max_rewind_commits: 5,
-                witness_quorum_senders_per_epoch: 2,
-                witness_quorum_epochs: 1,
-                max_witness_override_depth: 1,
-            },
-            app_message_past_epoch_limit: 5,
-            settlement_quiescence_ms: 1_000,
-            max_convergence_pass_ms: 5_000,
-        },
+        base_test_policy(),
         2_000,
     )
     .expect("stored OpenMLS canonicalization succeeds");
@@ -1007,17 +967,7 @@ async fn stored_openmls_canonicalization_applies_selected_branch_to_retained_gro
             seen_message_ids: BTreeSet::new(),
         },
         vec![],
-        CanonicalizationPolicy {
-            convergence: ConvergencePolicy {
-                max_rewind_commits: 5,
-                witness_quorum_senders_per_epoch: 2,
-                witness_quorum_epochs: 1,
-                max_witness_override_depth: 1,
-            },
-            app_message_past_epoch_limit: 5,
-            settlement_quiescence_ms: 1_000,
-            max_convergence_pass_ms: 5_000,
-        },
+        base_test_policy(),
         2_000,
     )
     .expect("stored OpenMLS canonicalization succeeds");

--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -73,6 +73,7 @@ fn one_rewind_policy() -> CanonicalizationPolicy {
         },
         app_message_past_epoch_limit: 5,
         settlement_quiescence_ms: 1_000,
+        max_convergence_pass_ms: 5_000,
     }
 }
 
@@ -464,6 +465,7 @@ async fn openmls_materializes_competing_commit_paths_from_same_anchor() {
                 },
                 app_message_past_epoch_limit: 5,
                 settlement_quiescence_ms: 1_000,
+                max_convergence_pass_ms: 5_000,
             },
             now_ms: 2_000,
         },
@@ -570,6 +572,7 @@ async fn openmls_canonicalization_maps_consumed_proposal_refs_to_pending_proposa
                 },
                 app_message_past_epoch_limit: 5,
                 settlement_quiescence_ms: 1_000,
+                max_convergence_pass_ms: 5_000,
             },
             now_ms: 2_000,
         },
@@ -686,6 +689,7 @@ async fn openmls_canonicalization_uses_app_messages_as_branch_witnesses() {
                 },
                 app_message_past_epoch_limit: 5,
                 settlement_quiescence_ms: 1_000,
+                max_convergence_pass_ms: 5_000,
             },
             now_ms: 2_000,
         },
@@ -795,6 +799,7 @@ async fn stored_openmls_messages_reconstruct_canonicalization_batch() {
             },
             app_message_past_epoch_limit: 5,
             settlement_quiescence_ms: 1_000,
+            max_convergence_pass_ms: 5_000,
         },
         2_000,
     )
@@ -901,6 +906,7 @@ async fn stored_openmls_canonicalization_persists_message_dispositions() {
             },
             app_message_past_epoch_limit: 5,
             settlement_quiescence_ms: 1_000,
+            max_convergence_pass_ms: 5_000,
         },
         2_000,
     )
@@ -1010,6 +1016,7 @@ async fn stored_openmls_canonicalization_applies_selected_branch_to_retained_gro
             },
             app_message_past_epoch_limit: 5,
             settlement_quiescence_ms: 1_000,
+            max_convergence_pass_ms: 5_000,
         },
         2_000,
     )

--- a/crates/cgka-conformance-simulator/tests/proptest_invariants.rs
+++ b/crates/cgka-conformance-simulator/tests/proptest_invariants.rs
@@ -1303,7 +1303,6 @@ fn stored_convergence_restart_equivalence(name: String, committer_idx: usize) {
         let live_member_count = clients[2].members().len();
 
         clients[2].restore_convergence_checkpoint("restart-equivalence");
-        clients[2].restart();
         let restarted_result = clients[2].converge_stored_at(&group_id, 1_000_000);
 
         prop_assert(

--- a/crates/cgka-conformance-simulator/tests/proptest_invariants.rs
+++ b/crates/cgka-conformance-simulator/tests/proptest_invariants.rs
@@ -32,7 +32,6 @@
 //!   result before and after rebuilding an engine over the same storage.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Arc;
 
 use cgka_conformance_simulator::bus::DeliveryPolicy;
 use cgka_conformance_simulator::canonicalization::{
@@ -48,19 +47,13 @@ use cgka_conformance_simulator::proptest_support::{
     ConfirmOutcome, DeliveryProfile, HarnessIntent, confirm_outcome, delivery_profile, intent_seq,
 };
 use cgka_conformance_simulator::{ClientBuilder, HarnessClient, TransportBus};
-use cgka_engine::EngineBuilder;
-use cgka_engine::account_identity_proof::{
-    AccountIdentityProofRequest, AccountIdentityProofSigner,
-};
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_traits::capabilities::{
     Capability, CapabilityRequirement, Feature, FeatureStatus, RequirementLevel, TransportKind,
 };
-use cgka_traits::convergence_pass::{ConvergenceCutoffCause, ConvergencePassPhase};
 use cgka_traits::engine::{SendIntent, SendResult};
 use cgka_traits::ingest::{IngestOutcome, InputRejectionCategory};
-use cgka_traits::storage::{ConvergencePassStorage, GroupStorage, MessageStorage};
-use cgka_traits::{CgkaEngine, CommitOrderingPriority};
+use cgka_traits::{CgkaEngine, CommitOrderingPriority, GroupStorage};
 use proptest::prelude::*;
 
 const REACTIONS_PROPOSAL: u16 = 0xF210;
@@ -78,46 +71,6 @@ fn pad32(name: &[u8]) -> Vec<u8> {
     let n = name.len().min(32);
     out[..n].copy_from_slice(&name[..n]);
     out
-}
-
-fn deterministic_nostr_keys(seed: &[u8]) -> nostr::Keys {
-    use sha2::{Digest, Sha256};
-    let mut counter = 0_u64;
-    loop {
-        let mut hasher = Sha256::new();
-        hasher.update(b"marmot-cgka-conformance-nostr-key-v1");
-        hasher.update(seed);
-        hasher.update(counter.to_be_bytes());
-        let secret = hasher.finalize();
-        if let Ok(keys) = nostr::Keys::parse(&hex::encode(secret)) {
-            return keys;
-        }
-        counter = counter
-            .checked_add(1)
-            .expect("deterministic Nostr key search exhausted");
-    }
-}
-
-#[derive(Clone)]
-struct NostrAccountIdentityProofSigner {
-    keys: nostr::Keys,
-}
-
-impl AccountIdentityProofSigner for NostrAccountIdentityProofSigner {
-    fn sign_account_identity_proof(
-        &self,
-        request: &AccountIdentityProofRequest,
-    ) -> Result<[u8; 64], String> {
-        if self.keys.public_key().to_bytes().as_slice() != request.account_identity.as_slice() {
-            return Err("request account identity does not match proptest key".into());
-        }
-        let event = request.proof_event().and_then(|event| {
-            event
-                .sign_with_keys(&self.keys)
-                .map_err(|err| err.to_string())
-        })?;
-        request.signature_from_signed_event(event)
-    }
 }
 
 fn registry() -> FeatureRegistry {
@@ -1342,60 +1295,16 @@ fn stored_convergence_restart_equivalence(name: String, committer_idx: usize) {
             .ingest(commit)
             .await
             .expect("observer buffers stored convergence input");
-        let mut pre_convergence_pass = clients[2]
-            .storage()
-            .convergence_pass(&group_id)
-            .expect("load pre-convergence durable pass")
-            .expect("ingest opened a durable convergence pass");
-        pre_convergence_pass.phase = ConvergencePassPhase::Frozen;
-        pre_convergence_pass.cutoff_cause = Some(ConvergenceCutoffCause::Quiescence);
-        pre_convergence_pass.frozen_at_wall_ms =
-            Some(pre_convergence_pass.quiescence_deadline_wall_ms);
-        clients[2]
-            .storage()
-            .put_convergence_pass(&pre_convergence_pass)
-            .expect("persist frozen restart boundary");
-
-        clients[2]
-            .storage()
-            .create_group_snapshot(&group_id, "restart-equivalence")
-            .expect("pre-convergence snapshot");
-        let live_result = clients[2]
-            .engine
-            .converge_stored_openmls_messages(&group_id, 1_000_000)
-            .expect("live convergence");
+        clients[2].freeze_convergence_pass(&group_id);
+        clients[2].checkpoint_convergence(&group_id, "restart-equivalence");
+        let live_result = clients[2].converge_stored_at(&group_id, 1_000_000);
         let live_epoch = clients[2].epoch().0;
-        let live_group = clients[2].storage().get_group(&group_id).unwrap();
+        let live_name = clients[2].group_name();
+        let live_member_count = clients[2].members().len();
 
-        clients[2]
-            .storage()
-            .rollback_group_to_snapshot(&group_id, "restart-equivalence")
-            .expect("rollback to pre-convergence snapshot");
-        // Group epoch snapshots intentionally do not rewind the convergence
-        // pass state. Restore the separately captured pass so both runs begin
-        // from the same durable engine/storage boundary.
-        clients[2]
-            .storage()
-            .put_convergence_pass(&pre_convergence_pass)
-            .expect("restore pre-convergence durable pass");
-        let restarted_seed = pad32(b"client-2");
-        let restarted_keys = deterministic_nostr_keys(&restarted_seed);
-        let restarted_identity = restarted_keys.public_key().to_bytes().to_vec();
-        let restarted_storage = clients[2].storage().clone();
-        let mut restarted = EngineBuilder::new(restarted_storage.clone())
-            .legacy_compatibility_profile()
-            .identity(restarted_identity.clone())
-            .account_identity_proof_signer(Arc::new(NostrAccountIdentityProofSigner {
-                keys: restarted_keys,
-            }))
-            .feature_registry(registry())
-            .peeler(Box::new(transport_nostr_peeler::NostrMlsPeeler::new()))
-            .build()
-            .expect("restarted engine builds");
-        let restarted_result = restarted
-            .converge_stored_openmls_messages(&group_id, 1_000_000)
-            .expect("restarted convergence");
-        let restarted_group = restarted_storage.get_group(&group_id).unwrap();
+        clients[2].restore_convergence_checkpoint("restart-equivalence");
+        clients[2].restart();
+        let restarted_result = clients[2].converge_stored_at(&group_id, 1_000_000);
 
         prop_assert(
             restarted_result,
@@ -1403,18 +1312,18 @@ fn stored_convergence_restart_equivalence(name: String, committer_idx: usize) {
             "restart should not change stored convergence result",
         );
         prop_assert(
-            restarted.epoch(&group_id).unwrap().0,
+            clients[2].epoch().0,
             live_epoch,
             "restart should not change converged epoch",
         );
         prop_assert(
-            restarted_group.name,
-            live_group.name,
+            clients[2].group_name(),
+            live_name,
             "restart should not change converged group name",
         );
         prop_assert(
-            restarted_group.members.len(),
-            live_group.members.len(),
+            clients[2].members().len(),
+            live_member_count,
             "restart should not change converged membership",
         );
     });

--- a/crates/cgka-conformance-simulator/tests/proptest_invariants.rs
+++ b/crates/cgka-conformance-simulator/tests/proptest_invariants.rs
@@ -56,9 +56,10 @@ use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_traits::capabilities::{
     Capability, CapabilityRequirement, Feature, FeatureStatus, RequirementLevel, TransportKind,
 };
+use cgka_traits::convergence_pass::{ConvergenceCutoffCause, ConvergencePassPhase};
 use cgka_traits::engine::{SendIntent, SendResult};
-use cgka_traits::ingest::{IngestOutcome, StaleReason};
-use cgka_traits::storage::{GroupStorage, MessageStorage};
+use cgka_traits::ingest::{IngestOutcome, InputRejectionCategory};
+use cgka_traits::storage::{ConvergencePassStorage, GroupStorage, MessageStorage};
 use cgka_traits::{CgkaEngine, CommitOrderingPriority};
 use proptest::prelude::*;
 
@@ -490,6 +491,7 @@ fn canonical_policy() -> CanonicalizationPolicy {
         },
         app_message_past_epoch_limit: 5,
         settlement_quiescence_ms: 1_000,
+        max_convergence_pass_ms: 5_000,
     }
 }
 
@@ -1340,6 +1342,19 @@ fn stored_convergence_restart_equivalence(name: String, committer_idx: usize) {
             .ingest(commit)
             .await
             .expect("observer buffers stored convergence input");
+        let mut pre_convergence_pass = clients[2]
+            .storage()
+            .convergence_pass(&group_id)
+            .expect("load pre-convergence durable pass")
+            .expect("ingest opened a durable convergence pass");
+        pre_convergence_pass.phase = ConvergencePassPhase::Frozen;
+        pre_convergence_pass.cutoff_cause = Some(ConvergenceCutoffCause::Quiescence);
+        pre_convergence_pass.frozen_at_wall_ms =
+            Some(pre_convergence_pass.quiescence_deadline_wall_ms);
+        clients[2]
+            .storage()
+            .put_convergence_pass(&pre_convergence_pass)
+            .expect("persist frozen restart boundary");
 
         clients[2]
             .storage()
@@ -1356,6 +1371,13 @@ fn stored_convergence_restart_equivalence(name: String, committer_idx: usize) {
             .storage()
             .rollback_group_to_snapshot(&group_id, "restart-equivalence")
             .expect("rollback to pre-convergence snapshot");
+        // Group epoch snapshots intentionally do not rewind the convergence
+        // pass state. Restore the separately captured pass so both runs begin
+        // from the same durable engine/storage boundary.
+        clients[2]
+            .storage()
+            .put_convergence_pass(&pre_convergence_pass)
+            .expect("restore pre-convergence durable pass");
         let restarted_seed = pad32(b"client-2");
         let restarted_keys = deterministic_nostr_keys(&restarted_seed);
         let restarted_identity = restarted_keys.public_key().to_bytes().to_vec();
@@ -1530,8 +1552,8 @@ fn true_same_id_replay(payload: Vec<u8>) {
             .filter(|o| {
                 matches!(
                     o,
-                    Ok(IngestOutcome::Stale {
-                        reason: StaleReason::AlreadySeen
+                    Ok(IngestOutcome::Ignored {
+                        category: InputRejectionCategory::Duplicate
                     })
                 )
             })

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -138,6 +138,10 @@ realises. Read those rustdocs as the source of truth — this table is just an i
 - **Module:** `convergence.rs`
   - **Owns:** the candidate-state-graph deterministic branch-selection policy
 
+- **Module:** `convergence_input.rs`
+  - **Owns:** role-aware convergence scheduling classification that distinguishes commit edges, proposal
+    dependencies, and potential application-message witnesses for pass opening, quiescence, and outbound gating
+
 - **Module:** `distributed_convergence.rs`
   - **Owns:** the engine entry point for stored-message distributed convergence
 

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -72,6 +72,7 @@ pub(crate) fn ingest_outcome_kind_str(outcome: &IngestOutcome) -> &'static str {
     }
 }
 
+#[allow(deprecated)]
 pub(crate) fn stale_reason_str(reason: &StaleReason) -> &'static str {
     match reason {
         StaleReason::AlreadySeen => "already_seen",

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -12,7 +12,7 @@ use cgka_traits::app_components::{
 use cgka_traits::engine::{GroupStateChange, SendIntent, SendResult};
 use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::error::{EngineError, PeelerError};
-use cgka_traits::ingest::{IngestOutcome, StaleReason};
+use cgka_traits::ingest::{IngestOutcome, InputRejectionCategory, LocalIngestState, StaleReason};
 use cgka_traits::message::MessageState;
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, MemberId, MessageId};
@@ -65,6 +65,8 @@ pub(crate) fn ingest_outcome_kind_str(outcome: &IngestOutcome) -> &'static str {
     match outcome {
         IngestOutcome::Processed => "processed",
         IngestOutcome::Buffered { .. } => "buffered",
+        IngestOutcome::Ignored { .. } => "ignored",
+        IngestOutcome::LocalState { .. } => "local_state",
         IngestOutcome::Stale { .. } => "stale",
         IngestOutcome::Rejected { .. } => "rejected",
     }
@@ -439,6 +441,22 @@ pub(crate) fn ingest_outcome_event(
         outcome_kind: ingest_outcome_kind_str(outcome).to_string(),
         stale_reason: match outcome {
             IngestOutcome::Stale { reason } => Some(stale_reason_str(reason).to_string()),
+            IngestOutcome::Ignored { category } => Some(
+                match category {
+                    InputRejectionCategory::Duplicate => "duplicate",
+                    InputRejectionCategory::OwnEcho => "own_echo",
+                    InputRejectionCategory::WrongRecipient => "wrong_recipient",
+                    InputRejectionCategory::UnknownGroup => "unknown_group",
+                }
+                .to_string(),
+            ),
+            IngestOutcome::LocalState { state } => Some(
+                match state {
+                    LocalIngestState::Removed => "removed",
+                    LocalIngestState::Quarantined => "quarantined",
+                }
+                .to_string(),
+            ),
             IngestOutcome::Rejected { category } => {
                 Some(crate::app_components::proposal_rejection_category_tag(*category).to_string())
             }

--- a/crates/cgka-engine/src/bounded_id_set.rs
+++ b/crates/cgka-engine/src/bounded_id_set.rs
@@ -1,7 +1,7 @@
 //! [`BoundedIdSet`] is a capacity-bounded FIFO membership cache.
 //!
 //! The engine keeps two in-memory dedup caches — `seen_message_ids` and
-//! `sent_message_ids` — that back `StaleReason::AlreadySeen` / `OwnEcho`. The
+//! `sent_message_ids` — that back typed duplicate / own-echo exclusions. The
 //! durable `MessageRecord` store is authoritative (checked first via
 //! `recorded_message_outcome` in `do_ingest`), so these caches are a hot-process
 //! fast path, not history. Backing them with a plain `HashSet` made them

--- a/crates/cgka-engine/src/canonicalization.rs
+++ b/crates/cgka-engine/src/canonicalization.rs
@@ -20,12 +20,25 @@ use serde::{Deserialize, Serialize};
 pub const V1_APP_MESSAGE_PAST_EPOCH_LIMIT: u64 = 5;
 /// Adopted v1 settlement quiescence window, in milliseconds.
 pub const V1_SETTLEMENT_QUIESCENCE_MS: u64 = 1_000;
+/// Adopted v1 absolute convergence-pass cap, in milliseconds.
+pub const V1_MAX_CONVERGENCE_PASS_MS: u64 = 5_000;
+
+const fn v1_max_convergence_pass_ms() -> u64 {
+    V1_MAX_CONVERGENCE_PASS_MS
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CanonicalizationPolicy {
     pub convergence: ConvergencePolicy,
     pub app_message_past_epoch_limit: u64,
     pub settlement_quiescence_ms: u64,
+    /// Immutable upper bound from pass admission to the frozen selection set.
+    ///
+    /// The serde default is only for records written before this field existed;
+    /// policy validation still requires exact equality with the adopted v1
+    /// policy.
+    #[serde(default = "v1_max_convergence_pass_ms")]
+    pub max_convergence_pass_ms: u64,
 }
 
 impl Default for CanonicalizationPolicy {
@@ -34,6 +47,7 @@ impl Default for CanonicalizationPolicy {
             convergence: ConvergencePolicy::default(),
             app_message_past_epoch_limit: V1_APP_MESSAGE_PAST_EPOCH_LIMIT,
             settlement_quiescence_ms: V1_SETTLEMENT_QUIESCENCE_MS,
+            max_convergence_pass_ms: V1_MAX_CONVERGENCE_PASS_MS,
         }
     }
 }
@@ -1051,6 +1065,7 @@ mod witness_window_tests {
                 },
                 app_message_past_epoch_limit: V1_APP_MESSAGE_PAST_EPOCH_LIMIT,
                 settlement_quiescence_ms: V1_SETTLEMENT_QUIESCENCE_MS,
+                max_convergence_pass_ms: V1_MAX_CONVERGENCE_PASS_MS,
             }
         );
         assert!(CanonicalizationPolicy::default().ensure_pinned_v1().is_ok());

--- a/crates/cgka-engine/src/convergence_input.rs
+++ b/crates/cgka-engine/src/convergence_input.rs
@@ -1,0 +1,259 @@
+//! Role-aware classification for retained convergence inputs.
+//!
+//! Commits form candidate branches, proposals can satisfy commit dependencies,
+//! and application messages can provide bounded witness evidence. Keeping
+//! those roles explicit prevents an unresolved payload disposition from being
+//! mistaken for ambiguous canonical group state.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use cgka_traits::message::MessageState;
+
+use crate::openmls_projection::OpenMlsContentKind;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ConvergenceInputRole {
+    CommitEdge,
+    ProposalDependency,
+    AppWitnessCandidate,
+}
+
+impl ConvergenceInputRole {
+    pub(crate) fn for_content_kind(kind: OpenMlsContentKind) -> Option<Self> {
+        match kind {
+            OpenMlsContentKind::Commit => Some(Self::CommitEdge),
+            OpenMlsContentKind::Proposal => Some(Self::ProposalDependency),
+            OpenMlsContentKind::Application => Some(Self::AppWitnessCandidate),
+            OpenMlsContentKind::Welcome | OpenMlsContentKind::Other => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ClassifiedConvergenceInput {
+    pub(crate) role: ConvergenceInputRole,
+    pub(crate) source_epoch: u64,
+    pub(crate) state: MessageState,
+    pub(crate) digest: [u8; 32],
+}
+
+impl ClassifiedConvergenceInput {
+    pub(crate) fn from_projection(
+        kind: OpenMlsContentKind,
+        source_epoch: u64,
+        state: MessageState,
+        digest: [u8; 32],
+    ) -> Option<Self> {
+        Some(Self {
+            role: ConvergenceInputRole::for_content_kind(kind)?,
+            source_epoch,
+            state,
+            digest,
+        })
+    }
+
+    fn can_start_pass(self) -> bool {
+        matches!(
+            self.state,
+            MessageState::Sent | MessageState::Created | MessageState::Retryable
+        )
+    }
+
+    fn can_gate_outbound(self) -> bool {
+        matches!(self.state, MessageState::Created | MessageState::Retryable)
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct ConvergenceInputContext {
+    commit_edges_by_source_epoch: BTreeMap<u64, BTreeSet<[u8; 32]>>,
+}
+
+impl ConvergenceInputContext {
+    pub(crate) fn from_inputs(
+        inputs: impl IntoIterator<Item = ClassifiedConvergenceInput>,
+    ) -> Self {
+        let mut context = Self::default();
+        for input in inputs {
+            if input.role == ConvergenceInputRole::CommitEdge {
+                context
+                    .commit_edges_by_source_epoch
+                    .entry(input.source_epoch)
+                    .or_default()
+                    .insert(input.digest);
+            }
+        }
+        context
+    }
+
+    fn has_commit_at(&self, source_epoch: u64) -> bool {
+        self.commit_edges_by_source_epoch
+            .get(&source_epoch)
+            .is_some_and(|edges| !edges.is_empty())
+    }
+
+    fn has_competing_commit_before(&self, source_epoch: u64) -> bool {
+        self.commit_edges_by_source_epoch
+            .range(..source_epoch)
+            .any(|(_, edges)| edges.len() > 1)
+    }
+
+    /// Whether admitting this input can change deterministic resolution of the
+    /// current batch.
+    ///
+    /// An application message is only potentially selection-relevant when the
+    /// frozen inputs contain competing commit edges from an earlier epoch.  A
+    /// proposal is only potentially relevant when a commit at the same source
+    /// epoch may depend on it. Authentication and actual dependency/witness
+    /// contribution are still proven by OpenMLS during frozen resolution.
+    pub(crate) fn is_potentially_selection_relevant(
+        &self,
+        input: ClassifiedConvergenceInput,
+    ) -> bool {
+        match input.role {
+            ConvergenceInputRole::CommitEdge => true,
+            ConvergenceInputRole::ProposalDependency => self.has_commit_at(input.source_epoch),
+            ConvergenceInputRole::AppWitnessCandidate => {
+                self.has_competing_commit_before(input.source_epoch)
+            }
+        }
+    }
+
+    pub(crate) fn opens_pass(&self, input: ClassifiedConvergenceInput) -> bool {
+        input.can_start_pass()
+            && match input.role {
+                ConvergenceInputRole::CommitEdge => true,
+                ConvergenceInputRole::ProposalDependency => false,
+                ConvergenceInputRole::AppWitnessCandidate => {
+                    self.has_competing_commit_before(input.source_epoch)
+                }
+            }
+    }
+
+    pub(crate) fn gates_outbound(&self, input: ClassifiedConvergenceInput) -> bool {
+        input.can_gate_outbound()
+            && match input.role {
+                ConvergenceInputRole::CommitEdge => true,
+                ConvergenceInputRole::ProposalDependency => false,
+                ConvergenceInputRole::AppWitnessCandidate => {
+                    self.has_competing_commit_before(input.source_epoch)
+                }
+            }
+    }
+
+    /// Whether a member of an already-active pass keeps outbound work gated.
+    ///
+    /// Pass membership, not the mutable message disposition, is authoritative
+    /// here. A crash can leave a frozen/resolving pass after an accepted commit
+    /// record has already moved to `Processed`; outbound work must still wait
+    /// until the durable pass reaches `Completed`.
+    pub(crate) fn active_pass_member_gates_outbound(
+        &self,
+        input: ClassifiedConvergenceInput,
+    ) -> bool {
+        match input.role {
+            ConvergenceInputRole::CommitEdge => true,
+            ConvergenceInputRole::ProposalDependency => false,
+            ConvergenceInputRole::AppWitnessCandidate => {
+                self.has_competing_commit_before(input.source_epoch)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(
+        role: ConvergenceInputRole,
+        source_epoch: u64,
+        state: MessageState,
+        digest_byte: u8,
+    ) -> ClassifiedConvergenceInput {
+        ClassifiedConvergenceInput {
+            role,
+            source_epoch,
+            state,
+            digest: [digest_byte; 32],
+        }
+    }
+
+    #[test]
+    fn future_app_without_a_candidate_branch_is_delivery_only_for_scheduling() {
+        let app = input(
+            ConvergenceInputRole::AppWitnessCandidate,
+            2,
+            MessageState::Created,
+            1,
+        );
+        let context = ConvergenceInputContext::from_inputs([app]);
+
+        assert!(!context.opens_pass(app));
+        assert!(!context.gates_outbound(app));
+        assert!(!context.is_potentially_selection_relevant(app));
+    }
+
+    #[test]
+    fn app_after_competing_edges_is_a_selection_relevant_witness_candidate() {
+        let first = input(
+            ConvergenceInputRole::CommitEdge,
+            1,
+            MessageState::Created,
+            1,
+        );
+        let second = input(
+            ConvergenceInputRole::CommitEdge,
+            1,
+            MessageState::Created,
+            2,
+        );
+        let app = input(
+            ConvergenceInputRole::AppWitnessCandidate,
+            2,
+            MessageState::Created,
+            3,
+        );
+        let context = ConvergenceInputContext::from_inputs([first, second, app]);
+
+        assert!(context.opens_pass(app));
+        assert!(context.gates_outbound(app));
+        assert!(context.is_potentially_selection_relevant(app));
+        assert!(context.active_pass_member_gates_outbound(app));
+    }
+
+    #[test]
+    fn proposal_only_becomes_potentially_relevant_beside_same_epoch_commit() {
+        let commit = input(
+            ConvergenceInputRole::CommitEdge,
+            4,
+            MessageState::Created,
+            1,
+        );
+        let proposal = input(
+            ConvergenceInputRole::ProposalDependency,
+            4,
+            MessageState::Created,
+            2,
+        );
+        let context = ConvergenceInputContext::from_inputs([commit, proposal]);
+
+        assert!(context.is_potentially_selection_relevant(proposal));
+        assert!(!context.opens_pass(proposal));
+        assert!(!context.gates_outbound(proposal));
+    }
+
+    #[test]
+    fn processed_commit_still_gates_while_its_durable_pass_is_active() {
+        let commit = input(
+            ConvergenceInputRole::CommitEdge,
+            7,
+            MessageState::Processed,
+            1,
+        );
+        let context = ConvergenceInputContext::from_inputs([commit]);
+
+        assert!(!context.gates_outbound(commit));
+        assert!(context.active_pass_member_gates_outbound(commit));
+    }
+}

--- a/crates/cgka-engine/src/convergence_input.rs
+++ b/crates/cgka-engine/src/convergence_input.rs
@@ -7,31 +7,23 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use cgka_traits::convergence_pass::{ConvergencePassMember, ConvergencePassMemberRole};
 use cgka_traits::message::MessageState;
 
 use crate::openmls_projection::OpenMlsContentKind;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum ConvergenceInputRole {
-    CommitEdge,
-    ProposalDependency,
-    AppWitnessCandidate,
-}
-
-impl ConvergenceInputRole {
-    pub(crate) fn for_content_kind(kind: OpenMlsContentKind) -> Option<Self> {
-        match kind {
-            OpenMlsContentKind::Commit => Some(Self::CommitEdge),
-            OpenMlsContentKind::Proposal => Some(Self::ProposalDependency),
-            OpenMlsContentKind::Application => Some(Self::AppWitnessCandidate),
-            OpenMlsContentKind::Welcome | OpenMlsContentKind::Other => None,
-        }
+pub(crate) fn role_for_content_kind(kind: OpenMlsContentKind) -> Option<ConvergencePassMemberRole> {
+    match kind {
+        OpenMlsContentKind::Commit => Some(ConvergencePassMemberRole::CommitEdge),
+        OpenMlsContentKind::Proposal => Some(ConvergencePassMemberRole::ProposalDependency),
+        OpenMlsContentKind::Application => Some(ConvergencePassMemberRole::AppWitnessCandidate),
+        OpenMlsContentKind::Welcome | OpenMlsContentKind::Other => None,
     }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct ClassifiedConvergenceInput {
-    pub(crate) role: ConvergenceInputRole,
+    pub(crate) role: ConvergencePassMemberRole,
     pub(crate) source_epoch: u64,
     pub(crate) state: MessageState,
     pub(crate) digest: [u8; 32],
@@ -45,7 +37,7 @@ impl ClassifiedConvergenceInput {
         digest: [u8; 32],
     ) -> Option<Self> {
         Some(Self {
-            role: ConvergenceInputRole::for_content_kind(kind)?,
+            role: role_for_content_kind(kind)?,
             source_epoch,
             state,
             digest,
@@ -75,12 +67,28 @@ impl ConvergenceInputContext {
     ) -> Self {
         let mut context = Self::default();
         for input in inputs {
-            if input.role == ConvergenceInputRole::CommitEdge {
+            if input.role == ConvergencePassMemberRole::CommitEdge {
                 context
                     .commit_edges_by_source_epoch
                     .entry(input.source_epoch)
                     .or_default()
                     .insert(input.digest);
+            }
+        }
+        context
+    }
+
+    pub(crate) fn from_pass_members<'a>(
+        members: impl IntoIterator<Item = &'a ConvergencePassMember>,
+    ) -> Self {
+        let mut context = Self::default();
+        for member in members {
+            if member.role == ConvergencePassMemberRole::CommitEdge {
+                context
+                    .commit_edges_by_source_epoch
+                    .entry(member.source_epoch)
+                    .or_default()
+                    .insert(member.payload_digest);
             }
         }
         context
@@ -111,9 +119,9 @@ impl ConvergenceInputContext {
         input: ClassifiedConvergenceInput,
     ) -> bool {
         match input.role {
-            ConvergenceInputRole::CommitEdge => true,
-            ConvergenceInputRole::ProposalDependency => self.has_commit_at(input.source_epoch),
-            ConvergenceInputRole::AppWitnessCandidate => {
+            ConvergencePassMemberRole::CommitEdge => true,
+            ConvergencePassMemberRole::ProposalDependency => self.has_commit_at(input.source_epoch),
+            ConvergencePassMemberRole::AppWitnessCandidate => {
                 self.has_competing_commit_before(input.source_epoch)
             }
         }
@@ -122,9 +130,9 @@ impl ConvergenceInputContext {
     pub(crate) fn opens_pass(&self, input: ClassifiedConvergenceInput) -> bool {
         input.can_start_pass()
             && match input.role {
-                ConvergenceInputRole::CommitEdge => true,
-                ConvergenceInputRole::ProposalDependency => false,
-                ConvergenceInputRole::AppWitnessCandidate => {
+                ConvergencePassMemberRole::CommitEdge => true,
+                ConvergencePassMemberRole::ProposalDependency => false,
+                ConvergencePassMemberRole::AppWitnessCandidate => {
                     self.has_competing_commit_before(input.source_epoch)
                 }
             }
@@ -133,9 +141,9 @@ impl ConvergenceInputContext {
     pub(crate) fn gates_outbound(&self, input: ClassifiedConvergenceInput) -> bool {
         input.can_gate_outbound()
             && match input.role {
-                ConvergenceInputRole::CommitEdge => true,
-                ConvergenceInputRole::ProposalDependency => false,
-                ConvergenceInputRole::AppWitnessCandidate => {
+                ConvergencePassMemberRole::CommitEdge => true,
+                ConvergencePassMemberRole::ProposalDependency => false,
+                ConvergencePassMemberRole::AppWitnessCandidate => {
                     self.has_competing_commit_before(input.source_epoch)
                 }
             }
@@ -147,15 +155,12 @@ impl ConvergenceInputContext {
     /// here. A crash can leave a frozen/resolving pass after an accepted commit
     /// record has already moved to `Processed`; outbound work must still wait
     /// until the durable pass reaches `Completed`.
-    pub(crate) fn active_pass_member_gates_outbound(
-        &self,
-        input: ClassifiedConvergenceInput,
-    ) -> bool {
-        match input.role {
-            ConvergenceInputRole::CommitEdge => true,
-            ConvergenceInputRole::ProposalDependency => false,
-            ConvergenceInputRole::AppWitnessCandidate => {
-                self.has_competing_commit_before(input.source_epoch)
+    pub(crate) fn active_pass_member_gates_outbound(&self, member: &ConvergencePassMember) -> bool {
+        match member.role {
+            ConvergencePassMemberRole::CommitEdge => true,
+            ConvergencePassMemberRole::ProposalDependency => false,
+            ConvergencePassMemberRole::AppWitnessCandidate => {
+                self.has_competing_commit_before(member.source_epoch)
             }
         }
     }
@@ -166,7 +171,7 @@ mod tests {
     use super::*;
 
     fn input(
-        role: ConvergenceInputRole,
+        role: ConvergencePassMemberRole,
         source_epoch: u64,
         state: MessageState,
         digest_byte: u8,
@@ -182,7 +187,7 @@ mod tests {
     #[test]
     fn future_app_without_a_candidate_branch_is_delivery_only_for_scheduling() {
         let app = input(
-            ConvergenceInputRole::AppWitnessCandidate,
+            ConvergencePassMemberRole::AppWitnessCandidate,
             2,
             MessageState::Created,
             1,
@@ -197,19 +202,19 @@ mod tests {
     #[test]
     fn app_after_competing_edges_is_a_selection_relevant_witness_candidate() {
         let first = input(
-            ConvergenceInputRole::CommitEdge,
+            ConvergencePassMemberRole::CommitEdge,
             1,
             MessageState::Created,
             1,
         );
         let second = input(
-            ConvergenceInputRole::CommitEdge,
+            ConvergencePassMemberRole::CommitEdge,
             1,
             MessageState::Created,
             2,
         );
         let app = input(
-            ConvergenceInputRole::AppWitnessCandidate,
+            ConvergencePassMemberRole::AppWitnessCandidate,
             2,
             MessageState::Created,
             3,
@@ -219,19 +224,25 @@ mod tests {
         assert!(context.opens_pass(app));
         assert!(context.gates_outbound(app));
         assert!(context.is_potentially_selection_relevant(app));
-        assert!(context.active_pass_member_gates_outbound(app));
+        let member = ConvergencePassMember {
+            message_id: cgka_traits::MessageId::new(vec![3]),
+            payload_digest: app.digest,
+            role: app.role,
+            source_epoch: app.source_epoch,
+        };
+        assert!(context.active_pass_member_gates_outbound(&member));
     }
 
     #[test]
     fn proposal_only_becomes_potentially_relevant_beside_same_epoch_commit() {
         let commit = input(
-            ConvergenceInputRole::CommitEdge,
+            ConvergencePassMemberRole::CommitEdge,
             4,
             MessageState::Created,
             1,
         );
         let proposal = input(
-            ConvergenceInputRole::ProposalDependency,
+            ConvergencePassMemberRole::ProposalDependency,
             4,
             MessageState::Created,
             2,
@@ -246,7 +257,7 @@ mod tests {
     #[test]
     fn processed_commit_still_gates_while_its_durable_pass_is_active() {
         let commit = input(
-            ConvergenceInputRole::CommitEdge,
+            ConvergencePassMemberRole::CommitEdge,
             7,
             MessageState::Processed,
             1,
@@ -254,6 +265,12 @@ mod tests {
         let context = ConvergenceInputContext::from_inputs([commit]);
 
         assert!(!context.gates_outbound(commit));
-        assert!(context.active_pass_member_gates_outbound(commit));
+        let member = ConvergencePassMember {
+            message_id: cgka_traits::MessageId::new(vec![1]),
+            payload_digest: commit.digest,
+            role: commit.role,
+            source_epoch: commit.source_epoch,
+        };
+        assert!(context.active_pass_member_gates_outbound(&member));
     }
 }

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -27,6 +27,7 @@ use crate::canonicalization::{
     CanonicalizationError, CanonicalizationPolicy, CanonicalizationResult, CanonicalizationState,
     ConvergenceStatus, InvalidatedAppMessageReason,
 };
+use crate::convergence_input::{ClassifiedConvergenceInput, ConvergenceInputContext};
 use crate::engine::Engine;
 use crate::openmls_projection::{
     OpenMlsContentKind, OpenMlsProjectionError, OpenMlsReplayObservation, ReplayProfilePolicy,
@@ -101,7 +102,7 @@ enum ConvergenceAdmissionOutcome {
 
 struct ConvergencePassCandidate {
     member: ConvergencePassMember,
-    kind: OpenMlsContentKind,
+    input: ClassifiedConvergenceInput,
 }
 
 impl From<StorageError> for FrozenPassVerificationError {
@@ -412,12 +413,28 @@ impl<S: StorageProvider> Engine<S> {
         let Some(candidate) = self.convergence_pass_candidate(message_id)? else {
             return Ok(ConvergenceAdmissionOutcome::Retained);
         };
+        let floor = pass
+            .base_epoch
+            .0
+            .saturating_sub(policy.convergence.max_rewind_commits);
+        let ceiling = pass
+            .base_epoch
+            .0
+            .saturating_add(policy.convergence.max_rewind_commits);
+        if candidate.input.source_epoch < floor || candidate.input.source_epoch > ceiling {
+            // Retain out-of-horizon input for a later base epoch, but never let
+            // it enter (or enlarge) the immutable batch for this pass.
+            return Ok(ConvergenceAdmissionOutcome::Retained);
+        }
+        let admitted_input = candidate.input;
         pass.members.push(candidate.member);
-        // Commits are the selection-relevant consensus-log input. Proposals
-        // cannot select a branch until a commit consumes them, and application
-        // messages may witness an already-admitted branch but MUST NOT let a
-        // traffic stream move the pass boundary.
-        if candidate.kind == OpenMlsContentKind::Commit {
+        let context =
+            ConvergenceInputContext::from_inputs(self.classified_convergence_pass_inputs(&pass)?);
+        // Restart quiescence only for an input role that can change this
+        // batch's deterministic resolution. Ordinary app delivery never
+        // reaches this path; a future app without competing candidate edges is
+        // retained but does not move the pass boundary.
+        if context.is_potentially_selection_relevant(admitted_input) {
             pass.quiescence_deadline_monotonic_ms =
                 now_ms.saturating_add(policy.settlement_quiescence_ms);
             pass.quiescence_deadline_wall_ms = self
@@ -611,27 +628,28 @@ impl<S: StorageProvider> Engine<S> {
                 if source_epoch < floor || source_epoch > ceiling {
                     return None;
                 }
+                let input = ClassifiedConvergenceInput::from_projection(
+                    projection.kind,
+                    source_epoch,
+                    record.state,
+                    projection.message_digest,
+                )?;
                 Some(Ok((
                     ConvergencePassMember {
                         message_id: record.id,
                         payload_digest: projection.message_digest,
                     },
-                    record.state,
-                    projection.kind,
+                    input,
                 )))
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let has_trigger = projected.iter().any(|(_, state, kind)| {
-            matches!(
-                state,
-                MessageState::Sent | MessageState::Created | MessageState::Retryable
-            ) && matches!(
-                kind,
-                OpenMlsContentKind::Commit | OpenMlsContentKind::Application
-            )
-        });
+        let context =
+            ConvergenceInputContext::from_inputs(projected.iter().map(|(_, input)| *input));
+        let has_trigger = projected
+            .iter()
+            .any(|(_, input)| context.opens_pass(*input));
         Ok((
-            projected.into_iter().map(|(member, _, _)| member).collect(),
+            projected.into_iter().map(|(member, _)| member).collect(),
             has_trigger,
         ))
     }
@@ -650,16 +668,53 @@ impl<S: StorageProvider> Engine<S> {
             return Ok(None);
         };
         let projection = project_mls_message(&message.payload)?;
-        if projection.source_epoch.is_none() {
+        let Some(source_epoch) = projection.source_epoch else {
             return Ok(None);
-        }
+        };
+        let Some(input) = ClassifiedConvergenceInput::from_projection(
+            projection.kind,
+            source_epoch,
+            record.state,
+            projection.message_digest,
+        ) else {
+            return Ok(None);
+        };
         Ok(Some(ConvergencePassCandidate {
             member: ConvergencePassMember {
                 message_id: message_id.clone(),
                 payload_digest: projection.message_digest,
             },
-            kind: projection.kind,
+            input,
         }))
+    }
+
+    fn classified_convergence_pass_inputs(
+        &self,
+        pass: &DurableConvergencePass,
+    ) -> Result<Vec<ClassifiedConvergenceInput>, OpenMlsProjectionError> {
+        pass.members
+            .iter()
+            .map(|member| {
+                self.convergence_pass_candidate(&member.message_id)?
+                    .map(|candidate| candidate.input)
+                    .ok_or_else(|| {
+                        OpenMlsProjectionError::Serialize(
+                            "convergence pass member is not a classified MLS input".into(),
+                        )
+                    })
+            })
+            .collect()
+    }
+
+    pub(crate) fn convergence_pass_gates_outbound(
+        &self,
+        pass: &DurableConvergencePass,
+    ) -> Result<bool, OpenMlsProjectionError> {
+        let inputs = self.classified_convergence_pass_inputs(pass)?;
+        let context = ConvergenceInputContext::from_inputs(inputs.iter().copied());
+        Ok(inputs
+            .into_iter()
+            .any(|input| context.active_pass_member_gates_outbound(input)))
     }
 
     fn verify_frozen_pass_members(

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -91,6 +91,19 @@ enum FrozenPassVerificationError {
     Integrity,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConvergenceAdmissionOutcome {
+    Retained,
+    Admitted,
+    Frozen,
+    FrozenIntegrityFailure,
+}
+
+struct ConvergencePassCandidate {
+    member: ConvergencePassMember,
+    kind: OpenMlsContentKind,
+}
+
 impl From<StorageError> for FrozenPassVerificationError {
     fn from(error: StorageError) -> Self {
         Self::Storage(error)
@@ -98,12 +111,19 @@ impl From<StorageError> for FrozenPassVerificationError {
 }
 
 impl<S: StorageProvider> Engine<S> {
-    pub fn convergence_cutoff_delay_ms(
-        &self,
+    /// Prepare a group's durable pass for runtime scheduling and return its
+    /// remaining process-local cutoff delay.
+    ///
+    /// This is intentionally a command, not a diagnostic query: when eligible
+    /// retained input exists it may open a pass, consume a dormant fairness
+    /// slot, or persist restart deadline rebasing before returning the delay.
+    pub fn prepare_convergence_cutoff_delay_ms(
+        &mut self,
         group_id: &GroupId,
     ) -> Result<Option<u64>, OpenMlsProjectionError> {
-        self.ensure_group_live(group_id)
-            .map_err(|error| OpenMlsProjectionError::Storage(error.to_string()))?;
+        if self.ensure_group_live(group_id).is_err() {
+            return Ok(None);
+        }
         let group = self
             .storage
             .get_group(group_id)
@@ -312,10 +332,30 @@ impl<S: StorageProvider> Engine<S> {
         // The retained row and its pass membership are one durability
         // boundary. A crash may leave an unassigned row only when admission is
         // intentionally blocked by an unstable local mutation owner.
-        self.storage.with_transaction(|storage| {
+        let admission = self.storage.with_transaction(|storage| {
             storage.put_message(&record)?;
-            self.admit_stored_message_to_convergence_pass(group_id, &content_id, now_ms)
-        })
+            let admission =
+                self.admit_stored_message_to_convergence_pass(group_id, &content_id, now_ms)?;
+            if admission == ConvergenceAdmissionOutcome::FrozenIntegrityFailure {
+                let mut group = storage.get_group(group_id)?;
+                group.unrecoverable = true;
+                storage.put_group(&group)?;
+            }
+            Ok::<ConvergenceAdmissionOutcome, OpenMlsProjectionError>(admission)
+        })?;
+        if admission == ConvergenceAdmissionOutcome::FrozenIntegrityFailure {
+            let epoch = self
+                .storage
+                .get_group(group_id)
+                .map_err(storage_projection_error)?
+                .epoch;
+            self.realize_group_unrecoverable_for_convergence_pass(
+                group_id,
+                epoch,
+                "frozen_member_integrity",
+            );
+        }
+        Ok(())
     }
 
     fn admit_stored_message_to_convergence_pass(
@@ -323,14 +363,14 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         message_id: &MessageId,
         now_ms: u64,
-    ) -> Result<(), OpenMlsProjectionError> {
+    ) -> Result<ConvergenceAdmissionOutcome, OpenMlsProjectionError> {
         let epoch_state = self.epoch_manager.state(group_id);
         let admission_allowed = matches!(epoch_state, Some(EpochState::Stable { .. }))
             || cfg!(feature = "test-policy-overrides") && epoch_state.is_none();
         if !admission_allowed {
             // PendingPublish/Merging retain the row but do not admit it. The
             // first stable scheduler run opens a pass and seeds retained work.
-            return Ok(());
+            return Ok(ConvergenceAdmissionOutcome::Retained);
         }
         let group = self
             .storage
@@ -340,31 +380,72 @@ impl<S: StorageProvider> Engine<S> {
         let Some(mut pass) =
             self.load_or_open_convergence_pass(group_id, group.epoch, &policy, now_ms)?
         else {
-            return Ok(());
+            return Ok(ConvergenceAdmissionOutcome::Retained);
         };
-        if pass.phase != ConvergencePassPhase::Collecting
-            || now_ms >= pass.cutoff_monotonic_ms()
-            || pass
-                .members
-                .iter()
-                .any(|member| &member.message_id == message_id)
+        if pass.phase != ConvergencePassPhase::Collecting {
+            return Ok(ConvergenceAdmissionOutcome::Retained);
+        }
+        if pass
+            .members
+            .iter()
+            .any(|member| &member.message_id == message_id)
         {
-            return Ok(());
+            return Ok(ConvergenceAdmissionOutcome::Retained);
+        }
+        if now_ms >= pass.cutoff_monotonic_ms() {
+            self.freeze_collecting_convergence_pass(&mut pass)?;
+            let outcome = match self.verify_frozen_pass_members(&pass) {
+                Ok(()) => ConvergenceAdmissionOutcome::Frozen,
+                Err(FrozenPassVerificationError::Integrity) => {
+                    ConvergenceAdmissionOutcome::FrozenIntegrityFailure
+                }
+                Err(FrozenPassVerificationError::Storage(error)) => {
+                    return Err(storage_projection_error(error));
+                }
+            };
+            self.storage
+                .put_convergence_pass(&pass)
+                .map_err(storage_projection_error)?;
+            return Ok(outcome);
         }
 
-        let Some(member) = self.convergence_pass_member(message_id)? else {
-            return Ok(());
+        let Some(candidate) = self.convergence_pass_candidate(message_id)? else {
+            return Ok(ConvergenceAdmissionOutcome::Retained);
         };
-        pass.members.push(member);
-        pass.quiescence_deadline_monotonic_ms =
-            now_ms.saturating_add(policy.settlement_quiescence_ms);
-        pass.quiescence_deadline_wall_ms = self
-            .wall_clock
-            .now_ms()
-            .saturating_add(policy.settlement_quiescence_ms);
+        pass.members.push(candidate.member);
+        // Commits are the selection-relevant consensus-log input. Proposals
+        // cannot select a branch until a commit consumes them, and application
+        // messages may witness an already-admitted branch but MUST NOT let a
+        // traffic stream move the pass boundary.
+        if candidate.kind == OpenMlsContentKind::Commit {
+            pass.quiescence_deadline_monotonic_ms =
+                now_ms.saturating_add(policy.settlement_quiescence_ms);
+            pass.quiescence_deadline_wall_ms = self
+                .wall_clock
+                .now_ms()
+                .saturating_add(policy.settlement_quiescence_ms);
+        }
         self.storage
             .put_convergence_pass(&pass)
-            .map_err(storage_projection_error)
+            .map_err(storage_projection_error)?;
+        Ok(ConvergenceAdmissionOutcome::Admitted)
+    }
+
+    fn freeze_collecting_convergence_pass(
+        &self,
+        pass: &mut DurableConvergencePass,
+    ) -> Result<(), OpenMlsProjectionError> {
+        let wall_now_ms = self.wall_clock.now_ms();
+        pass.phase = ConvergencePassPhase::Frozen;
+        pass.frozen_at_wall_ms = Some(wall_now_ms);
+        pass.cutoff_cause = Some(if wall_now_ms < pass.opened_wall_ms {
+            ConvergenceCutoffCause::ClockDiscontinuity
+        } else if pass.absolute_deadline_monotonic_ms <= pass.quiescence_deadline_monotonic_ms {
+            ConvergenceCutoffCause::AbsoluteDeadline
+        } else {
+            ConvergenceCutoffCause::Quiescence
+        });
+        Ok(())
     }
 
     fn load_or_open_convergence_pass(
@@ -418,45 +499,30 @@ impl<S: StorageProvider> Engine<S> {
             if pass.phase == ConvergencePassPhase::Collecting
                 && pass.clock_instance_id != self.convergence_clock_instance_id
             {
-                #[cfg(feature = "test-policy-overrides")]
-                {
-                    pass.clock_instance_id = self.convergence_clock_instance_id;
-                    pass.opened_monotonic_ms = 0;
-                    pass.quiescence_deadline_monotonic_ms = policy.settlement_quiescence_ms;
-                    pass.absolute_deadline_monotonic_ms = policy.max_convergence_pass_ms;
-                    self.storage
-                        .put_convergence_pass(&pass)
-                        .map_err(storage_projection_error)?;
-                    return Ok(Some(pass));
-                }
-                #[cfg(not(feature = "test-policy-overrides"))]
-                {
-                    // A process-local monotonic deadline cannot survive
-                    // restart. Rebase it from persisted millisecond wall
-                    // deadlines. A backwards wall jump fails closed by making
-                    // the cutoff due immediately.
-                    let wall_now_ms = self.wall_clock.now_ms();
-                    let backwards = wall_now_ms < pass.opened_wall_ms;
-                    let quiescence_remaining = if backwards {
-                        0
-                    } else {
-                        pass.quiescence_deadline_wall_ms.saturating_sub(wall_now_ms)
-                    };
-                    let absolute_remaining = if backwards {
-                        0
-                    } else {
-                        pass.absolute_deadline_wall_ms.saturating_sub(wall_now_ms)
-                    };
-                    pass.clock_instance_id = self.convergence_clock_instance_id;
-                    pass.opened_monotonic_ms =
-                        now_ms.saturating_sub(wall_now_ms.saturating_sub(pass.opened_wall_ms));
-                    pass.quiescence_deadline_monotonic_ms =
-                        now_ms.saturating_add(quiescence_remaining);
-                    pass.absolute_deadline_monotonic_ms = now_ms.saturating_add(absolute_remaining);
-                    self.storage
-                        .put_convergence_pass(&pass)
-                        .map_err(storage_projection_error)?;
-                }
+                // A process-local monotonic deadline cannot survive restart.
+                // Rebase every build, including policy-override tests, from the
+                // same persisted millisecond wall deadlines. A backwards wall
+                // jump fails closed by making the cutoff due immediately.
+                let wall_now_ms = self.wall_clock.now_ms();
+                let backwards = wall_now_ms < pass.opened_wall_ms;
+                let quiescence_remaining = if backwards {
+                    0
+                } else {
+                    pass.quiescence_deadline_wall_ms.saturating_sub(wall_now_ms)
+                };
+                let absolute_remaining = if backwards {
+                    0
+                } else {
+                    pass.absolute_deadline_wall_ms.saturating_sub(wall_now_ms)
+                };
+                pass.clock_instance_id = self.convergence_clock_instance_id;
+                pass.opened_monotonic_ms =
+                    now_ms.saturating_sub(wall_now_ms.saturating_sub(pass.opened_wall_ms));
+                pass.quiescence_deadline_monotonic_ms = now_ms.saturating_add(quiescence_remaining);
+                pass.absolute_deadline_monotonic_ms = now_ms.saturating_add(absolute_remaining);
+                self.storage
+                    .put_convergence_pass(&pass)
+                    .map_err(storage_projection_error)?;
             }
             return Ok(Some(pass));
         }
@@ -509,12 +575,15 @@ impl<S: StorageProvider> Engine<S> {
         base_epoch: EpochId,
         policy: &CanonicalizationPolicy,
     ) -> Result<(Vec<ConvergencePassMember>, bool), OpenMlsProjectionError> {
+        let floor = base_epoch
+            .0
+            .saturating_sub(policy.convergence.max_rewind_commits);
         let ceiling = base_epoch
             .0
             .saturating_add(policy.convergence.max_rewind_commits);
         let projected = self
             .storage
-            .list_messages(group_id, EpochId(0))
+            .list_messages(group_id, EpochId(floor))
             .map_err(storage_projection_error)?
             .into_iter()
             .filter(|record| {
@@ -539,7 +608,7 @@ impl<S: StorageProvider> Engine<S> {
                     Err(error) => return Some(Err(error)),
                 };
                 let source_epoch = projection.source_epoch?;
-                if source_epoch > ceiling {
+                if source_epoch < floor || source_epoch > ceiling {
                     return None;
                 }
                 Some(Ok((
@@ -567,10 +636,10 @@ impl<S: StorageProvider> Engine<S> {
         ))
     }
 
-    fn convergence_pass_member(
+    fn convergence_pass_candidate(
         &self,
         message_id: &MessageId,
-    ) -> Result<Option<ConvergencePassMember>, OpenMlsProjectionError> {
+    ) -> Result<Option<ConvergencePassCandidate>, OpenMlsProjectionError> {
         let record = self
             .storage
             .get_message(message_id)
@@ -580,15 +649,16 @@ impl<S: StorageProvider> Engine<S> {
         let Some(message) = payload.as_openmls_wire() else {
             return Ok(None);
         };
-        if project_mls_message(&message.payload)?
-            .source_epoch
-            .is_none()
-        {
+        let projection = project_mls_message(&message.payload)?;
+        if projection.source_epoch.is_none() {
             return Ok(None);
         }
-        Ok(Some(ConvergencePassMember {
-            message_id: message_id.clone(),
-            payload_digest: Sha256::digest(&message.payload).into(),
+        Ok(Some(ConvergencePassCandidate {
+            member: ConvergencePassMember {
+                message_id: message_id.clone(),
+                payload_digest: projection.message_digest,
+            },
+            kind: projection.kind,
         }))
     }
 
@@ -606,7 +676,10 @@ impl<S: StorageProvider> Engine<S> {
         for member in &pass.members {
             let record = storage
                 .get_message(&member.message_id)
-                .map_err(FrozenPassVerificationError::Storage)?;
+                .map_err(|error| match error {
+                    StorageError::NotFound => FrozenPassVerificationError::Integrity,
+                    other => FrozenPassVerificationError::Storage(other),
+                })?;
             let payload = StoredMessagePayload::decode(&record.payload)
                 .map_err(|_| FrozenPassVerificationError::Integrity)?;
             let message = payload
@@ -625,6 +698,19 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         epoch: EpochId,
     ) -> Result<(), OpenMlsProjectionError> {
+        self.mark_group_unrecoverable_for_convergence_pass(
+            group_id,
+            epoch,
+            "frozen_member_integrity",
+        )
+    }
+
+    fn mark_group_unrecoverable_for_convergence_pass(
+        &mut self,
+        group_id: &GroupId,
+        epoch: EpochId,
+        error_kind: &'static str,
+    ) -> Result<(), OpenMlsProjectionError> {
         let mut group = self
             .storage
             .get_group(group_id)
@@ -635,6 +721,16 @@ impl<S: StorageProvider> Engine<S> {
                 .put_group(&group)
                 .map_err(storage_projection_error)?;
         }
+        self.realize_group_unrecoverable_for_convergence_pass(group_id, epoch, error_kind);
+        Ok(())
+    }
+
+    fn realize_group_unrecoverable_for_convergence_pass(
+        &mut self,
+        group_id: &GroupId,
+        epoch: EpochId,
+        error_kind: &'static str,
+    ) {
         self.epoch_manager.mark_unrecoverable(group_id);
         self.events_buf.push_back(GroupEvent::GroupUnrecoverable {
             group_id: group_id.clone(),
@@ -645,11 +741,17 @@ impl<S: StorageProvider> Engine<S> {
                 phase: ConvergencePhase::Unrecoverable,
                 current_tip_epoch: Some(epoch.0),
                 retained_anchor_horizon: None,
-                reason: Some("frozen_pass_integrity_failure".to_string()),
-                error_kind: Some("frozen_member_integrity".to_string()),
+                reason: Some(
+                    if error_kind == "base_epoch_mismatch" {
+                        "convergence_pass_base_changed"
+                    } else {
+                        "frozen_pass_integrity_failure"
+                    }
+                    .to_string(),
+                ),
+                error_kind: Some(error_kind.to_string()),
             },
         );
-        Ok(())
     }
 
     /// Canonicalize retained stored OpenMLS messages and, once the caller's
@@ -762,22 +864,21 @@ impl<S: StorageProvider> Engine<S> {
             );
             return Ok(settled_empty_result(previous_tip.0));
         };
+        if pass.is_active() && pass.base_epoch != previous_tip {
+            self.mark_group_unrecoverable_for_convergence_pass(
+                group_id,
+                previous_tip,
+                "base_epoch_mismatch",
+            )?;
+            return Ok(unrecoverable_result(previous_tip.0));
+        }
+        let mut just_frozen = false;
         if pass.phase == ConvergencePassPhase::Collecting {
             let cutoff = pass.cutoff_monotonic_ms();
             if now_ms < cutoff {
                 return Ok(waiting_result(previous_tip.0));
             }
-            let wall_now_ms = self.wall_clock.now_ms();
-            let cutoff_cause = if wall_now_ms < pass.opened_wall_ms {
-                ConvergenceCutoffCause::ClockDiscontinuity
-            } else if pass.absolute_deadline_monotonic_ms <= pass.quiescence_deadline_monotonic_ms {
-                ConvergenceCutoffCause::AbsoluteDeadline
-            } else {
-                ConvergenceCutoffCause::Quiescence
-            };
-            pass.phase = ConvergencePassPhase::Frozen;
-            pass.frozen_at_wall_ms = Some(wall_now_ms);
-            pass.cutoff_cause = Some(cutoff_cause);
+            self.freeze_collecting_convergence_pass(&mut pass)?;
             let freeze_result = self.storage.with_transaction(|storage| {
                 Self::verify_frozen_pass_members_in(storage, &pass)?;
                 storage.put_convergence_pass(&pass)?;
@@ -793,11 +894,14 @@ impl<S: StorageProvider> Engine<S> {
                     return Ok(unrecoverable_result(previous_tip.0));
                 }
             }
+            just_frozen = true;
         }
-        if matches!(
-            pass.phase,
-            ConvergencePassPhase::Frozen | ConvergencePassPhase::Resolving
-        ) {
+        if !just_frozen
+            && matches!(
+                pass.phase,
+                ConvergencePassPhase::Frozen | ConvergencePassPhase::Resolving
+            )
+        {
             match self.verify_frozen_pass_members(&pass) {
                 Ok(()) => {}
                 Err(FrozenPassVerificationError::Storage(error)) => {
@@ -871,6 +975,7 @@ impl<S: StorageProvider> Engine<S> {
             },
         )?;
         let mut result = result;
+        let evaluated_status = result.convergence_status;
         // Missing dependencies stay retained for the next generation. Once a
         // pass is frozen, later arrivals cannot extend or alter this batch.
         if matches!(
@@ -896,7 +1001,7 @@ impl<S: StorageProvider> Engine<S> {
             ),
         );
         if matches!(
-            result.convergence_status,
+            evaluated_status,
             ConvergenceStatus::Syncing | ConvergenceStatus::Resolving
         ) {
             self.audit_group_with_context(
@@ -907,7 +1012,7 @@ impl<S: StorageProvider> Engine<S> {
                     current_tip_epoch: Some(previous_tip.0),
                     retained_anchor_horizon: Some(retained_anchor_epoch),
                     reason: Some(
-                        match result.convergence_status {
+                        match evaluated_status {
                             ConvergenceStatus::Resolving => "resolving",
                             _ => "syncing",
                         }
@@ -916,7 +1021,6 @@ impl<S: StorageProvider> Engine<S> {
                     error_kind: None,
                 },
             );
-            return Ok(result);
         }
 
         // retained-history.md:30-31 — a required retained state missing inside
@@ -984,16 +1088,28 @@ impl<S: StorageProvider> Engine<S> {
                     error_kind: None,
                 },
             );
+            pass.phase = ConvergencePassPhase::Completed;
+            pass.fairness_slot_available = false;
+            self.storage
+                .put_convergence_pass(&pass)
+                .map_err(storage_projection_error)?;
             return Ok(result);
         }
 
-        let observations = apply_openmls_canonicalization_result_with_profile_policy(
-            &self.storage,
-            group_id,
-            &result,
-            max_retained_anchor_rewind,
-            replay_profile_policy,
-        )?;
+        let mut completed_pass = pass.clone();
+        completed_pass.phase = ConvergencePassPhase::Completed;
+        completed_pass.fairness_slot_available = true;
+        let observations = self.storage.with_transaction(|storage| {
+            let observations = apply_openmls_canonicalization_result_with_profile_policy(
+                storage,
+                group_id,
+                &result,
+                max_retained_anchor_rewind,
+                replay_profile_policy,
+            )?;
+            storage.put_convergence_pass(&completed_pass)?;
+            Ok::<_, OpenMlsProjectionError>(observations)
+        })?;
         // #740 rotation: a routing-component update commit applied through
         // convergence may have changed this group's nostr_group_id; additively
         // refresh the transport-id index so it resolves on the inbound path
@@ -1063,11 +1179,6 @@ impl<S: StorageProvider> Engine<S> {
         );
 
         self.remember_canonicalization_result_messages(&result);
-        pass.phase = ConvergencePassPhase::Completed;
-        pass.fairness_slot_available = true;
-        self.storage
-            .put_convergence_pass(&pass)
-            .map_err(storage_projection_error)?;
         Ok(result)
     }
 

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -27,7 +27,9 @@ use crate::canonicalization::{
     CanonicalizationError, CanonicalizationPolicy, CanonicalizationResult, CanonicalizationState,
     ConvergenceStatus, InvalidatedAppMessageReason,
 };
-use crate::convergence_input::{ClassifiedConvergenceInput, ConvergenceInputContext};
+use crate::convergence_input::{
+    ClassifiedConvergenceInput, ConvergenceInputContext, role_for_content_kind,
+};
 use crate::engine::Engine;
 use crate::openmls_projection::{
     OpenMlsContentKind, OpenMlsProjectionError, OpenMlsReplayObservation, ReplayProfilePolicy,
@@ -428,8 +430,7 @@ impl<S: StorageProvider> Engine<S> {
         }
         let admitted_input = candidate.input;
         pass.members.push(candidate.member);
-        let context =
-            ConvergenceInputContext::from_inputs(self.classified_convergence_pass_inputs(&pass)?);
+        let context = ConvergenceInputContext::from_pass_members(&pass.members);
         // Restart quiescence only for an input role that can change this
         // batch's deterministic resolution. Ordinary app delivery never
         // reaches this path; a future app without competing candidate edges is
@@ -638,6 +639,8 @@ impl<S: StorageProvider> Engine<S> {
                     ConvergencePassMember {
                         message_id: record.id,
                         payload_digest: projection.message_digest,
+                        role: input.role,
+                        source_epoch,
                     },
                     input,
                 )))
@@ -683,38 +686,18 @@ impl<S: StorageProvider> Engine<S> {
             member: ConvergencePassMember {
                 message_id: message_id.clone(),
                 payload_digest: projection.message_digest,
+                role: input.role,
+                source_epoch,
             },
             input,
         }))
     }
 
-    fn classified_convergence_pass_inputs(
-        &self,
-        pass: &DurableConvergencePass,
-    ) -> Result<Vec<ClassifiedConvergenceInput>, OpenMlsProjectionError> {
+    pub(crate) fn convergence_pass_gates_outbound(&self, pass: &DurableConvergencePass) -> bool {
+        let context = ConvergenceInputContext::from_pass_members(&pass.members);
         pass.members
             .iter()
-            .map(|member| {
-                self.convergence_pass_candidate(&member.message_id)?
-                    .map(|candidate| candidate.input)
-                    .ok_or_else(|| {
-                        OpenMlsProjectionError::Serialize(
-                            "convergence pass member is not a classified MLS input".into(),
-                        )
-                    })
-            })
-            .collect()
-    }
-
-    pub(crate) fn convergence_pass_gates_outbound(
-        &self,
-        pass: &DurableConvergencePass,
-    ) -> Result<bool, OpenMlsProjectionError> {
-        let inputs = self.classified_convergence_pass_inputs(pass)?;
-        let context = ConvergenceInputContext::from_inputs(inputs.iter().copied());
-        Ok(inputs
-            .into_iter()
-            .any(|input| context.active_pass_member_gates_outbound(input)))
+            .any(|member| context.active_pass_member_gates_outbound(member))
     }
 
     fn verify_frozen_pass_members(
@@ -742,6 +725,13 @@ impl<S: StorageProvider> Engine<S> {
                 .ok_or(FrozenPassVerificationError::Integrity)?;
             let actual: [u8; 32] = Sha256::digest(&message.payload).into();
             if actual != member.payload_digest {
+                return Err(FrozenPassVerificationError::Integrity);
+            }
+            let projection = project_mls_message(&message.payload)
+                .map_err(|_| FrozenPassVerificationError::Integrity)?;
+            let role = role_for_content_kind(projection.kind)
+                .ok_or(FrozenPassVerificationError::Integrity)?;
+            if role != member.role || projection.source_epoch != Some(member.source_epoch) {
                 return Err(FrozenPassVerificationError::Integrity);
             }
         }

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -30,15 +30,19 @@ use crate::canonicalization::{
 use crate::engine::Engine;
 use crate::openmls_projection::{
     OpenMlsContentKind, OpenMlsProjectionError, OpenMlsReplayObservation, ReplayProfilePolicy,
-    apply_openmls_canonicalization_result_with_profile_policy,
+    StoredCanonicalizationOptions, apply_openmls_canonicalization_result_with_profile_policy,
     canonicalize_stored_openmls_messages_with_profile_policy, project_mls_message,
     retain_current_group_epoch_snapshot,
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use cgka_traits::convergence_pass::{
+    ConvergenceCutoffCause, ConvergencePassMember, ConvergencePassPhase, DurableConvergencePass,
+};
 use cgka_traits::engine::{
     AppMessageInvalidationReason, GroupEvent, GroupStateChange, GroupStateInvalidationReason,
 };
+use cgka_traits::engine_state::EpochState;
 use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
 use cgka_traits::storage::{StorageError, StorageProvider};
 use cgka_traits::transport::TransportMessage;
@@ -74,11 +78,48 @@ fn convergence_run_context(run_id: &str, phase: ConvergencePhase) -> AuditEventC
     }
 }
 
+fn storage_projection_error(error: StorageError) -> OpenMlsProjectionError {
+    OpenMlsProjectionError::Storage(format!("{error:?}"))
+}
+
 /// Admin pubkeys, avatar component bytes, and message retention snapshotted on
 /// either side of a convergence apply, for unattributed group-state-change diffs.
 type ReorgComponentSnapshot = (Vec<[u8; 32]>, [Option<Vec<u8>>; 2], Option<u64>);
 
+enum FrozenPassVerificationError {
+    Storage(StorageError),
+    Integrity,
+}
+
+impl From<StorageError> for FrozenPassVerificationError {
+    fn from(error: StorageError) -> Self {
+        Self::Storage(error)
+    }
+}
+
 impl<S: StorageProvider> Engine<S> {
+    pub fn convergence_cutoff_delay_ms(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Option<u64>, OpenMlsProjectionError> {
+        self.ensure_group_live(group_id)
+            .map_err(|error| OpenMlsProjectionError::Storage(error.to_string()))?;
+        let group = self
+            .storage
+            .get_group(group_id)
+            .map_err(storage_projection_error)?;
+        let policy = self.convergence_policy_for_group(group_id)?;
+        let now_ms = self.convergence_now_ms();
+        let pass = self.load_or_open_convergence_pass(group_id, group.epoch, &policy, now_ms)?;
+        Ok(match pass {
+            Some(pass) if pass.phase == ConvergencePassPhase::Collecting => {
+                Some(pass.cutoff_monotonic_ms().saturating_sub(now_ms))
+            }
+            Some(pass) if pass.is_active() => Some(0),
+            _ => None,
+        })
+    }
+
     /// Install the process-wide convergence policy.
     ///
     /// Normal builds accept only the pinned v1 baseline. Test harnesses built
@@ -259,19 +300,355 @@ impl<S: StorageProvider> Engine<S> {
             id: content_id.clone(),
             ..message
         };
+        let record = MessageRecord {
+            id: content_id.clone(),
+            group_id: group_id.clone(),
+            epoch: EpochId(source_epoch),
+            state: MessageState::Created,
+            payload: StoredMessagePayload::openmls_wire(message)
+                .encode()
+                .map_err(|e| OpenMlsProjectionError::Serialize(format!("{e:?}")))?,
+        };
+        // The retained row and its pass membership are one durability
+        // boundary. A crash may leave an unassigned row only when admission is
+        // intentionally blocked by an unstable local mutation owner.
+        self.storage.with_transaction(|storage| {
+            storage.put_message(&record)?;
+            self.admit_stored_message_to_convergence_pass(group_id, &content_id, now_ms)
+        })
+    }
+
+    fn admit_stored_message_to_convergence_pass(
+        &self,
+        group_id: &GroupId,
+        message_id: &MessageId,
+        now_ms: u64,
+    ) -> Result<(), OpenMlsProjectionError> {
+        let epoch_state = self.epoch_manager.state(group_id);
+        let admission_allowed = matches!(epoch_state, Some(EpochState::Stable { .. }))
+            || cfg!(feature = "test-policy-overrides") && epoch_state.is_none();
+        if !admission_allowed {
+            // PendingPublish/Merging retain the row but do not admit it. The
+            // first stable scheduler run opens a pass and seeds retained work.
+            return Ok(());
+        }
+        let group = self
+            .storage
+            .get_group(group_id)
+            .map_err(storage_projection_error)?;
+        let policy = self.convergence_policy_for_group(group_id)?;
+        let Some(mut pass) =
+            self.load_or_open_convergence_pass(group_id, group.epoch, &policy, now_ms)?
+        else {
+            return Ok(());
+        };
+        if pass.phase != ConvergencePassPhase::Collecting
+            || now_ms >= pass.cutoff_monotonic_ms()
+            || pass
+                .members
+                .iter()
+                .any(|member| &member.message_id == message_id)
+        {
+            return Ok(());
+        }
+
+        let Some(member) = self.convergence_pass_member(message_id)? else {
+            return Ok(());
+        };
+        pass.members.push(member);
+        pass.quiescence_deadline_monotonic_ms =
+            now_ms.saturating_add(policy.settlement_quiescence_ms);
+        pass.quiescence_deadline_wall_ms = self
+            .wall_clock
+            .now_ms()
+            .saturating_add(policy.settlement_quiescence_ms);
         self.storage
-            .put_message(&MessageRecord {
-                id: content_id,
-                group_id: group_id.clone(),
-                epoch: EpochId(source_epoch),
-                state: MessageState::Created,
-                payload: StoredMessagePayload::openmls_wire(message)
-                    .encode()
-                    .map_err(|e| OpenMlsProjectionError::Serialize(format!("{e:?}")))?,
+            .put_convergence_pass(&pass)
+            .map_err(storage_projection_error)
+    }
+
+    fn load_or_open_convergence_pass(
+        &self,
+        group_id: &GroupId,
+        base_epoch: EpochId,
+        policy: &CanonicalizationPolicy,
+        now_ms: u64,
+    ) -> Result<Option<DurableConvergencePass>, OpenMlsProjectionError> {
+        let previous = self
+            .storage
+            .convergence_pass(group_id)
+            .map_err(storage_projection_error)?;
+        if let Some(pass) = previous.as_ref()
+            && pass.phase == ConvergencePassPhase::Completed
+            && pass.fairness_slot_available
+        {
+            let queued = self
+                .storage
+                .list_queued_outbound_intents(group_id)
+                .map_err(storage_projection_error)?;
+            if !queued.is_empty() {
+                return Ok(Some(pass.clone()));
+            }
+            let mut consumed = pass.clone();
+            consumed.fairness_slot_available = false;
+            self.storage
+                .put_convergence_pass(&consumed)
+                .map_err(storage_projection_error)?;
+        }
+        if let Some(mut pass) = previous.clone()
+            && pass.is_active()
+        {
+            #[cfg(feature = "test-policy-overrides")]
+            if policy.settlement_quiescence_ms == 0 {
+                // Test harnesses intentionally mutate the otherwise pinned
+                // process policy to make settlement immediate.
+                pass.quiescence_deadline_monotonic_ms = pass
+                    .opened_monotonic_ms
+                    .saturating_add(policy.settlement_quiescence_ms);
+                pass.absolute_deadline_monotonic_ms = pass
+                    .opened_monotonic_ms
+                    .saturating_add(policy.max_convergence_pass_ms);
+                pass.quiescence_deadline_wall_ms = pass
+                    .opened_wall_ms
+                    .saturating_add(policy.settlement_quiescence_ms);
+                pass.absolute_deadline_wall_ms = pass
+                    .opened_wall_ms
+                    .saturating_add(policy.max_convergence_pass_ms);
+            }
+            if pass.phase == ConvergencePassPhase::Collecting
+                && pass.clock_instance_id != self.convergence_clock_instance_id
+            {
+                #[cfg(feature = "test-policy-overrides")]
+                {
+                    pass.clock_instance_id = self.convergence_clock_instance_id;
+                    pass.opened_monotonic_ms = 0;
+                    pass.quiescence_deadline_monotonic_ms = policy.settlement_quiescence_ms;
+                    pass.absolute_deadline_monotonic_ms = policy.max_convergence_pass_ms;
+                    self.storage
+                        .put_convergence_pass(&pass)
+                        .map_err(storage_projection_error)?;
+                    return Ok(Some(pass));
+                }
+                #[cfg(not(feature = "test-policy-overrides"))]
+                {
+                    // A process-local monotonic deadline cannot survive
+                    // restart. Rebase it from persisted millisecond wall
+                    // deadlines. A backwards wall jump fails closed by making
+                    // the cutoff due immediately.
+                    let wall_now_ms = self.wall_clock.now_ms();
+                    let backwards = wall_now_ms < pass.opened_wall_ms;
+                    let quiescence_remaining = if backwards {
+                        0
+                    } else {
+                        pass.quiescence_deadline_wall_ms.saturating_sub(wall_now_ms)
+                    };
+                    let absolute_remaining = if backwards {
+                        0
+                    } else {
+                        pass.absolute_deadline_wall_ms.saturating_sub(wall_now_ms)
+                    };
+                    pass.clock_instance_id = self.convergence_clock_instance_id;
+                    pass.opened_monotonic_ms =
+                        now_ms.saturating_sub(wall_now_ms.saturating_sub(pass.opened_wall_ms));
+                    pass.quiescence_deadline_monotonic_ms =
+                        now_ms.saturating_add(quiescence_remaining);
+                    pass.absolute_deadline_monotonic_ms = now_ms.saturating_add(absolute_remaining);
+                    self.storage
+                        .put_convergence_pass(&pass)
+                        .map_err(storage_projection_error)?;
+                }
+            }
+            return Ok(Some(pass));
+        }
+
+        let epoch_state = self.epoch_manager.state(group_id);
+        let admission_allowed = matches!(epoch_state, Some(EpochState::Stable { .. }))
+            || cfg!(feature = "test-policy-overrides") && epoch_state.is_none();
+        if !admission_allowed {
+            return Ok(None);
+        }
+        let (members, has_trigger) =
+            self.seed_convergence_pass_members(group_id, base_epoch, policy)?;
+        if members.is_empty() || !has_trigger {
+            return Ok(None);
+        }
+        let wall_now_ms = self.wall_clock.now_ms();
+        let generation = previous
+            .as_ref()
+            .map_or(0, |pass| pass.generation.saturating_add(1));
+        let opened_monotonic_ms = now_ms;
+        let pass = DurableConvergencePass {
+            group_id: group_id.clone(),
+            generation,
+            phase: ConvergencePassPhase::Collecting,
+            base_epoch,
+            clock_instance_id: self.convergence_clock_instance_id,
+            opened_monotonic_ms,
+            quiescence_deadline_monotonic_ms: opened_monotonic_ms
+                .saturating_add(policy.settlement_quiescence_ms),
+            absolute_deadline_monotonic_ms: opened_monotonic_ms
+                .saturating_add(policy.max_convergence_pass_ms),
+            opened_wall_ms: wall_now_ms,
+            quiescence_deadline_wall_ms: wall_now_ms
+                .saturating_add(policy.settlement_quiescence_ms),
+            absolute_deadline_wall_ms: wall_now_ms.saturating_add(policy.max_convergence_pass_ms),
+            members,
+            frozen_at_wall_ms: None,
+            cutoff_cause: None,
+            fairness_slot_available: false,
+        };
+        self.storage
+            .put_convergence_pass(&pass)
+            .map_err(storage_projection_error)?;
+        Ok(Some(pass))
+    }
+
+    fn seed_convergence_pass_members(
+        &self,
+        group_id: &GroupId,
+        base_epoch: EpochId,
+        policy: &CanonicalizationPolicy,
+    ) -> Result<(Vec<ConvergencePassMember>, bool), OpenMlsProjectionError> {
+        let ceiling = base_epoch
+            .0
+            .saturating_add(policy.convergence.max_rewind_commits);
+        let projected = self
+            .storage
+            .list_messages(group_id, EpochId(0))
+            .map_err(storage_projection_error)?
+            .into_iter()
+            .filter(|record| {
+                matches!(
+                    record.state,
+                    MessageState::Sent
+                        | MessageState::Created
+                        | MessageState::Retryable
+                        | MessageState::Processed
+                )
             })
-            .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?;
-        self.last_convergence_relevant_input_ms
-            .insert(group_id.clone(), now_ms);
+            .filter_map(|record| {
+                let payload = match StoredMessagePayload::decode(&record.payload) {
+                    Ok(payload) => payload,
+                    Err(error) => {
+                        return Some(Err(OpenMlsProjectionError::Serialize(format!("{error:?}"))));
+                    }
+                };
+                let message = payload.as_openmls_wire()?;
+                let projection = match project_mls_message(&message.payload) {
+                    Ok(projection) => projection,
+                    Err(error) => return Some(Err(error)),
+                };
+                let source_epoch = projection.source_epoch?;
+                if source_epoch > ceiling {
+                    return None;
+                }
+                Some(Ok((
+                    ConvergencePassMember {
+                        message_id: record.id,
+                        payload_digest: projection.message_digest,
+                    },
+                    record.state,
+                    projection.kind,
+                )))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let has_trigger = projected.iter().any(|(_, state, kind)| {
+            matches!(
+                state,
+                MessageState::Sent | MessageState::Created | MessageState::Retryable
+            ) && matches!(
+                kind,
+                OpenMlsContentKind::Commit | OpenMlsContentKind::Application
+            )
+        });
+        Ok((
+            projected.into_iter().map(|(member, _, _)| member).collect(),
+            has_trigger,
+        ))
+    }
+
+    fn convergence_pass_member(
+        &self,
+        message_id: &MessageId,
+    ) -> Result<Option<ConvergencePassMember>, OpenMlsProjectionError> {
+        let record = self
+            .storage
+            .get_message(message_id)
+            .map_err(storage_projection_error)?;
+        let payload = StoredMessagePayload::decode(&record.payload)
+            .map_err(|error| OpenMlsProjectionError::Serialize(format!("{error:?}")))?;
+        let Some(message) = payload.as_openmls_wire() else {
+            return Ok(None);
+        };
+        if project_mls_message(&message.payload)?
+            .source_epoch
+            .is_none()
+        {
+            return Ok(None);
+        }
+        Ok(Some(ConvergencePassMember {
+            message_id: message_id.clone(),
+            payload_digest: Sha256::digest(&message.payload).into(),
+        }))
+    }
+
+    fn verify_frozen_pass_members(
+        &self,
+        pass: &DurableConvergencePass,
+    ) -> Result<(), FrozenPassVerificationError> {
+        Self::verify_frozen_pass_members_in(&self.storage, pass)
+    }
+
+    fn verify_frozen_pass_members_in(
+        storage: &S,
+        pass: &DurableConvergencePass,
+    ) -> Result<(), FrozenPassVerificationError> {
+        for member in &pass.members {
+            let record = storage
+                .get_message(&member.message_id)
+                .map_err(FrozenPassVerificationError::Storage)?;
+            let payload = StoredMessagePayload::decode(&record.payload)
+                .map_err(|_| FrozenPassVerificationError::Integrity)?;
+            let message = payload
+                .as_openmls_wire()
+                .ok_or(FrozenPassVerificationError::Integrity)?;
+            let actual: [u8; 32] = Sha256::digest(&message.payload).into();
+            if actual != member.payload_digest {
+                return Err(FrozenPassVerificationError::Integrity);
+            }
+        }
+        Ok(())
+    }
+
+    fn mark_group_unrecoverable_for_frozen_pass(
+        &mut self,
+        group_id: &GroupId,
+        epoch: EpochId,
+    ) -> Result<(), OpenMlsProjectionError> {
+        let mut group = self
+            .storage
+            .get_group(group_id)
+            .map_err(storage_projection_error)?;
+        if !group.unrecoverable {
+            group.unrecoverable = true;
+            self.storage
+                .put_group(&group)
+                .map_err(storage_projection_error)?;
+        }
+        self.epoch_manager.mark_unrecoverable(group_id);
+        self.events_buf.push_back(GroupEvent::GroupUnrecoverable {
+            group_id: group_id.clone(),
+        });
+        self.audit_group(
+            group_id,
+            marmot_forensics::AuditEventKind::ConvergenceRunState {
+                phase: ConvergencePhase::Unrecoverable,
+                current_tip_epoch: Some(epoch.0),
+                retained_anchor_horizon: None,
+                reason: Some("frozen_pass_integrity_failure".to_string()),
+                error_kind: Some("frozen_member_integrity".to_string()),
+            },
+        );
         Ok(())
     }
 
@@ -351,19 +728,108 @@ impl<S: StorageProvider> Engine<S> {
             .epoch(group_id)
             .unwrap_or(previous_group.epoch);
         let policy = self.convergence_policy_for_group(group_id)?;
+        let Some(mut pass) =
+            self.load_or_open_convergence_pass(group_id, previous_tip, &policy, now_ms)?
+        else {
+            // Preserve the observable no-op convergence run used by diagnostics
+            // and manual repair tooling. With no eligible input there is no
+            // mutable candidate set to freeze.
+            let retained_anchor_epoch = previous_tip
+                .0
+                .saturating_sub(policy.convergence.max_rewind_commits);
+            let run_id = convergence_run_id(group_id, previous_tip.0);
+            self.audit_group_with_context(
+                group_id,
+                convergence_run_context(&run_id, ConvergencePhase::Started),
+                marmot_forensics::AuditEventKind::ConvergenceRunState {
+                    phase: ConvergencePhase::Started,
+                    current_tip_epoch: Some(previous_tip.0),
+                    retained_anchor_horizon: Some(retained_anchor_epoch),
+                    reason: Some("no_eligible_input".to_string()),
+                    error_kind: None,
+                },
+            );
+            self.audit_group_with_context(
+                group_id,
+                convergence_run_context(&run_id, ConvergencePhase::Evaluating),
+                crate::audit_helpers::convergence_decision_event(
+                    previous_tip.0,
+                    policy.convergence.max_rewind_commits,
+                    None,
+                    Vec::new(),
+                    self.recorder.data_mode() == marmot_forensics::AuditDataMode::FullData,
+                ),
+            );
+            return Ok(settled_empty_result(previous_tip.0));
+        };
+        if pass.phase == ConvergencePassPhase::Collecting {
+            let cutoff = pass.cutoff_monotonic_ms();
+            if now_ms < cutoff {
+                return Ok(waiting_result(previous_tip.0));
+            }
+            let wall_now_ms = self.wall_clock.now_ms();
+            let cutoff_cause = if wall_now_ms < pass.opened_wall_ms {
+                ConvergenceCutoffCause::ClockDiscontinuity
+            } else if pass.absolute_deadline_monotonic_ms <= pass.quiescence_deadline_monotonic_ms {
+                ConvergenceCutoffCause::AbsoluteDeadline
+            } else {
+                ConvergenceCutoffCause::Quiescence
+            };
+            pass.phase = ConvergencePassPhase::Frozen;
+            pass.frozen_at_wall_ms = Some(wall_now_ms);
+            pass.cutoff_cause = Some(cutoff_cause);
+            let freeze_result = self.storage.with_transaction(|storage| {
+                Self::verify_frozen_pass_members_in(storage, &pass)?;
+                storage.put_convergence_pass(&pass)?;
+                Ok::<(), FrozenPassVerificationError>(())
+            });
+            match freeze_result {
+                Ok(()) => {}
+                Err(FrozenPassVerificationError::Storage(error)) => {
+                    return Err(storage_projection_error(error));
+                }
+                Err(FrozenPassVerificationError::Integrity) => {
+                    self.mark_group_unrecoverable_for_frozen_pass(group_id, previous_tip)?;
+                    return Ok(unrecoverable_result(previous_tip.0));
+                }
+            }
+        }
+        if matches!(
+            pass.phase,
+            ConvergencePassPhase::Frozen | ConvergencePassPhase::Resolving
+        ) {
+            match self.verify_frozen_pass_members(&pass) {
+                Ok(()) => {}
+                Err(FrozenPassVerificationError::Storage(error)) => {
+                    return Err(storage_projection_error(error));
+                }
+                Err(FrozenPassVerificationError::Integrity) => {
+                    self.mark_group_unrecoverable_for_frozen_pass(group_id, previous_tip)?;
+                    return Ok(unrecoverable_result(previous_tip.0));
+                }
+            }
+        }
+        if pass.phase == ConvergencePassPhase::Frozen {
+            pass.phase = ConvergencePassPhase::Resolving;
+            self.storage
+                .put_convergence_pass(&pass)
+                .map_err(storage_projection_error)?;
+        }
+        if pass.phase == ConvergencePassPhase::Completed {
+            return Ok(settled_empty_result(previous_tip.0));
+        }
         let max_retained_anchor_rewind = policy.convergence.max_rewind_commits;
         let retained_anchor_epoch = previous_tip
             .0
             .saturating_sub(policy.convergence.max_rewind_commits);
-        let last_convergence_relevant_input_ms = self
-            .last_convergence_relevant_input_ms
-            .get(group_id)
-            .copied()
-            .unwrap_or(0);
         let state = CanonicalizationState {
             current_tip_epoch: previous_tip.0,
             retained_anchor_epoch,
-            last_convergence_relevant_input_ms,
+            // The pass has already crossed its immutable cutoff. Keep the
+            // canonicalization model's legacy status calculation settled;
+            // membership, not a live re-enumeration, now controls the batch.
+            last_convergence_relevant_input_ms: now_ms
+                .saturating_sub(policy.settlement_quiescence_ms),
             // #636: reuse the cached hex snapshot across the up-to-16 passes of a
             // convergence drain; it is re-encoded only when the seen set changed.
             seen_message_ids: self.seen_message_ids_hex_for_convergence(),
@@ -387,6 +853,11 @@ impl<S: StorageProvider> Engine<S> {
             reject_legacy_group_additions: self.new_protocol_profile
                 == cgka_traits::group::ProtocolProfile::Current,
         };
+        let admitted_message_ids: HashSet<MessageId> = pass
+            .members
+            .iter()
+            .map(|member| member.message_id.clone())
+            .collect();
         let result = canonicalize_stored_openmls_messages_with_profile_policy(
             &self.storage,
             group_id,
@@ -394,8 +865,20 @@ impl<S: StorageProvider> Engine<S> {
             vec![],
             policy,
             now_ms,
-            replay_profile_policy,
+            StoredCanonicalizationOptions {
+                replay_profile: replay_profile_policy,
+                admitted_message_ids: Some(&admitted_message_ids),
+            },
         )?;
+        let mut result = result;
+        // Missing dependencies stay retained for the next generation. Once a
+        // pass is frozen, later arrivals cannot extend or alter this batch.
+        if matches!(
+            result.convergence_status,
+            ConvergenceStatus::Syncing | ConvergenceStatus::Resolving
+        ) {
+            result.convergence_status = ConvergenceStatus::Settled;
+        }
         let error_kinds: Vec<String> = result
             .errors
             .iter()
@@ -580,6 +1063,11 @@ impl<S: StorageProvider> Engine<S> {
         );
 
         self.remember_canonicalization_result_messages(&result);
+        pass.phase = ConvergencePassPhase::Completed;
+        pass.fairness_slot_available = true;
+        self.storage
+            .put_convergence_pass(&pass)
+            .map_err(storage_projection_error)?;
         Ok(result)
     }
 
@@ -1177,6 +1665,36 @@ fn unrecoverable_result(current_tip: u64) -> CanonicalizationResult {
         errors: vec![CanonicalizationError::MissingRetainedAnchor],
         selection_trace: None,
     }
+}
+
+/// Collecting-pass no-op result. The caller must schedule the group's durable
+/// cutoff rather than interpreting this as a canonicalization failure.
+fn waiting_result(current_tip: u64) -> CanonicalizationResult {
+    CanonicalizationResult {
+        previous_tip: current_tip,
+        selected_tip: None,
+        selected_fork_epoch: None,
+        selected_branch_id: None,
+        candidate_count: 0,
+        eligible_count: 0,
+        convergence_status: ConvergenceStatus::Syncing,
+        accepted_commits: Vec::new(),
+        accepted_proposals: Vec::new(),
+        accepted_app_messages: Vec::new(),
+        invalidated_app_messages: Vec::new(),
+        dropped_messages: Vec::new(),
+        already_seen: Vec::new(),
+        queued_outbound_intents: Vec::new(),
+        publishable_outbound_messages: Vec::new(),
+        errors: Vec::new(),
+        selection_trace: None,
+    }
+}
+
+fn settled_empty_result(current_tip: u64) -> CanonicalizationResult {
+    let mut result = waiting_result(current_tip);
+    result.convergence_status = ConvergenceStatus::Settled;
+    result
 }
 
 /// Blocked no-op result for a hydration-quarantined group: convergence ran

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -183,7 +183,7 @@ pub struct Engine<S: StorageProvider> {
     /// and dropped in `do_publish_failed`.
     pub(crate) pending_state_changes: HashMap<PendingStateRef, Vec<PendingGroupStateChange>>,
 
-    /// MessageIds the engine has ingested. Backs `StaleReason::AlreadySeen`.
+    /// MessageIds the engine has ingested. Backs the typed duplicate exclusion.
     ///
     /// Bounded hot-process cache in front of the authoritative durable
     /// `MessageRecord` store (checked first in `do_ingest`), so an id that ages
@@ -196,7 +196,7 @@ pub struct Engine<S: StorageProvider> {
     pub(crate) retryable_unpersisted_ingest_id: Option<MessageId>,
 
     /// MessageIds this engine has produced via `send` or `create_group` /
-    /// `invite`. Backs `StaleReason::OwnEcho` when a message we produced
+    /// `invite`. Backs the typed own-echo exclusion when a message we produced
     /// bounces back via ingest before we filter it client-side.
     ///
     /// Bounded hot-process cache; see `seen_message_ids` above.
@@ -2282,11 +2282,11 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
         self.pending_convergence_groups.drain().collect()
     }
 
-    fn convergence_cutoff_delay_ms(
+    fn prepare_convergence_cutoff_delay_ms(
         &mut self,
         group_id: &GroupId,
     ) -> Result<Option<u64>, EngineError> {
-        Engine::convergence_cutoff_delay_ms(self, group_id)
+        Engine::prepare_convergence_cutoff_delay_ms(self, group_id)
             .map_err(|error| EngineError::Backend(format!("load convergence cutoff: {error}")))
     }
 

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -63,6 +63,15 @@ impl WallClock for SystemWallClock {
                 .as_secs(),
         )
     }
+
+    fn now_ms(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX)
+    }
 }
 
 #[derive(Debug, Default)]
@@ -226,8 +235,11 @@ pub struct Engine<S: StorageProvider> {
     pub(crate) queued_intent_by_pending: HashMap<PendingStateRef, (GroupId, MessageId)>,
 
     pub(crate) convergence_policy: crate::canonicalization::CanonicalizationPolicy,
-    pub(crate) last_convergence_relevant_input_ms: HashMap<GroupId, u64>,
     pub(crate) convergence_clock_started_at: Instant,
+    /// Identifies the process-local monotonic clock domain persisted in active
+    /// convergence passes. A mismatch on hydration forces deadline rebasing
+    /// from the required millisecond wall clock.
+    pub(crate) convergence_clock_instance_id: u64,
 
     /// Diagnostic post-settle reorg telemetry. Recorded at the convergence
     /// apply site and exposed via [`Engine::engine_metrics`]. Never an input to
@@ -497,8 +509,8 @@ impl<S: StorageProvider> EngineBuilder<S> {
                 app_message_past_epoch_limit: self.max_past_epochs as u64,
                 ..crate::canonicalization::CanonicalizationPolicy::default()
             },
-            last_convergence_relevant_input_ms: HashMap::new(),
             convergence_clock_started_at: Instant::now(),
+            convergence_clock_instance_id: rand::rngs::OsRng.next_u64(),
             engine_metrics: crate::engine_metrics::EngineMetrics::default(),
             recorder: self.recorder.unwrap_or_else(|| Box::new(NoopRecorder)),
             audit_operation_counter: 0,
@@ -2268,6 +2280,14 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
 
     fn drain_pending_convergence_groups(&mut self) -> Vec<GroupId> {
         self.pending_convergence_groups.drain().collect()
+    }
+
+    fn convergence_cutoff_delay_ms(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<Option<u64>, EngineError> {
+        Engine::convergence_cutoff_delay_ms(self, group_id)
+            .map_err(|error| EngineError::Backend(format!("load convergence cutoff: {error}")))
     }
 
     async fn send(&mut self, intent: SendIntent) -> Result<SendResult, EngineError> {

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -1112,6 +1112,12 @@ impl<S: StorageProvider> Engine<S> {
                 };
                 mirror_app_components_into_record(&mls_group, &mut group_record);
                 storage.put_group(&group_record)?;
+                if local_state_is_stale {
+                    // A verified replacement Welcome establishes a new local
+                    // MLS copy. Frozen-pass membership belongs to the discarded
+                    // copy and must not re-halt the repaired group.
+                    storage.delete_convergence_pass(&group_id)?;
+                }
                 crate::capability_manager::cache_self_capabilities(
                     storage,
                     &group_id,

--- a/crates/cgka-engine/src/lib.rs
+++ b/crates/cgka-engine/src/lib.rs
@@ -22,6 +22,7 @@
 //! - [`group_lifecycle`] - `create_group`, `join_welcome`, group records.
 //! - [`message_processor`] - inbound `ingest` and outbound `send`.
 //! - [`distributed_convergence`] - stored-message convergence entry points.
+//! - `convergence_input` - role-aware convergence scheduling classification.
 //! - [`canonicalization`] and [`convergence`] - executable policy model.
 //! - [`openmls_projection`] - bytes-first bridge between OpenMLS and the model.
 //! - [`epoch_manager`] - per-group state transitions and pending references.
@@ -42,6 +43,7 @@ pub mod canonicalization;
 pub mod capabilities;
 pub mod capability_manager;
 pub mod convergence;
+pub(crate) mod convergence_input;
 pub mod distributed_convergence;
 pub mod engine;
 pub mod engine_metrics;

--- a/crates/cgka-engine/src/message_disposition.rs
+++ b/crates/cgka-engine/src/message_disposition.rs
@@ -30,7 +30,7 @@ pub(crate) enum MessageDisposition {
     /// undecryptable input cannot grow the durable store unboundedly.
     DeferredCapExceeded,
     /// The group is under hydration quarantine; input is retained for
-    /// post-repair replay (see `StaleReason::Quarantined`).
+    /// post-repair replay (see `LocalIngestState::Quarantined`).
     Quarantined,
 }
 

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1,10 +1,10 @@
 //! Inbound ingest path for [`Engine`]: peel, classify, apply or buffer.
 //!
 //! Inbound messages are peeled, classified, stored, and either applied or
-//! buffered for convergence. Classifiable stale ingest cases return
-//! `Ok(IngestOutcome::Stale { .. })`; authenticated protocol-admission
-//! failures return `Ok(IngestOutcome::Rejected { .. })`. `Err` is reserved for
-//! storage, peeler, serialization, and unclassified OpenMLS failures.
+//! buffered for convergence. Routing/dedup exclusions, local canonical state,
+//! stale convergence input, and authenticated proposal rejection are distinct
+//! typed outcomes. `Err` is reserved for storage, peeler, serialization, and
+//! unclassified OpenMLS failures.
 
 use super::{content_dedup_id, route_wrapped_group_message};
 use crate::engine::{Engine, ScheduledSelfRemoveAutoCommit};
@@ -24,7 +24,10 @@ use cgka_traits::engine::{
     GroupStateInvalidationReason,
 };
 use cgka_traits::error::{EngineError, PeelerError};
-use cgka_traits::ingest::{IngestOutcome, PeeledContent, ProposalRejectionCategory, StaleReason};
+use cgka_traits::ingest::{
+    IngestOutcome, InputRejectionCategory, LocalIngestState, PeeledContent,
+    ProposalRejectionCategory, StaleReason,
+};
 use cgka_traits::message::{MessageState, StoredMessagePayload};
 use cgka_traits::storage::{StorageError, StorageProvider};
 use cgka_traits::transport::{EncryptedPayload, TransportMessage};
@@ -90,8 +93,8 @@ impl<S: StorageProvider> Engine<S> {
         // member assumption. `NotForThisClient` also makes routing failures
         // easier to distinguish from decryption failures.
         if &recipient != self.identity.self_id() {
-            return Ok(IngestOutcome::Stale {
-                reason: StaleReason::NotForThisClient,
+            return Ok(IngestOutcome::Ignored {
+                category: InputRejectionCategory::WrongRecipient,
             });
         }
 
@@ -107,14 +110,14 @@ impl<S: StorageProvider> Engine<S> {
             }
             Err(EngineError::WelcomeAlreadyProcessed) => {
                 self.storage.put_ingress_dedup_marker(&msg.id)?;
-                Ok(IngestOutcome::Stale {
-                    reason: StaleReason::AlreadySeen,
+                Ok(IngestOutcome::Ignored {
+                    category: InputRejectionCategory::Duplicate,
                 })
             }
             Err(EngineError::Peeler(PeelerError::WrongRecipient)) => {
                 self.storage.put_ingress_dedup_marker(&msg.id)?;
-                Ok(IngestOutcome::Stale {
-                    reason: StaleReason::NotForThisClient,
+                Ok(IngestOutcome::Ignored {
+                    category: InputRejectionCategory::WrongRecipient,
                 })
             }
             Err(error) if group_lifecycle::terminal_welcome_error(&error) => {
@@ -179,8 +182,8 @@ impl<S: StorageProvider> Engine<S> {
                     },
                 );
             }
-            return Ok(IngestOutcome::Stale {
-                reason: StaleReason::Quarantined,
+            return Ok(IngestOutcome::LocalState {
+                state: LocalIngestState::Quarantined,
             });
         }
 
@@ -215,8 +218,8 @@ impl<S: StorageProvider> Engine<S> {
                         EpochId(0),
                         MessageState::Retryable,
                     )?;
-                    return Ok(IngestOutcome::Stale {
-                        reason: StaleReason::UnknownGroup,
+                    return Ok(IngestOutcome::Ignored {
+                        category: InputRejectionCategory::UnknownGroup,
                     });
                 }
                 Err(e) => {
@@ -244,8 +247,8 @@ impl<S: StorageProvider> Engine<S> {
                     MessageState::Failed,
                 )?;
                 self.realize_self_eviction(&group_id, current_epoch)?;
-                return Ok(IngestOutcome::Stale {
-                    reason: StaleReason::SelfEvicted,
+                return Ok(IngestOutcome::LocalState {
+                    state: LocalIngestState::Removed,
                 });
             }
             if !self.epoch_manager.can_ingest(&group_id) {
@@ -580,13 +583,13 @@ impl<S: StorageProvider> Engine<S> {
                 return Ok(outcome);
             }
             if self.seen_message_ids.contains(&content_id) {
-                return Ok(IngestOutcome::Stale {
-                    reason: StaleReason::AlreadySeen,
+                return Ok(IngestOutcome::Ignored {
+                    category: InputRejectionCategory::Duplicate,
                 });
             }
             if self.sent_message_ids.contains(&content_id) {
-                return Ok(IngestOutcome::Stale {
-                    reason: StaleReason::OwnEcho,
+                return Ok(IngestOutcome::Ignored {
+                    category: InputRejectionCategory::OwnEcho,
                 });
             }
             let content_msg = TransportMessage {
@@ -887,8 +890,8 @@ impl<S: StorageProvider> Engine<S> {
                     // OpenMLS signal itself.
                     self.update_stored_message_state(&msg.id, MessageState::Failed)?;
                     self.realize_self_eviction(&group_id, current_epoch)?;
-                    return Ok(IngestOutcome::Stale {
-                        reason: StaleReason::SelfEvicted,
+                    return Ok(IngestOutcome::LocalState {
+                        state: LocalIngestState::Removed,
                     });
                 }
                 Err(e) => {
@@ -1475,8 +1478,8 @@ impl<S: StorageProvider> Engine<S> {
                         "own_echo",
                     )?;
                     self.seen_message_ids.insert(msg.id.clone());
-                    Ok(IngestOutcome::Stale {
-                        reason: StaleReason::OwnEcho,
+                    Ok(IngestOutcome::Ignored {
+                        category: InputRejectionCategory::OwnEcho,
                     })
                 }
                 ProcessedMessageContent::UnresolvedAppDataCommit(_) => {
@@ -1972,8 +1975,11 @@ impl<S: StorageProvider> Engine<S> {
     ) -> Result<IngestOutcome, EngineError> {
         self.mark_raw_transport_message_failed_if_awaiting_retry(raw_msg_id, reason)?;
         self.seen_message_ids.insert(msg_id.clone());
-        Ok(IngestOutcome::Stale {
-            reason: stale_reason,
+        Ok(match stale_reason {
+            StaleReason::NotForThisClient => IngestOutcome::Ignored {
+                category: InputRejectionCategory::WrongRecipient,
+            },
+            other => IngestOutcome::Stale { reason: other },
         })
     }
 
@@ -2389,8 +2395,8 @@ fn convergence_ingest_outcome(
         .iter()
         .any(|seen| seen.message_id == message_id || seen.message_id == content_message_id)
     {
-        return IngestOutcome::Stale {
-            reason: StaleReason::AlreadySeen,
+        return IngestOutcome::Ignored {
+            category: InputRejectionCategory::Duplicate,
         };
     }
 

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -346,11 +346,11 @@ impl<S: StorageProvider> Engine<S> {
                             );
                         }
                         Err(EngineError::Peeler(PeelerError::WrongRecipient)) => {
-                            return self.terminal_peel_rejection_stale(
+                            return self.terminal_peel_rejection_ignored(
                                 &raw_msg_id,
                                 &msg.id,
                                 "wrong_recipient_snapshot_fallback",
-                                StaleReason::NotForThisClient,
+                                InputRejectionCategory::WrongRecipient,
                             );
                         }
                         Err(e) => return Err(e),
@@ -457,11 +457,11 @@ impl<S: StorageProvider> Engine<S> {
                             );
                         }
                         Err(EngineError::Peeler(PeelerError::WrongRecipient)) => {
-                            return self.terminal_peel_rejection_stale(
+                            return self.terminal_peel_rejection_ignored(
                                 &raw_msg_id,
                                 &msg.id,
                                 "wrong_recipient_snapshot_fallback",
-                                StaleReason::NotForThisClient,
+                                InputRejectionCategory::WrongRecipient,
                             );
                         }
                         Err(e) => return Err(e),
@@ -538,11 +538,11 @@ impl<S: StorageProvider> Engine<S> {
                     );
                 }
                 Err(PeelerError::WrongRecipient) => {
-                    return self.terminal_peel_rejection_stale(
+                    return self.terminal_peel_rejection_ignored(
                         &raw_msg_id,
                         &msg.id,
                         "wrong_recipient",
-                        StaleReason::NotForThisClient,
+                        InputRejectionCategory::WrongRecipient,
                     );
                 }
                 Err(e) => return Err(EngineError::Peeler(e)),
@@ -699,9 +699,14 @@ impl<S: StorageProvider> Engine<S> {
                     })?;
                     let within_rewind_horizon = current_epoch.0.saturating_sub(msg_epoch.0)
                         <= policy.convergence.max_rewind_commits;
+                    let active_pass = self
+                        .storage
+                        .convergence_pass(&group_id)?
+                        .is_some_and(|pass| pass.is_active());
                     within_rewind_horizon
-                        && !self.epoch_manager.we_committed_from(&group_id, msg_epoch)
-                        && self.has_retained_anchor_snapshot(&group_id, msg_epoch)?
+                        && (active_pass
+                            || (!self.epoch_manager.we_committed_from(&group_id, msg_epoch)
+                                && self.has_retained_anchor_snapshot(&group_id, msg_epoch)?))
                 }
             } else {
                 false
@@ -1975,12 +1980,21 @@ impl<S: StorageProvider> Engine<S> {
     ) -> Result<IngestOutcome, EngineError> {
         self.mark_raw_transport_message_failed_if_awaiting_retry(raw_msg_id, reason)?;
         self.seen_message_ids.insert(msg_id.clone());
-        Ok(match stale_reason {
-            StaleReason::NotForThisClient => IngestOutcome::Ignored {
-                category: InputRejectionCategory::WrongRecipient,
-            },
-            other => IngestOutcome::Stale { reason: other },
+        Ok(IngestOutcome::Stale {
+            reason: stale_reason,
         })
+    }
+
+    fn terminal_peel_rejection_ignored(
+        &mut self,
+        raw_msg_id: &MessageId,
+        msg_id: &MessageId,
+        reason: &'static str,
+        category: InputRejectionCategory,
+    ) -> Result<IngestOutcome, EngineError> {
+        self.mark_raw_transport_message_failed_if_awaiting_retry(raw_msg_id, reason)?;
+        self.seen_message_ids.insert(msg_id.clone());
+        Ok(IngestOutcome::Ignored { category })
     }
 
     /// Whether `msg_epoch` predates this device's membership in `group_id`

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -4,9 +4,9 @@
 //! buffered for convergence. Outbound intents are checked against local epoch
 //! state and unresolved convergence inputs before any OpenMLS mutation.
 //!
-//! Classifiable stale ingest cases return
-//! `Ok(IngestOutcome::Stale { .. })` with a typed `StaleReason`. `Err` is
-//! reserved for storage, peeler, serialization, and OpenMLS failures.
+//! Classifiable ingest exclusions and local-state blocks return typed ordinary
+//! outcomes. `Err` is reserved for storage, peeler, serialization, and
+//! OpenMLS failures.
 
 mod ingest;
 mod send;
@@ -20,7 +20,7 @@ use crate::openmls_projection::{OpenMlsContentKind, decode_openmls_wire_projecti
 use cgka_traits::engine::{GroupEvent, GroupStateChange, SendIntent, SendResult};
 use cgka_traits::engine_state::EpochState;
 use cgka_traits::error::EngineError;
-use cgka_traits::ingest::{IngestOutcome, StaleReason};
+use cgka_traits::ingest::{IngestOutcome, InputRejectionCategory, LocalIngestState, StaleReason};
 use cgka_traits::message::{MessageState, StoredMessagePayload};
 use cgka_traits::storage::{QueuedOutboundIntent, StorageError, StorageProvider};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
@@ -146,8 +146,8 @@ impl<S: StorageProvider> Engine<S> {
         // In-memory fallback for messages produced before the durable record
         // is visible to this path.
         if self.seen_message_ids.contains(&msg.id) {
-            return Ok(IngestOutcome::Stale {
-                reason: StaleReason::AlreadySeen,
+            return Ok(IngestOutcome::Ignored {
+                category: InputRejectionCategory::Duplicate,
             });
         }
         if self.sent_message_ids.contains(&msg.id) {
@@ -158,8 +158,8 @@ impl<S: StorageProvider> Engine<S> {
                 EpochId(0),
                 MessageState::Sent,
             )?;
-            return Ok(IngestOutcome::Stale {
-                reason: StaleReason::OwnEcho,
+            return Ok(IngestOutcome::Ignored {
+                category: InputRejectionCategory::OwnEcho,
             });
         }
 
@@ -299,10 +299,28 @@ impl<S: StorageProvider> Engine<S> {
 
         let queued = self.storage.list_queued_outbound_intents(group_id)?;
         let mut drained = Vec::new();
+        let mut fairness_slot_available =
+            self.storage
+                .convergence_pass(group_id)?
+                .is_some_and(|pass| {
+                    pass.phase == cgka_traits::ConvergencePassPhase::Completed
+                        && pass.fairness_slot_available
+                });
+        if fairness_slot_available && !self.has_unresolved_convergence_inputs(group_id)? {
+            // The slot orders local group-state work before an inbound-only
+            // follow-up pass. With no such inbound work, normal queue draining
+            // proceeds and the dormant slot must not leak into a later pass.
+            self.consume_convergence_fairness_slot(group_id)?;
+            fairness_slot_available = false;
+        }
         for record in queued {
-            if !self
-                .advance_convergence_inputs_until_settled(group_id, now_ms)
-                .await?
+            if fairness_slot_available && !is_admin_group_state_fairness_intent(&record.intent) {
+                continue;
+            }
+            if !fairness_slot_available
+                && !self
+                    .advance_convergence_inputs_until_settled(group_id, now_ms)
+                    .await?
             {
                 break;
             }
@@ -316,7 +334,18 @@ impl<S: StorageProvider> Engine<S> {
             if self.load_leave_request_state(group_id)?.is_some() {
                 break;
             }
-            let result = self.do_send_ready(record.intent.clone()).await?;
+            let result = match self.do_send_ready(record.intent.clone()).await {
+                Ok(result) => result,
+                Err(_) if fairness_slot_available => {
+                    // The protocol grants one preparation attempt, not an
+                    // indefinite reservation. Keep the durable intent queued,
+                    // consume the slot, and let retained inbound work proceed.
+                    self.consume_convergence_fairness_slot(group_id)?;
+                    fairness_slot_available = false;
+                    break;
+                }
+                Err(error) => return Err(error),
+            };
             let pauses_for_pending_publish = matches!(result, SendResult::GroupEvolution { .. });
             match &result {
                 SendResult::ApplicationMessage { msg, .. } | SendResult::Proposal { msg } => {
@@ -332,11 +361,32 @@ impl<S: StorageProvider> Engine<S> {
                 | SendResult::Queued { .. } => {}
             }
             drained.push(result);
+            if fairness_slot_available {
+                self.consume_convergence_fairness_slot(group_id)?;
+                fairness_slot_available = false;
+                if self.has_unresolved_convergence_inputs(group_id)? {
+                    break;
+                }
+            }
             if pauses_for_pending_publish {
                 break;
             }
         }
+        if fairness_slot_available {
+            // No already-queued admin group-state intent was eligible for the
+            // fairness attempt. Do not let unrelated app/leave/maintenance
+            // work hold the next inbound generation indefinitely.
+            self.consume_convergence_fairness_slot(group_id)?;
+        }
         Ok(drained)
+    }
+
+    fn consume_convergence_fairness_slot(&self, group_id: &GroupId) -> Result<(), EngineError> {
+        if let Some(mut pass) = self.storage.convergence_pass(group_id)? {
+            pass.fairness_slot_available = false;
+            self.storage.put_convergence_pass(&pass)?;
+        }
+        Ok(())
     }
 
     async fn should_queue_outbound_intent(
@@ -454,9 +504,12 @@ impl<S: StorageProvider> Engine<S> {
                 {
                     return Ok(false);
                 }
-                if self.has_unresolved_convergence_inputs(group_id)? {
-                    return Ok(false);
-                }
+                // A completed frozen batch grants one queued user intent before
+                // an inbound-only follow-up pass. Retry one deferred-peel sweep
+                // first so newly available canonical context is visible, then
+                // return to the drain rather than opening generation N+1 here.
+                let _ = self.retry_deferred_peels(group_id).await?;
+                return Ok(true);
             }
 
             if self.retry_deferred_peels(group_id).await? == 0 {
@@ -467,7 +520,17 @@ impl<S: StorageProvider> Engine<S> {
         Ok(false)
     }
 
-    fn has_unresolved_convergence_inputs(&self, group_id: &GroupId) -> Result<bool, EngineError> {
+    pub(crate) fn has_unresolved_convergence_inputs(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<bool, EngineError> {
+        if self
+            .storage
+            .convergence_pass(group_id)?
+            .is_some_and(|pass| pass.is_active())
+        {
+            return Ok(true);
+        }
         // The convergence horizon is bounded on BOTH sides (mdk#736). The past
         // side (`anchor`) drops inputs older than the retained-anchor window.
         // The future side (`ceiling`) is symmetric: a convergence input more
@@ -688,8 +751,8 @@ impl<S: StorageProvider> Engine<S> {
                 Ok(IngestOutcome::Stale {
                     reason: StaleReason::PeelFailed,
                 }) => {}
-                Ok(IngestOutcome::Stale {
-                    reason: StaleReason::Quarantined,
+                Ok(IngestOutcome::LocalState {
+                    state: LocalIngestState::Quarantined,
                 }) => {
                     // Defense-in-depth: the gate above should keep this loop
                     // from running for a quarantined group at all, but if a
@@ -717,7 +780,12 @@ impl<S: StorageProvider> Engine<S> {
                     self.note_peel_deferred_row_retired(group_id, &record.id);
                     progressed += 1;
                 }
-                Ok(IngestOutcome::Stale { .. } | IngestOutcome::Rejected { .. }) => {
+                Ok(
+                    IngestOutcome::Stale { .. }
+                    | IngestOutcome::Ignored { .. }
+                    | IngestOutcome::LocalState { .. }
+                    | IngestOutcome::Rejected { .. },
+                ) => {
                     // Terminal stale classifications are still successful
                     // reclassifications of this raw deferred row. Retire it only
                     // while it is still awaiting retry: the reachable case is
@@ -1012,10 +1080,17 @@ impl<S: StorageProvider> Engine<S> {
                         self.update_stored_message_state(&record.id, MessageState::Retryable)?;
                     }
                 }
-                Ok(IngestOutcome::Stale {
-                    reason:
-                        StaleReason::PeelFailed | StaleReason::Quarantined | StaleReason::UnknownGroup,
-                }) => {
+                Ok(
+                    IngestOutcome::Stale {
+                        reason: StaleReason::PeelFailed,
+                    }
+                    | IngestOutcome::LocalState {
+                        state: LocalIngestState::Quarantined,
+                    }
+                    | IngestOutcome::Ignored {
+                        category: InputRejectionCategory::UnknownGroup,
+                    },
+                ) => {
                     // Leave the row in its retry state so a later pass re-attempts
                     // it. `PeelFailed`: still un-peelable, or already retired to
                     // `Failed` by a terminal-after-peel path inside
@@ -1132,6 +1207,16 @@ fn send_intent_group_id(intent: &SendIntent) -> &GroupId {
         | SendIntent::UpdateAppComponents { group_id, .. }
         | SendIntent::UpdateGroupData { group_id, .. } => group_id,
     }
+}
+
+fn is_admin_group_state_fairness_intent(intent: &SendIntent) -> bool {
+    matches!(
+        intent,
+        SendIntent::Invite { .. }
+            | SendIntent::RemoveMembers { .. }
+            | SendIntent::UpdateAppComponents { .. }
+            | SendIntent::UpdateGroupData { .. }
+    )
 }
 
 #[cfg(test)]

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -285,18 +285,6 @@ impl<S: StorageProvider> Engine<S> {
             return Ok(Vec::new());
         }
 
-        if self
-            .stage_due_self_remove_auto_commit(group_id, now_ms)
-            .await?
-        {
-            return Ok(Vec::new());
-        }
-
-        self.try_auto_repropose_leave_request(group_id).await;
-        if self.load_leave_request_state(group_id)?.is_some() {
-            return Ok(Vec::new());
-        }
-
         let queued = self.storage.list_queued_outbound_intents(group_id)?;
         let mut drained = Vec::new();
         let mut fairness_slot_available =
@@ -313,6 +301,20 @@ impl<S: StorageProvider> Engine<S> {
             self.consume_convergence_fairness_slot(group_id)?;
             fairness_slot_available = false;
         }
+        // A persisted fairness slot orders one already-queued administrative
+        // evolution before automatic SelfRemove or leave-maintenance mutation.
+        if !fairness_slot_available {
+            if self
+                .stage_due_self_remove_auto_commit(group_id, now_ms)
+                .await?
+            {
+                return Ok(Vec::new());
+            }
+            self.try_auto_repropose_leave_request(group_id).await;
+            if self.load_leave_request_state(group_id)?.is_some() {
+                return Ok(Vec::new());
+            }
+        }
         for record in queued {
             if fairness_slot_available && !is_admin_group_state_fairness_intent(&record.intent) {
                 continue;
@@ -324,15 +326,17 @@ impl<S: StorageProvider> Engine<S> {
             {
                 break;
             }
-            if self
-                .stage_due_self_remove_auto_commit(group_id, now_ms)
-                .await?
-            {
-                break;
-            }
-            self.try_auto_repropose_leave_request(group_id).await;
-            if self.load_leave_request_state(group_id)?.is_some() {
-                break;
+            if !fairness_slot_available {
+                if self
+                    .stage_due_self_remove_auto_commit(group_id, now_ms)
+                    .await?
+                {
+                    break;
+                }
+                self.try_auto_repropose_leave_request(group_id).await;
+                if self.load_leave_request_state(group_id)?.is_some() {
+                    break;
+                }
             }
             let result = match self.do_send_ready(record.intent.clone()).await {
                 Ok(result) => result,
@@ -377,6 +381,13 @@ impl<S: StorageProvider> Engine<S> {
             // fairness attempt. Do not let unrelated app/leave/maintenance
             // work hold the next inbound generation indefinitely.
             self.consume_convergence_fairness_slot(group_id)?;
+            if self
+                .stage_due_self_remove_auto_commit(group_id, now_ms)
+                .await?
+            {
+                return Ok(drained);
+            }
+            self.try_auto_repropose_leave_request(group_id).await;
         }
         Ok(drained)
     }
@@ -506,10 +517,20 @@ impl<S: StorageProvider> Engine<S> {
                 }
                 // A completed frozen batch grants one queued user intent before
                 // an inbound-only follow-up pass. Retry one deferred-peel sweep
-                // first so newly available canonical context is visible, then
-                // return to the drain rather than opening generation N+1 here.
+                // first so newly available canonical context is visible. Return
+                // to the drain only when that durable slot actually exists.
                 let _ = self.retry_deferred_peels(group_id).await?;
-                return Ok(true);
+                let fairness_slot_available =
+                    self.storage
+                        .convergence_pass(group_id)?
+                        .is_some_and(|pass| {
+                            pass.phase == cgka_traits::ConvergencePassPhase::Completed
+                                && pass.fairness_slot_available
+                        });
+                if fairness_slot_available {
+                    return Ok(true);
+                }
+                continue;
             }
 
             if self.retry_deferred_peels(group_id).await? == 0 {

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -548,11 +548,7 @@ impl<S: StorageProvider> Engine<S> {
     ) -> Result<bool, EngineError> {
         if let Some(pass) = self.storage.convergence_pass(group_id)?
             && pass.is_active()
-            && self
-                .convergence_pass_gates_outbound(&pass)
-                .map_err(|error| {
-                    EngineError::Backend(format!("classify active convergence pass: {error}"))
-                })?
+            && self.convergence_pass_gates_outbound(&pass)
         {
             return Ok(true);
         }
@@ -1142,16 +1138,17 @@ impl<S: StorageProvider> Engine<S> {
                     // derived row now carries the real verdict — applied
                     // (`Processed`), a same-epoch fork the incumbent won
                     // (`AlreadyAtEpoch`, content row `EpochInvalidated`), a
-                    // duplicate (`AlreadySeen`), our own echo (`OwnEcho`), or our
-                    // own eviction (`SelfEvicted`). Retire the raw wrapper so it
-                    // leaves the retry lifecycle instead of being re-peeled on
-                    // every subsequent publish-cycle replay — but ONLY while it is
-                    // still awaiting retry. `record.state` is the pre-ingest
-                    // snapshot; `ingest_group_message` may have already committed a
-                    // terminal state to this same row during the call. The
-                    // reachable case is `SelfEvicted`: a buffered peer commit that
-                    // evicts our leaf makes the next buffered row hit `!is_active`,
-                    // which persists that row `Failed` (ingest.rs). That
+                    // duplicate (`Ignored { category: Duplicate }`), our own echo
+                    // (`Ignored { category: OwnEcho }`), or our own eviction
+                    // (`LocalState { state: Removed }`). Retire the raw wrapper so
+                    // it leaves the retry lifecycle instead of being re-peeled on
+                    // every subsequent publish-cycle replay — but ONLY while it
+                    // is still awaiting retry. `record.state` is the pre-ingest
+                    // snapshot; `ingest_group_message` may have already committed
+                    // a terminal state to this same row during the call. The
+                    // reachable removal case is a buffered peer commit that evicts
+                    // our leaf: the next buffered row hits `!is_active`, which
+                    // persists that row `Failed` (ingest.rs). That
                     // ingest-committed verdict is authoritative — relabeling an
                     // evicted-on row `Processed` would sweep it back into
                     // canonicalization (`openmls_projection` /

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -15,8 +15,9 @@ mod store;
 pub(crate) use ingest::avatar_component_snapshot;
 pub(crate) use send::merge_capabilities;
 
+use crate::convergence_input::{ClassifiedConvergenceInput, ConvergenceInputContext};
 use crate::engine::{Engine, ScheduledSelfRemoveAutoCommit};
-use crate::openmls_projection::{OpenMlsContentKind, decode_openmls_wire_projection};
+use crate::openmls_projection::decode_openmls_wire_projection;
 use cgka_traits::engine::{GroupEvent, GroupStateChange, SendIntent, SendResult};
 use cgka_traits::engine_state::EpochState;
 use cgka_traits::error::EngineError;
@@ -545,10 +546,13 @@ impl<S: StorageProvider> Engine<S> {
         &self,
         group_id: &GroupId,
     ) -> Result<bool, EngineError> {
-        if self
-            .storage
-            .convergence_pass(group_id)?
-            .is_some_and(|pass| pass.is_active())
+        if let Some(pass) = self.storage.convergence_pass(group_id)?
+            && pass.is_active()
+            && self
+                .convergence_pass_gates_outbound(&pass)
+                .map_err(|error| {
+                    EngineError::Backend(format!("classify active convergence pass: {error}"))
+                })?
         {
             return Ok(true);
         }
@@ -584,10 +588,14 @@ impl<S: StorageProvider> Engine<S> {
         };
         let records = self.storage.list_messages(group_id, EpochId(anchor))?;
         let mut skipped_non_resolvable: usize = 0;
+        let mut classified = Vec::new();
         for record in records {
             if !matches!(
                 record.state,
-                MessageState::Created | MessageState::Retryable
+                MessageState::Sent
+                    | MessageState::Created
+                    | MessageState::Retryable
+                    | MessageState::Processed
             ) {
                 continue;
             }
@@ -610,26 +618,31 @@ impl<S: StorageProvider> Engine<S> {
             if projection.source_epoch.is_some_and(|epoch| epoch > ceiling) {
                 continue;
             }
-            // A lone uncommitted Proposal does NOT make canonical state
-            // ambiguous: commits are the consensus log; a proposal only takes
-            // effect once a commit consumes it (convergence.md:7-8). The
-            // SelfRemove send-side rule is enforced earlier: remaining members
-            // that may commit a SelfRemove stage a pending commit, and the
-            // leaver is held by `leaving_groups`.
-            //
-            // The Proposal record stays in its `Created`/`Retryable` state and
-            // continues to contribute to the OpenMLS candidate-path graph, so a
-            // later consuming commit still resolves it through convergence; it
-            // simply does not count as *unresolved convergence work* for the
-            // outbound-send gate. Commits and application messages remain
-            // gating: those genuinely leave canonical state ambiguous until
-            // convergence settles.
-            if matches!(
+            let Some(source_epoch) = projection.source_epoch else {
+                skipped_non_resolvable += 1;
+                continue;
+            };
+            let Some(input) = ClassifiedConvergenceInput::from_projection(
                 projection.kind,
-                OpenMlsContentKind::Commit | OpenMlsContentKind::Application
-            ) {
-                return Ok(true);
-            }
+                source_epoch,
+                record.state,
+                projection.message_digest,
+            ) else {
+                continue;
+            };
+            classified.push(input);
+        }
+        let context = ConvergenceInputContext::from_inputs(classified.iter().copied());
+        // An unresolved commit always gates because it can advance or replace
+        // canonical state. An application message gates only when retained
+        // competing commit edges make it a potential branch-selection witness;
+        // unresolved delivery by itself does not make group state ambiguous.
+        // Proposals remain dependencies and do not gate independently.
+        if classified
+            .into_iter()
+            .any(|input| context.gates_outbound(input))
+        {
+            return Ok(true);
         }
         // Reached only when nothing gates: surface any fail-open skips so an
         // insider spraying undecodable rows (which no longer wedges the gate but

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -4,7 +4,7 @@
 use super::content_dedup_id;
 use crate::engine::Engine;
 use cgka_traits::error::EngineError;
-use cgka_traits::ingest::{IngestOutcome, StaleReason};
+use cgka_traits::ingest::{IngestOutcome, InputRejectionCategory};
 use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
 use cgka_traits::storage::{LeaveRequest, StorageError, StorageProvider};
 use cgka_traits::transport::TransportMessage;
@@ -16,8 +16,8 @@ impl<S: StorageProvider> Engine<S> {
         id: &MessageId,
     ) -> Result<Option<IngestOutcome>, EngineError> {
         if self.storage.has_ingress_dedup_marker(id)? {
-            return Ok(Some(IngestOutcome::Stale {
-                reason: StaleReason::AlreadySeen,
+            return Ok(Some(IngestOutcome::Ignored {
+                category: InputRejectionCategory::Duplicate,
             }));
         }
         let record = match self.storage.get_message(id) {
@@ -27,8 +27,8 @@ impl<S: StorageProvider> Engine<S> {
         };
 
         let outcome = match record.state {
-            MessageState::Sent => IngestOutcome::Stale {
-                reason: StaleReason::OwnEcho,
+            MessageState::Sent => IngestOutcome::Ignored {
+                category: InputRejectionCategory::OwnEcho,
             },
             MessageState::Created | MessageState::Retryable => IngestOutcome::Buffered {
                 group_id: record.group_id,
@@ -36,8 +36,8 @@ impl<S: StorageProvider> Engine<S> {
             },
             MessageState::PeelDeferred => return Ok(None),
             MessageState::Processed | MessageState::Failed | MessageState::EpochInvalidated => {
-                IngestOutcome::Stale {
-                    reason: StaleReason::AlreadySeen,
+                IngestOutcome::Ignored {
+                    category: InputRejectionCategory::Duplicate,
                 }
             }
         };

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -6,7 +6,7 @@
 //! snapshot-and-replay messages for candidate materialization or apply a
 //! selected canonical branch to retained storage.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use crate::provider::EngineOpenMlsProvider;
 use cgka_traits::app_event::AppMessageRetentionDecision;
@@ -222,6 +222,12 @@ enum CandidatePathProbeResult {
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct ReplayProfilePolicy {
     pub(crate) reject_legacy_group_additions: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct StoredCanonicalizationOptions<'a> {
+    pub(crate) replay_profile: ReplayProfilePolicy,
+    pub(crate) admitted_message_ids: Option<&'a HashSet<MessageId>>,
 }
 
 #[derive(Clone, Debug)]
@@ -736,7 +742,7 @@ pub fn canonicalize_stored_openmls_messages<S: StorageProvider>(
         outbound_intents,
         policy,
         now_ms,
-        ReplayProfilePolicy::default(),
+        StoredCanonicalizationOptions::default(),
     )
 }
 
@@ -747,8 +753,9 @@ pub(crate) fn canonicalize_stored_openmls_messages_with_profile_policy<S: Storag
     outbound_intents: Vec<OutboundIntent>,
     policy: CanonicalizationPolicy,
     now_ms: u64,
-    profile_policy: ReplayProfilePolicy,
+    options: StoredCanonicalizationOptions<'_>,
 ) -> Result<CanonicalizationResult, OpenMlsProjectionError> {
+    let profile_policy = options.replay_profile;
     let current_epoch = storage
         .get_group(group_id)
         .map_err(|e| OpenMlsProjectionError::Storage(format!("{e:?}")))?
@@ -764,6 +771,12 @@ pub(crate) fn canonicalize_stored_openmls_messages_with_profile_policy<S: Storag
     let mut own_commits = PrevalidatedOwnCommits::default();
 
     for record in records {
+        if options
+            .admitted_message_ids
+            .is_some_and(|admitted| !admitted.contains(&record.id))
+        {
+            continue;
+        }
         if !record_state_can_contribute_to_openmls_graph(record.state) {
             continue;
         }

--- a/crates/cgka-engine/tests/audit_log.rs
+++ b/crates/cgka-engine/tests/audit_log.rs
@@ -14,7 +14,7 @@ use cgka_traits::CgkaEngine;
 use cgka_traits::engine::{CreateGroupRequest, SendResult};
 use cgka_traits::error::PeelerError;
 use cgka_traits::group_context::GroupContextSnapshot;
-use cgka_traits::ingest::{IngestOutcome, PeeledMessage, StaleReason};
+use cgka_traits::ingest::{IngestOutcome, PeeledMessage};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -117,8 +117,8 @@ async fn audit_log_records_ingest_entry_and_outcome_via_jsonl() {
     assert!(
         matches!(
             outcome,
-            IngestOutcome::Stale {
-                reason: StaleReason::NotForThisClient
+            IngestOutcome::Ignored {
+                category: cgka_traits::ingest::InputRejectionCategory::WrongRecipient
             }
         ),
         "expected NotForThisClient stale, got {outcome:?}"
@@ -183,8 +183,8 @@ async fn audit_log_records_ingest_entry_and_outcome_via_jsonl() {
             stale_reason,
             ..
         } => {
-            assert_eq!(outcome_kind, "stale");
-            assert_eq!(stale_reason.as_deref(), Some("not_for_this_client"));
+            assert_eq!(outcome_kind, "ignored");
+            assert_eq!(stale_reason.as_deref(), Some("wrong_recipient"));
         }
         _ => unreachable!(),
     }
@@ -311,8 +311,8 @@ async fn engine_without_recorder_is_silent_and_does_not_crash() {
     let outcome = engine.ingest(msg).await.expect("ingest");
     assert!(matches!(
         outcome,
-        IngestOutcome::Stale {
-            reason: StaleReason::NotForThisClient
+        IngestOutcome::Ignored {
+            category: cgka_traits::ingest::InputRejectionCategory::WrongRecipient
         }
     ));
 }

--- a/crates/cgka-engine/tests/auto_commit_atomicity.rs
+++ b/crates/cgka-engine/tests/auto_commit_atomicity.rs
@@ -29,10 +29,10 @@ use cgka_traits::message::{MessageRecord, MessageState};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
-    ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage, LeaveRequest,
-    LeaveRequestStorage, MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage,
-    OutboundIntentStorage, QueuedOutboundIntent, StorageError, StorageProvider, StorageResult,
-    StoredKeyPackageBundle, WelcomeStorage,
+    ConvergencePassStorage, ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage,
+    LeaveRequest, LeaveRequestStorage, MemberValidationCacheStorage, MessageStorage,
+    OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent, StorageError,
+    StorageProvider, StorageResult, StoredKeyPackageBundle, WelcomeStorage,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -361,6 +361,30 @@ impl KeyPackageBundleStorage for FaultStorage {
 
     fn delete_stored_key_package_bundle(&self, storage_key: &[u8]) -> StorageResult<()> {
         self.inner.delete_stored_key_package_bundle(storage_key)
+    }
+}
+
+impl ConvergencePassStorage for FaultStorage {
+    fn convergence_pass(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Option<cgka_traits::DurableConvergencePass>> {
+        self.inner.convergence_pass(group_id)
+    }
+
+    fn put_convergence_pass(
+        &self,
+        pass: &cgka_traits::DurableConvergencePass,
+    ) -> StorageResult<()> {
+        self.inner.put_convergence_pass(pass)
+    }
+
+    fn list_convergence_passes(&self) -> StorageResult<Vec<cgka_traits::DurableConvergencePass>> {
+        self.inner.list_convergence_passes()
+    }
+
+    fn delete_convergence_pass(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.inner.delete_convergence_pass(group_id)
     }
 }
 

--- a/crates/cgka-engine/tests/convergence_policy_pin.rs
+++ b/crates/cgka-engine/tests/convergence_policy_pin.rs
@@ -121,6 +121,19 @@ fn default_build_set_convergence_policy_rejects_non_pinned() {
 
 #[cfg(not(feature = "test-policy-overrides"))]
 #[test]
+fn default_build_rejects_non_pinned_absolute_pass_cap() {
+    let mut engine = build_engine();
+    let err = engine
+        .set_convergence_policy(CanonicalizationPolicy {
+            max_convergence_pass_ms: 5_001,
+            ..CanonicalizationPolicy::default()
+        })
+        .expect_err("normal builds must pin the absolute pass cap");
+    assert!(matches!(err, OpenMlsProjectionError::InvalidPolicy(_)));
+}
+
+#[cfg(not(feature = "test-policy-overrides"))]
+#[test]
 fn default_build_builder_rejects_non_default_max_past_epochs() {
     let result = EngineBuilder::new(SqliteAccountStorage::in_memory().unwrap())
         .identity(valid_identity(b"pin-policy-epochs"))

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -816,6 +816,50 @@ async fn engine_converges_stored_openmls_messages_to_selected_branch() {
         .expect("repeated convergence after applying is a no-op");
     assert!(repeated.accepted_commits.is_empty());
     assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(2));
+
+    let completed_pass = carol_storage
+        .convergence_pass(&group_id)
+        .unwrap()
+        .expect("completed witness pass remains durable");
+    assert_eq!(
+        completed_pass.phase,
+        cgka_traits::ConvergencePassPhase::Completed
+    );
+    let post_race_app = if app_branch_index == 0 {
+        send_app(
+            &mut alice,
+            &group_id,
+            b"ordinary app after settled race".to_vec(),
+        )
+        .await
+    } else {
+        send_app(
+            &mut bob,
+            &group_id,
+            b"ordinary app after settled race".to_vec(),
+        )
+        .await
+    };
+    assert!(matches!(
+        carol.ingest(post_race_app.clone()).await.unwrap(),
+        IngestOutcome::Processed
+    ));
+    assert_message_state(&carol_storage, &post_race_app, MessageState::Processed);
+    let pass_after_app = carol_storage
+        .convergence_pass(&group_id)
+        .unwrap()
+        .expect("ordinary app does not replace the completed pass");
+    assert_eq!(pass_after_app.generation, completed_pass.generation);
+    assert_eq!(
+        pass_after_app.phase,
+        cgka_traits::ConvergencePassPhase::Completed
+    );
+    assert!(
+        !carol
+            .has_pending_convergence_inputs(&group_id)
+            .expect("pending convergence query succeeds"),
+        "the epoch-invalidated loser must not keep gating ordinary app traffic"
+    );
 }
 
 #[tokio::test]
@@ -4211,9 +4255,9 @@ async fn collecting_pass_restart_preserves_remaining_window_and_backward_clock_f
         .prepare_convergence_cutoff_delay_ms(&group_id)
         .unwrap()
         .expect("collecting pass remains active");
-    assert!(
-        remaining <= 600,
-        "restart must preserve at most the original 600ms remainder, got {remaining}"
+    assert_eq!(
+        remaining, 600,
+        "restart must preserve the original 600ms remainder"
     );
 
     wall_ms.store(9_000, Ordering::SeqCst);
@@ -5000,6 +5044,23 @@ async fn input_at_effective_cutoff_is_retained_for_the_next_generation() {
         MessageState::Created,
         "the cutoff input remains durable for the next generation"
     );
+
+    carol
+        .prepare_convergence_cutoff_delay_ms(&group_id)
+        .expect("next generation opens")
+        .expect("cutoff input starts the next collecting pass");
+    let next = carol_storage
+        .convergence_pass(&group_id)
+        .unwrap()
+        .expect("generation one is durable");
+    assert_eq!(next.generation, 1);
+    assert_eq!(next.phase, cgka_traits::ConvergencePassPhase::Collecting);
+    assert!(
+        next.members
+            .iter()
+            .any(|member| member.message_id == content_id(&at_cutoff)),
+        "input retained at generation-zero cutoff must join generation one"
+    );
 }
 
 #[tokio::test]
@@ -5100,13 +5161,17 @@ async fn missing_frozen_pass_member_fails_closed_to_unrecoverable() {
         .unwrap();
 
     let mut pass = carol_storage.convergence_pass(&group_id).unwrap().unwrap();
+    pass.phase = cgka_traits::ConvergencePassPhase::Frozen;
+    pass.frozen_at_wall_ms = Some(pass.cutoff_wall_ms());
+    pass.cutoff_cause = Some(cgka_traits::ConvergenceCutoffCause::Quiescence);
     pass.members[0].message_id = MessageId::new(b"missing-frozen-member".to_vec());
     carol_storage.put_convergence_pass(&pass).unwrap();
 
-    let result = carol
-        .converge_stored_openmls_messages(&group_id, 2_000)
-        .expect("missing member is a classified fail-closed halt");
-    assert_eq!(result.convergence_status, ConvergenceStatus::Blocked);
+    let drained = carol
+        .advance_convergence(&group_id)
+        .await
+        .expect("production advance classifies the missing member as a fail-closed halt");
+    assert!(drained.is_empty());
     assert!(carol_storage.get_group(&group_id).unwrap().unrecoverable);
     assert!(carol.drain_events().iter().any(|event| matches!(
         event,

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -40,6 +40,8 @@ use openmls::prelude::BasicCredential;
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_traits::OpenMlsProvider as _;
 use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use storage_sqlite::SqliteAccountStorage;
 use tls_codec::Serialize as _;
 
@@ -69,6 +71,27 @@ fn pad32(name: &[u8]) -> Vec<u8> {
 
 struct MockPeeler;
 struct EpochGatePeeler;
+
+#[derive(Clone)]
+struct TestWallClock(Arc<AtomicU64>);
+
+impl cgka_traits::maintenance::WallClock for TestWallClock {
+    fn now(&self) -> cgka_traits::Timestamp {
+        cgka_traits::Timestamp(self.0.load(Ordering::SeqCst) / 1_000)
+    }
+
+    fn now_ms(&self) -> u64 {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+struct FixedMaintenanceRandom;
+
+impl cgka_traits::maintenance::MaintenanceRandom for FixedMaintenanceRandom {
+    fn next_u64(&self) -> u64 {
+        0
+    }
+}
 
 fn commit_tiebreak_winner_index(first: &MemberId, second: &MemberId) -> usize {
     if first.as_slice() < second.as_slice() {
@@ -287,6 +310,22 @@ fn build_client_with_storage(
         .account_identity_proof_signer(proof_signer(id))
         .feature_registry(selfremove_registry())
         .peeler(Box::new(MockPeeler))
+        .build()
+        .unwrap()
+}
+
+fn build_client_with_storage_and_clock(
+    id: &[u8],
+    storage: SqliteAccountStorage,
+    wall_clock: TestWallClock,
+) -> Engine<SqliteAccountStorage> {
+    EngineBuilder::new(storage)
+        .legacy_compatibility_profile()
+        .identity(pad32(id))
+        .account_identity_proof_signer(proof_signer(id))
+        .feature_registry(selfremove_registry())
+        .peeler(Box::new(MockPeeler))
+        .maintenance_sources(Arc::new(wall_clock), Arc::new(FixedMaintenanceRandom))
         .build()
         .unwrap()
 }
@@ -3119,7 +3158,7 @@ async fn engine_prunes_retained_anchor_snapshots_to_rewind_horizon() {
 }
 
 #[tokio::test]
-async fn engine_invalidates_commit_older_than_retained_anchor() {
+async fn engine_does_not_reseed_commit_older_than_retained_anchor() {
     let (mut alice, _alice_storage) = build_client(b"alice");
     let (mut bob, _bob_storage) = build_client(b"bob");
     let (mut carol, carol_storage) = build_client(b"carol");
@@ -3214,17 +3253,20 @@ async fn engine_invalidates_commit_older_than_retained_anchor() {
         .expect("stale bob commit buffered");
     let result = carol
         .converge_stored_openmls_messages(&group_id, u64::MAX)
-        .expect("stale commit is resolved without historical replay");
+        .expect("stale commit outside the retained horizon is ignored");
 
-    assert!(result.dropped_messages.iter().any(|dropped| {
-        dropped.message_id == content_hex(&stale_bob_commit)
-            && dropped.kind == MessageKind::Commit
-            && dropped.reason == DroppedMessageReason::BeyondAnchor
-    }));
-    assert_message_state(
-        &carol_storage,
-        &stale_bob_commit,
-        MessageState::EpochInvalidated,
+    assert!(result.dropped_messages.is_empty());
+    assert_message_state(&carol_storage, &stale_bob_commit, MessageState::Created);
+    assert!(
+        carol_storage
+            .convergence_pass(&group_id)
+            .unwrap()
+            .is_some_and(|pass| {
+                pass.members
+                    .iter()
+                    .all(|member| member.message_id != content_id(&stale_bob_commit))
+            }),
+        "below-anchor history must not be copied into the durable pass"
     );
     assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(3));
     assert!(
@@ -3237,7 +3279,7 @@ async fn engine_invalidates_commit_older_than_retained_anchor() {
 }
 
 #[tokio::test]
-async fn rebuilt_engine_invalidates_commit_older_than_retained_anchor() {
+async fn rebuilt_engine_does_not_reseed_commit_older_than_retained_anchor() {
     let (mut alice, _alice_storage) = build_client(b"alice");
     let (mut bob, _bob_storage) = build_client(b"bob");
     let (mut carol, carol_storage) = build_client(b"carol");
@@ -3338,18 +3380,10 @@ async fn rebuilt_engine_invalidates_commit_older_than_retained_anchor() {
         .expect("stale bob commit buffered after restart");
     let result = carol
         .converge_stored_openmls_messages(&group_id, 5_000_000)
-        .expect("rebuilt engine resolves stale commit without historical replay");
+        .expect("rebuilt engine ignores input outside the retained horizon");
 
-    assert!(result.dropped_messages.iter().any(|dropped| {
-        dropped.message_id == content_hex(&stale_bob_commit)
-            && dropped.kind == MessageKind::Commit
-            && dropped.reason == DroppedMessageReason::BeyondAnchor
-    }));
-    assert_message_state(
-        &carol_storage,
-        &stale_bob_commit,
-        MessageState::EpochInvalidated,
-    );
+    assert!(result.dropped_messages.is_empty());
+    assert_message_state(&carol_storage, &stale_bob_commit, MessageState::Created);
     assert_eq!(
         carol_storage.get_group(&group_id).unwrap().epoch,
         EpochId(3)
@@ -4061,10 +4095,82 @@ async fn rebuilt_engine_emits_canonical_app_message_after_convergence() {
 }
 
 #[tokio::test]
+async fn collecting_pass_restart_preserves_remaining_window_and_backward_clock_fails_closed() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let carol_storage = SqliteAccountStorage::in_memory().unwrap();
+    let wall_ms = Arc::new(AtomicU64::new(10_000));
+    let wall_clock = TestWallClock(wall_ms.clone());
+    let mut carol =
+        build_client_with_storage_and_clock(b"carol", carol_storage.clone(), wall_clock.clone());
+    let mut david = build_client(b"david").0;
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-collecting-restart".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    let invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (commit, _) = evolution(invite);
+    carol
+        .buffer_openmls_convergence_message(&group_id, route(commit, &group_id), 1_000)
+        .unwrap();
+
+    wall_ms.store(10_400, Ordering::SeqCst);
+    let mut restarted =
+        build_client_with_storage_and_clock(b"carol", carol_storage.clone(), wall_clock.clone());
+    let remaining = restarted
+        .prepare_convergence_cutoff_delay_ms(&group_id)
+        .unwrap()
+        .expect("collecting pass remains active");
+    assert!(
+        remaining <= 600,
+        "restart must preserve at most the original 600ms remainder, got {remaining}"
+    );
+
+    wall_ms.store(9_000, Ordering::SeqCst);
+    let mut backwards =
+        build_client_with_storage_and_clock(b"carol", carol_storage.clone(), wall_clock);
+    assert_eq!(
+        backwards
+            .prepare_convergence_cutoff_delay_ms(&group_id)
+            .unwrap(),
+        Some(0),
+        "a backward wall-clock jump in a new clock domain must make cutoff immediately due"
+    );
+}
+
+#[tokio::test]
 async fn rebuilt_engine_emits_losing_branch_app_invalidation_after_convergence() {
     let (mut alice, _alice_storage) = build_client(b"alice");
     let (mut bob, _bob_storage) = build_client(b"bob");
-    let (mut carol, carol_storage) = build_client(b"carol");
+    let carol_storage = SqliteAccountStorage::in_memory().unwrap();
+    let wall_ms = Arc::new(AtomicU64::new(10_000));
+    let wall_clock = TestWallClock(wall_ms.clone());
+    let mut carol =
+        build_client_with_storage_and_clock(b"carol", carol_storage.clone(), wall_clock.clone());
     let (mut david, _david_storage) = build_client(b"david");
     let (mut eve, _eve_storage) = build_client(b"eve");
 
@@ -4133,14 +4239,9 @@ async fn rebuilt_engine_emits_losing_branch_app_invalidation_after_convergence()
             .expect("message buffered");
     }
 
-    let mut restarted = EngineBuilder::new(carol_storage.clone())
-        .legacy_compatibility_profile()
-        .identity(pad32(b"carol"))
-        .account_identity_proof_signer(proof_signer(b"carol"))
-        .feature_registry(selfremove_registry())
-        .peeler(Box::new(MockPeeler))
-        .build()
-        .unwrap();
+    wall_ms.store(12_000, Ordering::SeqCst);
+    let mut restarted =
+        build_client_with_storage_and_clock(b"carol", carol_storage.clone(), wall_clock);
 
     let result = restarted
         .converge_stored_openmls_messages(&group_id, 1_000_000)
@@ -4457,7 +4558,63 @@ async fn engine_duplicate_convergence_input_does_not_reset_quiescence() {
 }
 
 #[tokio::test]
-async fn convergence_pass_freezes_at_absolute_cap_under_continuous_input() {
+async fn application_input_does_not_reset_convergence_quiescence() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage) = build_client(b"carol");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-convergence-app-quiescence".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    let rename = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("selection-relevant commit".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (commit, pending) = evolution(rename);
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .buffer_openmls_convergence_message(&group_id, route(commit, &group_id), 1_000)
+        .unwrap();
+    let app = send_app(&mut alice, &group_id, b"ordinary application".to_vec()).await;
+    carol
+        .buffer_openmls_convergence_message(&group_id, app, 1_900)
+        .unwrap();
+
+    let pass = carol_storage.convergence_pass(&group_id).unwrap().unwrap();
+    assert_eq!(pass.quiescence_deadline_monotonic_ms, 2_000);
+    assert_eq!(
+        carol
+            .converge_stored_openmls_messages(&group_id, 2_000)
+            .unwrap()
+            .convergence_status,
+        ConvergenceStatus::Settled
+    );
+}
+
+#[tokio::test]
+async fn convergence_pass_freezes_at_absolute_cap_under_continuous_selection_input() {
     let (mut alice, _alice_storage) = build_client(b"alice");
     let (mut carol, carol_storage) = build_client(b"carol");
 
@@ -4487,14 +4644,18 @@ async fn convergence_pass_freezes_at_absolute_cap_under_continuous_input() {
         .into_iter()
         .enumerate()
     {
-        let message = send_app(
-            &mut alice,
-            &group_id,
-            format!("continuous witness {index}").into_bytes(),
-        )
-        .await;
+        let update = alice
+            .send(SendIntent::UpdateGroupData {
+                group_id: group_id.clone(),
+                name: Some(format!("continuous selection {index}")),
+                description: None,
+            })
+            .await
+            .unwrap();
+        let (message, pending) = evolution(update);
+        alice.confirm_published(pending).await.unwrap();
         carol
-            .buffer_openmls_convergence_message(&group_id, message, now_ms)
+            .buffer_openmls_convergence_message(&group_id, route(message, &group_id), now_ms)
             .unwrap();
     }
 
@@ -4565,8 +4726,13 @@ async fn input_at_effective_cutoff_is_retained_for_the_next_generation() {
     let collecting = carol_storage
         .convergence_pass(&group_id)
         .unwrap()
-        .expect("generation zero remains durable until resolution");
+        .expect("generation zero freezes durably at admission cutoff");
     assert_eq!(collecting.generation, 0);
+    assert_eq!(collecting.phase, cgka_traits::ConvergencePassPhase::Frozen);
+    assert_eq!(
+        collecting.cutoff_cause,
+        Some(cgka_traits::ConvergenceCutoffCause::Quiescence)
+    );
     assert_eq!(collecting.members.len(), 1);
     assert_eq!(collecting.members[0].message_id, content_id(&first));
     assert!(
@@ -4642,6 +4808,61 @@ async fn frozen_pass_member_tampering_fails_closed_to_unrecoverable() {
     let result = carol
         .converge_stored_openmls_messages(&group_id, 2_000)
         .expect("integrity failure is a classified halt");
+    assert_eq!(result.convergence_status, ConvergenceStatus::Blocked);
+    assert!(carol_storage.get_group(&group_id).unwrap().unrecoverable);
+    assert!(carol.drain_events().iter().any(|event| matches!(
+        event,
+        GroupEvent::GroupUnrecoverable { group_id: halted } if halted == &group_id
+    )));
+}
+
+#[tokio::test]
+async fn missing_frozen_pass_member_fails_closed_to_unrecoverable() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-convergence-missing-member".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    let invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (commit, _) = evolution(invite);
+    carol
+        .buffer_openmls_convergence_message(&group_id, route(commit, &group_id), 1_000)
+        .unwrap();
+
+    let mut pass = carol_storage.convergence_pass(&group_id).unwrap().unwrap();
+    pass.members[0].message_id = MessageId::new(b"missing-frozen-member".to_vec());
+    carol_storage.put_convergence_pass(&pass).unwrap();
+
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 2_000)
+        .expect("missing member is a classified fail-closed halt");
     assert_eq!(result.convergence_status, ConvergenceStatus::Blocked);
     assert!(carol_storage.get_group(&group_id).unwrap().unrecoverable);
     assert!(carol.drain_events().iter().any(|event| matches!(
@@ -5902,7 +6123,11 @@ async fn queued_group_evolution_pauses_later_queued_intents_until_publish_resolv
 async fn queued_outbound_intent_survives_engine_rebuild() {
     let (mut alice, _alice_storage) = build_client(b"alice");
     let (mut bob, _bob_storage) = build_client(b"bob");
-    let (mut carol, carol_storage) = build_client(b"carol");
+    let carol_storage = SqliteAccountStorage::in_memory().unwrap();
+    let wall_ms = Arc::new(AtomicU64::new(10_000));
+    let wall_clock = TestWallClock(wall_ms.clone());
+    let mut carol =
+        build_client_with_storage_and_clock(b"carol", carol_storage.clone(), wall_clock.clone());
     let (mut david, _david_storage) = build_client(b"david");
 
     let bob_kp = bob.fresh_key_package().await.unwrap();
@@ -5962,14 +6187,9 @@ async fn queued_outbound_intent_survives_engine_rebuild() {
         1
     );
 
-    let mut restarted = EngineBuilder::new(carol_storage.clone())
-        .legacy_compatibility_profile()
-        .identity(pad32(b"carol"))
-        .account_identity_proof_signer(proof_signer(b"carol"))
-        .feature_registry(selfremove_registry())
-        .peeler(Box::new(MockPeeler))
-        .build()
-        .unwrap();
+    wall_ms.store(12_000, Ordering::SeqCst);
+    let mut restarted =
+        build_client_with_storage_and_clock(b"carol", carol_storage.clone(), wall_clock);
     let drained = restarted
         .converge_and_drain_queued_outbound_intents(&group_id, 1_000_000)
         .await

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -3479,6 +3479,72 @@ async fn engine_ingest_buffers_future_epoch_app_message_as_convergence_witness()
     );
 }
 
+#[tokio::test]
+async fn future_app_without_reachable_commit_is_retained_without_gating_sends() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "future-app-no-candidate".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    let invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (_withheld_commit, pending) = evolution(invite);
+    alice.confirm_published(pending).await.unwrap();
+    let future_app = send_app(&mut alice, &group_id, b"waiting for parent".to_vec()).await;
+
+    assert!(matches!(
+        carol.ingest(future_app.clone()).await.unwrap(),
+        IngestOutcome::Buffered { .. }
+    ));
+    assert_message_state(&carol_storage, &future_app, MessageState::Created);
+    assert!(
+        carol_storage.convergence_pass(&group_id).unwrap().is_none(),
+        "an app payload without a reachable candidate branch must not open a pass"
+    );
+    assert!(
+        !carol.has_pending_convergence_inputs(&group_id).unwrap(),
+        "an unresolved payload disposition alone must not make group state ambiguous"
+    );
+
+    let sent = carol
+        .send(SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload: app_payload_for(&carol, b"current branch remains usable"),
+        })
+        .await
+        .unwrap();
+    assert!(
+        matches!(sent, SendResult::ApplicationMessage { .. }),
+        "future app without a candidate commit must not gate sends, got {sent:?}"
+    );
+}
+
 /// Regression for mdk#383 (audit item S3 on the convergence/replay seam): a
 /// replayed application message whose attribution fails validation is never
 /// surfaced as `MessageReceived` and lands in a terminal state, exactly as on
@@ -4614,6 +4680,163 @@ async fn application_input_does_not_reset_convergence_quiescence() {
 }
 
 #[tokio::test]
+async fn app_witness_beside_competing_commits_resets_convergence_quiescence() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut bob, _bob_storage) = build_client(b"bob");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+    let (mut eve, _eve_storage) = build_client(b"eve");
+
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "selection-relevant-app-quiescence".into(),
+            description: "".into(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    bob.join_welcome(welcome_for(&welcomes, b"bob"))
+        .await
+        .unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    let alice_invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let bob_invite = bob
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (alice_commit, alice_pending) = evolution(alice_invite);
+    let (bob_commit, _bob_pending) = evolution(bob_invite);
+    alice.confirm_published(alice_pending).await.unwrap();
+    let app = send_app(&mut alice, &group_id, b"branch witness".to_vec()).await;
+
+    carol
+        .buffer_openmls_convergence_message(&group_id, route(alice_commit, &group_id), 1_000)
+        .unwrap();
+    carol
+        .buffer_openmls_convergence_message(&group_id, route(bob_commit, &group_id), 1_000)
+        .unwrap();
+    carol
+        .buffer_openmls_convergence_message(&group_id, app, 1_900)
+        .unwrap();
+
+    let pass = carol_storage
+        .convergence_pass(&group_id)
+        .unwrap()
+        .expect("competing commits open a pass");
+    assert_eq!(
+        pass.quiescence_deadline_monotonic_ms, 2_900,
+        "a potential witness that can change the branch score is selection-relevant"
+    );
+    assert_eq!(
+        pass.absolute_deadline_monotonic_ms, 6_000,
+        "witness traffic must never move the absolute pass boundary"
+    );
+}
+
+#[tokio::test]
+async fn far_future_app_is_not_admitted_to_an_active_pass() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+    let (mut eve, _eve_storage) = build_client(b"eve");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "active-pass-future-horizon".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+    carol
+        .set_convergence_policy(CanonicalizationPolicy {
+            convergence: ConvergencePolicy {
+                max_rewind_commits: 1,
+                ..ConvergencePolicy::default()
+            },
+            ..CanonicalizationPolicy::default()
+        })
+        .unwrap();
+
+    let first_invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (first_commit, pending) = evolution(first_invite);
+    alice.confirm_published(pending).await.unwrap();
+    let second_invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (_withheld_second_commit, pending) = evolution(second_invite);
+    alice.confirm_published(pending).await.unwrap();
+    let far_future_app = send_app(&mut alice, &group_id, b"outside active horizon".to_vec()).await;
+
+    carol
+        .buffer_openmls_convergence_message(&group_id, route(first_commit, &group_id), 1_000)
+        .unwrap();
+    carol
+        .buffer_openmls_convergence_message(&group_id, far_future_app.clone(), 1_900)
+        .unwrap();
+
+    let pass = carol_storage
+        .convergence_pass(&group_id)
+        .unwrap()
+        .expect("first commit opens a pass");
+    assert_eq!(pass.members.len(), 1);
+    assert!(
+        pass.members
+            .iter()
+            .all(|member| member.message_id != content_id(&far_future_app)),
+        "outside-horizon input must be retained outside the active frozen batch"
+    );
+    assert_eq!(pass.quiescence_deadline_monotonic_ms, 2_000);
+    assert_message_state(&carol_storage, &far_future_app, MessageState::Created);
+}
+
+#[tokio::test]
 async fn convergence_pass_freezes_at_absolute_cap_under_continuous_selection_input() {
     let (mut alice, _alice_storage) = build_client(b"alice");
     let (mut carol, carol_storage) = build_client(b"carol");
@@ -4714,8 +4937,28 @@ async fn input_at_effective_cutoff_is_retained_for_the_next_generation() {
         .await
         .unwrap();
 
-    let first = send_app(&mut alice, &group_id, b"before cutoff".to_vec()).await;
-    let at_cutoff = send_app(&mut alice, &group_id, b"at cutoff".to_vec()).await;
+    let first_update = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("before cutoff".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (first, pending) = evolution(first_update);
+    alice.confirm_published(pending).await.unwrap();
+    let first = route(first, &group_id);
+    let cutoff_update = alice
+        .send(SendIntent::UpdateGroupData {
+            group_id: group_id.clone(),
+            name: Some("at cutoff".into()),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (at_cutoff, pending) = evolution(cutoff_update);
+    alice.confirm_published(pending).await.unwrap();
+    let at_cutoff = route(at_cutoff, &group_id);
     carol
         .buffer_openmls_convergence_message(&group_id, first.clone(), 1_000)
         .unwrap();

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -23,8 +23,8 @@ use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage};
 use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
-    AccountDeviceSignerStorage, GroupStorage, MessageStorage, OutboundIntentStorage,
-    QueuedOutboundIntent, StorageProvider,
+    AccountDeviceSignerStorage, ConvergencePassStorage, GroupStorage, MessageStorage,
+    OutboundIntentStorage, QueuedOutboundIntent, StorageProvider,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -1420,7 +1420,7 @@ async fn superseded_self_removal_clears_removed_marker_and_restores_send() {
         .buffer_openmls_convergence_message(&group_id, rename_commit.clone(), 1_001_000)
         .expect("sibling rename commit buffered");
     let result = carol
-        .converge_stored_openmls_messages(&group_id, 3_000_000)
+        .converge_stored_openmls_messages(&group_id, u64::MAX)
         .expect("reorg over the superseded removal");
     assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
     assert_eq!(result.accepted_commits, vec![content_hex(&rename_commit)]);
@@ -2038,7 +2038,7 @@ async fn engine_keeps_child_commit_pending_until_parent_arrives() {
             members: vec![carol_kp],
             required_features: vec![],
             app_components: vec![],
-            initial_admins: vec![],
+            initial_admins: vec![carol.self_id()],
         })
         .await
         .unwrap();
@@ -2060,8 +2060,9 @@ async fn engine_keeps_child_commit_pending_until_parent_arrives() {
         })
         .await
         .unwrap();
-    let (_commit_david, pending_david) = evolution(invite_david);
+    let (commit_david, pending_david) = evolution(invite_david);
     alice.confirm_published(pending_david).await.unwrap();
+    let commit_david = route(commit_david, &group_id);
 
     let eve_kp = eve.fresh_key_package().await.unwrap();
     let invite_eve = alice
@@ -2077,6 +2078,19 @@ async fn engine_keeps_child_commit_pending_until_parent_arrives() {
     carol
         .buffer_openmls_convergence_message(&group_id, commit_eve.clone(), 1_000)
         .expect("child commit buffered without parent");
+    let queued_intent_id = MessageId::new(b"fairness-before-generation-one".to_vec());
+    carol_storage
+        .put_queued_outbound_intent(&QueuedOutboundIntent {
+            id: queued_intent_id.clone(),
+            group_id: group_id.clone(),
+            intent: SendIntent::UpdateGroupData {
+                group_id: group_id.clone(),
+                name: Some("fairness before generation one".into()),
+                description: None,
+            },
+            created_at_ms: 1_001,
+        })
+        .expect("persist already-queued admin group-state intent");
 
     let result = carol
         .converge_stored_openmls_messages(&group_id, 1_000_000)
@@ -2087,6 +2101,77 @@ async fn engine_keeps_child_commit_pending_until_parent_arrives() {
     assert!(result.dropped_messages.is_empty());
     assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
     assert_message_state(&carol_storage, &commit_eve, MessageState::Created);
+    let first_pass = carol_storage
+        .convergence_pass(&group_id)
+        .unwrap()
+        .expect("first frozen pass persisted");
+    assert_eq!(first_pass.generation, 0);
+    assert_eq!(
+        first_pass.phase,
+        cgka_traits::ConvergencePassPhase::Completed
+    );
+    assert_eq!(first_pass.members.len(), 1);
+
+    // The missing parent arrives only after generation 0 froze. It must not
+    // mutate that completed membership set; generation 1 seeds both retained
+    // inputs and resolves the fixed batch.
+    carol
+        .buffer_openmls_convergence_message(&group_id, commit_david.clone(), 1_000_001)
+        .expect("late parent retained for next pass");
+    let fairness_turn = carol
+        .converge_and_drain_queued_outbound_intents(&group_id, 1_002_000)
+        .await
+        .expect("completed pass grants one queued user-intent turn");
+    assert_eq!(fairness_turn.len(), 1);
+    let fairness_pending = match fairness_turn[0] {
+        SendResult::GroupEvolution { pending, .. } => pending,
+        ref other => panic!("expected queued group-state evolution, got {other:?}"),
+    };
+    let after_fairness = carol_storage
+        .convergence_pass(&group_id)
+        .unwrap()
+        .expect("completed pass remains until its fairness slot is consumed");
+    assert_eq!(after_fairness.generation, 0);
+    assert_eq!(
+        after_fairness.phase,
+        cgka_traits::ConvergencePassPhase::Completed
+    );
+    assert!(!after_fairness.fairness_slot_available);
+    assert_message_state(&carol_storage, &commit_david, MessageState::Created);
+    carol
+        .confirm_published(fairness_pending)
+        .await
+        .expect("published fairness evolution leaves the durable queue");
+    assert!(
+        carol_storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .iter()
+            .all(|record| record.id != queued_intent_id)
+    );
+
+    let collecting_second = carol
+        .converge_stored_openmls_messages(&group_id, 1_002_000)
+        .expect("next generation opens only after the fairness turn");
+    assert_eq!(
+        collecting_second.convergence_status,
+        ConvergenceStatus::Syncing
+    );
+    let second = carol
+        .converge_stored_openmls_messages(&group_id, 1_003_000)
+        .expect("next frozen generation resolves parent and child");
+    assert_eq!(second.convergence_status, ConvergenceStatus::Settled);
+    assert_eq!(
+        second.accepted_commits,
+        vec![content_hex(&commit_david), content_hex(&commit_eve)]
+    );
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(3));
+    let second_pass = carol_storage
+        .convergence_pass(&group_id)
+        .unwrap()
+        .expect("second pass persisted");
+    assert_eq!(second_pass.generation, 1);
+    assert!(second_pass.members.len() >= 2);
 }
 
 #[tokio::test]
@@ -3128,7 +3213,7 @@ async fn engine_invalidates_commit_older_than_retained_anchor() {
         .buffer_openmls_convergence_message(&group_id, stale_bob_commit.clone(), 4_000)
         .expect("stale bob commit buffered");
     let result = carol
-        .converge_stored_openmls_messages(&group_id, 5_000_000)
+        .converge_stored_openmls_messages(&group_id, u64::MAX)
         .expect("stale commit is resolved without historical replay");
 
     assert!(result.dropped_messages.iter().any(|dropped| {
@@ -3863,7 +3948,7 @@ async fn late_reorg_invalidates_an_already_delivered_losing_branch_message() {
         .buffer_openmls_convergence_message(&group_id, apps[winning_index].clone(), 2_000)
         .unwrap();
     let second = carol
-        .converge_stored_openmls_messages(&group_id, 2_000_000)
+        .converge_stored_openmls_messages(&group_id, u64::MAX)
         .unwrap();
 
     assert!(second.invalidated_app_messages.iter().any(|invalidated| {
@@ -3936,6 +4021,14 @@ async fn rebuilt_engine_emits_canonical_app_message_after_convergence() {
         .ingest(route(commit, &group_id))
         .await
         .expect("commit is stored");
+    let mut frozen_pass = carol_storage
+        .convergence_pass(&group_id)
+        .unwrap()
+        .expect("collecting pass persisted before restart");
+    frozen_pass.phase = cgka_traits::ConvergencePassPhase::Frozen;
+    frozen_pass.frozen_at_wall_ms = Some(frozen_pass.cutoff_wall_ms());
+    frozen_pass.cutoff_cause = Some(cgka_traits::ConvergenceCutoffCause::Quiescence);
+    carol_storage.put_convergence_pass(&frozen_pass).unwrap();
 
     let mut restarted = EngineBuilder::new(carol_storage.clone())
         .legacy_compatibility_profile()
@@ -4361,6 +4454,200 @@ async fn engine_duplicate_convergence_input_does_not_reset_quiescence() {
     assert_eq!(result.convergence_status, ConvergenceStatus::Settled);
     assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(2));
     assert_message_state(&carol_storage, &commit, MessageState::Processed);
+}
+
+#[tokio::test]
+async fn convergence_pass_freezes_at_absolute_cap_under_continuous_input() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage) = build_client(b"carol");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-convergence-absolute-cap".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    for (index, now_ms) in [1_000, 1_900, 2_800, 3_700, 4_600, 5_500]
+        .into_iter()
+        .enumerate()
+    {
+        let message = send_app(
+            &mut alice,
+            &group_id,
+            format!("continuous witness {index}").into_bytes(),
+        )
+        .await;
+        carol
+            .buffer_openmls_convergence_message(&group_id, message, now_ms)
+            .unwrap();
+    }
+
+    let pass = carol_storage
+        .convergence_pass(&group_id)
+        .unwrap()
+        .expect("collecting pass persisted");
+    assert_eq!(pass.quiescence_deadline_monotonic_ms, 6_500);
+    assert_eq!(pass.absolute_deadline_monotonic_ms, 6_000);
+    assert_eq!(pass.members.len(), 6);
+    assert_eq!(
+        carol
+            .converge_stored_openmls_messages(&group_id, 5_999)
+            .unwrap()
+            .convergence_status,
+        ConvergenceStatus::Syncing
+    );
+    assert_eq!(
+        carol
+            .converge_stored_openmls_messages(&group_id, 6_000)
+            .unwrap()
+            .convergence_status,
+        ConvergenceStatus::Settled
+    );
+    let frozen = carol_storage.convergence_pass(&group_id).unwrap().unwrap();
+    assert_eq!(
+        frozen.cutoff_cause,
+        Some(cgka_traits::ConvergenceCutoffCause::AbsoluteDeadline)
+    );
+}
+
+#[tokio::test]
+async fn input_at_effective_cutoff_is_retained_for_the_next_generation() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage) = build_client(b"carol");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-convergence-exact-cutoff".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    let first = send_app(&mut alice, &group_id, b"before cutoff".to_vec()).await;
+    let at_cutoff = send_app(&mut alice, &group_id, b"at cutoff".to_vec()).await;
+    carol
+        .buffer_openmls_convergence_message(&group_id, first.clone(), 1_000)
+        .unwrap();
+    carol
+        .buffer_openmls_convergence_message(&group_id, at_cutoff.clone(), 2_000)
+        .unwrap();
+
+    let collecting = carol_storage
+        .convergence_pass(&group_id)
+        .unwrap()
+        .expect("generation zero remains durable until resolution");
+    assert_eq!(collecting.generation, 0);
+    assert_eq!(collecting.members.len(), 1);
+    assert_eq!(collecting.members[0].message_id, content_id(&first));
+    assert!(
+        !collecting
+            .members
+            .iter()
+            .any(|member| member.message_id == content_id(&at_cutoff)),
+        "admission at the cutoff must not mutate the frozen generation"
+    );
+
+    carol
+        .converge_stored_openmls_messages(&group_id, 2_000)
+        .expect("generation zero freezes and resolves at the exact cutoff");
+    let completed = carol_storage.convergence_pass(&group_id).unwrap().unwrap();
+    assert_eq!(completed.generation, 0);
+    assert_eq!(completed.members.len(), 1);
+    assert_eq!(
+        carol_storage
+            .get_message(&content_id(&at_cutoff))
+            .unwrap()
+            .state,
+        MessageState::Created,
+        "the cutoff input remains durable for the next generation"
+    );
+}
+
+#[tokio::test]
+async fn frozen_pass_member_tampering_fails_closed_to_unrecoverable() {
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut carol, carol_storage) = build_client(b"carol");
+    let (mut david, _david_storage) = build_client(b"david");
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-convergence-member-integrity".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    let invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (commit, _) = evolution(invite);
+    let commit = route(commit, &group_id);
+    carol
+        .buffer_openmls_convergence_message(&group_id, commit.clone(), 1_000)
+        .unwrap();
+
+    let id = content_id(&commit);
+    let mut record = carol_storage.get_message(&id).unwrap();
+    record.payload = vec![0xff];
+    carol_storage.put_message(&record).unwrap();
+
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 2_000)
+        .expect("integrity failure is a classified halt");
+    assert_eq!(result.convergence_status, ConvergenceStatus::Blocked);
+    assert!(carol_storage.get_group(&group_id).unwrap().unrecoverable);
+    assert!(carol.drain_events().iter().any(|event| matches!(
+        event,
+        GroupEvent::GroupUnrecoverable { group_id: halted } if halted == &group_id
+    )));
 }
 
 #[tokio::test]

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -13,10 +13,10 @@ use cgka_traits::message::{MessageRecord, MessageState};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
-    ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage, LeaveRequest,
-    LeaveRequestStorage, MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage,
-    OutboundIntentStorage, QueuedOutboundIntent, StorageError, StorageProvider, StorageResult,
-    StoredKeyPackageBundle, WelcomeStorage,
+    ConvergencePassStorage, ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage,
+    LeaveRequest, LeaveRequestStorage, MemberValidationCacheStorage, MessageStorage,
+    OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent, StorageError,
+    StorageProvider, StorageResult, StoredKeyPackageBundle, WelcomeStorage,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -553,6 +553,30 @@ impl KeyPackageBundleStorage for FlakyGroupRecordStorage {
     }
 }
 
+impl ConvergencePassStorage for FlakyGroupRecordStorage {
+    fn convergence_pass(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Option<cgka_traits::DurableConvergencePass>> {
+        self.inner.convergence_pass(group_id)
+    }
+
+    fn put_convergence_pass(
+        &self,
+        pass: &cgka_traits::DurableConvergencePass,
+    ) -> StorageResult<()> {
+        self.inner.put_convergence_pass(pass)
+    }
+
+    fn list_convergence_passes(&self) -> StorageResult<Vec<cgka_traits::DurableConvergencePass>> {
+        self.inner.list_convergence_passes()
+    }
+
+    fn delete_convergence_pass(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.inner.delete_convergence_pass(group_id)
+    }
+}
+
 impl StorageProvider for FlakyGroupRecordStorage {
     type Mls = <SqliteAccountStorage as StorageProvider>::Mls;
 
@@ -1035,8 +1059,8 @@ async fn quarantined_group_rejects_valid_inbound_commit_on_do_ingest() {
     assert!(
         matches!(
             outcome,
-            cgka_traits::ingest::IngestOutcome::Stale {
-                reason: cgka_traits::ingest::StaleReason::Quarantined
+            cgka_traits::ingest::IngestOutcome::LocalState {
+                state: cgka_traits::ingest::LocalIngestState::Quarantined
             }
         ),
         "expected Stale::Quarantined, got {outcome:?}"
@@ -1170,8 +1194,8 @@ async fn repair_replays_buffered_commit_and_group_catches_up() {
         .expect("ingest classifies");
     assert!(matches!(
         outcome,
-        cgka_traits::ingest::IngestOutcome::Stale {
-            reason: cgka_traits::ingest::StaleReason::Quarantined
+        cgka_traits::ingest::IngestOutcome::LocalState {
+            state: cgka_traits::ingest::LocalIngestState::Quarantined
         }
     ));
 
@@ -1329,8 +1353,8 @@ async fn rejoin_welcome_replays_and_retires_quarantine_retained_input() {
         .expect("quarantine gate classifies");
     assert!(matches!(
         outcome,
-        cgka_traits::ingest::IngestOutcome::Stale {
-            reason: cgka_traits::ingest::StaleReason::Quarantined
+        cgka_traits::ingest::IngestOutcome::LocalState {
+            state: cgka_traits::ingest::LocalIngestState::Quarantined
         }
     ));
     let deferred_before = alice_storage

--- a/crates/cgka-engine/tests/ingest.rs
+++ b/crates/cgka-engine/tests/ingest.rs
@@ -874,18 +874,9 @@ async fn malformed_group_message_is_stale_and_does_not_wedge_ingest() {
     );
 }
 
-fn expected_transport_rejection_outcome(reason: StaleReason) -> IngestOutcome {
-    match reason {
-        StaleReason::NotForThisClient => IngestOutcome::Ignored {
-            category: InputRejectionCategory::WrongRecipient,
-        },
-        reason => IngestOutcome::Stale { reason },
-    }
-}
-
 async fn assert_typed_terminal_transport_rejection(
     rejection: BoundaryRejection,
-    expected_reason: StaleReason,
+    expected_outcome: IngestOutcome,
 ) {
     let mut alice = build_client(b"alice-terminal-rejection");
     let mut bob = build_client_with_peeler(
@@ -932,10 +923,7 @@ async fn assert_typed_terminal_transport_rejection(
         .ingest(rejected.clone())
         .await
         .expect("boundary rejection is terminal input, not a drain failure");
-    assert_eq!(
-        outcome,
-        expected_transport_rejection_outcome(expected_reason)
-    );
+    assert_eq!(outcome, expected_outcome);
 
     let duplicate = bob
         .ingest(rejected)
@@ -952,7 +940,7 @@ async fn assert_typed_terminal_transport_rejection(
 async fn assert_snapshot_fallback_terminal_transport_rejection(
     rejection: BoundaryRejection,
     initial_failure: InitialPeelFailure,
-    expected_reason: StaleReason,
+    expected_outcome: IngestOutcome,
 ) {
     let mut alice = build_client(b"alice-snapshot-boundary-rejection");
     let live_epoch = 2u64;
@@ -1030,10 +1018,7 @@ async fn assert_snapshot_fallback_terminal_transport_rejection(
         .ingest(rejected.clone())
         .await
         .expect("snapshot-fallback boundary rejection is terminal, not a drain failure");
-    assert_eq!(
-        outcome,
-        expected_transport_rejection_outcome(expected_reason)
-    );
+    assert_eq!(outcome, expected_outcome);
 
     let duplicate = bob
         .ingest(rejected)
@@ -1051,7 +1036,9 @@ async fn assert_snapshot_fallback_terminal_transport_rejection(
 async fn invalid_transport_signature_is_typed_terminal_input() {
     assert_typed_terminal_transport_rejection(
         BoundaryRejection::InvalidSignature,
-        StaleReason::PeelFailed,
+        IngestOutcome::Stale {
+            reason: StaleReason::PeelFailed,
+        },
     )
     .await;
 }
@@ -1060,7 +1047,9 @@ async fn invalid_transport_signature_is_typed_terminal_input() {
 async fn wrong_transport_recipient_is_typed_terminal_input() {
     assert_typed_terminal_transport_rejection(
         BoundaryRejection::WrongRecipient,
-        StaleReason::NotForThisClient,
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::WrongRecipient,
+        },
     )
     .await;
 }
@@ -1113,7 +1102,9 @@ async fn invalid_transport_signature_after_decrypt_failed_fallback_is_terminal()
     assert_snapshot_fallback_terminal_transport_rejection(
         BoundaryRejection::InvalidSignature,
         InitialPeelFailure::DecryptFailed,
-        StaleReason::PeelFailed,
+        IngestOutcome::Stale {
+            reason: StaleReason::PeelFailed,
+        },
     )
     .await;
 }
@@ -1123,7 +1114,9 @@ async fn wrong_transport_recipient_after_stale_epoch_fallback_is_terminal() {
     assert_snapshot_fallback_terminal_transport_rejection(
         BoundaryRejection::WrongRecipient,
         InitialPeelFailure::StaleEpoch,
-        StaleReason::NotForThisClient,
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::WrongRecipient,
+        },
     )
     .await;
 }

--- a/crates/cgka-engine/tests/ingest.rs
+++ b/crates/cgka-engine/tests/ingest.rs
@@ -11,7 +11,9 @@ use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, Requ
 use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, GroupEvent, SendIntent, SendResult};
 use cgka_traits::error::PeelerError;
 use cgka_traits::group_context::GroupContextSnapshot;
-use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage, StaleReason};
+use cgka_traits::ingest::{
+    IngestOutcome, InputRejectionCategory, PeeledContent, PeeledMessage, StaleReason,
+};
 use cgka_traits::message::MessageState;
 use cgka_traits::peeler::{GroupMessageMetadata, TransportPeeler};
 use cgka_traits::storage::{MessageStorage, StorageError};
@@ -583,8 +585,8 @@ async fn ingest_unknown_group_message_returns_unknown_group() {
     let outcome = engine.ingest(msg).await.unwrap();
     assert!(matches!(
         outcome,
-        IngestOutcome::Stale {
-            reason: StaleReason::UnknownGroup
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::UnknownGroup
         }
     ));
 }
@@ -605,8 +607,8 @@ async fn ingest_welcome_for_another_client_returns_not_for_this_client() {
     let outcome = engine.ingest(msg).await.unwrap();
     assert!(matches!(
         outcome,
-        IngestOutcome::Stale {
-            reason: StaleReason::NotForThisClient
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::WrongRecipient
         }
     ));
 }
@@ -629,8 +631,8 @@ async fn ingest_duplicate_message_id_returns_already_seen() {
     let outcome = engine.ingest(msg).await.unwrap();
     assert!(matches!(
         outcome,
-        IngestOutcome::Stale {
-            reason: StaleReason::AlreadySeen
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::Duplicate
         }
     ));
 }
@@ -671,8 +673,8 @@ async fn malformed_peeled_welcome_is_terminal_and_restart_deduplicated() {
         .expect("poisoned welcome must not hard-error after restart");
     assert!(matches!(
         replay,
-        IngestOutcome::Stale {
-            reason: StaleReason::AlreadySeen
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::Duplicate
         }
     ));
 }
@@ -717,8 +719,8 @@ async fn rewrapped_identical_welcome_uses_content_dedup() {
     let outcome = bob.ingest(rewrapped).await.unwrap();
     assert!(matches!(
         outcome,
-        IngestOutcome::Stale {
-            reason: StaleReason::AlreadySeen
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::Duplicate
         }
     ));
     assert!(
@@ -872,6 +874,15 @@ async fn malformed_group_message_is_stale_and_does_not_wedge_ingest() {
     );
 }
 
+fn expected_transport_rejection_outcome(reason: StaleReason) -> IngestOutcome {
+    match reason {
+        StaleReason::NotForThisClient => IngestOutcome::Ignored {
+            category: InputRejectionCategory::WrongRecipient,
+        },
+        reason => IngestOutcome::Stale { reason },
+    }
+}
+
 async fn assert_typed_terminal_transport_rejection(
     rejection: BoundaryRejection,
     expected_reason: StaleReason,
@@ -923,9 +934,7 @@ async fn assert_typed_terminal_transport_rejection(
         .expect("boundary rejection is terminal input, not a drain failure");
     assert_eq!(
         outcome,
-        IngestOutcome::Stale {
-            reason: expected_reason
-        }
+        expected_transport_rejection_outcome(expected_reason)
     );
 
     let duplicate = bob
@@ -934,8 +943,8 @@ async fn assert_typed_terminal_transport_rejection(
         .expect("redelivery short-circuits after terminal rejection");
     assert!(matches!(
         duplicate,
-        IngestOutcome::Stale {
-            reason: StaleReason::AlreadySeen
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::Duplicate
         }
     ));
 }
@@ -1023,9 +1032,7 @@ async fn assert_snapshot_fallback_terminal_transport_rejection(
         .expect("snapshot-fallback boundary rejection is terminal, not a drain failure");
     assert_eq!(
         outcome,
-        IngestOutcome::Stale {
-            reason: expected_reason
-        }
+        expected_transport_rejection_outcome(expected_reason)
     );
 
     let duplicate = bob
@@ -1034,8 +1041,8 @@ async fn assert_snapshot_fallback_terminal_transport_rejection(
         .expect("redelivery short-circuits after snapshot-fallback rejection");
     assert_eq!(
         duplicate,
-        IngestOutcome::Stale {
-            reason: StaleReason::AlreadySeen
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::Duplicate
         }
     );
 }
@@ -1084,8 +1091,8 @@ async fn wrong_transport_welcome_recipient_is_typed_terminal_input() {
         .expect("wrong-recipient welcome is terminal input, not a drain failure");
     assert_eq!(
         outcome,
-        IngestOutcome::Stale {
-            reason: StaleReason::NotForThisClient
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::WrongRecipient
         }
     );
 
@@ -1095,8 +1102,8 @@ async fn wrong_transport_welcome_recipient_is_typed_terminal_input() {
         .expect("redelivery short-circuits after wrong-recipient welcome");
     assert_eq!(
         duplicate,
-        IngestOutcome::Stale {
-            reason: StaleReason::AlreadySeen
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::Duplicate
         }
     );
 }
@@ -1268,7 +1275,10 @@ async fn malformed_message_buffered_during_pending_publish_lands_terminal_after_
     alice.publish_failed(staged).await.unwrap();
     let after_replay = alice.ingest(garbage).await.unwrap();
     assert!(
-        matches!(after_replay, IngestOutcome::Stale { .. }),
+        matches!(
+            after_replay,
+            IngestOutcome::Stale { .. } | IngestOutcome::Ignored { .. }
+        ),
         "a malformed message must land terminal once classified — a \
          `Buffered` here means the stored row is still non-terminal and \
          perpetually reported as pending, got {after_replay:?}"
@@ -1460,8 +1470,8 @@ async fn ingest_own_created_message_returns_own_echo() {
     let outcome = alice.ingest(routed).await.unwrap();
     assert!(matches!(
         outcome,
-        IngestOutcome::Stale {
-            reason: StaleReason::OwnEcho
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::OwnEcho
         }
     ));
     let _ = (bob, create);
@@ -1658,8 +1668,8 @@ async fn rewrapped_own_openmls_message_after_restart_returns_own_echo() {
     assert!(
         matches!(
             outcome,
-            IngestOutcome::Stale {
-                reason: StaleReason::OwnEcho
+            IngestOutcome::Ignored {
+                category: InputRejectionCategory::OwnEcho
             }
         ),
         "re-wrapped own OpenMLS echo after restart must be OwnEcho, got {outcome:?}"
@@ -2135,8 +2145,8 @@ async fn rewrapped_mls_message_with_new_transport_id_is_a_duplicate() {
     assert!(
         matches!(
             bob.ingest(rewrapped).await.unwrap(),
-            IngestOutcome::Stale {
-                reason: StaleReason::AlreadySeen
+            IngestOutcome::Ignored {
+                category: InputRejectionCategory::Duplicate
             }
         ),
         "re-wrapped duplicate MLS message must be classified AlreadySeen"

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -13,7 +13,7 @@ use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, KeyPackage, SendIntent
 use cgka_traits::error::PeelerError;
 use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
-use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage, StaleReason};
+use cgka_traits::ingest::{IngestOutcome, LocalIngestState, PeeledContent, PeeledMessage};
 use cgka_traits::message::MessageState;
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
@@ -1017,8 +1017,8 @@ async fn post_eviction_message_realizes_self_removal_and_returns_self_evicted() 
     assert!(
         matches!(
             outcome,
-            IngestOutcome::Stale {
-                reason: StaleReason::SelfEvicted
+            IngestOutcome::LocalState {
+                state: LocalIngestState::Removed
             }
         ),
         "post-eviction input must classify SelfEvicted; got {outcome:?}"
@@ -1078,8 +1078,8 @@ async fn realization_with_pending_leave_request_attributes_member_left() {
     let outcome = bob.ingest(routed_app).await.unwrap();
     assert!(matches!(
         outcome,
-        IngestOutcome::Stale {
-            reason: StaleReason::SelfEvicted
+        IngestOutcome::LocalState {
+            state: LocalIngestState::Removed
         }
     ));
     let bob_events = bob.drain_events();
@@ -1225,8 +1225,8 @@ async fn drain_on_removed_copy_discards_queued_intents_without_error() {
     let outcome = bob.ingest(routed_app).await.unwrap();
     assert!(matches!(
         outcome,
-        IngestOutcome::Stale {
-            reason: StaleReason::SelfEvicted
+        IngestOutcome::LocalState {
+            state: LocalIngestState::Removed
         }
     ));
     assert!(
@@ -1283,8 +1283,8 @@ async fn second_post_eviction_message_is_self_evicted_without_duplicate_notifica
         assert!(
             matches!(
                 outcome,
-                IngestOutcome::Stale {
-                    reason: StaleReason::SelfEvicted
+                IngestOutcome::LocalState {
+                    state: LocalIngestState::Removed
                 }
             ),
             "round {round}: post-eviction input stays SelfEvicted; got {outcome:?}"
@@ -1313,8 +1313,8 @@ async fn missed_removal_commit_without_evidence_is_not_self_evicted() {
     assert!(
         !matches!(
             outcome,
-            IngestOutcome::Stale {
-                reason: StaleReason::SelfEvicted
+            IngestOutcome::LocalState {
+                state: LocalIngestState::Removed
             }
         ),
         "undecryptable input without authenticated evidence must not be SelfEvicted; got {outcome:?}"

--- a/crates/cgka-engine/tests/mip03_guards.rs
+++ b/crates/cgka-engine/tests/mip03_guards.rs
@@ -612,13 +612,8 @@ async fn inbound_self_update_rejects_account_identity_spoofing() {
 
     let outcome = alice.ingest(spoofed).await.unwrap();
     assert!(
-        matches!(
-            outcome,
-            IngestOutcome::Stale {
-                reason: cgka_traits::ingest::StaleReason::PeelFailed
-            }
-        ),
-        "terminally invalid same-epoch commits should not remain buffered, got {outcome:?}"
+        matches!(outcome, IngestOutcome::Buffered { .. }),
+        "same-epoch commits are classified against the frozen pass, got {outcome:?}"
     );
     let result = alice
         .converge_stored_openmls_messages(&group_id, 1_000_000)
@@ -722,13 +717,8 @@ async fn inbound_by_reference_update_rejects_account_identity_spoofing() {
 
     let outcome = carol.ingest(by_reference_commit).await.unwrap();
     assert!(
-        matches!(
-            outcome,
-            IngestOutcome::Stale {
-                reason: cgka_traits::ingest::StaleReason::PeelFailed
-            }
-        ),
-        "terminally invalid by-reference Update commits should not remain buffered, got {outcome:?}"
+        matches!(outcome, IngestOutcome::Buffered { .. }),
+        "same-epoch commits are classified against the frozen pass, got {outcome:?}"
     );
     let result = carol
         .converge_stored_openmls_messages(&group_id, 1_000_000)
@@ -816,13 +806,21 @@ async fn current_by_reference_non_admin_update_is_rejected_at_commit() {
     );
     let before_epoch = carol.epoch(&group_id).expect("carol has current group");
 
+    let commit_id = canonicalization_message_id(&commit);
     let outcome = carol.ingest(commit).await.unwrap();
-    assert_eq!(
-        outcome,
-        IngestOutcome::Rejected {
-            category: ProposalRejectionCategory::AuthorizationFailed,
-        },
-        "commit-time revalidation must reject a non-admin by-reference Update"
+    assert!(
+        matches!(outcome, IngestOutcome::Buffered { .. }),
+        "same-epoch commits are classified against the frozen pass, got {outcome:?}"
+    );
+    let result = carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("convergence should classify unauthorized by-reference update");
+    assert!(
+        result.dropped_messages.iter().any(|dropped| {
+            dropped.message_id == commit_id
+                && dropped.reason == DroppedMessageReason::InvalidAgainstCandidateState
+        }),
+        "commit-time revalidation must reject a non-admin by-reference Update, got {result:?}"
     );
     assert_eq!(carol.epoch(&group_id).unwrap(), before_epoch);
 }
@@ -1439,8 +1437,8 @@ async fn committer_must_not_be_leaver_holds_for_self_proposal() {
     assert!(
         matches!(
             outcome,
-            IngestOutcome::Stale {
-                reason: cgka_traits::ingest::StaleReason::OwnEcho
+            IngestOutcome::Ignored {
+                category: cgka_traits::ingest::InputRejectionCategory::OwnEcho
             }
         ),
         "bob should classify his own proposal as OwnEcho"

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -34,10 +34,10 @@ use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
-    ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage, LeaveRequest,
-    LeaveRequestStorage, MaintenanceStorage, MemberValidationCacheStorage, MessageStorage,
-    OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent, StorageError,
-    StorageProvider, StorageResult, StoredKeyPackageBundle, WelcomeStorage,
+    ConvergencePassStorage, ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage,
+    LeaveRequest, LeaveRequestStorage, MaintenanceStorage, MemberValidationCacheStorage,
+    MessageStorage, OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent,
+    StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle, WelcomeStorage,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -1240,6 +1240,30 @@ impl MaintenanceStorage for FaultStorage {
         policy: PeriodicMaintenancePolicy,
     ) -> StorageResult<()> {
         self.inner.put_periodic_maintenance_policy(policy)
+    }
+}
+
+impl ConvergencePassStorage for FaultStorage {
+    fn convergence_pass(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Option<cgka_traits::DurableConvergencePass>> {
+        self.inner.convergence_pass(group_id)
+    }
+
+    fn put_convergence_pass(
+        &self,
+        pass: &cgka_traits::DurableConvergencePass,
+    ) -> StorageResult<()> {
+        self.inner.put_convergence_pass(pass)
+    }
+
+    fn list_convergence_passes(&self) -> StorageResult<Vec<cgka_traits::DurableConvergencePass>> {
+        self.inner.list_convergence_passes()
+    }
+
+    fn delete_convergence_pass(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.inner.delete_convergence_pass(group_id)
     }
 }
 

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -801,6 +801,16 @@ impl AccountDeviceSession {
         Ok(self.engine.has_pending_convergence_inputs(group_id)?)
     }
 
+    pub fn convergence_cutoff_delay_ms(
+        &mut self,
+        group_id: &GroupId,
+    ) -> SessionResult<Option<u64>> {
+        Ok(CgkaEngine::convergence_cutoff_delay_ms(
+            &mut self.engine,
+            group_id,
+        )?)
+    }
+
     pub fn confirm_regenerated_queued_intent(
         &mut self,
         intent: &QueuedIntentRef,
@@ -1108,6 +1118,8 @@ fn ingest_outcome_kind(outcome: &IngestOutcome) -> &'static str {
     match outcome {
         IngestOutcome::Processed => "processed",
         IngestOutcome::Buffered { .. } => "buffered",
+        IngestOutcome::Ignored { .. } => "ignored",
+        IngestOutcome::LocalState { .. } => "local_state",
         IngestOutcome::Stale { .. } => "stale",
         IngestOutcome::Rejected { .. } => "rejected",
     }

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -801,11 +801,11 @@ impl AccountDeviceSession {
         Ok(self.engine.has_pending_convergence_inputs(group_id)?)
     }
 
-    pub fn convergence_cutoff_delay_ms(
+    pub fn prepare_convergence_cutoff_delay_ms(
         &mut self,
         group_id: &GroupId,
     ) -> SessionResult<Option<u64>> {
-        Ok(CgkaEngine::convergence_cutoff_delay_ms(
+        Ok(CgkaEngine::prepare_convergence_cutoff_delay_ms(
             &mut self.engine,
             group_id,
         )?)

--- a/crates/cgka-session/tests/nostr_stack.rs
+++ b/crates/cgka-session/tests/nostr_stack.rs
@@ -5,7 +5,7 @@ use cgka_session::IngestEffects;
 use cgka_session::PublishWork;
 use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
 use cgka_traits::engine::{CreateGroupRequest, GroupEvent, KeyPackage, SendIntent};
-use cgka_traits::ingest::{IngestOutcome, StaleReason};
+use cgka_traits::ingest::{IngestOutcome, InputRejectionCategory};
 use cgka_traits::{
     EpochId, MessageId, TransportAdapterError, TransportEndpoint, TransportPublishReport,
 };
@@ -227,8 +227,8 @@ async fn duplicate_group_relay_delivery_is_idempotent_at_session_boundary() {
         .expect("duplicate delivery should still route to bob");
     assert!(matches!(
         duplicate.outcome,
-        IngestOutcome::Stale {
-            reason: StaleReason::AlreadySeen
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::Duplicate
         }
     ));
     assert!(duplicate.effects.events.is_empty());
@@ -281,8 +281,8 @@ async fn reordered_and_duplicated_group_app_deliveries_preserve_valid_outputs() 
     assert_eq!(message_payloads(&middle), vec![b"one".to_vec()]);
     assert!(matches!(
         duplicate.outcome,
-        IngestOutcome::Stale {
-            reason: StaleReason::AlreadySeen
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::Duplicate
         }
     ));
     assert!(duplicate.effects.events.is_empty());

--- a/crates/cgka-session/tests/nostr_stack_chaos.rs
+++ b/crates/cgka-session/tests/nostr_stack_chaos.rs
@@ -7,7 +7,7 @@ use cgka_session::IngestEffects;
 use cgka_session::PublishWork;
 use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
 use cgka_traits::engine::{CreateGroupRequest, GroupEvent, KeyPackage, SendIntent};
-use cgka_traits::ingest::{IngestOutcome, StaleReason};
+use cgka_traits::ingest::{IngestOutcome, InputRejectionCategory, StaleReason};
 use cgka_traits::{EpochId, GroupId, MemberId, MessageId, TransportEndpoint, TransportMessage};
 use serde::Serialize;
 use support::nostr_stack::{CreatedGroup, NostrStackHarness, StackClient};
@@ -122,8 +122,8 @@ async fn invite_lifecycle_chaos_handles_wrong_routes_replays_and_welcome_before_
         .expect("welcome replay should still route to Carol");
     assert!(matches!(
         carol_welcome_replay.outcome,
-        IngestOutcome::Stale {
-            reason: StaleReason::AlreadySeen
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::Duplicate
         }
     ));
     assert!(carol_welcome_replay.effects.events.is_empty());
@@ -563,8 +563,8 @@ impl ChaosRunState<'_> {
         if self.seen[message_index] {
             if !matches!(
                 ingest.outcome,
-                IngestOutcome::Stale {
-                    reason: StaleReason::AlreadySeen
+                IngestOutcome::Ignored {
+                    category: InputRejectionCategory::Duplicate
                 }
             ) {
                 self.failures.push(format!(
@@ -641,8 +641,8 @@ impl ChaosRunState<'_> {
         let payloads = message_payloads(&ingest);
         if !matches!(
             ingest.outcome,
-            IngestOutcome::Stale {
-                reason: StaleReason::AlreadySeen
+            IngestOutcome::Ignored {
+                category: InputRejectionCategory::Duplicate
             }
         ) {
             self.failures.push(format!(
@@ -874,10 +874,10 @@ fn assert_already_seen(effects: &IngestEffects) {
     assert!(
         matches!(
             effects.outcome,
-            IngestOutcome::Stale {
-                reason: StaleReason::AlreadySeen
-                    | StaleReason::AlreadyAtEpoch { .. }
-                    | StaleReason::PeelFailed
+            IngestOutcome::Ignored {
+                category: InputRejectionCategory::Duplicate
+            } | IngestOutcome::Stale {
+                reason: StaleReason::AlreadyAtEpoch { .. } | StaleReason::PeelFailed
             }
         ),
         "expected duplicate/stale epoch outcome, got {:?}",

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -1426,6 +1426,13 @@ where
         Ok(self.session.has_pending_convergence_inputs(group_id)?)
     }
 
+    pub fn convergence_cutoff_delay_ms(
+        &mut self,
+        group_id: &GroupId,
+    ) -> AccountResult<Option<u64>> {
+        Ok(self.session.convergence_cutoff_delay_ms(group_id)?)
+    }
+
     pub fn members(&self, group_id: &GroupId) -> AccountResult<Vec<Member>> {
         Ok(self.session.members(group_id)?)
     }

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -1426,11 +1426,11 @@ where
         Ok(self.session.has_pending_convergence_inputs(group_id)?)
     }
 
-    pub fn convergence_cutoff_delay_ms(
+    pub fn prepare_convergence_cutoff_delay_ms(
         &mut self,
         group_id: &GroupId,
     ) -> AccountResult<Option<u64>> {
-        Ok(self.session.convergence_cutoff_delay_ms(group_id)?)
+        Ok(self.session.prepare_convergence_cutoff_delay_ms(group_id)?)
     }
 
     pub fn members(&self, group_id: &GroupId) -> AccountResult<Vec<Member>> {

--- a/crates/marmot-account/src/time.rs
+++ b/crates/marmot-account/src/time.rs
@@ -21,6 +21,15 @@ impl WallClock for SystemWallClock {
                 .as_secs(),
         )
     }
+
+    fn now_ms(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX)
+    }
 }
 
 #[derive(Debug)]

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -111,6 +111,10 @@ impl WallClock for TestWallClock {
     fn now(&self) -> Timestamp {
         Timestamp(self.0.load(Ordering::Relaxed))
     }
+
+    fn now_ms(&self) -> u64 {
+        self.0.load(Ordering::Relaxed).saturating_mul(1_000)
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -30,12 +30,12 @@ impl AppClient {
             .unwrap_or(false)
     }
 
-    pub(crate) fn convergence_cutoff_delay_ms(
+    pub(crate) fn prepare_convergence_cutoff_delay_ms(
         &mut self,
         group_id: &cgka_traits::GroupId,
     ) -> Option<u64> {
         self.runtime
-            .convergence_cutoff_delay_ms(group_id)
+            .prepare_convergence_cutoff_delay_ms(group_id)
             .ok()
             .flatten()
     }

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -30,6 +30,16 @@ impl AppClient {
             .unwrap_or(false)
     }
 
+    pub(crate) fn convergence_cutoff_delay_ms(
+        &mut self,
+        group_id: &cgka_traits::GroupId,
+    ) -> Option<u64> {
+        self.runtime
+            .convergence_cutoff_delay_ms(group_id)
+            .ok()
+            .flatten()
+    }
+
     fn remember_buffered_convergence_outcome(&mut self, outcome: &IngestOutcome) {
         if let IngestOutcome::Buffered { group_id, .. } = outcome {
             self.pending_convergence_groups.insert(group_id.clone());

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -1,7 +1,7 @@
 //! Per-account worker: command surface, the worker loop, reconnect backoff,
 //! and the runtime-event publishing helpers the loop drives.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::pin::Pin;
 use std::time::{Duration, Instant};
 
@@ -518,7 +518,7 @@ async fn run_app_runtime_account_worker(
     let catch_up_result = match startup_sync_result {
         Ok(summary) => {
             publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
-            scheduled_convergence.schedule_groups(client.take_pending_convergence_groups());
+            schedule_pending_convergence_groups(&mut scheduled_convergence, &mut client);
             run_pending_epoch_backfill_reporting_arm(
                 &mut client,
                 &events,
@@ -581,7 +581,7 @@ async fn run_app_runtime_account_worker(
     // the loop, otherwise buffered groups stay stranded until the next unrelated
     // command/event (a liveness gap). `schedule_groups` is an idempotent set
     // insert, so this is safe even when the loop buffered nothing.
-    scheduled_convergence.schedule_groups(client.take_pending_convergence_groups());
+    schedule_pending_convergence_groups(&mut scheduled_convergence, &mut client);
 
     let mut reconnect_backoff = AccountWorkerReconnectBackoff::default();
     let mut maintenance_tick = interval(Duration::from_secs(15));
@@ -604,7 +604,10 @@ async fn run_app_runtime_account_worker(
                             match client.advance_convergence_after_runtime_sync(&group_id).await {
                                 Ok(summary) => {
                                     publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
-                                    scheduled_convergence.schedule_groups(client.take_pending_convergence_groups());
+                                    schedule_pending_convergence_groups(
+                                        &mut scheduled_convergence,
+                                        &mut client,
+                                    );
                                     if sync_summary_triggers_audit_tracker_update(&summary) {
                                         shared.schedule_audit_log_tracker_update("scheduled_convergence");
                                     }
@@ -652,7 +655,10 @@ async fn run_app_runtime_account_worker(
                             &shared,
                         )
                         .await;
-                        scheduled_convergence.schedule_groups(client.take_pending_convergence_groups());
+                        schedule_pending_convergence_groups(
+                            &mut scheduled_convergence,
+                            &mut client,
+                        );
                         if may_change_push_registration_work {
                             scheduled_push_retry.observe_pending(
                                 client.has_pending_push_registration_work(),
@@ -676,7 +682,10 @@ async fn run_app_runtime_account_worker(
                     Ok(summary) => {
                         reconnect_backoff.reset();
                         publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
-                        scheduled_convergence.schedule_groups(client.take_pending_convergence_groups());
+                        schedule_pending_convergence_groups(
+                            &mut scheduled_convergence,
+                            &mut client,
+                        );
                         run_pending_epoch_backfill_reporting_arm(
                             &mut client,
                             &events,
@@ -758,8 +767,10 @@ async fn run_app_runtime_account_worker(
                                 &account_id_hex,
                                 &account_label,
                             );
-                            scheduled_convergence
-                                .schedule_groups(client.take_pending_convergence_groups());
+                            schedule_pending_convergence_groups(
+                                &mut scheduled_convergence,
+                                &mut client,
+                            );
                         }
                         Ok(Err(err)) => {
                             publish_app_runtime_account_error(
@@ -798,8 +809,10 @@ async fn run_app_runtime_account_worker(
                             &account_id_hex,
                             &account_label,
                         );
-                        scheduled_convergence
-                            .schedule_groups(client.take_pending_convergence_groups());
+                        schedule_pending_convergence_groups(
+                            &mut scheduled_convergence,
+                            &mut client,
+                        );
                     }
                     Err(err) => {
                         publish_app_runtime_account_error(
@@ -1691,7 +1704,7 @@ const CONVERGENCE_UNSETTLED_MAX_REARMS: u32 = 10;
 
 struct ScheduledConvergence {
     delay: Duration,
-    groups: HashSet<GroupId>,
+    deadlines: HashMap<GroupId, TokioInstant>,
     retry_attempts: HashMap<GroupId, u32>,
     unsettled_rearm_attempts: HashMap<GroupId, u32>,
     timer: Pin<Box<Sleep>>,
@@ -1701,7 +1714,7 @@ impl ScheduledConvergence {
     fn new(delay: Duration) -> Self {
         Self {
             delay,
-            groups: HashSet::new(),
+            deadlines: HashMap::new(),
             retry_attempts: HashMap::new(),
             unsettled_rearm_attempts: HashMap::new(),
             timer: Box::pin(sleep(IDLE_CONVERGENCE_TIMER_DELAY)),
@@ -1716,32 +1729,35 @@ impl ScheduledConvergence {
         }
     }
 
+    #[cfg(test)]
     fn schedule_groups(&mut self, groups: impl IntoIterator<Item = GroupId>) {
-        let mut saw_group = false;
-        for group_id in groups {
-            saw_group = true;
+        let delay = self.normal_delay();
+        self.schedule_groups_with_delays(groups.into_iter().map(|group_id| (group_id, delay)));
+    }
+
+    fn schedule_groups_with_delays(
+        &mut self,
+        groups: impl IntoIterator<Item = (GroupId, Duration)>,
+    ) {
+        let now = TokioInstant::now();
+        for (group_id, delay) in groups {
             self.retry_attempts.remove(&group_id);
             self.unsettled_rearm_attempts.remove(&group_id);
-            self.groups.insert(group_id);
+            self.deadlines
+                .insert(group_id, now + delay.max(MIN_CONVERGENCE_SETTLEMENT_DELAY));
         }
-        if saw_group {
-            let delay = self.normal_delay();
-            self.timer.as_mut().reset(TokioInstant::now() + delay);
-        }
+        self.reset_timer_to_earliest();
     }
 
     fn schedule_retry_groups(&mut self, groups: impl IntoIterator<Item = GroupId>) {
-        let mut delay: Option<Duration> = None;
+        let now = TokioInstant::now();
         for group_id in groups {
             let attempts = self.retry_attempts.entry(group_id.clone()).or_insert(0);
             *attempts = attempts.saturating_add(1);
             let group_delay = retry_delay_for_attempt(*attempts);
-            delay = Some(delay.unwrap_or(group_delay).max(group_delay));
-            self.groups.insert(group_id);
+            self.deadlines.insert(group_id, now + group_delay);
         }
-        if let Some(delay) = delay {
-            self.timer.as_mut().reset(TokioInstant::now() + delay);
-        }
+        self.reset_timer_to_earliest();
     }
 
     /// Re-arm the timer for groups whose scheduled pass did not settle stored
@@ -1749,47 +1765,87 @@ impl ScheduledConvergence {
     /// window). Unlike [`Self::schedule_retry_groups`], this is not an error
     /// backoff — it waits one full settlement delay before retrying.
     fn schedule_unsettled_groups(&mut self, groups: impl IntoIterator<Item = GroupId>) {
-        let mut normal_delay = false;
-        let mut retry_delay: Option<Duration> = None;
+        let now = TokioInstant::now();
+        let normal_delay = self.normal_delay();
         for group_id in groups {
             let attempts = self
                 .unsettled_rearm_attempts
                 .entry(group_id.clone())
                 .or_insert(0);
             *attempts = attempts.saturating_add(1);
-            self.groups.insert(group_id.clone());
             if *attempts > CONVERGENCE_UNSETTLED_MAX_REARMS {
-                let retry_attempts = self.retry_attempts.entry(group_id).or_insert(0);
+                let retry_attempts = self.retry_attempts.entry(group_id.clone()).or_insert(0);
                 *retry_attempts = retry_attempts.saturating_add(1);
                 let group_delay = retry_delay_for_attempt(*retry_attempts);
-                retry_delay = Some(retry_delay.unwrap_or(group_delay).max(group_delay));
+                self.deadlines.insert(group_id.clone(), now + group_delay);
             } else {
-                normal_delay = true;
+                self.deadlines.insert(group_id.clone(), now + normal_delay);
             }
         }
-        if let Some(delay) = retry_delay {
-            self.timer.as_mut().reset(TokioInstant::now() + delay);
-        } else if normal_delay {
-            let delay = self.normal_delay();
-            self.timer.as_mut().reset(TokioInstant::now() + delay);
-        }
+        self.reset_timer_to_earliest();
     }
 
     fn take_ready(&mut self) -> Vec<GroupId> {
-        self.timer
-            .as_mut()
-            .reset(TokioInstant::now() + IDLE_CONVERGENCE_TIMER_DELAY);
-        self.groups.drain().collect()
+        let Some(earliest) = self.deadlines.values().copied().min() else {
+            self.reset_timer_to_earliest();
+            return Vec::new();
+        };
+        let ready: Vec<GroupId> = self
+            .deadlines
+            .iter()
+            .filter(|(_, deadline)| **deadline <= earliest)
+            .map(|(group_id, _)| group_id.clone())
+            .collect();
+        for group_id in &ready {
+            self.deadlines.remove(group_id);
+        }
+        self.reset_timer_to_earliest();
+        ready
     }
 
     fn note_success(&mut self, group_id: &GroupId) {
         self.retry_attempts.remove(group_id);
         self.unsettled_rearm_attempts.remove(group_id);
+        self.deadlines.remove(group_id);
+        self.reset_timer_to_earliest();
     }
 
     fn normal_delay(&self) -> Duration {
         self.delay.max(MIN_CONVERGENCE_SETTLEMENT_DELAY)
     }
+
+    fn reset_timer_to_earliest(&mut self) {
+        let deadline = self
+            .deadlines
+            .values()
+            .copied()
+            .min()
+            .unwrap_or_else(|| TokioInstant::now() + IDLE_CONVERGENCE_TIMER_DELAY);
+        self.timer.as_mut().reset(deadline);
+    }
+}
+
+fn schedule_pending_convergence_groups(
+    scheduled: &mut ScheduledConvergence,
+    client: &mut AppClient,
+) {
+    let fallback = scheduled.normal_delay();
+    let groups = client
+        .take_pending_convergence_groups()
+        .into_iter()
+        .map(|group_id| {
+            let delay = client
+                .convergence_cutoff_delay_ms(&group_id)
+                .map(|delay_ms| {
+                    Duration::from_millis(
+                        delay_ms.saturating_add(CONVERGENCE_SETTLEMENT_SCHEDULE_MARGIN_MS),
+                    )
+                })
+                .unwrap_or(fallback);
+            (group_id, delay)
+        })
+        .collect::<Vec<_>>();
+    scheduled.schedule_groups_with_delays(groups);
 }
 
 fn convergence_settlement_delay(app: &MarmotApp) -> Duration {
@@ -2132,7 +2188,25 @@ mod tests {
 
         assert!(!scheduled.retry_attempts.contains_key(&group_id));
         assert!(!scheduled.unsettled_rearm_attempts.contains_key(&group_id));
-        assert!(scheduled.groups.is_empty());
+        assert!(scheduled.deadlines.is_empty());
+    }
+
+    #[tokio::test]
+    async fn scheduling_one_group_never_postpones_an_earlier_group_cutoff() {
+        let first = test_group_id(21);
+        let noisy = test_group_id(22);
+        let mut scheduled = ScheduledConvergence::new(Duration::from_millis(1_100));
+
+        scheduled.schedule_groups_with_delays([
+            (first.clone(), Duration::from_millis(50)),
+            (noisy.clone(), Duration::from_millis(100)),
+        ]);
+        let first_deadline = scheduled.deadlines[&first];
+        scheduled.schedule_groups_with_delays([(noisy.clone(), Duration::from_millis(500))]);
+
+        assert_eq!(scheduled.deadlines[&first], first_deadline);
+        assert_eq!(scheduled.take_ready(), vec![first]);
+        assert!(scheduled.deadlines.contains_key(&noisy));
     }
 
     #[tokio::test]

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -604,6 +604,10 @@ async fn run_app_runtime_account_worker(
                             match client.advance_convergence_after_runtime_sync(&group_id).await {
                                 Ok(summary) => {
                                     publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
+                                    scheduled_convergence.schedule_after_pass(
+                                        &group_id,
+                                        client.has_pending_convergence_inputs(&group_id),
+                                    );
                                     schedule_pending_convergence_groups(
                                         &mut scheduled_convergence,
                                         &mut client,
@@ -611,10 +615,6 @@ async fn run_app_runtime_account_worker(
                                     if sync_summary_triggers_audit_tracker_update(&summary) {
                                         shared.schedule_audit_log_tracker_update("scheduled_convergence");
                                     }
-                                    scheduled_convergence.schedule_after_pass(
-                                        &group_id,
-                                        client.has_pending_convergence_inputs(&group_id),
-                                    );
                                 }
                                 Err(err) => {
                                     let mut retry_groups = client.take_pending_convergence_groups();
@@ -1743,8 +1743,7 @@ impl ScheduledConvergence {
         for (group_id, delay) in groups {
             self.retry_attempts.remove(&group_id);
             self.unsettled_rearm_attempts.remove(&group_id);
-            self.deadlines
-                .insert(group_id, now + delay.max(MIN_CONVERGENCE_SETTLEMENT_DELAY));
+            self.arm_no_later(group_id, now + delay.max(MIN_CONVERGENCE_SETTLEMENT_DELAY));
         }
         self.reset_timer_to_earliest();
     }
@@ -1755,7 +1754,7 @@ impl ScheduledConvergence {
             let attempts = self.retry_attempts.entry(group_id.clone()).or_insert(0);
             *attempts = attempts.saturating_add(1);
             let group_delay = retry_delay_for_attempt(*attempts);
-            self.deadlines.insert(group_id, now + group_delay);
+            self.arm_no_later(group_id, now + group_delay);
         }
         self.reset_timer_to_earliest();
     }
@@ -1777,9 +1776,9 @@ impl ScheduledConvergence {
                 let retry_attempts = self.retry_attempts.entry(group_id.clone()).or_insert(0);
                 *retry_attempts = retry_attempts.saturating_add(1);
                 let group_delay = retry_delay_for_attempt(*retry_attempts);
-                self.deadlines.insert(group_id.clone(), now + group_delay);
+                self.arm_no_later(group_id.clone(), now + group_delay);
             } else {
-                self.deadlines.insert(group_id.clone(), now + normal_delay);
+                self.arm_no_later(group_id.clone(), now + normal_delay);
             }
         }
         self.reset_timer_to_earliest();
@@ -1790,12 +1789,21 @@ impl ScheduledConvergence {
             self.reset_timer_to_earliest();
             return Vec::new();
         };
-        let ready: Vec<GroupId> = self
+        let now = TokioInstant::now();
+        let mut ready: Vec<GroupId> = self
             .deadlines
             .iter()
-            .filter(|(_, deadline)| **deadline <= earliest)
+            .filter(|(_, deadline)| **deadline <= now)
             .map(|(group_id, _)| group_id.clone())
             .collect();
+        if ready.is_empty() {
+            ready.extend(
+                self.deadlines
+                    .iter()
+                    .filter(|(_, deadline)| **deadline == earliest)
+                    .map(|(group_id, _)| group_id.clone()),
+            );
+        }
         for group_id in &ready {
             self.deadlines.remove(group_id);
         }
@@ -1812,6 +1820,13 @@ impl ScheduledConvergence {
 
     fn normal_delay(&self) -> Duration {
         self.delay.max(MIN_CONVERGENCE_SETTLEMENT_DELAY)
+    }
+
+    fn arm_no_later(&mut self, group_id: GroupId, deadline: TokioInstant) {
+        self.deadlines
+            .entry(group_id)
+            .and_modify(|current| *current = (*current).min(deadline))
+            .or_insert(deadline);
     }
 
     fn reset_timer_to_earliest(&mut self) {
@@ -1835,7 +1850,7 @@ fn schedule_pending_convergence_groups(
         .into_iter()
         .map(|group_id| {
             let delay = client
-                .convergence_cutoff_delay_ms(&group_id)
+                .prepare_convergence_cutoff_delay_ms(&group_id)
                 .map(|delay_ms| {
                     Duration::from_millis(
                         delay_ms.saturating_add(CONVERGENCE_SETTLEMENT_SCHEDULE_MARGIN_MS),
@@ -2207,6 +2222,45 @@ mod tests {
         assert_eq!(scheduled.deadlines[&first], first_deadline);
         assert_eq!(scheduled.take_ready(), vec![first]);
         assert!(scheduled.deadlines.contains_key(&noisy));
+    }
+
+    #[tokio::test]
+    async fn rescheduling_same_group_never_postpones_its_frozen_cutoff() {
+        let group_id = test_group_id(23);
+        let mut scheduled = ScheduledConvergence::new(Duration::from_millis(1_100));
+        scheduled.schedule_groups_with_delays([(group_id.clone(), Duration::from_millis(50))]);
+        let frozen_cutoff = scheduled.deadlines[&group_id];
+
+        scheduled.schedule_unsettled_groups([group_id.clone()]);
+        scheduled.schedule_retry_groups([group_id.clone()]);
+
+        assert_eq!(scheduled.deadlines[&group_id], frozen_cutoff);
+    }
+
+    #[tokio::test]
+    async fn take_ready_drains_every_overdue_group_in_one_tick() {
+        let first = test_group_id(24);
+        let second = test_group_id(25);
+        let future = test_group_id(26);
+        let mut scheduled = ScheduledConvergence::new(Duration::from_millis(1_100));
+        let now = TokioInstant::now();
+        scheduled.deadlines.insert(first.clone(), now);
+        scheduled
+            .deadlines
+            .insert(second.clone(), now - Duration::from_millis(1));
+        scheduled
+            .deadlines
+            .insert(future.clone(), now + Duration::from_secs(10));
+
+        let ready = scheduled.take_ready();
+
+        assert_eq!(ready.len(), 2);
+        assert!(ready.contains(&first));
+        assert!(ready.contains(&second));
+        assert_eq!(
+            scheduled.deadlines.keys().collect::<Vec<_>>(),
+            vec![&future]
+        );
     }
 
     #[tokio::test]

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -66,6 +66,8 @@ mod migration_0032_encrypted_media_secret_references;
 mod migration_0033_push_registration_gossip_outbox;
 #[path = "migrations/0034_maintenance_publication.rs"]
 mod migration_0034_maintenance_publication;
+#[path = "migrations/0035_durable_convergence_passes.rs"]
+mod migration_0035_durable_convergence_passes;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -247,6 +249,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 34,
         name: "0034_maintenance_publication",
         apply: migration_0034_maintenance_publication::apply,
+    },
+    Migration {
+        version: 35,
+        name: "0035_durable_convergence_passes",
+        apply: migration_0035_durable_convergence_passes::apply,
     },
 ];
 

--- a/crates/storage-sqlite/src/migrations/0035_durable_convergence_passes.rs
+++ b/crates/storage-sqlite/src/migrations/0035_durable_convergence_passes.rs
@@ -1,0 +1,17 @@
+//! Migration 0035: durable per-group frozen convergence-pass state.
+
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE cgka_convergence_passes (
+    group_id BLOB PRIMARY KEY REFERENCES cgka_groups(id) ON DELETE CASCADE,
+    record BLOB NOT NULL
+);
+"#,
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/storage/convergence_passes.rs
+++ b/crates/storage-sqlite/src/storage/convergence_passes.rs
@@ -1,0 +1,113 @@
+use crate::{SqliteAccountStorage, SqliteResultExt, deserialize, serialize};
+use cgka_traits::convergence_pass::DurableConvergencePass;
+use cgka_traits::storage::{ConvergencePassStorage, StorageResult};
+use cgka_traits::types::GroupId;
+use rusqlite::{OptionalExtension, params};
+
+impl ConvergencePassStorage for SqliteAccountStorage {
+    fn convergence_pass(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Option<DurableConvergencePass>> {
+        let encoded: Option<Vec<u8>> = self
+            .lock()?
+            .query_row(
+                "SELECT record FROM cgka_convergence_passes WHERE group_id = ?1",
+                params![group_id.as_slice()],
+                |row| row.get(0),
+            )
+            .optional()
+            .storage()?;
+        encoded.map(|record| deserialize(&record)).transpose()
+    }
+
+    fn put_convergence_pass(&self, pass: &DurableConvergencePass) -> StorageResult<()> {
+        let record = serialize(pass)?;
+        self.lock()?
+            .execute(
+                "INSERT INTO cgka_convergence_passes (group_id, record)
+                 VALUES (?1, ?2)
+                 ON CONFLICT(group_id) DO UPDATE SET record = excluded.record",
+                params![pass.group_id.as_slice(), record],
+            )
+            .storage()?;
+        Ok(())
+    }
+
+    fn list_convergence_passes(&self) -> StorageResult<Vec<DurableConvergencePass>> {
+        let connection = self.lock()?;
+        let mut statement = connection
+            .prepare("SELECT record FROM cgka_convergence_passes ORDER BY group_id")
+            .storage()?;
+        let rows = statement
+            .query_map([], |row| row.get::<_, Vec<u8>>(0))
+            .storage()?;
+        rows.map(|row| deserialize(&row.storage()?)).collect()
+    }
+
+    fn delete_convergence_pass(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.lock()?
+            .execute(
+                "DELETE FROM cgka_convergence_passes WHERE group_id = ?1",
+                params![group_id.as_slice()],
+            )
+            .storage()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::test_support::{gid, sample_group};
+    use cgka_traits::convergence_pass::{
+        ConvergenceCutoffCause, ConvergencePassMember, ConvergencePassPhase,
+    };
+    use cgka_traits::storage::GroupStorage;
+    use cgka_traits::{EpochId, MessageId};
+
+    fn sample_pass(group_id: GroupId) -> DurableConvergencePass {
+        DurableConvergencePass {
+            group_id,
+            generation: 7,
+            phase: ConvergencePassPhase::Frozen,
+            base_epoch: EpochId(4),
+            clock_instance_id: 99,
+            opened_monotonic_ms: 10,
+            quiescence_deadline_monotonic_ms: 1_010,
+            absolute_deadline_monotonic_ms: 5_010,
+            opened_wall_ms: 20,
+            quiescence_deadline_wall_ms: 1_020,
+            absolute_deadline_wall_ms: 5_020,
+            members: vec![ConvergencePassMember {
+                message_id: MessageId::new(vec![8]),
+                payload_digest: [9; 32],
+            }],
+            frozen_at_wall_ms: Some(1_020),
+            cutoff_cause: Some(ConvergenceCutoffCause::Quiescence),
+            fairness_slot_available: false,
+        }
+    }
+
+    #[test]
+    fn convergence_pass_round_trips_updates_and_cascades() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group = sample_group(gid(1), 4, 0);
+        store.put_group(&group).unwrap();
+
+        let mut pass = sample_pass(group.id.clone());
+        store.put_convergence_pass(&pass).unwrap();
+        assert_eq!(
+            store.convergence_pass(&group.id).unwrap(),
+            Some(pass.clone())
+        );
+        assert_eq!(store.list_convergence_passes().unwrap(), vec![pass.clone()]);
+
+        pass.phase = ConvergencePassPhase::Completed;
+        store.put_convergence_pass(&pass).unwrap();
+        assert_eq!(store.convergence_pass(&group.id).unwrap(), Some(pass));
+
+        store.delete_group(&group.id).unwrap();
+        assert_eq!(store.convergence_pass(&group.id).unwrap(), None);
+    }
+}

--- a/crates/storage-sqlite/src/storage/convergence_passes.rs
+++ b/crates/storage-sqlite/src/storage/convergence_passes.rs
@@ -61,7 +61,8 @@ mod tests {
     use super::*;
     use crate::storage::test_support::{gid, sample_group};
     use cgka_traits::convergence_pass::{
-        ConvergenceCutoffCause, ConvergencePassMember, ConvergencePassPhase,
+        ConvergenceCutoffCause, ConvergencePassMember, ConvergencePassMemberRole,
+        ConvergencePassPhase,
     };
     use cgka_traits::storage::GroupStorage;
     use cgka_traits::{EpochId, MessageId};
@@ -82,6 +83,8 @@ mod tests {
             members: vec![ConvergencePassMember {
                 message_id: MessageId::new(vec![8]),
                 payload_digest: [9; 32],
+                role: ConvergencePassMemberRole::CommitEdge,
+                source_epoch: 4,
             }],
             frozen_at_wall_ms: Some(1_020),
             cutoff_cause: Some(ConvergenceCutoffCause::Quiescence),

--- a/crates/storage-sqlite/src/storage/mod.rs
+++ b/crates/storage-sqlite/src/storage/mod.rs
@@ -1,5 +1,6 @@
 mod account_device_signer;
 mod capabilities;
+mod convergence_passes;
 mod convergence_policy;
 mod groups;
 mod leave_requests;

--- a/crates/traits/src/convergence_pass.rs
+++ b/crates/traits/src/convergence_pass.rs
@@ -1,0 +1,80 @@
+//! Durable state for one bounded convergence pass.
+//!
+//! A pass admits selection-relevant inputs while collecting, freezes an
+//! immutable membership set at the earlier cutoff, and resolves only that set.
+//! The record is account-device-local engine state, not a wire protocol type.
+
+use crate::{EpochId, GroupId, MessageId};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConvergencePassPhase {
+    Collecting,
+    Frozen,
+    Resolving,
+    Completed,
+}
+
+impl ConvergencePassPhase {
+    pub const fn is_active(self) -> bool {
+        !matches!(self, Self::Completed)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConvergenceCutoffCause {
+    Quiescence,
+    AbsoluteDeadline,
+    ClockDiscontinuity,
+}
+
+/// One immutable member of a frozen convergence batch.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConvergencePassMember {
+    pub message_id: MessageId,
+    /// SHA-256 of the canonical peeled MLS payload admitted to this pass.
+    pub payload_digest: [u8; 32],
+}
+
+/// Durable per-group convergence-pass state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DurableConvergencePass {
+    pub group_id: GroupId,
+    pub generation: u64,
+    pub phase: ConvergencePassPhase,
+    pub base_epoch: EpochId,
+    /// Random process-local clock-domain identifier.
+    pub clock_instance_id: u64,
+    pub opened_monotonic_ms: u64,
+    pub quiescence_deadline_monotonic_ms: u64,
+    pub absolute_deadline_monotonic_ms: u64,
+    pub opened_wall_ms: u64,
+    pub quiescence_deadline_wall_ms: u64,
+    pub absolute_deadline_wall_ms: u64,
+    pub members: Vec<ConvergencePassMember>,
+    pub frozen_at_wall_ms: Option<u64>,
+    pub cutoff_cause: Option<ConvergenceCutoffCause>,
+    /// A completed pass grants one queued user intent before an inbound-only
+    /// follow-up pass. Persisting the slot prevents restart from erasing the
+    /// fairness edge.
+    #[serde(default)]
+    pub fairness_slot_available: bool,
+}
+
+impl DurableConvergencePass {
+    pub const fn is_active(&self) -> bool {
+        self.phase.is_active()
+    }
+
+    pub fn cutoff_monotonic_ms(&self) -> u64 {
+        self.quiescence_deadline_monotonic_ms
+            .min(self.absolute_deadline_monotonic_ms)
+    }
+
+    pub fn cutoff_wall_ms(&self) -> u64 {
+        self.quiescence_deadline_wall_ms
+            .min(self.absolute_deadline_wall_ms)
+    }
+}

--- a/crates/traits/src/convergence_pass.rs
+++ b/crates/traits/src/convergence_pass.rs
@@ -30,12 +30,29 @@ pub enum ConvergenceCutoffCause {
     ClockDiscontinuity,
 }
 
+/// Protocol role of one durable convergence-pass member.
+///
+/// This metadata is derived from the digest-pinned MLS payload at admission
+/// and re-verified before frozen resolution. Keeping it in the pass record
+/// lets scheduling and outbound gating avoid re-reading every member row.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConvergencePassMemberRole {
+    CommitEdge,
+    ProposalDependency,
+    AppWitnessCandidate,
+}
+
 /// One immutable member of a frozen convergence batch.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConvergencePassMember {
     pub message_id: MessageId,
     /// SHA-256 of the canonical peeled MLS payload admitted to this pass.
     pub payload_digest: [u8; 32],
+    /// Scheduling/selection role derived from the pinned payload.
+    pub role: ConvergencePassMemberRole,
+    /// MLS source epoch derived from the pinned payload.
+    pub source_epoch: u64,
 }
 
 /// Durable per-group convergence-pass state.

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -580,9 +580,10 @@ pub trait CgkaEngine: Send + Sync {
     /// [`IngestOutcome::Buffered`] and replay once the state returns to
     /// `Stable`.
     ///
-    /// **Errors.** `UnknownGroup`, `Peeler`, `ForkedEpoch`, `Backend`. Stale
-    /// / duplicate / not-for-us messages return
-    /// `Ok(IngestOutcome::Stale { .. })`, **not** `Err`.
+    /// **Errors.** `UnknownGroup`, `Peeler`, `ForkedEpoch`, `Backend`.
+    /// Duplicate/routing exclusions return `Ignored`, canonical local blocks
+    /// return `LocalState`, and stale convergence dispositions return `Stale`;
+    /// none are `Err`.
     async fn ingest(&mut self, msg: TransportMessage) -> Result<IngestOutcome, EngineError>;
 
     /// Drain ordered `GroupEvent`s produced since the last drain. Application
@@ -610,6 +611,15 @@ pub trait CgkaEngine: Send + Sync {
     /// these groups through the same convergence timer they use for
     /// [`IngestOutcome::Buffered`].
     fn drain_pending_convergence_groups(&mut self) -> Vec<GroupId>;
+
+    /// Remaining process-local delay until this group's durable pass cutoff.
+    ///
+    /// `None` means no eligible pass is active. Applications use this to arm
+    /// independent per-group timers; it is not a branch-selection input.
+    fn convergence_cutoff_delay_ms(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<Option<u64>, EngineError>;
 
     // ── Outbound ────────────────────────────────────────────────────────────
 

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -612,11 +612,15 @@ pub trait CgkaEngine: Send + Sync {
     /// [`IngestOutcome::Buffered`].
     fn drain_pending_convergence_groups(&mut self) -> Vec<GroupId>;
 
-    /// Remaining process-local delay until this group's durable pass cutoff.
+    /// Prepare this group's durable pass and return its remaining process-local
+    /// cutoff delay.
     ///
-    /// `None` means no eligible pass is active. Applications use this to arm
-    /// independent per-group timers; it is not a branch-selection input.
-    fn convergence_cutoff_delay_ms(
+    /// This command may open a pass for eligible retained input, consume a
+    /// dormant fairness slot, or persist restart deadline rebasing. `None`
+    /// means no eligible pass is active. Applications use it only to arm
+    /// independent per-group timers; it is not a diagnostic query or a
+    /// branch-selection input.
+    fn prepare_convergence_cutoff_delay_ms(
         &mut self,
         group_id: &GroupId,
     ) -> Result<Option<u64>, EngineError>;

--- a/crates/traits/src/ingest.rs
+++ b/crates/traits/src/ingest.rs
@@ -1,9 +1,8 @@
 //! Typed outcomes from [`crate::engine::CgkaEngine::ingest`] plus the
 //! peeled-message intermediate form.
 //!
-//! `IngestOutcome` separates applied messages from classifiable stale cases.
-//! Hard errors stay in `EngineError`; stale routing, dedupe, and epoch cases
-//! remain ordinary outcomes.
+//! `IngestOutcome` separates pre-convergence exclusions, convergence
+//! dispositions, and canonical local state. Hard errors stay in `EngineError`.
 
 use crate::transport::TransportMessage;
 use crate::types::{EpochId, GroupId, MemberId, MessageId};
@@ -19,12 +18,35 @@ pub enum IngestOutcome {
     /// publish-before-apply transition. The engine replays buffered messages
     /// when the group returns to `Stable`.
     Buffered { group_id: GroupId, epoch: EpochId },
+    /// Rejected before convergence admission because routing or deduplication
+    /// proved the input cannot affect this account-device's canonical state.
+    Ignored { category: InputRejectionCategory },
+    /// A canonical local condition blocked processing. This is deliberately
+    /// separate from convergence dispositions.
+    LocalState { state: LocalIngestState },
     /// Message was not applied. The variant names why — callers log by
     /// category rather than pattern-matching error strings.
     Stale { reason: StaleReason },
     /// A standalone or commit-carried MLS proposal failed Marmot semantic
     /// admission before it could enter pending state or affect group state.
     Rejected { category: ProposalRejectionCategory },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum InputRejectionCategory {
+    Duplicate,
+    OwnEcho,
+    WrongRecipient,
+    UnknownGroup,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LocalIngestState {
+    /// Authenticated MLS state records this account-device's removal. The
+    /// engine has already performed the realizing-removal side effects.
+    Removed,
+    /// Hydration validation froze the local group copy pending repair.
+    Quarantined,
 }
 
 /// Stable rejection taxonomy for authenticated MLS proposals that fail

--- a/crates/traits/src/ingest.rs
+++ b/crates/traits/src/ingest.rs
@@ -69,6 +69,7 @@ pub enum ProposalRejectionCategory {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StaleReason {
     /// The engine has already seen this `MessageId`. Coordinator dedup.
+    #[deprecated(note = "use IngestOutcome::Ignored { category: Duplicate }")]
     AlreadySeen,
     /// The engine is already at or past the message's epoch. Commonly hit
     /// when a commit arrives after a welcome that already advanced the
@@ -79,10 +80,13 @@ pub enum StaleReason {
     },
     /// Input addressed to another member, or whose signed transport routing
     /// metadata conflicts with the envelope presented to the engine.
+    #[deprecated(note = "use IngestOutcome::Ignored { category: WrongRecipient }")]
     NotForThisClient,
     /// No local group matches this message's routing.
+    #[deprecated(note = "use IngestOutcome::Ignored { category: UnknownGroup }")]
     UnknownGroup,
     /// The message is our own commit echoed back by the transport.
+    #[deprecated(note = "use IngestOutcome::Ignored { category: OwnEcho }")]
     OwnEcho,
     /// The peeler rejected the message. The stored message may be terminal or
     /// retryable depending on whether the engine has evidence that another
@@ -98,6 +102,7 @@ pub enum StaleReason {
     /// evidence (the local MLS state records the eviction) maps here — a bare
     /// decrypt failure is a missing-history/repair condition, never
     /// `SelfEvicted`.
+    #[deprecated(note = "use IngestOutcome::LocalState { state: Removed }")]
     SelfEvicted,
     /// The group is under hydration quarantine: it failed session-open
     /// validation and is frozen until explicit repair. The message was not
@@ -107,6 +112,7 @@ pub enum StaleReason {
     /// welcome) clears the quarantine. Terminal for the message until then.
     /// The application can read the quarantine reason from
     /// `quarantined_groups()`.
+    #[deprecated(note = "use IngestOutcome::LocalState { state: Quarantined }")]
     Quarantined,
 }
 

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -67,7 +67,8 @@ pub use capabilities::{
     TransportKind,
 };
 pub use convergence_pass::{
-    ConvergenceCutoffCause, ConvergencePassMember, ConvergencePassPhase, DurableConvergencePass,
+    ConvergenceCutoffCause, ConvergencePassMember, ConvergencePassMemberRole, ConvergencePassPhase,
+    DurableConvergencePass,
 };
 pub use engine::{
     AutoPublish, CgkaEngine, CommitOrderingKey, CommitOrderingPriority, CreateGroupRequest,

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -9,6 +9,7 @@ pub mod agent_text_stream;
 pub mod app_components;
 pub mod app_event;
 pub mod capabilities;
+pub mod convergence_pass;
 pub mod engine;
 pub mod engine_state;
 pub mod error;
@@ -65,6 +66,9 @@ pub use capabilities::{
     Capability, CapabilityRequirement, Feature, FeatureStatus, GroupCapabilities, RequirementLevel,
     TransportKind,
 };
+pub use convergence_pass::{
+    ConvergenceCutoffCause, ConvergencePassMember, ConvergencePassPhase, DurableConvergencePass,
+};
 pub use engine::{
     AutoPublish, CgkaEngine, CommitOrderingKey, CommitOrderingPriority, CreateGroupRequest,
     GroupEvent, GroupStateChange, KeyPackage, KeyPackageSource, SendIntent, SendResult,
@@ -78,7 +82,8 @@ pub use error::{EngineError, PeelerError};
 pub use group::{Group, Member};
 pub use group_context::{GroupContext, GroupContextSnapshot, SecretBytes};
 pub use ingest::{
-    IngestOutcome, PeeledContent, PeeledMessage, ProposalRejectionCategory, StaleReason,
+    IngestOutcome, InputRejectionCategory, LocalIngestState, PeeledContent, PeeledMessage,
+    ProposalRejectionCategory, StaleReason,
 };
 pub use maintenance::{
     DurableGroupEvolution, DurableTransportFanout, GroupEvolutionPhase, GroupEvolutionSemantic,
@@ -91,9 +96,9 @@ pub use maintenance::{
 pub use message::{MessageRecord, MessageState, OwnCommitConvergenceStamp, StoredMessagePayload};
 pub use peeler::{GroupMessageMetadata, TransportPeeler};
 pub use storage::{
-    CapabilityStorage, GroupStorage, LeaveRequest, LeaveRequestStorage, MaintenanceStorage,
-    MessageStorage, OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent,
-    StorageError, StorageProvider, StorageResult, WelcomeStorage,
+    CapabilityStorage, ConvergencePassStorage, GroupStorage, LeaveRequest, LeaveRequestStorage,
+    MaintenanceStorage, MessageStorage, OutboundFanoutStorage, OutboundIntentStorage,
+    QueuedOutboundIntent, StorageError, StorageProvider, StorageResult, WelcomeStorage,
 };
 pub use transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,

--- a/crates/traits/src/maintenance.rs
+++ b/crates/traits/src/maintenance.rs
@@ -18,6 +18,13 @@ pub const POST_JOIN_CONTENTION_JITTER_MAX_MS: u64 = 30_000;
 /// Injectable wall clock for persisted maintenance deadlines.
 pub trait WallClock: Send + Sync {
     fn now(&self) -> Timestamp;
+
+    /// Milliseconds since the Unix epoch.
+    ///
+    /// Persisted sub-second deadlines must use this value directly. Implementors
+    /// must not derive it from [`Self::now`], whose protocol timestamp has
+    /// second precision.
+    fn now_ms(&self) -> u64;
 }
 
 /// Injectable monotonic clock for process-local quiet windows and timeouts.

--- a/crates/traits/src/peeler.rs
+++ b/crates/traits/src/peeler.rs
@@ -100,7 +100,8 @@ impl GroupMessageMetadata {
 ///   maps both to `StaleReason::PeelFailed`, choosing retry or terminal
 ///   storage from the available epoch evidence.
 /// - `peel_welcome` MUST fail cleanly for welcomes not addressed to the
-///   local identity — the engine maps that to `StaleReason::NotForThisClient`.
+///   local identity — the engine maps that to
+///   `InputRejectionCategory::WrongRecipient`.
 /// - `wrap_group_message` MUST be deterministic given the same input
 ///   (same `EncryptedPayload` + same `GroupContextSnapshot.epoch` →
 ///   reproducible wire bytes modulo outer-layer nonces/timestamps). The

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -10,6 +10,7 @@
 //! methods in `tokio::task::spawn_blocking`.
 
 use crate::capabilities::{CapabilityRequirement, GroupCapabilities};
+use crate::convergence_pass::DurableConvergencePass;
 use crate::engine::SendIntent;
 use crate::group::{Group, Member};
 use crate::maintenance::{
@@ -335,6 +336,20 @@ pub trait MaintenanceStorage {
     ) -> StorageResult<()>;
 }
 
+// ── ConvergencePassStorage ─────────────────────────────────────────────────
+
+/// Account-device-local frozen convergence-pass state.
+///
+/// This is a required part of the engine store because resolving a mutable
+/// re-enumeration after restart would violate the convergence cutoff.
+pub trait ConvergencePassStorage {
+    fn convergence_pass(&self, group_id: &GroupId)
+    -> StorageResult<Option<DurableConvergencePass>>;
+    fn put_convergence_pass(&self, pass: &DurableConvergencePass) -> StorageResult<()>;
+    fn list_convergence_passes(&self) -> StorageResult<Vec<DurableConvergencePass>>;
+    fn delete_convergence_pass(&self, group_id: &GroupId) -> StorageResult<()>;
+}
+
 // ── StorageProvider aggregate ───────────────────────────────────────────────
 
 /// The single storage type parameter carried by the engine.
@@ -351,6 +366,7 @@ pub trait StorageProvider:
     + WelcomeStorage
     + CapabilityStorage
     + ConvergencePolicyStorage
+    + ConvergencePassStorage
     + MemberValidationCacheStorage
     + AccountDeviceSignerStorage
     + KeyPackageBundleStorage

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -351,6 +351,7 @@ fn snapshot_encrypted_payload() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn snapshot_ingest_outcomes() {
     insta::assert_json_snapshot!("processed", IngestOutcome::Processed);
     insta::assert_json_snapshot!(

--- a/docs/marmot-architecture/audit-logging.md
+++ b/docs/marmot-architecture/audit-logging.md
@@ -1,7 +1,7 @@
 ---
 title: "Forensic Audit Logging Inventory"
 created: 2026-06-10
-updated: 2026-06-24
+updated: 2026-07-25
 tags: [marmot, architecture, audit, forensics, jsonl, privacy]
 status: current
 ---
@@ -328,25 +328,29 @@ Emitted after `do_ingest()` returns `Ok(outcome)`.
 | Field | Meaning |
 | --- | --- |
 | `msg_id` | Hex `MessageId` of the inbound message. |
-| `outcome_kind` | `processed`, `buffered`, or `stale`. |
-| `stale_reason` | Present only when `outcome_kind == "stale"`. |
+| `outcome_kind` | `processed`, `buffered`, `ignored`, `local_state`, `stale`, or `rejected`. |
+| `stale_reason` | Legacy optional category field used by non-processed outcomes. |
 | `epoch` | Present for buffered outcomes and `already_at_epoch` stale outcomes. |
 
 `stale_reason` values:
 
 | Value | Meaning |
 | --- | --- |
-| `already_seen` | Message id was already ingested. |
+| `duplicate` | Message id or content was already ingested. |
 | `already_at_epoch` | Engine is already at or beyond the message epoch; `epoch` records the current epoch. |
-| `not_for_this_client` | Welcome/inbox message was not addressed to this client. |
+| `wrong_recipient` | Welcome/inbox message was not addressed to this client. |
 | `unknown_group` | Message referenced a group the engine does not know. |
 | `own_echo` | Message was produced by this engine and bounced back through ingest. |
 | `peel_failed` | MLS/transport peeling failed or could not be recovered. |
+| `removed` | Authenticated canonical state records this local member's removal. |
+| `quarantined` | Hydration validation froze the local group pending repair. |
 
 Metadata notes:
 
 - This event is not emitted if `do_ingest()` returns an `Err`.
 - It has `group_ref` when the outcome is `buffered`, because that outcome carries the group id.
+- The JSON field remains named `stale_reason` for v1/v2 schema compatibility. Its type and required-field set did not
+  change, so this additive outcome taxonomy does not require a forensic schema-version bump.
 
 ### `ingest_error`
 
@@ -809,8 +813,8 @@ metadata keys for indexing.
 | Category | Values |
 | --- | --- |
 | `envelope_kind` | `welcome`, `group_message` |
-| `outcome_kind` | `processed`, `buffered`, `stale` |
-| `stale_reason` | `already_seen`, `already_at_epoch`, `not_for_this_client`, `unknown_group`, `own_echo`, `peel_failed` |
+| `outcome_kind` | `processed`, `buffered`, `ignored`, `local_state`, `stale`, `rejected` |
+| `stale_reason` | `duplicate`, `already_at_epoch`, `wrong_recipient`, `unknown_group`, `own_echo`, `peel_failed`, `removed`, `quarantined` |
 | `engine error_kind` | `unknown_group`, `unknown_pending`, `not_a_member`, `not_group_admin`, `unknown_member`, `invalid_credential_identity`, `admin_cannot_self_remove`, `admin_depletion`, `missing_required_capabilities`, `unsupported_ciphersuite`, `invalid_app_message_payload`, `invalid_account_identity_proof`, `forked_epoch`, `invalid_transition`, `storage`, `peeler`, `serialize`, `backend`, `other` |
 | `peeler error_kind` | `malformed`, `decrypt_failed`, `stale_epoch`, `missing_context`, `wrap_failed`, `backend` |
 | `intent_kind` | `app_message`, `invite`, `remove_members`, `leave`, `update_app_components`, `update_group_data` |

--- a/docs/marmot-architecture/cgka-engine-spec.md
+++ b/docs/marmot-architecture/cgka-engine-spec.md
@@ -107,9 +107,14 @@ TransportMessage
   -> emit IngestOutcome and later GroupEvent values
 ```
 
-The engine MUST return stale and non-applicable messages as typed `IngestOutcome::Stale` values. Duplicate messages,
-messages for unknown groups, messages addressed to another client, own echoes, and already-applied messages MUST NOT
-require string parsing by the caller.
+The engine MUST keep pre-convergence rejection, convergence disposition, and local canonical state distinct:
+
+- duplicate, own-echo, wrong-recipient, and unknown-group inputs return typed `IngestOutcome::Ignored` categories;
+- stale or invalid convergence candidates use convergence dispositions; and
+- authenticated local removal and quarantine return `IngestOutcome::LocalState`.
+
+Realizing removal remains an engine side effect even though removal is not a stale convergence disposition. None of
+these classifications may require string parsing by the caller.
 
 During `PendingPublish` or `Merging`, inbound group messages MAY be buffered. The engine MUST replay buffered messages
 when the group returns to `Stable`.

--- a/docs/marmot-architecture/distributed-convergence.md
+++ b/docs/marmot-architecture/distributed-convergence.md
@@ -1,7 +1,7 @@
 # Distributed Convergence
 
-**Status:** design draft. This is the target model for Marmot clients that need to converge on one MLS group state from
-unordered multi-relay input.
+**Status:** implemented engine architecture. This is the MDK model for converging one MLS group state from unordered
+multi-relay input.
 
 The engine contract that packages this model as a state-machine operation lives in
 [`cgka-engine-canonicalization-contract.md`](./cgka-engine-canonicalization-contract.md).
@@ -104,6 +104,41 @@ against the engine's monotonic clock and, when convergence is settled, returns r
 local work. A regenerated group evolution pauses draining until its publish lifecycle is resolved; timer ticks in that
 pending-publish window return no work.
 
+## Frozen pass boundary
+
+Each group owns an independent durable pass. Retaining a message is not itself admission: the engine opens or extends a
+pass only while that group is stable and the input can participate inside the current replay horizon.
+
+A collecting pass persists:
+
+- its generation and base epoch;
+- process-local monotonic and millisecond wall-clock deadlines;
+- the immutable absolute deadline;
+- every admitted message id and SHA-256 digest of its peeled MLS bytes; and
+- its collecting, frozen, resolving, or completed phase.
+
+The cutoff is:
+
+```text
+min(last_selection_relevant_input + 1000ms,
+    pass_opened + 5000ms)
+```
+
+At the cutoff, the engine verifies the persisted payload digests and freezes the exact membership set. Candidate
+materialization and replay receive only those members. A message retained after the cutoff remains stored for the next
+generation; it cannot alter the frozen result. Missing dependencies likewise remain eligible for a later generation
+instead of reopening the current one.
+
+Monotonic deadlines are never trusted across process restart. The engine rebases a collecting pass from its persisted
+millisecond wall deadlines. An elapsed deadline becomes immediately due, and a backwards wall-clock discontinuity
+fails closed to an immediate cutoff. Frozen and resolving passes resume their exact persisted membership without
+re-enumerating storage.
+
+The runtime arms one timer deadline per group. Scheduling traffic for one group cannot postpone another group's earlier
+cutoff. After a completed pass, one persisted, already-queued admin group-state intent receives one preparation attempt
+before an inbound-only follow-up generation. App messages, leave work, and automatic maintenance do not consume that
+slot; a failed preparation cannot hold it indefinitely.
+
 ## Branch Selection
 
 Only eligible branches are scored.
@@ -168,6 +203,7 @@ convergence_policy = {
   max_rewind_commits: 5,
   app_payload_past_epoch_limit: 5,
   settlement_quiescence_ms: 1000,
+  max_convergence_pass_ms: 5000,
   witness_quorum_senders_per_epoch: 2,
   witness_quorum_epochs: 1,
   max_witness_override_depth: 1,

--- a/docs/marmot-architecture/distributed-convergence.md
+++ b/docs/marmot-architecture/distributed-convergence.md
@@ -112,10 +112,14 @@ pass only while that group is stable and the input can participate inside the cu
 A collecting pass persists:
 
 - its generation and base epoch;
-- process-local monotonic and millisecond wall-clock deadlines;
+- its opening time and quiescence deadline in millisecond wall-clock terms;
 - the immutable absolute deadline;
 - every admitted message id and SHA-256 digest of its peeled MLS bytes; and
 - its collecting, frozen, resolving, or completed phase.
+
+Process-local monotonic deadlines are in-memory scheduling state derived from
+those durable wall-clock terms. They are stored only to identify and schedule
+the current clock domain and are never authoritative after restart.
 
 The cutoff is:
 

--- a/docs/marmot-architecture/further-context/issue-806-frozen-convergence-pass-plan.md
+++ b/docs/marmot-architecture/further-context/issue-806-frozen-convergence-pass-plan.md
@@ -1,0 +1,1079 @@
+---
+title: "Issue #806 — Durable Frozen Convergence Pass Implementation Plan"
+created: 2026-07-25
+updated: 2026-07-25
+tags: [marmot, mdk, convergence, canonicalization, storage, recovery, implementation-plan]
+status: implemented-awaiting-review
+related:
+  - https://github.com/marmot-protocol/mdk/issues/806
+  - https://github.com/marmot-protocol/mdk/pull/1107
+  - https://github.com/marmot-protocol/mdk/pull/1103
+  - https://github.com/marmot-protocol/marmot/pull/408
+---
+
+# Issue #806 — Durable Frozen Convergence Pass Implementation Plan
+
+> **Implementation record.**
+>
+> Implementation began on `codex/issue-806-frozen-convergence` from settled post-prerequisite
+> `origin/master` at `e40fa5fc677a26f680f786c6f9bde88c64e5f6cd`, after both prerequisite pull requests merged:
+>
+> - [MDK PR #1107 — pin convergence policy to the adopted v1 baseline](https://github.com/marmot-protocol/mdk/pull/1107)
+> - [MDK PR #1103 — durable KeyPackage and self-update maintenance](https://github.com/marmot-protocol/mdk/pull/1103)
+>
+> The branch confirmed migration `0035` was next, retained the merged maintenance/evolution architecture, and
+> implemented the durable frozen-pass design described below. The detailed checklist remains as review context; where
+> it offered multiple design alternatives, the architecture documents describe the selected implementation.
+
+## 1. Purpose
+
+[Issue #806](https://github.com/marmot-protocol/mdk/issues/806) closes a protocol-significant convergence gap.
+The existing convergence scheduler can extend its collection timer when additional input arrives. Under continuous
+traffic, this can prevent selection indefinitely and allow clients to resolve different moving input sets.
+
+The adopted Marmot v1 behavior requires one convergence pass to have:
+
+- a normal cutoff after 1000 milliseconds without selection-relevant input;
+- an absolute collection cap exactly 5000 milliseconds after its first eligible input;
+- an immutable input and selection snapshot at cutoff;
+- no admission of post-cutoff input into the current pass;
+- restart recovery that preserves the original cutoff terms and frozen batch;
+- bounded, fair processing across groups; and
+- protocol-facing outcomes that match the adopted taxonomy.
+
+This is not merely an application timer correction. The collection boundary must be owned by the engine and durable
+storage because it controls which state transition becomes canonical.
+
+## 2. Normative and implementation context
+
+### 2.1 Normative source
+
+The implementation must be checked against the adopted specification rather than this plan:
+
+- [`protocol-core/convergence.md`](https://github.com/marmot-protocol/marmot/blob/master/protocol-core/convergence.md)
+- [`protocol-core/inbound-processing.md`](https://github.com/marmot-protocol/marmot/blob/master/protocol-core/inbound-processing.md)
+- [`protocol-core/publish-lifecycle.md`](https://github.com/marmot-protocol/marmot/blob/master/protocol-core/publish-lifecycle.md)
+- [Marmot PR #408](https://github.com/marmot-protocol/marmot/pull/408)
+
+This document describes how MDK should implement those rules. It does not replace or restate the protocol
+specification authoritatively.
+
+### 2.2 Related MDK work
+
+- [Issue #707](https://github.com/marmot-protocol/mdk/issues/707)
+- [Issue #970](https://github.com/marmot-protocol/mdk/issues/970)
+- [Issue #1027](https://github.com/marmot-protocol/mdk/issues/1027)
+- [PR #1107](https://github.com/marmot-protocol/mdk/pull/1107)
+- [PR #1103](https://github.com/marmot-protocol/mdk/pull/1103)
+
+PR #1107 should resolve the production policy-divergence prerequisite from #970. PR #1103 introduces durable group
+evolutions, maintenance obligations, exact transport fanout, and shared deterministic clock seams. Issue #806 must
+extend those foundations without creating a competing state-management layer.
+
+### 2.3 Snapshot of the prerequisite pull requests
+
+At the time this plan was last updated:
+
+| Pull request | Current state | Relevant revision | Relevant effect |
+| --- | --- | --- | --- |
+| #1107 | Merged 2026-07-25 | merge `e40fa5fc677a26f680f786c6f9bde88c64e5f6cd` | Pins the adopted convergence policy in release builds while preserving validated debug/test overrides |
+| #1103 | Merged 2026-07-25 | merge `b34fa9a0a6f7c421c959d5d3378b9bd66e0f0f63` | Adds durable KeyPackage/self-update maintenance, semantic group evolution, exact fanout, and wall/monotonic clock seams |
+
+Both pull requests were based on the same pre-merge master and overlapped in:
+
+- `crates/cgka-engine/src/engine.rs`
+- `crates/cgka-session/src/lib.rs`
+- `crates/marmot-app/src/lib.rs`
+- `crates/marmot-app/src/runtime/account_worker.rs`
+
+The final merged form of those files—not either reviewed branch in isolation—is the implementation baseline. Current
+master contains migration `0034_maintenance_publication`; #806 is therefore expected to use `0035`, subject to a final
+branch-time confirmation after #1107 and any intervening master changes.
+
+## 3. Goals
+
+The implementation must:
+
+1. Close each pass at the earlier of 1000 milliseconds of selection-relevant quiescence or its immutable 5000
+   millisecond absolute cap.
+2. Make cutoff membership deterministic at the before/exactly-at/after boundary.
+3. Persist enough immutable state to reconstruct the same pass after restart.
+4. Prevent mutable storage, new network input, or local group mutations from changing a frozen result.
+5. Preserve the existing selector ordering, witness scoring, rollback horizon, and publish lifecycle unless the adopted
+   specification explicitly requires a change.
+6. Allow multiple busy groups to make bounded progress.
+7. Integrate safely with durable self-update, maintenance, queued outbound intent, and exact fanout.
+8. Fail closed without discarding evidence when durable pass state is inconsistent.
+9. Produce the same adopted outcome classes through direct and wrapped ingest seams.
+10. Keep transport-specific concerns outside `cgka-engine`, `traits`, and storage.
+
+## 4. Non-goals
+
+This work should not:
+
+- redesign branch selection or witness scoring;
+- add a host-configurable convergence policy in release builds;
+- turn the application runtime timer into the source of truth;
+- create a second general-purpose maintenance or group-evolution framework;
+- persist transport envelopes inside replayable MLS group-state snapshots;
+- rewind, delete, or duplicate externally visible publication intent during candidate replay;
+- introduce a broad new public outcome stream unless final-master consumers require it;
+- use a production feature flag that permits clients to retain the old moving-window behavior;
+- solve unrelated transport reliability, KeyPackage, or self-update issues; or
+- assume migration `0035` without confirming that it is still next on the final implementation branch.
+
+## 5. Required invariants
+
+These invariants should be written down in code comments at the owning state transitions and covered by tests.
+
+### 5.1 Policy invariants
+
+- Adopted v1 pins `settlement_quiescence_ms = 1000`.
+- Adopted v1 pins `max_convergence_pass_ms = 5000`.
+- Release builds reject convergence policy values that differ from the adopted v1 baseline.
+- Debug and test overrides remain available only through the validated seam established by PR #1107.
+- The application-message past-epoch window remains aligned with the engine's configured maximum past epochs.
+
+### 5.2 Collection invariants
+
+- The first **eligible engine admission** opens pass generation `N`.
+- Its absolute deadline is calculated once as `opened_at + 5000 ms`.
+- Its quiescence deadline is initially `opened_at + 1000 ms`.
+- Newly admitted selection-relevant input before cutoff restarts only the quiescence deadline:
+  `last_selection_relevant_admission + 1000 ms`.
+- Later input never moves the absolute deadline.
+- Duplicate, invalid, stale, already-dominated, already-fully-counted witness, and ordinary application input that
+  cannot affect selection do not restart quiescence.
+- The effective cutoff is:
+
+  ```text
+  freeze_at = min(
+      last_selection_relevant_admission + settlement_quiescence_ms,
+      opened_at + max_convergence_pass_ms
+  )
+  ```
+
+- Admission before the effective cutoff may join generation `N`.
+- Admission exactly at or after the effective cutoff does not join generation `N`.
+- Transport observation time is not authoritative; the engine admission transaction assigns membership.
+- Once frozen, pass membership cannot change.
+
+### 5.3 Resolution invariants
+
+For a frozen generation `N`, the result must be a deterministic function of:
+
+```text
+result(N) = resolve(
+    pinned_policy,
+    pinned_base_state,
+    frozen_authenticated_inputs,
+    pinned_candidate_parent_and_dependency_state
+)
+```
+
+Resolution must not consult newly arrived input, mutable candidate membership, a later group state, or newly fetched
+dependencies.
+
+- Candidate probing has no externally visible side effect.
+- Canonical group state changes only in the final successful transition.
+- No partial winner or loser disposition becomes visible before the final transaction.
+- Missing parents or dependencies are deferred to a later pass.
+- Post-cutoff arrival order cannot affect the current result.
+
+### 5.4 Mutation ownership invariants
+
+At most one subsystem may own a pending MLS group mutation:
+
+- an active convergence pass;
+- a prepared/attempting/publishing durable group evolution; or
+- an authorized local outbound group-state intent being prepared.
+
+These states must be mutually exclusive. Inputs may be retained while another owner is active, but they must not open a
+pass against an unstable base state.
+
+### 5.5 Persistence invariants
+
+- Restart never grants a fresh quiescence or 5000 millisecond window to an existing pass.
+- Restart reconstructs the same last selection-relevant admission, absolute deadline, effective cutoff, or frozen
+  manifest.
+- In-process scheduling uses monotonic time.
+- Durable recovery uses a persisted millisecond wall deadline.
+- If restart-time continuity cannot be trusted, the implementation freezes immediately rather than extending the
+  collection window.
+- A corrupt or incomplete frozen record blocks group evolution and preserves evidence.
+- Storage cleanup occurs only after completion is durably recorded.
+
+### 5.6 Side-effect isolation invariants
+
+Replayable convergence snapshots contain MLS group state, not unrelated durable workflow state.
+
+Candidate replay must not rewind or clone:
+
+- maintenance obligations;
+- KeyPackage publication state;
+- durable group evolutions;
+- exact signed transport fanout;
+- queued outbound intents;
+- convergence pass rows; or
+- records describing external side effects.
+
+## 6. Time model
+
+### 6.1 Reuse the shared clock seam
+
+PR #1103 adds shared wall and monotonic clock abstractions with deterministic test injection. Issue #806 should reuse and
+extend this seam rather than introduce convergence-only clock traits.
+
+The existing `WallClock::now() -> Timestamp` is seconds-quantized. `Timestamp` is already a seconds-domain transport and
+maintenance type and must not be widened for convergence.
+
+The final design must either:
+
+- add a required millisecond method to the shared clock contract and update every implementation explicitly; or
+- add a separate required millisecond wall-clock trait beside the existing seconds clock.
+
+There must be no default `now_ms()` derived from `Timestamp`: it would silently quantize existing and test
+implementations to whole seconds and make exact millisecond boundary tests vacuous.
+
+### 6.2 Live process
+
+When a process opens a pass:
+
+1. Sample the injected monotonic clock for scheduling.
+2. Sample the injected wall clock in milliseconds for persistence.
+3. Persist the opening time, last selection-relevant admission, quiescence deadline, and absolute wall deadline in the
+   same transaction that creates the pass and admits its first input.
+4. Record the corresponding in-memory monotonic cutoff for efficient wakeup.
+
+The monotonic effective cutoff governs the live process. Selection-relevant admission may move the quiescence term but
+must not move the absolute term. Wall-clock changes must not move either live monotonic term.
+
+### 6.3 Restart
+
+After restart:
+
+1. Read the original durable opening time, last selection-relevant admission, quiescence deadline, and absolute
+   deadline.
+2. Compare it with the current wall time through the injected clock seam.
+3. If either reconstructed cutoff term has elapsed, freeze immediately.
+4. If the effective cutoff is plausibly in the future, schedule only the remaining duration.
+5. If continuity is untrustworthy because of detected backward movement, invalid timestamps, overflow, or inconsistent
+   records, freeze immediately.
+
+The failure policy favors a shorter collection window over a silently extended moving window.
+
+### 6.4 Exact cutoff
+
+The storage-backed engine admission operation evaluates both terms:
+
+```text
+effective_cutoff = min(quiescence_deadline, absolute_deadline)
+
+admission_time < effective_cutoff  => current generation
+admission_time >= effective_cutoff => freeze current generation first,
+                                      then retain input for a later generation
+```
+
+The timestamp and membership decision must occur inside one serialized storage operation. An application-level timer
+wakeup cannot decide membership retroactively.
+
+## 7. Durable pass model
+
+The exact Rust and SQL types should be designed after final master settles. Conceptually, storage needs the following
+records.
+
+This is a greenfield scheduling-persistence layer. Current master retains messages durably, but
+`last_convergence_relevant_input_ms` and the scheduler's group/timer state are process-local. Restart currently loses
+the timing state and can grant retained input a fresh quiescence window. Phase 2 therefore adds new pass tables and
+trait operations; it is not a data migration from an existing convergence-schedule row.
+
+### 7.1 Pass header
+
+A pass header should contain:
+
+- opaque pass identifier;
+- opaque group identifier;
+- monotonically increasing group-local generation;
+- phase;
+- policy version or digest;
+- opening wall time in milliseconds;
+- last selection-relevant admission time in milliseconds;
+- quiescence deadline in milliseconds;
+- absolute wall deadline in milliseconds;
+- base epoch;
+- pinned base-state reference and digest;
+- frozen-at time, when applicable;
+- completion or failure metadata;
+- aggregate bounded-work counters needed for safety limits.
+
+Candidate phases are:
+
+```text
+Collecting -> Frozen -> Resolving -> Completed
+```
+
+Do not introduce a third fail-closed group state named `RecoveryRequired`. The existing precedence remains:
+
+1. a durable protocol `Unrecoverable` halt blocks all group mutation;
+2. hydration/storage quarantine blocks processing until explicit repair; and
+3. only then may an active pass run.
+
+Missing required retained state enters the existing protocol `Unrecoverable` path. Structurally corrupt pass storage
+uses a quarantine-shaped explicit repair path that preserves the pass and its inputs. Whether this reuses the exact
+hydration quarantine record or a pass-specific blocked reason must be decided in the storage review, but it must share
+the same operator-facing repair model rather than create a fourth recovery mechanism.
+
+### 7.2 Frozen membership
+
+Each frozen member should contain the minimum data needed to prove and reproduce its admission:
+
+- canonical engine input identifier;
+- digest of the canonical peeled MLS bytes;
+- authenticated sender and epoch metadata required by selection;
+- candidate-parent reference;
+- dependency references;
+- relevant validation result or version;
+- deterministic ordering key; and
+- storage reference to the immutable input material.
+
+The digest must cover canonical peeled MLS input, not incidental Nostr event or transport framing bytes. Exact signed
+events used for relay fanout remain in the publication/fanout subsystem introduced by the merged master.
+
+### 7.3 Snapshot references
+
+The frozen manifest should pin:
+
+- the current base MLS state;
+- retained candidate-parent states;
+- dependency state used by selection; and
+- the policy under which selection runs.
+
+Prefer pass-owned references and pruning pins over duplicating complete group snapshots where the existing snapshot
+model already provides immutable, digestible state. If a dedicated snapshot is necessary, it must be explicitly
+state-only and must exclude queue, maintenance, publication, fanout, and pass records.
+
+### 7.4 Storage constraints
+
+The final schema should enforce, where possible:
+
+- one group-local generation number per group;
+- no more than one current collecting/frozen/resolving pass for a group;
+- immutable frozen membership;
+- unique membership of an input in a pass generation;
+- valid phase transitions;
+- referential integrity between a pass and its frozen members;
+- retained snapshot pins while a pass is active; and
+- transactional finalization.
+
+SQLite constraints supplement engine validation; neither layer should assume the other is sufficient.
+
+## 8. Transaction boundaries
+
+### 8.1 Open and first admission
+
+One transaction must:
+
+1. Verify there is no conflicting local group mutation.
+2. Classify the input as convergence-eligible.
+3. Allocate the next generation.
+4. Capture the base-state reference.
+5. Persist opening time, initial quiescence deadline, and immutable absolute deadline.
+6. Admit the first input.
+
+Failure leaves neither an empty pass nor a half-admitted input.
+
+### 8.2 Later pre-cutoff admission
+
+One transaction must:
+
+1. Load and validate the collecting pass.
+2. Sample admission time.
+3. Calculate the current effective cutoff.
+4. If the cutoff has already been reached, freeze the current pass before retaining this input for a later generation.
+5. Otherwise insert the input membership.
+6. If and only if the input is selection-relevant, persist its admission as the new quiescence anchor without changing
+   the absolute deadline.
+
+Duplicate membership is classified before convergence or handled idempotently without altering the pass.
+
+### 8.3 Cutoff and freeze
+
+One transaction must:
+
+1. Serialize against admission.
+2. Verify that selection-relevant quiescence, the absolute maximum, or a fail-closed recovery condition requires
+   cutoff.
+3. Capture the complete eligible membership.
+4. Pin base, candidate-parent, and dependency state.
+5. Persist the frozen manifest and its aggregate digest.
+6. Persist the cutoff cause: `Quiescence`, `MaxPassDeadline`, or `FailClosed`.
+7. Transition the phase from `Collecting` to `Frozen`.
+
+Nothing may join the pass after this transaction commits.
+
+### 8.4 Post-cutoff arrival
+
+An input admitted while generation `N` is frozen or resolving is retained for generation `N+1`. It must not:
+
+- mutate `N`;
+- cause `N` to consult new dependencies;
+- change `N`'s winner;
+- start `N+1` against an unstable base state; or
+- become stale merely because it arrived during resolution.
+
+The implementation may store it as unassigned retained input until the next pass is allowed to open.
+
+### 8.5 Final application
+
+One logical transaction must:
+
+1. Revalidate the frozen pass header and base-state identity.
+2. Apply the selected canonical transition.
+3. Record accepted, deferred, stale, or invalidated dispositions.
+4. Emit the appropriate internal group-state invalidation/evolution events.
+5. Mark the pass complete.
+6. Release pass-owned snapshot pins only when they are no longer needed.
+7. Make the next-generation retained inputs eligible for scheduling.
+
+If the storage provider cannot express the entire transition in one database transaction, the design must use the
+repository's intent-first and compensation discipline. It must never confirm a transition that reached no durable
+state.
+
+## 9. Engine state machine
+
+### 9.1 Pre-convergence classification
+
+The engine should classify these conditions before attempting pass admission:
+
+- `duplicate`;
+- `own_echo`;
+- `wrong_recipient`; and
+- `unknown_group`.
+
+They are not stale convergence candidates. Direct ingest and wrapped/session ingest must call the same classifier.
+
+### 9.2 Admission gate
+
+An otherwise eligible input can open or join a pass only when:
+
+- the group base state is stable;
+- there is no prepared or publishing local group evolution;
+- there is no conflicting local mutation authority;
+- the durable pass record is internally consistent; and
+- required authenticated metadata is already available.
+
+If the group is temporarily unstable, retain the input durably. Do not discard it and do not open a pass whose base
+state may change underneath it.
+
+### 9.3 Frozen resolution
+
+Resolution must receive an immutable value representing the frozen manifest. It should not receive a storage query
+capability that can enumerate newly arrived convergence input.
+
+Existing selection behavior should first be extracted behind a single-shot immutable interface resembling:
+
+```rust
+resolve_frozen_pass(
+    pinned_policy,
+    pinned_base,
+    frozen_inputs,
+    pinned_candidate_state,
+    work_budget,
+) -> Result<FrozenPassResolution, FrozenPassError>
+```
+
+This is illustrative, not a prescribed public API.
+
+The error must distinguish at least total safety-limit exhaustion, missing frozen dependency, snapshot/digest mismatch,
+and unrecoverable local consistency failure.
+
+### 9.4 Start single-shot; add slicing only if fairness requires it
+
+The durable source of truth is the immutable pass, not an evolving serialized search cursor.
+
+The first implementation should preserve the existing bounded replay budget and 16-pass drain cap while resolving one
+immutable frozen pass in a single scheduler turn. The multi-group fairness test must measure the worst-case effect of
+that turn.
+
+If the acceptance test demonstrates that one bounded single-shot pass can still starve another ready group, then split
+resolution into deterministic in-memory slices. Between slices, canonical state remains unchanged, the scheduler gives
+another group a turn, the frozen manifest remains durable, and newly arrived input remains assigned to a later
+generation.
+
+In either design, a crash restarts resolution deterministically from the frozen manifest. A durable internal cursor
+should be introduced only if profiling proves reconstruction unacceptably expensive and a separately reviewed design
+can preserve determinism and torn-write safety.
+
+### 9.5 Failure behavior
+
+Failures must not silently reopen collection or fall back to mutable live replay.
+
+- A transient runtime interruption leaves the pass restartable.
+- If optional slicing is required, slice exhaustion yields to the scheduler without changing canonical state.
+- A total safety-limit exhaustion places the pass in a safe blocked/recovery state.
+- A snapshot digest mismatch blocks mutation and preserves the frozen evidence.
+- A missing dependency that was not frozen is deferred to a later pass.
+- A storage invariant violation does not delete the pass or its inputs.
+
+## 10. Integration with durable self-update and maintenance
+
+PR #1103 introduces a durable semantic group-evolution lifecycle independently from exact transport fanout. Issue #806
+must preserve that separation.
+
+### 10.1 Prepared local evolution blocks pass opening
+
+If a self-update or other local group evolution is `Prepared`, `Attempting`, or awaiting publication resolution:
+
+- the group base state is not available for a new convergence pass;
+- incoming convergence input is retained durably;
+- no pass collection clock begins until the local evolution resolves; and
+- restart recovery continues the existing exact-event publication lifecycle.
+
+This follows the issue's "first eligible input" language: retained input becomes eligible only when the group has a
+stable base state.
+
+### 10.2 Active convergence blocks maintenance mutation
+
+While a pass is collecting, frozen, or resolving:
+
+- automatic self-update remains an obligation but cannot stage an MLS mutation;
+- manual self-update receives the existing queued/retryable disposition appropriate to final master;
+- maintenance may perform unrelated non-group-mutating work if it cannot delay the convergence cutoff;
+- exact transport fanout retries for already-confirmed state remain governed by their own durable lifecycle; and
+- no maintenance code may bypass the engine's mutation-ownership gate.
+
+The final-master audit must replace any broad `has_pending_convergence_inputs` check with the precise active-pass and
+retained-input semantics introduced here without weakening send-path preflight. That predicate is used by engine,
+session, account, app-runtime, maintenance, and simulator paths; several call sites gate whether a send may proceed.
+The refactor must preserve the behavior covered by
+`bob_send_after_quiescence_replays_deferred_post_promote_messages` in
+`issue_494_admin_promote_delivery.rs`.
+
+### 10.3 Superseded self-update reconciliation
+
+If convergence invalidates a branch containing a previously confirmed self-update:
+
+- preserve the merged `GroupStateInvalidated` event flow;
+- preserve `SupersededByConvergence` reconciliation;
+- determine whether the selected branch already rotated the local leaf;
+- complete or re-arm the maintenance obligation accordingly; and
+- never resend or reconstruct an exact signed event from candidate replay.
+
+### 10.4 Local-intent fairness
+
+After convergence settlement, the adopted fairness rule gives one already-queued, admin-authorized user group-state
+intent an opportunity before an inbound-only next pass.
+
+Automatic maintenance self-update is not that user-authorized fairness intent. It must not consume the slot or jump
+ahead of it.
+
+The ordering is:
+
+1. Complete and commit the current frozen pass.
+2. Reconcile invalidated local evolution and maintenance state.
+3. Give one eligible queued authorized user group-state intent its preparation opportunity.
+4. If no such intent runs, allow the next retained inbound generation to open.
+5. Run automatic self-update only after convergence and user-intent fairness permit it.
+
+## 11. Account-runtime scheduling
+
+### 11.1 Authority
+
+The application runtime schedules wakeups; it does not decide collection membership or cutoff. Durable engine state is
+authoritative.
+
+### 11.2 Earliest cutoff
+
+Current `ScheduledConvergence` is one global timer plus a set of groups. Input for any group resets that timer and a
+wakeup drains every pending group. Issue #806 requires replacing it with per-group cutoff state and a ready queue, not
+tuning the existing shared delay.
+
+The replacement should:
+
+- query or receive each active group's effective cutoff;
+- arm one monotonic runtime wakeup for the earliest effective cutoff;
+- update only the affected group's quiescence term when selection-relevant input arrives;
+- never let group B move group A's cutoff;
+- reconstruct it from durable state after restart;
+- process all expired groups fairly; and
+- re-arm after every bounded unit of work.
+
+Freeze must also be driven by the next engine admission if the runtime wakes late: the admission transaction checks the
+durable cutoff before deciding membership. Retry or unsettled backoff may delay another resolution attempt, but it may
+not extend collection membership or postpone the durable freeze decision by up to the current 60-second retry ceiling.
+
+The existing 100 millisecond settlement margin must not become part of cutoff semantics. The new scheduler should arm
+from the exact remaining duration and safely re-arm if it wakes early; no margin may extend the absolute cap or admit
+post-cutoff input.
+
+### 11.3 Fair bounded work
+
+A ready queue should initially give each group one bounded single-shot frozen resolution before rotating. The existing
+replay budget and drain cap provide the initial bound.
+
+If the multi-group acceptance test shows that this bound is still too large, introduce deterministic in-memory slices
+measured in replay/selection operations rather than elapsed wall time.
+
+Optional slice fairness does not replace the total replay/work safety bound: slicing prevents one group from starving
+another, while the total bound prevents adversarial input from creating unbounded computation.
+
+### 11.4 Maintenance ordering
+
+The maintenance interval introduced by PR #1103 must not become the convergence clock.
+
+When convergence and maintenance are both ready:
+
+- an expired convergence cutoff is processed first;
+- one bounded convergence turn runs;
+- the scheduler may rotate among other ready convergence groups;
+- maintenance runs only where it cannot stage a conflicting group mutation; and
+- long maintenance work is itself bounded so it cannot delay convergence wakeups.
+
+The final merged `biased` worker selection and sync behavior must be audited for this property.
+
+## 12. Outcome taxonomy
+
+The protocol-facing taxonomy should be corrected with the smallest coherent API change.
+
+Current master exposes one serialized `cgka_traits::ingest::StaleReason` enum that mixes pre-convergence routing/dedupe
+conditions with canonical local states. It is also mapped into the forensic JSONL schema. Phase 6 is therefore a typed
+API and forensic-schema migration, not a label-only cleanup.
+
+### 12.1 Pre-convergence categories
+
+- duplicate;
+- own echo;
+- wrong recipient;
+- unknown group.
+
+These outcomes never become convergence members and are not reported as stale convergence candidates.
+
+### 12.2 Convergence dispositions
+
+Frozen-pass work is classified as:
+
+- accepted;
+- deferred;
+- stale; or
+- invalidated.
+
+Exact names should follow the adopted specification and existing final-master type conventions.
+
+### 12.3 Local canonical state
+
+`SelfEvicted` is behavioral today: authenticated local eviction triggers "realizing removal", emits the self-removed
+notification, and marks the local group copy removed. That behavior must be preserved as a local canonical transition
+even though `SelfEvicted` must not remain a protocol convergence disposition.
+
+The convergence reorg path must preserve its existing coupling to the removed marker so a later input cannot re-emit
+the departure notification.
+
+### 12.4 API scope
+
+Prefer:
+
+- one shared classifier used by direct and wrapped ingest;
+- narrow changes to existing result types;
+- exhaustive conversion tests; and
+- explicit internal-to-protocol mapping;
+- an explicit compatibility/version decision for the Marmot forensics JSONL schema; and
+- preservation of the realizing-removal side effect independently from the protocol outcome.
+
+Do not add a repository-wide public outcome stream or binding expansion unless the final-master call graph demonstrates
+a concrete consumer requirement.
+
+## 13. Observability and diagnostics
+
+Diagnostics must follow the repository privacy contract.
+
+Safe aggregate fields include:
+
+- pass phase;
+- number of frozen inputs;
+- number of deferred post-cutoff inputs;
+- resolution turn count and, if optional slicing is enabled, slice count;
+- aggregate candidate count;
+- cutoff cause: quiescence, maximum pass deadline, or fail-closed recovery;
+- recovery/rebuild count;
+- work-budget exhaustion; and
+- aggregate scheduling delay.
+
+Do not log:
+
+- account identifiers;
+- group identifiers;
+- input or message identifiers;
+- relay URLs;
+- public keys;
+- payloads;
+- ciphertext or plaintext;
+- snapshot bytes; or
+- key material.
+
+Metrics and traces are diagnostic only. They must never become correctness inputs.
+
+## 14. Implementation phases
+
+### Phase 0 — final-master rebaseline
+
+1. Confirm merged PR #1103 is present and wait for PR #1107 to rebase and merge.
+2. Fetch the settled `origin/master`.
+3. Record the two merge commits and any follow-up conflict-resolution commits.
+4. Create a clean isolated worktree and branch from that exact master.
+5. Re-read the adopted spec and issue acceptance criteria.
+6. Reinspect the four overlapping prerequisite files.
+7. Inventory final policy, clock, maintenance, fanout, queue, snapshot, and storage APIs.
+8. Confirm that `0035` is still the next migration number on final master.
+9. Run a clean baseline test suite.
+10. Update this plan if the merged architecture differs from the assumptions above.
+
+No #806 implementation starts until this phase is complete.
+
+### Phase 1 — policy and clock contract
+
+1. Add the named adopted `max_convergence_pass_ms = 5000` constant to the policy established by #1107.
+2. Extend release-mode pinned-policy assertions.
+3. Add a required millisecond wall-clock method or trait and update every implementation explicitly; do not provide a
+   seconds-derived default.
+4. Add deterministic cutoff and restart-continuity unit tests.
+5. Document and test the two-term quiescence/absolute cutoff comparison.
+
+### Phase 2 — storage model and migration
+
+1. Add pass header, membership, and snapshot-pin storage types.
+2. Add transactional trait operations rather than exposing table-shaped CRUD to the engine.
+3. Implement the greenfield SQLite scheduling schema and constraints, expected as migration `0035`.
+4. Add atomic open, admit, freeze, retain-next-generation, finalize, and recovery operations.
+5. Add migration, reopen, corruption, and torn-write tests.
+6. Verify that snapshot serialization excludes workflow and external-side-effect records.
+
+### Phase 3 — engine collection boundary
+
+1. Route all convergence-eligible admission through the durable pass API.
+2. Perform pre-convergence classification before admission.
+3. Open immutable absolute and restartable quiescence terms on the first eligible input.
+4. Restart only quiescence for newly admitted selection-relevant input.
+5. Freeze atomically at the earlier normal cutoff or a fail-closed recovery cutoff.
+6. Assign post-cutoff input to retained next-generation work.
+7. Hydrate collecting and frozen passes on restart.
+8. Remove mutable live-batch enumeration from the resolution path.
+
+### Phase 4 — frozen resolution and fairness
+
+1. Adapt existing selector/replay behavior to accept only a frozen manifest.
+2. Add state-only snapshot pinning and digest validation.
+3. Land bounded single-shot frozen resolution using the existing replay budget and drain cap.
+4. Replace global `ScheduledConvergence` timing with per-group cutoffs and a ready queue.
+5. Preserve the existing total replay safety budget.
+6. Commit only the final selected transition and dispositions.
+7. Add crash-and-rebuild coverage for every phase.
+8. Add deterministic in-memory slicing only if the multi-group fairness acceptance test fails.
+
+### Phase 5 — maintenance and local-intent integration
+
+1. Add one mutation-ownership gate shared by convergence and durable local evolution.
+2. Retain inbound input without opening a pass during pending publication.
+3. Prevent maintenance from staging self-update during an active pass.
+4. Preserve exact fanout and maintenance reconciliation.
+5. Implement user-authorized local-intent fairness before the next inbound generation.
+6. Preserve send-path preflight gating while splitting active-pass from retained-input predicates.
+7. Audit the final account-worker selection order and maintenance tick.
+
+### Phase 6 — outcome normalization
+
+1. Introduce the smallest shared classification types required by final master.
+2. Remove pre-convergence conditions from stale convergence reporting.
+3. Separate `SelfEvicted` realizing-removal behavior from protocol-facing convergence outcomes.
+4. Update or version the Marmot forensics JSONL mapping explicitly.
+5. Test direct, engine, session, account, app-runtime, forensic, and binding conversions as applicable.
+
+### Phase 7 — conformance, formal model, and documentation
+
+1. Add deterministic-clock acceptance tests.
+2. Add storage restart and failure-injection tests.
+3. Extend multi-client simulator/vector scenarios.
+4. Update the matching Tamarin scenario or model if the frozen boundary changes a modeled transition.
+5. Update engine architecture/current-state docs.
+6. Run targeted suites, `just fast-ci`, and the full `just ci` matrix where practical before review.
+
+## 15. Test plan
+
+### 15.1 Clock and cutoff
+
+- First eligible input opens one quiescence deadline and one immutable absolute deadline.
+- A quiet single-input pass freezes after 1000 milliseconds rather than waiting 5000 milliseconds.
+- Selection-relevant input one millisecond before quiescence restarts quiescence.
+- Non-selection-relevant input does not restart quiescence.
+- Continuous selection-relevant arrivals restart quiescence but never extend the 5000 millisecond absolute deadline.
+- Input admitted one millisecond before either effective cutoff joins the current pass.
+- Input admitted exactly at either effective cutoff joins the next generation.
+- Input admitted one millisecond after either effective cutoff joins the next generation.
+- A wall-clock change during a live process does not move the monotonic cutoff terms.
+- Restart with time remaining schedules only the remainder.
+- Restart after expiry freezes immediately.
+- Backward wall movement fails closed without granting extra time.
+- Invalid or overflowing persisted time fails closed.
+- A deliberately seconds-quantized test clock cannot satisfy the millisecond clock contract.
+
+### 15.2 Frozen membership and determinism
+
+- Frozen membership is immutable.
+- Post-cutoff arrival permutations do not affect the current winner or dispositions.
+- Canonical peeled input digest is stable across transport-envelope differences.
+- Manifest digest mismatch blocks mutation.
+- Candidate-parent state cannot be pruned while pinned.
+- Newly fetched or late dependency state is not admitted into the frozen pass.
+- A missing frozen dependency fails safely or is deferred according to the adopted rule.
+
+### 15.3 Restart and torn writes
+
+- Restart during `Collecting` preserves both cutoff terms and membership.
+- Restart after either effective cutoff freezes the original membership.
+- Restart during `Frozen` reproduces the same result.
+- Restart during resolution rebuilds from the same manifest, including between slices if optional slicing is enabled.
+- Restart during final application produces one canonical result.
+- Failure injection at each storage write boundary leaves a valid prior or next state, never an unowned intermediate
+  mutation.
+- Completed-pass cleanup cannot delete retained next-generation input.
+
+### 15.4 Multi-group fairness
+
+- A large pass for group A cannot prevent an expired pass for group B from receiving work.
+- Sustained selection-relevant traffic in group B cannot move group A's quiescence or absolute cutoff.
+- A runtime wakeup arriving late freezes the original batch before resolving or admitting later input.
+- Retry backoff cannot delay the durable cutoff or add membership after it.
+- Every ready group receives a bounded turn under sustained load.
+- Total adversarial replay limits still apply.
+- An unrecoverable or quarantined group does not block unrelated groups.
+- Scheduling delay is bounded independently of the maintenance interval.
+
+### 15.5 Maintenance and publication
+
+- A prepared self-update prevents pass opening.
+- Inputs arriving during pending publication are retained.
+- Publication completion makes retained input eligible without changing its stored arrival identity.
+- An active convergence pass prevents automatic self-update preparation.
+- A manual self-update receives the correct queued/retryable disposition.
+- Candidate replay does not alter durable fanout records.
+- Candidate replay does not alter maintenance obligations.
+- Convergence invalidation preserves `SupersededByConvergence` reconciliation.
+- A selected branch that already rotated the local leaf completes the appropriate obligation.
+- Automatic maintenance cannot consume the authorized user-intent fairness slot.
+
+### 15.6 Outcome taxonomy
+
+- Duplicate is rejected before convergence.
+- Own echo is rejected before convergence.
+- Wrong recipient is rejected before convergence.
+- Unknown group is rejected before convergence.
+- Accepted, deferred, stale, and invalidated map consistently through all owning seams.
+- `SelfEvicted` is absent from protocol-facing convergence outcomes.
+- Authenticated self-eviction still performs realizing removal exactly once.
+- The forensic schema change is versioned or proven backward-compatible.
+- Direct and wrapped ingest produce equivalent outcome classes.
+
+### 15.7 Regression and conformance
+
+- Existing selector-ordering tests remain unchanged and green.
+- Existing witness-scoring tests remain unchanged and green.
+- Existing rollback-horizon tests remain unchanged and green.
+- Existing pending-publication and exact-fanout tests remain green.
+- Existing maintenance restart tests remain green.
+- `bob_send_after_quiescence_replays_deferred_post_promote_messages` remains green.
+- Simulator scenarios converge under arrival permutations and restart.
+- Release builds reject a non-v1 `max_convergence_pass_ms`.
+
+## 16. Validation commands
+
+Exact targeted commands should be confirmed after final master settles. The expected validation shape is:
+
+```sh
+just fast-ci
+cargo test -p cgka-engine
+cargo test -p cgka-session
+cargo test -p storage-sqlite
+cargo test -p marmot-account
+cargo test -p marmot-app
+cargo test -p cgka-conformance-simulator
+cargo test -p marmot-forensics
+```
+
+For formal-model changes:
+
+```sh
+just tamarin
+```
+
+Full local CI parity:
+
+```sh
+just ci
+```
+
+After #1107 merges, run its concrete release-mode pin target:
+
+```sh
+just test-convergence-policy-pin
+```
+
+This executes `crates/cgka-engine/tests/convergence_policy_pin.rs` with debug assertions disabled.
+
+## 17. Suggested commit boundaries
+
+Keep the implementation reviewable and bisectable. These are intended as independently mergeable PR-sized units, not
+necessarily single commits:
+
+1. **Policy and time contract**
+   - v1 maximum pass constant;
+   - release assertion;
+   - millisecond clock seam;
+   - deterministic time tests.
+   - Independently mergeable before the storage work.
+
+2. **Durable pass storage**
+   - shared storage types and transactional trait;
+   - SQLite migration and implementation;
+   - migration/restart/failure tests.
+   - Independently mergeable with no production callers before engine cutover.
+
+3. **Engine collection boundary**
+   - durable admission;
+   - quiescence and immutable absolute cutoff terms;
+   - atomic freeze;
+   - next-generation retention.
+
+4. **Frozen resolution and scheduler**
+   - immutable resolution input;
+   - bounded single-shot resolution;
+   - per-group fairness;
+   - restart reconstruction.
+   - Optional slicing only if acceptance evidence requires it.
+
+5. **Maintenance and local-intent integration**
+   - mutation ownership;
+   - self-update gating;
+   - invalidation reconciliation;
+   - fairness ordering.
+
+6. **Outcome taxonomy**
+   - pre-convergence classification;
+   - protocol disposition mapping;
+   - seam compatibility tests.
+
+7. **Conformance and documentation**
+   - simulator/vector/formal coverage;
+   - architecture docs;
+   - final regression evidence.
+
+A commit boundary may move if the final-master APIs make an intermediate commit uncompilable, but each commit should
+still leave the repository in a coherent, testable state.
+
+## 18. Risk register
+
+| Risk | Failure mode | Mitigation |
+| --- | --- | --- |
+| 5000 ms cap replaces quiescence | Every quiet group adds roughly four seconds of avoidable latency | Freeze at the earlier of quiescence or absolute cap; test both boundaries |
+| Millisecond clock defaults from seconds | Exact boundary tests pass vacuously and production cutoffs are quantized | Require every millisecond clock implementation explicitly |
+| Moving deadline survives below the app scheduler | Clients collect different batches | Make engine/storage admission authoritative; test continuous arrival |
+| Global app timer remains | Traffic in group B postpones group A | Replace it with per-group cutoffs plus an earliest-deadline ready queue |
+| Retry backoff delays cutoff | Runtime can arrive up to 60 seconds late | Freeze on admission and preserve the durable cutoff independently from retry |
+| Frozen pass stores only input IDs | Candidate-parent or validation state changes during resolution | Pin complete authenticated selection inputs and state references |
+| Restart grants a new window | Busy clients diverge after process interruption | Persist original cutoff terms; hybrid monotonic/wall recovery; fail closed |
+| Resolution mutates state incrementally | Crash exposes a half-selected branch | Probe from isolated state; commit only the final result |
+| Durable cursor becomes another workflow engine | Torn writes and incompatible recovery paths | Keep resolution cursor rebuildable and in memory initially |
+| Snapshot captures maintenance/fanout state | Replay duplicates or erases external effects | Use state-only snapshots and explicit exclusion tests |
+| Convergence races self-update | Two owners mutate one MLS group | Enforce one durable mutation owner and mutual exclusion |
+| Maintenance steals fairness slot | User-authorized intent starves behind automatic rotation | Distinguish user intent from maintenance obligation |
+| One group monopolizes resolution | Other groups miss progress/deadlines | Test bounded single-shot behavior first; add deterministic slicing only if required |
+| Outcome refactor expands across bindings or silently changes forensic JSONL | High-risk API/schema churn | Implement the narrowest shared classifier and make schema compatibility explicit |
+| `SelfEvicted` label removal drops behavior | Realizing removal is no longer emitted or persisted | Preserve the local transition and exactly-once side effect outside protocol dispositions |
+| Corrupt pass is silently discarded | Inputs are recollected under a different base | Reuse quarantine/unrecoverable repair discipline and preserve evidence |
+| Release configuration remains tunable | Honest clients permanently fork | Extend PR #1107's pinned release-policy assertions |
+| Migration assumes current numbering | Merge collision or invalid upgrade path | Expect `0035`, but confirm it remains next on the implementation branch |
+
+## 19. Review gates
+
+Implementation should not proceed past each gate without evidence.
+
+### Gate A — baseline
+
+- PR #1103 is confirmed on master and PR #1107 is rebased and merged.
+- Settled master is green.
+- The merged architecture matches or updates this plan.
+- The normative spec has been reread.
+
+### Gate B — storage design
+
+- Transaction boundaries and constraints are reviewed.
+- Snapshot inclusion/exclusion is explicit.
+- Restart and corrupt-state behavior is agreed.
+- Migration works from the immediately preceding production schema.
+
+### Gate C — engine behavior
+
+- Exact quiescence and absolute-cap semantics are demonstrated with deterministic millisecond tests.
+- Resolution cannot enumerate mutable live input.
+- No external-side-effect record participates in replay.
+- Existing branch selection behavior remains stable.
+
+### Gate D — scheduler and maintenance
+
+- Multi-group fairness is measured.
+- The global convergence timer has been replaced by per-group cutoff state.
+- Convergence deadlines are independent of maintenance polling.
+- Mutation ownership and self-update reconciliation are demonstrated.
+- The authorized user-intent fairness slot is preserved.
+
+### Gate E — release readiness
+
+- Targeted and full validation are green.
+- Release-policy assertions include the new 5000 millisecond invariant.
+- Simulator/restart/failure scenarios pass.
+- Architecture and operational diagnostics are current.
+
+## 20. Questions for reviewers
+
+Reviewers should focus especially on these decisions:
+
+1. Is persisting immutable pass state while rebuilding the resolution cursor after restart sufficient, or is there a
+   demonstrated need for a durable resolution checkpoint?
+2. Does the final self-update lifecycle have any state in which inbound convergence may safely collect before
+   publication resolution, or should all such input remain unassigned?
+3. Are the proposed state-only snapshot references sufficient to reproduce candidate-parent authorization and
+   dependency state without copying unrelated workflow records?
+4. What should the operator-visible recovery path be for a digest mismatch or structurally corrupt frozen pass?
+5. Is the authorized local-intent fairness ordering correctly separated from automatic maintenance?
+6. Does the existing replay budget and 16-pass drain cap pass the multi-group fairness test? If not, what deterministic
+   unit of work best bounds a resolution slice without making results platform-dependent?
+7. Can the final storage transaction atomically apply canonical state, dispositions, pass completion, and snapshot-pin
+   release, or is an intent/compensation record required?
+8. Which outcome types are already public through UniFFI, the daemon, or agent control after PR #1103, and what is the
+   smallest compatible taxonomy correction?
+9. Should the required millisecond clock be a new trait or an explicit required method beside
+   `WallClock::now() -> Timestamp`?
+10. Which Tamarin property or trace should explicitly model frozen membership and post-cutoff deferral?
+
+## 21. Definition of done
+
+Issue #806 is complete only when:
+
+- the first eligible input creates one restartable quiescence term and one immutable 5000 millisecond absolute cap;
+- a quiet pass freezes after 1000 milliseconds without selection-relevant input;
+- continuous selection-relevant arrivals can restart quiescence but cannot extend the absolute cap;
+- exact cutoff membership is deterministic;
+- the complete resolution snapshot is frozen durably;
+- restart preserves both cutoff terms and the frozen result;
+- post-cutoff input is retained for a later pass;
+- branch resolution uses no mutable live input;
+- no candidate replay can rewind or duplicate maintenance/publication state;
+- self-update and convergence cannot concurrently own group mutation;
+- multiple busy groups make bounded progress;
+- traffic in one group cannot move another group's cutoff;
+- direct and wrapped ingest expose the adopted outcome classes;
+- realizing removal remains correct when `SelfEvicted` is removed from protocol-facing dispositions;
+- release builds enforce the adopted v1 constant;
+- all required engine, storage, runtime, simulator, formal, and CI validation passes; and
+- the implementation and architecture documentation describe the same behavior.
+
+The intended result is one small, durable authority boundary around the existing convergence engine—not a second
+general orchestration framework alongside durable maintenance.

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -34,6 +34,11 @@ CGKA engine/convergence workspace here is being shaped into spec text.
 - **Encrypted Media V2** — `marmot.group.encrypted-media.v2`, with frozen V1 support for already-joined legacy groups
 - **MIP-05** — Push Notifications
 
+**Implemented engine contracts:**
+
+- **Distributed convergence** — deterministic branch selection for unordered transport input, including the durable
+  frozen-pass boundary, in [`../distributed-convergence.md`](../distributed-convergence.md)
+
 **In PR / design:**
 
 - **MIP-06** — Multi-Device Support
@@ -41,8 +46,6 @@ CGKA engine/convergence workspace here is being shaped into spec text.
   [marmot-protocol/marmot](https://github.com/marmot-protocol/marmot)
 - **CGKA engine canonicalization** — post-peeling commit/proposal/app-message contract in
   [`../cgka-engine-canonicalization-contract.md`](../cgka-engine-canonicalization-contract.md)
-- **Distributed convergence** — deterministic branch selection for unordered transport input in
-  [`../distributed-convergence.md`](../distributed-convergence.md)
 
 The current spec pressure point is commit ordering. MLS wants one ordered commit log; Nostr and other transports may
 deliver unordered, duplicated, delayed input. The engine contract is where that mismatch gets resolved.

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -1,7 +1,7 @@
 ---
 title: "Current State — Implementations & Spec"
 created: 2026-04-19
-updated: 2026-07-23
+updated: 2026-07-25
 tags: [marmot, overview, current-state, implementations]
 status: overview
 ---
@@ -46,6 +46,11 @@ CGKA engine/convergence workspace here is being shaped into spec text.
 
 The current spec pressure point is commit ordering. MLS wants one ordered commit log; Nostr and other transports may
 deliver unordered, duplicated, delayed input. The engine contract is where that mismatch gets resolved.
+
+MDK now persists a per-group frozen convergence pass around that selector. The pass closes at the earlier of the pinned
+one-second selection-relevant quiescence window and five-second absolute cap, resumes safely across restart, resolves
+only its digest-bound membership set, and uses independent runtime deadlines so traffic in one group cannot postpone
+another group.
 
 ## Protocol implementations
 


### PR DESCRIPTION
## Summary

Closes #806.

This adds an engine- and storage-owned frozen convergence pass boundary so a group resolves a stable authenticated input set instead of repeatedly reading a moving live batch.

The implementation is based on `master` after #1103 and #1107 merged.

## What changed

- Add durable convergence-pass state with explicit collecting, frozen, resolving, and completed phases.
- Admit the stored message and its pass membership atomically.
- Freeze content-derived message identifiers and peeled MLS payload digests.
- Bound collection by both quiescence and the v1 five-second absolute deadline.
- Reconstruct collecting passes safely after restart and preserve exact frozen membership across restart.
- Fail closed and mark the group unrecoverable if a frozen member is missing or its digest changes.
- Restrict canonicalization to the frozen member set so post-cutoff input cannot affect the active pass.
- Persist a one-turn fairness slot for already-queued administrative group-state evolution before the next inbound pass.
- Replace the app worker's global convergence timer with independent per-group deadlines.
- Split ignored transport/input cases and local-state outcomes from protocol-stale outcomes.
- Add SQLite migration `0035_durable_convergence_passes`.
- Document the architecture, invariants, recovery behavior, rollout considerations, and review plan.

## Safety properties

- Duplicate delivery does not extend a pass.
- Continuous input cannot postpone convergence beyond the absolute deadline.
- Input arriving at or after the cutoff is retained for a later generation but excluded from the frozen pass.
- Pass admission, freeze transitions, and workflow completion are transactionally persisted.
- Group epoch snapshots intentionally do not rewind convergence workflow state.
- Active passes gate sends and automatic self-updates.
- A failed fairness-slot preparation does not block subsequent inbound convergence.
- Scheduling activity for one group cannot postpone another group's cutoff.

## Validation

- `just ci`
  - default nextest matrix: 2,971 passed, 2 skipped
  - OTLP-feature nextest matrix: 2,977 passed, 2 skipped
  - workspace doc tests passed
- focused distributed convergence suite: 62 passed
- SQLite storage suite: 271 passed
- `git diff --check`

## Review guide

The complete implementation and review plan is in:

`docs/marmot-architecture/further-context/issue-806-frozen-convergence-pass-plan.md`

The main code entry points are:

- `crates/cgka-engine/src/distributed_convergence.rs`
- `crates/traits/src/convergence_pass.rs`
- `crates/storage-sqlite/src/storage/convergence_passes.rs`
- `crates/marmot-app/src/runtime/account_worker.rs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable, restart-safe frozen convergence passes with per-group cutoff scheduling and an absolute 5s convergence-pass cap.
  * Exposed per-group convergence eligibility delay to the session/runtime, enabling clients to observe when convergence can run.
  * Added typed ingest outcome categories for duplicates/own-echo/wrong-recipient/unknown-group, plus local terminal states (removed/quarantined).
* **Bug Fixes**
  * Improved fail-closed integrity verification for frozen convergence membership and tightened replay/determinism around convergence cutoff handling.
* **Documentation**
  * Updated architecture/audit-log docs to reflect the revised convergence and ingest outcome semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->