### PR TITLE
fix: configure Hermes Marmot sender authorization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,3 +358,53 @@ jobs:
 
       - name: Run Tamarin proofs
         run: make -C formal/tamarin prove
+
+  hermes-installer-auth:
+    name: Hermes installer auth
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install system dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends python3 python3-venv git
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+
+      - name: Hermes configure_gateway Python unit tests
+        run: |
+          set -euo pipefail
+          env -i HOME="$HOME" PATH="$PATH" USER="${USER:-runner}" \
+            python3 -m unittest discover -s integrations/hermes/marmot/tests -v
+
+      - name: Prepare isolated Hermes checkout for authorization E2E
+        run: |
+          set -euo pipefail
+          ./scripts/hermes_marmot_dev_setup.sh \
+            --root "$RUNNER_TEMP/hermes-installer-auth" \
+            --hermes-ref af8d698b418ede7dc8b078a8116510699ec94eb7
+
+      - name: Hermes installer unit and mock regressions
+        run: |
+          set -euo pipefail
+          bash -n scripts/install-hermes-marmot.sh
+          bash -n integrations/hermes/marmot/tests/test_installer_env.sh
+          bash -n scripts/hermes_marmot_deterministic_e2e.sh
+          python3 -m py_compile scripts/hermes_marmot_configure_gateway.py integrations/hermes/marmot/tests/e2e_gateway_auth.py
+          integrations/hermes/marmot/tests/test_dev_scripts.sh
+
+      - name: Real Hermes authorization and deterministic Marmot E2E
+        run: |
+          set -euo pipefail
+          # The deterministic runner sources the pinned dev root, runs
+          # test_installer_env.sh against its real GatewayRunner, then runs the
+          # adapter E2E. A missing Hermes venv is a hard failure, not a skip.
+          ./scripts/hermes_marmot_deterministic_e2e.sh --root "$RUNNER_TEMP/hermes-installer-auth"

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -38,13 +38,15 @@ curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-la
 ```
 
 For repeatable noninteractive setup, pass the allowed inviter/welcomer and allowed
-message sender as either an `npub` or raw hex public key:
+message sender as either an `npub` or raw hex public key. `--allow-user` may be
+repeated to authorize multiple senders:
 
 ```sh
 curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh" | \
   bash -s -- --yes \
     --allow-welcomer npub1... \
-    --allow-user npub1...
+    --allow-user npub1... \
+    --allow-user 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
 To accept Marmot messages from any sender (explicit opt-in):

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -37,13 +37,27 @@ One-line install:
 curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh" | bash
 ```
 
-For repeatable noninteractive setup, pass the allowed inviter/welcomer as either
-an `npub` or raw hex public key:
+For repeatable noninteractive setup, pass the allowed inviter/welcomer and allowed
+message sender as either an `npub` or raw hex public key:
 
 ```sh
 curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh" | \
-  bash -s -- --yes --allow-welcomer npub1...
+  bash -s -- --yes \
+    --allow-welcomer npub1... \
+    --allow-user npub1...
 ```
+
+To accept Marmot messages from any sender (explicit opt-in):
+
+```sh
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh" | \
+  bash -s -- --yes --allow-all-users
+```
+
+Welcomer allowlist entries control which accounts may invite the Marmot agent
+through `wn-agent`. Message-sender allowlist entries control which Marmot senders
+Hermes accepts after gateway restart via `$HERMES_HOME/.env`
+(`MARMOT_ALLOWED_USERS` and `MARMOT_ALLOW_ALL_USERS`).
 
 Use a versioned `wn-agent-v<version>` release URL when you need a pinned install.
 
@@ -328,6 +342,19 @@ On connect, `MARMOT_WELCOMER_ALLOWLIST` (or `MARMOT_DM_ALLOW_FROM`) mirrors
 configured hex account ids into `wn-agent`'s welcomer allowlist so approved
 inviters are accepted. Non-hex entries are ignored. When unset, the adapter
 does not touch an allowlist managed directly on `wn-agent`.
+
+### Hermes message-sender authorization
+
+Hermes applies a separate sender gate before Marmot messages reach the agent.
+The installer persists this in `$HERMES_HOME/.env`, which Hermes loads at gateway
+startup:
+
+- `MARMOT_ALLOWED_USERS` — comma-separated lowercase hex Marmot account ids
+- `MARMOT_ALLOW_ALL_USERS` — explicit opt-in to accept any Marmot sender
+
+These variables are independent from the welcomer allowlist above. A phone user
+may be allowed to invite the agent without being allowed to message Hermes, and
+vice versa. Restart Hermes after changing either variable.
 
 ### Media trust model
 

--- a/integrations/hermes/marmot/plugin.yaml
+++ b/integrations/hermes/marmot/plugin.yaml
@@ -45,6 +45,12 @@ optional_env:
   - name: MARMOT_WELCOMER_ALLOWLIST
     description: "Comma-separated hex account ids mirrored into wn-agent's welcomer allowlist on connect (also MARMOT_DM_ALLOW_FROM)"
     password: false
+  - name: MARMOT_ALLOWED_USERS
+    description: "Comma-separated hex Marmot account ids allowed to message Hermes; loaded from $HERMES_HOME/.env at gateway startup"
+    password: false
+  - name: MARMOT_ALLOW_ALL_USERS
+    description: "When true, accept Marmot messages from any sender; loaded from $HERMES_HOME/.env at gateway startup"
+    password: false
   - name: MARMOT_MEDIA_LOCAL_ROOTS
     description: "Comma-separated local directories allowed for outbound media sends; defaults to $MARMOT_HOME/dev/inbound-media"
     password: false

--- a/integrations/hermes/marmot/tests/e2e_gateway_auth.py
+++ b/integrations/hermes/marmot/tests/e2e_gateway_auth.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Fresh-process Hermes gateway authorization check against installed Marmot .env."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    hermes_home = os.environ.get("HERMES_HOME")
+    if not hermes_home:
+        print("error: HERMES_HOME is required", file=sys.stderr)
+        return 2
+
+    allowed_hex = os.environ.get("MARMOT_TEST_ALLOWED_USER_HEX")
+    unknown_hex = os.environ.get("MARMOT_TEST_UNKNOWN_USER_HEX")
+    if not allowed_hex or not unknown_hex:
+        print(
+            "error: MARMOT_TEST_ALLOWED_USER_HEX and MARMOT_TEST_UNKNOWN_USER_HEX are required",
+            file=sys.stderr,
+        )
+        return 2
+
+    from hermes_cli.env_loader import load_hermes_dotenv
+    load_hermes_dotenv(hermes_home=hermes_home)
+
+    from hermes_cli.plugins import discover_plugins
+
+    discover_plugins()
+
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+    from gateway.session import SessionSource
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner.pairing_store = None
+    runner.pairing_stores = {}
+
+    allowed_source = SessionSource(
+        platform=Platform("marmot"),
+        chat_id=allowed_hex,
+        chat_type="dm",
+        user_id=allowed_hex,
+    )
+    unknown_source = SessionSource(
+        platform=Platform("marmot"),
+        chat_id=unknown_hex,
+        chat_type="dm",
+        user_id=unknown_hex,
+    )
+
+    allowed_ok = runner._is_user_authorized(allowed_source)
+    unknown_ok = runner._is_user_authorized(unknown_source)
+
+    print(f"allowed={str(allowed_ok).lower()} unknown={str(unknown_ok).lower()}")
+    return 0 if allowed_ok and not unknown_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/hermes/marmot/tests/e2e_gateway_auth.py
+++ b/integrations/hermes/marmot/tests/e2e_gateway_auth.py
@@ -34,9 +34,16 @@ def main() -> int:
     from gateway.session import SessionSource
 
     runner = object.__new__(GatewayRunner)
-    runner.adapters = {}
-    runner.pairing_store = None
-    runner.pairing_stores = {}
+    try:
+        runner.adapters = {}
+        runner.pairing_store = None
+        runner.pairing_stores = {}
+    except AttributeError:
+        print(
+            "error: Hermes GatewayRunner internals changed; update e2e_gateway_auth.py",
+            file=sys.stderr,
+        )
+        return 3
 
     allowed_source = SessionSource(
         platform=Platform("marmot"),
@@ -51,8 +58,15 @@ def main() -> int:
         user_id=unknown_hex,
     )
 
-    allowed_ok = runner._is_user_authorized(allowed_source)
-    unknown_ok = runner._is_user_authorized(unknown_source)
+    try:
+        allowed_ok = runner._is_user_authorized(allowed_source)
+        unknown_ok = runner._is_user_authorized(unknown_source)
+    except AttributeError:
+        print(
+            "error: Hermes GatewayRunner authorization hook changed; update e2e_gateway_auth.py",
+            file=sys.stderr,
+        )
+        return 3
 
     print(f"allowed={str(allowed_ok).lower()} unknown={str(unknown_ok).lower()}")
     return 0 if allowed_ok and not unknown_ok else 1

--- a/integrations/hermes/marmot/tests/test_configure_gateway.py
+++ b/integrations/hermes/marmot/tests/test_configure_gateway.py
@@ -476,7 +476,10 @@ class ConfigureHermesEnvTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             home = Path(tempdir)
             with self.assertRaises(ValueError):
-                self.module.validate_sender_auth_entries(["   "])
+                self.module.configure_hermes_env(
+                    hermes_home=home,
+                    add_allowed_users=["   "],
+                )
             self.assertFalse((home / ".env").exists())
 
     def test_requires_explicit_auth_for_fresh_target(self):
@@ -711,6 +714,10 @@ class ConfigureGatewayTransactionTests(unittest.TestCase):
             config_original = "model: gpt-4o\n"
             env_path.write_text(env_original, encoding="utf-8")
             config_path.write_text(config_original, encoding="utf-8")
+            env_path.chmod(0o640)
+            config_path.chmod(0o644)
+            env_mode_original = env_path.stat().st_mode & 0o777
+            config_mode_original = config_path.stat().st_mode & 0o777
             real_replace = os.replace
             replace_calls = {"count": 0}
 
@@ -735,6 +742,8 @@ class ConfigureGatewayTransactionTests(unittest.TestCase):
             self.assertEqual(replace_calls["count"], 3)
             self.assertEqual(env_path.read_text(encoding="utf-8"), env_original)
             self.assertEqual(config_path.read_text(encoding="utf-8"), config_original)
+            self.assertEqual(env_path.stat().st_mode & 0o777, env_mode_original)
+            self.assertEqual(config_path.stat().st_mode & 0o777, config_mode_original)
             self.assertFalse(
                 config_path.with_suffix(config_path.suffix + ".tmp").exists()
             )
@@ -889,42 +898,43 @@ class ConfigureGatewayCliTests(unittest.TestCase):
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("unrecognized arguments", completed.stderr)
 
-    def test_empty_allow_users_loops_are_guarded_for_bash_3_2(self):
-        source = INSTALL_SCRIPT.read_text(encoding="utf-8")
-        loop = 'for user in "${ALLOW_USERS[@]}"; do'
-        offsets = []
-        start = 0
-        while True:
-            offset = source.find(loop, start)
-            if offset == -1:
-                break
-            offsets.append(offset)
-            start = offset + len(loop)
-
-        self.assertGreater(len(offsets), 0)
-        for offset in offsets:
-            function_start = source.rfind("\n}", 0, offset) + 2
-            prefix = source[function_start:offset]
-            guarded = (
-                'if [ "${#ALLOW_USERS[@]}" -gt 0 ]; then' in prefix
-                or (
-                    'if [ "${#ALLOW_USERS[@]}" -eq 0 ]; then' in prefix
-                    and "return" in prefix
-                )
-            )
-            self.assertTrue(
-                guarded,
-                f"unguarded Bash 3.2 empty-array expansion near byte {offset}",
-            )
-
-        strict_start = source.index("strict_validate_sender_auth_preflight()")
-        strict_end = source.index("\n}\n", strict_start)
-        strict_body = source[strict_start:strict_end]
-        self.assertIn(
-            '"${args[@]+"${args[@]}"}"',
-            strict_body,
-            "empty preflight args must use the Bash 3.2-compatible expansion",
-        )
+    def test_installer_empty_allow_users_paths_run_under_nounset(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            cases = [
+                ("allow-all", ["--allow-all-users"]),
+                ("existing-auth", []),
+            ]
+            for name, extra_args in cases:
+                with self.subTest(name=name):
+                    home = root / name
+                    home.mkdir()
+                    if name == "existing-auth":
+                        (home / ".env").write_text(
+                            f"MARMOT_ALLOWED_USERS={USER_A}\n"
+                            "MARMOT_ALLOW_ALL_USERS=false\n",
+                            encoding="utf-8",
+                        )
+                    completed = subprocess.run(
+                        [
+                            "bash",
+                            str(INSTALL_SCRIPT),
+                            "--dry-run",
+                            "--yes",
+                            "--hermes-home",
+                            str(home),
+                            *extra_args,
+                        ],
+                        capture_output=True,
+                        text=True,
+                        env=scrub_marmot_env(),
+                    )
+                    self.assertEqual(
+                        completed.returncode,
+                        0,
+                        f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+                    )
+                    self.assertNotIn("unbound variable", completed.stderr)
 
     def test_installer_dry_run_accepts_allow_user(self):
         with tempfile.TemporaryDirectory() as tempdir:

--- a/integrations/hermes/marmot/tests/test_configure_gateway.py
+++ b/integrations/hermes/marmot/tests/test_configure_gateway.py
@@ -648,6 +648,28 @@ class ConfigureGatewayTransactionTests(unittest.TestCase):
     def setUp(self):
         self.module = load_module()
 
+    def test_env_dry_run_requires_configure_env_and_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            hermes_home = Path(tempdir) / "hermes"
+            env_path = hermes_home / ".env"
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--env-dry-run",
+                    "--allow-user",
+                    USER_A,
+                ],
+                capture_output=True,
+                text=True,
+                env={**scrub_marmot_env(), "HERMES_HOME": str(hermes_home)},
+            )
+            self.assertEqual(completed.returncode, 2)
+            self.assertIn(
+                "--env-dry-run requires --configure-env", completed.stderr
+            )
+            self.assertFalse(env_path.exists())
+
     def test_invalid_bool_leaves_env_and_config_byte_identical(self):
         with tempfile.TemporaryDirectory() as tempdir:
             home = Path(tempdir)

--- a/integrations/hermes/marmot/tests/test_configure_gateway.py
+++ b/integrations/hermes/marmot/tests/test_configure_gateway.py
@@ -23,6 +23,9 @@ USER_C = "33" * 32
 
 
 def load_module():
+    scripts_dir = str(SCRIPT_PATH.parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
     spec = importlib.util.spec_from_file_location(
         "hermes_marmot_configure_gateway",
         SCRIPT_PATH,
@@ -469,6 +472,13 @@ class ConfigureHermesEnvTests(unittest.TestCase):
                 )
             self.assertFalse((home / ".env").exists())
 
+    def test_rejects_blank_explicit_user(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            with self.assertRaises(ValueError):
+                self.module.validate_sender_auth_entries(["   "])
+            self.assertFalse((home / ".env").exists())
+
     def test_requires_explicit_auth_for_fresh_target(self):
         with tempfile.TemporaryDirectory() as tempdir:
             home = Path(tempdir)
@@ -505,6 +515,28 @@ class ConfigureHermesEnvTests(unittest.TestCase):
 
         self.assertEqual(state.allowed_users_hex, [USER_A])
         self.assertTrue(state.allow_all_users)
+
+    def test_preserves_export_prefix_when_rewriting_managed_env_lines(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            env_path = home / ".env"
+            env_path.write_text(
+                "\n".join(
+                    [
+                        f"export MARMOT_ALLOWED_USERS={USER_A}",
+                        "export MARMOT_ALLOW_ALL_USERS=false",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            self.module.configure_hermes_env(
+                hermes_home=home,
+                add_allowed_users=[USER_B],
+            )
+            text = env_path.read_text(encoding="utf-8")
+
+        self.assertIn(f"export MARMOT_ALLOWED_USERS={USER_A},{USER_B}", text)
+        self.assertIn("export MARMOT_ALLOW_ALL_USERS=false", text)
 
     def test_reads_unquoted_inline_comments(self):
         with tempfile.TemporaryDirectory() as tempdir:
@@ -612,6 +644,138 @@ class ConfigureHermesEnvTests(unittest.TestCase):
             self.assertFalse((home / ".env").exists())
 
 
+class ConfigureGatewayTransactionTests(unittest.TestCase):
+    def setUp(self):
+        self.module = load_module()
+
+    def test_invalid_bool_leaves_env_and_config_byte_identical(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            env_path = home / ".env"
+            config_path = home / "config.yaml"
+            env_original = f"MARMOT_ALLOWED_USERS={USER_A}\nMARMOT_ALLOW_ALL_USERS=false\n"
+            config_original = "model: gpt-4o\n"
+            env_path.write_text(env_original, encoding="utf-8")
+            config_path.write_text(config_original, encoding="utf-8")
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--home",
+                    str(home),
+                    "--configure-env",
+                    "--quiet",
+                    "--allow-user",
+                    USER_B,
+                    "--agent-home",
+                    str(home / "marmot-agent"),
+                    "--streaming",
+                    "maybe",
+                ],
+                capture_output=True,
+                text=True,
+                env=scrub_marmot_env(),
+            )
+            self.assertEqual(completed.returncode, 2, completed.stderr)
+            self.assertEqual(env_path.read_text(encoding="utf-8"), env_original)
+            self.assertEqual(config_path.read_text(encoding="utf-8"), config_original)
+
+    def test_config_write_failure_restores_env_byte_identical(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            env_path = home / ".env"
+            config_path = home / "config.yaml"
+            env_original = f"MARMOT_ALLOWED_USERS={USER_A}\nMARMOT_ALLOW_ALL_USERS=false\n"
+            config_original = "model: gpt-4o\n"
+            env_path.write_text(env_original, encoding="utf-8")
+            config_path.write_text(config_original, encoding="utf-8")
+            real_replace = os.replace
+            replace_calls = {"count": 0}
+
+            def replace_side_effect(src, dst, *args, **kwargs):
+                replace_calls["count"] += 1
+                if replace_calls["count"] == 2:
+                    raise OSError("replace failed")
+                return real_replace(src, dst, *args, **kwargs)
+
+            with mock.patch("os.replace", side_effect=replace_side_effect):
+                with self.assertRaises(OSError):
+                    self.module.commit_env_and_config_transaction(
+                        env_path=env_path,
+                        env_lines=[
+                            f"MARMOT_ALLOWED_USERS={USER_A},{USER_B}",
+                            "MARMOT_ALLOW_ALL_USERS=false",
+                        ],
+                        config_path=config_path,
+                        config_text="platforms: {}\n",
+                        config_backup=False,
+                    )
+            self.assertEqual(replace_calls["count"], 3)
+            self.assertEqual(env_path.read_text(encoding="utf-8"), env_original)
+            self.assertEqual(config_path.read_text(encoding="utf-8"), config_original)
+            self.assertFalse(
+                config_path.with_suffix(config_path.suffix + ".tmp").exists()
+            )
+
+    def test_env_only_invalid_bool_leaves_env_byte_identical(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            env_path = home / ".env"
+            env_original = f"MARMOT_ALLOWED_USERS={USER_A}\nMARMOT_ALLOW_ALL_USERS=false\n"
+            env_path.write_text(env_original, encoding="utf-8")
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--home",
+                    str(home),
+                    "--configure-env",
+                    "--quiet",
+                    "--allow-user",
+                    USER_B,
+                    "--streaming",
+                    "maybe",
+                ],
+                capture_output=True,
+                text=True,
+                env=scrub_marmot_env(),
+            )
+            self.assertEqual(completed.returncode, 2, completed.stderr)
+            self.assertEqual(env_path.read_text(encoding="utf-8"), env_original)
+
+    def test_malformed_existing_config_leaves_targets_byte_identical(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            env_path = home / ".env"
+            config_path = home / "config.yaml"
+            env_original = f"MARMOT_ALLOWED_USERS={USER_A}\nMARMOT_ALLOW_ALL_USERS=false\n"
+            config_original = "model: gpt-4o\nplatforms: <<\n"
+            env_path.write_text(env_original, encoding="utf-8")
+            config_path.write_text(config_original, encoding="utf-8")
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--home",
+                    str(home),
+                    "--configure-env",
+                    "--quiet",
+                    "--allow-user",
+                    USER_B,
+                    "--agent-home",
+                    str(home / "marmot-agent"),
+                    "--streaming",
+                    "0",
+                ],
+                capture_output=True,
+                text=True,
+                env=scrub_marmot_env(),
+            )
+            self.assertEqual(completed.returncode, 2, completed.stderr)
+            self.assertEqual(env_path.read_text(encoding="utf-8"), env_original)
+            self.assertEqual(config_path.read_text(encoding="utf-8"), config_original)
+
+
 class ConfigureGatewayEnvDryRunTests(unittest.TestCase):
     def test_env_dry_run_with_ambient_marmot_home_writes_nothing(self):
         with tempfile.TemporaryDirectory() as tempdir:
@@ -647,6 +811,47 @@ class ConfigureGatewayEnvDryRunTests(unittest.TestCase):
 
 
 class ConfigureGatewayCliTests(unittest.TestCase):
+    def _write_mock_curl(self, tempdir: Path) -> tuple[Path, Path]:
+        mock_bin = tempdir / "mock-bin"
+        mock_bin.mkdir()
+        curl_log = tempdir / "curl.log"
+        curl_log.write_text("", encoding="utf-8")
+        (mock_bin / "curl").write_text(
+            "\n".join(
+                [
+                    "#!/usr/bin/env bash",
+                    "set -euo pipefail",
+                    'printf "%s\\n" "$2" >>"${CURL_LOG:?}"',
+                    "exit 0",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        (mock_bin / "curl").chmod(0o755)
+        return mock_bin, curl_log
+
+    def _run_streamed_installer(
+        self,
+        tempdir: Path,
+        extra_args: list[str],
+        *,
+        env_extra: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        env = scrub_marmot_env(
+            {
+                "WN_AGENT_SHA": "9.9.9",
+                "MARMOT_RELEASE_TAG": "wn-agent-v9.9.9-test",
+                **(env_extra or {}),
+            }
+        )
+        return subprocess.run(
+            ["bash", "-s", "--", *extra_args],
+            input=INSTALL_SCRIPT.read_text(encoding="utf-8"),
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
     def test_skip_auth_requirement_flag_removed(self):
         completed = subprocess.run(
             [
@@ -662,10 +867,48 @@ class ConfigureGatewayCliTests(unittest.TestCase):
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("unrecognized arguments", completed.stderr)
 
+    def test_empty_allow_users_loops_are_guarded_for_bash_3_2(self):
+        source = INSTALL_SCRIPT.read_text(encoding="utf-8")
+        loop = 'for user in "${ALLOW_USERS[@]}"; do'
+        offsets = []
+        start = 0
+        while True:
+            offset = source.find(loop, start)
+            if offset == -1:
+                break
+            offsets.append(offset)
+            start = offset + len(loop)
+
+        self.assertGreater(len(offsets), 0)
+        for offset in offsets:
+            function_start = source.rfind("\n}", 0, offset) + 2
+            prefix = source[function_start:offset]
+            guarded = (
+                'if [ "${#ALLOW_USERS[@]}" -gt 0 ]; then' in prefix
+                or (
+                    'if [ "${#ALLOW_USERS[@]}" -eq 0 ]; then' in prefix
+                    and "return" in prefix
+                )
+            )
+            self.assertTrue(
+                guarded,
+                f"unguarded Bash 3.2 empty-array expansion near byte {offset}",
+            )
+
+        strict_start = source.index("strict_validate_sender_auth_preflight()")
+        strict_end = source.index("\n}\n", strict_start)
+        strict_body = source[strict_start:strict_end]
+        self.assertIn(
+            '"${args[@]+"${args[@]}"}"',
+            strict_body,
+            "empty preflight args must use the Bash 3.2-compatible expansion",
+        )
+
     def test_installer_dry_run_accepts_allow_user(self):
         with tempfile.TemporaryDirectory() as tempdir:
             completed = subprocess.run(
                 [
+                    "bash",
                     str(INSTALL_SCRIPT),
                     "--dry-run",
                     "--yes",
@@ -687,6 +930,102 @@ class ConfigureGatewayCliTests(unittest.TestCase):
         output = completed.stdout + completed.stderr
         self.assertIn("would configure Marmot message-sender authorization", output)
         self.assertNotIn(USER_A, output)
+
+    def test_streamed_install_rejects_checksum_invalid_npub_before_download(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            hermes_home = Path(tempdir) / "hermes-home"
+            mock_bin, curl_log = self._write_mock_curl(Path(tempdir))
+            completed = self._run_streamed_installer(
+                Path(tempdir),
+                [
+                    "--yes",
+                    "--hermes-home",
+                    str(hermes_home),
+                    "--no-service",
+                    "--allow-user",
+                    INVALID_NPUB,
+                ],
+                env_extra={
+                    "PATH": f"{mock_bin}:/usr/bin:/bin",
+                    "CURL_LOG": str(curl_log),
+                },
+            )
+            self.assertNotEqual(completed.returncode, 0)
+            combined = completed.stdout + completed.stderr
+            self.assertNotIn("npub1qq", combined)
+            self.assertEqual(curl_log.read_text(encoding="utf-8"), "")
+            self.assertFalse((hermes_home / ".env").exists())
+            self.assertFalse((hermes_home / "plugins" / "marmot").exists())
+
+    def test_streamed_dry_run_accepts_valid_npub_without_helper(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            hermes_home = Path(tempdir) / "hermes-home"
+            completed = self._run_streamed_installer(
+                Path(tempdir),
+                [
+                    "--dry-run",
+                    "--yes",
+                    "--hermes-home",
+                    str(hermes_home),
+                    "--allow-user",
+                    NPUB_SAMPLE,
+                ],
+            )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        output = completed.stdout + completed.stderr
+        self.assertIn("would configure Marmot message-sender authorization", output)
+        self.assertNotIn(NPUB_HEX, output)
+
+    def test_streamed_non_dry_rejects_blank_allow_user_before_download(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            hermes_home = Path(tempdir) / "hermes-home"
+            mock_bin, curl_log = self._write_mock_curl(Path(tempdir))
+            completed = self._run_streamed_installer(
+                Path(tempdir),
+                [
+                    "--yes",
+                    "--hermes-home",
+                    str(hermes_home),
+                    "--no-service",
+                    "--allow-user",
+                    "   ",
+                ],
+                env_extra={
+                    "PATH": f"{mock_bin}:/usr/bin:/bin",
+                    "CURL_LOG": str(curl_log),
+                },
+            )
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertEqual(curl_log.read_text(encoding="utf-8"), "")
+            self.assertFalse((hermes_home / ".env").exists())
+            self.assertFalse((hermes_home / "plugins" / "marmot").exists())
+
+
+    def test_guided_tty_read_failure_aborts_without_looping(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            hermes_home = Path(tempdir) / "hermes-home"
+            completed = subprocess.run(
+                [
+                    "bash",
+                    "-s",
+                    "--",
+                    "--hermes-home",
+                    str(hermes_home),
+                ],
+                input=INSTALL_SCRIPT.read_text(encoding="utf-8"),
+                capture_output=True,
+                text=True,
+                env=scrub_marmot_env(
+                    {
+                        "WN_AGENT_SHA": "9.9.9",
+                        "MARMOT_RELEASE_TAG": "wn-agent-v9.9.9-test",
+                        "HERMES_INSTALLER_TEST_PROMPT_TTY": "/dev/null",
+                    }
+                ),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        combined = completed.stdout + completed.stderr
+        self.assertIn("guided setup input is unavailable", combined)
 
     def test_installer_dry_run_rejects_bad_npub_without_helper(self):
         with tempfile.TemporaryDirectory() as tempdir:
@@ -740,7 +1079,7 @@ class ConfigureGatewayCliTests(unittest.TestCase):
             )
         self.assertNotEqual(completed.returncode, 0)
 
-    def test_streamed_dry_run_rejects_existing_env_without_helper(self):
+    def test_streamed_dry_run_accepts_valid_existing_env_without_helper(self):
         with tempfile.TemporaryDirectory() as tempdir:
             hermes_home = Path(tempdir) / "hermes-home"
             hermes_home.mkdir()
@@ -748,30 +1087,62 @@ class ConfigureGatewayCliTests(unittest.TestCase):
                 f"MARMOT_ALLOWED_USERS={USER_A}\nMARMOT_ALLOW_ALL_USERS=false\n",
                 encoding="utf-8",
             )
-            completed = subprocess.run(
+            completed = self._run_streamed_installer(
+                Path(tempdir),
                 [
-                    "bash",
-                    "-s",
-                    "--",
                     "--dry-run",
                     "--yes",
                     "--hermes-home",
                     str(hermes_home),
                 ],
-                input=INSTALL_SCRIPT.read_text(encoding="utf-8"),
-                capture_output=True,
-                text=True,
-                env=scrub_marmot_env(
-                    {
-                        "WN_AGENT_SHA": "9.9.9",
-                        "MARMOT_RELEASE_TAG": "wn-agent-v9.9.9-test",
-                    }
-                ),
             )
-        self.assertNotEqual(completed.returncode, 0)
-        combined = completed.stdout + completed.stderr
-        self.assertIn("cannot strictly validate existing sender authorization", combined)
-        self.assertNotIn(USER_A, combined)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        output = completed.stdout + completed.stderr
+        self.assertIn("would preserve or update existing Marmot message-sender authorization", output)
+        self.assertNotIn(USER_A, output)
+
+    def test_streamed_non_dry_malformed_existing_env_fails_before_download(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            hermes_home = Path(tempdir) / "hermes-home"
+            hermes_home.mkdir()
+            env_original = "MARMOT_ALLOWED_USERS=not-a-valid-user\n"
+            (hermes_home / ".env").write_text(env_original, encoding="utf-8")
+            mock_bin, curl_log = self._write_mock_curl(Path(tempdir))
+            completed = self._run_streamed_installer(
+                Path(tempdir),
+                [
+                    "--yes",
+                    "--hermes-home",
+                    str(hermes_home),
+                    "--no-service",
+                ],
+                env_extra={
+                    "PATH": f"{mock_bin}:/usr/bin:/bin",
+                    "CURL_LOG": str(curl_log),
+                },
+            )
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertEqual(curl_log.read_text(encoding="utf-8"), "")
+            self.assertEqual((hermes_home / ".env").read_text(encoding="utf-8"), env_original)
+            self.assertFalse((hermes_home / "plugins" / "marmot").exists())
+
+    def test_streamed_dry_run_valid_existing_env_preserves_bytes(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            hermes_home = Path(tempdir) / "hermes-home"
+            hermes_home.mkdir()
+            env_original = f"MARMOT_ALLOWED_USERS={USER_A}\nMARMOT_ALLOW_ALL_USERS=false\n"
+            (hermes_home / ".env").write_text(env_original, encoding="utf-8")
+            completed = self._run_streamed_installer(
+                Path(tempdir),
+                [
+                    "--dry-run",
+                    "--yes",
+                    "--hermes-home",
+                    str(hermes_home),
+                ],
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual((hermes_home / ".env").read_text(encoding="utf-8"), env_original)
 
     def test_streamed_install_fails_before_download_without_sender_auth(self):
         with tempfile.TemporaryDirectory() as tempdir:

--- a/integrations/hermes/marmot/tests/test_configure_gateway.py
+++ b/integrations/hermes/marmot/tests/test_configure_gateway.py
@@ -1,3 +1,4 @@
+import ast
 import importlib.util
 import os
 import socket
@@ -842,6 +843,69 @@ class ConfigureGatewayEnvDryRunTests(unittest.TestCase):
 
 
 class ConfigureGatewayCliTests(unittest.TestCase):
+    def test_streamed_auth_validator_matches_canonical_helper(self):
+        canonical_source = SCRIPT_PATH.read_text(encoding="utf-8")
+        installer_source = INSTALL_SCRIPT.read_text(encoding="utf-8")
+        heredoc_start = installer_source.index(
+            "        python3 - \"${args[@]+\"${args[@]}\"}\" <<'PY'\n"
+        )
+        embedded_start = installer_source.index("\n", heredoc_start) + 1
+        embedded_end = installer_source.index("\nPY\n}", embedded_start)
+        embedded_source = installer_source[embedded_start:embedded_end]
+
+        canonical_tree = ast.parse(canonical_source)
+        embedded_tree = ast.parse(embedded_source)
+
+        def definitions(tree: ast.Module) -> dict[str, str]:
+            return {
+                node.name: ast.dump(node, include_attributes=False)
+                for node in tree.body
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+
+        def assignments(tree: ast.Module) -> dict[str, str]:
+            result: dict[str, str] = {}
+            for node in tree.body:
+                if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+                    continue
+                target = node.targets[0]
+                if isinstance(target, ast.Name):
+                    result[target.id] = ast.dump(node.value, include_attributes=False)
+            return result
+
+        canonical_definitions = definitions(canonical_tree)
+        embedded_definitions = definitions(embedded_tree)
+        for name in (
+            "_bech32_polymod",
+            "_convert_bits",
+            "_npub_to_hex",
+            "normalize_account_id",
+            "_validate_account_id",
+            "validate_sender_auth_entries",
+            "_parse_dotenv_scalar",
+            "_parse_allowed_users_value",
+            "_managed_env_key",
+        ):
+            with self.subTest(definition=name):
+                self.assertEqual(
+                    embedded_definitions[name],
+                    canonical_definitions[name],
+                )
+
+        canonical_assignments = assignments(canonical_tree)
+        embedded_assignments = assignments(embedded_tree)
+        for name in (
+            "ACCOUNT_ID_HEX_RE",
+            "_BECH32_CHARSET",
+            "_BECH32_VALUES",
+            "MANAGED_ENV_KEYS",
+        ):
+            with self.subTest(assignment=name):
+                self.assertEqual(
+                    embedded_assignments[name],
+                    canonical_assignments[name],
+                )
+
     def _write_mock_curl(self, tempdir: Path) -> tuple[Path, Path]:
         mock_bin = tempdir / "mock-bin"
         mock_bin.mkdir()
@@ -1007,6 +1071,26 @@ class ConfigureGatewayCliTests(unittest.TestCase):
         output = completed.stdout + completed.stderr
         self.assertIn("would configure Marmot message-sender authorization", output)
         self.assertNotIn(NPUB_HEX, output)
+
+    def test_streamed_dry_run_accepts_comma_separated_users_without_helper(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            hermes_home = Path(tempdir) / "hermes-home"
+            completed = self._run_streamed_installer(
+                Path(tempdir),
+                [
+                    "--dry-run",
+                    "--yes",
+                    "--hermes-home",
+                    str(hermes_home),
+                    "--allow-user",
+                    f"{USER_A},{USER_B}",
+                ],
+            )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        output = completed.stdout + completed.stderr
+        self.assertIn("would configure Marmot message-sender authorization", output)
+        self.assertNotIn(USER_A, output)
+        self.assertNotIn(USER_B, output)
 
     def test_streamed_non_dry_rejects_blank_allow_user_before_download(self):
         with tempfile.TemporaryDirectory() as tempdir:

--- a/integrations/hermes/marmot/tests/test_configure_gateway.py
+++ b/integrations/hermes/marmot/tests/test_configure_gateway.py
@@ -1,14 +1,25 @@
 import importlib.util
 import os
 import socket
+import subprocess
+import sys
 import tempfile
 import unittest
 import unittest.mock
 from pathlib import Path
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "hermes_marmot_configure_gateway.py"
+INSTALL_SCRIPT = REPO_ROOT / "scripts" / "install-hermes-marmot.sh"
+
+NPUB_SAMPLE = "npub14f8usejl26twx0dhuxjh9cas7keav9vr0v8nvtwtrjqx3vycc76qqh9nsy"
+INVALID_NPUB = "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"
+NPUB_HEX = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4"
+USER_A = "11" * 32
+USER_B = "22" * 32
+USER_C = "33" * 32
 
 
 def load_module():
@@ -18,6 +29,7 @@ def load_module():
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
+    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
 
@@ -88,6 +100,16 @@ def restore_marmot_env(saved):
         if key.startswith("MARMOT_"):
             os.environ.pop(key)
     os.environ.update(saved)
+
+
+def scrub_marmot_env(env: dict[str, str] | None = None) -> dict[str, str]:
+    base = dict(os.environ)
+    for key in list(base):
+        if key.startswith("MARMOT_"):
+            base.pop(key, None)
+    if env:
+        base.update(env)
+    return base
 
 
 class ConfigureGatewayTests(unittest.TestCase):
@@ -310,6 +332,473 @@ class MarmotPlatformEnablementTests(unittest.TestCase):
                 self.assertEqual(adapter.socket_path, str(socket_path))
         finally:
             restore_marmot_env(saved_env)
+
+
+class ConfigureHermesEnvTests(unittest.TestCase):
+    def setUp(self):
+        self.module = load_module()
+
+    def test_fresh_env_writes_allowlist_and_disallow_all(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            self.module.configure_hermes_env(
+                hermes_home=home,
+                add_allowed_users=[USER_A],
+            )
+            env_path = home / ".env"
+            text = env_path.read_text(encoding="utf-8")
+            state = self.module.read_hermes_env_auth(env_path)
+
+            self.assertIn(f"MARMOT_ALLOWED_USERS={USER_A}", text)
+            self.assertIn("MARMOT_ALLOW_ALL_USERS=false", text)
+            self.assertEqual(state.allowed_users_hex, [USER_A])
+            self.assertFalse(state.allow_all_users)
+            self.assertEqual(env_path.stat().st_mode & 0o777, 0o600)
+
+    def test_normalizes_mixed_npub_and_hex_users(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            self.module.configure_hermes_env(
+                hermes_home=home,
+                add_allowed_users=[NPUB_SAMPLE, USER_B.upper(), f"0x{USER_C}"],
+            )
+            state = self.module.read_hermes_env_auth(home / ".env")
+
+        self.assertEqual(
+            state.allowed_users_hex,
+            sorted([NPUB_HEX, USER_B, USER_C]),
+        )
+
+    def test_reinstall_unions_users_and_preserves_unrelated_env_lines(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            env_path = home / ".env"
+            env_path.write_text(
+                "\n".join(
+                    [
+                        "# gateway secrets",
+                        "",
+                        "OPENAI_API_KEY=secret",
+                        f'MARMOT_ALLOWED_USERS = "{USER_A}"',
+                        "MARMOT_ALLOW_ALL_USERS=false",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            self.module.configure_hermes_env(
+                hermes_home=home,
+                add_allowed_users=[USER_B],
+            )
+            text = env_path.read_text(encoding="utf-8")
+            state = self.module.read_hermes_env_auth(env_path)
+
+        self.assertIn("OPENAI_API_KEY=secret", text)
+        self.assertIn("# gateway secrets", text)
+        self.assertEqual(state.allowed_users_hex, sorted([USER_A, USER_B]))
+        self.assertFalse(state.allow_all_users)
+        self.assertEqual(text.count("MARMOT_ALLOWED_USERS="), 1)
+        self.assertEqual(text.count("MARMOT_ALLOW_ALL_USERS="), 1)
+
+    def test_reinstall_without_new_users_preserves_existing_allowlist(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            env_path = home / ".env"
+            env_path.write_text(
+                f"MARMOT_ALLOWED_USERS={USER_A}\nMARMOT_ALLOW_ALL_USERS=false\n",
+                encoding="utf-8",
+            )
+            before = env_path.read_text(encoding="utf-8")
+            self.module.configure_hermes_env(
+                hermes_home=home,
+                add_allowed_users=[],
+            )
+            after = env_path.read_text(encoding="utf-8")
+
+        self.assertEqual(before, after)
+
+    def test_explicit_allow_all_opt_in(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            self.module.configure_hermes_env(
+                hermes_home=home,
+                add_allowed_users=[USER_A],
+                allow_all_opt_in=True,
+            )
+            state = self.module.read_hermes_env_auth(home / ".env")
+
+        self.assertTrue(state.allow_all_users)
+
+    def test_preserves_existing_allow_all_on_reinstall(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            env_path = home / ".env"
+            env_path.write_text(
+                f"MARMOT_ALLOWED_USERS={USER_A}\nMARMOT_ALLOW_ALL_USERS=true\n",
+                encoding="utf-8",
+            )
+            self.module.configure_hermes_env(
+                hermes_home=home,
+                add_allowed_users=[USER_B],
+            )
+            state = self.module.read_hermes_env_auth(env_path)
+
+        self.assertTrue(state.allow_all_users)
+        self.assertEqual(state.allowed_users_hex, sorted([USER_A, USER_B]))
+
+    def test_malformed_existing_env_fails_closed_without_modifying(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            env_path = home / ".env"
+            original = "MARMOT_ALLOWED_USERS=not-a-valid-user\n"
+            env_path.write_text(original, encoding="utf-8")
+            with self.assertRaises(ValueError):
+                self.module.configure_hermes_env(
+                    hermes_home=home,
+                    add_allowed_users=[USER_A],
+                )
+            self.assertEqual(env_path.read_text(encoding="utf-8"), original)
+
+    def test_malformed_explicit_user_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            with self.assertRaises(ValueError):
+                self.module.configure_hermes_env(
+                    hermes_home=home,
+                    add_allowed_users=["npub1invalid"],
+                )
+            self.assertFalse((home / ".env").exists())
+
+    def test_requires_explicit_auth_for_fresh_target(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            with self.assertRaises(ValueError):
+                self.module.configure_hermes_env(hermes_home=home)
+
+    def test_existing_valid_auth_satisfies_requirement_without_new_users(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            env_path = home / ".env"
+            env_path.write_text(
+                f"MARMOT_ALLOWED_USERS={USER_A}\nMARMOT_ALLOW_ALL_USERS=false\n",
+                encoding="utf-8",
+            )
+            self.module.configure_hermes_env(hermes_home=home)
+            state = self.module.read_hermes_env_auth(env_path)
+
+        self.assertEqual(state.allowed_users_hex, [USER_A])
+
+    def test_reads_exported_allowlist_and_allow_all(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            env_path = home / ".env"
+            env_path.write_text(
+                "\n".join(
+                    [
+                        f"  export MARMOT_ALLOWED_USERS={USER_A}",
+                        "export MARMOT_ALLOW_ALL_USERS=true",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            state = self.module.read_hermes_env_auth(env_path)
+
+        self.assertEqual(state.allowed_users_hex, [USER_A])
+        self.assertTrue(state.allow_all_users)
+
+    def test_reads_unquoted_inline_comments(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            env_path = home / ".env"
+            env_path.write_text(
+                f"MARMOT_ALLOWED_USERS={USER_A}  # phone user\n"
+                "MARMOT_ALLOW_ALL_USERS=false  # keep restricted\n",
+                encoding="utf-8",
+            )
+            state = self.module.read_hermes_env_auth(env_path)
+
+        self.assertEqual(state.allowed_users_hex, [USER_A])
+        self.assertFalse(state.allow_all_users)
+
+    def test_reads_tab_before_inline_comments(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            env_path = home / ".env"
+            env_path.write_text(
+                f"MARMOT_ALLOWED_USERS={USER_A}\t# tabbed comment\n"
+                "MARMOT_ALLOW_ALL_USERS=false\n",
+                encoding="utf-8",
+            )
+            state = self.module.read_hermes_env_auth(env_path)
+
+        self.assertEqual(state.allowed_users_hex, [USER_A])
+        self.assertFalse(state.allow_all_users)
+
+    def test_atomic_write_closes_fd_when_chmod_fails(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            with mock.patch("os.chmod", side_effect=OSError("chmod failed")):
+                with self.assertRaises(OSError):
+                    self.module.configure_hermes_env(
+                        hermes_home=home,
+                        add_allowed_users=[USER_A],
+                    )
+            self.assertEqual(list(home.glob(".env.*")), [])
+            self.assertFalse((home / ".env").exists())
+
+    def test_last_assignment_wins_for_duplicate_managed_keys(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            env_path = home / ".env"
+            env_path.write_text(
+                "\n".join(
+                    [
+                        f"MARMOT_ALLOWED_USERS={USER_A}",
+                        "OPENAI_API_KEY=secret",
+                        f"MARMOT_ALLOWED_USERS={USER_B}",
+                        "MARMOT_ALLOW_ALL_USERS=false",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            self.module.configure_hermes_env(
+                hermes_home=home,
+                add_allowed_users=[USER_C],
+            )
+            text = env_path.read_text(encoding="utf-8")
+            state = self.module.read_hermes_env_auth(env_path)
+
+        self.assertEqual(state.allowed_users_hex, sorted([USER_B, USER_C]))
+        self.assertEqual(text.count("MARMOT_ALLOWED_USERS="), 1)
+        self.assertIn("OPENAI_API_KEY=secret", text)
+
+    def test_ambient_marmot_auth_env_does_not_broaden_target(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "MARMOT_ALLOWED_USERS": USER_B,
+                    "MARMOT_ALLOW_ALL_USERS": "true",
+                },
+                clear=False,
+            ):
+                with self.assertRaises(ValueError):
+                    self.module.configure_hermes_env(hermes_home=home)
+
+    def test_atomic_replace_uses_private_mode(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            self.module.configure_hermes_env(
+                hermes_home=home,
+                add_allowed_users=[USER_A],
+            )
+            env_path = home / ".env"
+            mode = env_path.stat().st_mode
+            self.assertEqual(mode & 0o777, 0o600)
+            self.assertFalse(env_path.with_suffix(".env.bak").exists())
+
+    def test_atomic_write_cleans_up_temp_file_on_failure(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            with mock.patch("os.replace", side_effect=OSError("replace failed")):
+                with self.assertRaises(OSError):
+                    self.module.configure_hermes_env(
+                        hermes_home=home,
+                        add_allowed_users=[USER_A],
+                    )
+            leftovers = list(home.glob(".env.*"))
+            self.assertEqual(leftovers, [])
+            self.assertFalse((home / ".env").exists())
+
+
+class ConfigureGatewayEnvDryRunTests(unittest.TestCase):
+    def test_env_dry_run_with_ambient_marmot_home_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            home = Path(tempdir)
+            ambient_home = home / "ambient-marmot"
+            ambient_home.mkdir()
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "--home",
+                    str(home / "hermes"),
+                    "--configure-env",
+                    "--env-dry-run",
+                    "--quiet",
+                    "--allow-user",
+                    USER_A,
+                ],
+                capture_output=True,
+                text=True,
+                env=scrub_marmot_env(
+                    {
+                        "MARMOT_HOME": str(ambient_home),
+                        "MARMOT_AGENT_SOCKET": str(ambient_home / "dev" / "wn-agent.sock"),
+                        "MARMOT_ACCOUNT_ID_HEX": USER_B,
+                    }
+                ),
+            )
+            hermes_home = home / "hermes"
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertFalse((hermes_home / ".env").exists())
+            self.assertFalse((hermes_home / "config.yaml").exists())
+
+
+class ConfigureGatewayCliTests(unittest.TestCase):
+    def test_skip_auth_requirement_flag_removed(self):
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--configure-env",
+                "--skip-auth-requirement",
+            ],
+            capture_output=True,
+            text=True,
+            env=scrub_marmot_env(),
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("unrecognized arguments", completed.stderr)
+
+    def test_installer_dry_run_accepts_allow_user(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            completed = subprocess.run(
+                [
+                    str(INSTALL_SCRIPT),
+                    "--dry-run",
+                    "--yes",
+                    "--hermes-home",
+                    tempdir,
+                    "--allow-user",
+                    USER_A,
+                ],
+                capture_output=True,
+                text=True,
+                env=scrub_marmot_env(
+                    {
+                        "WN_AGENT_SHA": "9.9.9",
+                        "MARMOT_RELEASE_TAG": "wn-agent-v9.9.9-test",
+                    }
+                ),
+            )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        output = completed.stdout + completed.stderr
+        self.assertIn("would configure Marmot message-sender authorization", output)
+        self.assertNotIn(USER_A, output)
+
+    def test_installer_dry_run_rejects_bad_npub_without_helper(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            completed = subprocess.run(
+                [
+                    "bash",
+                    "-s",
+                    "--",
+                    "--dry-run",
+                    "--yes",
+                    "--hermes-home",
+                    tempdir,
+                    "--allow-user",
+                    INVALID_NPUB,
+                ],
+                input=INSTALL_SCRIPT.read_text(encoding="utf-8"),
+                capture_output=True,
+                text=True,
+                env=scrub_marmot_env(
+                    {
+                        "WN_AGENT_SHA": "9.9.9",
+                        "MARMOT_RELEASE_TAG": "wn-agent-v9.9.9-test",
+                    }
+                ),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        combined = completed.stdout + completed.stderr
+        self.assertNotIn("npub1qq", combined)
+
+    def test_installer_dry_run_rejects_missing_sender_without_helper(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            completed = subprocess.run(
+                [
+                    "bash",
+                    "-s",
+                    "--",
+                    "--dry-run",
+                    "--yes",
+                    "--hermes-home",
+                    tempdir,
+                ],
+                input=INSTALL_SCRIPT.read_text(encoding="utf-8"),
+                capture_output=True,
+                text=True,
+                env=scrub_marmot_env(
+                    {
+                        "WN_AGENT_SHA": "9.9.9",
+                        "MARMOT_RELEASE_TAG": "wn-agent-v9.9.9-test",
+                    }
+                ),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+
+    def test_streamed_dry_run_rejects_existing_env_without_helper(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            hermes_home = Path(tempdir) / "hermes-home"
+            hermes_home.mkdir()
+            (hermes_home / ".env").write_text(
+                f"MARMOT_ALLOWED_USERS={USER_A}\nMARMOT_ALLOW_ALL_USERS=false\n",
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                [
+                    "bash",
+                    "-s",
+                    "--",
+                    "--dry-run",
+                    "--yes",
+                    "--hermes-home",
+                    str(hermes_home),
+                ],
+                input=INSTALL_SCRIPT.read_text(encoding="utf-8"),
+                capture_output=True,
+                text=True,
+                env=scrub_marmot_env(
+                    {
+                        "WN_AGENT_SHA": "9.9.9",
+                        "MARMOT_RELEASE_TAG": "wn-agent-v9.9.9-test",
+                    }
+                ),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        combined = completed.stdout + completed.stderr
+        self.assertIn("cannot strictly validate existing sender authorization", combined)
+        self.assertNotIn(USER_A, combined)
+
+    def test_streamed_install_fails_before_download_without_sender_auth(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            hermes_home = Path(tempdir) / "hermes-home"
+            completed = subprocess.run(
+                [
+                    "bash",
+                    "-s",
+                    "--",
+                    "--yes",
+                    "--hermes-home",
+                    str(hermes_home),
+                    "--no-service",
+                ],
+                input=INSTALL_SCRIPT.read_text(encoding="utf-8"),
+                capture_output=True,
+                text=True,
+                env=scrub_marmot_env(
+                    {
+                        "WN_AGENT_SHA": "9.9.9",
+                        "MARMOT_RELEASE_TAG": "wn-agent-v9.9.9-test",
+                    }
+                ),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertFalse((hermes_home / ".env").exists())
+        self.assertFalse((hermes_home / "plugins" / "marmot").exists())
 
 
 if __name__ == "__main__":

--- a/integrations/hermes/marmot/tests/test_dev_scripts.sh
+++ b/integrations/hermes/marmot/tests/test_dev_scripts.sh
@@ -93,26 +93,104 @@ source "$default_root/env.sh"
 [ ! -e "$default_root" ]
 
 [ -x "$repo_root/scripts/install-hermes-marmot.sh" ]
+allowed_sender_hex="$(printf 'aa%.0s' {1..32})"
+installer_hermes_home="$tmp_parent/hermes-install-home"
+mkdir -p "$installer_hermes_home"
+
+run_installer_scrubbed() {
+    python3 - "$@" <<'PY'
+import os
+import subprocess
+import sys
+
+extra = {}
+args = sys.argv[1:]
+while args and args[0] == "--env":
+    args.pop(0)
+    key, value = args.pop(0).split("=", 1)
+    extra[key] = value
+
+env = {key: value for key, value in os.environ.items() if not key.startswith("MARMOT_")}
+env.update(extra)
+completed = subprocess.run(args, env=env, capture_output=True, text=True)
+sys.stdout.write(completed.stdout)
+sys.stderr.write(completed.stderr)
+raise SystemExit(completed.returncode)
+PY
+}
+
 "$repo_root/integrations/test_installer_systemd_service.sh" hermes
 installer_dry_run="$(
-    env -u MARMOT_HOME -u MARMOT_AGENT_SOCKET \
-        WN_AGENT_SHA="9.9.9" \
-        MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
-    "$repo_root/scripts/install-hermes-marmot.sh" --dry-run --yes
+    run_installer_scrubbed \
+        --env "WN_AGENT_SHA=9.9.9" \
+        --env "MARMOT_RELEASE_TAG=wn-agent-v9.9.9-test" \
+        --env "HERMES_HOME=$installer_hermes_home" \
+        "$repo_root/scripts/install-hermes-marmot.sh" --dry-run --yes --allow-user "$allowed_sender_hex"
 )"
 installer_stdin_dry_run="$(
-    env -u MARMOT_HOME -u MARMOT_AGENT_SOCKET \
-        WN_AGENT_SHA="9.9.9" \
-        MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
-    bash -s -- --dry-run --yes < "$repo_root/scripts/install-hermes-marmot.sh"
+    python3 - "$repo_root/scripts/install-hermes-marmot.sh" "$allowed_sender_hex" "$installer_hermes_home" <<'PY'
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+installer = Path(sys.argv[1])
+allowed_sender_hex = sys.argv[2]
+installer_hermes_home = sys.argv[3]
+env = {key: value for key, value in os.environ.items() if not key.startswith("MARMOT_")}
+env.update(
+    {
+        "WN_AGENT_SHA": "9.9.9",
+        "MARMOT_RELEASE_TAG": "wn-agent-v9.9.9-test",
+        "HERMES_HOME": installer_hermes_home,
+    }
+)
+completed = subprocess.run(
+    [
+        "bash",
+        "-s",
+        "--",
+        "--dry-run",
+        "--yes",
+        "--allow-user",
+        allowed_sender_hex,
+    ],
+    input=installer.read_text(encoding="utf-8"),
+    capture_output=True,
+    text=True,
+    env=env,
+)
+sys.stdout.write(completed.stdout)
+sys.stderr.write(completed.stderr)
+raise SystemExit(completed.returncode)
+PY
 )"
 installer_bad_welcomer_status=0
-env -u MARMOT_HOME -u MARMOT_AGENT_SOCKET \
-    WN_AGENT_SHA="9.9.9" \
-    MARMOT_RELEASE_TAG="wn-agent-v9.9.9-test" \
+run_installer_scrubbed \
+    --env "WN_AGENT_SHA=9.9.9" \
+    --env "MARMOT_RELEASE_TAG=wn-agent-v9.9.9-test" \
+    --env "HERMES_HOME=$installer_hermes_home" \
     "$repo_root/scripts/install-hermes-marmot.sh" --dry-run --yes --allow-welcomer not-a-key \
     >/dev/null 2>&1 || installer_bad_welcomer_status=$?
+installer_missing_sender_status=0
+run_installer_scrubbed \
+    --env "WN_AGENT_SHA=9.9.9" \
+    --env "MARMOT_RELEASE_TAG=wn-agent-v9.9.9-test" \
+    --env "HERMES_HOME=$installer_hermes_home" \
+    "$repo_root/scripts/install-hermes-marmot.sh" --dry-run --yes \
+    >/dev/null 2>&1 || installer_missing_sender_status=$?
 [ "$installer_bad_welcomer_status" -ne 0 ]
+[ "$installer_missing_sender_status" -ne 0 ]
+case "$installer_dry_run" in
+    *"would configure Marmot message-sender authorization"* ) ;;
+    *) echo "Hermes installer dry-run did not describe sender authorization" >&2; exit 1;;
+esac
+case "$installer_dry_run" in
+    *"$allowed_sender_hex"* )
+        echo "Hermes installer dry-run leaked sender identity" >&2
+        exit 1
+        ;;
+esac
 case "$installer_dry_run" in
     *"wn-agent-"*"9.9.9.tar.gz"* ) ;;
     *) echo "Hermes installer dry-run did not use WN_AGENT_SHA asset suffix" >&2; exit 1;;
@@ -171,5 +249,7 @@ case "$installer_stdin_dry_run" in
     *"--label hermes-agent"* ) ;;
     *) echo "Hermes installer stdin dry-run did not pass the Hermes bootstrap label" >&2; exit 1;;
 esac
+
+bash "$repo_root/integrations/hermes/marmot/tests/test_installer_env.sh"
 
 echo "dev script test passed"

--- a/integrations/hermes/marmot/tests/test_installer_env.sh
+++ b/integrations/hermes/marmot/tests/test_installer_env.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+installer="$repo_root/scripts/install-hermes-marmot.sh"
+configure_gateway="$repo_root/scripts/hermes_marmot_configure_gateway.py"
+integration_plugin="$repo_root/integrations/hermes/marmot"
+e2e_gateway_auth="$repo_root/integrations/hermes/marmot/tests/e2e_gateway_auth.py"
+user_a="$(printf '11%.0s' {1..32})"
+user_b="$(printf '22%.0s' {1..32})"
+user_c="$(printf '33%.0s' {1..32})"
+user_unknown="$(printf '44%.0s' {1..32})"
+
+[ -f "$installer" ]
+[ -f "$configure_gateway" ]
+bash -n "$installer"
+
+fixture_root="$(mktemp -d)"
+trap 'rm -rf "$fixture_root"' EXIT
+mock_bin="$fixture_root/mock-bin"
+mkdir -p "$mock_bin"
+curl_log="$fixture_root/curl.log"
+: >"$curl_log"
+
+cat >"$mock_bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+destination=""
+url=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o) destination="$2"; shift 2 ;;
+        http*) url="$1"; shift ;;
+        *) shift ;;
+    esac
+done
+printf '%s\n' "$url" >>"${CURL_LOG:?}"
+if [[ "$url" == *.sha256 ]]; then
+    printf '%s\n' fixture-hash >"$destination"
+else
+    : >"$destination"
+fi
+EOF
+
+cat >"$mock_bin/shasum" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' fixture-hash
+EOF
+
+cat >"$mock_bin/tar" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+archive=""
+destination=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -xzf) archive="$2"; shift 2 ;;
+        -C) destination="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+archive_name="$(basename "$archive")"
+case "$archive_name" in
+    wn-agent-*)
+        platform="${archive_name#wn-agent-}"
+        platform="${platform%-9.9.9.tar.gz}"
+        output_dir="$destination/wn-agent-$platform"
+        mkdir -p "$output_dir"
+        cat >"$output_dir/wn-agent" <<'SCRIPT'
+#!/usr/bin/env bash
+if [ "${1:-}" = bootstrap ]; then
+    printf '%s\n' '{"account_id_hex":"aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4","welcomer_account_ids_hex":["bb"]}'
+fi
+SCRIPT
+        chmod +x "$output_dir/wn-agent"
+        ;;
+    hermes-marmot-plugin-*)
+        plugin_dir="$destination/hermes-marmot-plugin"
+        mkdir -p "$plugin_dir"
+        cp "$INTEGRATION_PLUGIN_SOURCE/__init__.py" \
+            "$INTEGRATION_PLUGIN_SOURCE/adapter.py" \
+            "$INTEGRATION_PLUGIN_SOURCE/plugin.yaml" \
+            "$plugin_dir/"
+        cp "$CONFIGURE_GATEWAY_SOURCE" "$plugin_dir/configure_gateway.py"
+        ;;
+    *)
+        echo "unexpected archive: $archive_name" >&2
+        exit 1
+        ;;
+esac
+EOF
+
+cat >"$mock_bin/hermes" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+cat >"$mock_bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$mock_bin"/*
+
+scrub_marmot_env_python() {
+    python3 - "$@" <<'PY'
+import os
+import subprocess
+import sys
+
+extra = {}
+args = sys.argv[1:]
+while args and args[0] == "--env":
+    args.pop(0)
+    key, value = args.pop(0).split("=", 1)
+    extra[key] = value
+
+env = {key: value for key, value in os.environ.items() if not key.startswith("MARMOT_")}
+env.update(extra)
+subprocess.run(args, env=env, check=True)
+PY
+}
+
+run_installer() {
+    local case_root="$1"
+    shift
+    mkdir -p "$case_root"
+    : >"$case_root/systemctl.log"
+    : >"$curl_log"
+    scrub_marmot_env_python \
+        --env "CURL_LOG=$curl_log" \
+        --env "SYSTEMCTL_LOG=$case_root/systemctl.log" \
+        --env "CONFIGURE_GATEWAY_SOURCE=$configure_gateway" \
+        --env "INTEGRATION_PLUGIN_SOURCE=$integration_plugin" \
+        --env "HOME=$case_root/home" \
+        --env "HERMES_HOME=$case_root/hermes-home" \
+        --env "MARMOT_HOME=$case_root/marmot-home" \
+        --env "MARMOT_INSTALL_PREFIX=$case_root/install" \
+        --env "PATH=$mock_bin:/usr/bin:/bin" \
+        --env "WN_AGENT_SHA=9.9.9" \
+        --env "MARMOT_RELEASE_TAG=wn-agent-v9.9.9-test" \
+        "$installer" --yes --no-service "$@"
+}
+
+run_streamed_installer() {
+    local case_root="$1"
+    shift
+    mkdir -p "$case_root"
+    : >"$case_root/systemctl.log"
+    : >"$curl_log"
+    CURL_LOG="$curl_log" python3 - "$installer" "$case_root" "$configure_gateway" "$integration_plugin" "$mock_bin" "$@" <<'PY'
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+installer = Path(sys.argv[1])
+case_root = sys.argv[2]
+configure_gateway = sys.argv[3]
+integration_plugin = sys.argv[4]
+mock_bin = sys.argv[5]
+extra_args = sys.argv[6:]
+
+env = {key: value for key, value in os.environ.items() if not key.startswith("MARMOT_")}
+env.update(
+    {
+        "CURL_LOG": os.environ["CURL_LOG"],
+        "SYSTEMCTL_LOG": f"{case_root}/systemctl.log",
+        "CONFIGURE_GATEWAY_SOURCE": configure_gateway,
+        "INTEGRATION_PLUGIN_SOURCE": integration_plugin,
+        "HOME": f"{case_root}/home",
+        "HERMES_HOME": f"{case_root}/hermes-home",
+        "MARMOT_HOME": f"{case_root}/marmot-home",
+        "MARMOT_INSTALL_PREFIX": f"{case_root}/install",
+        "PATH": f"{mock_bin}:/usr/bin:/bin",
+        "WN_AGENT_SHA": "9.9.9",
+        "MARMOT_RELEASE_TAG": "wn-agent-v9.9.9-test",
+    }
+)
+completed = subprocess.run(
+    ["bash", "-s", "--", "--yes", "--no-service", *extra_args],
+    input=installer.read_text(encoding="utf-8"),
+    env=env,
+    text=True,
+)
+raise SystemExit(completed.returncode)
+PY
+}
+
+assert_env_contains() {
+    local env_file="$1"
+    local expected="$2"
+    if ! grep -Fq "$expected" "$env_file"; then
+        echo "missing expected managed env assignment: $expected" >&2
+        if ! grep -Eq '^(export[[:space:]]+)?MARMOT_(ALLOWED_USERS|ALLOW_ALL_USERS)=' "$env_file"; then
+            echo "no managed Marmot authorization keys present" >&2
+        fi
+        return 1
+    fi
+}
+
+assert_curl_not_called() {
+    if [ -s "$curl_log" ]; then
+        echo "expected installer to fail before download, but curl was invoked" >&2
+        return 1
+    fi
+}
+
+case_root="$fixture_root/fresh-install"
+run_installer "$case_root" --allow-user "$user_a"
+env_file="$case_root/hermes-home/.env"
+[ -f "$env_file" ]
+assert_env_contains "$env_file" "MARMOT_ALLOWED_USERS=$user_a"
+assert_env_contains "$env_file" "MARMOT_ALLOW_ALL_USERS=false"
+
+case_root="$fixture_root/reinstall-union"
+run_installer "$case_root" --allow-user "$user_a"
+env_file="$case_root/hermes-home/.env"
+printf '%s\n' \
+    "# unrelated" \
+    "OPENAI_API_KEY=secret" \
+    >"$case_root/hermes-home/.env.prelude"
+cat "$env_file" >>"$case_root/hermes-home/.env.prelude"
+mv "$case_root/hermes-home/.env.prelude" "$env_file"
+run_installer "$case_root" --allow-user "$user_b"
+assert_env_contains "$env_file" "MARMOT_ALLOWED_USERS=$user_a,$user_b"
+assert_env_contains "$env_file" "OPENAI_API_KEY=secret"
+assert_env_contains "$env_file" "MARMOT_ALLOW_ALL_USERS=false"
+
+case_root="$fixture_root/reinstall-idempotent"
+run_installer "$case_root" --allow-user "$user_a"
+env_file="$case_root/hermes-home/.env"
+before="$(cat "$env_file")"
+run_installer "$case_root" --allow-user "$user_a"
+after="$(cat "$env_file")"
+[ "$before" = "$after" ]
+
+case_root="$fixture_root/reinstall-preserve-without-args"
+run_installer "$case_root" --allow-user "$user_a"
+env_file="$case_root/hermes-home/.env"
+before="$(cat "$env_file")"
+run_installer "$case_root"
+after="$(cat "$env_file")"
+[ "$before" = "$after" ]
+
+case_root="$fixture_root/ambient-env-ignored"
+run_installer "$case_root" --allow-user "$user_a"
+env_file="$case_root/hermes-home/.env"
+scrub_marmot_env_python \
+    --env "MARMOT_ALLOWED_USERS=$user_b" \
+    --env "MARMOT_ALLOW_ALL_USERS=true" \
+    --env "CURL_LOG=$curl_log" \
+    --env "SYSTEMCTL_LOG=$case_root/systemctl.log" \
+    --env "CONFIGURE_GATEWAY_SOURCE=$configure_gateway" \
+    --env "INTEGRATION_PLUGIN_SOURCE=$integration_plugin" \
+    --env "HOME=$case_root/home" \
+    --env "HERMES_HOME=$case_root/hermes-home" \
+    --env "MARMOT_HOME=$case_root/marmot-home" \
+    --env "MARMOT_INSTALL_PREFIX=$case_root/install" \
+    --env "PATH=$mock_bin:/usr/bin:/bin" \
+    --env "WN_AGENT_SHA=9.9.9" \
+    --env "MARMOT_RELEASE_TAG=wn-agent-v9.9.9-test" \
+    "$installer" --yes --no-service --allow-user "$user_c" >/dev/null
+assert_env_contains "$env_file" "MARMOT_ALLOWED_USERS=$user_a,$user_c"
+assert_env_contains "$env_file" "MARMOT_ALLOW_ALL_USERS=false"
+
+case_root="$fixture_root/malformed-existing"
+mkdir -p "$case_root/hermes-home"
+printf '%s\n' "MARMOT_ALLOWED_USERS=not-a-valid-user" >"$case_root/hermes-home/.env"
+malformed_status=0
+run_installer "$case_root" --allow-user "$user_a" >/dev/null 2>&1 || malformed_status=$?
+[ "$malformed_status" -ne 0 ]
+[ "$(cat "$case_root/hermes-home/.env")" = "MARMOT_ALLOWED_USERS=not-a-valid-user" ]
+
+case_root="$fixture_root/malformed-explicit"
+malformed_explicit_status=0
+run_installer "$case_root" --allow-user "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq" >/dev/null 2>&1 || malformed_explicit_status=$?
+[ "$malformed_explicit_status" -ne 0 ]
+[ ! -f "$case_root/hermes-home/.env" ]
+
+case_root="$fixture_root/fresh-streamed-fail-early"
+fresh_status=0
+run_streamed_installer "$case_root" >/dev/null 2>&1 || fresh_status=$?
+[ "$fresh_status" -ne 0 ]
+assert_curl_not_called
+
+case_root="$fixture_root/upgrade-legacy-helper"
+mkdir -p "$case_root/hermes-home/plugins/marmot"
+cat >"$case_root/hermes-home/plugins/marmot/configure_gateway.py" <<'PY'
+#!/usr/bin/env python3
+import sys
+if "--configure-env" in sys.argv:
+    print("error: unrecognized arguments: --configure-env", file=sys.stderr)
+    raise SystemExit(2)
+raise SystemExit(0)
+PY
+chmod +x "$case_root/hermes-home/plugins/marmot/configure_gateway.py"
+run_streamed_installer "$case_root" --allow-user "$user_a" --force
+env_file="$case_root/hermes-home/.env"
+[ -f "$env_file" ]
+assert_env_contains "$env_file" "MARMOT_ALLOWED_USERS=$user_a"
+python3 "$case_root/hermes-home/plugins/marmot/configure_gateway.py" \
+    --configure-env --env-dry-run --home "$case_root/hermes-home" --quiet --allow-user "$user_a"
+
+hermes_repo="${HERMES_AGENT_REPO:-}"
+if [ -n "$hermes_repo" ] && [ -x "$hermes_repo/.venv/bin/hermes" ] && [ -x "$hermes_repo/.venv/bin/python" ]; then
+    case_root="$fixture_root/real-hermes-gateway-auth"
+    run_installer "$case_root" --allow-user "$user_a"
+    env_file="$case_root/hermes-home/.env"
+    [ -f "$env_file" ]
+    env -i \
+        HOME="$case_root/home" \
+        HERMES_HOME="$case_root/hermes-home" \
+        PATH="$hermes_repo/.venv/bin:/usr/bin:/bin" \
+        "$hermes_repo/.venv/bin/hermes" plugins enable marmot >/dev/null
+    auth_output="$(
+        cd "$hermes_repo"
+        env -i \
+            HOME="$case_root/home" \
+            HERMES_HOME="$case_root/hermes-home" \
+            PATH="/usr/bin:/bin" \
+            MARMOT_TEST_ALLOWED_USER_HEX="$user_a" \
+            MARMOT_TEST_UNKNOWN_USER_HEX="$user_unknown" \
+        "$hermes_repo/.venv/bin/python" "$e2e_gateway_auth"
+    )"
+    case "$auth_output" in
+        *"allowed=true"*"unknown=false"*) echo "real Hermes gateway auth: $auth_output" ;;
+        *)
+            echo "unexpected real Hermes gateway auth output: $auth_output" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+echo "installer env test passed"

--- a/integrations/hermes/marmot/tests/test_installer_env.sh
+++ b/integrations/hermes/marmot/tests/test_installer_env.sh
@@ -298,10 +298,20 @@ guided_log="$case_root/guided.log"
 if command -v script >/dev/null 2>&1 \
     && command -v timeout >/dev/null 2>&1 \
     && script --version 2>&1 | grep -qi 'util-linux'; then
-    printf '\n\n\nn\n' | timeout 10s script -qefc \
+    guided_status=0
+    printf '\n\n\nn\nn\n%s\n\n' "$user_a" | timeout 10s script -qefc \
         "env -i HOME='$case_root/home' HERMES_HOME='$case_root/hermes-home' PATH=/usr/bin:/bin WN_AGENT_SHA=9.9.9 MARMOT_RELEASE_TAG=wn-agent-v9.9.9-test bash '$installer' --dry-run --hermes-home '$case_root/hermes-home' --allow-welcomer '$user_a'" \
-        /dev/null >"$guided_log" 2>&1 || true
-    grep -Fq "Allow Marmot messages from any sender?" "$guided_log"
+        /dev/null >"$guided_log" 2>&1 || guided_status=$?
+    if [ "$guided_status" -ne 0 ]; then
+        echo "guided prompt integration failed with status $guided_status; captured log:" >&2
+        cat "$guided_log" >&2
+        exit 1
+    fi
+    if ! grep -Fq "Allow Marmot messages from any sender?" "$guided_log"; then
+        echo "guided prompt output missing; captured log:" >&2
+        cat "$guided_log" >&2
+        exit 1
+    fi
 else
     echo "skip: guided prompt integration (util-linux script(1) and timeout required)"
 fi

--- a/integrations/hermes/marmot/tests/test_installer_env.sh
+++ b/integrations/hermes/marmot/tests/test_installer_env.sh
@@ -277,6 +277,56 @@ run_installer "$case_root" --allow-user "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
 [ "$malformed_explicit_status" -ne 0 ]
 [ ! -f "$case_root/hermes-home/.env" ]
 
+case_root="$fixture_root/streamed-malformed-npub"
+streamed_bad_status=0
+run_streamed_installer "$case_root" --allow-user "npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq" >/dev/null 2>&1 || streamed_bad_status=$?
+[ "$streamed_bad_status" -ne 0 ]
+assert_curl_not_called
+[ ! -f "$case_root/hermes-home/.env" ]
+[ ! -d "$case_root/hermes-home/plugins/marmot" ]
+
+case_root="$fixture_root/streamed-blank-allow-user"
+streamed_blank_status=0
+run_streamed_installer "$case_root" --allow-user "   " >/dev/null 2>&1 || streamed_blank_status=$?
+[ "$streamed_blank_status" -ne 0 ]
+assert_curl_not_called
+[ ! -f "$case_root/hermes-home/.env" ]
+
+case_root="$fixture_root/guided-no-continues"
+mkdir -p "$case_root"
+guided_log="$case_root/guided.log"
+if command -v script >/dev/null 2>&1 \
+    && command -v timeout >/dev/null 2>&1 \
+    && script --version 2>&1 | grep -qi 'util-linux'; then
+    printf '\n\n\nn\n' | timeout 10s script -qefc \
+        "env -i HOME='$case_root/home' HERMES_HOME='$case_root/hermes-home' PATH=/usr/bin:/bin WN_AGENT_SHA=9.9.9 MARMOT_RELEASE_TAG=wn-agent-v9.9.9-test bash '$installer' --dry-run --hermes-home '$case_root/hermes-home' --allow-welcomer '$user_a'" \
+        /dev/null >"$guided_log" 2>&1 || true
+    grep -Fq "Allow Marmot messages from any sender?" "$guided_log"
+else
+    echo "skip: guided prompt integration (util-linux script(1) and timeout required)"
+fi
+
+case_root="$fixture_root/allow-all-users"
+run_installer "$case_root" --allow-all-users
+env_file="$case_root/hermes-home/.env"
+[ -f "$env_file" ]
+assert_env_contains "$env_file" "MARMOT_ALLOW_ALL_USERS=true"
+
+case_root="$fixture_root/streamed-reinstall-preserves-existing-auth"
+mkdir -p "$case_root/hermes-home"
+env_file="$case_root/hermes-home/.env"
+printf '%s\n' \
+    "MARMOT_ALLOWED_USERS=$user_a" \
+    "MARMOT_ALLOW_ALL_USERS=false" \
+    >"$env_file"
+before="$(cat "$env_file")"
+run_streamed_installer "$case_root" --force
+after_first="$(cat "$env_file")"
+run_streamed_installer "$case_root" --force
+after_second="$(cat "$env_file")"
+[ "$before" = "$after_first" ]
+[ "$before" = "$after_second" ]
+
 case_root="$fixture_root/fresh-streamed-fail-early"
 fresh_status=0
 run_streamed_installer "$case_root" >/dev/null 2>&1 || fresh_status=$?
@@ -329,6 +379,8 @@ if [ -n "$hermes_repo" ] && [ -x "$hermes_repo/.venv/bin/hermes" ] && [ -x "$her
             exit 1
             ;;
     esac
+else
+    echo "skip: real Hermes gateway authorization E2E (set HERMES_AGENT_REPO to an isolated checkout with .venv/bin/hermes)"
 fi
 
 echo "installer env test passed"

--- a/scripts/hermes_marmot_configure_gateway.py
+++ b/scripts/hermes_marmot_configure_gateway.py
@@ -787,6 +787,8 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.env_dry_run and not args.configure_env:
+        parser.error("--env-dry-run requires --configure-env")
 
     try:
         hermes_home = Path(args.home).expanduser()

--- a/scripts/hermes_marmot_configure_gateway.py
+++ b/scripts/hermes_marmot_configure_gateway.py
@@ -331,13 +331,17 @@ def configure_hermes_env(
     return env_state
 
 
-def _restore_path_bytes(path: Path, backup: bytes | None) -> None:
+def _restore_path_bytes(
+    path: Path,
+    backup: bytes | None,
+    backup_mode: int | None,
+) -> None:
     if backup is None:
         if path.exists():
             path.unlink()
         return
     path.parent.mkdir(parents=True, exist_ok=True)
-    current_mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o600
+    restore_mode = backup_mode if backup_mode is not None else 0o600
     fd, tmp_name = tempfile.mkstemp(
         prefix=f".{path.name}.rollback.",
         suffix=".tmp",
@@ -346,7 +350,7 @@ def _restore_path_bytes(path: Path, backup: bytes | None) -> None:
     tmp_path = Path(tmp_name)
     owns_fd = True
     try:
-        os.chmod(tmp_path, current_mode)
+        os.chmod(tmp_path, restore_mode)
         with os.fdopen(fd, "wb") as handle:
             owns_fd = False
             handle.write(backup)
@@ -360,6 +364,16 @@ def _restore_path_bytes(path: Path, backup: bytes | None) -> None:
         raise
 
 
+def _read_path_backup(path: Path | None) -> tuple[bytes | None, int | None]:
+    if path is None:
+        return None, None
+    try:
+        with path.open("rb") as handle:
+            return handle.read(), stat.S_IMODE(os.fstat(handle.fileno()).st_mode)
+    except FileNotFoundError:
+        return None, None
+
+
 def commit_env_and_config_transaction(
     *,
     env_path: Path | None,
@@ -368,10 +382,8 @@ def commit_env_and_config_transaction(
     config_text: str | None,
     config_backup: bool = True,
 ) -> None:
-    env_backup = env_path.read_bytes() if env_path is not None and env_path.exists() else None
-    config_backup_bytes = (
-        config_path.read_bytes() if config_path is not None and config_path.exists() else None
-    )
+    env_backup, env_backup_mode = _read_path_backup(env_path)
+    config_backup_bytes, config_backup_mode = _read_path_backup(config_path)
 
     wrote_env = False
     wrote_config = False
@@ -391,9 +403,9 @@ def commit_env_and_config_transaction(
             wrote_config = True
     except Exception:
         if wrote_env and env_path is not None:
-            _restore_path_bytes(env_path, env_backup)
+            _restore_path_bytes(env_path, env_backup, env_backup_mode)
         if wrote_config and config_path is not None:
-            _restore_path_bytes(config_path, config_backup_bytes)
+            _restore_path_bytes(config_path, config_backup_bytes, config_backup_mode)
         for cleanup_path in (config_tmp_path, config_backup_path):
             if cleanup_path is None:
                 continue
@@ -882,22 +894,14 @@ def main(argv: list[str] | None = None) -> int:
             profile_name_onboarding=profile_name_onboarding,
             configure_global_streaming=args.configure_global_streaming,
         )
-        if env_prepared is not None:
-            commit_env_and_config_transaction(
-                env_path=env_prepared[0],
-                env_lines=env_prepared[1],
-                config_path=config_path,
-                config_text=config_text,
-                config_backup=not args.no_backup,
-            )
-        else:
-            commit_env_and_config_transaction(
-                env_path=None,
-                env_lines=None,
-                config_path=config_path,
-                config_text=config_text,
-                config_backup=not args.no_backup,
-            )
+        env_path, env_lines = env_prepared if env_prepared is not None else (None, None)
+        commit_env_and_config_transaction(
+            env_path=env_path,
+            env_lines=env_lines,
+            config_path=config_path,
+            config_text=config_text,
+            config_backup=not args.no_backup,
+        )
     except Exception as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/scripts/hermes_marmot_configure_gateway.py
+++ b/scripts/hermes_marmot_configure_gateway.py
@@ -4,13 +4,16 @@
 from __future__ import annotations
 
 import argparse
-import shutil
 import os
 import re
+import shutil
+import stat
 import sys
+import tempfile
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable, Optional
 
 try:
     import yaml  # type: ignore[import-not-found]
@@ -22,6 +25,273 @@ except ModuleNotFoundError as exc:  # pragma: no cover - exercised on hosts with
 
 VALID_TOOL_PROGRESS = {"off", "new", "all", "verbose"}
 VALID_STREAMING_TRANSPORT = {"auto", "draft", "edit", "off"}
+MANAGED_ENV_KEYS = ("MARMOT_ALLOWED_USERS", "MARMOT_ALLOW_ALL_USERS")
+ACCOUNT_ID_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+_BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+_BECH32_VALUES = {character: index for index, character in enumerate(_BECH32_CHARSET)}
+
+
+@dataclass(frozen=True)
+class HermesEnvAuthState:
+    allowed_users_hex: list[str]
+    allow_all_users: bool
+
+
+def _bech32_polymod(values: Iterable[int]) -> int:
+    generators = (0x3B6A57B2, 0x26508E6D, 0x1EA119FA, 0x3D4233DD, 0x2A1462B3)
+    checksum = 1
+    for value in values:
+        top = checksum >> 25
+        checksum = ((checksum & 0x1FFFFFF) << 5) ^ value
+        for index, generator in enumerate(generators):
+            if (top >> index) & 1:
+                checksum ^= generator
+    return checksum
+
+
+def _convert_bits(values: Iterable[int], from_bits: int, to_bits: int) -> Optional[bytes]:
+    accumulator = 0
+    bit_count = 0
+    result = bytearray()
+    max_value = (1 << to_bits) - 1
+    for value in values:
+        if value < 0 or value >> from_bits:
+            return None
+        accumulator = (accumulator << from_bits) | value
+        bit_count += from_bits
+        while bit_count >= to_bits:
+            bit_count -= to_bits
+            result.append((accumulator >> bit_count) & max_value)
+    if bit_count >= from_bits or ((accumulator << (to_bits - bit_count)) & max_value):
+        return None
+    return bytes(result)
+
+
+def _npub_to_hex(value: str) -> Optional[str]:
+    if not value or len(value) > 90 or (value.lower() != value and value.upper() != value):
+        return None
+    normalized = value.lower()
+    separator = normalized.rfind("1")
+    if separator <= 0 or normalized[:separator] != "npub" or separator + 7 > len(normalized):
+        return None
+    try:
+        data = [_BECH32_VALUES[character] for character in normalized[separator + 1 :]]
+    except KeyError:
+        return None
+    hrp = normalized[:separator]
+    expanded_hrp = [ord(character) >> 5 for character in hrp]
+    expanded_hrp.extend([0])
+    expanded_hrp.extend(ord(character) & 31 for character in hrp)
+    if _bech32_polymod([*expanded_hrp, *data]) != 1:
+        return None
+    decoded = _convert_bits(data[:-6], 5, 8)
+    if decoded is None or len(decoded) != 32:
+        return None
+    return decoded.hex()
+
+
+def normalize_account_id(entry: str) -> str:
+    normalized = str(entry).strip()
+    if not normalized:
+        return ""
+    if normalized.lower().startswith("npub1"):
+        return _npub_to_hex(normalized) or ""
+    return normalized.lower().removeprefix("0x")
+
+
+def _validate_account_id(entry: str, *, label: str) -> str:
+    normalized = normalize_account_id(entry)
+    if not ACCOUNT_ID_HEX_RE.fullmatch(normalized):
+        raise ValueError(
+            f"invalid {label}: expected a Nostr npub or 64-character hex account id"
+        )
+    return normalized
+
+
+def _parse_dotenv_scalar(raw_value: str) -> str:
+    value = raw_value.strip()
+    if not value:
+        return ""
+    if value[0] in {"'", '"'}:
+        quote = value[0]
+        end = value.find(quote, 1)
+        if end == -1:
+            return value[1:]
+        return value[1:end]
+    value = re.sub(r"\s+#.*$", "", value).strip()
+    return value
+
+
+def _parse_allowed_users_value(raw_value: str) -> list[str]:
+    parsed = _parse_dotenv_scalar(raw_value)
+    if not parsed.strip():
+        return []
+    users: list[str] = []
+    for entry in parsed.split(","):
+        normalized = normalize_account_id(entry)
+        if not normalized:
+            if entry.strip():
+                raise ValueError("invalid MARMOT_ALLOWED_USERS entry")
+            continue
+        if not ACCOUNT_ID_HEX_RE.fullmatch(normalized):
+            raise ValueError("invalid MARMOT_ALLOWED_USERS entry")
+        users.append(normalized)
+    return sorted(dict.fromkeys(users))
+
+
+def _parse_allow_all_value(raw_value: str) -> bool:
+    return parse_bool(_parse_dotenv_scalar(raw_value), name="MARMOT_ALLOW_ALL_USERS")
+
+
+def _managed_env_key(line: str) -> Optional[str]:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    if "=" not in stripped:
+        return None
+    key = stripped.split("=", 1)[0].strip()
+    if key.startswith("export "):
+        key = key[7:].strip()
+    if key in MANAGED_ENV_KEYS:
+        return key
+    return None
+
+
+def read_hermes_env_auth(env_path: Path) -> HermesEnvAuthState:
+    if not env_path.exists():
+        return HermesEnvAuthState(allowed_users_hex=[], allow_all_users=False)
+
+    allowed_users: list[str] | None = None
+    allow_all_users: bool | None = None
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        key = _managed_env_key(line)
+        if key is None:
+            continue
+        _, raw_value = line.split("=", 1)
+        if key == "MARMOT_ALLOWED_USERS":
+            allowed_users = _parse_allowed_users_value(raw_value)
+        elif key == "MARMOT_ALLOW_ALL_USERS":
+            allow_all_users = _parse_allow_all_value(raw_value)
+
+    if allowed_users is None:
+        allowed_users = []
+    if allow_all_users is None:
+        allow_all_users = False
+    return HermesEnvAuthState(
+        allowed_users_hex=allowed_users,
+        allow_all_users=allow_all_users,
+    )
+
+
+def _render_env_lines(
+    *,
+    existing_lines: list[str],
+    allowed_users_hex: list[str],
+    allow_all_users: bool,
+) -> list[str]:
+    rendered_allowed = f"MARMOT_ALLOWED_USERS={','.join(allowed_users_hex)}"
+    rendered_allow_all = f"MARMOT_ALLOW_ALL_USERS={'true' if allow_all_users else 'false'}"
+    managed_values = {
+        "MARMOT_ALLOWED_USERS": rendered_allowed,
+        "MARMOT_ALLOW_ALL_USERS": rendered_allow_all,
+    }
+    last_indices: dict[str, int] = {}
+    for index, line in enumerate(existing_lines):
+        key = _managed_env_key(line)
+        if key is not None:
+            last_indices[key] = index
+
+    output: list[str] = []
+    seen: set[str] = set()
+    for index, line in enumerate(existing_lines):
+        key = _managed_env_key(line)
+        if key is None:
+            output.append(line)
+            continue
+        if last_indices.get(key) != index:
+            continue
+        output.append(managed_values[key])
+        seen.add(key)
+
+    for key in MANAGED_ENV_KEYS:
+        if key in seen:
+            continue
+        output.append(managed_values[key])
+    return output
+
+
+def _write_env_atomically(env_path: Path, lines: list[str]) -> None:
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    text = "\n".join(lines)
+    if text and not text.endswith("\n"):
+        text += "\n"
+    fd, tmp_name = tempfile.mkstemp(prefix=".env.", suffix=".tmp", dir=env_path.parent)
+    tmp_path = Path(tmp_name)
+    owns_fd = True
+    try:
+        try:
+            os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)
+        except Exception:
+            os.close(fd)
+            owns_fd = False
+            raise
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                owns_fd = False
+                handle.write(text)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except Exception:
+            if owns_fd:
+                os.close(fd)
+                owns_fd = False
+            raise
+        os.replace(tmp_path, env_path)
+        os.chmod(env_path, stat.S_IRUSR | stat.S_IWUSR)
+    except Exception:
+        if owns_fd:
+            os.close(fd)
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def configure_hermes_env(
+    *,
+    hermes_home: Path,
+    add_allowed_users: list[str] | None = None,
+    allow_all_opt_in: bool = False,
+    dry_run: bool = False,
+) -> HermesEnvAuthState:
+    env_path = hermes_home / ".env"
+    existing_lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
+    current = read_hermes_env_auth(env_path)
+
+    normalized_new = [
+        _validate_account_id(entry, label="allowed user")
+        for entry in (add_allowed_users or [])
+        if str(entry).strip()
+    ]
+    merged_users = sorted(dict.fromkeys([*current.allowed_users_hex, *normalized_new]))
+    merged_allow_all = current.allow_all_users or allow_all_opt_in
+
+    if not merged_users and not merged_allow_all:
+        raise ValueError(
+            "Hermes Marmot authorization is not configured: add at least one "
+            "--allow-user npub-or-hex, opt into --allow-all-users, or keep an "
+            "existing valid allowlist in $HERMES_HOME/.env"
+        )
+
+    rendered_lines = _render_env_lines(
+        existing_lines=existing_lines,
+        allowed_users_hex=merged_users,
+        allow_all_users=merged_allow_all,
+    )
+    if not dry_run:
+        _write_env_atomically(env_path, rendered_lines)
+    return HermesEnvAuthState(
+        allowed_users_hex=merged_users,
+        allow_all_users=merged_allow_all,
+    )
 
 
 def _yaml_string_needs_quotes(text: str) -> bool:
@@ -328,6 +598,27 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--no-backup", action="store_true")
     parser.add_argument("--quiet", action="store_true")
+    parser.add_argument(
+        "--configure-env",
+        action="store_true",
+        help="Update $HERMES_HOME/.env Marmot sender authorization variables",
+    )
+    parser.add_argument(
+        "--allow-user",
+        action="append",
+        default=[],
+        help="Allowed Marmot message sender npub or hex account id; may be repeated or comma-separated",
+    )
+    parser.add_argument(
+        "--allow-all-users",
+        action="store_true",
+        help="Explicitly opt into MARMOT_ALLOW_ALL_USERS=true",
+    )
+    parser.add_argument(
+        "--env-dry-run",
+        action="store_true",
+        help="Validate and print Hermes .env authorization changes without writing",
+    )
     return parser
 
 
@@ -336,6 +627,48 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
+        hermes_home = Path(args.home).expanduser()
+        allowed_users: list[str] = []
+        for value in args.allow_user:
+            allowed_users.extend(value.split(","))
+        env_state: HermesEnvAuthState | None = None
+        if args.configure_env or allowed_users or args.allow_all_users:
+            env_state = configure_hermes_env(
+                hermes_home=hermes_home,
+                add_allowed_users=allowed_users,
+                allow_all_opt_in=args.allow_all_users,
+                dry_run=args.env_dry_run,
+            )
+
+        if args.configure_env and args.env_dry_run:
+            if not args.quiet and env_state is not None:
+                print(
+                    "Hermes Marmot gateway env:"
+                    f" path={hermes_home / '.env'}"
+                    f" allowed_users={len(env_state.allowed_users_hex)}"
+                    f" allow_all_users={str(env_state.allow_all_users).lower()}"
+                    f" dry_run={str(args.env_dry_run).lower()}"
+                )
+            return 0
+
+        if args.configure_env and not (
+            args.agent_home
+            or args.socket_path
+            or args.account_id_hex
+            or args.welcomer_allowlist
+            or args.profile_name_onboarding is not None
+            or args.configure_global_streaming
+        ):
+            if not args.quiet and env_state is not None:
+                print(
+                    "Hermes Marmot gateway env:"
+                    f" path={hermes_home / '.env'}"
+                    f" allowed_users={len(env_state.allowed_users_hex)}"
+                    f" allow_all_users={str(env_state.allow_all_users).lower()}"
+                    f" dry_run={str(args.env_dry_run).lower()}"
+                )
+            return 0
+
         streaming_enabled = parse_bool(args.streaming, name="streaming")
         interim_assistant_messages = parse_bool(
             args.interim_messages,
@@ -363,7 +696,7 @@ def main(argv: list[str] | None = None) -> int:
         for value in args.welcomer_allowlist:
             welcomer_allowlist.extend(value.split(","))
         config_path = configure_gateway_config(
-            hermes_home=Path(args.home).expanduser(),
+            hermes_home=hermes_home,
             platform=args.platform,
             streaming_enabled=streaming_enabled,
             streaming_transport=args.transport,
@@ -395,6 +728,14 @@ def main(argv: list[str] | None = None) -> int:
             f" busy_ack_detail={str(busy_ack_detail).lower()}"
             f" global_streaming={str(args.configure_global_streaming).lower()}"
         )
+        if env_state is not None:
+            print(
+                "Hermes Marmot gateway env:"
+                f" path={hermes_home / '.env'}"
+                f" allowed_users={len(env_state.allowed_users_hex)}"
+                f" allow_all_users={str(env_state.allow_all_users).lower()}"
+                f" dry_run={str(args.env_dry_run).lower()}"
+            )
     return 0
 
 

--- a/scripts/hermes_marmot_configure_gateway.py
+++ b/scripts/hermes_marmot_configure_gateway.py
@@ -108,6 +108,13 @@ def _validate_account_id(entry: str, *, label: str) -> str:
     return normalized
 
 
+def validate_sender_auth_entries(entries: list[str]) -> None:
+    for entry in entries:
+        if not str(entry).strip():
+            raise ValueError("invalid allowed user: empty value is not allowed")
+        _validate_account_id(entry, label="allowed user")
+
+
 def _parse_dotenv_scalar(raw_value: str) -> str:
     value = raw_value.strip()
     if not value:
@@ -157,13 +164,17 @@ def _managed_env_key(line: str) -> Optional[str]:
     return None
 
 
-def read_hermes_env_auth(env_path: Path) -> HermesEnvAuthState:
-    if not env_path.exists():
-        return HermesEnvAuthState(allowed_users_hex=[], allow_all_users=False)
+def _managed_env_export_prefix(line: str) -> str:
+    stripped = line.strip()
+    if stripped.startswith("export "):
+        return "export "
+    return ""
 
+
+def read_hermes_env_auth_from_lines(lines: list[str]) -> HermesEnvAuthState:
     allowed_users: list[str] | None = None
     allow_all_users: bool | None = None
-    for line in env_path.read_text(encoding="utf-8").splitlines():
+    for line in lines:
         key = _managed_env_key(line)
         if key is None:
             continue
@@ -183,6 +194,14 @@ def read_hermes_env_auth(env_path: Path) -> HermesEnvAuthState:
     )
 
 
+def read_hermes_env_auth(env_path: Path) -> HermesEnvAuthState:
+    if not env_path.exists():
+        return HermesEnvAuthState(allowed_users_hex=[], allow_all_users=False)
+    return read_hermes_env_auth_from_lines(
+        env_path.read_text(encoding="utf-8").splitlines()
+    )
+
+
 def _render_env_lines(
     *,
     existing_lines: list[str],
@@ -196,10 +215,12 @@ def _render_env_lines(
         "MARMOT_ALLOW_ALL_USERS": rendered_allow_all,
     }
     last_indices: dict[str, int] = {}
+    managed_prefixes: dict[str, str] = {}
     for index, line in enumerate(existing_lines):
         key = _managed_env_key(line)
         if key is not None:
             last_indices[key] = index
+            managed_prefixes[key] = _managed_env_export_prefix(line)
 
     output: list[str] = []
     seen: set[str] = set()
@@ -210,7 +231,7 @@ def _render_env_lines(
             continue
         if last_indices.get(key) != index:
             continue
-        output.append(managed_values[key])
+        output.append(f"{managed_prefixes.get(key, '')}{managed_values[key]}")
         seen.add(key)
 
     for key in MANAGED_ENV_KEYS:
@@ -247,7 +268,6 @@ def _write_env_atomically(env_path: Path, lines: list[str]) -> None:
                 owns_fd = False
             raise
         os.replace(tmp_path, env_path)
-        os.chmod(env_path, stat.S_IRUSR | stat.S_IWUSR)
     except Exception:
         if owns_fd:
             os.close(fd)
@@ -255,21 +275,19 @@ def _write_env_atomically(env_path: Path, lines: list[str]) -> None:
         raise
 
 
-def configure_hermes_env(
+def prepare_hermes_env(
     *,
     hermes_home: Path,
     add_allowed_users: list[str] | None = None,
     allow_all_opt_in: bool = False,
-    dry_run: bool = False,
-) -> HermesEnvAuthState:
+) -> tuple[HermesEnvAuthState, Path, list[str]]:
     env_path = hermes_home / ".env"
     existing_lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
-    current = read_hermes_env_auth(env_path)
+    current = read_hermes_env_auth_from_lines(existing_lines)
 
     normalized_new = [
         _validate_account_id(entry, label="allowed user")
         for entry in (add_allowed_users or [])
-        if str(entry).strip()
     ]
     merged_users = sorted(dict.fromkeys([*current.allowed_users_hex, *normalized_new]))
     merged_allow_all = current.allow_all_users or allow_all_opt_in
@@ -286,11 +304,118 @@ def configure_hermes_env(
         allowed_users_hex=merged_users,
         allow_all_users=merged_allow_all,
     )
+    return (
+        HermesEnvAuthState(
+            allowed_users_hex=merged_users,
+            allow_all_users=merged_allow_all,
+        ),
+        env_path,
+        rendered_lines,
+    )
+
+
+def configure_hermes_env(
+    *,
+    hermes_home: Path,
+    add_allowed_users: list[str] | None = None,
+    allow_all_opt_in: bool = False,
+    dry_run: bool = False,
+) -> HermesEnvAuthState:
+    env_state, env_path, rendered_lines = prepare_hermes_env(
+        hermes_home=hermes_home,
+        add_allowed_users=add_allowed_users,
+        allow_all_opt_in=allow_all_opt_in,
+    )
     if not dry_run:
         _write_env_atomically(env_path, rendered_lines)
-    return HermesEnvAuthState(
-        allowed_users_hex=merged_users,
-        allow_all_users=merged_allow_all,
+    return env_state
+
+
+def _restore_path_bytes(path: Path, backup: bytes | None) -> None:
+    if backup is None:
+        if path.exists():
+            path.unlink()
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    current_mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o600
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.rollback.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    tmp_path = Path(tmp_name)
+    owns_fd = True
+    try:
+        os.chmod(tmp_path, current_mode)
+        with os.fdopen(fd, "wb") as handle:
+            owns_fd = False
+            handle.write(backup)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        if owns_fd:
+            os.close(fd)
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def commit_env_and_config_transaction(
+    *,
+    env_path: Path | None,
+    env_lines: list[str] | None,
+    config_path: Path | None,
+    config_text: str | None,
+    config_backup: bool = True,
+) -> None:
+    env_backup = env_path.read_bytes() if env_path is not None and env_path.exists() else None
+    config_backup_bytes = (
+        config_path.read_bytes() if config_path is not None and config_path.exists() else None
+    )
+
+    wrote_env = False
+    wrote_config = False
+    config_tmp_path: Path | None = None
+    config_backup_path: Path | None = None
+    try:
+        if env_path is not None and env_lines is not None:
+            _write_env_atomically(env_path, env_lines)
+            wrote_env = True
+        if config_path is not None and config_text is not None:
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            if config_backup:
+                config_backup_path = _create_backup(config_path)
+            config_tmp_path = config_path.with_suffix(config_path.suffix + ".tmp")
+            config_tmp_path.write_text(config_text, encoding="utf-8")
+            os.replace(config_tmp_path, config_path)
+            wrote_config = True
+    except Exception:
+        if wrote_env and env_path is not None:
+            _restore_path_bytes(env_path, env_backup)
+        if wrote_config and config_path is not None:
+            _restore_path_bytes(config_path, config_backup_bytes)
+        for cleanup_path in (config_tmp_path, config_backup_path):
+            if cleanup_path is None:
+                continue
+            try:
+                cleanup_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise
+
+
+def print_env_summary(
+    *,
+    hermes_home: Path,
+    env_state: HermesEnvAuthState,
+    env_dry_run: bool,
+) -> None:
+    print(
+        "Hermes Marmot gateway env:"
+        f" path={hermes_home / '.env'}"
+        f" allowed_users={len(env_state.allowed_users_hex)}"
+        f" allow_all_users={str(env_state.allow_all_users).lower()}"
+        f" dry_run={str(env_dry_run).lower()}"
     )
 
 
@@ -480,7 +605,7 @@ def _create_backup(config_path: Path) -> Path | None:
     return backup_path
 
 
-def configure_gateway_config(
+def prepare_gateway_config(
     *,
     hermes_home: Path,
     platform: str,
@@ -496,8 +621,7 @@ def configure_gateway_config(
     welcomer_allowlist: list[str] | None = None,
     profile_name_onboarding: bool | None = None,
     configure_global_streaming: bool = False,
-    backup: bool = True,
-) -> Path:
+) -> tuple[Path, str]:
     if streaming_transport not in VALID_STREAMING_TRANSPORT:
         valid = ", ".join(sorted(VALID_STREAMING_TRANSPORT))
         raise ValueError(f"streaming transport must be one of: {valid}")
@@ -506,7 +630,6 @@ def configure_gateway_config(
         raise ValueError(f"tool progress must be one of: {valid}")
 
     config_path = hermes_home / "config.yaml"
-    hermes_home.mkdir(parents=True, exist_ok=True)
     config = load_config(config_path)
     effective_streaming = streaming_enabled and streaming_transport != "off"
 
@@ -543,11 +666,50 @@ def configure_gateway_config(
     platform_config["long_running_notifications"] = long_running_notifications
     platform_config["busy_ack_detail"] = busy_ack_detail
 
-    if backup:
-        _create_backup(config_path)
-    tmp_path = config_path.with_suffix(config_path.suffix + ".tmp")
-    tmp_path.write_text(dump_config(config), encoding="utf-8")
-    os.replace(tmp_path, config_path)
+    return config_path, dump_config(config)
+
+
+def configure_gateway_config(
+    *,
+    hermes_home: Path,
+    platform: str,
+    streaming_enabled: bool,
+    streaming_transport: str,
+    tool_progress: str,
+    interim_assistant_messages: bool,
+    long_running_notifications: bool,
+    busy_ack_detail: bool,
+    agent_home: Path | None = None,
+    socket_path: Path | None = None,
+    account_id_hex: str | None = None,
+    welcomer_allowlist: list[str] | None = None,
+    profile_name_onboarding: bool | None = None,
+    configure_global_streaming: bool = False,
+    backup: bool = True,
+) -> Path:
+    config_path, config_text = prepare_gateway_config(
+        hermes_home=hermes_home,
+        platform=platform,
+        streaming_enabled=streaming_enabled,
+        streaming_transport=streaming_transport,
+        tool_progress=tool_progress,
+        interim_assistant_messages=interim_assistant_messages,
+        long_running_notifications=long_running_notifications,
+        busy_ack_detail=busy_ack_detail,
+        agent_home=agent_home,
+        socket_path=socket_path,
+        account_id_hex=account_id_hex,
+        welcomer_allowlist=welcomer_allowlist,
+        profile_name_onboarding=profile_name_onboarding,
+        configure_global_streaming=configure_global_streaming,
+    )
+    commit_env_and_config_transaction(
+        env_path=None,
+        env_lines=None,
+        config_path=config_path,
+        config_text=config_text,
+        config_backup=backup,
+    )
     return config_path
 
 
@@ -631,43 +793,9 @@ def main(argv: list[str] | None = None) -> int:
         allowed_users: list[str] = []
         for value in args.allow_user:
             allowed_users.extend(value.split(","))
-        env_state: HermesEnvAuthState | None = None
-        if args.configure_env or allowed_users or args.allow_all_users:
-            env_state = configure_hermes_env(
-                hermes_home=hermes_home,
-                add_allowed_users=allowed_users,
-                allow_all_opt_in=args.allow_all_users,
-                dry_run=args.env_dry_run,
-            )
 
-        if args.configure_env and args.env_dry_run:
-            if not args.quiet and env_state is not None:
-                print(
-                    "Hermes Marmot gateway env:"
-                    f" path={hermes_home / '.env'}"
-                    f" allowed_users={len(env_state.allowed_users_hex)}"
-                    f" allow_all_users={str(env_state.allow_all_users).lower()}"
-                    f" dry_run={str(args.env_dry_run).lower()}"
-                )
-            return 0
-
-        if args.configure_env and not (
-            args.agent_home
-            or args.socket_path
-            or args.account_id_hex
-            or args.welcomer_allowlist
-            or args.profile_name_onboarding is not None
-            or args.configure_global_streaming
-        ):
-            if not args.quiet and env_state is not None:
-                print(
-                    "Hermes Marmot gateway env:"
-                    f" path={hermes_home / '.env'}"
-                    f" allowed_users={len(env_state.allowed_users_hex)}"
-                    f" allow_all_users={str(env_state.allow_all_users).lower()}"
-                    f" dry_run={str(args.env_dry_run).lower()}"
-                )
-            return 0
+        if allowed_users:
+            validate_sender_auth_entries(allowed_users)
 
         streaming_enabled = parse_bool(args.streaming, name="streaming")
         interim_assistant_messages = parse_bool(
@@ -687,6 +815,47 @@ def main(argv: list[str] | None = None) -> int:
                 name="profile name onboarding",
             )
         )
+
+        env_state: HermesEnvAuthState | None = None
+        env_prepared: tuple[Path, list[str]] | None = None
+        needs_env = args.configure_env or allowed_users or args.allow_all_users
+        if needs_env:
+            env_state, env_path, env_lines = prepare_hermes_env(
+                hermes_home=hermes_home,
+                add_allowed_users=allowed_users,
+                allow_all_opt_in=args.allow_all_users,
+            )
+            if not (args.configure_env and args.env_dry_run):
+                env_prepared = (env_path, env_lines)
+
+        if args.configure_env and args.env_dry_run:
+            if not args.quiet and env_state is not None:
+                print_env_summary(
+                    hermes_home=hermes_home,
+                    env_state=env_state,
+                    env_dry_run=args.env_dry_run,
+                )
+            return 0
+
+        env_only = args.configure_env and not (
+            args.agent_home
+            or args.socket_path
+            or args.account_id_hex
+            or args.welcomer_allowlist
+            or args.profile_name_onboarding is not None
+            or args.configure_global_streaming
+        )
+        if env_only:
+            if env_prepared is not None:
+                _write_env_atomically(env_prepared[0], env_prepared[1])
+            if not args.quiet and env_state is not None:
+                print_env_summary(
+                    hermes_home=hermes_home,
+                    env_state=env_state,
+                    env_dry_run=args.env_dry_run,
+                )
+            return 0
+
         welcomer_allowlist = []
         env_allowlist = os.environ.get("MARMOT_WELCOMER_ALLOWLIST") or os.environ.get(
             "MARMOT_DM_ALLOW_FROM"
@@ -695,7 +864,7 @@ def main(argv: list[str] | None = None) -> int:
             welcomer_allowlist.extend(env_allowlist.split(","))
         for value in args.welcomer_allowlist:
             welcomer_allowlist.extend(value.split(","))
-        config_path = configure_gateway_config(
+        config_path, config_text = prepare_gateway_config(
             hermes_home=hermes_home,
             platform=args.platform,
             streaming_enabled=streaming_enabled,
@@ -710,8 +879,23 @@ def main(argv: list[str] | None = None) -> int:
             welcomer_allowlist=welcomer_allowlist,
             profile_name_onboarding=profile_name_onboarding,
             configure_global_streaming=args.configure_global_streaming,
-            backup=not args.no_backup,
         )
+        if env_prepared is not None:
+            commit_env_and_config_transaction(
+                env_path=env_prepared[0],
+                env_lines=env_prepared[1],
+                config_path=config_path,
+                config_text=config_text,
+                config_backup=not args.no_backup,
+            )
+        else:
+            commit_env_and_config_transaction(
+                env_path=None,
+                env_lines=None,
+                config_path=config_path,
+                config_text=config_text,
+                config_backup=not args.no_backup,
+            )
     except Exception as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -729,12 +913,10 @@ def main(argv: list[str] | None = None) -> int:
             f" global_streaming={str(args.configure_global_streaming).lower()}"
         )
         if env_state is not None:
-            print(
-                "Hermes Marmot gateway env:"
-                f" path={hermes_home / '.env'}"
-                f" allowed_users={len(env_state.allowed_users_hex)}"
-                f" allow_all_users={str(env_state.allow_all_users).lower()}"
-                f" dry_run={str(args.env_dry_run).lower()}"
+            print_env_summary(
+                hermes_home=hermes_home,
+                env_state=env_state,
+                env_dry_run=args.env_dry_run,
             )
     return 0
 

--- a/scripts/hermes_marmot_deterministic_e2e.sh
+++ b/scripts/hermes_marmot_deterministic_e2e.sh
@@ -44,6 +44,11 @@ fi
 
 source "$dev_root/env.sh"
 
+if [ -n "${HERMES_AGENT_REPO:-}" ]; then
+    export HERMES_AGENT_REPO
+    "$MDK_REPO/integrations/hermes/marmot/tests/test_installer_env.sh"
+fi
+
 if [ ! -x "$HERMES_AGENT_REPO/.venv/bin/python" ]; then
     echo "error: Hermes venv python not found at $HERMES_AGENT_REPO/.venv/bin/python" >&2
     echo "       Rerun setup without --skip-hermes-install." >&2

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -150,7 +150,25 @@ append_csv() {
 }
 
 have_tty() {
-    [ -r /dev/tty ] && [ -w /dev/tty ]
+    local tty_path
+    tty_path="$(prompt_tty_path)"
+    [ -r "$tty_path" ] && [ -w "$tty_path" ]
+}
+
+prompt_tty_path() {
+    if [ -n "${HERMES_INSTALLER_TEST_PROMPT_TTY:-}" ]; then
+        case "${HERMES_INSTALLER_TEST_PROMPT_TTY}" in
+            /dev/null | /dev/fd/[0-9]*)
+                printf '%s\n' "${HERMES_INSTALLER_TEST_PROMPT_TTY}"
+                ;;
+            *)
+                echo "error: HERMES_INSTALLER_TEST_PROMPT_TTY must be /dev/null or an inherited /dev/fd/* handle" >&2
+                exit 1
+                ;;
+        esac
+        return 0
+    fi
+    printf '%s\n' /dev/tty
 }
 
 prompt_value() {
@@ -162,16 +180,19 @@ prompt_value() {
         return 0
     fi
     if [ -n "$default_value" ]; then
-        printf '%s [%s]: ' "$prompt" "$default_value" >/dev/tty
+        printf '%s [%s]: ' "$prompt" "$default_value" >"$(prompt_tty_path)"
     else
-        printf '%s: ' "$prompt" >/dev/tty
+        printf '%s: ' "$prompt" >"$(prompt_tty_path)"
     fi
-    IFS= read -r reply </dev/tty || reply=""
+    if ! IFS= read -r reply <"$(prompt_tty_path)"; then
+        return 1
+    fi
     if [ -z "$reply" ]; then
         printf '%s\n' "$default_value"
     else
         printf '%s\n' "$reply"
     fi
+    return 0
 }
 
 prompt_yes_no() {
@@ -188,14 +209,16 @@ prompt_yes_no() {
         suffix="y/N"
     fi
     while true; do
-        printf '%s [%s]: ' "$prompt" "$suffix" >/dev/tty
-        IFS= read -r reply </dev/tty || reply=""
+        printf '%s [%s]: ' "$prompt" "$suffix" >"$(prompt_tty_path)"
+        if ! IFS= read -r reply <"$(prompt_tty_path)"; then
+            return 2
+        fi
         reply="${reply:-$default_value}"
         normalized="$(printf '%s' "$reply" | tr '[:upper:]' '[:lower:]')"
         case "$normalized" in
             y | yes) return 0 ;;
             n | no) return 1 ;;
-            *) printf 'Please answer yes or no.\n' >/dev/tty ;;
+            *) printf 'Please answer yes or no.\n' >"$(prompt_tty_path)" ;;
         esac
     done
 }
@@ -262,6 +285,217 @@ same_version_configure_gateway_helper_path() {
     return 1
 }
 
+strict_validate_sender_auth_preflight() {
+    need_cmd python3
+    local -a args=()
+    if [ "${#ALLOW_USERS[@]}" -gt 0 ]; then
+        local user
+        for user in "${ALLOW_USERS[@]}"; do
+            args+=(--allow-user "$user")
+        done
+    fi
+    local helper=""
+    if helper="$(same_version_configure_gateway_helper_path 2>/dev/null)"; then
+        run_gateway_helper_env_dry_run "$helper"
+        return $?
+    fi
+    INSTALL_SCRIPT_DIR="$SCRIPT_DIR" HERMES_HOME="$HERMES_HOME" \
+        python3 - "${args[@]+"${args[@]}"}" <<'PY'
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+ACCOUNT_ID_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+_BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+_BECH32_VALUES = {character: index for index, character in enumerate(_BECH32_CHARSET)}
+MANAGED_ENV_KEYS = ("MARMOT_ALLOWED_USERS", "MARMOT_ALLOW_ALL_USERS")
+
+
+def _bech32_polymod(values: Iterable[int]) -> int:
+    generators = (0x3B6A57B2, 0x26508E6D, 0x1EA119FA, 0x3D4233DD, 0x2A1462B3)
+    checksum = 1
+    for value in values:
+        top = checksum >> 25
+        checksum = ((checksum & 0x1FFFFFF) << 5) ^ value
+        for index, generator in enumerate(generators):
+            if (top >> index) & 1:
+                checksum ^= generator
+    return checksum
+
+
+def _convert_bits(values: Iterable[int], from_bits: int, to_bits: int) -> Optional[bytes]:
+    accumulator = 0
+    bit_count = 0
+    result = bytearray()
+    max_value = (1 << to_bits) - 1
+    for value in values:
+        if value < 0 or value >> from_bits:
+            return None
+        accumulator = (accumulator << from_bits) | value
+        bit_count += from_bits
+        while bit_count >= to_bits:
+            bit_count -= to_bits
+            result.append((accumulator >> bit_count) & max_value)
+    if bit_count >= from_bits or ((accumulator << (to_bits - bit_count)) & max_value):
+        return None
+    return bytes(result)
+
+
+def _npub_to_hex(value: str) -> Optional[str]:
+    if not value or len(value) > 90 or (value.lower() != value and value.upper() != value):
+        return None
+    normalized = value.lower()
+    separator = normalized.rfind("1")
+    if separator <= 0 or normalized[:separator] != "npub" or separator + 7 > len(normalized):
+        return None
+    try:
+        data = [_BECH32_VALUES[character] for character in normalized[separator + 1 :]]
+    except KeyError:
+        return None
+    hrp = normalized[:separator]
+    expanded_hrp = [ord(character) >> 5 for character in hrp]
+    expanded_hrp.extend([0])
+    expanded_hrp.extend(ord(character) & 31 for character in hrp)
+    if _bech32_polymod([*expanded_hrp, *data]) != 1:
+        return None
+    decoded = _convert_bits(data[:-6], 5, 8)
+    if decoded is None or len(decoded) != 32:
+        return None
+    return decoded.hex()
+
+
+def normalize_account_id(entry: str) -> str:
+    normalized = str(entry).strip()
+    if not normalized:
+        return ""
+    if normalized.lower().startswith("npub1"):
+        return _npub_to_hex(normalized) or ""
+    return normalized.lower().removeprefix("0x")
+
+
+def validate_account_id(entry: str, *, label: str) -> str:
+    normalized = normalize_account_id(entry)
+    if not ACCOUNT_ID_HEX_RE.fullmatch(normalized):
+        raise ValueError(
+            f"invalid {label}: expected a Nostr npub or 64-character hex account id"
+        )
+    return normalized
+
+
+def _parse_dotenv_scalar(raw_value: str) -> str:
+    value = raw_value.strip()
+    if not value:
+        return ""
+    if value[0] in {"'", '"'}:
+        quote = value[0]
+        end = value.find(quote, 1)
+        if end == -1:
+            return value[1:]
+        return value[1:end]
+    value = re.sub(r"\s+#.*$", "", value).strip()
+    return value
+
+
+def _parse_bool(value: str, *, name: str) -> bool:
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be a boolean-ish value, got {value!r}")
+
+
+def _managed_env_key(line: str) -> Optional[str]:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    if "=" not in stripped:
+        return None
+    key = stripped.split("=", 1)[0].strip()
+    if key.startswith("export "):
+        key = key[7:].strip()
+    if key in MANAGED_ENV_KEYS:
+        return key
+    return None
+
+
+def _parse_allowed_users_value(raw_value: str) -> list[str]:
+    parsed = _parse_dotenv_scalar(raw_value)
+    if not parsed.strip():
+        return []
+    users: list[str] = []
+    for entry in parsed.split(","):
+        normalized = normalize_account_id(entry)
+        if not normalized:
+            if entry.strip():
+                raise ValueError("invalid MARMOT_ALLOWED_USERS entry")
+            continue
+        if not ACCOUNT_ID_HEX_RE.fullmatch(normalized):
+            raise ValueError("invalid MARMOT_ALLOWED_USERS entry")
+        users.append(normalized)
+    return sorted(dict.fromkeys(users))
+
+
+def validate_existing_env_auth(env_path: Path) -> None:
+    if not env_path.is_file():
+        return
+    allowed_users: list[str] | None = None
+    allow_all_users: bool | None = None
+    saw_managed = False
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        key = _managed_env_key(line)
+        if key is None:
+            continue
+        saw_managed = True
+        _, raw_value = line.split("=", 1)
+        if key == "MARMOT_ALLOWED_USERS":
+            allowed_users = _parse_allowed_users_value(raw_value)
+        elif key == "MARMOT_ALLOW_ALL_USERS":
+            allow_all_users = _parse_bool(
+                _parse_dotenv_scalar(raw_value),
+                name="MARMOT_ALLOW_ALL_USERS",
+            )
+    if not saw_managed:
+        return
+    if allowed_users is None:
+        allowed_users = []
+    if allow_all_users is None:
+        allow_all_users = False
+    if not allowed_users and not allow_all_users:
+        raise ValueError("invalid existing Hermes Marmot sender authorization")
+
+
+args = sys.argv[1:]
+index = 0
+while index < len(args):
+    if args[index] == "--allow-user":
+        index += 1
+        if index >= len(args):
+            print("error: missing value for --allow-user", file=sys.stderr)
+            raise SystemExit(2)
+        entry = args[index]
+        if not str(entry).strip():
+            print("error: invalid allowed user: empty value is not allowed", file=sys.stderr)
+            raise SystemExit(2)
+        try:
+            validate_account_id(entry, label="allowed user")
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            raise SystemExit(2) from exc
+    index += 1
+
+hermes_home = Path(os.environ.get("HERMES_HOME", ""))
+if hermes_home:
+    try:
+        validate_existing_env_auth(hermes_home / ".env")
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+PY
+}
+
 installed_configure_gateway_helper_path() {
     if [ -f "$MARMOT_PLUGIN_DIR/configure_gateway.py" ]; then
         printf '%s\n' "$MARMOT_PLUGIN_DIR/configure_gateway.py"
@@ -275,29 +509,6 @@ hermes_env_has_managed_sender_auth_keys() {
     [ -f "$env_file" ] || return 1
     grep -Eq '^[[:space:]]*(export[[:space:]]+)?MARMOT_ALLOWED_USERS[[:space:]]*=' "$env_file" && return 0
     grep -Eq '^[[:space:]]*(export[[:space:]]+)?MARMOT_ALLOW_ALL_USERS[[:space:]]*=' "$env_file" && return 0
-    return 1
-}
-
-is_strict_hex_account_id() {
-    local value normalized
-    value="${1#"${1%%[![:space:]]*}"}"
-    value="${value%"${value##*[![:space:]]}"}"
-    normalized="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
-    normalized="${normalized#0x}"
-    [[ "$normalized" =~ ^[0-9a-f]{64}$ ]]
-}
-
-allow_users_need_helper_validation() {
-    local user normalized
-    for user in "${ALLOW_USERS[@]}"; do
-        normalized="$(printf '%s' "$user" | tr '[:upper:]' '[:lower:]')"
-        case "$normalized" in
-            npub1*) return 0 ;;
-        esac
-        if ! is_strict_hex_account_id "$user"; then
-            return 0
-        fi
-    done
     return 1
 }
 
@@ -315,10 +526,12 @@ run_gateway_helper_env_dry_run() {
         --env-dry-run
         --quiet
     )
-    local user
-    for user in "${ALLOW_USERS[@]}"; do
-        args+=(--allow-user "$user")
-    done
+    if [ "${#ALLOW_USERS[@]}" -gt 0 ]; then
+        local user
+        for user in "${ALLOW_USERS[@]}"; do
+            args+=(--allow-user "$user")
+        done
+    fi
     if [ "$EXPLICIT_ALLOW_ALL" -eq 1 ]; then
         args+=(--allow-all-users)
     fi
@@ -330,6 +543,10 @@ sender_auth_not_configured_message() {
     echo "Pass one or more --allow-user npub-or-hex values, opt into --allow-all-users," >&2
     echo "or keep an existing valid allowlist in $HERMES_HOME/.env." >&2
     echo "Use --no-configure-hermes to install assets without patching Hermes." >&2
+}
+
+guided_setup_input_failed() {
+    echo "error: guided setup input is unavailable; use --yes with explicit flags." >&2
 }
 
 log_sender_auth_dry_run_intent() {
@@ -352,24 +569,18 @@ validate_hermes_sender_auth_pre_install() {
         return 0
     fi
 
+    if ! strict_validate_sender_auth_preflight; then
+        echo "error: invalid Hermes Marmot sender authorization inputs" >&2
+        exit 1
+    fi
+
     if [ "$DRY_RUN" -eq 0 ] && [ "$ASSUME_YES" -eq 1 ]; then
         if [ "$EXPLICIT_ALLOW_ALL" -eq 0 ] && [ "${#ALLOW_USERS[@]}" -eq 0 ]; then
             if ! hermes_env_has_managed_sender_auth_keys; then
                 sender_auth_not_configured_message
                 exit 1
             fi
-            return 0
         fi
-    fi
-
-    local helper=""
-    if same_version_configure_gateway_helper_path >/dev/null 2>&1; then
-        helper="$(same_version_configure_gateway_helper_path)"
-        if ! run_gateway_helper_env_dry_run "$helper"; then
-            echo "error: invalid Hermes Marmot sender authorization inputs" >&2
-            exit 1
-        fi
-        return 0
     fi
 
     if [ "$DRY_RUN" -eq 1 ]; then
@@ -377,15 +588,10 @@ validate_hermes_sender_auth_pre_install() {
             return 0
         fi
         if [ "${#ALLOW_USERS[@]}" -gt 0 ]; then
-            if allow_users_need_helper_validation; then
-                echo "error: cannot strictly validate sender authorization without the configure helper" >&2
-                exit 1
-            fi
             return 0
         fi
         if hermes_env_has_managed_sender_auth_keys; then
-            echo "error: cannot strictly validate existing sender authorization without the configure helper" >&2
-            exit 1
+            return 0
         fi
         sender_auth_not_configured_message
         exit 1
@@ -888,10 +1094,12 @@ configure_hermes_gateway() {
             args+=(--welcomer-allowlist "$welcomer")
         done
     fi
-    local user
-    for user in "${ALLOW_USERS[@]}"; do
-        args+=(--allow-user "$user")
-    done
+    if [ "${#ALLOW_USERS[@]}" -gt 0 ]; then
+        local user
+        for user in "${ALLOW_USERS[@]}"; do
+            args+=(--allow-user "$user")
+        done
+    fi
     if [ "$EXPLICIT_ALLOW_ALL" -eq 1 ]; then
         args+=(--allow-all-users)
     fi
@@ -1042,8 +1250,14 @@ fi
 
 if [ "$INTERACTIVE" -eq 1 ]; then
     log "guided setup will prompt on /dev/tty; press Enter to accept defaults"
-    HERMES_HOME="$(prompt_value "Hermes home" "$HERMES_HOME")"
-    MARMOT_HOME="$(prompt_value "Marmot agent home" "$MARMOT_HOME")"
+    if ! HERMES_HOME="$(prompt_value "Hermes home" "$HERMES_HOME")"; then
+        guided_setup_input_failed
+        exit 1
+    fi
+    if ! MARMOT_HOME="$(prompt_value "Marmot agent home" "$MARMOT_HOME")"; then
+        guided_setup_input_failed
+        exit 1
+    fi
     MARMOT_PLUGIN_DIR="${MARMOT_PLUGIN_DIR_OVERRIDE:-$HERMES_HOME/plugins/marmot}"
     MARMOT_AGENT_SOCKET="${MARMOT_AGENT_SOCKET_OVERRIDE:-$MARMOT_HOME/dev/wn-agent.sock}"
     if [ -e "$MARMOT_HOME" ]; then
@@ -1051,7 +1265,10 @@ if [ "$INTERACTIVE" -eq 1 ]; then
     fi
     if [ "${#ALLOW_WELCOMERS[@]}" -eq 0 ]; then
         while true; do
-            welcomer_reply="$(prompt_value "Allowed inviter/welcomer npub or hex (blank to skip)" "")"
+            if ! welcomer_reply="$(prompt_value "Allowed inviter/welcomer npub or hex (blank to skip)" "")"; then
+                guided_setup_input_failed
+                exit 1
+            fi
             if [ -n "$welcomer_reply" ]; then
                 ALLOW_WELCOMERS+=("$welcomer_reply")
                 break
@@ -1071,7 +1288,10 @@ if [ "$INTERACTIVE" -eq 1 ]; then
         fi
         if [ "$prompt_sender_auth" -eq 1 ]; then
             while true; do
-                user_reply="$(prompt_value "Allowed Marmot message sender npub or hex (blank to finish)" "")"
+                if ! user_reply="$(prompt_value "Allowed Marmot message sender npub or hex (blank to finish)" "")"; then
+                    sender_auth_not_configured_message
+                    exit 1
+                fi
                 if [ -n "$user_reply" ]; then
                     ALLOW_USERS+=("$user_reply")
                     continue
@@ -1082,6 +1302,12 @@ if [ "$INTERACTIVE" -eq 1 ]; then
                 if [ "${#ALLOW_WELCOMERS[@]}" -gt 0 ]; then
                     if prompt_yes_no "Also allow configured welcomer identity/identities to message Hermes?" "no"; then
                         ALLOW_USERS+=("${ALLOW_WELCOMERS[@]}")
+                    else
+                        welcomer_prompt_status=$?
+                        if [ "$welcomer_prompt_status" -eq 2 ]; then
+                            sender_auth_not_configured_message
+                            exit 1
+                        fi
                     fi
                 fi
                 if [ "${#ALLOW_USERS[@]}" -gt 0 ]; then
@@ -1090,8 +1316,14 @@ if [ "$INTERACTIVE" -eq 1 ]; then
                 if prompt_yes_no "Allow Marmot messages from any sender? This sets MARMOT_ALLOW_ALL_USERS=true." "no"; then
                     EXPLICIT_ALLOW_ALL=1
                     break
+                else
+                    allow_all_prompt_status=$?
+                    if [ "$allow_all_prompt_status" -eq 2 ]; then
+                        sender_auth_not_configured_message
+                        exit 1
+                    fi
                 fi
-                printf 'Add at least one allowed sender or opt into allow-all before continuing.\n' >/dev/tty
+                printf 'Add at least one allowed sender or opt into allow-all before continuing.\n' >"$(prompt_tty_path)"
             done
         fi
     fi

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -257,16 +257,21 @@ validate_welcomer_inputs() {
 }
 
 validate_user_inputs() {
-    local user
+    local user entry remaining
     if [ "${#ALLOW_USERS[@]}" -eq 0 ]; then
         return 0
     fi
     for user in "${ALLOW_USERS[@]}"; do
-        if ! is_user_ref_syntax "$user"; then
-            echo "error: invalid message sender allowlist entry" >&2
-            echo "expected a Nostr npub or 64-character hex account id" >&2
-            exit 1
-        fi
+        remaining="$user,"
+        while [[ "$remaining" == *,* ]]; do
+            entry="${remaining%%,*}"
+            remaining="${remaining#*,}"
+            if ! is_user_ref_syntax "$entry"; then
+                echo "error: invalid message sender allowlist entry" >&2
+                echo "expected a Nostr npub or 64-character hex account id" >&2
+                exit 1
+            fi
+        done
     done
 }
 
@@ -307,6 +312,9 @@ import sys
 from pathlib import Path
 from typing import Iterable, Optional
 
+# These constants and the identity-parsing functions below intentionally mirror
+# scripts/hermes_marmot_configure_gateway.py. A semantic parity test guards this
+# streamed-install fallback against drifting from the installed helper.
 ACCOUNT_ID_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
 _BECH32_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
 _BECH32_VALUES = {character: index for index, character in enumerate(_BECH32_CHARSET)}
@@ -375,13 +383,20 @@ def normalize_account_id(entry: str) -> str:
     return normalized.lower().removeprefix("0x")
 
 
-def validate_account_id(entry: str, *, label: str) -> str:
+def _validate_account_id(entry: str, *, label: str) -> str:
     normalized = normalize_account_id(entry)
     if not ACCOUNT_ID_HEX_RE.fullmatch(normalized):
         raise ValueError(
             f"invalid {label}: expected a Nostr npub or 64-character hex account id"
         )
     return normalized
+
+
+def validate_sender_auth_entries(entries: list[str]) -> None:
+    for entry in entries:
+        if not str(entry).strip():
+            raise ValueError("invalid allowed user: empty value is not allowed")
+        _validate_account_id(entry, label="allowed user")
 
 
 def _parse_dotenv_scalar(raw_value: str) -> str:
@@ -469,22 +484,21 @@ def validate_existing_env_auth(env_path: Path) -> None:
 
 args = sys.argv[1:]
 index = 0
+allowed_users: list[str] = []
 while index < len(args):
     if args[index] == "--allow-user":
         index += 1
         if index >= len(args):
             print("error: missing value for --allow-user", file=sys.stderr)
             raise SystemExit(2)
-        entry = args[index]
-        if not str(entry).strip():
-            print("error: invalid allowed user: empty value is not allowed", file=sys.stderr)
-            raise SystemExit(2)
-        try:
-            validate_account_id(entry, label="allowed user")
-        except ValueError as exc:
-            print(f"error: {exc}", file=sys.stderr)
-            raise SystemExit(2) from exc
+        allowed_users.extend(args[index].split(","))
     index += 1
+
+try:
+    validate_sender_auth_entries(allowed_users)
+except ValueError as exc:
+    print(f"error: {exc}", file=sys.stderr)
+    raise SystemExit(2) from exc
 
 hermes_home = Path(os.environ.get("HERMES_HOME", ""))
 if hermes_home:
@@ -1107,6 +1121,8 @@ configure_hermes_gateway() {
 }
 
 print_next_steps() {
+    # Account ids stay in the bootstrap/config files but are intentionally
+    # omitted here to keep installer diagnostics privacy-safe.
     cat <<EOF
 
 Install complete.

--- a/scripts/install-hermes-marmot.sh
+++ b/scripts/install-hermes-marmot.sh
@@ -50,7 +50,9 @@ WN_AGENT_TEMP_PID=""
 
 RELAYS=()
 ALLOW_WELCOMERS=()
+ALLOW_USERS=()
 QUIC_CANDIDATES=()
+EXPLICIT_ALLOW_ALL=0
 
 usage() {
     cat <<'USAGE'
@@ -65,6 +67,8 @@ Options:
   --home PATH              Marmot agent home (default: ~/.marmot-agents/hermes)
   --hermes-home PATH       Hermes home (default: $HERMES_HOME or ~/.hermes)
   --allow-welcomer VALUE   Allow invites from this npub or hex pubkey; may repeat
+  --allow-user VALUE       Allow Marmot messages from this npub or hex account id; may repeat
+  --allow-all-users        Allow Marmot messages from any sender (explicit opt-in)
   --relay URL              Relay URL for wn-agent/bootstrap; may repeat
   --enable-streaming       Configure Marmot live preview streaming
   --quic-candidate URI     QUIC preview candidate used with --enable-streaming
@@ -92,10 +96,19 @@ Environment:
   MARMOT_RELAYS            Relay CSV used by wn-agent and bootstrap
   MARMOT_WELCOMER_ALLOWLIST Comma-separated npub or hex allowlist values
 
+Welcomer allowlist entries control which accounts may invite the Marmot agent
+through wn-agent. Message-sender allowlist entries control which Marmot senders
+Hermes accepts after gateway restart via $HERMES_HOME/.env.
+
 Example:
   curl -fsSL https://github.com/marmot-protocol/mdk/releases/download/wn-agent-latest/install-hermes-marmot.sh | bash
 
-  curl -fsSL .../install-hermes-marmot.sh | bash -s -- --yes --allow-welcomer npub1...
+  curl -fsSL .../install-hermes-marmot.sh | bash -s -- --yes \
+    --allow-welcomer npub1... \
+    --allow-user npub1...
+
+  curl -fsSL .../install-hermes-marmot.sh | bash -s -- --yes \
+    --allow-all-users
 USAGE
 }
 
@@ -202,6 +215,10 @@ is_welcomer_ref_syntax() {
     esac
 }
 
+is_user_ref_syntax() {
+    is_welcomer_ref_syntax "$1"
+}
+
 validate_welcomer_inputs() {
     local welcomer
     if [ "${#ALLOW_WELCOMERS[@]}" -eq 0 ]; then
@@ -209,11 +226,192 @@ validate_welcomer_inputs() {
     fi
     for welcomer in "${ALLOW_WELCOMERS[@]}"; do
         if ! is_welcomer_ref_syntax "$welcomer"; then
-            echo "error: invalid welcomer allowlist value: $welcomer" >&2
+            echo "error: invalid welcomer allowlist entry" >&2
             echo "expected a Nostr npub or 64-character hex account id" >&2
             exit 1
         fi
     done
+}
+
+validate_user_inputs() {
+    local user
+    if [ "${#ALLOW_USERS[@]}" -eq 0 ]; then
+        return 0
+    fi
+    for user in "${ALLOW_USERS[@]}"; do
+        if ! is_user_ref_syntax "$user"; then
+            echo "error: invalid message sender allowlist entry" >&2
+            echo "expected a Nostr npub or 64-character hex account id" >&2
+            exit 1
+        fi
+    done
+}
+
+configure_gateway_helper_path() {
+    if installed_configure_gateway_helper_path; then
+        return 0
+    fi
+    same_version_configure_gateway_helper_path
+}
+
+same_version_configure_gateway_helper_path() {
+    if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/hermes_marmot_configure_gateway.py" ]; then
+        printf '%s\n' "$SCRIPT_DIR/hermes_marmot_configure_gateway.py"
+        return 0
+    fi
+    return 1
+}
+
+installed_configure_gateway_helper_path() {
+    if [ -f "$MARMOT_PLUGIN_DIR/configure_gateway.py" ]; then
+        printf '%s\n' "$MARMOT_PLUGIN_DIR/configure_gateway.py"
+        return 0
+    fi
+    return 1
+}
+
+hermes_env_has_managed_sender_auth_keys() {
+    local env_file="$HERMES_HOME/.env"
+    [ -f "$env_file" ] || return 1
+    grep -Eq '^[[:space:]]*(export[[:space:]]+)?MARMOT_ALLOWED_USERS[[:space:]]*=' "$env_file" && return 0
+    grep -Eq '^[[:space:]]*(export[[:space:]]+)?MARMOT_ALLOW_ALL_USERS[[:space:]]*=' "$env_file" && return 0
+    return 1
+}
+
+is_strict_hex_account_id() {
+    local value normalized
+    value="${1#"${1%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    normalized="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+    normalized="${normalized#0x}"
+    [[ "$normalized" =~ ^[0-9a-f]{64}$ ]]
+}
+
+allow_users_need_helper_validation() {
+    local user normalized
+    for user in "${ALLOW_USERS[@]}"; do
+        normalized="$(printf '%s' "$user" | tr '[:upper:]' '[:lower:]')"
+        case "$normalized" in
+            npub1*) return 0 ;;
+        esac
+        if ! is_strict_hex_account_id "$user"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+run_gateway_helper_env_dry_run() {
+    local helper="${1:-}"
+    if [ -z "$helper" ]; then
+        if ! helper="$(configure_gateway_helper_path)"; then
+            return 1
+        fi
+    fi
+    local -a args=(
+        "$helper"
+        --home "$HERMES_HOME"
+        --configure-env
+        --env-dry-run
+        --quiet
+    )
+    local user
+    for user in "${ALLOW_USERS[@]}"; do
+        args+=(--allow-user "$user")
+    done
+    if [ "$EXPLICIT_ALLOW_ALL" -eq 1 ]; then
+        args+=(--allow-all-users)
+    fi
+    python3 "${args[@]}"
+}
+
+sender_auth_not_configured_message() {
+    echo "error: Hermes Marmot sender authorization is not configured." >&2
+    echo "Pass one or more --allow-user npub-or-hex values, opt into --allow-all-users," >&2
+    echo "or keep an existing valid allowlist in $HERMES_HOME/.env." >&2
+    echo "Use --no-configure-hermes to install assets without patching Hermes." >&2
+}
+
+log_sender_auth_dry_run_intent() {
+    if [ "${#ALLOW_USERS[@]}" -gt 0 ]; then
+        log "would configure Marmot message-sender authorization for ${#ALLOW_USERS[@]} allowed sender(s)"
+    elif [ -f "$HERMES_HOME/.env" ]; then
+        log "would preserve or update existing Marmot message-sender authorization in Hermes env"
+    else
+        log "would configure Marmot message-sender authorization in Hermes env"
+    fi
+    if [ "$EXPLICIT_ALLOW_ALL" -eq 1 ]; then
+        log "would set MARMOT_ALLOW_ALL_USERS=true"
+    else
+        log "would keep MARMOT_ALLOW_ALL_USERS=false unless already true in Hermes env"
+    fi
+}
+
+validate_hermes_sender_auth_pre_install() {
+    if [ "$CONFIGURE_HERMES" -ne 1 ]; then
+        return 0
+    fi
+
+    if [ "$DRY_RUN" -eq 0 ] && [ "$ASSUME_YES" -eq 1 ]; then
+        if [ "$EXPLICIT_ALLOW_ALL" -eq 0 ] && [ "${#ALLOW_USERS[@]}" -eq 0 ]; then
+            if ! hermes_env_has_managed_sender_auth_keys; then
+                sender_auth_not_configured_message
+                exit 1
+            fi
+            return 0
+        fi
+    fi
+
+    local helper=""
+    if same_version_configure_gateway_helper_path >/dev/null 2>&1; then
+        helper="$(same_version_configure_gateway_helper_path)"
+        if ! run_gateway_helper_env_dry_run "$helper"; then
+            echo "error: invalid Hermes Marmot sender authorization inputs" >&2
+            exit 1
+        fi
+        return 0
+    fi
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        if [ "$EXPLICIT_ALLOW_ALL" -eq 1 ]; then
+            return 0
+        fi
+        if [ "${#ALLOW_USERS[@]}" -gt 0 ]; then
+            if allow_users_need_helper_validation; then
+                echo "error: cannot strictly validate sender authorization without the configure helper" >&2
+                exit 1
+            fi
+            return 0
+        fi
+        if hermes_env_has_managed_sender_auth_keys; then
+            echo "error: cannot strictly validate existing sender authorization without the configure helper" >&2
+            exit 1
+        fi
+        sender_auth_not_configured_message
+        exit 1
+    fi
+
+    if [ "$EXPLICIT_ALLOW_ALL" -eq 1 ] || [ "${#ALLOW_USERS[@]}" -gt 0 ] || hermes_env_has_managed_sender_auth_keys; then
+        return 0
+    fi
+
+    sender_auth_not_configured_message
+    exit 1
+}
+
+validate_hermes_sender_auth_post_install() {
+    if [ "$CONFIGURE_HERMES" -ne 1 ] || [ "$DRY_RUN" -eq 1 ]; then
+        return 0
+    fi
+    local helper
+    if ! helper="$(installed_configure_gateway_helper_path)"; then
+        echo "error: Hermes config helper not found after plugin install" >&2
+        exit 1
+    fi
+    if ! run_gateway_helper_env_dry_run "$helper"; then
+        echo "error: Hermes Marmot sender authorization validation failed after plugin install" >&2
+        exit 1
+    fi
 }
 
 detect_platform() {
@@ -649,15 +847,22 @@ configure_hermes_gateway() {
     if [ "$CONFIGURE_HERMES" -ne 1 ]; then
         return 0
     fi
-    local helper="$MARMOT_PLUGIN_DIR/configure_gateway.py"
+    local helper
+    if ! helper="$(configure_gateway_helper_path)"; then
+        if [ "$DRY_RUN" -eq 1 ]; then
+            log "would patch Hermes config: $HERMES_HOME/config.yaml"
+            log "would preserve other Hermes connectors and only update platforms.marmot/display.platforms.marmot"
+            log_sender_auth_dry_run_intent
+            return 0
+        fi
+        echo "error: Hermes config helper not found" >&2
+        exit 1
+    fi
     if [ "$DRY_RUN" -eq 1 ]; then
         log "would patch Hermes config: $HERMES_HOME/config.yaml"
         log "would preserve other Hermes connectors and only update platforms.marmot/display.platforms.marmot"
+        log_sender_auth_dry_run_intent
         return 0
-    fi
-    if [ ! -f "$helper" ]; then
-        echo "error: Hermes config helper not found in plugin: $helper" >&2
-        exit 1
     fi
 
     local -a args=(
@@ -670,17 +875,25 @@ configure_hermes_gateway() {
         --interim-messages 0
         --long-running-notifications 0
         --busy-ack-detail 0
+        --configure-env
     )
     if [ "$ENABLE_STREAMING" -eq 1 ]; then
         args+=(--streaming 1 --transport auto --configure-global-streaming)
     else
         args+=(--streaming 0 --transport off)
     fi
+    local welcomer
     if [ "${#ALLOW_WELCOMERS[@]}" -gt 0 ]; then
-        local welcomer
         for welcomer in "${ALLOW_WELCOMERS[@]}"; do
             args+=(--welcomer-allowlist "$welcomer")
         done
+    fi
+    local user
+    for user in "${ALLOW_USERS[@]}"; do
+        args+=(--allow-user "$user")
+    done
+    if [ "$EXPLICIT_ALLOW_ALL" -eq 1 ]; then
+        args+=(--allow-all-users)
     fi
     run python3 "${args[@]}"
 }
@@ -695,7 +908,6 @@ Marmot agent:
   home: $MARMOT_HOME
   socket: $MARMOT_AGENT_SOCKET
   service: $MARMOT_AGENT_SERVICE_NAME.service (Linux) / $MARMOT_AGENT_LAUNCHD_LABEL (macOS)
-  account: $BOOTSTRAP_ACCOUNT_ID_HEX
   bootstrap JSON: $BOOTSTRAP_JSON_PATH
 EOF
     if [ -n "${WN_AGENT_TEMP_PID:-}" ]; then
@@ -711,6 +923,10 @@ Hermes:
 
 Restart your existing Hermes gateway when you are ready for it to load the Marmot plugin/config:
   hermes gateway restart
+
+Hermes loads sender authorization from $HERMES_HOME/.env at gateway startup.
+After changing MARMOT_ALLOWED_USERS or MARMOT_ALLOW_ALL_USERS, restart Hermes
+so allowed Marmot senders are accepted.
 
 Existing Hermes connectors were not removed or disabled. The installer only updated the Marmot plugin and Marmot-specific config entries.
 
@@ -739,6 +955,14 @@ while [ "$#" -gt 0 ]; do
         --allow-welcomer)
             ALLOW_WELCOMERS+=("${2:?missing value for --allow-welcomer}")
             shift 2
+            ;;
+        --allow-user)
+            ALLOW_USERS+=("${2:?missing value for --allow-user}")
+            shift 2
+            ;;
+        --allow-all-users)
+            EXPLICIT_ALLOW_ALL=1
+            shift
             ;;
         --relay)
             CLI_RELAYS=1
@@ -837,11 +1061,47 @@ if [ "$INTERACTIVE" -eq 1 ]; then
             fi
         done
     fi
+    if [ "${#ALLOW_USERS[@]}" -eq 0 ] && [ "$EXPLICIT_ALLOW_ALL" -ne 1 ]; then
+        prompt_sender_auth=1
+        if hermes_env_has_managed_sender_auth_keys; then
+            log "existing Marmot message-sender authorization found in Hermes env; preserving unless you add entries"
+            if ! prompt_yes_no "Add more allowed Marmot message senders?" "no"; then
+                prompt_sender_auth=0
+            fi
+        fi
+        if [ "$prompt_sender_auth" -eq 1 ]; then
+            while true; do
+                user_reply="$(prompt_value "Allowed Marmot message sender npub or hex (blank to finish)" "")"
+                if [ -n "$user_reply" ]; then
+                    ALLOW_USERS+=("$user_reply")
+                    continue
+                fi
+                if [ "${#ALLOW_USERS[@]}" -gt 0 ]; then
+                    break
+                fi
+                if [ "${#ALLOW_WELCOMERS[@]}" -gt 0 ]; then
+                    if prompt_yes_no "Also allow configured welcomer identity/identities to message Hermes?" "no"; then
+                        ALLOW_USERS+=("${ALLOW_WELCOMERS[@]}")
+                    fi
+                fi
+                if [ "${#ALLOW_USERS[@]}" -gt 0 ]; then
+                    break
+                fi
+                if prompt_yes_no "Allow Marmot messages from any sender? This sets MARMOT_ALLOW_ALL_USERS=true." "no"; then
+                    EXPLICIT_ALLOW_ALL=1
+                    break
+                fi
+                printf 'Add at least one allowed sender or opt into allow-all before continuing.\n' >/dev/tty
+            done
+        fi
+    fi
 fi
 
 MARMOT_OUTBOUND_MEDIA_DIR="${MARMOT_OUTBOUND_MEDIA_DIR_OVERRIDE:-$MARMOT_HOME/dev/outbound-media}"
 
 validate_welcomer_inputs
+validate_user_inputs
+validate_hermes_sender_auth_pre_install
 
 need_cmd curl
 need_cmd tar
@@ -872,6 +1132,7 @@ log "Marmot socket: $MARMOT_AGENT_SOCKET"
 log "Marmot agent label: $MARMOT_AGENT_LABEL"
 install_wn_agent "$platform" "$tmpdir"
 install_plugin "$tmpdir"
+validate_hermes_sender_auth_post_install
 enable_hermes_plugin
 bootstrap_agent
 configure_hermes_gateway


### PR DESCRIPTION
Fixes #1129

## Summary
- add separate, repeatable `--allow-user` and explicit `--allow-all-users` installer controls for Hermes inbound Marmot senders, distinct from `wn-agent` welcomers
- strictly validate and normalize npub/hex identities before mutation, then transactionally persist `$HERMES_HOME/.env` and `config.yaml` with atomic rollback and private `.env` mode `0600`
- preserve existing allowlists, allow-all state, unrelated dotenv/config content, and fail closed on malformed or missing authorization
- add mocked streamed/fresh/reinstall/upgrade installer coverage plus a fresh-process E2E against real Hermes `GatewayRunner` authorization
- document restart-required behavior without restarting the gateway automatically
- intentionally omit account identifiers from installer console summaries; they remain available in the private bootstrap/config artifacts

## Verification
- `python3 -m unittest discover -s integrations/hermes/marmot/tests -v` — 152 passed after rebase onto `33596a3d`, with inherited `MARMOT_*` scrubbed
- `integrations/hermes/marmot/tests/test_dev_scripts.sh` — passed
- real Hermes `af8d698b418ede7dc8b078a8116510699ec94eb7` installer/auth check — `allowed=true unknown=false`
- `scripts/hermes_marmot_deterministic_e2e.sh` — passed
- GNU Bash 3.2.57 container checks — allow-all and existing-auth empty-array paths passed
- shell syntax, Python byte-compilation, workflow parse, and `git diff --check` — passed
- `just fast-ci` — passed after the final review fix

## Sensitive paths
This changes inbound authorization semantics and persistence:
- `scripts/install-hermes-marmot.sh`
- `scripts/hermes_marmot_configure_gateway.py`
- `integrations/hermes/marmot/plugin.yaml`
- authorization installer/E2E tests

Manual merge approval is required.

## Coordination
Rebased onto #1130 (`33596a3d`) and retained its persisted-config readiness tests plus `hermes gateway restart` guidance. This intentionally excludes #1127.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Hermes Marmot message-sender authorization support during installation and configuration, with repeatable `--allow-user` and explicit `--allow-all-users` opt-in.
  * Accepts sender identities in `npub` or 64-char hex formats and merges/updates authorization across reinstalls.
  * Added `--env-dry-run` and improved interactive prompts, including guidance to restart Hermes after changes.
* **Documentation**
  * Expanded the Hermes Marmot README with a dedicated “message-sender authorization” section and clearer welcomer vs sender separation.
* **Tests**
  * Added/expanded installer and gateway auth test coverage and introduced a new CI job covering authorization flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
