### PR TITLE
fix(hermes): preserve Markdown-balanced stream previews

### DIFF
--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -1541,7 +1541,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
     ) -> SendResult:
         self._capture_loop()
         chat_id = _normalize_hex(chat_id, "chat_id")
-        visible_content = self._strip_streaming_cursor(content)
+        visible_content, is_preview = self._split_stream_preview(content)
 
         tool_events = _tool_events_from_progress_text(visible_content)
         if tool_events:
@@ -1551,7 +1551,6 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
                 reply_to_message_id_hex=_optional_hex(reply_to),
             )
 
-        is_preview = self._looks_like_stream_preview(content)
         if _delivery_routes_to_commentary_activity(metadata) and not is_preview:
             return await self._send_commentary_activity(
                 chat_id,
@@ -2888,19 +2887,39 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             )
         return True
 
-    def _looks_like_stream_preview(self, content: str) -> bool:
-        return bool(self.streaming_cursor and str(content or "").rstrip().endswith(self.streaming_cursor))
-
-    def _strip_streaming_cursor(self, content: str) -> str:
+    def _split_stream_preview(self, content: str) -> tuple[str, bool]:
         text = str(content or "")
         cursor = self.streaming_cursor
-        if cursor and text.rstrip().endswith(cursor):
-            trailing_len = len(text) - len(text.rstrip())
-            stripped = text.rstrip()
-            text = stripped[: -len(cursor)]
-            if trailing_len:
-                text += " " * trailing_len
-        return text
+        if not cursor:
+            return text, False
+
+        trimmed = text.rstrip()
+        # Hermes balances Markdown after appending its streaming cursor. An
+        # unclosed inline span therefore ends with the cursor followed by one
+        # backtick, while an unclosed fenced block adds a newline plus three
+        # backticks. If both need balancing, the two closers form four trailing
+        # backticks. These display-only closers are not part of the append-only
+        # stream transcript.
+        cursor_suffixes = (
+            cursor,
+            cursor + "`",
+            cursor + "\n```",
+            cursor + "\n````",
+        )
+        for suffix in cursor_suffixes:
+            if not trimmed.endswith(suffix):
+                continue
+            visible = trimmed[: -len(suffix)]
+            return visible + text[len(trimmed) :], True
+        return text, False
+
+    def _looks_like_stream_preview(self, content: str) -> bool:
+        _, is_preview = self._split_stream_preview(content)
+        return is_preview
+
+    def _strip_streaming_cursor(self, content: str) -> str:
+        visible, _ = self._split_stream_preview(content)
+        return visible
 
 
 def check_requirements() -> bool:

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -1980,6 +1980,120 @@ class MarmotPlatformAdapterTests(unittest.IsolatedAsyncioTestCase):
             "Based on my research, here's the answer",
         )
 
+    async def test_markdown_balancers_after_cursor_stay_a_preview(self):
+        class FakeClient:
+            def __init__(self):
+                self.stream_appends = []
+                self.stream_finalizes = []
+                self.final_sends = []
+
+            async def stream_begin(
+                self,
+                account_id_hex,
+                group_id_hex,
+                *,
+                stream_id_hex=None,
+                parent_message_id_hex=None,
+                quic_candidates=(),
+                request_id=None,
+            ):
+                return {
+                    "type": "stream_begun",
+                    "stream_id_hex": "55" * 32,
+                    "stream_capability": "33" * 32,
+                    "start_message_id_hex": "66" * 32,
+                    "quic_candidates": list(quic_candidates),
+                }
+
+            async def stream_append(self, stream_id_hex, stream_capability, append_text):
+                self.stream_appends.append((stream_id_hex, append_text))
+                return {"type": "ack"}
+
+            async def stream_finalize(
+                self,
+                stream_id_hex,
+                stream_capability,
+                final_text,
+                transcript_hash_hex,
+                chunk_count,
+                idempotency_key=None,
+            ):
+                self.stream_finalizes.append((stream_id_hex, final_text))
+                return {
+                    "type": "stream_finalized",
+                    "stream_id_hex": stream_id_hex,
+                    "message_ids_hex": ["77" * 32],
+                }
+
+            async def send_final(
+                self,
+                account_id_hex,
+                group_id_hex,
+                text,
+                reply_to_message_id_hex=None,
+                idempotency_key=None,
+            ):
+                self.final_sends.append((account_id_hex, group_id_hex, text))
+                return {"type": "final_sent", "message_ids_hex": ["88" * 32]}
+
+        fake_client = FakeClient()
+        adapter = self.adapter_module.MarmotPlatformAdapter(
+            self.config_cls(
+                extra={
+                    "account_id_hex": "11" * 32,
+                    "quic_candidates": ["quic://127.0.0.1:4433"],
+                }
+            ),
+            client=fake_client,
+        )
+
+        # Hermes balances an open inline-code span after adding its cursor. The
+        # trailing backtick is display-only and must not hide the preview marker.
+        preview = await adapter.send("22" * 32, "Result: `partial \u2589`")
+        final = await adapter.send("22" * 32, "Result: `partial value`")
+
+        self.assertTrue(preview.success)
+        self.assertTrue(final.success)
+        self.assertEqual(fake_client.final_sends, [])
+        self.assertEqual(fake_client.stream_appends[0][1], "Result: `partial ")
+        self.assertEqual(
+            fake_client.stream_finalizes,
+            [("55" * 32, "Result: `partial value`")],
+        )
+
+        # Fenced blocks are balanced with a newline plus three backticks.
+        append_offset = len(fake_client.stream_appends)
+        finalize_offset = len(fake_client.stream_finalizes)
+        fenced_preview = await adapter.send("22" * 32, "```text\npartial \u2589\n```")
+        fenced_final = await adapter.send("22" * 32, "```text\npartial value\n```")
+
+        self.assertTrue(fenced_preview.success)
+        self.assertTrue(fenced_final.success)
+        self.assertEqual(fake_client.final_sends, [])
+        self.assertEqual(fake_client.stream_appends[append_offset][1], "```text\npartial ")
+        self.assertEqual(len(fake_client.stream_finalizes), finalize_offset + 1)
+        self.assertEqual(
+            fake_client.stream_finalizes[finalize_offset],
+            ("55" * 32, "```text\npartial value\n```"),
+        )
+
+        both_balancers = "`outside\n```text\npartial \u2589\n````"
+        self.assertTrue(adapter._looks_like_stream_preview(both_balancers))
+        self.assertEqual(
+            adapter._strip_streaming_cursor(both_balancers),
+            "`outside\n```text\npartial ",
+        )
+
+        # Whitespace after the cursor is part of the visible snapshot. Preserve
+        # its exact bytes so later append-only comparisons see the same text.
+        for trailing_whitespace in (" ", "\t", "\r\n", " \t\r\n"):
+            with self.subTest(trailing_whitespace=repr(trailing_whitespace)):
+                preview_with_whitespace = "partial \u2589`" + trailing_whitespace
+                self.assertEqual(
+                    adapter._split_stream_preview(preview_with_whitespace),
+                    ("partial " + trailing_whitespace, True),
+                )
+
     async def test_whitespace_mismatched_final_replaces_preview_without_duplication(self):
         class FakeClient:
             def __init__(self):


### PR DESCRIPTION
## Summary

- recognize Hermes streaming cursors when Markdown balancing adds a closing inline backtick or fenced-block delimiter after the cursor
- remove the cursor and display-only balancing delimiter before composing the append-only stream transcript
- keep those balanced snapshots on the preview path so only the later complete answer becomes durable

## Root cause

Hermes appends the streaming cursor and then balances unclosed Markdown spans for display:

- [`ensure_closed_code_fences`](https://github.com/NousResearch/hermes-agent/blob/d710276a206d2dfeefc8763c301c7d72050647e8/gateway/stream_consumer.py#L76-L124)

The Marmot adapter only recognized the cursor when it was the literal text suffix:

- [`_looks_like_stream_preview` / `_strip_streaming_cursor`](https://github.com/marmot-protocol/mdk/blob/33596a3d856ce2a1f478fa0beb68ad6bb167e49d/integrations/hermes/marmot/adapter.py#L2891-L2903)

When Hermes added a synthetic Markdown closer after the cursor, the adapter treated the snapshot as an ordinary final send. This patch recognizes the finite set of suffixes emitted by the Hermes balancer and removes both transport artifacts.

This is an MDK-side mitigation for [#1088](https://github.com/marmot-protocol/mdk/issues/1088). It does not replace the stable delivery identity/finality contract tracked upstream in [NousResearch/hermes-agent#70694](https://github.com/NousResearch/hermes-agent/issues/70694).

No private message content or identifiers are included.

## Tests

- regression test failed before the adapter change: balanced previews produced two direct final sends
- regression test now covers inline-code and fenced-block balancing, asserting zero direct final sends and one stream finalization for each complete answer
- `python -m unittest discover -s integrations/hermes/marmot/tests -v` — 112 passed
- `integrations/hermes/marmot/tests/test_dev_scripts.sh` — passed
- `python -m py_compile ...` and `git diff --check` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming live-preview detection when streamed text includes Markdown code formatting (inline code and fenced code blocks).
  * Preserved exact trailing whitespace when removing streaming cursor markers.
  * Ensured preview vs. finalization behavior remains consistent when the cursor is added or removed.
* **Tests**
  * Added coverage for cursor handling in inline code and fenced code blocks, including whitespace preservation and Markdown balance scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->