### PR TITLE
fix(deps): clear active RustSec vulnerabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "apple-native-keyring-store"
@@ -1220,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3421,9 +3421,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.44.2"
+version = "0.44.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa5e3b6a278ed061835fe1ee293b71641e6bf8b401cfe4e1834bbf4ef0a34e1"
+checksum = "0112d3433a5550ba13481970d5b6844714510ddcdaca4d9d0aa6e7b83f270271"
 dependencies = [
  "base64",
  "bech32",
@@ -4370,9 +4370,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/crates/marmot-app/src/notifications/tests.rs
+++ b/crates/marmot-app/src/notifications/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use nostr::secp256k1::{Secp256k1, ecdh::SharedSecret};
+use nostr::secp256k1::{Keypair, Secp256k1, ecdh::SharedSecret};
 
 fn server_secret() -> SecretKey {
     let secp = Secp256k1::new();
@@ -1387,9 +1387,10 @@ fn sign_removal_record_with_event_kind(
 
 fn sign_token_record_raw_legacy(record: &mut GroupPushTokenRecord, keys: &Keys) {
     let message = Message::from_digest(record.signing_digest().unwrap());
+    let keypair = Keypair::from_secret_key(SECP256K1, keys.secret_key());
     record.owner_sig = hex::encode(
         SECP256K1
-            .sign_schnorr_no_aux_rand(&message, keys.key_pair(SECP256K1))
+            .sign_schnorr_no_aux_rand(&message, &keypair)
             .serialize(),
     );
 }
@@ -1400,9 +1401,10 @@ fn sign_removal_record_raw_legacy(
     keys: &Keys,
 ) {
     let message = Message::from_digest(record.signing_digest(group_id_hex).unwrap());
+    let keypair = Keypair::from_secret_key(SECP256K1, keys.secret_key());
     record.owner_sig = hex::encode(
         SECP256K1
-            .sign_schnorr_no_aux_rand(&message, keys.key_pair(SECP256K1))
+            .sign_schnorr_no_aux_rand(&message, &keypair)
             .serialize(),
     );
 }


### PR DESCRIPTION
## Summary

- update `quinn-proto` from 0.11.14 to 0.11.15, fixing RUSTSEC-2026-0185
- update `crossbeam-epoch` from 0.9.18 to 0.9.20, fixing RUSTSEC-2026-0204
- update `anyhow` from 1.0.102 to 1.0.103, clearing the RUSTSEC-2026-0190 unsoundness finding
- update `nostr` from yanked 0.44.2 to non-yanked 0.44.5 and preserve deterministic legacy push-proof test signing with its current API
- track the five remaining unmaintained-only findings in #1116

`cargo audit --json` now reports zero vulnerabilities, zero unsoundness findings, and zero yanked packages. It still reports five unmaintained packages; no audit ignores were added.

## Verification

- `cargo audit --json`
- `just fast-ci`
- `cargo test -p transport-quic-stream --locked`
- `cargo test -p transport-quic-broker --locked`
- `cargo test -p cgka-engine --features test-policy-overrides --locked`
- `cargo test -p cgka-conformance-simulator --test openmls_replay_probe --locked`
- `cargo test -p marmot-app notifications::tests::current_and_legacy_profiles_enforce_the_owner_proof_matrix --locked`
- exact locked CI check/clippy commands for default and all features

## Sensitive scope

The lockfile updates affect the runtime QUIC and OpenMLS/CGKA dependency paths. The only Rust source change is test-only compatibility code for Nostr keypair construction.

Fixes #918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated notification signing test coverage to use the current key construction approach.
  * Preserved validation for token and removal signature flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->