### PR TITLE
Batch KeyPackage deletion publishes over scoped relay connections

### DIFF
--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -64,9 +64,9 @@ use storage_sqlite::{
 };
 use transport_nostr_adapter::{
     KIND_MARMOT_INBOX_RELAY_LIST, KIND_MARMOT_KEY_PACKAGE, KIND_NIP65_RELAY_LIST,
-    NostrAccountRelayListKind, NostrAccountRelayListPublication, NostrKeyPackagePublication,
-    NostrKeyPackagePublisher, NostrNip65RelayListPublication, NostrNip65RelaySet, NostrRelayClient,
-    NostrSdkRelayClient, parse_nip65_relay_set,
+    NostrAccountRelayListKind, NostrAccountRelayListPublication, NostrEventPublishRequest,
+    NostrKeyPackagePublication, NostrKeyPackagePublisher, NostrNip65RelayListPublication,
+    NostrNip65RelaySet, NostrRelayClient, NostrSdkRelayClient, parse_nip65_relay_set,
 };
 use transport_nostr_peeler::{NostrMlsPeeler, NostrTransportEvent};
 
@@ -803,6 +803,18 @@ pub struct AccountKeyPackageRecord {
     pub local: bool,
     /// True when this exact event id was discovered from a relay.
     pub relay: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct KeyPackageDeletionTarget {
+    pub event_id_hex: String,
+    pub source_relays: Vec<TransportEndpoint>,
+}
+
+#[derive(Debug)]
+pub(crate) struct KeyPackageDeletionResult {
+    pub event_id_hex: String,
+    pub result: Result<usize, AppError>,
 }
 
 /// Per-account unread aggregate, suitable for an account-switcher badge
@@ -2973,47 +2985,126 @@ impl MarmotApp {
         event_id_hex: &str,
         source_relays: Vec<TransportEndpoint>,
     ) -> Result<usize, AppError> {
-        let event_id_hex = parse_key_package_event_id_hex(event_id_hex)?;
+        let mut outcomes = self
+            .delete_key_package_events(
+                label,
+                vec![KeyPackageDeletionTarget {
+                    event_id_hex: event_id_hex.to_owned(),
+                    source_relays,
+                }],
+            )
+            .await?;
+        outcomes
+            .pop()
+            .expect("single-event deletion batch returns one outcome")
+            .result
+    }
+
+    pub(crate) async fn delete_key_package_events(
+        &self,
+        label: &str,
+        targets: Vec<KeyPackageDeletionTarget>,
+    ) -> Result<Vec<KeyPackageDeletionResult>, AppError> {
         let account = self.account_home().account(label)?;
         let signer = self.account_signer_for_summary(&account)?;
         let account_id_hex = account.account_id_hex;
-        let mut endpoints = source_relays;
-        if endpoints.is_empty() {
-            let relay_lists = self.account_relay_list_status_for_account_id(&account_id_hex)?;
-            endpoints = self.key_package_endpoints(&relay_lists);
-        }
-        if endpoints.is_empty() {
-            return Err(AppError::MissingRelayLists(vec![
-                MissingRelayListKind::Nip65,
-            ]));
+        let mut results = targets
+            .iter()
+            .map(|target| KeyPackageDeletionResult {
+                event_id_hex: target.event_id_hex.clone(),
+                result: Err(AppError::Publish("deletion was not attempted".to_owned())),
+            })
+            .collect::<Vec<_>>();
+        let mut requests = Vec::new();
+        let mut request_indices = Vec::new();
+        let mut all_endpoints = Vec::new();
+
+        for (index, target) in targets.into_iter().enumerate() {
+            let event_id_hex = match parse_key_package_event_id_hex(&target.event_id_hex) {
+                Ok(event_id_hex) => event_id_hex,
+                Err(error) => {
+                    results[index].result = Err(error);
+                    continue;
+                }
+            };
+            let endpoints = if target.source_relays.is_empty() {
+                match self.account_relay_list_status_for_account_id(&account_id_hex) {
+                    Ok(relay_lists) => self.key_package_endpoints(&relay_lists),
+                    Err(error) => {
+                        results[index].result = Err(error);
+                        continue;
+                    }
+                }
+            } else {
+                target.source_relays
+            };
+            if endpoints.is_empty() {
+                results[index].result = Err(AppError::MissingRelayLists(vec![
+                    MissingRelayListKind::Nip65,
+                ]));
+                continue;
+            }
+            let endpoints = match self
+                .relay_plane
+                .sanitize_relay_endpoints(endpoints, "key package deletion publish")
+            {
+                Ok(endpoints) => endpoints,
+                Err(error) => {
+                    results[index].result = Err(AppError::Transport(
+                        cgka_traits::TransportAdapterError::Publish(error),
+                    ));
+                    continue;
+                }
+            };
+            all_endpoints.extend(endpoints.iter().cloned());
+            requests.push(NostrEventPublishRequest {
+                endpoints,
+                event: NostrTransportEvent::new_unsigned(
+                    account_id_hex.clone(),
+                    5,
+                    vec![
+                        vec!["e".into(), event_id_hex],
+                        vec!["k".into(), KIND_MARMOT_KEY_PACKAGE.to_string()],
+                    ],
+                    String::new(),
+                ),
+                required_acks: 1,
+            });
+            request_indices.push(index);
         }
 
-        let event = NostrTransportEvent::new_unsigned(
-            account_id_hex,
-            5,
-            vec![
-                vec!["e".into(), event_id_hex.clone()],
-                vec!["k".into(), KIND_MARMOT_KEY_PACKAGE.to_string()],
-            ],
-            String::new(),
-        );
-        let outcome = self
-            .relay_client_for_endpoints(signer.as_nostr_signer(), &endpoints)
-            .publish_event(&endpoints, &event, 1)
-            .await?;
-
-        let path = self.key_package_record_path(label);
-        if let Ok(record) = read_json::<KeyPackageRecord>(&path)
-            && record.key_package_event_id == event_id_hex
-        {
-            match fs::remove_file(path) {
-                Ok(()) => {}
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-                Err(err) => return Err(err.into()),
+        if !requests.is_empty() {
+            let relay_client =
+                self.relay_client_for_endpoints(signer.as_nostr_signer(), &all_endpoints);
+            let outcomes = relay_client.publish_events(&requests).await;
+            for (index, outcome) in request_indices.into_iter().zip(outcomes) {
+                results[index].result = match outcome {
+                    Ok(outcome) if !outcome.accepted.is_empty() => Ok(outcome.accepted.len()),
+                    Ok(_) => Err(AppError::Publish(
+                        "relay acknowledged zero key package deletions".to_owned(),
+                    )),
+                    Err(error) => Err(error.into()),
+                };
             }
         }
 
-        Ok(outcome.accepted.len())
+        let path = self.key_package_record_path(label);
+        for result in &mut results {
+            if result.result.is_err() {
+                continue;
+            }
+            if let Ok(record) = read_json::<KeyPackageRecord>(&path)
+                && record.key_package_event_id == result.event_id_hex
+            {
+                match fs::remove_file(&path) {
+                    Ok(()) => {}
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(err) => result.result = Err(err.into()),
+                }
+            }
+        }
+
+        Ok(results)
     }
 
     fn key_package_record_path(&self, label: &str) -> PathBuf {
@@ -3952,7 +4043,11 @@ impl MarmotApp {
 
     #[cfg(test)]
     fn with_test_relay_client(mut self, client: Arc<dyn NostrRelayClient>) -> Self {
-        self.relay_plane = MarmotRelayPlane::new(None, client.clone());
+        self.relay_plane = MarmotRelayPlane::new_with_loopback(
+            None,
+            client.clone(),
+            self.config.allow_loopback_relay_endpoints,
+        );
         self.test_relay_client = Some(client);
         self
     }

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -147,6 +147,14 @@ impl MarmotRelayPlane {
         subscription_rebuild_lookback: Option<Duration>,
         relay_client: Arc<dyn NostrRelayClient>,
     ) -> Self {
+        Self::new_with_loopback(subscription_rebuild_lookback, relay_client, false)
+    }
+
+    pub(crate) fn new_with_loopback(
+        subscription_rebuild_lookback: Option<Duration>,
+        relay_client: Arc<dyn NostrRelayClient>,
+        allow_loopback: bool,
+    ) -> Self {
         let adapter = NostrTransportAdapter::new(relay_client);
         Self::from_adapter(
             subscription_rebuild_lookback,
@@ -154,7 +162,7 @@ impl MarmotRelayPlane {
             None,
             None,
             Arc::new(NostrSdkDirectoryRelayFetcher::standalone()),
-            false,
+            allow_loopback,
         )
     }
 

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -34,15 +34,16 @@ use crate::{
     AppQuarantinedGroup, AuditLogDeleteOutcome, AuditLogFile, AuditLogSettings,
     AuditLogTrackerConfig, AuditLogTrackerUpdateResult, AuditLogUploadResult,
     BackgroundNotificationCollection, ChatListRow, ChatNotificationSettings,
-    GroupInviteDeclineResult, GroupPushDebugInfo, MAX_SEEN_EVENT_IDS, MarmotApp, MarmotRelayPlane,
-    MarmotServiceEndpoints, MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest,
-    MediaUploadResult, MessageDraft, MessageDraftAttachment, MessageDraftSummary,
-    NotificationCollectionStatus, NotificationSettings, NotificationUpdate, NotificationWakeSource,
-    PendingWelcomeDelivery, PushPlatform, PushRegistration, PushRegistrationShareOutcome,
-    PushRegistrationSyncResult, ReceivedMessage, RelayTelemetryExportConfig,
-    RelayTelemetryRuntimeConfig, RelayTelemetrySettings, SecureDeleteExpiredResult, SendSummary,
-    TimelineMessageQuery, TimelinePage, UserDirectoryRefresh, UserProfileMetadata,
-    default_profile_pseudonym, unix_now_seconds,
+    GroupInviteDeclineResult, GroupPushDebugInfo, KeyPackageDeletionTarget, MAX_SEEN_EVENT_IDS,
+    MarmotApp, MarmotRelayPlane, MarmotServiceEndpoints, MediaAttachmentReference,
+    MediaDownloadResult, MediaUploadRequest, MediaUploadResult, MessageDraft,
+    MessageDraftAttachment, MessageDraftSummary, NotificationCollectionStatus,
+    NotificationSettings, NotificationUpdate, NotificationWakeSource, PendingWelcomeDelivery,
+    PushPlatform, PushRegistration, PushRegistrationShareOutcome, PushRegistrationSyncResult,
+    ReceivedMessage, RelayTelemetryExportConfig, RelayTelemetryRuntimeConfig,
+    RelayTelemetrySettings, SecureDeleteExpiredResult, SendSummary, TimelineMessageQuery,
+    TimelinePage, UserDirectoryRefresh, UserProfileMetadata, default_profile_pseudonym,
+    unix_now_seconds,
 };
 
 mod account_worker;
@@ -654,8 +655,8 @@ pub struct SignOutOutcome {
     /// `0` when `delete_key_packages` was `false`.
     pub key_packages_deleted: u32,
     /// Per-relay KeyPackage deletion (or discovery) failures. Best-effort: a
-    /// failure here never blocks local cleanup, and the app can show a
-    /// "will retry on next sign-in" hint.
+    /// failure here never blocks local cleanup. No durable remote-deletion
+    /// retry is implied by this outcome.
     pub key_package_failures: Vec<RelayFailure>,
     /// Result of the always-run local teardown (worker shutdown, subscription
     /// deactivation, in-memory cache eviction). Unlike a wipe this never
@@ -2042,6 +2043,70 @@ impl MarmotAppRuntime {
             .await
     }
 
+    async fn delete_relay_key_packages(
+        &self,
+        account_label: &str,
+        packages: Vec<AccountKeyPackageRecord>,
+    ) -> (u32, Vec<RelayFailure>) {
+        let targets = packages
+            .into_iter()
+            .filter(|package| package.relay)
+            .map(|package| KeyPackageDeletionTarget {
+                event_id_hex: package.key_package_event_id,
+                source_relays: package
+                    .source_relays
+                    .into_iter()
+                    .map(TransportEndpoint)
+                    .collect(),
+            })
+            .collect::<Vec<_>>();
+        if targets.is_empty() {
+            return (0, Vec::new());
+        }
+        let event_ids = targets
+            .iter()
+            .map(|target| target.event_id_hex.clone())
+            .collect::<Vec<_>>();
+        let results = match self
+            .accounts
+            .app
+            .delete_key_package_events(account_label, targets)
+            .await
+        {
+            Ok(results) => results,
+            Err(error) => {
+                let reason = wipe_failure_reason(&error);
+                return (
+                    0,
+                    event_ids
+                        .into_iter()
+                        .map(|event_id_hex| RelayFailure {
+                            event_id_hex,
+                            reason: reason.clone(),
+                        })
+                        .collect(),
+                );
+            }
+        };
+
+        let mut deleted = 0;
+        let mut failures = Vec::new();
+        for result in results {
+            match result.result {
+                Ok(accepted) if accepted > 0 => deleted += 1,
+                Ok(_) => failures.push(RelayFailure {
+                    event_id_hex: result.event_id_hex,
+                    reason: "relay publish failed".to_owned(),
+                }),
+                Err(error) => failures.push(RelayFailure {
+                    event_id_hex: result.event_id_hex,
+                    reason: wipe_failure_reason(&error),
+                }),
+            }
+        }
+        (deleted, failures)
+    }
+
     /// Non-destructive sign-out: deactivate the account on this device and
     /// (optionally) clean up its relay-published KeyPackages, while keeping all
     /// local state so the same identity can be signed back in later.
@@ -2071,8 +2136,8 @@ impl MarmotAppRuntime {
     /// - The MLS state DB is never touched — that is the "sign back in and
     ///   resume" contract.
     /// - KeyPackage cleanup is best-effort and per-relay: a failure is recorded
-    ///   in [`SignOutOutcome::key_package_failures`] (so the app can show a
-    ///   "will retry on next sign-in" hint) and never blocks the local teardown.
+    ///   in [`SignOutOutcome::key_package_failures`] and never blocks the local
+    ///   teardown. The runtime does not persist a remote-deletion retry queue.
     /// - A discovery failure (could not enumerate KeyPackages) is recorded as a
     ///   single failure with an empty `event_id_hex`, not silently treated as
     ///   "no KeyPackages".
@@ -2108,28 +2173,11 @@ impl MarmotAppRuntime {
         if options.delete_key_packages {
             match self.account_key_packages(account_ref, Vec::new()).await {
                 Ok(packages) => {
-                    for package in packages {
-                        if !package.relay {
-                            continue;
-                        }
-                        let event_id_hex = package.key_package_event_id.clone();
-                        let relays = package
-                            .source_relays
-                            .iter()
-                            .cloned()
-                            .map(TransportEndpoint)
-                            .collect::<Vec<_>>();
-                        match self
-                            .delete_key_package(account_ref, &event_id_hex, relays)
-                            .await
-                        {
-                            Ok(_) => outcome.key_packages_deleted += 1,
-                            Err(err) => outcome.key_package_failures.push(RelayFailure {
-                                event_id_hex,
-                                reason: wipe_failure_reason(&err),
-                            }),
-                        }
-                    }
+                    let (deleted, failures) = self
+                        .delete_relay_key_packages(&account.label, packages)
+                        .await;
+                    outcome.key_packages_deleted += deleted;
+                    outcome.key_package_failures.extend(failures);
                 }
                 Err(err) => outcome.key_package_failures.push(RelayFailure {
                     event_id_hex: String::new(),
@@ -2265,28 +2313,11 @@ impl MarmotAppRuntime {
         // (no event id) and must not abort the wipe.
         match self.account_key_packages(account_ref, Vec::new()).await {
             Ok(packages) => {
-                for package in packages {
-                    if !package.relay {
-                        continue;
-                    }
-                    let event_id_hex = package.key_package_event_id.clone();
-                    let relays = package
-                        .source_relays
-                        .iter()
-                        .cloned()
-                        .map(TransportEndpoint)
-                        .collect::<Vec<_>>();
-                    match self
-                        .delete_key_package(account_ref, &event_id_hex, relays)
-                        .await
-                    {
-                        Ok(_) => outcome.key_packages_deleted += 1,
-                        Err(err) => outcome.key_package_failures.push(RelayFailure {
-                            event_id_hex,
-                            reason: wipe_failure_reason(&err),
-                        }),
-                    }
-                }
+                let (deleted, failures) = self
+                    .delete_relay_key_packages(&account.label, packages)
+                    .await;
+                outcome.key_packages_deleted += deleted;
+                outcome.key_package_failures.extend(failures);
             }
             Err(err) => outcome.key_package_failures.push(RelayFailure {
                 event_id_hex: String::new(),

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -13,7 +13,9 @@ use cgka_traits::app_event::{
 };
 use marmot_account::AccountHomeError;
 use storage_sqlite::StoredRelayTelemetrySettings;
-use transport_nostr_adapter::{NostrPublishOutcome, NostrRelayClient, NostrSubscription};
+use transport_nostr_adapter::{
+    NostrEventPublishRequest, NostrPublishOutcome, NostrRelayClient, NostrSubscription,
+};
 use transport_nostr_peeler::NostrTransportEvent;
 use transport_quic_broker::BrokerServerTrust;
 
@@ -34,6 +36,8 @@ use crate::messages::{AppMessageIntent, build_inner_event};
 struct ScriptedPushRelayClient {
     publish_results: std::sync::Mutex<std::collections::VecDeque<bool>>,
     block_next_publish: std::sync::atomic::AtomicBool,
+    zero_ack_next_publish: std::sync::atomic::AtomicBool,
+    batch_calls: std::sync::atomic::AtomicUsize,
     publish_started: tokio::sync::Notify,
     publish_release: tokio::sync::Notify,
 }
@@ -45,6 +49,11 @@ impl ScriptedPushRelayClient {
 
     fn block_next_publish(&self) {
         self.block_next_publish
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    fn zero_ack_next_publish(&self) {
+        self.zero_ack_next_publish
             .store(true, std::sync::atomic::Ordering::SeqCst);
     }
 
@@ -94,6 +103,12 @@ impl NostrRelayClient for ScriptedPushRelayClient {
             self.publish_release.notified().await;
         }
         if self
+            .zero_ack_next_publish
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+        {
+            return Ok(NostrPublishOutcome::default());
+        }
+        if self
             .publish_results
             .lock()
             .unwrap()
@@ -106,6 +121,22 @@ impl NostrRelayClient for ScriptedPushRelayClient {
                 "injected publish failure".to_owned(),
             ))
         }
+    }
+
+    async fn publish_events(
+        &self,
+        requests: &[NostrEventPublishRequest],
+    ) -> Vec<Result<NostrPublishOutcome, cgka_traits::TransportAdapterError>> {
+        self.batch_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let mut outcomes = Vec::with_capacity(requests.len());
+        for request in requests {
+            outcomes.push(
+                self.publish_event(&request.endpoints, &request.event, request.required_acks)
+                    .await,
+            );
+        }
+        outcomes
     }
 }
 
@@ -696,6 +727,180 @@ async fn key_package_cutover_replacement_intent_survives_cache_retirement_and_re
     );
     reopened.clear_key_package_cutover_replacement_pending(label);
     assert!(!reopened.key_package_cutover_replacement_pending(label));
+}
+
+#[tokio::test]
+async fn key_package_deletion_batch_preserves_partial_results_and_cache_ownership() {
+    let directory = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(directory.path())
+        .create_account("delete-batch")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    relay.script([true, false]);
+    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example")
+        .with_test_relay_client(relay.clone());
+    let first_event_id = "11".repeat(32);
+    let retained_event_id = "22".repeat(32);
+    write_json(
+        app.key_package_record_path(&account.label),
+        &KeyPackageRecord {
+            account_label: account.label.clone(),
+            account_id_hex: account.account_id_hex,
+            key_package_id: "current-slot".into(),
+            key_package_ref_hex: "33".repeat(32),
+            key_package_event_id: retained_event_id.clone(),
+            published_at: 1,
+            key_package_hex: "00".into(),
+        },
+    )
+    .unwrap();
+
+    let results = app
+        .delete_key_package_events(
+            &account.label,
+            vec![
+                KeyPackageDeletionTarget {
+                    event_id_hex: first_event_id,
+                    source_relays: vec![
+                        TransportEndpoint("wss://relay.example".into()),
+                        TransportEndpoint("wss://relay.example".into()),
+                    ],
+                },
+                KeyPackageDeletionTarget {
+                    event_id_hex: retained_event_id,
+                    source_relays: vec![TransportEndpoint("wss://second.example".into())],
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(results.len(), 2);
+    assert!(results[0].result.is_ok());
+    assert!(results[1].result.is_err());
+    assert_eq!(
+        relay.batch_calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "all deletion events must use one batch publisher"
+    );
+    assert!(
+        app.key_package_record_path(&account.label).exists(),
+        "one acknowledged event must not clear another event's retained cache"
+    );
+}
+
+#[tokio::test]
+async fn manual_key_package_deletion_uses_batch_and_requires_ack_before_cache_removal() {
+    let directory = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(directory.path())
+        .create_account("manual-delete")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(directory.path(), "wss://relay.example")
+        .with_test_relay_client(relay.clone());
+    let event_id = "44".repeat(32);
+    write_json(
+        app.key_package_record_path(&account.label),
+        &KeyPackageRecord {
+            account_label: account.label.clone(),
+            account_id_hex: account.account_id_hex,
+            key_package_id: "current-slot".into(),
+            key_package_ref_hex: "55".repeat(32),
+            key_package_event_id: event_id.clone(),
+            published_at: 1,
+            key_package_hex: "00".into(),
+        },
+    )
+    .unwrap();
+
+    relay.zero_ack_next_publish();
+    let error = app
+        .delete_key_package_event(
+            &account.label,
+            &event_id,
+            vec![TransportEndpoint("wss://relay.example".into())],
+        )
+        .await
+        .expect_err("zero acknowledgements must not confirm deletion");
+    assert!(matches!(error, AppError::Publish(_)));
+    assert!(app.key_package_record_path(&account.label).exists());
+
+    app.delete_key_package_event(
+        &account.label,
+        &event_id,
+        vec![TransportEndpoint("wss://relay.example".into())],
+    )
+    .await
+    .unwrap();
+    assert!(!app.key_package_record_path(&account.label).exists());
+    assert_eq!(
+        relay.batch_calls.load(std::sync::atomic::Ordering::SeqCst),
+        2,
+        "manual deletion must route through the one-item batch"
+    );
+}
+
+#[tokio::test]
+async fn key_package_deletion_routes_endpoints_through_relay_safety_policy() {
+    let directory = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(directory.path())
+        .create_account("safe-delete")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relays_and_account_home(
+        directory.path(),
+        vec!["wss://relay.example".into()],
+        AccountHome::open(directory.path()),
+    )
+    .with_test_relay_client(relay.clone());
+
+    let result = app
+        .delete_key_package_events(
+            &account.label,
+            vec![KeyPackageDeletionTarget {
+                event_id_hex: "66".repeat(32),
+                source_relays: vec![TransportEndpoint("ws://127.0.0.1:7777".into())],
+            }],
+        )
+        .await
+        .unwrap()
+        .remove(0);
+    assert!(result.result.is_err());
+    assert_eq!(
+        relay.batch_calls.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "unsafe endpoint must be rejected before publisher invocation"
+    );
+
+    let dev_directory = tempfile::tempdir().unwrap();
+    let dev_account = AccountHome::open(dev_directory.path())
+        .create_account("dev-delete")
+        .unwrap();
+    let dev_relay = Arc::new(ScriptedPushRelayClient::default());
+    let dev_app = MarmotApp::with_relays_and_config(
+        dev_directory.path(),
+        vec!["ws://127.0.0.1:7777".into()],
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
+    )
+    .with_test_relay_client(dev_relay.clone());
+    let result = dev_app
+        .delete_key_package_events(
+            &dev_account.label,
+            vec![KeyPackageDeletionTarget {
+                event_id_hex: "77".repeat(32),
+                source_relays: vec![TransportEndpoint("ws://127.0.0.1:7777".into())],
+            }],
+        )
+        .await
+        .unwrap()
+        .remove(0);
+    assert!(result.result.is_ok());
+    assert_eq!(
+        dev_relay
+            .batch_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
 }
 
 #[tokio::test]

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -22,7 +23,8 @@ use marmot_app::{
 };
 use nostr::base64::Engine as _;
 use nostr::base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use nostr_relay_builder::MockRelay;
+use nostr_relay_builder::prelude::{BoxedFuture, PolicyResult, WritePolicy};
+use nostr_relay_builder::{LocalRelay, MockRelay, RelayBuilder};
 use nostr_sdk::prelude::{
     Alphabet, Client as NostrSdkClient, EventBuilder, Keys, Kind, SingleLetterTag, Tag, TagKind,
     Timestamp as NostrTimestamp,
@@ -57,6 +59,37 @@ async fn mock_app(dir: &tempfile::TempDir) -> (MockRelay, MarmotApp, String) {
         MarmotAppConfig::default()
             .with_allow_loopback_blob_endpoints(true)
             .with_allow_loopback_relay_endpoints(true),
+    );
+    (relay, app, url)
+}
+
+#[derive(Debug)]
+struct RejectDeletionEvents;
+
+impl WritePolicy for RejectDeletionEvents {
+    fn admit_event<'a>(
+        &'a self,
+        event: &'a nostr::Event,
+        _addr: &'a SocketAddr,
+    ) -> BoxedFuture<'a, PolicyResult> {
+        Box::pin(async move {
+            if event.kind == Kind::EventDeletion {
+                PolicyResult::Reject("injected deletion rejection".into())
+            } else {
+                PolicyResult::Accept
+            }
+        })
+    }
+}
+
+async fn deletion_rejecting_app(dir: &tempfile::TempDir) -> (LocalRelay, MarmotApp, String) {
+    let relay = LocalRelay::new(RelayBuilder::default().write_policy(RejectDeletionEvents));
+    relay.run().await.unwrap();
+    let url = relay.url().await.to_string();
+    let app = MarmotApp::with_relay_and_config(
+        dir.path(),
+        url.clone(),
+        MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true),
     );
     (relay, app, url)
 }
@@ -5464,6 +5497,37 @@ async fn app_runtime_sign_out_and_wipe_removes_account_and_deletes_key_package()
 }
 
 #[tokio::test]
+async fn app_runtime_wipe_reports_deletion_failure_and_still_removes_local_account() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = deletion_rejecting_app(&dir).await;
+    let home = AccountHome::open(dir.path());
+    let runtime = MarmotAppRuntime::new(app);
+    let created = runtime
+        .create_identity(AccountSetupRequest {
+            default_relays: vec![endpoint(&url)],
+            bootstrap_relays: vec![endpoint(&url)],
+            publish_initial_key_package: true,
+            ..AccountSetupRequest::default()
+        })
+        .await
+        .unwrap();
+    let account_id = created.account.account_id_hex;
+
+    let outcome = runtime.sign_out_and_wipe(&account_id).await.unwrap();
+
+    assert_eq!(outcome.key_packages_deleted, 0);
+    assert!(!outcome.key_package_failures.is_empty());
+    assert!(outcome.local_cleanup.completed);
+    assert!(
+        home.accounts()
+            .unwrap()
+            .into_iter()
+            .all(|account| account.account_id_hex != account_id),
+        "best-effort remote failure must not block destructive local cleanup"
+    );
+}
+
+#[tokio::test]
 async fn app_runtime_sign_out_and_wipe_leaves_pending_confirmation_groups() {
     // Regression for mdk#478: an incoming Welcome auto-joins MLS state
     // while the app keeps the invite `pending_confirmation` until accepted. A
@@ -5659,6 +5723,39 @@ async fn app_runtime_sign_out_deletes_key_packages_but_keeps_local_state() {
         "signed-out account ref must stay valid for a later sign-in"
     );
 
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn app_runtime_sign_out_reports_deletion_failure_and_keeps_local_state() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = deletion_rejecting_app(&dir).await;
+    let home = AccountHome::open(dir.path());
+    let runtime = MarmotAppRuntime::new(app);
+    let created = runtime
+        .create_identity(AccountSetupRequest {
+            default_relays: vec![endpoint(&url)],
+            bootstrap_relays: vec![endpoint(&url)],
+            publish_initial_key_package: true,
+            ..AccountSetupRequest::default()
+        })
+        .await
+        .unwrap();
+    let account_id = created.account.account_id_hex;
+
+    let outcome = runtime
+        .sign_out(&account_id, SignOutOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.key_packages_deleted, 0);
+    assert!(!outcome.key_package_failures.is_empty());
+    assert!(outcome.local_cleanup.completed);
+    assert!(home.account(&account_id).unwrap().signed_out);
+    assert!(
+        runtime.accounts().resolve(&account_id).is_ok(),
+        "best-effort remote failure must keep the local account"
+    );
     runtime.shutdown().await;
 }
 

--- a/crates/marmot-uniffi/src/commands/account.rs
+++ b/crates/marmot-uniffi/src/commands/account.rs
@@ -83,8 +83,9 @@ impl Marmot {
     /// same identity can be signed back in from the account picker with its
     /// groups, message history, and drafts intact. The account ref stays valid
     /// after this returns. The returned `SignOutOutcomeFfi` surfaces per-relay
-    /// KeyPackage cleanup failures so the app can show a "will retry on next
-    /// sign-in" hint (mdk#477).
+    /// KeyPackage cleanup failures. These are the final best-effort results for
+    /// this call; the runtime does not persist a remote-deletion retry queue
+    /// (mdk#477).
     pub async fn sign_out(
         &self,
         account_ref: String,

--- a/crates/marmot-uniffi/src/conversions/account.rs
+++ b/crates/marmot-uniffi/src/conversions/account.rs
@@ -183,7 +183,7 @@ pub struct LocalCleanupReportFfi {
 /// Structured result of the non-destructive `signOut`. The account's local
 /// state is kept on device; only the relay-published KeyPackages are cleaned
 /// up (when requested), so the app can render the same per-relay
-/// partial-failure sheet as a wipe and show a "will retry on next sign-in" hint.
+/// partial-failure sheet as a wipe. Failures are not durably queued for retry.
 #[derive(Clone, Debug, Default, uniffi::Record)]
 pub struct SignOutOutcomeFfi {
     /// Relay-published KeyPackage events successfully deleted. `0` when

--- a/crates/transport-nostr-adapter/src/lib.rs
+++ b/crates/transport-nostr-adapter/src/lib.rs
@@ -299,6 +299,19 @@ impl NostrPublishOutcome {
     }
 }
 
+/// One event in an ordered relay publish batch.
+///
+/// Batch-capable relay clients may retain and connect the union of these
+/// endpoints for the duration of [`NostrRelayClient::publish_events`]. Results
+/// remain ordered one-for-one with requests so callers can preserve per-event
+/// partial-success reporting.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NostrEventPublishRequest {
+    pub endpoints: Vec<TransportEndpoint>,
+    pub event: NostrTransportEvent,
+    pub required_acks: usize,
+}
+
 /// Relay event as observed by the Nostr relay client.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NostrRelayEvent {
@@ -327,6 +340,25 @@ pub trait NostrRelayClient: Send + Sync {
         event: &NostrTransportEvent,
         required_acks: usize,
     ) -> Result<NostrPublishOutcome, TransportAdapterError>;
+
+    /// Publish an ordered batch through one client lifecycle.
+    ///
+    /// The default preserves compatibility for injected relay clients. Socket
+    /// implementations should override this when they can safely retain scoped
+    /// write-only connections across the batch.
+    async fn publish_events(
+        &self,
+        requests: &[NostrEventPublishRequest],
+    ) -> Vec<Result<NostrPublishOutcome, TransportAdapterError>> {
+        let mut outcomes = Vec::with_capacity(requests.len());
+        for request in requests {
+            outcomes.push(
+                self.publish_event(&request.endpoints, &request.event, request.required_acks)
+                    .await,
+            );
+        }
+        outcomes
+    }
 }
 
 /// Nostr implementation of the shared transport adapter boundary.

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -18,8 +18,8 @@ use tokio::time::timeout;
 use transport_nostr_peeler::{KIND_MARMOT_GROUP_MESSAGE, NostrTransportEvent};
 
 use crate::{
-    NostrPublishOutcome, NostrRelayClient, NostrRelayEvent, NostrSubscription,
-    NostrTransportAdapter,
+    NostrEventPublishRequest, NostrPublishOutcome, NostrRelayClient, NostrRelayEvent,
+    NostrSubscription, NostrTransportAdapter,
 };
 
 const SDK_RELAY_CONNECT_WAIT: Duration = Duration::from_secs(5);
@@ -40,6 +40,10 @@ const SDK_RELAY_PUBLISH_RETRY_BACKOFF: Duration = Duration::from_millis(600);
 /// that degraded case. Sized to still allow a slow relay one full connect plus
 /// send attempt (`SDK_RELAY_CONNECT_WAIT + SDK_RELAY_PUBLISH_WAIT`) with margin.
 const SDK_RELAY_PUBLISH_OVERALL_WAIT: Duration = Duration::from_secs(20);
+/// Whole-batch ceiling. Individual events retain the existing 20-second
+/// ceiling, while a pathological multi-event teardown cannot multiply that
+/// bound without limit.
+const SDK_RELAY_BATCH_OVERALL_WAIT: Duration = Duration::from_secs(60);
 
 /// Planned SDK subscription derived from a transport-adapter subscription.
 #[derive(Clone, Debug)]
@@ -91,6 +95,10 @@ pub struct NostrSdkRelayClient {
     client: Client,
     account_subscriptions: Arc<RwLock<HashMap<MemberId, Vec<SubscriptionId>>>>,
     publish_relay_refs: Arc<Mutex<HashMap<RelayUrl, usize>>>,
+    #[cfg(test)]
+    publish_connect_attempts: Arc<Mutex<HashMap<RelayUrl, usize>>>,
+    #[cfg(test)]
+    publish_release_attempts: Arc<Mutex<HashMap<RelayUrl, usize>>>,
     /// Per-account, per-relay subscription-registration outcomes accumulated
     /// since that account's last
     /// [`take_subscription_registrations`](Self::take_subscription_registrations)
@@ -105,12 +113,74 @@ pub struct NostrSdkRelayClient {
     registration_log: Arc<Mutex<HashMap<MemberId, HashMap<RelayUrl, bool>>>>,
 }
 
+struct ScopedPublishRelayLease {
+    owner: NostrSdkRelayClient,
+    endpoints: Vec<RelayUrl>,
+}
+
+impl ScopedPublishRelayLease {
+    fn new(owner: NostrSdkRelayClient) -> Self {
+        Self {
+            owner,
+            endpoints: Vec::new(),
+        }
+    }
+
+    fn retain(&mut self, endpoint: RelayUrl) {
+        self.endpoints.push(endpoint);
+    }
+
+    async fn release(mut self) {
+        while let Some(endpoint) = self.endpoints.last().cloned() {
+            if self.owner.release_publish_relay(endpoint).await.is_err() {
+                tracing::warn!(
+                    target: "transport_nostr_adapter::sdk_client",
+                    method = "release_publish_batch",
+                    "failed to clean up SDK publish relay"
+                );
+            }
+            // Pop only after the awaited release. If this future is cancelled
+            // during cleanup, Drop still owns this endpoint and delegates the
+            // remaining cleanup to an independent task.
+            self.endpoints.pop();
+        }
+    }
+}
+
+impl Drop for ScopedPublishRelayLease {
+    fn drop(&mut self) {
+        let endpoints = std::mem::take(&mut self.endpoints);
+        if endpoints.is_empty() {
+            return;
+        }
+        let owner = self.owner.clone();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            // A dropped batch future is cancellation. Hand cleanup to an
+            // independent task so transient write relays do not outlive the
+            // cancelled scope.
+            runtime.spawn(async move {
+                owner.cleanup_publish_relays(endpoints).await;
+            });
+        }
+    }
+}
+
+struct PreparedPublish {
+    endpoints: Vec<RelayUrl>,
+    event: Event,
+    required_acks: usize,
+}
+
 impl NostrSdkRelayClient {
     pub fn new(client: Client) -> Self {
         Self {
             client,
             account_subscriptions: Arc::new(RwLock::new(HashMap::new())),
             publish_relay_refs: Arc::new(Mutex::new(HashMap::new())),
+            #[cfg(test)]
+            publish_connect_attempts: Arc::new(Mutex::new(HashMap::new())),
+            #[cfg(test)]
+            publish_release_attempts: Arc::new(Mutex::new(HashMap::new())),
             registration_log: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -361,38 +431,49 @@ impl NostrSdkRelayClient {
             .map_err(|e| TransportAdapterError::Publish(format!("sign event: {e}")))
     }
 
-    async fn publish_to_relay(
-        client: Client,
+    async fn connect_publish_relay(
+        &self,
         endpoint: RelayUrl,
-        event: Event,
-    ) -> Result<TransportEndpointReceipt, TransportEndpointFailure> {
+    ) -> Result<RelayUrl, TransportEndpointFailure> {
+        #[cfg(test)]
+        {
+            *self
+                .publish_connect_attempts
+                .lock()
+                .await
+                .entry(endpoint.clone())
+                .or_default() += 1;
+        }
         let transport_endpoint = TransportEndpoint(endpoint.to_string());
         match timeout(
             SDK_RELAY_CONNECT_WAIT,
-            client.connect_relay(endpoint.clone()),
+            self.client.connect_relay(endpoint.clone()),
         )
         .await
         {
-            Ok(Ok(())) => {}
+            Ok(Ok(())) => Ok(endpoint),
             // Failure reasons never embed the nostr-sdk error Display: it
             // commonly carries the relay URL, and these reasons flow into
             // `TransportAdapterError::Publish` Display (see
             // `finish_publish_outcome`), which upper layers may log. The
             // endpoint stays available on the structured failure record.
-            Ok(Err(_)) => {
-                return Err(TransportEndpointFailure {
-                    endpoint: transport_endpoint,
-                    reason: "connect relay failed".to_owned(),
-                });
-            }
-            Err(_) => {
-                return Err(TransportEndpointFailure {
-                    endpoint: transport_endpoint,
-                    reason: "connect relay timed out".to_owned(),
-                });
-            }
+            Ok(Err(_)) => Err(TransportEndpointFailure {
+                endpoint: transport_endpoint,
+                reason: "connect relay failed".to_owned(),
+            }),
+            Err(_) => Err(TransportEndpointFailure {
+                endpoint: transport_endpoint,
+                reason: "connect relay timed out".to_owned(),
+            }),
         }
+    }
 
+    async fn send_event_to_relay(
+        client: Client,
+        endpoint: RelayUrl,
+        event: Event,
+    ) -> Result<TransportEndpointReceipt, TransportEndpointFailure> {
+        let transport_endpoint = TransportEndpoint(endpoint.to_string());
         let mut last_error = "send event failed".to_owned();
         for attempt in 1..=SDK_RELAY_PUBLISH_ATTEMPTS {
             match timeout(
@@ -438,6 +519,176 @@ impl NostrSdkRelayClient {
             endpoint: transport_endpoint,
             reason: last_error,
         })
+    }
+
+    async fn publish_prepared_event(
+        &self,
+        request: PreparedPublish,
+        unavailable: &HashMap<RelayUrl, TransportEndpointFailure>,
+    ) -> Result<NostrPublishOutcome, TransportAdapterError> {
+        // A configured threshold of zero relaxes the quorum but never permits
+        // confirming work that no relay accepted.
+        let ack_goal = request.required_acks.max(1);
+        let message_id = cgka_traits::MessageId::new(request.event.id.to_bytes().to_vec());
+        let mut accepted = Vec::new();
+        let mut failed = Vec::new();
+        let mut publishes = JoinSet::new();
+        for endpoint in request.endpoints {
+            if let Some(failure) = unavailable.get(&endpoint) {
+                failed.push(failure.clone());
+                continue;
+            }
+            publishes.spawn(Self::send_event_to_relay(
+                self.client.clone(),
+                endpoint,
+                request.event.clone(),
+            ));
+        }
+
+        let deadline = tokio::time::Instant::now() + SDK_RELAY_PUBLISH_OVERALL_WAIT;
+        let mut aborted_publishes = false;
+        let mut timed_out = false;
+        let result = loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                publishes.abort_all();
+                aborted_publishes = true;
+                timed_out = true;
+                break Self::finish_publish_outcome(
+                    message_id,
+                    accepted,
+                    failed,
+                    request.required_acks,
+                    timed_out,
+                );
+            }
+            match timeout(remaining, publishes.join_next()).await {
+                Err(_) => {
+                    publishes.abort_all();
+                    aborted_publishes = true;
+                    timed_out = true;
+                    break Self::finish_publish_outcome(
+                        message_id,
+                        accepted,
+                        failed,
+                        request.required_acks,
+                        timed_out,
+                    );
+                }
+                Ok(None) => {
+                    break Self::finish_publish_outcome(
+                        message_id,
+                        accepted,
+                        failed,
+                        request.required_acks,
+                        timed_out,
+                    );
+                }
+                Ok(Some(result)) => match result {
+                    Ok(Ok(receipt)) => {
+                        accepted.push(receipt);
+                        if accepted.len() >= ack_goal {
+                            publishes.abort_all();
+                            aborted_publishes = true;
+                            break Self::finish_publish_outcome(
+                                message_id,
+                                accepted,
+                                failed,
+                                request.required_acks,
+                                timed_out,
+                            );
+                        }
+                    }
+                    Ok(Err(failure)) => failed.push(failure),
+                    Err(_) => {}
+                },
+            }
+        };
+        // `JoinSet::abort_all` is non-blocking. Drain aborted tasks before
+        // releasing the batch lease so no send future can race cleanup.
+        if aborted_publishes {
+            while publishes.join_next().await.is_some() {}
+        }
+        result
+    }
+
+    async fn publish_prepared_batch(
+        &self,
+        requests: Vec<Result<PreparedPublish, TransportAdapterError>>,
+    ) -> Vec<Result<NostrPublishOutcome, TransportAdapterError>> {
+        let mut unique_endpoints = Vec::new();
+        let mut seen_endpoints = HashSet::new();
+        for request in requests.iter().filter_map(|request| request.as_ref().ok()) {
+            for endpoint in &request.endpoints {
+                if seen_endpoints.insert(endpoint.clone()) {
+                    unique_endpoints.push(endpoint.clone());
+                }
+            }
+        }
+
+        let mut lease = ScopedPublishRelayLease::new(self.clone());
+        let mut unavailable = HashMap::new();
+        let mut connectable = Vec::new();
+        for endpoint in unique_endpoints {
+            match self.retain_publish_relay(&endpoint).await {
+                Ok(retained) => {
+                    if retained {
+                        lease.retain(endpoint.clone());
+                    }
+                    connectable.push(endpoint);
+                }
+                Err(failure) => {
+                    unavailable.insert(endpoint, failure);
+                }
+            }
+        }
+
+        // Connect the union once. Per-event sends below reuse these scoped
+        // write-only relay connections and never install subscriptions.
+        let mut connects = JoinSet::new();
+        for endpoint in connectable {
+            let client = self.clone();
+            connects.spawn(async move { client.connect_publish_relay(endpoint).await });
+        }
+        while let Some(result) = connects.join_next().await {
+            if let Ok(Err(failure)) = result
+                && let Ok(endpoint) = RelayUrl::parse(failure.endpoint.as_str())
+            {
+                unavailable.insert(endpoint, failure);
+            }
+        }
+
+        let deadline = tokio::time::Instant::now() + SDK_RELAY_BATCH_OVERALL_WAIT;
+        let mut outcomes = Vec::with_capacity(requests.len());
+        for request in requests {
+            let request = match request {
+                Ok(request) => request,
+                Err(error) => {
+                    outcomes.push(Err(error));
+                    continue;
+                }
+            };
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                outcomes.push(Err(TransportAdapterError::Publish(
+                    "publish batch timed out".to_owned(),
+                )));
+                continue;
+            }
+            match timeout(
+                remaining,
+                self.publish_prepared_event(request, &unavailable),
+            )
+            .await
+            {
+                Ok(outcome) => outcomes.push(outcome),
+                Err(_) => outcomes.push(Err(TransportAdapterError::Publish(
+                    "publish batch timed out".to_owned(),
+                ))),
+            }
+        }
+        lease.release().await;
+        outcomes
     }
 
     async fn add_subscription_relay(
@@ -499,6 +750,15 @@ impl NostrSdkRelayClient {
     }
 
     async fn release_publish_relay(&self, endpoint: RelayUrl) -> Result<(), ()> {
+        #[cfg(test)]
+        {
+            *self
+                .publish_release_attempts
+                .lock()
+                .await
+                .entry(endpoint.clone())
+                .or_default() += 1;
+        }
         let mut publish_relay_refs = self.publish_relay_refs.lock().await;
         match publish_relay_refs.get_mut(&endpoint) {
             Some(ref_count) if *ref_count > 1 => {
@@ -706,116 +966,57 @@ impl NostrRelayClient for NostrSdkRelayClient {
         event: &NostrTransportEvent,
         required_acks: usize,
     ) -> Result<NostrPublishOutcome, TransportAdapterError> {
-        let parsed_endpoints = parse_endpoints(endpoints, "publish")?;
-        let mut seen_endpoints = HashSet::new();
-        let parsed_endpoints = parsed_endpoints
+        let request = NostrEventPublishRequest {
+            endpoints: endpoints.to_vec(),
+            event: event.clone(),
+            required_acks,
+        };
+        self.publish_events(std::slice::from_ref(&request))
+            .await
             .into_iter()
-            .filter(|endpoint| seen_endpoints.insert(endpoint.clone()))
-            .collect::<Vec<_>>();
-        let event = self.event_for_publish(event).await?;
-        tracing::debug!(
-            target: "transport_nostr_adapter::sdk_client",
-            method = "publish_event",
-            endpoint_count = parsed_endpoints.len(),
-            "publishing SDK relay event"
-        );
-        // A configured threshold of zero relaxes the quorum but never permits
-        // confirming work that no relay accepted.
-        let ack_goal = required_acks.max(1);
-        let message_id = cgka_traits::MessageId::new(event.id.to_bytes().to_vec());
-        let mut accepted = Vec::new();
-        let mut failed = Vec::new();
-        let mut cleanup_endpoints = Vec::new();
-        let mut publishes = JoinSet::new();
-        for endpoint in parsed_endpoints {
-            match self.retain_publish_relay(&endpoint).await {
-                Ok(true) => cleanup_endpoints.push(endpoint.clone()),
-                Ok(false) => {}
-                Err(failure) => {
-                    failed.push(failure);
+            .next()
+            .expect("single-event batch returns one outcome")
+    }
+
+    async fn publish_events(
+        &self,
+        requests: &[NostrEventPublishRequest],
+    ) -> Vec<Result<NostrPublishOutcome, TransportAdapterError>> {
+        let mut prepared = Vec::with_capacity(requests.len());
+        for request in requests {
+            let endpoints = match parse_endpoints(&request.endpoints, "publish") {
+                Ok(endpoints) => {
+                    let mut seen_endpoints = HashSet::new();
+                    endpoints
+                        .into_iter()
+                        .filter(|endpoint| seen_endpoints.insert(endpoint.clone()))
+                        .collect::<Vec<_>>()
+                }
+                Err(error) => {
+                    prepared.push(Err(error));
                     continue;
                 }
-            }
-            publishes.spawn(Self::publish_to_relay(
-                self.client.clone(),
-                endpoint,
-                event.clone(),
-            ));
-        }
-
-        // Drain completions, but bound the whole fan-out by an overall deadline
-        // so a publish to unreachable (or under-acking) relays fails in bounded
-        // time instead of waiting out every relay's full retry budget. Per-relay
-        // early returns once `required_acks` is met are unaffected.
-        let deadline = tokio::time::Instant::now() + SDK_RELAY_PUBLISH_OVERALL_WAIT;
-        let mut aborted_publishes = false;
-        let mut timed_out = false;
-        let result = loop {
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            if remaining.is_zero() {
-                publishes.abort_all();
-                aborted_publishes = true;
-                timed_out = true;
-                break Self::finish_publish_outcome(
-                    message_id,
-                    accepted,
-                    failed,
-                    required_acks,
-                    timed_out,
-                );
-            }
-            match timeout(remaining, publishes.join_next()).await {
-                Err(_elapsed) => {
-                    publishes.abort_all();
-                    aborted_publishes = true;
-                    timed_out = true;
-                    break Self::finish_publish_outcome(
-                        message_id,
-                        accepted,
-                        failed,
-                        required_acks,
-                        timed_out,
-                    );
+            };
+            let event = match self.event_for_publish(&request.event).await {
+                Ok(event) => event,
+                Err(error) => {
+                    prepared.push(Err(error));
+                    continue;
                 }
-                Ok(None) => {
-                    break Self::finish_publish_outcome(
-                        message_id,
-                        accepted,
-                        failed,
-                        required_acks,
-                        timed_out,
-                    );
-                }
-                Ok(Some(result)) => match result {
-                    Ok(Ok(receipt)) => {
-                        accepted.push(receipt);
-                        if accepted.len() >= ack_goal {
-                            publishes.abort_all();
-                            aborted_publishes = true;
-                            break Ok(NostrPublishOutcome {
-                                message_id: Some(message_id),
-                                accepted,
-                                failed,
-                            });
-                        }
-                    }
-                    Ok(Err(failure)) => failed.push(failure),
-                    Err(e) => {
-                        publishes.abort_all();
-                        aborted_publishes = true;
-                        break Err(TransportAdapterError::Publish(format!(
-                            "publish task failed: {e}"
-                        )));
-                    }
-                },
-            }
-        };
-
-        if aborted_publishes {
-            while publishes.join_next().await.is_some() {}
+            };
+            prepared.push(Ok(PreparedPublish {
+                endpoints,
+                event,
+                required_acks: request.required_acks,
+            }));
         }
-        self.cleanup_publish_relays(cleanup_endpoints).await;
-        result
+        tracing::debug!(
+            target: "transport_nostr_adapter::sdk_client",
+            method = "publish_events",
+            event_count = prepared.len(),
+            "publishing SDK relay event batch"
+        );
+        self.publish_prepared_batch(prepared).await
     }
 }
 
@@ -1317,6 +1518,34 @@ mod tests {
         assert_eq!(event.content, dto.content);
     }
 
+    #[tokio::test]
+    async fn concurrent_batch_clients_keep_account_signers_isolated() {
+        let keys_a = Keys::generate();
+        let keys_b = Keys::generate();
+        let sdk_a = NostrSdkRelayClient::new(Client::builder().signer(keys_a.clone()).build());
+        let sdk_b = NostrSdkRelayClient::new(Client::builder().signer(keys_b.clone()).build());
+        let event_a = NostrTransportEvent::new_unsigned(
+            keys_a.public_key().to_hex(),
+            5,
+            vec![vec!["e".into(), "11".repeat(32)]],
+            String::new(),
+        );
+        let event_b = NostrTransportEvent::new_unsigned(
+            keys_b.public_key().to_hex(),
+            5,
+            vec![vec!["e".into(), "22".repeat(32)]],
+            String::new(),
+        );
+
+        let (signed_a, signed_b) = tokio::join!(
+            sdk_a.event_for_publish(&event_a),
+            sdk_b.event_for_publish(&event_b)
+        );
+
+        assert_eq!(signed_a.unwrap().pubkey, keys_a.public_key());
+        assert_eq!(signed_b.unwrap().pubkey, keys_b.public_key());
+    }
+
     #[test]
     fn publish_timeout_exceeds_sdk_ok_wait() {
         assert!(SDK_RELAY_PUBLISH_WAIT > Duration::from_secs(10));
@@ -1488,6 +1717,158 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("accepted 1 of required 2"));
+    }
+
+    #[tokio::test]
+    async fn publish_batch_connects_shared_relay_once_and_cleans_scope() {
+        let relay = MockRelay::run().await.unwrap();
+        let endpoint = TransportEndpoint(relay.url().await.to_string());
+        let relay_url = RelayUrl::parse(endpoint.as_str()).unwrap();
+        let client = Client::builder().signer(Keys::generate()).build();
+        let sdk = NostrSdkRelayClient::new(client);
+        let requests = [
+            NostrEventPublishRequest {
+                endpoints: vec![endpoint.clone()],
+                event: signed_group_event_dto(),
+                required_acks: 1,
+            },
+            NostrEventPublishRequest {
+                endpoints: vec![endpoint],
+                event: signed_group_event_dto(),
+                required_acks: 1,
+            },
+        ];
+
+        let outcomes = sdk.publish_events(&requests).await;
+
+        assert_eq!(outcomes.len(), 2);
+        assert!(outcomes.into_iter().all(|outcome| outcome.is_ok()));
+        assert_eq!(
+            sdk.publish_connect_attempts.lock().await.get(&relay_url),
+            Some(&1)
+        );
+        assert_eq!(
+            sdk.publish_release_attempts.lock().await.get(&relay_url),
+            Some(&1)
+        );
+        assert_eq!(sdk.relay_health().await.total_relays, 0);
+    }
+
+    #[tokio::test]
+    async fn publish_batch_deduplicates_mixed_endpoint_sets() {
+        let relay_a = MockRelay::run().await.unwrap();
+        let relay_b = MockRelay::run().await.unwrap();
+        let endpoint_a = TransportEndpoint(relay_a.url().await.to_string());
+        let endpoint_b = TransportEndpoint(relay_b.url().await.to_string());
+        let relay_url_a = RelayUrl::parse(endpoint_a.as_str()).unwrap();
+        let relay_url_b = RelayUrl::parse(endpoint_b.as_str()).unwrap();
+        let client = Client::builder().signer(Keys::generate()).build();
+        let sdk = NostrSdkRelayClient::new(client);
+        let requests = [
+            NostrEventPublishRequest {
+                endpoints: vec![endpoint_a.clone(), endpoint_b.clone(), endpoint_a],
+                event: signed_group_event_dto(),
+                required_acks: 1,
+            },
+            NostrEventPublishRequest {
+                endpoints: vec![endpoint_b],
+                event: signed_group_event_dto(),
+                required_acks: 1,
+            },
+        ];
+
+        let outcomes = sdk.publish_events(&requests).await;
+
+        assert!(outcomes.into_iter().all(|outcome| outcome.is_ok()));
+        let attempts = sdk.publish_connect_attempts.lock().await;
+        assert_eq!(attempts.get(&relay_url_a), Some(&1));
+        assert_eq!(attempts.get(&relay_url_b), Some(&1));
+        drop(attempts);
+        assert_eq!(sdk.relay_health().await.total_relays, 0);
+    }
+
+    #[tokio::test]
+    async fn publish_batch_cleans_write_only_relay_after_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = TransportEndpoint(format!("ws://{}", listener.local_addr().unwrap()));
+        drop(listener);
+        let relay_url = RelayUrl::parse(endpoint.as_str()).unwrap();
+        let client = Client::builder().signer(Keys::generate()).build();
+        let sdk = NostrSdkRelayClient::new(client);
+
+        let err = sdk
+            .publish_events(&[NostrEventPublishRequest {
+                endpoints: vec![endpoint],
+                event: signed_group_event_dto(),
+                required_acks: 1,
+            }])
+            .await
+            .remove(0)
+            .expect_err("unreachable relay must fail");
+
+        assert!(!err.to_string().is_empty());
+        assert_eq!(
+            sdk.publish_release_attempts.lock().await.get(&relay_url),
+            Some(&1)
+        );
+        assert_eq!(sdk.relay_health().await.total_relays, 0);
+    }
+
+    #[tokio::test]
+    async fn cancelled_publish_batch_cleans_write_only_relay() {
+        let endpoint = TransportEndpoint(silent_relay_url().await);
+        let relay_url = RelayUrl::parse(endpoint.as_str()).unwrap();
+        let client = Client::builder().signer(Keys::generate()).build();
+        let sdk = NostrSdkRelayClient::new(client);
+        let publish_sdk = sdk.clone();
+        let publish = tokio::spawn(async move {
+            publish_sdk
+                .publish_events(&[NostrEventPublishRequest {
+                    endpoints: vec![endpoint],
+                    event: signed_group_event_dto(),
+                    required_acks: 1,
+                }])
+                .await
+        });
+
+        for _ in 0..100 {
+            if sdk
+                .publish_connect_attempts
+                .lock()
+                .await
+                .contains_key(&relay_url)
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        let relay = sdk
+            .client()
+            .relays()
+            .await
+            .get(&relay_url)
+            .cloned()
+            .expect("batch must retain its transient relay");
+        assert!(relay.flags().has_write());
+        assert!(
+            !relay.flags().has_read(),
+            "publish-only relay must not inherit subscriptions"
+        );
+
+        publish.abort();
+        let _ = publish.await;
+        for _ in 0..100 {
+            if sdk.relay_health().await.total_relays == 0 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        assert_eq!(
+            sdk.publish_release_attempts.lock().await.get(&relay_url),
+            Some(&1)
+        );
+        assert_eq!(sdk.relay_health().await.total_relays, 0);
     }
 
     #[test]

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -525,6 +525,7 @@ impl NostrSdkRelayClient {
         &self,
         request: PreparedPublish,
         unavailable: &HashMap<RelayUrl, TransportEndpointFailure>,
+        connect_before_send: bool,
     ) -> Result<NostrPublishOutcome, TransportAdapterError> {
         // A configured threshold of zero relaxes the quorum but never permits
         // confirming work that no relay accepted.
@@ -538,11 +539,14 @@ impl NostrSdkRelayClient {
                 failed.push(failure.clone());
                 continue;
             }
-            publishes.spawn(Self::send_event_to_relay(
-                self.client.clone(),
-                endpoint,
-                request.event.clone(),
-            ));
+            let sdk = self.clone();
+            let event = request.event.clone();
+            publishes.spawn(async move {
+                if connect_before_send {
+                    sdk.connect_publish_relay(endpoint.clone()).await?;
+                }
+                Self::send_event_to_relay(sdk.client.clone(), endpoint, event).await
+            });
         }
 
         let deadline = tokio::time::Instant::now() + SDK_RELAY_PUBLISH_OVERALL_WAIT;
@@ -612,6 +616,37 @@ impl NostrSdkRelayClient {
         result
     }
 
+    async fn publish_prepared_single(
+        &self,
+        request: PreparedPublish,
+    ) -> Result<NostrPublishOutcome, TransportAdapterError> {
+        let mut lease = ScopedPublishRelayLease::new(self.clone());
+        let mut unavailable = HashMap::new();
+        for endpoint in &request.endpoints {
+            match self.retain_publish_relay(endpoint).await {
+                Ok(retained) => {
+                    if retained {
+                        lease.retain(endpoint.clone());
+                    }
+                }
+                Err(failure) => {
+                    unavailable.insert(endpoint.clone(), failure);
+                }
+            }
+        }
+
+        // Preserve the original single-event latency behavior: each relay
+        // races connect + send as one task, and reaching the acknowledgement
+        // goal aborts relays that are still connecting. The multi-event path
+        // below may pre-connect because it amortizes those connections across
+        // the batch.
+        let outcome = self
+            .publish_prepared_event(request, &unavailable, true)
+            .await;
+        lease.release().await;
+        outcome
+    }
+
     async fn publish_prepared_batch(
         &self,
         requests: Vec<Result<PreparedPublish, TransportAdapterError>>,
@@ -677,7 +712,7 @@ impl NostrSdkRelayClient {
             }
             match timeout(
                 remaining,
-                self.publish_prepared_event(request, &unavailable),
+                self.publish_prepared_event(request, &unavailable, false),
             )
             .await
             {
@@ -1016,6 +1051,12 @@ impl NostrRelayClient for NostrSdkRelayClient {
             event_count = prepared.len(),
             "publishing SDK relay event batch"
         );
+        if prepared.len() == 1 {
+            return match prepared.pop().expect("one prepared publish") {
+                Ok(request) => vec![self.publish_prepared_single(request).await],
+                Err(error) => vec![Err(error)],
+            };
+        }
         self.publish_prepared_batch(prepared).await
     }
 }
@@ -1589,6 +1630,29 @@ mod tests {
         assert_eq!(sdk.relay_health().await.total_relays, 0);
     }
 
+    #[tokio::test]
+    async fn publish_event_does_not_wait_for_hung_connect_once_required_ack_is_met() {
+        let relay = MockRelay::run().await.unwrap();
+        let reachable = TransportEndpoint(relay.url().await.to_string());
+        let hung_connect = TransportEndpoint(hanging_connect_relay_url().await);
+        let keys = Keys::generate();
+        let client = Client::builder().signer(keys).build();
+        let sdk = NostrSdkRelayClient::new(client);
+        let dto = signed_group_event_dto();
+
+        let outcome = timeout(
+            Duration::from_secs(2),
+            sdk.publish_event(&[hung_connect, reachable.clone()], &dto, 1),
+        )
+        .await
+        .expect("a hung relay connect must not delay a healthy acknowledgement")
+        .expect("one healthy relay should satisfy the publish");
+
+        assert_eq!(outcome.accepted.len(), 1);
+        assert_eq!(outcome.accepted[0].endpoint, reachable);
+        assert_eq!(sdk.relay_health().await.total_relays, 0);
+    }
+
     #[tokio::test(start_paused = true)]
     async fn publish_event_cleans_one_shot_relay_after_overall_timeout() {
         let silent = TransportEndpoint(silent_relay_url().await);
@@ -1898,6 +1962,20 @@ mod tests {
                     if tokio_tungstenite::accept_async(stream).await.is_ok() {
                         std::future::pending::<()>().await;
                     }
+                });
+            }
+        });
+        format!("ws://{addr}")
+    }
+
+    async fn hanging_connect_relay_url() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let _stream = stream;
+                    std::future::pending::<()>().await;
                 });
             }
         });


### PR DESCRIPTION
## Summary

- add adapter-owned ordered batch publishing with a scoped write-only relay lease
- batch sign-out, wipe, and manual KeyPackage deletion through one account-bound signer and relay client after relay-safety validation
- preserve per-event acknowledgement, cache, and teardown semantics while correcting comments that implied a durable retry queue

## Corrected diagnosis

Issue #705 correctly identifies per-event Nostr SDK client construction as part of the pathology. Reusing only the client object is insufficient, however, because publish-only relays are intentionally removed after each existing single-event publish. The adapter therefore owns a scoped batch lease: it deduplicates the union of write relays, connects each once, reuses them for the ordered batch, and cleans them up on success, error, timeout, or cancellation. The lease does not inherit subscriptions or retain relays permanently, and concurrent leases are reference-counted.

## Lifecycle semantics

- `sign_out` attempts the whole deletion batch before stopping the account worker and keeps matching local KeyPackages when an event is not acknowledged.
- `wipe` reports publication failures but continues destructive local cleanup; once account keys are erased, there is intentionally no durable retry/outbox in this change.
- manual deletion uses the same batch path with one item.
- local cache entries are removed only for the exact matching event after at least one relay acknowledgement.
- every endpoint is still passed through the host relay-safety policy before any publish call; loopback remains dev-only.
- the account signer is isolated to the account-bound client and every event is pre-signed exactly once before network publication.

A durable post-wipe deletion outbox is outside the scope of this PR.

## API and bindings

The public Rust transport adapter API adds `NostrEventPublishRequest` and the default-compatible `NostrRelayClient::publish_events` method. There is no Marmot wire-format change and no UniFFI or generated-binding contract change.

## Validation

- `cargo test -p transport-nostr-adapter --features sdk` — 51 unit tests and 30 inbound-routing tests passed
- focused `marmot-app` deletion unit tests passed
- focused relay-runtime sign-out and wipe publication-failure tests passed
- `cargo test -p marmot-account` — 13 library, 30 home, and 33 runtime tests passed
- `cargo test -p marmot-uniffi` — 67 library, 2 media-fixture, and 24 smoke tests passed
- `cargo check -p marmot-app`
- `cargo check -p marmot-uniffi`
- `just fast-ci`
- `git diff --check`

The full `cargo test -p marmot-app` run passed all 445 library tests and the new relay-runtime cases, but the relay-runtime integration binary ended with five existing failures:

- `encrypted_media_endpoint_updates_are_full_replacement_and_admin_only`
- `encrypted_media_upload_sends_ciphertext_and_download_decrypts_plaintext`
- `relay_app_runtime_synthesizes_system_row_for_retention_change`
- `retained_media_rehydrates_a_retired_current_epoch_before_the_group_advances`
- `self_removal_suppresses_account_unread_while_peer_removal_preserves_it`

The first failure was reproduced unchanged in an isolated clean worktree at `origin/master` (`left: 3`, `right: 1`), confirming the suite is not fully green on the base revision.

Closes #705

Refs #1062

Refs #1061