### PR TITLE
fix(openclaw): bind first-turn replies to inbound routes

### DIFF
--- a/crates/agent-connector/AGENTS.md
+++ b/crates/agent-connector/AGENTS.md
@@ -43,7 +43,8 @@ several files in the same crate); methods shared across those files are `pub(cra
   `SendIdempotencyStore` (`$MARMOT_HOME/dev/send-idempotency.json`, 1024-entry FIFO,
   versioned SHA-256 request fingerprints, `stream_finalize_v2:` keys for durable finalized sends,
   crash-safe atomic writes, plus bounded same-key/same-fingerprint in-flight gates whose followers
-  reuse a leader's successful result or receive `send_in_progress` when the gate wait expires), and
+  reuse a leader's successful result or receive `send_in_progress` when the gate wait expires;
+  same-key/different-fingerprint reuse fails closed with `idempotency_conflict`), and
   the `DebugFinalSendStore` recorder.
 - `src/media_temp.rs` — TTL sweep of decrypted inbound media temp dirs under
   `$TMPDIR/marmot-media/`.

--- a/crates/agent-connector/src/error.rs
+++ b/crates/agent-connector/src/error.rs
@@ -32,6 +32,8 @@ pub enum ConnectorError {
     OperationTimedOut(&'static str),
     #[error("matching send is still in progress")]
     SendInProgress,
+    #[error("idempotency key was reused with different send inputs")]
+    SendIdempotencyConflict,
     #[error("outbound media path denied: {0}")]
     MediaPathDenied(&'static str),
     #[error("stream id is already reserved")]
@@ -60,6 +62,7 @@ impl ConnectorError {
             Self::InvalidProfileName(_) => "invalid_profile_name",
             Self::OperationTimedOut(_) => "operation_timed_out",
             Self::SendInProgress => "send_in_progress",
+            Self::SendIdempotencyConflict => "idempotency_conflict",
             Self::MediaPathDenied(_) => "media_path_denied",
             Self::StreamIdInUse => "stream_id_in_use",
             Self::StreamCapabilityDenied => "stream_capability_denied",
@@ -80,6 +83,9 @@ impl ConnectorError {
             Self::OperationTimedOut(_) => "connector operation timed out",
             Self::SendInProgress => {
                 "matching send is still in progress; retry with the same idempotency key"
+            }
+            Self::SendIdempotencyConflict => {
+                "idempotency key was reused with different send inputs"
             }
             Self::MediaPathDenied(_) => "media path is not allowed",
             Self::StreamIdInUse => "stream id is already in use",

--- a/crates/agent-connector/src/messaging.rs
+++ b/crates/agent-connector/src/messaging.rs
@@ -103,12 +103,15 @@ impl AgentConnector {
     ) -> Result<AgentControlResponse, ConnectorError> {
         let group_id_hex = normalize_hex(group_id_hex)?;
         if self.debug_controls {
-            return self.debug_record_final_send_response(
-                account_id_hex,
-                &group_id_hex,
-                text,
-                reply_to_message_id_hex,
-            );
+            return self
+                .debug_record_final_send_response(
+                    account_id_hex,
+                    &group_id_hex,
+                    text,
+                    reply_to_message_id_hex,
+                    idempotency_key,
+                )
+                .await;
         }
 
         // Reject unknown accounts and malformed group ids before a request can
@@ -257,14 +260,37 @@ impl AgentConnector {
         })
     }
 
-    fn debug_record_final_send_response(
+    async fn debug_record_final_send_response(
         &self,
         account_id_hex: &str,
         group_id_hex: &str,
         text: String,
         reply_to_message_id_hex: Option<String>,
+        idempotency_key: Option<String>,
     ) -> Result<AgentControlResponse, ConnectorError> {
         self.ensure_debug_controls()?;
+        let fingerprint = send_final_fingerprint(
+            account_id_hex,
+            group_id_hex,
+            &text,
+            reply_to_message_id_hex.as_deref(),
+        );
+        let idempotency = if let Some(key) = idempotency_key {
+            match self.idempotency.acquire(&key, &fingerprint).await? {
+                SendIdempotencyAcquisition::Completed((
+                    message_ids_hex,
+                    maintenance_disposition,
+                )) => {
+                    return Ok(AgentControlResponse::FinalSent {
+                        message_ids_hex,
+                        maintenance_disposition,
+                    });
+                }
+                SendIdempotencyAcquisition::Leader(reservation) => Some((key, reservation)),
+            }
+        } else {
+            None
+        };
         let record = self.debug_final_sends.record(AgentControlDebugFinalSend {
             account_id_hex: normalize_hex(account_id_hex)?,
             group_id_hex: normalize_hex(group_id_hex)?,
@@ -274,6 +300,17 @@ impl AgentConnector {
                 .transpose()?,
             message_ids_hex: Vec::new(),
         });
+        if let Some((key, reservation)) = idempotency {
+            let message_ids = record.message_ids_hex.clone();
+            let maintenance_disposition = AgentControlSendMaintenanceDisposition::Ready;
+            self.idempotency.record_with_disposition(
+                key,
+                fingerprint,
+                message_ids.clone(),
+                maintenance_disposition,
+            );
+            reservation.complete(message_ids.clone(), maintenance_disposition);
+        }
         Ok(AgentControlResponse::FinalSent {
             message_ids_hex: record.message_ids_hex,
             maintenance_disposition: AgentControlSendMaintenanceDisposition::Ready,

--- a/crates/agent-connector/src/messaging.rs
+++ b/crates/agent-connector/src/messaging.rs
@@ -121,8 +121,8 @@ impl AgentConnector {
 
         // Server-derived request fingerprint: a reused idempotency key only short-
         // circuits when the request it identifies is the same one. A reused key
-        // carrying a different request body is a cache miss, so dedup can never
-        // return ids belonging to an unrelated send.
+        // carrying a different request body fails closed so a replay with
+        // regenerated text cannot publish a second durable message.
         let fingerprint = send_final_fingerprint(
             account_id_hex,
             &group_id_hex,
@@ -159,8 +159,8 @@ impl AgentConnector {
                 .await?
         };
         // Record only after a successful send so a failed send remains retryable.
-        // A key already bound to a different fingerprint is left untouched (first
-        // write wins), so this send simply proceeds without caching.
+        // The acquisition above guarantees this key is either new or bound to
+        // the same fingerprint.
         if let Some((key, reservation)) = idempotency {
             let message_ids = summary.message_ids.clone();
             let maintenance_disposition =

--- a/crates/agent-connector/src/stream_session.rs
+++ b/crates/agent-connector/src/stream_session.rs
@@ -68,10 +68,10 @@ struct SendIdempotencyGate {
 /// A retry that reuses the same key AND matches the recorded fingerprint returns
 /// the cached ids without re-sending, so a retry after a post-write timeout cannot
 /// double-post an unrecallable encrypted message. A reused key whose fingerprint
-/// differs (a different request body under the same key) is treated as a cache
-/// miss, so it can never return ids belonging to an unrelated send. Keys are
-/// evicted oldest-first once the capacity is reached and the eviction is mirrored
-/// to disk.
+/// differs (a different request body under the same logical identity) fails
+/// closed, so regenerated content cannot publish a second durable message. Keys
+/// are evicted oldest-first once the capacity is reached and the eviction is
+/// mirrored to disk.
 ///
 /// Records are persisted under [`SEND_IDEMPOTENCY_FILE`] with crash-safe atomic
 /// renames so a connector restart can still dedup a bounded retry window. The
@@ -96,9 +96,7 @@ pub(crate) struct SendIdempotencyLeader {
 
 impl SendIdempotencyLeader {
     /// Publish the leader's successful result to callers that were already
-    /// waiting on this in-process gate. This remains transient so a sequential
-    /// reuse of a key with a different fingerprint keeps its legacy cache-miss
-    /// behavior.
+    /// waiting on this in-process gate.
     pub(crate) fn complete(
         &self,
         message_ids: Vec<String>,
@@ -165,6 +163,24 @@ impl SendIdempotencyStore {
             .map(|(_, ids, disposition)| (ids.clone(), *disposition))
     }
 
+    /// Return a committed matching result, reject an existing key bound to
+    /// different inputs, or report that the key has not committed yet.
+    fn committed_for_acquire(
+        &self,
+        key: &str,
+        fingerprint: &str,
+    ) -> Result<Option<SendIdempotencyResult>, ConnectorError> {
+        let inner = crate::lock_recover(&self.inner);
+        let Some((recorded, ids, disposition)) = inner.seen.get(key) else {
+            return Ok(None);
+        };
+        if constant_time_eq(recorded.as_bytes(), fingerprint.as_bytes()) {
+            Ok(Some((ids.clone(), *disposition)))
+        } else {
+            Err(ConnectorError::SendIdempotencyConflict)
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn in_flight_participant_count(&self, key: &str, fingerprint: &str) -> usize {
         crate::lock_recover(&self.in_flight)
@@ -177,19 +193,19 @@ impl SendIdempotencyStore {
     /// result after the leader exits; if the leader failed, the follower becomes
     /// the next leader and may retry.
     ///
-    /// The gate includes the fingerprint so the existing behavior for a reused
-    /// key with a different request body remains a cache miss rather than
-    /// blocking behind or reusing an unrelated send. A leader intentionally
-    /// holds its gate across the external send and result recording. Those
-    /// operations are not cancelled here because cancellation cannot prove that
-    /// an unrecallable send did not land; a follower instead receives
-    /// [`ConnectorError::SendInProgress`] after the bounded gate wait.
+    /// A live or committed key bound to a different fingerprint is rejected:
+    /// allowing a second leader would let a replay with regenerated text publish
+    /// another unrecallable message. A leader intentionally holds its gate across
+    /// the external send and result recording. Those operations are not cancelled
+    /// here because cancellation cannot prove that an unrecallable send did not
+    /// land; a follower instead receives [`ConnectorError::SendInProgress`] after
+    /// the bounded gate wait.
     pub(crate) async fn acquire(
         &self,
         key: &str,
         fingerprint: &str,
     ) -> Result<SendIdempotencyAcquisition, ConnectorError> {
-        if let Some(result) = self.get_with_disposition(key, fingerprint) {
+        if let Some(result) = self.committed_for_acquire(key, fingerprint)? {
             return Ok(SendIdempotencyAcquisition::Completed(result));
         }
 
@@ -197,6 +213,19 @@ impl SendIdempotencyStore {
         let gate = {
             let mut in_flight = crate::lock_recover(&self.in_flight);
             in_flight.retain(|_, gate| gate.strong_count() > 0);
+            if in_flight
+                .iter()
+                .any(|((existing_key, existing_fingerprint), gate)| {
+                    existing_key == key
+                        && gate.strong_count() > 0
+                        && !constant_time_eq(
+                            existing_fingerprint.as_bytes(),
+                            fingerprint.as_bytes(),
+                        )
+                })
+            {
+                return Err(ConnectorError::SendIdempotencyConflict);
+            }
             if let Some(gate) = in_flight.get(&gate_key).and_then(Weak::upgrade) {
                 gate
             } else {
@@ -215,7 +244,7 @@ impl SendIdempotencyStore {
         .await
         .map_err(|_| ConnectorError::SendInProgress)?;
 
-        if let Some(result) = self.get_with_disposition(key, fingerprint) {
+        if let Some(result) = self.committed_for_acquire(key, fingerprint)? {
             return Ok(SendIdempotencyAcquisition::Completed(result));
         }
         if let Some(result) = crate::lock_recover(&gate.completed).clone() {

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -73,6 +73,16 @@ fn send_in_progress_has_a_distinct_retry_contract() {
     );
 }
 
+#[test]
+fn idempotency_conflict_has_a_distinct_fail_closed_contract() {
+    let error = crate::ConnectorError::SendIdempotencyConflict;
+    assert_eq!(error.code(), "idempotency_conflict");
+    assert_eq!(
+        error.client_message(),
+        "idempotency key was reused with different send inputs"
+    );
+}
+
 #[tokio::test]
 async fn control_frame_write_timeout_includes_flush() {
     struct FlushStallingWriter;
@@ -4187,69 +4197,33 @@ async fn send_idempotency_store_failed_leader_leaves_request_retryable() {
 }
 
 #[tokio::test]
-async fn concurrent_new_fingerprint_reuses_transient_leader_result() {
+async fn send_idempotency_store_rejects_a_conflicting_in_flight_fingerprint() {
     use crate::stream_session::{SendIdempotencyAcquisition, SendIdempotencyStore};
 
     let dir = tempfile::tempdir().unwrap();
     let store = SendIdempotencyStore::new(dir.path());
-    store.record(
-        "shared-key".to_owned(),
-        "first-fingerprint".to_owned(),
-        vec!["aa".repeat(32)],
-    );
     let leader = match store
-        .acquire("shared-key", "second-fingerprint")
+        .acquire("shared-key", "first-fingerprint")
         .await
         .unwrap()
     {
         SendIdempotencyAcquisition::Leader(leader) => leader,
         SendIdempotencyAcquisition::Completed(_) => {
-            panic!("a new request body must remain a cache miss")
+            panic!("the first request must lead")
         }
     };
 
-    let follower_store = store.clone();
-    let follower = tokio::spawn(async move {
-        follower_store
-            .acquire("shared-key", "second-fingerprint")
-            .await
-            .unwrap()
-    });
-    wait_for_idempotency_follower(&store, "shared-key", "second-fingerprint").await;
-    assert!(!follower.is_finished());
-
-    let ids = vec!["bb".repeat(32)];
-    store.record(
-        "shared-key".to_owned(),
-        "second-fingerprint".to_owned(),
-        ids.clone(),
-    );
-    assert_eq!(
-        store.get("shared-key", "second-fingerprint"),
-        None,
-        "the original durable key binding remains first-write-wins"
-    );
-    leader.complete(
-        ids.clone(),
-        AgentControlSendMaintenanceDisposition::PostJoinRotationPendingRetryable,
-    );
+    assert!(matches!(
+        store.acquire("shared-key", "different-fingerprint").await,
+        Err(crate::ConnectorError::SendIdempotencyConflict)
+    ));
     drop(leader);
 
-    match follower.await.unwrap() {
-        SendIdempotencyAcquisition::Completed((recorded, disposition)) => {
-            assert_eq!(recorded, ids);
-            assert_eq!(
-                disposition,
-                AgentControlSendMaintenanceDisposition::PostJoinRotationPendingRetryable
-            );
-        }
-        SendIdempotencyAcquisition::Leader(_) => {
-            panic!("a concurrent follower must reuse the transient leader result")
-        }
-    }
+    // If the first leader failed before committing, the logical key remains
+    // available for a later replay rather than being poisoned indefinitely.
     assert!(matches!(
         store
-            .acquire("shared-key", "second-fingerprint")
+            .acquire("shared-key", "different-fingerprint")
             .await
             .unwrap(),
         SendIdempotencyAcquisition::Leader(_)
@@ -4257,8 +4231,8 @@ async fn concurrent_new_fingerprint_reuses_transient_leader_result() {
 }
 
 #[tokio::test]
-async fn send_idempotency_store_different_fingerprint_remains_a_cache_miss() {
-    use crate::stream_session::{SendIdempotencyAcquisition, SendIdempotencyStore};
+async fn send_idempotency_store_rejects_a_conflicting_committed_fingerprint() {
+    use crate::stream_session::SendIdempotencyStore;
 
     let dir = tempfile::tempdir().unwrap();
     let store = SendIdempotencyStore::new(dir.path());
@@ -4268,16 +4242,10 @@ async fn send_idempotency_store_different_fingerprint_remains_a_cache_miss() {
         vec!["aa".repeat(32)],
     );
 
-    match store
-        .acquire("shared-key", "different-fingerprint")
-        .await
-        .unwrap()
-    {
-        SendIdempotencyAcquisition::Leader(_) => {}
-        SendIdempotencyAcquisition::Completed(_) => {
-            panic!("different request bodies must not reuse unrelated message ids")
-        }
-    }
+    assert!(matches!(
+        store.acquire("shared-key", "different-fingerprint").await,
+        Err(crate::ConnectorError::SendIdempotencyConflict)
+    ));
 }
 
 #[test]

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -1233,6 +1233,81 @@ async fn connector_debug_controls_inject_inbound_and_record_final_sends() {
 }
 
 #[tokio::test]
+async fn connector_debug_send_final_reuses_idempotency_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("dev").join("wn-agent.sock");
+    let account_id_hex = "11".repeat(32);
+    let group_id_hex = "22".repeat(32);
+    let message_id_hex = "33".repeat(32);
+    let idempotency_key = "turn-replay-key".to_owned();
+    let reply_text = "debug idempotent final".to_owned();
+    let server = tokio::spawn(serve_socket(test_config(
+        dir.path(),
+        socket.clone(),
+        Vec::new(),
+        false,
+        true,
+    )));
+
+    let first = send_control_request(
+        &socket,
+        "req-debug-final-idem-1",
+        AgentControlRequest::SendFinal {
+            account_id_hex: account_id_hex.clone(),
+            group_id_hex: group_id_hex.clone(),
+            text: reply_text.clone(),
+            reply_to_message_id_hex: Some(message_id_hex.clone()),
+            idempotency_key: Some(idempotency_key.clone()),
+        },
+    )
+    .await;
+    let AgentControlResponse::FinalSent {
+        message_ids_hex: first_ids,
+        ..
+    } = first.payload
+    else {
+        panic!("expected first debug final sent response");
+    };
+
+    let second = send_control_request(
+        &socket,
+        "req-debug-final-idem-2",
+        AgentControlRequest::SendFinal {
+            account_id_hex: account_id_hex.clone(),
+            group_id_hex: group_id_hex.clone(),
+            text: reply_text.clone(),
+            reply_to_message_id_hex: Some(message_id_hex.clone()),
+            idempotency_key: Some(idempotency_key.clone()),
+        },
+    )
+    .await;
+    let AgentControlResponse::FinalSent {
+        message_ids_hex: second_ids,
+        ..
+    } = second.payload
+    else {
+        panic!("expected second debug final sent response");
+    };
+    assert_eq!(second_ids, first_ids);
+
+    let recorded = send_control_request(
+        &socket,
+        "req-debug-finals-idem",
+        AgentControlRequest::DebugRecordedFinals,
+    )
+    .await;
+    let AgentControlResponse::DebugRecordedFinals { sends } = recorded.payload else {
+        panic!("expected recorded debug finals");
+    };
+    assert_eq!(sends.len(), 1);
+    assert_eq!(sends[0].text, reply_text);
+    assert_eq!(sends[0].message_ids_hex, first_ids);
+
+    server.abort();
+    let _ = server.await;
+}
+
+#[tokio::test]
 async fn connector_debug_controls_are_disabled_by_default() {
     let dir = tempfile::tempdir().unwrap();
     let socket = dir.path().join("dev").join("wn-agent.sock");

--- a/integrations/openclaw/marmot/index.ts
+++ b/integrations/openclaw/marmot/index.ts
@@ -1,25 +1,12 @@
-// OpenClaw plugin runtime entry. Registers the Marmot channel, syncs the
-// welcomer allowlist, and starts the inbound subscription that drives the agent
-// turn (modeled on the bundled Telegram channel). See README.md for setup.
+// OpenClaw plugin runtime entry. Registers the Marmot channel and owns inbound
+// subscriptions via `gateway.startAccount`. See README.md for setup.
 
 import {
   defineChannelPluginEntry,
   type OpenClawPluginApi,
 } from "openclaw/plugin-sdk/channel-core";
 
-import {
-  createMarmotChannelPlugin,
-  MARMOT_CHANNEL_ID,
-  resolveMarmotChannelAccount,
-} from "./src/channel.js";
-import { clientForAccount } from "./src/config.js";
-import { createMarmotInboundDispatcher, type OpenClawChannelRuntime } from "./src/dispatch.js";
-import {
-  startMarmotInbound,
-  syncMarmotAllowlist,
-  type MarmotAmbientSurfacer,
-} from "./src/inbound-runtime.js";
-import { DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID } from "./src/runtime-state.js";
+import { createMarmotChannelPlugin, MARMOT_CHANNEL_ID } from "./src/channel.js";
 
 export default defineChannelPluginEntry({
   id: MARMOT_CHANNEL_ID,
@@ -32,82 +19,5 @@ export default defineChannelPluginEntry({
         (api as { registrationMode?: unknown }).registrationMode ?? "unknown",
       )})`,
     );
-    void (async () => {
-      try {
-        // Mirror configured dm.allowFrom welcomers into wn-agent before consuming
-        // inbound, so the welcomer policy is in place when the agent goes live.
-        // (syncMarmotAllowlist is self-guarded and never rejects.)
-        await syncMarmotAllowlist(api);
-
-        const resolved = resolveMarmotChannelAccount(api.config, null);
-
-        // Inherit the configured OpenClaw agent name (if any): it seeds the
-        // profile-name onboarding flow and, as a trigger phrase, lets the agent
-        // recognize being addressed by name in a group.
-        const agents = (api.config as {
-          agents?: { list?: Array<{ name?: string; default?: boolean }> };
-        }).agents;
-        const agentList = agents?.list ?? [];
-        const configuredAgentName =
-          agentList.find((entry) => entry.default)?.name ?? agentList[0]?.name ?? null;
-        const mentionPatterns = [...resolved.mentionPatterns, configuredAgentName].filter(
-          (pattern): pattern is string => typeof pattern === "string" && pattern.trim().length > 0,
-        );
-
-        // Inbound -> agent turn dispatch (Telegram-modeled): the bridge feeds each
-        // received Marmot message into runChannelInboundEvent, and the agent's
-        // reply is delivered back through send_final / live QUIC previews.
-        const dispatch = createMarmotInboundDispatcher({
-          cfg: api.config,
-          runtimeChannel: api.runtime.channel as unknown as OpenClawChannelRuntime,
-          client: clientForAccount(resolved),
-          channelAccountId: resolved.accountId ?? DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID,
-          streamMode: resolved.streamMode,
-          blockStreaming: resolved.blockStreaming,
-          quicCandidates: resolved.quicCandidates,
-          groupActivation: resolved.groupActivation,
-          mentionPatterns,
-          log: (message) => api.logger.info(message),
-        });
-
-        // Ambient surfacer: route a passive group event to the agent's session as
-        // quiet next-turn context. Built here (over the full `api`) because it
-        // needs `api.runtime.channel.routing` + `api.runtime.system`, which the
-        // narrowed inbound api does not expose. Feature-detected at runtime so it
-        // degrades to a no-op on a host without the system-event surface.
-        const channelAccountId = resolved.accountId ?? DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID;
-        const surfaceAmbientEvent: MarmotAmbientSurfacer = ({ groupIdHex, text, contextKey }) => {
-          const enqueue = api.runtime?.system?.enqueueSystemEvent;
-          if (typeof enqueue !== "function") {
-            api.logger.warn(
-              "marmot: runtime has no system-event surface; ambient event not delivered",
-            );
-            return;
-          }
-          const route = api.runtime.channel.routing.resolveAgentRoute({
-            cfg: api.config,
-            channel: MARMOT_CHANNEL_ID,
-            accountId: channelAccountId,
-            peer: { kind: "group", id: groupIdHex },
-          });
-          enqueue(text, { sessionKey: route.sessionKey, contextKey: contextKey ?? null });
-        };
-
-        startMarmotInbound(api, dispatch, {
-          configuredAgentName,
-          surfaceAmbientEvent,
-          invalidateGroupActivation: dispatch.invalidateGroupActivation,
-          clearGroupActivationCache: dispatch.clearGroupActivationCache,
-        });
-      } catch {
-        // This runs in a fire-and-forget IIFE, so an unguarded throw (e.g. a
-        // malformed channels.marmot config that fails account resolution) would
-        // surface as an unhandledRejection — and OpenClaw's handler process.exit(1)s
-        // the whole gateway on a non-transient rejection, taking sibling channels
-        // down with it. Contain it: log a privacy-safe notice and leave the Marmot
-        // channel inert instead of crashing the gateway.
-        api.logger.warn("marmot: inbound startup failed; channel is inactive");
-      }
-    })();
   },
 });

--- a/integrations/openclaw/marmot/src/bounded-keyed-async-queue.ts
+++ b/integrations/openclaw/marmot/src/bounded-keyed-async-queue.ts
@@ -1,6 +1,30 @@
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 
+import {
+  MarmotDispatchAmbiguousDeliveryError,
+  MarmotDispatchDeliveryFailedError,
+  MarmotDispatchNotReadyError,
+} from "./dispatch-errors.js";
+
 export const DEFAULT_INBOUND_QUEUE_MAX_DEPTH = 32;
+
+/**
+ * Map queue task failures onto fixed privacy-safe operator categories. Never
+ * forward an arbitrary error message because it may contain route or payload
+ * material from an upstream SDK failure.
+ */
+export function inboundDispatchFailureCategory(error: unknown): string {
+  if (error instanceof MarmotDispatchAmbiguousDeliveryError) {
+    return "ambiguous_delivery";
+  }
+  if (error instanceof MarmotDispatchDeliveryFailedError) {
+    return "delivery_failed";
+  }
+  if (error instanceof MarmotDispatchNotReadyError) {
+    return "not_ready";
+  }
+  return "unexpected";
+}
 
 /**
  * Per-key FIFO dispatch with a bounded queue depth. When a key is at capacity,
@@ -40,7 +64,11 @@ export class BoundedKeyedAsyncQueue {
           }
         }
       })
-      .catch(() => this.onShed?.("marmot: inbound dispatch task failed"));
+      .catch((error) =>
+        this.onShed?.(
+          `marmot: inbound dispatch task failed (${inboundDispatchFailureCategory(error)})`,
+        ),
+      );
     return true;
   }
 }

--- a/integrations/openclaw/marmot/src/bounded-keyed-async-queue.ts
+++ b/integrations/openclaw/marmot/src/bounded-keyed-async-queue.ts
@@ -19,11 +19,12 @@ export class BoundedKeyedAsyncQueue {
     this.maxDepthPerKey = Math.max(1, maxDepthPerKey);
   }
 
-  enqueue(key: string, task: () => Promise<void>): void {
+  /** Returns false when the per-key depth cap rejects the task. */
+  enqueue(key: string, task: () => Promise<void>): boolean {
     const depth = this.depths.get(key) ?? 0;
     if (depth >= this.maxDepthPerKey) {
       this.onShed?.("marmot: inbound queue depth exceeded; shedding turn");
-      return;
+      return false;
     }
     this.depths.set(key, depth + 1);
     void this.queue
@@ -40,5 +41,6 @@ export class BoundedKeyedAsyncQueue {
         }
       })
       .catch(() => this.onShed?.("marmot: inbound dispatch task failed"));
+    return true;
   }
 }

--- a/integrations/openclaw/marmot/src/channel.ts
+++ b/integrations/openclaw/marmot/src/channel.ts
@@ -32,7 +32,7 @@ import {
 import { createMarmotMessagingAdapter } from "./messaging.js";
 import { createMarmotMessageAdapter } from "./outbound.js";
 import { startMarmotGatewayAccount } from "./gateway.js";
-import { canonicalizeMarmotGroupTarget } from "./target.js";
+import { canonicalizeMarmotGroupTarget, MarmotTargetError } from "./target.js";
 import {
   DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID,
   marmotInboundRuntimeSnapshot,
@@ -164,10 +164,20 @@ export function createMarmotDeleteActionAdapter(
       }
       const to = typeof ctx.params.to === "string" ? ctx.params.to : undefined;
       if (to) {
-        const { client, marmotAccountIdHex } = await deps.resolveTarget(ctx.cfg, ctx.accountId ?? null);
-        const groupIdHex = canonicalizeMarmotGroupTarget(to);
-        await client.deleteMessage(marmotAccountIdHex, groupIdHex, messageId);
-        return jsonResult({ ok: true, deleted: true });
+        try {
+          const { client, marmotAccountIdHex } = await deps.resolveTarget(
+            ctx.cfg,
+            ctx.accountId ?? null,
+          );
+          const groupIdHex = canonicalizeMarmotGroupTarget(to);
+          await client.deleteMessage(marmotAccountIdHex, groupIdHex, messageId);
+          return jsonResult({ ok: true, deleted: true });
+        } catch (error) {
+          if (error instanceof MarmotTargetError) {
+            return jsonResult({ ok: false, error: error.message });
+          }
+          throw error;
+        }
       }
       return jsonResult({ ok: false, error: "could not resolve group for this message id" });
     },

--- a/integrations/openclaw/marmot/src/channel.ts
+++ b/integrations/openclaw/marmot/src/channel.ts
@@ -31,6 +31,8 @@ import {
 } from "./config.js";
 import { createMarmotMessagingAdapter } from "./messaging.js";
 import { createMarmotMessageAdapter } from "./outbound.js";
+import { startMarmotGatewayAccount } from "./gateway.js";
+import { canonicalizeMarmotGroupTarget } from "./target.js";
 import {
   DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID,
   marmotInboundRuntimeSnapshot,
@@ -82,22 +84,23 @@ function accountSnapshot(
   probe?: unknown,
 ): ChannelAccountSnapshot {
   const accountId = account.accountId ?? DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID;
-  const inbound = marmotInboundRuntimeSnapshot(accountId);
+  // Gateway-owned `setStatus` snapshots win; the legacy runtime-state shim is only
+  // for direct legacy callers/tests that start inbound without a gateway account.
+  const status = runtime ?? marmotInboundRuntimeSnapshot(accountId);
   return {
-    ...runtime,
-    ...inbound,
+    ...status,
     accountId,
     name: accountId,
     enabled: true,
     configured: true,
-    running: inbound.running === true,
-    connected: inbound.connected === true,
-    lastStartAt: inbound.lastStartAt ?? runtime?.lastStartAt ?? null,
-    lastStopAt: inbound.lastStopAt ?? runtime?.lastStopAt ?? null,
-    lastError: inbound.lastError ?? runtime?.lastError ?? null,
-    lastInboundAt: inbound.lastInboundAt ?? runtime?.lastInboundAt ?? null,
-    lastOutboundAt: inbound.lastOutboundAt ?? runtime?.lastOutboundAt ?? null,
-    reconnectAttempts: inbound.reconnectAttempts ?? runtime?.reconnectAttempts,
+    running: status.running === true,
+    connected: status.connected === true,
+    lastStartAt: status.lastStartAt ?? null,
+    lastStopAt: status.lastStopAt ?? null,
+    lastError: status.lastError ?? null,
+    lastInboundAt: status.lastInboundAt ?? null,
+    lastOutboundAt: status.lastOutboundAt ?? null,
+    reconnectAttempts: status.reconnectAttempts,
     mode: account.streamMode,
     dmPolicy: account.dmPolicy ?? "allowlist",
     allowFrom: account.allowFrom.map(String),
@@ -162,7 +165,8 @@ export function createMarmotDeleteActionAdapter(
       const to = typeof ctx.params.to === "string" ? ctx.params.to : undefined;
       if (to) {
         const { client, marmotAccountIdHex } = await deps.resolveTarget(ctx.cfg, ctx.accountId ?? null);
-        await client.deleteMessage(marmotAccountIdHex, to, messageId);
+        const groupIdHex = canonicalizeMarmotGroupTarget(to);
+        await client.deleteMessage(marmotAccountIdHex, groupIdHex, messageId);
         return jsonResult({ ok: true, deleted: true });
       }
       return jsonResult({ ok: false, error: "could not resolve group for this message id" });
@@ -248,6 +252,9 @@ export function createMarmotChannelPlugin() {
         ],
       },
       actions,
+      gateway: {
+        startAccount: (ctx) => startMarmotGatewayAccount(ctx),
+      },
     },
     security: {
       dm: {

--- a/integrations/openclaw/marmot/src/dispatch-errors.ts
+++ b/integrations/openclaw/marmot/src/dispatch-errors.ts
@@ -1,5 +1,23 @@
 // Typed, privacy-safe inbound dispatch failures surfaced to the inbound queue.
 
+/** Inbound dispatch failed because a durable reply never landed with a definite receipt. */
+export class MarmotDispatchAmbiguousDeliveryError extends Error {
+  constructor() {
+    super(
+      "marmot: durable reply delivery ended with an ambiguous outcome; inbound dispatch failed",
+    );
+    this.name = "MarmotDispatchAmbiguousDeliveryError";
+  }
+}
+
+/** Inbound dispatch failed because OpenClaw reported a terminal final delivery failure. */
+export class MarmotDispatchDeliveryFailedError extends Error {
+  constructor() {
+    super("marmot: reply final delivery failed; inbound dispatch failed");
+    this.name = "MarmotDispatchDeliveryFailedError";
+  }
+}
+
 /** Inbound dispatch failed because outbound group readiness never converged. */
 export class MarmotDispatchNotReadyError extends Error {
   readonly reason: "timeout" | "non_retryable";

--- a/integrations/openclaw/marmot/src/dispatch-errors.ts
+++ b/integrations/openclaw/marmot/src/dispatch-errors.ts
@@ -1,0 +1,16 @@
+// Typed, privacy-safe inbound dispatch failures surfaced to the inbound queue.
+
+/** Inbound dispatch failed because outbound group readiness never converged. */
+export class MarmotDispatchNotReadyError extends Error {
+  readonly reason: "timeout" | "non_retryable";
+
+  constructor(reason: "timeout" | "non_retryable") {
+    super(
+      reason === "timeout"
+        ? "marmot: outbound group readiness timed out; inbound dispatch failed"
+        : "marmot: outbound group readiness check failed; inbound dispatch failed",
+    );
+    this.name = "MarmotDispatchNotReadyError";
+    this.reason = reason;
+  }
+}

--- a/integrations/openclaw/marmot/src/dispatch.ts
+++ b/integrations/openclaw/marmot/src/dispatch.ts
@@ -23,7 +23,7 @@ import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
 import { NonAppendOnlyUpdateError } from "./append-only.js";
 import { isRetryable, type GroupInfoResponse, type MarmotAgentControlClient } from "./client.js";
 import type { GroupActivation, StreamMode } from "./config.js";
-import { MarmotDispatchNotReadyError } from "./dispatch-errors.js";
+import { MarmotDispatchAmbiguousDeliveryError, MarmotDispatchDeliveryFailedError, MarmotDispatchNotReadyError } from "./dispatch-errors.js";
 import type { MarmotInboundMessage } from "./inbound.js";
 import { MarmotLivePreview, type StreamControlClient } from "./live.js";
 import { waitForGroupReadiness } from "./readiness.js";
@@ -36,8 +36,10 @@ import {
   resolveTurnIdempotencyKey,
   runInMarmotTurn,
   shouldSuppressSinkDurableDelivery,
+  assertTurnDurableDeliveryResolved,
   type MarmotTurnRoute,
 } from "./turn-delivery.js";
+import { deriveTurnIdempotencyKeyFromInbound } from "./turn-idempotency.js";
 
 // --- reply sink (unit-tested) -----------------------------------------------
 
@@ -75,6 +77,25 @@ export interface MarmotReplySinkOptions {
 
 const MIN_TRUNCATED_FINAL_PREFIX_CHARS = 48;
 const MIN_TRUNCATED_FINAL_CONTINUATION_CHARS = 24;
+
+interface BufferedDispatchResult {
+  failedCounts?: Partial<Record<ReplyDelivery["kind"], number>>;
+}
+
+function assertBufferedDispatchDeliverySucceeded(result: unknown): void {
+  const failedCounts = (result as BufferedDispatchResult | undefined)?.failedCounts;
+  if ((failedCounts?.final ?? 0) > 0) {
+    throw new MarmotDispatchDeliveryFailedError();
+  }
+}
+
+function assertTurnDispatchDeliverySettled(): void {
+  const turn = getMarmotTurnDelivery();
+  if (!turn) {
+    return;
+  }
+  assertTurnDurableDeliveryResolved(turn);
+}
 
 function stripTrailingEllipsis(text: string): string {
   return text.replace(/(?:\s*(?:\.{3}|…))+$/u, "").trimEnd();
@@ -323,7 +344,11 @@ export class MarmotReplySink {
     if (!turn) {
       return "proceed";
     }
-    return acquireSinkDeliveryOrSuppress(turn);
+    const gate = await acquireSinkDeliveryOrSuppress(turn);
+    if (gate === "suppress") {
+      assertTurnDurableDeliveryResolved(turn);
+    }
+    return gate;
   }
 
   private async sendFinal(text: string): Promise<void> {
@@ -415,7 +440,7 @@ export class MarmotReplySink {
     const turn = getMarmotTurnDelivery();
     if (turn) {
       await awaitTurnOutboundResolution(turn);
-      if (shouldSuppressSinkDurableDelivery(turn)) {
+      if (turn.outboundDelivered) {
         if (this.preview?.isActive && !this.previewAbandoned) {
           await this.abandonPreview("sink_delivery_suppressed");
         }
@@ -423,6 +448,7 @@ export class MarmotReplySink {
         this.log("marmot: durable reply already owned for this turn; skipping sink commit");
         return true;
       }
+      assertTurnDurableDeliveryResolved(turn);
     }
     const finalText = await this.bestFinalText(text);
     if (!finalText.trim()) {
@@ -437,11 +463,11 @@ export class MarmotReplySink {
       this.log("marmot: durable reply already owned for this turn; skipping sink commit");
       return true;
     }
-    this.finalized = true;
     this.logPartialSummary();
     if (this.preview && this.preview.isActive && !this.previewAbandoned) {
       try {
         await this.preview.finalize(finalText);
+        this.finalized = true;
         this.log(`marmot: live preview finalized (${finalText.length} chars)`);
         return true;
       } catch (error) {
@@ -461,6 +487,7 @@ export class MarmotReplySink {
       }
     }
     await this.sendFinal(finalText);
+    this.finalized = true;
     return true;
   }
 
@@ -806,7 +833,7 @@ export function createMarmotInboundDispatcher(
       marmotAccountIdHex: message.accountIdHex,
       groupIdHex: message.groupIdHex,
       replyToMessageIdHex: message.messageIdHex,
-      idempotencyKey: randomUUID(),
+      idempotencyKey: deriveTurnIdempotencyKeyFromInbound(message),
     };
 
     await runInMarmotTurn(turnRoute, async () => {
@@ -878,7 +905,7 @@ export function createMarmotInboundDispatcher(
     deps.log?.("marmot: agent turn starting");
     await sink.prewarm();
     const turnCfg = buildMarmotTurnConfigOverlay(deps.cfg);
-    await runChannelInboundEvent({
+    const dispatchResult = await runChannelInboundEvent({
       channel: "marmot",
       accountId: channelAccountId,
       raw: message,
@@ -895,8 +922,8 @@ export function createMarmotInboundDispatcher(
           storePath,
           ctxPayload,
           recordInboundSession: deps.runtimeChannel.session.recordInboundSession as never,
-          runDispatch: () =>
-            deps.runtimeChannel.reply.dispatchReplyWithBufferedBlockDispatcher({
+          runDispatch: async () => {
+            const result = await deps.runtimeChannel.reply.dispatchReplyWithBufferedBlockDispatcher({
               ctx: ctxPayload,
               cfg: turnCfg,
               dispatcherOptions: {
@@ -921,13 +948,18 @@ export function createMarmotInboundDispatcher(
                 onToolStart: () => sink.progress("Working..."),
                 onCommandOutput: () => sink.progress("Working..."),
               },
-            }) as never,
+            });
+            assertBufferedDispatchDeliverySucceeded(result);
+            return result;
+          },
         }),
       },
     });
+    assertBufferedDispatchDeliverySucceeded(dispatchResult);
     // Block streaming can finish a turn with only `block` deliveries; commit the
     // accumulated reply durably if no explicit `final` did.
     await sink.flush();
+    assertTurnDispatchDeliverySettled();
     deps.log?.(`marmot: agent turn done (sink deliveries=${sink.deliveries})`);
   };
 

--- a/integrations/openclaw/marmot/src/dispatch.ts
+++ b/integrations/openclaw/marmot/src/dispatch.ts
@@ -477,12 +477,15 @@ export class MarmotReplySink {
           await this.abandonPreview(reason);
         } else {
           const retryable = isRetryable(error);
-          this.log(
-            retryable
-              ? "marmot: preview finalize failed (retryable); not falling back to send_final"
-              : "marmot: preview finalize failed (ambiguous); not falling back to send_final",
-          );
-          throw error;
+          if (retryable) {
+            this.log(
+              "marmot: preview finalize failed (ambiguous); not falling back to send_final",
+            );
+            throw error;
+          }
+          const reason = "preview_finalize_definite_failure";
+          this.log(`marmot: preview finalize failed (${reason}); falling back to a durable send`);
+          await this.abandonPreview(reason);
         }
       }
     }
@@ -698,7 +701,7 @@ async function resolveInboundTurnGate(
     if (isRetryable(err)) {
       return { proceed: true, needsMembershipCheck: true };
     }
-    deps.log?.("marmot: outbound group readiness check failed (non-retryable)");
+    deps.log?.("marmot: inbound activation membership lookup failed (non-retryable)");
     return { proceed: false, kind: "not_ready", reason: "non_retryable" };
   }
 }

--- a/integrations/openclaw/marmot/src/dispatch.ts
+++ b/integrations/openclaw/marmot/src/dispatch.ts
@@ -21,12 +21,23 @@ import {
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
 
 import { NonAppendOnlyUpdateError } from "./append-only.js";
-import { isRetryable, type MarmotAgentControlClient } from "./client.js";
+import { isRetryable, type GroupInfoResponse, type MarmotAgentControlClient } from "./client.js";
 import type { GroupActivation, StreamMode } from "./config.js";
+import { MarmotDispatchNotReadyError } from "./dispatch-errors.js";
 import type { MarmotInboundMessage } from "./inbound.js";
 import { MarmotLivePreview, type StreamControlClient } from "./live.js";
+import { waitForGroupReadiness } from "./readiness.js";
 import { DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID } from "./runtime-state.js";
 import { resolveLatestAssistantTextFromSessionStore } from "./session-transcript.js";
+import {
+  acquireSinkDeliveryOrSuppress,
+  awaitTurnOutboundResolution,
+  getMarmotTurnDelivery,
+  resolveTurnIdempotencyKey,
+  runInMarmotTurn,
+  shouldSuppressSinkDurableDelivery,
+  type MarmotTurnRoute,
+} from "./turn-delivery.js";
 
 // --- reply sink (unit-tested) -----------------------------------------------
 
@@ -307,14 +318,27 @@ export class MarmotReplySink {
     );
   }
 
+  private async resolveSinkDeliveryGate(): Promise<"suppress" | "proceed"> {
+    const turn = getMarmotTurnDelivery();
+    if (!turn) {
+      return "proceed";
+    }
+    return acquireSinkDeliveryOrSuppress(turn);
+  }
+
   private async sendFinal(text: string): Promise<void> {
+    const gate = await this.resolveSinkDeliveryGate();
+    if (gate === "suppress") {
+      this.log("marmot: durable reply already owned for this turn; skipping sink send_final");
+      return;
+    }
     this.log(`marmot: sending durable final (${text.length} chars)`);
     // One idempotency key for all attempts of THIS durable reply: a retry after a
     // post-write timeout reuses the key so the connector dedups instead of
     // double-posting an unrecallable encrypted message. Bounded retries with a
     // tiny backoff cover the transient/timeout window; non-retryable errors fail
     // fast and the last error is rethrown.
-    const idempotencyKey = randomUUID();
+    const idempotencyKey = resolveTurnIdempotencyKey(getMarmotTurnDelivery()) ?? randomUUID();
     const backoffMs = [100, 300];
     let attempt = 0;
     for (;;) {
@@ -388,9 +412,30 @@ export class MarmotReplySink {
     if (this.finalized) {
       return true;
     }
+    const turn = getMarmotTurnDelivery();
+    if (turn) {
+      await awaitTurnOutboundResolution(turn);
+      if (shouldSuppressSinkDurableDelivery(turn)) {
+        if (this.preview?.isActive && !this.previewAbandoned) {
+          await this.abandonPreview("sink_delivery_suppressed");
+        }
+        this.finalized = true;
+        this.log("marmot: durable reply already owned for this turn; skipping sink commit");
+        return true;
+      }
+    }
     const finalText = await this.bestFinalText(text);
-    if (!finalText) {
+    if (!finalText.trim()) {
       return false;
+    }
+    const gate = await this.resolveSinkDeliveryGate();
+    if (gate === "suppress") {
+      if (this.preview?.isActive && !this.previewAbandoned) {
+        await this.abandonPreview("sink_delivery_suppressed");
+      }
+      this.finalized = true;
+      this.log("marmot: durable reply already owned for this turn; skipping sink commit");
+      return true;
     }
     this.finalized = true;
     this.logPartialSummary();
@@ -400,10 +445,19 @@ export class MarmotReplySink {
         this.log(`marmot: live preview finalized (${finalText.length} chars)`);
         return true;
       } catch (error) {
-        const reason =
-          error instanceof NonAppendOnlyUpdateError ? "final_not_append_only" : "finalize_error";
-        this.log(`marmot: preview finalize failed (${reason}); falling back to a durable send`);
-        await this.abandonPreview(reason);
+        if (error instanceof NonAppendOnlyUpdateError) {
+          const reason = "final_not_append_only";
+          this.log(`marmot: preview finalize failed (${reason}); falling back to a durable send`);
+          await this.abandonPreview(reason);
+        } else {
+          const retryable = isRetryable(error);
+          this.log(
+            retryable
+              ? "marmot: preview finalize failed (retryable); not falling back to send_final"
+              : "marmot: preview finalize failed (ambiguous); not falling back to send_final",
+          );
+          throw error;
+        }
       }
     }
     await this.sendFinal(finalText);
@@ -443,6 +497,38 @@ export class MarmotReplySink {
 }
 
 // --- inbound turn dispatch (SDK-coupled; harness-validated) ------------------
+
+const MARMOT_TURN_DENIED_TOOLS = ["sessions_send"] as const;
+const MARMOT_TURN_ALSO_ALLOW_TOOLS = ["message"] as const;
+
+function mergeUniqueToolNames(existing: readonly string[] | undefined, additions: readonly string[]): string[] {
+  const merged = new Set(existing ?? []);
+  for (const entry of additions) {
+    merged.add(entry);
+  }
+  return [...merged];
+}
+
+/**
+ * Immutable per-turn config overlay: deny cross-session `sessions_send` for the
+ * source-bound Marmot reply turn while keeping the shared `message` tool available
+ * for out-of-band sends. Never mutates `baseCfg`.
+ */
+export function buildMarmotTurnConfigOverlay(baseCfg: unknown): Record<string, unknown> {
+  const cfg = baseCfg as {
+    tools?: { deny?: string[]; alsoAllow?: string[]; allow?: string[]; profile?: string };
+    agents?: { list?: Array<{ tools?: { deny?: string[]; alsoAllow?: string[] } }> };
+  };
+  const tools = cfg.tools ?? {};
+  return {
+    ...cfg,
+    tools: {
+      ...tools,
+      deny: mergeUniqueToolNames(tools.deny, MARMOT_TURN_DENIED_TOOLS),
+      alsoAllow: mergeUniqueToolNames(tools.alsoAllow, MARMOT_TURN_ALSO_ALLOW_TOOLS),
+    },
+  };
+}
 
 /** Narrow view of `api.runtime.channel` (only the members we drive). */
 export interface OpenClawChannelRuntime {
@@ -538,6 +624,11 @@ export class GroupActivationCache {
   }
 }
 
+type InboundTurnGateResult =
+  | { proceed: false; kind: "not_addressed" }
+  | { proceed: false; kind: "not_ready"; reason: "non_retryable" }
+  | { proceed: true; groupInfo?: GroupInfoResponse; needsMembershipCheck: boolean };
+
 /**
  * Decide whether an inbound group message should run an agent turn. Always reply
  * when addressed (`mentionsSelf`, a trigger matches) or in an effective DM
@@ -545,38 +636,43 @@ export class GroupActivationCache {
  * otherwise unaddressed — to avoid a round-trip on the common addressed case, and
  * the `is_direct` result is cached per (account, group) so repeated ambient
  * messages don't each re-read MLS state (the cache is invalidated on a
- * `group_state_changed` event). On a membership-lookup error we fail **closed**
- * (skip the turn): under the `mention` policy an unaddressed message in a group
- * whose membership we can't resolve is more likely a multi-party conversation the
- * agent wasn't addressed in, and barging in there is worse (and unrecallable)
- * than dropping a single reply in a true two-party DM, where the user can simply
- * re-send or address the agent explicitly. The error is not cached.
+ * `group_state_changed` event). A transient membership-lookup error defers to
+ * {@link waitForGroupReadiness} instead of skipping before retries can run. A
+ * non-retryable membership error is surfaced as a readiness failure; it is not
+ * evidence that the message was merely unaddressed and is not cached.
  */
-async function shouldRunTurn(
+async function resolveInboundTurnGate(
   deps: MarmotDispatchDeps,
   cache: GroupActivationCache,
   message: MarmotInboundMessage,
-): Promise<boolean> {
+): Promise<InboundTurnGateResult> {
   if (deps.groupActivation === "always") {
-    return true;
+    return { proceed: true, needsMembershipCheck: false };
   }
   if (message.mentionsSelf) {
-    return true;
+    return { proceed: true, needsMembershipCheck: false };
   }
   if (matchesMentionPattern(message.text, deps.mentionPatterns)) {
-    return true;
+    return { proceed: true, needsMembershipCheck: false };
   }
   const cached = cache.get(message.accountIdHex, message.groupIdHex);
   if (cached !== undefined) {
-    return cached;
+    return cached
+      ? { proceed: true, needsMembershipCheck: false }
+      : { proceed: false, kind: "not_addressed" };
   }
   try {
     const info = await deps.client.groupInfo(message.accountIdHex, message.groupIdHex);
     cache.set(message.accountIdHex, message.groupIdHex, info.is_direct);
-    return info.is_direct;
-  } catch {
-    deps.log?.("marmot: group membership lookup failed; skipping turn (fail-closed)");
-    return false;
+    return info.is_direct
+      ? { proceed: true, groupInfo: info, needsMembershipCheck: false }
+      : { proceed: false, kind: "not_addressed" };
+  } catch (err) {
+    if (isRetryable(err)) {
+      return { proceed: true, needsMembershipCheck: true };
+    }
+    deps.log?.("marmot: outbound group readiness check failed (non-retryable)");
+    return { proceed: false, kind: "not_ready", reason: "non_retryable" };
   }
 }
 
@@ -673,12 +769,56 @@ export function createMarmotInboundDispatcher(
   // it lives exactly as long as the inbound subscription that owns it.
   const activationCache = new GroupActivationCache();
   const dispatch = async (message: MarmotInboundMessage): Promise<void> => {
-    // Activation gating: in a multi-party group, only run a turn when addressed.
-    if (!(await shouldRunTurn(deps, activationCache, message))) {
+    const gate = await resolveInboundTurnGate(deps, activationCache, message);
+    if (!gate.proceed) {
+      if (gate.kind === "not_ready") {
+        throw new MarmotDispatchNotReadyError(gate.reason);
+      }
       deps.log?.("marmot: inbound not addressed; skipping turn (groupActivation=mention)");
       return;
     }
+
+    let groupInfo = gate.groupInfo;
+    if (!groupInfo) {
+      const readiness = await waitForGroupReadiness({
+        client: deps.client,
+        accountIdHex: message.accountIdHex,
+        groupIdHex: message.groupIdHex,
+        log: deps.log,
+      });
+      if (readiness.status !== "ready") {
+        throw new MarmotDispatchNotReadyError(readiness.reason);
+      }
+      groupInfo = readiness.groupInfo;
+    }
+
+    if (gate.needsMembershipCheck) {
+      activationCache.set(message.accountIdHex, message.groupIdHex, groupInfo.is_direct);
+      if (!groupInfo.is_direct) {
+        deps.log?.("marmot: inbound not addressed; skipping turn (groupActivation=mention)");
+        return;
+      }
+    }
+
     const channelAccountId = deps.channelAccountId?.trim() || DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID;
+    const turnRoute: MarmotTurnRoute = {
+      channelAccountId,
+      marmotAccountIdHex: message.accountIdHex,
+      groupIdHex: message.groupIdHex,
+      replyToMessageIdHex: message.messageIdHex,
+      idempotencyKey: randomUUID(),
+    };
+
+    await runInMarmotTurn(turnRoute, async () => {
+      await dispatchTurn(deps, message, channelAccountId);
+    });
+  };
+
+  const dispatchTurn = async (
+    deps: MarmotDispatchDeps,
+    message: MarmotInboundMessage,
+    channelAccountId: string,
+  ): Promise<void> => {
     const route = deps.runtimeChannel.routing.resolveAgentRoute({
       cfg: deps.cfg,
       channel: "marmot",
@@ -737,6 +877,7 @@ export function createMarmotInboundDispatcher(
 
     deps.log?.("marmot: agent turn starting");
     await sink.prewarm();
+    const turnCfg = buildMarmotTurnConfigOverlay(deps.cfg);
     await runChannelInboundEvent({
       channel: "marmot",
       accountId: channelAccountId,
@@ -757,12 +898,16 @@ export function createMarmotInboundDispatcher(
           runDispatch: () =>
             deps.runtimeChannel.reply.dispatchReplyWithBufferedBlockDispatcher({
               ctx: ctxPayload,
-              cfg: deps.cfg,
+              cfg: turnCfg,
               dispatcherOptions: {
                 deliver: (payload: ReplyPayloadLike, info: ReplyDelivery) =>
                   sink.deliver(payload, info),
               },
               replyOptions: {
+                // Keep the bound Marmot reply sink as the durable owner for this
+                // turn. sessions_send / message_tool_only must not suppress an
+                // assistant final that never reached send_final.
+                sourceReplyDeliveryMode: "automatic",
                 disableBlockStreaming: deps.blockStreaming ? false : true,
                 onPartialReply: (payload: PartialReplyPayloadLike) => sink.partial(payload),
                 onAssistantMessageStart: () => sink.status("Thinking..."),

--- a/integrations/openclaw/marmot/src/dispatch.ts
+++ b/integrations/openclaw/marmot/src/dispatch.ts
@@ -82,6 +82,7 @@ interface BufferedDispatchResult {
   failedCounts?: Partial<Record<ReplyDelivery["kind"], number>>;
 }
 
+/** Fail the inbound turn when OpenClaw reports any failed final delivery. */
 function assertBufferedDispatchDeliverySucceeded(result: unknown): void {
   const failedCounts = (result as BufferedDispatchResult | undefined)?.failedCounts;
   if ((failedCounts?.final ?? 0) > 0) {
@@ -89,6 +90,7 @@ function assertBufferedDispatchDeliverySucceeded(result: unknown): void {
   }
 }
 
+/** Fail closed if the active turn ended without a definite durable outcome. */
 function assertTurnDispatchDeliverySettled(): void {
   const turn = getMarmotTurnDelivery();
   if (!turn) {
@@ -531,6 +533,7 @@ export class MarmotReplySink {
 const MARMOT_TURN_DENIED_TOOLS = ["sessions_send"] as const;
 const MARMOT_TURN_ALSO_ALLOW_TOOLS = ["message"] as const;
 
+/** Append tool names without mutating the caller's list or adding duplicates. */
 function mergeUniqueToolNames(existing: readonly string[] | undefined, additions: readonly string[]): string[] {
   const merged = new Set(existing ?? []);
   for (const entry of additions) {

--- a/integrations/openclaw/marmot/src/gateway.ts
+++ b/integrations/openclaw/marmot/src/gateway.ts
@@ -1,0 +1,127 @@
+// Marmot channel gateway lifecycle: owns the wn-agent inbound subscription per
+// OpenClaw channel account via `gateway.startAccount`.
+
+import type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-runtime";
+import { enqueueSystemEvent } from "openclaw/plugin-sdk/channel-runtime";
+import {
+  createAccountStatusSink,
+  runPassiveAccountLifecycle,
+} from "openclaw/plugin-sdk/channel-lifecycle";
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/status-helpers";
+
+import { clientForAccount, type ResolvedMarmotAccount } from "./config.js";
+import { createMarmotInboundDispatcher, type OpenClawChannelRuntime } from "./dispatch.js";
+import {
+  startMarmotInbound,
+  syncMarmotAllowlist,
+  type InboundPluginApi,
+  type MarmotAmbientSurfacer,
+} from "./inbound-runtime.js";
+import { DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID } from "./runtime-state.js";
+
+function resolveConfiguredAgentName(cfg: unknown): string | null {
+  const agents = (cfg as { agents?: { list?: Array<{ name?: string; default?: boolean }> } })
+    .agents;
+  const agentList = agents?.list ?? [];
+  return agentList.find((entry) => entry.default)?.name ?? agentList[0]?.name ?? null;
+}
+
+/** Start the passive inbound subscription for one Marmot channel account. */
+export async function startMarmotGatewayAccount(
+  ctx: ChannelGatewayContext<ResolvedMarmotAccount>,
+): Promise<void> {
+  const account = ctx.account;
+  const statusSink = createAccountStatusSink({
+    accountId: ctx.accountId,
+    setStatus: ctx.setStatus,
+  });
+  const markRunning = (patch: Partial<ChannelAccountSnapshot> = {}) => {
+    statusSink({
+      running: true,
+      connected: patch.connected ?? false,
+      lastStartAt: patch.lastStartAt ?? Date.now(),
+      lastStopAt: null,
+      lastError: null,
+      ...patch,
+    });
+  };
+  const markStopped = () => {
+    statusSink({
+      running: false,
+      connected: false,
+      lastStopAt: Date.now(),
+    });
+  };
+
+  markRunning({ connected: false });
+  ctx.log?.info?.("marmot: starting inbound subscription");
+
+  const api: InboundPluginApi = {
+    config: ctx.cfg,
+    logger: {
+      info: (message) => ctx.log?.info?.(message),
+      warn: (message) => ctx.log?.warn?.(message),
+    },
+  };
+  await syncMarmotAllowlist(api, { channelAccountId: ctx.accountId });
+
+  const configuredAgentName = resolveConfiguredAgentName(ctx.cfg);
+  const mentionPatterns = [...account.mentionPatterns, configuredAgentName].filter(
+    (pattern): pattern is string => typeof pattern === "string" && pattern.trim().length > 0,
+  );
+  const channelRuntime = ctx.channelRuntime as unknown as OpenClawChannelRuntime | undefined;
+  if (!channelRuntime) {
+    throw new Error("marmot: channelRuntime is required for inbound agent dispatch");
+  }
+
+  const dispatch = createMarmotInboundDispatcher({
+    cfg: ctx.cfg,
+    runtimeChannel: channelRuntime,
+    client: clientForAccount(account),
+    channelAccountId: account.accountId ?? DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID,
+    streamMode: account.streamMode,
+    blockStreaming: account.blockStreaming,
+    quicCandidates: account.quicCandidates,
+    groupActivation: account.groupActivation,
+    mentionPatterns,
+    log: (message) => ctx.log?.info?.(message),
+  });
+
+  const surfaceAmbientEvent: MarmotAmbientSurfacer = ({ groupIdHex, text, contextKey }) => {
+    const route = channelRuntime.routing.resolveAgentRoute({
+      cfg: ctx.cfg,
+      channel: "marmot",
+      accountId: account.accountId ?? DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID,
+      peer: { kind: "group", id: groupIdHex },
+    });
+    enqueueSystemEvent(text, {
+      sessionKey: route.sessionKey,
+      contextKey: contextKey ?? null,
+    });
+  };
+
+  await runPassiveAccountLifecycle({
+    abortSignal: ctx.abortSignal,
+    start: async () =>
+      startMarmotInbound(api, dispatch, {
+        signal: ctx.abortSignal,
+        channelAccountId: ctx.accountId,
+        configuredAgentName,
+        surfaceAmbientEvent,
+        invalidateGroupActivation: dispatch.invalidateGroupActivation,
+        clearGroupActivationCache: dispatch.clearGroupActivationCache,
+        statusSink: (patch) => {
+          statusSink({
+            running: true,
+            ...patch,
+          });
+        },
+      }),
+    stop: async (stopInbound) => {
+      stopInbound?.();
+    },
+    onStop: () => {
+      markStopped();
+    },
+  });
+}

--- a/integrations/openclaw/marmot/src/gateway.ts
+++ b/integrations/openclaw/marmot/src/gateway.ts
@@ -19,6 +19,7 @@ import {
 } from "./inbound-runtime.js";
 import { DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID } from "./runtime-state.js";
 
+/** Resolve the configured default agent's display name for onboarding prompts. */
 function resolveConfiguredAgentName(cfg: unknown): string | null {
   const agents = (cfg as { agents?: { list?: Array<{ name?: string; default?: boolean }> } })
     .agents;

--- a/integrations/openclaw/marmot/src/inbound-runtime.ts
+++ b/integrations/openclaw/marmot/src/inbound-runtime.ts
@@ -12,18 +12,27 @@
 
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
 
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/status-helpers";
+
 import { BoundedKeyedAsyncQueue, DEFAULT_INBOUND_QUEUE_MAX_DEPTH } from "./bounded-keyed-async-queue.js";
 import { resolveSingleAccount } from "./account.js";
 import { resolveMarmotChannelAccount } from "./channel.js";
 import type { MarmotAgentControlClient } from "./client.js";
 import { clientForAccount, type ResolvedMarmotAccount } from "./config.js";
-import { MarmotInboundBridge, type MarmotInboundMessage } from "./inbound.js";
+import { MarmotDispatchNotReadyError } from "./dispatch-errors.js";
+import {
+  inboundDedupeForAccount,
+  MarmotInboundBridge,
+  resetInboundDedupeForTests,
+  type MarmotInboundMessage,
+} from "./inbound.js";
 import {
   maybeHandleProfileOnboardingInbound,
   maybeSendProfilePromptOnJoin,
   ProfileNameOnboardingStore,
 } from "./profile-onboarding.js";
 import {
+  DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID,
   markMarmotInboundReady,
   markMarmotInboundReceived,
   markMarmotInboundReconnect,
@@ -47,10 +56,13 @@ export interface InboundPluginApi {
 
 type ClientFactory = (resolved: ResolvedMarmotAccount) => MarmotAgentControlClient;
 
-function resolveAccount(api: InboundPluginApi): ResolvedMarmotAccount {
+function resolveConfiguredAccount(
+  api: InboundPluginApi,
+  channelAccountId?: string | null,
+): ResolvedMarmotAccount {
   return resolveMarmotChannelAccount(
     api.config as Parameters<typeof resolveMarmotChannelAccount>[0],
-    null,
+    channelAccountId ?? null,
   );
 }
 
@@ -120,6 +132,7 @@ function coalesceInboundMessages(items: MarmotInboundMessage[]): MarmotInboundMe
     mentionsSelf: items.some((item) => item.mentionsSelf === true),
     replyToMessageIdHex,
     media,
+    coalescedMessageIdsHex: items.map((item) => item.messageIdHex),
   };
 }
 
@@ -142,6 +155,10 @@ export type MarmotAmbientSurfacer = (event: {
 
 export interface StartMarmotInboundOptions {
   signal?: AbortSignal;
+  /** OpenClaw channel account id for multi-account deployments. */
+  channelAccountId?: string;
+  /** Gateway-owned status writer; preferred over the legacy runtime-state shim. */
+  statusSink?: (patch: Partial<ChannelAccountSnapshot>) => void;
   /** Override the control-client factory (tests inject a stub). */
   clientFactory?: ClientFactory;
   /**
@@ -167,15 +184,38 @@ export interface StartMarmotInboundOptions {
    * have been missed, so no cached membership can be trusted.
    */
   clearGroupActivationCache?: () => void;
+  /** Override per-group inbound dispatch queue depth (tests). */
+  inboundQueueMaxDepth?: number;
 }
 
-// The gateway can full-load the plugin in more than one in-process context
-// (the HTTP server and the agent-runtime pre-warm each invoke `registerFull`),
-// so `startMarmotInbound` can be called more than once in a single process. A
-// second live subscription would deliver — and dispatch an agent turn for —
-// every inbound message twice, so only the first start is honored until it is
-// stopped.
-let inboundActive = false;
+// Per OpenClaw channel account: only one live subscription at a time.
+const inboundActiveByAccount = new Map<string, boolean>();
+
+const DISPATCH_NOT_READY_MAX_ATTEMPTS = 3;
+const DISPATCH_NOT_READY_BACKOFF_MS = [50, 100, 200] as const;
+
+async function sleepMs(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveInboundAccountKey(
+  api: InboundPluginApi,
+  channelAccountId?: string | null,
+): string {
+  if (channelAccountId?.trim()) {
+    return channelAccountId.trim();
+  }
+  try {
+    return resolveConfiguredAccount(api, channelAccountId).accountId ?? DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID;
+  } catch {
+    return DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID;
+  }
+}
+
+export function resetMarmotInboundAccountsForTests(): void {
+  inboundActiveByAccount.clear();
+  resetInboundDedupeForTests();
+}
 
 /**
  * Run the wn-agent inbound subscription, dispatching each mapped message to
@@ -187,21 +227,49 @@ export function startMarmotInbound(
   dispatch: InboundAgentDispatcher,
   options: StartMarmotInboundOptions = {},
 ): () => void {
-  if (inboundActive) {
+  const inboundAccountKey = resolveInboundAccountKey(api, options.channelAccountId);
+  if (inboundActiveByAccount.get(inboundAccountKey)) {
     api.logger.info("marmot: inbound subscription already active; ignoring duplicate start");
     return () => {};
   }
-  const resolved = resolveAccount(api);
-  const statusAccountId = resolved.accountId ?? null;
-  inboundActive = true;
-  markMarmotInboundStarting(statusAccountId);
+  const resolved = resolveMarmotChannelAccount(
+    api.config as Parameters<typeof resolveMarmotChannelAccount>[0],
+    options.channelAccountId ?? null,
+  );
+  // Complete synchronous construction before claiming the per-account guard. A
+  // bad socket/config or onboarding-store path must not poison later restarts.
+  const client = (options.clientFactory ?? clientForAccount)(resolved);
+  const onboardingStore = resolved.profileNameOnboarding
+    ? new ProfileNameOnboardingStore(resolved.profileOnboardingStatePath)
+    : null;
+  const statusAccountId = resolved.accountId ?? inboundAccountKey;
+  inboundActiveByAccount.set(inboundAccountKey, true);
+  const publishStatus = (patch: Partial<ChannelAccountSnapshot>) => {
+    options.statusSink?.({ accountId: statusAccountId, ...patch });
+    if (!options.statusSink) {
+      if (patch.running === true && patch.connected === true) {
+        markMarmotInboundReady(statusAccountId);
+      } else if (patch.running === true && patch.connected === false) {
+        if (patch.lastError) {
+          markMarmotInboundReconnect(statusAccountId);
+        } else {
+          markMarmotInboundStarting(statusAccountId);
+        }
+      } else if (patch.running === false) {
+        markMarmotInboundStopped(statusAccountId);
+      } else if (patch.lastInboundAt) {
+        markMarmotInboundReceived(statusAccountId);
+      }
+    }
+  };
+  publishStatus({ running: true, connected: false, lastStartAt: Date.now(), lastStopAt: null, lastError: null });
   const controller = new AbortController();
   // Release the guard when the loop is stopped so a clean restart can re-subscribe.
   controller.signal.addEventListener(
     "abort",
     () => {
-      inboundActive = false;
-      markMarmotInboundStopped(statusAccountId);
+      inboundActiveByAccount.delete(inboundAccountKey);
+      publishStatus({ running: false, connected: false, lastStopAt: Date.now() });
     },
     { once: true },
   );
@@ -215,12 +283,6 @@ export function startMarmotInbound(
     }
   }
   const signal = controller.signal;
-  const client = (options.clientFactory ?? clientForAccount)(resolved);
-  // One-time, opt-in public profile-name flow (default off). Runs ahead of the
-  // agent turn so a consent prompt/reply isn't fed to the model.
-  const onboardingStore = resolved.profileNameOnboarding
-    ? new ProfileNameOnboardingStore(resolved.profileOnboardingStatePath)
-    : null;
 
   void (async () => {
     let accountIdHex: string;
@@ -228,8 +290,8 @@ export function startMarmotInbound(
       accountIdHex = resolved.marmotAccountIdHex ?? (await resolveSingleAccount(client));
     } catch {
       api.logger.warn("marmot: could not resolve an agent account for the inbound subscription");
-      inboundActive = false;
-      markMarmotInboundStopped(statusAccountId);
+      inboundActiveByAccount.delete(inboundAccountKey);
+      publishStatus({ running: false, connected: false, lastStopAt: Date.now() });
       return;
     }
     let readyLogged = false;
@@ -238,9 +300,16 @@ export function startMarmotInbound(
     // group stays FIFO. A slow/hung turn in one group no longer blocks inbound
     // dispatch for every other group (the previous inline `await dispatch` did).
     const dispatchQueue = new BoundedKeyedAsyncQueue(
-      DEFAULT_INBOUND_QUEUE_MAX_DEPTH,
+      options.inboundQueueMaxDepth ?? DEFAULT_INBOUND_QUEUE_MAX_DEPTH,
       (message) => api.logger.warn(message),
     );
+    const inboundDedupe = inboundDedupeForAccount(inboundAccountKey);
+    const rollbackInboundDedupe = (message: MarmotInboundMessage): void => {
+      const ids = message.coalescedMessageIdsHex ?? [message.messageIdHex];
+      for (const id of ids) {
+        inboundDedupe.remove(id);
+      }
+    };
     const handleInbound = async (message: MarmotInboundMessage): Promise<void> => {
       if (onboardingStore) {
         const intercepted = await maybeHandleProfileOnboardingInbound({
@@ -260,10 +329,35 @@ export function startMarmotInbound(
         }
       }
       api.logger.info("marmot: inbound message received; dispatching agent turn");
-      await dispatch(message);
+      for (let attempt = 0; attempt < DISPATCH_NOT_READY_MAX_ATTEMPTS; attempt += 1) {
+        try {
+          await dispatch(message);
+          return;
+        } catch (error) {
+          if (!(error instanceof MarmotDispatchNotReadyError)) {
+            throw error;
+          }
+          const exhausted =
+            error.reason === "non_retryable" || attempt >= DISPATCH_NOT_READY_MAX_ATTEMPTS - 1;
+          if (exhausted) {
+            rollbackInboundDedupe(message);
+            api.logger.warn(
+              error.reason === "non_retryable"
+                ? "marmot: inbound dispatch failed (readiness non-retryable)"
+                : "marmot: inbound dispatch failed after readiness exhaustion",
+            );
+            throw error;
+          }
+          api.logger.warn("marmot: inbound dispatch not ready; retrying after backoff");
+          await sleepMs(DISPATCH_NOT_READY_BACKOFF_MS[attempt] ?? 100);
+        }
+      }
     };
     const runQueued = (message: MarmotInboundMessage): void => {
-      dispatchQueue.enqueue(message.groupIdHex, () => handleInbound(message));
+      const accepted = dispatchQueue.enqueue(message.groupIdHex, () => handleInbound(message));
+      if (!accepted) {
+        rollbackInboundDedupe(message);
+      }
     };
     // Optional debounce: coalesce rapid same-sender/group bursts into a single turn.
     const debouncer =
@@ -292,8 +386,15 @@ export function startMarmotInbound(
     const bridge = new MarmotInboundBridge(client, {
       accountIdHex,
       groupIdHex: resolved.groupIdHex ?? null,
+      dedupe: inboundDedupe,
       onReady: () => {
-        markMarmotInboundReady(statusAccountId);
+        publishStatus({
+          running: true,
+          connected: true,
+          lastStartAt: Date.now(),
+          lastStopAt: null,
+          lastError: null,
+        });
         api.logger.info(
           readyLogged
             ? "marmot: inbound subscription re-established"
@@ -302,17 +403,11 @@ export function startMarmotInbound(
         readyLogged = true;
       },
       onMessage: (message) => {
-        // Non-blocking: record receipt, then hand off to the per-group queue so the
-        // inbound loop keeps reading (enables cross-group concurrency). Dedupe in
-        // MarmotInboundBridge.handle() already ran synchronously before this.
-        markMarmotInboundReceived(statusAccountId);
+        publishStatus({ lastInboundAt: Date.now() });
         submitInbound(message);
       },
       onMessageDeleted: (deletion) => {
-        // A peer retracted a message. Surface it to the agent as quiet ambient
-        // (next-turn) context when a surfacer is wired; always recorded + logged
-        // privacy-safely (no ids/pubkeys in the log).
-        markMarmotInboundReceived(statusAccountId);
+        publishStatus({ lastInboundAt: Date.now() });
         api.logger.info("marmot: inbound message deletion observed");
         void Promise.resolve(
           options.surfaceAmbientEvent?.({
@@ -324,11 +419,7 @@ export function startMarmotInbound(
         ).catch(() => api.logger.warn("marmot: failed to surface message deletion to the agent"));
       },
       onGroupStateChanged: (change) => {
-        // A durable group-state change (membership/admin/rename/avatar) was
-        // observed. The change kind contents are NOT logged; they ARE surfaced to
-        // the agent as quiet ambient context (via the surfacer) when wired. The
-        // mapped sentence never carries a member pubkey.
-        markMarmotInboundReceived(statusAccountId);
+        publishStatus({ lastInboundAt: Date.now() });
         api.logger.info("marmot: inbound group state change observed");
         // Drop the cached is_direct activation fact for this group: a
         // membership change can flip whether the group is an effective DM, so the
@@ -347,7 +438,7 @@ export function startMarmotInbound(
       },
       onGroupInvite: onboardingStore
         ? async ({ accountIdHex: joinedAccountIdHex, groupIdHex: joinedGroupIdHex }) => {
-            markMarmotInboundReceived(statusAccountId);
+            publishStatus({ lastInboundAt: Date.now() });
             // Greet on join: offer to publish a public profile name (once).
             await maybeSendProfilePromptOnJoin({
               store: onboardingStore,
@@ -360,7 +451,7 @@ export function startMarmotInbound(
           }
         : undefined,
       onResync: ({ droppedEvents }) => {
-        markMarmotInboundReceived(statusAccountId);
+        publishStatus({ lastInboundAt: Date.now() });
         api.logger.warn(
           `marmot: inbound resync required (${droppedEvents} broadcast slots dropped)`,
         );
@@ -369,7 +460,11 @@ export function startMarmotInbound(
         options.clearGroupActivationCache?.();
       },
       onError: () => {
-        markMarmotInboundReconnect(statusAccountId);
+        publishStatus({
+          running: true,
+          connected: false,
+          lastError: "inbound subscription dropped",
+        });
         api.logger.warn("marmot: inbound subscription dropped; reconnecting");
       },
     });
@@ -381,6 +476,8 @@ export function startMarmotInbound(
 
 export interface SyncAllowlistOptions {
   clientFactory?: ClientFactory;
+  /** OpenClaw channel account id for multi-account deployments. */
+  channelAccountId?: string | null;
 }
 
 /**
@@ -393,7 +490,7 @@ export async function syncMarmotAllowlist(
   options: SyncAllowlistOptions = {},
 ): Promise<void> {
   try {
-    const resolved = resolveAccount(api);
+    const resolved = resolveConfiguredAccount(api, options.channelAccountId);
     if (resolved.allowFrom.length === 0) {
       return;
     }

--- a/integrations/openclaw/marmot/src/inbound-runtime.ts
+++ b/integrations/openclaw/marmot/src/inbound-runtime.ts
@@ -330,6 +330,10 @@ export function startMarmotInbound(
       }
       api.logger.info("marmot: inbound message received; dispatching agent turn");
       for (let attempt = 0; attempt < DISPATCH_NOT_READY_MAX_ATTEMPTS; attempt += 1) {
+        if (signal.aborted) {
+          rollbackInboundDedupe(message);
+          return;
+        }
         try {
           await dispatch(message);
           return;
@@ -348,8 +352,16 @@ export function startMarmotInbound(
             );
             throw error;
           }
+          if (signal.aborted) {
+            rollbackInboundDedupe(message);
+            return;
+          }
           api.logger.warn("marmot: inbound dispatch not ready; retrying after backoff");
           await sleepMs(DISPATCH_NOT_READY_BACKOFF_MS[attempt] ?? 100);
+          if (signal.aborted) {
+            rollbackInboundDedupe(message);
+            return;
+          }
         }
       }
     };

--- a/integrations/openclaw/marmot/src/inbound-runtime.ts
+++ b/integrations/openclaw/marmot/src/inbound-runtime.ts
@@ -19,7 +19,11 @@ import { resolveSingleAccount } from "./account.js";
 import { resolveMarmotChannelAccount } from "./channel.js";
 import type { MarmotAgentControlClient } from "./client.js";
 import { clientForAccount, type ResolvedMarmotAccount } from "./config.js";
-import { MarmotDispatchNotReadyError } from "./dispatch-errors.js";
+import {
+  MarmotDispatchAmbiguousDeliveryError,
+  MarmotDispatchDeliveryFailedError,
+  MarmotDispatchNotReadyError,
+} from "./dispatch-errors.js";
 import {
   inboundDedupeForAccount,
   MarmotInboundBridge,
@@ -194,10 +198,12 @@ const inboundActiveByAccount = new Map<string, boolean>();
 const DISPATCH_NOT_READY_MAX_ATTEMPTS = 3;
 const DISPATCH_NOT_READY_BACKOFF_MS = [50, 100, 200] as const;
 
+/** Sleep between bounded readiness retries. */
 async function sleepMs(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Resolve the stable per-channel-account key used for guards and dedupe. */
 function resolveInboundAccountKey(
   api: InboundPluginApi,
   channelAccountId?: string | null,
@@ -212,6 +218,7 @@ function resolveInboundAccountKey(
   }
 }
 
+/** Clear per-account subscription guards and dedupe between isolated tests. */
 export function resetMarmotInboundAccountsForTests(): void {
   inboundActiveByAccount.clear();
   resetInboundDedupeForTests();
@@ -338,6 +345,17 @@ export function startMarmotInbound(
           await dispatch(message);
           return;
         } catch (error) {
+          if (
+            error instanceof MarmotDispatchAmbiguousDeliveryError ||
+            error instanceof MarmotDispatchDeliveryFailedError
+          ) {
+            // These failures are explicitly replay-safe: the turn identity is
+            // deterministic and wn-agent either reuses the committed receipt or
+            // rejects a regenerated payload under the same key. Clear every
+            // coalesced source id so reconnect redelivery can run that replay.
+            rollbackInboundDedupe(message);
+            throw error;
+          }
           if (!(error instanceof MarmotDispatchNotReadyError)) {
             throw error;
           }

--- a/integrations/openclaw/marmot/src/inbound.ts
+++ b/integrations/openclaw/marmot/src/inbound.ts
@@ -149,6 +149,7 @@ export function inboundDedupeForAccount(accountKey: string): InboundMessageDedup
   return dedupe;
 }
 
+/** Clear all process-local inbound dedupe windows between isolated tests. */
 export function resetInboundDedupeForTests(): void {
   dedupeByAccount.clear();
 }

--- a/integrations/openclaw/marmot/src/inbound.ts
+++ b/integrations/openclaw/marmot/src/inbound.ts
@@ -29,6 +29,11 @@ export interface MarmotInboundMessage {
   senderDisplayName?: string | null;
   /** Encrypted media references (`imeta` tags) attached to this message, if any. */
   media?: AgentControlMediaRef[];
+  /**
+   * When debounce coalescing merged multiple inbound events, every source message
+   * id so a failed pre-turn dispatch can roll back dedupe for the whole burst.
+   */
+  coalescedMessageIdsHex?: string[];
 }
 
 export interface MarmotGroupInvite {
@@ -75,6 +80,8 @@ export interface MarmotInboundBridgeOptions {
   /** Cap on the reconnect delay after exponential growth. */
   maxReconnectDelayMs?: number;
   dedupeWindow?: number;
+  /** Optional shared dedupe owner (survives bridge restarts within one process). */
+  dedupe?: InboundMessageDedupe;
 }
 
 const DEFAULT_RECONNECT_DELAY_MS = 1000;
@@ -105,7 +112,7 @@ export function reconnectBackoffMs(
 }
 
 /** Bounded insertion-ordered set for recent message-id dedupe. */
-class RecentIds {
+export class InboundMessageDedupe {
   private readonly ids = new Set<string>();
   constructor(private readonly max: number) {}
 
@@ -122,6 +129,28 @@ class RecentIds {
       }
     }
   }
+
+  /** Drop one id so a failed pre-turn dispatch can be replayed safely. */
+  remove(id: string): void {
+    this.ids.delete(id);
+  }
+}
+
+const dedupeByAccount = new Map<string, InboundMessageDedupe>();
+
+/** Per OpenClaw channel account dedupe that survives subscription restarts. */
+export function inboundDedupeForAccount(accountKey: string): InboundMessageDedupe {
+  const key = accountKey.trim() || "default";
+  let dedupe = dedupeByAccount.get(key);
+  if (!dedupe) {
+    dedupe = new InboundMessageDedupe(DEFAULT_DEDUPE_WINDOW);
+    dedupeByAccount.set(key, dedupe);
+  }
+  return dedupe;
+}
+
+export function resetInboundDedupeForTests(): void {
+  dedupeByAccount.clear();
 }
 
 function delay(ms: number, signal: AbortSignal): Promise<void> {
@@ -142,13 +171,14 @@ function delay(ms: number, signal: AbortSignal): Promise<void> {
 }
 
 export class MarmotInboundBridge {
-  private readonly recent: RecentIds;
+  private readonly recent: InboundMessageDedupe;
 
   constructor(
     private readonly client: InboundSubscribeClient,
     private readonly options: MarmotInboundBridgeOptions,
   ) {
-    this.recent = new RecentIds(options.dedupeWindow ?? DEFAULT_DEDUPE_WINDOW);
+    this.recent =
+      options.dedupe ?? new InboundMessageDedupe(options.dedupeWindow ?? DEFAULT_DEDUPE_WINDOW);
   }
 
   /** Run until `signal` aborts, reconnecting between subscription drops. */

--- a/integrations/openclaw/marmot/src/messaging.ts
+++ b/integrations/openclaw/marmot/src/messaging.ts
@@ -24,8 +24,11 @@ import type {
 } from "openclaw/plugin-sdk/channel-runtime";
 
 import {
+  canonicalizeMarmotGroupTarget,
   isMarmotGroupIdHex,
+  isMarmotOwnedTargetCandidate,
   MARMOT_TARGET_PREFIX,
+  MarmotTargetError,
   tryCanonicalizeMarmotGroupTarget,
 } from "./target.js";
 
@@ -48,10 +51,7 @@ export function normalizeMarmotTarget(raw: string): string | undefined {
  * (Marmot has none) and treats a group id as an explicit id.
  */
 export function looksLikeMarmotTarget(raw: string): boolean {
-  if (raw.trim().toLowerCase().startsWith(`${MARMOT_TARGET_PREFIX}:`)) {
-    return true;
-  }
-  return normalizeMarmotTarget(raw) !== undefined;
+  return isMarmotOwnedTargetCandidate(raw);
 }
 
 /**
@@ -64,8 +64,8 @@ export function looksLikeMarmotTarget(raw: string): boolean {
  * - `targetResolver.looksLikeId` lets a bare or `marmot:`-prefixed group id skip
  *   directory search and resolve as an explicit id.
  * - `targetResolver.resolveTarget` normalizes the input to the bare hex wn-agent
- *   expects and tags it as a group; it returns `null` for anything that is not a
- *   Marmot group id so an invalid target still fails cleanly (with `hint`).
+ *   expects and tags it as a group; invalid targets throw a privacy-safe
+ *   `MarmotTargetError` before OpenClaw can echo the raw target.
  * - `targetPrefixes` lets `marmot:<hex>` self-route to this channel and lets core
  *   reject another channel's prefix.
  * - `normalizeTarget` strips the `marmot:`/`0x` decoration so the resolved `to`
@@ -80,10 +80,11 @@ export function createMarmotMessagingAdapter(): ChannelMessagingAdapter {
       hint: "<marmot group id hex, e.g. marmot:<hex> or the bare hex>",
       looksLikeId: (raw) => looksLikeMarmotTarget(raw),
       resolveTarget: async ({ input, normalized }) => {
-        const to = normalizeMarmotTarget(input) ?? normalizeMarmotTarget(normalized);
-        if (!to) {
-          return null;
+        const raw = input?.trim() ? input : normalized;
+        if (!raw?.trim()) {
+          throw new MarmotTargetError("empty");
         }
+        const to = canonicalizeMarmotGroupTarget(raw);
         return { to, kind: "group", source: "normalized" };
       },
     },

--- a/integrations/openclaw/marmot/src/messaging.ts
+++ b/integrations/openclaw/marmot/src/messaging.ts
@@ -24,12 +24,11 @@ import type {
 } from "openclaw/plugin-sdk/channel-runtime";
 
 import {
-  canonicalizeMarmotGroupTarget,
+  canonicalizeMarmotExternalTarget,
   isMarmotGroupIdHex,
   isMarmotOwnedTargetCandidate,
   MARMOT_TARGET_PREFIX,
   MarmotTargetError,
-  tryCanonicalizeMarmotGroupTarget,
 } from "./target.js";
 
 export { isMarmotGroupIdHex, MARMOT_TARGET_PREFIX } from "./target.js";
@@ -40,13 +39,20 @@ export { isMarmotGroupIdHex, MARMOT_TARGET_PREFIX } from "./target.js";
  * `group:<hex>` announce/fallback routes.
  */
 export function normalizeMarmotTarget(raw: string): string | undefined {
-  return tryCanonicalizeMarmotGroupTarget(raw);
+  try {
+    return canonicalizeMarmotExternalTarget(raw);
+  } catch (error) {
+    if (error instanceof MarmotTargetError) {
+      return undefined;
+    }
+    throw error;
+  }
 }
 
 /**
  * Whether a raw `message`-tool target looks like a Marmot conversation id. An
  * explicit `marmot:` prefix always qualifies (the agent named our channel); a
- * bare value qualifies when it normalizes to a valid group id hex. Used as
+ * bare value qualifies when it is plausible 16–64-byte group-id hex. Used as
  * `targetResolver.looksLikeId` so core short-circuits its directory search
  * (Marmot has none) and treats a group id as an explicit id.
  */
@@ -84,7 +90,7 @@ export function createMarmotMessagingAdapter(): ChannelMessagingAdapter {
         if (!raw?.trim()) {
           throw new MarmotTargetError("empty");
         }
-        const to = canonicalizeMarmotGroupTarget(raw);
+        const to = canonicalizeMarmotExternalTarget(raw);
         return { to, kind: "group", source: "normalized" };
       },
     },

--- a/integrations/openclaw/marmot/src/messaging.ts
+++ b/integrations/openclaw/marmot/src/messaging.ts
@@ -23,43 +23,21 @@ import type {
   ChatType,
 } from "openclaw/plugin-sdk/channel-runtime";
 
-/** Explicit cross-channel target prefix, e.g. `marmot:<groupIdHex>`. */
-export const MARMOT_TARGET_PREFIX = "marmot";
+import {
+  isMarmotGroupIdHex,
+  MARMOT_TARGET_PREFIX,
+  tryCanonicalizeMarmotGroupTarget,
+} from "./target.js";
 
-// Marmot conversation ids are MLS group ids: opaque byte strings rendered as
-// lowercase hex. OpenMLS mints a 16-byte (32 hex char) id at group creation; a
-// wider even-length band is accepted so a non-default-length group id still
-// resolves, while staying narrow enough not to swallow unrelated short tokens.
-const MIN_GROUP_ID_HEX_CHARS = 32;
-const MAX_GROUP_ID_HEX_CHARS = 128;
-
-/** True for an even-length lowercase hex string in the Marmot group-id size band. */
-export function isMarmotGroupIdHex(value: string): boolean {
-  if (value.length < MIN_GROUP_ID_HEX_CHARS || value.length > MAX_GROUP_ID_HEX_CHARS) {
-    return false;
-  }
-  if (value.length % 2 !== 0) {
-    return false;
-  }
-  return /^[0-9a-f]+$/.test(value);
-}
+export { isMarmotGroupIdHex, MARMOT_TARGET_PREFIX } from "./target.js";
 
 /**
  * Normalize a raw target into a bare Marmot group id hex, or `undefined` when it
- * is not a Marmot group id. Strips an optional `marmot:` channel prefix and an
- * optional `0x`, lowercases, and validates an even-length hex string within the
- * group-id size band. The returned value is exactly what wn-agent's `send_final`
- * expects as the group id (no prefix), matching `normalizeHex` in src/client.ts.
+ * is not a Marmot group id. Accepts bare hex, `marmot:<hex>`, and internal
+ * `group:<hex>` announce/fallback routes.
  */
 export function normalizeMarmotTarget(raw: string): string | undefined {
-  let text = raw.trim().toLowerCase();
-  if (text.startsWith(`${MARMOT_TARGET_PREFIX}:`)) {
-    text = text.slice(MARMOT_TARGET_PREFIX.length + 1).trim();
-  }
-  if (text.startsWith("0x")) {
-    text = text.slice(2);
-  }
-  return isMarmotGroupIdHex(text) ? text : undefined;
+  return tryCanonicalizeMarmotGroupTarget(raw);
 }
 
 /**

--- a/integrations/openclaw/marmot/src/outbound.ts
+++ b/integrations/openclaw/marmot/src/outbound.ts
@@ -25,7 +25,16 @@ import {
   getDefaultLocalRoots,
 } from "openclaw/plugin-sdk/media-runtime";
 
-import type { AgentControlMediaUpload, MarmotAgentControlClient } from "./client.js";
+import { isRetryable, type AgentControlMediaUpload, type MarmotAgentControlClient } from "./client.js";
+import { canonicalizeMarmotGroupTarget, MarmotTargetError } from "./target.js";
+import {
+  getMarmotTurnDelivery,
+  matchesMarmotTurnRoute,
+  MarmotTurnDurableOwnershipError,
+  resolveTurnIdempotencyKey,
+  runTurnOutboundSendOnce,
+  type MarmotTurnDeliveryState,
+} from "./turn-delivery.js";
 
 /** Marmot send target resolved from OpenClaw config + the inbound chat id. */
 export interface ResolvedMarmotTarget {
@@ -248,6 +257,45 @@ function defaultOutboundMediaDir(): string {
   return join(process.env.MARMOT_HOME ?? join(homedir(), ".marmot"), "dev", "outbound-media");
 }
 
+const MESSAGE_SEND_RETRY_BACKOFF_MS = [100, 300] as const;
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Durable text send with one idempotency key reused across bounded retryable
+ * attempts. SDK queue replay after process death cannot preserve the key because
+ * `ChannelMessageSendTextContext` exposes no queue id.
+ */
+async function sendFinalWithIdempotentRetry(
+  client: MarmotAgentControlClient,
+  accountIdHex: string,
+  groupIdHex: string,
+  text: string,
+  replyToMessageIdHex?: string | null,
+  idempotencyKey: string = randomUUID(),
+): Promise<Awaited<ReturnType<MarmotAgentControlClient["sendFinal"]>>> {
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await client.sendFinal(
+        accountIdHex,
+        groupIdHex,
+        text,
+        replyToMessageIdHex ?? null,
+        idempotencyKey,
+      );
+    } catch (err) {
+      if (attempt >= MESSAGE_SEND_RETRY_BACKOFF_MS.length || !isRetryable(err)) {
+        throw err;
+      }
+      await sleep(MESSAGE_SEND_RETRY_BACKOFF_MS[attempt] ?? 100);
+      attempt += 1;
+    }
+  }
+}
+
 /** Stage bytes under the connector-approved root; each copy is group-readable for split-user deployments. */
 async function defaultWriteTempMedia(
   fileName: string,
@@ -260,6 +308,34 @@ async function defaultWriteTempMedia(
   await writeFile(path, bytes, { flag: "wx", mode: 0o640 });
   await chmod(path, 0o640);
   return path;
+}
+
+function resolveOutboundGroupTarget(
+  rawTo: string | undefined | null,
+  turn: MarmotTurnDeliveryState | undefined,
+): string {
+  const trimmed = rawTo?.trim();
+  if (trimmed) {
+    return canonicalizeMarmotGroupTarget(trimmed);
+  }
+  if (turn) {
+    return turn.route.groupIdHex;
+  }
+  throw new MarmotTargetError("empty");
+}
+
+function resolveOutboundChannelAccountId(
+  rawAccountId: string | undefined | null,
+  turn: MarmotTurnDeliveryState | undefined,
+): string | undefined | null {
+  const trimmed = rawAccountId?.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+  if (turn) {
+    return turn.route.channelAccountId;
+  }
+  return rawAccountId ?? null;
 }
 
 /**
@@ -311,20 +387,55 @@ export function createMarmotMessageAdapter(deps: MarmotMessageAdapterDeps) {
     },
     send: {
       text: async (ctx: ChannelMessageSendTextContext) => {
-        const { client, marmotAccountIdHex } = await deps.resolveTarget(ctx.cfg, ctx.accountId);
-        const response = await client.sendFinal(
+        const turn = getMarmotTurnDelivery();
+        const groupIdHex = resolveOutboundGroupTarget(ctx.to, turn);
+        const channelAccountId = resolveOutboundChannelAccountId(ctx.accountId, turn);
+        const { client, marmotAccountIdHex } = await deps.resolveTarget(ctx.cfg, channelAccountId);
+        const sameTurnRoute =
+          turn &&
+          matchesMarmotTurnRoute(turn, {
+            channelAccountId,
+            marmotAccountIdHex,
+            groupIdHex,
+          });
+        if (sameTurnRoute && turn.outboundDelivered && turn.outboundReceipt) {
+          return {
+            receipt: receiptFromMessageIds(turn.outboundReceipt.messageIdsHex, now()),
+          };
+        }
+        if (sameTurnRoute && turn.durableOwner === "sink") {
+          throw new MarmotTurnDurableOwnershipError();
+        }
+        const idempotencyKey =
+          sameTurnRoute && resolveTurnIdempotencyKey(turn)
+            ? resolveTurnIdempotencyKey(turn)!
+            : randomUUID();
+        const replyToMessageIdHex =
+          ctx.replyToId?.trim() || (sameTurnRoute ? turn.route.replyToMessageIdHex : null);
+        const executeSend = async () => {
+          const response = await sendFinalWithIdempotentRetry(
+            client,
+            marmotAccountIdHex,
+            groupIdHex,
+            ctx.text,
+            replyToMessageIdHex,
+            idempotencyKey,
+          );
+          return { messageIdsHex: response.message_ids_hex };
+        };
+        const receipt = sameTurnRoute
+          ? await runTurnOutboundSendOnce(turn, executeSend, isRetryable)
+          : await executeSend();
+        sentTargets.recordAll(receipt.messageIdsHex, {
           marmotAccountIdHex,
-          ctx.to,
-          ctx.text,
-          ctx.replyToId ?? null,
-        );
-        sentTargets.recordAll(response.message_ids_hex, {
-          marmotAccountIdHex,
-          groupIdHex: ctx.to,
+          groupIdHex,
         });
-        return { receipt: receiptFromMessageIds(response.message_ids_hex, now()) };
+        return { receipt: receiptFromMessageIds(receipt.messageIdsHex, now()) };
       },
       media: async (ctx: ChannelMessageSendMediaContext) => {
+        const turn = getMarmotTurnDelivery();
+        const groupIdHex = resolveOutboundGroupTarget(ctx.to, turn);
+        const channelAccountId = resolveOutboundChannelAccountId(ctx.accountId, turn);
         const resolved = await resolveOutboundMediaUpload(ctx, writeTempMedia);
         if (!resolved) {
           throw new Error(
@@ -332,17 +443,17 @@ export function createMarmotMessageAdapter(deps: MarmotMessageAdapterDeps) {
           );
         }
         try {
-          const { client, marmotAccountIdHex } = await deps.resolveTarget(ctx.cfg, ctx.accountId);
+          const { client, marmotAccountIdHex } = await deps.resolveTarget(ctx.cfg, channelAccountId);
           const caption = ctx.text.trim().length > 0 ? ctx.text : null;
           const response = await client.sendMedia(
             marmotAccountIdHex,
-            ctx.to,
+            groupIdHex,
             [resolved.upload],
             caption,
           );
           sentTargets.recordAll(response.message_ids_hex, {
             marmotAccountIdHex,
-            groupIdHex: ctx.to,
+            groupIdHex,
           });
           return { receipt: receiptFromMessageIds(response.message_ids_hex, now(), "media") };
         } finally {

--- a/integrations/openclaw/marmot/src/outbound.ts
+++ b/integrations/openclaw/marmot/src/outbound.ts
@@ -30,7 +30,6 @@ import { canonicalizeMarmotGroupTarget, MarmotTargetError } from "./target.js";
 import {
   getMarmotTurnDelivery,
   matchesMarmotTurnRoute,
-  MarmotTurnDurableOwnershipError,
   resolveTurnIdempotencyKey,
   runTurnOutboundSendOnce,
   type MarmotTurnDeliveryState,
@@ -335,7 +334,7 @@ function resolveOutboundChannelAccountId(
   if (turn) {
     return turn.route.channelAccountId;
   }
-  return rawAccountId ?? null;
+  return null;
 }
 
 /**
@@ -398,14 +397,6 @@ export function createMarmotMessageAdapter(deps: MarmotMessageAdapterDeps) {
             marmotAccountIdHex,
             groupIdHex,
           });
-        if (sameTurnRoute && turn.outboundDelivered && turn.outboundReceipt) {
-          return {
-            receipt: receiptFromMessageIds(turn.outboundReceipt.messageIdsHex, now()),
-          };
-        }
-        if (sameTurnRoute && turn.durableOwner === "sink") {
-          throw new MarmotTurnDurableOwnershipError();
-        }
         const idempotencyKey =
           sameTurnRoute && resolveTurnIdempotencyKey(turn)
             ? resolveTurnIdempotencyKey(turn)!

--- a/integrations/openclaw/marmot/src/outbound.ts
+++ b/integrations/openclaw/marmot/src/outbound.ts
@@ -6,6 +6,12 @@
 // previews are layered on separately via the finalizable-live-preview adapter
 // (see src/live.ts) and are only declared as capabilities once backed by
 // contract tests.
+//
+// During an inbound Marmot turn, exactly one same-route durable reply may own
+// delivery. Text can participate because send_final carries the deterministic
+// turn idempotency key. send_media has no equivalent key, so same-route media
+// fails before file access instead of bypassing ownership with an ambiguous
+// restart contract. Explicit cross-route media remains supported.
 
 import { randomUUID } from "node:crypto";
 import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
@@ -29,6 +35,7 @@ import { isRetryable, type AgentControlMediaUpload, type MarmotAgentControlClien
 import { canonicalizeMarmotGroupTarget, MarmotTargetError } from "./target.js";
 import {
   getMarmotTurnDelivery,
+  MarmotTurnDurableOwnershipError,
   matchesMarmotTurnRoute,
   resolveTurnIdempotencyKey,
   runTurnOutboundSendOnce,
@@ -258,6 +265,7 @@ function defaultOutboundMediaDir(): string {
 
 const MESSAGE_SEND_RETRY_BACKOFF_MS = [100, 300] as const;
 
+/** Sleep between bounded durable-send retries. */
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -309,6 +317,7 @@ async function defaultWriteTempMedia(
   return path;
 }
 
+/** Resolve an explicit or turn-inherited outbound group target. */
 function resolveOutboundGroupTarget(
   rawTo: string | undefined | null,
   turn: MarmotTurnDeliveryState | undefined,
@@ -323,6 +332,7 @@ function resolveOutboundGroupTarget(
   throw new MarmotTargetError("empty");
 }
 
+/** Resolve an explicit or turn-inherited OpenClaw channel account id. */
 function resolveOutboundChannelAccountId(
   rawAccountId: string | undefined | null,
   turn: MarmotTurnDeliveryState | undefined,
@@ -427,6 +437,17 @@ export function createMarmotMessageAdapter(deps: MarmotMessageAdapterDeps) {
         const turn = getMarmotTurnDelivery();
         const groupIdHex = resolveOutboundGroupTarget(ctx.to, turn);
         const channelAccountId = resolveOutboundChannelAccountId(ctx.accountId, turn);
+        const { client, marmotAccountIdHex } = await deps.resolveTarget(ctx.cfg, channelAccountId);
+        if (
+          turn &&
+          matchesMarmotTurnRoute(turn, {
+            channelAccountId,
+            marmotAccountIdHex,
+            groupIdHex,
+          })
+        ) {
+          throw new MarmotTurnDurableOwnershipError();
+        }
         const resolved = await resolveOutboundMediaUpload(ctx, writeTempMedia);
         if (!resolved) {
           throw new Error(
@@ -434,7 +455,6 @@ export function createMarmotMessageAdapter(deps: MarmotMessageAdapterDeps) {
           );
         }
         try {
-          const { client, marmotAccountIdHex } = await deps.resolveTarget(ctx.cfg, channelAccountId);
           const caption = ctx.text.trim().length > 0 ? ctx.text : null;
           const response = await client.sendMedia(
             marmotAccountIdHex,

--- a/integrations/openclaw/marmot/src/readiness.ts
+++ b/integrations/openclaw/marmot/src/readiness.ts
@@ -1,0 +1,65 @@
+// Bounded readiness wait before the first agent turn on a fresh group.
+
+import { isRetryable, type GroupInfoResponse, type MarmotAgentControlClient } from "./client.js";
+
+export interface GroupReadinessClient {
+  groupInfo(accountIdHex: string, groupIdHex: string): Promise<GroupInfoResponse>;
+}
+
+export interface WaitForGroupReadinessOptions {
+  client: GroupReadinessClient;
+  accountIdHex: string;
+  groupIdHex: string;
+  maxAttempts?: number;
+  backoffMs?: readonly number[];
+  log?: (message: string) => void;
+}
+
+const DEFAULT_BACKOFF_MS = [50, 100, 200] as const;
+
+export type GroupReadinessResult =
+  | { status: "ready"; groupInfo: GroupInfoResponse }
+  | { status: "not_ready"; reason: "timeout" | "non_retryable" };
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Wait until wn-agent can resolve the local MLS group for outbound sends. Used
+ * immediately after invite convergence so the first turn does not race group
+ * state. Bounded: returns `not_ready` after `maxAttempts` so the caller can fail
+ * the inbound dispatch instead of silently skipping.
+ */
+export async function waitForGroupReadiness(
+  options: WaitForGroupReadinessOptions,
+): Promise<GroupReadinessResult> {
+  const backoff = options.backoffMs ?? DEFAULT_BACKOFF_MS;
+  const maxAttempts = options.maxAttempts ?? backoff.length + 1;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      const groupInfo = await options.client.groupInfo(options.accountIdHex, options.groupIdHex);
+      if (attempt > 0) {
+        options.log?.("marmot: outbound group readiness established after retry");
+      }
+      return { status: "ready", groupInfo };
+    } catch (error) {
+      const retryable = isRetryable(error);
+      if (!retryable) {
+        options.log?.("marmot: outbound group readiness check failed (non-retryable)");
+        return { status: "not_ready", reason: "non_retryable" };
+      }
+      if (attempt >= maxAttempts - 1) {
+        options.log?.("marmot: outbound group readiness timed out");
+        return { status: "not_ready", reason: "timeout" };
+      }
+      options.log?.(
+        `marmot: outbound group not ready; retrying (attempt ${attempt + 1}/${maxAttempts - 1})`,
+      );
+      await sleep(backoff[Math.min(attempt, backoff.length - 1)] ?? 100);
+    }
+  }
+  return { status: "not_ready", reason: "timeout" };
+}
+
+export type OutboundReadinessClient = Pick<MarmotAgentControlClient, "groupInfo">;

--- a/integrations/openclaw/marmot/src/readiness.ts
+++ b/integrations/openclaw/marmot/src/readiness.ts
@@ -21,6 +21,7 @@ export type GroupReadinessResult =
   | { status: "ready"; groupInfo: GroupInfoResponse }
   | { status: "not_ready"; reason: "timeout" | "non_retryable" };
 
+/** Sleep between bounded group-readiness probes. */
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/integrations/openclaw/marmot/src/target.ts
+++ b/integrations/openclaw/marmot/src/target.ts
@@ -3,7 +3,7 @@
 // Every wn-agent send/delete path must receive bare lowercase even-length
 // group-id hex (MLS GroupId is variable-length opaque bytes). Internal OpenClaw
 // routes (including announce fallbacks) may arrive as `group:<hex>`; explicit
-// agent targets may use bare hex or `marmot:<hex>`. Invalid forms are rejected
+// agent targets may use plausible bare hex or `marmot:<hex>`. Invalid forms are rejected
 // locally with a privacy-safe category error — never forwarded to
 // sendFinal/sendMedia/delete. Do not conflate MLS group ids with 32-byte Nostr
 // routing ids.
@@ -12,6 +12,9 @@
 export const MARMOT_TARGET_PREFIX = "marmot";
 
 const INTERNAL_GROUP_PREFIX = "group:";
+/** Bare unprefixed targets: plausible MLS group-id byte lengths (16–64 bytes). */
+const MIN_BARE_GROUP_ID_HEX_CHARS = 32;
+const MAX_BARE_GROUP_ID_HEX_CHARS = 128;
 const REJECTED_KIND_PREFIXES = [
   "user:",
   "channel:",
@@ -26,6 +29,15 @@ export function isMarmotGroupIdHex(value: string): boolean {
     return false;
   }
   return /^[0-9a-f]+$/.test(value);
+}
+
+/** True when bare unprefixed hex is a plausible MLS group id (16–64 bytes). */
+export function isPlausibleBareMarmotGroupIdHex(value: string): boolean {
+  return (
+    isMarmotGroupIdHex(value) &&
+    value.length >= MIN_BARE_GROUP_ID_HEX_CHARS &&
+    value.length <= MAX_BARE_GROUP_ID_HEX_CHARS
+  );
 }
 
 export type MarmotTargetRejectCategory =
@@ -88,7 +100,7 @@ export function marmotTargetRejectMessage(category: MarmotTargetRejectCategory):
     case "invalid_hex":
       return (
         "marmot: outbound target must be even-length group-id hex " +
-        "(optionally prefixed marmot: or group:)"
+        "(bare targets: 32–128 hex chars; marmot: or group: prefixes allow shorter ids)"
       );
   }
 }
@@ -131,16 +143,35 @@ export function canonicalizeMarmotGroupTarget(raw: string): string {
     }
   } else if (candidate.startsWith(INTERNAL_GROUP_PREFIX)) {
     candidate = candidate.slice(INTERNAL_GROUP_PREFIX.length);
+    if (candidate.includes(":")) {
+      throw new MarmotTargetError("decorated_route");
+    }
   }
   if (candidate.startsWith("0x")) {
     candidate = candidate.slice(2);
   }
   candidate = candidate.trim().toLowerCase();
 
-  if (isMarmotGroupIdHex(candidate)) {
-    return candidate;
+  if (!isMarmotGroupIdHex(candidate)) {
+    throw new MarmotTargetError("invalid_hex");
   }
-  throw new MarmotTargetError("invalid_hex");
+  return candidate;
+}
+
+/**
+ * Canonicalize user-supplied OpenClaw target input. Bare values use a generous
+ * plausibility band so unrelated numeric ids are not claimed as Marmot groups;
+ * explicit `marmot:`/`group:` routes retain variable-length MLS semantics.
+ */
+export function canonicalizeMarmotExternalTarget(raw: string): string {
+  const trimmed = raw.trim().toLowerCase();
+  const explicitlyPrefixed =
+    trimmed.startsWith(`${MARMOT_TARGET_PREFIX}:`) || trimmed.startsWith(INTERNAL_GROUP_PREFIX);
+  const canonical = canonicalizeMarmotGroupTarget(raw);
+  if (!explicitlyPrefixed && !isPlausibleBareMarmotGroupIdHex(canonical)) {
+    throw new MarmotTargetError("invalid_hex");
+  }
+  return canonical;
 }
 
 /** Whether Marmot should own target resolution for this raw message-tool input. */
@@ -165,7 +196,15 @@ export function isMarmotOwnedTargetCandidate(raw: string): boolean {
   if (looksLikeMarmotCrossChannelTarget(lower)) {
     return true;
   }
-  return tryCanonicalizeMarmotGroupTarget(trimmed) !== undefined;
+  try {
+    canonicalizeMarmotExternalTarget(trimmed);
+    return true;
+  } catch (error) {
+    if (error instanceof MarmotTargetError) {
+      return false;
+    }
+    throw error;
+  }
 }
 
 /** Best-effort normalize for target resolution; returns undefined when invalid. */

--- a/integrations/openclaw/marmot/src/target.ts
+++ b/integrations/openclaw/marmot/src/target.ts
@@ -1,0 +1,148 @@
+// Outbound target canonicalization for Marmot MLS group ids.
+//
+// Every wn-agent send/delete path must receive bare lowercase even-length
+// group-id hex (MLS GroupId is variable-length opaque bytes). Internal OpenClaw
+// routes (including announce fallbacks) may arrive as `group:<hex>`; explicit
+// agent targets may use bare hex or `marmot:<hex>`. Invalid forms are rejected
+// locally with a privacy-safe category error — never forwarded to
+// sendFinal/sendMedia/delete. Do not conflate MLS group ids with 32-byte Nostr
+// routing ids.
+
+/** Explicit cross-channel target prefix, e.g. `marmot:<groupIdHex>`. */
+export const MARMOT_TARGET_PREFIX = "marmot";
+
+const INTERNAL_GROUP_PREFIX = "group:";
+const REJECTED_KIND_PREFIXES = [
+  "user:",
+  "channel:",
+  "room:",
+  "conversation:",
+  "dm:",
+] as const;
+
+/** True for a non-empty even-length lowercase hex string (MLS group id bytes). */
+export function isMarmotGroupIdHex(value: string): boolean {
+  if (value.length === 0 || value.length % 2 !== 0) {
+    return false;
+  }
+  return /^[0-9a-f]+$/.test(value);
+}
+
+export type MarmotTargetRejectCategory =
+  | "empty"
+  | "session_key"
+  | "cross_channel"
+  | "decorated_route"
+  | "invalid_hex";
+
+function looksLikeSessionKey(value: string): boolean {
+  const lower = value.toLowerCase();
+  if (lower.startsWith("agent:")) {
+    return true;
+  }
+  // Composite OpenClaw session routes embed the channel id between colons.
+  return lower.includes(`:${MARMOT_TARGET_PREFIX}:`);
+}
+
+function looksLikeCrossChannelTarget(value: string): boolean {
+  const match = /^([a-z][a-z0-9-]*):/.exec(value.toLowerCase());
+  if (!match) {
+    return false;
+  }
+  const prefix = match[1];
+  return prefix !== MARMOT_TARGET_PREFIX && prefix !== "group";
+}
+
+function hasRejectedKindPrefix(value: string): boolean {
+  const lower = value.toLowerCase();
+  return REJECTED_KIND_PREFIXES.some((prefix) => lower.startsWith(prefix));
+}
+
+export function marmotTargetRejectMessage(category: MarmotTargetRejectCategory): string {
+  switch (category) {
+    case "empty":
+      return "marmot: outbound target is required";
+    case "session_key":
+      return (
+        "marmot: outbound target must be a Marmot group id, not an OpenClaw session key; " +
+        "use bare group-id hex or marmot:<hex>"
+      );
+    case "cross_channel":
+      return (
+        "marmot: outbound target must stay on the Marmot channel; " +
+        "use bare group-id hex, marmot:<hex>, or group:<hex>"
+      );
+    case "decorated_route":
+      return (
+        "marmot: outbound target is not a Marmot group id; " +
+        "use bare group-id hex, marmot:<hex>, or group:<hex>"
+      );
+    case "invalid_hex":
+      return (
+        "marmot: outbound target must be even-length group-id hex " +
+        "(optionally prefixed marmot: or group:)"
+      );
+  }
+}
+
+export class MarmotTargetError extends Error {
+  readonly category: MarmotTargetRejectCategory;
+
+  constructor(category: MarmotTargetRejectCategory) {
+    super(marmotTargetRejectMessage(category));
+    this.name = "MarmotTargetError";
+    this.category = category;
+  }
+}
+
+/**
+ * Canonicalize a raw outbound target to bare group-id hex for wn-agent, or throw
+ * {@link MarmotTargetError} when the value is not a Marmot group conversation id.
+ */
+export function canonicalizeMarmotGroupTarget(raw: string): string {
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) {
+    throw new MarmotTargetError("empty");
+  }
+  if (looksLikeSessionKey(trimmed)) {
+    throw new MarmotTargetError("session_key");
+  }
+  if (hasRejectedKindPrefix(trimmed)) {
+    throw new MarmotTargetError("decorated_route");
+  }
+  if (looksLikeCrossChannelTarget(trimmed)) {
+    throw new MarmotTargetError("cross_channel");
+  }
+
+  let candidate = trimmed;
+  if (candidate.startsWith(`${MARMOT_TARGET_PREFIX}:`)) {
+    candidate = candidate.slice(MARMOT_TARGET_PREFIX.length + 1).trim();
+    // Prefix composition is an internal/session route, not a channel target.
+    if (candidate.includes(":")) {
+      throw new MarmotTargetError("decorated_route");
+    }
+  } else if (candidate.startsWith(INTERNAL_GROUP_PREFIX)) {
+    candidate = candidate.slice(INTERNAL_GROUP_PREFIX.length);
+  }
+  if (candidate.startsWith("0x")) {
+    candidate = candidate.slice(2);
+  }
+  candidate = candidate.trim().toLowerCase();
+
+  if (isMarmotGroupIdHex(candidate)) {
+    return candidate;
+  }
+  throw new MarmotTargetError("invalid_hex");
+}
+
+/** Best-effort normalize for target resolution; returns undefined when invalid. */
+export function tryCanonicalizeMarmotGroupTarget(raw: string): string | undefined {
+  try {
+    return canonicalizeMarmotGroupTarget(raw);
+  } catch (error) {
+    if (error instanceof MarmotTargetError) {
+      return undefined;
+    }
+    throw error;
+  }
+}

--- a/integrations/openclaw/marmot/src/target.ts
+++ b/integrations/openclaw/marmot/src/target.ts
@@ -47,6 +47,7 @@ export type MarmotTargetRejectCategory =
   | "decorated_route"
   | "invalid_hex";
 
+/** True when a target is an OpenClaw session key involving Marmot routing. */
 export function looksLikeMarmotSessionKey(value: string): boolean {
   const lower = value.toLowerCase();
   if (lower.startsWith("agent:")) {
@@ -56,10 +57,12 @@ export function looksLikeMarmotSessionKey(value: string): boolean {
   return lower.includes(`:${MARMOT_TARGET_PREFIX}:`);
 }
 
+/** Internal alias kept local to the canonicalization decision tree. */
 function looksLikeSessionKey(value: string): boolean {
   return looksLikeMarmotSessionKey(value);
 }
 
+/** True when a target explicitly names a non-Marmot channel prefix. */
 export function looksLikeMarmotCrossChannelTarget(value: string): boolean {
   const match = /^([a-z][a-z0-9-]*):/.exec(value.toLowerCase());
   if (!match) {
@@ -69,15 +72,18 @@ export function looksLikeMarmotCrossChannelTarget(value: string): boolean {
   return prefix !== MARMOT_TARGET_PREFIX && prefix !== "group";
 }
 
+/** Internal alias kept local to the canonicalization decision tree. */
 function looksLikeCrossChannelTarget(value: string): boolean {
   return looksLikeMarmotCrossChannelTarget(value);
 }
 
+/** True when the input starts with a known non-group Marmot object kind. */
 export function hasMarmotRejectedKindPrefix(value: string): boolean {
   const lower = value.toLowerCase();
   return REJECTED_KIND_PREFIXES.some((prefix) => lower.startsWith(prefix));
 }
 
+/** Return the fixed privacy-safe message for a target rejection category. */
 export function marmotTargetRejectMessage(category: MarmotTargetRejectCategory): string {
   switch (category) {
     case "empty":
@@ -105,6 +111,7 @@ export function marmotTargetRejectMessage(category: MarmotTargetRejectCategory):
   }
 }
 
+/** Typed target rejection whose message never echoes the raw target. */
 export class MarmotTargetError extends Error {
   readonly category: MarmotTargetRejectCategory;
 

--- a/integrations/openclaw/marmot/src/target.ts
+++ b/integrations/openclaw/marmot/src/target.ts
@@ -35,7 +35,7 @@ export type MarmotTargetRejectCategory =
   | "decorated_route"
   | "invalid_hex";
 
-function looksLikeSessionKey(value: string): boolean {
+export function looksLikeMarmotSessionKey(value: string): boolean {
   const lower = value.toLowerCase();
   if (lower.startsWith("agent:")) {
     return true;
@@ -44,7 +44,11 @@ function looksLikeSessionKey(value: string): boolean {
   return lower.includes(`:${MARMOT_TARGET_PREFIX}:`);
 }
 
-function looksLikeCrossChannelTarget(value: string): boolean {
+function looksLikeSessionKey(value: string): boolean {
+  return looksLikeMarmotSessionKey(value);
+}
+
+export function looksLikeMarmotCrossChannelTarget(value: string): boolean {
   const match = /^([a-z][a-z0-9-]*):/.exec(value.toLowerCase());
   if (!match) {
     return false;
@@ -53,7 +57,11 @@ function looksLikeCrossChannelTarget(value: string): boolean {
   return prefix !== MARMOT_TARGET_PREFIX && prefix !== "group";
 }
 
-function hasRejectedKindPrefix(value: string): boolean {
+function looksLikeCrossChannelTarget(value: string): boolean {
+  return looksLikeMarmotCrossChannelTarget(value);
+}
+
+export function hasMarmotRejectedKindPrefix(value: string): boolean {
   const lower = value.toLowerCase();
   return REJECTED_KIND_PREFIXES.some((prefix) => lower.startsWith(prefix));
 }
@@ -107,7 +115,7 @@ export function canonicalizeMarmotGroupTarget(raw: string): string {
   if (looksLikeSessionKey(trimmed)) {
     throw new MarmotTargetError("session_key");
   }
-  if (hasRejectedKindPrefix(trimmed)) {
+  if (hasMarmotRejectedKindPrefix(trimmed)) {
     throw new MarmotTargetError("decorated_route");
   }
   if (looksLikeCrossChannelTarget(trimmed)) {
@@ -133,6 +141,31 @@ export function canonicalizeMarmotGroupTarget(raw: string): string {
     return candidate;
   }
   throw new MarmotTargetError("invalid_hex");
+}
+
+/** Whether Marmot should own target resolution for this raw message-tool input. */
+export function isMarmotOwnedTargetCandidate(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith(`${MARMOT_TARGET_PREFIX}:`)) {
+    return true;
+  }
+  if (lower.startsWith(INTERNAL_GROUP_PREFIX)) {
+    return true;
+  }
+  if (looksLikeMarmotSessionKey(lower)) {
+    return true;
+  }
+  if (hasMarmotRejectedKindPrefix(lower)) {
+    return true;
+  }
+  if (looksLikeMarmotCrossChannelTarget(lower)) {
+    return true;
+  }
+  return tryCanonicalizeMarmotGroupTarget(trimmed) !== undefined;
 }
 
 /** Best-effort normalize for target resolution; returns undefined when invalid. */

--- a/integrations/openclaw/marmot/src/turn-delivery.ts
+++ b/integrations/openclaw/marmot/src/turn-delivery.ts
@@ -212,23 +212,21 @@ export async function awaitTurnOutboundResolution(state: MarmotTurnDeliveryState
 }
 
 /**
- * Run one same-route outbound send for the turn. Concurrent callers await the
- * first in-flight operation and share its result or failure. Success and
- * retryable/non-retryable failure are recorded before the shared promise settles.
+ * Run one same-route outbound send for the turn. A second sequential or
+ * concurrent caller is rejected because this coordinator has no payload
+ * identity with which to prove it is the same logical send. Success and
+ * retryable/non-retryable failure are recorded before the promise settles.
  */
 export function runTurnOutboundSendOnce(
   state: MarmotTurnDeliveryState,
   send: () => Promise<MarmotTurnOutboundReceipt>,
   isRetryableError: (error: unknown) => boolean = () => true,
 ): Promise<MarmotTurnOutboundReceipt> {
-  if (state.outboundDelivered && state.outboundReceipt) {
-    return Promise.resolve(state.outboundReceipt);
+  if (state.outboundDelivered || state.outboundInFlight) {
+    return Promise.reject(new MarmotTurnDurableOwnershipError());
   }
   if (state.durableOwner === "sink") {
     return Promise.reject(new MarmotTurnDurableOwnershipError());
-  }
-  if (state.outboundInFlight) {
-    return state.outboundInFlight;
   }
   // Reserve outbound ownership synchronously before connector I/O so the sink
   // cannot claim in the scheduling gap after awaitTurnOutboundResolution.

--- a/integrations/openclaw/marmot/src/turn-delivery.ts
+++ b/integrations/openclaw/marmot/src/turn-delivery.ts
@@ -6,6 +6,8 @@
 
 import { AsyncLocalStorage } from "node:async_hooks";
 
+import { MarmotDispatchAmbiguousDeliveryError } from "./dispatch-errors.js";
+
 /** Immutable route identity for one inbound Marmot agent turn. */
 export interface MarmotTurnRoute {
   readonly channelAccountId: string;
@@ -138,6 +140,19 @@ export function recordTurnOutboundFailure(state: MarmotTurnDeliveryState, retrya
 /** Whether the bound sink must not commit a durable reply for this turn. */
 export function shouldSuppressSinkDurableDelivery(state: MarmotTurnDeliveryState): boolean {
   return state.outboundDelivered || state.outboundAmbiguousFailure;
+}
+
+/**
+ * Fail closed when a same-route outbound send ended ambiguously without a
+ * durable receipt. Successful outbound delivery is not an error.
+ */
+export function assertTurnDurableDeliveryResolved(state: MarmotTurnDeliveryState): void {
+  if (state.outboundDelivered) {
+    return;
+  }
+  if (state.outboundAmbiguousFailure) {
+    throw new MarmotDispatchAmbiguousDeliveryError();
+  }
 }
 
 /** Claim sink ownership before committing (no-op when outbound already owns delivery). */

--- a/integrations/openclaw/marmot/src/turn-delivery.ts
+++ b/integrations/openclaw/marmot/src/turn-delivery.ts
@@ -1,0 +1,238 @@
+// Turn-scoped durable reply ownership via AsyncLocalStorage.
+//
+// Coordinates the bound MarmotReplySink and outbound message-tool sends so an
+// inbound turn commits at most one durable reply to its source route. Scoped to
+// the active inbound dispatch — never a global or last-seen route cache.
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/** Immutable route identity for one inbound Marmot agent turn. */
+export interface MarmotTurnRoute {
+  readonly channelAccountId: string;
+  readonly marmotAccountIdHex: string;
+  readonly groupIdHex: string;
+  readonly replyToMessageIdHex: string;
+  readonly idempotencyKey: string;
+}
+
+export type MarmotTurnDurableOwner = "none" | "sink" | "outbound";
+
+/** Same-route outbound send rejected because the sink already owns durable delivery. */
+export class MarmotTurnDurableOwnershipError extends Error {
+  constructor() {
+    super("marmot: durable reply already owned for this turn");
+    this.name = "MarmotTurnDurableOwnershipError";
+  }
+}
+
+export interface MarmotTurnOutboundReceipt {
+  messageIdsHex: string[];
+}
+
+export interface MarmotTurnDeliveryState {
+  route: MarmotTurnRoute;
+  durableOwner: MarmotTurnDurableOwner;
+  /** True after a same-route outbound send succeeded for this turn. */
+  outboundDelivered: boolean;
+  /**
+   * True when a same-route outbound send exhausted retryable attempts without a
+   * definite outcome — the sink must not fall back with a different idempotency key.
+   */
+  outboundAmbiguousFailure: boolean;
+  outboundReceipt?: MarmotTurnOutboundReceipt;
+  /** In-flight same-route outbound send shared by concurrent tool calls. */
+  outboundInFlight?: Promise<MarmotTurnOutboundReceipt>;
+}
+
+const turnDeliveryStorage = new AsyncLocalStorage<MarmotTurnDeliveryState>();
+
+function freezeTurnRoute(route: MarmotTurnRoute): MarmotTurnRoute {
+  return Object.freeze({
+    channelAccountId: route.channelAccountId,
+    marmotAccountIdHex: route.marmotAccountIdHex,
+    groupIdHex: route.groupIdHex,
+    replyToMessageIdHex: route.replyToMessageIdHex,
+    idempotencyKey: route.idempotencyKey,
+  });
+}
+
+function initialTurnState(route: MarmotTurnRoute): MarmotTurnDeliveryState {
+  return {
+    route: freezeTurnRoute(route),
+    durableOwner: "none",
+    outboundDelivered: false,
+    outboundAmbiguousFailure: false,
+  };
+}
+
+/** Run `fn` with turn-scoped delivery coordination bound to `route`. */
+export function runInMarmotTurn<T>(route: MarmotTurnRoute, fn: () => T | Promise<T>): Promise<T> {
+  return Promise.resolve(turnDeliveryStorage.run(initialTurnState(route), fn));
+}
+
+/** Active turn delivery state, if any. */
+export function getMarmotTurnDelivery(): MarmotTurnDeliveryState | undefined {
+  return turnDeliveryStorage.getStore();
+}
+
+export interface MarmotTurnRouteTarget {
+  channelAccountId?: string | null;
+  marmotAccountIdHex: string;
+  groupIdHex: string;
+}
+
+/** Whether an outbound target matches the bound inbound turn route. */
+export function matchesMarmotTurnRoute(
+  state: MarmotTurnDeliveryState,
+  target: MarmotTurnRouteTarget,
+): boolean {
+  const route = state.route;
+  if (route.marmotAccountIdHex !== target.marmotAccountIdHex) {
+    return false;
+  }
+  if (route.groupIdHex !== target.groupIdHex) {
+    return false;
+  }
+  const channelAccountId = target.channelAccountId?.trim();
+  if (channelAccountId && route.channelAccountId !== channelAccountId) {
+    return false;
+  }
+  return true;
+}
+
+/** Resolve the turn idempotency key when inside a turn, else undefined. */
+export function resolveTurnIdempotencyKey(state?: MarmotTurnDeliveryState): string | undefined {
+  return state?.route.idempotencyKey;
+}
+
+/**
+ * Record a successful same-route outbound durable send. Repeated calls return
+ * false so the adapter can skip duplicate posts while reusing the first receipt.
+ */
+export function recordTurnOutboundDelivery(
+  state: MarmotTurnDeliveryState,
+  receipt: MarmotTurnOutboundReceipt,
+): boolean {
+  if (state.outboundDelivered) {
+    return false;
+  }
+  state.outboundDelivered = true;
+  state.durableOwner = "outbound";
+  state.outboundReceipt = receipt;
+  return true;
+}
+
+/** Record a same-route outbound failure; retryable exhaustion blocks sink fallback. */
+export function recordTurnOutboundFailure(state: MarmotTurnDeliveryState, retryable: boolean): void {
+  if (retryable) {
+    state.outboundAmbiguousFailure = true;
+    return;
+  }
+  // A definite non-retryable failure releases the tentative outbound claim so the
+  // sink can commit durably with the shared turn idempotency key.
+  if (!state.outboundDelivered) {
+    state.durableOwner = "none";
+  }
+}
+
+/** Whether the bound sink must not commit a durable reply for this turn. */
+export function shouldSuppressSinkDurableDelivery(state: MarmotTurnDeliveryState): boolean {
+  return state.outboundDelivered || state.outboundAmbiguousFailure;
+}
+
+/** Claim sink ownership before committing (no-op when outbound already owns delivery). */
+export function claimTurnSinkDelivery(state: MarmotTurnDeliveryState): boolean {
+  if (shouldSuppressSinkDurableDelivery(state)) {
+    return false;
+  }
+  if (state.outboundInFlight) {
+    return false;
+  }
+  if (state.durableOwner === "sink") {
+    return true;
+  }
+  if (state.durableOwner === "outbound") {
+    return false;
+  }
+  state.durableOwner = "sink";
+  return true;
+}
+
+/**
+ * Wait for any in-flight same-route outbound send, then claim sink ownership or
+ * report suppression. Loops when an outbound send starts in the window after
+ * resolution returns but before the sink claim lands.
+ */
+export async function acquireSinkDeliveryOrSuppress(
+  state: MarmotTurnDeliveryState,
+): Promise<"suppress" | "proceed"> {
+  for (;;) {
+    if (state.outboundInFlight) {
+      await state.outboundInFlight.catch(() => undefined);
+      continue;
+    }
+    if (shouldSuppressSinkDurableDelivery(state)) {
+      return "suppress";
+    }
+    if (claimTurnSinkDelivery(state)) {
+      return "proceed";
+    }
+    return "suppress";
+  }
+}
+
+/**
+ * Wait for a same-route outbound send to settle and record its terminal outcome
+ * before the sink decides whether to commit durably.
+ */
+export async function awaitTurnOutboundResolution(state: MarmotTurnDeliveryState): Promise<void> {
+  if (!state.outboundInFlight) {
+    return;
+  }
+  try {
+    await state.outboundInFlight;
+  } catch {
+    // Terminal failure is recorded on the shared state before the promise rejects.
+  }
+}
+
+/**
+ * Run one same-route outbound send for the turn. Concurrent callers await the
+ * first in-flight operation and share its result or failure. Success and
+ * retryable/non-retryable failure are recorded before the shared promise settles.
+ */
+export function runTurnOutboundSendOnce(
+  state: MarmotTurnDeliveryState,
+  send: () => Promise<MarmotTurnOutboundReceipt>,
+  isRetryableError: (error: unknown) => boolean = () => true,
+): Promise<MarmotTurnOutboundReceipt> {
+  if (state.outboundDelivered && state.outboundReceipt) {
+    return Promise.resolve(state.outboundReceipt);
+  }
+  if (state.durableOwner === "sink") {
+    return Promise.reject(new MarmotTurnDurableOwnershipError());
+  }
+  if (state.outboundInFlight) {
+    return state.outboundInFlight;
+  }
+  // Reserve outbound ownership synchronously before connector I/O so the sink
+  // cannot claim in the scheduling gap after awaitTurnOutboundResolution.
+  state.durableOwner = "outbound";
+  const tracked = (async () => {
+    try {
+      const receipt = await send();
+      recordTurnOutboundDelivery(state, receipt);
+      return receipt;
+    } catch (error) {
+      recordTurnOutboundFailure(state, isRetryableError(error));
+      throw error;
+    }
+  })();
+  const inFlight = tracked.finally(() => {
+    if (state.outboundInFlight === inFlight) {
+      state.outboundInFlight = undefined;
+    }
+  });
+  state.outboundInFlight = inFlight;
+  return inFlight;
+}

--- a/integrations/openclaw/marmot/src/turn-delivery.ts
+++ b/integrations/openclaw/marmot/src/turn-delivery.ts
@@ -2,7 +2,10 @@
 //
 // Coordinates the bound MarmotReplySink and outbound message-tool sends so an
 // inbound turn commits at most one durable reply to its source route. Scoped to
-// the active inbound dispatch — never a global or last-seen route cache.
+// the active inbound dispatch — never a global or last-seen route cache. A
+// second same-route text send is rejected even when its content differs; without
+// a deterministic per-send ordinal, it cannot receive a distinct replay-stable
+// identity without weakening the exactly-one reply contract.
 
 import { AsyncLocalStorage } from "node:async_hooks";
 
@@ -48,6 +51,7 @@ export interface MarmotTurnDeliveryState {
 
 const turnDeliveryStorage = new AsyncLocalStorage<MarmotTurnDeliveryState>();
 
+/** Freeze the immutable route portion before exposing it through async context. */
 function freezeTurnRoute(route: MarmotTurnRoute): MarmotTurnRoute {
   return Object.freeze({
     channelAccountId: route.channelAccountId,
@@ -58,6 +62,7 @@ function freezeTurnRoute(route: MarmotTurnRoute): MarmotTurnRoute {
   });
 }
 
+/** Construct the unclaimed delivery state for a newly-dispatched turn. */
 function initialTurnState(route: MarmotTurnRoute): MarmotTurnDeliveryState {
   return {
     route: freezeTurnRoute(route),

--- a/integrations/openclaw/marmot/src/turn-idempotency.ts
+++ b/integrations/openclaw/marmot/src/turn-idempotency.ts
@@ -1,0 +1,93 @@
+// Deterministic, versioned, privacy-preserving idempotency keys for one inbound
+// turn's durable reply. Derived from account/group identity and the complete
+// logical source-message set so a plugin process restart can safely replay the
+// same wn-agent send_final without double-posting.
+
+import { createHash } from "node:crypto";
+
+import type { MarmotInboundMessage } from "./inbound.js";
+
+const TURN_IDEMPOTENCY_DOMAIN = "openclaw.marmot.turn-reply.v1";
+
+export interface DeriveTurnIdempotencyKeyParams {
+  marmotAccountIdHex: string;
+  groupIdHex: string;
+  /** Primary inbound message id plus any coalesced source ids for this turn. */
+  sourceMessageIdsHex: readonly string[];
+}
+
+function encodeLengthPrefixedUtf8(value: string): Buffer {
+  const bytes = Buffer.from(value, "utf8");
+  const len = Buffer.alloc(2);
+  len.writeUInt16BE(bytes.length);
+  return Buffer.concat([len, bytes]);
+}
+
+function encodeLengthPrefixedHex(value: string): Buffer {
+  const normalized = value.trim().toLowerCase();
+  const bytes = Buffer.from(normalized, "hex");
+  if (bytes.length === 0 || bytes.length * 2 !== normalized.length) {
+    throw new Error("marmot: turn idempotency requires normalized hex ids");
+  }
+  const len = Buffer.alloc(2);
+  len.writeUInt16BE(bytes.length);
+  return Buffer.concat([len, bytes]);
+}
+
+/** Canonical sorted unique source ids for one logical inbound turn. */
+export function canonicalizeTurnSourceMessageIds(
+  primaryMessageIdHex: string,
+  coalescedMessageIdsHex?: readonly string[],
+): string[] {
+  const ids = new Set<string>();
+  const add = (value: string | undefined | null) => {
+    const trimmed = value?.trim().toLowerCase();
+    if (trimmed) {
+      ids.add(trimmed);
+    }
+  };
+  add(primaryMessageIdHex);
+  for (const id of coalescedMessageIdsHex ?? []) {
+    add(id);
+  }
+  return [...ids].sort();
+}
+
+/** Derive a stable idempotency key that does not expose raw account/group/message ids. */
+export function deriveTurnIdempotencyKey(params: DeriveTurnIdempotencyKeyParams): string {
+  const sourceIds = [...new Set(
+    params.sourceMessageIdsHex.map((id) => id.trim().toLowerCase()).filter(Boolean),
+  )].sort();
+  if (sourceIds.length === 0) {
+    throw new Error("marmot: turn idempotency requires at least one source message id");
+  }
+  const parts: Buffer[] = [
+    encodeLengthPrefixedUtf8(TURN_IDEMPOTENCY_DOMAIN),
+    encodeLengthPrefixedHex(params.marmotAccountIdHex),
+    encodeLengthPrefixedHex(params.groupIdHex),
+  ];
+  const count = Buffer.alloc(2);
+  count.writeUInt16BE(sourceIds.length);
+  parts.push(count);
+  for (const id of sourceIds) {
+    parts.push(encodeLengthPrefixedHex(id));
+  }
+  return createHash("sha256").update(Buffer.concat(parts)).digest("hex");
+}
+
+export function deriveTurnIdempotencyKeyFromInbound(
+  message: Pick<
+    MarmotInboundMessage,
+    "accountIdHex" | "groupIdHex" | "messageIdHex" | "coalescedMessageIdsHex"
+  >,
+): string {
+  const sourceIds = canonicalizeTurnSourceMessageIds(
+    message.messageIdHex,
+    message.coalescedMessageIdsHex,
+  );
+  return deriveTurnIdempotencyKey({
+    marmotAccountIdHex: message.accountIdHex,
+    groupIdHex: message.groupIdHex,
+    sourceMessageIdsHex: sourceIds,
+  });
+}

--- a/integrations/openclaw/marmot/src/turn-idempotency.ts
+++ b/integrations/openclaw/marmot/src/turn-idempotency.ts
@@ -16,6 +16,7 @@ export interface DeriveTurnIdempotencyKeyParams {
   sourceMessageIdsHex: readonly string[];
 }
 
+/** Encode one UTF-8 field without concatenation ambiguity. */
 function encodeLengthPrefixedUtf8(value: string): Buffer {
   const bytes = Buffer.from(value, "utf8");
   const len = Buffer.alloc(2);
@@ -23,6 +24,7 @@ function encodeLengthPrefixedUtf8(value: string): Buffer {
   return Buffer.concat([len, bytes]);
 }
 
+/** Validate and encode one hex field without concatenation ambiguity. */
 function encodeLengthPrefixedHex(value: string): Buffer {
   const normalized = value.trim().toLowerCase();
   const bytes = Buffer.from(normalized, "hex");
@@ -75,6 +77,7 @@ export function deriveTurnIdempotencyKey(params: DeriveTurnIdempotencyKeyParams)
   return createHash("sha256").update(Buffer.concat(parts)).digest("hex");
 }
 
+/** Derive the turn key directly from the inbound message identity fields. */
 export function deriveTurnIdempotencyKeyFromInbound(
   message: Pick<
     MarmotInboundMessage,

--- a/integrations/openclaw/marmot/test/bounded-keyed-async-queue.test.ts
+++ b/integrations/openclaw/marmot/test/bounded-keyed-async-queue.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { BoundedKeyedAsyncQueue } from "../src/bounded-keyed-async-queue.js";
+import {
+  MarmotDispatchAmbiguousDeliveryError,
+  MarmotDispatchDeliveryFailedError,
+  MarmotDispatchNotReadyError,
+} from "../src/dispatch-errors.js";
 
 describe("BoundedKeyedAsyncQueue", () => {
   it("reports whether enqueue accepted the task", () => {
@@ -49,5 +54,31 @@ describe("BoundedKeyedAsyncQueue", () => {
     });
 
     await vi.waitFor(() => expect(ran).toEqual(["after-reject"]));
+  });
+
+  it.each([
+    [
+      new MarmotDispatchAmbiguousDeliveryError(),
+      "marmot: inbound dispatch task failed (ambiguous_delivery)",
+    ],
+    [
+      new MarmotDispatchDeliveryFailedError(),
+      "marmot: inbound dispatch task failed (delivery_failed)",
+    ],
+    [
+      new MarmotDispatchNotReadyError("non_retryable"),
+      "marmot: inbound dispatch task failed (not_ready)",
+    ],
+    [new Error("secret route and payload"), "marmot: inbound dispatch task failed (unexpected)"],
+  ])("logs a fixed privacy-safe category for %s", async (error, expected) => {
+    const warnings: string[] = [];
+    const queue = new BoundedKeyedAsyncQueue(1, (message) => warnings.push(message));
+
+    queue.enqueue("group-a", async () => {
+      throw error;
+    });
+
+    await vi.waitFor(() => expect(warnings).toEqual([expected]));
+    expect(warnings.join(" ")).not.toContain("secret route and payload");
   });
 });

--- a/integrations/openclaw/marmot/test/bounded-keyed-async-queue.test.ts
+++ b/integrations/openclaw/marmot/test/bounded-keyed-async-queue.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it, vi } from "vitest";
 import { BoundedKeyedAsyncQueue } from "../src/bounded-keyed-async-queue.js";
 
 describe("BoundedKeyedAsyncQueue", () => {
+  it("reports whether enqueue accepted the task", () => {
+    const queue = new BoundedKeyedAsyncQueue(1);
+    expect(queue.enqueue("group-a", async () => {})).toBe(true);
+    expect(queue.enqueue("group-a", async () => {})).toBe(false);
+  });
+
   it("sheds incoming turns once per-key depth is reached", async () => {
     let releaseFirst: (() => void) | undefined;
     const firstStarted = new Promise<void>((resolve) => {

--- a/integrations/openclaw/marmot/test/channel.test.ts
+++ b/integrations/openclaw/marmot/test/channel.test.ts
@@ -236,6 +236,28 @@ describe("createMarmotDeleteActionAdapter", () => {
     expect(resultError(result)).toMatch(/could not resolve group/);
   });
 
+  it("returns a structured privacy-safe error for malformed delete targets", async () => {
+    const deleteMessage = vi.fn(async () => undefined);
+    const adapter = createMarmotDeleteActionAdapter({
+      deleteByMessageId: async () => false,
+      resolveTarget: async () => ({
+        client: { deleteMessage },
+        marmotAccountIdHex: HEX32("aa"),
+      }),
+    });
+
+    const sensitive = `agent:main:marmot:group:${HEX32("cc")}`;
+    const result = await adapter.handleAction!(
+      deleteCtx({ messageId: HEX32("99"), to: sensitive }),
+    );
+
+    expect(deleteMessage).not.toHaveBeenCalled();
+    expect(resultOk(result)).toBe(false);
+    expect(resultError(result)).toMatch(/session key/);
+    expect(resultError(result)).not.toContain(sensitive);
+    expect(resultError(result)).not.toContain(HEX32("cc"));
+  });
+
   it("rejects an unsupported action", async () => {
     const adapter = createMarmotDeleteActionAdapter({
       deleteByMessageId: async () => true,

--- a/integrations/openclaw/marmot/test/channel.test.ts
+++ b/integrations/openclaw/marmot/test/channel.test.ts
@@ -116,6 +116,39 @@ describe("resolveMarmotChannelAccount", () => {
       probe,
     });
   });
+
+  it("prefers gateway runtime status over the legacy shim when runtime is present", async () => {
+    const cfg = { channels: { marmot: { profileNameOnboarding: false } } } as unknown as Cfg;
+    const plugin = createMarmotChannelPlugin();
+    const status = plugin.status;
+    if (!status?.buildAccountSnapshot) {
+      throw new Error("Marmot plugin should expose channel status hooks");
+    }
+    const account = resolveMarmotChannelAccount(cfg, "default");
+    const gatewayRuntime = {
+      accountId: "default",
+      running: true,
+      connected: true,
+      lastStartAt: 42,
+      lastInboundAt: 99,
+      lastStopAt: null,
+      lastError: null,
+    };
+
+    const snapshot = await status.buildAccountSnapshot({
+      account,
+      cfg,
+      runtime: gatewayRuntime,
+      probe: undefined,
+      audit: undefined,
+    });
+    expect(snapshot).toMatchObject({
+      running: true,
+      connected: true,
+      lastStartAt: 42,
+      lastInboundAt: 99,
+    });
+  });
 });
 
 describe("createMarmotDeleteActionAdapter", () => {

--- a/integrations/openclaw/marmot/test/dispatch.test.ts
+++ b/integrations/openclaw/marmot/test/dispatch.test.ts
@@ -1,15 +1,24 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { NonAppendOnlyUpdateError } from "../src/append-only.js";
 import type { StreamMode } from "../src/config.js";
 import { AgentControlError, type AgentControlMediaRef } from "../src/client.js";
 import type { MarmotInboundMessage } from "../src/inbound.js";
 import {
+  buildMarmotTurnConfigOverlay,
   createMarmotInboundDispatcher,
   MarmotReplySink,
   type MarmotDispatchClient,
   type MarmotSinkClient,
   type OpenClawChannelRuntime,
 } from "../src/dispatch.js";
+import { MarmotDispatchNotReadyError } from "../src/dispatch-errors.js";
+import {
+  getMarmotTurnDelivery,
+  recordTurnOutboundDelivery,
+  runInMarmotTurn,
+  type MarmotTurnRoute,
+} from "../src/turn-delivery.js";
 
 import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
 
@@ -160,6 +169,12 @@ describe("MarmotReplySink", () => {
     expect(calls.begin).toBe(0);
     expect(calls.append).toEqual([]);
     expect(calls.sendFinal.map((c) => c.text)).toEqual(["hello world"]);
+  });
+
+  it("preserves final reply whitespace while checking for non-empty text", async () => {
+    const calls = emptyCalls();
+    await makeSink(calls).deliver({ text: "  hello world  \n" }, { kind: "final" });
+    expect(calls.sendFinal.map((c) => c.text)).toEqual(["  hello world  \n"]);
   });
 
   it("streams progressive blocks as append-only deltas and finalizes", async () => {
@@ -352,11 +367,11 @@ describe("MarmotReplySink", () => {
     expect(calls.sendFinal.map((c) => c.text)).toEqual(["hello world"]);
   });
 
-  it("falls back to a durable final when preview finalize fails", async () => {
+  it("falls back to a durable final when preview finalize fails with NonAppendOnlyUpdateError", async () => {
     const calls = emptyCalls();
     const client = stubClient(calls);
     client.streamFinalize = (async () => {
-      throw new Error("finalize failed");
+      throw new NonAppendOnlyUpdateError();
     }) as typeof client.streamFinalize;
     const sink = new MarmotReplySink({
       client,
@@ -370,10 +385,72 @@ describe("MarmotReplySink", () => {
     await sink.deliver({ text: "hello" }, { kind: "block" });
     await sink.deliver({ text: "hello world" }, { kind: "final" });
 
-    // The final suffix is appended before stream_finalize is attempted; the
-    // finalize then throws, so we abandon and re-send the whole text durably.
     expect(calls.append).toEqual(["hel", "lo", " world"]);
     expect(calls.sendFinal.map((c) => c.text)).toEqual(["hello world"]);
+  });
+
+  it("does not fall back to send_final when preview finalize exhausts retryable errors", async () => {
+    const calls = emptyCalls();
+    const client = stubClient(calls);
+    client.streamFinalize = (async (
+      _id: string,
+      _capability: string,
+      _final: string,
+      hash: string,
+      count: number,
+    ) => {
+      calls.finalize.push({ hash, count });
+      throw new AgentControlError("timed out waiting for stream finalize", { retryable: true });
+    }) as typeof client.streamFinalize;
+    const sink = new MarmotReplySink({
+      client,
+      accountIdHex: HEX32("aa"),
+      groupIdHex: HEX32("cc"),
+      streamMode: "block",
+      quicCandidates: ["quic://broker:4450"],
+    });
+
+    await sink.deliver({ text: "hel" }, { kind: "block" });
+    await expect(sink.deliver({ text: "hello world" }, { kind: "final" })).rejects.toThrow(
+      "timed out waiting for stream finalize",
+    );
+
+    expect(calls.finalize.length).toBeGreaterThan(1);
+    expect(calls.sendFinal).toEqual([]);
+  });
+
+  it("logs ambiguous finalize failure without send_final fallback for non-retryable errors", async () => {
+    const calls = emptyCalls();
+    const logs: string[] = [];
+    const client = stubClient(calls);
+    client.streamFinalize = (async (
+      _id: string,
+      _capability: string,
+      _final: string,
+      hash: string,
+      count: number,
+    ) => {
+      calls.finalize.push({ hash, count });
+      throw new AgentControlError("bad request", { retryable: false });
+    }) as typeof client.streamFinalize;
+    const sink = new MarmotReplySink({
+      client,
+      accountIdHex: HEX32("aa"),
+      groupIdHex: HEX32("cc"),
+      streamMode: "block",
+      quicCandidates: ["quic://broker:4450"],
+      log: (message) => logs.push(message),
+    });
+
+    await sink.deliver({ text: "hel" }, { kind: "block" });
+    await expect(sink.deliver({ text: "hello world" }, { kind: "final" })).rejects.toThrow(
+      "bad request",
+    );
+
+    expect(calls.finalize).toHaveLength(1);
+    expect(calls.sendFinal).toEqual([]);
+    expect(logs.some((line) => line.includes("ambiguous"))).toBe(true);
+    expect(logs.some((line) => line.includes("retryable"))).toBe(false);
   });
 
   it("commits the streamed reply at flush when the turn sends blocks but no final", async () => {
@@ -494,9 +571,106 @@ describe("MarmotReplySink", () => {
     await expect(sink.deliver({ text: "hello" }, { kind: "final" })).rejects.toThrow("bad request");
     expect(attempts).toBe(1);
   });
+
+  it("cancels a prewarmed preview when tool-owned delivery suppresses sink commit", async () => {
+    const calls = emptyCalls();
+    const route: MarmotTurnRoute = {
+      channelAccountId: "default",
+      marmotAccountIdHex: HEX32("aa"),
+      groupIdHex: HEX32("cc"),
+      replyToMessageIdHex: HEX32("dd"),
+      idempotencyKey: "turn-key",
+    };
+    await runInMarmotTurn(route, async () => {
+      recordTurnOutboundDelivery(getMarmotTurnDelivery()!, { messageIdsHex: [HEX32("11")] });
+      const sink = new MarmotReplySink({
+        client: stubClient(calls),
+        accountIdHex: HEX32("aa"),
+        groupIdHex: HEX32("cc"),
+        streamMode: "block",
+        quicCandidates: ["quic://broker:4450"],
+      });
+      await sink.prewarm();
+      await sink.deliver({ text: "suppressed final" }, { kind: "final" });
+    });
+    expect(calls.begin).toBe(1);
+    expect(calls.cancel).toHaveLength(1);
+    expect(calls.finalize).toEqual([]);
+    expect(calls.sendFinal).toEqual([]);
+  });
+});
+
+describe("buildMarmotTurnConfigOverlay", () => {
+  it("denies sessions_send, alsoAllows message, and leaves the base cfg untouched", () => {
+    const baseCfg = {
+      tools: { deny: ["exec"], alsoAllow: ["browser"], profile: "coding" },
+      channels: { marmot: { socketPath: "/tmp/m.sock" } },
+    };
+    const overlay = buildMarmotTurnConfigOverlay(baseCfg);
+    expect(overlay.tools).toMatchObject({
+      deny: ["exec", "sessions_send"],
+      alsoAllow: ["browser", "message"],
+      profile: "coding",
+    });
+    expect(baseCfg.tools).toEqual({ deny: ["exec"], alsoAllow: ["browser"], profile: "coding" });
+    expect(baseCfg).not.toBe(overlay);
+  });
 });
 
 describe("createMarmotInboundDispatcher", () => {
+  it("passes the turn-local cfg overlay into dispatchReplyWithBufferedBlockDispatcher", async () => {
+    const calls = emptyCalls();
+    const captured: unknown[] = [];
+    const baseCfg = { tools: { deny: ["exec"] } };
+    const runtimeChannel: OpenClawChannelRuntime = {
+      routing: {
+        resolveAgentRoute: () => ({
+          agentId: "agent",
+          accountId: "default",
+          sessionKey: "agent:marmot",
+        }),
+      },
+      session: {
+        resolveStorePath: () => "/tmp/openclaw-marmot-overlay-test",
+        recordInboundSession: vi.fn(),
+      },
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: async (params: unknown) => {
+          captured.push(params);
+          const deliver = (params as {
+            dispatcherOptions: {
+              deliver: (payload: { text: string }, info: { kind: "final" }) => Promise<void>;
+            };
+          }).dispatcherOptions.deliver;
+          await deliver({ text: "done" }, { kind: "final" });
+        },
+      },
+    };
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: baseCfg,
+      runtimeChannel,
+      client: stubClient(calls) as unknown as MarmotDispatchClient,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+    await dispatch({
+      accountIdHex: HEX32("aa"),
+      groupIdHex: HEX32("cc"),
+      messageIdHex: HEX32("dd"),
+      senderAccountIdHex: HEX32("bb"),
+      text: "hello",
+    });
+    const params = captured[0] as { cfg: { tools?: { deny?: string[]; alsoAllow?: string[] } } };
+    expect(params.cfg).not.toBe(baseCfg);
+    expect(params.cfg.tools?.deny).toContain("sessions_send");
+    expect(params.cfg.tools?.alsoAllow).toContain("message");
+    expect(baseCfg.tools?.deny).toEqual(["exec"]);
+  });
+
   it("enables OpenClaw block streaming when Marmot live block streaming is resolved on", async () => {
     const calls = emptyCalls();
     const captured: unknown[] = [];
@@ -562,6 +736,10 @@ describe("createMarmotInboundDispatcher", () => {
       (captured[0] as { replyOptions: { disableBlockStreaming?: boolean } }).replyOptions
         .disableBlockStreaming,
     ).toBe(false);
+    expect(
+      (captured[0] as { replyOptions: { sourceReplyDeliveryMode?: string } }).replyOptions
+        .sourceReplyDeliveryMode,
+    ).toBe("automatic");
     expect(calls.sendFinal[0]?.accountIdHex).toBe(HEX32("aa"));
     expect(calls.sendFinal.map((c) => c.text)).toEqual(["done"]);
     // GAP-01: the durable reply threads to the triggering message id.
@@ -738,6 +916,22 @@ describe("createMarmotInboundDispatcher activation cache", () => {
     });
   }
 
+  it("throws MarmotDispatchNotReadyError when initial groupInfo fails non-retryably", async () => {
+    const turns = { count: 0 };
+    const client = {
+      async sendFinal() {
+        return { type: "final_sent", message_ids_hex: [HEX32("ab")] };
+      },
+      async groupInfo() {
+        throw new AgentControlError("permanent membership failure", { retryable: false });
+      },
+    } as unknown as MarmotDispatchClient;
+    const dispatch = makeDispatch(client, turns);
+
+    await expect(dispatch(baseMessage)).rejects.toBeInstanceOf(MarmotDispatchNotReadyError);
+    expect(turns.count).toBe(0);
+  });
+
   it("queries group membership once and reuses the cached is_direct fact", async () => {
     const turns = { count: 0 };
     const { client, groupInfoCalls } = countingClient({ isDirect: false });
@@ -759,7 +953,7 @@ describe("createMarmotInboundDispatcher activation cache", () => {
 
     await dispatch({ ...baseMessage, mentionsSelf: true });
 
-    expect(groupInfoCalls()).toBe(0);
+    expect(groupInfoCalls()).toBe(1);
     expect(turns.count).toBe(1);
   });
 
@@ -796,33 +990,97 @@ describe("createMarmotInboundDispatcher activation cache", () => {
     expect(groupInfoCalls()).toBe(2);
   });
 
-  it("fails closed (skips the turn) when the membership lookup errors", async () => {
+  it("throws MarmotDispatchNotReadyError when the membership lookup fails non-retryably", async () => {
     const turns = { count: 0 };
     const { client, groupInfoCalls } = countingClient({ isDirect: true, throwError: () => true });
     const dispatch = makeDispatch(client, turns);
 
-    await dispatch({ ...baseMessage });
+    await expect(dispatch(baseMessage)).rejects.toBeInstanceOf(MarmotDispatchNotReadyError);
 
-    // An unaddressed message with an unresolvable membership must NOT barge in.
     expect(turns.count).toBe(0);
     expect(groupInfoCalls()).toBe(1);
   });
 
-  it("does not cache a membership-lookup error (retries on the next message)", async () => {
+  it("does not cache a non-retryable membership lookup (next message retries groupInfo)", async () => {
     const turns = { count: 0 };
     let fail = true;
     const { client, groupInfoCalls } = countingClient({ isDirect: true, throwError: () => fail });
     const dispatch = makeDispatch(client, turns);
 
-    expect(await runTurn(dispatch, turns, { ...baseMessage, messageIdHex: HEX32("01") })).toBe(
-      false,
-    );
+    await expect(
+      dispatch({ ...baseMessage, messageIdHex: HEX32("01") }),
+    ).rejects.toBeInstanceOf(MarmotDispatchNotReadyError);
     expect(groupInfoCalls()).toBe(1);
 
-    // The error was not cached: the next message re-reads, succeeds, and (DM) replies.
     fail = false;
     expect(await runTurn(dispatch, turns, { ...baseMessage, messageIdHex: HEX32("02") })).toBe(true);
     expect(groupInfoCalls()).toBe(2);
+  });
+
+  it("retries a transient membership lookup and starts one effective-DM turn", async () => {
+    const turns = { count: 0 };
+    let calls = 0;
+    const client = {
+      async sendFinal() {
+        return { type: "final_sent", message_ids_hex: [HEX32("ab")] };
+      },
+      async groupInfo(accountIdHex: string, groupIdHex: string) {
+        calls += 1;
+        if (calls === 1) {
+          throw new AgentControlError("temporary", { retryable: true });
+        }
+        return {
+          type: "group_info" as const,
+          account_id_hex: accountIdHex,
+          group_id_hex: groupIdHex,
+          member_count: 2,
+          is_direct: true,
+          subject: null,
+        };
+      },
+    } as unknown as MarmotDispatchClient;
+    const dispatch = makeDispatch(client, turns);
+
+    expect(await runTurn(dispatch, turns, baseMessage)).toBe(true);
+    expect(calls).toBe(2);
+    expect(turns.count).toBe(1);
+  });
+
+  it("throws a typed not-ready failure after readiness exhaustion", async () => {
+    const turns = { count: 0 };
+    const client = {
+      async sendFinal() {
+        return { type: "final_sent", message_ids_hex: [HEX32("ab")] };
+      },
+      async groupInfo() {
+        throw new AgentControlError("temporary", { retryable: true });
+      },
+    } as unknown as MarmotDispatchClient;
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel: cachingRuntime(turns),
+      client,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    await expect(dispatch({ ...baseMessage, mentionsSelf: true })).rejects.toBeInstanceOf(
+      MarmotDispatchNotReadyError,
+    );
+    expect(turns.count).toBe(0);
+  });
+
+  it("skips without throwing when the message is not addressed", async () => {
+    const turns = { count: 0 };
+    const { client } = countingClient({ isDirect: false });
+    const dispatch = makeDispatch(client, turns);
+
+    await expect(dispatch(baseMessage)).resolves.toBeUndefined();
+    expect(turns.count).toBe(0);
   });
 
   /** Dispatch a message and report whether an agent turn ran (the gate let it through). */

--- a/integrations/openclaw/marmot/test/dispatch.test.ts
+++ b/integrations/openclaw/marmot/test/dispatch.test.ts
@@ -419,7 +419,7 @@ describe("MarmotReplySink", () => {
     expect(calls.sendFinal).toEqual([]);
   });
 
-  it("logs ambiguous finalize failure without send_final fallback for non-retryable errors", async () => {
+  it("falls back to a durable final when preview finalize fails with a definite non-retryable error", async () => {
     const calls = emptyCalls();
     const logs: string[] = [];
     const client = stubClient(calls);
@@ -443,13 +443,11 @@ describe("MarmotReplySink", () => {
     });
 
     await sink.deliver({ text: "hel" }, { kind: "block" });
-    await expect(sink.deliver({ text: "hello world" }, { kind: "final" })).rejects.toThrow(
-      "bad request",
-    );
+    await sink.deliver({ text: "hello world" }, { kind: "final" });
 
     expect(calls.finalize).toHaveLength(1);
-    expect(calls.sendFinal).toEqual([]);
-    expect(logs.some((line) => line.includes("ambiguous"))).toBe(true);
+    expect(calls.sendFinal.map((c) => c.text)).toEqual(["hello world"]);
+    expect(logs.some((line) => line.includes("preview_finalize_definite_failure"))).toBe(true);
     expect(logs.some((line) => line.includes("retryable"))).toBe(false);
   });
 

--- a/integrations/openclaw/marmot/test/dispatch.test.ts
+++ b/integrations/openclaw/marmot/test/dispatch.test.ts
@@ -12,7 +12,7 @@ import {
   type MarmotSinkClient,
   type OpenClawChannelRuntime,
 } from "../src/dispatch.js";
-import { MarmotDispatchNotReadyError } from "../src/dispatch-errors.js";
+import { MarmotDispatchAmbiguousDeliveryError, MarmotDispatchDeliveryFailedError, MarmotDispatchNotReadyError } from "../src/dispatch-errors.js";
 import {
   getMarmotTurnDelivery,
   recordTurnOutboundDelivery,
@@ -26,7 +26,7 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", () => ({
   buildChannelInboundEventContext: vi.fn((params: unknown) => params),
   runChannelInboundEvent: vi.fn(
     async (params: { adapter: { resolveTurn: () => { runDispatch: () => Promise<unknown> } } }) => {
-      await params.adapter.resolveTurn().runDispatch();
+      return await params.adapter.resolveTurn().runDispatch();
     },
   ),
 }));
@@ -570,6 +570,32 @@ describe("MarmotReplySink", () => {
 
     await expect(sink.deliver({ text: "hello" }, { kind: "final" })).rejects.toThrow("bad request");
     expect(attempts).toBe(1);
+  });
+
+  it("does not treat ambiguous outbound suppression as a successful sink commit", async () => {
+    const calls = emptyCalls();
+    const route: MarmotTurnRoute = {
+      channelAccountId: "default",
+      marmotAccountIdHex: HEX32("aa"),
+      groupIdHex: HEX32("cc"),
+      replyToMessageIdHex: HEX32("dd"),
+      idempotencyKey: "turn-key",
+    };
+    await runInMarmotTurn(route, async () => {
+      const state = getMarmotTurnDelivery()!;
+      state.outboundAmbiguousFailure = true;
+      const sink = new MarmotReplySink({
+        client: stubClient(calls),
+        accountIdHex: HEX32("aa"),
+        groupIdHex: HEX32("cc"),
+        streamMode: "off",
+        quicCandidates: [],
+      });
+      await expect(sink.deliver({ text: "must fail" }, { kind: "final" })).rejects.toBeInstanceOf(
+        MarmotDispatchAmbiguousDeliveryError,
+      );
+      expect(calls.sendFinal).toEqual([]);
+    });
   });
 
   it("cancels a prewarmed preview when tool-owned delivery suppresses sink commit", async () => {
@@ -1266,5 +1292,105 @@ describe("createMarmotInboundDispatcher inbound media", () => {
     expect(downloads).toHaveLength(0);
     const ctxArg = buildCtxMock.mock.calls[0]?.[0] as Record<string, unknown>;
     expect("media" in ctxArg).toBe(false);
+  });
+});
+
+describe("createMarmotInboundDispatcher delivery failures", () => {
+  it("fails closed when OpenClaw reports a failed final delivery", async () => {
+    const calls = emptyCalls();
+    const runtimeChannel: OpenClawChannelRuntime = {
+      routing: {
+        resolveAgentRoute: () => ({
+          agentId: "agent",
+          accountId: "default",
+          sessionKey: "agent:marmot",
+        }),
+      },
+      session: {
+        resolveStorePath: () => "/tmp/openclaw-marmot-dispatch-failure-test",
+        recordInboundSession: vi.fn(),
+      },
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: async () => ({
+          queuedFinal: false,
+          counts: { tool: 0, block: 0, final: 0 },
+          failedCounts: { final: 1 },
+        }),
+      },
+    };
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel,
+      client: stubClient(calls) as unknown as MarmotDispatchClient,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    await expect(
+      dispatch({
+        accountIdHex: HEX32("aa"),
+        groupIdHex: HEX32("cc"),
+        messageIdHex: HEX32("dd"),
+        senderAccountIdHex: HEX32("bb"),
+        text: "hello",
+      }),
+    ).rejects.toBeInstanceOf(MarmotDispatchDeliveryFailedError);
+    expect(calls.sendFinal).toEqual([]);
+  });
+
+  it("does not fail the turn when OpenClaw reports failed tool or block deliveries", async () => {
+    const calls = emptyCalls();
+    const runtimeChannel: OpenClawChannelRuntime = {
+      routing: {
+        resolveAgentRoute: () => ({
+          agentId: "agent",
+          accountId: "default",
+          sessionKey: "agent:marmot",
+        }),
+      },
+      session: {
+        resolveStorePath: () => "/tmp/openclaw-marmot-dispatch-tool-block-test",
+        recordInboundSession: vi.fn(),
+      },
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: async (params: unknown) => {
+          const deliver = (params as {
+            dispatcherOptions: {
+              deliver: (payload: { text: string }, info: { kind: "final" }) => Promise<void>;
+            };
+          }).dispatcherOptions.deliver;
+          await deliver({ text: "done" }, { kind: "final" });
+          return {
+            queuedFinal: false,
+            counts: { tool: 0, block: 0, final: 1 },
+            failedCounts: { tool: 1, block: 1 },
+          };
+        },
+      },
+    };
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel,
+      client: stubClient(calls) as unknown as MarmotDispatchClient,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    await dispatch({
+      accountIdHex: HEX32("aa"),
+      groupIdHex: HEX32("cc"),
+      messageIdHex: HEX32("dd"),
+      senderAccountIdHex: HEX32("bb"),
+      text: "hello",
+    });
+    expect(calls.sendFinal).toHaveLength(1);
   });
 });

--- a/integrations/openclaw/marmot/test/e2e-connector.test.ts
+++ b/integrations/openclaw/marmot/test/e2e-connector.test.ts
@@ -450,14 +450,38 @@ maybeDescribe("OpenClaw Marmot connector E2E", () => {
             sender_account_id_hex: SENDER_ACCOUNT_ID_HEX,
             text: "replay",
           });
-          await new Promise((resolve) => setTimeout(resolve, 200));
+          const observationMessageId = "dd".repeat(32);
+          await client.request({
+            type: "debug_inject_inbound",
+            account_id_hex: ACCOUNT_ID_HEX,
+            group_id_hex: GROUP_ID_HEX,
+            message_id_hex: observationMessageId,
+            sender_account_id_hex: SENDER_ACCOUNT_ID_HEX,
+            text: "post-replay observation",
+          });
+          // The subscription and same-group queue preserve order. Seeing this
+          // later event complete proves the replay was observed before the
+          // unchanged duplicate-count assertions below.
+          await waitFor(
+            () => delivered.some((message) => message.messageIdHex === observationMessageId),
+            { label: "post-replay positive observation" },
+          );
+          await waitFor(
+            async () =>
+              (await recordedFinals(client)).sends.filter(
+                (send) =>
+                  send.text === "adapter-owned-turn-reply" &&
+                  send.group_id_hex === GROUP_ID_HEX,
+              ).length === 4,
+            { label: "post-replay observation final" },
+          );
 
           const finalsAfterReplay = await recordedFinals(client);
           expect(
             finalsAfterReplay.sends.filter(
               (send) => send.text === "adapter-owned-turn-reply" && send.group_id_hex === GROUP_ID_HEX,
             ),
-          ).toHaveLength(3);
+          ).toHaveLength(4);
           expect(
             finalsAfterReplay.sends.filter(
               (send) => send.text === "bound-final" && send.group_id_hex === GROUP_ID_HEX,
@@ -476,7 +500,7 @@ maybeDescribe("OpenClaw Marmot connector E2E", () => {
   );
 
   it(
-    "reuses a derived idempotency key across independent plugin processes without duplicating durable sends",
+    "rejects regenerated text under a restart-stable key without duplicating durable sends",
     async () => {
       const tempRoot = await mkdtemp("/tmp/omce-restart-");
       const { client, proc, socketPath } = await startWnAgent(tempRoot);
@@ -496,6 +520,7 @@ maybeDescribe("OpenClaw Marmot connector E2E", () => {
           MARMOT_E2E_GROUP: GROUP_ID_HEX,
           MARMOT_E2E_MESSAGE: MESSAGE_ID_HEX,
           MARMOT_E2E_REPLY: replyText,
+          MARMOT_E2E_REPLAY_REPLY: "restart-idempotency-regenerated-reply",
         };
         const pluginRoot = join(import.meta.dirname, "..");
         const clientModule = join(pluginRoot, "dist/src/client.js");
@@ -553,14 +578,18 @@ maybeDescribe("OpenClaw Marmot connector E2E", () => {
             socketPath: process.env.MARMOT_E2E_SOCKET,
             requestTimeoutMs: 5_000,
           });
-          const response = await client.sendFinal(
-            inbound.accountIdHex,
-            inbound.groupIdHex,
-            process.env.MARMOT_E2E_REPLY,
-            inbound.messageIdHex,
-            key,
-          );
-          console.log(JSON.stringify({ key, messageIdsHex: response.message_ids_hex }));
+          try {
+            await client.sendFinal(
+              inbound.accountIdHex,
+              inbound.groupIdHex,
+              process.env.MARMOT_E2E_REPLAY_REPLY,
+              inbound.messageIdHex,
+              key,
+            );
+            console.log(JSON.stringify({ key, errorCode: null }));
+          } catch (error) {
+            console.log(JSON.stringify({ key, errorCode: error?.code ?? null }));
+          }
         `;
 
         const runChild = <T>(script: string) =>
@@ -612,13 +641,16 @@ maybeDescribe("OpenClaw Marmot connector E2E", () => {
         );
         const committedMessageIdsHex = committed.message_ids_hex;
 
-        const replay = await runChild<{ key: string; messageIdsHex: string[] }>(replayChildScript);
+        const replay = await runChild<{ key: string; errorCode: string | null }>(replayChildScript);
         expect(replay.key).toBe(committedKey);
-        expect(replay.messageIdsHex).toEqual(committedMessageIdsHex);
+        expect(replay.errorCode).toBe("idempotency_conflict");
 
         const finals = await recordedFinals(client);
         expect(finals.sends.filter(matchesReply)).toHaveLength(1);
         expect(finals.sends.filter(matchesReply)[0]?.message_ids_hex).toEqual(committedMessageIdsHex);
+        expect(
+          finals.sends.filter((send) => send.text === childEnv.MARMOT_E2E_REPLAY_REPLY),
+        ).toHaveLength(0);
       } finally {
         await stopProcess(proc);
         await rm(tempRoot, { recursive: true, force: true });

--- a/integrations/openclaw/marmot/test/e2e-connector.test.ts
+++ b/integrations/openclaw/marmot/test/e2e-connector.test.ts
@@ -2,12 +2,25 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { MarmotAgentControlClient } from "../src/client.js";
-import { startMarmotInbound, type InboundPluginApi } from "../src/inbound-runtime.js";
+import type { ChannelMessageSendTextContext } from "openclaw/plugin-sdk/channel-outbound";
+
+import { MarmotAgentControlClient, AgentControlError } from "../src/client.js";
+import {
+  createMarmotInboundDispatcher,
+  type MarmotDispatchClient,
+  type OpenClawChannelRuntime,
+} from "../src/dispatch.js";
+import {
+  resetMarmotInboundAccountsForTests,
+  startMarmotInbound,
+  type InboundPluginApi,
+} from "../src/inbound-runtime.js";
 import type { MarmotInboundMessage } from "../src/inbound.js";
+import { createMarmotMessageAdapter } from "../src/outbound.js";
 import { resetMarmotInboundRuntimeForTests } from "../src/runtime-state.js";
+import { MarmotTargetError } from "../src/target.js";
 
 const RUN_CONNECTOR_E2E = process.env.MARMOT_OPENCLAW_CONNECTOR_E2E === "1";
 const maybeDescribe = RUN_CONNECTOR_E2E ? describe : describe.skip;
@@ -81,58 +94,62 @@ async function recordedFinals(
   })) as unknown as DebugRecordedFinalsResponse;
 }
 
+async function startWnAgent(tempRoot: string): Promise<{
+  client: MarmotAgentControlClient;
+  proc: ChildProcess;
+  socketPath: string;
+}> {
+  const marmotHome = join(tempRoot, "marmot-home");
+  const socketPath = join(tempRoot, "a.sock");
+  const proc = spawn(
+    "cargo",
+    [
+      "run",
+      "-q",
+      "-p",
+      "agent-connector",
+      "--bin",
+      "wn-agent",
+      "--",
+      "--home",
+      marmotHome,
+      "--socket",
+      socketPath,
+      "--debug-controls",
+    ],
+    {
+      cwd: repoRoot(),
+      env: { ...process.env, RUST_LOG: process.env.RUST_LOG ?? "warn" },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const client = new MarmotAgentControlClient({
+    socketPath,
+    requestTimeoutMs: 5_000,
+  });
+  await waitFor(
+    async () => {
+      await recordedFinals(client);
+      return true;
+    },
+    { timeoutMs: 120_000, label: "wn-agent debug control socket" },
+  );
+  return { client, proc, socketPath };
+}
+
 afterEach(() => {
   resetMarmotInboundRuntimeForTests();
+  resetMarmotInboundAccountsForTests();
 });
 
 maybeDescribe("OpenClaw Marmot connector E2E", () => {
   it(
-    "dispatches debug-injected inbound through the OpenClaw inbound runtime into real wn-agent send_final",
+    "dispatches debug-injected inbound through the inbound runtime into real wn-agent send_final",
     async () => {
-      // Keep the Unix socket path short for macOS sockaddr_un limits.
       const tempRoot = await mkdtemp("/tmp/omce-");
-      const marmotHome = join(tempRoot, "marmot-home");
-      const socketPath = join(tempRoot, "a.sock");
-      const proc = spawn(
-        "cargo",
-        [
-          "run",
-          "-q",
-          "-p",
-          "agent-connector",
-          "--bin",
-          "wn-agent",
-          "--",
-          "--home",
-          marmotHome,
-          "--socket",
-          socketPath,
-          "--debug-controls",
-        ],
-        {
-          cwd: repoRoot(),
-          env: { ...process.env, RUST_LOG: process.env.RUST_LOG ?? "warn" },
-          stdio: ["ignore", "pipe", "pipe"],
-        },
-      );
-      const stdout: string[] = [];
-      const stderr: string[] = [];
-      proc.stdout.on("data", (chunk) => stdout.push(String(chunk)));
-      proc.stderr.on("data", (chunk) => stderr.push(String(chunk)));
+      const { client, proc, socketPath } = await startWnAgent(tempRoot);
 
       try {
-        const client = new MarmotAgentControlClient({
-          socketPath,
-          requestTimeoutMs: 5_000,
-        });
-        await waitFor(
-          async () => {
-            await recordedFinals(client);
-            return true;
-          },
-          { timeoutMs: 60_000, label: "wn-agent debug control socket" },
-        );
-
         let resolveReady: () => void = () => {};
         const ready = new Promise<void>((resolve) => {
           resolveReady = resolve;
@@ -194,37 +211,260 @@ maybeDescribe("OpenClaw Marmot connector E2E", () => {
             senderAccountIdHex: SENDER_ACCOUNT_ID_HEX,
             text: INBOUND_TEXT,
           });
-          const final = await waitFor(
+          const finals = await waitFor(
             async () => {
               const recorded = await recordedFinals(client);
-              return recorded.sends[0] ?? null;
+              return recorded.sends.find((send) => send.text === DETERMINISTIC_RESPONSE) ?? null;
             },
             { timeoutMs: 10_000, label: "recorded final send" },
           );
-          expect(final).toMatchObject({
+          expect(finals).toMatchObject({
             account_id_hex: ACCOUNT_ID_HEX,
             group_id_hex: GROUP_ID_HEX,
             text: DETERMINISTIC_RESPONSE,
             reply_to_message_id_hex: MESSAGE_ID_HEX,
             message_ids_hex: ["1".padStart(64, "0")],
           });
+          expect(
+            (await recordedFinals(client)).sends.filter((send) => send.text === DETERMINISTIC_RESPONSE),
+          ).toHaveLength(1);
         } finally {
           stopInbound();
         }
-      } catch (error) {
-        const detail = [
-          error instanceof Error ? error.message : String(error),
-          stdout.length ? `stdout:\n${stdout.join("")}` : "",
-          stderr.length ? `stderr:\n${stderr.join("")}` : "",
-        ]
-          .filter(Boolean)
-          .join("\n\n");
-        throw new Error(detail);
       } finally {
         await stopProcess(proc);
         await rm(tempRoot, { recursive: true, force: true });
       }
     },
     90_000,
+  );
+
+  it(
+    "canonical outbound targets, readiness retry, exact sequential finals, and same-process replay dedupe",
+    async () => {
+      const tempRoot = await mkdtemp("/tmp/omce-");
+      const { client, proc, socketPath } = await startWnAgent(tempRoot);
+
+      try {
+        const adapter = createMarmotMessageAdapter({
+          resolveTarget: async () => ({
+            client,
+            marmotAccountIdHex: ACCOUNT_ID_HEX,
+          }),
+        });
+        for (const target of [GROUP_ID_HEX, `marmot:${GROUP_ID_HEX}`, `group:${GROUP_ID_HEX}`]) {
+          await adapter.send!.text!({
+            cfg: {},
+            to: target,
+            text: "canonical-target",
+          } as ChannelMessageSendTextContext);
+        }
+        await expect(
+          adapter.send!.text!({
+            cfg: {},
+            to: `agent:main:marmot:group:${GROUP_ID_HEX}`,
+            text: "bad",
+          } as ChannelMessageSendTextContext),
+        ).rejects.toBeInstanceOf(MarmotTargetError);
+
+        const readinessLogs: string[] = [];
+        let groupInfoCalls = 0;
+        const replyOptions: unknown[] = [];
+        const runtimeChannel: OpenClawChannelRuntime = {
+          routing: {
+            resolveAgentRoute: () => ({
+              agentId: "main",
+              accountId: "default",
+              sessionKey: "agent:main:marmot:group",
+            }),
+          },
+          session: {
+            resolveStorePath: () => join(tempRoot, "sessions.json"),
+            recordInboundSession: vi.fn(),
+          },
+          reply: {
+            dispatchReplyWithBufferedBlockDispatcher: async (params: unknown) => {
+              const typed = params as {
+                cfg: { tools?: { deny?: string[] } };
+                replyOptions?: { sourceReplyDeliveryMode?: string };
+                dispatcherOptions: {
+                  deliver: (payload: { text?: string }, info: { kind: "final" }) => Promise<void>;
+                };
+              };
+              replyOptions.push(typed.replyOptions ?? {});
+              expect(typed.cfg.tools?.deny).toContain("sessions_send");
+              // Same-process outbound adapter send inside the dispatch callback (not a
+              // real OpenClaw shared-tool invocation) before the bound sink final.
+              await adapter.send!.text!({
+                cfg: {},
+                accountId: "default",
+                to: GROUP_ID_HEX,
+                text: "adapter-owned-turn-reply",
+              } as ChannelMessageSendTextContext);
+              await typed.dispatcherOptions.deliver({ text: "bound-final" }, { kind: "final" });
+            },
+          },
+        };
+        const dispatchClient = Object.assign(client, {
+          async groupInfo(accountIdHex: string, groupIdHex: string) {
+            groupInfoCalls += 1;
+            if (groupInfoCalls === 1) {
+              throw new AgentControlError("group not ready yet", { retryable: true });
+            }
+            return {
+              type: "group_info" as const,
+              account_id_hex: accountIdHex,
+              group_id_hex: groupIdHex,
+              member_count: 2,
+              is_direct: true,
+              subject: null,
+            };
+          },
+        }) as unknown as MarmotDispatchClient;
+        const dispatch = createMarmotInboundDispatcher({
+          cfg: { tools: { deny: ["exec"] } },
+          runtimeChannel,
+          client: dispatchClient,
+          channelAccountId: "default",
+          streamMode: "off",
+          blockStreaming: false,
+          quicCandidates: [],
+          groupActivation: "always",
+          mentionPatterns: [],
+          log: (message) => readinessLogs.push(message),
+        });
+
+        let subscriptionReadyCount = 0;
+        const api: InboundPluginApi = {
+          config: {
+            channels: {
+              marmot: {
+                socketPath,
+                accountIdHex: ACCOUNT_ID_HEX,
+                profileNameOnboarding: false,
+              },
+            },
+          },
+          logger: {
+            info: (message) => {
+              if (message.includes("inbound subscription established")) {
+                subscriptionReadyCount += 1;
+              }
+            },
+            warn: () => {},
+          },
+        };
+
+        const delivered: MarmotInboundMessage[] = [];
+        const runInbound = () =>
+          startMarmotInbound(
+            api,
+            async (message) => {
+              delivered.push(message);
+              await dispatch(message);
+            },
+            { clientFactory: () => client },
+          );
+
+        let stopInbound = runInbound();
+        try {
+          await waitFor(() => subscriptionReadyCount === 1, {
+            label: "initial inbound subscription readiness",
+          });
+          const messageIds = ["aa", "bb", "cc"].map((byte) => byte.repeat(32));
+          for (const [idx, messageHex] of messageIds.entries()) {
+            await client.request({
+              type: "debug_inject_inbound",
+              account_id_hex: ACCOUNT_ID_HEX,
+              group_id_hex: GROUP_ID_HEX,
+              message_id_hex: messageHex,
+              sender_account_id_hex: SENDER_ACCOUNT_ID_HEX,
+              text: `sequential-${idx + 1}`,
+            });
+            await waitFor(() => delivered.length === idx + 1);
+            await waitFor(
+              async () => {
+                const recorded = await recordedFinals(client);
+                return (
+                  recorded.sends.filter(
+                    (send) =>
+                      send.text === "adapter-owned-turn-reply" &&
+                      send.group_id_hex === GROUP_ID_HEX,
+                  ).length ===
+                  idx + 1
+                );
+              },
+              { label: `sequential adapter-owned final ${idx + 1}` },
+            );
+            const turnFinals = (await recordedFinals(client)).sends.filter(
+              (send) =>
+                (send.text === "adapter-owned-turn-reply" || send.text === "bound-final") &&
+                send.group_id_hex === GROUP_ID_HEX,
+            );
+            expect(turnFinals).toHaveLength(idx + 1);
+            expect(turnFinals.every((send) => send.text === "adapter-owned-turn-reply")).toBe(true);
+            const sourceReplies = turnFinals.filter(
+              (send) => send.text === "adapter-owned-turn-reply",
+            );
+            expect(sourceReplies[idx]?.reply_to_message_id_hex).toBe(messageHex);
+          }
+          expect(replyOptions.at(-1)).toMatchObject({ sourceReplyDeliveryMode: "automatic" });
+          expect(readinessLogs.some((line) => line.includes("readiness established after retry"))).toBe(
+            true,
+          );
+
+          const finalsBeforeRestart = await recordedFinals(client);
+          expect(
+            finalsBeforeRestart.sends.filter(
+              (send) => send.text === "adapter-owned-turn-reply" && send.group_id_hex === GROUP_ID_HEX,
+            ),
+          ).toHaveLength(3);
+          expect(
+            finalsBeforeRestart.sends.filter(
+              (send) => send.text === "bound-final" && send.group_id_hex === GROUP_ID_HEX,
+            ),
+          ).toHaveLength(0);
+          expect(
+            finalsBeforeRestart.sends.filter(
+              (send) => send.text === "canonical-target" && send.group_id_hex === GROUP_ID_HEX,
+            ),
+          ).toHaveLength(3);
+
+          stopInbound();
+          stopInbound = runInbound();
+          await waitFor(() => subscriptionReadyCount === 2, {
+            label: "restarted inbound subscription readiness",
+          });
+          await client.request({
+            type: "debug_inject_inbound",
+            account_id_hex: ACCOUNT_ID_HEX,
+            group_id_hex: GROUP_ID_HEX,
+            message_id_hex: messageIds[0]!,
+            sender_account_id_hex: SENDER_ACCOUNT_ID_HEX,
+            text: "replay",
+          });
+          await new Promise((resolve) => setTimeout(resolve, 200));
+
+          const finalsAfterReplay = await recordedFinals(client);
+          expect(
+            finalsAfterReplay.sends.filter(
+              (send) => send.text === "adapter-owned-turn-reply" && send.group_id_hex === GROUP_ID_HEX,
+            ),
+          ).toHaveLength(3);
+          expect(
+            finalsAfterReplay.sends.filter(
+              (send) => send.text === "bound-final" && send.group_id_hex === GROUP_ID_HEX,
+            ),
+          ).toHaveLength(0);
+          expect(delivered.filter((message) => message.messageIdHex === messageIds[0])).toHaveLength(1);
+        } finally {
+          stopInbound();
+        }
+      } finally {
+        await stopProcess(proc);
+        await rm(tempRoot, { recursive: true, force: true });
+      }
+    },
+    120_000,
   );
 });

--- a/integrations/openclaw/marmot/test/e2e-connector.test.ts
+++ b/integrations/openclaw/marmot/test/e2e-connector.test.ts
@@ -467,4 +467,156 @@ maybeDescribe("OpenClaw Marmot connector E2E", () => {
     },
     120_000,
   );
+
+  it(
+    "reuses a derived idempotency key across independent plugin processes without duplicating durable sends",
+    async () => {
+      const tempRoot = await mkdtemp("/tmp/omce-restart-");
+      const { client, proc, socketPath } = await startWnAgent(tempRoot);
+
+      try {
+        const inbound = {
+          accountIdHex: ACCOUNT_ID_HEX,
+          groupIdHex: GROUP_ID_HEX,
+          messageIdHex: MESSAGE_ID_HEX,
+          coalescedMessageIdsHex: [MESSAGE_ID_HEX],
+        };
+        const replyText = "restart-idempotency-reply";
+        const childEnv = {
+          ...process.env,
+          MARMOT_E2E_SOCKET: socketPath,
+          MARMOT_E2E_ACCOUNT: ACCOUNT_ID_HEX,
+          MARMOT_E2E_GROUP: GROUP_ID_HEX,
+          MARMOT_E2E_MESSAGE: MESSAGE_ID_HEX,
+          MARMOT_E2E_REPLY: replyText,
+        };
+        const pluginRoot = join(import.meta.dirname, "..");
+        const clientModule = join(pluginRoot, "dist/src/client.js");
+        const idempotencyModule = join(pluginRoot, "dist/src/turn-idempotency.js");
+        const commitChildScript = `
+          import { createConnection } from "node:net";
+          import { randomUUID } from "node:crypto";
+          import { AGENT_CONTROL_PROTOCOL_V2 } from ${JSON.stringify(clientModule)};
+          import { deriveTurnIdempotencyKeyFromInbound } from ${JSON.stringify(idempotencyModule)};
+          const inbound = {
+            accountIdHex: process.env.MARMOT_E2E_ACCOUNT,
+            groupIdHex: process.env.MARMOT_E2E_GROUP,
+            messageIdHex: process.env.MARMOT_E2E_MESSAGE,
+            coalescedMessageIdsHex: [process.env.MARMOT_E2E_MESSAGE],
+          };
+          const key = deriveTurnIdempotencyKeyFromInbound(inbound);
+          const envelope = {
+            marmot_agent_control: AGENT_CONTROL_PROTOCOL_V2,
+            id: randomUUID(),
+            type: "send_final",
+            account_id_hex: inbound.accountIdHex,
+            group_id_hex: inbound.groupIdHex,
+            text: process.env.MARMOT_E2E_REPLY,
+            reply_to_message_id_hex: inbound.messageIdHex,
+            idempotency_key: key,
+          };
+          await new Promise((resolve, reject) => {
+            const socket = createConnection({ path: process.env.MARMOT_E2E_SOCKET });
+            socket.once("error", reject);
+            socket.once("connect", () => {
+              const frame = Buffer.from(\`\${JSON.stringify(envelope)}\\n\`, "utf8");
+              socket.write(frame, (err) => {
+                if (err) {
+                  reject(err);
+                  return;
+                }
+                socket.end();
+                resolve(undefined);
+              });
+            });
+          });
+          console.log(JSON.stringify({ key }));
+        `;
+        const replayChildScript = `
+          import { MarmotAgentControlClient } from ${JSON.stringify(clientModule)};
+          import { deriveTurnIdempotencyKeyFromInbound } from ${JSON.stringify(idempotencyModule)};
+          const inbound = {
+            accountIdHex: process.env.MARMOT_E2E_ACCOUNT,
+            groupIdHex: process.env.MARMOT_E2E_GROUP,
+            messageIdHex: process.env.MARMOT_E2E_MESSAGE,
+            coalescedMessageIdsHex: [process.env.MARMOT_E2E_MESSAGE],
+          };
+          const key = deriveTurnIdempotencyKeyFromInbound(inbound);
+          const client = new MarmotAgentControlClient({
+            socketPath: process.env.MARMOT_E2E_SOCKET,
+            requestTimeoutMs: 5_000,
+          });
+          const response = await client.sendFinal(
+            inbound.accountIdHex,
+            inbound.groupIdHex,
+            process.env.MARMOT_E2E_REPLY,
+            inbound.messageIdHex,
+            key,
+          );
+          console.log(JSON.stringify({ key, messageIdsHex: response.message_ids_hex }));
+        `;
+
+        const runChild = <T>(script: string) =>
+          new Promise<T>((resolve, reject) => {
+            const child = spawn(
+              process.execPath,
+              ["--input-type=module", "-e", script],
+              { env: childEnv, stdio: ["ignore", "pipe", "pipe"] },
+            );
+            let stdout = "";
+            let stderr = "";
+            child.stdout.on("data", (chunk) => {
+              stdout += String(chunk);
+            });
+            child.stderr.on("data", (chunk) => {
+              stderr += String(chunk);
+            });
+            child.on("error", reject);
+            child.on("close", (code) => {
+              if (code !== 0) {
+                reject(new Error(`child exited ${code}: ${stderr}`));
+                return;
+              }
+              try {
+                resolve(JSON.parse(stdout.trim()) as T);
+              } catch (error) {
+                reject(new Error(`child output parse failed: ${stdout}\n${stderr}\n${error}`));
+              }
+            });
+          });
+
+        const matchesReply = (send: DebugRecordedFinalSend) =>
+          send.text === replyText &&
+          send.group_id_hex === GROUP_ID_HEX &&
+          send.reply_to_message_id_hex === MESSAGE_ID_HEX;
+
+        const { key: committedKey } = await runChild<{ key: string }>(commitChildScript);
+        const committed = await waitFor(
+          async () => {
+            const finals = await recordedFinals(client);
+            const matching = finals.sends.filter(matchesReply);
+            const committedSend = matching[0];
+            if (matching.length === 1 && committedSend && committedSend.message_ids_hex.length > 0) {
+              return committedSend;
+            }
+            return null;
+          },
+          { label: "post-commit debug_recorded_finals", timeoutMs: 10_000 },
+        );
+        const committedMessageIdsHex = committed.message_ids_hex;
+
+        const replay = await runChild<{ key: string; messageIdsHex: string[] }>(replayChildScript);
+        expect(replay.key).toBe(committedKey);
+        expect(replay.messageIdsHex).toEqual(committedMessageIdsHex);
+
+        const finals = await recordedFinals(client);
+        expect(finals.sends.filter(matchesReply)).toHaveLength(1);
+        expect(finals.sends.filter(matchesReply)[0]?.message_ids_hex).toEqual(committedMessageIdsHex);
+      } finally {
+        await stopProcess(proc);
+        await rm(tempRoot, { recursive: true, force: true });
+      }
+    },
+    120_000,
+  );
 });

--- a/integrations/openclaw/marmot/test/e2e-connector.test.ts
+++ b/integrations/openclaw/marmot/test/e2e-connector.test.ts
@@ -123,17 +123,24 @@ async function startWnAgent(tempRoot: string): Promise<{
       stdio: ["ignore", "pipe", "pipe"],
     },
   );
+  proc.stdout?.resume();
+  proc.stderr?.resume();
   const client = new MarmotAgentControlClient({
     socketPath,
     requestTimeoutMs: 5_000,
   });
-  await waitFor(
-    async () => {
-      await recordedFinals(client);
-      return true;
-    },
-    { timeoutMs: 120_000, label: "wn-agent debug control socket" },
-  );
+  try {
+    await waitFor(
+      async () => {
+        await recordedFinals(client);
+        return true;
+      },
+      { timeoutMs: 120_000, label: "wn-agent debug control socket" },
+    );
+  } catch (error) {
+    await stopProcess(proc);
+    throw error;
+  }
   return { client, proc, socketPath };
 }
 

--- a/integrations/openclaw/marmot/test/gateway.test.ts
+++ b/integrations/openclaw/marmot/test/gateway.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-runtime";
+
+import type { ResolvedMarmotAccount } from "../src/config.js";
+import { startMarmotGatewayAccount } from "../src/gateway.js";
+import {
+  resetMarmotInboundAccountsForTests,
+  type InboundPluginApi,
+} from "../src/inbound-runtime.js";
+import { resetMarmotInboundRuntimeForTests } from "../src/runtime-state.js";
+
+const syncCalls: { channelAccountId?: string | null }[] = [];
+const lifecycleCalls: {
+  start?: () => Promise<() => void>;
+  stop?: (stopInbound?: () => void) => Promise<void>;
+  onStop?: () => void;
+}[] = [];
+const statusPatches: Array<Record<string, unknown>> = [];
+
+vi.mock("openclaw/plugin-sdk/channel-lifecycle", () => ({
+  createAccountStatusSink: ({ setStatus }: { setStatus: (next: unknown) => void }) => {
+    return (patch: Record<string, unknown>) => {
+      statusPatches.push(patch);
+      setStatus(patch);
+    };
+  },
+  runPassiveAccountLifecycle: async (opts: {
+    start: () => Promise<() => void>;
+    stop: (stopInbound?: () => void) => Promise<void>;
+    onStop: () => void;
+  }) => {
+    lifecycleCalls.push(opts);
+    const stopInbound = await opts.start();
+    await opts.stop(stopInbound);
+    opts.onStop();
+  },
+}));
+
+vi.mock("../src/inbound-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/inbound-runtime.js")>();
+  return {
+    ...actual,
+    syncMarmotAllowlist: vi.fn(async (_api: InboundPluginApi, options = {}) => {
+      syncCalls.push(options);
+    }),
+    startMarmotInbound: vi.fn(() => () => {}),
+  };
+});
+
+function baseAccount(overrides: Partial<ResolvedMarmotAccount> = {}): ResolvedMarmotAccount {
+  return {
+    accountId: "default",
+    socketPath: "/tmp/marmot.sock",
+    streamMode: "off",
+    blockStreaming: false,
+    quicCandidates: [],
+    groupActivation: "always",
+    mentionPatterns: [],
+    allowFrom: [],
+    profileNameOnboarding: false,
+    profileOnboardingStatePath: "/tmp/onboarding.json",
+    debounceMs: 0,
+    dmPolicy: "allowlist",
+    ...overrides,
+  };
+}
+
+function gatewayCtx(
+  account: ResolvedMarmotAccount,
+  accountId = account.accountId ?? "default",
+): ChannelGatewayContext<ResolvedMarmotAccount> {
+  return {
+    cfg: { channels: { marmot: { accounts: { [accountId]: { socketPath: account.socketPath } } } } },
+    accountId,
+    account,
+    runtime: {} as never,
+    abortSignal: AbortSignal.timeout(5_000),
+    getStatus: () => ({ accountId, running: false, connected: false }),
+    setStatus: () => {},
+    channelRuntime: {
+      routing: { resolveAgentRoute: () => ({ agentId: "main", accountId, sessionKey: "sk" }) },
+      runtimeContexts: {},
+    } as never,
+    log: { info: () => {}, warn: () => {}, error: () => {} },
+  };
+}
+
+afterEach(() => {
+  resetMarmotInboundRuntimeForTests();
+  resetMarmotInboundAccountsForTests();
+  syncCalls.length = 0;
+  lifecycleCalls.length = 0;
+  statusPatches.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("startMarmotGatewayAccount", () => {
+  it("awaits account-scoped allowlist sync before starting inbound", async () => {
+    const account = baseAccount({ allowFrom: ["aa".repeat(32)] });
+    await startMarmotGatewayAccount(gatewayCtx(account, "acct-a"));
+    expect(syncCalls).toEqual([{ channelAccountId: "acct-a" }]);
+    const inbound = await import("../src/inbound-runtime.js");
+    expect(inbound.startMarmotInbound).toHaveBeenCalled();
+  });
+
+  it("marks running then stopped across the passive lifecycle", async () => {
+    const account = baseAccount();
+    await startMarmotGatewayAccount(gatewayCtx(account));
+    expect(statusPatches.some((patch) => patch.running === true)).toBe(true);
+    expect(statusPatches.at(-1)).toMatchObject({ running: false, connected: false });
+    expect(lifecycleCalls).toHaveLength(1);
+  });
+
+  it("isolates two account starts without sharing lifecycle state", async () => {
+    const accountA = baseAccount({ accountId: "acct-a", socketPath: "/tmp/a.sock" });
+    const accountB = baseAccount({ accountId: "acct-b", socketPath: "/tmp/b.sock" });
+    await startMarmotGatewayAccount(gatewayCtx(accountA, "acct-a"));
+    const firstLifecycleCount = lifecycleCalls.length;
+    await startMarmotGatewayAccount(gatewayCtx(accountB, "acct-b"));
+    expect(syncCalls).toEqual([
+      { channelAccountId: "acct-a" },
+      { channelAccountId: "acct-b" },
+    ]);
+    expect(lifecycleCalls.length).toBe(firstLifecycleCount + 1);
+  });
+});

--- a/integrations/openclaw/marmot/test/inbound-event-context.test.ts
+++ b/integrations/openclaw/marmot/test/inbound-event-context.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+
+import { createMarmotMessagingAdapter } from "../src/messaging.js";
+import { createMarmotMessageAdapter } from "../src/outbound.js";
+import type { MarmotAgentControlClient } from "../src/client.js";
+
+const CHANNEL_ACCOUNT_ID = "default";
+const GROUP_ID_HEX = "cc".repeat(32);
+const MESSAGE_ID_HEX = "dd".repeat(32);
+const SENDER_ACCOUNT_ID_HEX = "bb".repeat(32);
+
+describe("buildChannelInboundEventContext (pinned SDK)", () => {
+  it("binds the Marmot group as the current messaging target and preserves account id", async () => {
+    const ctx = buildChannelInboundEventContext({
+      channel: "marmot",
+      accountId: CHANNEL_ACCOUNT_ID,
+      messageId: MESSAGE_ID_HEX,
+      from: SENDER_ACCOUNT_ID_HEX,
+      sender: { id: SENDER_ACCOUNT_ID_HEX },
+      conversation: { kind: "group", id: GROUP_ID_HEX },
+      route: {
+        agentId: "main",
+        accountId: CHANNEL_ACCOUNT_ID,
+        routeSessionKey: `agent:main:marmot:group:${GROUP_ID_HEX}`,
+      },
+      reply: { to: GROUP_ID_HEX },
+      message: { rawBody: "hello", bodyForAgent: "hello" },
+    });
+
+    expect(ctx.AccountId).toBe(CHANNEL_ACCOUNT_ID);
+    expect(ctx.To).toBe(GROUP_ID_HEX);
+    expect(ctx.ChatType).toBe("group");
+  });
+});
+
+describe("messaging adapter target normalization (adapter boundary)", () => {
+  // The pinned OpenClaw SDK does not expose a stable public runner seam for
+  // omitted-target message-tool sends. This test covers the Marmot messaging +
+  // outbound adapters directly; turn-scoped delivery ownership is validated in
+  // test/turn-coordination.test.ts.
+  it("normalizes a bare group id through the messaging adapter for outbound send_final", async () => {
+    const messaging = createMarmotMessagingAdapter();
+    const resolved = await messaging.targetResolver!.resolveTarget!({
+      cfg: {} as never,
+      input: GROUP_ID_HEX,
+      normalized: GROUP_ID_HEX,
+    });
+    expect(resolved).toEqual({ to: GROUP_ID_HEX, kind: "group", source: "normalized" });
+
+    const sendCalls: { groupIdHex: string; text: string }[] = [];
+    const client = {
+      async sendFinal(_accountIdHex: string, groupIdHex: string, text: string) {
+        sendCalls.push({ groupIdHex, text });
+        return { type: "final_sent", message_ids_hex: ["ee".repeat(32)] };
+      },
+    } as unknown as MarmotAgentControlClient;
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: async () => ({ client, marmotAccountIdHex: "aa".repeat(32) }),
+    });
+    await adapter.send!.text!({
+      cfg: {},
+      accountId: CHANNEL_ACCOUNT_ID,
+      to: resolved!.to,
+      text: "tool-send",
+    } as never);
+
+    expect(sendCalls).toEqual([{ groupIdHex: GROUP_ID_HEX, text: "tool-send" }]);
+  });
+});

--- a/integrations/openclaw/marmot/test/inbound-runtime.test.ts
+++ b/integrations/openclaw/marmot/test/inbound-runtime.test.ts
@@ -5,7 +5,11 @@ import type {
   AgentControlMediaRef,
   MarmotAgentControlClient,
 } from "../src/client.js";
-import { MarmotDispatchNotReadyError } from "../src/dispatch-errors.js";
+import {
+  MarmotDispatchAmbiguousDeliveryError,
+  MarmotDispatchDeliveryFailedError,
+  MarmotDispatchNotReadyError,
+} from "../src/dispatch-errors.js";
 import {
   startMarmotInbound,
   syncMarmotAllowlist,
@@ -673,6 +677,49 @@ describe("startMarmotInbound readiness redelivery", () => {
     await waitFor(() => dispatched.length === 1);
     stopSecond();
     expect(dispatched).toEqual([secondId]);
+  });
+
+  it.each([
+    ["ambiguous delivery", () => new MarmotDispatchAmbiguousDeliveryError()],
+    ["terminal delivery failure", () => new MarmotDispatchDeliveryFailedError()],
+  ])("rolls back every coalesced id after %s so reconnect can replay", async (_label, failure) => {
+    const firstId = HEX32("c1");
+    const secondId = HEX32("c2");
+    const firstEvent = inboundEvent("cc", "c1");
+    firstEvent.message_id_hex = firstId;
+    firstEvent.text = "part one";
+    const secondEvent = inboundEvent("cc", "c2");
+    secondEvent.message_id_hex = secondId;
+    secondEvent.text = "part two";
+    const warnings: string[] = [];
+    const api: InboundPluginApi = {
+      config: { channels: { marmot: { debounceMs: 10, profileNameOnboarding: false } } },
+      logger: { info: () => {}, warn: (message) => warnings.push(message) },
+    };
+
+    const stopFirst = startMarmotInbound(
+      api,
+      async () => {
+        throw failure();
+      },
+      { clientFactory: () => inboundStubClient([firstEvent, secondEvent]) },
+    );
+    await waitFor(() => warnings.some((message) => message.includes("dispatch task failed")));
+    stopFirst();
+
+    const replayed: MarmotInboundMessage[] = [];
+    const stopSecond = startMarmotInbound(
+      api,
+      (message) => {
+        replayed.push(message);
+      },
+      { clientFactory: () => inboundStubClient([firstEvent, secondEvent]) },
+    );
+    await waitFor(() => replayed.length === 1);
+    stopSecond();
+
+    expect(replayed[0]?.messageIdHex).toBe(secondId);
+    expect(replayed[0]?.coalescedMessageIdsHex).toEqual([firstId, secondId]);
   });
 
   it("stops readiness retries on abort and rolls back dedupe without dispatching again", async () => {

--- a/integrations/openclaw/marmot/test/inbound-runtime.test.ts
+++ b/integrations/openclaw/marmot/test/inbound-runtime.test.ts
@@ -674,6 +674,56 @@ describe("startMarmotInbound readiness redelivery", () => {
     stopSecond();
     expect(dispatched).toEqual([secondId]);
   });
+
+  it("stops readiness retries on abort and rolls back dedupe without dispatching again", async () => {
+    const messageId = HEX32("f5");
+    const event = inboundEvent("cc", "f5");
+    event.message_id_hex = messageId;
+    let attempts = 0;
+    const controller = new AbortController();
+    let releaseAttempt: (() => void) | undefined;
+    const attemptGate = new Promise<void>((resolve) => {
+      releaseAttempt = resolve;
+    });
+    let notifyAttemptStarted: (() => void) | undefined;
+    const attemptStarted = new Promise<void>((resolve) => {
+      notifyAttemptStarted = resolve;
+    });
+    const api: InboundPluginApi = {
+      config: { channels: { marmot: { profileNameOnboarding: false } } },
+      logger: noopLogger,
+    };
+
+    const stop = startMarmotInbound(
+      api,
+      async () => {
+        attempts += 1;
+        notifyAttemptStarted?.();
+        await attemptGate;
+        throw new MarmotDispatchNotReadyError("timeout");
+      },
+      { clientFactory: () => inboundStubClient([event]), signal: controller.signal },
+    );
+    await attemptStarted;
+    controller.abort();
+    releaseAttempt?.();
+    await new Promise((resolve) => setImmediate(resolve));
+    stop();
+
+    expect(attempts).toBe(1);
+
+    let replayAttempts = 0;
+    const stopReplay = startMarmotInbound(
+      api,
+      async (message) => {
+        replayAttempts += 1;
+        expect(message.messageIdHex).toBe(messageId);
+      },
+      { clientFactory: () => inboundStubClient([event]) },
+    );
+    await waitFor(() => replayAttempts === 1);
+    stopReplay();
+  });
 });
 
 describe("startMarmotInbound queue shedding", () => {

--- a/integrations/openclaw/marmot/test/inbound-runtime.test.ts
+++ b/integrations/openclaw/marmot/test/inbound-runtime.test.ts
@@ -5,9 +5,11 @@ import type {
   AgentControlMediaRef,
   MarmotAgentControlClient,
 } from "../src/client.js";
+import { MarmotDispatchNotReadyError } from "../src/dispatch-errors.js";
 import {
   startMarmotInbound,
   syncMarmotAllowlist,
+  resetMarmotInboundAccountsForTests,
   type InboundPluginApi,
 } from "../src/inbound-runtime.js";
 import type { MarmotInboundMessage } from "../src/inbound.js";
@@ -78,9 +80,33 @@ async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void
 
 afterEach(() => {
   resetMarmotInboundRuntimeForTests();
+  resetMarmotInboundAccountsForTests();
 });
 
 describe("startMarmotInbound", () => {
+  it("does not poison the account guard when control-client construction fails", async () => {
+    const logs: string[] = [];
+    const api: InboundPluginApi = {
+      config: { channels: { marmot: { profileNameOnboarding: false } } },
+      logger: { info: (message) => logs.push(message), warn: (message) => logs.push(message) },
+    };
+
+    expect(() =>
+      startMarmotInbound(api, () => {}, {
+        clientFactory: () => {
+          throw new Error("client construction failed");
+        },
+      }),
+    ).toThrow("client construction failed");
+
+    const stop = startMarmotInbound(api, () => {}, {
+      clientFactory: () => inboundStubClient([]),
+    });
+    await waitFor(() => logs.some((message) => message.includes("subscription established")));
+    stop();
+    expect(logs).not.toContain("marmot: inbound subscription already active; ignoring duplicate start");
+  });
+
   it("resolves the agent account and dispatches mapped inbound messages", async () => {
     const dispatched: MarmotInboundMessage[] = [];
     let resolveFirst: () => void = () => {};
@@ -459,5 +485,281 @@ describe("syncMarmotAllowlist", () => {
       },
     });
     expect(used).toBe(false);
+  });
+
+  it("syncs the requested multi-account slice, not only default", async () => {
+    const synced: string[] = [];
+    const client = {
+      async accountList() {
+        return {
+          type: "account_list",
+          accounts: [{ account_id_hex: HEX32("aa"), label: "agent", local_signing: true }],
+        };
+      },
+      async allowlistList() {
+        return { type: "allowlist", account_id_hex: HEX32("aa"), welcomer_account_ids_hex: [] };
+      },
+      async allowlistAdd(_account: string, id: string) {
+        synced.push(id);
+        return { type: "ack" };
+      },
+      async allowlistRemove() {
+        return { type: "ack" };
+      },
+    } as unknown as MarmotAgentControlClient;
+    const api: InboundPluginApi = {
+      config: {
+        channels: {
+          marmot: {
+            accounts: {
+              alice: { socketPath: "/a.sock", dm: { allowFrom: [HEX32("11")] } },
+              bob: { socketPath: "/b.sock", dm: { allowFrom: [HEX32("22")] } },
+            },
+          },
+        },
+      },
+      logger: noopLogger,
+    };
+    await syncMarmotAllowlist(api, { clientFactory: () => client, channelAccountId: "bob" });
+    expect(synced).toEqual([HEX32("22")]);
+  });
+});
+
+describe("startMarmotInbound readiness redelivery", () => {
+  it("retries readiness timeout inside the per-group queue and dispatches one turn", async () => {
+    const messageId = HEX32("f2");
+    const event = inboundEvent("cc", "f2");
+    event.message_id_hex = messageId;
+    let attempts = 0;
+    const dispatched: string[] = [];
+    const api: InboundPluginApi = {
+      config: { channels: { marmot: { profileNameOnboarding: false } } },
+      logger: noopLogger,
+    };
+
+    const stop = startMarmotInbound(
+      api,
+      async (message) => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new MarmotDispatchNotReadyError("timeout");
+        }
+        dispatched.push(message.messageIdHex);
+      },
+      { clientFactory: () => inboundStubClient([event]) },
+    );
+    await waitFor(() => dispatched.length === 1);
+    stop();
+    expect(dispatched).toEqual([messageId]);
+    expect(attempts).toBe(3);
+  });
+
+  it("fails fast on non-retryable readiness without consuming retry slots", async () => {
+    const messageId = HEX32("f4");
+    const event = inboundEvent("cc", "f4");
+    event.message_id_hex = messageId;
+    let attempts = 0;
+    const api: InboundPluginApi = {
+      config: { channels: { marmot: { profileNameOnboarding: false } } },
+      logger: noopLogger,
+    };
+
+    const stop = startMarmotInbound(
+      api,
+      async () => {
+        attempts += 1;
+        throw new MarmotDispatchNotReadyError("non_retryable");
+      },
+      { clientFactory: () => inboundStubClient([event]) },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    stop();
+    expect(attempts).toBe(1);
+  });
+
+  it("clears dedupe on exhausted readiness so stop/start replay can dispatch once", async () => {
+    const messageId = HEX32("f3");
+    const event = inboundEvent("cc", "f3");
+    event.message_id_hex = messageId;
+    const dispatched: string[] = [];
+    const api: InboundPluginApi = {
+      config: { channels: { marmot: { profileNameOnboarding: false } } },
+      logger: noopLogger,
+    };
+
+    const stopFirst = startMarmotInbound(
+      api,
+      async () => {
+        throw new MarmotDispatchNotReadyError("non_retryable");
+      },
+      { clientFactory: () => inboundStubClient([event]) },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    stopFirst();
+
+    const stopSecond = startMarmotInbound(
+      api,
+      (message) => {
+        dispatched.push(message.messageIdHex);
+      },
+      { clientFactory: () => inboundStubClient([event]) },
+    );
+    await waitFor(() => dispatched.length === 1);
+    stopSecond();
+    expect(dispatched).toEqual([messageId]);
+  });
+
+  it("keeps successful inbound messages deduped after readiness exhaustion on another id", async () => {
+    const successId = HEX32("a1");
+    const failedId = HEX32("a2");
+    const successEvent = inboundEvent("cc", "a1");
+    successEvent.message_id_hex = successId;
+    const failedEvent = inboundEvent("cc", "a2");
+    failedEvent.message_id_hex = failedId;
+    const dispatched: string[] = [];
+    const api: InboundPluginApi = {
+      config: { channels: { marmot: { profileNameOnboarding: false } } },
+      logger: noopLogger,
+    };
+
+    const stop = startMarmotInbound(
+      api,
+      async (message) => {
+        dispatched.push(message.messageIdHex);
+        if (message.messageIdHex === failedId) {
+          throw new MarmotDispatchNotReadyError("non_retryable");
+        }
+      },
+      { clientFactory: () => inboundStubClient([successEvent, failedEvent, successEvent]) },
+    );
+    await waitFor(() => dispatched.includes(successId) && dispatched.includes(failedId));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    stop();
+    expect(dispatched.filter((id) => id === successId)).toEqual([successId]);
+  });
+
+  it("rolls back dedupe for every coalesced debounced id after readiness exhaustion", async () => {
+    const firstId = HEX32("b1");
+    const secondId = HEX32("b2");
+    const firstEvent = inboundEvent("cc", "b1");
+    firstEvent.message_id_hex = firstId;
+    firstEvent.text = "part one";
+    const secondEvent = inboundEvent("cc", "b2");
+    secondEvent.message_id_hex = secondId;
+    secondEvent.text = "part two";
+    const dispatched: string[] = [];
+    const api: InboundPluginApi = {
+      config: { channels: { marmot: { debounceMs: 10, profileNameOnboarding: false } } },
+      logger: noopLogger,
+    };
+
+    const stopFirst = startMarmotInbound(
+      api,
+      async () => {
+        throw new MarmotDispatchNotReadyError("non_retryable");
+      },
+      { clientFactory: () => inboundStubClient([firstEvent, secondEvent]) },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    stopFirst();
+
+    const stopSecond = startMarmotInbound(
+      api,
+      (message) => {
+        dispatched.push(message.messageIdHex);
+      },
+      { clientFactory: () => inboundStubClient([firstEvent, secondEvent]) },
+    );
+    await waitFor(() => dispatched.length === 1);
+    stopSecond();
+    expect(dispatched).toEqual([secondId]);
+  });
+});
+
+describe("startMarmotInbound queue shedding", () => {
+  it("rolls back dedupe when enqueue rejects due to per-group depth", async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const groupId = HEX32("cc");
+    const msg1 = inboundEvent("cc", "01");
+    const msg2 = inboundEvent("cc", "02");
+    const msg3 = inboundEvent("cc", "03");
+    msg1.group_id_hex = groupId;
+    msg2.group_id_hex = groupId;
+    msg3.group_id_hex = groupId;
+    const dispatched: string[] = [];
+    const api: InboundPluginApi = {
+      config: { channels: { marmot: { profileNameOnboarding: false } } },
+      logger: noopLogger,
+    };
+
+    const stopFirst = startMarmotInbound(
+      api,
+      async (message) => {
+        dispatched.push(message.messageIdHex);
+        if (message.messageIdHex === msg1.message_id_hex) {
+          await firstGate;
+        }
+      },
+      {
+        clientFactory: () => inboundStubClient([msg1, msg2, msg3]),
+        inboundQueueMaxDepth: 2,
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    releaseFirst?.();
+    await waitFor(() => dispatched.length === 2);
+    stopFirst();
+
+    const stopSecond = startMarmotInbound(
+      api,
+      (message) => {
+        dispatched.push(message.messageIdHex);
+      },
+      { clientFactory: () => inboundStubClient([msg3]) },
+    );
+    await waitFor(() => dispatched.filter((id) => id === msg3.message_id_hex).length === 1);
+    stopSecond();
+
+    expect(dispatched.filter((id) => id === msg3.message_id_hex)).toEqual([msg3.message_id_hex]);
+  });
+});
+
+describe("startMarmotInbound subscription restart dedupe", () => {
+  it("does not dispatch the same inbound message id twice after stop/start in one process", async () => {
+    const messageId = HEX32("f1");
+    const event = inboundEvent("cc", "f1");
+    event.message_id_hex = messageId;
+    let generation = 0;
+    const dispatched: string[] = [];
+    const api: InboundPluginApi = {
+      config: { channels: { marmot: { profileNameOnboarding: false } } },
+      logger: noopLogger,
+    };
+    const stopFirst = startMarmotInbound(
+      api,
+      (message) => {
+        dispatched.push(message.messageIdHex);
+      },
+      {
+        clientFactory: () => {
+          generation += 1;
+          return inboundStubClient(generation === 1 ? [event] : [event]);
+        },
+      },
+    );
+    await waitFor(() => dispatched.length === 1);
+    stopFirst();
+    const stopSecond = startMarmotInbound(api, (message) => {
+      dispatched.push(message.messageIdHex);
+    }, {
+      clientFactory: () => inboundStubClient([event]),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    stopSecond();
+    expect(dispatched).toEqual([messageId]);
   });
 });

--- a/integrations/openclaw/marmot/test/messaging.test.ts
+++ b/integrations/openclaw/marmot/test/messaging.test.ts
@@ -13,17 +13,18 @@ const GID16 = "a".repeat(32);
 const GID32 = "b".repeat(64);
 
 describe("isMarmotGroupIdHex", () => {
-  it("accepts 16-byte and 32-byte lowercase hex", () => {
+  it("accepts any non-empty even-length lowercase hex", () => {
     expect(isMarmotGroupIdHex(GID16)).toBe(true);
     expect(isMarmotGroupIdHex(GID32)).toBe(true);
+    expect(isMarmotGroupIdHex("ab")).toBe(true);
+    expect(isMarmotGroupIdHex("abcd")).toBe(true);
   });
 
-  it("rejects too-short, odd-length, non-hex, and uppercase input", () => {
-    expect(isMarmotGroupIdHex("ab")).toBe(false); // too short
+  it("rejects empty, odd-length, non-hex, and uppercase input", () => {
+    expect(isMarmotGroupIdHex("")).toBe(false);
     expect(isMarmotGroupIdHex("a".repeat(31))).toBe(false); // odd length
     expect(isMarmotGroupIdHex(`zz${"a".repeat(30)}`)).toBe(false); // non-hex
     expect(isMarmotGroupIdHex("A".repeat(32))).toBe(false); // not normalized
-    expect(isMarmotGroupIdHex("a".repeat(130))).toBe(false); // beyond the band
   });
 });
 
@@ -36,6 +37,7 @@ describe("normalizeMarmotTarget", () => {
     expect(normalizeMarmotTarget(`  ${MARMOT_TARGET_PREFIX}:${GID16}  `)).toBe(GID16);
     expect(normalizeMarmotTarget(`0x${GID16}`)).toBe(GID16);
     expect(normalizeMarmotTarget(`MARMOT:0X${"A".repeat(32)}`)).toBe(GID16);
+    expect(normalizeMarmotTarget(`group:${GID16}`)).toBe(GID16);
   });
 
   it("returns undefined for non-group-id input", () => {

--- a/integrations/openclaw/marmot/test/messaging.test.ts
+++ b/integrations/openclaw/marmot/test/messaging.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { createMarmotChannelPlugin } from "../src/channel.js";
 import {
   createMarmotMessagingAdapter,
   isMarmotGroupIdHex,
@@ -7,6 +8,33 @@ import {
   MARMOT_TARGET_PREFIX,
   normalizeMarmotTarget,
 } from "../src/messaging.js";
+import { MarmotTargetError } from "../src/target.js";
+
+async function resolveThroughOpenClawTargetResolver(input: string): Promise<unknown> {
+  const plugin = createMarmotChannelPlugin();
+  const resolverUrl = new URL(
+    "../node_modules/openclaw/dist/target-resolver-BWTwFOHy.js",
+    import.meta.url,
+  ).href;
+  const resolver = (await import(/* @vite-ignore */ resolverUrl)) as {
+    i: (params: {
+      cfg: Record<string, never>;
+      channel: string;
+      input: string;
+      plugin: ReturnType<typeof createMarmotChannelPlugin>;
+    }) => Promise<{ ok: boolean; error?: unknown; target?: unknown }>;
+  };
+  const resolved = await resolver.i({
+    cfg: {},
+    channel: "marmot",
+    input,
+    plugin,
+  });
+  if (!resolved.ok) {
+    throw resolved.error;
+  }
+  return resolved.target;
+}
 
 // 16-byte (OpenMLS default) and 32-byte group ids, lowercase hex.
 const GID16 = "a".repeat(32);
@@ -61,6 +89,11 @@ describe("looksLikeMarmotTarget", () => {
     expect(looksLikeMarmotTarget("alice")).toBe(false);
     expect(looksLikeMarmotTarget("#general")).toBe(false);
   });
+
+  it("claims session keys and decorated group routes so Marmot can reject them locally", () => {
+    expect(looksLikeMarmotTarget(`agent:main:${MARMOT_TARGET_PREFIX}:group:${GID16}`)).toBe(true);
+    expect(looksLikeMarmotTarget(`group:zz${"a".repeat(30)}`)).toBe(true);
+  });
 });
 
 describe("createMarmotMessagingAdapter", () => {
@@ -91,10 +124,50 @@ describe("createMarmotMessagingAdapter", () => {
     ).resolves.toEqual({ to: GID16, kind: "group", source: "normalized" });
   });
 
-  it("returns null from resolveTarget for a non-group-id target", async () => {
+  it("throws MarmotTargetError from resolveTarget for a non-group-id target", async () => {
     const resolveTarget = adapter.targetResolver?.resolveTarget;
     await expect(
       resolveTarget!({ cfg: {} as never, input: "alice", normalized: "alice" }),
-    ).resolves.toBeNull();
+    ).rejects.toBeInstanceOf(MarmotTargetError);
+  });
+
+  it("rejects session keys through OpenClaw target resolution without leaking the raw target", async () => {
+    const sensitive = `agent:main:${MARMOT_TARGET_PREFIX}:group:${GID16}`;
+    await expect(resolveThroughOpenClawTargetResolver(sensitive)).rejects.toMatchObject({
+      name: "MarmotTargetError",
+      category: "session_key",
+    });
+    try {
+      await resolveThroughOpenClawTargetResolver(sensitive);
+    } catch (error) {
+      expect((error as Error).message).not.toContain(sensitive);
+      expect((error as Error).message).not.toContain(GID16);
+    }
+  });
+
+  it("rejects malformed group routes through OpenClaw target resolution without leaking the raw target", async () => {
+    const sensitive = `group:zz${"a".repeat(30)}`;
+    await expect(resolveThroughOpenClawTargetResolver(sensitive)).rejects.toBeInstanceOf(
+      MarmotTargetError,
+    );
+    try {
+      await resolveThroughOpenClawTargetResolver(sensitive);
+    } catch (error) {
+      expect((error as Error).message).not.toContain(sensitive);
+    }
+  });
+
+  it("rejects cross-channel targets through OpenClaw target resolution without leaking the raw target", async () => {
+    const sensitive = `telegram:${GID16}`;
+    await expect(resolveThroughOpenClawTargetResolver(sensitive)).rejects.toMatchObject({
+      name: "MarmotTargetError",
+      category: "cross_channel",
+    });
+    try {
+      await resolveThroughOpenClawTargetResolver(sensitive);
+    } catch (error) {
+      expect((error as Error).message).not.toContain(sensitive);
+      expect((error as Error).message).not.toContain(GID16);
+    }
   });
 });

--- a/integrations/openclaw/marmot/test/messaging.test.ts
+++ b/integrations/openclaw/marmot/test/messaging.test.ts
@@ -71,6 +71,7 @@ describe("normalizeMarmotTarget", () => {
   it("returns undefined for non-group-id input", () => {
     expect(normalizeMarmotTarget("alice")).toBeUndefined();
     expect(normalizeMarmotTarget("@alice")).toBeUndefined();
+    expect(normalizeMarmotTarget("1234567890")).toBeUndefined();
     expect(normalizeMarmotTarget("")).toBeUndefined();
     expect(normalizeMarmotTarget(`${MARMOT_TARGET_PREFIX}:not-hex`)).toBeUndefined();
   });
@@ -85,9 +86,10 @@ describe("looksLikeMarmotTarget", () => {
     expect(looksLikeMarmotTarget(`${MARMOT_TARGET_PREFIX}:whatever`)).toBe(true);
   });
 
-  it("is false for unprefixed non-id input", () => {
+  it("is false for unprefixed non-id input and implausible bare numeric strings", () => {
     expect(looksLikeMarmotTarget("alice")).toBe(false);
     expect(looksLikeMarmotTarget("#general")).toBe(false);
+    expect(looksLikeMarmotTarget("1234567890")).toBe(false);
   });
 
   it("claims session keys and decorated group routes so Marmot can reject them locally", () => {
@@ -154,6 +156,16 @@ describe("createMarmotMessagingAdapter", () => {
       await resolveThroughOpenClawTargetResolver(sensitive);
     } catch (error) {
       expect((error as Error).message).not.toContain(sensitive);
+    }
+  });
+
+  it("does not claim short bare numeric strings through OpenClaw target resolution", async () => {
+    expect(looksLikeMarmotTarget("1234567890")).toBe(false);
+    await expect(resolveThroughOpenClawTargetResolver("1234567890")).rejects.toThrow();
+    try {
+      await resolveThroughOpenClawTargetResolver("1234567890");
+    } catch (error) {
+      expect((error as Error).message).not.toContain("1234567890");
     }
   });
 

--- a/integrations/openclaw/marmot/test/outbound.test.ts
+++ b/integrations/openclaw/marmot/test/outbound.test.ts
@@ -592,6 +592,23 @@ describe("createMarmotMessageAdapter", () => {
     expect(resolvedTargets).toBe(0);
   });
 
+  it("trims whitespace-only accountId to null outside a turn", async () => {
+    const resolveCalls: { accountId?: string | null }[] = [];
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: (_cfg, accountId) => {
+        resolveCalls.push({ accountId });
+        return { client: stubClient(emptyClientCalls()), marmotAccountIdHex: HEX32("aa") };
+      },
+    });
+    await adapter.send!.text!({
+      cfg: {},
+      accountId: "   ",
+      to: HEX32("cc"),
+      text: "hello",
+    } as ChannelMessageSendTextContext);
+    expect(resolveCalls).toEqual([{ accountId: null }]);
+  });
+
   it("inherits group, account, reply-to, and idempotency during a Marmot turn", async () => {
     const calls = emptyClientCalls();
     const route: MarmotTurnRoute = {

--- a/integrations/openclaw/marmot/test/outbound.test.ts
+++ b/integrations/openclaw/marmot/test/outbound.test.ts
@@ -8,15 +8,13 @@ import type {
   ChannelMessageSendTextContext,
 } from "openclaw/plugin-sdk/channel-outbound";
 
-import type {
-  AgentControlMediaUpload,
-  MarmotAgentControlClient,
-} from "../src/client.js";
+import { AgentControlError, type AgentControlMediaUpload, type MarmotAgentControlClient } from "../src/client.js";
 import {
   createMarmotMessageAdapter,
   receiptFromMessageIds,
   SentMessageTargetCache,
 } from "../src/outbound.js";
+import { runInMarmotTurn, type MarmotTurnRoute } from "../src/turn-delivery.js";
 
 const HEX32 = (b: string) => b.repeat(32);
 
@@ -25,6 +23,11 @@ interface SendFinalCall {
   groupIdHex: string;
   text: string;
   replyToMessageIdHex?: string | null;
+  idempotencyKey?: string;
+}
+
+interface SendFinalKeyCall extends SendFinalCall {
+  idempotencyKey?: string;
 }
 
 interface SendMediaCall {
@@ -51,15 +54,43 @@ function emptyClientCalls(): ClientCalls {
 }
 
 /** Minimal stub of the control client capturing send_final / send_media / delete. */
-function stubClient(calls: ClientCalls, messageIdsHex: string[] = [HEX32("ab")]): MarmotAgentControlClient {
+function stubClient(
+  calls: ClientCalls,
+  messageIdsHex: string[] = [HEX32("ab")],
+  opts: {
+    sendFinalImpl?: (
+      accountIdHex: string,
+      groupIdHex: string,
+      text: string,
+      replyToMessageIdHex?: string | null,
+      idempotencyKey?: string,
+    ) => Promise<{ type: string; message_ids_hex: string[] }>;
+  } = {},
+): MarmotAgentControlClient {
   return {
     async sendFinal(
       accountIdHex: string,
       groupIdHex: string,
       text: string,
       replyToMessageIdHex?: string | null,
+      idempotencyKey?: string,
     ) {
-      calls.sendFinal.push({ accountIdHex, groupIdHex, text, replyToMessageIdHex });
+      calls.sendFinal.push({
+        accountIdHex,
+        groupIdHex,
+        text,
+        replyToMessageIdHex,
+        idempotencyKey,
+      });
+      if (opts.sendFinalImpl) {
+        return opts.sendFinalImpl(
+          accountIdHex,
+          groupIdHex,
+          text,
+          replyToMessageIdHex,
+          idempotencyKey,
+        );
+      }
       return { type: "final_sent", message_ids_hex: messageIdsHex };
     },
     async sendMedia(
@@ -418,6 +449,208 @@ describe("createMarmotMessageAdapter", () => {
     });
     expect(await adapter.deleteByMessageId(HEX32("77"), { cfg: {}, accountId: null })).toBe(false);
     expect(calls.delete).toHaveLength(0);
+  });
+
+  it("rejects invalid outbound targets before calling wn-agent", async () => {
+    const calls = emptyClientCalls();
+    let resolvedTargets = 0;
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: () => {
+        resolvedTargets += 1;
+        return {
+          client: stubClient(calls),
+          marmotAccountIdHex: HEX32("aa"),
+        };
+      },
+    });
+    await expect(
+      adapter.send!.text!({
+        cfg: {},
+        to: `agent:main:marmot:group:${HEX32("cc")}`,
+        text: "nope",
+      } as ChannelMessageSendTextContext),
+    ).rejects.toThrow(/session key/);
+    expect(resolvedTargets).toBe(0);
+    expect(calls.sendFinal).toHaveLength(0);
+  });
+
+  it("rejects an invalid media target before reading or staging media", async () => {
+    const calls = emptyClientCalls();
+    let resolvedTargets = 0;
+    let mediaReads = 0;
+    let mediaWrites = 0;
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: () => {
+        resolvedTargets += 1;
+        return { client: stubClient(calls), marmotAccountIdHex: HEX32("aa") };
+      },
+      writeTempMedia: async () => {
+        mediaWrites += 1;
+        return "/tmp/unused";
+      },
+    });
+
+    await expect(
+      adapter.send!.media!({
+        cfg: {},
+        to: `agent:main:marmot:group:${HEX32("cc")}`,
+        text: "nope",
+        mediaUrl: "https://example.test/photo.jpg",
+        mediaReadFile: async () => {
+          mediaReads += 1;
+          return Buffer.from("bytes");
+        },
+      } as ChannelMessageSendMediaContext),
+    ).rejects.toThrow(/session key/);
+    expect(resolvedTargets).toBe(0);
+    expect(mediaReads).toBe(0);
+    expect(mediaWrites).toBe(0);
+    expect(calls.sendMedia).toHaveLength(0);
+  });
+
+  it("canonicalizes internal group:<hex> before send_final", async () => {
+    const calls = emptyClientCalls();
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: () => ({
+        client: stubClient(calls),
+        marmotAccountIdHex: HEX32("aa"),
+      }),
+    });
+    await adapter.send!.text!({
+      cfg: {},
+      to: `group:${HEX32("cc")}`,
+      text: "hello",
+    } as ChannelMessageSendTextContext);
+    expect(calls.sendFinal[0]?.groupIdHex).toBe(HEX32("cc"));
+  });
+
+  it("retries a retryable message-tool send_final with one idempotency key", async () => {
+    const calls = emptyClientCalls();
+    let attempts = 0;
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: () => ({
+        client: stubClient(calls, [HEX32("ab")], {
+          sendFinalImpl: async () => {
+            attempts += 1;
+            if (attempts === 1) {
+              throw new AgentControlError("temporary", { retryable: true });
+            }
+            return { type: "final_sent", message_ids_hex: [HEX32("ab")] };
+          },
+        }),
+        marmotAccountIdHex: HEX32("aa"),
+      }),
+    });
+    await adapter.send!.text!({
+      cfg: {},
+      to: HEX32("cc"),
+      text: "retry-me",
+    } as ChannelMessageSendTextContext);
+    expect(attempts).toBe(2);
+    expect(calls.sendFinal).toHaveLength(2);
+    const keys = (calls.sendFinal as SendFinalKeyCall[]).map((call) => call.idempotencyKey);
+    expect(keys[0]).toBeTruthy();
+    expect(keys[1]).toBe(keys[0]);
+  });
+
+  it("does not retry a non-retryable message-tool send_final", async () => {
+    const calls = emptyClientCalls();
+    let attempts = 0;
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: () => ({
+        client: stubClient(calls, [HEX32("ab")], {
+          sendFinalImpl: async () => {
+            attempts += 1;
+            throw new AgentControlError("bad", { retryable: false });
+          },
+        }),
+        marmotAccountIdHex: HEX32("aa"),
+      }),
+    });
+    await expect(
+      adapter.send!.text!({
+        cfg: {},
+        to: HEX32("cc"),
+        text: "nope",
+      } as ChannelMessageSendTextContext),
+    ).rejects.toThrow("bad");
+    expect(attempts).toBe(1);
+    expect(calls.sendFinal).toHaveLength(1);
+  });
+
+  it("rejects omitted to outside a turn before resolveTarget", async () => {
+    let resolvedTargets = 0;
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: () => {
+        resolvedTargets += 1;
+        return { client: stubClient(emptyClientCalls()), marmotAccountIdHex: HEX32("aa") };
+      },
+    });
+    await expect(
+      adapter.send!.text!({ cfg: {}, text: "nope" } as ChannelMessageSendTextContext),
+    ).rejects.toThrow(/outbound target is required/);
+    expect(resolvedTargets).toBe(0);
+  });
+
+  it("inherits group, account, reply-to, and idempotency during a Marmot turn", async () => {
+    const calls = emptyClientCalls();
+    const route: MarmotTurnRoute = {
+      channelAccountId: "acct-a",
+      marmotAccountIdHex: HEX32("aa"),
+      groupIdHex: HEX32("cc"),
+      replyToMessageIdHex: HEX32("dd"),
+      idempotencyKey: "turn-key-inherit",
+    };
+    const resolveCalls: { accountId?: string | null }[] = [];
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: (_cfg, accountId) => {
+        resolveCalls.push({ accountId });
+        return { client: stubClient(calls), marmotAccountIdHex: HEX32("aa") };
+      },
+    });
+    await runInMarmotTurn(route, async () => {
+      await adapter.send!.text!({
+        cfg: {},
+        text: "inherited route",
+      } as ChannelMessageSendTextContext);
+    });
+    expect(resolveCalls).toEqual([{ accountId: "acct-a" }]);
+    expect(calls.sendFinal).toEqual([
+      {
+        accountIdHex: HEX32("aa"),
+        groupIdHex: HEX32("cc"),
+        text: "inherited route",
+        replyToMessageIdHex: HEX32("dd"),
+        idempotencyKey: "turn-key-inherit",
+      },
+    ]);
+  });
+
+  it("prefers explicit to and accountId over the bound turn route", async () => {
+    const calls = emptyClientCalls();
+    const route: MarmotTurnRoute = {
+      channelAccountId: "acct-a",
+      marmotAccountIdHex: HEX32("aa"),
+      groupIdHex: HEX32("cc"),
+      replyToMessageIdHex: HEX32("dd"),
+      idempotencyKey: "turn-key",
+    };
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: () => ({ client: stubClient(calls), marmotAccountIdHex: HEX32("aa") }),
+    });
+    await runInMarmotTurn(route, async () => {
+      await adapter.send!.text!({
+        cfg: {},
+        accountId: "acct-b",
+        to: HEX32("ff"),
+        text: "explicit target",
+        replyToId: HEX32("ee"),
+      } as ChannelMessageSendTextContext);
+    });
+    expect(calls.sendFinal[0]).toMatchObject({
+      groupIdHex: HEX32("ff"),
+      replyToMessageIdHex: HEX32("ee"),
+    });
   });
 });
 

--- a/integrations/openclaw/marmot/test/outbound.test.ts
+++ b/integrations/openclaw/marmot/test/outbound.test.ts
@@ -14,7 +14,11 @@ import {
   receiptFromMessageIds,
   SentMessageTargetCache,
 } from "../src/outbound.js";
-import { runInMarmotTurn, type MarmotTurnRoute } from "../src/turn-delivery.js";
+import {
+  MarmotTurnDurableOwnershipError,
+  runInMarmotTurn,
+  type MarmotTurnRoute,
+} from "../src/turn-delivery.js";
 
 const HEX32 = (b: string) => b.repeat(32);
 
@@ -641,6 +645,81 @@ describe("createMarmotMessageAdapter", () => {
         idempotencyKey: "turn-key-inherit",
       },
     ]);
+  });
+
+  it("rejects same-route turn media before reading or staging the file", async () => {
+    const calls = emptyClientCalls();
+    const route: MarmotTurnRoute = {
+      channelAccountId: "acct-a",
+      marmotAccountIdHex: HEX32("aa"),
+      groupIdHex: HEX32("cc"),
+      replyToMessageIdHex: HEX32("dd"),
+      idempotencyKey: "turn-key-media",
+    };
+    let mediaReads = 0;
+    let mediaWrites = 0;
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: () => ({
+        client: stubClient(calls),
+        marmotAccountIdHex: HEX32("aa"),
+      }),
+      writeTempMedia: async () => {
+        mediaWrites += 1;
+        return "/tmp/unused";
+      },
+    });
+
+    await runInMarmotTurn(route, async () => {
+      await expect(
+        adapter.send!.media!({
+          cfg: {},
+          accountId: "acct-a",
+          to: HEX32("cc"),
+          text: "same-route media",
+          mediaUrl: "https://example.test/photo.jpg",
+          mediaReadFile: async () => {
+            mediaReads += 1;
+            return Buffer.from("bytes");
+          },
+        } as ChannelMessageSendMediaContext),
+      ).rejects.toBeInstanceOf(MarmotTurnDurableOwnershipError);
+    });
+
+    expect(mediaReads).toBe(0);
+    expect(mediaWrites).toBe(0);
+    expect(calls.sendMedia).toHaveLength(0);
+  });
+
+  it("keeps explicit cross-route media available during a Marmot turn", async () => {
+    const calls = emptyClientCalls();
+    const route: MarmotTurnRoute = {
+      channelAccountId: "acct-a",
+      marmotAccountIdHex: HEX32("aa"),
+      groupIdHex: HEX32("cc"),
+      replyToMessageIdHex: HEX32("dd"),
+      idempotencyKey: "turn-key-cross-route-media",
+    };
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: () => ({
+        client: stubClient(calls),
+        marmotAccountIdHex: HEX32("aa"),
+      }),
+      writeTempMedia: async () => "/tmp/staged-photo.jpg",
+    });
+
+    await runInMarmotTurn(route, async () => {
+      await adapter.send!.media!({
+        cfg: {},
+        accountId: "acct-a",
+        to: HEX32("ff"),
+        text: "cross-route media",
+        mediaUrl: "https://example.test/photo.jpg",
+        mediaReadFile: async () => Buffer.from("bytes"),
+      } as ChannelMessageSendMediaContext);
+    });
+
+    expect(calls.sendMedia).toHaveLength(1);
+    expect(calls.sendMedia[0]?.groupIdHex).toBe(HEX32("ff"));
   });
 
   it("prefers explicit to and accountId over the bound turn route", async () => {

--- a/integrations/openclaw/marmot/test/readiness.test.ts
+++ b/integrations/openclaw/marmot/test/readiness.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AgentControlError } from "../src/client.js";
+import { waitForGroupReadiness } from "../src/readiness.js";
+
+const HEX = "a".repeat(32);
+
+function groupInfoStub() {
+  return {
+    type: "group_info" as const,
+    account_id_hex: HEX,
+    group_id_hex: HEX,
+    member_count: 2,
+    is_direct: true,
+    subject: null,
+  };
+}
+
+describe("waitForGroupReadiness", () => {
+  it("returns ready with group info on the first successful group_info", async () => {
+    const client = {
+      groupInfo: vi.fn(async () => groupInfoStub()),
+    };
+    await expect(
+      waitForGroupReadiness({
+        client,
+        accountIdHex: HEX,
+        groupIdHex: HEX,
+      }),
+    ).resolves.toEqual({ status: "ready", groupInfo: groupInfoStub() });
+    expect(client.groupInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries transient failures then succeeds once", async () => {
+    let calls = 0;
+    const client = {
+      groupInfo: vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new AgentControlError("temporary", { retryable: true });
+        }
+        return groupInfoStub();
+      }),
+    };
+    await expect(
+      waitForGroupReadiness({
+        client,
+        accountIdHex: HEX,
+        groupIdHex: HEX,
+        backoffMs: [1],
+        maxAttempts: 3,
+      }),
+    ).resolves.toMatchObject({ status: "ready" });
+    expect(client.groupInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops after bounded attempts", async () => {
+    const client = {
+      groupInfo: vi.fn(async () => {
+        throw new AgentControlError("temporary", { retryable: true });
+      }),
+    };
+    await expect(
+      waitForGroupReadiness({
+        client,
+        accountIdHex: HEX,
+        groupIdHex: HEX,
+        backoffMs: [1],
+        maxAttempts: 2,
+      }),
+    ).resolves.toEqual({ status: "not_ready", reason: "timeout" });
+    expect(client.groupInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops retrying after a retryable failure is followed by a non-retryable error", async () => {
+    let calls = 0;
+    const client = {
+      groupInfo: vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw new AgentControlError("temporary", { retryable: true });
+        }
+        throw new AgentControlError("permanent", { retryable: false });
+      }),
+    };
+    await expect(
+      waitForGroupReadiness({
+        client,
+        accountIdHex: HEX,
+        groupIdHex: HEX,
+        backoffMs: [1],
+        maxAttempts: 4,
+      }),
+    ).resolves.toEqual({ status: "not_ready", reason: "non_retryable" });
+    expect(client.groupInfo).toHaveBeenCalledTimes(2);
+  });
+});

--- a/integrations/openclaw/marmot/test/target.test.ts
+++ b/integrations/openclaw/marmot/test/target.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { MARMOT_TARGET_PREFIX } from "../src/target.js";
+import {
+  canonicalizeMarmotGroupTarget,
+  MarmotTargetError,
+  marmotTargetRejectMessage,
+  tryCanonicalizeMarmotGroupTarget,
+} from "../src/target.js";
+
+const GID = "a".repeat(32);
+
+describe("canonicalizeMarmotGroupTarget", () => {
+  it("accepts bare hex, marmot:, and internal group: prefixes", () => {
+    expect(canonicalizeMarmotGroupTarget(GID)).toBe(GID);
+    expect(canonicalizeMarmotGroupTarget(`${MARMOT_TARGET_PREFIX}:${GID}`)).toBe(GID);
+    expect(canonicalizeMarmotGroupTarget(`group:${GID}`)).toBe(GID);
+    expect(canonicalizeMarmotGroupTarget(`GROUP:${GID.toUpperCase()}`)).toBe(GID);
+  });
+
+  it("rejects session keys without echoing the target", () => {
+    expect(() => canonicalizeMarmotGroupTarget(`agent:main:${MARMOT_TARGET_PREFIX}:group:${GID}`)).toThrow(
+      MarmotTargetError,
+    );
+    try {
+      canonicalizeMarmotGroupTarget(`agent:main:${MARMOT_TARGET_PREFIX}:group:${GID}`);
+    } catch (error) {
+      expect(error).toBeInstanceOf(MarmotTargetError);
+      expect((error as MarmotTargetError).category).toBe("session_key");
+      expect((error as MarmotTargetError).message).not.toContain(GID);
+    }
+  });
+
+  it("rejects cross-channel and decorated routes locally", () => {
+    expect(() => canonicalizeMarmotGroupTarget("telegram:123")).toThrow(MarmotTargetError);
+    expect(() => canonicalizeMarmotGroupTarget("group:not-hex")).toThrow(MarmotTargetError);
+  });
+
+  it.each([
+    "user:",
+    "channel:",
+    "room:",
+    "conversation:",
+    "dm:",
+  ] as const)("rejects %s<validhex> even when the suffix is valid group-id hex", (prefix) => {
+    expect(() => canonicalizeMarmotGroupTarget(`${prefix}${GID}`)).toThrow(MarmotTargetError);
+    try {
+      canonicalizeMarmotGroupTarget(`${prefix}${GID}`);
+    } catch (error) {
+      expect(error).toBeInstanceOf(MarmotTargetError);
+      expect((error as MarmotTargetError).category).toBe("decorated_route");
+      expect((error as MarmotTargetError).message).not.toContain(GID);
+      expect((error as MarmotTargetError).message).not.toMatch(/lowercase/i);
+    }
+  });
+
+  it("rejects combined channel/kind decorations even with valid hex", () => {
+    for (const target of [
+      `marmot:group:${GID}`,
+      `marmot:user:${GID}`,
+      `marmot:channel:${GID}`,
+    ]) {
+      expect(() => canonicalizeMarmotGroupTarget(target)).toThrow(MarmotTargetError);
+    }
+  });
+
+  it("rejects malformed hex without leaking the value", () => {
+    for (const target of ["a".repeat(31), `group:zz${"a".repeat(30)}`]) {
+      try {
+        canonicalizeMarmotGroupTarget(target);
+        throw new Error(`expected rejection for ${target.length} char form`);
+      } catch (error) {
+        expect(error).toBeInstanceOf(MarmotTargetError);
+        expect((error as MarmotTargetError).message).not.toContain(target);
+      }
+    }
+  });
+
+  it("accepts short even-length hex ids", () => {
+    expect(canonicalizeMarmotGroupTarget("ab")).toBe("ab");
+    expect(canonicalizeMarmotGroupTarget("abcd")).toBe("abcd");
+  });
+
+  it("maps reject categories to actionable privacy-safe messages", () => {
+    expect(marmotTargetRejectMessage("invalid_hex")).toContain("group-id hex");
+    expect(marmotTargetRejectMessage("invalid_hex")).not.toMatch(/lowercase/i);
+    expect(marmotTargetRejectMessage("session_key")).toContain("session key");
+    expect(tryCanonicalizeMarmotGroupTarget("telegram:123")).toBeUndefined();
+  });
+});

--- a/integrations/openclaw/marmot/test/target.test.ts
+++ b/integrations/openclaw/marmot/test/target.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { MARMOT_TARGET_PREFIX } from "../src/target.js";
 import {
+  canonicalizeMarmotExternalTarget,
   canonicalizeMarmotGroupTarget,
   MarmotTargetError,
   marmotTargetRejectMessage,
@@ -16,6 +17,22 @@ describe("canonicalizeMarmotGroupTarget", () => {
     expect(canonicalizeMarmotGroupTarget(`${MARMOT_TARGET_PREFIX}:${GID}`)).toBe(GID);
     expect(canonicalizeMarmotGroupTarget(`group:${GID}`)).toBe(GID);
     expect(canonicalizeMarmotGroupTarget(`GROUP:${GID.toUpperCase()}`)).toBe(GID);
+  });
+
+  it("rejects implausible bare unprefixed input only at the external target boundary", () => {
+    expect(canonicalizeMarmotGroupTarget("1234567890")).toBe("1234567890");
+    expect(() => canonicalizeMarmotExternalTarget("1234567890")).toThrow(MarmotTargetError);
+    try {
+      canonicalizeMarmotExternalTarget("1234567890");
+    } catch (error) {
+      expect((error as MarmotTargetError).category).toBe("invalid_hex");
+      expect((error as MarmotTargetError).message).not.toContain("1234567890");
+    }
+  });
+
+  it("allows shorter variable-length ids under explicit marmot: or group: prefixes", () => {
+    expect(canonicalizeMarmotGroupTarget(`group:ab`)).toBe("ab");
+    expect(canonicalizeMarmotGroupTarget(`${MARMOT_TARGET_PREFIX}:abcd`)).toBe("abcd");
   });
 
   it("rejects session keys without echoing the target", () => {
@@ -34,6 +51,13 @@ describe("canonicalizeMarmotGroupTarget", () => {
   it("rejects cross-channel and decorated routes locally", () => {
     expect(() => canonicalizeMarmotGroupTarget("telegram:123")).toThrow(MarmotTargetError);
     expect(() => canonicalizeMarmotGroupTarget("group:not-hex")).toThrow(MarmotTargetError);
+    expect(() => canonicalizeMarmotGroupTarget(`group:user:${GID}`)).toThrow(MarmotTargetError);
+    try {
+      canonicalizeMarmotGroupTarget(`group:user:${GID}`);
+    } catch (error) {
+      expect((error as MarmotTargetError).category).toBe("decorated_route");
+      expect((error as MarmotTargetError).message).not.toContain(GID);
+    }
   });
 
   it.each([
@@ -76,9 +100,11 @@ describe("canonicalizeMarmotGroupTarget", () => {
     }
   });
 
-  it("accepts short even-length hex ids", () => {
+  it("keeps the low-level MLS canonicalizer variable-length", () => {
     expect(canonicalizeMarmotGroupTarget("ab")).toBe("ab");
-    expect(canonicalizeMarmotGroupTarget("abcd")).toBe("abcd");
+    expect(canonicalizeMarmotGroupTarget(`group:ab`)).toBe("ab");
+    expect(canonicalizeMarmotGroupTarget(`marmot:abcd`)).toBe("abcd");
+    expect(canonicalizeMarmotExternalTarget(`marmot:abcd`)).toBe("abcd");
   });
 
   it("maps reject categories to actionable privacy-safe messages", () => {

--- a/integrations/openclaw/marmot/test/turn-coordination.test.ts
+++ b/integrations/openclaw/marmot/test/turn-coordination.test.ts
@@ -13,8 +13,8 @@ import type { MarmotInboundMessage } from "../src/inbound.js";
 import { createMarmotMessageAdapter } from "../src/outbound.js";
 import * as turnDelivery from "../src/turn-delivery.js";
 import {
-  MarmotTurnDurableOwnershipError,
   awaitTurnOutboundResolution,
+  MarmotTurnDurableOwnershipError,
   recordTurnOutboundDelivery,
   runInMarmotTurn,
   type MarmotTurnRoute,
@@ -326,7 +326,7 @@ describe("inbound turn delivery coordination", () => {
     ]);
   });
 
-  it("dedupes repeated same-route tool sends within one turn", async () => {
+  it("rejects a second same-route tool send within one turn", async () => {
     const sendFinalCalls: string[] = [];
     const client = {
       async sendFinal(_accountIdHex: string, _groupIdHex: string, text: string) {
@@ -362,12 +362,14 @@ describe("inbound turn delivery coordination", () => {
           text: "first tool send",
         } as never;
         await adapter.send!.text!(ctx);
-        await adapter.send!.text!({
-          cfg: {},
-          accountId: "default",
-          to: HEX("cc"),
-          text: "duplicate tool send",
-        } as never);
+        await expect(
+          adapter.send!.text!({
+            cfg: {},
+            accountId: "default",
+            to: HEX("cc"),
+            text: "duplicate tool send",
+          } as never),
+        ).rejects.toBeInstanceOf(MarmotTurnDurableOwnershipError);
       }),
       client,
       channelAccountId: "default",
@@ -389,7 +391,7 @@ describe("inbound turn delivery coordination", () => {
     expect(sendFinalCalls).toEqual(["first tool send"]);
   });
 
-  it("coordinates parallel same-route tool sends through one connector call", async () => {
+  it("rejects parallel same-route tool sends after the first claims durable ownership", async () => {
     let concurrent = 0;
     const sendFinalCalls: string[] = [];
     const client = {
@@ -434,7 +436,16 @@ describe("inbound turn delivery coordination", () => {
           to: HEX("cc"),
           text: "parallel text B",
         } as never;
-        await Promise.all([adapter.send!.text!(ctxA), adapter.send!.text!(ctxB)]);
+        const [first, second] = await Promise.allSettled([
+          adapter.send!.text!(ctxA),
+          adapter.send!.text!(ctxB),
+        ]);
+        expect([first.status, second.status].sort()).toEqual(["fulfilled", "rejected"]);
+        const rejected = first.status === "rejected" ? first : second;
+        expect(rejected.status).toBe("rejected");
+        if (rejected.status === "rejected") {
+          expect(rejected.reason).toBeInstanceOf(MarmotTurnDurableOwnershipError);
+        }
       }),
       client,
       channelAccountId: "default",
@@ -453,7 +464,7 @@ describe("inbound turn delivery coordination", () => {
       text: "hello",
     });
 
-    expect(sendFinalCalls).toEqual(["parallel text A"]);
+    expect(sendFinalCalls).toHaveLength(1);
     expect(concurrent).toBe(0);
   });
 
@@ -531,11 +542,16 @@ describe("inbound turn delivery coordination", () => {
     const sinkSendGate = new Promise<void>((resolve) => {
       releaseSinkSend = resolve;
     });
+    let notifySinkClaimed: (() => void) | undefined;
+    const sinkClaimed = new Promise<void>((resolve) => {
+      notifySinkClaimed = resolve;
+    });
     const sendFinalCalls: string[] = [];
     const client = {
       async sendFinal(_accountIdHex: string, _groupIdHex: string, text: string) {
         sendFinalCalls.push(text);
         if (text === "sink-owned reply") {
+          notifySinkClaimed?.();
           await sinkSendGate;
         }
         return { type: "final_sent", message_ids_hex: [HEX("11")] };
@@ -563,7 +579,7 @@ describe("inbound turn delivery coordination", () => {
       cfg: {},
       runtimeChannel: dualPathRuntime(async (deliver) => {
         const sinkSend = deliver({ text: "sink-owned reply" }, { kind: "final" });
-        await new Promise((resolve) => setTimeout(resolve, 5));
+        await sinkClaimed;
         await expect(
           adapter.send!.text!({
             cfg: {},
@@ -670,6 +686,7 @@ describe("inbound turn delivery coordination", () => {
 
     expect(sendFinalCalls).toEqual(["tool-owned reply"]);
   });
+
 });
 
 describe("MarmotReplySink turn idempotency", () => {
@@ -847,10 +864,13 @@ describe("outbound adapter omitted-target inheritance", () => {
       }),
     ]);
 
-    expect(sendFinalCalls).toEqual([
-      { groupIdHex: HEX("01"), text: "reply-01" },
-      { groupIdHex: HEX("02"), text: "reply-02" },
-    ]);
+    expect(sendFinalCalls).toEqual(
+      expect.arrayContaining([
+        { groupIdHex: HEX("01"), text: "reply-01" },
+        { groupIdHex: HEX("02"), text: "reply-02" },
+      ]),
+    );
+    expect(sendFinalCalls).toHaveLength(2);
   });
 
   it("allows a same-route tool send after an empty sink final", async () => {

--- a/integrations/openclaw/marmot/test/turn-coordination.test.ts
+++ b/integrations/openclaw/marmot/test/turn-coordination.test.ts
@@ -8,6 +8,7 @@ import {
   type MarmotSinkClient,
   type OpenClawChannelRuntime,
 } from "../src/dispatch.js";
+import { MarmotDispatchAmbiguousDeliveryError } from "../src/dispatch-errors.js";
 import type { MarmotInboundMessage } from "../src/inbound.js";
 import { createMarmotMessageAdapter } from "../src/outbound.js";
 import * as turnDelivery from "../src/turn-delivery.js";
@@ -27,7 +28,7 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", () => ({
         resolveTurn: () => { runDispatch: () => Promise<unknown> };
       };
     }) => {
-      await params.adapter.resolveTurn().runDispatch();
+      return await params.adapter.resolveTurn().runDispatch();
     },
   ),
 }));
@@ -247,13 +248,15 @@ describe("inbound turn delivery coordination", () => {
       mentionPatterns: [],
     });
 
-    await dispatch({
-      accountIdHex: HEX("aa"),
-      groupIdHex: HEX("cc"),
-      messageIdHex: HEX("dd"),
-      senderAccountIdHex: HEX("bb"),
-      text: "hello",
-    });
+    await expect(
+      dispatch({
+        accountIdHex: HEX("aa"),
+        groupIdHex: HEX("cc"),
+        messageIdHex: HEX("dd"),
+        senderAccountIdHex: HEX("bb"),
+        text: "hello",
+      }),
+    ).rejects.toBeInstanceOf(MarmotDispatchAmbiguousDeliveryError);
 
     expect(sendFinalCalls.length).toBeGreaterThan(1);
     expect(sendFinalCalls.every((text) => text === "ambiguous tool send")).toBe(true);

--- a/integrations/openclaw/marmot/test/turn-coordination.test.ts
+++ b/integrations/openclaw/marmot/test/turn-coordination.test.ts
@@ -1,0 +1,907 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AgentControlError, type MarmotAgentControlClient } from "../src/client.js";
+import {
+  createMarmotInboundDispatcher,
+  MarmotReplySink,
+  type MarmotDispatchClient,
+  type MarmotSinkClient,
+  type OpenClawChannelRuntime,
+} from "../src/dispatch.js";
+import type { MarmotInboundMessage } from "../src/inbound.js";
+import { createMarmotMessageAdapter } from "../src/outbound.js";
+import * as turnDelivery from "../src/turn-delivery.js";
+import {
+  MarmotTurnDurableOwnershipError,
+  awaitTurnOutboundResolution,
+  recordTurnOutboundDelivery,
+  runInMarmotTurn,
+  type MarmotTurnRoute,
+} from "../src/turn-delivery.js";
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", () => ({
+  buildChannelInboundEventContext: vi.fn((params: unknown) => params),
+  runChannelInboundEvent: vi.fn(
+    async (params: {
+      adapter: {
+        resolveTurn: () => { runDispatch: () => Promise<unknown> };
+      };
+    }) => {
+      await params.adapter.resolveTurn().runDispatch();
+    },
+  ),
+}));
+
+const HEX = (b: string) => b.repeat(32);
+
+function dualPathRuntime(
+  onDispatch: (deliver: (payload: { text: string }, info: { kind: "final" }) => Promise<void>) => Promise<void>,
+): OpenClawChannelRuntime {
+  return {
+    routing: {
+      resolveAgentRoute: () => ({
+        agentId: "agent",
+        accountId: "default",
+        sessionKey: "agent:marmot",
+      }),
+    },
+    session: {
+      resolveStorePath: () => "/tmp/openclaw-marmot-turn-coordination",
+      recordInboundSession: vi.fn(),
+    },
+    reply: {
+      dispatchReplyWithBufferedBlockDispatcher: async (params: unknown) => {
+        const deliver = (params as {
+          dispatcherOptions: {
+            deliver: (payload: { text: string }, info: { kind: "final" }) => Promise<void>;
+          };
+        }).dispatcherOptions.deliver;
+        await onDispatch(deliver);
+      },
+    },
+  };
+}
+
+describe("inbound turn delivery coordination", () => {
+  it("suppresses the sink final after a same-route message-tool send succeeds", async () => {
+    const sendFinalCalls: { text: string; replyTo: string | null; key?: string }[] = [];
+    const client = {
+      async sendFinal(
+        _accountIdHex: string,
+        _groupIdHex: string,
+        text: string,
+        replyTo: string | null,
+        idempotencyKey?: string,
+      ) {
+        sendFinalCalls.push({ text, replyTo, key: idempotencyKey });
+        return { type: "final_sent", message_ids_hex: [HEX("11")] };
+      },
+      async groupInfo(accountIdHex: string, groupIdHex: string) {
+        return {
+          type: "group_info",
+          account_id_hex: accountIdHex,
+          group_id_hex: groupIdHex,
+          member_count: 2,
+          is_direct: true,
+          subject: null,
+        };
+      },
+    } as unknown as MarmotDispatchClient;
+
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: async () => ({
+        client: client as unknown as MarmotAgentControlClient,
+        marmotAccountIdHex: HEX("aa"),
+      }),
+    });
+
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel: dualPathRuntime(async (deliver) => {
+        await adapter.send!.text!({
+          cfg: {},
+          accountId: "default",
+          to: HEX("cc"),
+          text: "tool-owned reply",
+        } as never);
+        await deliver({ text: "assistant final should be suppressed" }, { kind: "final" });
+      }),
+      client,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    await dispatch({
+      accountIdHex: HEX("aa"),
+      groupIdHex: HEX("cc"),
+      messageIdHex: HEX("dd"),
+      senderAccountIdHex: HEX("bb"),
+      text: "hello",
+    });
+
+    expect(sendFinalCalls).toEqual([
+      { text: "tool-owned reply", replyTo: HEX("dd"), key: expect.any(String) },
+    ]);
+  });
+
+  it("does not suppress the sink final after a definite same-route tool send failure", async () => {
+    const sendFinalCalls: { text: string }[] = [];
+    let toolAttempts = 0;
+    const client = {
+      async sendFinal(
+        _accountIdHex: string,
+        _groupIdHex: string,
+        text: string,
+      ) {
+        sendFinalCalls.push({ text });
+        toolAttempts += 1;
+        if (toolAttempts === 1) {
+          throw new AgentControlError("permanent", { retryable: false });
+        }
+        return { type: "final_sent", message_ids_hex: [HEX("11")] };
+      },
+      async groupInfo(accountIdHex: string, groupIdHex: string) {
+        return {
+          type: "group_info",
+          account_id_hex: accountIdHex,
+          group_id_hex: groupIdHex,
+          member_count: 2,
+          is_direct: true,
+          subject: null,
+        };
+      },
+    } as unknown as MarmotDispatchClient;
+
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: async () => ({
+        client: client as unknown as MarmotAgentControlClient,
+        marmotAccountIdHex: HEX("aa"),
+      }),
+    });
+
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel: dualPathRuntime(async (deliver) => {
+        await expect(
+          adapter.send!.text!({
+            cfg: {},
+            accountId: "default",
+            to: HEX("cc"),
+            text: "failed tool send",
+          } as never),
+        ).rejects.toThrow("permanent");
+        await deliver({ text: "sink-owned reply" }, { kind: "final" });
+      }),
+      client,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    await dispatch({
+      accountIdHex: HEX("aa"),
+      groupIdHex: HEX("cc"),
+      messageIdHex: HEX("dd"),
+      senderAccountIdHex: HEX("bb"),
+      text: "hello",
+    });
+
+    expect(sendFinalCalls.map((call) => call.text)).toEqual([
+      "failed tool send",
+      "sink-owned reply",
+    ]);
+  });
+
+  it("blocks the sink final after an ambiguous same-route tool send exhausts retries", async () => {
+    const sendFinalCalls: string[] = [];
+    const client = {
+      async sendFinal(_accountIdHex: string, _groupIdHex: string, text: string) {
+        sendFinalCalls.push(text);
+        throw new AgentControlError("timed out waiting for send", { retryable: true });
+      },
+      async groupInfo(accountIdHex: string, groupIdHex: string) {
+        return {
+          type: "group_info",
+          account_id_hex: accountIdHex,
+          group_id_hex: groupIdHex,
+          member_count: 2,
+          is_direct: true,
+          subject: null,
+        };
+      },
+    } as unknown as MarmotDispatchClient;
+
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: async () => ({
+        client: client as unknown as MarmotAgentControlClient,
+        marmotAccountIdHex: HEX("aa"),
+      }),
+    });
+
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel: dualPathRuntime(async (deliver) => {
+        await expect(
+          adapter.send!.text!({
+            cfg: {},
+            accountId: "default",
+            to: HEX("cc"),
+            text: "ambiguous tool send",
+          } as never),
+        ).rejects.toThrow("timed out waiting for send");
+        await deliver({ text: "must not duplicate" }, { kind: "final" });
+      }),
+      client,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    await dispatch({
+      accountIdHex: HEX("aa"),
+      groupIdHex: HEX("cc"),
+      messageIdHex: HEX("dd"),
+      senderAccountIdHex: HEX("bb"),
+      text: "hello",
+    });
+
+    expect(sendFinalCalls.length).toBeGreaterThan(1);
+    expect(sendFinalCalls.every((text) => text === "ambiguous tool send")).toBe(true);
+  });
+
+  it("does not suppress the sink when the tool sends to another group", async () => {
+    const sendFinalCalls: { groupIdHex: string; text: string }[] = [];
+    const client = {
+      async sendFinal(
+        _accountIdHex: string,
+        groupIdHex: string,
+        text: string,
+      ) {
+        sendFinalCalls.push({ groupIdHex, text });
+        return { type: "final_sent", message_ids_hex: [HEX("11")] };
+      },
+      async groupInfo(accountIdHex: string, groupIdHex: string) {
+        return {
+          type: "group_info",
+          account_id_hex: accountIdHex,
+          group_id_hex: groupIdHex,
+          member_count: 2,
+          is_direct: true,
+          subject: null,
+        };
+      },
+    } as unknown as MarmotDispatchClient;
+
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: async () => ({
+        client: client as unknown as MarmotAgentControlClient,
+        marmotAccountIdHex: HEX("aa"),
+      }),
+    });
+
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel: dualPathRuntime(async (deliver) => {
+        await adapter.send!.text!({
+          cfg: {},
+          accountId: "default",
+          to: HEX("ff"),
+          text: "out-of-band",
+        } as never);
+        await deliver({ text: "source reply" }, { kind: "final" });
+      }),
+      client,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    await dispatch({
+      accountIdHex: HEX("aa"),
+      groupIdHex: HEX("cc"),
+      messageIdHex: HEX("dd"),
+      senderAccountIdHex: HEX("bb"),
+      text: "hello",
+    });
+
+    expect(sendFinalCalls).toEqual([
+      { groupIdHex: HEX("ff"), text: "out-of-band" },
+      { groupIdHex: HEX("cc"), text: "source reply" },
+    ]);
+  });
+
+  it("dedupes repeated same-route tool sends within one turn", async () => {
+    const sendFinalCalls: string[] = [];
+    const client = {
+      async sendFinal(_accountIdHex: string, _groupIdHex: string, text: string) {
+        sendFinalCalls.push(text);
+        return { type: "final_sent", message_ids_hex: [HEX("11")] };
+      },
+      async groupInfo(accountIdHex: string, groupIdHex: string) {
+        return {
+          type: "group_info",
+          account_id_hex: accountIdHex,
+          group_id_hex: groupIdHex,
+          member_count: 2,
+          is_direct: true,
+          subject: null,
+        };
+      },
+    } as unknown as MarmotDispatchClient;
+
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: async () => ({
+        client: client as unknown as MarmotAgentControlClient,
+        marmotAccountIdHex: HEX("aa"),
+      }),
+    });
+
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel: dualPathRuntime(async () => {
+        const ctx = {
+          cfg: {},
+          accountId: "default",
+          to: HEX("cc"),
+          text: "first tool send",
+        } as never;
+        await adapter.send!.text!(ctx);
+        await adapter.send!.text!({
+          cfg: {},
+          accountId: "default",
+          to: HEX("cc"),
+          text: "duplicate tool send",
+        } as never);
+      }),
+      client,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    await dispatch({
+      accountIdHex: HEX("aa"),
+      groupIdHex: HEX("cc"),
+      messageIdHex: HEX("dd"),
+      senderAccountIdHex: HEX("bb"),
+      text: "hello",
+    });
+
+    expect(sendFinalCalls).toEqual(["first tool send"]);
+  });
+
+  it("coordinates parallel same-route tool sends through one connector call", async () => {
+    let concurrent = 0;
+    const sendFinalCalls: string[] = [];
+    const client = {
+      async sendFinal(_accountIdHex: string, _groupIdHex: string, text: string) {
+        concurrent += 1;
+        sendFinalCalls.push(text);
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        concurrent -= 1;
+        return { type: "final_sent", message_ids_hex: [HEX("11")] };
+      },
+      async groupInfo(accountIdHex: string, groupIdHex: string) {
+        return {
+          type: "group_info",
+          account_id_hex: accountIdHex,
+          group_id_hex: groupIdHex,
+          member_count: 2,
+          is_direct: true,
+          subject: null,
+        };
+      },
+    } as unknown as MarmotDispatchClient;
+
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: async () => ({
+        client: client as unknown as MarmotAgentControlClient,
+        marmotAccountIdHex: HEX("aa"),
+      }),
+    });
+
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel: dualPathRuntime(async () => {
+        const ctxA = {
+          cfg: {},
+          accountId: "default",
+          to: HEX("cc"),
+          text: "parallel text A",
+        } as never;
+        const ctxB = {
+          cfg: {},
+          accountId: "default",
+          to: HEX("cc"),
+          text: "parallel text B",
+        } as never;
+        await Promise.all([adapter.send!.text!(ctxA), adapter.send!.text!(ctxB)]);
+      }),
+      client,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    await dispatch({
+      accountIdHex: HEX("aa"),
+      groupIdHex: HEX("cc"),
+      messageIdHex: HEX("dd"),
+      senderAccountIdHex: HEX("bb"),
+      text: "hello",
+    });
+
+    expect(sendFinalCalls).toEqual(["parallel text A"]);
+    expect(concurrent).toBe(0);
+  });
+
+  it("awaits an in-flight tool send before suppressing the sink final (tool-first race)", async () => {
+    let releaseToolSend: (() => void) | undefined;
+    const toolSendGate = new Promise<void>((resolve) => {
+      releaseToolSend = resolve;
+    });
+    const sendFinalCalls: string[] = [];
+    const client = {
+      async sendFinal(_accountIdHex: string, _groupIdHex: string, text: string) {
+        sendFinalCalls.push(text);
+        if (text === "tool-owned reply") {
+          await toolSendGate;
+        }
+        return { type: "final_sent", message_ids_hex: [HEX("11")] };
+      },
+      async groupInfo(accountIdHex: string, groupIdHex: string) {
+        return {
+          type: "group_info",
+          account_id_hex: accountIdHex,
+          group_id_hex: groupIdHex,
+          member_count: 2,
+          is_direct: true,
+          subject: null,
+        };
+      },
+    } as unknown as MarmotDispatchClient;
+
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: async () => ({
+        client: client as unknown as MarmotAgentControlClient,
+        marmotAccountIdHex: HEX("aa"),
+      }),
+    });
+
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel: dualPathRuntime(async (deliver) => {
+        const toolSend = adapter.send!.text!({
+          cfg: {},
+          accountId: "default",
+          to: HEX("cc"),
+          text: "tool-owned reply",
+        } as never);
+        await vi.waitFor(() => sendFinalCalls.length === 1);
+        const sinkCommit = deliver({ text: "sink must wait and suppress" }, { kind: "final" });
+        await vi.waitFor(() => sendFinalCalls.length === 1);
+        releaseToolSend?.();
+        await sinkCommit;
+        await toolSend;
+      }),
+      client,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    await dispatch({
+      accountIdHex: HEX("aa"),
+      groupIdHex: HEX("cc"),
+      messageIdHex: HEX("dd"),
+      senderAccountIdHex: HEX("bb"),
+      text: "hello",
+    });
+
+    expect(sendFinalCalls).toEqual(["tool-owned reply"]);
+  });
+
+  it("rejects a same-route tool send after the sink claims durable ownership (sink-first race)", async () => {
+    let releaseSinkSend: (() => void) | undefined;
+    const sinkSendGate = new Promise<void>((resolve) => {
+      releaseSinkSend = resolve;
+    });
+    const sendFinalCalls: string[] = [];
+    const client = {
+      async sendFinal(_accountIdHex: string, _groupIdHex: string, text: string) {
+        sendFinalCalls.push(text);
+        if (text === "sink-owned reply") {
+          await sinkSendGate;
+        }
+        return { type: "final_sent", message_ids_hex: [HEX("11")] };
+      },
+      async groupInfo(accountIdHex: string, groupIdHex: string) {
+        return {
+          type: "group_info",
+          account_id_hex: accountIdHex,
+          group_id_hex: groupIdHex,
+          member_count: 2,
+          is_direct: true,
+          subject: null,
+        };
+      },
+    } as unknown as MarmotDispatchClient;
+
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: async () => ({
+        client: client as unknown as MarmotAgentControlClient,
+        marmotAccountIdHex: HEX("aa"),
+      }),
+    });
+
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel: dualPathRuntime(async (deliver) => {
+        const sinkSend = deliver({ text: "sink-owned reply" }, { kind: "final" });
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        await expect(
+          adapter.send!.text!({
+            cfg: {},
+            accountId: "default",
+            to: HEX("cc"),
+            text: "tool must not send",
+          } as never),
+        ).rejects.toBeInstanceOf(MarmotTurnDurableOwnershipError);
+        releaseSinkSend?.();
+        await sinkSend;
+      }),
+      client,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    await dispatch({
+      accountIdHex: HEX("aa"),
+      groupIdHex: HEX("cc"),
+      messageIdHex: HEX("dd"),
+      senderAccountIdHex: HEX("bb"),
+      text: "hello",
+    });
+
+    expect(sendFinalCalls).toEqual(["sink-owned reply"]);
+  });
+
+  it("prevents duplicate connector calls when outbound starts in the sink gate gap", async () => {
+    let releaseAfterResolution: (() => void) | undefined;
+    const afterResolutionGate = new Promise<void>((resolve) => {
+      releaseAfterResolution = resolve;
+    });
+    const sendFinalCalls: string[] = [];
+    const client = {
+      async sendFinal(_accountIdHex: string, _groupIdHex: string, text: string) {
+        sendFinalCalls.push(text);
+        return { type: "final_sent", message_ids_hex: [HEX("11")] };
+      },
+      async groupInfo(accountIdHex: string, groupIdHex: string) {
+        return {
+          type: "group_info",
+          account_id_hex: accountIdHex,
+          group_id_hex: groupIdHex,
+          member_count: 2,
+          is_direct: true,
+          subject: null,
+        };
+      },
+    } as unknown as MarmotDispatchClient;
+
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: async () => ({
+        client: client as unknown as MarmotAgentControlClient,
+        marmotAccountIdHex: HEX("aa"),
+      }),
+    });
+
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel: dualPathRuntime(async (deliver) => {
+        const sinkCommit = deliver({ text: "sink must lose race" }, { kind: "final" });
+        await afterResolutionGate;
+        const toolSend = adapter.send!.text!({
+          cfg: {},
+          accountId: "default",
+          to: HEX("cc"),
+          text: "tool-owned reply",
+        } as never);
+        await Promise.all([sinkCommit, toolSend]);
+      }),
+      client,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    const originalAcquire = turnDelivery.acquireSinkDeliveryOrSuppress;
+    const acquireSpy = vi.spyOn(turnDelivery, "acquireSinkDeliveryOrSuppress");
+    acquireSpy.mockImplementation(async (state) => {
+      await awaitTurnOutboundResolution(state);
+      releaseAfterResolution?.();
+      await new Promise((resolve) => setImmediate(resolve));
+      return originalAcquire(state);
+    });
+
+    try {
+      await dispatch({
+        accountIdHex: HEX("aa"),
+        groupIdHex: HEX("cc"),
+        messageIdHex: HEX("dd"),
+        senderAccountIdHex: HEX("bb"),
+        text: "hello",
+      });
+    } finally {
+      acquireSpy.mockRestore();
+    }
+
+    expect(sendFinalCalls).toEqual(["tool-owned reply"]);
+  });
+});
+
+describe("MarmotReplySink turn idempotency", () => {
+  it("reuses the turn idempotency key for sink send_final", async () => {
+    const keys: (string | undefined)[] = [];
+    const client = {
+      async sendFinal(
+        _accountIdHex: string,
+        _groupIdHex: string,
+        _text: string,
+        _replyTo: string | null,
+        idempotencyKey?: string,
+      ) {
+        keys.push(idempotencyKey);
+        return { type: "final_sent", message_ids_hex: [HEX("11")] };
+      },
+    } as unknown as MarmotSinkClient;
+    const route: MarmotTurnRoute = {
+      channelAccountId: "default",
+      marmotAccountIdHex: HEX("aa"),
+      groupIdHex: HEX("cc"),
+      replyToMessageIdHex: HEX("dd"),
+      idempotencyKey: "shared-turn-key",
+    };
+    await runInMarmotTurn(route, async () => {
+      const sink = new MarmotReplySink({
+        client,
+        accountIdHex: HEX("aa"),
+        groupIdHex: HEX("cc"),
+        streamMode: "off",
+        quicCandidates: [],
+      });
+      await sink.deliver({ text: "hello" }, { kind: "final" });
+    });
+    expect(keys).toEqual(["shared-turn-key"]);
+  });
+});
+
+describe("outbound adapter omitted-target inheritance", () => {
+  it("inherits route fields from the bound turn when to is runtime-undefined", async () => {
+    const sendFinalCalls: {
+      groupIdHex: string;
+      text: string;
+      replyTo: string | null;
+      key?: string;
+    }[] = [];
+    const resolveCalls: { accountId?: string | null }[] = [];
+    const client = {
+      async sendFinal(
+        _accountIdHex: string,
+        groupIdHex: string,
+        text: string,
+        replyTo: string | null,
+        idempotencyKey?: string,
+      ) {
+        sendFinalCalls.push({ groupIdHex, text, replyTo, key: idempotencyKey });
+        return { type: "final_sent", message_ids_hex: [HEX("11")] };
+      },
+      async groupInfo(accountIdHex: string, groupIdHex: string) {
+        return {
+          type: "group_info",
+          account_id_hex: accountIdHex,
+          group_id_hex: groupIdHex,
+          member_count: 2,
+          is_direct: true,
+          subject: null,
+        };
+      },
+    } as unknown as MarmotDispatchClient;
+
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: async (_cfg, accountId) => {
+        resolveCalls.push({ accountId });
+        return {
+          client: client as unknown as MarmotAgentControlClient,
+          marmotAccountIdHex: HEX("aa"),
+        };
+      },
+    });
+
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel: dualPathRuntime(async () => {
+        await adapter.send!.text!({
+          cfg: {},
+          text: "inherited tool send",
+        } as never);
+      }),
+      client,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    await dispatch({
+      accountIdHex: HEX("aa"),
+      groupIdHex: HEX("cc"),
+      messageIdHex: HEX("dd"),
+      senderAccountIdHex: HEX("bb"),
+      text: "hello",
+    });
+
+    expect(resolveCalls).toEqual([{ accountId: "default" }]);
+    expect(sendFinalCalls).toEqual([
+      {
+        groupIdHex: HEX("cc"),
+        text: "inherited tool send",
+        replyTo: HEX("dd"),
+        key: expect.any(String),
+      },
+    ]);
+  });
+
+  it("keeps concurrent turns isolated across accounts and groups", async () => {
+    const sendFinalCalls: { groupIdHex: string; text: string }[] = [];
+    const client = {
+      async sendFinal(_accountIdHex: string, groupIdHex: string, text: string) {
+        sendFinalCalls.push({ groupIdHex, text });
+        return { type: "final_sent", message_ids_hex: [HEX("11")] };
+      },
+      async groupInfo(accountIdHex: string, groupIdHex: string) {
+        return {
+          type: "group_info",
+          account_id_hex: accountIdHex,
+          group_id_hex: groupIdHex,
+          member_count: 2,
+          is_direct: true,
+          subject: null,
+        };
+      },
+    } as unknown as MarmotDispatchClient;
+
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: async () => ({
+        client: client as unknown as MarmotAgentControlClient,
+        marmotAccountIdHex: HEX("aa"),
+      }),
+    });
+
+    const makeDispatch = (groupByte: string, accountId: string) =>
+      createMarmotInboundDispatcher({
+        cfg: {},
+        runtimeChannel: dualPathRuntime(async () => {
+          await adapter.send!.text!({
+            cfg: {},
+            text: `reply-${groupByte}`,
+          } as never);
+        }),
+        client,
+        channelAccountId: accountId,
+        streamMode: "off",
+        blockStreaming: false,
+        quicCandidates: [],
+        groupActivation: "always",
+        mentionPatterns: [],
+      });
+
+    await Promise.all([
+      makeDispatch("01", "acct-a")({
+        accountIdHex: HEX("aa"),
+        groupIdHex: HEX("01"),
+        messageIdHex: HEX("d1"),
+        senderAccountIdHex: HEX("bb"),
+        text: "one",
+      }),
+      makeDispatch("02", "acct-b")({
+        accountIdHex: HEX("aa"),
+        groupIdHex: HEX("02"),
+        messageIdHex: HEX("d2"),
+        senderAccountIdHex: HEX("bb"),
+        text: "two",
+      }),
+    ]);
+
+    expect(sendFinalCalls).toEqual([
+      { groupIdHex: HEX("01"), text: "reply-01" },
+      { groupIdHex: HEX("02"), text: "reply-02" },
+    ]);
+  });
+
+  it("allows a same-route tool send after an empty sink final", async () => {
+    const sendFinalCalls: string[] = [];
+    const client = {
+      async sendFinal(_accountIdHex: string, _groupIdHex: string, text: string) {
+        sendFinalCalls.push(text);
+        return { type: "final_sent", message_ids_hex: [HEX("11")] };
+      },
+      async groupInfo(accountIdHex: string, groupIdHex: string) {
+        return {
+          type: "group_info",
+          account_id_hex: accountIdHex,
+          group_id_hex: groupIdHex,
+          member_count: 2,
+          is_direct: true,
+          subject: null,
+        };
+      },
+    } as unknown as MarmotDispatchClient;
+
+    const adapter = createMarmotMessageAdapter({
+      resolveTarget: async () => ({
+        client: client as unknown as MarmotAgentControlClient,
+        marmotAccountIdHex: HEX("aa"),
+      }),
+    });
+
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel: dualPathRuntime(async (deliver) => {
+        await deliver({ text: "" }, { kind: "final" });
+        await adapter.send!.text!({
+          cfg: {},
+          text: "tool recovery",
+        } as never);
+      }),
+      client,
+      channelAccountId: "default",
+      streamMode: "off",
+      blockStreaming: false,
+      quicCandidates: [],
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    await dispatch({
+      accountIdHex: HEX("aa"),
+      groupIdHex: HEX("cc"),
+      messageIdHex: HEX("dd"),
+      senderAccountIdHex: HEX("bb"),
+      text: "hello",
+    });
+
+    expect(sendFinalCalls).toEqual(["tool recovery"]);
+  });
+});

--- a/integrations/openclaw/marmot/test/turn-delivery.test.ts
+++ b/integrations/openclaw/marmot/test/turn-delivery.test.ts
@@ -6,6 +6,7 @@ import {
   claimTurnSinkDelivery,
   getMarmotTurnDelivery,
   matchesMarmotTurnRoute,
+  MarmotTurnDurableOwnershipError,
   recordTurnOutboundDelivery,
   recordTurnOutboundFailure,
   runInMarmotTurn,
@@ -148,6 +149,21 @@ describe("turn delivery coordination", () => {
         groupIdHex: HEX("ff"),
       }),
     ).toBe(false);
+  });
+
+  it("rejects a second same-route outbound send after the first succeeds", async () => {
+    await runInMarmotTurn(sampleRoute(), async () => {
+      const state = getMarmotTurnDelivery()!;
+      const first = await runTurnOutboundSendOnce(state, async () => ({
+        messageIdsHex: [HEX("11")],
+      }));
+      expect(first.messageIdsHex).toEqual([HEX("11")]);
+      await expect(
+        runTurnOutboundSendOnce(state, async () => ({
+          messageIdsHex: [HEX("22")],
+        })),
+      ).rejects.toBeInstanceOf(MarmotTurnDurableOwnershipError);
+    });
   });
 
   it("stores a frozen route copy isolated from caller mutation", async () => {

--- a/integrations/openclaw/marmot/test/turn-delivery.test.ts
+++ b/integrations/openclaw/marmot/test/turn-delivery.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  acquireSinkDeliveryOrSuppress,
+  awaitTurnOutboundResolution,
+  claimTurnSinkDelivery,
+  getMarmotTurnDelivery,
+  matchesMarmotTurnRoute,
+  recordTurnOutboundDelivery,
+  recordTurnOutboundFailure,
+  runInMarmotTurn,
+  runTurnOutboundSendOnce,
+  shouldSuppressSinkDurableDelivery,
+  type MarmotTurnRoute,
+} from "../src/turn-delivery.js";
+
+const HEX = (b: string) => b.repeat(32);
+
+function sampleRoute(overrides: Partial<MarmotTurnRoute> = {}): MarmotTurnRoute {
+  return {
+    channelAccountId: "default",
+    marmotAccountIdHex: HEX("aa"),
+    groupIdHex: HEX("cc"),
+    replyToMessageIdHex: HEX("dd"),
+    idempotencyKey: "turn-key-1",
+    ...overrides,
+  };
+}
+
+describe("turn delivery coordination", () => {
+  it("scopes delivery state to the active async turn only", async () => {
+    const outer: MarmotTurnRoute[] = [];
+    await runInMarmotTurn(sampleRoute(), async () => {
+      outer.push(getMarmotTurnDelivery()!.route);
+    });
+    expect(getMarmotTurnDelivery()).toBeUndefined();
+    expect(outer).toHaveLength(1);
+  });
+
+  it("isolates concurrent turns across accounts and groups", async () => {
+    const routeA = sampleRoute({ groupIdHex: HEX("01"), idempotencyKey: "a" });
+    const routeB = sampleRoute({
+      marmotAccountIdHex: HEX("bb"),
+      groupIdHex: HEX("02"),
+      idempotencyKey: "b",
+    });
+    const seen: string[] = [];
+    await Promise.all([
+      runInMarmotTurn(routeA, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        recordTurnOutboundDelivery(getMarmotTurnDelivery()!, {
+          messageIdsHex: [HEX("11")],
+        });
+        seen.push(getMarmotTurnDelivery()!.route.idempotencyKey);
+      }),
+      runInMarmotTurn(routeB, async () => {
+        recordTurnOutboundDelivery(getMarmotTurnDelivery()!, {
+          messageIdsHex: [HEX("22")],
+        });
+        seen.push(getMarmotTurnDelivery()!.route.idempotencyKey);
+      }),
+    ]);
+    expect(seen.sort()).toEqual(["a", "b"]);
+  });
+
+  it("suppresses the sink after a successful same-route outbound delivery", () => {
+    const state = {
+      route: sampleRoute(),
+      durableOwner: "none" as const,
+      outboundDelivered: false,
+      outboundAmbiguousFailure: false,
+    };
+    recordTurnOutboundDelivery(state, { messageIdsHex: [HEX("ee")] });
+    expect(shouldSuppressSinkDurableDelivery(state)).toBe(true);
+    expect(recordTurnOutboundDelivery(state, { messageIdsHex: [HEX("ff")] })).toBe(false);
+  });
+
+  it("blocks sink fallback after an ambiguous same-route outbound failure", () => {
+    const state = {
+      route: sampleRoute(),
+      durableOwner: "none" as const,
+      outboundDelivered: false,
+      outboundAmbiguousFailure: false,
+    };
+    recordTurnOutboundFailure(state, true);
+    expect(shouldSuppressSinkDurableDelivery(state)).toBe(true);
+    expect(state.durableOwner).toBe("none");
+  });
+
+  it("releases tentative outbound ownership after a definite non-retryable failure", () => {
+    const state = {
+      route: sampleRoute(),
+      durableOwner: "outbound" as const,
+      outboundDelivered: false,
+      outboundAmbiguousFailure: false,
+    };
+    recordTurnOutboundFailure(state, false);
+    expect(state.durableOwner).toBe("none");
+    expect(shouldSuppressSinkDurableDelivery(state)).toBe(false);
+    expect(claimTurnSinkDelivery(state)).toBe(true);
+  });
+
+  it("claims outbound ownership synchronously before connector I/O", async () => {
+    await runInMarmotTurn(sampleRoute(), async () => {
+      const state = getMarmotTurnDelivery()!;
+      let releaseSend: (() => void) | undefined;
+      const sendGate = new Promise<void>((resolve) => {
+        releaseSend = resolve;
+      });
+      const outbound = runTurnOutboundSendOnce(state, async () => {
+        await sendGate;
+        return { messageIdsHex: [HEX("11")] };
+      });
+      expect(state.durableOwner).toBe("outbound");
+      expect(claimTurnSinkDelivery(state)).toBe(false);
+      releaseSend?.();
+      await outbound;
+    });
+  });
+
+  it("suppresses the sink when outbound starts after resolution returns but before claim", async () => {
+    await runInMarmotTurn(sampleRoute(), async () => {
+      const state = getMarmotTurnDelivery()!;
+      let connectorCalls = 0;
+      await awaitTurnOutboundResolution(state);
+      const outbound = runTurnOutboundSendOnce(state, async () => {
+        connectorCalls += 1;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return { messageIdsHex: [HEX("11")] };
+      });
+      const gate = await acquireSinkDeliveryOrSuppress(state);
+      await outbound;
+      expect(gate).toBe("suppress");
+      expect(connectorCalls).toBe(1);
+    });
+  });
+
+  it("does not match a different group on the same account", () => {
+    const state = {
+      route: sampleRoute(),
+      durableOwner: "none" as const,
+      outboundDelivered: false,
+      outboundAmbiguousFailure: false,
+    };
+    expect(
+      matchesMarmotTurnRoute(state, {
+        marmotAccountIdHex: HEX("aa"),
+        groupIdHex: HEX("ff"),
+      }),
+    ).toBe(false);
+  });
+
+  it("stores a frozen route copy isolated from caller mutation", async () => {
+    const route = sampleRoute({ idempotencyKey: "original-key" });
+    await runInMarmotTurn(route, async () => {
+      const stored = getMarmotTurnDelivery()!.route;
+      (route as { idempotencyKey: string }).idempotencyKey = "mutated-key";
+      expect(stored.idempotencyKey).toBe("original-key");
+      expect(Object.isFrozen(stored)).toBe(true);
+    });
+    expect(route.idempotencyKey).toBe("mutated-key");
+  });
+});

--- a/integrations/openclaw/marmot/test/turn-idempotency.test.ts
+++ b/integrations/openclaw/marmot/test/turn-idempotency.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalizeTurnSourceMessageIds,
+  deriveTurnIdempotencyKey,
+  deriveTurnIdempotencyKeyFromInbound,
+} from "../src/turn-idempotency.js";
+
+const HEX = (b: string) => b.repeat(32);
+
+describe("deriveTurnIdempotencyKey", () => {
+  it("is deterministic for the same account, group, and source message set", () => {
+    const params = {
+      marmotAccountIdHex: HEX("aa"),
+      groupIdHex: HEX("cc"),
+      sourceMessageIdsHex: [HEX("dd"), HEX("ee")],
+    };
+    const first = deriveTurnIdempotencyKey(params);
+    const second = deriveTurnIdempotencyKey(params);
+    expect(first).toBe(second);
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+    expect(first).not.toContain(HEX("aa"));
+    expect(first).not.toContain(HEX("cc"));
+    expect(first).not.toContain(HEX("dd"));
+  });
+
+  it("canonicalizes coalesced source ids as a sorted unique set", () => {
+    const account = HEX("aa");
+    const group = HEX("cc");
+    const primary = HEX("01");
+    const secondary = HEX("02");
+    const ordered = deriveTurnIdempotencyKey({
+      marmotAccountIdHex: account,
+      groupIdHex: group,
+      sourceMessageIdsHex: [primary, secondary],
+    });
+    const reversed = deriveTurnIdempotencyKey({
+      marmotAccountIdHex: account,
+      groupIdHex: group,
+      sourceMessageIdsHex: [secondary, primary, primary],
+    });
+    expect(reversed).toBe(ordered);
+    expect(canonicalizeTurnSourceMessageIds(primary, [secondary, primary])).toEqual([
+      primary,
+      secondary,
+    ]);
+  });
+
+  it("derives the same key from inbound messages across process restarts", () => {
+    const inbound = {
+      accountIdHex: HEX("aa"),
+      groupIdHex: HEX("cc"),
+      messageIdHex: HEX("dd"),
+      coalescedMessageIdsHex: [HEX("ee"), HEX("dd")],
+    };
+    const processA = deriveTurnIdempotencyKeyFromInbound(inbound);
+    const processB = deriveTurnIdempotencyKeyFromInbound({
+      ...inbound,
+      coalescedMessageIdsHex: [HEX("ee")],
+    });
+    expect(processB).toBe(processA);
+  });
+});

--- a/integrations/openclaw/marmot/vitest.config.ts
+++ b/integrations/openclaw/marmot/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
     environment: "node",
+    fileParallelism: process.env.MARMOT_OPENCLAW_CONNECTOR_E2E !== "1",
   },
 });


### PR DESCRIPTION
Fixes #1125

## Summary
- inherit omitted shared-message targets from an immutable turn-scoped Marmot account/group route while preserving explicit-target precedence and multi-account isolation
- canonicalize variable-length MLS group IDs locally and route session/decorated/cross-channel failures through privacy-safe `MarmotTargetError` diagnostics before OpenClaw can echo raw targets
- gate first dispatch on bounded outbound readiness and keep the long-lived subscription under the OpenClaw gateway lifecycle
- fail inbound turns closed when final durable delivery fails or remains ambiguous; mark the sink finalized only after a durable receipt and reject additional same-route tool sends explicitly
- derive a versioned SHA-256 idempotency key from the account, group, and sorted logical inbound message set; verify post-commit/pre-observation replay across independent plugin processes without a duplicate send
- stop readiness retries on gateway abort, preserve variable-length internal MLS group IDs, and apply the 16–64-byte plausibility band only to bare user-supplied OpenClaw targets

## Verification
- `pnpm typecheck`
- `pnpm test` — 296 passed, 3 connector-gated skipped
- `pnpm build`
- `cargo test -p agent-connector --locked` — 130 unit tests plus 1 integration test passed
- `just openclaw-dev-script-test`
- `just openclaw-dev-e2e-connector` — 3 real `wn-agent` E2E tests passed
- `just fast-ci`
- independent fail-closed Composer review — passed with no blocking findings

## Sensitive paths
- `crates/agent-connector/src/messaging.rs`
- `crates/agent-connector/src/tests.rs`

The connector change is limited to making debug-control `send_final` honor the same persisted idempotency store as production so the real process-restart E2E proves deduplication. No MLS, CGKA, key handling, or storage schema changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable, idempotent reply delivery to prevent duplicate messages, including after reconnects or restarts.
  * Added support for multiple channel accounts with independent lifecycle and status tracking.
  * Added bounded readiness retries for groups before sending messages.
  * Improved canonicalization and validation of group targets.

* **Bug Fixes**
  * Prevented duplicate durable replies and incorrectly repeated inbound messages.
  * Improved handling of failed previews, outbound sends, and malformed delete targets with privacy-safe errors.
  * Preserved message routing and reply metadata across retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->