### PR TITLE
fix(cli): preserve durable chat activity ordering

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,14 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Fixed
+
+- TUI chat ordering now follows the durable `activity_sort_at` anchor exposed on
+  `chats list`/`subscribe`/`mark-read` rows (and timeline `chat_list_row`
+  updates) instead of re-sorting by `last_message.timeline_at`, so all-pruned
+  chats keep their storage position. Equal-activity rows tie-break on ascending
+  `group_id`, matching storage.
+
 ## [0.9.7] - 2026-07-26
 
 ### Fixed

--- a/crates/cli/src/commands/chats.rs
+++ b/crates/cli/src/commands/chats.rs
@@ -155,9 +155,10 @@ pub(crate) async fn chats_command_with_runtime(
 }
 
 /// Render the `chats mark-read` response: the account/group identity plus the
-/// refreshed chat-list projection (unread state, last-message preview, last-read
-/// marker) via [`insert_chat_projection`], so the five projection keys are
-/// byte-identical to the `chats list` rows and the `chats subscribe` feed.
+/// refreshed chat-list projection (unread state, durable activity anchor,
+/// last-message preview, last-read marker) via [`insert_chat_projection`], so the
+/// projection keys are byte-identical to the `chats list` rows and the
+/// `chats subscribe` feed.
 fn chat_mark_read_json(
     account_id_hex: &str,
     group_id_hex: &str,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -877,8 +877,8 @@ pub(crate) fn chat_json(group: AppGroupRecord, chat_list_row: Option<ChatListRow
 /// `chat_list_row` object embedded on every `timeline_projection_updated`
 /// event, so the snapshot feed (`chats list`/`subscribe`) and the live timeline
 /// feed agree key-for-key. The surface is deliberately the minimal reviewed set
-/// — unread state, a last-message preview, and the last-read marker — rather
-/// than the full `ChatListRow` (whose title/avatar/membership fields either
+/// — unread state, durable `activity_sort_at`, a last-message preview, and the
+/// last-read marker — rather than the full `ChatListRow` (whose title/avatar/membership fields either
 /// duplicate `group_json` or are group-state concerns).
 ///
 /// The keys are always present: a group with no projection row yet (or no
@@ -888,25 +888,34 @@ pub(crate) fn insert_chat_projection(value: &mut Value, chat_list_row: Option<Ch
     let Some(object) = value.as_object_mut() else {
         return;
     };
-    let (unread_count, has_unread, last_message, last_read_message_id_hex, last_read_timeline_at) =
-        match chat_list_row {
-            Some(row) => (
-                json!(row.unread_count),
-                json!(row.has_unread),
-                json!(row.last_message),
-                json!(row.last_read_message_id_hex),
-                json!(row.last_read_timeline_at),
-            ),
-            None => (
-                json!(0),
-                json!(false),
-                Value::Null,
-                Value::Null,
-                Value::Null,
-            ),
-        };
+    let (
+        unread_count,
+        has_unread,
+        activity_sort_at,
+        last_message,
+        last_read_message_id_hex,
+        last_read_timeline_at,
+    ) = match chat_list_row {
+        Some(row) => (
+            json!(row.unread_count),
+            json!(row.has_unread),
+            json!(row.activity_sort_at),
+            json!(row.last_message),
+            json!(row.last_read_message_id_hex),
+            json!(row.last_read_timeline_at),
+        ),
+        None => (
+            json!(0),
+            json!(false),
+            json!(0),
+            Value::Null,
+            Value::Null,
+            Value::Null,
+        ),
+    };
     object.insert("unread_count".to_owned(), unread_count);
     object.insert("has_unread".to_owned(), has_unread);
+    object.insert("activity_sort_at".to_owned(), activity_sort_at);
     object.insert("last_message".to_owned(), last_message);
     object.insert(
         "last_read_message_id_hex".to_owned(),
@@ -1272,6 +1281,7 @@ mod tests {
         assert_eq!(value["archived"], false);
         assert_eq!(value["unread_count"], 0);
         assert_eq!(value["has_unread"], false);
+        assert_eq!(value["activity_sort_at"], 0);
         assert!(value["last_message"].is_null());
         assert!(value["last_read_message_id_hex"].is_null());
         assert!(value["last_read_timeline_at"].is_null());
@@ -1318,6 +1328,7 @@ mod tests {
 
         assert_eq!(value["unread_count"], 3);
         assert_eq!(value["has_unread"], true);
+        assert_eq!(value["activity_sort_at"], 1_700_000_050_u64);
         assert_eq!(value["last_read_message_id_hex"], "r1");
         assert_eq!(value["last_read_timeline_at"], 1_700_000_000_u64);
         // `last_message` is byte-identical to the timeline feed's preview.

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -84,9 +84,9 @@ pub(crate) struct ChatProjection {
 }
 
 /// The last-message preview embedded in a chat projection (`last_message`). The
-/// chat list renders `sender`/`plaintext` and orders by `timeline_at`; `kind`
-/// lets a group-system row render its summary instead of raw JSON. Every field
-/// is parsed tolerantly.
+/// chat list renders `sender`/`plaintext`; rows are ordered by the projection's
+/// `activity_sort_at`. `kind` lets a group-system row render its summary instead
+/// of raw JSON. Every field is parsed tolerantly.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ChatLastMessage {
     pub(crate) sender: Option<String>,

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -75,6 +75,9 @@ pub(crate) struct ChatRow {
 pub(crate) struct ChatProjection {
     pub(crate) unread_count: usize,
     pub(crate) has_unread: bool,
+    /// Durable user-visible activity anchor from the chat-list projection.
+    /// Matches storage `ORDER BY activity_sort_at DESC, group_id_hex`.
+    pub(crate) activity_sort_at: u64,
     pub(crate) last_message: Option<ChatLastMessage>,
     pub(crate) last_read_message_id_hex: Option<String>,
     pub(crate) last_read_timeline_at: Option<u64>,
@@ -2046,7 +2049,7 @@ pub(crate) fn parse_chat(value: &Value) -> Option<ChatRow> {
     })
 }
 
-/// Parse the five chat-projection keys off any object that carries them: a
+/// Parse the chat-projection keys off any object that carries them: a
 /// `chats list`/`subscribe` row, the timeline feed's `chat_list_row`, or the
 /// `chats mark-read` response. Every field is optional — a group with no
 /// projection yet (or a row missing a key) takes the empty default — so the
@@ -2062,6 +2065,10 @@ pub(crate) fn parse_chat_projection(value: &Value) -> ChatProjection {
             .get("has_unread")
             .and_then(Value::as_bool)
             .unwrap_or(false),
+        activity_sort_at: value
+            .get("activity_sort_at")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
         last_message: value
             .get("last_message")
             .filter(|message| !message.is_null())
@@ -3428,20 +3435,19 @@ pub(crate) fn selected_chat_index(chats: &[ChatRow], group_id: Option<&str>) -> 
     group_id.and_then(|group_id| chats.iter().position(|chat| chat.group_id == group_id))
 }
 
-/// The activity timestamp a chat orders by: its last message's `timeline_at`, or
-/// `0` when it has no messages yet (message-less chats sort to the bottom).
+/// The durable activity anchor a chat orders by (`activity_sort_at`).
 pub(crate) fn chat_activity(chat: &ChatRow) -> u64 {
-    chat.projection
-        .last_message
-        .as_ref()
-        .map_or(0, |message| message.timeline_at)
+    chat.projection.activity_sort_at
 }
 
-/// Order chats by last activity, newest first. A stable sort keyed only on
-/// activity, so equal-activity rows (all message-less chats, or same-second
-/// activity) keep the order `chats list` returned — the documented fallback.
+/// Order chats by durable activity, newest first, then ascending `group_id` —
+/// matching storage `ORDER BY activity_sort_at DESC, group_id_hex`.
 pub(crate) fn sort_chats_by_activity(chats: &mut [ChatRow]) {
-    chats.sort_by_key(|chat| std::cmp::Reverse(chat_activity(chat)));
+    chats.sort_by(|left, right| {
+        chat_activity(right)
+            .cmp(&chat_activity(left))
+            .then_with(|| left.group_id.cmp(&right.group_id))
+    });
 }
 
 /// Re-order chats by activity while keeping the highlight on the same chat by

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -2628,6 +2628,7 @@ fn projected_chat(
         projection: ChatProjection {
             unread_count: unread,
             has_unread: unread > 0,
+            activity_sort_at: last_activity.unwrap_or(0),
             last_message: last_activity.map(|timeline_at| ChatLastMessage {
                 sender: Some("bob".to_owned()),
                 sender_display_name: Some("Bob".to_owned()),
@@ -2799,13 +2800,12 @@ fn chats_order_by_last_activity_preserving_selection() {
 }
 
 #[test]
-fn message_less_chats_keep_the_list_order_as_a_stable_fallback() {
-    // Equal-activity rows (here: all message-less) keep the order they came in —
-    // the documented stable fallback.
+fn message_less_chats_tie_break_on_group_id() {
+    // Equal `activity_sort_at` rows follow storage: ascending `group_id_hex`.
     let mut chats = vec![
+        projected_chat("cc", "third", 0, None),
         projected_chat("aa", "first", 0, None),
         projected_chat("bb", "second", 0, None),
-        projected_chat("cc", "third", 0, None),
     ];
     sort_chats_by_activity(&mut chats);
     assert_eq!(
@@ -2814,6 +2814,33 @@ fn message_less_chats_keep_the_list_order_as_a_stable_fallback() {
             .map(|chat| chat.group_id.as_str())
             .collect::<Vec<_>>(),
         vec!["aa", "bb", "cc"]
+    );
+}
+
+#[test]
+fn all_pruned_chat_orders_by_durable_activity_sort_at() {
+    // Storage keeps a nonzero `activity_sort_at` after secure prune even when
+    // `last_message` is null; the TUI must not sink the row to the bottom.
+    let mut chats = vec![
+        projected_chat("bb", "recent-preview", 0, Some(10)),
+        ChatRow {
+            group_id: "aa".to_owned(),
+            name: "pruned".to_owned(),
+            archived: false,
+            projection: ChatProjection {
+                activity_sort_at: 30,
+                ..ChatProjection::default()
+            },
+        },
+    ];
+    sort_chats_by_activity(&mut chats);
+    assert_eq!(
+        chats
+            .iter()
+            .map(|chat| chat.group_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["aa", "bb"],
+        "durable activity_sort_at beats a younger preview-only row"
     );
 }
 
@@ -2830,6 +2857,7 @@ fn timeline_chat_list_row_folds_into_the_loaded_chat() {
         "chat_list_row": {
             "unread_count": 3,
             "has_unread": true,
+            "activity_sort_at": 30,
             "last_message": {
                 "sender_display_name": "Bob",
                 "plaintext": "new here",


### PR DESCRIPTION
Fixes #1121

## Summary
- expose durable `activity_sort_at` on CLI chat projection JSON
- parse and sort TUI snapshot/live rows by that anchor
- match storage ties with ascending group id
- cover all-pruned chats with no last-message preview

## Verification
- `cargo fmt --all --check`
- focused all-pruned and group-id tie regression tests
- `cargo test -p wn-cli --lib --locked -- --test-threads=1` (426 passed)
- `RUSTFLAGS='-D warnings' cargo check -p wn-cli --all-targets --locked`
- `cargo clippy -p wn-cli --all-targets --locked -- -D warnings`

## Dependency
Stacked on agent-owned PR #1119 (`pip/mdk-1086-v2`), which introduces `ChatListRow.activity_sort_at`. Retarget this PR to `master` after #1119 merges. The diff against its current base is CLI-only.

## Sensitive paths
None. CLI/TUI only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat list ordering to consistently follow durable activity timestamps.
  * Preserved the correct order for chats without messages and chats whose messages were pruned.
  * Added deterministic ordering for chats with equal activity timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->