### PR TITLE
fix: complete QUIC preview lifecycle and nonce safety

### DIFF
--- a/crates/agent-connector/src/quic.rs
+++ b/crates/agent-connector/src/quic.rs
@@ -4,6 +4,7 @@ use std::net::SocketAddr;
 
 use cgka_traits::app_components::{is_loopback_candidate_host, reject_non_public_socket_addr};
 use transport_quic_broker::BrokerServerTrust;
+use transport_quic_stream::QuicCandidate;
 
 use crate::error::ConnectorError;
 use crate::with_control_operation_timeout;
@@ -18,33 +19,18 @@ pub(crate) struct ParsedQuicCandidate {
 pub(crate) fn first_quic_candidate(candidates: &[String]) -> Result<String, ConnectorError> {
     candidates
         .iter()
-        .find(|candidate| candidate.trim().starts_with("quic://"))
-        .map(|candidate| candidate.trim().to_owned())
+        .find(|candidate| QuicCandidate::parse(candidate).is_ok())
+        .cloned()
         .ok_or_else(|| ConnectorError::Stream("stream begin requires a quic:// candidate".into()))
 }
 
 pub(crate) fn parse_quic_candidate(candidate: &str) -> Result<ParsedQuicCandidate, ConnectorError> {
-    let trimmed = candidate.trim();
-    let Some(rest) = trimmed.strip_prefix("quic://") else {
-        return Err(ConnectorError::Stream(format!(
-            "invalid QUIC candidate: {trimmed}"
-        )));
-    };
-    // Per transports/quic.md a receiver MUST ignore any path, query, or
-    // fragment after the authority; the authority ends at the first of '/',
-    // '?', or '#'. Mirror the app/CLI parsers so this connector accepts the
-    // same candidates the rest of the stack does.
-    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
-    if authority.is_empty() {
-        return Err(ConnectorError::Stream(format!(
-            "invalid QUIC candidate: {trimmed}"
-        )));
-    }
-    let server_name = candidate_server_name(authority)?;
+    let parsed = QuicCandidate::parse(candidate)
+        .map_err(|_| ConnectorError::Stream("invalid QUIC candidate".to_owned()))?;
     Ok(ParsedQuicCandidate {
-        original: trimmed.to_owned(),
-        authority: authority.to_owned(),
-        server_name,
+        original: parsed.original().to_owned(),
+        authority: parsed.authority().to_owned(),
+        server_name: parsed.host().to_owned(),
     })
 }
 
@@ -82,24 +68,6 @@ pub(crate) async fn resolve_quic_candidate_addr(
         ))
     })?;
     Ok(addr)
-}
-
-pub(crate) fn candidate_server_name(authority: &str) -> Result<String, ConnectorError> {
-    if let Some(rest) = authority.strip_prefix('[') {
-        let Some((host, _)) = rest.split_once(']') else {
-            return Err(ConnectorError::Stream(format!(
-                "invalid QUIC candidate authority: {authority}"
-            )));
-        };
-        return Ok(host.to_owned());
-    }
-    authority
-        .rsplit_once(':')
-        .map(|(host, _)| host.to_owned())
-        .filter(|host| !host.is_empty())
-        .ok_or_else(|| {
-            ConnectorError::Stream(format!("invalid QUIC candidate authority: {authority}"))
-        })
 }
 
 /// Select TLS trust for a broker candidate from configuration and the LITERAL

--- a/crates/agent-connector/src/quic.rs
+++ b/crates/agent-connector/src/quic.rs
@@ -16,14 +16,6 @@ pub(crate) struct ParsedQuicCandidate {
     pub(crate) server_name: String,
 }
 
-pub(crate) fn first_quic_candidate(candidates: &[String]) -> Result<String, ConnectorError> {
-    candidates
-        .iter()
-        .find(|candidate| QuicCandidate::parse(candidate).is_ok())
-        .cloned()
-        .ok_or_else(|| ConnectorError::Stream("stream begin requires a quic:// candidate".into()))
-}
-
 pub(crate) fn parse_quic_candidate(candidate: &str) -> Result<ParsedQuicCandidate, ConnectorError> {
     let parsed = QuicCandidate::parse(candidate)
         .map_err(|_| ConnectorError::Stream("invalid QUIC candidate".to_owned()))?;

--- a/crates/agent-connector/src/stream.rs
+++ b/crates/agent-connector/src/stream.rs
@@ -241,6 +241,7 @@ impl AgentConnector {
             chunk_count: 0,
             error: None,
         };
+        let start_event_id = MessageId::new(hex::decode(&start_message_id_hex)?);
         let open = OpenBrokerTextPublisher {
             broker_addr: live_candidates
                 .first()
@@ -255,7 +256,7 @@ impl AgentConnector {
                 .map(|(_, _, _, trust)| trust.clone())
                 .unwrap_or(BrokerServerTrust::InsecureLocal),
             stream_id: stream_id.clone(),
-            start_event_id: MessageId::new(hex::decode(&start_message_id_hex)?),
+            start_event_id: start_event_id.clone(),
             crypto: Some(crypto.crypto.clone()),
             max_plaintext_frame_len: policy_max_plaintext_frame_len,
         };
@@ -267,10 +268,7 @@ impl AgentConnector {
                     server_name,
                     trust,
                     stream_id: stream_id.clone(),
-                    start_event_id: MessageId::new(
-                        hex::decode(&start_message_id_hex)
-                            .expect("validated start message id remains valid"),
-                    ),
+                    start_event_id: start_event_id.clone(),
                     crypto: Some(crypto.crypto.clone()),
                     max_plaintext_frame_len: policy_max_plaintext_frame_len,
                 },

--- a/crates/agent-connector/src/stream.rs
+++ b/crates/agent-connector/src/stream.rs
@@ -1,23 +1,22 @@
 //! QUIC text-stream preview session lifecycle and the idle-session sweeper.
 
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Instant;
 
 use agent_control::AgentControlResponse;
 use agent_stream_compose::{
-    StreamComposeCommand, StreamComposeReport, StreamFinishExpectation, run_stream_compose_session,
+    StreamComposeCommand, StreamComposeReport, StreamFinishExpectation,
+    run_stream_compose_session_candidates, run_stream_compose_session_without_live,
 };
 use cgka_traits::{GroupId, MessageId};
 use marmot_app::AgentTextStreamFinishRequest;
 use rand::{RngCore, rngs::OsRng};
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{mpsc, oneshot};
-use transport_quic_broker::OpenBrokerTextPublisher;
+use transport_quic_broker::{BrokerServerTrust, OpenBrokerTextPublisher};
 
 use crate::error::ConnectorError;
-use crate::quic::{
-    broker_trust_for_candidate, first_quic_candidate, parse_quic_candidate,
-    resolve_quic_candidate_addr,
-};
+use crate::quic::{broker_trust_for_candidate, parse_quic_candidate, resolve_quic_candidate_addr};
 use crate::stream_session::{
     ActiveStreamSession, FinalizedStream, SendIdempotencyAcquisition, SendIdempotencyLeader,
     StreamBeginReceipt, StreamBeginReservation, normalize_stream_capability,
@@ -177,15 +176,6 @@ impl AgentConnector {
         let mut stream_capability = [0u8; 32];
         OsRng.fill_bytes(&mut stream_capability);
         let stream_capability_hex = hex::encode(stream_capability);
-        let candidate = first_quic_candidate(&quic_candidates)?;
-        let parsed_candidate = parse_quic_candidate(&candidate)?;
-        let broker_addr =
-            resolve_quic_candidate_addr(&parsed_candidate, self.allow_insecure_local_broker)
-                .await?;
-        let trust = broker_trust_for_candidate(
-            &parsed_candidate.server_name,
-            self.allow_insecure_local_broker,
-        );
         let (_payload, summary) = self
             .runtime
             .start_agent_text_stream_with_parent(
@@ -212,6 +202,27 @@ impl AgentConnector {
             .await?;
 
         let policy_max_plaintext_frame_len = crypto.policy_max_plaintext_frame_len;
+        let mut live_candidates = Vec::new();
+        for candidate in &quic_candidates {
+            let Ok(parsed) = parse_quic_candidate(candidate) else {
+                continue;
+            };
+            let Ok(addr) =
+                resolve_quic_candidate_addr(&parsed, self.allow_insecure_local_broker).await
+            else {
+                continue;
+            };
+            live_candidates.push((
+                candidate.clone(),
+                addr,
+                parsed.server_name.clone(),
+                broker_trust_for_candidate(&parsed.server_name, self.allow_insecure_local_broker),
+            ));
+        }
+        let candidate = live_candidates
+            .first()
+            .map(|(candidate, ..)| candidate.clone())
+            .unwrap_or_default();
 
         let (tx, rx) = mpsc::channel(STREAM_COMPOSE_CHANNEL_DEPTH);
         // Dedicated cancel signal: a separate, bounded channel that cannot be
@@ -230,21 +241,59 @@ impl AgentConnector {
             chunk_count: 0,
             error: None,
         };
-        let handle = tokio::spawn(run_stream_compose_session(
-            OpenBrokerTextPublisher {
-                broker_addr,
-                server_name: parsed_candidate.server_name,
-                trust,
-                stream_id: stream_id.clone(),
-                start_event_id: MessageId::new(hex::decode(&start_message_id_hex)?),
-                crypto: Some(crypto.crypto),
-                max_plaintext_frame_len: policy_max_plaintext_frame_len,
-            },
-            STREAM_COMPOSE_CHUNK_BYTES,
-            rx,
-            cancel_rx,
-            report,
-        ));
+        let open = OpenBrokerTextPublisher {
+            broker_addr: live_candidates
+                .first()
+                .map(|(_, addr, ..)| *addr)
+                .unwrap_or_else(|| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9)),
+            server_name: live_candidates
+                .first()
+                .map(|(_, _, server_name, _)| server_name.clone())
+                .unwrap_or_else(|| "localhost".to_owned()),
+            trust: live_candidates
+                .first()
+                .map(|(_, _, _, trust)| trust.clone())
+                .unwrap_or(BrokerServerTrust::InsecureLocal),
+            stream_id: stream_id.clone(),
+            start_event_id: MessageId::new(hex::decode(&start_message_id_hex)?),
+            crypto: Some(crypto.crypto.clone()),
+            max_plaintext_frame_len: policy_max_plaintext_frame_len,
+        };
+        let candidate_opens = live_candidates
+            .into_iter()
+            .map(
+                |(_, broker_addr, server_name, trust)| OpenBrokerTextPublisher {
+                    broker_addr,
+                    server_name,
+                    trust,
+                    stream_id: stream_id.clone(),
+                    start_event_id: MessageId::new(
+                        hex::decode(&start_message_id_hex)
+                            .expect("validated start message id remains valid"),
+                    ),
+                    crypto: Some(crypto.crypto.clone()),
+                    max_plaintext_frame_len: policy_max_plaintext_frame_len,
+                },
+            )
+            .collect::<Vec<_>>();
+        let handle = if candidate_opens.is_empty() {
+            tokio::spawn(run_stream_compose_session_without_live(
+                open,
+                STREAM_COMPOSE_CHUNK_BYTES,
+                rx,
+                cancel_rx,
+                report,
+            ))
+        } else {
+            tokio::spawn(run_stream_compose_session_candidates(
+                open,
+                candidate_opens,
+                STREAM_COMPOSE_CHUNK_BYTES,
+                rx,
+                cancel_rx,
+                report,
+            ))
+        };
         self.streams.insert_new(
             stream_id_hex.clone(),
             ActiveStreamSession {

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -2216,7 +2216,7 @@ async fn connector_socket_sends_final_message() {
 }
 
 #[tokio::test]
-async fn connector_socket_composes_and_finalizes_stream() {
+async fn connector_socket_composes_and_finalizes_stream_without_quic_candidates() {
     let dir = tempfile::tempdir().unwrap();
     let relay = MockRelay::run().await.unwrap();
     let relay_url = relay.url().await.to_string();
@@ -2262,7 +2262,7 @@ async fn connector_socket_composes_and_finalizes_stream() {
             &group_id_hex,
             Some(stream_id_hex.clone()),
             Some(parent_message_id_hex.clone()),
-            vec!["quic://127.0.0.1:9".to_owned()],
+            Vec::new(),
         )
         .await;
     assert!(matches!(
@@ -2275,7 +2275,7 @@ async fn connector_socket_composes_and_finalizes_stream() {
         group_id_hex: group_id_hex.clone(),
         stream_id_hex: Some(stream_id_hex.clone()),
         parent_message_id_hex: Some(parent_message_id_hex.clone()),
-        quic_candidates: vec!["quic://127.0.0.1:9".to_owned()],
+        quic_candidates: Vec::new(),
     };
     let begun = serve_control_request_once(
         &connector,
@@ -2310,7 +2310,7 @@ async fn connector_socket_composes_and_finalizes_stream() {
             group_id_hex: group_id_hex.clone(),
             stream_id_hex: Some(stream_id_hex.clone()),
             parent_message_id_hex: None,
-            quic_candidates: vec!["quic://127.0.0.1:9".to_owned()],
+            quic_candidates: Vec::new(),
         },
     )
     .await;
@@ -2346,7 +2346,7 @@ async fn connector_socket_composes_and_finalizes_stream() {
     assert_eq!(stream_capability.len(), 64);
     assert_eq!(hex::decode(&stream_capability).unwrap().len(), 32);
     assert_eq!(stream_capability, stream_capability.to_ascii_lowercase());
-    assert_eq!(quic_candidates, vec!["quic://127.0.0.1:9"]);
+    assert!(quic_candidates.is_empty());
     let stored = connector
         .runtime
         .messages_with_query(

--- a/crates/agent-stream-compose/src/lib.rs
+++ b/crates/agent-stream-compose/src/lib.rs
@@ -149,6 +149,74 @@ pub async fn run_stream_compose_session(
     .await;
 }
 
+/// Try resolved broker candidates in advertised order before disabling the
+/// provisional transport. Every candidate carries the same start-bound crypto
+/// and publisher store, so failover continues one sequence space.
+pub async fn run_stream_compose_session_candidates(
+    open: OpenBrokerTextPublisher,
+    candidates: Vec<OpenBrokerTextPublisher>,
+    chunk_bytes: usize,
+    rx: mpsc::Receiver<StreamComposeCommand>,
+    cancel_rx: mpsc::Receiver<()>,
+    report: StreamComposeReport,
+) {
+    let connect_timeout = DEFAULT_LIVE_BROKER_TIMEOUTS
+        .connect
+        .saturating_mul(u32::try_from(candidates.len()).unwrap_or(u32::MAX).max(1))
+        .saturating_add(Duration::from_secs(1));
+    let connect = async move {
+        let mut last_error = None;
+        for candidate in candidates {
+            match tokio::time::timeout(
+                DEFAULT_LIVE_BROKER_TIMEOUTS.connect,
+                BrokerTextPublisher::connect(candidate),
+            )
+            .await
+            {
+                Ok(Ok(publisher)) => return Ok(publisher),
+                Ok(Err(err)) => last_error = Some(err.to_string()),
+                Err(_) => last_error = Some("live broker connect timed out".to_owned()),
+            }
+        }
+        Err(last_error.unwrap_or_else(|| "live QUIC preview is unavailable".to_owned()))
+    };
+    run_stream_compose_session_with_connector(
+        open,
+        connect,
+        chunk_bytes,
+        rx,
+        cancel_rx,
+        report,
+        LiveBrokerTimeouts {
+            connect: connect_timeout,
+            ..DEFAULT_LIVE_BROKER_TIMEOUTS
+        },
+    )
+    .await;
+}
+
+/// Run the authoritative compose/transcript lifecycle with live QUIC disabled.
+/// Commands and finalization continue normally; only provisional writes fail
+/// closed. Used for valid zero-candidate starts and unusable live routes.
+pub async fn run_stream_compose_session_without_live(
+    open: OpenBrokerTextPublisher,
+    chunk_bytes: usize,
+    rx: mpsc::Receiver<StreamComposeCommand>,
+    cancel_rx: mpsc::Receiver<()>,
+    report: StreamComposeReport,
+) {
+    run_stream_compose_session_with_connector::<BrokerTextPublisher, _, String>(
+        open,
+        std::future::ready(Err("live QUIC preview is unavailable".to_owned())),
+        chunk_bytes,
+        rx,
+        cancel_rx,
+        report,
+        DEFAULT_LIVE_BROKER_TIMEOUTS,
+    )
+    .await;
+}
+
 async fn run_stream_compose_session_with_connector<P, C, E>(
     open: OpenBrokerTextPublisher,
     connect: C,

--- a/crates/agent-stream-compose/src/tests.rs
+++ b/crates/agent-stream-compose/src/tests.rs
@@ -83,6 +83,82 @@ fn expected_stream_transcript_hash_for_records(
 }
 
 #[tokio::test]
+async fn compose_candidates_fail_over_in_advertised_order() {
+    let server = QuicBrokerServer::bind(QuicBrokerConfig {
+        bind_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+        ..QuicBrokerConfig::default()
+    })
+    .unwrap();
+    let broker_addr = server.local_addr().unwrap();
+    let server_cert = server.server_cert_der().to_vec();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let broker_task = tokio::spawn(server.run_until(async {
+        let _ = shutdown_rx.await;
+    }));
+    let stream_id = vec![0xa1; 32];
+    let start = MessageId::new(vec![0xa2; 32]);
+    let subscriber = tokio::spawn(subscribe_text_from_broker(SubscribeTextFromBroker {
+        broker_addr,
+        server_name: "localhost".to_owned(),
+        trust: BrokerServerTrust::CertificateDer(server_cert.clone()),
+        stream_id: stream_id.clone(),
+        start_event_id: start.clone(),
+        crypto: None,
+    }));
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let first = test_stream_compose_open(stream_id.clone(), start.clone());
+    let second = OpenBrokerTextPublisher {
+        broker_addr,
+        server_name: "localhost".to_owned(),
+        trust: BrokerServerTrust::CertificateDer(server_cert),
+        stream_id: stream_id.clone(),
+        start_event_id: start,
+        crypto: None,
+        max_plaintext_frame_len: None,
+    };
+    let (tx, rx) = mpsc::channel(4);
+    let (_cancel_tx, cancel_rx) = mpsc::channel(1);
+    let session = tokio::spawn(run_stream_compose_session_candidates(
+        first.clone(),
+        vec![first, second],
+        16,
+        rx,
+        cancel_rx,
+        test_stream_compose_report(&stream_id),
+    ));
+    // The first candidate is deliberately unreachable and gets its bounded
+    // five-second attempt before the live second candidate is selected.
+    tokio::time::sleep(Duration::from_secs(6)).await;
+    let (append_tx, append_rx) = oneshot::channel();
+    tx.send(StreamComposeCommand::Append {
+        text: "fallback".to_owned(),
+        respond: append_tx,
+    })
+    .await
+    .unwrap();
+    append_rx.await.unwrap().unwrap();
+    let (finish_tx, finish_rx) = oneshot::channel();
+    tx.send(StreamComposeCommand::Finish {
+        expected: None,
+        respond: finish_tx,
+    })
+    .await
+    .unwrap();
+    finish_rx.await.unwrap().unwrap();
+
+    let received = tokio::time::timeout(Duration::from_secs(12), subscriber)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(received.text, "fallback");
+    session.await.unwrap();
+    let _ = shutdown_tx.send(());
+    broker_task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
 async fn compose_session_finalizes_local_transcript_when_broker_connect_is_pending() {
     let stream_id = vec![0xaa; 32];
     let start_event_id = MessageId::new(vec![0xbb; 32]);

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -14,6 +14,8 @@ versioning through the workspace version in the root `Cargo.toml`.
   adopted 512-byte authority rules, preserve ordered candidate failover, and
   durably reserve encrypted publisher sequences so repeated `stream send`,
   reconnect, or daemon reuse cannot restart at sequence 1 for one start.
+  Zero-candidate daemon compose returns a `streaming` payload with
+  `candidate: ""` for TUI and script consumers instead of failing the start.
 
 ## [0.9.6] - 2026-07-26
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,14 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Agent text-stream QUIC starts now accept zero broker candidates for durable
+  final-message fallback, validate complete candidate values against the
+  adopted 512-byte authority rules, preserve ordered candidate failover, and
+  durably reserve encrypted publisher sequences so repeated `stream send`,
+  reconnect, or daemon reuse cannot restart at sequence 1 for one start.
+
 ## [0.9.6] - 2026-07-26
 
 ### Added

--- a/crates/cli/src/commands/stream.rs
+++ b/crates/cli/src/commands/stream.rs
@@ -689,29 +689,13 @@ pub(crate) struct ParsedQuicCandidate {
     pub(crate) server_name: String,
 }
 
-/// Extract the `host:port` (or `[ipv6]:port`) authority from a `quic://` URL
-/// remainder, ignoring any path, query, or fragment after it. Per
-/// `transports/quic.md` the authority ends at the first `/`, `?`, or `#`. Shared
-/// by both quic-candidate parsers below (and mirrors `marmot_app`'s
-/// `parse_quic_candidate`) so the rule cannot drift.
-fn quic_authority(rest: &str) -> &str {
-    rest.split(['/', '?', '#']).next().unwrap_or(rest)
-}
-
 pub(crate) fn parse_quic_candidate(candidate: &str) -> Result<ParsedQuicCandidate, WnError> {
-    let trimmed = candidate.trim();
-    let Some(rest) = trimmed.strip_prefix("quic://") else {
-        return Err(WnError::InvalidQuicCandidate(trimmed.to_owned()));
-    };
-    let authority = quic_authority(rest);
-    if authority.is_empty() {
-        return Err(WnError::InvalidQuicCandidate(trimmed.to_owned()));
-    }
-    let server_name = candidate_server_name(authority)?;
+    let parsed = transport_quic_stream::QuicCandidate::parse(candidate)
+        .map_err(|_| WnError::InvalidQuicCandidate(candidate.to_owned()))?;
     Ok(ParsedQuicCandidate {
-        original: trimmed.to_owned(),
-        authority: authority.to_owned(),
-        server_name,
+        original: parsed.original().to_owned(),
+        authority: parsed.authority().to_owned(),
+        server_name: parsed.host().to_owned(),
     })
 }
 
@@ -754,38 +738,18 @@ fn socket_addr_is_unsafe(addr: SocketAddr) -> bool {
     !is_public_ip(addr.ip())
 }
 
-fn candidate_server_name(authority: &str) -> Result<String, WnError> {
-    if let Some(rest) = authority.strip_prefix('[') {
-        let Some((host, _)) = rest.split_once(']') else {
-            return Err(WnError::InvalidQuicCandidate(authority.to_owned()));
-        };
-        return Ok(host.to_owned());
-    }
-    authority
-        .rsplit_once(':')
-        .map(|(host, _)| host.to_owned())
-        .filter(|host| !host.is_empty())
-        .ok_or_else(|| WnError::InvalidQuicCandidate(authority.to_owned()))
-}
-
 pub(crate) fn first_quic_candidate_is_loopback(candidates: &[String]) -> bool {
     candidates
         .iter()
-        .find(|candidate| candidate.trim().starts_with("quic://"))
+        .find(|candidate| transport_quic_stream::QuicCandidate::parse(candidate).is_ok())
         .and_then(|candidate| quic_candidate_host(candidate))
         .is_some_and(|host| quic_host_is_loopback(&host))
 }
 
 pub(crate) fn quic_candidate_host(candidate: &str) -> Option<String> {
-    let rest = candidate.trim().strip_prefix("quic://")?;
-    let authority = quic_authority(rest);
-    if let Some(rest) = authority.strip_prefix('[') {
-        return rest.split_once(']').map(|(host, _)| host.to_owned());
-    }
-    authority
-        .rsplit_once(':')
-        .map(|(host, _)| host.to_owned())
-        .filter(|host| !host.is_empty())
+    transport_quic_stream::QuicCandidate::parse(candidate)
+        .ok()
+        .map(|candidate| candidate.host().to_owned())
 }
 
 fn quic_host_is_loopback(host: &str) -> bool {

--- a/crates/cli/src/commands/stream.rs
+++ b/crates/cli/src/commands/stream.rs
@@ -13,8 +13,8 @@ use marmot_app::{
 };
 use serde_json::{Value, json};
 use transport_quic_broker::{
-    BrokerServerTrust, PublishTextToBroker, SubscribeTextFromBroker, publish_text_to_broker,
-    subscribe_text_from_broker_with_limits,
+    BrokerServerTrust, BrokerTextReceiverState, PublishTextToBroker, SubscribeTextFromBroker,
+    publish_text_to_broker, subscribe_text_from_broker_with_resume,
 };
 use transport_quic_stream::{
     AgentTextStreamReceiveLimits, QuicTextStreamReceiver, SendTextStream, ServerTrust,
@@ -525,16 +525,6 @@ where
             stream_route_label(&start_payload.route).to_owned(),
         ));
     }
-    let candidate = start_payload
-        .quic_candidates
-        .iter()
-        .find(|candidate| candidate.trim().starts_with("quic://"))
-        .ok_or(WnError::MissingQuicCandidate)?;
-    let candidate = parse_quic_candidate(candidate)?;
-    // Only an explicit local `--insecure-local` opt-in may resolve to a
-    // local/private endpoint; otherwise reject unsafe sender-provided candidates.
-    let candidate_addr = resolve_quic_candidate_addr(&candidate, insecure_local).await?;
-    let trust = broker_trust(candidate_addr, server_cert_der_hex, insecure_local)?;
     let stream_id_hex = start_payload.stream_id_hex.clone();
     let start_event_id = MessageId::new(hex::decode(&start_message_id_hex)?);
     let (stream_id, crypto, policy_max_plaintext_frame_len) = stream_crypto_for_start_event(
@@ -554,29 +544,74 @@ where
     let delta_account = account_flag.or(Some(account.account_id_hex.clone()));
     let delta_group_id = group_id_hex.clone();
     let delta_stream_id = stream_id_hex.clone();
-    let received = subscribe_text_from_broker_with_limits(
-        SubscribeTextFromBroker {
-            broker_addr: candidate_addr,
-            server_name: candidate.server_name.clone(),
-            trust: trust.clone(),
-            stream_id,
-            start_event_id,
-            crypto,
-        },
-        limits,
-        |chunk| {
-            on_delta(AgentStreamDelta {
-                account: delta_account.clone(),
-                group_id: delta_group_id.clone(),
-                stream_id: delta_stream_id.clone(),
-                seq: chunk.seq,
-                record_type: chunk.record_type,
-                flags: chunk.flags,
-                text: chunk.text.clone(),
-            });
-        },
-    )
-    .await?;
+    let mut receiver_state =
+        BrokerTextReceiverState::new(stream_id.clone(), start_event_id.clone(), limits);
+    let mut last_error = None;
+    let mut selected = None;
+    let mut received = None;
+    for candidate_value in &start_payload.quic_candidates {
+        let candidate = match parse_quic_candidate(candidate_value) {
+            Ok(candidate) => candidate,
+            Err(err) => {
+                last_error = Some(err);
+                continue;
+            }
+        };
+        let candidate_addr = match resolve_quic_candidate_addr(&candidate, insecure_local).await {
+            Ok(addr) => addr,
+            Err(err) => {
+                last_error = Some(err);
+                continue;
+            }
+        };
+        let trust = match broker_trust_for_candidate(
+            &candidate.server_name,
+            candidate_addr,
+            server_cert_der_hex.clone(),
+            insecure_local,
+        ) {
+            Ok(trust) => trust,
+            Err(err) => {
+                last_error = Some(err);
+                continue;
+            }
+        };
+        let result = subscribe_text_from_broker_with_resume(
+            SubscribeTextFromBroker {
+                broker_addr: candidate_addr,
+                server_name: candidate.server_name.clone(),
+                trust: trust.clone(),
+                stream_id: stream_id.clone(),
+                start_event_id: start_event_id.clone(),
+                crypto: crypto.clone(),
+            },
+            limits,
+            &mut receiver_state,
+            |chunk| {
+                on_delta(AgentStreamDelta {
+                    account: delta_account.clone(),
+                    group_id: delta_group_id.clone(),
+                    stream_id: delta_stream_id.clone(),
+                    seq: chunk.seq,
+                    record_type: chunk.record_type,
+                    flags: chunk.flags,
+                    text: chunk.text.clone(),
+                });
+            },
+        )
+        .await;
+        match result {
+            Ok(value) => {
+                selected = Some((candidate, candidate_addr, trust));
+                received = Some(value);
+                break;
+            }
+            Err(err) => last_error = Some(err.into()),
+        }
+    }
+    let received = received.ok_or_else(|| last_error.unwrap_or(WnError::MissingQuicCandidate))?;
+    let (candidate, candidate_addr, trust) =
+        selected.expect("a received stream always has a selected candidate");
     Ok(CommandOutput {
         plain: format!(
             "received brokered stream {} chunks={}\n{}",
@@ -790,6 +825,18 @@ pub(crate) fn broker_trust(
         .transpose()
         .map(|trust| trust.unwrap_or(BrokerServerTrust::Platform))
         .map_err(Into::into)
+}
+
+pub(crate) fn broker_trust_for_candidate(
+    candidate_host: &str,
+    server_addr: SocketAddr,
+    server_cert_der_hex: Option<String>,
+    insecure_local: bool,
+) -> Result<BrokerServerTrust, WnError> {
+    if insecure_local && !quic_host_is_loopback(candidate_host) {
+        return broker_trust(server_addr, server_cert_der_hex, false);
+    }
+    broker_trust(server_addr, server_cert_der_hex, insecure_local)
 }
 
 fn broker_trust_name(trust: &BrokerServerTrust) -> &'static str {

--- a/crates/cli/src/commands/stream.rs
+++ b/crates/cli/src/commands/stream.rs
@@ -585,7 +585,6 @@ where
                 start_event_id: start_event_id.clone(),
                 crypto: crypto.clone(),
             },
-            limits,
             &mut receiver_state,
             |chunk| {
                 on_delta(AgentStreamDelta {
@@ -833,6 +832,9 @@ pub(crate) fn broker_trust_for_candidate(
     server_cert_der_hex: Option<String>,
     insecure_local: bool,
 ) -> Result<BrokerServerTrust, WnError> {
+    if insecure_local && server_cert_der_hex.is_some() {
+        return Err(WnError::ConflictingStreamTrust);
+    }
     if insecure_local && !quic_host_is_loopback(candidate_host) {
         return broker_trust(server_addr, server_cert_der_hex, false);
     }

--- a/crates/cli/src/daemon/mod.rs
+++ b/crates/cli/src/daemon/mod.rs
@@ -11,7 +11,12 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 
-use agent_stream_compose::{StreamComposeCommand, StreamComposeReport, run_stream_compose_session};
+#[cfg(test)]
+use agent_stream_compose::run_stream_compose_session;
+use agent_stream_compose::{
+    StreamComposeCommand, StreamComposeReport, run_stream_compose_session_candidates,
+    run_stream_compose_session_without_live,
+};
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};

--- a/crates/cli/src/daemon/stream_workers.rs
+++ b/crates/cli/src/daemon/stream_workers.rs
@@ -389,37 +389,6 @@ pub(crate) async fn open_stream_compose(
         Ok(None) => hex::encode(transport_quic_stream::random_stream_id()),
         Err(err) => return daemon_error(cli.json, "stream_compose_failed", err.to_string()),
     };
-    let Some(candidate) = quic_candidates
-        .iter()
-        .find(|candidate| candidate.trim().starts_with("quic://"))
-        .cloned()
-    else {
-        return daemon_error(
-            cli.json,
-            "stream_compose_failed",
-            "stream compose requires a quic:// candidate".to_owned(),
-        );
-    };
-    let parsed_candidate = match crate::commands::stream::parse_quic_candidate(&candidate) {
-        Ok(candidate) => candidate,
-        Err(err) => return daemon_error(cli.json, "stream_compose_failed", err.to_string()),
-    };
-    // Only an explicit local `--insecure-local` opt-in may resolve to a
-    // local/private endpoint; otherwise reject unsafe candidates.
-    let candidate_addr = match crate::commands::stream::resolve_quic_candidate_addr(
-        &parsed_candidate,
-        insecure_local,
-    )
-    .await
-    {
-        Ok(addr) => addr,
-        Err(err) => return daemon_error(cli.json, "stream_compose_failed", err.to_string()),
-    };
-    let trust = match crate::commands::stream::broker_trust(candidate_addr, None, insecure_local) {
-        Ok(trust) => trust,
-        Err(err) => return daemon_error(cli.json, "stream_compose_failed", err.to_string()),
-    };
-
     let mut start_cli = cli.clone();
     start_cli.json = true;
     start_cli.command = crate::Command::Stream {
@@ -492,6 +461,35 @@ pub(crate) async fn open_stream_compose(
         }
     };
 
+    let mut live_candidates = Vec::new();
+    for candidate in &quic_candidates {
+        let parsed = match crate::commands::stream::parse_quic_candidate(candidate) {
+            Ok(parsed) => parsed,
+            Err(_) => continue,
+        };
+        let addr =
+            match crate::commands::stream::resolve_quic_candidate_addr(&parsed, insecure_local)
+                .await
+            {
+                Ok(addr) => addr,
+                Err(_) => continue,
+            };
+        let trust = match crate::commands::stream::broker_trust_for_candidate(
+            &parsed.server_name,
+            addr,
+            None,
+            insecure_local,
+        ) {
+            Ok(trust) => trust,
+            Err(_) => continue,
+        };
+        live_candidates.push((candidate.clone(), addr, parsed.server_name, trust));
+    }
+    let candidate = live_candidates
+        .first()
+        .map(|(candidate, ..)| candidate.clone())
+        .unwrap_or_default();
+
     let key = stream_compose_key(account.as_deref(), &stream_id);
     let (tx, rx) = mpsc::channel(32);
     // Dedicated cancel signal: a bounded channel that can't be starved behind
@@ -511,24 +509,56 @@ pub(crate) async fn open_stream_compose(
         error: None,
     };
     let task_report = report.clone();
-    let handle = tokio::spawn(async move {
-        run_stream_compose_session(
-            OpenBrokerTextPublisher {
-                broker_addr: candidate_addr,
-                server_name: parsed_candidate.server_name,
+    let fallback_open = OpenBrokerTextPublisher {
+        broker_addr: live_candidates
+            .first()
+            .map(|(_, addr, ..)| *addr)
+            .unwrap_or_else(|| "127.0.0.1:9".parse().expect("literal socket address")),
+        server_name: live_candidates
+            .first()
+            .map(|(_, _, server_name, _)| server_name.clone())
+            .unwrap_or_else(|| "localhost".to_owned()),
+        trust: live_candidates
+            .first()
+            .map(|(_, _, _, trust)| trust.clone())
+            .unwrap_or(transport_quic_broker::BrokerServerTrust::InsecureLocal),
+        stream_id: stream_id_bytes.clone(),
+        start_event_id: start_event_id.clone(),
+        crypto: crypto.clone(),
+        max_plaintext_frame_len: policy_max_plaintext_frame_len,
+    };
+    let candidate_opens = live_candidates
+        .into_iter()
+        .map(
+            |(_, broker_addr, server_name, trust)| OpenBrokerTextPublisher {
+                broker_addr,
+                server_name,
                 trust,
-                stream_id: stream_id_bytes,
-                start_event_id,
-                crypto,
+                stream_id: stream_id_bytes.clone(),
+                start_event_id: start_event_id.clone(),
+                crypto: crypto.clone(),
                 max_plaintext_frame_len: policy_max_plaintext_frame_len,
             },
+        )
+        .collect::<Vec<_>>();
+    let handle = if candidate_opens.is_empty() {
+        tokio::spawn(run_stream_compose_session_without_live(
+            fallback_open,
             chunk_bytes,
             rx,
             cancel_rx,
             task_report,
-        )
-        .await;
-    });
+        ))
+    } else {
+        tokio::spawn(run_stream_compose_session_candidates(
+            fallback_open,
+            candidate_opens,
+            chunk_bytes,
+            rx,
+            cancel_rx,
+            task_report,
+        ))
+    };
     workers.insert(
         key,
         StreamComposeSession {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1251,8 +1251,8 @@ mod tests {
     };
     use super::commands::relay_stats::{relay_stats_output, relay_stats_plain};
     use super::commands::stream::{
-        first_quic_candidate_is_loopback, parse_quic_candidate, quic_candidate_host,
-        resolve_quic_candidate_addr,
+        broker_trust_for_candidate, first_quic_candidate_is_loopback, parse_quic_candidate,
+        quic_candidate_host, resolve_quic_candidate_addr,
     };
     use super::{
         Cli, Command, StreamCommand, WnError, daemon, daemon_socket_for_client,
@@ -1874,6 +1874,17 @@ mod tests {
             .await
             .expect("loopback resolves with opt-in");
         assert!(addr.ip().is_loopback());
+    }
+
+    #[test]
+    fn candidate_trust_rejects_conflicting_insecure_and_certificate_flags() {
+        let result = broker_trust_for_candidate(
+            "broker.example",
+            "203.0.113.10:4450".parse().unwrap(),
+            Some(hex::encode([1_u8; 8])),
+            true,
+        );
+        assert!(matches!(result, Err(WnError::ConflictingStreamTrust)));
     }
 
     #[tokio::test]

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -87,6 +87,7 @@ mod media;
 mod messages;
 mod notifications;
 mod projection;
+mod publisher_sequences;
 mod relay_plane;
 mod relay_telemetry_export;
 mod runtime;

--- a/crates/marmot-app/src/messages/intents.rs
+++ b/crates/marmot-app/src/messages/intents.rs
@@ -353,7 +353,7 @@ pub(crate) fn build_inner_event(
                     "agent text stream id must be 32 bytes".into(),
                 ));
             }
-            for candidate in &quic_candidates {
+            for candidate in quic_candidates {
                 transport_quic_stream::QuicCandidate::parse(candidate)
                     .map_err(|_| AppError::AgentStreamInvalidCandidate(candidate.clone()))?;
             }
@@ -374,8 +374,8 @@ pub(crate) fn build_inner_event(
             }
             tags.extend(
                 quic_candidates
-                    .into_iter()
-                    .map(|candidate| vec![STREAM_BROKER_TAG.to_owned(), candidate]),
+                    .iter()
+                    .map(|candidate| vec![STREAM_BROKER_TAG.to_owned(), candidate.clone()]),
             );
             Ok(event(
                 MARMOT_APP_EVENT_KIND_AGENT_STREAM_START,

--- a/crates/marmot-app/src/messages/intents.rs
+++ b/crates/marmot-app/src/messages/intents.rs
@@ -353,12 +353,9 @@ pub(crate) fn build_inner_event(
                     "agent text stream id must be 32 bytes".into(),
                 ));
             }
-            let brokers: Vec<&String> = quic_candidates
-                .iter()
-                .filter(|candidate| !candidate.trim().is_empty())
-                .collect();
-            if brokers.is_empty() {
-                return Err(AppError::AgentStreamMissingCandidate);
+            for candidate in &quic_candidates {
+                transport_quic_stream::QuicCandidate::parse(candidate)
+                    .map_err(|_| AppError::AgentStreamInvalidCandidate(candidate.clone()))?;
             }
             let mut tags = vec![
                 vec![STREAM_TAG.to_owned(), stream_id_hex],
@@ -376,9 +373,9 @@ pub(crate) fn build_inner_event(
                 ]);
             }
             tags.extend(
-                brokers
+                quic_candidates
                     .into_iter()
-                    .map(|candidate| vec![STREAM_BROKER_TAG.to_owned(), candidate.clone()]),
+                    .map(|candidate| vec![STREAM_BROKER_TAG.to_owned(), candidate]),
             );
             Ok(event(
                 MARMOT_APP_EVENT_KIND_AGENT_STREAM_START,

--- a/crates/marmot-app/src/publisher_sequences.rs
+++ b/crates/marmot-app/src/publisher_sequences.rs
@@ -1,0 +1,70 @@
+//! SQLCipher-backed QUIC preview publisher lifecycle state.
+
+use storage_sqlite::{AgentStreamPublisherReservationRequest, SqliteAccountStorage};
+use transport_quic_stream::{
+    PublisherSequenceReservation, PublisherSequenceSnapshot, PublisherSequenceStore,
+};
+
+pub(crate) struct SqlitePublisherSequenceStore {
+    storage: SqliteAccountStorage,
+}
+
+impl SqlitePublisherSequenceStore {
+    pub(crate) fn new(storage: SqliteAccountStorage) -> Self {
+        Self { storage }
+    }
+}
+
+impl PublisherSequenceStore for SqlitePublisherSequenceStore {
+    fn load(&self, context_id: &[u8; 32]) -> Result<Option<PublisherSequenceSnapshot>, String> {
+        self.storage
+            .agent_stream_publisher_state(context_id)
+            .map_err(|err| err.to_string())?
+            .map(|state| {
+                if state.ambiguous {
+                    return Err("publisher continuity is ambiguous".to_owned());
+                }
+                if state.next_seq == 0 {
+                    return Err("publisher sequence state is corrupt".to_owned());
+                }
+                Ok(PublisherSequenceSnapshot {
+                    next_seq: state.next_seq,
+                    transcript_hash: state.transcript_hash,
+                    chunk_count: state.chunk_count,
+                })
+            })
+            .transpose()
+    }
+
+    fn reserve(
+        &self,
+        context_id: &[u8; 32],
+        initial_transcript_hash: &[u8; 32],
+        reservation: &PublisherSequenceReservation,
+    ) -> Result<(), String> {
+        let record_count = reservation
+            .resulting
+            .chunk_count
+            .checked_sub(reservation.expected.chunk_count)
+            .ok_or_else(|| "publisher transcript count regressed".to_owned())?;
+        self.storage
+            .reserve_agent_stream_publisher_records(AgentStreamPublisherReservationRequest {
+                context_id,
+                initial_transcript_hash,
+                expected_transcript_hash: &reservation.expected.transcript_hash,
+                expected_chunk_count: reservation.expected.chunk_count,
+                resulting_transcript_hash: &reservation.resulting.transcript_hash,
+                record_count,
+                resulting_chunk_count: reservation.resulting.chunk_count,
+                token: reservation.token,
+            })
+            .map(|_| ())
+            .map_err(|err| err.to_string())
+    }
+
+    fn confirm(&self, context_id: &[u8; 32], token: &[u8; 16]) -> Result<(), String> {
+        self.storage
+            .confirm_agent_stream_publisher_reservation(context_id, token)
+            .map_err(|err| err.to_string())
+    }
+}

--- a/crates/marmot-app/src/runtime/agent_stream_watch.rs
+++ b/crates/marmot-app/src/runtime/agent_stream_watch.rs
@@ -260,7 +260,10 @@ async fn wait_for_preview_invalidation(
                 }
                 _ => {}
             },
-            Ok(_) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+            Ok(_) => {}
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                return "agent stream preview event stream lagged; preview withdrawn".to_owned();
+            }
             Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                 return "agent stream preview event source closed".to_owned();
             }
@@ -410,58 +413,51 @@ async fn watch_broker_candidates(
                     crypto: watch.crypto.clone(),
                 };
                 let chunk_tx = updates_tx.clone();
-                match subscribe_text_from_broker_with_resume(
-                    config,
-                    limits,
-                    &mut receiver_state,
-                    |chunk| {
-                        let update = match chunk.record_type {
-                            AGENT_TEXT_STREAM_RECORD_TEXT_DELTA => {
-                                RuntimeAgentStreamUpdate::Chunk {
-                                    seq: chunk.seq,
-                                    text: chunk.text.clone(),
-                                }
-                            }
-                            AGENT_TEXT_STREAM_RECORD_STATUS => RuntimeAgentStreamUpdate::Status {
+                match subscribe_text_from_broker_with_resume(config, &mut receiver_state, |chunk| {
+                    let update = match chunk.record_type {
+                        AGENT_TEXT_STREAM_RECORD_TEXT_DELTA => RuntimeAgentStreamUpdate::Chunk {
+                            seq: chunk.seq,
+                            text: chunk.text.clone(),
+                        },
+                        AGENT_TEXT_STREAM_RECORD_STATUS => RuntimeAgentStreamUpdate::Status {
+                            seq: chunk.seq,
+                            status: chunk.text.clone(),
+                        },
+                        AGENT_TEXT_STREAM_RECORD_PROGRESS_DELTA => {
+                            RuntimeAgentStreamUpdate::Progress {
                                 seq: chunk.seq,
-                                status: chunk.text.clone(),
-                            },
-                            AGENT_TEXT_STREAM_RECORD_PROGRESS_DELTA => {
-                                RuntimeAgentStreamUpdate::Progress {
-                                    seq: chunk.seq,
-                                    text: chunk.text.clone(),
-                                }
-                            }
-                            record_type => RuntimeAgentStreamUpdate::Record {
-                                seq: chunk.seq,
-                                record_type,
                                 text: chunk.text.clone(),
-                            },
-                        };
-                        match chunk_tx.try_send(update) {
-                            Ok(()) => {}
-                            Err(mpsc::error::TrySendError::Full(_))
-                                if chunk.record_type == AGENT_TEXT_STREAM_RECORD_TEXT_DELTA =>
-                            {
-                                tracing::warn!(
-                                    target: "marmot_app::agent_stream",
-                                    method = "watch_agent_text_stream",
-                                    "dropping live agent text stream delta; consumer is behind",
-                                );
                             }
-                            Err(mpsc::error::TrySendError::Full(_)) => {
-                                tracing::warn!(
-                                    target: "marmot_app::agent_stream",
-                                    method = "watch_agent_text_stream",
-                                    record_type = chunk.record_type,
-                                    dropped_record_class = "non_text",
-                                    "dropping non-text agent stream record; consumer is behind",
-                                );
-                            }
-                            Err(mpsc::error::TrySendError::Closed(_)) => {}
                         }
-                    },
-                )
+                        record_type => RuntimeAgentStreamUpdate::Record {
+                            seq: chunk.seq,
+                            record_type,
+                            text: chunk.text.clone(),
+                        },
+                    };
+                    match chunk_tx.try_send(update) {
+                        Ok(()) => {}
+                        Err(mpsc::error::TrySendError::Full(_))
+                            if chunk.record_type == AGENT_TEXT_STREAM_RECORD_TEXT_DELTA =>
+                        {
+                            tracing::warn!(
+                                target: "marmot_app::agent_stream",
+                                method = "watch_agent_text_stream",
+                                "dropping live agent text stream delta; consumer is behind",
+                            );
+                        }
+                        Err(mpsc::error::TrySendError::Full(_)) => {
+                            tracing::warn!(
+                                target: "marmot_app::agent_stream",
+                                method = "watch_agent_text_stream",
+                                record_type = chunk.record_type,
+                                dropped_record_class = "non_text",
+                                "dropping non-text agent stream record; consumer is behind",
+                            );
+                        }
+                        Err(mpsc::error::TrySendError::Closed(_)) => {}
+                    }
+                })
                 .await
                 {
                     Ok(received) => {
@@ -593,6 +589,26 @@ mod tests {
         assert_eq!(
             wait_for_preview_invalidation(&mut receiver, &group, &hex::encode([3; 32])).await,
             "agent stream preview start was invalidated"
+        );
+    }
+
+    #[tokio::test]
+    async fn lagged_runtime_events_withdraw_the_preview_fail_closed() {
+        let (events, mut receiver) = tokio::sync::broadcast::channel(1);
+        let group = GroupId::new(vec![1; 16]);
+        for _ in 0..2 {
+            events
+                .send(runtime_group_event(GroupEvent::EpochChanged {
+                    group_id: GroupId::new(vec![2; 16]),
+                    from: EpochId(1),
+                    to: EpochId(2),
+                }))
+                .unwrap();
+        }
+
+        assert_eq!(
+            wait_for_preview_invalidation(&mut receiver, &group, &hex::encode([3; 32])).await,
+            "agent stream preview event stream lagged; preview withdrawn"
         );
     }
 }

--- a/crates/marmot-app/src/runtime/agent_stream_watch.rs
+++ b/crates/marmot-app/src/runtime/agent_stream_watch.rs
@@ -2,6 +2,7 @@
 //! the [`MarmotAppRuntime`] entry points that drive them.
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use cgka_traits::agent_text_stream::{
     AGENT_TEXT_STREAM_RECORD_PROGRESS_DELTA, AGENT_TEXT_STREAM_RECORD_STATUS,
@@ -14,7 +15,8 @@ use cgka_traits::app_event::{
 use cgka_traits::{GroupId, MemberId, MessageId};
 use tokio::sync::{mpsc, oneshot};
 use transport_quic_broker::{
-    BrokerServerTrust, SubscribeTextFromBroker, subscribe_text_from_broker_with_limits,
+    BrokerServerTrust, BrokerTextReceiverState, SubscribeTextFromBroker,
+    subscribe_text_from_broker_with_resume,
 };
 use transport_quic_stream::{AgentTextStreamCrypto, AgentTextStreamReceiveLimits, QuicCandidate};
 
@@ -87,21 +89,31 @@ impl MarmotAppRuntime {
         let (updates_tx, updates_rx) = mpsc::channel(1024);
         let (terminal_tx, terminal_rx) = oneshot::channel();
         let mut stopping = self.shared.lifecycle().subscribe_shutdown();
+        let mut runtime_events = self.subscribe();
+        let invalidation_group_id = group_id.clone();
+        let invalidation_start_id = start_message_id_hex.clone();
         let handle = tokio::spawn(async move {
+            let watch = watch_broker_candidates(
+                BrokerWatch {
+                    candidates,
+                    server_cert_der,
+                    insecure_local,
+                    stream_id: crypto_context.stream_id,
+                    start_event_id: crypto_context.start_event_id,
+                    crypto: Some(crypto_context.crypto),
+                    policy_max_plaintext_frame_len,
+                },
+                updates_tx.clone(),
+            );
+            tokio::pin!(watch);
             let final_update = tokio::select! {
                 _ = wait_for_runtime_shutdown(&mut stopping) => return,
-                update = watch_broker_candidates(
-                    BrokerWatch {
-                        candidates,
-                        server_cert_der,
-                        insecure_local,
-                        stream_id: crypto_context.stream_id,
-                        start_event_id: crypto_context.start_event_id,
-                        crypto: Some(crypto_context.crypto),
-                        policy_max_plaintext_frame_len,
-                    },
-                    updates_tx.clone(),
-                ) => update,
+                update = &mut watch => update,
+                reason = wait_for_preview_invalidation(
+                    &mut runtime_events,
+                    &invalidation_group_id,
+                    &invalidation_start_id,
+                ) => RuntimeAgentStreamUpdate::Failed { message: reason },
             };
             let _ = terminal_tx.send(final_update);
         });
@@ -180,6 +192,11 @@ impl MarmotAppRuntime {
                     Ok(secret) => secret,
                     Err(_) => continue,
                 };
+                let publisher_store = Arc::new(
+                    crate::publisher_sequences::SqlitePublisherSequenceStore::new(
+                        self.accounts.app.account_storage(&account.label)?,
+                    ),
+                );
                 let crypto = AgentTextStreamCrypto::new(
                     stream_secret,
                     AgentTextStreamKeyContextV1::new(
@@ -189,7 +206,8 @@ impl MarmotAppRuntime {
                         MemberId::new(hex::decode(message.sender)?),
                         start_event_id.clone(),
                     ),
-                );
+                )
+                .with_publisher_sequence_store(publisher_store);
                 // Carry the group policy alongside the start-event-bound crypto
                 // so send/watch/compose paths enforce the durable MLS component
                 // instead of silently falling back to the app-profile ceiling.
@@ -215,6 +233,38 @@ impl MarmotAppRuntime {
         }
 
         Err(AppError::AgentStreamMissingStart)
+    }
+}
+
+async fn wait_for_preview_invalidation(
+    events: &mut tokio::sync::broadcast::Receiver<crate::MarmotAppEvent>,
+    group_id: &GroupId,
+    start_message_id_hex: &str,
+) -> String {
+    loop {
+        match events.recv().await {
+            Ok(crate::MarmotAppEvent::GroupEvent(runtime_event)) => match runtime_event.event {
+                cgka_traits::engine::GroupEvent::EpochChanged {
+                    group_id: changed, ..
+                } if &changed == group_id => {
+                    return "agent stream preview closed by epoch change".to_owned();
+                }
+                cgka_traits::engine::GroupEvent::AppMessageInvalidated {
+                    group_id: changed,
+                    message_id,
+                    ..
+                } if &changed == group_id
+                    && hex::encode(message_id.as_slice()) == start_message_id_hex =>
+                {
+                    return "agent stream preview start was invalidated".to_owned();
+                }
+                _ => {}
+            },
+            Ok(_) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                return "agent stream preview event source closed".to_owned();
+            }
+        }
     }
 }
 
@@ -334,6 +384,11 @@ async fn watch_broker_candidates(
             max_plaintext_frame_len.min(limits.max_plaintext_frame_len);
     }
     let mut last_error = None;
+    let mut receiver_state = BrokerTextReceiverState::new(
+        watch.stream_id.clone(),
+        watch.start_event_id.clone(),
+        limits,
+    );
     for candidate in watch.candidates {
         match resolve_broker_addr(&candidate.authority, watch.insecure_local).await {
             Ok(broker_addr) => {
@@ -355,51 +410,58 @@ async fn watch_broker_candidates(
                     crypto: watch.crypto.clone(),
                 };
                 let chunk_tx = updates_tx.clone();
-                match subscribe_text_from_broker_with_limits(config, limits, |chunk| {
-                    let update = match chunk.record_type {
-                        AGENT_TEXT_STREAM_RECORD_TEXT_DELTA => RuntimeAgentStreamUpdate::Chunk {
-                            seq: chunk.seq,
-                            text: chunk.text.clone(),
-                        },
-                        AGENT_TEXT_STREAM_RECORD_STATUS => RuntimeAgentStreamUpdate::Status {
-                            seq: chunk.seq,
-                            status: chunk.text.clone(),
-                        },
-                        AGENT_TEXT_STREAM_RECORD_PROGRESS_DELTA => {
-                            RuntimeAgentStreamUpdate::Progress {
-                                seq: chunk.seq,
-                                text: chunk.text.clone(),
+                match subscribe_text_from_broker_with_resume(
+                    config,
+                    limits,
+                    &mut receiver_state,
+                    |chunk| {
+                        let update = match chunk.record_type {
+                            AGENT_TEXT_STREAM_RECORD_TEXT_DELTA => {
+                                RuntimeAgentStreamUpdate::Chunk {
+                                    seq: chunk.seq,
+                                    text: chunk.text.clone(),
+                                }
                             }
+                            AGENT_TEXT_STREAM_RECORD_STATUS => RuntimeAgentStreamUpdate::Status {
+                                seq: chunk.seq,
+                                status: chunk.text.clone(),
+                            },
+                            AGENT_TEXT_STREAM_RECORD_PROGRESS_DELTA => {
+                                RuntimeAgentStreamUpdate::Progress {
+                                    seq: chunk.seq,
+                                    text: chunk.text.clone(),
+                                }
+                            }
+                            record_type => RuntimeAgentStreamUpdate::Record {
+                                seq: chunk.seq,
+                                record_type,
+                                text: chunk.text.clone(),
+                            },
+                        };
+                        match chunk_tx.try_send(update) {
+                            Ok(()) => {}
+                            Err(mpsc::error::TrySendError::Full(_))
+                                if chunk.record_type == AGENT_TEXT_STREAM_RECORD_TEXT_DELTA =>
+                            {
+                                tracing::warn!(
+                                    target: "marmot_app::agent_stream",
+                                    method = "watch_agent_text_stream",
+                                    "dropping live agent text stream delta; consumer is behind",
+                                );
+                            }
+                            Err(mpsc::error::TrySendError::Full(_)) => {
+                                tracing::warn!(
+                                    target: "marmot_app::agent_stream",
+                                    method = "watch_agent_text_stream",
+                                    record_type = chunk.record_type,
+                                    dropped_record_class = "non_text",
+                                    "dropping non-text agent stream record; consumer is behind",
+                                );
+                            }
+                            Err(mpsc::error::TrySendError::Closed(_)) => {}
                         }
-                        record_type => RuntimeAgentStreamUpdate::Record {
-                            seq: chunk.seq,
-                            record_type,
-                            text: chunk.text.clone(),
-                        },
-                    };
-                    match chunk_tx.try_send(update) {
-                        Ok(()) => {}
-                        Err(mpsc::error::TrySendError::Full(_))
-                            if chunk.record_type == AGENT_TEXT_STREAM_RECORD_TEXT_DELTA =>
-                        {
-                            tracing::warn!(
-                                target: "marmot_app::agent_stream",
-                                method = "watch_agent_text_stream",
-                                "dropping live agent text stream delta; consumer is behind",
-                            );
-                        }
-                        Err(mpsc::error::TrySendError::Full(_)) => {
-                            tracing::warn!(
-                                target: "marmot_app::agent_stream",
-                                method = "watch_agent_text_stream",
-                                record_type = chunk.record_type,
-                                dropped_record_class = "non_text",
-                                "dropping non-text agent stream record; consumer is behind",
-                            );
-                        }
-                        Err(mpsc::error::TrySendError::Closed(_)) => {}
-                    }
-                })
+                    },
+                )
                 .await
                 {
                     Ok(received) => {
@@ -463,4 +525,74 @@ pub(crate) fn broker_trust_for_candidate(
     server_cert_der
         .map(BrokerServerTrust::CertificateDer)
         .unwrap_or(BrokerServerTrust::Platform)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{MarmotAppEvent, RuntimeGroupEvent};
+    use cgka_traits::EpochId;
+    use cgka_traits::engine::{AppMessageInvalidationReason, GroupEvent};
+
+    fn runtime_group_event(event: GroupEvent) -> MarmotAppEvent {
+        MarmotAppEvent::GroupEvent(RuntimeGroupEvent {
+            account_id_hex: "account".to_owned(),
+            account_label: "label".to_owned(),
+            event,
+        })
+    }
+
+    #[tokio::test]
+    async fn epoch_change_closes_only_the_matching_group_preview() {
+        let (events, mut receiver) = tokio::sync::broadcast::channel(4);
+        let group = GroupId::new(vec![1; 16]);
+        events
+            .send(runtime_group_event(GroupEvent::EpochChanged {
+                group_id: GroupId::new(vec![2; 16]),
+                from: EpochId(1),
+                to: EpochId(2),
+            }))
+            .unwrap();
+        events
+            .send(runtime_group_event(GroupEvent::EpochChanged {
+                group_id: group.clone(),
+                from: EpochId(1),
+                to: EpochId(2),
+            }))
+            .unwrap();
+
+        assert_eq!(
+            wait_for_preview_invalidation(&mut receiver, &group, &hex::encode([3; 32])).await,
+            "agent stream preview closed by epoch change"
+        );
+    }
+
+    #[tokio::test]
+    async fn losing_branch_invalidation_withdraws_only_the_matching_start() {
+        let (events, mut receiver) = tokio::sync::broadcast::channel(4);
+        let group = GroupId::new(vec![1; 16]);
+        events
+            .send(runtime_group_event(GroupEvent::AppMessageInvalidated {
+                group_id: group.clone(),
+                message_id: MessageId::new(vec![2; 32]),
+                epoch: EpochId(1),
+                reason: AppMessageInvalidationReason::LosingBranch,
+                decrypted_payload_ref: None,
+            }))
+            .unwrap();
+        events
+            .send(runtime_group_event(GroupEvent::AppMessageInvalidated {
+                group_id: group.clone(),
+                message_id: MessageId::new(vec![3; 32]),
+                epoch: EpochId(1),
+                reason: AppMessageInvalidationReason::LosingBranch,
+                decrypted_payload_ref: None,
+            }))
+            .unwrap();
+
+        assert_eq!(
+            wait_for_preview_invalidation(&mut receiver, &group, &hex::encode([3; 32])).await,
+            "agent stream preview start was invalidated"
+        );
+    }
 }

--- a/crates/marmot-app/src/runtime/agent_stream_watch.rs
+++ b/crates/marmot-app/src/runtime/agent_stream_watch.rs
@@ -16,7 +16,7 @@ use tokio::sync::{mpsc, oneshot};
 use transport_quic_broker::{
     BrokerServerTrust, SubscribeTextFromBroker, subscribe_text_from_broker_with_limits,
 };
-use transport_quic_stream::{AgentTextStreamCrypto, AgentTextStreamReceiveLimits};
+use transport_quic_stream::{AgentTextStreamCrypto, AgentTextStreamReceiveLimits, QuicCandidate};
 
 use super::{
     AgentStreamWatchOptions, AgentTextStreamCryptoContext, MarmotAppRuntime,
@@ -289,21 +289,11 @@ fn normalize_hex_app(value: &str) -> Result<String, AppError> {
 }
 
 pub(crate) fn parse_quic_candidate(candidate: &str) -> Result<ParsedQuicCandidate, AppError> {
-    let trimmed = candidate.trim();
-    let Some(rest) = trimmed.strip_prefix("quic://") else {
-        return Err(AppError::AgentStreamInvalidCandidate(trimmed.to_owned()));
-    };
-    // Per transports/quic.md a receiver MUST ignore any path, query, or
-    // fragment after the authority; the authority ends at the first of '/',
-    // '?', or '#'.
-    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
-    if authority.is_empty() {
-        return Err(AppError::AgentStreamInvalidCandidate(trimmed.to_owned()));
-    }
-    let server_name = candidate_server_name(authority)?;
+    let parsed = QuicCandidate::parse(candidate)
+        .map_err(|_| AppError::AgentStreamInvalidCandidate(candidate.to_owned()))?;
     Ok(ParsedQuicCandidate {
-        authority: authority.to_owned(),
-        server_name,
+        authority: parsed.authority().to_owned(),
+        server_name: parsed.host().to_owned(),
     })
 }
 
@@ -312,27 +302,12 @@ pub(crate) fn parse_quic_candidates(
 ) -> Result<Vec<ParsedQuicCandidate>, AppError> {
     let parsed = candidates
         .iter()
-        .filter(|candidate| candidate.trim().starts_with("quic://"))
         .filter_map(|candidate| parse_quic_candidate(candidate).ok())
         .collect::<Vec<_>>();
     if parsed.is_empty() {
         return Err(AppError::AgentStreamMissingCandidate);
     }
     Ok(parsed)
-}
-
-fn candidate_server_name(authority: &str) -> Result<String, AppError> {
-    if let Some(rest) = authority.strip_prefix('[') {
-        let Some((host, _)) = rest.split_once(']') else {
-            return Err(AppError::AgentStreamInvalidCandidate(authority.to_owned()));
-        };
-        return Ok(host.to_owned());
-    }
-    authority
-        .rsplit_once(':')
-        .map(|(host, _)| host.to_owned())
-        .filter(|host| !host.is_empty())
-        .ok_or_else(|| AppError::AgentStreamInvalidCandidate(authority.to_owned()))
 }
 
 /// One broker-watch attempt: every reachable candidate for one preview

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -3192,17 +3192,37 @@ fn stream_start_intent_without_parent_omits_parent_tag() {
 }
 
 #[test]
-fn stream_start_intent_requires_a_broker() {
-    let result = build_inner_event(
-        &AppMessageIntent::StreamStart {
-            stream_id: vec![0xab; 32],
-            parent_message_id: None,
-            quic_candidates: vec!["   ".to_owned()],
-        },
-        SENDER_HEX,
-        1,
-    );
-    assert!(matches!(result, Err(AppError::AgentStreamMissingCandidate)));
+fn stream_start_intent_accepts_zero_brokers_for_durable_fallback() {
+    let event = build(AppMessageIntent::StreamStart {
+        stream_id: vec![0xab; 32],
+        parent_message_id: None,
+        quic_candidates: Vec::new(),
+    });
+    let start = StreamStartView::from_event(event.kind, &event.tags).unwrap();
+    assert!(start.quic_candidates.is_empty());
+}
+
+#[test]
+fn stream_start_intent_rejects_each_malformed_broker_value() {
+    for candidate in [
+        "   ",
+        "https://broker.example:4450",
+        "quic://broker.example",
+    ] {
+        let result = build_inner_event(
+            &AppMessageIntent::StreamStart {
+                stream_id: vec![0xab; 32],
+                parent_message_id: None,
+                quic_candidates: vec![candidate.to_owned()],
+            },
+            SENDER_HEX,
+            1,
+        );
+        assert!(matches!(
+            result,
+            Err(AppError::AgentStreamInvalidCandidate(_))
+        ));
+    }
 }
 
 #[test]

--- a/crates/storage-sqlite/src/agent_stream_sequences.rs
+++ b/crates/storage-sqlite/src/agent_stream_sequences.rs
@@ -191,22 +191,24 @@ impl SqliteAccountStorage {
         context_id: &[u8; 32],
         token: &[u8; 16],
     ) -> StorageResult<()> {
-        let changed = self
-            .connection
-            .lock()?
-            .execute(
-                "UPDATE agent_stream_publisher_sequences
+        retry_on_busy(|| {
+            let changed = self
+                .connection
+                .lock()?
+                .execute(
+                    "UPDATE agent_stream_publisher_sequences
              SET reservation_token = NULL, updated_at_ms = ?3
              WHERE context_id = ?1 AND reservation_token = ?2 AND disabled = 0",
-                params![context_id.as_slice(), token.as_slice(), unix_now_ms()],
-            )
-            .storage()?;
-        if changed != 1 {
-            return Err(StorageError::Backend(
-                "agent stream publisher reservation is not current".to_owned(),
-            ));
-        }
-        Ok(())
+                    params![context_id.as_slice(), token.as_slice(), unix_now_ms()],
+                )
+                .storage()?;
+            if changed != 1 {
+                return Err(StorageError::Backend(
+                    "agent stream publisher reservation is not current".to_owned(),
+                ));
+            }
+            Ok(())
+        })
     }
 
     pub fn agent_stream_publisher_state(

--- a/crates/storage-sqlite/src/agent_stream_sequences.rs
+++ b/crates/storage-sqlite/src/agent_stream_sequences.rs
@@ -1,0 +1,378 @@
+//! Durable, fail-closed publisher sequence reservations for QUIC previews.
+
+use crate::{SqliteAccountStorage, SqliteResultExt, connection::retry_on_busy, unix_now_ms};
+use cgka_traits::storage::{StorageError, StorageResult};
+use rusqlite::{OptionalExtension, TransactionBehavior, params};
+
+/// Hard bound for durable start contexts in one account-device database.
+/// Once reached, an unseen context fails closed instead of evicting a nonce
+/// tombstone that could later permit sequence reuse.
+pub const MAX_AGENT_STREAM_PUBLISHER_CONTEXTS: u64 = 4096;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AgentStreamPublisherReservation {
+    pub first_seq: u64,
+    pub token: [u8; 16],
+}
+
+pub struct AgentStreamPublisherReservationRequest<'a> {
+    pub context_id: &'a [u8; 32],
+    pub initial_transcript_hash: &'a [u8; 32],
+    pub expected_transcript_hash: &'a [u8; 32],
+    pub expected_chunk_count: u64,
+    pub resulting_transcript_hash: &'a [u8; 32],
+    pub record_count: u64,
+    pub resulting_chunk_count: u64,
+    pub token: [u8; 16],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AgentStreamPublisherState {
+    pub next_seq: u64,
+    pub transcript_hash: [u8; 32],
+    pub chunk_count: u64,
+    pub ambiguous: bool,
+}
+
+impl SqliteAccountStorage {
+    /// Atomically advance the next-unused sequence and transcript before any
+    /// external record write. A surviving reservation token after a crash is
+    /// intentionally ambiguous and permanently disables that preview.
+    pub fn reserve_agent_stream_publisher_records(
+        &self,
+        request: AgentStreamPublisherReservationRequest<'_>,
+    ) -> StorageResult<AgentStreamPublisherReservation> {
+        if request.record_count == 0 {
+            return Err(StorageError::Backend(
+                "agent stream reservation cannot be empty".to_owned(),
+            ));
+        }
+        retry_on_busy(|| {
+            let mut conn = self.connection.lock()?;
+            let tx = conn
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .storage()?;
+            let row = tx
+                .query_row(
+                    "SELECT next_seq, transcript_hash, chunk_count,
+                            reservation_token, disabled
+                     FROM agent_stream_publisher_sequences
+                     WHERE context_id = ?1",
+                    params![request.context_id.as_slice()],
+                    |row| {
+                        Ok((
+                            row.get::<_, i64>(0)?,
+                            row.get::<_, Vec<u8>>(1)?,
+                            row.get::<_, i64>(2)?,
+                            row.get::<_, Option<Vec<u8>>>(3)?,
+                            row.get::<_, bool>(4)?,
+                        ))
+                    },
+                )
+                .optional()
+                .storage()?;
+
+            let (first_seq, current_hash, current_chunks) = match row {
+                Some((next_seq, transcript_hash, chunk_count, reservation, disabled)) => {
+                    if disabled || reservation.is_some() {
+                        tx.execute(
+                            "UPDATE agent_stream_publisher_sequences
+                             SET disabled = 1, updated_at_ms = ?2
+                             WHERE context_id = ?1",
+                            params![request.context_id.as_slice(), unix_now_ms()],
+                        )
+                        .storage()?;
+                        tx.commit().storage()?;
+                        return Err(StorageError::Backend(
+                            "agent stream publisher continuity is ambiguous".to_owned(),
+                        ));
+                    }
+                    if transcript_hash.len() != 32 || chunk_count < 0 || next_seq < 1 {
+                        return Err(StorageError::Backend(
+                            "agent stream publisher state is corrupt".to_owned(),
+                        ));
+                    }
+                    let current_hash: [u8; 32] = transcript_hash.try_into().map_err(|_| {
+                        StorageError::Backend(
+                            "agent stream publisher transcript is corrupt".to_owned(),
+                        )
+                    })?;
+                    (
+                        u64::try_from(next_seq).map_err(|_| {
+                            StorageError::Backend(
+                                "agent stream publisher sequence is corrupt".to_owned(),
+                            )
+                        })?,
+                        current_hash,
+                        u64::try_from(chunk_count).map_err(|_| {
+                            StorageError::Backend(
+                                "agent stream publisher chunk count is corrupt".to_owned(),
+                            )
+                        })?,
+                    )
+                }
+                None => {
+                    let count = tx
+                        .query_row(
+                            "SELECT count(*) FROM agent_stream_publisher_sequences",
+                            [],
+                            |row| row.get::<_, i64>(0),
+                        )
+                        .storage()?;
+                    if u64::try_from(count).unwrap_or(u64::MAX)
+                        >= MAX_AGENT_STREAM_PUBLISHER_CONTEXTS
+                    {
+                        return Err(StorageError::Backend(
+                            "agent stream publisher state limit reached".to_owned(),
+                        ));
+                    }
+                    tx.execute(
+                        "INSERT INTO agent_stream_publisher_sequences (
+                            context_id, next_seq, transcript_hash, chunk_count,
+                            reservation_token, disabled, updated_at_ms
+                         ) VALUES (?1, 1, ?2, 0, NULL, 0, ?3)",
+                        params![
+                            request.context_id.as_slice(),
+                            request.initial_transcript_hash.as_slice(),
+                            unix_now_ms()
+                        ],
+                    )
+                    .storage()?;
+                    (1, *request.initial_transcript_hash, 0)
+                }
+            };
+            if current_hash != *request.expected_transcript_hash
+                || current_chunks != request.expected_chunk_count
+            {
+                return Err(StorageError::Backend(
+                    "agent stream publisher state changed concurrently".to_owned(),
+                ));
+            }
+            if request.resulting_chunk_count != current_chunks.saturating_add(request.record_count)
+            {
+                return Err(StorageError::Backend(
+                    "agent stream transcript count does not match reservation".to_owned(),
+                ));
+            }
+            let next_seq = first_seq.checked_add(request.record_count).ok_or_else(|| {
+                StorageError::Backend("agent stream publisher sequence exhausted".to_owned())
+            })?;
+            tx.execute(
+                "UPDATE agent_stream_publisher_sequences
+                 SET next_seq = ?2, transcript_hash = ?3, chunk_count = ?4,
+                     reservation_token = ?5, updated_at_ms = ?6
+                 WHERE context_id = ?1",
+                params![
+                    request.context_id.as_slice(),
+                    i64::try_from(next_seq).map_err(|_| StorageError::Backend(
+                        "agent stream publisher sequence exhausted".to_owned()
+                    ))?,
+                    request.resulting_transcript_hash.as_slice(),
+                    i64::try_from(request.resulting_chunk_count).map_err(|_| {
+                        StorageError::Backend(
+                            "agent stream publisher chunk count exhausted".to_owned(),
+                        )
+                    })?,
+                    request.token.as_slice(),
+                    unix_now_ms(),
+                ],
+            )
+            .storage()?;
+            tx.commit().storage()?;
+            Ok(AgentStreamPublisherReservation {
+                first_seq,
+                token: request.token,
+            })
+        })
+    }
+
+    pub fn confirm_agent_stream_publisher_reservation(
+        &self,
+        context_id: &[u8; 32],
+        token: &[u8; 16],
+    ) -> StorageResult<()> {
+        let changed = self
+            .connection
+            .lock()?
+            .execute(
+                "UPDATE agent_stream_publisher_sequences
+             SET reservation_token = NULL, updated_at_ms = ?3
+             WHERE context_id = ?1 AND reservation_token = ?2 AND disabled = 0",
+                params![context_id.as_slice(), token.as_slice(), unix_now_ms()],
+            )
+            .storage()?;
+        if changed != 1 {
+            return Err(StorageError::Backend(
+                "agent stream publisher reservation is not current".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn agent_stream_publisher_state(
+        &self,
+        context_id: &[u8; 32],
+    ) -> StorageResult<Option<AgentStreamPublisherState>> {
+        self.connection
+            .lock()?
+            .query_row(
+                "SELECT next_seq, transcript_hash, chunk_count,
+                        reservation_token IS NOT NULL OR disabled
+                 FROM agent_stream_publisher_sequences
+                 WHERE context_id = ?1",
+                params![context_id.as_slice()],
+                |row| {
+                    let next_seq = row.get::<_, i64>(0)?;
+                    let hash = row.get::<_, Vec<u8>>(1)?;
+                    let chunks = row.get::<_, i64>(2)?;
+                    let ambiguous = row.get::<_, bool>(3)?;
+                    let hash: [u8; 32] = hash.try_into().map_err(|_| {
+                        rusqlite::Error::InvalidColumnType(
+                            1,
+                            "transcript_hash".to_owned(),
+                            rusqlite::types::Type::Blob,
+                        )
+                    })?;
+                    Ok(AgentStreamPublisherState {
+                        next_seq: u64::try_from(next_seq).unwrap_or_default(),
+                        transcript_hash: hash,
+                        chunk_count: u64::try_from(chunks).unwrap_or_default(),
+                        ambiguous,
+                    })
+                },
+            )
+            .optional()
+            .storage()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reservation_is_durable_monotonic_and_fail_closed_when_ambiguous() {
+        let storage = SqliteAccountStorage::in_memory().unwrap();
+        let context = [1_u8; 32];
+        let initial = [2_u8; 32];
+        let after = [3_u8; 32];
+        let token = [4_u8; 16];
+
+        let reserved = storage
+            .reserve_agent_stream_publisher_records(AgentStreamPublisherReservationRequest {
+                context_id: &context,
+                initial_transcript_hash: &initial,
+                expected_transcript_hash: &initial,
+                expected_chunk_count: 0,
+                resulting_transcript_hash: &after,
+                record_count: 2,
+                resulting_chunk_count: 2,
+                token,
+            })
+            .unwrap();
+        assert_eq!(reserved.first_seq, 1);
+        assert_eq!(
+            storage.agent_stream_publisher_state(&context).unwrap(),
+            Some(AgentStreamPublisherState {
+                next_seq: 3,
+                transcript_hash: after,
+                chunk_count: 2,
+                ambiguous: true,
+            })
+        );
+        assert!(
+            storage
+                .reserve_agent_stream_publisher_records(AgentStreamPublisherReservationRequest {
+                    context_id: &context,
+                    initial_transcript_hash: &initial,
+                    expected_transcript_hash: &after,
+                    expected_chunk_count: 2,
+                    resulting_transcript_hash: &[5; 32],
+                    record_count: 1,
+                    resulting_chunk_count: 3,
+                    token: [6; 16],
+                })
+                .is_err()
+        );
+        assert!(
+            storage
+                .confirm_agent_stream_publisher_reservation(&context, &token)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn confirmed_reservation_continues_at_next_sequence() {
+        let storage = SqliteAccountStorage::in_memory().unwrap();
+        let context = [1_u8; 32];
+        let initial = [2_u8; 32];
+        let after_one = [3_u8; 32];
+        let first = storage
+            .reserve_agent_stream_publisher_records(AgentStreamPublisherReservationRequest {
+                context_id: &context,
+                initial_transcript_hash: &initial,
+                expected_transcript_hash: &initial,
+                expected_chunk_count: 0,
+                resulting_transcript_hash: &after_one,
+                record_count: 1,
+                resulting_chunk_count: 1,
+                token: [4; 16],
+            })
+            .unwrap();
+        storage
+            .confirm_agent_stream_publisher_reservation(&context, &first.token)
+            .unwrap();
+        let second = storage
+            .reserve_agent_stream_publisher_records(AgentStreamPublisherReservationRequest {
+                context_id: &context,
+                initial_transcript_hash: &initial,
+                expected_transcript_hash: &after_one,
+                expected_chunk_count: 1,
+                resulting_transcript_hash: &[5; 32],
+                record_count: 1,
+                resulting_chunk_count: 2,
+                token: [6; 16],
+            })
+            .unwrap();
+        assert_eq!(second.first_seq, 2);
+    }
+
+    #[test]
+    fn corrupt_publisher_state_fails_closed() {
+        let storage = SqliteAccountStorage::in_memory().unwrap();
+        let context = [1_u8; 32];
+        let connection = storage.connection.lock().unwrap();
+        connection
+            .execute_batch("PRAGMA ignore_check_constraints = ON;")
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO agent_stream_publisher_sequences (
+                    context_id, next_seq, transcript_hash, chunk_count,
+                    reservation_token, disabled, updated_at_ms
+                 ) VALUES (?1, 0, ?2, 0, NULL, 0, 0)",
+                params![context.as_slice(), [2_u8; 31].as_slice()],
+            )
+            .unwrap();
+        connection
+            .execute_batch("PRAGMA ignore_check_constraints = OFF;")
+            .unwrap();
+        drop(connection);
+
+        assert!(
+            storage
+                .reserve_agent_stream_publisher_records(AgentStreamPublisherReservationRequest {
+                    context_id: &context,
+                    initial_transcript_hash: &[3; 32],
+                    expected_transcript_hash: &[3; 32],
+                    expected_chunk_count: 0,
+                    resulting_transcript_hash: &[4; 32],
+                    record_count: 1,
+                    resulting_chunk_count: 1,
+                    token: [5; 16],
+                })
+                .is_err(),
+            "a corrupt sequence/hash row must never fall back to seq=1"
+        );
+    }
+}

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -6,6 +6,7 @@
 //! layers.
 
 mod account_projection;
+mod agent_stream_sequences;
 mod chat_list;
 mod codec;
 mod connection;
@@ -51,6 +52,10 @@ pub use timeline::{
     TimelineReplyPreview, TimelineUpdateTrigger, TimelineUserReaction,
 };
 
+pub use agent_stream_sequences::{
+    AgentStreamPublisherReservation, AgentStreamPublisherReservationRequest,
+    AgentStreamPublisherState, MAX_AGENT_STREAM_PUBLISHER_CONTEXTS,
+};
 pub(crate) use codec::{
     SqliteResultExt, bool_i64, created_at_to_i64, deserialize, epoch_to_i64, i64_to_u64,
     message_state_to_i64, optional_u64_to_i64, serialize, tags_from_json, u64_to_i64, unix_now_ms,

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -68,6 +68,8 @@ mod migration_0033_push_registration_gossip_outbox;
 mod migration_0034_maintenance_publication;
 #[path = "migrations/0035_durable_convergence_passes.rs"]
 mod migration_0035_durable_convergence_passes;
+#[path = "migrations/0036_agent_stream_publisher_sequences.rs"]
+mod migration_0036_agent_stream_publisher_sequences;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -254,6 +256,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 35,
         name: "0035_durable_convergence_passes",
         apply: migration_0035_durable_convergence_passes::apply,
+    },
+    Migration {
+        version: 36,
+        name: "0036_agent_stream_publisher_sequences",
+        apply: migration_0036_agent_stream_publisher_sequences::apply,
     },
 ];
 

--- a/crates/storage-sqlite/src/migrations/0036_agent_stream_publisher_sequences.rs
+++ b/crates/storage-sqlite/src/migrations/0036_agent_stream_publisher_sequences.rs
@@ -1,0 +1,22 @@
+//! Migration 0036: durable QUIC preview publisher sequence reservations.
+
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE agent_stream_publisher_sequences (
+    context_id BLOB PRIMARY KEY NOT NULL CHECK(length(context_id) = 32),
+    next_seq INTEGER NOT NULL CHECK(next_seq >= 1),
+    transcript_hash BLOB NOT NULL CHECK(length(transcript_hash) = 32),
+    chunk_count INTEGER NOT NULL CHECK(chunk_count >= 0),
+    reservation_token BLOB CHECK(reservation_token IS NULL OR length(reservation_token) = 16),
+    disabled INTEGER NOT NULL DEFAULT 0 CHECK(disabled IN (0, 1)),
+    updated_at_ms INTEGER NOT NULL
+);
+"#,
+    )
+    .storage()
+}

--- a/crates/traits/src/agent_text_stream.rs
+++ b/crates/traits/src/agent_text_stream.rs
@@ -452,6 +452,23 @@ impl AgentTextStreamTranscriptV1 {
         }
     }
 
+    /// Resume a transcript whose hash/count were loaded from durable publisher
+    /// or receiver lifecycle state. The caller must bind that state to the same
+    /// stream/start context before using this constructor.
+    pub fn from_state(
+        stream_id: impl Into<Vec<u8>>,
+        start_event_id: MessageId,
+        hash: [u8; 32],
+        chunk_count: u64,
+    ) -> Self {
+        Self {
+            stream_id: stream_id.into(),
+            start_event_id,
+            hash,
+            chunk_count,
+        }
+    }
+
     pub fn append(&mut self, seq: u64, record_type: u8, plaintext_frame: &[u8]) {
         let mut hasher = Sha256::new();
         hasher.update(self.hash);

--- a/crates/transport-quic-broker/src/client.rs
+++ b/crates/transport-quic-broker/src/client.rs
@@ -88,6 +88,7 @@ pub struct BrokerTextPublisher {
 pub struct BrokerTextReceiverState {
     high_water: u64,
     frames_read: u64,
+    limits: AgentTextStreamReceiveLimits,
     chunks: Vec<ReceivedTextChunk>,
     text: String,
     transcript: AgentTextStreamTranscriptV1,
@@ -103,6 +104,7 @@ impl BrokerTextReceiverState {
         Self {
             high_water: 0,
             frames_read: 0,
+            limits,
             chunks: Vec::new(),
             text: String::new(),
             transcript: AgentTextStreamTranscriptV1::new(stream_id, start_event_id),
@@ -114,17 +116,13 @@ impl BrokerTextReceiverState {
         self.high_water
     }
 
-    fn begin_record(
-        &mut self,
-        seq: u64,
-        limits: AgentTextStreamReceiveLimits,
-    ) -> Result<bool, QuicBrokerError> {
+    fn begin_record(&mut self, seq: u64) -> Result<bool, QuicBrokerError> {
         self.frames_read = self.frames_read.saturating_add(1);
-        if self.frames_read > limits.max_records {
+        if self.frames_read > self.limits.max_records {
             return Err(QuicBrokerError::ReceiveLimit(
                 AgentTextStreamReceiveLimitError::RecordLimitExceeded {
                     attempted: self.frames_read,
-                    limit: limits.max_records,
+                    limit: self.limits.max_records,
                 },
             ));
         }
@@ -312,17 +310,19 @@ impl BrokerTextPublisher {
                 )
             })
             .transpose()?;
-        let record = reservation
-            .as_ref()
-            .map(|reservation| reservation.records[0].clone())
-            .unwrap_or_else(|| {
-                AgentTextStreamRecordV1::new(
-                    self.transcript.stream_id().to_vec(),
-                    self.next_seq,
-                    AGENT_TEXT_STREAM_RECORD_ABORT,
-                    Vec::new(),
+        let record = match &reservation {
+            Some(reservation) => reservation.records.first().cloned().ok_or_else(|| {
+                transport_quic_stream::QuicTextStreamError::PublisherSequence(
+                    "publisher reservation returned no records".to_owned(),
                 )
-            });
+            })?,
+            None => AgentTextStreamRecordV1::new(
+                self.transcript.stream_id().to_vec(),
+                self.next_seq,
+                AGENT_TEXT_STREAM_RECORD_ABORT,
+                Vec::new(),
+            ),
+        };
         record.validate()?;
         if reservation.is_none() {
             self.next_seq += 1;
@@ -421,12 +421,11 @@ where
         config.start_event_id.clone(),
         limits,
     );
-    subscribe_text_from_broker_with_resume(config, limits, &mut state, on_chunk).await
+    subscribe_text_from_broker_with_resume(config, &mut state, on_chunk).await
 }
 
 pub async fn subscribe_text_from_broker_with_resume<F>(
     config: SubscribeTextFromBroker,
-    limits: AgentTextStreamReceiveLimits,
     state: &mut BrokerTextReceiverState,
     mut on_chunk: F,
 ) -> Result<ReceivedTextStream, QuicBrokerError>
@@ -453,7 +452,7 @@ where
     // records at or below it (duplicates, broker backlog replayed on
     // reconnect) are discarded silently and are never stream-fatal; the next
     // accepted record is high_water + 1; a record further ahead is a gap.
-    let max_frame_len = frame_len_cap(Some(limits.max_plaintext_frame_len));
+    let max_frame_len = frame_len_cap(Some(state.limits.max_plaintext_frame_len));
     // The broker is untrusted and can replay `seq <= high_water` frames
     // forever. Those discards never reach `limit_state.observe`, so count every
     // frame read off the wire here and trip `max_records` before the dedup
@@ -462,7 +461,7 @@ where
     while let Some(record) =
         read_record_frame(&mut recv, Some(RECORD_QUIET_GAP_DEADLINE), max_frame_len).await?
     {
-        if !state.begin_record(record.seq, limits)? {
+        if !state.begin_record(record.seq)? {
             continue;
         }
         let record = if let Some(crypto) = &config.crypto {
@@ -500,16 +499,16 @@ mod lifecycle_tests {
         let mut state = BrokerTextReceiverState::new(stream_id.clone(), start.clone(), limits);
 
         let first = AgentTextStreamRecordV1::text_delta(stream_id.clone(), 1, b"one".to_vec());
-        assert!(state.begin_record(first.seq, limits).unwrap());
+        assert!(state.begin_record(first.seq).unwrap());
         state.accept_record(first, &stream_id).unwrap();
 
         let replay = AgentTextStreamRecordV1::text_delta(stream_id.clone(), 1, b"one".to_vec());
         assert!(
-            !state.begin_record(replay.seq, limits).unwrap(),
+            !state.begin_record(replay.seq).unwrap(),
             "a reconnect replay at the high-water mark is harmless"
         );
         let second = AgentTextStreamRecordV1::text_delta(stream_id.clone(), 2, b"two".to_vec());
-        assert!(state.begin_record(second.seq, limits).unwrap());
+        assert!(state.begin_record(second.seq).unwrap());
         state.accept_record(second, &stream_id).unwrap();
 
         let mut expected = AgentTextStreamTranscriptV1::new(stream_id, start);

--- a/crates/transport-quic-broker/src/client.rs
+++ b/crates/transport-quic-broker/src/client.rs
@@ -82,6 +82,91 @@ pub struct BrokerTextPublisher {
     max_plaintext_frame_len: Option<u32>,
 }
 
+/// Receiver lifecycle state retained across reconnects and ordered candidate
+/// failover. Sequence, transcript, and limits continue from the same durable
+/// kind-1200 start context.
+pub struct BrokerTextReceiverState {
+    high_water: u64,
+    frames_read: u64,
+    chunks: Vec<ReceivedTextChunk>,
+    text: String,
+    transcript: AgentTextStreamTranscriptV1,
+    limit_state: AgentTextStreamReceiveAccumulator,
+}
+
+impl BrokerTextReceiverState {
+    pub fn new(
+        stream_id: Vec<u8>,
+        start_event_id: MessageId,
+        limits: AgentTextStreamReceiveLimits,
+    ) -> Self {
+        Self {
+            high_water: 0,
+            frames_read: 0,
+            chunks: Vec::new(),
+            text: String::new(),
+            transcript: AgentTextStreamTranscriptV1::new(stream_id, start_event_id),
+            limit_state: AgentTextStreamReceiveAccumulator::new(limits),
+        }
+    }
+
+    pub fn high_water(&self) -> u64 {
+        self.high_water
+    }
+
+    fn begin_record(
+        &mut self,
+        seq: u64,
+        limits: AgentTextStreamReceiveLimits,
+    ) -> Result<bool, QuicBrokerError> {
+        self.frames_read = self.frames_read.saturating_add(1);
+        if self.frames_read > limits.max_records {
+            return Err(QuicBrokerError::ReceiveLimit(
+                AgentTextStreamReceiveLimitError::RecordLimitExceeded {
+                    attempted: self.frames_read,
+                    limit: limits.max_records,
+                },
+            ));
+        }
+        if seq <= self.high_water {
+            return Ok(false);
+        }
+        if seq != self.high_water + 1 {
+            return Err(QuicBrokerError::UnexpectedSequence {
+                expected: self.high_water + 1,
+                actual: seq,
+            });
+        }
+        Ok(true)
+    }
+
+    fn accept_record(
+        &mut self,
+        record: AgentTextStreamRecordV1,
+        expected_stream_id: &[u8],
+    ) -> Result<ReceivedTextChunk, QuicBrokerError> {
+        self.limit_state.observe(&record)?;
+        if record.stream_id != expected_stream_id {
+            return Err(QuicBrokerError::MixedStreamIds);
+        }
+        self.high_water = record.seq;
+        let frame_text = stream_record_text(&record);
+        if record.record_type == AGENT_TEXT_STREAM_RECORD_TEXT_DELTA {
+            self.text.push_str(&frame_text);
+        }
+        self.transcript
+            .append(record.seq, record.record_type, &record.plaintext_frame);
+        let chunk = ReceivedTextChunk {
+            seq: record.seq,
+            record_type: record.record_type,
+            flags: record.flags,
+            text: frame_text,
+        };
+        self.chunks.push(chunk.clone());
+        Ok(chunk)
+    }
+}
+
 impl BrokerTextPublisher {
     pub async fn connect(config: OpenBrokerTextPublisher) -> Result<Self, QuicBrokerError> {
         let endpoint = client_endpoint(config.trust, config.broker_addr)?;
@@ -143,16 +228,44 @@ impl BrokerTextPublisher {
         let max_chunk_bytes =
             max_chunk_bytes.min(effective_plaintext_cap(self.max_plaintext_frame_len));
 
+        let frames = transport_quic_stream::split_text_deltas(text, max_chunk_bytes)
+            .into_iter()
+            .map(|chunk| (record_type, chunk))
+            .collect::<Vec<_>>();
+        let reservation = self
+            .crypto
+            .as_ref()
+            .filter(|_| !frames.is_empty())
+            .map(|crypto| {
+                transport_quic_stream::reserve_publisher_records_for_transport(
+                    crypto,
+                    self.transcript.stream_id(),
+                    self.transcript.start_event_id(),
+                    &frames,
+                )
+            })
+            .transpose()?;
+        let records = if let Some(reservation) = &reservation {
+            reservation.records.clone()
+        } else {
+            frames
+                .into_iter()
+                .map(|(record_type, chunk)| {
+                    let record = AgentTextStreamRecordV1::new(
+                        self.transcript.stream_id().to_vec(),
+                        self.next_seq,
+                        record_type,
+                        chunk,
+                    );
+                    self.next_seq += 1;
+                    record
+                })
+                .collect()
+        };
+
         let mut appended = 0_u64;
-        for chunk in transport_quic_stream::split_text_deltas(text, max_chunk_bytes) {
-            let record = AgentTextStreamRecordV1::new(
-                self.transcript.stream_id().to_vec(),
-                self.next_seq,
-                record_type,
-                chunk,
-            );
+        for record in records {
             record.validate()?;
-            self.next_seq += 1;
             let wire_record = if let Some(crypto) = &self.crypto {
                 encrypt_record(crypto, &record)?
             } else {
@@ -166,6 +279,18 @@ impl BrokerTextPublisher {
                 sleep(chunk_delay).await;
             }
         }
+        if let Some(reservation) = reservation {
+            let hash = reservation.transcript_hash;
+            let count = reservation.chunk_count;
+            reservation.confirm()?;
+            self.transcript = AgentTextStreamTranscriptV1::from_state(
+                self.transcript.stream_id().to_vec(),
+                self.transcript.start_event_id().clone(),
+                hash,
+                count,
+            );
+            self.next_seq = count.saturating_add(1);
+        }
         Ok(appended)
     }
 
@@ -174,14 +299,34 @@ impl BrokerTextPublisher {
     /// cancelled. `Abort` carries no durable text; it consumes one `seq` and
     /// contributes to the transcript like any other record.
     pub async fn append_abort(&mut self) -> Result<(), QuicBrokerError> {
-        let record = AgentTextStreamRecordV1::new(
-            self.transcript.stream_id().to_vec(),
-            self.next_seq,
-            AGENT_TEXT_STREAM_RECORD_ABORT,
-            Vec::new(),
-        );
+        let frames = vec![(AGENT_TEXT_STREAM_RECORD_ABORT, Vec::new())];
+        let reservation = self
+            .crypto
+            .as_ref()
+            .map(|crypto| {
+                transport_quic_stream::reserve_publisher_records_for_transport(
+                    crypto,
+                    self.transcript.stream_id(),
+                    self.transcript.start_event_id(),
+                    &frames,
+                )
+            })
+            .transpose()?;
+        let record = reservation
+            .as_ref()
+            .map(|reservation| reservation.records[0].clone())
+            .unwrap_or_else(|| {
+                AgentTextStreamRecordV1::new(
+                    self.transcript.stream_id().to_vec(),
+                    self.next_seq,
+                    AGENT_TEXT_STREAM_RECORD_ABORT,
+                    Vec::new(),
+                )
+            });
         record.validate()?;
-        self.next_seq += 1;
+        if reservation.is_none() {
+            self.next_seq += 1;
+        }
         let wire_record = if let Some(crypto) = &self.crypto {
             encrypt_record(crypto, &record)?
         } else {
@@ -190,6 +335,18 @@ impl BrokerTextPublisher {
         write_record_frame(&mut self.send, &wire_record).await?;
         self.transcript
             .append(record.seq, record.record_type, &record.plaintext_frame);
+        if let Some(reservation) = reservation {
+            let hash = reservation.transcript_hash;
+            let count = reservation.chunk_count;
+            reservation.confirm()?;
+            self.transcript = AgentTextStreamTranscriptV1::from_state(
+                self.transcript.stream_id().to_vec(),
+                self.transcript.start_event_id().clone(),
+                hash,
+                count,
+            );
+            self.next_seq = count.saturating_add(1);
+        }
         Ok(())
     }
 
@@ -254,6 +411,23 @@ where
 pub async fn subscribe_text_from_broker_with_limits<F>(
     config: SubscribeTextFromBroker,
     limits: AgentTextStreamReceiveLimits,
+    on_chunk: F,
+) -> Result<ReceivedTextStream, QuicBrokerError>
+where
+    F: FnMut(&ReceivedTextChunk),
+{
+    let mut state = BrokerTextReceiverState::new(
+        config.stream_id.clone(),
+        config.start_event_id.clone(),
+        limits,
+    );
+    subscribe_text_from_broker_with_resume(config, limits, &mut state, on_chunk).await
+}
+
+pub async fn subscribe_text_from_broker_with_resume<F>(
+    config: SubscribeTextFromBroker,
+    limits: AgentTextStreamReceiveLimits,
+    state: &mut BrokerTextReceiverState,
     mut on_chunk: F,
 ) -> Result<ReceivedTextStream, QuicBrokerError>
 where
@@ -279,76 +453,71 @@ where
     // records at or below it (duplicates, broker backlog replayed on
     // reconnect) are discarded silently and are never stream-fatal; the next
     // accepted record is high_water + 1; a record further ahead is a gap.
-    let mut high_water = 0_u64;
-    let mut chunks = Vec::new();
-    let mut text = String::new();
-    let mut transcript =
-        AgentTextStreamTranscriptV1::new(config.stream_id.clone(), config.start_event_id);
-    let mut limit_state = AgentTextStreamReceiveAccumulator::new(limits);
     let max_frame_len = frame_len_cap(Some(limits.max_plaintext_frame_len));
     // The broker is untrusted and can replay `seq <= high_water` frames
     // forever. Those discards never reach `limit_state.observe`, so count every
     // frame read off the wire here and trip `max_records` before the dedup
     // `continue` can silently bypass it. A read deadline (instead of `None`)
     // breaks a starved read so a malicious broker cannot wedge the loop.
-    let mut frames_read = 0_u64;
-
     while let Some(record) =
         read_record_frame(&mut recv, Some(RECORD_QUIET_GAP_DEADLINE), max_frame_len).await?
     {
-        frames_read = frames_read.saturating_add(1);
-        if frames_read > limits.max_records {
-            return Err(QuicBrokerError::ReceiveLimit(
-                AgentTextStreamReceiveLimitError::RecordLimitExceeded {
-                    attempted: frames_read,
-                    limit: limits.max_records,
-                },
-            ));
-        }
-        if record.seq <= high_water {
+        if !state.begin_record(record.seq, limits)? {
             continue;
-        }
-        if record.seq != high_water + 1 {
-            return Err(QuicBrokerError::UnexpectedSequence {
-                expected: high_water + 1,
-                actual: record.seq,
-            });
         }
         let record = if let Some(crypto) = &config.crypto {
             decrypt_record(crypto, &record)?
         } else {
             record
         };
-        limit_state.observe(&record)?;
-        if record.stream_id != config.stream_id {
-            return Err(QuicBrokerError::MixedStreamIds);
-        }
-        high_water = record.seq;
-
-        let frame_text = stream_record_text(&record);
-        if record.record_type == AGENT_TEXT_STREAM_RECORD_TEXT_DELTA {
-            text.push_str(&frame_text);
-        }
-        transcript.append(record.seq, record.record_type, &record.plaintext_frame);
-        let chunk = ReceivedTextChunk {
-            seq: record.seq,
-            record_type: record.record_type,
-            flags: record.flags,
-            text: frame_text,
-        };
+        let chunk = state.accept_record(record, &config.stream_id)?;
         on_chunk(&chunk);
-        chunks.push(chunk);
     }
 
     connection.close(0_u32.into(), b"done");
-    if chunks.is_empty() {
+    if state.chunks.is_empty() {
         return Err(QuicBrokerError::EmptyStream);
     }
     Ok(ReceivedTextStream {
-        stream_id: transcript.stream_id().to_vec(),
-        chunks,
-        text,
-        transcript_hash: transcript.hash(),
-        chunk_count: transcript.chunk_count(),
+        stream_id: state.transcript.stream_id().to_vec(),
+        chunks: state.chunks.clone(),
+        text: state.text.clone(),
+        transcript_hash: state.transcript.hash(),
+        chunk_count: state.transcript.chunk_count(),
     })
+}
+
+#[cfg(test)]
+mod lifecycle_tests {
+    use super::*;
+    use cgka_traits::agent_text_stream::AgentTextStreamRecordV1;
+
+    #[test]
+    fn receiver_state_continues_high_water_and_transcript_across_reconnects() {
+        let stream_id = vec![0x31; 32];
+        let start = MessageId::new(vec![0x41; 32]);
+        let limits = AgentTextStreamReceiveLimits::default();
+        let mut state = BrokerTextReceiverState::new(stream_id.clone(), start.clone(), limits);
+
+        let first = AgentTextStreamRecordV1::text_delta(stream_id.clone(), 1, b"one".to_vec());
+        assert!(state.begin_record(first.seq, limits).unwrap());
+        state.accept_record(first, &stream_id).unwrap();
+
+        let replay = AgentTextStreamRecordV1::text_delta(stream_id.clone(), 1, b"one".to_vec());
+        assert!(
+            !state.begin_record(replay.seq, limits).unwrap(),
+            "a reconnect replay at the high-water mark is harmless"
+        );
+        let second = AgentTextStreamRecordV1::text_delta(stream_id.clone(), 2, b"two".to_vec());
+        assert!(state.begin_record(second.seq, limits).unwrap());
+        state.accept_record(second, &stream_id).unwrap();
+
+        let mut expected = AgentTextStreamTranscriptV1::new(stream_id, start);
+        expected.append(1, AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"one");
+        expected.append(2, AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"two");
+        assert_eq!(state.high_water(), 2);
+        assert_eq!(state.text, "onetwo");
+        assert_eq!(state.transcript.hash(), expected.hash());
+        assert_eq!(state.transcript.chunk_count(), 2);
+    }
 }

--- a/crates/transport-quic-broker/src/lib.rs
+++ b/crates/transport-quic-broker/src/lib.rs
@@ -19,9 +19,10 @@ mod tls;
 mod tests;
 
 pub use client::{
-    BrokerServerTrust, BrokerTextPublisher, OpenBrokerTextPublisher, PublishTextToBroker,
-    SubscribeTextFromBroker, publish_text_to_broker, subscribe_text_from_broker,
-    subscribe_text_from_broker_with_limits, subscribe_text_from_broker_with_updates,
+    BrokerServerTrust, BrokerTextPublisher, BrokerTextReceiverState, OpenBrokerTextPublisher,
+    PublishTextToBroker, SubscribeTextFromBroker, publish_text_to_broker,
+    subscribe_text_from_broker, subscribe_text_from_broker_with_limits,
+    subscribe_text_from_broker_with_resume, subscribe_text_from_broker_with_updates,
 };
 pub use config::{QuicBrokerConfig, QuicBrokerTlsConfig};
 pub use control::{BrokerStreamKey, QuicBrokerControlEnvelopeV1, QuicBrokerControlTypeV1};

--- a/crates/transport-quic-broker/src/tests.rs
+++ b/crates/transport-quic-broker/src/tests.rs
@@ -18,7 +18,7 @@ use tokio::sync::oneshot;
 use tokio::time::{sleep, timeout};
 use transport_quic_stream::{
     AgentTextStreamCrypto, AgentTextStreamReceiveLimitError, AgentTextStreamReceiveLimits,
-    stream_record_text,
+    EphemeralPublisherSequenceStore, stream_record_text,
 };
 
 use crate::client::{
@@ -2145,7 +2145,8 @@ async fn broker_publish_frame_byte_limit_counts_wire_bytes_for_encrypted_records
             MemberId::new(vec![0x02; 32]),
             start_event_id.clone(),
         ),
-    );
+    )
+    .with_publisher_sequence_store(Arc::new(EphemeralPublisherSequenceStore::default()));
 
     let server = QuicBrokerServer::bind(QuicBrokerConfig {
         bind_addr: LOCAL_SERVER_BIND,

--- a/crates/transport-quic-stream/README.md
+++ b/crates/transport-quic-stream/README.md
@@ -12,6 +12,8 @@ orchestration stay in higher layers.
   early-data policy) also consumed by `transport-quic-broker`.
 - Seals and opens length-delimited preview records with HKDF-derived keys and AAD.
 - Sends and receives text-stream preview chunks over ordered QUIC streams.
+- Requires encrypted publishers to reserve sequences through an account-device
+  durable state boundary before record writes; ambiguous state fails closed.
 
 ## What it does not do
 

--- a/crates/transport-quic-stream/src/candidate.rs
+++ b/crates/transport-quic-stream/src/candidate.rs
@@ -1,0 +1,207 @@
+//! Adopted `quic://` broker-candidate parsing.
+
+use std::net::IpAddr;
+
+/// Maximum byte length of one complete kind-1200 `broker` tag value.
+pub const QUIC_CANDIDATE_MAX_LEN: usize = 512;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QuicCandidate {
+    original: String,
+    authority: String,
+    host: String,
+    port: u16,
+}
+
+impl QuicCandidate {
+    /// Parse and validate one complete candidate value. The authority ends at
+    /// the first `/`, `?`, or `#`; the suffix is deliberately ignored.
+    pub fn parse(candidate: &str) -> Result<Self, QuicCandidateError> {
+        Self::parse_bytes(candidate.as_bytes())
+    }
+
+    /// Byte-oriented entry point so callers decoding untrusted tag bytes can
+    /// enforce UTF-8 before constructing a `String`.
+    pub fn parse_bytes(candidate: &[u8]) -> Result<Self, QuicCandidateError> {
+        if candidate.len() > QUIC_CANDIDATE_MAX_LEN {
+            return Err(QuicCandidateError::TooLong(candidate.len()));
+        }
+        let candidate =
+            std::str::from_utf8(candidate).map_err(|_| QuicCandidateError::InvalidUtf8)?;
+        let rest = candidate
+            .strip_prefix("quic://")
+            .ok_or(QuicCandidateError::InvalidScheme)?;
+        let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+        if authority.is_empty() {
+            return Err(QuicCandidateError::MissingAuthority);
+        }
+
+        let (host, port_text) = if let Some(bracketed) = authority.strip_prefix('[') {
+            let close = bracketed
+                .find(']')
+                .ok_or(QuicCandidateError::InvalidAuthority)?;
+            let host = &bracketed[..close];
+            let suffix = &bracketed[close + 1..];
+            let port = suffix
+                .strip_prefix(':')
+                .filter(|port| !port.is_empty())
+                .ok_or(QuicCandidateError::MissingPort)?;
+            if suffix[1..].contains(':') || host.parse::<std::net::Ipv6Addr>().is_err() {
+                return Err(QuicCandidateError::InvalidAuthority);
+            }
+            (host, port)
+        } else {
+            let (host, port) = authority
+                .rsplit_once(':')
+                .ok_or(QuicCandidateError::MissingPort)?;
+            if host.is_empty() || host.contains(':') || port.is_empty() {
+                return Err(QuicCandidateError::InvalidAuthority);
+            }
+            validate_unbracketed_host(host)?;
+            (host, port)
+        };
+        let port = port_text
+            .parse::<u16>()
+            .map_err(|_| QuicCandidateError::InvalidPort)?;
+
+        Ok(Self {
+            original: candidate.to_owned(),
+            authority: authority.to_owned(),
+            host: host.to_owned(),
+            port,
+        })
+    }
+
+    pub fn original(&self) -> &str {
+        &self.original
+    }
+
+    pub fn authority(&self) -> &str {
+        &self.authority
+    }
+
+    /// Candidate host used for TLS identity selection. DNS names remain DNS
+    /// names; IP literals remain IP literals.
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn ip_literal(&self) -> Option<IpAddr> {
+        self.host.parse().ok()
+    }
+}
+
+fn validate_unbracketed_host(host: &str) -> Result<(), QuicCandidateError> {
+    if host.parse::<std::net::Ipv4Addr>().is_ok() {
+        return Ok(());
+    }
+    if host.len() > 253
+        || host.starts_with('.')
+        || host.ends_with('.')
+        || host.split('.').any(|label| {
+            label.is_empty()
+                || label.len() > 63
+                || label.starts_with('-')
+                || label.ends_with('-')
+                || !label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        })
+    {
+        return Err(QuicCandidateError::InvalidHost);
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum QuicCandidateError {
+    #[error("QUIC candidate is not valid UTF-8")]
+    InvalidUtf8,
+    #[error("QUIC candidate exceeds 512 bytes: {0}")]
+    TooLong(usize),
+    #[error("QUIC candidate must use the quic:// scheme")]
+    InvalidScheme,
+    #[error("QUIC candidate is missing an authority")]
+    MissingAuthority,
+    #[error("QUIC candidate authority is invalid")]
+    InvalidAuthority,
+    #[error("QUIC candidate host is invalid")]
+    InvalidHost,
+    #[error("QUIC candidate is missing a port")]
+    MissingPort,
+    #[error("QUIC candidate port is invalid")]
+    InvalidPort,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn complete_candidate_length_and_utf8_are_enforced() {
+        let prefix = "quic://a:1#";
+        let one = "x";
+        assert!(QuicCandidate::parse(one).is_err());
+        let candidate_512 = format!(
+            "{prefix}{}",
+            "x".repeat(QUIC_CANDIDATE_MAX_LEN - prefix.len())
+        );
+        assert_eq!(candidate_512.len(), 512);
+        assert!(QuicCandidate::parse(&candidate_512).is_ok());
+        let candidate_513 = format!("{candidate_512}x");
+        assert_eq!(
+            QuicCandidate::parse(&candidate_513),
+            Err(QuicCandidateError::TooLong(513))
+        );
+        assert_eq!(
+            QuicCandidate::parse_bytes(&[0xff]),
+            Err(QuicCandidateError::InvalidUtf8)
+        );
+    }
+
+    #[test]
+    fn suffixes_are_ignored_after_authority() {
+        for suffix in ["/path", "?query", "#fragment", "/path?query#fragment"] {
+            let parsed = QuicCandidate::parse(&format!("quic://broker.example:443{suffix}"))
+                .expect("candidate");
+            assert_eq!(parsed.authority(), "broker.example:443");
+            assert_eq!(parsed.host(), "broker.example");
+            assert_eq!(parsed.port(), 443);
+        }
+    }
+
+    #[test]
+    fn dns_ipv4_and_bracketed_ipv6_are_distinguished() {
+        let dns = QuicCandidate::parse("quic://broker.example:443").unwrap();
+        assert_eq!(dns.ip_literal(), None);
+        let ipv4 = QuicCandidate::parse("quic://192.0.2.1:443").unwrap();
+        assert_eq!(ipv4.ip_literal(), Some("192.0.2.1".parse().unwrap()));
+        let ipv6 = QuicCandidate::parse("quic://[2001:db8::1]:443").unwrap();
+        assert_eq!(ipv6.host(), "2001:db8::1");
+        assert_eq!(ipv6.ip_literal(), Some("2001:db8::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn malformed_scheme_authority_port_and_ipv6_are_rejected() {
+        for candidate in [
+            "https://broker.example:443",
+            "quic://",
+            "quic://broker.example",
+            "quic://broker.example:nope",
+            "quic://broker..example:443",
+            "quic://2001:db8::1:443",
+            "quic://[2001:db8::1",
+            "quic://[2001:db8::1]",
+            "quic://[not-v6]:443",
+        ] {
+            assert!(
+                QuicCandidate::parse(candidate).is_err(),
+                "accepted {candidate}"
+            );
+        }
+    }
+}

--- a/crates/transport-quic-stream/src/crypto.rs
+++ b/crates/transport-quic-stream/src/crypto.rs
@@ -1,6 +1,8 @@
 //! Per-stream AEAD: the `AgentTextStreamCrypto` key material, record
 //! seal/open, and the HKDF key/nonce and AAD derivations vectors pin.
 
+use std::sync::Arc;
+
 use cgka_traits::agent_text_stream::{
     AGENT_TEXT_STREAM_PROFILE_STREAM_ID_LEN, AGENT_TEXT_STREAM_RECORD_VERSION,
     AGENT_TEXT_STREAM_START_EVENT_ID_LEN, AgentTextStreamKeyContextV1, AgentTextStreamRecordV1,
@@ -19,6 +21,7 @@ use crate::protocol::{AEAD_TAG_LEN, AGENT_TEXT_STREAM_SECRET_LEN};
 pub struct AgentTextStreamCrypto {
     pub stream_secret: SecretBytes,
     pub context: AgentTextStreamKeyContextV1,
+    publisher_sequence_store: Option<Arc<dyn crate::PublisherSequenceStore>>,
 }
 
 impl AgentTextStreamCrypto {
@@ -26,7 +29,22 @@ impl AgentTextStreamCrypto {
         Self {
             stream_secret,
             context,
+            publisher_sequence_store: None,
         }
+    }
+
+    pub fn with_publisher_sequence_store(
+        mut self,
+        store: Arc<dyn crate::PublisherSequenceStore>,
+    ) -> Self {
+        self.publisher_sequence_store = Some(store);
+        self
+    }
+
+    pub(crate) fn publisher_sequence_store(
+        &self,
+    ) -> Option<Arc<dyn crate::PublisherSequenceStore>> {
+        self.publisher_sequence_store.clone()
     }
 }
 

--- a/crates/transport-quic-stream/src/error.rs
+++ b/crates/transport-quic-stream/src/error.rs
@@ -73,6 +73,10 @@ pub enum QuicTextStreamError {
     UnexpectedSequence { expected: u64, actual: u64 },
     #[error("agent text stream crypto failed: {0}")]
     Crypto(String),
+    #[error("durable publisher sequence state is required for encrypted preview records")]
+    PublisherSequenceStateRequired,
+    #[error("agent text stream publisher sequence state failed: {0}")]
+    PublisherSequence(String),
 }
 
 impl From<QuicConnectFault> for QuicTextStreamError {

--- a/crates/transport-quic-stream/src/lib.rs
+++ b/crates/transport-quic-stream/src/lib.rs
@@ -6,6 +6,7 @@
 //! constants live in `cgka-traits`; live chunks are provisional preview data
 //! and the final MLS app payload remains authoritative.
 
+mod candidate;
 mod crypto;
 mod error;
 mod frame;
@@ -19,6 +20,7 @@ mod tls;
 #[cfg(test)]
 mod tests;
 
+pub use candidate::{QUIC_CANDIDATE_MAX_LEN, QuicCandidate, QuicCandidateError};
 pub use crypto::{
     AgentTextStreamCrypto, decrypt_record, derive_record_key, derive_record_nonce, encrypt_record,
     record_aad,

--- a/crates/transport-quic-stream/src/lib.rs
+++ b/crates/transport-quic-stream/src/lib.rs
@@ -13,6 +13,7 @@ mod frame;
 mod hardening;
 mod limits;
 mod protocol;
+mod publisher_sequence;
 mod receive;
 mod send;
 mod tls;
@@ -38,6 +39,12 @@ pub use limits::{
 pub use protocol::{
     AGENT_TEXT_STREAM_FRAME_ALLOWANCE, QUIC_STREAM_ALPN_V1, QUIC_STREAM_PROTOCOL_V1,
     effective_plaintext_cap, frame_len_cap,
+};
+#[doc(hidden)]
+pub use publisher_sequence::reserve_publisher_records as reserve_publisher_records_for_transport;
+pub use publisher_sequence::{
+    EphemeralPublisherSequenceStore, PublisherSequenceReservation, PublisherSequenceSnapshot,
+    PublisherSequenceStore, ReservedPublisherRecords,
 };
 pub use receive::{
     QuicTextStreamReceiver, ReceivedTextChunk, ReceivedTextStream, ServerTrust, stream_record_text,

--- a/crates/transport-quic-stream/src/publisher_sequence.rs
+++ b/crates/transport-quic-stream/src/publisher_sequence.rs
@@ -1,0 +1,267 @@
+//! Durable publisher-sequence reservation boundary.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use cgka_traits::MessageId;
+use cgka_traits::agent_text_stream::{AgentTextStreamRecordV1, AgentTextStreamTranscriptV1};
+use rand::{RngCore, rngs::OsRng};
+use sha2::{Digest, Sha256};
+
+use crate::{AgentTextStreamCrypto, QuicTextStreamError};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PublisherSequenceSnapshot {
+    pub next_seq: u64,
+    pub transcript_hash: [u8; 32],
+    pub chunk_count: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PublisherSequenceReservation {
+    pub expected: PublisherSequenceSnapshot,
+    pub resulting: PublisherSequenceSnapshot,
+    pub token: [u8; 16],
+}
+
+pub trait PublisherSequenceStore: Send + Sync {
+    fn load(&self, context_id: &[u8; 32]) -> Result<Option<PublisherSequenceSnapshot>, String>;
+
+    fn reserve(
+        &self,
+        context_id: &[u8; 32],
+        initial_transcript_hash: &[u8; 32],
+        reservation: &PublisherSequenceReservation,
+    ) -> Result<(), String>;
+
+    fn confirm(&self, context_id: &[u8; 32], token: &[u8; 16]) -> Result<(), String>;
+}
+
+pub struct ReservedPublisherRecords {
+    pub records: Vec<AgentTextStreamRecordV1>,
+    pub transcript_hash: [u8; 32],
+    pub chunk_count: u64,
+    context_id: [u8; 32],
+    token: [u8; 16],
+    store: Arc<dyn PublisherSequenceStore>,
+}
+
+impl ReservedPublisherRecords {
+    pub fn confirm(self) -> Result<(), QuicTextStreamError> {
+        self.store
+            .confirm(&self.context_id, &self.token)
+            .map_err(QuicTextStreamError::PublisherSequence)
+    }
+}
+
+pub fn reserve_publisher_records(
+    crypto: &AgentTextStreamCrypto,
+    stream_id: &[u8],
+    start_event_id: &MessageId,
+    frames: &[(u8, Vec<u8>)],
+) -> Result<ReservedPublisherRecords, QuicTextStreamError> {
+    let store = crypto
+        .publisher_sequence_store()
+        .ok_or(QuicTextStreamError::PublisherSequenceStateRequired)?;
+    let context_id: [u8; 32] = Sha256::digest(crypto.context.encode()).into();
+    let initial =
+        AgentTextStreamTranscriptV1::new(stream_id.to_vec(), start_event_id.clone()).hash();
+    let expected = store
+        .load(&context_id)
+        .map_err(QuicTextStreamError::PublisherSequence)?
+        .unwrap_or(PublisherSequenceSnapshot {
+            next_seq: 1,
+            transcript_hash: initial,
+            chunk_count: 0,
+        });
+    let mut transcript = AgentTextStreamTranscriptV1::from_state(
+        stream_id.to_vec(),
+        start_event_id.clone(),
+        expected.transcript_hash,
+        expected.chunk_count,
+    );
+    let mut records = Vec::with_capacity(frames.len());
+    for (offset, (record_type, plaintext)) in frames.iter().enumerate() {
+        let seq = expected
+            .next_seq
+            .checked_add(offset as u64)
+            .ok_or_else(|| {
+                QuicTextStreamError::PublisherSequence(
+                    "agent stream publisher sequence exhausted".to_owned(),
+                )
+            })?;
+        let record =
+            AgentTextStreamRecordV1::new(stream_id.to_vec(), seq, *record_type, plaintext.clone());
+        record.validate()?;
+        transcript.append(seq, *record_type, plaintext);
+        records.push(record);
+    }
+    let mut token = [0_u8; 16];
+    OsRng.fill_bytes(&mut token);
+    let resulting = PublisherSequenceSnapshot {
+        next_seq: expected
+            .next_seq
+            .checked_add(records.len() as u64)
+            .ok_or_else(|| {
+                QuicTextStreamError::PublisherSequence(
+                    "agent stream publisher sequence exhausted".to_owned(),
+                )
+            })?,
+        transcript_hash: transcript.hash(),
+        chunk_count: transcript.chunk_count(),
+    };
+    store
+        .reserve(
+            &context_id,
+            &initial,
+            &PublisherSequenceReservation {
+                expected,
+                resulting,
+                token,
+            },
+        )
+        .map_err(QuicTextStreamError::PublisherSequence)?;
+    Ok(ReservedPublisherRecords {
+        records,
+        transcript_hash: resulting.transcript_hash,
+        chunk_count: resulting.chunk_count,
+        context_id,
+        token,
+        store,
+    })
+}
+
+/// Process-local implementation for tests and explicit development harnesses.
+/// Production encrypted publishers use the account SQLCipher-backed store.
+type EphemeralPublisherState = HashMap<[u8; 32], (PublisherSequenceSnapshot, Option<[u8; 16]>)>;
+
+#[derive(Default)]
+pub struct EphemeralPublisherSequenceStore {
+    states: Mutex<EphemeralPublisherState>,
+}
+
+impl PublisherSequenceStore for EphemeralPublisherSequenceStore {
+    fn load(&self, context_id: &[u8; 32]) -> Result<Option<PublisherSequenceSnapshot>, String> {
+        let states = self.states.lock().map_err(|_| "state lock poisoned")?;
+        match states.get(context_id) {
+            Some((_, Some(_))) => Err("publisher continuity is ambiguous".to_owned()),
+            Some((snapshot, None)) => Ok(Some(*snapshot)),
+            None => Ok(None),
+        }
+    }
+
+    fn reserve(
+        &self,
+        context_id: &[u8; 32],
+        _initial_transcript_hash: &[u8; 32],
+        reservation: &PublisherSequenceReservation,
+    ) -> Result<(), String> {
+        let mut states = self.states.lock().map_err(|_| "state lock poisoned")?;
+        if let Some((current, token)) = states.get(context_id)
+            && (*current != reservation.expected || token.is_some())
+        {
+            return Err("publisher state changed or is ambiguous".to_owned());
+        }
+        states.insert(
+            *context_id,
+            (reservation.resulting, Some(reservation.token)),
+        );
+        Ok(())
+    }
+
+    fn confirm(&self, context_id: &[u8; 32], token: &[u8; 16]) -> Result<(), String> {
+        let mut states = self.states.lock().map_err(|_| "state lock poisoned")?;
+        let (_, current) = states
+            .get_mut(context_id)
+            .ok_or_else(|| "publisher reservation is missing".to_owned())?;
+        if current.as_ref() != Some(token) {
+            return Err("publisher reservation is not current".to_owned());
+        }
+        *current = None;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgka_traits::{
+        EpochId, GroupId, MemberId, SecretBytes,
+        agent_text_stream::{AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, AgentTextStreamKeyContextV1},
+    };
+
+    fn crypto(store: Arc<dyn PublisherSequenceStore>) -> AgentTextStreamCrypto {
+        let stream_id = vec![0x22; 32];
+        let start_event_id = MessageId::new(vec![0x44; 32]);
+        AgentTextStreamCrypto::new(
+            SecretBytes::new(vec![0x11; 32]),
+            AgentTextStreamKeyContextV1::new(
+                GroupId::new(vec![0x33; 16]),
+                stream_id,
+                EpochId(7),
+                MemberId::new(vec![0x55; 32]),
+                start_event_id,
+            ),
+        )
+        .with_publisher_sequence_store(store)
+    }
+
+    #[test]
+    fn repeated_session_use_continues_sequence_and_never_reuses_key_nonce() {
+        let store = Arc::new(EphemeralPublisherSequenceStore::default());
+        let crypto = crypto(store);
+        let stream_id = crypto.context.stream_id.clone();
+        let start = crypto.context.start_event_id.clone();
+        let first = reserve_publisher_records(
+            &crypto,
+            &stream_id,
+            &start,
+            &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"one".to_vec())],
+        )
+        .unwrap();
+        let first_record = first.records[0].clone();
+        first.confirm().unwrap();
+        let second = reserve_publisher_records(
+            &crypto,
+            &stream_id,
+            &start,
+            &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"two".to_vec())],
+        )
+        .unwrap();
+        let second_record = second.records[0].clone();
+        assert_eq!((first_record.seq, second_record.seq), (1, 2));
+        assert_eq!(
+            crate::derive_record_key(&crypto).unwrap(),
+            crate::derive_record_key(&crypto).unwrap()
+        );
+        assert_ne!(
+            crate::derive_record_nonce(&crypto, first_record.seq).unwrap(),
+            crate::derive_record_nonce(&crypto, second_record.seq).unwrap()
+        );
+        second.confirm().unwrap();
+    }
+
+    #[test]
+    fn unconfirmed_reservation_fails_closed_after_restart_boundary() {
+        let store = Arc::new(EphemeralPublisherSequenceStore::default());
+        let crypto = crypto(store);
+        let stream_id = crypto.context.stream_id.clone();
+        let start = crypto.context.start_event_id.clone();
+        let _ambiguous = reserve_publisher_records(
+            &crypto,
+            &stream_id,
+            &start,
+            &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"reserved".to_vec())],
+        )
+        .unwrap();
+        assert!(matches!(
+            reserve_publisher_records(
+                &crypto,
+                &stream_id,
+                &start,
+                &[(AGENT_TEXT_STREAM_RECORD_TEXT_DELTA, b"retry".to_vec())],
+            ),
+            Err(QuicTextStreamError::PublisherSequence(_))
+        ));
+    }
+}

--- a/crates/transport-quic-stream/src/send.rs
+++ b/crates/transport-quic-stream/src/send.rs
@@ -16,6 +16,7 @@ use crate::error::QuicTextStreamError;
 use crate::frame::write_record;
 use crate::hardening::{QUIC_PREVIEW_CONNECT_TIMEOUT, connect_with_timeout};
 use crate::protocol::{SEND_CLOSE_WAIT, effective_plaintext_cap};
+use crate::publisher_sequence::reserve_publisher_records;
 use crate::receive::ServerTrust;
 use crate::tls::client_endpoint;
 
@@ -70,15 +71,43 @@ pub async fn send_text_stream(
     )
     .await?;
     let mut send = connection.open_uni().await?;
-    let mut transcript =
-        AgentTextStreamTranscriptV1::new(config.stream_id.clone(), config.start_event_id);
-
-    for (index, chunk) in split_text_deltas(&config.text, max_chunk_bytes)
+    let frames = split_text_deltas(&config.text, max_chunk_bytes)
         .into_iter()
-        .enumerate()
-    {
-        let record =
-            AgentTextStreamRecordV1::text_delta(config.stream_id.clone(), index as u64 + 1, chunk);
+        .map(|chunk| {
+            (
+                cgka_traits::agent_text_stream::AGENT_TEXT_STREAM_RECORD_TEXT_DELTA,
+                chunk,
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut transcript =
+        AgentTextStreamTranscriptV1::new(config.stream_id.clone(), config.start_event_id.clone());
+    let reservation = config
+        .crypto
+        .as_ref()
+        .filter(|_| !frames.is_empty())
+        .map(|crypto| {
+            reserve_publisher_records(crypto, &config.stream_id, &config.start_event_id, &frames)
+        })
+        .transpose()?;
+    let records = if let Some(reservation) = &reservation {
+        reservation.records.clone()
+    } else {
+        frames
+            .into_iter()
+            .enumerate()
+            .map(|(index, (record_type, plaintext))| {
+                AgentTextStreamRecordV1::new(
+                    config.stream_id.clone(),
+                    index as u64 + 1,
+                    record_type,
+                    plaintext,
+                )
+            })
+            .collect()
+    };
+
+    for record in records {
         let wire_record = if let Some(crypto) = &config.crypto {
             encrypt_record(crypto, &record)?
         } else {
@@ -90,6 +119,14 @@ pub async fn send_text_stream(
             sleep(config.chunk_delay).await;
         }
     }
+    let (transcript_hash, chunk_count) = if let Some(reservation) = reservation {
+        let transcript_hash = reservation.transcript_hash;
+        let chunk_count = reservation.chunk_count;
+        reservation.confirm()?;
+        (transcript_hash, chunk_count)
+    } else {
+        (transcript.hash(), transcript.chunk_count())
+    };
 
     send.finish()?;
     if timeout(SEND_CLOSE_WAIT, connection.closed()).await.is_err() {
@@ -98,8 +135,8 @@ pub async fn send_text_stream(
     endpoint.wait_idle().await;
     Ok(SentTextStream {
         stream_id: transcript.stream_id().to_vec(),
-        transcript_hash: transcript.hash(),
-        chunk_count: transcript.chunk_count(),
+        transcript_hash,
+        chunk_count,
     })
 }
 

--- a/docs/marmot-architecture/overview/current-state.md
+++ b/docs/marmot-architecture/overview/current-state.md
@@ -1,7 +1,7 @@
 ---
 title: "Current State — Implementations & Spec"
 created: 2026-04-19
-updated: 2026-07-25
+updated: 2026-07-26
 tags: [marmot, overview, current-state, implementations]
 status: overview
 ---
@@ -105,7 +105,9 @@ This repository now has the main engine candidate:
 - `crates/transport-nostr-peeler` — Nostr boundary mapping for kind `445` / `1059` events, kind `445` group envelope
   peeling, and NIP-59 welcome wrap/peel with injected local signer/decrypter.
 - `crates/transport-quic-stream` — raw QUIC transport binding for transient agent text stream previews over reliable
-  ordered QUIC streams, with transcript hashes tied to durable MLS start/final app-message payloads.
+  ordered QUIC streams, with transcript hashes tied to durable MLS start/final app-message payloads. Encrypted
+  publishers reserve the next sequence and transcript in the per-account SQLCipher database before writing records;
+  ambiguous crash state disables that start's live preview rather than risking nonce reuse.
 - `crates/transport-quic-broker` — memory-only QUIC pub/sub broker for forwarding live preview records by
   `stream_id + start_event_id` without account state, relay integration, or payload persistence.
 - `crates/cgka-conformance-simulator` — multi-client simulator, vectors, generated scenarios, and property tests.


### PR DESCRIPTION
## Summary

- adopt the v1 QUIC candidate grammar, including the 512-byte complete-value bound, required authority/port, DNS/IPv4/bracketed-IPv6 handling, ignored path/query/fragment suffixes, zero-candidate starts, and ordered bounded failover
- give each encrypted `(stream secret, AgentTextStreamKeyContextV1)` one durable publisher sequence/transcript space across direct sends, broker reconnects, connector compose, daemon reuse, and repeated CLI invocation
- retain receiver high-water/transcript state across candidate failover, close previews on epoch change, withdraw losing-branch starts, and preserve durable kind-9 fallback whenever live preview is unavailable or unverifiable

Closes #787
Closes #1060

This advances the focused current-profile release tracker #1062 and the relevant QUIC work listed by broad tracker #710. It does not close #710.

## Normative source

Implemented against `marmot-protocol/marmot@dedeaf429a6f52a4f1c62f3e992be012dab61b7b`:

- `features/agent-text-streams-quic.md`
- `transports/quic.md`
- `app-components/agent-text-stream-quic-v1.md`
- `foundation/registries.md`

No session salt or wire-format change was introduced. `AgentTextStreamKeyContextV1`, `AgentTextStreamRecordV1`, broker envelopes, and ALPNs are unchanged: adopted v1 prevents nonce reuse by making the start-bound publisher sequence space durable.

## Persistence and crash boundaries

Migration 0036 adds a bounded (4096-context), per-account SQLCipher publisher-state table. An immediate transaction reserves the complete next sequence range and resulting transcript hash/count, with a random reservation token, before any record write. Successful writes confirm by clearing that token.

A crash or error after reservation can skip sequences, but it cannot reuse them. An unconfirmed token, corrupt row, missing continuity proof, state-limit exhaustion, or storage error fails the live preview closed. Tombstones are not evicted. Compose/finalization continues locally so the authoritative final kind-9 message remains deliverable.

Receiver high-water, transcript, limits, and accepted text survive ordered candidate attempts within the supported watch lifecycle. Duplicate records at or below high-water are ignored and `seq` remains authoritative. Process restart does not claim hidden resume state: replay must reconstruct from sequence 1, otherwise a gap makes the preview unverifiable and consumers wait for the durable final.

## Validation

Passed:

- `cargo test -p transport-quic-stream` — 33 passed
- `cargo test -p transport-quic-broker` — 46 unit tests plus 2 and 3 integration tests passed; 1 public-endpoint test intentionally ignored
- `cargo test -p agent-stream-compose` — 19 passed
- `cargo test -p agent-connector` — 118 passed
- `cargo test -p wn-cli --lib` — 426 passed
- `cargo test -p wn-cli --test cli stream_send_and_receive_show_quic_text_content` — 1 passed
- `cargo test -p storage-sqlite` — 274 passed
- targeted `marmot-app` preview/agent-stream tests — 10 and 12 passed
- `cargo test -p cgka-engine --test capabilities` — 22 passed
- `cargo test -p cgka-conformance-simulator --test agent_text_stream_vectors` — 6 passed
- `just fast-ci`

Full-suite baseline notes:

- `cargo test -p wn-cli` passed all 425 library tests, then reported 13 integration failures in unrelated daemon/relay/group tests. The representative `daemon_defaults_create_identities_and_block_loopback_auto_watch_without_manual_sync_or_relay_env` failure reproduces unchanged on `origin/master`.
- `cargo test -p marmot-app` reported five unrelated `relay_runtime` failures. `encrypted_media_endpoint_updates_are_full_replacement_and_admin_only` reproduces unchanged on `origin/master`.

## Out of scope

#733 and unrelated #710 children remain out of scope, including signed broker policy and the optional operator-local allowlist. No `agent-ok` label is requested or applied.
