### PR TITLE
fix(hermes): use persisted config for gateway readiness

### DIFF
--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -63,7 +63,8 @@ Supported platforms: Linux x86_64, Linux arm64, macOS Apple Silicon, macOS Intel
 Both install scripts verify SHA256 checksums for downloaded release assets.
 
 The installer prints restart guidance for your existing Hermes gateway. It does
-not restart Hermes automatically.
+not restart Hermes automatically. Restart a managed gateway with
+`hermes gateway restart`.
 
 Manual equivalent:
 

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -2904,7 +2904,9 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
 
 
 def check_requirements() -> bool:
-    return validate_config(_MinimalConfig(extra={}))
+    # Install-time only: runtime readiness is validated with the effective
+    # PlatformConfig by validate_config() before the adapter factory runs.
+    return True
 
 
 def validate_config(config) -> bool:
@@ -3508,8 +3510,3 @@ async def _close_writer(writer: asyncio.StreamWriter) -> None:
         await writer.wait_closed()
     except Exception as exc:
         logger.debug("error while closing Marmot socket writer: %s", exc)
-
-
-class _MinimalConfig:
-    def __init__(self, extra: Optional[Dict[str, Any]] = None):
-        self.extra = extra or {}

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -3027,6 +3027,7 @@ def register(ctx):
         label="Marmot",
         adapter_factory=lambda cfg: MarmotPlatformAdapter(cfg),
         check_fn=check_requirements,
+        is_connected=validate_config,
         validate_config=validate_config,
         env_enablement_fn=_env_enablement,
         cron_deliver_env_var="MARMOT_HOME_CHANNEL",

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -2,6 +2,7 @@ import asyncio
 from contextlib import suppress
 import importlib.util
 import json
+import os
 import sys
 import tempfile
 import types
@@ -3867,6 +3868,33 @@ class KeyedAsyncQueueDepthTests(unittest.IsolatedAsyncioTestCase):
 
         release.set()
         await queue.join()
+
+
+class MarmotGatewayReadinessTests(unittest.TestCase):
+    def setUp(self):
+        self.adapter_module = load_adapter_module()
+        self.config_cls = sys.modules["gateway.config"].PlatformConfig
+
+    def test_environment_only_config_still_validates(self):
+        saved_home = os.environ.pop("MARMOT_HOME", None)
+        saved_socket = os.environ.pop("MARMOT_AGENT_SOCKET", None)
+        try:
+            with tempfile.TemporaryDirectory() as tempdir:
+                socket_path = Path(tempdir) / "wn-agent.sock"
+                os.environ["MARMOT_AGENT_SOCKET"] = str(socket_path)
+
+                platform_config = self.config_cls(enabled=True, extra={})
+
+                self.assertTrue(self.adapter_module.check_requirements())
+                self.assertTrue(self.adapter_module.validate_config(platform_config))
+                adapter = self.adapter_module.MarmotPlatformAdapter(platform_config, client=object())
+                self.assertEqual(adapter.socket_path, str(socket_path))
+        finally:
+            os.environ.pop("MARMOT_AGENT_SOCKET", None)
+            if saved_socket is not None:
+                os.environ["MARMOT_AGENT_SOCKET"] = saved_socket
+            if saved_home is not None:
+                os.environ["MARMOT_HOME"] = saved_home
 
 
 if __name__ == "__main__":

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -2,7 +2,6 @@ import asyncio
 from contextlib import suppress
 import importlib.util
 import json
-import os
 import sys
 import tempfile
 import types
@@ -3868,33 +3867,6 @@ class KeyedAsyncQueueDepthTests(unittest.IsolatedAsyncioTestCase):
 
         release.set()
         await queue.join()
-
-
-class MarmotGatewayReadinessTests(unittest.TestCase):
-    def setUp(self):
-        self.adapter_module = load_adapter_module()
-        self.config_cls = sys.modules["gateway.config"].PlatformConfig
-
-    def test_environment_only_config_still_validates(self):
-        saved_home = os.environ.pop("MARMOT_HOME", None)
-        saved_socket = os.environ.pop("MARMOT_AGENT_SOCKET", None)
-        try:
-            with tempfile.TemporaryDirectory() as tempdir:
-                socket_path = Path(tempdir) / "wn-agent.sock"
-                os.environ["MARMOT_AGENT_SOCKET"] = str(socket_path)
-
-                platform_config = self.config_cls(enabled=True, extra={})
-
-                self.assertTrue(self.adapter_module.check_requirements())
-                self.assertTrue(self.adapter_module.validate_config(platform_config))
-                adapter = self.adapter_module.MarmotPlatformAdapter(platform_config, client=object())
-                self.assertEqual(adapter.socket_path, str(socket_path))
-        finally:
-            os.environ.pop("MARMOT_AGENT_SOCKET", None)
-            if saved_socket is not None:
-                os.environ["MARMOT_AGENT_SOCKET"] = saved_socket
-            if saved_home is not None:
-                os.environ["MARMOT_HOME"] = saved_home
 
 
 if __name__ == "__main__":

--- a/integrations/hermes/marmot/tests/test_configure_gateway.py
+++ b/integrations/hermes/marmot/tests/test_configure_gateway.py
@@ -1,4 +1,6 @@
 import importlib.util
+import os
+import socket
 import tempfile
 import unittest
 from pathlib import Path
@@ -17,6 +19,30 @@ def load_module():
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
+
+
+def load_adapter_module():
+    helper_path = REPO_ROOT / "integrations" / "hermes" / "marmot" / "tests" / "test_adapter.py"
+    spec = importlib.util.spec_from_file_location("hermes_marmot_test_adapter_helpers", helper_path)
+    helper = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(helper)
+    return helper.load_adapter_module()
+
+
+class PlatformRegistryHarness:
+    """Minimal copy of Hermes' check, validate, then create registry flow."""
+
+    def register_platform(self, **entry):
+        self.entry = entry
+
+    def create_adapter(self, config):
+        if not self.entry["check_fn"]():
+            return None
+        validate = self.entry.get("validate_config")
+        if validate is not None and not validate(config):
+            return None
+        return self.entry["adapter_factory"](config)
 
 
 class ConfigureGatewayTests(unittest.TestCase):
@@ -155,6 +181,54 @@ class ConfigureGatewayTests(unittest.TestCase):
         self.assertTrue(config["streaming"]["enabled"])
         self.assertEqual(config["streaming"]["transport"], "auto")
         self.assertTrue(config["display"]["platforms"]["marmot"]["streaming"])
+
+    def test_persisted_config_creates_adapter_without_marmot_env(self):
+        adapter_module = load_adapter_module()
+        saved_env = {key: os.environ.pop(key) for key in list(os.environ) if key.startswith("MARMOT_")}
+        try:
+            with tempfile.TemporaryDirectory() as tempdir:
+                home = Path(tempdir)
+                agent_home = home / "marmot-agent"
+                socket_dir = agent_home / "dev"
+                socket_dir.mkdir(parents=True)
+                socket_path = socket_dir / "wn-agent.sock"
+
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+                    server.bind(str(socket_path))
+                    server.listen(1)
+                    self.assertTrue(socket_path.is_socket())
+
+                    self.module.configure_gateway_config(
+                        hermes_home=home,
+                        platform="marmot",
+                        streaming_enabled=False,
+                        streaming_transport="off",
+                        tool_progress="off",
+                        interim_assistant_messages=False,
+                        long_running_notifications=False,
+                        busy_ack_detail=False,
+                        agent_home=agent_home,
+                        socket_path=socket_path,
+                        account_id_hex="11" * 32,
+                    )
+                    config = self.module.load_config(home / "config.yaml")
+                    extra = config["platforms"]["marmot"]["extra"]
+                    platform_config = type(
+                        "PlatformConfig",
+                        (),
+                        {"enabled": True, "extra": extra},
+                    )()
+                    registry = PlatformRegistryHarness()
+                    adapter_module.register(registry)
+
+                    adapter = registry.create_adapter(platform_config)
+
+                    self.assertTrue(config["platforms"]["marmot"]["enabled"])
+                    self.assertIsInstance(adapter, adapter_module.MarmotPlatformAdapter)
+                    assert adapter is not None
+                    self.assertEqual(adapter.socket_path, str(socket_path))
+        finally:
+            os.environ.update(saved_env)
 
 
 if __name__ == "__main__":

--- a/integrations/hermes/marmot/tests/test_configure_gateway.py
+++ b/integrations/hermes/marmot/tests/test_configure_gateway.py
@@ -3,6 +3,7 @@ import os
 import socket
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 
@@ -30,11 +31,43 @@ def load_adapter_module():
     return helper.load_adapter_module()
 
 
+class PlatformConfigHarness:
+    def __init__(self, *, enabled=False, extra=None):
+        self.enabled = enabled
+        self.extra = extra or {}
+
+
 class PlatformRegistryHarness:
-    """Minimal copy of Hermes' check, validate, then create registry flow."""
+    """Minimal copy of Hermes platform enablement and adapter creation."""
+
+    def __init__(self):
+        self.entry = {}
 
     def register_platform(self, **entry):
         self.entry = entry
+
+    def apply_env_overrides(self, platform_config=None):
+        """Mirror the relevant gateway.config._apply_env_overrides plugin gate."""
+        existing = platform_config
+        env_fn = self.entry.get("env_enablement_fn")
+        seed = env_fn() if env_fn else None
+        is_connected = self.entry.get("is_connected")
+        if (existing is None or not existing.enabled) and is_connected is not None:
+            probe_extra = dict(getattr(existing, "extra", {}) or {})
+            if isinstance(seed, dict):
+                probe_extra.update({key: value for key, value in seed.items() if key != "home_channel"})
+            probe = PlatformConfigHarness(enabled=True, extra=probe_extra)
+            if not is_connected(probe):
+                return existing
+
+        if not self.entry["check_fn"]():
+            return existing
+        if existing is None:
+            existing = PlatformConfigHarness()
+        existing.enabled = True
+        if isinstance(seed, dict):
+            existing.extra.update({key: value for key, value in seed.items() if key != "home_channel"})
+        return existing
 
     def create_adapter(self, config):
         if not self.entry["check_fn"]():
@@ -43,6 +76,18 @@ class PlatformRegistryHarness:
         if validate is not None and not validate(config):
             return None
         return self.entry["adapter_factory"](config)
+
+
+def clear_marmot_env():
+    saved = {key: os.environ.pop(key) for key in list(os.environ) if key.startswith("MARMOT_")}
+    return saved
+
+
+def restore_marmot_env(saved):
+    for key in list(os.environ):
+        if key.startswith("MARMOT_"):
+            os.environ.pop(key)
+    os.environ.update(saved)
 
 
 class ConfigureGatewayTests(unittest.TestCase):
@@ -184,7 +229,7 @@ class ConfigureGatewayTests(unittest.TestCase):
 
     def test_persisted_config_creates_adapter_without_marmot_env(self):
         adapter_module = load_adapter_module()
-        saved_env = {key: os.environ.pop(key) for key in list(os.environ) if key.startswith("MARMOT_")}
+        saved_env = clear_marmot_env()
         try:
             with tempfile.TemporaryDirectory() as tempdir:
                 home = Path(tempdir)
@@ -213,22 +258,58 @@ class ConfigureGatewayTests(unittest.TestCase):
                     )
                     config = self.module.load_config(home / "config.yaml")
                     extra = config["platforms"]["marmot"]["extra"]
-                    platform_config = type(
-                        "PlatformConfig",
-                        (),
-                        {"enabled": True, "extra": extra},
-                    )()
+                    platform_config = PlatformConfigHarness(enabled=True, extra=extra)
                     registry = PlatformRegistryHarness()
                     adapter_module.register(registry)
 
-                    adapter = registry.create_adapter(platform_config)
+                    enabled_config = registry.apply_env_overrides(platform_config)
+                    self.assertIs(enabled_config, platform_config)
+                    adapter = registry.create_adapter(enabled_config)
 
                     self.assertTrue(config["platforms"]["marmot"]["enabled"])
                     self.assertIsInstance(adapter, adapter_module.MarmotPlatformAdapter)
                     assert adapter is not None
                     self.assertEqual(adapter.socket_path, str(socket_path))
         finally:
-            os.environ.update(saved_env)
+            restore_marmot_env(saved_env)
+
+
+class MarmotPlatformEnablementTests(unittest.TestCase):
+    def setUp(self):
+        self.adapter_module = load_adapter_module()
+        self.registry = PlatformRegistryHarness()
+        self.adapter_module.register(self.registry)
+
+    def test_register_wires_is_connected_for_env_override_gate(self):
+        self.assertIs(self.registry.entry.get("is_connected"), self.adapter_module.validate_config)
+
+    def test_unconfigured_platform_stays_disabled_without_marmot_env(self):
+        saved_env = clear_marmot_env()
+        try:
+            with unittest.mock.patch.object(Path, "exists", return_value=False):
+                self.assertIsNone(self.registry.apply_env_overrides())
+        finally:
+            restore_marmot_env(saved_env)
+
+    def test_environment_only_config_enables_and_creates_adapter(self):
+        saved_env = clear_marmot_env()
+        try:
+            with tempfile.TemporaryDirectory() as tempdir:
+                socket_path = Path(tempdir) / "wn-agent.sock"
+                os.environ["MARMOT_AGENT_SOCKET"] = str(socket_path)
+
+                platform_config = self.registry.apply_env_overrides()
+                self.assertIsNotNone(platform_config)
+                assert platform_config is not None
+                self.assertTrue(platform_config.enabled)
+                self.assertEqual(platform_config.extra["socket_path"], str(socket_path))
+                adapter = self.registry.create_adapter(platform_config)
+
+                self.assertIsInstance(adapter, self.adapter_module.MarmotPlatformAdapter)
+                assert adapter is not None
+                self.assertEqual(adapter.socket_path, str(socket_path))
+        finally:
+            restore_marmot_env(saved_env)
 
 
 if __name__ == "__main__":

--- a/integrations/hermes/marmot/tests/test_dev_scripts.sh
+++ b/integrations/hermes/marmot/tests/test_dev_scripts.sh
@@ -147,6 +147,10 @@ if [ "$(uname -s)" = Linux ]; then
         *) echo "Hermes installer dry-run did not describe active-service upgrade behavior" >&2; exit 1;;
     esac
 fi
+case "$installer_dry_run" in
+    *"hermes gateway restart"* ) ;;
+    *) echo "Hermes installer dry-run did not print gateway restart guidance" >&2; exit 1;;
+esac
 case "$installer_stdin_dry_run" in
     *"wn-agent-"*"9.9.9.tar.gz"* ) ;;
     *) echo "Hermes installer stdin dry-run did not use WN_AGENT_SHA asset suffix" >&2; exit 1;;

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -710,7 +710,7 @@ Hermes:
   plugin: $MARMOT_PLUGIN_DIR
 
 Restart your existing Hermes gateway when you are ready for it to load the Marmot plugin/config:
-  hermes gateway run
+  hermes gateway restart
 
 Existing Hermes connectors were not removed or disabled. The installer only updated the Marmot plugin and Marmot-specific config entries.
 


### PR DESCRIPTION
Fixes #1127

## Summary
- split dependency readiness from effective configuration validation and register Hermes’ `is_connected` gate so unconfigured Marmot stays disabled
- prove unconfigured/no-env, installer-persisted, and environment-only enablement paths through adapter creation
- preserve environment-only deployments and correct the managed-gateway restart guidance

## Verification
- Marmot Python unittest suite: 111 passed
- Hermes dev/installer script test: passed
- `just fast-ci`: passed; convergence pin 5/5

## Sensitive paths
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Marmot gateway readiness when only the configured agent socket is available.
  * Persisted gateway configuration can now create the Marmot adapter without requiring additional environment settings.

* **Documentation**
  * Updated installation guidance to clarify that existing Hermes gateways must be restarted manually.
  * Installer output now recommends `hermes gateway restart` to apply Marmot changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->