### PR TITLE
Select retained SelfRemove proposals deterministically

### DIFF
--- a/crates/cgka-engine/src/auto_committer.rs
+++ b/crates/cgka-engine/src/auto_committer.rs
@@ -23,6 +23,7 @@
 use openmls::framing::Sender;
 use openmls::group::MlsGroup;
 use openmls::prelude::{LeafNodeIndex, Proposal, QueuedProposal};
+use std::collections::BTreeMap;
 
 /// Decision returned by the policy.
 pub(crate) enum AutoCommitDecision {
@@ -35,6 +36,34 @@ pub(crate) enum AutoCommitDecision {
 pub(crate) struct AutoCommitDecisionReport {
     pub decision: AutoCommitDecision,
     pub reason: &'static str,
+}
+
+/// Return the candidate indexes selected for a new local SelfRemove-only
+/// Commit.
+///
+/// `member-departure.md` requires one deterministic choice when more than one
+/// distinct valid SelfRemove proposal names the same leaving leaf and source
+/// epoch. The caller scopes candidates to one source epoch; this helper groups
+/// by leaf and chooses the lexicographically lowest SHA-256 digest of the
+/// complete serialized proposal MLSMessage. Output is leaf-ordered so commit
+/// preparation is independent of arrival and map iteration order.
+pub(crate) fn select_lowest_digest_per_leaf(
+    candidates: &[(LeafNodeIndex, [u8; 32])],
+) -> Vec<usize> {
+    let mut selected: BTreeMap<u32, ([u8; 32], usize)> = BTreeMap::new();
+    for (index, (leaf, digest)) in candidates.iter().enumerate() {
+        match selected.get_mut(&leaf.u32()) {
+            Some((selected_digest, selected_index)) if digest < selected_digest => {
+                *selected_digest = *digest;
+                *selected_index = index;
+            }
+            None => {
+                selected.insert(leaf.u32(), (*digest, index));
+            }
+            _ => {}
+        }
+    }
+    selected.into_values().map(|(_, index)| index).collect()
 }
 
 /// Inspect a QueuedProposal and decide whether we should auto-commit.
@@ -157,6 +186,41 @@ fn pubkey_at_leaf_index(
     let mut out = [0u8; 32];
     out.copy_from_slice(id);
     PubkeyResult::Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::select_lowest_digest_per_leaf;
+    use openmls::prelude::LeafNodeIndex;
+
+    #[test]
+    fn self_remove_selection_is_lowest_digest_per_leaf_for_every_arrival_order() {
+        let candidates = [
+            (LeafNodeIndex::new(3), [0x90; 32]),
+            (LeafNodeIndex::new(1), [0x40; 32]),
+            (LeafNodeIndex::new(3), [0x10; 32]),
+        ];
+        for order in [
+            [0usize, 1, 2],
+            [0, 2, 1],
+            [1, 0, 2],
+            [1, 2, 0],
+            [2, 0, 1],
+            [2, 1, 0],
+        ] {
+            let permuted = order.map(|index| candidates[index]);
+            let selected = select_lowest_digest_per_leaf(&permuted);
+            let selected_values: Vec<_> =
+                selected.into_iter().map(|index| permuted[index]).collect();
+            assert_eq!(
+                selected_values,
+                vec![
+                    (LeafNodeIndex::new(1), [0x40; 32]),
+                    (LeafNodeIndex::new(3), [0x10; 32]),
+                ]
+            );
+        }
+    }
 }
 
 // The commit-staging work happens in `message_processor::ingest_group_message`

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -1308,7 +1308,14 @@ impl<S: StorageProvider> Engine<S> {
             });
         }
 
-        if has_queued_intents || has_convergence_inputs {
+        let restored_self_remove_work = self
+            .restore_self_remove_auto_commit_schedules_for_group(
+                group_id,
+                group.epoch,
+                self.convergence_now_ms(),
+            )
+            .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
+        if has_queued_intents || has_convergence_inputs || restored_self_remove_work {
             self.schedule_pending_convergence_group(group_id);
         }
         Ok(group.epoch)

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -10,7 +10,7 @@ use super::{content_dedup_id, route_wrapped_group_message};
 use crate::engine::{Engine, ScheduledSelfRemoveAutoCommit};
 use crate::fork_recovery::ForkResolution;
 use crate::group_lifecycle::{self};
-use crate::identity::{member_id_at_leaf, member_id_of_sender};
+use crate::identity::member_id_of_sender;
 use crate::openmls_projection::{
     OpenMlsContentKind, process_commit_with_app_data_updates, project_mls_message,
     retained_anchor_epoch_from_snapshot_name,
@@ -47,6 +47,12 @@ struct PastPeelRecovery {
     message_retention_seconds: Option<u64>,
     snapshot_name: String,
     attempt_count: u64,
+}
+
+struct RetainedSelfRemoveProposal {
+    leaf: openmls::prelude::LeafNodeIndex,
+    digest: [u8; 32],
+    queued: QueuedProposal,
 }
 
 enum ScheduledAutoCommitReplay {
@@ -1527,7 +1533,13 @@ impl<S: StorageProvider> Engine<S> {
                 .scheduled_self_remove_auto_commits
                 .values()
                 .filter(|scheduled| &scheduled.group_id == group_id)
-                .min_by_key(|scheduled| scheduled.due_at_ms)
+                .min_by(|left, right| {
+                    left.due_at_ms.cmp(&right.due_at_ms).then_with(|| {
+                        left.proposal_id
+                            .as_slice()
+                            .cmp(right.proposal_id.as_slice())
+                    })
+                })
                 .cloned()
             else {
                 return Ok(false);
@@ -1565,46 +1577,11 @@ impl<S: StorageProvider> Engine<S> {
             return Ok(ScheduledAutoCommitReplay::NotApplicable);
         }
 
-        let record = match self.storage.get_message(&schedule.proposal_id) {
-            Ok(record) => record,
-            Err(StorageError::NotFound) => return Ok(ScheduledAutoCommitReplay::NotApplicable),
-            Err(err) => return Err(EngineError::Storage(err)),
-        };
-        if !matches!(
-            record.state,
-            MessageState::Created | MessageState::Retryable
-        ) {
-            return Ok(ScheduledAutoCommitReplay::NotApplicable);
-        }
-
-        let Ok(stored_payload) = StoredMessagePayload::decode(&record.payload) else {
-            return Ok(ScheduledAutoCommitReplay::NotApplicable);
-        };
-        let Some(message) = stored_payload.as_openmls_wire() else {
-            return Ok(ScheduledAutoCommitReplay::NotApplicable);
-        };
-        let Ok(projection) = project_mls_message(&message.payload) else {
-            return Ok(ScheduledAutoCommitReplay::NotApplicable);
-        };
-        if projection.kind != OpenMlsContentKind::Proposal
-            || projection.source_epoch != Some(schedule.source_epoch.0)
-        {
-            return Ok(ScheduledAutoCommitReplay::NotApplicable);
-        }
-
-        let msg_in = MlsMessageIn::tls_deserialize_exact(message.payload.as_slice())
-            .map_err(|e| EngineError::Serialize(format!("message deserialize: {e:?}")))?;
-        let proto: ProtocolMessage = match msg_in.extract() {
-            MlsMessageBodyIn::PrivateMessage(p) => p.into(),
-            MlsMessageBodyIn::PublicMessage(p) => p.into(),
-            _ => return Ok(ScheduledAutoCommitReplay::NotApplicable),
-        };
-
-        let (mut mls_group, queued) = {
+        let mut mls_group = {
             let provider =
                 EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
             let mls_gid = openmls::group::GroupId::from_slice(schedule.group_id.as_slice());
-            let mut mls_group = MlsGroup::load(
+            let mls_group = MlsGroup::load(
                 <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(
                     &provider,
                 ),
@@ -1615,84 +1592,149 @@ impl<S: StorageProvider> Engine<S> {
             if EpochId(mls_group.epoch().as_u64()) != schedule.source_epoch {
                 return Ok(ScheduledAutoCommitReplay::NotApplicable);
             }
-
-            let processed = match mls_group.process_message(&provider, proto) {
-                Ok(processed) => processed,
-                Err(_) => return Ok(ScheduledAutoCommitReplay::NotApplicable),
-            };
-            let queued = match processed.into_content() {
-                ProcessedMessageContent::ProposalMessage(queued)
-                    if matches!(queued.proposal(), Proposal::SelfRemove) =>
-                {
-                    queued
-                }
-                _ => return Ok(ScheduledAutoCommitReplay::NotApplicable),
-            };
-            (mls_group, queued)
+            mls_group
         };
 
-        if let Err(rejection) =
-            crate::app_components::authorize_standalone_proposal(&mls_group, &queued)
-        {
-            self.terminalize_rejected_proposal(
-                &schedule.group_id,
-                &schedule.proposal_id,
-                None,
-                rejection.category,
-            )?;
+        let selected = self.retained_self_remove_proposals_for_local_commit(
+            &schedule.group_id,
+            schedule.source_epoch,
+            &mut mls_group,
+        )?;
+        if selected.is_empty() {
             return Ok(ScheduledAutoCommitReplay::NotApplicable);
         }
 
         if self
-            .stage_auto_commit_for_queued_proposal(&schedule.group_id, &mut mls_group, queued)
+            .stage_auto_commit_for_queued_proposals(&schedule.group_id, &mut mls_group, selected)
             .await?
         {
             Ok(ScheduledAutoCommitReplay::Staged)
         } else {
+            self.schedule_self_remove_auto_commit(
+                &schedule.group_id,
+                &schedule.proposal_id,
+                schedule.source_epoch,
+                self.convergence_now_ms(),
+            )?;
             Ok(ScheduledAutoCommitReplay::NotApplicable)
         }
     }
 
-    async fn stage_auto_commit_for_queued_proposal(
+    fn retained_self_remove_proposals_for_local_commit(
+        &self,
+        group_id: &GroupId,
+        source_epoch: EpochId,
+        mls_group: &mut MlsGroup,
+    ) -> Result<Vec<QueuedProposal>, EngineError> {
+        let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
+        let mut candidates = Vec::new();
+        for record in self.storage.list_messages(group_id, source_epoch)? {
+            if record.epoch != source_epoch
+                || !matches!(
+                    record.state,
+                    MessageState::Created | MessageState::Retryable | MessageState::Processed
+                )
+            {
+                continue;
+            }
+            let Ok(stored_payload) = StoredMessagePayload::decode(&record.payload) else {
+                continue;
+            };
+            let Some(message) = stored_payload.as_openmls_wire() else {
+                continue;
+            };
+            let Ok(projection) = project_mls_message(&message.payload) else {
+                continue;
+            };
+            if projection.kind != OpenMlsContentKind::Proposal
+                || projection.source_epoch != Some(source_epoch.0)
+            {
+                continue;
+            }
+            let Ok(msg_in) = MlsMessageIn::tls_deserialize_exact(message.payload.as_slice()) else {
+                continue;
+            };
+            let proto: ProtocolMessage = match msg_in.extract() {
+                MlsMessageBodyIn::PrivateMessage(private) => private.into(),
+                MlsMessageBodyIn::PublicMessage(public) => public.into(),
+                _ => continue,
+            };
+            let Ok(processed) = mls_group.process_message(&provider, proto) else {
+                continue;
+            };
+            let ProcessedMessageContent::ProposalMessage(queued) = processed.into_content() else {
+                continue;
+            };
+            if !matches!(queued.proposal(), Proposal::SelfRemove)
+                || crate::app_components::authorize_standalone_proposal(mls_group, &queued).is_err()
+                || !matches!(
+                    crate::auto_committer::decide_with_reason(mls_group, &queued).decision,
+                    crate::auto_committer::AutoCommitDecision::Commit
+                )
+            {
+                continue;
+            }
+            let Sender::Member(leaf) = queued.sender() else {
+                continue;
+            };
+            let mut digest = [0u8; 32];
+            digest.copy_from_slice(&Sha256::digest(message.payload.as_slice()));
+            candidates.push(RetainedSelfRemoveProposal {
+                leaf: *leaf,
+                digest,
+                queued: *queued,
+            });
+        }
+
+        let selection_inputs: Vec<_> = candidates
+            .iter()
+            .map(|candidate| (candidate.leaf, candidate.digest))
+            .collect();
+        let selected = crate::auto_committer::select_lowest_digest_per_leaf(&selection_inputs);
+        Ok(selected
+            .into_iter()
+            .map(|index| candidates[index].queued.clone())
+            .collect())
+    }
+
+    async fn stage_auto_commit_for_queued_proposals(
         &mut self,
         group_id: &GroupId,
         mls_group: &mut MlsGroup,
-        queued: Box<QueuedProposal>,
+        queued_proposals: Vec<QueuedProposal>,
     ) -> Result<bool, EngineError> {
-        let decision_report = crate::auto_committer::decide_with_reason(mls_group, &queued);
-        let decision_str = match &decision_report.decision {
-            crate::auto_committer::AutoCommitDecision::Commit => "commit",
-            crate::auto_committer::AutoCommitDecision::Observe => "observe",
-        };
-        self.audit_group(
-            group_id,
-            marmot_forensics::AuditEventKind::AutoCommitDecision {
-                proposal_kind: crate::audit_helpers::proposal_kind_str(queued.proposal())
-                    .to_string(),
-                decision: decision_str.to_string(),
-                reason: Some(decision_report.reason.to_string()),
-            },
-        );
-        if !matches!(
-            decision_report.decision,
-            crate::auto_committer::AutoCommitDecision::Commit
-        ) {
+        if queued_proposals.is_empty() {
             return Ok(false);
         }
+        for queued in &queued_proposals {
+            let decision_report = crate::auto_committer::decide_with_reason(mls_group, queued);
+            let decision_str = match &decision_report.decision {
+                crate::auto_committer::AutoCommitDecision::Commit => "commit",
+                crate::auto_committer::AutoCommitDecision::Observe => "observe",
+            };
+            self.audit_group(
+                group_id,
+                marmot_forensics::AuditEventKind::AutoCommitDecision {
+                    proposal_kind: crate::audit_helpers::proposal_kind_str(queued.proposal())
+                        .to_string(),
+                    decision: decision_str.to_string(),
+                    reason: Some(decision_report.reason.to_string()),
+                },
+            );
+            if !matches!(
+                decision_report.decision,
+                crate::auto_committer::AutoCommitDecision::Commit
+            ) || crate::app_components::authorize_standalone_proposal(mls_group, queued).is_err()
+            {
+                return Ok(false);
+            }
+        }
 
-        let auto_removed: Vec<MemberId> = match queued.proposal() {
-            Proposal::Remove(r) => member_id_at_leaf(mls_group, r.removed())
-                .into_iter()
-                .collect(),
-            Proposal::SelfRemove => member_id_of_sender(queued.sender(), mls_group)
-                .into_iter()
-                .collect(),
-            _ => Vec::new(),
-        };
-        let auto_is_self_remove = matches!(queued.proposal(), Proposal::SelfRemove);
-        let auto_proposer = member_id_of_sender(queued.sender(), mls_group);
-        let auto_proposal_kind =
-            crate::audit_helpers::proposal_kind_str(queued.proposal()).to_string();
+        let auto_removed: Vec<MemberId> = queued_proposals
+            .iter()
+            .filter_map(|queued| member_id_of_sender(queued.sender(), mls_group))
+            .collect();
+        let auto_proposal_kind = "self_remove".to_string();
 
         let is_stable = self
             .epoch_manager
@@ -1712,20 +1754,30 @@ impl<S: StorageProvider> Engine<S> {
         }
 
         let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
-        let stored_proposal_ref = queued.proposal_reference_ref().clone();
-        mls_group
-            .store_pending_proposal(
-                <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(
-                    &provider,
-                ),
-                *queued,
-            )
-            .map_err(|e| EngineError::Backend(format!("store_pending: {e:?}")))?;
+        // This path must never consume unrelated pending proposals. In normal
+        // engine operation retained inbound proposals live in MessageStorage,
+        // not OpenMLS's proposal store; a non-empty store therefore means some
+        // other operation owns it and SelfRemove preparation waits.
+        if mls_group.has_pending_proposals() {
+            self.schedule_pending_convergence_group(group_id);
+            return Ok(false);
+        }
 
         let pre_commit_epoch = EpochId(mls_group.epoch().as_u64());
         let mut pending_commit_guard =
             PendingCommitCleanupGuard::arm(&self.storage, &provider, group_id.clone());
-        pending_commit_guard.set_stored_proposal_ref(stored_proposal_ref);
+        for queued in queued_proposals {
+            let stored_proposal_ref = queued.proposal_reference_ref().clone();
+            mls_group
+                .store_pending_proposal(
+                    <EngineOpenMlsProvider<'_, S> as openmls_traits::OpenMlsProvider>::storage(
+                        &provider,
+                    ),
+                    queued,
+                )
+                .map_err(|e| EngineError::Backend(format!("store_pending: {e:?}")))?;
+            pending_commit_guard.set_stored_proposal_ref(stored_proposal_ref);
+        }
         let recovery_snapshot =
             self.fork_recovery
                 .create_snapshot(&self.storage, group_id, pre_commit_epoch)?;
@@ -1817,7 +1869,7 @@ impl<S: StorageProvider> Engine<S> {
             if self.epoch_manager.rollback_publish(pending_ref).is_err() {
                 tracing::warn!(
                     target: "cgka_engine::message_processor",
-                    method = "stage_auto_commit_for_queued_proposal",
+                    method = "stage_auto_commit_for_queued_proposals",
                     "state-machine rollback failed after group record projection failure"
                 );
             }
@@ -1851,19 +1903,10 @@ impl<S: StorageProvider> Engine<S> {
             .iter()
             .cloned()
             .map(|member| {
-                let (change, actor) = if auto_is_self_remove {
-                    (
-                        GroupStateChange::MemberLeft {
-                            member: member.clone(),
-                        },
-                        Some(member),
-                    )
-                } else {
-                    (
-                        GroupStateChange::MemberRemoved { member },
-                        auto_proposer.clone(),
-                    )
+                let change = GroupStateChange::MemberLeft {
+                    member: member.clone(),
                 };
+                let actor = Some(member);
                 crate::engine::PendingGroupStateChange { actor, change }
             })
             .collect();

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -479,6 +479,41 @@ impl<S: StorageProvider> Engine<S> {
             .retain(|_, scheduled| &scheduled.group_id != group_id);
     }
 
+    /// Rebuild the in-memory jitter edges for durable current-epoch proposal
+    /// rows. Replay performs the authenticated SelfRemove/type/authorization
+    /// checks before staging; this scan only restores wakeups lost at restart
+    /// or after publish rollback.
+    pub(crate) fn restore_self_remove_auto_commit_schedules_for_group(
+        &mut self,
+        group_id: &GroupId,
+        source_epoch: EpochId,
+        now_ms: u64,
+    ) -> Result<bool, EngineError> {
+        let mut restored = false;
+        for record in self.storage.list_messages(group_id, source_epoch)? {
+            if record.epoch != source_epoch
+                || !matches!(
+                    record.state,
+                    MessageState::Created | MessageState::Retryable | MessageState::Processed
+                )
+            {
+                continue;
+            }
+            let Some((_message, projection)) = decode_openmls_wire_projection(&record.payload)
+            else {
+                continue;
+            };
+            if projection.kind != crate::openmls_projection::OpenMlsContentKind::Proposal
+                || projection.source_epoch != Some(source_epoch.0)
+            {
+                continue;
+            }
+            self.schedule_self_remove_auto_commit(group_id, &record.id, source_epoch, now_ms)?;
+            restored = true;
+        }
+        Ok(restored)
+    }
+
     fn self_remove_auto_commit_jitter_ms(
         &self,
         group_id: &GroupId,

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -30,6 +30,20 @@ impl<S: StorageProvider> Engine<S> {
             MessageState::Sent => IngestOutcome::Ignored {
                 category: InputRejectionCategory::OwnEcho,
             },
+            MessageState::Created | MessageState::Retryable
+                if crate::openmls_projection::decode_openmls_wire_projection(&record.payload)
+                    .is_some_and(|(_, projection)| {
+                        projection.kind == crate::openmls_projection::OpenMlsContentKind::Proposal
+                    }) =>
+            {
+                // Retained standalone proposals stay Created/Retryable until
+                // convergence consumes or invalidates them, but byte-identical
+                // transport repeats are still duplicates. Internal replay
+                // bypasses this outer durable-dedup seam.
+                IngestOutcome::Ignored {
+                    category: InputRejectionCategory::Duplicate,
+                }
+            }
             MessageState::Created | MessageState::Retryable => IngestOutcome::Buffered {
                 group_id: record.group_id,
                 epoch: record.epoch,

--- a/crates/cgka-engine/src/pending_commit_guard.rs
+++ b/crates/cgka-engine/src/pending_commit_guard.rs
@@ -54,10 +54,10 @@ pub(crate) struct PendingCommitCleanupGuard<S: StorageProvider> {
     // caller created one. `None` for paths that stage a commit without a
     // snapshot (e.g. group creation).
     snapshot_name: Option<String>,
-    // Proposal this staging attempt stored via `store_pending_proposal`, to
-    // remove from the OpenMLS proposal store on Drop. `None` for the send
-    // paths, which commit proposals they did not store themselves.
-    stored_proposal_ref: Option<ProposalRef>,
+    // Proposals this staging attempt stored via `store_pending_proposal`, to
+    // remove from the OpenMLS proposal store on Drop. Empty for send paths,
+    // which commit proposals they did not store themselves.
+    stored_proposal_refs: Vec<ProposalRef>,
     armed: bool,
 }
 
@@ -77,7 +77,7 @@ impl<S: StorageProvider> PendingCommitCleanupGuard<S> {
             mls_storage: provider.storage() as *const S::Mls,
             group_id,
             snapshot_name: None,
-            stored_proposal_ref: None,
+            stored_proposal_refs: Vec::new(),
             armed: true,
         }
     }
@@ -95,7 +95,7 @@ impl<S: StorageProvider> PendingCommitCleanupGuard<S> {
     /// OpenMLS 0.8.1 panics when a later `remove_members` commit filters a
     /// leftover SelfRemove proposal against a Remove for the same leaf.
     pub(crate) fn set_stored_proposal_ref(&mut self, proposal_ref: ProposalRef) {
-        self.stored_proposal_ref = Some(proposal_ref);
+        self.stored_proposal_refs.push(proposal_ref);
     }
 
     /// The staged commit (and its snapshot) is now tracked by `EpochManager`
@@ -180,17 +180,17 @@ impl<S: StorageProvider> Drop for PendingCommitCleanupGuard<S> {
         // snapshot decision below: a proposal that is already gone is benign
         // (`clear_pending_commit` does not remove stored proposals, but a
         // concurrent merge would have consumed it).
-        if let (Some(mls_group), Some(proposal_ref)) =
-            (loaded_group.as_mut(), self.stored_proposal_ref.as_ref())
-        {
-            match mls_group.remove_pending_proposal(mls_storage, proposal_ref) {
-                Ok(()) | Err(RemoveProposalError::ProposalNotFound) => {}
-                Err(_e) => {
-                    tracing::warn!(
-                        target: TRACE_TARGET,
-                        method = "drop",
-                        "pending commit guard could not remove stored proposal"
-                    );
+        if let Some(mls_group) = loaded_group.as_mut() {
+            for proposal_ref in &self.stored_proposal_refs {
+                match mls_group.remove_pending_proposal(mls_storage, proposal_ref) {
+                    Ok(()) | Err(RemoveProposalError::ProposalNotFound) => {}
+                    Err(_e) => {
+                        tracing::warn!(
+                            target: TRACE_TARGET,
+                            method = "drop",
+                            "pending commit guard could not remove stored proposal"
+                        );
+                    }
                 }
             }
         }

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -346,6 +346,13 @@ impl<S: StorageProvider> Engine<S> {
             .transpose()?;
 
         let has_pending_commit = mls_group.pending_commit().is_some();
+        let pending_was_self_remove_only = mls_group.pending_commit().is_some_and(|staged| {
+            let mut count = 0usize;
+            staged.queued_proposals().all(|queued| {
+                count += 1;
+                matches!(queued.proposal(), openmls::prelude::Proposal::SelfRemove)
+            }) && count > 0
+        });
         self.storage
             .with_transaction(|storage| -> Result<(), EngineError> {
                 if has_pending_commit {
@@ -354,6 +361,18 @@ impl<S: StorageProvider> Engine<S> {
                     mls_group
                         .clear_pending_commit(tx_provider.storage())
                         .map_err(|e| EngineError::Backend(format!("clear_pending: {e:?}")))?;
+                    if pending_was_self_remove_only {
+                        // Auto-commit preparation started from an empty
+                        // OpenMLS proposal store and queued only its selected
+                        // SelfRemove references. Drop that staging residue so
+                        // the durable retained-message scan can deterministically
+                        // rebuild the same selection after publish failure.
+                        mls_group
+                            .clear_pending_proposals(tx_provider.storage())
+                            .map_err(|e| {
+                                EngineError::Backend(format!("clear_pending_proposals: {e:?}"))
+                            })?;
+                    }
                 }
 
                 // Re-derive the Marmot projection in the same durable unit as the
@@ -417,6 +436,11 @@ impl<S: StorageProvider> Engine<S> {
             self.schedule_pending_convergence_group(&queued_group_id);
         }
         self.forget_pending_commit_for_recovery(pending)?;
+        self.restore_self_remove_auto_commit_schedules_for_group(
+            &group_id,
+            prior_epoch,
+            self.convergence_now_ms(),
+        )?;
         self.replay_buffered_messages(&group_id).await?;
         Ok(())
     }

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -27,10 +27,14 @@ use cgka_traits::types::{GroupId, MemberId, MessageId};
 use openmls::component::ComponentData;
 use openmls::group::MlsGroup;
 use openmls::messages::proposals::{AppDataUpdateOperation, AppDataUpdateProposal, Proposal};
-use openmls::prelude::{BasicCredential, MlsMessageBodyIn, MlsMessageIn, ProtocolVersion};
+use openmls::prelude::{
+    BasicCredential, LeafNodeParameters, MlsMessageBodyIn, MlsMessageIn, MlsMessageOut,
+    ProcessedMessageContent, ProtocolMessage, ProtocolVersion,
+};
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::RustCrypto;
 use openmls_traits::OpenMlsProvider as _;
+use sha2::Digest as _;
 use storage_sqlite::SqliteAccountStorage;
 use tls_codec::{Deserialize as _, Serialize as _};
 
@@ -236,6 +240,110 @@ fn build_with_storage(id: &[u8]) -> (Engine<SqliteAccountStorage>, SqliteAccount
     let storage = SqliteAccountStorage::in_memory().unwrap();
     let engine = build_client_on_storage(id, storage.clone());
     (engine, storage)
+}
+
+fn load_group_and_signer(
+    storage: &SqliteAccountStorage,
+    member: &MemberId,
+    group_id: &GroupId,
+) -> (MlsGroup, SignatureKeyPair) {
+    let crypto = RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load group")
+        .expect("group present");
+    let binding = storage
+        .account_device_signer(member)
+        .expect("signer binding")
+        .expect("signer binding present");
+    let signer = SignatureKeyPair::read(
+        storage.mls_storage(),
+        &binding.mls_signature_public_key,
+        DEFAULT_CIPHERSUITE.signature_algorithm(),
+    )
+    .expect("MLS signer present");
+    (mls_group, signer)
+}
+
+fn proposal_transport(message: MlsMessageOut, group_id: &GroupId) -> TransportMessage {
+    let payload = message
+        .tls_serialize_detached()
+        .expect("serialize proposal MLSMessage");
+    TransportMessage {
+        id: MessageId::new(sha2::Sha256::digest(&payload).to_vec()),
+        payload,
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("raw-proposal".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    }
+}
+
+fn raw_self_remove_proposal(
+    storage: &SqliteAccountStorage,
+    sender: &MemberId,
+    group_id: &GroupId,
+    aad: &[u8],
+) -> TransportMessage {
+    let crypto = RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, storage.mls_storage());
+    let (mut group, signer) = load_group_and_signer(storage, sender, group_id);
+    group.set_aad(aad.to_vec());
+    let message = group
+        .leave_group_via_self_remove(&provider, &signer)
+        .expect("build SelfRemove proposal");
+    proposal_transport(message, group_id)
+}
+
+fn raw_self_update_proposal(
+    storage: &SqliteAccountStorage,
+    sender: &MemberId,
+    group_id: &GroupId,
+) -> TransportMessage {
+    let crypto = RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, storage.mls_storage());
+    let (mut group, signer) = load_group_and_signer(storage, sender, group_id);
+    let (message, _) = group
+        .propose_self_update(&provider, &signer, LeafNodeParameters::default())
+        .expect("build self-update proposal");
+    proposal_transport(message, group_id)
+}
+
+fn proposal_reference_for(
+    storage: &SqliteAccountStorage,
+    group_id: &GroupId,
+    proposal: &TransportMessage,
+) -> Vec<u8> {
+    let crypto = RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mut group = MlsGroup::load(provider.storage(), &mls_gid)
+        .expect("load observer group")
+        .expect("observer group present");
+    let message = MlsMessageIn::tls_deserialize_exact(proposal.payload.as_slice())
+        .expect("deserialize proposal");
+    let protocol: ProtocolMessage = match message.extract() {
+        MlsMessageBodyIn::PrivateMessage(private) => private.into(),
+        MlsMessageBodyIn::PublicMessage(public) => public.into(),
+        other => panic!("expected handshake message, got {other:?}"),
+    };
+    let processed = group
+        .process_message(&provider, protocol)
+        .expect("process proposal");
+    let ProcessedMessageContent::ProposalMessage(queued) = processed.into_content() else {
+        panic!("expected queued proposal");
+    };
+    queued
+        .proposal_reference_ref()
+        .tls_serialize_detached()
+        .expect("serialize proposal ref")
 }
 
 fn clone_key_package_for_invite(kp: &KeyPackage) -> openmls::prelude::KeyPackage {
@@ -1995,6 +2103,232 @@ async fn engine_rejects_malformed_local_credential_identity_at_build() {
 // ── Leave (MIP-03 SelfRemove) ───────────────────────────────────────────────
 
 #[tokio::test]
+async fn selfremove_local_selection_uses_lowest_complete_message_digest_after_restart() {
+    let (mut alice, alice_storage) = build_with_storage(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let (mut carol, carol_storage) = build_with_storage(b"carol");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "selfremove digest selection".into(),
+            description: String::new(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let mut welcomes = match create {
+        SendResult::GroupCreated { pending, welcomes } => {
+            alice.confirm_published(pending).await.unwrap();
+            welcomes
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcomes.remove(0)).await.unwrap();
+    carol.join_welcome(welcomes.remove(0)).await.unwrap();
+
+    // Distinct authenticated-data bytes produce distinct complete serialized
+    // handshake MLSMessages carrying the same leaf-scoped SelfRemove.
+    let first = raw_self_remove_proposal(&bob_storage, &bob.self_id(), &group_id, b"variant-a");
+    let second = raw_self_remove_proposal(&bob_storage, &bob.self_id(), &group_id, b"variant-b");
+    assert_ne!(first.payload, second.payload);
+    let (lowest, highest) =
+        if sha2::Sha256::digest(&first.payload) < sha2::Sha256::digest(&second.payload) {
+            (&first, &second)
+        } else {
+            (&second, &first)
+        };
+    let expected_ref = proposal_reference_for(&carol_storage, &group_id, lowest);
+
+    // Deliberately ingest the higher digest first. Startup must reconstruct the
+    // scheduling edge from durable rows and make the same local choice.
+    for proposal in [highest, lowest] {
+        assert!(matches!(
+            alice.ingest(proposal.clone()).await.unwrap(),
+            IngestOutcome::Processed
+        ));
+    }
+    assert!(matches!(
+        alice.ingest(highest.clone()).await.unwrap(),
+        IngestOutcome::Ignored {
+            category: cgka_traits::ingest::InputRejectionCategory::Duplicate
+        }
+    ));
+    drop(alice);
+    let mut alice = build_client_on_storage(b"alice", alice_storage.clone());
+    alice.hydrate_stable_groups_from_storage().unwrap();
+    advance_selfremove_auto_commit(&mut alice, &group_id).await;
+
+    let crypto = RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, alice_storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let group = MlsGroup::load(provider.storage(), &mls_gid)
+        .unwrap()
+        .unwrap();
+    let staged = group.pending_commit().expect("SelfRemove commit staged");
+    let refs: Vec<_> = staged
+        .queued_proposals()
+        .map(|queued| {
+            queued
+                .proposal_reference_ref()
+                .tls_serialize_detached()
+                .unwrap()
+        })
+        .collect();
+    assert_eq!(refs, vec![expected_ref]);
+    assert_eq!(alice.drain_auto_publish().len(), 1);
+    assert!(
+        alice
+            .advance_convergence(&group_id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "pending local selection must not produce a duplicate commit"
+    );
+}
+
+#[tokio::test]
+async fn non_selected_selfremove_alternative_remains_processable_by_peer_commit() {
+    let (mut alice, _alice_storage) = build_with_storage(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let mut carol = build_client(b"carol");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "selfremove alternative retention".into(),
+            description: String::new(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let mut welcomes = match create {
+        SendResult::GroupCreated { pending, welcomes } => {
+            alice.confirm_published(pending).await.unwrap();
+            welcomes
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcomes.remove(0)).await.unwrap();
+    carol.join_welcome(welcomes.remove(0)).await.unwrap();
+
+    let first = raw_self_remove_proposal(&bob_storage, &bob.self_id(), &group_id, b"variant-a");
+    let second = raw_self_remove_proposal(&bob_storage, &bob.self_id(), &group_id, b"variant-b");
+    let (lowest, alternative) =
+        if sha2::Sha256::digest(&first.payload) < sha2::Sha256::digest(&second.payload) {
+            (&first, &second)
+        } else {
+            (&second, &first)
+        };
+    assert!(matches!(
+        alice.ingest(lowest.clone()).await.unwrap(),
+        IngestOutcome::Processed
+    ));
+    assert!(matches!(
+        alice.ingest(alternative.clone()).await.unwrap(),
+        IngestOutcome::Processed
+    ));
+
+    // Carol sees only the higher-digest alternative and validly references it.
+    assert!(matches!(
+        carol.ingest(alternative.clone()).await.unwrap(),
+        IngestOutcome::Processed
+    ));
+    advance_selfremove_auto_commit(&mut carol, &group_id).await;
+    let mut peer_publish = carol.drain_auto_publish();
+    assert_eq!(peer_publish.len(), 1);
+    let peer_publish = peer_publish.remove(0);
+    let peer_commit = peer_publish.msg.clone();
+    carol.confirm_published(peer_publish.pending).await.unwrap();
+
+    // Alice's own local rule would choose `lowest`, but the peer's valid
+    // alternative remains retained for proposal-reference replay.
+    assert!(matches!(
+        alice.ingest(peer_commit).await.unwrap(),
+        IngestOutcome::Buffered { .. }
+    ));
+    converge_buffered_commit(&mut alice, &group_id);
+    assert!(
+        alice
+            .members(&group_id)
+            .unwrap()
+            .iter()
+            .all(|member| member.id != bob.self_id()),
+        "peer commit referencing the non-selected alternative must remove bob"
+    );
+}
+
+#[tokio::test]
+async fn multiple_leavers_stage_one_selfremove_only_commit_excluding_unrelated_proposals() {
+    let (mut alice, alice_storage) = build_with_storage(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let (mut carol, carol_storage) = build_with_storage(b"carol");
+    let (mut dave, dave_storage) = build_with_storage(b"dave");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let dave_kp = dave.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "selfremove multiple leaves".into(),
+            description: String::new(),
+            members: vec![bob_kp, carol_kp, dave_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let mut welcomes = match create {
+        SendResult::GroupCreated { pending, welcomes } => {
+            alice.confirm_published(pending).await.unwrap();
+            welcomes
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcomes.remove(0)).await.unwrap();
+    carol.join_welcome(welcomes.remove(0)).await.unwrap();
+    dave.join_welcome(welcomes.remove(0)).await.unwrap();
+
+    let unrelated = raw_self_update_proposal(&dave_storage, &dave.self_id(), &group_id);
+    let bob_leave = raw_self_remove_proposal(&bob_storage, &bob.self_id(), &group_id, b"bob-leave");
+    let carol_leave =
+        raw_self_remove_proposal(&carol_storage, &carol.self_id(), &group_id, b"carol-leave");
+    for proposal in [unrelated, bob_leave, carol_leave] {
+        assert!(matches!(
+            alice.ingest(proposal).await.unwrap(),
+            IngestOutcome::Processed
+        ));
+    }
+    advance_selfremove_auto_commit(&mut alice, &group_id).await;
+
+    let crypto = RustCrypto::default();
+    let provider =
+        EngineOpenMlsProvider::<SqliteAccountStorage>::new(&crypto, alice_storage.mls_storage());
+    let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let group = MlsGroup::load(provider.storage(), &mls_gid)
+        .unwrap()
+        .unwrap();
+    let staged = group.pending_commit().expect("SelfRemove commit staged");
+    let proposals: Vec<_> = staged.queued_proposals().collect();
+    assert_eq!(proposals.len(), 2);
+    assert!(
+        proposals
+            .iter()
+            .all(|queued| matches!(queued.proposal(), Proposal::SelfRemove))
+    );
+}
+
+#[tokio::test]
 async fn selfremove_full_flow_with_auto_commit() {
     // MIP-03 end-to-end (post-§149):
     //   alice creates group with bob + carol, confirms; both join via welcome
@@ -2542,6 +2876,13 @@ async fn selfremove_auto_commit_publish_failed_rolls_back_projection() {
     assert!(
         !emits_departure_of(&events, &bob.self_id()),
         "failed auto-publish must not emit a departure; got {events:?}"
+    );
+
+    advance_selfremove_auto_commit(&mut alice, &group_id).await;
+    assert_eq!(
+        alice.drain_auto_publish().len(),
+        1,
+        "publish failure must leave the retained SelfRemove eligible for retry"
     );
 }
 


### PR DESCRIPTION
## Summary

Implements the adopted SelfRemove local-commit preparation contract from [`protocol-core/member-departure.md`, “SelfRemove commits”](https://github.com/marmot-protocol/marmot/blob/dedeaf429a6f52a4f1c62f3e992be012dab61b7b/protocol-core/member-departure.md#selfremove-commits).

- Selects the proposal with the lexicographically lowest `SHA-256(serialized_proposal_mls_message)` for each leaving leaf/source epoch.
- Rebuilds the selection from retained wire messages, so it is independent of arrival order, map order, timing, local identity, and restart.
- Stages only revalidated SelfRemove proposals. Selected proposals for multiple distinct leaves may share one commit; unrelated pending proposals cannot leak into it.
- Keeps every non-selected valid alternative retained for inbound proposal-reference resolution.
- Restores retry scheduling after restart and publish rollback while preserving publish-before-apply behavior.
- Leaves randomized per-member jitter, ordinary competing-commit convergence, and convergence scoring unchanged.

## Correction to the former issue wording

The adopted specification does **not** elect one deterministic SelfRemove committer, does **not** require every eligible SelfRemove to be batched, and does **not** make a valid unselected alternative stale. This PR implements deterministic *local proposal selection per leaving leaf/source epoch* only. Issue #1054 has been rewritten to match that contract.

## Test mapping

| Contract | Coverage |
| --- | --- |
| Lowest complete-MLSMessage digest; arrival-order independence | `auto_committer::tests::self_remove_selection_is_lowest_digest_per_leaf_for_every_arrival_order`; `selfremove_local_selection_uses_lowest_complete_message_digest_after_restart` |
| Non-selected alternative remains consumable by a peer commit | `non_selected_selfremove_alternative_remains_processable_by_peer_commit` |
| Byte-identical repeats remain duplicates | `selfremove_local_selection_uses_lowest_complete_message_digest_after_restart` |
| Multiple leaves; SelfRemove-only shape; unrelated proposal excluded | `multiple_leavers_stage_one_selfremove_only_commit_excluding_unrelated_proposals` |
| Leaver cannot commit its own proposal | existing `self_remove_committer_must_not_be_leaver` coverage in `mip03_guards` |
| Active-admin/last-admin protection | existing `admin_cannot_self_remove_*` and auto-committer guard coverage in `mip03_guards` |
| Competing committers use ordinary convergence | existing `add_then_self_remove_via_harness` canonical simulator scenario |
| Publish rollback retains retryable work | enhanced `selfremove_auto_commit_publish_failed_rolls_back_projection` |
| Restart selection is stable and does not duplicate commits | `selfremove_local_selection_uses_lowest_complete_message_digest_after_restart` |

## Validation

- `cargo fmt --check`
- `cargo test -p cgka-engine --features test-policy-overrides`
- `cargo test -p cgka-engine --test convergence_policy_pin --locked`
- `cargo test -p cgka-conformance-simulator`
- `just fast-ci`

The literal default-feature `cargo test -p cgka-engine` still encounters the existing `deferred_peel_lifecycle` fixture mismatch: those tests install a non-pinned convergence policy without enabling `test-policy-overrides`. The same seven failures reproduce on clean `origin/master` at `1d6b9f1d`; the repository’s broader engine/CI test matrix explicitly enables that feature, while the separate locked pin test above verifies the default policy gate.

Refs #1054