### PR TITLE
feat(uniffi): surface durable pending leave intent

### DIFF
--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -779,6 +779,7 @@ fn observe_engine_error(error: &EngineError) -> String {
         EngineError::AdminCannotSelfRemove { .. } | EngineError::AdminDepletion { .. } => {
             "admin_policy"
         }
+        EngineError::LeaveAlreadyRequested { .. } => "leave_already_requested",
         EngineError::Serialize(_) => "invalid_admin_policy",
         EngineError::InvalidWelcome => "invalid_welcome",
         EngineError::WelcomeAlreadyProcessed => "welcome_already_processed",

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -596,6 +596,7 @@ pub(crate) fn engine_error_kind(err: &EngineError) -> &'static str {
         EngineError::UnknownMember { .. } => "unknown_member",
         EngineError::InvalidCredentialIdentity(_) => "invalid_credential_identity",
         EngineError::AdminCannotSelfRemove { .. } => "admin_cannot_self_remove",
+        EngineError::LeaveAlreadyRequested { .. } => "leave_already_requested",
         EngineError::AdminDepletion { .. } => "admin_depletion",
         EngineError::MissingRequiredCapabilities { .. } => "missing_required_capabilities",
         EngineError::UnsupportedCiphersuite { .. } => "unsupported_ciphersuite",

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -640,13 +640,16 @@ impl<S: StorageProvider> Engine<S> {
             == Some(current_epoch)
         {
             self.leaving_groups.insert(group_id.clone());
-            return Err(EngineError::InvalidTransition(
-                cgka_traits::engine_state::InvalidTransition {
-                    from: "Leaving",
-                    to: "Leave",
-                    reason: "leave already requested for current epoch",
-                },
-            ));
+            // Authoritative classification for "already leaving". Decided here
+            // rather than by a caller-side precheck because this read and the
+            // durable write below happen under the same lock: two concurrent
+            // leaves can both observe "not pending" above this layer, and the
+            // loser has to learn the real reason from here. Typed rather than
+            // `InvalidTransition` (an engine-bug signal) so it can cross the FFI
+            // boundary as a named error instead of an opaque runtime failure.
+            return Err(EngineError::LeaveAlreadyRequested {
+                group_id: group_id.clone(),
+            });
         }
 
         let (msg, proposal_bytes, proposed_epoch) =

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -2654,9 +2654,100 @@ async fn selfremove_leave_request_reproposes_when_later_epoch_keeps_member() {
             group_id: group_id.clone(),
         })
         .await;
+    // Typed, not `InvalidTransition`: a repeat leave is routine user input (a
+    // double tap), not the engine bug that `InvalidTransition` denotes, and
+    // callers above the engine need the reason by name. Note the contrast with
+    // the app send just above, which stays `InvalidTransition` because a blocked
+    // ordinary send really is an illegal transition out of the leaving state.
     assert!(
-        matches!(leave_again, Err(EngineError::InvalidTransition(_))),
+        matches!(
+            leave_again,
+            Err(EngineError::LeaveAlreadyRequested { group_id: ref g }) if *g == group_id
+        ),
         "bob should not duplicate a SelfRemove proposal for the same new epoch; got {leave_again:?}"
+    );
+}
+
+/// The already-requested verdict is decided inside the engine, under the same
+/// lock as the durable read and write, so it cannot be raced past.
+///
+/// Callers above the engine (`Marmot::leave_group`) precheck a pending flag for
+/// fast UX, but that read and the send that follows it are not atomic: two
+/// concurrent leaves can both observe "not pending". Whichever one the engine
+/// serializes second must still learn the real reason from here, by name, rather
+/// than getting an opaque failure. Guards the error contract this exposes to the
+/// bindings.
+#[tokio::test]
+async fn repeat_leave_in_the_same_epoch_is_classified_by_the_engine() {
+    let mut alice = build_client(b"alice");
+    let (mut bob, bob_storage) = build_with_storage(b"bob");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "leave-classification".into(),
+            description: "".into(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let welcome_for_bob = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            welcomes.remove(0)
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcome_for_bob).await.unwrap();
+
+    // First leave records the durable request and mints the proposal.
+    let first = bob
+        .send(SendIntent::Leave {
+            group_id: group_id.clone(),
+        })
+        .await;
+    assert!(
+        matches!(first, Ok(SendResult::Proposal { .. })),
+        "the first leave should mint a SelfRemove proposal; got {first:?}"
+    );
+    let recorded = bob_storage
+        .leave_request(&group_id)
+        .unwrap()
+        .expect("the first leave records a durable request");
+    assert!(
+        recorded.last_proposed_epoch.is_some(),
+        "the durable request must record the epoch it proposed for"
+    );
+
+    // Every subsequent leave in the same epoch is refused by name, repeatably —
+    // a host retrying must keep getting the same answer, never an opaque one.
+    for attempt in 0..3 {
+        let repeat = bob
+            .send(SendIntent::Leave {
+                group_id: group_id.clone(),
+            })
+            .await;
+        match repeat {
+            Err(EngineError::LeaveAlreadyRequested { group_id: ref got }) => {
+                assert_eq!(*got, group_id, "the error must name the group it refused")
+            }
+            other => {
+                panic!("repeat leave {attempt} must be typed as already-requested; got {other:?}")
+            }
+        }
+    }
+
+    // Refusing a duplicate must not disturb the durable request it protects.
+    assert_eq!(
+        bob_storage.leave_request(&group_id).unwrap(),
+        Some(recorded),
+        "refused duplicates must leave the durable request byte-identical"
     );
 }
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,23 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Added
+
+- MarmotKit now exposes the durable pending leave intent, so a cold launch can
+  rediscover a leave that has not reached terminal `Left` membership yet.
+  `ChatListRowFfi`, `AppGroupRecordFfi`, and `GroupManagementStateFfi` carry
+  `leave_request_pending` plus `leave_requested_at_ms` (always equal to
+  `leave_requested_at_ms != null`), derived at read time from the engine-owned
+  `cgka_leave_requests` rows rather than a denormalized projection column, so the
+  value cannot go stale when the engine clears a request without notifying the app
+  layer. `GroupManagementStateFfi.can_leave` is now `false` while a leave is
+  pending, and `Marmot::leave_group` returns the new
+  `MarmotKitError::LeaveAlreadyRequested` instead of an opaque runtime error when
+  the engine would reject a same-epoch repeat. A failed leave now also publishes
+  a group-state update, so subscribers see the pending flag without waiting for an
+  unrelated refresh. `chats list --json` / `chat_list_row` rows gain a matching
+  `leave_requested_at_ms` field; no other JSON response shapes changed.
+
 ### Fixed
 
 - TUI chat ordering now follows the durable `activity_sort_at` anchor exposed on

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -14,19 +14,35 @@ versioning through the workspace version in the root `Cargo.toml`.
   and bootstrap that exact account without creating a replacement identity.
   Interactive installs also provide a masked `/dev/tty` identity prompt.
 - MarmotKit now exposes the durable pending leave intent, so a cold launch can
-  rediscover a leave that has not reached terminal `Left` membership yet.
-  `ChatListRowFfi`, `AppGroupRecordFfi`, and `GroupManagementStateFfi` carry
-  `leave_request_pending` plus `leave_requested_at_ms` (always equal to
-  `leave_requested_at_ms != null`), derived at read time from the engine-owned
-  `cgka_leave_requests` rows rather than a denormalized projection column, so the
-  value cannot go stale when the engine clears a request without notifying the app
-  layer. `GroupManagementStateFfi.can_leave` is now `false` while a leave is
-  pending, and `Marmot::leave_group` returns the new
-  `MarmotKitError::LeaveAlreadyRequested` instead of an opaque runtime error when
-  the engine would reject a same-epoch repeat. A failed leave now also publishes
-  a group-state update, so subscribers see the pending flag without waiting for an
-  unrelated refresh. `chats list --json` / `chat_list_row` rows gain a matching
-  `leave_requested_at_ms` field; no other JSON response shapes changed.
+  rediscover a leave whose request has not resolved yet — including one whose
+  publish failed. `ChatListRowFfi`, `AppGroupRecordFfi`, and
+  `GroupManagementStateFfi` carry `leave_request_pending` plus
+  `leave_requested_at_ms` (always equal to `leave_requested_at_ms != null`),
+  derived at read time from the engine-owned `cgka_leave_requests` rows rather
+  than a denormalized projection column, so the value cannot go stale when the
+  engine clears a request without notifying the app layer. The flag is
+  orthogonal to `self_membership`, which records the locally classified
+  departure: `Left` is written as soon as the SelfRemove proposal publishes, so
+  a pending request and `Left` routinely coexist while the group waits for a
+  member to commit the removal. `GroupManagementStateFfi.can_leave` is now
+  `false` while a leave is pending, and a repeat leave returns the new
+  `MarmotKitError::LeaveAlreadyRequested` instead of an opaque runtime error.
+  A failed leave now also publishes a group-state update, so subscribers see the
+  pending flag without waiting for an unrelated refresh. `chats list --json` /
+  `chat_list_row` rows gain a matching `leave_requested_at_ms` field; no other
+  JSON response shapes changed.
+
+### Changed
+
+- A leave request that already covers the current epoch is now reported as
+  `EngineError::LeaveAlreadyRequested` instead of
+  `EngineError::InvalidTransition`, which is documented as indicating an engine
+  bug and was flattened to an opaque error at the UniFFI boundary. A user
+  double-tapping Leave is routine input, and the classification is made inside
+  the engine — under the same lock as the durable read and write — so concurrent
+  leaves cannot race past a caller-side precheck and lose the reason. Forensic
+  audit records and conformance observations for this case change from
+  `invalid_transition` to `leave_already_requested`.
 
 ### Security
 

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -115,8 +115,13 @@ pub struct AppGroupRecord {
     /// Derived from the engine-owned `cgka_leave_requests` table when the record
     /// is read; not part of the stored `account_groups` projection. MLS
     /// SelfRemove proposals are epoch-bound while the product intent is not, so
-    /// `self_membership` does not reach `Left` until a commit actually removes
-    /// us — until then this is the only durable evidence of the request, and the
+    /// the engine keeps re-proposing until a commit removes the local member.
+    ///
+    /// Orthogonal to [`Self::self_membership`]: that field records the locally
+    /// classified departure (`Left` is written as soon as the proposal
+    /// publishes, before anyone commits it), while this one tracks whether the
+    /// request has resolved. Both can be set at once, and this is the only
+    /// durable evidence of the intent when a publish failed — so it is also the
     /// only way a cold launch can rediscover it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub leave_requested_at_ms: Option<u64>,

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -109,6 +109,17 @@ pub struct AppGroupRecord {
     /// whether it left voluntarily (`Left`) or was removed (`Removed`).
     #[serde(default)]
     pub self_membership: SelfMembership,
+    /// When the local account asked to leave this group, if a durable leave
+    /// request is still outstanding.
+    ///
+    /// Derived from the engine-owned `cgka_leave_requests` table when the record
+    /// is read; not part of the stored `account_groups` projection. MLS
+    /// SelfRemove proposals are epoch-bound while the product intent is not, so
+    /// `self_membership` does not reach `Left` until a commit actually removes
+    /// us — until then this is the only durable evidence of the request, and the
+    /// only way a cold launch can rediscover it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub leave_requested_at_ms: Option<u64>,
     /// The engine has frozen this local group copy because it cannot safely
     /// select canonical state from retained material. Sending and applying
     /// group traffic remain blocked until a verified repair replaces it.
@@ -448,6 +459,7 @@ impl AppGroupRecord {
             archived: false,
             pending_confirmation: false,
             self_membership: SelfMembership::Member,
+            leave_requested_at_ms: None,
             unrecoverable: false,
             welcomer_account_id_hex: None,
             via_welcome_message_id_hex: None,

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -2328,7 +2328,31 @@ impl MarmotApp {
 
     pub fn groups(&self, label: &str) -> Result<Vec<AppGroupRecord>, AppError> {
         self.ensure_account_state(label)?;
-        Ok(self.load_state(label)?.groups)
+        let mut groups = self.load_state(label)?.groups;
+        // `leave_requested_at_ms` is not part of the stored projection, so stamp
+        // it from the engine-owned leave-request table here. This is the single
+        // population point for the group record: `visible_groups`, `group`, and
+        // `subscribe_chats` all read through this method.
+        let pending = self.pending_leave_requests(label)?;
+        if !pending.is_empty() {
+            for group in &mut groups {
+                group.leave_requested_at_ms = pending.get(&group.group_id_hex).copied();
+            }
+        }
+        Ok(groups)
+    }
+
+    /// Outstanding durable leave requests for this account, keyed by group id hex
+    /// and mapped to when the user asked to leave.
+    ///
+    /// Reads the engine's own `cgka_leave_requests` rows rather than a
+    /// denormalized projection column: the engine clears them from paths that
+    /// never notify the app layer (an accepted commit that removed us, hydration
+    /// finding the local member gone, a convergence reorg), so a cached copy
+    /// would silently go stale.
+    pub fn pending_leave_requests(&self, label: &str) -> Result<HashMap<String, u64>, AppError> {
+        self.ensure_account_state(label)?;
+        Ok(self.account_storage(label)?.pending_leave_requests()?)
     }
 
     pub fn visible_groups(&self, label: &str) -> Result<Vec<AppGroupRecord>, AppError> {

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -1105,6 +1105,19 @@ async fn handle_account_worker_command(
         }
         AccountWorkerCommand::LeaveGroup { group_id, respond } => {
             let result = client.leave_group(&group_id).await;
+            // Published regardless of outcome. The engine records the durable
+            // leave request before it publishes, so a leave that failed at the
+            // relay still changed what subscribers should render: the group is
+            // now pending-leave even though `self_membership` is still `Member`.
+            // Without this, a failed leave leaves the flag invisible until some
+            // unrelated refresh. A no-op re-read is cheap — `subscribe_chat_list`
+            // fingerprint-dedupes it away when nothing actually changed.
+            publish_app_runtime_group_state_updated(
+                events,
+                account_id_hex,
+                account_label,
+                &group_id,
+            );
             let _ = respond.send(result);
         }
         AccountWorkerCommand::DeleteGroupLocal { group_id, respond } => {

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -1052,6 +1052,7 @@ fn chat_list_test_row(group_id_hex: &str, title: &str) -> ChatListRow {
         activity_sort_at: 0,
         updated_at: 0,
         self_membership: crate::SelfMembership::Member,
+        leave_requested_at_ms: None,
     }
 }
 

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -3484,6 +3484,102 @@ async fn local_leave_suppresses_account_unread_total() {
 }
 
 #[tokio::test]
+async fn pending_leave_request_survives_a_cold_launch() {
+    // The durable `LeaveRequest` is recorded before the leave publishes, but
+    // nothing above the engine could see it, so a cold launch could not
+    // rediscover the intent: `self_membership` only reaches a terminal `Left`
+    // once a commit actually removes the local member, which in a two-party
+    // group needs the other side to commit bob's SelfRemove proposal. This
+    // asserts the read-time projection makes that window visible on both the
+    // chat-list row and the group record, and that reopening the app over the
+    // same database still reports it.
+    let dir = tempfile::tempdir().unwrap();
+    let home = AccountHome::open(dir.path());
+    home.create_account("alice").unwrap();
+    home.create_account("bob").unwrap();
+
+    let (_relay, app, url) = mock_app(&dir).await;
+    let mut bob = app.client("bob").await.unwrap();
+    bob.publish_key_package().await.unwrap();
+
+    let mut alice = app.client("alice").await.unwrap();
+    let group_id = alice
+        .create_group("pending departures", &["bob"])
+        .await
+        .unwrap();
+    bob.sync().await.unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+
+    // Nothing pending before the leave.
+    assert_eq!(
+        app.chat_list_row("bob", &group_id_hex)
+            .unwrap()
+            .expect("bob's row exists before the leave")
+            .leave_requested_at_ms,
+        None
+    );
+
+    bob.leave_group(&group_id).await.unwrap();
+    drop(bob);
+    drop(alice);
+
+    // Alice has not committed the SelfRemove yet, so the request is still
+    // outstanding even though the local projection optimistically reads `Left`.
+    let row = app
+        .chat_list_row("bob", &group_id_hex)
+        .unwrap()
+        .expect("bob's row survives the leave");
+    let requested_at = row
+        .leave_requested_at_ms
+        .expect("the durable leave request must be visible on the chat-list row");
+    assert!(
+        requested_at > 0,
+        "requested_at_ms should be a real clock reading"
+    );
+    let group = app
+        .group("bob", &group_id_hex)
+        .unwrap()
+        .expect("bob's group record survives the leave");
+    assert_eq!(group.leave_requested_at_ms, Some(requested_at));
+
+    // Cold launch: a fresh `MarmotApp` over the same directory, as if the process
+    // had been terminated mid-leave. This is the case that was previously
+    // unrecoverable.
+    drop(app);
+    let reopened = MarmotApp::with_relay_and_config(
+        dir.path(),
+        url,
+        MarmotAppConfig::default()
+            .with_allow_loopback_blob_endpoints(true)
+            .with_allow_loopback_relay_endpoints(true),
+    );
+    assert_eq!(
+        reopened
+            .chat_list_row("bob", &group_id_hex)
+            .unwrap()
+            .expect("bob's row survives the reopen")
+            .leave_requested_at_ms,
+        Some(requested_at),
+        "a cold launch must rediscover the pending leave intent"
+    );
+    assert_eq!(
+        reopened
+            .group("bob", &group_id_hex)
+            .unwrap()
+            .expect("bob's group record survives the reopen")
+            .leave_requested_at_ms,
+        Some(requested_at)
+    );
+    assert_eq!(
+        reopened
+            .pending_leave_requests("bob")
+            .unwrap()
+            .get(&group_id_hex),
+        Some(&requested_at)
+    );
+}
+
+#[tokio::test]
 async fn open_backfill_preserves_unread_for_still_member_account() {
     // mdk#573 review follow-up (blocking finding 1): the one-time
     // open/upgrade backfill derives `self_membership` from current engine

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -3510,12 +3510,14 @@ async fn local_leave_suppresses_account_unread_total() {
 async fn pending_leave_request_survives_a_cold_launch() {
     // The durable `LeaveRequest` is recorded before the leave publishes, but
     // nothing above the engine could see it, so a cold launch could not
-    // rediscover the intent: `self_membership` only reaches a terminal `Left`
-    // once a commit actually removes the local member, which in a two-party
-    // group needs the other side to commit bob's SelfRemove proposal. This
-    // asserts the read-time projection makes that window visible on both the
-    // chat-list row and the group record, and that reopening the app over the
-    // same database still reports it.
+    // rediscover the intent.
+    //
+    // The two states are orthogonal, and this pins that: `self_membership`
+    // becomes `Left` as soon as the proposal publishes (the local classification
+    // of a voluntary departure), while the request stays outstanding until some
+    // member commits the SelfRemove — which in this two-party group alice never
+    // does. So `Left` and a pending request coexist here, and a host must read
+    // the pending flag rather than infer resolution from `Left`.
     let dir = tempfile::tempdir().unwrap();
     let home = AccountHome::open(dir.path());
     home.create_account("alice").unwrap();
@@ -3558,6 +3560,14 @@ async fn pending_leave_request_survives_a_cold_launch() {
     assert!(
         requested_at > 0,
         "requested_at_ms should be a real clock reading"
+    );
+    // The documented coexistence, asserted rather than merely narrated: an
+    // optimistic `Left` alongside an unresolved request. If a future change made
+    // `Left` imply resolution, this is what would catch it.
+    assert_eq!(
+        row.self_membership,
+        SelfMembership::Left,
+        "a published leave classifies as Left immediately, while the request stays pending"
     );
     let group = app
         .group("bob", &group_id_hex)
@@ -6178,4 +6188,85 @@ async fn app_runtime_exposes_welcome_redelivery_surface() {
     );
 
     runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn concurrent_leaves_report_already_requested_not_an_opaque_error() {
+    // PR #1138 review (P1): `Marmot::leave_group` prechecks the pending flag, but
+    // that read is not atomic with the send it guards. Two concurrent leaves — a
+    // rapid double tap launching two async tasks — can both observe "not
+    // pending". The account worker then serializes them, and the loser used to
+    // receive `EngineError::InvalidTransition`, which flattens to an opaque error
+    // at the UniFFI boundary: exactly what surfacing this state was meant to
+    // remove. The classification is now made inside the engine, so the loser
+    // learns the real reason by name no matter who wins the race.
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let bob = runtime.create_identity(setup).await.unwrap();
+    let alice_id = alice.account.account_id_hex.clone();
+    let bob_id = bob.account.account_id_hex.clone();
+    let mut events = runtime.subscribe();
+
+    let group_id = runtime
+        .create_group(&alice_id, "double tap", std::slice::from_ref(&bob_id), None)
+        .await
+        .unwrap();
+    wait_for_event(&mut events, |event| {
+        matches!(
+            event,
+            MarmotAppEvent::GroupJoined { account_id_hex, group_id: joined, .. }
+                if account_id_hex == &bob_id && joined == &group_id
+        )
+    })
+    .await;
+
+    // Both leaves are in flight before either worker command runs, so neither
+    // can benefit from the other having recorded the request.
+    let (first, second) = tokio::join!(
+        runtime.leave_group(&bob_id, &group_id),
+        runtime.leave_group(&bob_id, &group_id),
+    );
+
+    // Exactly one wins; the ordering is genuinely racy, so accept either.
+    let (winner, loser) = match (&first, &second) {
+        (Ok(_), Err(err)) => (&first, err),
+        (Err(err), Ok(_)) => (&second, err),
+        (a, b) => panic!("exactly one concurrent leave should succeed; got {a:?} and {b:?}"),
+    };
+    assert!(winner.is_ok());
+
+    let engine_error = loser
+        .as_engine_error()
+        .unwrap_or_else(|| panic!("the losing leave should carry an engine error; got {loser:?}"));
+    match engine_error {
+        cgka_traits::error::EngineError::LeaveAlreadyRequested { group_id: refused } => {
+            assert_eq!(
+                *refused, group_id,
+                "the error must name the group it refused"
+            );
+        }
+        other => panic!(
+            "the losing leave must be typed as already-requested, never an opaque \
+             InvalidTransition; got {other:?}"
+        ),
+    }
+
+    // The race resolved into one durable request, and it is visible to hosts.
+    let group_id_hex = hex::encode(group_id.as_slice());
+    assert!(
+        app.chat_list_row(&bob.account.label, &group_id_hex)
+            .unwrap()
+            .expect("bob's row survives the leave")
+            .leave_requested_at_ms
+            .is_some(),
+        "the winning leave leaves exactly one durable request behind"
+    );
 }

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -378,9 +378,15 @@ impl Marmot {
         let group_id_hex = hex::encode(group_id.as_slice());
         let state =
             group_management_state_for(self, &account_ref, &group_id, &group_id_hex).await?;
-        // Checked first: a pending leave also clears `can_leave`, so letting the
-        // checks below run would report a wrong reason (`MemberNotInGroup`) for a
-        // group the account is very much still in.
+        // A fast-path reject only, not the source of correctness: this read and
+        // the worker command that acts on it are not atomic, so two concurrent
+        // leaves can both pass here. The engine settles it under its own lock and
+        // returns `EngineError::LeaveAlreadyRequested`, which maps to this same
+        // variant — see `MarmotKitError::from_engine_error`.
+        //
+        // Checked before the two below because a pending leave also clears
+        // `can_leave`, so letting them run would report a wrong reason
+        // (`MemberNotInGroup`) for a group the account is very much still in.
         if state.leave_request_pending {
             return Err(MarmotKitError::LeaveAlreadyRequested {
                 group_id_hex: group_id_hex.clone(),

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -378,6 +378,14 @@ impl Marmot {
         let group_id_hex = hex::encode(group_id.as_slice());
         let state =
             group_management_state_for(self, &account_ref, &group_id, &group_id_hex).await?;
+        // Checked first: a pending leave also clears `can_leave`, so letting the
+        // checks below run would report a wrong reason (`MemberNotInGroup`) for a
+        // group the account is very much still in.
+        if state.leave_request_pending {
+            return Err(MarmotKitError::LeaveAlreadyRequested {
+                group_id_hex: group_id_hex.clone(),
+            });
+        }
         if state.requires_self_demote_before_leave {
             return Err(MarmotKitError::AdminCannotSelfRemove {
                 group_id_hex: group_id_hex.clone(),
@@ -873,6 +881,8 @@ mod tests {
             can_invite: self_admin,
             can_leave: !self_admin,
             requires_self_demote_before_leave: self_admin,
+            leave_request_pending: false,
+            leave_requested_at_ms: None,
             member_actions: vec![
                 GroupMemberActionStateFfi {
                     member_id_hex: self_id.into(),

--- a/crates/marmot-uniffi/src/conversions/chat_list.rs
+++ b/crates/marmot-uniffi/src/conversions/chat_list.rs
@@ -102,10 +102,24 @@ pub struct ChatListRowFfi {
     /// resolved yet. Render the conversation as leaving, and do not offer Leave
     /// again — see `GroupManagementStateFfi::can_leave`.
     ///
-    /// `self_membership` only reaches a terminal `Left` once a commit actually
-    /// removes the local member, which may be many epochs later or never (a
-    /// publish can fail, and the intent survives app termination). This flag is
-    /// the durable intent in between, so a cold launch can rediscover it.
+    /// Durable unresolved *intent*, which survives a failed publish and app
+    /// termination — so a cold launch can rediscover it. Read this rather than
+    /// `self_membership` to decide whether to show a leave in progress.
+    ///
+    /// This is orthogonal to `self_membership`, not a precursor to it. The two
+    /// answer different questions and combine freely:
+    ///
+    /// | `self_membership` | this flag | meaning |
+    /// |---|---|---|
+    /// | `Member` | `true`  | leave requested, publish failed or was interrupted |
+    /// | `Left`   | `true`  | leave published, still waiting for a member to commit it |
+    /// | `Left`   | `false` | leave resolved |
+    /// | `Removed`| `false` | removed by someone else |
+    ///
+    /// `self_membership` is the locally *classified departure* — `Left` is
+    /// recorded as soon as the SelfRemove proposal publishes, so it does **not**
+    /// imply a commit removed the member, and `Removed` marks an involuntary
+    /// removal. This flag is about whether the request is still outstanding.
     ///
     /// Always equal to `leave_requested_at_ms != null`.
     pub leave_request_pending: bool,

--- a/crates/marmot-uniffi/src/conversions/chat_list.rs
+++ b/crates/marmot-uniffi/src/conversions/chat_list.rs
@@ -98,6 +98,20 @@ pub struct ChatListRowFfi {
     /// Whether the local account is still a member of this group, and if not,
     /// whether it left voluntarily or was removed.
     pub self_membership: SelfMembershipFfi,
+    /// The local account asked to leave this group and the request has not
+    /// resolved yet. Render the conversation as leaving, and do not offer Leave
+    /// again — see `GroupManagementStateFfi::can_leave`.
+    ///
+    /// `self_membership` only reaches a terminal `Left` once a commit actually
+    /// removes the local member, which may be many epochs later or never (a
+    /// publish can fail, and the intent survives app termination). This flag is
+    /// the durable intent in between, so a cold launch can rediscover it.
+    ///
+    /// Always equal to `leave_requested_at_ms != null`.
+    pub leave_request_pending: bool,
+    /// When the local account asked to leave, in milliseconds since the Unix
+    /// epoch; `null` when no leave is pending.
+    pub leave_requested_at_ms: Option<u64>,
 }
 
 impl From<ChatListRow> for ChatListRowFfi {
@@ -122,6 +136,8 @@ impl From<ChatListRow> for ChatListRowFfi {
             activity_sort_at: value.activity_sort_at,
             updated_at: value.updated_at,
             self_membership: value.self_membership.into(),
+            leave_request_pending: value.leave_requested_at_ms.is_some(),
+            leave_requested_at_ms: value.leave_requested_at_ms,
         }
     }
 }
@@ -192,9 +208,8 @@ impl From<marmot_app::ChatListUpdateTrigger> for ChatListUpdateTriggerFfi {
 mod tests {
     use super::*;
 
-    #[test]
-    fn chat_list_row_exports_semantic_timestamps() {
-        let ffi = ChatListRowFfi::from(ChatListRow {
+    fn sample_row() -> ChatListRow {
+        ChatListRow {
             group_id_hex: "11".to_owned(),
             archived: false,
             pending_confirmation: false,
@@ -214,11 +229,37 @@ mod tests {
             activity_sort_at: 200,
             updated_at: 300,
             self_membership: marmot_app::SelfMembership::Member,
-        });
+            leave_requested_at_ms: None,
+        }
+    }
+
+    #[test]
+    fn chat_list_row_exports_semantic_timestamps() {
+        let ffi = ChatListRowFfi::from(sample_row());
 
         assert_eq!(ffi.conversation_created_at, 100);
         assert_eq!(ffi.activity_sort_at, 200);
         assert_eq!(ffi.updated_at, 300);
+    }
+
+    #[test]
+    fn chat_list_row_exports_pending_leave_alongside_active_membership() {
+        // The pair must stay consistent: hosts branch on the bool and render the
+        // timestamp, so a `true` with no timestamp (or vice versa) would be a
+        // contradiction. Also note membership is still `Member` here — that is the
+        // whole window this field exists to cover.
+        let ffi = ChatListRowFfi::from(ChatListRow {
+            leave_requested_at_ms: Some(1_700_000_000_123),
+            ..sample_row()
+        });
+
+        assert!(ffi.leave_request_pending);
+        assert_eq!(ffi.leave_requested_at_ms, Some(1_700_000_000_123));
+        assert!(matches!(ffi.self_membership, SelfMembershipFfi::Member));
+
+        let ffi = ChatListRowFfi::from(sample_row());
+        assert!(!ffi.leave_request_pending);
+        assert_eq!(ffi.leave_requested_at_ms, None);
     }
 
     #[test]

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -48,8 +48,9 @@ pub struct AppGroupRecordFfi {
     /// whether it left voluntarily or was removed.
     pub self_membership: SelfMembershipFfi,
     /// The local account asked to leave this group and the request has not
-    /// resolved yet. See `ChatListRowFfi::leave_request_pending` for why this is
-    /// distinct from a terminal `self_membership` of `Left`.
+    /// resolved yet. Orthogonal to `self_membership`, which records the locally
+    /// classified departure rather than whether the request resolved — see
+    /// `ChatListRowFfi::leave_request_pending` for the full state table.
     ///
     /// Always equal to `leave_requested_at_ms != null`.
     pub leave_request_pending: bool,

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -47,6 +47,15 @@ pub struct AppGroupRecordFfi {
     /// Whether the local account is still a member of this group, and if not,
     /// whether it left voluntarily or was removed.
     pub self_membership: SelfMembershipFfi,
+    /// The local account asked to leave this group and the request has not
+    /// resolved yet. See `ChatListRowFfi::leave_request_pending` for why this is
+    /// distinct from a terminal `self_membership` of `Left`.
+    ///
+    /// Always equal to `leave_requested_at_ms != null`.
+    pub leave_request_pending: bool,
+    /// When the local account asked to leave, in milliseconds since the Unix
+    /// epoch; `null` when no leave is pending.
+    pub leave_requested_at_ms: Option<u64>,
     pub welcomer_account_id_hex: Option<String>,
     pub via_welcome_message_id_hex: Option<String>,
 }
@@ -87,6 +96,8 @@ impl From<AppGroupRecord> for AppGroupRecordFfi {
             pending_confirmation: value.pending_confirmation,
             unrecoverable: value.unrecoverable,
             self_membership: value.self_membership.into(),
+            leave_request_pending: value.leave_requested_at_ms.is_some(),
+            leave_requested_at_ms: value.leave_requested_at_ms,
             welcomer_account_id_hex: value.welcomer_account_id_hex,
             via_welcome_message_id_hex: value.via_welcome_message_id_hex,
         }
@@ -231,8 +242,22 @@ pub struct GroupManagementStateFfi {
     pub is_self_admin: bool,
     pub is_last_admin: bool,
     pub can_invite: bool,
+    /// Whether a Leave action would do anything: the local account is a member,
+    /// is not an admin, and has no leave already in flight.
+    ///
+    /// When this is `false`, the reason is one of
+    /// `requires_self_demote_before_leave` (demote first) or
+    /// `leave_request_pending` (already leaving) — or the account is not a member
+    /// at all. Check those before reporting an error to the user.
     pub can_leave: bool,
     pub requires_self_demote_before_leave: bool,
+    /// A leave is already in flight for this group; `Marmot::leave_group` would
+    /// return `MarmotKitError::LeaveAlreadyRequested`. Render progress rather
+    /// than a Leave affordance.
+    pub leave_request_pending: bool,
+    /// When the local account asked to leave, in milliseconds since the Unix
+    /// epoch; `null` when no leave is pending.
+    pub leave_requested_at_ms: Option<u64>,
     pub member_actions: Vec<GroupMemberActionStateFfi>,
 }
 
@@ -335,7 +360,12 @@ pub(crate) fn group_management_state_ffi(
     let is_self_admin = self_member.is_some_and(|member| member.is_admin);
     let is_last_admin = is_self_admin && admin_count == 1;
     let can_invite = is_self_admin;
-    let can_leave = self_member.is_some() && !is_self_admin;
+    // A leave already in flight suppresses `can_leave` so hosts do not offer a
+    // second Leave that the engine would reject: the durable request is not
+    // epoch-bound, but the SelfRemove proposal backing it is, and re-requesting
+    // inside the same epoch is an invalid transition.
+    let leave_request_pending = details.group.leave_request_pending;
+    let can_leave = self_member.is_some() && !is_self_admin && !leave_request_pending;
     let requires_self_demote_before_leave = self_member.is_some() && is_self_admin;
     let member_actions = details
         .members
@@ -362,6 +392,8 @@ pub(crate) fn group_management_state_ffi(
         can_invite,
         can_leave,
         requires_self_demote_before_leave,
+        leave_request_pending,
+        leave_requested_at_ms: details.group.leave_requested_at_ms,
         member_actions,
     }
 }

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -364,7 +364,10 @@ pub(crate) fn group_management_state_ffi(
     // A leave already in flight suppresses `can_leave` so hosts do not offer a
     // second Leave that the engine would reject: the durable request is not
     // epoch-bound, but the SelfRemove proposal backing it is, and re-requesting
-    // inside the same epoch is an invalid transition.
+    // inside the same epoch returns `EngineError::LeaveAlreadyRequested`, which
+    // reaches the host as `MarmotKitError::LeaveAlreadyRequested`. Suppressing
+    // the affordance keeps that error off the happy path; it does not prevent it,
+    // since this state is not read atomically with the leave it guards.
     let leave_request_pending = details.group.leave_request_pending;
     let can_leave = self_member.is_some() && !is_self_admin && !leave_request_pending;
     let requires_self_demote_before_leave = self_member.is_some() && is_self_admin;

--- a/crates/marmot-uniffi/src/conversions/mod.rs
+++ b/crates/marmot-uniffi/src/conversions/mod.rs
@@ -93,6 +93,8 @@ mod tests {
             pending_confirmation: false,
             unrecoverable: false,
             self_membership: SelfMembershipFfi::Member,
+            leave_request_pending: false,
+            leave_requested_at_ms: None,
             welcomer_account_id_hex: None,
             via_welcome_message_id_hex: None,
         }
@@ -176,6 +178,40 @@ mod tests {
         assert!(bob_action.can_remove);
         assert!(bob_action.can_promote);
         assert!(!bob_action.can_demote);
+    }
+
+    #[test]
+    fn group_management_state_suppresses_leave_while_a_request_is_pending() {
+        // A non-admin member normally has `can_leave`. Once a leave is durable the
+        // engine rejects a second same-epoch request, so the affordance has to go
+        // away — but `requires_self_demote_before_leave` must stay false, since
+        // that is how hosts tell "demote first" from "already leaving".
+        let self_id = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+        let bob_id = "bb4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+        let mut leaving = group(vec![bob_id]);
+        leaving.leave_request_pending = true;
+        leaving.leave_requested_at_ms = Some(1_700_000_000_123);
+        let details = GroupDetailsFfi {
+            group: leaving,
+            members: vec![member(self_id, false, true), member(bob_id, true, false)],
+        };
+
+        let state = group_management_state_ffi(self_id, &details);
+
+        assert!(!state.can_leave);
+        assert!(!state.requires_self_demote_before_leave);
+        assert!(state.leave_request_pending);
+        assert_eq!(state.leave_requested_at_ms, Some(1_700_000_000_123));
+
+        // Same roster without the pending request: Leave is offered again.
+        let details = GroupDetailsFfi {
+            group: group(vec![bob_id]),
+            members: details.members,
+        };
+        let state = group_management_state_ffi(self_id, &details);
+        assert!(state.can_leave);
+        assert!(!state.leave_request_pending);
+        assert_eq!(state.leave_requested_at_ms, None);
     }
 
     #[test]

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -217,6 +217,13 @@ impl MarmotKitError {
             EngineError::AdminCannotSelfRemove { group_id } => Self::AdminCannotSelfRemove {
                 group_id_hex: hex::encode(group_id.as_slice()),
             },
+            // The authoritative already-leaving signal. `Marmot::leave_group`
+            // prechecks the pending flag for fast UX, but that check is a
+            // check-then-act race, so the engine's verdict must map to the same
+            // named error rather than falling through to `Runtime`.
+            EngineError::LeaveAlreadyRequested { group_id } => Self::LeaveAlreadyRequested {
+                group_id_hex: hex::encode(group_id.as_slice()),
+            },
             EngineError::AdminDepletion { group_id } => Self::WouldRemoveLastAdmin {
                 group_id_hex: hex::encode(group_id.as_slice()),
             },
@@ -267,6 +274,49 @@ mod tests {
             }
             other => panic!("expected AccountCatchUp, got {other:?}"),
         }
+    }
+
+    // The `leave_group` precheck on `leave_request_pending` is not atomic with
+    // the send it guards, so two concurrent leaves can both pass it. The engine
+    // settles the race under its own lock, and the loser's verdict has to reach
+    // the host as the same named error the precheck would have produced — never
+    // the untyped `Runtime` bucket, which is exactly the opaque failure this
+    // field was added to eliminate.
+    // Asserted against `from_engine_error` directly rather than through an
+    // `AppError`: a leave failure arrives wrapped as
+    // `AppError::Session(SessionError::Engine(..))`, and `cgka-session` is not a
+    // dependency of this crate. `From<AppError>` funnels every such error through
+    // `as_engine_error()` into this same function (see above), so this covers the
+    // mapping without pulling in a crate just to construct a wrapper.
+    #[test]
+    fn leave_already_requested_crosses_ffi_as_typed_variant() {
+        let group_id = cgka_traits::GroupId::new(vec![0x11; 16]);
+        let ffi = MarmotKitError::from_engine_error(&EngineError::LeaveAlreadyRequested {
+            group_id: group_id.clone(),
+        });
+        match ffi {
+            MarmotKitError::LeaveAlreadyRequested { group_id_hex } => {
+                assert_eq!(group_id_hex, hex::encode(group_id.as_slice()));
+            }
+            other => panic!("expected LeaveAlreadyRequested, got {other:?}"),
+        }
+    }
+
+    // The variant it replaced must not regress into the opaque bucket by way of
+    // some future refactor reusing `InvalidTransition` for this case.
+    #[test]
+    fn invalid_transition_remains_the_untyped_engine_bug_signal() {
+        let ffi = MarmotKitError::from_engine_error(&EngineError::InvalidTransition(
+            cgka_traits::engine_state::InvalidTransition {
+                from: "Leaving",
+                to: "AppMessage",
+                reason: "leave request is current",
+            },
+        ));
+        assert!(
+            matches!(ffi, MarmotKitError::Runtime { .. }),
+            "InvalidTransition denotes an engine bug and stays untyped; got {ffi:?}"
+        );
     }
 
     #[test]

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -45,6 +45,12 @@ pub enum MarmotKitError {
     NotGroupAdmin { group_id_hex: String },
     #[error("admin must self-demote before leaving group {group_id_hex}")]
     AdminCannotSelfRemove { group_id_hex: String },
+    /// A leave is already in flight for this group. The durable request survives
+    /// restarts and the engine keeps re-proposing until a commit removes us, so
+    /// this is not a failure to retry — surface progress instead. Check
+    /// `GroupManagementStateFfi::leave_request_pending` before offering Leave.
+    #[error("a leave request is already pending for group {group_id_hex}")]
+    LeaveAlreadyRequested { group_id_hex: String },
     #[error("operation would remove the last admin from group {group_id_hex}")]
     WouldRemoveLastAdmin { group_id_hex: String },
     #[error("member {member_id_hex} is not in group {group_id_hex}")]

--- a/crates/marmot-uniffi/tests/smoke.rs
+++ b/crates/marmot-uniffi/tests/smoke.rs
@@ -355,6 +355,31 @@ async fn delete_group_local_binding_is_public_and_validates_group_hex() {
 }
 
 #[tokio::test]
+async fn leave_group_binding_is_public_and_validates_group_hex() {
+    install_mock_keyring();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let kit = Marmot::new(
+        tmp.path().to_string_lossy().into_owned(),
+        vec!["wss://relay.invalid.test".to_string()],
+    )
+    .expect("open marmot kit");
+
+    // Group-hex validation runs before the account lookup, so a malformed id
+    // never reaches the runtime.
+    let error = kit
+        .leave_group("alice".into(), "not-hex".into())
+        .await
+        .expect_err("invalid group hex should fail before the leave");
+    assert!(format!("{error}").contains("invalid hex"));
+
+    let error = kit
+        .leave_group("alice".into(), "11".repeat(16))
+        .await
+        .expect_err("a missing account cannot leave a group");
+    assert!(matches!(error, MarmotKitError::UnknownAccount { .. }));
+}
+
+#[tokio::test]
 async fn group_image_binding_methods_are_public_and_validate_inputs() {
     install_mock_keyring();
     let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -1,3 +1,4 @@
+use crate::storage::leave_requests::pending_leave_requests_by_group_hex_tx;
 use crate::{
     SelfMembership, SqliteAccountStorage, SqliteResultExt, bool_i64, i64_to_u64,
     optional_u64_to_i64, u64_to_i64, unix_now_seconds,
@@ -99,6 +100,17 @@ pub struct ChatListRow {
     /// The local account's membership in this group (active member, left, or
     /// removed). Denormalized from `account_groups.self_membership`.
     pub self_membership: SelfMembership,
+    /// When the local account asked to leave this group, if a durable leave
+    /// request is still outstanding.
+    ///
+    /// This is *not* a `chat_list_rows` column. It is derived at read time from
+    /// the engine-owned `cgka_leave_requests` table, which is the only source of
+    /// truth: `self_membership` does not reach a terminal `Left` until a commit
+    /// actually removes us, so between the request and that commit — across a
+    /// publish failure or a process restart — this is the only durable record
+    /// that the user asked to leave.
+    #[serde(default)]
+    pub leave_requested_at_ms: Option<u64>,
 }
 
 #[derive(Clone, Debug)]
@@ -372,6 +384,10 @@ fn set_chat_list_mention_counts_version_tx(tx: &Connection, version: i64) -> Sto
     Ok(())
 }
 
+/// Deliberately does not consider pending-leave state.
+/// `ChatListRow::leave_requested_at_ms` is derived at read time rather than
+/// materialized, so there is no stored value that can drift out of date — and
+/// comparing a read-time-only field here would mark every row stale forever.
 fn chat_list_projection_complete_tx(
     tx: &Connection,
     local_account_id_hex: &str,
@@ -598,6 +614,10 @@ fn projection_has_rows_tx<P: Params>(tx: &Connection, sql: &str, params: P) -> S
     Ok(exists != 0)
 }
 
+/// Deliberately writes no pending-leave state. `ChatListRow::leave_requested_at_ms`
+/// is derived from `cgka_leave_requests` when the row is *read*, so there is no
+/// column here to keep in sync and no rebuild to trigger when the engine clears a
+/// leave request behind the projection's back.
 fn rebuild_chat_list_row_for_group_tx(
     tx: &Connection,
     local_account_id_hex: &str,
@@ -997,10 +1017,20 @@ fn chat_list_rows_tx(tx: &Connection, query: ChatListQuery) -> StorageResult<Vec
          ORDER BY activity_sort_at DESC, group_id_hex"
     };
     let mut stmt = tx.prepare(sql).storage()?;
-    stmt.query_map([], chat_list_row_from_row)
+    let mut rows = stmt
+        .query_map([], chat_list_row_from_row)
         .storage()?
         .collect::<Result<Vec<_>, _>>()
-        .storage()
+        .storage()?;
+    // Derived at read time, inside the same transaction as the projection read,
+    // so the pending-leave stamp is always consistent with the row it rides on.
+    let pending = pending_leave_requests_by_group_hex_tx(tx)?;
+    if !pending.is_empty() {
+        for row in &mut rows {
+            row.leave_requested_at_ms = pending.get(&row.group_id_hex).copied();
+        }
+    }
+    Ok(rows)
 }
 
 fn chat_list_row_tx(tx: &Connection, group_id_hex: &str) -> StorageResult<Option<ChatListRow>> {
@@ -1021,7 +1051,15 @@ fn chat_list_row_tx(tx: &Connection, group_id_hex: &str) -> StorageResult<Option
         chat_list_row_from_row,
     )
     .optional()
-    .storage()
+    .storage()?
+    .map(|mut row| {
+        // Same read-time derivation as `chat_list_rows_tx`; see there.
+        row.leave_requested_at_ms = pending_leave_requests_by_group_hex_tx(tx)?
+            .get(&row.group_id_hex)
+            .copied();
+        Ok(row)
+    })
+    .transpose()
 }
 
 fn chat_list_row_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChatListRow> {
@@ -1090,6 +1128,9 @@ fn chat_list_row_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ChatListR
         activity_sort_at: row.get::<_, i64>(23)?.try_into().unwrap_or_default(),
         updated_at: row.get::<_, i64>(24)?.try_into().unwrap_or_default(),
         self_membership: SelfMembership::from_storage(&row.get::<_, String>(25)?),
+        // Not a `chat_list_rows` column; the callers above stamp it from
+        // `cgka_leave_requests` after the row is decoded.
+        leave_requested_at_ms: None,
     })
 }
 

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -105,10 +105,16 @@ pub struct ChatListRow {
     ///
     /// This is *not* a `chat_list_rows` column. It is derived at read time from
     /// the engine-owned `cgka_leave_requests` table, which is the only source of
-    /// truth: `self_membership` does not reach a terminal `Left` until a commit
-    /// actually removes us, so between the request and that commit — across a
-    /// publish failure or a process restart — this is the only durable record
-    /// that the user asked to leave.
+    /// truth for unresolved intent.
+    ///
+    /// Orthogonal to [`Self::self_membership`], and the two combine freely.
+    /// `self_membership` records the locally *classified departure*: the leave
+    /// path writes `Left` as soon as the SelfRemove proposal publishes, without
+    /// waiting for another member to commit it. This field tracks whether the
+    /// request itself has *resolved*. So `Left` + `Some(..)` means the leave
+    /// published and is awaiting a committer, `Member` + `Some(..)` means the
+    /// publish failed (or the process died before the membership write), and
+    /// `None` means no leave is outstanding.
     #[serde(default)]
     pub leave_requested_at_ms: Option<u64>,
 }

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::storage::test_support::sample_group;
 use crate::{
     SelfMembership, StoredAccountGroup, StoredAccountGroupComponent, StoredAccountState,
     StoredAppEvent,
@@ -10,6 +11,8 @@ use cgka_traits::app_components::{
 use cgka_traits::app_event::{
     EVENT_REF_TAG, MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_REACTION,
 };
+use cgka_traits::storage::{GroupStorage, LeaveRequest, LeaveRequestStorage};
+use cgka_traits::types::{EpochId, GroupId};
 
 const LOCAL: &str = "aa";
 const REMOTE: &str = "bb";
@@ -1410,5 +1413,77 @@ fn set_group_self_membership_propagates_backend_errors() {
     assert!(
         result.is_err(),
         "a failed self_membership projection write must return an error, not silently succeed"
+    );
+}
+
+#[test]
+fn chat_list_rows_report_the_durable_leave_request_at_read_time() {
+    // A leave is durable in `cgka_leave_requests` from the moment the engine
+    // mints the SelfRemove proposal, but `self_membership` stays `Member` until a
+    // commit actually removes us. Between those two points — across a publish
+    // failure or a cold launch — this read-time derivation is the only way the
+    // chat list can tell that the user asked to leave.
+    let store = setup_store();
+    let group_id = GroupId::new(hex::decode(GROUP).unwrap());
+    store
+        .put_group(&sample_group(group_id.clone(), 3, 0))
+        .unwrap();
+    store.ensure_chat_list_rows(LOCAL, &no_mentions).unwrap();
+
+    // No request yet: the field is absent, not defaulted to some sentinel.
+    let row = store.chat_list_row(GROUP).unwrap().unwrap();
+    assert_eq!(row.leave_requested_at_ms, None);
+    assert_eq!(row.self_membership, SelfMembership::Member);
+
+    store
+        .put_leave_request(&LeaveRequest {
+            group_id: group_id.clone(),
+            requested_at_ms: 1_700_000_000_123,
+            last_proposed_epoch: Some(EpochId(3)),
+        })
+        .unwrap();
+
+    // Visible through both read paths without any projection rebuild, and while
+    // membership is still `Member` — that is the whole point.
+    let row = store.chat_list_row(GROUP).unwrap().unwrap();
+    assert_eq!(row.leave_requested_at_ms, Some(1_700_000_000_123));
+    assert_eq!(row.self_membership, SelfMembership::Member);
+    let rows = store
+        .chat_list_rows(ChatListQuery {
+            include_archived: true,
+        })
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].leave_requested_at_ms, Some(1_700_000_000_123));
+
+    // Read-time derivation means a rebuild neither clears nor staleness-flags the
+    // value: the projection has no column for it.
+    store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    assert_eq!(
+        store
+            .chat_list_row(GROUP)
+            .unwrap()
+            .unwrap()
+            .leave_requested_at_ms,
+        Some(1_700_000_000_123)
+    );
+    {
+        let conn = store.lock().unwrap();
+        assert!(
+            chat_list_projection_complete_tx(&conn, LOCAL, &no_mentions).unwrap(),
+            "a pending leave request must not make the projection look stale"
+        );
+    }
+
+    // The engine clears the request from paths that never touch the projection,
+    // so the derived value has to disappear with it and not linger.
+    store.clear_leave_request(&group_id).unwrap();
+    assert_eq!(
+        store
+            .chat_list_row(GROUP)
+            .unwrap()
+            .unwrap()
+            .leave_requested_at_ms,
+        None
     );
 }

--- a/crates/storage-sqlite/src/storage/leave_requests.rs
+++ b/crates/storage-sqlite/src/storage/leave_requests.rs
@@ -1,7 +1,54 @@
 use crate::{SqliteAccountStorage, SqliteResultExt, deserialize, serialize};
 use cgka_traits::storage::{LeaveRequest, LeaveRequestStorage, StorageResult};
 use cgka_traits::types::GroupId;
-use rusqlite::{OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, params};
+use std::collections::HashMap;
+
+/// Every durable leave request keyed by lowercase hex group id, mapped to its
+/// `requested_at_ms`.
+///
+/// The engine owns this table and clears rows from several paths that never
+/// notify the app projection (an accepted commit that removed us, hydration
+/// finding the local member already gone, a convergence reorg). Projections that
+/// want to show a pending leave therefore read through to it at read time rather
+/// than denormalizing a column that could silently go stale.
+///
+/// The table is bounded by leaves that are still in flight — normally zero or
+/// one row — so sweeping it whole is cheaper than a per-row lookup, and it lets
+/// callers join in Rust instead of expression-joining `hex(group_id)` against
+/// `group_id_hex` (which could not use the primary-key index anyway).
+pub(crate) fn pending_leave_requests_by_group_hex_tx(
+    tx: &Connection,
+) -> StorageResult<HashMap<String, u64>> {
+    let mut statement = tx
+        .prepare("SELECT group_id, record FROM cgka_leave_requests")
+        .storage()?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?))
+        })
+        .storage()?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .storage()?;
+    rows.into_iter()
+        .map(|(group_id, record)| {
+            let request: LeaveRequest = deserialize(&record)?;
+            Ok((hex::encode(group_id), request.requested_at_ms))
+        })
+        .collect()
+}
+
+impl SqliteAccountStorage {
+    /// Every outstanding durable leave request, keyed by lowercase hex group id.
+    ///
+    /// The app layer uses this to project a pending leave onto group records
+    /// without denormalizing a column; see
+    /// [`pending_leave_requests_by_group_hex_tx`].
+    pub fn pending_leave_requests(&self) -> StorageResult<HashMap<String, u64>> {
+        let conn = self.lock()?;
+        pending_leave_requests_by_group_hex_tx(&conn)
+    }
+}
 
 impl LeaveRequestStorage for SqliteAccountStorage {
     fn put_leave_request(&self, request: &LeaveRequest) -> StorageResult<()> {

--- a/crates/storage-sqlite/src/storage/mod.rs
+++ b/crates/storage-sqlite/src/storage/mod.rs
@@ -3,7 +3,9 @@ mod capabilities;
 mod convergence_passes;
 mod convergence_policy;
 mod groups;
-mod leave_requests;
+/// `pub(crate)` because the chat-list projection reads durable leave requests at
+/// read time instead of denormalizing them into `chat_list_rows`.
+pub(crate) mod leave_requests;
 mod maintenance;
 mod member_validation_cache;
 mod messages;

--- a/crates/traits/src/error.rs
+++ b/crates/traits/src/error.rs
@@ -37,6 +37,23 @@ pub enum EngineError {
     #[error("admin cannot self-remove: leave the admin set first")]
     AdminCannotSelfRemove { group_id: GroupId },
 
+    /// A durable leave request already covers this group's current epoch, so a
+    /// fresh SelfRemove proposal would be redundant.
+    ///
+    /// Not an engine bug and not a transient failure: the durable intent is
+    /// already recorded and the engine re-proposes on each new epoch until a
+    /// commit removes the local member. Callers should surface progress rather
+    /// than retry.
+    ///
+    /// This is deliberately its own variant rather than an
+    /// [`InvalidTransition`](crate::engine_state::InvalidTransition), which is
+    /// documented below as indicating an engine bug: a user double-tapping Leave
+    /// is routine input, and the classification has to be decided here — under
+    /// the same lock as the durable read and write — because any check made
+    /// above this layer is a check-then-act race.
+    #[error("leave already requested for the current epoch")]
+    LeaveAlreadyRequested { group_id: GroupId },
+
     /// MIP-03 §150 — a commit that would result in zero admins is rejected
     /// before construction. Used when an inbound SelfRemove from the only
     /// admin would deplete admins on commit.


### PR DESCRIPTION
## Why

Leaving a group is two-phase. `cgka-engine` records a durable `LeaveRequest` (`crates/traits/src/storage.rs:155`, table `cgka_leave_requests`) **before** it publishes, because MLS SelfRemove proposals are epoch-bound while the product intent is not — the engine re-proposes each new epoch until a commit actually removes us.

Terminal `SelfMembership::Left` is only written at the *end* of `leave_group_with_audit_context`. So a publish failure (`fail_if_publish_failed` returns early) or app termination mid-flight left the intent durable on disk but invisible above the engine boundary: `leave_request` appeared only in `cgka-engine`, `storage-sqlite`, and `traits`, with no accessor on `Engine`, `cgka_session::Session`, `marmot-app`, `marmot-uniffi`, or the CLI.

Reported from mobile:

- A cold launch could not rediscover a pending leave — the group rendered as a normal active conversation with an enabled Leave button.
- Tapping Leave again in the same epoch hit `EngineError::InvalidTransition { from: "Leaving" }`, which reached the host as an opaque `MarmotKitError::Runtime`.

## Approach

**Derive at read time from `cgka_leave_requests`. No new column.**

`LeaveRequestStorage` is already implemented for `SqliteAccountStorage`, and `MarmotApp::account_storage()` returns exactly that type against the same `session.sqlite` file — so this needs **no migration, no backfill, and no new engine or session accessor**. The table was directly readable from the app layer all along, just never read.

It is also the correct source of truth, not merely the cheap one: the engine clears leave requests from five paths that never notify the app projection (`engine.rs:1466`, `ingest.rs:1322`, `ingest.rs:2006`, `send.rs:759`, `distributed_convergence.rs:1403`). A denormalized column would silently go stale.

`rebuild_chat_list_row_for_group_tx` and `chat_list_projection_complete_tx` are **deliberately untouched**, with comments saying so. There is no stored column to keep fresh, and comparing a read-time-only field in the freshness predicate would mark every row stale forever.

Two population points cover the entire surface:

| Populated in | Reaches |
| --- | --- |
| `chat_list_rows_tx` / `chat_list_row_tx` | `chat_list`, `chat_list_row`, `subscribe_chat_list`, `ChatListSubscription`, `wn-cli` JSON |
| `MarmotApp::groups` | `group`, `visible_groups`, `subscribe_chats` (snapshot **and** deltas — both read through `app.groups`/`app.group`), `group_details`, `group_management_state` |

No new `ChatListUpdateTrigger` variant. `chat_list_row_fingerprint` and `app_group_record_fingerprint` both serde the whole struct, so change detection picks the field up automatically, and `MembershipChanged` is already the accurate trigger — adding a variant would break exhaustive `switch`/`when` in host code for no gain.

## Host-visible surface

`ChatListRowFfi`, `AppGroupRecordFfi`, and `GroupManagementStateFfi` gain `leave_request_pending: bool` and `leave_requested_at_ms: Option<u64>`. Internally only the `Option<u64>` is carried and the FFI layer derives the bool, so the pair cannot hold a contradictory value.

Behavior changes a reviewer should weigh:

- **`GroupManagementStateFfi.can_leave` is now `false` while a leave is pending.** It now means "a Leave tap will do something"; `leave_request_pending` is what distinguishes "already leaving" from "admin, must self-demote first". This changes existing semantics for hosts, chosen so the button disables rather than erroring on a second tap.
- **New `MarmotKitError::LeaveAlreadyRequested`.** Checked **first** in `leave_group`'s preflight — order matters, because the tightened `can_leave` would otherwise report `MemberNotInGroup` for a group the account is very much still in.

## Two deviations from the original plan

- **The publish-failure notification moved.** The plan called for `refresh_group` in the client's error branch; that would have notified nobody, since `refresh_group` only mutates in-memory state. The events channel lives in the worker, so the `LeaveGroup` arm now publishes `GroupStateUpdated` on both paths. A no-op re-read is cheap — `subscribe_chat_list` fingerprint-dedupes it away.
- **Pending check ordering** in `leave_group`, as described above.

## Verification

- `just fast-ci` green.
- `cargo test -p storage-sqlite` (279), `-p marmot-uniffi` (70 + 25 smoke), `-p marmot-app` (451 unit) pass.
- `pending_leave_request_survives_a_cold_launch` reproduces the reported bug: bob leaves, alice has not committed the SelfRemove, and a fresh `MarmotApp` over the same directory still reports the intent on both the chat-list row and the group record.
- Generated Kotlin confirms the contract actually changed (`output/` is gitignored and CI never builds bindings, so this is the only real check): fields land on `AppGroupRecordFfi`, `ChatListRowFfi`, `GroupManagementStateFfi`, plus the `LeaveAlreadyRequested` exception class. Only the bindgen half of `kotlin-bindings.sh` was run — the four Android ABI cross-builds do not affect the generated surface, and `cargo-ndk`/`ANDROID_NDK_HOME` are not configured on this machine.

**Correction to an earlier revision of this description:** it claimed 5 `relay_runtime` tests were failing pre-existing. That was wrong — my invocation was missing `test-policy-overrides`, which the pinned convergence policy (mdk#970) requires. With the flag CI uses, `relay_runtime` is 78/78 green. No pre-existing failures.

## Release note

CHANGELOG `Unreleased` entry added; **no `Cargo.toml` bump**. The UniFFI record and error-variant changes do require a workspace version bump per `crates/marmot-uniffi/AGENTS.md` and `release.md`, but that happens at release time while Unreleased entries accumulate.

`chats list --json` / `chat_list_row` rows gain a `leave_requested_at_ms` field; no other JSON response shapes changed. Rendering "Leaving…" in the TUI was left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round 2 (`7fcaa6eb`)

Addresses both findings from @erskingardner's review.

### P1 — already-requested classification is now atomic

The preflight was a TOCTOU check. Two concurrent leaves could both observe `false`; the worker serialized them and the loser got `EngineError::InvalidTransition` → the untyped `Runtime` bucket, preserving the exact opaque error this PR set out to remove.

New `EngineError::LeaveAlreadyRequested`, returned from `do_send_leave` under the same lock as the durable read and write, so it cannot be raced past. The preflight stays as a fast path, demoted to an optimization with the engine as the authority.

**Worth noting beyond the review:** `InvalidTransition` was the wrong carrier regardless of the race — [error.rs](../blob/master/crates/traits/src/error.rs) documents it as *"Indicates an engine bug"*, and a double-tap is routine input. An ordinary send blocked by a current leave stays `InvalidTransition`; that one genuinely is an illegal transition. The forensic-audit and conformance classifiers gain matching `leave_already_requested` arms (no vector asserted the old string).

Three regression tests, one per seam:

| Seam | Asserts |
| --- | --- |
| `cgka-engine/tests/invite_leave.rs` | repeats refused by name, repeatably; durable request left byte-identical |
| `marmot-app/tests/relay_runtime.rs` | two `leave_group` calls via `tokio::join!` → exactly one success, one typed refusal |
| `marmot-uniffi/src/errors.rs` | variant crosses FFI as `LeaveAlreadyRequested`; `InvalidTransition` stays untyped |

The runtime-level path has no preflight (that lives in the uniffi layer), so the losing call necessarily reaches the engine — the concurrent test exercises the real classification rather than the precheck.

### P2 — the lifecycle docs were wrong

Correct, and my error: the leave path writes `SelfMembership::Left` as soon as the proposal publishes, so `Left` does not imply a commit removed the member. My field docs claimed the opposite while my own cold-launch test narrated the truth in a comment.

Now documented as orthogonal, with a state table on `ChatListRowFfi`:

| `self_membership` | `leave_request_pending` | meaning |
|---|---|---|
| `Member` | `true` | leave requested, publish failed or was interrupted |
| `Left` | `true` | leave published, awaiting a member to commit it |
| `Left` | `false` | resolved |
| `Removed` | `false` | removed by someone else |

Fixed in all four declarations, the CHANGELOG, and the test comment — and the coexistence is now asserted rather than only described, so the docs can't drift back.

### Also in this round

Merged `origin/master` (`6b4de626`). Only the CHANGELOG conflicted, additively; the four Rust files auto-merged, and I hand-verified the `LeaveGroup` worker arm since #1134 rewrote 117 lines of that file.

Verification: `just fast-ci` green; `cgka-traits`, `storage-sqlite`, `marmot-uniffi`, `cgka-engine`, `cgka-conformance-simulator`, and `marmot-app` suites all green with the feature flag CI uses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visible pending-leave status and request timestamp to group and chat list information.
  * Pending leave requests now remain discoverable after restarting the app.
  * Leave controls are disabled while a request is in progress.
  * Added a specific “leave already requested” error for repeated or concurrent leave attempts.

* **Bug Fixes**
  * Group state updates now appear immediately after leave attempts, including failures.
  * Pending leave status is derived consistently across chat lists, group views, and bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->