### PR TITLE
Expose encrypted Blossom group image bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -852,7 +852,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "hex",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "libc",
  "tempfile",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "cgka-conformance-simulator",
  "serde",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "fs-private",
  "serde",
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5437,7 +5437,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6031,7 +6031,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6050,7 +6050,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6087,7 +6087,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7142,7 +7142,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.7"
+version = "0.9.5"
 dependencies = [
  "agent-control",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.7"
+version = "0.9.5"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.7",
+  "conformance_version": "0.9.5",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -140,6 +140,16 @@ fn ensure_group_admin(
     }
 }
 
+fn validate_group_image_plaintext(plaintext: &[u8]) -> Result<(), MarmotKitError> {
+    if plaintext.is_empty() {
+        Err(MarmotKitError::InvalidMediaReference {
+            details: "group image cannot be empty; use clear_group_image to remove it".into(),
+        })
+    } else {
+        Ok(())
+    }
+}
+
 fn ensure_can_remove_members(
     state: &GroupManagementStateFfi,
     group_id_hex: &str,
@@ -458,6 +468,41 @@ impl Marmot {
         let summary = self
             .runtime
             .update_group_profile(&account_ref, &group_id, name, description)
+            .await?;
+        Ok(summary.into())
+    }
+
+    /// Encrypt and upload a group avatar to Blossom, then commit the
+    /// `marmot.group.blossom.image.v1` component. `plaintext` must contain the
+    /// decoded image bytes; use `clear_group_image` to remove an existing
+    /// encrypted Blossom avatar.
+    pub async fn update_group_image(
+        &self,
+        account_ref: String,
+        group_id_hex: String,
+        plaintext: Vec<u8>,
+        media_type: String,
+    ) -> Result<SendSummaryFfi, MarmotKitError> {
+        validate_group_image_plaintext(&plaintext)?;
+        let group_id = group_id_from_hex(&group_id_hex)?;
+        let summary = self
+            .runtime
+            .update_group_image(&account_ref, &group_id, plaintext, media_type)
+            .await?;
+        Ok(summary.into())
+    }
+
+    /// Clear the group's encrypted Blossom avatar by committing the absent
+    /// `marmot.group.blossom.image.v1` component state.
+    pub async fn clear_group_image(
+        &self,
+        account_ref: String,
+        group_id_hex: String,
+    ) -> Result<SendSummaryFfi, MarmotKitError> {
+        let group_id = group_id_from_hex(&group_id_hex)?;
+        let summary = self
+            .runtime
+            .update_group_image(&account_ref, &group_id, Vec::new(), String::new())
             .await?;
         Ok(summary.into())
     }
@@ -894,5 +939,18 @@ mod tests {
             ensure_can_demote_admin(&state(false, false), &group_id_hex, absent_member)
                 .expect_err("non-admin demote should fail");
         assert!(matches!(demote_err, MarmotKitError::NotGroupAdmin { .. }));
+    }
+
+    #[test]
+    fn group_image_upload_requires_nonempty_plaintext() {
+        let err = validate_group_image_plaintext(&[])
+            .expect_err("empty image bytes must use the explicit clear method");
+        assert!(matches!(
+            err,
+            MarmotKitError::InvalidMediaReference { details }
+                if details.contains("clear_group_image")
+        ));
+        validate_group_image_plaintext(&[0x89, b'P', b'N', b'G'])
+            .expect("nonempty image bytes should reach the runtime");
     }
 }

--- a/crates/marmot-uniffi/tests/smoke.rs
+++ b/crates/marmot-uniffi/tests/smoke.rs
@@ -355,6 +355,48 @@ async fn delete_group_local_binding_is_public_and_validates_group_hex() {
 }
 
 #[tokio::test]
+async fn group_image_binding_methods_are_public_and_validate_inputs() {
+    install_mock_keyring();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let kit = Marmot::new(
+        tmp.path().to_string_lossy().into_owned(),
+        vec!["wss://relay.invalid.test".to_string()],
+    )
+    .expect("open marmot kit");
+
+    let empty_upload = kit
+        .update_group_image(
+            "alice".into(),
+            "not-hex".into(),
+            Vec::new(),
+            "image/png".into(),
+        )
+        .await
+        .expect_err("empty image bytes should use the explicit clear method");
+    assert!(matches!(
+        empty_upload,
+        MarmotKitError::InvalidMediaReference { .. }
+    ));
+
+    let upload_error = kit
+        .update_group_image(
+            "alice".into(),
+            "not-hex".into(),
+            vec![0x89, b'P', b'N', b'G'],
+            "image/png".into(),
+        )
+        .await
+        .expect_err("invalid group hex should fail before upload");
+    assert!(format!("{upload_error}").contains("invalid hex"));
+
+    let clear_error = kit
+        .clear_group_image("alice".into(), "not-hex".into())
+        .await
+        .expect_err("invalid group hex should fail before clear");
+    assert!(format!("{clear_error}").contains("invalid hex"));
+}
+
+#[tokio::test]
 async fn media_binding_records_are_public_and_methods_validate_group_hex() {
     install_mock_keyring();
     let tmp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

- expose `update_group_image` through UniFFI so Swift and Kotlin clients can encrypt, upload, and commit `marmot.group.blossom.image.v1`
- add an explicit `clear_group_image` binding instead of requiring an empty-byte sentinel
- reject empty upload bytes with the existing typed media error
- align the workspace, lockfile, and all conformance fixtures with the `0.9.5` release cohort

## Why

Marmot app/runtime already implements the encrypted group-image flow, including fresh content key/nonce generation, opaque Blossom upload with an image-specific signer, and the admin-gated MLS component commit. The mutation was not available through MarmotKit even though initial-image creation and encrypted-image download were already exposed.

Generated clients receive approximately:

```swift
updateGroupImage(
    accountRef: String,
    groupIdHex: String,
    plaintext: Data,
    mediaType: String
) async throws -> SendSummaryFfi

clearGroupImage(
    accountRef: String,
    groupIdHex: String
) async throws -> SendSummaryFfi
```

## Validation

- `just fast-ci`
- `cargo test -p marmot-uniffi group_image`
- `cargo test -p cgka-conformance-simulator canonical_vector_fixtures_match_generated_traces`
- `git diff --check`
- generated Swift XCFramework and binding signature verification
- generated Kotlin binding and arm64 Android JNI build

An exploratory full `cargo test -p marmot-app` run passed all 432 library tests but encountered five failures in untouched `relay_runtime` encrypted-media, retention-projection, and unread-state cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty group-image uploads are now rejected with a clear validation error.
  * Group identifiers are validated before updating or clearing group images.
  * Users are directed to clear the image when removing an avatar.

* **Conformance**
  * Updated conformance metadata to version 0.9.5 across simulator scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->