### PR TITLE
test(hermes): exercise persisted config startup

### DIFF
--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - .github/workflows/wn-agent-binaries.yml
       - scripts/install-hermes-marmot.sh
+      - scripts/hermes_marmot_configure_gateway.py
+      - scripts/hermes_marmot_dev_setup.sh
+      - scripts/hermes_marmot_verify_persisted_config.sh
       - integrations/hermes/marmot/**
       - scripts/install-openclaw-marmot.sh
       - integrations/openclaw/marmot/**
@@ -309,6 +312,43 @@ jobs:
           path: dist/hermes-marmot-plugin/*
           if-no-files-found: error
 
+  hermes-marmot-integration:
+    name: Hermes Marmot persisted config
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Run Hermes Marmot unit tests
+        run: PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s integrations/hermes/marmot/tests
+
+      - name: Run Hermes dev-script smoke test
+        run: integrations/hermes/marmot/tests/test_dev_scripts.sh
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          python-version: "3.11"
+
+      - name: Prepare isolated Hermes dev root
+        env:
+          HERMES_MARMOT_INTEGRATION_REF: c7b75a7849cb260e6f17a045473bfdd0ea21ca81
+        run: |
+          set -euo pipefail
+          dev_root="$RUNNER_TEMP/hermes-marmot-integration"
+          ./scripts/hermes_marmot_dev_setup.sh \
+            --root "$dev_root" \
+            --hermes-ref "$HERMES_MARMOT_INTEGRATION_REF" \
+            --no-enable-plugin
+          echo "HERMES_MARMOT_DEV_ROOT=$dev_root" >> "$GITHUB_ENV"
+
+      - name: Run real Hermes persisted-config probe
+        run: ./scripts/hermes_marmot_verify_persisted_config.sh --root "$HERMES_MARMOT_DEV_ROOT"
+
   openclaw-plugin:
     name: Package OpenClaw plugin
     runs-on: ubuntu-latest
@@ -390,6 +430,7 @@ jobs:
     needs:
       - build
       - plugin
+      - hermes-marmot-integration
       - openclaw-plugin
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -333,6 +333,7 @@ jobs:
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: "3.11"
+          enable-cache: false
 
       - name: Prepare isolated Hermes dev root
         env:

--- a/Justfile
+++ b/Justfile
@@ -95,6 +95,15 @@ hermes-dev-teardown args="":
 hermes-dev-script-test:
     integrations/hermes/marmot/tests/test_dev_scripts.sh
 
+hermes-verify-persisted-config root="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -z "{{root}}" ]; then
+        ./scripts/hermes_marmot_verify_persisted_config.sh
+    else
+        ./scripts/hermes_marmot_verify_persisted_config.sh --root "{{root}}"
+    fi
+
 release-all version:
     ./scripts/cut-full-release.sh {{version}}
 

--- a/Justfile
+++ b/Justfile
@@ -95,14 +95,9 @@ hermes-dev-teardown args="":
 hermes-dev-script-test:
     integrations/hermes/marmot/tests/test_dev_scripts.sh
 
+[positional-arguments]
 hermes-verify-persisted-config root="":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ -z "{{root}}" ]; then
-        ./scripts/hermes_marmot_verify_persisted_config.sh
-    else
-        ./scripts/hermes_marmot_verify_persisted_config.sh --root "{{root}}"
-    fi
+    ./scripts/hermes_marmot_verify_persisted_config.sh {{ if root == "" { "" } else { "--root \"$1\"" } }}
 
 release-all version:
     ./scripts/cut-full-release.sh {{version}}

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -117,7 +117,7 @@ The setup script creates these paths under that root:
 - `marmot-agent-home` for isolated `wn-agent` state.
 - `hermes-home/plugins/marmot` as a symlink back to this plugin directory.
 - helper scripts: `smoke-plugin.sh`, `e2e-deterministic.sh`,
-  `e2e-connector.sh`, `bootstrap-agent.sh`,
+  `e2e-connector.sh`, `verify-persisted-config.sh`, `bootstrap-agent.sh`,
   `run-wn-agent.sh`, `run-hermes-gateway.sh`, `start-wn-agent.sh`,
   `start-hermes-gateway.sh`, and `stop-dev-processes.sh`.
 
@@ -151,6 +151,21 @@ Smoke-test the plugin import against the isolated Hermes venv:
 ```sh
 just hermes-dev-smoke
 ```
+
+Verify Marmot loads from persisted Hermes config after a gateway restart with no
+inherited `MARMOT_*` environment (installer/configure + fresh subprocess probe):
+
+```sh
+just hermes-dev-setup --hermes-ref c7b75a7849cb260e6f17a045473bfdd0ea21ca81 --install-uv --print-env
+source /tmp/hermes-marmot-test/env.sh
+just hermes-verify-persisted-config
+```
+
+This uses the real Hermes checkout pinned above, runs `configure_gateway.py` and
+`hermes plugins enable marmot`, then launches a fresh Python process with all
+`MARMOT_*` variables removed. The probe exercises Hermes plugin discovery,
+`load_gateway_config()`, and `platform_registry.create_adapter()` only. It does
+not start `hermes gateway run` or require a model provider.
 
 Run the deterministic adapter E2E:
 

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -152,8 +152,9 @@ Smoke-test the plugin import against the isolated Hermes venv:
 just hermes-dev-smoke
 ```
 
-Verify Marmot loads from persisted Hermes config after a gateway restart with no
-inherited `MARMOT_*` environment (installer/configure + fresh subprocess probe):
+Verify Marmot loads from persisted Hermes config in a fresh Hermes subprocess
+with no inherited `MARMOT_*` environment (installer/configure + fresh subprocess
+probe):
 
 ```sh
 just hermes-dev-setup --hermes-ref c7b75a7849cb260e6f17a045473bfdd0ea21ca81 --install-uv --print-env

--- a/integrations/hermes/marmot/tests/real_hermes_persisted_config.py
+++ b/integrations/hermes/marmot/tests/real_hermes_persisted_config.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Verify Marmot loads from persisted Hermes config with no MARMOT_* env.
+
+Boundary exercised (Hermes gateway startup, without ``hermes gateway run``):
+
+* ``hermes_cli.plugins.discover_plugins()`` registers the Marmot plugin
+* ``gateway.config.load_gateway_config()`` loads ``config.yaml`` and runs
+  ``_apply_env_overrides()``
+* ``gateway.platform_registry.create_adapter()`` constructs the Marmot adapter
+
+This deliberately does not start the long-lived gateway process, dial a model
+provider, or connect to a real ``wn-agent`` account.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    expected_socket = Path(os.environ["HERMES_MARMOT_EXPECTED_SOCKET"])
+    inherited_marmot_env = sorted(key for key in os.environ if key.startswith("MARMOT_"))
+    if inherited_marmot_env:
+        print(
+            "fresh Hermes probe inherited MARMOT_* variables: "
+            + ", ".join(inherited_marmot_env),
+            file=sys.stderr,
+        )
+        return 1
+
+    from hermes_cli.plugins import discover_plugins
+    from gateway.config import Platform, load_gateway_config
+    from gateway.platform_registry import platform_registry
+
+    discover_plugins(force=True)
+    if not platform_registry.is_registered("marmot"):
+        print("marmot platform was not registered by Hermes plugin discovery", file=sys.stderr)
+        return 1
+
+    config = load_gateway_config()
+    platform = Platform("marmot")
+    platform_config = config.platforms.get(platform)
+    if platform_config is None:
+        print("marmot platform missing from loaded gateway config", file=sys.stderr)
+        return 1
+    if not platform_config.enabled:
+        print("marmot platform is not enabled after load_gateway_config()", file=sys.stderr)
+        return 1
+
+    extra = platform_config.extra or {}
+    socket_path = extra.get("socket_path") or extra.get("agent_socket") or extra.get("socket")
+    if str(socket_path) != str(expected_socket):
+        print(
+            "persisted socket_path mismatch: "
+            f"expected {expected_socket}, got {socket_path!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(2.0)
+            client.connect(str(expected_socket))
+    except OSError as exc:
+        print(f"configured wn-agent socket is not healthy: {exc}", file=sys.stderr)
+        return 1
+
+    adapter = platform_registry.create_adapter("marmot", platform_config)
+    if adapter is None:
+        print("platform_registry.create_adapter('marmot', ...) returned None", file=sys.stderr)
+        return 1
+
+    adapter_socket = getattr(adapter, "socket_path", None)
+    if str(adapter_socket) != str(expected_socket):
+        print(
+            "adapter socket_path mismatch: "
+            f"expected {expected_socket}, got {adapter_socket!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("real hermes persisted-config probe ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/hermes/marmot/tests/real_hermes_persisted_config.py
+++ b/integrations/hermes/marmot/tests/real_hermes_persisted_config.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 
 def main() -> int:
+    """Exercise persisted-config adapter construction in a fresh Hermes process."""
     expected_socket = Path(os.environ["HERMES_MARMOT_EXPECTED_SOCKET"])
     inherited_marmot_env = sorted(key for key in os.environ if key.startswith("MARMOT_"))
     if inherited_marmot_env:
@@ -53,19 +54,15 @@ def main() -> int:
     extra = platform_config.extra or {}
     socket_path = extra.get("socket_path") or extra.get("agent_socket") or extra.get("socket")
     if str(socket_path) != str(expected_socket):
-        print(
-            "persisted socket_path mismatch: "
-            f"expected {expected_socket}, got {socket_path!r}",
-            file=sys.stderr,
-        )
+        print("persisted socket configuration did not match the probe socket", file=sys.stderr)
         return 1
 
     try:
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
             client.settimeout(2.0)
             client.connect(str(expected_socket))
-    except OSError as exc:
-        print(f"configured wn-agent socket is not healthy: {exc}", file=sys.stderr)
+    except OSError:
+        print("configured wn-agent socket is not healthy", file=sys.stderr)
         return 1
 
     adapter = platform_registry.create_adapter("marmot", platform_config)
@@ -75,11 +72,7 @@ def main() -> int:
 
     adapter_socket = getattr(adapter, "socket_path", None)
     if str(adapter_socket) != str(expected_socket):
-        print(
-            "adapter socket_path mismatch: "
-            f"expected {expected_socket}, got {adapter_socket!r}",
-            file=sys.stderr,
-        )
+        print("adapter socket configuration did not match the probe socket", file=sys.stderr)
         return 1
 
     print("real hermes persisted-config probe ok")

--- a/integrations/hermes/marmot/tests/test_configure_gateway.py
+++ b/integrations/hermes/marmot/tests/test_configure_gateway.py
@@ -71,7 +71,10 @@ class PlatformRegistryHarness:
         if (existing is None or not existing.enabled) and is_connected is not None:
             probe_extra = dict(getattr(existing, "extra", {}) or {})
             if isinstance(seed, dict):
-                probe_extra.update({key: value for key, value in seed.items() if key != "home_channel"})
+                for key, value in seed.items():
+                    if key == "home_channel":
+                        continue
+                    probe_extra.setdefault(key, value)
             probe = PlatformConfigHarness(enabled=True, extra=probe_extra)
             if not is_connected(probe):
                 return existing
@@ -315,6 +318,40 @@ class MarmotPlatformEnablementTests(unittest.TestCase):
             with unittest.mock.patch.object(Path, "exists", return_value=False):
                 self.assertIsNone(self.registry.apply_env_overrides())
         finally:
+            restore_marmot_env(saved_env)
+
+    def test_persisted_extra_wins_over_overlapping_env_seed_during_probe(self):
+        saved_env = clear_marmot_env()
+        probe_socket_paths: list[str] = []
+
+        def capture_probe(config):
+            probe_socket_paths.append(config.extra.get("socket_path", ""))
+            return self.adapter_module.validate_config(config)
+
+        original_is_connected = self.registry.entry["is_connected"]
+        self.registry.entry["is_connected"] = capture_probe
+        try:
+            with tempfile.TemporaryDirectory() as tempdir:
+                persisted_socket = Path(tempdir) / "persisted.sock"
+                conflicting_socket = Path(tempdir) / "conflicting.sock"
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+                    server.bind(str(persisted_socket))
+                    server.listen(1)
+
+                os.environ["MARMOT_AGENT_SOCKET"] = str(conflicting_socket)
+                platform_config = PlatformConfigHarness(
+                    enabled=False,
+                    extra={"socket_path": str(persisted_socket)},
+                )
+
+                enabled_config = self.registry.apply_env_overrides(platform_config)
+
+                self.assertEqual(probe_socket_paths, [str(persisted_socket)])
+                self.assertIsNotNone(enabled_config)
+                assert enabled_config is not None
+                self.assertTrue(enabled_config.enabled)
+        finally:
+            self.registry.entry["is_connected"] = original_is_connected
             restore_marmot_env(saved_env)
 
     def test_environment_only_config_enables_and_creates_adapter(self):

--- a/integrations/hermes/marmot/tests/test_configure_gateway.py
+++ b/integrations/hermes/marmot/tests/test_configure_gateway.py
@@ -334,22 +334,33 @@ class MarmotPlatformEnablementTests(unittest.TestCase):
             with tempfile.TemporaryDirectory() as tempdir:
                 persisted_socket = Path(tempdir) / "persisted.sock"
                 conflicting_socket = Path(tempdir) / "conflicting.sock"
-                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
-                    server.bind(str(persisted_socket))
-                    server.listen(1)
+                with (
+                    socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as persisted_server,
+                    socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as conflicting_server,
+                ):
+                    persisted_server.bind(str(persisted_socket))
+                    persisted_server.listen(1)
+                    conflicting_server.bind(str(conflicting_socket))
+                    conflicting_server.listen(1)
 
-                os.environ["MARMOT_AGENT_SOCKET"] = str(conflicting_socket)
-                platform_config = PlatformConfigHarness(
-                    enabled=False,
-                    extra={"socket_path": str(persisted_socket)},
-                )
+                    os.environ["MARMOT_AGENT_SOCKET"] = str(conflicting_socket)
+                    platform_config = PlatformConfigHarness(
+                        enabled=False,
+                        extra={"socket_path": str(persisted_socket)},
+                    )
 
-                enabled_config = self.registry.apply_env_overrides(platform_config)
+                    enabled_config = self.registry.apply_env_overrides(platform_config)
 
-                self.assertEqual(probe_socket_paths, [str(persisted_socket)])
-                self.assertIsNotNone(enabled_config)
-                assert enabled_config is not None
-                self.assertTrue(enabled_config.enabled)
+                    self.assertEqual(probe_socket_paths, [str(persisted_socket)])
+                    self.assertIsNotNone(enabled_config)
+                    assert enabled_config is not None
+                    self.assertTrue(enabled_config.enabled)
+                    self.assertEqual(enabled_config.extra["socket_path"], str(conflicting_socket))
+
+                    adapter = self.registry.create_adapter(enabled_config)
+                    self.assertIsInstance(adapter, self.adapter_module.MarmotPlatformAdapter)
+                    assert adapter is not None
+                    self.assertEqual(adapter.socket_path, str(conflicting_socket))
         finally:
             self.registry.entry["is_connected"] = original_is_connected
             restore_marmot_env(saved_env)

--- a/integrations/hermes/marmot/tests/test_dev_scripts.sh
+++ b/integrations/hermes/marmot/tests/test_dev_scripts.sh
@@ -47,6 +47,8 @@ for helper in \
     "$dev_root/bootstrap-agent.sh"; do
     bash -n "$helper"
 done
+grep -F 'hermes_marmot_verify_persisted_config.sh" "$@" --root "$dev_root"' \
+    "$dev_root/verify-persisted-config.sh" >/dev/null
 
 # shellcheck disable=SC1091
 source "$dev_root/env.sh"

--- a/integrations/hermes/marmot/tests/test_dev_scripts.sh
+++ b/integrations/hermes/marmot/tests/test_dev_scripts.sh
@@ -30,6 +30,7 @@ group_id="$(printf '22%.0s' {1..32})"
 [ -x "$dev_root/smoke-plugin.sh" ]
 [ -x "$dev_root/e2e-deterministic.sh" ]
 [ -x "$dev_root/e2e-connector.sh" ]
+[ -x "$dev_root/verify-persisted-config.sh" ]
 [ -x "$dev_root/bootstrap-agent.sh" ]
 [ -L "$dev_root/hermes-home/plugins/marmot" ]
 
@@ -42,6 +43,7 @@ for helper in \
     "$dev_root/smoke-plugin.sh" \
     "$dev_root/e2e-deterministic.sh" \
     "$dev_root/e2e-connector.sh" \
+    "$dev_root/verify-persisted-config.sh" \
     "$dev_root/bootstrap-agent.sh"; do
     bash -n "$helper"
 done

--- a/scripts/hermes_marmot_dev_setup.sh
+++ b/scripts/hermes_marmot_dev_setup.sh
@@ -392,6 +392,14 @@ source "$dev_root/env.sh"
 exec "$MDK_REPO/scripts/hermes_marmot_connector_e2e.sh" --root "$dev_root"
 SCRIPT
 
+    cat >"$dev_root/verify-persisted-config.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+dev_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$dev_root/env.sh"
+exec "$MDK_REPO/scripts/hermes_marmot_verify_persisted_config.sh" --root "$dev_root" "$@"
+SCRIPT
+
     cat >"$dev_root/bootstrap-agent.sh" <<'SCRIPT'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -461,6 +469,7 @@ SCRIPT
         "$dev_root/smoke-plugin.sh" \
         "$dev_root/e2e-deterministic.sh" \
         "$dev_root/e2e-connector.sh" \
+        "$dev_root/verify-persisted-config.sh" \
         "$dev_root/bootstrap-agent.sh" \
         "$dev_root/start-wn-agent.sh" \
         "$dev_root/start-hermes-gateway.sh" \
@@ -509,6 +518,7 @@ if [ "$print_env" -eq 1 ]; then
     echo "  $(printf '%q' "$dev_root/smoke-plugin.sh")"
     echo "  $(printf '%q' "$dev_root/e2e-deterministic.sh")"
     echo "  $(printf '%q' "$dev_root/e2e-connector.sh")"
+    echo "  $(printf '%q' "$dev_root/verify-persisted-config.sh")"
     echo "  $(printf '%q' "$dev_root/bootstrap-agent.sh") --qr"
     echo "  $(printf '%q' "$dev_root/run-wn-agent.sh")"
     echo "  $(printf '%q' "$dev_root/run-hermes-gateway.sh")"

--- a/scripts/hermes_marmot_dev_setup.sh
+++ b/scripts/hermes_marmot_dev_setup.sh
@@ -397,7 +397,7 @@ SCRIPT
 set -euo pipefail
 dev_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$dev_root/env.sh"
-exec "$MDK_REPO/scripts/hermes_marmot_verify_persisted_config.sh" --root "$dev_root" "$@"
+exec "$MDK_REPO/scripts/hermes_marmot_verify_persisted_config.sh" "$@" --root "$dev_root"
 SCRIPT
 
     cat >"$dev_root/bootstrap-agent.sh" <<'SCRIPT'

--- a/scripts/hermes_marmot_verify_persisted_config.sh
+++ b/scripts/hermes_marmot_verify_persisted_config.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/hermes_marmot_verify_persisted_config.sh [options]
+
+Configure Marmot in an isolated Hermes home, then verify Hermes loads the
+Marmot adapter from persisted platforms.marmot.extra in a fresh subprocess with
+all MARMOT_* environment variables removed.
+
+This exercises Hermes plugin discovery, load_gateway_config(), and
+platform_registry.create_adapter(). It does not start ``hermes gateway run``.
+
+Options:
+  --root PATH      Dev root (default: ${HERMES_MARMOT_DEV_ROOT:-${TMPDIR:-/tmp}/hermes-marmot-test})
+  --account-id-hex HEX  Account id written into persisted config (default: 11..11)
+  -h, --help       Show this help
+USAGE
+}
+
+default_tmp="${TMPDIR:-/tmp}"
+dev_root="${HERMES_MARMOT_DEV_ROOT:-${default_tmp%/}/hermes-marmot-test}"
+account_id_hex="$(printf '11%.0s' {1..32})"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --root)
+            dev_root="$2"
+            shift 2
+            ;;
+        --account-id-hex)
+            account_id_hex="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ ! -f "$dev_root/env.sh" ]; then
+    echo "error: $dev_root/env.sh not found. Run scripts/hermes_marmot_dev_setup.sh first." >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1091
+source "$dev_root/env.sh"
+
+if [ ! -x "$HERMES_AGENT_REPO/.venv/bin/python" ]; then
+    echo "error: Hermes venv python not found at $HERMES_AGENT_REPO/.venv/bin/python" >&2
+    echo "       Rerun setup without --skip-hermes-install." >&2
+    exit 1
+fi
+
+socket_path="$MARMOT_HOME/dev/wn-agent.sock"
+python3 - "$socket_path" <<'PY' &
+import socket
+import sys
+from pathlib import Path
+
+socket_path = Path(sys.argv[1])
+socket_path.parent.mkdir(parents=True, exist_ok=True)
+try:
+    socket_path.unlink()
+except FileNotFoundError:
+    pass
+with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+    server.bind(str(socket_path))
+    server.listen(1)
+    connection, _ = server.accept()
+    connection.close()
+PY
+socket_server_pid=$!
+cleanup() {
+    kill "$socket_server_pid" 2>/dev/null || true
+    wait "$socket_server_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+for _ in {1..50}; do
+    [ -S "$socket_path" ] && break
+    sleep 0.1
+done
+if [ ! -S "$socket_path" ]; then
+    echo "error: test wn-agent socket did not become ready: $socket_path" >&2
+    exit 1
+fi
+
+python3 "$repo_root/scripts/hermes_marmot_configure_gateway.py" \
+    --home "$HERMES_HOME" \
+    --agent-home "$MARMOT_HOME" \
+    --socket-path "$socket_path" \
+    --account-id-hex "$account_id_hex" \
+    --streaming 0 \
+    --transport off \
+    --tool-progress off \
+    --interim-messages 0 \
+    --long-running-notifications 0 \
+    --busy-ack-detail 0
+
+(
+    export HERMES_HOME
+    cd "$HERMES_AGENT_REPO"
+    .venv/bin/hermes plugins enable marmot
+)
+
+cd "$HERMES_AGENT_REPO"
+env -i \
+    HOME="$HOME" \
+    HERMES_HOME="$HERMES_HOME" \
+    HERMES_MARMOT_EXPECTED_SOCKET="$socket_path" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PATH="$HERMES_AGENT_REPO/.venv/bin:$PATH" \
+    "$HERMES_AGENT_REPO/.venv/bin/python" \
+    "$MDK_REPO/integrations/hermes/marmot/tests/real_hermes_persisted_config.py"
+wait "$socket_server_pid"


### PR DESCRIPTION
## Summary

- add a pinned real-Hermes integration probe for persisted Marmot configuration with no inherited `MARMOT_*` environment
- mirror Hermes' persisted-over-environment probe precedence and cover overlapping persisted/environment socket values
- wire the probe into the Hermes dev harness, documentation, and WN Agent release workflow

## Why

This is the follow-up commit intended for #1130 that missed the merge train. PR #1130 fixed persisted-config gateway readiness, but the merged test harness used different precedence from real Hermes and CI did not exercise the actual persisted-config startup boundary. This closes both gaps without changing production adapter behavior.

## Verification

- pinned real-Hermes persisted-config probe: passed
- Hermes Python suite under Python 3.11: 156 passed
- `integrations/hermes/marmot/tests/test_dev_scripts.sh`: passed
- `just fast-ci`: passed, including convergence policy pin 5/5
- `git diff --check origin/master..HEAD`: passed

## Notes

The macOS system Python 3.14 run exposes a pre-existing malformed-YAML transaction-test failure that reproduces unchanged on `origin/master`; the supported Python 3.11 suite is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end verification workflow for persisted Marmot configuration across gateway restarts.
  * Added a command and generated helper script to verify persisted configuration in isolated development environments.
  * Added integration checks for plugin discovery, gateway settings, socket connectivity, and adapter configuration.

* **Bug Fixes**
  * Persisted platform settings now take precedence over overlapping environment values during connection checks.

* **Documentation**
  * Expanded Marmot development setup and persisted-configuration verification instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->