### PR TITLE
fix(agent): skip onboarding for existing profiles

### DIFF
--- a/crates/agent-connector/src/account.rs
+++ b/crates/agent-connector/src/account.rs
@@ -1,6 +1,6 @@
 //! Account listing/creation, profile publishing, and welcomer-allowlist operations.
 
-use agent_control::{AgentControlAccount, AgentControlResponse};
+use agent_control::{AgentControlAccount, AgentControlProfileLookupStatus, AgentControlResponse};
 use marmot_account::{AccountHome, AccountHomeError, AccountSummary};
 use marmot_app::{AccountRelayListBootstrap, UserProfileMetadata};
 
@@ -74,6 +74,36 @@ impl AgentConnector {
             account_id_hex: account.account_id_hex,
             name,
             display_name: Some(display_name),
+        })
+    }
+
+    pub(crate) async fn profile_lookup_response(
+        &self,
+        account_id_hex: &str,
+    ) -> Result<AgentControlResponse, ConnectorError> {
+        let account = self.local_account_for_account_id(account_id_hex)?;
+        let source_relays = self.configured_relay_endpoints();
+        if source_relays.is_empty() {
+            return Ok(AgentControlResponse::ProfileLookup {
+                account_id_hex: account.account_id_hex,
+                status: AgentControlProfileLookupStatus::Indeterminate,
+                retryable: true,
+            });
+        }
+
+        let status = match self
+            .runtime
+            .fetch_current_user_profile_for_account_id(&account.account_id_hex, source_relays)
+            .await
+        {
+            Ok(Some(_)) => AgentControlProfileLookupStatus::ProfileFound,
+            Ok(None) => AgentControlProfileLookupStatus::ProfileNotFound,
+            Err(_) => AgentControlProfileLookupStatus::Indeterminate,
+        };
+        Ok(AgentControlResponse::ProfileLookup {
+            account_id_hex: account.account_id_hex,
+            status,
+            retryable: status == AgentControlProfileLookupStatus::Indeterminate,
         })
     }
 

--- a/crates/agent-connector/src/bootstrap.rs
+++ b/crates/agent-connector/src/bootstrap.rs
@@ -466,6 +466,7 @@ fn response_type_name(response: &AgentControlResponse) -> &'static str {
         AgentControlResponse::AccountCreated { .. } => "account_created",
         AgentControlResponse::KeyPackagePublished { .. } => "key_package_published",
         AgentControlResponse::ProfilePublished { .. } => "profile_published",
+        AgentControlResponse::ProfileLookup { .. } => "profile_lookup",
         AgentControlResponse::FinalSent { .. } => "final_sent",
         AgentControlResponse::AppEventSent { .. } => "app_event_sent",
         AgentControlResponse::Allowlist { .. } => "allowlist",

--- a/crates/agent-connector/src/connection.rs
+++ b/crates/agent-connector/src/connection.rs
@@ -354,6 +354,9 @@ impl AgentConnector {
                 self.publish_profile_response(&account_id_hex, name, display_name)
                     .await
             }
+            AgentControlRequest::AccountProfileLookup { account_id_hex } => {
+                self.profile_lookup_response(&account_id_hex).await
+            }
             AgentControlRequest::SendAgentActivity {
                 account_id_hex,
                 group_id_hex,

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -2,8 +2,8 @@
 
 use agent_control::{
     AGENT_CONTROL_STREAM_STATUS_STARTED, AgentControlEnvelope, AgentControlEvent,
-    AgentControlRequest, AgentControlResponse, AgentControlSendMaintenanceDisposition,
-    read_envelope, write_frame,
+    AgentControlProfileLookupStatus, AgentControlRequest, AgentControlResponse,
+    AgentControlSendMaintenanceDisposition, read_envelope, write_frame,
 };
 use cgka_traits::agent_text_stream::{
     AGENT_TEXT_STREAM_MAX_PLAINTEXT_FRAME_LEN, AGENT_TEXT_STREAM_RECORD_STATUS,
@@ -2113,6 +2113,87 @@ async fn connector_socket_publishes_profile_metadata() {
     assert_eq!(profile.display_name.as_deref(), Some("Hermes Agent"));
 
     server.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn connector_profile_lookup_distinguishes_existing_and_absent_profiles() {
+    let dir = tempfile::tempdir().unwrap();
+    let relay = MockRelay::run().await.unwrap();
+    let relay_url = relay.url().await.to_string();
+    let account_home = AccountHome::open(dir.path());
+    let account = account_home.create_account("agent").unwrap();
+    let connector = AgentConnector::open(test_config(
+        dir.path(),
+        dir.path().join("dev").join("wn-agent.sock"),
+        vec![relay_url],
+        false,
+        false,
+    ))
+    .unwrap();
+
+    let absent = connector
+        .profile_lookup_response(&account.account_id_hex)
+        .await
+        .unwrap();
+    assert!(matches!(
+        absent,
+        AgentControlResponse::ProfileLookup {
+            status: AgentControlProfileLookupStatus::ProfileNotFound,
+            retryable: false,
+            ..
+        }
+    ));
+
+    connector
+        .publish_profile_response(
+            &account.account_id_hex,
+            "Existing Agent".to_owned(),
+            Some("Existing Agent".to_owned()),
+        )
+        .await
+        .unwrap();
+
+    let found = connector
+        .profile_lookup_response(&account.account_id_hex)
+        .await
+        .unwrap();
+    assert!(matches!(
+        found,
+        AgentControlResponse::ProfileLookup {
+            status: AgentControlProfileLookupStatus::ProfileFound,
+            retryable: false,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn connector_profile_lookup_without_relays_is_indeterminate() {
+    let dir = tempfile::tempdir().unwrap();
+    let account = AccountHome::open(dir.path())
+        .create_account("agent")
+        .unwrap();
+    let connector = AgentConnector::open(test_config(
+        dir.path(),
+        dir.path().join("dev").join("wn-agent.sock"),
+        Vec::new(),
+        false,
+        false,
+    ))
+    .unwrap();
+
+    let response = connector
+        .profile_lookup_response(&account.account_id_hex)
+        .await
+        .unwrap();
+    assert!(matches!(
+        response,
+        AgentControlResponse::ProfileLookup {
+            status: AgentControlProfileLookupStatus::Indeterminate,
+            retryable: true,
+            ..
+        }
+    ));
 }
 
 #[tokio::test]

--- a/crates/agent-connector/src/validation.rs
+++ b/crates/agent-connector/src/validation.rs
@@ -114,6 +114,7 @@ pub(crate) fn agent_control_request_type(request: &AgentControlRequest) -> &'sta
         AgentControlRequest::AccountCreate { .. } => "account_create",
         AgentControlRequest::AccountPublishKeyPackage { .. } => "account_publish_key_package",
         AgentControlRequest::AccountPublishProfile { .. } => "account_publish_profile",
+        AgentControlRequest::AccountProfileLookup { .. } => "account_profile_lookup",
         AgentControlRequest::SendAgentActivity { .. } => "send_agent_activity",
         AgentControlRequest::SendAgentOperationEvent { .. } => "send_agent_operation_event",
         AgentControlRequest::SendGroupSystemEvent { .. } => "send_group_system_event",

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -147,6 +147,12 @@ pub enum AgentControlRequest {
         name: String,
         display_name: Option<String>,
     },
+    /// Resolve whether the selected account already has a valid published
+    /// Nostr kind-0 profile. The connector returns a typed outcome so relay
+    /// failures can never be mistaken for a confirmed absence.
+    AccountProfileLookup {
+        account_id_hex: String,
+    },
     SendAgentActivity {
         account_id_hex: String,
         group_id_hex: String,
@@ -310,6 +316,11 @@ pub enum AgentControlResponse {
         name: String,
         display_name: Option<String>,
     },
+    ProfileLookup {
+        account_id_hex: String,
+        status: AgentControlProfileLookupStatus,
+        retryable: bool,
+    },
     FinalSent {
         message_ids_hex: Vec<String>,
         #[serde(default)]
@@ -387,6 +398,14 @@ pub enum AgentControlSendMaintenanceDisposition {
     #[default]
     Ready,
     PostJoinRotationPendingRetryable,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentControlProfileLookupStatus {
+    ProfileFound,
+    ProfileNotFound,
+    Indeterminate,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -627,10 +646,10 @@ mod tests {
     use tokio::io::BufReader;
 
     use crate::{
-        AgentControlEnvelope, AgentControlError, AgentControlEvent, AgentControlRequest,
-        AgentControlResponse, AgentControlSendMaintenanceDisposition,
-        MAX_AGENT_CONTROL_FRAME_BYTES, decode_envelope, encode_frame, read_envelope, read_frame,
-        write_frame,
+        AgentControlEnvelope, AgentControlError, AgentControlEvent,
+        AgentControlProfileLookupStatus, AgentControlRequest, AgentControlResponse,
+        AgentControlSendMaintenanceDisposition, MAX_AGENT_CONTROL_FRAME_BYTES, decode_envelope,
+        encode_frame, read_envelope, read_frame, write_frame,
     };
 
     #[test]
@@ -1059,6 +1078,12 @@ mod tests {
                 "account_publish_profile",
             ),
             (
+                AgentControlRequest::AccountProfileLookup {
+                    account_id_hex: account(),
+                },
+                "account_profile_lookup",
+            ),
+            (
                 AgentControlRequest::SendAgentActivity {
                     account_id_hex: account(),
                     group_id_hex: group(),
@@ -1233,6 +1258,34 @@ mod tests {
         for (request, expected_type) in requests {
             let value = serde_json::to_value(request).unwrap();
             assert_eq!(value["type"], expected_type);
+        }
+    }
+
+    #[test]
+    fn account_profile_lookup_has_typed_found_absent_and_indeterminate_outcomes() {
+        let request = AgentControlRequest::AccountProfileLookup {
+            account_id_hex: account(),
+        };
+        let request_json = serde_json::to_value(&request).unwrap();
+        assert_eq!(request_json["type"], "account_profile_lookup");
+        assert_eq!(request_json["account_id_hex"], account());
+
+        for (status, retryable) in [
+            (AgentControlProfileLookupStatus::ProfileFound, false),
+            (AgentControlProfileLookupStatus::ProfileNotFound, false),
+            (AgentControlProfileLookupStatus::Indeterminate, true),
+        ] {
+            let response = AgentControlResponse::ProfileLookup {
+                account_id_hex: account(),
+                status,
+                retryable,
+            };
+            let value = serde_json::to_value(&response).unwrap();
+            assert_eq!(value["type"], "profile_lookup");
+            assert_eq!(value["account_id_hex"], account());
+            assert_eq!(value["retryable"], retryable);
+            let round_tripped: AgentControlResponse = serde_json::from_value(value).unwrap();
+            assert_eq!(round_tripped, response);
         }
     }
 

--- a/crates/marmot-app/src/directory/records.rs
+++ b/crates/marmot-app/src/directory/records.rs
@@ -246,6 +246,7 @@ pub(crate) fn profile_from_record(
     record: RelayEventRecord,
 ) -> Option<(String, UserProfileMetadata)> {
     let content = serde_json::from_str::<serde_json::Value>(&record.event.content).ok()?;
+    content.as_object()?;
     Some((
         record.event.pubkey.clone(),
         UserProfileMetadata {
@@ -535,6 +536,9 @@ pub(crate) fn latest_fresh_profiles_from_records(
 
 #[cfg(test)]
 mod tests {
+    use cgka_traits::TransportEndpoint;
+    use transport_nostr_peeler::NostrTransportEvent;
+
     use super::*;
 
     #[test]
@@ -549,6 +553,27 @@ mod tests {
             Some("alice[2Jadmin")
         );
         assert_eq!(string_field(&content, "about"), None);
+    }
+
+    #[test]
+    fn malformed_profile_content_is_not_treated_as_an_existing_profile() {
+        for malformed in ["not-json", "null", "[]", r#""string""#] {
+            let account_id = "11".repeat(32);
+            let records = vec![RelayEventRecord {
+                endpoints: vec![TransportEndpoint("wss://relay.example".to_owned())],
+                event: NostrTransportEvent::new_unsigned(
+                    account_id.clone(),
+                    KIND_NOSTR_METADATA,
+                    Vec::new(),
+                    malformed.to_owned(),
+                ),
+            }];
+
+            assert!(
+                !latest_profiles_from_records(records).contains_key(&account_id),
+                "accepted malformed kind-0 content: {malformed}"
+            );
+        }
     }
 
     #[test]

--- a/crates/marmot-app/src/relay_plane/directory.rs
+++ b/crates/marmot-app/src/relay_plane/directory.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use cgka_traits::TransportEndpoint;
-use nostr_sdk::prelude::{Client as NostrSdkClient, Filter, Kind, PublicKey, RelayUrl};
+use nostr_sdk::prelude::{Client as NostrSdkClient, Event, Filter, Kind, PublicKey, RelayUrl};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, oneshot};
 use tokio::time::timeout;
@@ -324,6 +324,22 @@ impl NostrSdkDirectoryRelayFetcher {
     }
 }
 
+fn validated_directory_event(
+    event: &Event,
+    query: &DirectoryEventQuery,
+) -> Option<NostrTransportEvent> {
+    if event.verify().is_err()
+        || u64::from(event.kind.as_u16()) != query.kind
+        || !query
+            .authors
+            .iter()
+            .any(|author| author == &event.pubkey.to_hex())
+    {
+        return None;
+    }
+    NostrTransportEvent::from_nostr_event(event).ok()
+}
+
 #[async_trait]
 impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
     async fn fetch_directory_events(
@@ -371,8 +387,9 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
                 .await
                 .map_err(|_| "fetch directory events failed".to_owned())?;
             for event in events {
-                let event = NostrTransportEvent::from_nostr_event(&event)
-                    .map_err(|_| "map directory event failed".to_owned())?;
+                let Some(event) = validated_directory_event(&event, &query) else {
+                    continue;
+                };
                 records.push(DirectoryRelayEventRecord {
                     endpoints: request.endpoints.clone(),
                     event,
@@ -386,6 +403,30 @@ impl DirectoryRelayFetcher for NostrSdkDirectoryRelayFetcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn directory_event_validation_rejects_invalid_signatures_and_wrong_authors() {
+        use nostr_sdk::prelude::{Event, EventBuilder, JsonUtil, Keys};
+
+        let expected = Keys::generate();
+        let wrong = Keys::generate();
+        let query = DirectoryEventQuery::new(0, vec![expected.public_key().to_hex()], 1);
+        let valid = EventBuilder::new(Kind::Metadata, r#"{"name":"agent"}"#)
+            .sign_with_keys(&expected)
+            .unwrap();
+        assert!(validated_directory_event(&valid, &query).is_some());
+
+        let wrong_author = EventBuilder::new(Kind::Metadata, r#"{"name":"other"}"#)
+            .sign_with_keys(&wrong)
+            .unwrap();
+        assert!(validated_directory_event(&wrong_author, &query).is_none());
+
+        let mut tampered = serde_json::to_value(&valid).unwrap();
+        tampered["content"] = serde_json::Value::String(r#"{"name":"tampered"}"#.to_owned());
+        let tampered = Event::from_json(tampered.to_string()).unwrap();
+        assert!(tampered.verify().is_err());
+        assert!(validated_directory_event(&tampered, &query).is_none());
+    }
 
     #[tokio::test]
     async fn sdk_fetcher_errors_do_not_echo_invalid_relay_urls() {

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -2350,6 +2350,20 @@ impl MarmotAppRuntime {
         Ok(outcome)
     }
 
+    /// Read the selected account's current published kind-0 profile through the
+    /// same validated directory path used by app clients. Relay failures remain
+    /// errors so callers can distinguish them from a confirmed absence.
+    pub async fn fetch_current_user_profile_for_account_id(
+        &self,
+        account_id_hex: &str,
+        source_relays: Vec<TransportEndpoint>,
+    ) -> Result<Option<UserProfileMetadata>, AppError> {
+        self.accounts
+            .app
+            .fetch_current_user_profile_for_account_id(account_id_hex, source_relays)
+            .await
+    }
+
     pub async fn publish_user_profile(
         &self,
         account_ref: &str,

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -16,11 +16,12 @@ import os
 import re
 import shutil
 import stat
+import time
 import uuid
 from collections import OrderedDict
 from contextvars import ContextVar
 from pathlib import Path
-from typing import Any, AsyncIterator, Dict, Iterable, Literal, Optional, Tuple
+from typing import Any, AsyncIterator, Awaitable, Callable, Dict, Iterable, Literal, Optional, Tuple
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
@@ -723,6 +724,9 @@ class ProfileNameOnboardingStore:
     async def mark_skipped(self, account_id_hex: str) -> None:
         await self._set(account_id_hex, {"status": "skipped"})
 
+    async def mark_profile_exists(self, account_id_hex: str) -> None:
+        await self._set(account_id_hex, {"status": "profile_exists"})
+
     async def _set(self, account_id_hex: str, record: Dict[str, Any]) -> None:
         async with self._lock:
             data = self._read()
@@ -790,6 +794,72 @@ class AgentTextStreamTranscript:
             self.chunk_count += 1
 
 
+ProfileLookupStatus = Literal["profile_found", "profile_not_found", "indeterminate"]
+PROFILE_LOOKUP_BACKOFF_S = (1.0, 5.0, 30.0)
+
+
+class ProfileLookupGate:
+    """Deduplicate account profile lookups and back off indeterminate results."""
+
+    def __init__(
+        self,
+        *,
+        now: Callable[[], float] = time.monotonic,
+        backoff_seconds: Tuple[float, ...] = PROFILE_LOOKUP_BACKOFF_S,
+    ):
+        self._now = now
+        self._backoff_seconds = backoff_seconds or PROFILE_LOOKUP_BACKOFF_S
+        self._lock = asyncio.Lock()
+        self._in_flight: Dict[str, asyncio.Task[ProfileLookupStatus]] = {}
+        self._failures: Dict[str, Tuple[int, float]] = {}
+
+    async def lookup(
+        self,
+        account_id_hex: str,
+        lookup: Callable[[], Awaitable[Dict[str, Any]]],
+    ) -> ProfileLookupStatus:
+        key = account_id_hex.lower()
+        async with self._lock:
+            failure = self._failures.get(key)
+            if failure is not None and self._now() < failure[1]:
+                return "indeterminate"
+            task = self._in_flight.get(key)
+            if task is None:
+                task = asyncio.create_task(self._perform_lookup(key, lookup))
+                self._in_flight[key] = task
+                task.add_done_callback(
+                    lambda completed, lookup_key=key: self._discard_completed(lookup_key, completed)
+                )
+
+        return await asyncio.shield(task)
+
+    def _discard_completed(self, key: str, task: asyncio.Task[ProfileLookupStatus]) -> None:
+        if self._in_flight.get(key) is task:
+            self._in_flight.pop(key, None)
+
+    async def _perform_lookup(
+        self,
+        key: str,
+        lookup: Callable[[], Awaitable[Dict[str, Any]]],
+    ) -> ProfileLookupStatus:
+        try:
+            response = await lookup()
+            status = response.get("status") if response.get("type") == "profile_lookup" else None
+            if status not in {"profile_found", "profile_not_found", "indeterminate"}:
+                status = "indeterminate"
+        except Exception:
+            status = "indeterminate"
+
+        if status != "indeterminate":
+            self._failures.pop(key, None)
+            return status
+
+        attempts = self._failures.get(key, (0, 0.0))[0] + 1
+        delay = self._backoff_seconds[min(attempts - 1, len(self._backoff_seconds) - 1)]
+        self._failures[key] = (attempts, self._now() + delay)
+        return "indeterminate"
+
+
 class MarmotAgentControlClient:
     """Small NDJSON client for ``crates/agent-control``."""
 
@@ -833,6 +903,22 @@ class MarmotAgentControlClient:
 
     async def account_list(self) -> Dict[str, Any]:
         return await self.request({"type": "account_list"})
+
+    async def account_lookup_profile(self, account_id_hex: str) -> Dict[str, Any]:
+        response = await self.request(
+            {
+                "type": "account_profile_lookup",
+                "account_id_hex": _normalize_hex(account_id_hex, "account_id_hex"),
+            }
+        )
+        status = response.get("status")
+        if (
+            response.get("type") != "profile_lookup"
+            or status not in {"profile_found", "profile_not_found", "indeterminate"}
+            or not isinstance(response.get("retryable"), bool)
+        ):
+            raise AgentControlError("wn-agent returned invalid profile_lookup response", code="protocol_error")
+        return response
 
     async def account_publish_profile(
         self,
@@ -1435,6 +1521,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             if self.profile_name_onboarding_enabled
             else None
         )
+        self._profile_lookup_gate = ProfileLookupGate()
         self._sent_targets = SentMessageTargetCache()
         self._activation_cache = GroupActivationCache()
         self._listener_task: Optional[asyncio.Task] = None
@@ -2764,21 +2851,45 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
         return "\n".join(pending)
 
     async def _maybe_send_profile_prompt_on_join(self, account_id_hex: str, group_id_hex: str) -> None:
+        await self._maybe_prompt_for_missing_profile(account_id_hex, group_id_hex)
+
+    async def _maybe_prompt_for_missing_profile(
+        self,
+        account_id_hex: str,
+        group_id_hex: str,
+        *,
+        reply_to_message_id_hex: Optional[str] = None,
+    ) -> bool:
         store = self.profile_name_onboarding
         if store is None:
-            return
+            return False
+        if (await store.get(account_id_hex)).get("status"):
+            return False
+
+        lookup_status = await self._profile_lookup_gate.lookup(
+            account_id_hex,
+            lambda: self.client.account_lookup_profile(account_id_hex),
+        )
+        if lookup_status == "profile_found":
+            await store.mark_profile_exists(account_id_hex)
+            return False
+        if lookup_status == "indeterminate":
+            return False
 
         suggested = valid_profile_name(self.agent_name)
         if not await store.try_claim_prompt(account_id_hex, group_id_hex, suggested):
-            return
-
+            return False
         result = await self._send_final_direct(
             group_id_hex,
             build_profile_prompt(suggested),
+            reply_to_message_id_hex=reply_to_message_id_hex,
         )
-        if not result.success:
-            logger.debug("Marmot profile-name prompt send failed on join: %s", result.error)
-            await store.clear(account_id_hex)
+        if result.success:
+            return True
+
+        logger.debug("Marmot profile-name prompt send failed: %s", result.error)
+        await store.clear(account_id_hex)
+        return False
 
     async def _maybe_handle_profile_name_onboarding(self, event: Dict[str, Any]) -> bool:
         store = self.profile_name_onboarding
@@ -2791,7 +2902,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             message_id_hex = _normalize_hex(event["message_id_hex"], "message_id_hex")
             state = await store.get(account_id_hex)
             status = state.get("status")
-            if status in {"published", "skipped"}:
+            if status in {"profile_exists", "published", "skipped"}:
                 return False
             if status == "prompted":
                 if state.get("group_id_hex") != group_id_hex:
@@ -2803,31 +2914,11 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                     str(event.get("text") or ""),
                 )
 
-            # Claim the one-time prompt slot atomically BEFORE sending. Under the new
-            # per-group concurrency (#513), two first messages for the same account in
-            # different groups could otherwise both read empty state and both prompt
-            # (double-prompting and swallowing both user messages). try_claim_prompt() is
-            # the single-lock claim that lets exactly one caller win; everyone else returns
-            # False here and falls through to a normal turn.
-            if not await store.try_claim_prompt(
+            return await self._maybe_prompt_for_missing_profile(
                 account_id_hex,
                 group_id_hex,
-                valid_profile_name(self.agent_name),
-            ):
-                return False
-
-            result = await self._send_final_direct(
-                group_id_hex,
-                build_profile_prompt(valid_profile_name(self.agent_name)),
                 reply_to_message_id_hex=message_id_hex,
             )
-            if not result.success:
-                # We claimed the slot but could not deliver the prompt; release it so a
-                # later inbound message retries, instead of permanently swallowing this one.
-                logger.debug("Marmot profile-name prompt send failed: %s", result.error)
-                await store.clear(account_id_hex)
-                return False
-            return True
         except Exception as exc:
             logger.debug("Marmot profile-name onboarding failed: %s", exc)
             return False

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -321,6 +321,33 @@ class AgentControlClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response["type"], "account_list")
         self.assertEqual(requests[0]["auth_token"], "test-token")
 
+    async def test_account_lookup_profile_writes_typed_lookup_request(self):
+        requests = []
+
+        async def handler(reader, writer):
+            request = await read_json_line(reader)
+            requests.append(request)
+            await write_json_line(
+                writer,
+                {
+                    "marmot_agent_control": "marmot.agent-control.v2",
+                    "id": request["id"],
+                    "type": "profile_lookup",
+                    "account_id_hex": request["account_id_hex"],
+                    "status": "profile_found",
+                    "retryable": False,
+                },
+            )
+            writer.close()
+
+        await self.start_server(handler)
+        client = self.adapter.MarmotAgentControlClient(self.socket_path)
+        response = await client.account_lookup_profile("11" * 32)
+
+        self.assertEqual(response["status"], "profile_found")
+        self.assertEqual(requests[0]["type"], "account_profile_lookup")
+        self.assertEqual(requests[0]["account_id_hex"], "11" * 32)
+
     async def test_account_publish_profile_writes_public_profile_request(self):
         requests = []
 
@@ -1185,6 +1212,9 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                 for event in events:
                     yield event
 
+            async def account_lookup_profile(self, account_id_hex):
+                return {"type": "profile_lookup", "status": "profile_not_found", "retryable": False}
+
             async def send_final(self, account_id_hex, group_id_hex, text, reply_to_message_id_hex=None, idempotency_key=None):
                 self.final_sends.append((account_id_hex, group_id_hex, text, reply_to_message_id_hex))
                 return {"type": "final_sent", "message_ids_hex": ["55" * 32]}
@@ -1211,6 +1241,107 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(group_id, "22" * 32)
         self.assertIn("public Nostr profile", text)
         self.assertEqual(reply_to, "33" * 32)
+
+    async def test_existing_public_profile_suppresses_prompt_and_persists_state(self):
+        account_id = "11" * 32
+        group_id = "22" * 32
+
+        class FakeClient:
+            def __init__(self):
+                self.lookup_calls = 0
+                self.final_sends = []
+
+            async def account_lookup_profile(self, requested_account_id):
+                self.lookup_calls += 1
+                self.asserted_account = requested_account_id
+                return {"type": "profile_lookup", "status": "profile_found", "retryable": False}
+
+            async def send_final(self, *args, **kwargs):
+                self.final_sends.append((args, kwargs))
+                return {"type": "final_sent", "message_ids_hex": ["55" * 32]}
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            state_path = Path(tempdir) / "profile-state.json"
+            fake_client = FakeClient()
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": account_id,
+                        "profile_name_onboarding": True,
+                        "profile_onboarding_state_path": str(state_path),
+                    }
+                ),
+                client=fake_client,
+            )
+            event = {
+                "type": "inbound_message",
+                "account_id_hex": account_id,
+                "group_id_hex": group_id,
+                "message_id_hex": "33" * 32,
+                "text": "hello",
+            }
+
+            self.assertFalse(await adapter._maybe_handle_profile_name_onboarding(event))
+            self.assertFalse(await adapter._maybe_handle_profile_name_onboarding(event))
+            self.assertEqual(fake_client.lookup_calls, 1)
+            self.assertEqual(fake_client.final_sends, [])
+            self.assertEqual((await adapter.profile_name_onboarding.get(account_id)).get("status"), "profile_exists")
+
+            reopened = self.adapter_module.ProfileNameOnboardingStore(state_path)
+            self.assertEqual((await reopened.get(account_id)).get("status"), "profile_exists")
+
+    async def test_indeterminate_profile_lookup_backs_off_without_prompting_then_retries(self):
+        account_id = "11" * 32
+        group_id = "22" * 32
+        now = [100.0]
+
+        class FakeClient:
+            def __init__(self):
+                self.lookup_calls = 0
+                self.final_sends = []
+
+            async def account_lookup_profile(self, requested_account_id):
+                self.lookup_calls += 1
+                status = "indeterminate" if self.lookup_calls == 1 else "profile_not_found"
+                return {"type": "profile_lookup", "status": status, "retryable": status == "indeterminate"}
+
+            async def send_final(self, account_id_hex, group_id_hex, text, reply_to_message_id_hex=None, idempotency_key=None):
+                self.final_sends.append((account_id_hex, group_id_hex, text))
+                return {"type": "final_sent", "message_ids_hex": ["55" * 32]}
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            fake_client = FakeClient()
+            adapter = self.adapter_module.MarmotPlatformAdapter(
+                self.config_cls(
+                    extra={
+                        "account_id_hex": account_id,
+                        "profile_name_onboarding": True,
+                        "profile_onboarding_state_path": str(Path(tempdir) / "profile-state.json"),
+                    }
+                ),
+                client=fake_client,
+            )
+            adapter._profile_lookup_gate = self.adapter_module.ProfileLookupGate(
+                now=lambda: now[0], backoff_seconds=(1.0, 5.0)
+            )
+            event = {
+                "type": "inbound_message",
+                "account_id_hex": account_id,
+                "group_id_hex": group_id,
+                "message_id_hex": "33" * 32,
+                "text": "hello",
+            }
+
+            self.assertFalse(await adapter._maybe_handle_profile_name_onboarding(event))
+            self.assertFalse(await adapter._maybe_handle_profile_name_onboarding(event))
+            self.assertEqual(fake_client.lookup_calls, 1)
+            self.assertEqual(fake_client.final_sends, [])
+            self.assertEqual(await adapter.profile_name_onboarding.get(account_id), {})
+
+            now[0] += 1.0
+            self.assertTrue(await adapter._maybe_handle_profile_name_onboarding(event))
+            self.assertEqual(fake_client.lookup_calls, 2)
+            self.assertEqual(len(fake_client.final_sends), 1)
 
     async def test_profile_name_reply_publishes_profile_and_acknowledges(self):
         account_id = "11" * 32
@@ -1398,12 +1529,21 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
         class FakeClient:
             def __init__(self):
                 self.final_sends = []
+                self.lookup_calls = 0
+                self._lookup_started = asyncio.Event()
+                self._release_lookup = asyncio.Event()
                 self._prompt_started = asyncio.Event()
                 self._release = asyncio.Event()
 
             async def inbound_events(self, account_id_hex=None, group_id_hex=None):
                 if False:  # pragma: no cover - generator shape only
                     yield {}
+
+            async def account_lookup_profile(self, account_id_hex):
+                self.lookup_calls += 1
+                self._lookup_started.set()
+                await self._release_lookup.wait()
+                return {"type": "profile_lookup", "status": "profile_not_found", "retryable": False}
 
             async def send_final(self, account_id_hex, group_id_hex, text, reply_to_message_id_hex=None, idempotency_key=None):
                 # Make the first prompt-send slow so both groups are in flight concurrently:
@@ -1443,7 +1583,12 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
                 group_b, lambda: adapter._dispatch_inbound_message(make_event(group_b, "02" * 32, "hi from B"))
             )
 
-            # Let both dispatch tasks reach the prompt-claim/send seam, then release the slow send.
+            # Let both groups share the same in-flight lookup, then release the slow prompt send.
+            for _ in range(200):
+                if fake_client._lookup_started.is_set():
+                    break
+                await asyncio.sleep(0.005)
+            fake_client._release_lookup.set()
             for _ in range(200):
                 if fake_client._prompt_started.is_set():
                     break
@@ -1451,6 +1596,7 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
             fake_client._release.set()
             await adapter._inbound_queue.join()
 
+        self.assertEqual(fake_client.lookup_calls, 1, "concurrent groups must share one profile lookup")
         # Exactly one prompt was sent (the claim winner); the loser did NOT also prompt.
         self.assertEqual(
             len(fake_client.final_sends), 1, f"expected exactly one prompt, got {fake_client.final_sends}"
@@ -1479,6 +1625,9 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
             async def inbound_events(self, account_id_hex=None, group_id_hex=None):
                 if False:  # pragma: no cover - generator shape only
                     yield {}
+
+            async def account_lookup_profile(self, account_id_hex):
+                return {"type": "profile_lookup", "status": "profile_not_found", "retryable": False}
 
             async def send_final(self, account_id_hex, group_id_hex, text, reply_to_message_id_hex=None, idempotency_key=None):
                 self.calls += 1
@@ -3802,6 +3951,9 @@ class GroupInviteOnboardingTests(unittest.IsolatedAsyncioTestCase):
             state_path = Path(tmpdir) / "profile-onboarding.json"
 
             class FakeClient:
+                async def account_lookup_profile(self, account_id_hex):
+                    return {"type": "profile_lookup", "status": "profile_not_found", "retryable": False}
+
                 async def send_final(self, account_id_hex, group_id_hex, text, reply_to_message_id_hex=None, idempotency_key=None):
                     self.last = (account_id_hex, group_id_hex, text, reply_to_message_id_hex)
                     return {"type": "final_sent", "message_ids_hex": ["55" * 32]}

--- a/integrations/openclaw/marmot/src/client.ts
+++ b/integrations/openclaw/marmot/src/client.ts
@@ -287,6 +287,29 @@ export class MarmotAgentControlClient {
     return (await this.request({ type: "account_list" })) as unknown as AccountListResponse;
   }
 
+  async accountLookupProfile(accountIdHex: string): Promise<{
+    type: "profile_lookup";
+    status: "profile_found" | "profile_not_found" | "indeterminate";
+    retryable: boolean;
+  }> {
+    const response = await this.request({
+      type: "account_profile_lookup",
+      account_id_hex: normalizeHex(accountIdHex, "account_id_hex"),
+    });
+    if (
+      response.type !== "profile_lookup" ||
+      !["profile_found", "profile_not_found", "indeterminate"].includes(String(response.status)) ||
+      typeof response.retryable !== "boolean"
+    ) {
+      throw new Error("wn-agent returned invalid profile_lookup response");
+    }
+    return response as {
+      type: "profile_lookup";
+      status: "profile_found" | "profile_not_found" | "indeterminate";
+      retryable: boolean;
+    };
+  }
+
   async accountPublishProfile(
     accountIdHex: string,
     name: string,

--- a/integrations/openclaw/marmot/src/profile-onboarding.ts
+++ b/integrations/openclaw/marmot/src/profile-onboarding.ts
@@ -105,7 +105,7 @@ export function parseProfileNameReply(text: string): ProfileNameReply {
 
 // --- persisted per-account status ------------------------------------------
 
-export type OnboardingStatus = "prompted" | "published" | "skipped";
+export type OnboardingStatus = "profile_exists" | "prompted" | "published" | "skipped";
 
 export interface OnboardingRecord {
   status: OnboardingStatus;
@@ -125,6 +125,7 @@ export interface ProfileOnboardingStateStore {
   ): Promise<boolean>;
   markPublished(accountIdHex: string, name: string): Promise<void>;
   markSkipped(accountIdHex: string): Promise<void>;
+  markProfileExists(accountIdHex: string): Promise<void>;
   /** Reset an account's record (used to retry after a prompt send fails). */
   clear(accountIdHex: string): Promise<void>;
 }
@@ -216,6 +217,10 @@ export class ProfileNameOnboardingStore implements ProfileOnboardingStateStore {
     return this.set(accountIdHex, { status: "skipped" });
   }
 
+  markProfileExists(accountIdHex: string): Promise<void> {
+    return this.set(accountIdHex, { status: "profile_exists" });
+  }
+
   clear(accountIdHex: string): Promise<void> {
     return this.serialize(async () => {
       const data = await this.load();
@@ -227,7 +232,99 @@ export class ProfileNameOnboardingStore implements ProfileOnboardingStateStore {
 
 // --- the runtime entry points ------------------------------------------------
 
+export type ProfileLookupStatus = "profile_found" | "profile_not_found" | "indeterminate";
+
+interface ProfileLookupGateOptions {
+  now?: () => number;
+  backoffMs?: readonly number[];
+}
+
+const DEFAULT_PROFILE_LOOKUP_BACKOFF_MS = [1_000, 5_000, 30_000] as const;
+
+export class ProfileLookupGate {
+  private readonly inFlight = new Map<string, Promise<ProfileLookupStatus>>();
+  private readonly failures = new Map<string, { attempts: number; retryAt: number }>();
+  private readonly now: () => number;
+  private readonly backoffMs: readonly number[];
+
+  constructor(options: ProfileLookupGateOptions = {}) {
+    this.now = options.now ?? Date.now;
+    this.backoffMs = options.backoffMs?.length ? options.backoffMs : DEFAULT_PROFILE_LOOKUP_BACKOFF_MS;
+  }
+
+  async lookup(
+    accountIdHex: string,
+    lookup: () => Promise<{
+      type: "profile_lookup";
+      status: ProfileLookupStatus;
+      retryable: boolean;
+    }>,
+  ): Promise<ProfileLookupStatus> {
+    const key = accountIdHex.toLowerCase();
+    const failure = this.failures.get(key);
+    if (failure && this.now() < failure.retryAt) {
+      return "indeterminate";
+    }
+    const existing = this.inFlight.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const pending = this.performLookup(key, lookup);
+    this.inFlight.set(key, pending);
+    try {
+      return await pending;
+    } finally {
+      if (this.inFlight.get(key) === pending) {
+        this.inFlight.delete(key);
+      }
+    }
+  }
+
+  private async performLookup(
+    key: string,
+    lookup: () => Promise<{
+      type: "profile_lookup";
+      status: ProfileLookupStatus;
+      retryable: boolean;
+    }>,
+  ): Promise<ProfileLookupStatus> {
+    let status: ProfileLookupStatus;
+    try {
+      const response = await lookup();
+      status = response.type === "profile_lookup" ? response.status : "indeterminate";
+    } catch {
+      status = "indeterminate";
+    }
+
+    if (status !== "indeterminate") {
+      this.failures.delete(key);
+      return status;
+    }
+    const attempts = (this.failures.get(key)?.attempts ?? 0) + 1;
+    const delay = this.backoffMs[Math.min(attempts - 1, this.backoffMs.length - 1)] ?? 30_000;
+    this.failures.set(key, { attempts, retryAt: this.now() + delay });
+    return status;
+  }
+}
+
+const PROFILE_LOOKUP_GATES = new WeakMap<ProfileOnboardingStateStore, ProfileLookupGate>();
+
+function profileLookupGateFor(store: ProfileOnboardingStateStore): ProfileLookupGate {
+  let gate = PROFILE_LOOKUP_GATES.get(store);
+  if (!gate) {
+    gate = new ProfileLookupGate();
+    PROFILE_LOOKUP_GATES.set(store, gate);
+  }
+  return gate;
+}
+
 export interface ProfileOnboardingClient {
+  accountLookupProfile(accountIdHex: string): Promise<{
+    type: "profile_lookup";
+    status: ProfileLookupStatus;
+    retryable: boolean;
+  }>;
   sendFinal(
     accountIdHex: string,
     groupIdHex: string,
@@ -254,23 +351,43 @@ interface OnboardingLogger {
 async function sendProfilePrompt(deps: {
   store: ProfileOnboardingStateStore;
   client: ProfileOnboardingClient;
+  lookupGate?: ProfileLookupGate;
   accountIdHex: string;
   groupIdHex: string;
   configuredName?: string | null;
   logger?: OnboardingLogger;
-}): Promise<void> {
+}): Promise<boolean> {
+  const current = await deps.store.get(deps.accountIdHex);
+  if (current.status) {
+    return false;
+  }
+
+  const lookupStatus = await (deps.lookupGate ?? profileLookupGateFor(deps.store)).lookup(
+    deps.accountIdHex,
+    () => deps.client.accountLookupProfile(deps.accountIdHex),
+  );
+  if (lookupStatus === "profile_found") {
+    await deps.store.markProfileExists(deps.accountIdHex);
+    return false;
+  }
+  if (lookupStatus === "indeterminate") {
+    return false;
+  }
+
   const suggested = validProfileName(deps.configuredName);
   const claimed = await deps.store.tryClaimPrompt(deps.accountIdHex, deps.groupIdHex, suggested);
   if (!claimed) {
-    return;
+    return false;
   }
   try {
     await deps.client.sendFinal(deps.accountIdHex, deps.groupIdHex, buildProfilePrompt(suggested));
     deps.logger?.info?.("marmot: profile onboarding prompt sent");
+    return true;
   } catch {
     // Could not deliver the prompt; release the slot so a later trigger retries.
     await deps.store.clear(deps.accountIdHex).catch(() => undefined);
     deps.logger?.warn?.("marmot: failed to send profile onboarding prompt");
+    return false;
   }
 }
 
@@ -278,11 +395,12 @@ async function sendProfilePrompt(deps: {
 export function maybeSendProfilePromptOnJoin(deps: {
   store: ProfileOnboardingStateStore;
   client: ProfileOnboardingClient;
+  lookupGate?: ProfileLookupGate;
   accountIdHex: string;
   groupIdHex: string;
   configuredName?: string | null;
   logger?: OnboardingLogger;
-}): Promise<void> {
+}): Promise<boolean> {
   return sendProfilePrompt(deps);
 }
 
@@ -330,6 +448,7 @@ async function publishAndConfirm(
 export async function maybeHandleProfileOnboardingInbound(deps: {
   store: ProfileOnboardingStateStore;
   client: ProfileOnboardingClient;
+  lookupGate?: ProfileLookupGate;
   message: ProfileOnboardingMessage;
   configuredName?: string | null;
   logger?: OnboardingLogger;
@@ -337,7 +456,11 @@ export async function maybeHandleProfileOnboardingInbound(deps: {
   const { store, client, message, logger } = deps;
   const record = await store.get(message.accountIdHex);
 
-  if (record.status === "published" || record.status === "skipped") {
+  if (
+    record.status === "profile_exists" ||
+    record.status === "published" ||
+    record.status === "skipped"
+  ) {
     return false;
   }
 
@@ -371,13 +494,13 @@ export async function maybeHandleProfileOnboardingInbound(deps: {
 
   // No status yet: the agent is already in this group (no join event replayed),
   // so fall back to prompting now and consume this message.
-  await sendProfilePrompt({
+  return sendProfilePrompt({
     store,
     client,
+    lookupGate: deps.lookupGate,
     accountIdHex: message.accountIdHex,
     groupIdHex: message.groupIdHex,
     configuredName: deps.configuredName,
     logger,
   });
-  return true;
 }

--- a/integrations/openclaw/marmot/test/client.test.ts
+++ b/integrations/openclaw/marmot/test/client.test.ts
@@ -27,6 +27,14 @@ function handleRequest(socket: Socket, req: Record<string, unknown>): void {
         accounts: [{ account_id_hex: HEX32("aa"), label: "agent", local_signing: true }],
       });
       break;
+    case "account_profile_lookup":
+      send(socket, id, {
+        type: "profile_lookup",
+        account_id_hex: req.account_id_hex,
+        status: "profile_found",
+        retryable: false,
+      });
+      break;
     case "send_final":
       // Echo back the idempotency_key (when present) so a test can assert the
       // client forwarded it; real wn-agent never returns it.
@@ -162,6 +170,15 @@ describe("MarmotAgentControlClient", () => {
     const res = await client.accountList();
     expect(res.accounts).toHaveLength(1);
     expect(res.accounts[0]?.label).toBe("agent");
+  });
+
+  it("round-trips the typed account profile lookup", async () => {
+    const res = await client.accountLookupProfile(HEX32("aa"));
+    expect(res).toMatchObject({
+      type: "profile_lookup",
+      status: "profile_found",
+      retryable: false,
+    });
   });
 
   it("returns durable message ids from send_final", async () => {

--- a/integrations/openclaw/marmot/test/profile-onboarding.test.ts
+++ b/integrations/openclaw/marmot/test/profile-onboarding.test.ts
@@ -16,6 +16,7 @@ import {
   PROFILE_NAME_SKIPPED,
   PROFILE_NAME_TOO_LONG,
   PROFILE_PROMPT_NO_NAME,
+  ProfileLookupGate,
   ProfileNameOnboardingStore,
   type OnboardingRecord,
   type ProfileOnboardingClient,
@@ -28,19 +29,32 @@ const GROUP = HEX("cc");
 const MSG = HEX("11");
 
 interface Calls {
+  lookup: number;
   sendFinal: string[];
   publish: { name: string; displayName: string | null }[];
 }
 
 function emptyCalls(): Calls {
-  return { sendFinal: [], publish: [] };
+  return { lookup: 0, sendFinal: [], publish: [] };
 }
 
 function stubClient(
   calls: Calls,
-  opts: { failPublish?: boolean; failSend?: boolean } = {},
+  opts: {
+    failPublish?: boolean;
+    failSend?: boolean;
+    profileStatus?: "profile_found" | "profile_not_found" | "indeterminate";
+  } = {},
 ): ProfileOnboardingClient {
   return {
+    async accountLookupProfile() {
+      calls.lookup += 1;
+      return {
+        type: "profile_lookup",
+        status: opts.profileStatus ?? "profile_not_found",
+        retryable: opts.profileStatus === "indeterminate",
+      };
+    },
     async sendFinal(_account, _group, text) {
       if (opts.failSend) {
         throw new Error("send failed");
@@ -83,6 +97,9 @@ class MemStore implements ProfileOnboardingStateStore {
   }
   async markSkipped(): Promise<void> {
     this.rec = { status: "skipped" };
+  }
+  async markProfileExists(): Promise<void> {
+    this.rec = { status: "profile_exists" };
   }
   async clear(): Promise<void> {
     this.rec = {};
@@ -136,6 +153,98 @@ describe("buildProfilePrompt", () => {
 });
 
 describe("maybeSendProfilePromptOnJoin", () => {
+  it("persists profile_exists and stays quiet when kind-0 already exists", async () => {
+    const calls = emptyCalls();
+    const store = new MemStore();
+    const client = stubClient(calls, { profileStatus: "profile_found" });
+
+    await maybeSendProfilePromptOnJoin({
+      store,
+      client,
+      accountIdHex: ACCOUNT,
+      groupIdHex: GROUP,
+      configuredName: "Marmot Bot",
+    });
+    await maybeSendProfilePromptOnJoin({
+      store,
+      client,
+      accountIdHex: ACCOUNT,
+      groupIdHex: HEX("dd"),
+      configuredName: "Marmot Bot",
+    });
+
+    expect(calls.lookup).toBe(1);
+    expect(calls.sendFinal).toEqual([]);
+    expect(store.rec).toEqual({ status: "profile_exists" });
+  });
+
+  it("backs off an indeterminate lookup without prompting, then retries later", async () => {
+    let now = 10_000;
+    const gate = new ProfileLookupGate({ now: () => now, backoffMs: [1_000, 5_000] });
+    const calls = emptyCalls();
+    const store = new MemStore();
+    const statuses = ["indeterminate", "profile_not_found"] as const;
+    const client = stubClient(calls);
+    client.accountLookupProfile = async () => {
+      calls.lookup += 1;
+      const status = statuses[Math.min(calls.lookup - 1, statuses.length - 1)]!;
+      return { type: "profile_lookup", status, retryable: status === "indeterminate" };
+    };
+
+    const trigger = () =>
+      maybeSendProfilePromptOnJoin({
+        store,
+        client,
+        lookupGate: gate,
+        accountIdHex: ACCOUNT,
+        groupIdHex: GROUP,
+      });
+    await trigger();
+    await trigger();
+    expect(calls.lookup).toBe(1);
+    expect(calls.sendFinal).toEqual([]);
+    expect(store.rec).toEqual({});
+
+    now += 1_000;
+    await trigger();
+    expect(calls.lookup).toBe(2);
+    expect(calls.sendFinal).toEqual([PROFILE_PROMPT_NO_NAME]);
+  });
+
+  it("deduplicates concurrent account lookups and prompts once", async () => {
+    const calls = emptyCalls();
+    const store = new MemStore();
+    let releaseLookup!: () => void;
+    const lookupReleased = new Promise<void>((resolve) => {
+      releaseLookup = resolve;
+    });
+    const client = stubClient(calls);
+    client.accountLookupProfile = async () => {
+      calls.lookup += 1;
+      await lookupReleased;
+      return { type: "profile_lookup", status: "profile_not_found", retryable: false };
+    };
+
+    const first = maybeSendProfilePromptOnJoin({
+      store,
+      client,
+      accountIdHex: ACCOUNT,
+      groupIdHex: GROUP,
+    });
+    const second = maybeSendProfilePromptOnJoin({
+      store,
+      client,
+      accountIdHex: ACCOUNT,
+      groupIdHex: HEX("dd"),
+    });
+    await Promise.resolve();
+    releaseLookup();
+    await Promise.all([first, second]);
+
+    expect(calls.lookup).toBe(1);
+    expect(calls.sendFinal).toHaveLength(1);
+  });
+
   it("prompts with the configured name and records the suggestion", async () => {
     const calls = emptyCalls();
     const store = new MemStore();
@@ -193,6 +302,36 @@ describe("maybeSendProfilePromptOnJoin", () => {
 });
 
 describe("maybeHandleProfileOnboardingInbound", () => {
+  it("does not consume the triggering message when a profile already exists", async () => {
+    const calls = emptyCalls();
+    const store = new MemStore();
+    const intercepted = await maybeHandleProfileOnboardingInbound({
+      store,
+      client: stubClient(calls, { profileStatus: "profile_found" }),
+      message: msg("hello"),
+    });
+
+    expect(intercepted).toBe(false);
+    expect(calls.lookup).toBe(1);
+    expect(calls.sendFinal).toEqual([]);
+    expect(store.rec).toEqual({ status: "profile_exists" });
+  });
+
+  it("does not consume the triggering message when profile lookup is indeterminate", async () => {
+    const calls = emptyCalls();
+    const store = new MemStore();
+    const intercepted = await maybeHandleProfileOnboardingInbound({
+      store,
+      client: stubClient(calls, { profileStatus: "indeterminate" }),
+      message: msg("hello"),
+    });
+
+    expect(intercepted).toBe(false);
+    expect(calls.lookup).toBe(1);
+    expect(calls.sendFinal).toEqual([]);
+    expect(store.rec).toEqual({});
+  });
+
   it("publishes the suggested name on an affirmative reply", async () => {
     const calls = emptyCalls();
     const store = new MemStore();
@@ -284,7 +423,7 @@ describe("maybeHandleProfileOnboardingInbound", () => {
   });
 
   it("does nothing once published or skipped", async () => {
-    for (const status of ["published", "skipped"] as const) {
+    for (const status of ["profile_exists", "published", "skipped"] as const) {
       const calls = emptyCalls();
       const store = new MemStore();
       store.rec = { status };
@@ -329,8 +468,13 @@ describe("ProfileNameOnboardingStore", () => {
     expect(await reopened.get(ACCOUNT)).toEqual({ status: "published", name: "Ada" });
 
     await reopened.clear(ACCOUNT);
-    expect(await reopened.get(ACCOUNT)).toEqual({});
+    await reopened.markProfileExists(ACCOUNT);
+    const reopenedWithProfile = new ProfileNameOnboardingStore(path);
+    expect(await reopenedWithProfile.get(ACCOUNT)).toEqual({ status: "profile_exists" });
+
+    await reopenedWithProfile.clear(ACCOUNT);
+    expect(await reopenedWithProfile.get(ACCOUNT)).toEqual({});
     // after clear, a fresh claim succeeds again
-    expect(await reopened.tryClaimPrompt(ACCOUNT, GROUP, undefined)).toBe(true);
+    expect(await reopenedWithProfile.tryClaimPrompt(ACCOUNT, GROUP, undefined)).toBe(true);
   });
 });

--- a/integrations/opencode/marmot/src/control.rs
+++ b/integrations/opencode/marmot/src/control.rs
@@ -302,6 +302,7 @@ fn response_name(response: &AgentControlResponse) -> &'static str {
         AgentControlResponse::AccountCreated { .. } => "account_created",
         AgentControlResponse::KeyPackagePublished { .. } => "key_package_published",
         AgentControlResponse::ProfilePublished { .. } => "profile_published",
+        AgentControlResponse::ProfileLookup { .. } => "profile_lookup",
         AgentControlResponse::FinalSent { .. } => "final_sent",
         AgentControlResponse::AppEventSent { .. } => "app_event_sent",
         AgentControlResponse::Allowlist { .. } => "allowlist",


### PR DESCRIPTION
## Summary

- add a typed account profile lookup over `marmot.agent-control.v2` that distinguishes found, absent, and indeterminate relay outcomes
- validate signature, author, kind, and JSON-object metadata before an event can satisfy profile onboarding
- persist account-level `profile_exists` state and share single-flight lookup/backoff semantics across OpenClaw and Hermes
- keep missing/failed lookups quiet while preserving the existing manual publication flow

## Verification

- `just fast-ci`
- `cargo test -p agent-control`
- `cargo test -p agent-connector` (120 passed)
- `cargo test -p wn-opencode` (48 passed, 1 connector E2E ignored)
- `cargo test -p marmot-app` (451 library tests and 71/76 relay-runtime tests passed; five unrelated relay-runtime failures remain on this host, with `encrypted_media_endpoint_updates_are_full_replacement_and_admin_only` reproduced from a clean `origin/master` archive)
- OpenClaw `pnpm typecheck` and full `pnpm test` (207 passed, 1 connector E2E skipped)
- `just openclaw-dev-script-test`
- targeted Hermes profile lookup/onboarding/restart/concurrency tests
- `just hermes-dev-script-test`

Fixes #1126
