### PR TITLE
fix(hermes): route commentary as agent activity

### DIFF
--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -345,12 +345,19 @@ directory with `--media-allowed-root`; without one, path sends fail closed.
   the Marmot group id and `user_id` set to the sender account id.
 - Hermes progressive edits open at most one live preview per chat at a time. A
   newer preview cancels the previous stream for that chat.
+- Explicit Hermes delivery context routes non-final commentary to durable agent
+  activity (`kind: 1201`, `status: commentary`). Preview and draft frames remain
+  transient; sealing the segment cancels its preview and emits one activity.
+- Final answers and approvals remain durable `kind: 9` messages. Missing delivery
+  context keeps this legacy final behavior for compatibility with older Hermes
+  versions.
 - Durable message text is exactly what Hermes hands the adapter. The adapter
   never merges, splices, or reconstructs text across sends; fragmented or
   duplicated finals must be fixed in Hermes message segmentation.
-- A plain send while a preview is open finalizes that stream as one tagged
-  stream-final `kind: 9` when the final text is an append-only extension of the
-  streamed text. There is no duplicate plain `send_final` for the same text.
+- A final or legacy plain send while a preview is open finalizes that stream as
+  one tagged stream-final `kind: 9` when the final text is an append-only
+  extension of the streamed text. There is no duplicate plain `send_final` for
+  the same text.
 - Otherwise the preview is cancelled and the final goes out verbatim as one
   plain `send_final`.
 - Status records are included in the stream transcript hash and chunk count.

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -1268,6 +1268,7 @@ class MarmotLiveStream:
         stream_id_hex: str,
         stream_capability: str,
         start_message_id_hex: str,
+        parent_message_id_hex: Optional[str],
         chunk_bytes: int,
     ):
         self.client = client
@@ -1276,6 +1277,10 @@ class MarmotLiveStream:
         self.stream_id_hex = stream_id_hex
         self.stream_capability = stream_capability
         self.start_message_id_hex = start_message_id_hex
+        self.parent_message_id_hex = _optional_hex(
+            parent_message_id_hex,
+            "parent_message_id_hex",
+        )
         self.text = AppendOnlyTextState()
         self.transcript = AgentTextStreamTranscript(
             stream_id_hex,
@@ -1332,6 +1337,7 @@ class MarmotLiveStream:
             stream_id_hex=response["stream_id_hex"],
             stream_capability=_normalize_stream_capability(response["stream_capability"]),
             start_message_id_hex=response["start_message_id_hex"],
+            parent_message_id_hex=parent_message_id_hex,
             chunk_bytes=effective_stream_chunk_bytes(
                 chunk_bytes,
                 response.get("policy_max_plaintext_frame_len"),
@@ -1545,7 +1551,16 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                 reply_to_message_id_hex=_optional_hex(reply_to),
             )
 
-        if self._looks_like_stream_preview(content):
+        is_preview = self._looks_like_stream_preview(content)
+        if _delivery_routes_to_commentary_activity(metadata) and not is_preview:
+            return await self._send_commentary_activity(
+                chat_id,
+                visible_content,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+
+        if is_preview:
             if not self.quic_candidates:
                 return SendResult(success=False, error="Marmot live preview requires MARMOT_QUIC_CANDIDATES")
             try:
@@ -1609,6 +1624,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         content: str,
         *,
         finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         self._capture_loop()
         if message_id.startswith(TOOL_PROGRESS_MESSAGE_PREFIX):
@@ -1629,6 +1645,14 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
 
         chat_id = _normalize_hex(chat_id, "chat_id")
         visible_content = self._strip_streaming_cursor(content)
+        if finalize and _delivery_routes_to_commentary_activity(metadata):
+            await self._cancel_stream(chat_id, message_id, stream, "non-final commentary")
+            return await self._send_commentary_activity(
+                chat_id,
+                visible_content,
+                reply_to=stream.parent_message_id_hex,
+                metadata=metadata,
+            )
         try:
             await stream.append_replacement(visible_content)
             if not finalize:
@@ -2223,15 +2247,61 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         status: str,
         text: str,
         reply_to_message_id_hex: Optional[str] = None,
-    ) -> None:
+    ) -> Dict[str, Any]:
         account_id = await self._ensure_account_id()
-        await self.client.send_agent_activity(
+        return await self.client.send_agent_activity(
             account_id,
             _normalize_hex(chat_id, "chat_id"),
             status=status,
             text=text,
             reply_to_message_id_hex=_optional_hex(reply_to_message_id_hex, "reply_to_message_id_hex"),
         )
+
+    async def _send_commentary_activity(
+        self,
+        chat_id: str,
+        text: str,
+        *,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if not str(text or "").strip():
+            return SendResult(success=True)
+        reply_to_message_id_hex = _reply_to_from_send_context(metadata, reply_to)
+        stream = self._last_chat_stream.get(chat_id)
+        if reply_to_message_id_hex is None and stream is not None:
+            reply_to_message_id_hex = stream.parent_message_id_hex
+        await self._cancel_other_chat_streams(chat_id, reason="non-final commentary")
+        try:
+            response = await self._send_agent_activity_event(
+                chat_id,
+                status="commentary",
+                text=text,
+                reply_to_message_id_hex=reply_to_message_id_hex,
+            )
+            message_ids = tuple(response.get("message_ids_hex") or ())
+            if response.get("type") != "app_event_sent" or not message_ids:
+                raise AgentControlError(
+                    "Marmot agent activity send returned no message ids",
+                    code="unexpected_activity_response",
+                    retryable=True,
+                )
+            message_id = message_ids[-1]
+            account_id = await self._ensure_account_id()
+            self._sent_targets.record_all(
+                message_ids,
+                account_id_hex=account_id,
+                group_id_hex=chat_id,
+            )
+            return SendResult(
+                success=True,
+                message_id=message_id,
+                raw_response=response,
+                continuation_message_ids=message_ids[:-1],
+            )
+        except Exception as exc:
+            logger.debug("Marmot send_agent_activity failed: %s", exc)
+            return SendResult(success=False, error=str(exc), retryable=is_retryable(exc))
 
     async def _cancel_other_draft_streams(
         self,
@@ -3203,6 +3273,62 @@ def _optional_hex(value: Any, field: str = "hex") -> Optional[str]:
     if value is None or str(value).strip() == "":
         return None
     return _normalize_hex(value, field)
+
+
+def _metadata_dict_value(metadata: Optional[Dict[str, Any]], key: str) -> Any:
+    if not metadata:
+        return None
+    if key in metadata:
+        return metadata[key]
+    for container_key in ("delivery", "delivery_context"):
+        container = metadata.get(container_key)
+        if isinstance(container, dict) and key in container:
+            return container[key]
+    return None
+
+
+def _delivery_class(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+    value = _metadata_dict_value(metadata, "delivery_class")
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    return text or None
+
+
+def _delivery_is_turn_final(metadata: Optional[Dict[str, Any]]) -> bool:
+    for key in ("is_turn_final", "turn_final"):
+        value = _metadata_dict_value(metadata, key)
+        if value is not None:
+            return _config_bool(value, default=True)
+    return True
+
+
+_DURABLE_DELIVERY_CLASSES = frozenset({"final", "approval"})
+_COMMENTARY_DELIVERY_CLASSES = frozenset({"commentary"})
+
+
+def _delivery_routes_to_commentary_activity(metadata: Optional[Dict[str, Any]]) -> bool:
+    delivery_class = _delivery_class(metadata)
+    if delivery_class in _DURABLE_DELIVERY_CLASSES:
+        return False
+    if delivery_class in _COMMENTARY_DELIVERY_CLASSES:
+        return True
+    if delivery_class is not None:
+        return False
+    return not _delivery_is_turn_final(metadata)
+
+
+def _reply_to_from_send_context(
+    metadata: Optional[Dict[str, Any]],
+    reply_to: Optional[str],
+) -> Optional[str]:
+    if reply_to is not None and str(reply_to).strip():
+        return _optional_hex(reply_to)
+    for key in ("reply_to_message_id_hex", "reply_to_message_id", "parent_message_id_hex"):
+        value = _metadata_dict_value(metadata, key)
+        if value is not None and str(value).strip():
+            return _optional_hex(value, key)
+    return _TURN_PARENT_MESSAGE_ID_HEX.get()
 
 
 def _encode_quic_varint(value: int) -> bytes:

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -1646,13 +1646,16 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         chat_id = _normalize_hex(chat_id, "chat_id")
         visible_content = self._strip_streaming_cursor(content)
         if finalize and _delivery_routes_to_commentary_activity(metadata):
-            await self._cancel_stream(chat_id, message_id, stream, "non-final commentary")
-            return await self._send_commentary_activity(
+            result = await self._send_commentary_activity(
                 chat_id,
                 visible_content,
                 reply_to=stream.parent_message_id_hex,
                 metadata=metadata,
+                preserve_stream=stream,
             )
+            if result.success:
+                await self._cancel_stream(chat_id, message_id, stream, "non-final commentary")
+            return result
         try:
             await stream.append_replacement(visible_content)
             if not finalize:
@@ -2264,6 +2267,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         *,
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        preserve_stream: Optional[MarmotLiveStream] = None,
     ) -> SendResult:
         if not str(text or "").strip():
             return SendResult(success=True)
@@ -2271,7 +2275,11 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         stream = self._last_chat_stream.get(chat_id)
         if reply_to_message_id_hex is None and stream is not None:
             reply_to_message_id_hex = stream.parent_message_id_hex
-        await self._cancel_other_chat_streams(chat_id, reason="non-final commentary")
+        await self._cancel_other_chat_streams(
+            chat_id,
+            reason="non-final commentary",
+            keep=preserve_stream,
+        )
         try:
             response = await self._send_agent_activity_event(
                 chat_id,
@@ -3295,12 +3303,12 @@ def _delivery_class(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
     return text or None
 
 
-def _delivery_is_turn_final(metadata: Optional[Dict[str, Any]]) -> bool:
+def _delivery_explicit_turn_final(metadata: Optional[Dict[str, Any]]) -> Optional[bool]:
     for key in ("is_turn_final", "turn_final"):
         value = _metadata_dict_value(metadata, key)
         if value is not None:
             return _config_bool(value, default=True)
-    return True
+    return None
 
 
 _DURABLE_DELIVERY_CLASSES = frozenset({"final", "approval"})
@@ -3308,14 +3316,15 @@ _COMMENTARY_DELIVERY_CLASSES = frozenset({"commentary"})
 
 
 def _delivery_routes_to_commentary_activity(metadata: Optional[Dict[str, Any]]) -> bool:
+    explicit = _delivery_explicit_turn_final(metadata)
+    if explicit is not None:
+        return not explicit
     delivery_class = _delivery_class(metadata)
-    if delivery_class in _DURABLE_DELIVERY_CLASSES:
-        return False
     if delivery_class in _COMMENTARY_DELIVERY_CLASSES:
         return True
-    if delivery_class is not None:
+    if delivery_class in _DURABLE_DELIVERY_CLASSES:
         return False
-    return not _delivery_is_turn_final(metadata)
+    return False
 
 
 def _reply_to_from_send_context(

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -2103,6 +2103,344 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class _DeliveryRoutingFakeClient:
+    def __init__(self):
+        self.activities = []
+        self.tool_events = []
+        self.final_sends = []
+        self.stream_begins = []
+        self.stream_appends = []
+        self.stream_finalizes = []
+        self.stream_cancels = []
+        self.activity_response = {
+            "type": "app_event_sent",
+            "message_ids_hex": ["aa" * 32],
+        }
+
+    async def send_agent_activity(self, account_id_hex, group_id_hex, **kwargs):
+        self.activities.append((account_id_hex, group_id_hex, kwargs))
+        return self.activity_response
+
+    async def send_agent_operation_event(self, account_id_hex, group_id_hex, **kwargs):
+        self.tool_events.append((account_id_hex, group_id_hex, kwargs))
+        return {"type": "app_event_sent", "message_ids_hex": ["bb" * 32]}
+
+    async def send_final(
+        self,
+        account_id_hex,
+        group_id_hex,
+        text,
+        reply_to_message_id_hex=None,
+        idempotency_key=None,
+    ):
+        self.final_sends.append((account_id_hex, group_id_hex, text, reply_to_message_id_hex))
+        return {"type": "final_sent", "message_ids_hex": ["cc" * 32]}
+
+    async def stream_begin(
+        self,
+        account_id_hex,
+        group_id_hex,
+        *,
+        stream_id_hex=None,
+        quic_candidates=(),
+        request_id=None,
+        parent_message_id_hex=None,
+    ):
+        self.stream_begins.append((account_id_hex, group_id_hex, parent_message_id_hex))
+        return {
+            "type": "stream_begun",
+            "stream_id_hex": "55" * 32,
+            "stream_capability": "33" * 32,
+            "start_message_id_hex": "66" * 32,
+            "quic_candidates": list(quic_candidates),
+        }
+
+    async def stream_append(self, stream_id_hex, stream_capability, append_text):
+        self.stream_appends.append((stream_id_hex, append_text))
+        return {"type": "ack"}
+
+    async def stream_finalize(
+        self,
+        stream_id_hex,
+        stream_capability,
+        final_text,
+        transcript_hash_hex,
+        chunk_count,
+        idempotency_key=None,
+    ):
+        self.stream_finalizes.append((stream_id_hex, final_text))
+        return {
+            "type": "stream_finalized",
+            "stream_id_hex": stream_id_hex,
+            "message_ids_hex": ["77" * 32],
+        }
+
+    async def stream_cancel(self, stream_id_hex, stream_capability, reason=None):
+        self.stream_cancels.append((stream_id_hex, reason))
+        return {"type": "ack"}
+
+
+class DeliveryMetadataRoutingTests(unittest.IsolatedAsyncioTestCase):
+    NON_FINAL_COMMENTARY = {"is_turn_final": False, "delivery_class": "commentary"}
+
+    async def asyncSetUp(self):
+        self.adapter_module = load_adapter_module()
+        self.config_cls = sys.modules["gateway.config"].PlatformConfig
+
+    def _adapter(self, fake_client, *, quic_candidates=None):
+        extra = {"account_id_hex": "11" * 32}
+        if quic_candidates is not None:
+            extra["quic_candidates"] = quic_candidates
+        return self.adapter_module.MarmotPlatformAdapter(
+            self.config_cls(extra=extra),
+            client=fake_client,
+        )
+
+    async def test_direct_commentary_metadata_variants_map_to_activity(self):
+        cases = [
+            ("is_turn_final canonical", {"is_turn_final": False}),
+            ("turn_final alias", {"turn_final": False}),
+            ("delivery_class commentary", {"delivery_class": "commentary", "is_turn_final": True}),
+            ("delivery_context container", {"delivery_context": {"is_turn_final": False}}),
+            ("delivery container", {"delivery": {"delivery_class": "commentary"}}),
+        ]
+        for label, metadata in cases:
+            with self.subTest(label=label):
+                fake_client = _DeliveryRoutingFakeClient()
+                adapter = self._adapter(fake_client)
+                result = await adapter.send(
+                    chat_id="22" * 32,
+                    content="I'll check that now.",
+                    reply_to="33" * 32,
+                    metadata=metadata,
+                )
+                self.assertTrue(result.success, label)
+                self.assertEqual(result.message_id, "aa" * 32, label)
+                self.assertEqual(len(fake_client.activities), 1, label)
+                self.assertEqual(fake_client.final_sends, [], label)
+                self.assertEqual(fake_client.activities[0][2]["status"], "commentary", label)
+                self.assertEqual(fake_client.activities[0][2]["reply_to_message_id_hex"], "33" * 32, label)
+
+    async def test_durable_delivery_class_overrides_non_final_flag(self):
+        for delivery_class in ("final", "approval"):
+            with self.subTest(delivery_class=delivery_class):
+                fake_client = _DeliveryRoutingFakeClient()
+                adapter = self._adapter(fake_client)
+                result = await adapter.send(
+                    chat_id="22" * 32,
+                    content="Needs your OK.",
+                    metadata={"delivery_class": delivery_class, "is_turn_final": False},
+                )
+                self.assertTrue(result.success)
+                self.assertEqual(fake_client.activities, [])
+                self.assertEqual(len(fake_client.final_sends), 1)
+                self.assertEqual(fake_client.final_sends[0][2], "Needs your OK.")
+
+    async def test_commentary_rejects_activity_response_without_message_ids(self):
+        fake_client = _DeliveryRoutingFakeClient()
+        fake_client.activity_response = {"type": "ack"}
+        adapter = self._adapter(fake_client)
+
+        result = await adapter.send(
+            chat_id="22" * 32,
+            content="I'll check that.",
+            metadata=self.NON_FINAL_COMMENTARY,
+        )
+
+        self.assertFalse(result.success)
+        self.assertTrue(result.retryable)
+        self.assertEqual(fake_client.final_sends, [])
+
+    async def test_commentary_before_tool_sends_one_activity_zero_finals(self):
+        fake_client = _DeliveryRoutingFakeClient()
+        adapter = self._adapter(fake_client)
+
+        commentary = await adapter.send(
+            chat_id="22" * 32,
+            content="Let me search for that.",
+            reply_to="33" * 32,
+            metadata=self.NON_FINAL_COMMENTARY,
+        )
+        tool = await adapter.send(
+            chat_id="22" * 32,
+            content='* search: "titanium prices"',
+            reply_to="33" * 32,
+        )
+
+        self.assertTrue(commentary.success)
+        self.assertTrue(tool.success)
+        self.assertEqual(len(fake_client.activities), 1)
+        self.assertEqual(fake_client.final_sends, [])
+        self.assertEqual(len(fake_client.tool_events), 1)
+        self.assertEqual(fake_client.activities[0][2]["text"], "Let me search for that.")
+
+    async def test_final_answer_after_commentary_sends_exactly_one_kind_9(self):
+        fake_client = _DeliveryRoutingFakeClient()
+        adapter = self._adapter(fake_client)
+
+        commentary = await adapter.send(
+            chat_id="22" * 32,
+            content="Let me look that up.",
+            metadata=self.NON_FINAL_COMMENTARY,
+        )
+        final = await adapter.send(
+            chat_id="22" * 32,
+            content="Here is the answer.",
+            metadata={"is_turn_final": True, "delivery_class": "final"},
+        )
+
+        self.assertTrue(commentary.success)
+        self.assertTrue(final.success)
+        self.assertEqual(len(fake_client.activities), 1)
+        self.assertEqual(len(fake_client.final_sends), 1)
+        self.assertEqual(fake_client.final_sends[0][2], "Here is the answer.")
+
+    async def test_missing_metadata_preserves_final_behavior(self):
+        fake_client = _DeliveryRoutingFakeClient()
+        adapter = self._adapter(fake_client)
+
+        result = await adapter.send(chat_id="22" * 32, content="pong", reply_to="33" * 32)
+
+        self.assertTrue(result.success)
+        self.assertEqual(fake_client.activities, [])
+        self.assertEqual(len(fake_client.final_sends), 1)
+        self.assertEqual(fake_client.final_sends[0][2], "pong")
+
+    async def test_same_text_across_two_turns_emits_two_activities(self):
+        fake_client = _DeliveryRoutingFakeClient()
+        adapter = self._adapter(fake_client)
+
+        first = await adapter.send(
+            chat_id="22" * 32,
+            content="Checking...",
+            metadata=self.NON_FINAL_COMMENTARY,
+        )
+        second = await adapter.send(
+            chat_id="22" * 32,
+            content="Checking...",
+            metadata=self.NON_FINAL_COMMENTARY,
+        )
+
+        self.assertTrue(first.success)
+        self.assertTrue(second.success)
+        self.assertEqual(len(fake_client.activities), 2)
+        self.assertEqual(fake_client.final_sends, [])
+
+    async def test_reply_parent_metadata_survives_direct_activity_mapping(self):
+        fake_client = _DeliveryRoutingFakeClient()
+        adapter = self._adapter(fake_client)
+
+        await adapter.send(
+            chat_id="22" * 32,
+            content="One moment.",
+            metadata={
+                **self.NON_FINAL_COMMENTARY,
+                "reply_to_message_id": "33" * 32,
+            },
+        )
+
+        self.assertEqual(fake_client.activities[0][2]["reply_to_message_id_hex"], "33" * 32)
+
+    async def test_non_final_preview_stream_lifecycle_emits_one_activity(self):
+        fake_client = _DeliveryRoutingFakeClient()
+        adapter = self._adapter(fake_client, quic_candidates=["quic://127.0.0.1:4433"])
+        metadata = self.NON_FINAL_COMMENTARY
+
+        preview = await adapter.send(
+            chat_id="22" * 32,
+            content="Let me search\u2589",
+            reply_to="33" * 32,
+            metadata=metadata,
+        )
+        self.assertTrue(preview.success)
+        self.assertEqual(len(fake_client.stream_begins), 1)
+        self.assertEqual(fake_client.activities, [])
+        self.assertEqual(fake_client.final_sends, [])
+
+        edited = await adapter.edit_message(
+            "22" * 32,
+            preview.message_id,
+            "Let me search the docs\u2589",
+            metadata=metadata,
+        )
+        self.assertTrue(edited.success)
+        self.assertEqual(fake_client.activities, [])
+        self.assertEqual(fake_client.stream_finalizes, [])
+        self.assertEqual(fake_client.final_sends, [])
+
+        result = await adapter.edit_message(
+            "22" * 32,
+            preview.message_id,
+            "Let me search the docs",
+            finalize=True,
+            metadata=metadata,
+        )
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "aa" * 32)
+        self.assertEqual(len(fake_client.activities), 1)
+        self.assertEqual(fake_client.activities[0][2]["text"], "Let me search the docs")
+        self.assertEqual(fake_client.activities[0][2]["reply_to_message_id_hex"], "33" * 32)
+        self.assertEqual(fake_client.stream_finalizes, [])
+        self.assertEqual(fake_client.final_sends, [])
+
+    async def test_non_final_draft_frames_then_sealed_send_emits_one_activity(self):
+        fake_client = _DeliveryRoutingFakeClient()
+        adapter = self._adapter(fake_client, quic_candidates=["quic://127.0.0.1:4433"])
+        metadata = self.NON_FINAL_COMMENTARY
+
+        first = await adapter.send_draft(
+            "22" * 32,
+            1,
+            "Let me search",
+            metadata={
+                **metadata,
+                "parent_message_id_hex": "33" * 32,
+            },
+        )
+        second = await adapter.send_draft(
+            "22" * 32,
+            1,
+            "Let me search the docs",
+            metadata=metadata,
+        )
+
+        self.assertTrue(first.success)
+        self.assertTrue(second.success)
+        self.assertEqual(len(fake_client.stream_begins), 1)
+        self.assertEqual(len(fake_client.stream_appends), 2)
+        self.assertEqual(fake_client.activities, [])
+        self.assertEqual(fake_client.final_sends, [])
+
+        result = await adapter.send(
+            chat_id="22" * 32,
+            content="Let me search the docs",
+            metadata=metadata,
+        )
+        self.assertTrue(result.success)
+        self.assertEqual(len(fake_client.activities), 1)
+        self.assertEqual(fake_client.activities[0][2]["text"], "Let me search the docs")
+        self.assertEqual(fake_client.activities[0][2]["reply_to_message_id_hex"], "33" * 32)
+        self.assertEqual(fake_client.stream_finalizes, [])
+        self.assertEqual(fake_client.final_sends, [])
+
+    async def test_turn_final_true_streaming_path_still_finalizes_kind_9(self):
+        fake_client = _DeliveryRoutingFakeClient()
+        adapter = self._adapter(fake_client, quic_candidates=["quic://127.0.0.1:4433"])
+
+        preview = await adapter.send("22" * 32, "Based on my research\u2589")
+        final = await adapter.send(
+            "22" * 32,
+            "Based on my research, here's the answer",
+            metadata={"is_turn_final": True, "delivery_class": "final"},
+        )
+
+        self.assertTrue(preview.success)
+        self.assertTrue(final.success)
+        self.assertEqual(fake_client.activities, [])
+        self.assertEqual(len(fake_client.stream_finalizes), 1)
+        self.assertEqual(fake_client.final_sends, [])
+
+
 class SendFinalIdempotencyRetryTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.adapter_module = load_adapter_module()

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -130,6 +130,7 @@ def load_adapter_module():
         "gateway.platforms",
         "gateway.platforms.base",
         "gateway.config",
+        "gateway.stream_events",
     ]:
         sys.modules.pop(name, None)
     install_fake_hermes_modules()
@@ -2112,12 +2113,18 @@ class _DeliveryRoutingFakeClient:
         self.stream_appends = []
         self.stream_finalizes = []
         self.stream_cancels = []
+        self.activity_attempts = 0
+        self.fail_next_activity = False
         self.activity_response = {
             "type": "app_event_sent",
             "message_ids_hex": ["aa" * 32],
         }
 
     async def send_agent_activity(self, account_id_hex, group_id_hex, **kwargs):
+        self.activity_attempts += 1
+        if self.fail_next_activity:
+            self.fail_next_activity = False
+            raise OSError("temporary activity failure")
         self.activities.append((account_id_hex, group_id_hex, kwargs))
         return self.activity_response
 
@@ -2200,7 +2207,6 @@ class DeliveryMetadataRoutingTests(unittest.IsolatedAsyncioTestCase):
         cases = [
             ("is_turn_final canonical", {"is_turn_final": False}),
             ("turn_final alias", {"turn_final": False}),
-            ("delivery_class commentary", {"delivery_class": "commentary", "is_turn_final": True}),
             ("delivery_context container", {"delivery_context": {"is_turn_final": False}}),
             ("delivery container", {"delivery": {"delivery_class": "commentary"}}),
         ]
@@ -2221,20 +2227,60 @@ class DeliveryMetadataRoutingTests(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(fake_client.activities[0][2]["status"], "commentary", label)
                 self.assertEqual(fake_client.activities[0][2]["reply_to_message_id_hex"], "33" * 32, label)
 
-    async def test_durable_delivery_class_overrides_non_final_flag(self):
-        for delivery_class in ("final", "approval"):
+    async def test_explicit_non_final_overrides_every_delivery_class(self):
+        delivery_classes = ("final", "approval", "commentary", "operation", "notice", "mystery")
+        for finality_key in ("is_turn_final", "turn_final"):
+            for delivery_class in delivery_classes:
+                with self.subTest(finality_key=finality_key, delivery_class=delivery_class):
+                    fake_client = _DeliveryRoutingFakeClient()
+                    adapter = self._adapter(fake_client)
+                    result = await adapter.send(
+                        chat_id="22" * 32,
+                        content="Still working.",
+                        metadata={"delivery_class": delivery_class, finality_key: False},
+                    )
+                    self.assertTrue(result.success)
+                    self.assertEqual(len(fake_client.activities), 1)
+                    self.assertEqual(fake_client.final_sends, [])
+                    self.assertEqual(fake_client.activities[0][2]["status"], "commentary")
+
+    async def test_explicit_turn_final_overrides_every_delivery_class(self):
+        delivery_classes = ("final", "approval", "commentary", "operation", "notice", "mystery")
+        for finality_key in ("is_turn_final", "turn_final"):
+            for delivery_class in delivery_classes:
+                with self.subTest(finality_key=finality_key, delivery_class=delivery_class):
+                    fake_client = _DeliveryRoutingFakeClient()
+                    adapter = self._adapter(fake_client)
+                    result = await adapter.send(
+                        chat_id="22" * 32,
+                        content="Authoritative answer.",
+                        metadata={"delivery_class": delivery_class, finality_key: True},
+                    )
+                    self.assertTrue(result.success)
+                    self.assertEqual(fake_client.activities, [])
+                    self.assertEqual(len(fake_client.final_sends), 1)
+
+    async def test_delivery_class_applies_only_when_finality_is_missing(self):
+        cases = (
+            ("commentary", True),
+            ("final", False),
+            ("approval", False),
+            ("operation", False),
+            ("notice", False),
+            ("mystery", False),
+        )
+        for delivery_class, expect_activity in cases:
             with self.subTest(delivery_class=delivery_class):
                 fake_client = _DeliveryRoutingFakeClient()
                 adapter = self._adapter(fake_client)
                 result = await adapter.send(
                     chat_id="22" * 32,
-                    content="Needs your OK.",
-                    metadata={"delivery_class": delivery_class, "is_turn_final": False},
+                    content="Classified by delivery class.",
+                    metadata={"delivery_class": delivery_class},
                 )
                 self.assertTrue(result.success)
-                self.assertEqual(fake_client.activities, [])
-                self.assertEqual(len(fake_client.final_sends), 1)
-                self.assertEqual(fake_client.final_sends[0][2], "Needs your OK.")
+                self.assertEqual(len(fake_client.activities), int(expect_activity))
+                self.assertEqual(len(fake_client.final_sends), int(not expect_activity))
 
     async def test_commentary_rejects_activity_response_without_message_ids(self):
         fake_client = _DeliveryRoutingFakeClient()
@@ -2423,6 +2469,59 @@ class DeliveryMetadataRoutingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(fake_client.stream_finalizes, [])
         self.assertEqual(fake_client.final_sends, [])
 
+    async def test_commentary_finalize_retryable_failure_preserves_stream_for_same_message_id(
+        self,
+    ):
+        fake_client = _DeliveryRoutingFakeClient()
+        fake_client.fail_next_activity = True
+        adapter = self._adapter(fake_client, quic_candidates=["quic://127.0.0.1:4433"])
+        metadata = self.NON_FINAL_COMMENTARY
+        chat_id = "22" * 32
+
+        preview = await adapter.send(
+            chat_id=chat_id,
+            content="Let me search\u2589",
+            reply_to="33" * 32,
+            metadata=metadata,
+        )
+        self.assertTrue(preview.success)
+        message_id = preview.message_id
+        self.assertIn(message_id, adapter._active_streams)
+
+        first = await adapter.edit_message(
+            chat_id,
+            message_id,
+            "Let me search the docs",
+            finalize=True,
+            metadata=metadata,
+        )
+        self.assertFalse(first.success)
+        self.assertTrue(first.retryable)
+        self.assertEqual(fake_client.activity_attempts, 1)
+        self.assertEqual(len(fake_client.activities), 0)
+        self.assertEqual(fake_client.final_sends, [])
+        self.assertEqual(fake_client.stream_finalizes, [])
+        self.assertEqual(fake_client.stream_cancels, [])
+        self.assertIn(message_id, adapter._active_streams)
+
+        second = await adapter.edit_message(
+            chat_id,
+            message_id,
+            "Let me search the docs",
+            finalize=True,
+            metadata=metadata,
+        )
+        self.assertTrue(second.success)
+        self.assertEqual(second.message_id, "aa" * 32)
+        self.assertEqual(fake_client.activity_attempts, 2)
+        self.assertEqual(len(fake_client.activities), 1)
+        self.assertEqual(fake_client.activities[0][2]["text"], "Let me search the docs")
+        self.assertEqual(fake_client.activities[0][2]["reply_to_message_id_hex"], "33" * 32)
+        self.assertEqual(fake_client.final_sends, [])
+        self.assertEqual(fake_client.stream_finalizes, [])
+        self.assertEqual(fake_client.stream_cancels, [("55" * 32, "non-final commentary")])
+        self.assertNotIn(message_id, adapter._active_streams)
+
     async def test_turn_final_true_streaming_path_still_finalizes_kind_9(self):
         fake_client = _DeliveryRoutingFakeClient()
         adapter = self._adapter(fake_client, quic_candidates=["quic://127.0.0.1:4433"])
@@ -2439,6 +2538,68 @@ class DeliveryMetadataRoutingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(fake_client.activities, [])
         self.assertEqual(len(fake_client.stream_finalizes), 1)
         self.assertEqual(fake_client.final_sends, [])
+
+
+def _install_stream_events_module():
+    stream_events = types.ModuleType("gateway.stream_events")
+
+    @dataclass
+    class Commentary:
+        text: str = ""
+
+    @dataclass
+    class MessageChunk:
+        text: str = ""
+
+    @dataclass
+    class MessageStop:
+        final: bool = True
+
+    stream_events.Commentary = Commentary
+    stream_events.MessageChunk = MessageChunk
+    stream_events.MessageStop = MessageStop
+    sys.modules["gateway.stream_events"] = stream_events
+    return stream_events
+
+
+class CommentaryRendererTests(unittest.TestCase):
+    def setUp(self):
+        self.adapter_module = load_adapter_module()
+        self.config_cls = sys.modules["gateway.config"].PlatformConfig
+
+    def test_render_message_event_commentary_schedules_one_activity(self):
+        stream_events = _install_stream_events_module()
+        adapter = self.adapter_module.MarmotPlatformAdapter(
+            self.config_cls(extra={"account_id_hex": "11" * 32}),
+            client=_DeliveryRoutingFakeClient(),
+        )
+        scheduled = []
+
+        def track_schedule(chat_id, *, status, text, reply_to_message_id_hex=None):
+            scheduled.append(
+                {
+                    "chat_id": chat_id,
+                    "status": status,
+                    "text": text,
+                    "reply_to_message_id_hex": reply_to_message_id_hex,
+                }
+            )
+
+        adapter._schedule_agent_activity = track_schedule
+
+        class Sink:
+            chat_id = "22" * 32
+            _initial_reply_to_id = "33" * 32
+
+        adapter.render_message_event(
+            stream_events.Commentary(text="Checking sources."),
+            Sink(),
+        )
+
+        self.assertEqual(len(scheduled), 1)
+        self.assertEqual(scheduled[0]["status"], "commentary")
+        self.assertEqual(scheduled[0]["text"], "Checking sources.")
+        self.assertEqual(scheduled[0]["reply_to_message_id_hex"], "33" * 32)
 
 
 class SendFinalIdempotencyRetryTests(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
Fixes #1087

## Summary
- consume canonical `delivery_class` / `is_turn_final` context (plus legacy `turn_final`) and route sealed commentary through `send_agent_activity`
- make explicit turn finality authoritative over every delivery class while retaining class-based and missing-metadata compatibility defaults
- keep edit and draft previews transient, emitting exactly one kind-1201 activity when a non-final segment seals while preserving its prompt relationship
- retain preview state after a retryable activity failure and clean it up only after confirmed activity delivery
- retain kind-9 behavior for finals, approvals, and missing metadata; keep tool lifecycle on kind 1202
- validate activity responses and document the updated delivery behavior

## Verification
- `python3.11 -m unittest discover -s integrations/hermes/marmot/tests` — 107 passed
- `integrations/hermes/marmot/tests/test_dev_scripts.sh` — passed
- `just fast-ci` — passed
- isolated real-Hermes deterministic E2E — passed (`final_text: marmot-e2e-ok: ping from marmot`)
- `python3.11 -m py_compile integrations/hermes/marmot/adapter.py integrations/hermes/marmot/tests/test_adapter.py` — passed
- `git diff --check` — passed
- independent read-only Composer review — passed; no blocking security or logic findings

## Dependency
Hermes must still expose the delivery context tracked in NousResearch/hermes-agent#70694. Missing metadata intentionally keeps the existing final/direct-send behavior.

## Sensitive paths
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata-aware routing for commentary, previews, drafts, final answers, and approvals.
  * Commentary is delivered as durable activity while previews remain transient until finalized.
  * Preserved reply-to threading for commentary messages.

* **Bug Fixes**
  * Prevented duplicate final messages when streamed content is finalized.
  * Maintained legacy final-send behavior when delivery metadata is unavailable.
  * Improved handling of missing activity responses with retryable failures.

* **Documentation**
  * Clarified delivery, preview, finalization, threading, and compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->