### PR TITLE
feat(installers): securely import existing agent identities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "tracing",
  "transport-quic-broker",
  "transport-quic-stream",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/agent-connector/Cargo.toml
+++ b/crates/agent-connector/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "proce
 tracing.workspace = true
 transport-quic-broker.workspace = true
 transport-quic-stream.workspace = true
+zeroize.workspace = true
 
 [dev-dependencies]
 nostr-relay-builder.workspace = true

--- a/crates/agent-connector/src/bin/wn-agent.rs
+++ b/crates/agent-connector/src/bin/wn-agent.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use agent_connector::{
     AgentConnectorConfig, BootstrapOptions, BootstrapResult, ConnectorError,
-    DEFAULT_BOOTSTRAP_LABEL, MAX_CONTROL_CONNECTIONS, default_socket_path,
+    DEFAULT_BOOTSTRAP_LABEL, MAX_CONTROL_CONNECTIONS, MAX_IDENTITY_BYTES, default_socket_path,
     import_existing_identity_file, import_existing_identity_secret, read_bootstrap_auth_token,
     resolve_bootstrap_home, resolve_bootstrap_quic_candidates, resolve_bootstrap_relays,
     resolve_bootstrap_socket, run_bootstrap, serve_socket,
@@ -304,8 +304,6 @@ fn read_identity_from_tty() -> Result<Zeroizing<String>, String> {
     use std::os::fd::AsRawFd;
     use std::os::unix::fs::OpenOptionsExt;
 
-    const MAX_IDENTITY_BYTES: usize = 4096;
-
     static PROMPT_SIGNAL: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(0);
     extern "C" fn record_prompt_signal(signal: libc::c_int) {
         PROMPT_SIGNAL.store(signal, std::sync::atomic::Ordering::Relaxed);
@@ -426,7 +424,7 @@ fn read_identity_from_tty() -> Result<Zeroizing<String>, String> {
     tty.flush()
         .map_err(|_| "could not flush /dev/tty prompt".to_owned())?;
 
-    let mut bytes = Zeroizing::new(Vec::with_capacity(128));
+    let mut bytes = Zeroizing::new(Vec::with_capacity(MAX_IDENTITY_BYTES as usize + 1));
     let mut byte = [0u8; 1];
     let read_result = loop {
         if PROMPT_SIGNAL.load(std::sync::atomic::Ordering::Relaxed) != 0 {
@@ -436,8 +434,8 @@ fn read_identity_from_tty() -> Result<Zeroizing<String>, String> {
             Ok(0) => break Ok(()),
             Ok(_) if byte[0] == b'\n' => break Ok(()),
             Ok(_) if byte[0] == b'\r' => {}
-            Ok(_) if bytes.len() == MAX_IDENTITY_BYTES => {
-                break Err("identity input exceeds 4096 bytes".to_owned());
+            Ok(_) if bytes.len() as u64 == MAX_IDENTITY_BYTES => {
+                break Err(format!("identity input exceeds {MAX_IDENTITY_BYTES} bytes"));
             }
             Ok(_) => bytes.push(byte[0]),
             Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,

--- a/crates/agent-connector/src/bin/wn-agent.rs
+++ b/crates/agent-connector/src/bin/wn-agent.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::process::{Command, ExitCode};
 use std::time::Duration;
@@ -5,10 +7,12 @@ use std::time::Duration;
 use agent_connector::{
     AgentConnectorConfig, BootstrapOptions, BootstrapResult, ConnectorError,
     DEFAULT_BOOTSTRAP_LABEL, MAX_CONTROL_CONNECTIONS, default_socket_path,
-    read_bootstrap_auth_token, resolve_bootstrap_home, resolve_bootstrap_quic_candidates,
-    resolve_bootstrap_relays, resolve_bootstrap_socket, run_bootstrap, serve_socket,
+    import_existing_identity_file, import_existing_identity_secret, read_bootstrap_auth_token,
+    resolve_bootstrap_home, resolve_bootstrap_quic_candidates, resolve_bootstrap_relays,
+    resolve_bootstrap_socket, run_bootstrap, serve_socket,
 };
 use clap::{Args, Parser, Subcommand};
+use zeroize::Zeroizing;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -27,6 +31,8 @@ struct Cli {
 enum Commands {
     /// Create or reuse a local agent account and print phone bootstrap details
     Bootstrap(BootstrapArgs),
+    /// Securely import an existing local-signing Nostr identity
+    ImportIdentity(ImportIdentityArgs),
 }
 
 #[derive(Debug, Args)]
@@ -183,13 +189,285 @@ struct BootstrapArgs {
     request_timeout: f64,
 }
 
-#[tokio::main]
-async fn main() -> ExitCode {
+#[derive(Debug, Args)]
+struct ImportIdentityArgs {
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Use this Marmot agent home directory"
+    )]
+    home: Option<PathBuf>,
+    #[arg(
+        long,
+        value_name = "LABEL",
+        default_value = DEFAULT_BOOTSTRAP_LABEL,
+        help = "Label for the imported local-signing account"
+    )]
+    label: String,
+    #[arg(
+        long,
+        value_name = "PATH",
+        conflicts_with = "prompt",
+        help = "Read the identity from this owner-only regular file"
+    )]
+    identity_file: Option<PathBuf>,
+    #[arg(
+        long,
+        conflicts_with = "identity_file",
+        help = "Read the identity with echo disabled from /dev/tty"
+    )]
+    prompt: bool,
+    #[arg(
+        long,
+        value_name = "NPUB_OR_HEX",
+        help = "Fail unless the imported key matches this public identity"
+    )]
+    expected_identity: Option<String>,
+    #[arg(long, help = "Print machine-readable JSON only")]
+    json: bool,
+}
+
+fn main() -> ExitCode {
     let cli = Cli::parse();
     match cli.command {
-        Some(Commands::Bootstrap(args)) => run_bootstrap_command(args).await,
-        None => run_serve_command(cli.serve).await,
+        Some(Commands::Bootstrap(args)) => run_async(run_bootstrap_command(args)),
+        Some(Commands::ImportIdentity(args)) => run_import_identity_command(args),
+        None => run_async(run_serve_command(cli.serve)),
     }
+}
+
+fn run_async(future: impl Future<Output = ExitCode>) -> ExitCode {
+    match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime.block_on(future),
+        Err(error) => {
+            eprintln!("wn-agent: startup failed code=runtime_init detail={error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run_import_identity_command(args: ImportIdentityArgs) -> ExitCode {
+    let home = resolve_bootstrap_home(args.home);
+    let expected_identity = args.expected_identity.as_deref();
+    let result = match (args.identity_file.as_deref(), args.prompt) {
+        (Some(identity_file), false) => {
+            import_existing_identity_file(&home, &args.label, identity_file, expected_identity)
+        }
+        (None, true) => match read_identity_from_tty() {
+            Ok(secret) => import_existing_identity_secret(
+                &home,
+                &args.label,
+                secret.as_str(),
+                expected_identity,
+            ),
+            Err(message) => {
+                eprintln!("error: {message}");
+                return ExitCode::FAILURE;
+            }
+        },
+        (None, false) => {
+            eprintln!("error: pass exactly one of --identity-file or --prompt");
+            return ExitCode::FAILURE;
+        }
+        (Some(_), true) => unreachable!("clap rejects conflicting identity sources"),
+    };
+
+    match result {
+        Ok(imported) => {
+            if args.json {
+                match serde_json::to_string_pretty(&imported) {
+                    Ok(json) => println!("{json}"),
+                    Err(error) => {
+                        eprintln!("error: failed to encode import result: {error}");
+                        return ExitCode::FAILURE;
+                    }
+                }
+            } else {
+                println!("Existing Marmot identity imported");
+                println!("Agent label: {}", imported.label);
+                println!("Agent account hex: {}", imported.account_id_hex);
+            }
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("error: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(unix)]
+fn read_identity_from_tty() -> Result<Zeroizing<String>, String> {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    const MAX_IDENTITY_BYTES: usize = 4096;
+
+    static PROMPT_SIGNAL: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(0);
+    extern "C" fn record_prompt_signal(signal: libc::c_int) {
+        PROMPT_SIGNAL.store(signal, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    struct JobControlMaskGuard {
+        previous: libc::sigset_t,
+    }
+    impl JobControlMaskGuard {
+        fn block() -> Result<Self, String> {
+            let mut blocked = std::mem::MaybeUninit::<libc::sigset_t>::uninit();
+            let mut previous = std::mem::MaybeUninit::<libc::sigset_t>::uninit();
+            unsafe {
+                libc::sigemptyset(blocked.as_mut_ptr());
+                let blocked = blocked.assume_init_mut();
+                libc::sigaddset(blocked, libc::SIGTTIN);
+                libc::sigaddset(blocked, libc::SIGTTOU);
+                if libc::pthread_sigmask(libc::SIG_BLOCK, blocked, previous.as_mut_ptr()) != 0 {
+                    return Err("could not protect masked /dev/tty prompt".to_owned());
+                }
+                Ok(Self {
+                    previous: previous.assume_init(),
+                })
+            }
+        }
+    }
+    impl Drop for JobControlMaskGuard {
+        fn drop(&mut self) {
+            unsafe {
+                libc::pthread_sigmask(libc::SIG_SETMASK, &self.previous, std::ptr::null_mut());
+            }
+        }
+    }
+
+    struct SignalHandlerGuard {
+        previous: Vec<(libc::c_int, libc::sigaction)>,
+    }
+    impl SignalHandlerGuard {
+        fn install() -> Result<Self, String> {
+            PROMPT_SIGNAL.store(0, std::sync::atomic::Ordering::Relaxed);
+            let mut guard = Self {
+                previous: Vec::new(),
+            };
+            for signal in [
+                libc::SIGHUP,
+                libc::SIGINT,
+                libc::SIGQUIT,
+                libc::SIGTERM,
+                libc::SIGTSTP,
+            ] {
+                let mut action = unsafe { std::mem::zeroed::<libc::sigaction>() };
+                action.sa_sigaction = record_prompt_signal as libc::sighandler_t;
+                unsafe { libc::sigemptyset(&mut action.sa_mask) };
+                let mut previous = std::mem::MaybeUninit::<libc::sigaction>::uninit();
+                if unsafe { libc::sigaction(signal, &action, previous.as_mut_ptr()) } != 0 {
+                    return Err("could not protect masked /dev/tty prompt".to_owned());
+                }
+                guard
+                    .previous
+                    .push((signal, unsafe { previous.assume_init() }));
+            }
+            Ok(guard)
+        }
+    }
+    impl Drop for SignalHandlerGuard {
+        fn drop(&mut self) {
+            for (signal, previous) in self.previous.iter().rev() {
+                unsafe { libc::sigaction(*signal, previous, std::ptr::null_mut()) };
+            }
+            let signal = PROMPT_SIGNAL.swap(0, std::sync::atomic::Ordering::Relaxed);
+            if signal != 0 {
+                unsafe { libc::raise(signal) };
+            }
+        }
+    }
+
+    // Blocking the job-control signals lets a backgrounded process restore
+    // termios instead of stopping with echo disabled. Other terminal interrupts
+    // become an interrupted read and are re-raised after echo is restored.
+    let job_control_guard = JobControlMaskGuard::block()?;
+    let signal_guard = SignalHandlerGuard::install()?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options
+        .read(true)
+        .write(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    let mut tty = options
+        .open("/dev/tty")
+        .map_err(|error| format!("could not open /dev/tty ({:?})", error.kind()))?;
+    let fd = tty.as_raw_fd();
+    let mut original = std::mem::MaybeUninit::<libc::termios>::uninit();
+    if unsafe { libc::tcgetattr(fd, original.as_mut_ptr()) } != 0 {
+        return Err("could not inspect /dev/tty settings".to_owned());
+    }
+    // SAFETY: tcgetattr succeeded and initialized `original`.
+    let original = unsafe { original.assume_init() };
+    let mut hidden = original;
+    hidden.c_lflag &= !libc::ECHO;
+    if unsafe { libc::tcsetattr(fd, libc::TCSAFLUSH, &hidden) } != 0 {
+        return Err("could not disable /dev/tty echo".to_owned());
+    }
+    struct EchoGuard {
+        fd: libc::c_int,
+        original: libc::termios,
+    }
+    impl Drop for EchoGuard {
+        fn drop(&mut self) {
+            unsafe {
+                libc::tcsetattr(self.fd, libc::TCSAFLUSH, &self.original);
+            }
+        }
+    }
+    let guard = EchoGuard { fd, original };
+
+    tty.write_all(b"Existing Nostr identity (nsec or raw hex): ")
+        .map_err(|_| "could not write prompt to /dev/tty".to_owned())?;
+    tty.flush()
+        .map_err(|_| "could not flush /dev/tty prompt".to_owned())?;
+
+    let mut bytes = Zeroizing::new(Vec::with_capacity(128));
+    let mut byte = [0u8; 1];
+    let read_result = loop {
+        if PROMPT_SIGNAL.load(std::sync::atomic::Ordering::Relaxed) != 0 {
+            break Err("identity prompt interrupted".to_owned());
+        }
+        match tty.read(&mut byte) {
+            Ok(0) => break Ok(()),
+            Ok(_) if byte[0] == b'\n' => break Ok(()),
+            Ok(_) if byte[0] == b'\r' => {}
+            Ok(_) if bytes.len() == MAX_IDENTITY_BYTES => {
+                break Err("identity input exceeds 4096 bytes".to_owned());
+            }
+            Ok(_) => bytes.push(byte[0]),
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) => {
+                break Err(format!(
+                    "could not read identity from /dev/tty ({:?})",
+                    error.kind()
+                ));
+            }
+        }
+    };
+    byte.fill(0);
+    drop(guard);
+    let _ = tty.write_all(b"\n");
+    drop(signal_guard);
+    drop(job_control_guard);
+    read_result?;
+
+    std::str::from_utf8(bytes.as_slice())
+        .map_err(|_| "identity input is not valid UTF-8".to_owned())?;
+    let bytes = std::mem::take(&mut *bytes);
+    // SAFETY: UTF-8 validity was checked immediately above.
+    Ok(Zeroizing::new(unsafe {
+        String::from_utf8_unchecked(bytes)
+    }))
+}
+
+#[cfg(not(unix))]
+fn read_identity_from_tty() -> Result<Zeroizing<String>, String> {
+    Err("masked identity prompts require a Unix /dev/tty".to_owned())
 }
 
 async fn run_serve_command(args: ServeArgs) -> ExitCode {

--- a/crates/agent-connector/src/bootstrap.rs
+++ b/crates/agent-connector/src/bootstrap.rs
@@ -726,7 +726,10 @@ mod tests {
             )
             .await;
 
-        let result = run_bootstrap(test_options(socket_path)).await.unwrap();
+        let mut options = test_options(socket_path);
+        options.account_id_hex = Some(ACCOUNT_ID.to_owned());
+        options.create_if_missing = false;
+        let result = run_bootstrap(options).await.unwrap();
         server.abort();
 
         assert!(!result.created);

--- a/crates/agent-connector/src/identity.rs
+++ b/crates/agent-connector/src/identity.rs
@@ -1,0 +1,270 @@
+//! Secure import of an existing local-signing Nostr identity.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read};
+use std::path::Path;
+
+use marmot_account::{AccountHome, AccountHomeError};
+use serde::Serialize;
+use thiserror::Error;
+use zeroize::Zeroizing;
+
+const MAX_IDENTITY_BYTES: u64 = 4096;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct ExistingIdentityImport {
+    pub account_id_hex: String,
+    pub label: String,
+    pub local_signing: bool,
+}
+
+#[derive(Debug, Error)]
+pub enum ExistingIdentityError {
+    #[error("could not open identity file ({0:?})")]
+    Open(io::ErrorKind),
+    #[error("could not read identity file ({0:?})")]
+    Read(io::ErrorKind),
+    #[error("identity source must be a regular file")]
+    NotRegularFile,
+    #[error("identity file must be owned by the current user")]
+    WrongOwner,
+    #[error("identity file must not be accessible by group or other users")]
+    UnsafePermissions,
+    #[error("identity file must have exactly one hard link")]
+    MultipleHardLinks,
+    #[error("identity input is empty")]
+    Empty,
+    #[error("identity input exceeds {MAX_IDENTITY_BYTES} bytes")]
+    TooLarge,
+    #[error("identity input is not valid UTF-8")]
+    InvalidUtf8,
+    #[error("expected identity must be an npub or 64-character hex public key")]
+    InvalidExpectedIdentity,
+    #[error("imported identity does not match the expected public identity")]
+    ExpectedIdentityMismatch,
+    #[error(transparent)]
+    Account(#[from] AccountHomeError),
+}
+
+pub fn import_existing_identity_file(
+    home: &Path,
+    label: &str,
+    identity_file: &Path,
+    expected_identity: Option<&str>,
+) -> Result<ExistingIdentityImport, ExistingIdentityError> {
+    let file = open_private_identity_file(identity_file)?;
+    let secret = read_identity(file)?;
+    import_existing_identity_secret(home, label, secret.as_str(), expected_identity)
+}
+
+pub fn import_existing_identity_secret(
+    home: &Path,
+    label: &str,
+    secret: &str,
+    expected_identity: Option<&str>,
+) -> Result<ExistingIdentityImport, ExistingIdentityError> {
+    let secret = secret.trim();
+    if secret.is_empty() {
+        return Err(ExistingIdentityError::Empty);
+    }
+
+    let account_id_hex = AccountHome::account_id_for_secret(secret)?;
+    if let Some(expected_identity) = expected_identity {
+        let expected_account_id = marmot_app::account_id_hex_from_ref(expected_identity)
+            .map_err(|_| ExistingIdentityError::InvalidExpectedIdentity)?;
+        if account_id_hex != expected_account_id {
+            return Err(ExistingIdentityError::ExpectedIdentityMismatch);
+        }
+    }
+
+    let account = AccountHome::open(home).import_account_idempotent(label, secret)?;
+    Ok(ExistingIdentityImport {
+        account_id_hex: account.account_id_hex,
+        label: account.label,
+        local_signing: account.local_signing,
+    })
+}
+
+fn open_private_identity_file(path: &Path) -> Result<File, ExistingIdentityError> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    }
+    let file = options
+        .open(path)
+        .map_err(|error| ExistingIdentityError::Open(error.kind()))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| ExistingIdentityError::Read(error.kind()))?;
+    if !metadata.file_type().is_file() {
+        return Err(ExistingIdentityError::NotRegularFile);
+    }
+    #[cfg(unix)]
+    validate_unix_identity_metadata(&metadata)?;
+    if metadata.len() > MAX_IDENTITY_BYTES {
+        return Err(ExistingIdentityError::TooLarge);
+    }
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn validate_unix_identity_metadata(
+    metadata: &std::fs::Metadata,
+) -> Result<(), ExistingIdentityError> {
+    use std::os::unix::fs::MetadataExt;
+
+    if metadata.uid() != unsafe { libc::geteuid() } {
+        return Err(ExistingIdentityError::WrongOwner);
+    }
+    if metadata.mode() & 0o077 != 0 {
+        return Err(ExistingIdentityError::UnsafePermissions);
+    }
+    if metadata.nlink() != 1 {
+        return Err(ExistingIdentityError::MultipleHardLinks);
+    }
+    Ok(())
+}
+
+fn read_identity(reader: impl Read) -> Result<Zeroizing<String>, ExistingIdentityError> {
+    let mut bytes = Zeroizing::new(Vec::with_capacity(128));
+    reader
+        .take(MAX_IDENTITY_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| ExistingIdentityError::Read(error.kind()))?;
+    if bytes.len() as u64 > MAX_IDENTITY_BYTES {
+        return Err(ExistingIdentityError::TooLarge);
+    }
+    std::str::from_utf8(bytes.as_slice()).map_err(|_| ExistingIdentityError::InvalidUtf8)?;
+    let bytes = std::mem::take(&mut *bytes);
+    // SAFETY: UTF-8 validity was checked immediately above, before ownership
+    // moved out of the zeroizing byte buffer.
+    let secret = unsafe { String::from_utf8_unchecked(bytes) };
+    let secret = Zeroizing::new(secret);
+    if secret.trim().is_empty() {
+        return Err(ExistingIdentityError::Empty);
+    }
+    Ok(secret)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    use super::*;
+
+    const NSEC: &str = "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99";
+    const NPUB: &str = "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy";
+
+    fn write_identity(path: &Path, value: &str) {
+        std::fs::write(path, value).unwrap();
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    #[test]
+    fn imports_and_idempotently_reuses_a_private_identity_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        let identity = dir.path().join("identity.nsec");
+        write_identity(&identity, NSEC);
+
+        let first = import_existing_identity_file(&home, "agent", &identity, None).unwrap();
+        let second = import_existing_identity_file(&home, "agent", &identity, None).unwrap();
+
+        assert_eq!(second, first);
+        assert_eq!(AccountHome::open(&home).accounts().unwrap().len(), 1);
+        let output = serde_json::to_string(&first).unwrap();
+        assert!(!output.contains(NSEC));
+        let account_record =
+            std::fs::read_to_string(home.join("accounts").join("agent").join("account.json"))
+                .unwrap();
+        assert!(!account_record.contains(NSEC));
+        assert_eq!(std::fs::read_to_string(&identity).unwrap(), NSEC);
+    }
+
+    #[test]
+    fn expected_identity_mismatch_fails_before_persistence() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        let identity = dir.path().join("identity.nsec");
+        write_identity(&identity, NSEC);
+        let other_identity = format!("{}01", "00".repeat(31));
+
+        let error = import_existing_identity_file(&home, "agent", &identity, Some(&other_identity))
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ExistingIdentityError::ExpectedIdentityMismatch
+        ));
+        assert!(AccountHome::open(&home).accounts().unwrap().is_empty());
+    }
+
+    #[test]
+    fn matching_expected_npub_is_accepted() {
+        let dir = tempfile::tempdir().unwrap();
+        let identity = dir.path().join("identity.nsec");
+        write_identity(&identity, NSEC);
+
+        let imported =
+            import_existing_identity_file(&dir.path().join("home"), "agent", &identity, Some(NPUB))
+                .unwrap();
+
+        assert!(imported.local_signing);
+    }
+
+    #[test]
+    fn accepts_raw_hex_secret_key_representation() {
+        let dir = tempfile::tempdir().unwrap();
+        let identity = dir.path().join("identity.hex");
+        let raw_secret = format!("{}01", "00".repeat(31));
+        write_identity(&identity, &raw_secret);
+
+        let imported =
+            import_existing_identity_file(&dir.path().join("home"), "agent", &identity, None)
+                .unwrap();
+
+        assert!(imported.local_signing);
+        assert_eq!(imported.account_id_hex.len(), 64);
+    }
+
+    #[test]
+    fn rejects_group_readable_and_symlinked_identity_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let identity = dir.path().join("identity.nsec");
+        write_identity(&identity, NSEC);
+        std::fs::set_permissions(&identity, std::fs::Permissions::from_mode(0o640)).unwrap();
+        assert!(matches!(
+            import_existing_identity_file(&dir.path().join("home"), "agent", &identity, None),
+            Err(ExistingIdentityError::UnsafePermissions)
+        ));
+
+        std::fs::set_permissions(&identity, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let alias = dir.path().join("alias.nsec");
+        symlink(&identity, &alias).unwrap();
+        assert!(matches!(
+            import_existing_identity_file(&dir.path().join("home"), "agent", &alias, None),
+            Err(ExistingIdentityError::Open(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_malformed_identity_without_echoing_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let identity = dir.path().join("identity.nsec");
+        let malformed = "nsec1-not-valid-secret-material";
+        write_identity(&identity, malformed);
+
+        let error =
+            import_existing_identity_file(&dir.path().join("home"), "agent", &identity, None)
+                .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ExistingIdentityError::Account(AccountHomeError::InvalidSecretKey)
+        ));
+        assert!(!error.to_string().contains(malformed));
+    }
+}

--- a/crates/agent-connector/src/identity.rs
+++ b/crates/agent-connector/src/identity.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use thiserror::Error;
 use zeroize::Zeroizing;
 
-const MAX_IDENTITY_BYTES: u64 = 4096;
+pub const MAX_IDENTITY_BYTES: u64 = 4096;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct ExistingIdentityImport {
@@ -129,7 +129,7 @@ fn validate_unix_identity_metadata(
 }
 
 fn read_identity(reader: impl Read) -> Result<Zeroizing<String>, ExistingIdentityError> {
-    let mut bytes = Zeroizing::new(Vec::with_capacity(128));
+    let mut bytes = new_identity_buffer();
     reader
         .take(MAX_IDENTITY_BYTES + 1)
         .read_to_end(&mut bytes)
@@ -147,6 +147,10 @@ fn read_identity(reader: impl Read) -> Result<Zeroizing<String>, ExistingIdentit
         return Err(ExistingIdentityError::Empty);
     }
     Ok(secret)
+}
+
+fn new_identity_buffer() -> Zeroizing<Vec<u8>> {
+    Zeroizing::new(Vec::with_capacity(MAX_IDENTITY_BYTES as usize + 1))
 }
 
 #[cfg(all(test, unix))]
@@ -264,6 +268,20 @@ mod tests {
         ));
         assert_eq!(std::fs::read_to_string(&identity).unwrap(), NSEC);
         assert_eq!(std::fs::read_to_string(&alias).unwrap(), NSEC);
+    }
+
+    #[test]
+    fn identity_buffer_does_not_reallocate_during_full_bounded_read() {
+        let mut bytes = new_identity_buffer();
+        let initial_capacity = bytes.capacity();
+
+        std::io::repeat(b'a')
+            .take(MAX_IDENTITY_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .unwrap();
+
+        assert_eq!(bytes.len(), MAX_IDENTITY_BYTES as usize + 1);
+        assert_eq!(bytes.capacity(), initial_capacity);
     }
 
     #[test]

--- a/crates/agent-connector/src/identity.rs
+++ b/crates/agent-connector/src/identity.rs
@@ -251,6 +251,22 @@ mod tests {
     }
 
     #[test]
+    fn rejects_identity_files_with_multiple_hard_links() {
+        let dir = tempfile::tempdir().unwrap();
+        let identity = dir.path().join("identity.nsec");
+        let alias = dir.path().join("identity-alias.nsec");
+        write_identity(&identity, NSEC);
+        std::fs::hard_link(&identity, &alias).unwrap();
+
+        assert!(matches!(
+            import_existing_identity_file(&dir.path().join("home"), "agent", &identity, None),
+            Err(ExistingIdentityError::MultipleHardLinks)
+        ));
+        assert_eq!(std::fs::read_to_string(&identity).unwrap(), NSEC);
+        assert_eq!(std::fs::read_to_string(&alias).unwrap(), NSEC);
+    }
+
+    #[test]
     fn rejects_malformed_identity_without_echoing_it() {
         let dir = tempfile::tempdir().unwrap();
         let identity = dir.path().join("identity.nsec");

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -6,6 +6,7 @@ mod bootstrap;
 mod connection;
 mod error;
 mod event_projection;
+mod identity;
 mod inbound;
 mod invite_policy;
 mod maintenance;
@@ -28,6 +29,10 @@ pub use bootstrap::{
     resolve_bootstrap_socket, run_bootstrap,
 };
 pub use error::ConnectorError;
+pub use identity::{
+    ExistingIdentityError, ExistingIdentityImport, import_existing_identity_file,
+    import_existing_identity_secret,
+};
 pub use socket::{bind_connector_socket, bind_connector_socket_with_mode, default_socket_path};
 
 use std::future::Future;

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -30,8 +30,8 @@ pub use bootstrap::{
 };
 pub use error::ConnectorError;
 pub use identity::{
-    ExistingIdentityError, ExistingIdentityImport, import_existing_identity_file,
-    import_existing_identity_secret,
+    ExistingIdentityError, ExistingIdentityImport, MAX_IDENTITY_BYTES,
+    import_existing_identity_file, import_existing_identity_secret,
 };
 pub use socket::{bind_connector_socket, bind_connector_socket_with_mode, default_socket_path};
 

--- a/crates/agent-connector/tests/identity_security.rs
+++ b/crates/agent-connector/tests/identity_security.rs
@@ -1,0 +1,176 @@
+#![cfg(unix)]
+
+use std::fs::File;
+use std::io::{self, Read};
+use std::mem::MaybeUninit;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::unix::process::{CommandExt, ExitStatusExt};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const PROMPT: &str = "Existing Nostr identity (nsec or raw hex): ";
+const PROCESS_TIMEOUT: Duration = Duration::from_secs(10);
+
+struct Pty {
+    master: File,
+    slave: File,
+}
+
+impl Pty {
+    fn open() -> Self {
+        let mut master = -1;
+        let mut slave = -1;
+        assert_eq!(
+            unsafe {
+                libc::openpty(
+                    &mut master,
+                    &mut slave,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                )
+            },
+            0,
+            "openpty failed: {}",
+            io::Error::last_os_error()
+        );
+
+        let master = unsafe { File::from_raw_fd(master) };
+        let slave = unsafe { File::from_raw_fd(slave) };
+        let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
+        assert_ne!(flags, -1, "F_GETFL failed: {}", io::Error::last_os_error());
+        assert_ne!(
+            unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) },
+            -1,
+            "F_SETFL failed: {}",
+            io::Error::last_os_error()
+        );
+
+        Self { master, slave }
+    }
+
+    fn echo_enabled(&self) -> bool {
+        let mut settings = MaybeUninit::<libc::termios>::uninit();
+        assert_eq!(
+            unsafe { libc::tcgetattr(self.slave.as_raw_fd(), settings.as_mut_ptr()) },
+            0,
+            "tcgetattr failed: {}",
+            io::Error::last_os_error()
+        );
+        unsafe { settings.assume_init() }.c_lflag & libc::ECHO != 0
+    }
+}
+
+struct KillOnDrop(Option<Child>);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        if let Some(child) = self.0.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn duplicate(file: &File) -> File {
+    let fd = unsafe { libc::dup(file.as_raw_fd()) };
+    assert_ne!(fd, -1, "dup failed: {}", io::Error::last_os_error());
+    unsafe { File::from_raw_fd(fd) }
+}
+
+fn read_until_prompt(master: &mut File, child: &mut Child) {
+    let deadline = Instant::now() + PROCESS_TIMEOUT;
+    let mut output = Vec::new();
+    let mut buffer = [0u8; 256];
+    while Instant::now() < deadline {
+        match master.read(&mut buffer) {
+            Ok(0) => {}
+            Ok(read) => {
+                output.extend_from_slice(&buffer[..read]);
+                if output
+                    .windows(PROMPT.len())
+                    .any(|window| window == PROMPT.as_bytes())
+                {
+                    return;
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+            Err(error) => panic!("failed to read PTY output: {error}"),
+        }
+        if let Some(status) = child.try_wait().expect("query prompt process") {
+            panic!(
+                "prompt process exited before displaying its prompt ({status}): {}",
+                String::from_utf8_lossy(&output)
+            );
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    panic!(
+        "prompt did not appear: {}",
+        String::from_utf8_lossy(&output)
+    );
+}
+
+fn wait_for_exit(child: &mut Child) -> ExitStatus {
+    let deadline = Instant::now() + PROCESS_TIMEOUT;
+    while Instant::now() < deadline {
+        if let Some(status) = child.try_wait().expect("query prompt process") {
+            return status;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    panic!("prompt process did not exit after signal");
+}
+
+#[test]
+fn masked_prompt_restores_tty_and_handler_before_reraising_sigint() {
+    let home = tempfile::tempdir().unwrap();
+    let mut pty = Pty::open();
+    assert!(pty.echo_enabled());
+
+    let slave_fd = pty.slave.as_raw_fd();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_wn-agent"));
+    command
+        .args([
+            "import-identity",
+            "--home",
+            home.path().to_str().unwrap(),
+            "--label",
+            "agent",
+            "--prompt",
+            "--json",
+        ])
+        .stdin(Stdio::from(duplicate(&pty.slave)))
+        .stdout(Stdio::from(duplicate(&pty.slave)))
+        .stderr(Stdio::from(duplicate(&pty.slave)));
+    unsafe {
+        command.pre_exec(move || {
+            if libc::setsid() == -1 {
+                return Err(io::Error::last_os_error());
+            }
+            if libc::ioctl(slave_fd, libc::TIOCSCTTY as _, 0) == -1 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let mut child = KillOnDrop(Some(command.spawn().expect("spawn prompt process")));
+    let process = child.0.as_mut().unwrap();
+    read_until_prompt(&mut pty.master, process);
+    assert!(!pty.echo_enabled(), "prompt must disable terminal echo");
+
+    assert_eq!(
+        unsafe { libc::kill(process.id() as libc::pid_t, libc::SIGINT) },
+        0
+    );
+    let status = wait_for_exit(process);
+    child.0.take();
+
+    assert_eq!(status.signal(), Some(libc::SIGINT));
+    assert!(
+        pty.echo_enabled(),
+        "prompt must restore terminal echo before re-raising SIGINT"
+    );
+}

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,20 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Added
+
+- The Hermes and OpenClaw release installers can now securely import an existing
+  Nostr identity from an owner-only file, optionally pin it to an expected npub,
+  and bootstrap that exact account without creating a replacement identity.
+  Interactive installs also provide a masked `/dev/tty` identity prompt.
+
+### Security
+
+- `wn-agent import-identity` keeps secret material out of argv, environment,
+  output, and bootstrap/config artifacts; rejects symlinked, shared, or
+  non-regular credential files; verifies the expected public identity before
+  persistence; and makes duplicate or interrupted imports recoverable.
+
 ## [0.9.7] - 2026-07-26
 
 ### Fixed

--- a/crates/marmot-account/src/home.rs
+++ b/crates/marmot-account/src/home.rs
@@ -167,6 +167,70 @@ impl AccountHome {
         self.write_signing_account_for_label(label, &keys)
     }
 
+    /// Import a local signing identity, reusing or repairing an exact match.
+    ///
+    /// This is intended for repeatable bootstrap flows. It never creates a
+    /// second local-signing record for the same public key, and a retry can
+    /// finish an import interrupted after the account record was persisted but
+    /// before its secret was written.
+    pub fn import_account_idempotent(
+        &self,
+        label: &str,
+        secret_key: &str,
+    ) -> AccountHomeResult<AccountSummary> {
+        let keys =
+            nostr::Keys::parse(secret_key).map_err(|_| AccountHomeError::InvalidSecretKey)?;
+        let _guard = self
+            .mutation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        validate_account_label(label)?;
+
+        let account_id_hex = keys.public_key().to_hex();
+        if self.account_record_path(label).exists() {
+            let account = self.account(label)?;
+            if account.account_id_hex != account_id_hex || !account.local_signing {
+                return Err(AccountHomeError::AccountExists(label.to_owned()));
+            }
+            return self.reuse_or_repair_signing_account(account, &keys);
+        }
+
+        if let Some(account) = self
+            .accounts()?
+            .into_iter()
+            .find(|account| account.local_signing && account.account_id_hex == account_id_hex)
+        {
+            return self.reuse_or_repair_signing_account(account, &keys);
+        }
+
+        let account = AccountSummary {
+            label: label.to_owned(),
+            account_id_hex,
+            local_signing: true,
+            external_signing: false,
+            signed_out: false,
+        };
+
+        // Recover a credential left behind by the old secret-first import
+        // ordering (#822), or a same-label local-file secret whose record was
+        // interrupted. Verify that it is the requested identity before making
+        // the account visible again.
+        if self.secret_store.has_secret_for_label(label)?
+            || self
+                .secret_store
+                .has_secret_for_account_id(&account.account_id_hex)?
+        {
+            let stored_keys = self.secret_store.load_secret(&account)?;
+            if stored_keys.public_key() != keys.public_key() {
+                return Err(AccountHomeError::AccountIdMismatch);
+            }
+            self.write_account_record(&account)?;
+            return Ok(account);
+        }
+
+        self.write_new_signing_account(&account, &keys)
+    }
+
     pub fn import_nostr_account(&self, secret_key: &str) -> AccountHomeResult<AccountSummary> {
         let keys =
             nostr::Keys::parse(secret_key).map_err(|_| AccountHomeError::InvalidSecretKey)?;
@@ -591,12 +655,50 @@ impl AccountHome {
             external_signing: false,
             signed_out: false,
         };
-        self.secret_store.write_secret(&account, keys)?;
-        if let Err(err) = self.write_account_record(&account) {
-            let _ = self.secret_store.remove_secret(&account);
-            return Err(err);
+        self.write_new_signing_account(&account, keys)
+    }
+
+    fn reuse_or_repair_signing_account(
+        &self,
+        mut account: AccountSummary,
+        keys: &nostr::Keys,
+    ) -> AccountHomeResult<AccountSummary> {
+        match self.secret_store.load_secret(&account) {
+            Ok(stored_keys) => {
+                if stored_keys.public_key() != keys.public_key() {
+                    return Err(AccountHomeError::AccountIdMismatch);
+                }
+            }
+            Err(AccountHomeError::SecretNotFound(_)) => {
+                self.secret_store.write_secret(&account, keys)?;
+            }
+            Err(AccountHomeError::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+                self.secret_store.write_secret(&account, keys)?;
+            }
+            Err(err) => return Err(err),
+        }
+        if account.signed_out {
+            account.signed_out = false;
+            self.write_account_record(&account)?;
         }
         Ok(account)
+    }
+
+    fn write_new_signing_account(
+        &self,
+        account: &AccountSummary,
+        keys: &nostr::Keys,
+    ) -> AccountHomeResult<AccountSummary> {
+        // Record first so a crash cannot leave an invisible keychain credential
+        // that permanently blocks re-import. A record without a secret is
+        // visible/removable and `import_account_idempotent` repairs it on retry.
+        self.write_account_record(account)?;
+        if let Err(err) = self.secret_store.write_secret(account, keys) {
+            let _ = fs::remove_file(self.account_record_path(&account.label));
+            let _ = fs::remove_dir(self.account_dir(&account.label));
+            return Err(err);
+        }
+        Ok(account.clone())
     }
 
     fn write_account_record(&self, account: &AccountSummary) -> AccountHomeResult<()> {

--- a/crates/marmot-account/tests/home.rs
+++ b/crates/marmot-account/tests/home.rs
@@ -108,6 +108,64 @@ fn account_home_import_accepts_nsec_and_reopens_the_same_identity() {
 }
 
 #[test]
+fn account_home_idempotent_import_reuses_existing_identity() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    let nsec = "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99";
+
+    let first = home.import_account_idempotent("agent", nsec).unwrap();
+    let second = home.import_account_idempotent("agent", nsec).unwrap();
+
+    assert_eq!(second, first);
+    assert_eq!(home.accounts().unwrap(), vec![first]);
+}
+
+#[test]
+fn account_home_idempotent_import_reactivates_signed_out_identity() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    let nsec = "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99";
+    home.import_account_idempotent("agent", nsec).unwrap();
+    home.set_account_signed_out("agent", true).unwrap();
+
+    let imported = home.import_account_idempotent("agent", nsec).unwrap();
+
+    assert!(!imported.signed_out);
+    assert!(!home.account("agent").unwrap().signed_out);
+}
+
+#[test]
+fn account_home_idempotent_import_repairs_interrupted_record_first_import() {
+    let dir = tempfile::tempdir().unwrap();
+    let keys = nostr::Keys::generate();
+    let account = AccountSummary {
+        label: "agent".to_owned(),
+        account_id_hex: keys.public_key().to_hex(),
+        local_signing: true,
+        external_signing: false,
+        signed_out: false,
+    };
+    let account_dir = dir.path().join("accounts").join(&account.label);
+    std::fs::create_dir_all(&account_dir).unwrap();
+    std::fs::write(
+        account_dir.join("account.json"),
+        serde_json::to_vec(&account).unwrap(),
+    )
+    .unwrap();
+    let home = AccountHome::open(dir.path());
+
+    let repaired = home
+        .import_account_idempotent("agent", &keys.secret_key().to_secret_hex())
+        .unwrap();
+
+    assert_eq!(repaired, account);
+    assert_eq!(
+        home.load_signing_keys("agent").unwrap().public_key(),
+        keys.public_key()
+    );
+}
+
+#[test]
 fn account_home_accounts_skips_unreadable_records() {
     let dir = tempfile::tempdir().unwrap();
     let home = AccountHome::open(dir.path());
@@ -361,6 +419,30 @@ fn account_home_keychain_rejects_second_label_for_same_account_id() {
         home.import_account("label-two", &secret_hex),
         Err(AccountHomeError::AccountIdInUse(_))
     ));
+}
+
+#[test]
+fn account_home_idempotent_import_recovers_orphaned_keychain_credential() {
+    install_mock_keyring();
+    let dir = tempfile::tempdir().unwrap();
+    let home =
+        AccountHome::open_with_keychain(dir.path(), "com.marmot.test.orphan-recovery").unwrap();
+    let keys = nostr::Keys::generate();
+    let secret_hex = keys.secret_key().to_secret_hex();
+    let original = home.import_account("old-label", &secret_hex).unwrap();
+    std::fs::remove_dir_all(home.account_dir(&original.label)).unwrap();
+    assert!(home.accounts().unwrap().is_empty());
+
+    let recovered = home
+        .import_account_idempotent("agent", &secret_hex)
+        .unwrap();
+
+    assert_eq!(recovered.label, "agent");
+    assert_eq!(recovered.account_id_hex, original.account_id_hex);
+    assert_eq!(
+        home.load_signing_keys("agent").unwrap().public_key(),
+        keys.public_key()
+    );
 }
 
 #[test]

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -45,7 +45,32 @@ curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-la
   bash -s -- --yes --allow-welcomer npub1...
 ```
 
-Use a versioned `wn-agent-v<version>` release URL when you need a pinned install.
+Generated-identity onboarding is the default (and can be selected explicitly
+with `--generate-identity`). To preserve an existing Nostr identity, place its
+`nsec` or raw secret hex in a regular file owned by the current user with mode
+`0600`, then use a pinned release URL:
+
+```sh
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.8/install-hermes-marmot.sh" | \
+  bash -s -- \
+    --yes \
+    --existing-identity-file "$HOME/.config/example/hermes-agent.nsec" \
+    --expected-npub npub1... \
+    --allow-welcomer npub1...
+```
+
+The installer passes only the file path, never the secret, in process arguments.
+`wn-agent` rejects symlinks, non-regular files, files owned by another user, and
+files accessible by group/other users. It verifies `--expected-npub` before
+starting the connector or changing Hermes configuration, imports idempotently,
+then bootstraps the exact account with creation disabled. During interactive
+setup, the same identity can instead be entered through a masked `/dev/tty`
+prompt, which remains usable when the installer itself arrives through a pipe.
+The source credential file is read-only and is not rewritten or removed.
+
+Hermes keeps its isolated default connector home. Reusing the same identity in
+another connector home, such as OpenClaw's, requires a separate explicit import;
+the installers never opt into shared home/socket state silently.
 
 Use the exact release version when reporting bugs:
 
@@ -71,12 +96,19 @@ Manual equivalent:
 export MARMOT_HOME="$HOME/.marmot-agents/hermes"
 export PATH="$HOME/.local/bin:$PATH"
 
+wn-agent import-identity --json \
+  --home "$MARMOT_HOME" \
+  --label hermes-agent \
+  --identity-file "$HOME/.config/example/hermes-agent.nsec" \
+  --expected-identity npub1...
+
 wn-agent --home "$MARMOT_HOME" \
   --socket "$MARMOT_HOME/dev/wn-agent.sock" \
   --relay wss://relay.eu.whitenoise.chat \
   --relay wss://relay.us.whitenoise.chat
 
-wn-agent bootstrap --home "$MARMOT_HOME" --label hermes-agent --qr
+wn-agent bootstrap --home "$MARMOT_HOME" --label hermes-agent \
+  --no-create --account-id-hex <imported-account-hex> --qr
 hermes gateway run
 ```
 

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -464,6 +464,7 @@ class AgentControlClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(event["text"], "ping")
 
     async def test_inbound_subscription_waits_without_request_timeout_after_ack(self):
+        ack_sent = asyncio.Event()
         release_event = asyncio.Event()
 
         async def handler(reader, writer):
@@ -476,6 +477,8 @@ class AgentControlClientTests(unittest.IsolatedAsyncioTestCase):
                     "type": "ack",
                 },
             )
+            await writer.drain()
+            ack_sent.set()
             await release_event.wait()
             await write_json_line(
                 writer,
@@ -494,12 +497,17 @@ class AgentControlClientTests(unittest.IsolatedAsyncioTestCase):
             writer.close()
 
         await self.start_server(handler)
-        client = self.adapter.MarmotAgentControlClient(self.socket_path, request_timeout=0.01)
+        request_timeout = 0.1
+        client = self.adapter.MarmotAgentControlClient(
+            self.socket_path,
+            request_timeout=request_timeout,
+        )
         events = client.inbound_events(account_id_hex="11" * 32)
 
         pending_event = asyncio.create_task(anext(events))
         try:
-            await asyncio.sleep(0.05)
+            await asyncio.wait_for(ack_sent.wait(), timeout=1.0)
+            await asyncio.sleep(request_timeout * 2)
             self.assertFalse(pending_event.done())
 
             release_event.set()

--- a/integrations/hermes/marmot/tests/test_dev_scripts.sh
+++ b/integrations/hermes/marmot/tests/test_dev_scripts.sh
@@ -106,6 +106,25 @@ installer_stdin_dry_run="$(
         MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
     bash -s -- --dry-run --yes < "$repo_root/scripts/install-hermes-marmot.sh"
 )"
+identity_secret="nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99"
+identity_file="$tmp_parent/hermes-agent.nsec"
+printf '%s\n' "$identity_secret" > "$identity_file"
+chmod 0600 "$identity_file"
+expected_identity="$(printf '11%.0s' {1..32})"
+installer_existing_identity_dry_run="$(
+    env -u MARMOT_HOME -u MARMOT_AGENT_SOCKET \
+        WN_AGENT_SHA="9.9.9" \
+        MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
+    "$repo_root/scripts/install-hermes-marmot.sh" --dry-run --yes \
+        --existing-identity-file "$identity_file" \
+        --expected-npub "$expected_identity"
+)"
+installer_generated_identity_dry_run="$(
+    env -u MARMOT_HOME -u MARMOT_AGENT_SOCKET \
+        WN_AGENT_SHA="9.9.9" \
+        MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
+    "$repo_root/scripts/install-hermes-marmot.sh" --dry-run --yes --generate-identity
+)"
 installer_bad_welcomer_status=0
 env -u MARMOT_HOME -u MARMOT_AGENT_SOCKET \
     WN_AGENT_SHA="9.9.9" \
@@ -113,6 +132,14 @@ env -u MARMOT_HOME -u MARMOT_AGENT_SOCKET \
     "$repo_root/scripts/install-hermes-marmot.sh" --dry-run --yes --allow-welcomer not-a-key \
     >/dev/null 2>&1 || installer_bad_welcomer_status=$?
 [ "$installer_bad_welcomer_status" -ne 0 ]
+installer_identity_conflict_status=0
+"$repo_root/scripts/install-hermes-marmot.sh" --dry-run --yes --generate-identity \
+    --existing-identity-file "$identity_file" >/dev/null 2>&1 || installer_identity_conflict_status=$?
+[ "$installer_identity_conflict_status" -ne 0 ]
+installer_expected_without_source_status=0
+"$repo_root/scripts/install-hermes-marmot.sh" --dry-run --yes --expected-npub "$expected_identity" \
+    >/dev/null 2>&1 || installer_expected_without_source_status=$?
+[ "$installer_expected_without_source_status" -ne 0 ]
 case "$installer_dry_run" in
     *"wn-agent-"*"9.9.9.tar.gz"* ) ;;
     *) echo "Hermes installer dry-run did not use WN_AGENT_SHA asset suffix" >&2; exit 1;;
@@ -166,6 +193,22 @@ esac
 case "$installer_stdin_dry_run" in
     *"--label hermes-agent"* ) ;;
     *) echo "Hermes installer stdin dry-run did not pass the Hermes bootstrap label" >&2; exit 1;;
+esac
+case "$installer_existing_identity_dry_run" in
+    *"import-identity"*"--identity-file"*"$identity_file"*"--expected-identity"*"$expected_identity"* ) ;;
+    *) echo "Hermes installer did not use the shared secure identity-import command" >&2; exit 1;;
+esac
+case "$installer_existing_identity_dry_run" in
+    *"bootstrap"*"--no-create"*"--account-id-hex"* ) ;;
+    *) echo "Hermes installer did not bootstrap the imported account with creation disabled" >&2; exit 1;;
+esac
+case "$installer_existing_identity_dry_run" in
+    *"$identity_secret"* ) echo "Hermes installer output exposed identity secret material" >&2; exit 1;;
+    *) ;;
+esac
+case "$installer_generated_identity_dry_run" in
+    *"import-identity"* | *"--no-create"* ) echo "Hermes generated-identity path used existing-identity flags" >&2; exit 1;;
+    *) ;;
 esac
 
 echo "dev script test passed"

--- a/integrations/hermes/marmot/tests/test_installer_env.sh
+++ b/integrations/hermes/marmot/tests/test_installer_env.sh
@@ -299,7 +299,7 @@ if command -v script >/dev/null 2>&1 \
     && command -v timeout >/dev/null 2>&1 \
     && script --version 2>&1 | grep -qi 'util-linux'; then
     guided_status=0
-    printf '\n\n\nn\nn\n%s\n\n' "$user_a" | timeout 10s script -qefc \
+    printf '\n\n\n\nn\nn\n%s\n\n' "$user_a" | timeout 10s script -qefc \
         "env -i HOME='$case_root/home' HERMES_HOME='$case_root/hermes-home' PATH=/usr/bin:/bin WN_AGENT_SHA=9.9.9 MARMOT_RELEASE_TAG=wn-agent-v9.9.9-test bash '$installer' --dry-run --hermes-home '$case_root/hermes-home' --allow-welcomer '$user_a'" \
         /dev/null >"$guided_log" 2>&1 || guided_status=$?
     if [ "$guided_status" -ne 0 ]; then

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -46,16 +46,47 @@ curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-la
   bash -s -- --yes --allow-welcomer npub1...
 ```
 
-Use a versioned `wn-agent-v<version>` release URL when you need a pinned install.
+Generated-identity onboarding is the default (and can be selected explicitly
+with `--generate-identity`). To preserve an existing Nostr identity, place its
+`nsec` or raw secret hex in a regular file owned by the current user with mode
+`0600`, then use a pinned release URL:
+
+```sh
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.8/install-openclaw-marmot.sh" | \
+  bash -s -- \
+    --yes \
+    --existing-identity-file "$HOME/.config/example/openclaw-agent.nsec" \
+    --expected-npub npub1... \
+    --allow-welcomer npub1...
+```
+
+The installer passes only the file path, never the secret, in process arguments.
+`wn-agent` rejects symlinks, non-regular files, files owned by another user, and
+files accessible by group/other users. It verifies `--expected-npub` before
+starting the connector or changing OpenClaw configuration, imports idempotently,
+then bootstraps the exact account with creation disabled. During interactive
+setup, the same identity can instead be entered through a masked `/dev/tty`
+prompt, which remains usable when the installer itself arrives through a pipe.
+The source credential file is read-only and is not rewritten or removed.
+
+OpenClaw keeps its isolated default connector home. Reusing the same identity in
+another connector home, such as Hermes's, requires a separate explicit import;
+the installers never opt into shared home/socket state silently.
 
 The installer prints restart guidance for your existing OpenClaw gateway. It
 does not restart OpenClaw automatically. Manual equivalent:
 
 ```sh
+wn-agent import-identity --json \
+  --home ~/.marmot-agents/openclaw \
+  --label openclaw-agent \
+  --identity-file "$HOME/.config/example/openclaw-agent.nsec" \
+  --expected-identity npub1...
 wn-agent --home ~/.marmot-agents/openclaw \
   --relay wss://relay.eu.whitenoise.chat \
   --relay wss://relay.us.whitenoise.chat
-wn-agent bootstrap --home ~/.marmot-agents/openclaw --label openclaw-agent --qr
+wn-agent bootstrap --home ~/.marmot-agents/openclaw --label openclaw-agent \
+  --no-create --account-id-hex <imported-account-hex> --qr
 openclaw gateway run
 ```
 

--- a/integrations/openclaw/marmot/test/dev-scripts.sh
+++ b/integrations/openclaw/marmot/test/dev-scripts.sh
@@ -116,6 +116,25 @@ installer_stdin_dry_run="$(
         MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
     bash -s -- --dry-run --yes < "$repo_root/scripts/install-openclaw-marmot.sh"
 )"
+identity_secret="nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99"
+identity_file="$tmp_parent/openclaw-agent.nsec"
+printf '%s\n' "$identity_secret" > "$identity_file"
+chmod 0600 "$identity_file"
+expected_identity="$(printf '11%.0s' {1..32})"
+installer_existing_identity_dry_run="$(
+    env -u MARMOT_HOME -u MARMOT_AGENT_SOCKET \
+        WN_AGENT_SHA="9.9.9" \
+        MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
+    "$repo_root/scripts/install-openclaw-marmot.sh" --dry-run --yes \
+        --existing-identity-file "$identity_file" \
+        --expected-npub "$expected_identity"
+)"
+installer_generated_identity_dry_run="$(
+    env -u MARMOT_HOME -u MARMOT_AGENT_SOCKET \
+        WN_AGENT_SHA="9.9.9" \
+        MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
+    "$repo_root/scripts/install-openclaw-marmot.sh" --dry-run --yes --generate-identity
+)"
 installer_bad_welcomer_status=0
 env -u MARMOT_HOME -u MARMOT_AGENT_SOCKET \
     WN_AGENT_SHA="9.9.9" \
@@ -123,6 +142,14 @@ env -u MARMOT_HOME -u MARMOT_AGENT_SOCKET \
     "$repo_root/scripts/install-openclaw-marmot.sh" --dry-run --yes --allow-welcomer not-a-key \
     >/dev/null 2>&1 || installer_bad_welcomer_status=$?
 [ "$installer_bad_welcomer_status" -ne 0 ]
+installer_identity_conflict_status=0
+"$repo_root/scripts/install-openclaw-marmot.sh" --dry-run --yes --generate-identity \
+    --existing-identity-file "$identity_file" >/dev/null 2>&1 || installer_identity_conflict_status=$?
+[ "$installer_identity_conflict_status" -ne 0 ]
+installer_expected_without_source_status=0
+"$repo_root/scripts/install-openclaw-marmot.sh" --dry-run --yes --expected-npub "$expected_identity" \
+    >/dev/null 2>&1 || installer_expected_without_source_status=$?
+[ "$installer_expected_without_source_status" -ne 0 ]
 case "$installer_dry_run" in
     *"wn-agent-"*"9.9.9.tar.gz"* ) ;;
     *) echo "OpenClaw installer dry-run did not use WN_AGENT_SHA asset suffix" >&2; exit 1;;
@@ -176,6 +203,22 @@ esac
 case "$installer_stdin_dry_run" in
     *"--label openclaw-agent"* ) ;;
     *) echo "OpenClaw installer stdin dry-run did not pass the OpenClaw bootstrap label" >&2; exit 1;;
+esac
+case "$installer_existing_identity_dry_run" in
+    *"import-identity"*"--identity-file"*"$identity_file"*"--expected-identity"*"$expected_identity"* ) ;;
+    *) echo "OpenClaw installer did not use the shared secure identity-import command" >&2; exit 1;;
+esac
+case "$installer_existing_identity_dry_run" in
+    *"bootstrap"*"--no-create"*"--account-id-hex"* ) ;;
+    *) echo "OpenClaw installer did not bootstrap the imported account with creation disabled" >&2; exit 1;;
+esac
+case "$installer_existing_identity_dry_run" in
+    *"$identity_secret"* ) echo "OpenClaw installer output exposed identity secret material" >&2; exit 1;;
+    *) ;;
+esac
+case "$installer_generated_identity_dry_run" in
+    *"import-identity"* | *"--no-create"* ) echo "OpenClaw generated-identity path used existing-identity flags" >&2; exit 1;;
+    *) ;;
 esac
 
 echo "OpenClaw dev script test passed"

--- a/integrations/test_installer_systemd_service.sh
+++ b/integrations/test_installer_systemd_service.sh
@@ -81,9 +81,17 @@ case "$archive_name" in
         mkdir -p "$output_dir"
         cat >"$output_dir/wn-agent" <<'SCRIPT'
 #!/usr/bin/env bash
-if [ "${1:-}" = bootstrap ]; then
-    printf '%s\n' '{"account_id_hex":"aa","welcomer_account_ids_hex":["bb"]}'
-fi
+set -euo pipefail
+printf '%q ' "$@" >>"$WN_AGENT_LOG"
+printf '\n' >>"$WN_AGENT_LOG"
+case "${1:-}" in
+    import-identity)
+        printf '%s\n' '{"account_id_hex":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","label":"imported-agent","local_signing":true}'
+        ;;
+    bootstrap)
+        printf '%s\n' '{"account_id_hex":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","created":false,"welcomer_account_ids_hex":["bb"]}'
+        ;;
+esac
 SCRIPT
         chmod +x "$output_dir/wn-agent"
         ;;
@@ -126,8 +134,10 @@ run_case() {
 
     mkdir -p "$case_root"
     : >"$log_file"
+    : >"$case_root/wn-agent.log"
     SYSTEMCTL_ACTIVE="$active" \
     SYSTEMCTL_LOG="$log_file" \
+    WN_AGENT_LOG="$case_root/wn-agent.log" \
     HOME="$case_root/home" \
     HERMES_HOME="$case_root/hermes-home" \
     OPENCLAW_HOME="$case_root/openclaw-home" \
@@ -171,3 +181,35 @@ assert_log_equals "$no_start_log" ""
 no_service_log="$fixture_root/systemctl-no-service.log"
 run_case no-service 1 "$no_service_log" --no-service
 assert_log_equals "$no_service_log" ""
+
+identity_secret="nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99"
+identity_file="$fixture_root/existing-identity.nsec"
+printf '%s\n' "$identity_secret" >"$identity_file"
+chmod 0600 "$identity_file"
+expected_identity="$(printf 'aa%.0s' {1..32})"
+existing_log="$fixture_root/systemctl-existing.log"
+run_case existing 0 "$existing_log" \
+    --existing-identity-file "$identity_file" \
+    --expected-npub "$expected_identity"
+assert_log_equals "$existing_log" "--user daemon-reload
+--user is-active --quiet $service
+--user enable --now $service"
+
+wn_agent_log="$fixture_root/existing/wn-agent.log"
+case "$(cat "$wn_agent_log")" in
+    *"import-identity"*"--identity-file"*"--expected-identity"*"bootstrap"*"--no-create"*"--account-id-hex"* ) ;;
+    *) echo "$flavor installer did not import then bootstrap the exact existing identity" >&2; exit 1 ;;
+esac
+bootstrap_json="$fixture_root/existing/marmot-home/bootstrap.json"
+python3 - "$bootstrap_json" <<'PY'
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+assert payload["created"] is False
+PY
+if grep -Fq "$identity_secret" "$wn_agent_log" "$bootstrap_json"; then
+    echo "$flavor installer exposed identity secret material" >&2
+    exit 1
+fi
+[ "$(cat "$identity_file")" = "$identity_secret" ]

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -46,6 +46,11 @@ SYSTEM_INSTALL=0
 CLI_RELAYS=0
 BOOTSTRAP_ACCOUNT_ID_HEX=""
 BOOTSTRAP_JSON_PATH=""
+EXISTING_IDENTITY_FILE=""
+EXISTING_IDENTITY_PROMPT=0
+GENERATE_IDENTITY_EXPLICIT=0
+EXPECTED_IDENTITY=""
+IMPORTED_ACCOUNT_ID_HEX=""
 WN_AGENT_TEMP_PID=""
 
 RELAYS=()
@@ -65,6 +70,12 @@ Options:
   --home PATH              Marmot agent home (default: ~/.marmot-agents/hermes)
   --hermes-home PATH       Hermes home (default: $HERMES_HOME or ~/.hermes)
   --allow-welcomer VALUE   Allow invites from this npub or hex pubkey; may repeat
+  --existing-identity-file PATH
+                           Import an existing nsec/raw-hex identity from an
+                           owner-only regular file before bootstrap
+  --expected-npub VALUE    Fail unless the imported identity matches this npub
+                           or 64-character hex public key
+  --generate-identity      Explicitly use generated-identity onboarding (default)
   --relay URL              Relay URL for wn-agent/bootstrap; may repeat
   --enable-streaming       Configure Marmot live preview streaming
   --quic-candidate URI     QUIC preview candidate used with --enable-streaming
@@ -96,6 +107,10 @@ Example:
   curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh | bash
 
   curl -fsSL .../install-hermes-marmot.sh | bash -s -- --yes --allow-welcomer npub1...
+
+  curl -fsSL .../install-hermes-marmot.sh | bash -s -- --yes \
+    --existing-identity-file "$HOME/.config/example/hermes-agent.nsec" \
+    --expected-npub npub1... --allow-welcomer npub1...
 USAGE
 }
 
@@ -581,6 +596,52 @@ start_temp_agent() {
     log "temporary wn-agent pid: $WN_AGENT_TEMP_PID"
 }
 
+import_existing_identity() {
+    if [ -z "$EXISTING_IDENTITY_FILE" ] && [ "$EXISTING_IDENTITY_PROMPT" -ne 1 ]; then
+        return 0
+    fi
+    ensure_path
+    if [ "$DRY_RUN" -eq 0 ]; then
+        need_cmd wn-agent
+        need_cmd python3
+    fi
+
+    local -a args=(
+        import-identity
+        --json
+        --home "$MARMOT_HOME"
+        --label "$MARMOT_AGENT_LABEL"
+    )
+    if [ -n "$EXISTING_IDENTITY_FILE" ]; then
+        args+=(--identity-file "$EXISTING_IDENTITY_FILE")
+    else
+        args+=(--prompt)
+    fi
+    if [ -n "$EXPECTED_IDENTITY" ]; then
+        args+=(--expected-identity "$EXPECTED_IDENTITY")
+    fi
+
+    log "importing and verifying existing Nostr identity"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '[dry-run] wn-agent'
+        printf ' %q' "${args[@]}"
+        printf '\n'
+        IMPORTED_ACCOUNT_ID_HEX="<account-id-from-identity-import>"
+        return 0
+    fi
+
+    local imported_json
+    imported_json="$(wn-agent "${args[@]}")"
+    IMPORTED_ACCOUNT_ID_HEX="$(
+        printf '%s\n' "$imported_json" |
+            python3 -c 'import json, sys; print(json.load(sys.stdin)["account_id_hex"])'
+    )"
+    if [ -z "$IMPORTED_ACCOUNT_ID_HEX" ]; then
+        echo "error: identity import did not return an account id" >&2
+        exit 1
+    fi
+}
+
 bootstrap_agent() {
     ensure_path
     if [ "$DRY_RUN" -eq 0 ]; then
@@ -604,6 +665,9 @@ bootstrap_agent() {
         --socket "$MARMOT_AGENT_SOCKET"
         --label "$MARMOT_AGENT_LABEL"
     )
+    if [ -n "$IMPORTED_ACCOUNT_ID_HEX" ]; then
+        args+=(--no-create --account-id-hex "$IMPORTED_ACCOUNT_ID_HEX")
+    fi
     local relay
     for relay in "${RELAYS[@]}"; do
         args+=(--relay "$relay")
@@ -736,6 +800,18 @@ while [ "$#" -gt 0 ]; do
             HERMES_HOME="${2:?missing value for --hermes-home}"
             shift 2
             ;;
+        --existing-identity-file)
+            EXISTING_IDENTITY_FILE="${2:?missing value for --existing-identity-file}"
+            shift 2
+            ;;
+        --expected-npub)
+            EXPECTED_IDENTITY="${2:?missing value for --expected-npub}"
+            shift 2
+            ;;
+        --generate-identity)
+            GENERATE_IDENTITY_EXPLICIT=1
+            shift
+            ;;
         --allow-welcomer)
             ALLOW_WELCOMERS+=("${2:?missing value for --allow-welcomer}")
             shift 2
@@ -825,6 +901,20 @@ if [ "$INTERACTIVE" -eq 1 ]; then
     if [ -e "$MARMOT_HOME" ]; then
         log "existing Marmot agent home detected; bootstrap will reuse or repair it: $MARMOT_HOME"
     fi
+    if [ "$GENERATE_IDENTITY_EXPLICIT" -ne 1 ] && [ -z "$EXISTING_IDENTITY_FILE" ]; then
+        if prompt_yes_no "Import an existing Nostr identity?" "no"; then
+            if prompt_yes_no "Read the identity from an owner-only file?" "yes"; then
+                EXISTING_IDENTITY_FILE="$(prompt_value "Existing identity file" "")"
+                if [ -z "$EXISTING_IDENTITY_FILE" ]; then
+                    echo "error: existing identity file path cannot be empty" >&2
+                    exit 1
+                fi
+            else
+                EXISTING_IDENTITY_PROMPT=1
+            fi
+            EXPECTED_IDENTITY="$(prompt_value "Expected npub or hex (blank to skip)" "$EXPECTED_IDENTITY")"
+        fi
+    fi
     if [ "${#ALLOW_WELCOMERS[@]}" -eq 0 ]; then
         while true; do
             welcomer_reply="$(prompt_value "Allowed inviter/welcomer npub or hex (blank to skip)" "")"
@@ -840,6 +930,15 @@ if [ "$INTERACTIVE" -eq 1 ]; then
 fi
 
 MARMOT_OUTBOUND_MEDIA_DIR="${MARMOT_OUTBOUND_MEDIA_DIR_OVERRIDE:-$MARMOT_HOME/dev/outbound-media}"
+
+if [ "$GENERATE_IDENTITY_EXPLICIT" -eq 1 ] && { [ -n "$EXISTING_IDENTITY_FILE" ] || [ "$EXISTING_IDENTITY_PROMPT" -eq 1 ]; }; then
+    echo "error: --generate-identity conflicts with existing-identity onboarding" >&2
+    exit 1
+fi
+if [ -n "$EXPECTED_IDENTITY" ] && [ -z "$EXISTING_IDENTITY_FILE" ] && [ "$EXISTING_IDENTITY_PROMPT" -ne 1 ]; then
+    echo "error: --expected-npub requires --existing-identity-file" >&2
+    exit 1
+fi
 
 validate_welcomer_inputs
 
@@ -871,6 +970,7 @@ log "Marmot home: $MARMOT_HOME"
 log "Marmot socket: $MARMOT_AGENT_SOCKET"
 log "Marmot agent label: $MARMOT_AGENT_LABEL"
 install_wn_agent "$platform" "$tmpdir"
+import_existing_identity
 install_plugin "$tmpdir"
 enable_hermes_plugin
 bootstrap_agent

--- a/scripts/install-openclaw-marmot.sh
+++ b/scripts/install-openclaw-marmot.sh
@@ -48,6 +48,11 @@ CLI_RELAYS=0
 BOOTSTRAP_ACCOUNT_ID_HEX=""
 BOOTSTRAP_JSON_PATH=""
 BOOTSTRAP_WELCOMER_ALLOWLIST_CSV=""
+EXISTING_IDENTITY_FILE=""
+EXISTING_IDENTITY_PROMPT=0
+GENERATE_IDENTITY_EXPLICIT=0
+EXPECTED_IDENTITY=""
+IMPORTED_ACCOUNT_ID_HEX=""
 WN_AGENT_TEMP_PID=""
 
 RELAYS=()
@@ -67,6 +72,12 @@ Options:
   --home PATH              Marmot agent home (default: ~/.marmot-agents/openclaw)
   --openclaw-home PATH     OpenClaw home (default: $OPENCLAW_HOME or $HOME)
   --allow-welcomer VALUE   Allow invites from this npub or hex pubkey; may repeat
+  --existing-identity-file PATH
+                           Import an existing nsec/raw-hex identity from an
+                           owner-only regular file before bootstrap
+  --expected-npub VALUE    Fail unless the imported identity matches this npub
+                           or 64-character hex public key
+  --generate-identity      Explicitly use generated-identity onboarding (default)
   --relay URL              Relay URL for wn-agent/bootstrap; may repeat
   --enable-streaming       Configure OpenClaw/Marmot live preview streaming
   --quic-candidate URI     QUIC preview candidate used with --enable-streaming
@@ -97,6 +108,10 @@ Example:
   curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-openclaw-marmot.sh | bash
 
   curl -fsSL .../install-openclaw-marmot.sh | bash -s -- --yes --allow-welcomer npub1...
+
+  curl -fsSL .../install-openclaw-marmot.sh | bash -s -- --yes \
+    --existing-identity-file "$HOME/.config/example/openclaw-agent.nsec" \
+    --expected-npub npub1... --allow-welcomer npub1...
 USAGE
 }
 
@@ -488,6 +503,52 @@ start_temp_agent() {
     log "temporary wn-agent pid: $WN_AGENT_TEMP_PID"
 }
 
+import_existing_identity() {
+    if [ -z "$EXISTING_IDENTITY_FILE" ] && [ "$EXISTING_IDENTITY_PROMPT" -ne 1 ]; then
+        return 0
+    fi
+    ensure_path
+    if [ "$DRY_RUN" -eq 0 ]; then
+        need_cmd wn-agent
+        need_cmd python3
+    fi
+
+    local -a args=(
+        import-identity
+        --json
+        --home "$MARMOT_HOME"
+        --label "$MARMOT_AGENT_LABEL"
+    )
+    if [ -n "$EXISTING_IDENTITY_FILE" ]; then
+        args+=(--identity-file "$EXISTING_IDENTITY_FILE")
+    else
+        args+=(--prompt)
+    fi
+    if [ -n "$EXPECTED_IDENTITY" ]; then
+        args+=(--expected-identity "$EXPECTED_IDENTITY")
+    fi
+
+    log "importing and verifying existing Nostr identity"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        printf '[dry-run] wn-agent'
+        printf ' %q' "${args[@]}"
+        printf '\n'
+        IMPORTED_ACCOUNT_ID_HEX="<account-id-from-identity-import>"
+        return 0
+    fi
+
+    local imported_json
+    imported_json="$(wn-agent "${args[@]}")"
+    IMPORTED_ACCOUNT_ID_HEX="$(
+        printf '%s\n' "$imported_json" |
+            python3 -c 'import json, sys; print(json.load(sys.stdin)["account_id_hex"])'
+    )"
+    if [ -z "$IMPORTED_ACCOUNT_ID_HEX" ]; then
+        echo "error: identity import did not return an account id" >&2
+        exit 1
+    fi
+}
+
 bootstrap_agent() {
     ensure_path
     if [ "$DRY_RUN" -eq 0 ]; then need_cmd wn-agent; fi
@@ -509,6 +570,9 @@ bootstrap_agent() {
         --socket "$MARMOT_AGENT_SOCKET"
         --label "$MARMOT_AGENT_LABEL"
     )
+    if [ -n "$IMPORTED_ACCOUNT_ID_HEX" ]; then
+        args+=(--no-create --account-id-hex "$IMPORTED_ACCOUNT_ID_HEX")
+    fi
     local relay
     for relay in "${RELAYS[@]}"; do args+=(--relay "$relay"); done
     if [ "$ENABLE_STREAMING" -eq 1 ]; then
@@ -655,6 +719,9 @@ while [ $# -gt 0 ]; do
         --yes | --non-interactive) ASSUME_YES=1; shift ;;
         --home) MARMOT_HOME="${2:?missing value for --home}"; MARMOT_AGENT_SOCKET_OVERRIDE=""; shift 2 ;;
         --openclaw-home) OPENCLAW_HOME="${2:?missing value for --openclaw-home}"; shift 2 ;;
+        --existing-identity-file) EXISTING_IDENTITY_FILE="${2:?missing value for --existing-identity-file}"; shift 2 ;;
+        --expected-npub) EXPECTED_IDENTITY="${2:?missing value for --expected-npub}"; shift 2 ;;
+        --generate-identity) GENERATE_IDENTITY_EXPLICIT=1; shift ;;
         --allow-welcomer) ALLOW_WELCOMERS+=("${2:?missing value for --allow-welcomer}"); shift 2 ;;
         --relay) CLI_RELAYS=1; RELAYS+=("${2:?missing value for --relay}"); shift 2 ;;
         --enable-streaming) ENABLE_STREAMING=1; shift ;;
@@ -692,6 +759,20 @@ if [ "$INTERACTIVE" -eq 1 ]; then
     if [ -e "$MARMOT_HOME" ]; then
         log "existing Marmot agent home detected; bootstrap will reuse or repair it: $MARMOT_HOME"
     fi
+    if [ "$GENERATE_IDENTITY_EXPLICIT" -ne 1 ] && [ -z "$EXISTING_IDENTITY_FILE" ]; then
+        if prompt_yes_no "Import an existing Nostr identity?" "no"; then
+            if prompt_yes_no "Read the identity from an owner-only file?" "yes"; then
+                EXISTING_IDENTITY_FILE="$(prompt_value "Existing identity file" "")"
+                if [ -z "$EXISTING_IDENTITY_FILE" ]; then
+                    echo "error: existing identity file path cannot be empty" >&2
+                    exit 1
+                fi
+            else
+                EXISTING_IDENTITY_PROMPT=1
+            fi
+            EXPECTED_IDENTITY="$(prompt_value "Expected npub or hex (blank to skip)" "$EXPECTED_IDENTITY")"
+        fi
+    fi
     if [ "${#ALLOW_WELCOMERS[@]}" -eq 0 ]; then
         while true; do
             welcomer_reply="$(prompt_value "Allowed inviter/welcomer npub or hex (blank to skip)" "")"
@@ -707,6 +788,15 @@ if [ "$INTERACTIVE" -eq 1 ]; then
 fi
 
 MARMOT_OUTBOUND_MEDIA_DIR="${MARMOT_OUTBOUND_MEDIA_DIR_OVERRIDE:-$MARMOT_HOME/dev/outbound-media}"
+
+if [ "$GENERATE_IDENTITY_EXPLICIT" -eq 1 ] && { [ -n "$EXISTING_IDENTITY_FILE" ] || [ "$EXISTING_IDENTITY_PROMPT" -eq 1 ]; }; then
+    echo "error: --generate-identity conflicts with existing-identity onboarding" >&2
+    exit 1
+fi
+if [ -n "$EXPECTED_IDENTITY" ] && [ -z "$EXISTING_IDENTITY_FILE" ] && [ "$EXISTING_IDENTITY_PROMPT" -ne 1 ]; then
+    echo "error: --expected-npub requires --existing-identity-file" >&2
+    exit 1
+fi
 
 validate_welcomer_inputs
 
@@ -737,6 +827,7 @@ log "Marmot home: $MARMOT_HOME"
 log "Marmot socket: $MARMOT_AGENT_SOCKET"
 log "Marmot agent label: $MARMOT_AGENT_LABEL"
 install_wn_agent "$platform" "$tmpdir"
+import_existing_identity
 install_plugin "$tmpdir"
 enable_openclaw_plugin
 bootstrap_agent


### PR DESCRIPTION
## Summary

- add `wn-agent import-identity` with secure owner-only file ingestion and masked `/dev/tty` input
- verify an optional expected npub/hex before persistence, then idempotently create, reuse, reactivate, or repair the exact local-signing account
- wire identical `--existing-identity-file`, `--expected-npub`, and `--generate-identity` behavior into the Hermes and OpenClaw installers
- bootstrap imported identities with `--no-create --account-id-hex`, preserving connector-specific homes, sockets, services, and labels
- document pinned-release flows and add account, connector, installer, and secret-leak regressions

## Security

This PR touches sensitive identity/key-handling paths and requires human review before merge.

- secret values never enter argv, environment variables, logs, installer output, host config, or `bootstrap.json`
- file imports reject symlinks, non-regular files, wrong ownership, group/other access, and multiple hard links
- expected-public-key mismatch fails before account persistence, service startup, KeyPackage publication, or host configuration
- transient input buffers zeroize on drop; masked prompts restore terminal state across interrupts and job-control signals
- interrupted/duplicate account imports recover without creating a second signing identity or invisible keychain orphan

## Verification

- `just fast-ci`
- `cargo test -p marmot-account`
- `cargo test -p agent-connector`
- `cargo clippy -p agent-connector -p marmot-account --all-targets --locked -- -D warnings`
- `just hermes-dev-script-test`
- `integrations/test_installer_systemd_service.sh hermes`
- `integrations/test_installer_systemd_service.sh openclaw`
- real PTY masked-import success and SIGINT restoration checks

`just openclaw-dev-script-test` passed after merging current `master`; the OpenClaw installer-specific systemd/import test also passed.

Fixes #1128
Fixes #822


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure import of existing Nostr identities from protected files or interactive prompts.
  * Added identity verification using an expected npub or hexadecimal identity.
  * Installers now support preserving an existing identity and reusing it during bootstrap.
  * Added options for existing-identity imports and explicit generated-identity onboarding.

* **Bug Fixes**
  * Improved recovery and idempotent reuse of interrupted or previously signed-out accounts.
  * Prevented identity secrets from appearing in command output, logs, or persisted account records.

* **Documentation**
  * Updated Hermes and OpenClaw installation guidance for existing-identity onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->