### PR TITLE
fix(storage): expose durable semantic chat-list ordering timestamps

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1306,6 +1306,8 @@ mod tests {
             "first_unread_message_id_hex": "m0",
             "last_read_message_id_hex": "r1",
             "last_read_timeline_at": 1_700_000_000_u64,
+            "conversation_created_at": 1_699_999_000_u64,
+            "activity_sort_at": 1_700_000_050_u64,
             "updated_at": 1_700_000_060_u64,
             "self_membership": "Member"
         }))

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -1048,6 +1048,8 @@ fn chat_list_test_row(group_id_hex: &str, title: &str) -> ChatListRow {
         first_unread_message_id_hex: None,
         last_read_message_id_hex: None,
         last_read_timeline_at: None,
+        conversation_created_at: 0,
+        activity_sort_at: 0,
         updated_at: 0,
         self_membership: crate::SelfMembership::Member,
     }

--- a/crates/marmot-uniffi/src/conversions/chat_list.rs
+++ b/crates/marmot-uniffi/src/conversions/chat_list.rs
@@ -92,6 +92,8 @@ pub struct ChatListRowFfi {
     pub first_unread_message_id_hex: Option<String>,
     pub last_read_message_id_hex: Option<String>,
     pub last_read_timeline_at: Option<u64>,
+    pub conversation_created_at: u64,
+    pub activity_sort_at: u64,
     pub updated_at: u64,
     /// Whether the local account is still a member of this group, and if not,
     /// whether it left voluntarily or was removed.
@@ -116,6 +118,8 @@ impl From<ChatListRow> for ChatListRowFfi {
             first_unread_message_id_hex: value.first_unread_message_id_hex,
             last_read_message_id_hex: value.last_read_message_id_hex,
             last_read_timeline_at: value.last_read_timeline_at,
+            conversation_created_at: value.conversation_created_at,
+            activity_sort_at: value.activity_sort_at,
             updated_at: value.updated_at,
             self_membership: value.self_membership.into(),
         }
@@ -187,6 +191,35 @@ impl From<marmot_app::ChatListUpdateTrigger> for ChatListUpdateTriggerFfi {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn chat_list_row_exports_semantic_timestamps() {
+        let ffi = ChatListRowFfi::from(ChatListRow {
+            group_id_hex: "11".to_owned(),
+            archived: false,
+            pending_confirmation: false,
+            title: "Marmot Lab".to_owned(),
+            group_name: "Marmot Lab".to_owned(),
+            avatar_url: None,
+            avatar: None,
+            last_message: None,
+            unread_count: 0,
+            has_unread: false,
+            unread_mention_count: 0,
+            has_unread_mention: false,
+            first_unread_message_id_hex: None,
+            last_read_message_id_hex: None,
+            last_read_timeline_at: None,
+            conversation_created_at: 100,
+            activity_sort_at: 200,
+            updated_at: 300,
+            self_membership: marmot_app::SelfMembership::Member,
+        });
+
+        assert_eq!(ffi.conversation_created_at, 100);
+        assert_eq!(ffi.activity_sort_at, 200);
+        assert_eq!(ffi.updated_at, 300);
+    }
 
     #[test]
     fn chat_list_avatar_debug_redacts_key_material() {

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -540,9 +540,10 @@ impl SqliteAccountStorage {
                         image_hash_hex, image_key_hex, image_nonce_hex,
                         image_upload_key_hex, image_media_type, admin_keys_hex, archived,
                         pending_confirmation, welcomer_account_id_hex, via_welcome_message_id_hex,
-                        nostr_routing_last_epoch, prior_nostr_routes_json, updated_at
+                        nostr_routing_last_epoch, prior_nostr_routes_json,
+                        conversation_created_at, updated_at
                      )
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
                      ON CONFLICT(group_id_hex) DO UPDATE SET
                         endpoint = excluded.endpoint,
                         profile_name = excluded.profile_name,
@@ -592,6 +593,7 @@ impl SqliteAccountStorage {
                         &group.via_welcome_message_id_hex,
                         nostr_routing_last_epoch,
                         prior_nostr_routes_json,
+                        now_i64,
                         now_i64
                     ],
                 )

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -90,6 +90,11 @@ pub struct ChatListRow {
     pub first_unread_message_id_hex: Option<String>,
     pub last_read_message_id_hex: Option<String>,
     pub last_read_timeline_at: Option<u64>,
+    /// Immutable local observation time for the conversation's creation.
+    pub conversation_created_at: u64,
+    /// Durable user-visible activity anchor. Projection maintenance never
+    /// advances this value.
+    pub activity_sort_at: u64,
     pub updated_at: u64,
     /// The local account's membership in this group (active member, left, or
     /// removed). Denormalized from `account_groups.self_membership`.
@@ -104,6 +109,7 @@ struct AccountGroupRow {
     profile_name: String,
     avatar_url: Option<String>,
     avatar: Option<ChatListAvatar>,
+    conversation_created_at: u64,
     self_membership: SelfMembership,
 }
 
@@ -297,11 +303,22 @@ fn rebuild_all_chat_list_rows_tx(
     local_account_id_hex: &str,
     mention_classifier: &MentionClassifier<'_>,
 ) -> StorageResult<()> {
-    tx.execute("DELETE FROM chat_list_rows", []).storage()?;
     let groups = account_groups_tx(tx)?;
     for group in groups {
         rebuild_chat_list_row_for_group_tx(tx, local_account_id_hex, group, mention_classifier)?;
     }
+    // Upsert in place so durable activity anchors survive a projection rebuild
+    // after their preview rows have been securely pruned. Remove only true
+    // orphans; normal account-group deletion already cascades this table.
+    tx.execute(
+        "DELETE FROM chat_list_rows
+         WHERE NOT EXISTS (
+             SELECT 1 FROM account_groups AS ag
+             WHERE ag.group_id_hex = chat_list_rows.group_id_hex
+         )",
+        [],
+    )
+    .storage()?;
     // #750: a full rebuild recomputes every mention count, so the projection is
     // current — advance the marker so warm-up completeness checks skip the
     // per-group recompute.
@@ -417,6 +434,7 @@ fn chat_list_projection_complete_tx(
                         WHEN 'removed' THEN 'removed'
                         ELSE 'member'
                       END
+                   OR row.conversation_created_at IS NOT ag.conversation_created_at
                    OR row.updated_at < COALESCE(avatar_url.updated_at, 0)
                    OR row.updated_at < ag.updated_at
              )",
@@ -505,6 +523,15 @@ fn chat_list_projection_complete_tx(
                         ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
                         LIMIT 1
                      ), 0)
+                   OR row.activity_sort_at < COALESCE((
+                        SELECT mt.timeline_at
+                        FROM message_timeline AS mt
+                        WHERE mt.group_id_hex = ag.group_id_hex
+                          AND mt.kind = ?1
+                          AND mt.invalidation_status IS NULL
+                        ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
+                        LIMIT 1
+                     ), ag.conversation_created_at)
              )",
         params![u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
     )? {
@@ -577,6 +604,16 @@ fn rebuild_chat_list_row_for_group_tx(
         read_state.as_ref(),
         mention_classifier,
     )?;
+    let activity_sort_at = latest
+        .as_ref()
+        .map(|message| message.timeline_at)
+        .into_iter()
+        .chain(
+            read_state
+                .as_ref()
+                .and_then(|state| state.last_read_timeline_at),
+        )
+        .fold(group.conversation_created_at, u64::max);
     let now = unix_now_seconds();
     tx.execute(
         "INSERT INTO chat_list_rows (
@@ -587,12 +624,13 @@ fn rebuild_chat_list_row_for_group_tx(
             last_message_id_hex, last_message_sender, last_message_preview,
             last_message_kind, last_message_timeline_at, last_message_deleted,
             unread_count, unread_mention_count, first_unread_message_id_hex,
-            last_read_message_id_hex, last_read_timeline_at, updated_at,
-            self_membership
+            last_read_message_id_hex, last_read_timeline_at,
+            conversation_created_at, activity_sort_at, updated_at, self_membership
          )
          VALUES (
             ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
-            ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24
+            ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20,
+            ?21, ?22, ?23, ?24, ?25, ?26
          )
          ON CONFLICT(group_id_hex) DO UPDATE SET
             archived = excluded.archived,
@@ -616,6 +654,8 @@ fn rebuild_chat_list_row_for_group_tx(
             first_unread_message_id_hex = excluded.first_unread_message_id_hex,
             last_read_message_id_hex = excluded.last_read_message_id_hex,
             last_read_timeline_at = excluded.last_read_timeline_at,
+            conversation_created_at = excluded.conversation_created_at,
+            activity_sort_at = MAX(chat_list_rows.activity_sort_at, excluded.activity_sort_at),
             updated_at = excluded.updated_at,
             self_membership = excluded.self_membership",
         params![
@@ -671,6 +711,8 @@ fn rebuild_chat_list_row_for_group_tx(
                     .as_ref()
                     .and_then(|state| state.last_read_timeline_at)
             )?,
+            u64_to_i64(group.conversation_created_at)?,
+            u64_to_i64(activity_sort_at)?,
             u64_to_i64(now)?,
             group.self_membership.as_str(),
         ],
@@ -772,7 +814,7 @@ fn account_groups_tx(tx: &Connection) -> StorageResult<Vec<AccountGroupRow>> {
             "SELECT ag.group_id_hex, ag.archived, ag.pending_confirmation, ag.profile_name,
                     image_hash_hex, image_key_hex, image_nonce_hex,
                     image_upload_key_hex, image_media_type, avatar_url.component_data_hex,
-                    ag.self_membership
+                    ag.conversation_created_at, ag.self_membership
              FROM account_groups AS ag
              LEFT JOIN account_group_app_components AS avatar_url
                 ON avatar_url.group_id_hex = ag.group_id_hex
@@ -793,7 +835,7 @@ fn account_group_tx(tx: &Connection, group_id_hex: &str) -> StorageResult<Option
         "SELECT ag.group_id_hex, ag.archived, ag.pending_confirmation, ag.profile_name,
                 image_hash_hex, image_key_hex, image_nonce_hex,
                 image_upload_key_hex, image_media_type, avatar_url.component_data_hex,
-                ag.self_membership
+                ag.conversation_created_at, ag.self_membership
          FROM account_groups AS ag
          LEFT JOIN account_group_app_components AS avatar_url
             ON avatar_url.group_id_hex = ag.group_id_hex
@@ -813,7 +855,8 @@ fn account_group_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AccountGr
     let image_upload_key_hex: String = row.get(7)?;
     let media_type: Option<String> = row.get(8)?;
     let avatar_url_component_hex: Option<String> = row.get(9)?;
-    let self_membership: String = row.get(10)?;
+    let conversation_created_at = row.get::<_, i64>(10)?.try_into().unwrap_or_default();
+    let self_membership: String = row.get(11)?;
     let has_avatar = !image_hash_hex.is_empty()
         || !image_key_hex.is_empty()
         || !image_nonce_hex.is_empty()
@@ -832,6 +875,7 @@ fn account_group_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<AccountGr
             image_upload_key_hex,
             media_type,
         }),
+        conversation_created_at,
         self_membership: SelfMembership::from_storage(&self_membership),
     })
 }
@@ -919,9 +963,10 @@ fn chat_list_rows_tx(tx: &Connection, query: ChatListQuery) -> StorageResult<Vec
                 last_message_kind, last_message_timeline_at, last_message_deleted,
                 unread_count, unread_mention_count, first_unread_message_id_hex,
                 last_read_message_id_hex,
-                last_read_timeline_at, updated_at, self_membership
+                last_read_timeline_at, conversation_created_at, activity_sort_at,
+                updated_at, self_membership
          FROM chat_list_rows
-         ORDER BY last_message_timeline_at DESC, group_id_hex"
+         ORDER BY activity_sort_at DESC, group_id_hex"
     } else {
         "SELECT group_id_hex, archived, pending_confirmation, title, group_name,
                 avatar_url,
@@ -931,10 +976,11 @@ fn chat_list_rows_tx(tx: &Connection, query: ChatListQuery) -> StorageResult<Vec
                 last_message_kind, last_message_timeline_at, last_message_deleted,
                 unread_count, unread_mention_count, first_unread_message_id_hex,
                 last_read_message_id_hex,
-                last_read_timeline_at, updated_at, self_membership
+                last_read_timeline_at, conversation_created_at, activity_sort_at,
+                updated_at, self_membership
          FROM chat_list_rows
          WHERE archived = 0
-         ORDER BY last_message_timeline_at DESC, group_id_hex"
+         ORDER BY activity_sort_at DESC, group_id_hex"
     };
     let mut stmt = tx.prepare(sql).storage()?;
     stmt.query_map([], chat_list_row_from_row)
@@ -953,7 +999,8 @@ fn chat_list_row_tx(tx: &Connection, group_id_hex: &str) -> StorageResult<Option
                 last_message_kind, last_message_timeline_at, last_message_deleted,
                 unread_count, unread_mention_count, first_unread_message_id_hex,
                 last_read_message_id_hex,
-                last_read_timeline_at, updated_at, self_membership
+                last_read_timeline_at, conversation_created_at, activity_sort_at,
+                updated_at, self_membership
          FROM chat_list_rows
          WHERE group_id_hex = ?1",
         params![group_id_hex],
@@ -1025,8 +1072,10 @@ fn chat_list_row_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChatListR
         last_read_timeline_at: row
             .get::<_, Option<i64>>(21)?
             .and_then(|value| value.try_into().ok()),
-        updated_at: row.get::<_, i64>(22)?.try_into().unwrap_or_default(),
-        self_membership: SelfMembership::from_storage(&row.get::<_, String>(23)?),
+        conversation_created_at: row.get::<_, i64>(22)?.try_into().unwrap_or_default(),
+        activity_sort_at: row.get::<_, i64>(23)?.try_into().unwrap_or_default(),
+        updated_at: row.get::<_, i64>(24)?.try_into().unwrap_or_default(),
+        self_membership: SelfMembership::from_storage(&row.get::<_, String>(25)?),
     })
 }
 

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -532,6 +532,32 @@ fn chat_list_projection_complete_tx(
                         ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
                         LIMIT 1
                      ), ag.conversation_created_at)
+                   -- A phantom-high anchor cannot self-heal on the too-low
+                   -- check above, so detect it explicitly: the stored anchor
+                   -- exceeds the durable recompute (latest non-invalidated
+                   -- kind-9, else conversation creation) AND an invalidated
+                   -- tombstone accounts for that excess. A legitimately
+                   -- preserved prune anchor has no such tombstone and is left
+                   -- untouched.
+                   OR (
+                        row.activity_sort_at > COALESCE((
+                            SELECT mt.timeline_at
+                            FROM message_timeline AS mt
+                            WHERE mt.group_id_hex = ag.group_id_hex
+                              AND mt.kind = ?1
+                              AND mt.invalidation_status IS NULL
+                            ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
+                            LIMIT 1
+                        ), ag.conversation_created_at)
+                        AND EXISTS (
+                            SELECT 1
+                            FROM message_timeline AS mt
+                            WHERE mt.group_id_hex = ag.group_id_hex
+                              AND mt.kind = ?1
+                              AND mt.invalidation_status IS NOT NULL
+                              AND mt.timeline_at >= row.activity_sort_at
+                        )
+                     )
              )",
         params![u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
     )? {
@@ -655,7 +681,29 @@ fn rebuild_chat_list_row_for_group_tx(
             last_read_message_id_hex = excluded.last_read_message_id_hex,
             last_read_timeline_at = excluded.last_read_timeline_at,
             conversation_created_at = excluded.conversation_created_at,
-            activity_sort_at = MAX(chat_list_rows.activity_sort_at, excluded.activity_sort_at),
+            -- Preserve a durable activity anchor across prune/delete (the preview
+            -- may be gone yet the row must keep its last visible position), but do
+            -- NOT conflate that with convergence invalidation. A pruned message
+            -- leaves no trace, so the prior anchor is the only durable record and
+            -- is preserved. An invalidated message is retained as a tombstone with
+            -- a non-NULL invalidation_status; when such a tombstone's timeline_at
+            -- accounts for the prior anchor, that anchor is phantom (the recompute
+            -- at ?24 already excludes invalidated rows) and must fall to the
+            -- recomputed value rather than staying permanently pinned.
+            activity_sort_at = MAX(
+                excluded.activity_sort_at,
+                CASE
+                    WHEN EXISTS (
+                        SELECT 1
+                        FROM message_timeline AS mt
+                        WHERE mt.group_id_hex = excluded.group_id_hex
+                          AND mt.kind = ?27
+                          AND mt.invalidation_status IS NOT NULL
+                          AND mt.timeline_at >= chat_list_rows.activity_sort_at
+                    ) THEN 0
+                    ELSE chat_list_rows.activity_sort_at
+                END
+            ),
             updated_at = excluded.updated_at,
             self_membership = excluded.self_membership",
         params![
@@ -715,6 +763,7 @@ fn rebuild_chat_list_row_for_group_tx(
             u64_to_i64(activity_sort_at)?,
             u64_to_i64(now)?,
             group.self_membership.as_str(),
+            u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?,
         ],
     )
     .storage()?;

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -523,24 +523,9 @@ fn chat_list_projection_complete_tx(
                         ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
                         LIMIT 1
                      ), 0)
-                   OR row.activity_sort_at < COALESCE((
-                        SELECT mt.timeline_at
-                        FROM message_timeline AS mt
-                        WHERE mt.group_id_hex = ag.group_id_hex
-                          AND mt.kind = ?1
-                          AND mt.invalidation_status IS NULL
-                        ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
-                        LIMIT 1
-                     ), ag.conversation_created_at)
-                   -- A phantom-high anchor cannot self-heal on the too-low
-                   -- check above, so detect it explicitly: the stored anchor
-                   -- exceeds the durable recompute (latest non-invalidated
-                   -- kind-9, else conversation creation) AND an invalidated
-                   -- tombstone accounts for that excess. A legitimately
-                   -- preserved prune anchor has no such tombstone and is left
-                   -- untouched.
-                   OR (
-                        row.activity_sort_at > COALESCE((
+                   OR row.activity_sort_at IS NOT MAX(
+                        row.retained_activity_sort_at,
+                        COALESCE((
                             SELECT mt.timeline_at
                             FROM message_timeline AS mt
                             WHERE mt.group_id_hex = ag.group_id_hex
@@ -548,15 +533,13 @@ fn chat_list_projection_complete_tx(
                               AND mt.invalidation_status IS NULL
                             ORDER BY mt.timeline_at DESC, mt.message_id_hex DESC
                             LIMIT 1
-                        ), ag.conversation_created_at)
-                        AND EXISTS (
-                            SELECT 1
-                            FROM message_timeline AS mt
-                            WHERE mt.group_id_hex = ag.group_id_hex
-                              AND mt.kind = ?1
-                              AND mt.invalidation_status IS NOT NULL
-                              AND mt.timeline_at >= row.activity_sort_at
-                        )
+                        ), 0),
+                        COALESCE((
+                            SELECT read_state.last_read_timeline_at
+                            FROM conversation_read_state AS read_state
+                            WHERE read_state.group_id_hex = ag.group_id_hex
+                        ), 0),
+                        ag.conversation_created_at
                      )
              )",
         params![u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
@@ -651,12 +634,13 @@ fn rebuild_chat_list_row_for_group_tx(
             last_message_kind, last_message_timeline_at, last_message_deleted,
             unread_count, unread_mention_count, first_unread_message_id_hex,
             last_read_message_id_hex, last_read_timeline_at,
-            conversation_created_at, activity_sort_at, updated_at, self_membership
+            conversation_created_at, activity_sort_at, retained_activity_sort_at,
+            updated_at, self_membership
          )
          VALUES (
             ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
             ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20,
-            ?21, ?22, ?23, ?24, ?25, ?26
+            ?21, ?22, ?23, ?24, 0, ?25, ?26
          )
          ON CONFLICT(group_id_hex) DO UPDATE SET
             archived = excluded.archived,
@@ -681,29 +665,11 @@ fn rebuild_chat_list_row_for_group_tx(
             last_read_message_id_hex = excluded.last_read_message_id_hex,
             last_read_timeline_at = excluded.last_read_timeline_at,
             conversation_created_at = excluded.conversation_created_at,
-            -- Preserve a durable activity anchor across prune/delete (the preview
-            -- may be gone yet the row must keep its last visible position), but do
-            -- NOT conflate that with convergence invalidation. A pruned message
-            -- leaves no trace, so the prior anchor is the only durable record and
-            -- is preserved. An invalidated message is retained as a tombstone with
-            -- a non-NULL invalidation_status; when such a tombstone's timeline_at
-            -- accounts for the prior anchor, that anchor is phantom (the recompute
-            -- at ?24 already excludes invalidated rows) and must fall to the
-            -- recomputed value rather than staying permanently pinned.
             activity_sort_at = MAX(
                 excluded.activity_sort_at,
-                CASE
-                    WHEN EXISTS (
-                        SELECT 1
-                        FROM message_timeline AS mt
-                        WHERE mt.group_id_hex = excluded.group_id_hex
-                          AND mt.kind = ?27
-                          AND mt.invalidation_status IS NOT NULL
-                          AND mt.timeline_at >= chat_list_rows.activity_sort_at
-                    ) THEN 0
-                    ELSE chat_list_rows.activity_sort_at
-                END
+                chat_list_rows.retained_activity_sort_at
             ),
+            retained_activity_sort_at = chat_list_rows.retained_activity_sort_at,
             updated_at = excluded.updated_at,
             self_membership = excluded.self_membership",
         params![
@@ -763,7 +729,6 @@ fn rebuild_chat_list_row_for_group_tx(
             u64_to_i64(activity_sort_at)?,
             u64_to_i64(now)?,
             group.self_membership.as_str(),
-            u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?,
         ],
     )
     .storage()?;

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -330,7 +330,7 @@ fn visible_activity_survives_read_metadata_membership_and_secure_prune_updates()
 
 #[test]
 fn migrated_durable_anchor_survives_a_real_rebuild_cycle() {
-    // Migration 0036 backfills `activity_sort_at` in pure SQL. This proves the
+    // Migration 0037 backfills `activity_sort_at` in pure SQL. This proves the
     // compatibility seam between a migrated row and the Rust upsert
     // (`rebuild_chat_list_row_for_group_tx`): a durable anchor whose preview has
     // since been pruned must be preserved across a real `refresh_chat_list_rows`
@@ -339,7 +339,7 @@ fn migrated_durable_anchor_survives_a_real_rebuild_cycle() {
     let store = setup_store();
 
     // Emulate the migration-backfilled state directly: create the row the way
-    // migration 0036 leaves it (SQL-populated, defaults elsewhere) carrying a
+    // migration 0037 leaves it (SQL-populated, defaults elsewhere) carrying a
     // durable anchor (350) and a low creation time (5), but with no kind-9
     // preview in the timeline — its message was securely pruned, so nothing
     // remains to reproduce 350. A read cursor at 300 is the only surviving

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -137,6 +137,92 @@ fn avatar_url_component(url: &str) -> StoredAccountGroupComponent {
 }
 
 #[test]
+fn never_messaged_rows_sort_by_creation_then_group_id_across_rebuilds() {
+    let second_group = StoredAccountGroup {
+        group_id_hex: "22".to_owned(),
+        profile_name: "Second".to_owned(),
+        ..group()
+    };
+    let tied_group = StoredAccountGroup {
+        group_id_hex: "33".to_owned(),
+        profile_name: "Tied".to_owned(),
+        ..group()
+    };
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                groups: vec![group(), second_group, tied_group],
+                ..StoredAccountState::default()
+            },
+            256,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+    {
+        let conn = store.lock().unwrap();
+        conn.execute(
+            "UPDATE account_groups
+             SET conversation_created_at = CASE group_id_hex
+                 WHEN ?1 THEN 100
+                 WHEN ?2 THEN 200
+                 WHEN ?3 THEN 100
+             END",
+            params![GROUP, "22", "33"],
+        )
+        .unwrap();
+    }
+
+    store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    let before = store
+        .chat_list_rows(crate::ChatListQuery::default())
+        .unwrap();
+    assert_eq!(
+        before
+            .iter()
+            .map(|row| row.group_id_hex.as_str())
+            .collect::<Vec<_>>(),
+        vec!["22", GROUP, "33"]
+    );
+    assert_eq!(before[0].conversation_created_at, 200);
+    assert_eq!(before[0].activity_sort_at, 200);
+    assert_eq!(before[1].conversation_created_at, 100);
+    assert_eq!(before[1].activity_sort_at, 100);
+
+    let semantic_before = before
+        .iter()
+        .map(|row| {
+            (
+                row.group_id_hex.clone(),
+                row.conversation_created_at,
+                row.activity_sort_at,
+            )
+        })
+        .collect::<Vec<_>>();
+    {
+        let conn = store.lock().unwrap();
+        conn.execute("UPDATE chat_list_rows SET updated_at = 4000000000", [])
+            .unwrap();
+    }
+    store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    let after = store
+        .chat_list_rows(crate::ChatListQuery::default())
+        .unwrap();
+    let semantic_after = after
+        .iter()
+        .map(|row| {
+            (
+                row.group_id_hex.clone(),
+                row.conversation_created_at,
+                row.activity_sort_at,
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(semantic_after, semantic_before);
+}
+
+#[test]
 fn initialize_chat_read_state_returns_none_for_unknown_group() {
     let store = setup_store();
 
@@ -145,6 +231,101 @@ fn initialize_chat_read_state_returns_none_for_unknown_group() {
         .unwrap();
 
     assert_eq!(row, None);
+}
+
+#[test]
+fn visible_activity_survives_read_metadata_membership_and_secure_prune_updates() {
+    for mark_read in [false, true] {
+        let store = setup_store();
+        {
+            let conn = store.lock().unwrap();
+            conn.execute(
+                "UPDATE account_groups SET conversation_created_at = 5 WHERE group_id_hex = ?1",
+                params![GROUP],
+            )
+            .unwrap();
+        }
+        store
+            .initialize_chat_read_state(LOCAL, GROUP, &no_mentions)
+            .unwrap();
+        store
+            .record_app_event(&chat("visible", REMOTE, 100, "semantic activity"))
+            .unwrap();
+        let mut row = store
+            .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+            .unwrap()
+            .expect("chat row");
+        assert_eq!(row.conversation_created_at, 5);
+        assert_eq!(row.activity_sort_at, 100);
+        assert_eq!(row.unread_count, 1);
+
+        if mark_read {
+            row = store
+                .mark_timeline_message_read(LOCAL, GROUP, "visible", &no_mentions)
+                .unwrap()
+                .expect("chat row");
+            assert_eq!(row.unread_count, 0);
+            assert_eq!(row.activity_sort_at, 100);
+        }
+
+        let mut renamed = group();
+        renamed.profile_name = "Renamed Lab".to_owned();
+        renamed
+            .components
+            .push(avatar_url_component("https://cdn.example.com/new.png"));
+        store
+            .save_account_projection_state(
+                &StoredAccountState {
+                    label: "alice".to_owned(),
+                    groups: vec![renamed],
+                    ..StoredAccountState::default()
+                },
+                256,
+                MAX_FUTURE_SKEW_SECS,
+            )
+            .unwrap();
+        store
+            .set_group_self_membership(GROUP, SelfMembership::Removed)
+            .unwrap();
+        row = store
+            .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+            .unwrap()
+            .expect("chat row");
+        assert_eq!(row.conversation_created_at, 5);
+        assert_eq!(row.activity_sort_at, 100);
+
+        store.secure_prune_app_events_before(GROUP, 101).unwrap();
+        row = store.chat_list_row(GROUP).unwrap().expect("chat row");
+        assert_eq!(row.last_message, None);
+        assert_eq!(row.unread_count, u64::from(!mark_read));
+        assert_eq!(row.activity_sort_at, 100);
+
+        if mark_read {
+            // A read cursor is durable source history: even if projection repair
+            // must recreate the row after pruning, it recovers the last visible
+            // activity rather than falling back to conversation creation.
+            let conn = store.lock().unwrap();
+            conn.execute(
+                "DELETE FROM chat_list_rows WHERE group_id_hex = ?1",
+                params![GROUP],
+            )
+            .unwrap();
+        }
+        store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+        row = store.chat_list_row(GROUP).unwrap().expect("chat row");
+        assert_eq!(row.last_message, None);
+        assert_eq!(row.conversation_created_at, 5);
+        assert_eq!(row.activity_sort_at, 100);
+
+        store
+            .record_app_event(&chat("new-visible", REMOTE, 200, "new activity"))
+            .unwrap();
+        row = store
+            .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+            .unwrap()
+            .expect("chat row");
+        assert_eq!(row.activity_sort_at, 200);
+    }
 }
 
 #[test]

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -325,25 +325,31 @@ fn visible_activity_survives_read_metadata_membership_and_secure_prune_updates()
             .unwrap()
             .expect("chat row");
         assert_eq!(row.activity_sort_at, 200);
+
+        store
+            .invalidate_app_event_by_message_id(GROUP, "new-visible", "LosingBranch")
+            .unwrap();
+        row = store
+            .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+            .unwrap()
+            .expect("chat row");
+        assert_eq!(row.last_message, None);
+        assert_eq!(row.activity_sort_at, 100);
     }
 }
 
 #[test]
-fn migrated_durable_anchor_survives_a_real_rebuild_cycle() {
-    // Migration 0037 backfills `activity_sort_at` in pure SQL. This proves the
-    // compatibility seam between a migrated row and the Rust upsert
-    // (`rebuild_chat_list_row_for_group_tx`): a durable anchor whose preview has
-    // since been pruned must be preserved across a real `refresh_chat_list_rows`
-    // cycle — not overwritten with the conversation-creation fallback — while a
-    // phantom anchor left over from a now-invalidated tombstone is still lowered.
+fn retained_pruned_anchor_survives_a_real_rebuild_cycle() {
+    // A securely pruned message leaves an explicit internal retained-activity
+    // floor. This proves the compatibility seam between that durable floor and
+    // `rebuild_chat_list_row_for_group_tx`: a retained anchor whose preview has
+    // been pruned must survive a real `refresh_chat_list_rows` cycle rather than
+    // being overwritten with the conversation-creation fallback.
     let store = setup_store();
 
-    // Emulate the migration-backfilled state directly: create the row the way
-    // migration 0037 leaves it (SQL-populated, defaults elsewhere) carrying a
-    // durable anchor (350) and a low creation time (5), but with no kind-9
-    // preview in the timeline — its message was securely pruned, so nothing
-    // remains to reproduce 350. A read cursor at 300 is the only surviving
-    // durable history below the anchor.
+    // Emulate the post-prune state directly: the public and retained anchors are
+    // 350 and creation is 5, but there is no kind-9 preview in the timeline.
+    // A read cursor at 300 is the only other durable history below the anchor.
     {
         let conn = store.lock().unwrap();
         conn.execute(
@@ -361,8 +367,9 @@ fn migrated_durable_anchor_survives_a_real_rebuild_cycle() {
         .unwrap();
         conn.execute(
             "INSERT INTO chat_list_rows (
-                group_id_hex, conversation_created_at, activity_sort_at, updated_at
-             ) VALUES (?1, 5, 350, 500)",
+                group_id_hex, conversation_created_at, activity_sort_at,
+                retained_activity_sort_at, updated_at
+             ) VALUES (?1, 5, 350, 350, 500)",
             params![GROUP],
         )
         .unwrap();
@@ -377,14 +384,13 @@ fn migrated_durable_anchor_survives_a_real_rebuild_cycle() {
     assert_eq!(row.conversation_created_at, 5);
     assert_eq!(row.activity_sort_at, 350);
 
-    // The completeness check must treat the migrated-then-rebuilt row as current
-    // (there is no invalidated tombstone accounting for 350), so ensure is a
-    // no-op rather than perpetually rebuilding.
+    // The completeness check must treat the retained-then-rebuilt row as current,
+    // so ensure is a no-op rather than perpetually rebuilding.
     store.ensure_chat_list_rows(LOCAL, &no_mentions).unwrap();
     let after_ensure = store.chat_list_row(GROUP).unwrap().expect("chat row");
     assert_eq!(after_ensure.activity_sort_at, 350);
 
-    // Now introduce a visible message strictly above the migrated anchor; the
+    // Now introduce a visible message strictly above the retained anchor; the
     // rebuild must advance to it, proving preservation is a floor, not a freeze.
     store
         .record_app_event(&chat("newer", REMOTE, 400, "newer activity"))

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -329,8 +329,77 @@ fn visible_activity_survives_read_metadata_membership_and_secure_prune_updates()
 }
 
 #[test]
+fn migrated_durable_anchor_survives_a_real_rebuild_cycle() {
+    // Migration 0036 backfills `activity_sort_at` in pure SQL. This proves the
+    // compatibility seam between a migrated row and the Rust upsert
+    // (`rebuild_chat_list_row_for_group_tx`): a durable anchor whose preview has
+    // since been pruned must be preserved across a real `refresh_chat_list_rows`
+    // cycle — not overwritten with the conversation-creation fallback — while a
+    // phantom anchor left over from a now-invalidated tombstone is still lowered.
+    let store = setup_store();
+
+    // Emulate the migration-backfilled state directly: create the row the way
+    // migration 0036 leaves it (SQL-populated, defaults elsewhere) carrying a
+    // durable anchor (350) and a low creation time (5), but with no kind-9
+    // preview in the timeline — its message was securely pruned, so nothing
+    // remains to reproduce 350. A read cursor at 300 is the only surviving
+    // durable history below the anchor.
+    {
+        let conn = store.lock().unwrap();
+        conn.execute(
+            "UPDATE account_groups SET conversation_created_at = 5 WHERE group_id_hex = ?1",
+            params![GROUP],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO conversation_read_state (
+                group_id_hex, last_read_message_id_hex, last_read_timeline_at,
+                initialized_at, updated_at
+             ) VALUES (?1, 'pruned-message', 300, 0, 300)",
+            params![GROUP],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO chat_list_rows (
+                group_id_hex, conversation_created_at, activity_sort_at, updated_at
+             ) VALUES (?1, 5, 350, 500)",
+            params![GROUP],
+        )
+        .unwrap();
+    }
+
+    // A full rebuild (app warm-up path) must retain the migrated anchor: the
+    // preview is gone but its durable position stays, and the recompute floor
+    // (max(read cursor 300, creation 5) = 300) does not lower it.
+    store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    let row = store.chat_list_row(GROUP).unwrap().expect("chat row");
+    assert_eq!(row.last_message, None);
+    assert_eq!(row.conversation_created_at, 5);
+    assert_eq!(row.activity_sort_at, 350);
+
+    // The completeness check must treat the migrated-then-rebuilt row as current
+    // (there is no invalidated tombstone accounting for 350), so ensure is a
+    // no-op rather than perpetually rebuilding.
+    store.ensure_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    let after_ensure = store.chat_list_row(GROUP).unwrap().expect("chat row");
+    assert_eq!(after_ensure.activity_sort_at, 350);
+
+    // Now introduce a visible message strictly above the migrated anchor; the
+    // rebuild must advance to it, proving preservation is a floor, not a freeze.
+    store
+        .record_app_event(&chat("newer", REMOTE, 400, "newer activity"))
+        .unwrap();
+    let advanced = store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(advanced.activity_sort_at, 400);
+}
+
+#[test]
 fn refresh_chat_list_row_returns_refreshed_single_group_projection() {
     let store = setup_store();
+
     store
         .record_app_event(&chat("latest", REMOTE, 10, "single row"))
         .unwrap();
@@ -745,6 +814,18 @@ fn chat_list_preview_skips_invalidated_kind9_tombstone() {
     // unread-count queries in #443.
     let store = setup_store();
 
+    // Pin conversation creation below the message timestamps so the activity
+    // anchor is driven by the kind-9 rows (not the wall-clock creation default),
+    // making the phantom-vs-fallback distinction observable.
+    {
+        let conn = store.lock().unwrap();
+        conn.execute(
+            "UPDATE account_groups SET conversation_created_at = 5 WHERE group_id_hex = ?1",
+            params![GROUP],
+        )
+        .unwrap();
+    }
+
     // Visible delivered chat.
     store
         .record_app_event(&chat("visible", REMOTE, 10, "real message"))
@@ -761,6 +842,8 @@ fn chat_list_preview_skips_invalidated_kind9_tombstone() {
         .expect("chat row");
     let last_message = row.last_message.expect("last message");
     assert_eq!(last_message.message_id_hex, "phantom");
+    // The losing branch also pinned the activity anchor to its claimed time.
+    assert_eq!(row.activity_sort_at, 11);
 
     // Convergence invalidates the losing-branch row (kept as a tombstone).
     store
@@ -768,7 +851,9 @@ fn chat_list_preview_skips_invalidated_kind9_tombstone() {
         .unwrap();
 
     // Preview and sort anchor must fall back to the visible delivered message,
-    // not the invalidated tombstone.
+    // not the invalidated tombstone. The MAX-preserve upsert must not conflate
+    // a convergence tombstone with a pruned message: the phantom anchor is
+    // lowered rather than staying permanently pinned at 11.
     let row = store
         .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
         .unwrap()
@@ -777,6 +862,7 @@ fn chat_list_preview_skips_invalidated_kind9_tombstone() {
     assert_eq!(last_message.message_id_hex, "visible");
     assert_eq!(last_message.plaintext, "real message");
     assert_eq!(last_message.timeline_at, 10);
+    assert_eq!(row.activity_sort_at, 10);
 
     // The cached projection read path agrees with the refresh path.
     let cached = store
@@ -788,6 +874,7 @@ fn chat_list_preview_skips_invalidated_kind9_tombstone() {
         cached.last_message.as_ref().unwrap().message_id_hex,
         "visible"
     );
+    assert_eq!(cached.activity_sort_at, 10);
 
     // And the completeness check considers the projection up to date, so a
     // subsequent ensure pass is a no-op rather than perpetually rebuilding.
@@ -801,6 +888,7 @@ fn chat_list_preview_skips_invalidated_kind9_tombstone() {
         after_ensure.last_message.as_ref().unwrap().message_id_hex,
         "visible"
     );
+    assert_eq!(after_ensure.activity_sort_at, 10);
 }
 
 #[test]

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -70,6 +70,8 @@ mod migration_0034_maintenance_publication;
 mod migration_0035_durable_convergence_passes;
 #[path = "migrations/0036_agent_stream_publisher_sequences.rs"]
 mod migration_0036_agent_stream_publisher_sequences;
+#[path = "migrations/0037_chat_list_semantic_timestamps.rs"]
+mod migration_0037_chat_list_semantic_timestamps;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -261,6 +263,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 36,
         name: "0036_agent_stream_publisher_sequences",
         apply: migration_0036_agent_stream_publisher_sequences::apply,
+    },
+    Migration {
+        version: 37,
+        name: "0037_chat_list_semantic_timestamps",
+        apply: migration_0037_chat_list_semantic_timestamps::apply,
     },
 ];
 
@@ -522,6 +529,113 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
         assert_eq!(managed, vec![(7, 1), (8, 0)]);
+    }
+
+    #[test]
+    fn chat_list_semantic_timestamps_backfill_from_durable_history() {
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.pragma_update(None, "foreign_keys", true).unwrap();
+        run(&mut conn, &MIGRATIONS[..35]).unwrap();
+        conn.execute(
+            "INSERT INTO account_groups (group_id_hex, endpoint, updated_at)
+             VALUES ('never-messaged', 'relay', 100),
+                    ('active', 'relay', 200),
+                    ('pruned-read', 'relay', 300)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO app_events (
+                group_id_hex, message_id_hex, direction, sender, plaintext, kind,
+                tags_json, recorded_at, received_at
+             ) VALUES ('active', 'origin', 'received', 'sender', 'origin', 9, '[]', 140, 140)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message_timeline (
+                group_id_hex, message_id_hex, direction, sender, plaintext, kind,
+                tags_json, timeline_at, received_at, reactions_json
+             ) VALUES ('active', 'latest', 'received', 'sender', 'latest', 9, '[]', 150, 150, '[]')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message_timeline (
+                group_id_hex, message_id_hex, direction, sender, plaintext, kind,
+                tags_json, timeline_at, received_at, reactions_json, invalidation_status
+             ) VALUES (
+                'active', 'invalidated', 'received', 'sender', 'losing branch',
+                9, '[]', 160, 160, '[]', 'LosingBranch'
+             )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO conversation_read_state (
+                group_id_hex, last_read_message_id_hex, last_read_timeline_at,
+                initialized_at, updated_at
+             ) VALUES ('pruned-read', 'pruned-message', 350, 0, 400)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message_timeline (
+                group_id_hex, message_id_hex, direction, sender, plaintext, kind,
+                tags_json, timeline_at, received_at, reactions_json
+             ) VALUES (
+                'pruned-read', 'older-survivor', 'received', 'sender', 'older',
+                9, '[]', 310, 310, '[]'
+             )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO chat_list_rows (group_id_hex, updated_at)
+             VALUES ('never-messaged', 500), ('active', 500), ('pruned-read', 500)",
+            [],
+        )
+        .unwrap();
+
+        run(&mut conn, MIGRATIONS).unwrap();
+
+        let rows = conn
+            .prepare(
+                "SELECT group_id_hex, conversation_created_at, activity_sort_at
+                 FROM chat_list_rows ORDER BY group_id_hex",
+            )
+            .unwrap()
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                ("active".to_owned(), 140, 150),
+                ("never-messaged".to_owned(), 100, 100),
+                ("pruned-read".to_owned(), 300, 350),
+            ]
+        );
+
+        run(&mut conn, MIGRATIONS).unwrap();
+        let after_second_run: Vec<(String, i64, i64)> = conn
+            .prepare(
+                "SELECT group_id_hex, conversation_created_at, activity_sort_at
+                 FROM chat_list_rows ORDER BY group_id_hex",
+            )
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(after_second_run, rows);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -468,6 +468,29 @@ mod tests {
             .collect()
     }
 
+    fn semantic_chat_list_timestamps(store: &SqliteAccountStorage) -> Vec<(String, u64, u64)> {
+        let mut rows = store
+            .chat_list_rows(crate::ChatListQuery {
+                include_archived: true,
+            })
+            .unwrap()
+            .into_iter()
+            .map(|row| {
+                (
+                    row.group_id_hex,
+                    row.conversation_created_at,
+                    row.activity_sort_at,
+                )
+            })
+            .collect::<Vec<_>>();
+        rows.sort_by(|left, right| left.0.cmp(&right.0));
+        rows
+    }
+
+    fn no_mentions(_plaintext: &str, _tags: &[Vec<String>]) -> bool {
+        false
+    }
+
     #[test]
     fn initial_schema_migration_is_recorded() {
         let store = SqliteAccountStorage::in_memory().unwrap();
@@ -653,6 +676,32 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
         assert_eq!(after_second_run, rows);
+
+        let store = SqliteAccountStorage::from_connection_with_options(
+            conn,
+            crate::SqliteStorageOptions::default(),
+        )
+        .unwrap();
+        let expected = rows
+            .into_iter()
+            .map(|(group_id, created_at, activity_at)| {
+                (
+                    group_id,
+                    u64::try_from(created_at).unwrap(),
+                    u64::try_from(activity_at).unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        store
+            .refresh_chat_list_rows("local-account", &no_mentions)
+            .unwrap();
+        assert_eq!(semantic_chat_list_timestamps(&store), expected);
+
+        store
+            .refresh_chat_list_rows("local-account", &no_mentions)
+            .unwrap();
+        assert_eq!(semantic_chat_list_timestamps(&store), expected);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -540,7 +540,8 @@ mod tests {
             "INSERT INTO account_groups (group_id_hex, endpoint, updated_at)
              VALUES ('never-messaged', 'relay', 100),
                     ('active', 'relay', 200),
-                    ('pruned-read', 'relay', 300)",
+                    ('pruned-read', 'relay', 300),
+                    ('zero-updated', 'relay', 0)",
             [],
         )
         .unwrap();
@@ -549,6 +550,20 @@ mod tests {
                 group_id_hex, message_id_hex, direction, sender, plaintext, kind,
                 tags_json, recorded_at, received_at
              ) VALUES ('active', 'origin', 'received', 'sender', 'origin', 9, '[]', 140, 140)",
+            [],
+        )
+        .unwrap();
+        // `zero-updated` exercises the `ag.updated_at = 0` sentinel branch: the
+        // group has app events but no persisted group timestamp, so
+        // `conversation_created_at` must fall back to the earliest event time
+        // (250) rather than collapsing to `MIN(0, 250) = 0`.
+        conn.execute(
+            "INSERT INTO app_events (
+                group_id_hex, message_id_hex, direction, sender, plaintext, kind,
+                tags_json, recorded_at, received_at
+             ) VALUES
+                ('zero-updated', 'first', 'received', 'sender', 'first', 9, '[]', 250, 250),
+                ('zero-updated', 'later', 'received', 'sender', 'later', 9, '[]', 275, 275)",
             [],
         )
         .unwrap();
@@ -592,7 +607,8 @@ mod tests {
         .unwrap();
         conn.execute(
             "INSERT INTO chat_list_rows (group_id_hex, updated_at)
-             VALUES ('never-messaged', 500), ('active', 500), ('pruned-read', 500)",
+             VALUES ('never-messaged', 500), ('active', 500), ('pruned-read', 500),
+                    ('zero-updated', 500)",
             [],
         )
         .unwrap();
@@ -621,6 +637,7 @@ mod tests {
                 ("active".to_owned(), 140, 150),
                 ("never-messaged".to_owned(), 100, 100),
                 ("pruned-read".to_owned(), 300, 350),
+                ("zero-updated".to_owned(), 250, 250),
             ]
         );
 

--- a/crates/storage-sqlite/src/migrations/0037_chat_list_semantic_timestamps.rs
+++ b/crates/storage-sqlite/src/migrations/0037_chat_list_semantic_timestamps.rs
@@ -1,0 +1,108 @@
+//! Add durable semantic timestamps for chat-list ordering (#1086).
+//!
+//! `conversation_created_at` is anchored once on the durable account-group row.
+//! Existing rows use the earliest retained app-event time when available, capped
+//! by the group's persisted first/last projection timestamp; never-messaged rows
+//! use that persisted group timestamp. `activity_sort_at` starts at the latest
+//! visible chat timeline time, then falls back to the durable read cursor and
+//! finally conversation creation. No migration wall clock participates.
+
+use crate::{SqliteResultExt, u64_to_i64};
+use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
+use cgka_traits::storage::StorageResult;
+use rusqlite::{Transaction, params};
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+ALTER TABLE account_groups
+    ADD COLUMN conversation_created_at INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE chat_list_rows
+    ADD COLUMN conversation_created_at INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE chat_list_rows
+    ADD COLUMN activity_sort_at INTEGER NOT NULL DEFAULT 0;
+"#,
+    )
+    .storage()?;
+
+    tx.execute(
+        "UPDATE account_groups AS ag
+         SET conversation_created_at = CASE
+             WHEN (
+                 SELECT MIN(events.recorded_at)
+                 FROM app_events AS events
+                 WHERE events.group_id_hex = ag.group_id_hex
+             ) IS NULL THEN ag.updated_at
+             WHEN ag.updated_at = 0 THEN (
+                 SELECT MIN(events.recorded_at)
+                 FROM app_events AS events
+                 WHERE events.group_id_hex = ag.group_id_hex
+             )
+             ELSE MIN(
+                 ag.updated_at,
+                 (
+                     SELECT MIN(events.recorded_at)
+                     FROM app_events AS events
+                     WHERE events.group_id_hex = ag.group_id_hex
+                 )
+             )
+         END",
+        [],
+    )
+    .storage()?;
+
+    tx.execute(
+        "UPDATE chat_list_rows AS row
+         SET conversation_created_at = COALESCE(
+                 (
+                     SELECT ag.conversation_created_at
+                     FROM account_groups AS ag
+                     WHERE ag.group_id_hex = row.group_id_hex
+                 ),
+                 0
+             ),
+             activity_sort_at = MAX(
+                 COALESCE(
+                     (
+                         SELECT timeline.timeline_at
+                         FROM message_timeline AS timeline
+                         WHERE timeline.group_id_hex = row.group_id_hex
+                           AND timeline.kind = ?1
+                           AND timeline.invalidation_status IS NULL
+                         ORDER BY timeline.timeline_at DESC, timeline.message_id_hex DESC
+                         LIMIT 1
+                     ),
+                     0
+                 ),
+                 COALESCE(
+                     (
+                         SELECT read_state.last_read_timeline_at
+                         FROM conversation_read_state AS read_state
+                         WHERE read_state.group_id_hex = row.group_id_hex
+                     ),
+                     0
+                 ),
+                 COALESCE(
+                     (
+                         SELECT ag.conversation_created_at
+                         FROM account_groups AS ag
+                         WHERE ag.group_id_hex = row.group_id_hex
+                     ),
+                     0
+                 )
+             )",
+        params![u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?],
+    )
+    .storage()?;
+
+    tx.execute_batch(
+        r#"
+DROP INDEX IF EXISTS idx_chat_list_rows_archived_order;
+CREATE INDEX idx_chat_list_rows_archived_activity_order
+    ON chat_list_rows (archived, activity_sort_at DESC, group_id_hex);
+"#,
+    )
+    .storage()?;
+
+    Ok(())
+}

--- a/crates/storage-sqlite/src/migrations/0037_chat_list_semantic_timestamps.rs
+++ b/crates/storage-sqlite/src/migrations/0037_chat_list_semantic_timestamps.rs
@@ -6,6 +6,8 @@
 //! use that persisted group timestamp. `activity_sort_at` starts at the latest
 //! visible chat timeline time, then falls back to the durable read cursor and
 //! finally conversation creation. No migration wall clock participates.
+//! `retained_activity_sort_at` is an internal floor advanced transactionally
+//! before visible timeline rows are securely pruned.
 
 use crate::{SqliteResultExt, u64_to_i64};
 use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
@@ -21,6 +23,8 @@ ALTER TABLE chat_list_rows
     ADD COLUMN conversation_created_at INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE chat_list_rows
     ADD COLUMN activity_sort_at INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE chat_list_rows
+    ADD COLUMN retained_activity_sort_at INTEGER NOT NULL DEFAULT 0;
 "#,
     )
     .storage()?;

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -959,6 +959,7 @@ fn secure_prune_selected_app_events_tx(
         )?);
     }
 
+    retain_pruned_chat_activity_tx(tx, group_id_hex, &pruned_message_ids)?;
     scrub_app_event_rows_by_ids_tx(tx, group_id_hex, &pruned_message_ids)?;
     // `message_timeline.plaintext` is indexed for search; overwriting it
     // under `secure_delete` before DELETE also rewrites the old index key.
@@ -986,6 +987,49 @@ fn secure_prune_selected_app_events_tx(
         pruned_media_epoch_secrets,
         media_ciphertext_sha256: media_ciphertext_sha256.into_iter().collect(),
     })
+}
+
+fn retain_pruned_chat_activity_tx(
+    tx: &Connection,
+    group_id_hex: &str,
+    pruned_message_ids: &BTreeSet<String>,
+) -> StorageResult<()> {
+    let mut statement = tx
+        .prepare(
+            "SELECT timeline_at
+             FROM message_timeline
+             WHERE group_id_hex = ?1
+               AND message_id_hex = ?2
+               AND kind = ?3
+               AND invalidation_status IS NULL",
+        )
+        .storage()?;
+    let mut latest_pruned_activity = None;
+    for message_id_hex in pruned_message_ids {
+        let timeline_at = statement
+            .query_row(
+                params![
+                    group_id_hex,
+                    message_id_hex,
+                    u64_to_i64(MARMOT_APP_EVENT_KIND_CHAT)?
+                ],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .storage()?;
+        latest_pruned_activity = latest_pruned_activity.max(timeline_at);
+    }
+    if let Some(timeline_at) = latest_pruned_activity {
+        tx.execute(
+            "UPDATE chat_list_rows
+             SET retained_activity_sort_at = MAX(retained_activity_sort_at, ?2),
+                 activity_sort_at = MAX(activity_sort_at, ?2)
+             WHERE group_id_hex = ?1",
+            params![group_id_hex, timeline_at],
+        )
+        .storage()?;
+    }
+    Ok(())
 }
 
 fn refresh_chat_list_last_message_after_secure_prune_tx(
@@ -1025,6 +1069,16 @@ fn refresh_chat_list_last_message_after_secure_prune_tx(
                  last_message_kind = ?4,
                  last_message_timeline_at = ?5,
                  last_message_deleted = ?6,
+                 activity_sort_at = MAX(
+                     retained_activity_sort_at,
+                     ?5,
+                     COALESCE((
+                         SELECT last_read_timeline_at
+                         FROM conversation_read_state
+                         WHERE group_id_hex = ?8
+                     ), 0),
+                     conversation_created_at
+                 ),
                  updated_at = ?7
              WHERE group_id_hex = ?8",
             params![
@@ -1048,6 +1102,15 @@ fn refresh_chat_list_last_message_after_secure_prune_tx(
                  last_message_kind = NULL,
                  last_message_timeline_at = NULL,
                  last_message_deleted = 0,
+                 activity_sort_at = MAX(
+                     retained_activity_sort_at,
+                     COALESCE((
+                         SELECT last_read_timeline_at
+                         FROM conversation_read_state
+                         WHERE group_id_hex = ?2
+                     ), 0),
+                     conversation_created_at
+                 ),
                  updated_at = ?1
              WHERE group_id_hex = ?2",
             params![updated_at, group_id_hex],


### PR DESCRIPTION
## Summary

Fixes #1086. Persists durable semantic timestamps on the chat-list projection so user-visible ordering no longer depends on projection-maintenance wall clock (`updated_at`), and exports them through UniFFI so Android can remove `updatedAt` from its fallback sort chain.

- **`conversation_created_at`** is the immutable per-conversation origin time.
- **`activity_sort_at`** is the durable visible-activity sort anchor: latest visible kind-9 activity, durable read cursor, securely pruned activity, then conversation creation.
- **`retained_activity_sort_at`** is private SQLite projection state. Secure pruning advances it transactionally before deleting visible timeline rows. Rebuilds use it as a floor, while invalidation can remove only the invalidated current activity.

This handles the blocker sequence correctly: visible `100` -> securely pruned -> visible `200` -> `200` invalidated -> activity returns to `100`, not conversation creation.

Ordering is **visible activity time -> immutable creation time -> stable group-ID tie-breaker**. Reads, unread recomputation, metadata/avatar/membership updates, projection repair, and migration wall clock do not advance semantic ordering.

## Invariant coverage

| Requirement | Coverage |
| --- | --- |
| Rebuild stability and deterministic never-messaged ordering | `never_messaged_rows_sort_by_creation_then_group_id_across_rebuilds` |
| All-pruned read and unread anchors survive maintenance | `visible_activity_survives_read_metadata_membership_and_secure_prune_updates` |
| A newer invalidated message falls back to an older pruned anchor | same test, both read-state variants |
| Retained prune floor survives full rebuild and advances for new activity | `retained_pruned_anchor_survives_a_real_rebuild_cycle` |
| Migration output survives first and second real rebuilds | `chat_list_semantic_timestamps_backfill_from_durable_history` |
| Ordinary invalidation drops a phantom high anchor | `chat_list_preview_skips_invalidated_kind9_tombstone` |
| UniFFI export | `chat_list_row_exports_semantic_timestamps` |

## Migration

`0037_chat_list_semantic_timestamps` adds and deterministically backfills the semantic columns, excluding invalidated rows and using durable history only. It also installs `idx_chat_list_rows_archived_activity_order (archived, activity_sort_at DESC, group_id_hex)`. No migration wall clock participates.

## Verification

Rebased onto `origin/master` at `33596a3d`. Final diff is 9 files, 749 insertions / 17 deletions, with **no workspace-version, Cargo.lock, or release-fixture changes**.

- `just fast-ci` - clean
- `cargo test -p storage-sqlite` - 278 passed
- `cargo test -p marmot-uniffi` - 68 unit + 2 fixture + 24 smoke passed
- `cargo test -p marmot-app --lib` - 449 passed
- `cargo test -p wn-cli --lib` - 424 passed; two media-worker timeout tests were starved while four cargo jobs ran concurrently, and both passed immediately in an isolated retry

Fresh GitHub CI is running on head `83f62d3a`.

## Sensitive paths

Touches SQLite schema migration/backfill, chat-list projection/rebuild completeness, and secure-prune timeline handling. Not auto-merged.