### PR TITLE
chore(release): prepare 0.9.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -852,7 +852,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "async-trait",
  "hex",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "libc",
  "tempfile",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "cgka-conformance-simulator",
  "serde",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "fs-private",
  "serde",
@@ -3231,7 +3231,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5439,7 +5439,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6033,7 +6033,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6052,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6089,7 +6089,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7144,7 +7144,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "agent-control",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.6"
+version = "0.9.7"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.6",
+  "conformance_version": "0.9.7",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,8 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+## [0.9.7] - 2026-07-26
+
 ### Fixed
 
 - Agent text-stream QUIC starts now accept zero broker candidates for durable
@@ -16,6 +18,22 @@ versioning through the workspace version in the root `Cargo.toml`.
   reconnect, or daemon reuse cannot restart at sequence 1 for one start.
   Zero-candidate daemon compose returns a `streaming` payload with
   `candidate: ""` for TUI and script consumers instead of failing the start.
+- KeyPackage deletion during sign-out, wipe, and explicit deletion now uses one
+  scoped, account-bound relay connection set for the complete batch instead of
+  cold-connecting a throwaway client for every deletion event. Relay
+  acknowledgement and local-cache removal remain tracked per event.
+- The Hermes plugin now maps explicitly non-final assistant commentary to
+  durable kind-1201 agent activity while retaining kind-9 delivery for final
+  answers and compatibility with Hermes versions that do not yet provide
+  delivery metadata.
+
+### Security
+
+- Updated `quinn-proto` and `crossbeam-epoch` to patched releases, clearing the
+  active RustSec vulnerabilities in the QUIC and OpenMLS dependency paths.
+  Also removed the remaining unsoundness and yanked-package findings without
+  adding audit ignores; unmaintained-only dependencies remain tracked in
+  issue #1116.
 
 ## [0.9.6] - 2026-07-26
 
@@ -721,7 +739,9 @@ Initial release of the `dm` command-line app, the `dmd` background daemon, and t
 - Local installation docs for `cargo install --path crates/cli --locked --bins`.
 - Homebrew release checklist and namespaced tap packaging path for `marmot-protocol/tap/darkmatter`.
 
-[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.5...HEAD
+[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.7...HEAD
+[0.9.7]: https://github.com/marmot-protocol/mdk/compare/v0.9.6...v0.9.7
+[0.9.6]: https://github.com/marmot-protocol/mdk/compare/v0.9.5...v0.9.6
 [0.9.5]: https://github.com/marmot-protocol/mdk/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/marmot-protocol/mdk/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/marmot-protocol/mdk/releases/tag/v0.9.3


### PR DESCRIPTION
## Summary

- bump the workspace and lockfile package versions to 0.9.7
- update all canonical conformance fixture provenance to 0.9.7
- roll the merged QUIC lifecycle, KeyPackage deletion, Hermes commentary routing, and RustSec fixes into the 0.9.7 changelog
- repair the stale 0.9.6 and Unreleased comparison links

## Release contents

- #1118 — QUIC candidate lifecycle, failover, restart handling, and durable nonce safety
- #1120 — scoped batch relay publishing for KeyPackage deletion
- #1113 — Hermes commentary routing to kind-1201 agent activity when delivery metadata is present
- #1117 — zero active RustSec vulnerabilities, unsoundness findings, or yanked packages

No UniFFI record, enum, or method surface changed after v0.9.6. The MarmotKit artifact remains part of the cohort so every distributed artifact records the same source commit and version.

## Validation

- `just fast-ci`
- `cargo audit --json` — 0 vulnerabilities; 5 unmaintained-only warnings tracked in #1116
- `cargo test -p cgka-conformance-simulator --test canonical_scenarios --locked` — 27 passed
- `cargo test -p marmot-uniffi --locked` — 67 unit, 2 media fixture, and 24 smoke tests passed
- `cargo test -p agent-connector --locked` — 118 passed
- `cargo test -p wn-opencode --locked` — 48 passed; 1 process E2E ignored by design
- Hermes adapter unit tests — 107 passed
- Hermes dev-script tests
- Hermes, OpenClaw, and OpenCode installer dry-runs — all resolve `wn-agent-v0.9.7` and 0.9.7 assets
- all conformance JSON fixtures parse successfully
- `git diff --check`

## Post-merge

Cut all three tags from the merged `origin/master` commit with `just release-all-draft 0.9.7` for manual release review, or `just release-all 0.9.7` for direct publication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the product version to **0.9.7**.
  * Added release notes and comparison links for version 0.9.7.

* **Conformance**
  * Updated conformance metadata across simulator scenarios to version **0.9.7**, with no changes to scenario behavior or expected outcomes.

* **Security**
  * Documented security improvements and vulnerability remediation included in the 0.9.7 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->