### PR TITLE
Verify all convergence selector rules and account witness dedupe

### DIFF
--- a/crates/cgka-conformance-simulator/src/bin/cgka-policy-casegen.rs
+++ b/crates/cgka-conformance-simulator/src/bin/cgka-policy-casegen.rs
@@ -3,7 +3,7 @@ use std::fs;
 
 use cgka_conformance_simulator::convergence::ConvergencePolicy;
 use cgka_conformance_simulator::policy_cases::{
-    PolicyCase, digest_rank, parse_policy_cases, reason_against,
+    PolicyCase, committer_rank, digest_rank, parse_policy_cases, priority_rank, reason_against,
 };
 
 fn main() {
@@ -90,16 +90,28 @@ fn print_tamarin(cases: &[PolicyCase]) {
         for candidate in &candidates {
             let score = candidate.score(&policy);
             println!(
-                "    Score(~run, '{}', '{}', '{}', '{}', '{}', '{}'),",
+                "    Score(~run, '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}'),",
                 candidate.id,
                 depth(score.valid_commit_depth),
                 depth(score.effective_commit_depth),
                 quorum(score.witness_quorum_met),
                 witness(score.app_witness_score),
+                priority_rank(score.tip_priority),
+                committer_rank(&score.tip_committer),
                 digest_rank(&score.tip_digest)
             );
         }
         match reason {
+            "priority_tie" => println!(
+                "    PriorityLower(~run, '{}', '{}')",
+                priority_rank(winner_score.tip_priority),
+                priority_rank(loser_score.tip_priority)
+            ),
+            "committer_tie" => println!(
+                "    CommitterLower(~run, '{}', '{}')",
+                committer_rank(&winner_score.tip_committer),
+                committer_rank(&loser_score.tip_committer)
+            ),
             "digest_tie" => println!(
                 "    DigestLower(~run, '{}', '{}')",
                 digest_rank(&winner_score.tip_digest),
@@ -133,16 +145,28 @@ fn print_tamarin(cases: &[PolicyCase]) {
         for candidate in &candidates {
             let score = candidate.score(&policy);
             println!(
-                "    !ScoreState(~run, '{}', '{}', '{}', '{}', '{}', '{}'),",
+                "    !ScoreState(~run, '{}', '{}', '{}', '{}', '{}', '{}', '{}', '{}'),",
                 candidate.id,
                 depth(score.valid_commit_depth),
                 depth(score.effective_commit_depth),
                 quorum(score.witness_quorum_met),
                 witness(score.app_witness_score),
+                priority_rank(score.tip_priority),
+                committer_rank(&score.tip_committer),
                 digest_rank(&score.tip_digest)
             );
         }
         match reason {
+            "priority_tie" => println!(
+                "    !PriorityLtState(~run, '{}', '{}')",
+                priority_rank(winner_score.tip_priority),
+                priority_rank(loser_score.tip_priority)
+            ),
+            "committer_tie" => println!(
+                "    !CommitterLtState(~run, '{}', '{}')",
+                committer_rank(&winner_score.tip_committer),
+                committer_rank(&loser_score.tip_committer)
+            ),
             "digest_tie" => println!(
                 "    !DigestLtState(~run, '{}', '{}')",
                 digest_rank(&winner_score.tip_digest),

--- a/crates/cgka-conformance-simulator/src/policy_cases.rs
+++ b/crates/cgka-conformance-simulator/src/policy_cases.rs
@@ -155,6 +155,17 @@ pub fn digest_rank(digest: &[u8; 32]) -> &'static str {
     }
 }
 
+pub fn priority_rank(priority: CommitOrderingPriority) -> &'static str {
+    match priority {
+        CommitOrderingPriority::Privileged => "p0",
+        CommitOrderingPriority::Ordinary => "p1",
+    }
+}
+
+pub fn committer_rank(committer: &[u8]) -> String {
+    format!("c{}", hex::encode(committer))
+}
+
 fn digest_from_rank(rank: &str) -> [u8; 32] {
     match rank {
         "00" | "g00" => [0x00; 32],

--- a/crates/cgka-conformance-simulator/tests/generated_policy_cases.rs
+++ b/crates/cgka-conformance-simulator/tests/generated_policy_cases.rs
@@ -46,6 +46,45 @@ fn generated_policy_cases_match_selector() {
     }
 }
 
+#[test]
+fn generated_priority_tie_matches_selector_before_digest() {
+    assert_named_pre_digest_case("priority_tie", "privileged", "priority_tie");
+}
+
+#[test]
+fn generated_committer_tie_matches_selector_before_digest() {
+    assert_named_pre_digest_case("committer_tie", "lower_committer", "committer_tie");
+}
+
+fn assert_named_pre_digest_case(name: &str, expected_branch: &str, expected_reason: &str) {
+    let case = parse_policy_cases(POLICY_CASES_JSON)
+        .into_iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("missing generated policy case {name:?}"));
+    let policy = ConvergencePolicy::from(&case.policy);
+    let candidates: Vec<BranchCandidate> = case
+        .branches
+        .iter()
+        .map(|branch| branch.to_candidate())
+        .collect();
+    let winner = select_canonical_branch(case.current_tip_epoch, &candidates, &policy)
+        .expect("named case selects a branch");
+    let loser = candidates
+        .iter()
+        .find(|candidate| candidate.id != winner.id)
+        .expect("named case has a loser");
+
+    assert_eq!(winner.id, expected_branch);
+    assert_eq!(
+        reason_against(&winner.score(&policy), &loser.score(&policy)),
+        expected_reason
+    );
+    assert!(
+        winner.tip_digest > loser.tip_digest,
+        "digest must favor the loser so the preceding rule is proven decisive"
+    );
+}
+
 fn candidate_orders(candidates: &[BranchCandidate]) -> Vec<Vec<BranchCandidate>> {
     let mut orders = vec![candidates.to_vec()];
     let mut reversed = candidates.to_vec();

--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -693,6 +693,268 @@ async fn openmls_canonicalization_uses_app_messages_as_branch_witnesses() {
 }
 
 #[tokio::test]
+async fn multi_device_account_witness_deduplication_uses_real_openmls_leaves() {
+    let bus = TransportBus::ordered();
+    let shared_account_seed = pad32(b"shared-account");
+    let mut device_a = ClientBuilder::new(shared_account_seed.clone())
+        .registry(selfremove_registry())
+        .protocol_profile(ProtocolProfile::Current)
+        .attach(&bus);
+    let mut device_b = ClientBuilder::new(shared_account_seed)
+        .registry(selfremove_registry())
+        .protocol_profile(ProtocolProfile::Current)
+        .attach(&bus);
+    let mut other_account = ClientBuilder::new(pad32(b"other-account"))
+        .registry(selfremove_registry())
+        .protocol_profile(ProtocolProfile::Current)
+        .attach(&bus);
+    let mut competitor = ClientBuilder::new(pad32(b"competitor"))
+        .registry(selfremove_registry())
+        .protocol_profile(ProtocolProfile::Current)
+        .attach(&bus);
+    let mut observer = ClientBuilder::new(pad32(b"observer"))
+        .registry(selfremove_registry())
+        .protocol_profile(ProtocolProfile::Current)
+        .attach(&bus);
+    let mut app_invitee = ClientBuilder::new(pad32(b"app-invitee"))
+        .registry(selfremove_registry())
+        .protocol_profile(ProtocolProfile::Current)
+        .attach(&bus);
+    let mut quiet_invitee = ClientBuilder::new(pad32(b"quiet-invitee"))
+        .registry(selfremove_registry())
+        .protocol_profile(ProtocolProfile::Current)
+        .attach(&bus);
+
+    assert_eq!(
+        device_a.member_id(),
+        device_b.member_id(),
+        "the two devices intentionally share one Marmot account credential"
+    );
+    let device_b_kp = device_b.fresh_key_package().await;
+    let other_account_kp = other_account.fresh_key_package().await;
+    let competitor_kp = competitor.fresh_key_package().await;
+    let observer_kp = observer.fresh_key_package().await;
+    let (group_id, pending) = device_a
+        .create_group_with_admins_maybe_pending(
+            "multi-device-account-witness-dedupe",
+            vec![device_b_kp, other_account_kp, competitor_kp, observer_kp],
+            vec![],
+            vec![competitor.member_id()],
+        )
+        .await;
+    assert!(
+        pending.is_none(),
+        "current-profile founding creation is immediately stable"
+    );
+    bus.deliver_all();
+    for client in [
+        &mut device_b,
+        &mut other_account,
+        &mut competitor,
+        &mut observer,
+    ] {
+        let outcomes = client.tick().await;
+        assert!(
+            outcomes.iter().all(Result::is_ok),
+            "client joins the shared base group: {outcomes:?}"
+        );
+    }
+
+    let base_epoch = observer.epoch().0;
+    let observer_members = observer.members();
+    let shared_account_leaves: Vec<_> = observer_members
+        .iter()
+        .filter(|member| member.id == device_a.member_id())
+        .collect();
+    assert_eq!(
+        shared_account_leaves.len(),
+        2,
+        "the base group must contain two MLS leaves for the shared account"
+    );
+    assert_ne!(
+        shared_account_leaves[0].credential, shared_account_leaves[1].credential,
+        "the shared-account leaves retain distinct MLS signature keys"
+    );
+
+    let shared_history = device_b
+        .send_app_capture(b"shared history before the fork".to_vec())
+        .await;
+    let shared_history = openmls_projection_message(&device_b, &shared_history).await;
+    assert_eq!(
+        project_mls_message(&shared_history.payload)
+            .expect("shared-history app projects")
+            .source_epoch,
+        Some(base_epoch),
+        "the control message is at the fork epoch and must not witness either branch"
+    );
+
+    let app_invitee_kp = app_invitee.fresh_key_package().await;
+    let quiet_invitee_kp = quiet_invitee.fresh_key_package().await;
+    let app_pending = device_a.invite(vec![app_invitee_kp]).await;
+    let _quiet_pending = competitor.invite(vec![quiet_invitee_kp]).await;
+    let commit_messages = queued_commit_messages(&observer, &bus).await;
+    assert_eq!(
+        commit_messages.len(),
+        2,
+        "the setup creates two branch tips"
+    );
+
+    let wrapped_app_commit = bus
+        .queued_messages()
+        .into_iter()
+        .find(|message| message.id == commit_messages[0].id)
+        .expect("wrapped app-branch commit remains queued");
+    device_a.confirm(app_pending).await;
+    for client in [&mut device_b, &mut other_account] {
+        bus.inject(client.bus_id, wrapped_app_commit.clone());
+        let outcomes = client.tick().await;
+        assert!(
+            outcomes.iter().all(Result::is_ok),
+            "peer advances onto the app branch: {outcomes:?}"
+        );
+        assert_eq!(client.epoch().0, base_epoch + 1);
+    }
+
+    let device_b_app = device_b
+        .send_app_capture(b"shared account device B".to_vec())
+        .await;
+    let device_b_app = openmls_projection_message(&device_b, &device_b_app).await;
+    let device_a_app = device_a
+        .send_app_capture(b"shared account device A".to_vec())
+        .await;
+    let device_a_app = openmls_projection_message(&device_a, &device_a_app).await;
+    let other_account_app = other_account
+        .send_app_capture(b"different account witness".to_vec())
+        .await;
+    let other_account_app = openmls_projection_message(&other_account, &other_account_app).await;
+
+    let canonicalize = |pending_messages: Vec<TransportMessage>| {
+        canonicalize_openmls_batch(
+            observer.storage(),
+            &group_id,
+            OpenMlsCanonicalizationBatch {
+                state: CanonicalizationState {
+                    current_tip_epoch: base_epoch,
+                    retained_anchor_epoch: base_epoch,
+                    last_convergence_relevant_input_ms: 0,
+                    seen_message_ids: BTreeSet::new(),
+                },
+                candidate_paths: vec![
+                    OpenMlsCandidatePath {
+                        branch_id: "same-account-branch".into(),
+                        messages: vec![commit_messages[0].clone()],
+                    },
+                    OpenMlsCandidatePath {
+                        branch_id: "quiet-branch".into(),
+                        messages: vec![commit_messages[1].clone()],
+                    },
+                ],
+                pending_messages,
+                already_delivered_app_ids: BTreeSet::new(),
+                outbound_intents: vec![],
+                policy: base_test_policy(),
+                now_ms: 2_000,
+            },
+        )
+        .expect("real OpenMLS canonicalization succeeds")
+    };
+
+    let device_b_first = canonicalize(vec![
+        shared_history.clone(),
+        device_b_app.clone(),
+        device_a_app.clone(),
+    ]);
+    let device_a_first = canonicalize(vec![
+        device_a_app.clone(),
+        shared_history.clone(),
+        device_b_app.clone(),
+    ]);
+    for result in [&device_b_first, &device_a_first] {
+        let trace = result
+            .selection_trace
+            .as_ref()
+            .expect("selection trace is recorded");
+        let candidate = trace
+            .candidates
+            .iter()
+            .find(|candidate| candidate.branch_id == "same-account-branch")
+            .expect("app branch is traced");
+        assert_eq!(candidate.app_witnesses.len(), 2);
+        assert_eq!(
+            candidate.score.app_witness_score, 1,
+            "two real leaves of one account count once"
+        );
+        assert!(
+            !candidate.score.witness_quorum_met,
+            "one distinct account cannot satisfy a two-account quorum"
+        );
+        assert_eq!(
+            result.selected_branch_id.as_deref(),
+            Some("same-account-branch")
+        );
+        assert_eq!(
+            trace
+                .rule_trace
+                .iter()
+                .find(|rule| rule.decisive)
+                .map(|rule| rule.rule_name),
+            Some("app_witness_score")
+        );
+    }
+    assert_eq!(
+        device_b_first.selection_trace, device_a_first.selection_trace,
+        "delivery order and which same-account device arrives first do not change selection"
+    );
+
+    let with_other_account = canonicalize(vec![
+        shared_history,
+        device_b_app,
+        other_account_app,
+        device_a_app,
+    ]);
+    let trace = with_other_account
+        .selection_trace
+        .as_ref()
+        .expect("selection trace is recorded");
+    let candidate = trace
+        .candidates
+        .iter()
+        .find(|candidate| candidate.branch_id == "same-account-branch")
+        .expect("app branch is traced");
+    assert_eq!(
+        candidate.app_witnesses.len(),
+        3,
+        "the fork-epoch shared-history message is excluded from branch witnesses"
+    );
+    assert_eq!(
+        candidate.score.app_witness_score, 2,
+        "a genuinely different account increases the witness score"
+    );
+    assert!(
+        candidate.score.witness_quorum_met,
+        "two distinct accounts satisfy the configured quorum"
+    );
+    assert_eq!(
+        with_other_account.selected_branch_id.as_deref(),
+        Some("same-account-branch")
+    );
+    assert_eq!(
+        trace
+            .rule_trace
+            .iter()
+            .find(|rule| rule.decisive)
+            .map(|rule| rule.rule_name),
+        Some("effective_commit_depth"),
+        "quorum boost is the first decisive selector field"
+    );
+    assert_eq!(
+        observer.epoch().0,
+        base_epoch,
+        "projection probes leave the retained observer state untouched"
+    );
+}
+
+#[tokio::test]
 async fn stored_openmls_messages_reconstruct_canonicalization_batch() {
     let bus = TransportBus::ordered();
     let mut alice = ClientBuilder::new(pad32(b"alice"))

--- a/formal/tamarin/README.md
+++ b/formal/tamarin/README.md
@@ -137,6 +137,8 @@ The v0 model now uses bounded symbolic score classes instead of an opaque `Score
 dN       commit-depth or effective-depth class
 wN       app-witness score class
 qyes/qno witness quorum class
+p0/p1    commit-priority rank class, where lower wins
+cHEX     authenticated-committer rank class, where lower wins
 g00/gff  digest rank class, where lower wins final ties
 ```
 
@@ -146,7 +148,9 @@ The derivation rules mirror the selector order:
 2. quorum tie,
 3. higher raw commit depth,
 4. higher app-witness score,
-5. lower digest rank.
+5. lower/preferred commit-priority rank,
+6. lexicographically lower authenticated-committer rank,
+7. lower digest rank.
 
 ## How Proofs Map To Tests
 
@@ -202,6 +206,13 @@ For bounded policy seeds, update `policy_cases.json` first. Then check both cons
 cargo test -p cgka-conformance-simulator --test generated_policy_cases
 cargo run -p cgka-conformance-simulator --bin cgka-policy-casegen -- --format tamarin formal/tamarin/policy_cases.json
 ```
+
+The seven-rule adjacency cases stay grep-aligned across both consumers:
+
+- `generated_priority_tie` / `generated_priority_tie_executable` /
+  `generated_priority_tie_matches_selector_before_digest`
+- `generated_committer_tie` / `generated_committer_tie_executable` /
+  `generated_committer_tie_matches_selector_before_digest`
 
 Use the executable lemmas as a fixture catalog. Each one says "this situation exists and the system must handle it." Use
 the universal lemmas as property-test targets. For example, `same_input_set_converges` maps to generated branch sets fed

--- a/formal/tamarin/distributed_convergence_v0.spthy
+++ b/formal/tamarin/distributed_convergence_v0.spthy
@@ -12,6 +12,8 @@
     dN: commit-depth or effective-depth class
     wN: app-witness score class
     qyes/qno: witness quorum class
+    p0/p1: commit-priority rank class, where lower rank wins
+    cHEX: authenticated-committer rank class, where lower rank wins
     g00/gff: digest rank class, where lower rank wins final ties
 
   The ordering facts are scenario-local so this model stays small and focused.
@@ -41,8 +43,8 @@ rule Init_Quorum_Override:
     Eligible(~run, 'withheld'),
     QuorumMet(~run, 'online'),
     BoostAllowed(~run, 'online'),
-    Score(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'gff'),
-    Score(~run, 'withheld', 'd5', 'd5', 'qno', 'w0', 'g00')
+    Score(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'p1', 'c00', 'gff'),
+    Score(~run, 'withheld', 'd5', 'd5', 'qno', 'w0', 'p1', 'c00', 'g00')
   ]->
   [
     Compare(~run, 'online', 'withheld'),
@@ -54,8 +56,8 @@ rule Init_Quorum_Override:
     !EligibleState(~run, 'withheld'),
     !QuorumState(~run, 'online'),
     !BoostAllowedState(~run, 'online'),
-    !ScoreState(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'gff'),
-    !ScoreState(~run, 'withheld', 'd5', 'd5', 'qno', 'w0', 'g00')
+    !ScoreState(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'p1', 'c00', 'gff'),
+    !ScoreState(~run, 'withheld', 'd5', 'd5', 'qno', 'w0', 'p1', 'c00', 'g00')
   ]
 
 /*
@@ -75,8 +77,8 @@ rule Init_Raw_Depth_Lead:
     Eligible(~run, 'withheld'),
     QuorumMet(~run, 'online'),
     BoostAllowed(~run, 'online'),
-    Score(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'gff'),
-    Score(~run, 'withheld', 'd6', 'd6', 'qno', 'w0', 'g00'),
+    Score(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'p1', 'c00', 'gff'),
+    Score(~run, 'withheld', 'd6', 'd6', 'qno', 'w0', 'p1', 'c00', 'g00'),
     ScoreGreater(~run, 'd6', 'd5')
   ]->
   [
@@ -89,8 +91,8 @@ rule Init_Raw_Depth_Lead:
     !EligibleState(~run, 'withheld'),
     !QuorumState(~run, 'online'),
     !BoostAllowedState(~run, 'online'),
-    !ScoreState(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'gff'),
-    !ScoreState(~run, 'withheld', 'd6', 'd6', 'qno', 'w0', 'g00'),
+    !ScoreState(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'p1', 'c00', 'gff'),
+    !ScoreState(~run, 'withheld', 'd6', 'd6', 'qno', 'w0', 'p1', 'c00', 'g00'),
     !GtState(~run, 'd6', 'd5')
   ]
 
@@ -109,8 +111,8 @@ rule Init_Witness_Score_Tie:
     PolicyLoaded(~run, 'group', 'default_policy'),
     Eligible(~run, 'used'),
     Eligible(~run, 'quiet'),
-    Score(~run, 'used', 'd2', 'd2', 'qno', 'w3', 'gff'),
-    Score(~run, 'quiet', 'd2', 'd2', 'qno', 'w1', 'g00'),
+    Score(~run, 'used', 'd2', 'd2', 'qno', 'w3', 'p1', 'c00', 'gff'),
+    Score(~run, 'quiet', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'g00'),
     ScoreGreater(~run, 'w3', 'w1')
   ]->
   [
@@ -121,8 +123,8 @@ rule Init_Witness_Score_Tie:
     !PolicyLoadedState(~run),
     !EligibleState(~run, 'used'),
     !EligibleState(~run, 'quiet'),
-    !ScoreState(~run, 'used', 'd2', 'd2', 'qno', 'w3', 'gff'),
-    !ScoreState(~run, 'quiet', 'd2', 'd2', 'qno', 'w1', 'g00'),
+    !ScoreState(~run, 'used', 'd2', 'd2', 'qno', 'w3', 'p1', 'c00', 'gff'),
+    !ScoreState(~run, 'quiet', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'g00'),
     !GtState(~run, 'w3', 'w1')
   ]
 
@@ -141,8 +143,8 @@ rule Init_Digest_Tie:
     PolicyLoaded(~run, 'group', 'default_policy'),
     Eligible(~run, 'lower_digest'),
     Eligible(~run, 'higher_digest'),
-    Score(~run, 'lower_digest', 'd2', 'd2', 'qno', 'w1', 'g00'),
-    Score(~run, 'higher_digest', 'd2', 'd2', 'qno', 'w1', 'gff'),
+    Score(~run, 'lower_digest', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'g00'),
+    Score(~run, 'higher_digest', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'gff'),
     DigestLower(~run, 'g00', 'gff')
   ]->
   [
@@ -153,8 +155,8 @@ rule Init_Digest_Tie:
     !PolicyLoadedState(~run),
     !EligibleState(~run, 'lower_digest'),
     !EligibleState(~run, 'higher_digest'),
-    !ScoreState(~run, 'lower_digest', 'd2', 'd2', 'qno', 'w1', 'g00'),
-    !ScoreState(~run, 'higher_digest', 'd2', 'd2', 'qno', 'w1', 'gff'),
+    !ScoreState(~run, 'lower_digest', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'g00'),
+    !ScoreState(~run, 'higher_digest', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'gff'),
     !DigestLtState(~run, 'g00', 'gff')
   ]
 
@@ -179,8 +181,8 @@ rule Init_Stale_Rewind:
     RewindDistance(~run, 'late', 'd7'),
     RewindLimit(~run, 'd5'),
     RewindTooDeep(~run, 'd7', 'd5'),
-    Score(~run, 'online', 'd3', 'd3', 'qno', 'w2', 'gff'),
-    Score(~run, 'late', 'd7', 'd7', 'qno', 'w0', 'g00'),
+    Score(~run, 'online', 'd3', 'd3', 'qno', 'w2', 'p1', 'c00', 'gff'),
+    Score(~run, 'late', 'd7', 'd7', 'qno', 'w0', 'p1', 'c00', 'g00'),
     ScoreGreater(~run, 'd7', 'd3')
   ]->
   [
@@ -195,8 +197,8 @@ rule Init_Stale_Rewind:
     !RewindDistanceState(~run, 'late', 'd7'),
     !RewindLimitState(~run, 'd5'),
     !RewindTooDeepState(~run, 'd7', 'd5'),
-    !ScoreState(~run, 'online', 'd3', 'd3', 'qno', 'w2', 'gff'),
-    !ScoreState(~run, 'late', 'd7', 'd7', 'qno', 'w0', 'g00'),
+    !ScoreState(~run, 'online', 'd3', 'd3', 'qno', 'w2', 'p1', 'c00', 'gff'),
+    !ScoreState(~run, 'late', 'd7', 'd7', 'qno', 'w0', 'p1', 'c00', 'g00'),
     !GtState(~run, 'd7', 'd3')
   ]
 
@@ -224,8 +226,8 @@ rule Init_Duplicate_Witness_Dedupe:
     DuplicateWitnessIgnored(~run, 'used', 'e2', 'alice'),
     WitnessScore(~run, 'used', 'w2'),
     WitnessScore(~run, 'quiet', 'w1'),
-    Score(~run, 'used', 'd2', 'd2', 'qno', 'w2', 'gff'),
-    Score(~run, 'quiet', 'd2', 'd2', 'qno', 'w1', 'g00'),
+    Score(~run, 'used', 'd2', 'd2', 'qno', 'w2', 'p1', 'c00', 'gff'),
+    Score(~run, 'quiet', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'g00'),
     ScoreGreater(~run, 'w2', 'w1')
   ]->
   [
@@ -238,8 +240,8 @@ rule Init_Duplicate_Witness_Dedupe:
     !EligibleState(~run, 'quiet'),
     !WitnessScoreState(~run, 'used', 'w2'),
     !WitnessScoreState(~run, 'quiet', 'w1'),
-    !ScoreState(~run, 'used', 'd2', 'd2', 'qno', 'w2', 'gff'),
-    !ScoreState(~run, 'quiet', 'd2', 'd2', 'qno', 'w1', 'g00'),
+    !ScoreState(~run, 'used', 'd2', 'd2', 'qno', 'w2', 'p1', 'c00', 'gff'),
+    !ScoreState(~run, 'quiet', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'g00'),
     !GtState(~run, 'w2', 'w1')
   ]
 
@@ -296,9 +298,9 @@ rule Init_Three_Branch_Permutation:
     Eligible(~run, 'best'),
     Eligible(~run, 'mid'),
     Eligible(~run, 'low'),
-    Score(~run, 'best', 'd4', 'd4', 'qno', 'w1', 'gff'),
-    Score(~run, 'mid', 'd3', 'd3', 'qno', 'w9', 'g00'),
-    Score(~run, 'low', 'd2', 'd2', 'qno', 'w9', 'g00'),
+    Score(~run, 'best', 'd4', 'd4', 'qno', 'w1', 'p1', 'c00', 'gff'),
+    Score(~run, 'mid', 'd3', 'd3', 'qno', 'w9', 'p1', 'c00', 'g00'),
+    Score(~run, 'low', 'd2', 'd2', 'qno', 'w9', 'p1', 'c00', 'g00'),
     ScoreGreater(~run, 'd4', 'd3'),
     ScoreGreater(~run, 'd4', 'd2')
   ]->
@@ -312,9 +314,9 @@ rule Init_Three_Branch_Permutation:
     !EligibleState(~run, 'best'),
     !EligibleState(~run, 'mid'),
     !EligibleState(~run, 'low'),
-    !ScoreState(~run, 'best', 'd4', 'd4', 'qno', 'w1', 'gff'),
-    !ScoreState(~run, 'mid', 'd3', 'd3', 'qno', 'w9', 'g00'),
-    !ScoreState(~run, 'low', 'd2', 'd2', 'qno', 'w9', 'g00'),
+    !ScoreState(~run, 'best', 'd4', 'd4', 'qno', 'w1', 'p1', 'c00', 'gff'),
+    !ScoreState(~run, 'mid', 'd3', 'd3', 'qno', 'w9', 'p1', 'c00', 'g00'),
+    !ScoreState(~run, 'low', 'd2', 'd2', 'qno', 'w9', 'p1', 'c00', 'g00'),
     !GtState(~run, 'd4', 'd3'),
     !GtState(~run, 'd4', 'd2')
   ]
@@ -345,8 +347,8 @@ rule Init_Withheld_Published_After_Anchor:
     RewindDistance(~run, 'late', 'd7'),
     RewindLimit(~run, 'd5'),
     RewindTooDeep(~run, 'd7', 'd5'),
-    Score(~run, 'online', 'd3', 'd3', 'qno', 'w2', 'gff'),
-    Score(~run, 'late', 'd7', 'd7', 'qno', 'w0', 'g00'),
+    Score(~run, 'online', 'd3', 'd3', 'qno', 'w2', 'p1', 'c00', 'gff'),
+    Score(~run, 'late', 'd7', 'd7', 'qno', 'w0', 'p1', 'c00', 'g00'),
     ScoreGreater(~run, 'd7', 'd3')
   ]->
   [
@@ -362,17 +364,16 @@ rule Init_Withheld_Published_After_Anchor:
     !RewindDistanceState(~run, 'late', 'd7'),
     !RewindLimitState(~run, 'd5'),
     !RewindTooDeepState(~run, 'd7', 'd5'),
-    !ScoreState(~run, 'online', 'd3', 'd3', 'qno', 'w2', 'gff'),
-    !ScoreState(~run, 'late', 'd7', 'd7', 'qno', 'w0', 'g00'),
+    !ScoreState(~run, 'online', 'd3', 'd3', 'qno', 'w2', 'p1', 'c00', 'gff'),
+    !ScoreState(~run, 'late', 'd7', 'd7', 'qno', 'w0', 'p1', 'c00', 'g00'),
     !GtState(~run, 'd7', 'd3')
   ]
 
 /*
   Scenario family 11:
 
-  These are hand-written seeds for the bounded cases we eventually want to
-  generate from the Rust policy model. Each case names the expected winner and
-  reason.
+  These bounded cases are generated from policy_cases.json by the Rust policy
+  model. Each case names the expected winner and reason.
 */
 rule Init_Generated_Family_QuorumOverride:
   [ Fr(~run) ]
@@ -387,8 +388,8 @@ rule Init_Generated_Family_QuorumOverride:
     Eligible(~run, 'withheld'),
     QuorumMet(~run, 'online'),
     BoostAllowed(~run, 'online'),
-    Score(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'gff'),
-    Score(~run, 'withheld', 'd5', 'd5', 'qno', 'w0', 'g00'),
+    Score(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'p1', 'c6f6e6c696e65', 'gff'),
+    Score(~run, 'withheld', 'd5', 'd5', 'qno', 'w0', 'p1', 'c7769746868656c64', 'g00'),
     QuorumTieCase(~run, 'online', 'withheld')
   ]->
   [
@@ -400,8 +401,8 @@ rule Init_Generated_Family_QuorumOverride:
     !EligibleState(~run, 'online'),
     !EligibleState(~run, 'withheld'),
     !BoostAllowedState(~run, 'online'),
-    !ScoreState(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'gff'),
-    !ScoreState(~run, 'withheld', 'd5', 'd5', 'qno', 'w0', 'g00'),
+    !ScoreState(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'p1', 'c6f6e6c696e65', 'gff'),
+    !ScoreState(~run, 'withheld', 'd5', 'd5', 'qno', 'w0', 'p1', 'c7769746868656c64', 'g00'),
     !QuorumTieCaseState(~run, 'online', 'withheld')
   ]
 
@@ -416,8 +417,8 @@ rule Init_Generated_Family_QuorumCappedByDepth:
     PolicyLoaded(~run, 'group', 'generated_policy'),
     Eligible(~run, 'online'),
     Eligible(~run, 'withheld'),
-    Score(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'gff'),
-    Score(~run, 'withheld', 'd6', 'd6', 'qno', 'w0', 'g00'),
+    Score(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'p1', 'c6f6e6c696e65', 'gff'),
+    Score(~run, 'withheld', 'd6', 'd6', 'qno', 'w0', 'p1', 'c7769746868656c64', 'g00'),
     ScoreGreater(~run, 'd6', 'd5')
   ]->
   [
@@ -428,8 +429,8 @@ rule Init_Generated_Family_QuorumCappedByDepth:
     !PolicyLoadedState(~run),
     !EligibleState(~run, 'online'),
     !EligibleState(~run, 'withheld'),
-    !ScoreState(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'gff'),
-    !ScoreState(~run, 'withheld', 'd6', 'd6', 'qno', 'w0', 'g00'),
+    !ScoreState(~run, 'online', 'd3', 'd5', 'qyes', 'w6', 'p1', 'c6f6e6c696e65', 'gff'),
+    !ScoreState(~run, 'withheld', 'd6', 'd6', 'qno', 'w0', 'p1', 'c7769746868656c64', 'g00'),
     !GtState(~run, 'd6', 'd5')
   ]
 
@@ -444,8 +445,8 @@ rule Init_Generated_Family_DepthPriority:
     PolicyLoaded(~run, 'group', 'generated_policy'),
     Eligible(~run, 'deep'),
     Eligible(~run, 'chatty'),
-    Score(~run, 'deep', 'd4', 'd4', 'qno', 'w0', 'gff'),
-    Score(~run, 'chatty', 'd3', 'd3', 'qno', 'w3', 'g00'),
+    Score(~run, 'deep', 'd4', 'd4', 'qno', 'w0', 'p1', 'c64656570', 'gff'),
+    Score(~run, 'chatty', 'd3', 'd3', 'qno', 'w3', 'p1', 'c636861747479', 'g00'),
     ScoreGreater(~run, 'd4', 'd3')
   ]->
   [
@@ -456,8 +457,8 @@ rule Init_Generated_Family_DepthPriority:
     !PolicyLoadedState(~run),
     !EligibleState(~run, 'deep'),
     !EligibleState(~run, 'chatty'),
-    !ScoreState(~run, 'deep', 'd4', 'd4', 'qno', 'w0', 'gff'),
-    !ScoreState(~run, 'chatty', 'd3', 'd3', 'qno', 'w3', 'g00'),
+    !ScoreState(~run, 'deep', 'd4', 'd4', 'qno', 'w0', 'p1', 'c64656570', 'gff'),
+    !ScoreState(~run, 'chatty', 'd3', 'd3', 'qno', 'w3', 'p1', 'c636861747479', 'g00'),
     !GtState(~run, 'd4', 'd3')
   ]
 
@@ -472,8 +473,8 @@ rule Init_Generated_Family_WitnessPriority:
     PolicyLoaded(~run, 'group', 'generated_policy'),
     Eligible(~run, 'chatty'),
     Eligible(~run, 'quiet'),
-    Score(~run, 'chatty', 'd2', 'd2', 'qno', 'w3', 'gff'),
-    Score(~run, 'quiet', 'd2', 'd2', 'qno', 'w1', 'g00'),
+    Score(~run, 'chatty', 'd2', 'd2', 'qno', 'w3', 'p1', 'c636861747479', 'gff'),
+    Score(~run, 'quiet', 'd2', 'd2', 'qno', 'w1', 'p1', 'c7175696574', 'g00'),
     ScoreGreater(~run, 'w3', 'w1')
   ]->
   [
@@ -484,9 +485,65 @@ rule Init_Generated_Family_WitnessPriority:
     !PolicyLoadedState(~run),
     !EligibleState(~run, 'chatty'),
     !EligibleState(~run, 'quiet'),
-    !ScoreState(~run, 'chatty', 'd2', 'd2', 'qno', 'w3', 'gff'),
-    !ScoreState(~run, 'quiet', 'd2', 'd2', 'qno', 'w1', 'g00'),
+    !ScoreState(~run, 'chatty', 'd2', 'd2', 'qno', 'w3', 'p1', 'c636861747479', 'gff'),
+    !ScoreState(~run, 'quiet', 'd2', 'd2', 'qno', 'w1', 'p1', 'c7175696574', 'g00'),
     !GtState(~run, 'w3', 'w1')
+  ]
+
+rule Init_Generated_Family_PriorityTie:
+  [ Fr(~run) ]
+--[
+    Scenario(~run, 'generated_priority_tie'),
+    GeneratedBoundedCase(~run, 'priority_tie'),
+    GeneratedExpectedSelection(~run, 'privileged', 'priority_tie'),
+    SameInputSet(~run, 'alice'),
+    SameInputSet(~run, 'bob'),
+    PolicyLoaded(~run, 'group', 'generated_policy'),
+    Eligible(~run, 'privileged'),
+    Eligible(~run, 'ordinary'),
+    Score(~run, 'privileged', 'd2', 'd2', 'qno', 'w1', 'p0', 'c7a', 'gff'),
+    Score(~run, 'ordinary', 'd2', 'd2', 'qno', 'w1', 'p1', 'c61', 'g00'),
+    PriorityLower(~run, 'p0', 'p1')
+  ]->
+  [
+    Compare(~run, 'privileged', 'ordinary'),
+    Compare(~run, 'ordinary', 'privileged'),
+    View(~run, 'alice', 'privileged', 'ordinary'),
+    View(~run, 'bob', 'ordinary', 'privileged'),
+    !PolicyLoadedState(~run),
+    !EligibleState(~run, 'privileged'),
+    !EligibleState(~run, 'ordinary'),
+    !ScoreState(~run, 'privileged', 'd2', 'd2', 'qno', 'w1', 'p0', 'c7a', 'gff'),
+    !ScoreState(~run, 'ordinary', 'd2', 'd2', 'qno', 'w1', 'p1', 'c61', 'g00'),
+    !PriorityLtState(~run, 'p0', 'p1')
+  ]
+
+rule Init_Generated_Family_CommitterTie:
+  [ Fr(~run) ]
+--[
+    Scenario(~run, 'generated_committer_tie'),
+    GeneratedBoundedCase(~run, 'committer_tie'),
+    GeneratedExpectedSelection(~run, 'lower_committer', 'committer_tie'),
+    SameInputSet(~run, 'alice'),
+    SameInputSet(~run, 'bob'),
+    PolicyLoaded(~run, 'group', 'generated_policy'),
+    Eligible(~run, 'lower_committer'),
+    Eligible(~run, 'higher_committer'),
+    Score(~run, 'lower_committer', 'd2', 'd2', 'qno', 'w1', 'p1', 'c61', 'gff'),
+    Score(~run, 'higher_committer', 'd2', 'd2', 'qno', 'w1', 'p1', 'c7a', 'g00'),
+    CommitterLower(~run, 'c61', 'c7a')
+  ]->
+  [
+    Compare(~run, 'lower_committer', 'higher_committer'),
+    Compare(~run, 'higher_committer', 'lower_committer'),
+    View(~run, 'alice', 'lower_committer', 'higher_committer'),
+    View(~run, 'bob', 'higher_committer', 'lower_committer'),
+    !PolicyLoadedState(~run),
+    !EligibleState(~run, 'lower_committer'),
+    !EligibleState(~run, 'higher_committer'),
+    !ScoreState(~run, 'lower_committer', 'd2', 'd2', 'qno', 'w1', 'p1', 'c61', 'gff'),
+    !ScoreState(~run, 'higher_committer', 'd2', 'd2', 'qno', 'w1', 'p1', 'c7a', 'g00'),
+    !CommitterLtState(~run, 'c61', 'c7a')
   ]
 
 rule Init_Generated_Family_DigestPriority:
@@ -500,8 +557,8 @@ rule Init_Generated_Family_DigestPriority:
     PolicyLoaded(~run, 'group', 'generated_policy'),
     Eligible(~run, 'low_digest'),
     Eligible(~run, 'high_digest'),
-    Score(~run, 'low_digest', 'd2', 'd2', 'qno', 'w1', 'g00'),
-    Score(~run, 'high_digest', 'd2', 'd2', 'qno', 'w1', 'gff'),
+    Score(~run, 'low_digest', 'd2', 'd2', 'qno', 'w1', 'p1', 'c73616d65', 'g00'),
+    Score(~run, 'high_digest', 'd2', 'd2', 'qno', 'w1', 'p1', 'c73616d65', 'gff'),
     DigestLower(~run, 'g00', 'gff')
   ]->
   [
@@ -512,8 +569,8 @@ rule Init_Generated_Family_DigestPriority:
     !PolicyLoadedState(~run),
     !EligibleState(~run, 'low_digest'),
     !EligibleState(~run, 'high_digest'),
-    !ScoreState(~run, 'low_digest', 'd2', 'd2', 'qno', 'w1', 'g00'),
-    !ScoreState(~run, 'high_digest', 'd2', 'd2', 'qno', 'w1', 'gff'),
+    !ScoreState(~run, 'low_digest', 'd2', 'd2', 'qno', 'w1', 'p1', 'c73616d65', 'g00'),
+    !ScoreState(~run, 'high_digest', 'd2', 'd2', 'qno', 'w1', 'p1', 'c73616d65', 'gff'),
     !DigestLtState(~run, 'g00', 'gff')
   ]
 
@@ -542,8 +599,8 @@ rule Init_Retained_Anchor_Within_Horizon:
     SameInputSet(~run, 'bob'),
     Eligible(~run, 'online'),
     Eligible(~run, 'late'),
-    Score(~run, 'online', 'd2', 'd2', 'qno', 'w1', 'gff'),
-    Score(~run, 'late', 'd2', 'd2', 'qno', 'w1', 'g00'),
+    Score(~run, 'online', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'gff'),
+    Score(~run, 'late', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'g00'),
     DigestLower(~run, 'g00', 'gff')
   ]->
   [
@@ -560,8 +617,8 @@ rule Init_Retained_Anchor_Within_Horizon:
     !BranchAtOrAfterAnchorState(~run, 'late', 'e1'),
     !EligibleState(~run, 'online'),
     !EligibleState(~run, 'late'),
-    !ScoreState(~run, 'online', 'd2', 'd2', 'qno', 'w1', 'gff'),
-    !ScoreState(~run, 'late', 'd2', 'd2', 'qno', 'w1', 'g00'),
+    !ScoreState(~run, 'online', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'gff'),
+    !ScoreState(~run, 'late', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'g00'),
     !DigestLtState(~run, 'g00', 'gff')
   ]
 
@@ -644,8 +701,8 @@ rule Init_Commit_Application_App_Output:
     PolicyLoaded(~run, 'group', 'default_policy'),
     Eligible(~run, 'selected'),
     Eligible(~run, 'losing'),
-    Score(~run, 'selected', 'd2', 'd2', 'qno', 'w1', 'gff'),
-    Score(~run, 'losing', 'd1', 'd1', 'qno', 'w1', 'g00'),
+    Score(~run, 'selected', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'gff'),
+    Score(~run, 'losing', 'd1', 'd1', 'qno', 'w1', 'p1', 'c00', 'g00'),
     ScoreGreater(~run, 'd2', 'd1'),
     AppDecryptsOnBranch(~run, 'app_selected', 'selected'),
     AppDecryptsOnBranch(~run, 'app_losing', 'losing'),
@@ -659,8 +716,8 @@ rule Init_Commit_Application_App_Output:
     !PolicyLoadedState(~run),
     !EligibleState(~run, 'selected'),
     !EligibleState(~run, 'losing'),
-    !ScoreState(~run, 'selected', 'd2', 'd2', 'qno', 'w1', 'gff'),
-    !ScoreState(~run, 'losing', 'd1', 'd1', 'qno', 'w1', 'g00'),
+    !ScoreState(~run, 'selected', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'gff'),
+    !ScoreState(~run, 'losing', 'd1', 'd1', 'qno', 'w1', 'p1', 'c00', 'g00'),
     !GtState(~run, 'd2', 'd1'),
     !AppDecryptsOnBranchState(~run, 'app_selected', 'selected'),
     !AppDecryptsOnBranchState(~run, 'app_losing', 'losing'),
@@ -739,8 +796,8 @@ rule Init_Proposal_Canonical_Consumption:
     PolicyLoaded(~run, 'group', 'default_policy'),
     Eligible(~run, 'selected'),
     Eligible(~run, 'losing'),
-    Score(~run, 'selected', 'd2', 'd2', 'qno', 'w1', 'gff'),
-    Score(~run, 'losing', 'd1', 'd1', 'qno', 'w1', 'g00'),
+    Score(~run, 'selected', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'gff'),
+    Score(~run, 'losing', 'd1', 'd1', 'qno', 'w1', 'p1', 'c00', 'g00'),
     ScoreGreater(~run, 'd2', 'd1'),
     ProposalMessage(~run, 'remove_bob', 'proposal_pending'),
     ProposalMessage(~run, 'losing_remove', 'losing'),
@@ -755,8 +812,8 @@ rule Init_Proposal_Canonical_Consumption:
     !PolicyLoadedState(~run),
     !EligibleState(~run, 'selected'),
     !EligibleState(~run, 'losing'),
-    !ScoreState(~run, 'selected', 'd2', 'd2', 'qno', 'w1', 'gff'),
-    !ScoreState(~run, 'losing', 'd1', 'd1', 'qno', 'w1', 'g00'),
+    !ScoreState(~run, 'selected', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'gff'),
+    !ScoreState(~run, 'losing', 'd1', 'd1', 'qno', 'w1', 'p1', 'c00', 'g00'),
     !GtState(~run, 'd2', 'd1'),
     !ProposalMessageState(~run, 'remove_bob', 'proposal_pending'),
     !ProposalMessageState(~run, 'losing_remove', 'losing'),
@@ -795,8 +852,8 @@ rule Init_Delivery_Order_Robustness:
     PolicyLoaded(~run, 'group', 'default_policy'),
     Eligible(~run, 'selected'),
     Eligible(~run, 'losing'),
-    Score(~run, 'selected', 'd2', 'd2', 'qno', 'w1', 'gff'),
-    Score(~run, 'losing', 'd1', 'd1', 'qno', 'w1', 'g00'),
+    Score(~run, 'selected', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'gff'),
+    Score(~run, 'losing', 'd1', 'd1', 'qno', 'w1', 'p1', 'c00', 'g00'),
     ScoreGreater(~run, 'd2', 'd1'),
     AppDecryptsOnBranch(~run, 'app_selected', 'selected'),
     AppDecryptsOnBranch(~run, 'app_losing', 'losing'),
@@ -815,8 +872,8 @@ rule Init_Delivery_Order_Robustness:
     !PolicyLoadedState(~run),
     !EligibleState(~run, 'selected'),
     !EligibleState(~run, 'losing'),
-    !ScoreState(~run, 'selected', 'd2', 'd2', 'qno', 'w1', 'gff'),
-    !ScoreState(~run, 'losing', 'd1', 'd1', 'qno', 'w1', 'g00'),
+    !ScoreState(~run, 'selected', 'd2', 'd2', 'qno', 'w1', 'p1', 'c00', 'gff'),
+    !ScoreState(~run, 'losing', 'd1', 'd1', 'qno', 'w1', 'p1', 'c00', 'g00'),
     !GtState(~run, 'd2', 'd1'),
     !AppDecryptsOnBranchState(~run, 'app_selected', 'selected'),
     !AppDecryptsOnBranchState(~run, 'app_losing', 'losing'),
@@ -855,8 +912,8 @@ rule Derive_Late_Withheld_Rejection:
 rule Derive_Better_By_Effective_Depth:
   [
     Compare(run, winner, loser),
-    !ScoreState(run, winner, raw_w, effective_w, quorum_w, witness_w, digest_w),
-    !ScoreState(run, loser, raw_l, effective_l, quorum_l, witness_l, digest_l),
+    !ScoreState(run, winner, raw_w, effective_w, quorum_w, witness_w, priority_w, committer_w, digest_w),
+    !ScoreState(run, loser, raw_l, effective_l, quorum_l, witness_l, priority_l, committer_l, digest_l),
     !GtState(run, effective_w, effective_l)
   ]
 --[
@@ -869,8 +926,8 @@ rule Derive_Better_By_Effective_Depth:
 rule Derive_Better_By_Quorum_Tie:
   [
     Compare(run, winner, loser),
-    !ScoreState(run, winner, raw_w, effective, 'qyes', witness_w, digest_w),
-    !ScoreState(run, loser, raw_l, effective, 'qno', witness_l, digest_l),
+    !ScoreState(run, winner, raw_w, effective, 'qyes', witness_w, priority_w, committer_w, digest_w),
+    !ScoreState(run, loser, raw_l, effective, 'qno', witness_l, priority_l, committer_l, digest_l),
     !BoostAllowedState(run, winner)
   ]
 --[
@@ -883,8 +940,8 @@ rule Derive_Better_By_Quorum_Tie:
 rule Derive_Better_By_Raw_Depth_Tie:
   [
     Compare(run, winner, loser),
-    !ScoreState(run, winner, raw_w, effective, quorum, witness_w, digest_w),
-    !ScoreState(run, loser, raw_l, effective, quorum, witness_l, digest_l),
+    !ScoreState(run, winner, raw_w, effective, quorum, witness_w, priority_w, committer_w, digest_w),
+    !ScoreState(run, loser, raw_l, effective, quorum, witness_l, priority_l, committer_l, digest_l),
     !GtState(run, raw_w, raw_l)
   ]
 --[
@@ -897,8 +954,8 @@ rule Derive_Better_By_Raw_Depth_Tie:
 rule Derive_Better_By_Witness_Score_Tie:
   [
     Compare(run, winner, loser),
-    !ScoreState(run, winner, raw, effective, quorum, witness_w, digest_w),
-    !ScoreState(run, loser, raw, effective, quorum, witness_l, digest_l),
+    !ScoreState(run, winner, raw, effective, quorum, witness_w, priority_w, committer_w, digest_w),
+    !ScoreState(run, loser, raw, effective, quorum, witness_l, priority_l, committer_l, digest_l),
     !GtState(run, witness_w, witness_l)
   ]
 --[
@@ -908,11 +965,39 @@ rule Derive_Better_By_Witness_Score_Tie:
     !BetterState(run, winner, loser, 'witness_score_tie')
   ]
 
+rule Derive_Better_By_Priority_Tie:
+  [
+    Compare(run, winner, loser),
+    !ScoreState(run, winner, raw, effective, quorum, witness, priority_w, committer_w, digest_w),
+    !ScoreState(run, loser, raw, effective, quorum, witness, priority_l, committer_l, digest_l),
+    !PriorityLtState(run, priority_w, priority_l)
+  ]
+--[
+    DerivedBetter(run, winner, loser, 'priority_tie')
+  ]->
+  [
+    !BetterState(run, winner, loser, 'priority_tie')
+  ]
+
+rule Derive_Better_By_Committer_Tie:
+  [
+    Compare(run, winner, loser),
+    !ScoreState(run, winner, raw, effective, quorum, witness, priority, committer_w, digest_w),
+    !ScoreState(run, loser, raw, effective, quorum, witness, priority, committer_l, digest_l),
+    !CommitterLtState(run, committer_w, committer_l)
+  ]
+--[
+    DerivedBetter(run, winner, loser, 'committer_tie')
+  ]->
+  [
+    !BetterState(run, winner, loser, 'committer_tie')
+  ]
+
 rule Derive_Better_By_Digest_Tie:
   [
     Compare(run, winner, loser),
-    !ScoreState(run, winner, raw, effective, quorum, witness, digest_w),
-    !ScoreState(run, loser, raw, effective, quorum, witness, digest_l),
+    !ScoreState(run, winner, raw, effective, quorum, witness, priority, committer, digest_w),
+    !ScoreState(run, loser, raw, effective, quorum, witness, priority, committer, digest_l),
     !DigestLtState(run, digest_w, digest_l)
   ]
 --[
@@ -1465,9 +1550,9 @@ lemma effective_depth_selection_requires_score_order:
   "All run client branch #i.
       Selected(run, client, branch, 'effective_depth') @ #i
     ==> (
-      Ex loser raw_b effective_b quorum_b witness_b digest_b raw_l effective_l quorum_l witness_l digest_l #j #k #m.
-          Score(run, branch, raw_b, effective_b, quorum_b, witness_b, digest_b) @ #j
-        & Score(run, loser, raw_l, effective_l, quorum_l, witness_l, digest_l) @ #k
+      Ex loser raw_b effective_b quorum_b witness_b priority_b committer_b digest_b raw_l effective_l quorum_l witness_l priority_l committer_l digest_l #j #k #m.
+          Score(run, branch, raw_b, effective_b, quorum_b, witness_b, priority_b, committer_b, digest_b) @ #j
+        & Score(run, loser, raw_l, effective_l, quorum_l, witness_l, priority_l, committer_l, digest_l) @ #k
         & ScoreGreater(run, effective_b, effective_l) @ #m
     )"
 
@@ -1475,9 +1560,9 @@ lemma quorum_tie_selection_requires_quorum_and_bound:
   "All run client branch #i.
       Selected(run, client, branch, 'quorum_tie') @ #i
     ==> (
-      Ex loser raw_b effective witness_b digest_b raw_l witness_l digest_l #j #k #m #n.
-          Score(run, branch, raw_b, effective, 'qyes', witness_b, digest_b) @ #j
-        & Score(run, loser, raw_l, effective, 'qno', witness_l, digest_l) @ #k
+      Ex loser raw_b effective witness_b priority_b committer_b digest_b raw_l witness_l priority_l committer_l digest_l #j #k #m #n.
+          Score(run, branch, raw_b, effective, 'qyes', witness_b, priority_b, committer_b, digest_b) @ #j
+        & Score(run, loser, raw_l, effective, 'qno', witness_l, priority_l, committer_l, digest_l) @ #k
         & QuorumMet(run, branch) @ #m
         & BoostAllowed(run, branch) @ #n
     )"
@@ -1486,19 +1571,39 @@ lemma witness_score_selection_requires_score_order:
   "All run client branch #i.
       Selected(run, client, branch, 'witness_score_tie') @ #i
     ==> (
-      Ex loser raw effective quorum witness_b digest_b witness_l digest_l #j #k #m.
-          Score(run, branch, raw, effective, quorum, witness_b, digest_b) @ #j
-        & Score(run, loser, raw, effective, quorum, witness_l, digest_l) @ #k
+      Ex loser raw effective quorum witness_b priority_b committer_b digest_b witness_l priority_l committer_l digest_l #j #k #m.
+          Score(run, branch, raw, effective, quorum, witness_b, priority_b, committer_b, digest_b) @ #j
+        & Score(run, loser, raw, effective, quorum, witness_l, priority_l, committer_l, digest_l) @ #k
         & ScoreGreater(run, witness_b, witness_l) @ #m
+    )"
+
+lemma priority_tie_selection_requires_preceding_equality_and_lower_priority:
+  "All run client branch #i.
+      Selected(run, client, branch, 'priority_tie') @ #i
+    ==> (
+      Ex loser raw effective quorum witness priority_b committer_b digest_b priority_l committer_l digest_l #j #k #m.
+          Score(run, branch, raw, effective, quorum, witness, priority_b, committer_b, digest_b) @ #j
+        & Score(run, loser, raw, effective, quorum, witness, priority_l, committer_l, digest_l) @ #k
+        & PriorityLower(run, priority_b, priority_l) @ #m
+    )"
+
+lemma committer_tie_selection_requires_preceding_equality_and_lower_committer:
+  "All run client branch #i.
+      Selected(run, client, branch, 'committer_tie') @ #i
+    ==> (
+      Ex loser raw effective quorum witness priority committer_b digest_b committer_l digest_l #j #k #m.
+          Score(run, branch, raw, effective, quorum, witness, priority, committer_b, digest_b) @ #j
+        & Score(run, loser, raw, effective, quorum, witness, priority, committer_l, digest_l) @ #k
+        & CommitterLower(run, committer_b, committer_l) @ #m
     )"
 
 lemma digest_tie_selection_requires_lower_digest:
   "All run client branch #i.
       Selected(run, client, branch, 'digest_tie') @ #i
     ==> (
-      Ex loser raw effective quorum witness digest_b digest_l #j #k #m.
-          Score(run, branch, raw, effective, quorum, witness, digest_b) @ #j
-        & Score(run, loser, raw, effective, quorum, witness, digest_l) @ #k
+      Ex loser raw effective quorum witness priority committer digest_b digest_l #j #k #m.
+          Score(run, branch, raw, effective, quorum, witness, priority, committer, digest_b) @ #j
+        & Score(run, loser, raw, effective, quorum, witness, priority, committer, digest_l) @ #k
         & DigestLower(run, digest_b, digest_l) @ #m
 	    )"
 
@@ -1815,6 +1920,18 @@ lemma generated_witness_priority_executable:
   "Ex run #i #j.
       GeneratedBoundedCase(run, 'witness_priority') @ #i
     & Selected(run, 'alice', 'chatty', 'witness_score_tie') @ #j"
+
+lemma generated_priority_tie_executable:
+  exists-trace
+  "Ex run #i #j.
+      GeneratedBoundedCase(run, 'priority_tie') @ #i
+    & Selected(run, 'alice', 'privileged', 'priority_tie') @ #j"
+
+lemma generated_committer_tie_executable:
+  exists-trace
+  "Ex run #i #j.
+      GeneratedBoundedCase(run, 'committer_tie') @ #i
+    & Selected(run, 'alice', 'lower_committer', 'committer_tie') @ #j"
 
 lemma generated_digest_priority_executable:
   exists-trace

--- a/formal/tamarin/policy_cases.json
+++ b/formal/tamarin/policy_cases.json
@@ -148,6 +148,84 @@
     ]
   },
   {
+    "name": "priority_tie",
+    "scenario": "generated_priority_tie",
+    "current_tip_epoch": 2,
+    "policy": {
+      "max_rewind_commits": 5,
+      "witness_quorum_senders_per_epoch": 10,
+      "witness_quorum_epochs": 2,
+      "max_witness_override_depth": 0
+    },
+    "expected": {
+      "branch": "privileged",
+      "reason": "priority_tie"
+    },
+    "branches": [
+      {
+        "id": "privileged",
+        "fork_epoch": 0,
+        "tip_epoch": 2,
+        "tip_priority": "privileged",
+        "tip_committer": "z",
+        "tip_digest": "ff",
+        "app_witnesses": [
+          { "epoch": 2, "sender": "alice" }
+        ]
+      },
+      {
+        "id": "ordinary",
+        "fork_epoch": 0,
+        "tip_epoch": 2,
+        "tip_priority": "ordinary",
+        "tip_committer": "a",
+        "tip_digest": "00",
+        "app_witnesses": [
+          { "epoch": 2, "sender": "alice" }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "committer_tie",
+    "scenario": "generated_committer_tie",
+    "current_tip_epoch": 2,
+    "policy": {
+      "max_rewind_commits": 5,
+      "witness_quorum_senders_per_epoch": 10,
+      "witness_quorum_epochs": 2,
+      "max_witness_override_depth": 0
+    },
+    "expected": {
+      "branch": "lower_committer",
+      "reason": "committer_tie"
+    },
+    "branches": [
+      {
+        "id": "lower_committer",
+        "fork_epoch": 0,
+        "tip_epoch": 2,
+        "tip_priority": "ordinary",
+        "tip_committer": "a",
+        "tip_digest": "ff",
+        "app_witnesses": [
+          { "epoch": 2, "sender": "alice" }
+        ]
+      },
+      {
+        "id": "higher_committer",
+        "fork_epoch": 0,
+        "tip_epoch": 2,
+        "tip_priority": "ordinary",
+        "tip_committer": "z",
+        "tip_digest": "00",
+        "app_witnesses": [
+          { "epoch": 2, "sender": "alice" }
+        ]
+      }
+    ]
+  },
+  {
     "name": "digest_priority",
     "scenario": "generated_digest_priority",
     "current_tip_epoch": 2,


### PR DESCRIPTION
## Summary

This focused verification PR closes the two remaining proof/test fidelity gaps in the convergence-v1 selector tracker.

The executable contract remains unchanged and is linked here: [`compare_scores` orders all seven fields](https://github.com/marmot-protocol/mdk/blob/1d6b9f1d65f8deb897d15a4e300a2443c9179e86/crates/cgka-engine/src/convergence.rs#L138-L146).

Fixes #990
Fixes #991
Related to #1027

## Formal model and generated cases (#990)

- Extends every Tamarin `Score` / `ScoreState` fact with commit-priority and authenticated-committer rank fields.
- Inserts `priority_tie` and `committer_tie` derivations after witness score and before digest.
- Adds all-traces evidence lemmas requiring equality on every preceding score field and strict ordering on the decisive priority/committer field.
- Adds generated bounded cases where digest favors the loser, proving priority and committer decide first.
- Extends `cgka-policy-casegen` to emit the new score fields and comparison facts while preserving the JSON -> generated Tamarin -> generated Rust drift check.
- Documents the complete seven-rule order and the grep-aligned case/lemma/test mapping.

Proof/test mapping:

| Policy case | Tamarin derivation/evidence/reachability | Rust selector regression |
| --- | --- | --- |
| `generated_priority_tie` | `Derive_Better_By_Priority_Tie`, `priority_tie_selection_requires_preceding_equality_and_lower_priority`, `generated_priority_tie_executable` | `generated_priority_tie_matches_selector_before_digest` |
| `generated_committer_tie` | `Derive_Better_By_Committer_Tie`, `committer_tie_selection_requires_preceding_equality_and_lower_committer`, `generated_committer_tie_executable` | `generated_committer_tie_matches_selector_before_digest` |

## Real multi-device regression (#991)

`multi_device_account_witness_deduplication_uses_real_openmls_leaves` uses the existing OpenMLS projection test seam rather than widening the production API or adding a harness identity mode.

Two current-profile harness clients share one real Marmot/Nostr account credential, while separate engine storage creates distinct MLS signature keys. An observer verifies that the group contains two real leaves with the same account `MemberId` and different signature keys. Application messages then travel through the actual OpenMLS replay path, including `Sender::Member` leaf lookup and leaf credential -> account `MemberId` materialization.

The regression proves:

- two post-fork messages from the two devices produce `app_witness_score == 1`;
- they do not satisfy a two-account quorum;
- a genuinely different account raises the score to two and meets quorum;
- a message at the fork epoch is excluded from branch witnesses;
- reversed same-account message delivery preserves the full selection trace;
- the selected branch and decisive rule are `app_witness_score` without quorum and `effective_commit_depth` after the quorum boost.

No draft multi-device `0x800a` component is introduced or exercised.

## Validation

Passed:

- `just policy-casegen` (final rerun left the diff unchanged)
- `cargo test -p cgka-conformance-simulator --test generated_policy_cases`
- `cargo test -p cgka-conformance-simulator --test candidate_state_graph`
- `cargo test -p cgka-conformance-simulator`
- `cargo test -p cgka-engine --features test-policy-overrides`
- `just tamarin` (all new and existing lemmas verified)
- `just fast-ci`
- `git diff --check`

Known baseline command caveat: plain `cargo test -p cgka-engine` reaches seven unchanged `deferred_peel_lifecycle` fixture failures because those tests set a non-pinned convergence policy without the repository's `test-policy-overrides` feature. The same fixture code is present on `origin/master`. The feature-enabled engine suite passes, and `just fast-ci` separately passes the default-build pinned-policy test. Tamarin also prints the same derivation-check timeout warning on `origin/master`; the proof run exits successfully and verifies every lemma.