### PR TITLE
test: add file-backed conformance and crash recovery coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         # The subprocess-heavy `wn-cli::cli` suite runs in its own
         # `cli-e2e` job so its fan-out never starves these fast unit tests
         # (issue #103). `relay_runtime` keeps its own serial job.
-        run: cargo nextest run --workspace --exclude cgka-conformance-simulator --features wn-cli/test-policy-overrides --locked --profile ci --partition count:${{ matrix.partition }}/4 -E 'not (package(marmot-app) & binary(relay_runtime)) and not (package(wn-cli) & binary(cli))'
+        run: cargo nextest run --workspace --exclude cgka-conformance-simulator --features wn-cli/test-policy-overrides,cgka-engine/test-crash-hooks --locked --profile ci --partition count:${{ matrix.partition }}/4 -E 'not (package(marmot-app) & binary(relay_runtime)) and not (package(wn-cli) & binary(cli))'
 
       - name: Run doctests
         if: matrix.partition == 1
@@ -313,12 +313,15 @@ jobs:
       - name: Run simulator doctests
         run: cargo test -p cgka-conformance-simulator --doc --locked
 
-      - name: Run vector report
+      - name: Run encrypted file-backed vector report
         run: |
           cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report --locked -- \
             --vectors crates/cgka-conformance-simulator/vectors \
             --out target/cgka-conformance-simulator-reports \
+            --storage file \
             --strict-oracle
+          jq -s -e 'all(.[]; .metadata.storage_backend == "encrypted-file-sqlite")' \
+            target/cgka-conformance-simulator-reports/*-report.json >/dev/null
 
       - name: Upload vector report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,6 +867,7 @@ dependencies = [
  "openmls_traits",
  "proptest",
  "rand 0.8.6",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,7 @@
 set shell := ["bash", "-cu"]
 
 otlp-features := "marmot-app/otlp-export,marmot-uniffi/otlp-export,wn-cli/otlp-export"
-test-features := "wn-cli/test-policy-overrides"
+test-features := "wn-cli/test-policy-overrides,cgka-engine/test-crash-hooks"
 
 default:
     @just --list

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -16,9 +16,11 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
 
 - **Module:** `src/client.rs`
   - **Role:** `HarnessClient` + `ClientBuilder`. Wraps an `Engine<SqliteAccountStorage>`, a real `NostrMlsPeeler`, and the bus
-    handle. It uses in-memory SQLite by default and can run on temp file-backed SQLite via
-    `MDK_CONFORMANCE_SQLITE_STORAGE=file` or `ClientBuilder::storage_mode`. `tick().await` drains pending inbound
-    for one client. `confirm(pending).await` finishes a `GroupEvolution`.
+    handle. It uses in-memory SQLite by default and can run on temp file-backed SQLite via the report CLI's
+    `--storage file`, `MDK_CONFORMANCE_SQLITE_STORAGE=file`, or `ClientBuilder::storage_mode`. Explicit CLI selection
+    overrides the environment. File-backed `restart()` drops all engine/storage handles, reopens the encrypted database,
+    and hydrates it. `tick().await` drains pending inbound for one client. `confirm(pending).await` finishes a
+    `GroupEvolution`.
 
 - **Module:** `cgka_engine::convergence`
   - **Role:** Candidate-state graph scoring rules for the distributed convergence design, re-exported by this crate for

--- a/crates/cgka-conformance-simulator/Cargo.toml
+++ b/crates/cgka-conformance-simulator/Cargo.toml
@@ -39,3 +39,4 @@ tempfile.workspace = true
 # the transport crates' key derivation, AAD, and broker control bytes.
 transport-quic-stream.workspace = true
 transport-quic-broker.workspace = true
+rusqlite.workspace = true

--- a/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
+++ b/crates/cgka-conformance-simulator/PROPERTY_TESTS.md
@@ -140,5 +140,5 @@ Used by selector, canonicalization, capability, quiescence, and restart properti
   properties cover those today.
 - Partition behavior is covered by fixed scenarios and generated families. The property-test delivery profiles cover
   FIFO, reverse, and seeded random delivery.
-- Storage-loss recovery is still future work. Restart equivalence covers rebuilding over the same storage, not missing
-  or corrupted local records.
+- File-backed restart and subprocess-kill coverage exercises close/reopen and crash recovery with an intact encrypted
+  database and WAL. Recovery from genuinely missing or corrupted local records is still future work.

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -6,9 +6,11 @@ The engine crate proves local engine rules. This crate asks the bigger question:
 the network behaves badly, do they still end up with the same group state?
 
 The simulator does not use real relays. It runs `Engine<SqliteAccountStorage>` clients against a deterministic in-memory
-`TransportBus`, using in-memory SQLite by default. Set `MDK_CONFORMANCE_SQLITE_STORAGE=file` to run harness
-clients on temporary encrypted SQLite files. Transport wrapping still goes through the real Nostr peeler, so group
-messages use the Marmot kind-445 envelope and welcomes use NIP-59 gift wraps before the bus delivers them.
+`TransportBus`, using in-memory SQLite by default. Report runs select storage explicitly with
+`--storage memory|file`; the flag overrides `MDK_CONFORMANCE_SQLITE_STORAGE` when both are present. File mode uses
+temporary encrypted SQLite databases and a restart fully closes and reopens each client database before hydration.
+Transport wrapping still goes through the real Nostr peeler, so group messages use the Marmot kind-445 envelope and
+welcomes use NIP-59 gift wraps before the bus delivers them.
 
 ## What this crate gives you
 
@@ -70,15 +72,19 @@ To run every portable vector fixture and write a report for each one:
 ```sh
 cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report -- \
   --vectors crates/cgka-conformance-simulator/vectors \
-  --out target/cgka-conformance-simulator-reports
+  --out target/cgka-conformance-simulator-reports \
+  --storage file \
+  --strict-oracle
 ```
 
 The normal `cargo test -p cgka-conformance-simulator` run already validates the top-level vector fixtures and checks the
-vector manifest / byte-fixture files. Use the report command when you want saved JSON reports and a human-readable
+vector manifest / byte-fixture files through the default in-memory backend. CI additionally runs every portable vector
+through encrypted file-backed storage. Use the report command when you want saved JSON reports and a human-readable
 pass/fail summary outside the test harness.
 
 The report command exits non-zero when any fixture expectation fails. Each report includes the exact scenario input,
-observed trace, flattened recovery and epoch observations, and the mismatched expected/actual JSON.
+selected storage backend, observed trace, flattened recovery and epoch observations, and the mismatched expected/actual
+JSON.
 
 ## Property tests
 
@@ -268,6 +274,10 @@ Reports are written as one file per case, for example
 candidates such as `target/cgka-conformance-simulator-reports/convergence-chaos-v1-seed-42-case-0-fixture.v1.json`.
 Pass `--strict-oracle` when a report run should fail on oracle coverage problems (`weak_oracle_warnings` or
 `missing_observed_behaviors`) instead of treating them as advisory metadata.
+
+File-backed restart tests and the engine subprocess-kill tests cover durability when the encrypted database and WAL are
+intact: handles are closed or the process is killed, the database is reopened, and hydration reconciles interrupted
+convergence state. Recovery when required local records are genuinely missing or corrupted remains future work.
 
 ## When to use the harness vs. integration tests
 

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -30,9 +30,10 @@ use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
 use cgka_traits::{ConvergenceCutoffCause, ConvergencePassPhase, DurableConvergencePass};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
-use storage_sqlite::{SqlCipherKey, SqliteAccountStorage};
+use storage_sqlite::{SqlCipherKey, SqliteAccountStorage, SqliteStorageOptions};
 use transport_nostr_peeler::NostrMlsPeeler;
 
 const STORAGE_MODE_ENV: &str = "MDK_CONFORMANCE_SQLITE_STORAGE";
@@ -41,11 +42,11 @@ const HARNESS_CONVERGENCE_SETTLED_AT_MS: u64 = 1_000_000;
 const HARNESS_CONVERGENCE_DRAIN_PASSES: usize = 8;
 
 pub struct HarnessClient {
-    pub engine: Engine<SqliteAccountStorage>,
+    engine: Option<Engine<SqliteAccountStorage>>,
     pub bus_id: ClientId,
     bus: TransportBus,
-    storage: SqliteAccountStorage,
-    _storage_dir: Option<tempfile::TempDir>,
+    storage: Option<SqliteAccountStorage>,
+    storage_backing: HarnessStorageBacking,
     identity: Vec<u8>,
     signer: nostr::Keys,
     registry: FeatureRegistry,
@@ -67,6 +68,8 @@ pub struct ClientBuilder {
     registry: FeatureRegistry,
     protocol_profile: ProtocolProfile,
     storage_mode: HarnessStorageMode,
+    storage_options: SqliteStorageOptions,
+    explicit_file_storage: Option<ExplicitFileStorage>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -76,34 +79,92 @@ pub enum HarnessStorageMode {
 }
 
 impl HarnessStorageMode {
-    fn from_env() -> Self {
+    pub fn from_env() -> Self {
         match std::env::var(STORAGE_MODE_ENV) {
-            Ok(value) if matches!(value.as_str(), "file" | "file-backed" | "tempfile") => {
-                Self::TempFileBackedSqlite
-            }
-            Ok(value) if matches!(value.as_str(), "memory" | "in-memory" | "sqlite-memory") => {
-                Self::InMemorySqlite
-            }
-            Ok(value) => panic!(
-                "{STORAGE_MODE_ENV} must be one of memory, in-memory, sqlite-memory, file, file-backed, or tempfile; got {value:?}"
-            ),
+            Ok(value) => Self::parse(&value).unwrap_or_else(|err| panic!("{err}")),
             Err(_) => Self::InMemorySqlite,
         }
     }
 
-    fn open(self) -> Result<(SqliteAccountStorage, Option<tempfile::TempDir>), String> {
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "file" | "file-backed" | "tempfile" => Ok(Self::TempFileBackedSqlite),
+            "memory" | "in-memory" | "sqlite-memory" => Ok(Self::InMemorySqlite),
+            _ => Err(format!(
+                "{STORAGE_MODE_ENV} and --storage must be one of memory, in-memory, sqlite-memory, file, file-backed, or tempfile; got {value:?}"
+            )),
+        }
+    }
+
+    pub fn report_label(self) -> &'static str {
         match self {
-            Self::InMemorySqlite => SqliteAccountStorage::in_memory()
-                .map(|storage| (storage, None))
-                .map_err(|err| err.to_string()),
-            Self::TempFileBackedSqlite => {
-                let dir = tempfile::tempdir().map_err(|err| err.to_string())?;
+            Self::InMemorySqlite => "in-memory-sqlite",
+            Self::TempFileBackedSqlite => "encrypted-file-sqlite",
+        }
+    }
+}
+
+struct ExplicitFileStorage {
+    path: PathBuf,
+    key: SqlCipherKey,
+    options: SqliteStorageOptions,
+}
+
+enum HarnessStorageBacking {
+    InMemory,
+    FileBacked {
+        _storage_dir: Option<tempfile::TempDir>,
+        path: PathBuf,
+        key: SqlCipherKey,
+        options: SqliteStorageOptions,
+    },
+}
+
+impl HarnessStorageBacking {
+    fn from_mode(mode: HarnessStorageMode, options: SqliteStorageOptions) -> Result<Self, String> {
+        match mode {
+            HarnessStorageMode::InMemorySqlite => Ok(Self::InMemory),
+            HarnessStorageMode::TempFileBackedSqlite => {
+                let storage_dir = tempfile::tempdir().map_err(|err| err.to_string())?;
+                let path = storage_dir.path().join("client.sqlite3");
                 let key = SqlCipherKey::new(TEMP_FILE_KEY).map_err(|err| err.to_string())?;
-                let storage =
-                    SqliteAccountStorage::open_encrypted(dir.path().join("client.sqlite3"), &key)
-                        .map_err(|err| err.to_string())?;
-                Ok((storage, Some(dir)))
+                Ok(Self::FileBacked {
+                    _storage_dir: Some(storage_dir),
+                    path,
+                    key,
+                    options,
+                })
             }
+        }
+    }
+
+    fn from_explicit(explicit: ExplicitFileStorage) -> Self {
+        Self::FileBacked {
+            _storage_dir: None,
+            path: explicit.path,
+            key: explicit.key,
+            options: explicit.options,
+        }
+    }
+
+    fn open(&self) -> Result<SqliteAccountStorage, String> {
+        match self {
+            Self::InMemory => SqliteAccountStorage::in_memory().map_err(|err| err.to_string()),
+            Self::FileBacked {
+                path, key, options, ..
+            } => SqliteAccountStorage::open_encrypted_with_options(path, key, options.clone())
+                .map_err(|err| err.to_string()),
+        }
+    }
+
+    fn is_file_backed(&self) -> bool {
+        matches!(self, Self::FileBacked { .. })
+    }
+
+    fn database_path(&self) -> Option<&Path> {
+        match self {
+            Self::InMemory => None,
+            Self::FileBacked { path, .. } => Some(path),
         }
     }
 }
@@ -120,6 +181,8 @@ impl ClientBuilder {
             registry: FeatureRegistry::new(),
             protocol_profile: ProtocolProfile::Legacy,
             storage_mode: HarnessStorageMode::from_env(),
+            storage_options: SqliteStorageOptions::default(),
+            explicit_file_storage: None,
         }
     }
 
@@ -130,6 +193,27 @@ impl ClientBuilder {
 
     pub fn storage_mode(mut self, mode: HarnessStorageMode) -> Self {
         self.storage_mode = mode;
+        self.explicit_file_storage = None;
+        self
+    }
+
+    pub fn storage_options(mut self, options: SqliteStorageOptions) -> Self {
+        self.storage_options = options;
+        self
+    }
+
+    pub fn file_backed_storage(
+        mut self,
+        path: impl Into<PathBuf>,
+        key: SqlCipherKey,
+        options: SqliteStorageOptions,
+    ) -> Self {
+        self.storage_mode = HarnessStorageMode::TempFileBackedSqlite;
+        self.explicit_file_storage = Some(ExplicitFileStorage {
+            path: path.into(),
+            key,
+            options,
+        });
         self
     }
 
@@ -139,7 +223,12 @@ impl ClientBuilder {
     }
 
     pub fn attach(self, bus: &TransportBus) -> HarnessClient {
-        let (storage, storage_dir) = self.storage_mode.open().expect("storage opens");
+        let storage_backing = match self.explicit_file_storage {
+            Some(explicit) => HarnessStorageBacking::from_explicit(explicit),
+            None => HarnessStorageBacking::from_mode(self.storage_mode, self.storage_options)
+                .expect("storage backing opens"),
+        };
+        let storage = storage_backing.open().expect("storage opens");
         let audit_capture = AuditCapture::default();
         let engine = build_harness_engine(
             &storage,
@@ -151,11 +240,11 @@ impl ClientBuilder {
         );
         let bus_id = bus.attach(MemberId::new(self.identity.clone()));
         HarnessClient {
-            engine,
+            engine: Some(engine),
             bus_id,
             bus: bus.clone(),
-            storage,
-            _storage_dir: storage_dir,
+            storage: Some(storage),
+            storage_backing,
             identity: self.identity,
             signer: self.signer,
             registry: self.registry,
@@ -313,13 +402,32 @@ fn logical_label_from_seed(seed: &[u8]) -> Option<String> {
 }
 
 impl HarnessClient {
+    pub fn engine(&self) -> &Engine<SqliteAccountStorage> {
+        self.engine.as_ref().expect("harness engine is available")
+    }
+
+    pub fn engine_mut(&mut self) -> &mut Engine<SqliteAccountStorage> {
+        self.engine.as_mut().expect("harness engine is available")
+    }
+
     pub fn storage(&self) -> &SqliteAccountStorage {
-        &self.storage
+        self.storage.as_ref().expect("harness storage is available")
+    }
+
+    pub fn database_path(&self) -> Option<&Path> {
+        self.storage_backing.database_path()
     }
 
     pub fn restart(&mut self) {
+        drop(self.engine.take());
+        let storage = if self.storage_backing.is_file_backed() {
+            drop(self.storage.take());
+            self.storage_backing.open().expect("file storage reopens")
+        } else {
+            self.storage().clone()
+        };
         let mut engine = build_harness_engine(
-            &self.storage,
+            &storage,
             &self.identity,
             &self.signer,
             &self.registry,
@@ -329,7 +437,8 @@ impl HarnessClient {
         engine
             .hydrate_stable_groups_from_storage()
             .expect("engine hydrates from storage");
-        self.engine = engine;
+        self.storage = Some(storage);
+        self.engine = Some(engine);
         self.pending_events.clear();
     }
 
@@ -338,14 +447,14 @@ impl HarnessClient {
     /// engine storage to manufacture the boundary themselves.
     pub fn freeze_convergence_pass(&mut self, group_id: &GroupId) {
         let mut pass = self
-            .storage
+            .storage()
             .convergence_pass(group_id)
             .expect("load durable convergence pass")
             .expect("durable convergence pass exists");
         pass.phase = ConvergencePassPhase::Frozen;
         pass.cutoff_cause = Some(ConvergenceCutoffCause::Quiescence);
         pass.frozen_at_wall_ms = Some(pass.quiescence_deadline_wall_ms);
-        self.storage
+        self.storage()
             .put_convergence_pass(&pass)
             .expect("persist frozen convergence pass");
     }
@@ -354,11 +463,11 @@ impl HarnessClient {
     /// epoch snapshots intentionally exclude.
     pub fn checkpoint_convergence(&mut self, group_id: &GroupId, name: &str) {
         let pass = self
-            .storage
+            .storage()
             .convergence_pass(group_id)
             .expect("load convergence pass for checkpoint")
             .expect("checkpoint requires a convergence pass");
-        self.storage
+        self.storage()
             .create_group_snapshot(group_id, name)
             .expect("create convergence group snapshot");
         self.convergence_checkpoints
@@ -374,7 +483,7 @@ impl HarnessClient {
             .get(name)
             .cloned()
             .expect("convergence checkpoint exists");
-        self.storage
+        self.storage()
             .with_transaction(|storage| {
                 storage.rollback_group_to_snapshot(&group_id, name)?;
                 storage.put_convergence_pass(&pass)
@@ -388,7 +497,7 @@ impl HarnessClient {
         group_id: &GroupId,
         now_ms: u64,
     ) -> CanonicalizationResult {
-        self.engine
+        self.engine_mut()
             .converge_stored_openmls_messages(group_id, now_ms)
             .expect("stored convergence succeeds")
     }
@@ -412,11 +521,11 @@ impl HarnessClient {
     }
 
     pub fn member_id(&self) -> MemberId {
-        self.engine.self_id()
+        self.engine().self_id()
     }
 
     pub async fn fresh_key_package(&mut self) -> KeyPackage {
-        let key_package = self.engine.fresh_key_package().await.expect("kp");
+        let key_package = self.engine_mut().fresh_key_package().await.expect("kp");
         key_package_with_harness_source(key_package)
     }
 
@@ -490,14 +599,15 @@ impl HarnessClient {
         required_features: Vec<cgka_traits::capabilities::Feature>,
         initial_admins: Vec<MemberId>,
     ) -> Result<(GroupId, Option<PendingStateRef>), EngineError> {
+        let routing_component = harness_nostr_routing_component(&self.identity, name);
         let res = self
-            .engine
+            .engine_mut()
             .create_group(CreateGroupRequest {
                 name: name.into(),
                 description: "".into(),
                 members: invitees,
                 required_features,
-                app_components: vec![harness_nostr_routing_component(&self.identity, name)],
+                app_components: vec![routing_component],
                 initial_admins,
             })
             .await?;
@@ -524,7 +634,7 @@ impl HarnessClient {
     /// action (create, invite, upgrade) when the simulated transport
     /// "succeeds."
     pub async fn confirm(&mut self, pending: PendingStateRef) {
-        self.engine
+        self.engine_mut()
             .confirm_published(pending)
             .await
             .expect("confirm_published");
@@ -534,7 +644,7 @@ impl HarnessClient {
     /// discards the staged commit and rewinds to `Stable` at the prior
     /// epoch. Used by the rollback proptest property.
     pub async fn fail(&mut self, pending: PendingStateRef) {
-        self.engine
+        self.engine_mut()
             .publish_failed(pending)
             .await
             .expect("publish_failed");
@@ -546,7 +656,7 @@ impl HarnessClient {
     pub async fn upgrade(&mut self) -> PendingStateRef {
         let gid = self.default_group.clone().expect("group");
         let res = self
-            .engine
+            .engine_mut()
             .upgrade_group_capabilities(&gid)
             .await
             .expect("upgrade");
@@ -569,7 +679,7 @@ impl HarnessClient {
     pub async fn update_group_data(&mut self, name: impl Into<String>) -> PendingStateRef {
         let gid = self.default_group.clone().expect("group");
         let res = self
-            .engine
+            .engine_mut()
             .send(SendIntent::UpdateGroupData {
                 group_id: gid.clone(),
                 name: Some(name.into()),
@@ -601,7 +711,7 @@ impl HarnessClient {
         let gid = self.default_group.clone().expect("group");
         let data = encode_admin_policy(admins)?;
         let res = self
-            .engine
+            .engine_mut()
             .send(SendIntent::UpdateAppComponents {
                 group_id: gid.clone(),
                 updates: vec![AppComponentData {
@@ -631,7 +741,7 @@ impl HarnessClient {
 
     pub fn admin_labels(&self) -> Vec<String> {
         let gid = self.default_group.clone().expect("group");
-        self.engine
+        self.engine()
             .admin_pubkeys(&gid)
             .expect("admin pubkeys")
             .into_iter()
@@ -649,7 +759,7 @@ impl HarnessClient {
             .expect("must create or join a group first");
         let payload = self.next_app_payload(payload.into());
         let res = self
-            .engine
+            .engine_mut()
             .send(SendIntent::AppMessage {
                 group_id: gid.clone(),
                 payload,
@@ -674,7 +784,7 @@ impl HarnessClient {
             .expect("must create or join a group first");
         let payload = self.next_app_payload(payload.into());
         let res = self
-            .engine
+            .engine_mut()
             .send(SendIntent::AppMessage {
                 group_id: gid.clone(),
                 payload,
@@ -703,7 +813,7 @@ impl HarnessClient {
     ) -> Result<PendingStateRef, EngineError> {
         let gid = self.default_group.clone().expect("group");
         let res = self
-            .engine
+            .engine_mut()
             .send(SendIntent::Invite {
                 group_id: gid.clone(),
                 key_packages: kps,
@@ -739,7 +849,7 @@ impl HarnessClient {
     pub async fn leave_capture(&mut self) -> TransportMessage {
         let gid = self.default_group.clone().expect("group");
         let res = self
-            .engine
+            .engine_mut()
             .send(SendIntent::Leave {
                 group_id: gid.clone(),
             })
@@ -760,7 +870,7 @@ impl HarnessClient {
         let mut outcomes = self.tick_ingest_only().await;
         if let Some(gid) = self.default_group.clone() {
             match self
-                .engine
+                .engine_mut()
                 .advance_convergence_inputs_until_settled(&gid, HARNESS_CONVERGENCE_SETTLED_AT_MS)
                 .await
             {
@@ -787,7 +897,7 @@ impl HarnessClient {
         let inbound = self.bus.mailbox(self.bus_id);
         let mut outcomes = Vec::with_capacity(inbound.len());
         for msg in inbound {
-            let result = self.engine.ingest(msg).await;
+            let result = self.engine_mut().ingest(msg).await;
             if result.is_ok() {
                 self.capture_engine_events();
             }
@@ -800,7 +910,7 @@ impl HarnessClient {
     ///
     /// Debug/test harness escape hatch; release builds reject non-v1 policies.
     pub fn set_convergence_policy(&mut self, policy: CanonicalizationPolicy) {
-        self.engine
+        self.engine_mut()
             .set_convergence_policy(policy)
             .expect("convergence policy accepted");
     }
@@ -809,7 +919,7 @@ impl HarnessClient {
     /// timer (`CgkaEngine::advance_convergence`), then capture emitted events.
     pub async fn advance_convergence(&mut self) -> Result<(), EngineError> {
         let gid = self.default_group.clone().expect("group");
-        let results = self.engine.advance_convergence(&gid).await?;
+        let results = self.engine_mut().advance_convergence(&gid).await?;
         self.capture_engine_events();
         for result in results {
             self.publish_send_result(result).await?;
@@ -844,7 +954,7 @@ impl HarnessClient {
 
     pub fn has_pending_convergence_inputs(&self) -> bool {
         let gid = self.default_group.clone().expect("group");
-        self.engine
+        self.engine()
             .has_pending_convergence_inputs(&gid)
             .expect("pending convergence probe")
     }
@@ -867,13 +977,13 @@ impl HarnessClient {
         outcomes: &mut Vec<Result<IngestOutcome, EngineError>>,
     ) {
         for _ in 0..HARNESS_CONVERGENCE_DRAIN_PASSES {
-            let groups = self.engine.drain_pending_convergence_groups();
+            let groups = self.engine_mut().drain_pending_convergence_groups();
             if groups.is_empty() {
                 return;
             }
             for group_id in groups {
                 let results = match self
-                    .engine
+                    .engine_mut()
                     .converge_and_drain_queued_outbound_intents(
                         &group_id,
                         HARNESS_CONVERGENCE_SETTLED_AT_MS,
@@ -925,14 +1035,14 @@ impl HarnessClient {
                     msg
                 };
                 self.bus.send(self.bus_id, routed);
-                self.engine.confirm_published(pending).await?;
+                self.engine_mut().confirm_published(pending).await?;
                 self.capture_engine_events();
             }
             SendResult::GroupCreated { welcomes, pending } => {
                 for welcome in welcomes {
                     self.bus.send(self.bus_id, welcome);
                 }
-                self.engine.confirm_published(pending).await?;
+                self.engine_mut().confirm_published(pending).await?;
                 self.capture_engine_events();
             }
             SendResult::FoundingGroupCreated { welcomes } => {
@@ -948,7 +1058,7 @@ impl HarnessClient {
 
     async fn drain_auto_publish_confirm(&mut self) -> Vec<Result<IngestOutcome, EngineError>> {
         let mut outcomes = Vec::new();
-        let auto = self.engine.drain_auto_publish();
+        let auto = self.engine_mut().drain_auto_publish();
         let gid = self.default_group.clone();
         for auto in auto {
             let routed = if let Some(gid) = &gid {
@@ -957,13 +1067,13 @@ impl HarnessClient {
                 auto.msg
             };
             self.bus.send(self.bus_id, routed);
-            if let Err(e) = self.engine.confirm_published(auto.pending).await {
+            if let Err(e) = self.engine_mut().confirm_published(auto.pending).await {
                 outcomes.push(Err(e));
                 continue;
             }
             self.capture_engine_events();
         }
-        let proposals = self.engine.drain_auto_proposals();
+        let proposals = self.engine_mut().drain_auto_proposals();
         for msg in proposals {
             let routed = if let Some(gid) = &gid {
                 route(msg, gid)
@@ -982,12 +1092,12 @@ impl HarnessClient {
 
     pub fn epoch(&self) -> EpochId {
         let gid = self.default_group.clone().expect("group");
-        self.engine.epoch(&gid).expect("epoch")
+        self.engine().epoch(&gid).expect("epoch")
     }
 
     pub fn members(&self) -> Vec<cgka_traits::group::Member> {
         let gid = self.default_group.clone().expect("group");
-        self.engine.members(&gid).expect("members")
+        self.engine().members(&gid).expect("members")
     }
 
     /// Current app-facing group name mirrored from signed group-profile state.
@@ -1000,7 +1110,7 @@ impl HarnessClient {
     /// catch a permanent fork that epoch/member equality alone would miss.
     pub fn group_name(&self) -> String {
         let gid = self.default_group.clone().expect("group");
-        self.engine.group_record(&gid).expect("group record").name
+        self.engine().group_record(&gid).expect("group record").name
     }
 
     pub fn group_id(&self) -> GroupId {
@@ -1013,7 +1123,7 @@ impl HarnessClient {
             .app_event_counter
             .checked_add(1)
             .expect("app event counter exhausted");
-        encode_harness_app_payload(&self.engine.self_id(), seq, payload)
+        encode_harness_app_payload(&self.engine().self_id(), seq, payload)
     }
 
     /// Return a clone of `msg` whose payload is the peeled MLS wire bytes.
@@ -1035,7 +1145,7 @@ impl HarnessClient {
             }
         };
         let ctx = self
-            .engine
+            .engine()
             .group_context(&group_id)
             .map_err(|e| format!("group context: {e}"))?;
         let snapshot = GroupContextSnapshot::from_context(
@@ -1058,7 +1168,7 @@ impl HarnessClient {
 
 impl HarnessClient {
     fn capture_engine_events(&mut self) {
-        for event in self.engine.drain_events() {
+        for event in self.engine_mut().drain_events() {
             if let GroupEvent::GroupJoined { group_id, .. } = &event
                 && self.default_group.is_none()
             {

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -4,8 +4,9 @@
 //! to replay or promote a generated case into a fixed vector.
 
 use crate::{
-    GeneratedScenarioMetadata, ScenarioReport, ScenarioRunError, ScenarioSpec, ScenarioStep,
-    ScenarioTrace, TraceExpectation, VectorFixture, run_scenario_report_with_outcomes,
+    GeneratedScenarioMetadata, HarnessStorageMode, ScenarioReport, ScenarioRunError, ScenarioSpec,
+    ScenarioStep, ScenarioTrace, TraceExpectation, VectorFixture,
+    run_scenario_report_with_outcomes_and_storage_mode,
 };
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -98,16 +99,30 @@ pub async fn run_generated_case_report(
     case: &GeneratedScenarioCase,
     expected_trace: Option<ScenarioTrace>,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    let mut report = run_scenario_report_with_outcomes(
+    run_generated_case_report_with_storage_mode(
+        case,
+        expected_trace,
+        HarnessStorageMode::from_env(),
+    )
+    .await
+}
+
+pub async fn run_generated_case_report_with_storage_mode(
+    case: &GeneratedScenarioCase,
+    expected_trace: Option<ScenarioTrace>,
+    storage_mode: HarnessStorageMode,
+) -> Result<ScenarioReport, ScenarioRunError> {
+    let mut report = run_scenario_report_with_outcomes_and_storage_mode(
         &case.scenario,
         expected_trace.clone(),
         case.expected_outcomes.clone(),
+        storage_mode,
     )
     .await?;
     let minimized_case = if report.expectation_failures.is_empty() {
         None
     } else {
-        minimize_failing_case(case, expected_trace.as_ref(), &report).await
+        minimize_failing_case(case, expected_trace.as_ref(), &report, storage_mode).await
     };
     report.metadata.generated = Some(GeneratedScenarioMetadata {
         family_name: case.family_name.clone(),
@@ -123,6 +138,7 @@ async fn minimize_failing_case(
     case: &GeneratedScenarioCase,
     expected_trace: Option<&ScenarioTrace>,
     failing_report: &ScenarioReport,
+    storage_mode: HarnessStorageMode,
 ) -> Option<ScenarioSpec> {
     let target_failures = failure_kinds(failing_report);
     if target_failures.is_empty() {
@@ -145,6 +161,7 @@ async fn minimize_failing_case(
             expected_trace.cloned(),
             case.expected_outcomes.clone(),
             &target_failures,
+            storage_mode,
         )
         .await
         {
@@ -163,8 +180,16 @@ async fn reproduces_failure(
     expected_trace: Option<ScenarioTrace>,
     expected_outcomes: Vec<TraceExpectation>,
     target_failures: &BTreeSet<String>,
+    storage_mode: HarnessStorageMode,
 ) -> bool {
-    match run_scenario_report_with_outcomes(scenario, expected_trace, expected_outcomes).await {
+    match run_scenario_report_with_outcomes_and_storage_mode(
+        scenario,
+        expected_trace,
+        expected_outcomes,
+        storage_mode,
+    )
+    .await
+    {
         Ok(report) => target_failures.is_subset(&failure_kinds(&report)),
         Err(_) => false,
     }

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -35,7 +35,7 @@ pub use client::{ClientBuilder, HarnessClient, HarnessStorageMode};
 pub use family::{
     GeneratedScenarioCase, generate_convergence_chaos_family,
     generate_convergence_e2e_delivery_family, generate_send_leave_family,
-    run_generated_case_report,
+    run_generated_case_report, run_generated_case_report_with_storage_mode,
 };
 pub use oracle::{
     BehaviorEvidenceSummary, CoverageMatrixEntry, OracleBehavior, OracleCoverageWarning,
@@ -51,8 +51,9 @@ pub use scenario::{
     AppInvalidationReportObservation, EpochChangeReportObservation, GeneratedScenarioMetadata,
     InvariantFailure, ScenarioReport, ScenarioReportMetadata, ScenarioRunError, ScenarioSpec,
     ScenarioStep, ScenarioStepLogEntry, ScenarioStepStatus, VectorFixtureMetadata,
-    run_scenario_report, run_scenario_report_with_outcomes, run_scenario_spec,
-    run_vector_fixture_report,
+    run_scenario_report, run_scenario_report_with_outcomes,
+    run_scenario_report_with_outcomes_and_storage_mode, run_scenario_report_with_storage_mode,
+    run_scenario_spec, run_vector_fixture_report, run_vector_fixture_report_with_storage_mode,
 };
 pub use vector::{
     AppInvalidationObservation, ApplicationProfileContract, ClientEventCounts, ClientObservation,

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -2,10 +2,10 @@ use std::error::Error;
 use std::path::{Path, PathBuf};
 
 use crate::{
-    CoverageMatrixEntry, GeneratedScenarioCase, ScenarioReport, VectorFixture,
+    CoverageMatrixEntry, GeneratedScenarioCase, HarnessStorageMode, ScenarioReport, VectorFixture,
     coverage_matrix_entry, generate_convergence_chaos_family,
     generate_convergence_e2e_delivery_family, generate_send_leave_family,
-    run_generated_case_report, run_vector_fixture_report,
+    run_generated_case_report_with_storage_mode, run_vector_fixture_report_with_storage_mode,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -13,6 +13,7 @@ pub struct ReportArgs {
     pub input: ReportInput,
     pub out: PathBuf,
     pub strict_oracle: bool,
+    pub storage_mode: HarnessStorageMode,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -157,11 +158,19 @@ pub async fn run_report(args: &ReportArgs) -> Result<ReportRunSummary, Box<dyn E
             seed,
             cases,
         } => {
-            run_generated_family_reports(family, *seed, *cases, &args.out, args.strict_oracle)
-                .await?
+            run_generated_family_reports(
+                family,
+                *seed,
+                *cases,
+                &args.out,
+                args.strict_oracle,
+                args.storage_mode,
+            )
+            .await?
         }
         ReportInput::VectorFixtures { paths } => {
-            run_vector_fixture_reports(paths, &args.out, args.strict_oracle).await?
+            run_vector_fixture_reports(paths, &args.out, args.strict_oracle, args.storage_mode)
+                .await?
         }
     };
 
@@ -183,6 +192,7 @@ async fn run_generated_family_reports(
     cases: usize,
     out: &Path,
     strict_oracle: bool,
+    storage_mode: HarnessStorageMode,
 ) -> Result<Vec<ScenarioReportSummary>, Box<dyn Error>> {
     let cases = match family {
         "send-leave/v1" => generate_send_leave_family(seed, cases),
@@ -193,7 +203,7 @@ async fn run_generated_family_reports(
 
     let mut summaries = Vec::with_capacity(cases.len());
     for case in cases {
-        let report = run_generated_case_report(&case, None).await?;
+        let report = run_generated_case_report_with_storage_mode(&case, None, storage_mode).await?;
         let output = out.join(format!(
             "{}-seed-{}-case-{}.json",
             case.family_name.replace('/', "-"),
@@ -254,12 +264,13 @@ async fn run_vector_fixture_reports(
     paths: &[PathBuf],
     out: &Path,
     strict_oracle: bool,
+    storage_mode: HarnessStorageMode,
 ) -> Result<Vec<ScenarioReportSummary>, Box<dyn Error>> {
     let fixture_paths = collect_vector_fixture_paths(paths)?;
     let mut summaries = Vec::with_capacity(fixture_paths.len());
     for path in fixture_paths {
         let fixture: VectorFixture = serde_json::from_str(&std::fs::read_to_string(&path)?)?;
-        let report = run_vector_fixture_report(&fixture).await?;
+        let report = run_vector_fixture_report_with_storage_mode(&fixture, storage_mode).await?;
         let output = out.join(format!(
             "{}-report.json",
             fixture.scenario_name.replace('/', "-")
@@ -350,6 +361,7 @@ pub fn parse_report_command(
     let mut vectors = Vec::new();
     let mut out = PathBuf::from("target/cgka-conformance-simulator-reports");
     let mut strict_oracle = false;
+    let mut storage_mode = None;
 
     let mut args = args.into_iter();
     while let Some(arg) = args.next() {
@@ -359,6 +371,12 @@ pub fn parse_report_command(
             "--cases" => cases = next_value(&mut args, "--cases")?.parse()?,
             "--vectors" => vectors.push(PathBuf::from(next_value(&mut args, "--vectors")?)),
             "--out" => out = PathBuf::from(next_value(&mut args, "--out")?),
+            "--storage" => {
+                storage_mode = Some(HarnessStorageMode::parse(&next_value(
+                    &mut args,
+                    "--storage",
+                )?)?)
+            }
             "--strict-oracle" => strict_oracle = true,
             "--help" | "-h" => return Ok(ReportCommand::Help),
             other => return Err(format!("unknown argument {other}").into()),
@@ -379,6 +397,7 @@ pub fn parse_report_command(
         input,
         out,
         strict_oracle,
+        storage_mode: storage_mode.unwrap_or_else(HarnessStorageMode::from_env),
     }))
 }
 
@@ -391,7 +410,7 @@ fn next_value(
 }
 
 pub fn report_usage() -> &'static str {
-    "Usage: cgka-conformance-simulator-report [--vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1 --seed N --cases N] [--out DIR] [--strict-oracle]"
+    "Usage: cgka-conformance-simulator-report [--vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle]"
 }
 
 #[cfg(test)]
@@ -408,6 +427,7 @@ mod tests {
                 scenario_name: "oracle-summary-test".into(),
                 spec_version: "1".into(),
                 step_count: 0,
+                storage_backend: "in-memory-sqlite".into(),
                 generated: None,
                 fixture: None,
             },

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -5,10 +5,10 @@
 //! their observed trace to exact or semantic fixture expectations.
 
 use crate::{
-    ClientBuilder, ExpectationFailure, HarnessClient, PendingResolutionObservation,
-    ScenarioAdminPolicyObservation, ScenarioErrorObservation, ScenarioOracleReport, ScenarioTrace,
-    TraceExpectation, TransportBus, VectorFixture, build_scenario_oracle_report,
-    compare_trace_expectations, observe_client,
+    ClientBuilder, ExpectationFailure, HarnessClient, HarnessStorageMode,
+    PendingResolutionObservation, ScenarioAdminPolicyObservation, ScenarioErrorObservation,
+    ScenarioOracleReport, ScenarioTrace, TraceExpectation, TransportBus, VectorFixture,
+    build_scenario_oracle_report, compare_trace_expectations, observe_client,
 };
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_traits::EngineError;
@@ -184,6 +184,7 @@ pub struct ScenarioReportMetadata {
     pub scenario_name: String,
     pub spec_version: String,
     pub step_count: usize,
+    pub storage_backend: String,
     pub generated: Option<GeneratedScenarioMetadata>,
     pub fixture: Option<VectorFixtureMetadata>,
 }
@@ -259,7 +260,24 @@ pub async fn run_scenario_report(
     spec: &ScenarioSpec,
     expected_trace: Option<ScenarioTrace>,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    run_scenario_report_inner(spec, expected_trace, vec![], None, ProtocolProfile::Legacy).await
+    run_scenario_report_with_storage_mode(spec, expected_trace, HarnessStorageMode::from_env())
+        .await
+}
+
+pub async fn run_scenario_report_with_storage_mode(
+    spec: &ScenarioSpec,
+    expected_trace: Option<ScenarioTrace>,
+    storage_mode: HarnessStorageMode,
+) -> Result<ScenarioReport, ScenarioRunError> {
+    run_scenario_report_inner(
+        spec,
+        expected_trace,
+        vec![],
+        None,
+        ProtocolProfile::Legacy,
+        storage_mode,
+    )
+    .await
 }
 
 pub async fn run_scenario_report_with_outcomes(
@@ -267,18 +285,41 @@ pub async fn run_scenario_report_with_outcomes(
     expected_trace: Option<ScenarioTrace>,
     expected_outcomes: Vec<TraceExpectation>,
 ) -> Result<ScenarioReport, ScenarioRunError> {
+    run_scenario_report_with_outcomes_and_storage_mode(
+        spec,
+        expected_trace,
+        expected_outcomes,
+        HarnessStorageMode::from_env(),
+    )
+    .await
+}
+
+pub async fn run_scenario_report_with_outcomes_and_storage_mode(
+    spec: &ScenarioSpec,
+    expected_trace: Option<ScenarioTrace>,
+    expected_outcomes: Vec<TraceExpectation>,
+    storage_mode: HarnessStorageMode,
+) -> Result<ScenarioReport, ScenarioRunError> {
     run_scenario_report_inner(
         spec,
         expected_trace,
         expected_outcomes,
         None,
         ProtocolProfile::Legacy,
+        storage_mode,
     )
     .await
 }
 
 pub async fn run_vector_fixture_report(
     fixture: &VectorFixture,
+) -> Result<ScenarioReport, ScenarioRunError> {
+    run_vector_fixture_report_with_storage_mode(fixture, HarnessStorageMode::from_env()).await
+}
+
+pub async fn run_vector_fixture_report_with_storage_mode(
+    fixture: &VectorFixture,
+    storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
     let protocol_profile = match fixture
         .application_profile
@@ -305,6 +346,7 @@ pub async fn run_vector_fixture_report(
             seed: fixture.seed,
         }),
         protocol_profile,
+        storage_mode,
     )
     .await
 }
@@ -315,6 +357,7 @@ async fn run_scenario_report_inner(
     expected_outcomes: Vec<TraceExpectation>,
     fixture: Option<VectorFixtureMetadata>,
     protocol_profile: ProtocolProfile,
+    storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
     if spec.spec_version != "1" {
         return Err(ScenarioRunError {
@@ -334,6 +377,7 @@ async fn run_scenario_report_inner(
         let client = ClientBuilder::new(pad32(label.as_bytes()))
             .registry(scenario_registry())
             .protocol_profile(protocol_profile)
+            .storage_mode(storage_mode)
             .attach(&bus);
         clients.insert(label.clone(), client);
     }
@@ -620,6 +664,7 @@ async fn run_scenario_report_inner(
             scenario_name: spec.name.clone(),
             spec_version: spec.spec_version.clone(),
             step_count: spec.steps.len(),
+            storage_backend: storage_mode.report_label().into(),
             generated: None,
             fixture,
         },

--- a/crates/cgka-conformance-simulator/tests/AGENTS.md
+++ b/crates/cgka-conformance-simulator/tests/AGENTS.md
@@ -32,7 +32,8 @@ Map for simulator tests.
   - **Owns:** Report artifact runner, oracle evidence, and coverage matrix coverage.
 
 - **File:** `sqlite_storage_modes.rs`
-  - **Owns:** Harness storage-mode coverage over temp file-backed SQLite.
+  - **Owns:** Harness storage-mode coverage over encrypted file-backed SQLite, including full close/reopen hydration,
+    production WAL defaults, encrypted headers, and busy-writer retry behavior.
 
 - **File:** `tracing_audit.rs`
   - **Owns:** Repo-wide production tracing privacy audit.

--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -250,7 +250,7 @@ async fn proposal_authorization_vector_rejects_direct_and_nostr_wrapped_input() 
     // auto-commit scheduling.
     let snapshot = {
         let context = alice
-            .engine
+            .engine_mut()
             .group_context(&group_id)
             .expect("load group context");
         GroupContextSnapshot::from_context(
@@ -289,7 +289,7 @@ async fn proposal_authorization_vector_rejects_direct_and_nostr_wrapped_input() 
         "wrapped rejection leaves a terminal failed content record"
     );
     assert!(
-        alice.engine.drain_auto_publish().is_empty(),
+        alice.engine_mut().drain_auto_publish().is_empty(),
         "rejected proposal cannot schedule an auto-commit"
     );
     assert_eq!(

--- a/crates/cgka-conformance-simulator/tests/proptest_invariants.rs
+++ b/crates/cgka-conformance-simulator/tests/proptest_invariants.rs
@@ -989,7 +989,7 @@ fn capability_negotiation_matches_matrix(case: CapabilityNegotiationCase) {
         alice.confirm(pending).await;
 
         let status = alice
-            .engine
+            .engine_mut()
             .feature_status(&group_id, &PROP_FEATURE)
             .unwrap_or_else(|err| panic!("feature_status should resolve for {case:?}: {err:?}"));
         match (feature_is_required, all_members_support, status) {
@@ -1070,12 +1070,13 @@ async fn drive_intents(
                     continue;
                 }
                 let gid = group_ids[idx].clone();
+                let sender = clients[idx].member_id();
                 let res = clients[idx]
-                    .engine
+                    .engine_mut()
                     .send(cgka_traits::engine::SendIntent::AppMessage {
                         group_id: gid.clone(),
                         payload: cgka_conformance_simulator::client::encode_harness_app_payload(
-                            &clients[idx].member_id(),
+                            &sender,
                             app_event_seq,
                             payload.clone(),
                         ),
@@ -1098,7 +1099,7 @@ async fn drive_intents(
                 }
                 let gid = group_ids[idx].clone();
                 let res = clients[idx]
-                    .engine
+                    .engine_mut()
                     .send(cgka_traits::engine::SendIntent::Leave {
                         group_id: gid.clone(),
                     })
@@ -1276,7 +1277,7 @@ fn stored_convergence_restart_equivalence(name: String, committer_idx: usize) {
         let mut clients = setup_group_with_admins(3, &bus, &initial_admin_indices).await;
         let group_id = clients[0].group_id();
         let res = clients[committer_idx]
-            .engine
+            .engine_mut()
             .send(SendIntent::UpdateGroupData {
                 group_id: group_id.clone(),
                 name: Some(name.clone()),
@@ -1291,7 +1292,7 @@ fn stored_convergence_restart_equivalence(name: String, committer_idx: usize) {
         clients[committer_idx].confirm(pending).await;
         let commit = reroute(commit, &group_id);
         clients[2]
-            .engine
+            .engine_mut()
             .ingest(commit)
             .await
             .expect("observer buffers stored convergence input");

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -2,8 +2,8 @@ use std::fs;
 use std::path::PathBuf;
 
 use cgka_conformance_simulator::{
-    OracleBehavior, ReportArgs, ReportCommand, ReportInput, ScenarioStimulus, parse_report_command,
-    property_test_coverage_entries, run_report,
+    HarnessStorageMode, OracleBehavior, ReportArgs, ReportCommand, ReportInput, ScenarioStimulus,
+    parse_report_command, property_test_coverage_entries, run_report,
 };
 
 #[test]
@@ -19,6 +19,7 @@ fn parse_defaults_to_send_leave_family() {
             },
             out: PathBuf::from("target/cgka-conformance-simulator-reports"),
             strict_oracle: false,
+            storage_mode: HarnessStorageMode::InMemorySqlite,
         })
     );
 }
@@ -47,8 +48,19 @@ fn parse_custom_report_args() {
             },
             out: PathBuf::from("target/custom"),
             strict_oracle: false,
+            storage_mode: HarnessStorageMode::InMemorySqlite,
         })
     );
+}
+
+#[test]
+fn explicit_storage_flag_overrides_environment_default() {
+    let command =
+        parse_report_command(["--storage".into(), "file".into()]).expect("storage mode args parse");
+    let ReportCommand::Run(args) = command else {
+        panic!("expected run command");
+    };
+    assert_eq!(args.storage_mode, HarnessStorageMode::TempFileBackedSqlite);
 }
 
 #[test]
@@ -69,6 +81,7 @@ fn parse_vector_fixture_report_args() {
             },
             out: PathBuf::from("target/vector-reports"),
             strict_oracle: false,
+            storage_mode: HarnessStorageMode::InMemorySqlite,
         })
     );
 }
@@ -92,6 +105,7 @@ fn parse_strict_oracle_report_args() {
             },
             out: PathBuf::from("target/cgka-conformance-simulator-reports"),
             strict_oracle: true,
+            storage_mode: HarnessStorageMode::InMemorySqlite,
         })
     );
 }
@@ -167,6 +181,7 @@ async fn report_runner_writes_send_leave_json_reports() {
         },
         out: out_dir.clone(),
         strict_oracle: false,
+        storage_mode: HarnessStorageMode::InMemorySqlite,
     })
     .await
     .expect("runner writes reports");
@@ -187,6 +202,7 @@ async fn report_runner_writes_send_leave_json_reports() {
     );
     assert_eq!(report["metadata"]["generated"]["seed"], 42);
     assert_eq!(report["metadata"]["generated"]["case_index"], 0);
+    assert_eq!(report["metadata"]["storage_backend"], "in-memory-sqlite");
     assert!(
         report["observed_trace"]["observations"]
             .as_array()
@@ -214,6 +230,7 @@ async fn report_runner_strict_oracle_counts_weak_warnings_as_failures() {
         },
         out: out_dir.clone(),
         strict_oracle: true,
+        storage_mode: HarnessStorageMode::InMemorySqlite,
     })
     .await
     .expect("strict runner writes reports");
@@ -248,6 +265,7 @@ async fn report_runner_writes_convergence_delivery_json_reports() {
         },
         out: out_dir.clone(),
         strict_oracle: false,
+        storage_mode: HarnessStorageMode::InMemorySqlite,
     })
     .await
     .expect("runner writes convergence delivery reports");
@@ -299,6 +317,7 @@ async fn report_runner_writes_convergence_chaos_reports_and_fixture_candidates()
         },
         out: out_dir.clone(),
         strict_oracle: false,
+        storage_mode: HarnessStorageMode::InMemorySqlite,
     })
     .await
     .expect("runner writes convergence chaos reports");
@@ -389,6 +408,7 @@ async fn report_runner_writes_vector_fixture_reports_and_summary() {
         },
         out: out_dir.clone(),
         strict_oracle: false,
+        storage_mode: HarnessStorageMode::InMemorySqlite,
     })
     .await
     .expect("runner writes vector reports");

--- a/crates/cgka-conformance-simulator/tests/sqlite_storage_modes.rs
+++ b/crates/cgka-conformance-simulator/tests/sqlite_storage_modes.rs
@@ -1,4 +1,13 @@
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
 use cgka_conformance_simulator::{ClientBuilder, HarnessStorageMode, TransportBus};
+use cgka_traits::storage::{GroupStorage, StorageProvider};
+use storage_sqlite::{
+    SqlCipherHardening, SqlCipherKey, SqliteAccountStorage, SqliteStorageOptions,
+    open_hardened_sqlcipher,
+};
 
 fn pad32(name: &[u8]) -> Vec<u8> {
     let mut out = vec![0u8; 32];
@@ -8,16 +17,113 @@ fn pad32(name: &[u8]) -> Vec<u8> {
 }
 
 #[tokio::test]
-async fn harness_can_use_temp_file_backed_sqlite_storage() {
+async fn encrypted_file_restart_closes_reopens_and_hydrates_group_state() {
+    let dir = tempfile::tempdir().expect("storage directory");
+    let path = dir.path().join("alice.sqlite3");
+    let key = SqlCipherKey::new("conformance explicit file key").expect("SQLCipher key");
     let bus = TransportBus::ordered();
     let mut alice = ClientBuilder::new(pad32(b"alice"))
-        .storage_mode(HarnessStorageMode::TempFileBackedSqlite)
+        .file_backed_storage(&path, key, SqliteStorageOptions::default())
         .attach(&bus);
     let member_id = alice.member_id();
 
-    let key_package = alice.fresh_key_package().await;
-    assert!(!key_package.bytes().is_empty());
+    let (group_id, pending) = alice
+        .create_group("file-backed", Vec::new(), Vec::new())
+        .await;
+    alice.confirm(pending).await;
+    let before = alice
+        .storage()
+        .get_group(&group_id)
+        .expect("group persisted before restart");
 
     alice.restart();
+
     assert_eq!(alice.member_id(), member_id);
+    assert_eq!(alice.epoch(), before.epoch);
+    assert_eq!(
+        alice
+            .storage()
+            .get_group(&group_id)
+            .expect("group persisted after restart"),
+        before
+    );
+    assert_eq!(alice.database_path(), Some(path.as_path()));
+
+    let bytes = std::fs::read(&path).expect("read encrypted database");
+    assert!(
+        !bytes.starts_with(b"SQLite format 3\0"),
+        "SQLCipher database must not expose a plaintext SQLite header"
+    );
+
+    let inspection = rusqlite::Connection::open(&path).expect("open inspection connection");
+    let inspection_key =
+        SqlCipherKey::new("conformance explicit file key").expect("inspection SQLCipher key");
+    open_hardened_sqlcipher(&inspection, &inspection_key, SqlCipherHardening::default())
+        .expect("key inspection connection");
+    let journal_mode: String = inspection
+        .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+        .expect("read journal mode");
+    let synchronous: i64 = inspection
+        .query_row("PRAGMA synchronous", [], |row| row.get(0))
+        .expect("read synchronous mode");
+    assert_eq!(journal_mode.to_ascii_lowercase(), "wal");
+    assert_eq!(synchronous, 2, "production default must be FULL");
+}
+
+#[tokio::test]
+async fn encrypted_file_harness_write_retries_a_busy_writer() {
+    let dir = tempfile::tempdir().expect("storage directory");
+    let path = dir.path().join("busy.sqlite3");
+    let options = SqliteStorageOptions {
+        busy_timeout_ms: 50,
+        ..SqliteStorageOptions::default()
+    };
+    let key = SqlCipherKey::new("conformance busy key").expect("SQLCipher key");
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice-busy"))
+        .file_backed_storage(&path, key, options.clone())
+        .attach(&bus);
+
+    let peer_key = SqlCipherKey::new("conformance busy key").expect("peer SQLCipher key");
+    let peer = SqliteAccountStorage::open_encrypted_with_options(&path, &peer_key, options)
+        .expect("peer storage opens");
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let blocker = thread::spawn(move || {
+        peer.with_transaction(|_| -> Result<(), cgka_traits::StorageError> {
+            ready_tx.send(()).expect("signal writer lock");
+            release_rx.recv().expect("release writer lock");
+            Ok(())
+        })
+        .expect("blocking transaction");
+    });
+    ready_rx.recv().expect("writer lock acquired");
+
+    let releaser = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(120));
+        release_tx.send(()).expect("release blocker");
+    });
+    let started = Instant::now();
+    let key_package = alice.fresh_key_package().await;
+    let elapsed = started.elapsed();
+
+    releaser.join().expect("releaser exits");
+    blocker.join().expect("blocker exits");
+    assert!(!key_package.bytes().is_empty());
+    assert!(
+        elapsed >= Duration::from_millis(50),
+        "operation must outlive the first busy timeout before retrying: {elapsed:?}"
+    );
+}
+
+#[test]
+fn storage_mode_parser_accepts_cli_names() {
+    assert_eq!(
+        HarnessStorageMode::parse("memory").expect("memory parses"),
+        HarnessStorageMode::InMemorySqlite
+    );
+    assert_eq!(
+        HarnessStorageMode::parse("file").expect("file parses"),
+        HarnessStorageMode::TempFileBackedSqlite
+    );
 }

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -11,6 +11,9 @@ default = []
 # Explicit escape hatch for engine/session integration tests that need custom
 # settlement or rewind policies. Production/app consumers must not enable it.
 test-policy-overrides = []
+# Debug-only subprocess crash points used by the SQLCipher durability tests.
+# Production/app consumers must not enable this feature.
+test-crash-hooks = []
 
 [dependencies]
 cgka-traits.workspace = true

--- a/crates/cgka-engine/src/lib.rs
+++ b/crates/cgka-engine/src/lib.rs
@@ -64,6 +64,7 @@ pub mod provider;
 pub mod publish;
 pub mod self_update;
 pub mod snapshot_guard;
+pub(crate) mod test_crash_hooks;
 pub mod update_group_data;
 pub mod upgrade;
 pub mod wire_format;

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -941,7 +941,10 @@ fn canonicalize_stored_openmls_messages_from_retained_anchor<S: StorageProvider>
 
     let anchor_snapshot = retained_anchor_snapshot_name(work.replay_start_epoch);
     let result = match storage.rollback_group_to_snapshot(group_id, &anchor_snapshot) {
-        Ok(()) => canonicalize_stored_openmls_messages_from_current(storage, group_id, work),
+        Ok(()) => {
+            crate::test_crash_hooks::pause_if_requested("retained-anchor-after-rewind");
+            canonicalize_stored_openmls_messages_from_current(storage, group_id, work)
+        }
         Err(StorageError::SnapshotMissing(_)) => Ok(missing_retained_anchor_result(
             work.state,
             work.outbound_intents,
@@ -1437,6 +1440,9 @@ pub(crate) fn apply_openmls_canonicalization_result_with_profile_policy<S: Stora
             &replay_messages,
             profile_policy,
         )?;
+        if apply_start_epoch < current_epoch {
+            crate::test_crash_hooks::pause_if_requested("historical-apply-before-commit");
+        }
         storage
             .release_group_snapshot(group_id, &snapshot)
             .map_err(|e| OpenMlsProjectionError::Snapshot(format!("{e:?}")))?;

--- a/crates/cgka-engine/src/test_crash_hooks.rs
+++ b/crates/cgka-engine/src/test_crash_hooks.rs
@@ -1,0 +1,33 @@
+//! Debug-only pause points for subprocess crash-durability tests.
+//!
+//! The feature is inert unless a child process explicitly selects one fixed
+//! point through `MDK_CGKA_TEST_CRASH_POINT`. No identifiers or state values
+//! are emitted.
+
+const CRASH_POINT_ENV: &str = "MDK_CGKA_TEST_CRASH_POINT";
+const READY_PREFIX: &str = "MDK_CGKA_TEST_CRASH_READY:";
+
+#[inline]
+pub(crate) fn pause_if_requested(point: &'static str) {
+    #[cfg(all(feature = "test-crash-hooks", debug_assertions))]
+    {
+        use std::io::Write as _;
+
+        if std::env::var(CRASH_POINT_ENV).as_deref() != Ok(point) {
+            return;
+        }
+        let stdout = std::io::stdout();
+        let mut stdout = stdout.lock();
+        writeln!(stdout, "{READY_PREFIX}{point}").expect("write crash-hook ready marker");
+        stdout.flush().expect("flush crash-hook ready marker");
+        drop(stdout);
+        loop {
+            std::thread::park();
+        }
+    }
+
+    #[cfg(not(all(feature = "test-crash-hooks", debug_assertions)))]
+    {
+        let _ = (point, CRASH_POINT_ENV, READY_PREFIX);
+    }
+}

--- a/crates/cgka-engine/tests/AGENTS.md
+++ b/crates/cgka-engine/tests/AGENTS.md
@@ -79,6 +79,11 @@ backend on the same rail.
 - **File:** `sqlite_storage.rs`
   - **Owns:** SQLCipher-backed `Engine<SqliteAccountStorage>` create + confirm smoke
 
+- **File:** `crash_recovery_sqlite.rs`
+  - **Owns:** Debug-feature-gated subprocess-kill coverage at retained-anchor rewind and historical-apply transaction
+    boundaries. Reopens encrypted SQLite, observes the stranded pre-hydration state, then verifies hydration restores
+    live state and releases convergence snapshots.
+
 - **File:** `update_group_data.rs`
   - **Owns:** Group profile `AppDataUpdate` commits and convergence-side Marmot record refresh
 

--- a/crates/cgka-engine/tests/crash_recovery_sqlite.rs
+++ b/crates/cgka-engine/tests/crash_recovery_sqlite.rs
@@ -1,0 +1,558 @@
+#![cfg(all(feature = "test-crash-hooks", debug_assertions))]
+
+//! Process-kill coverage for convergence rewrite durability (#1025).
+//!
+//! The ignored child test drives the real retained-anchor late-commit path over
+//! encrypted file-backed SQLite. Parent tests stop it at fixed debug-only crash
+//! points, then reopen and hydrate the database without running child
+//! destructors.
+
+use std::collections::BTreeSet;
+use std::hash::{Hash, Hasher};
+use std::io::{BufRead, BufReader, Read};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cgka_engine::canonicalization::{CanonicalizationPolicy, CanonicalizationState};
+use cgka_engine::feature_registry::FeatureRegistry;
+use cgka_engine::openmls_projection::{
+    apply_openmls_canonicalization_result, canonicalize_stored_openmls_messages,
+};
+use cgka_engine::{Engine, EngineBuilder};
+use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent};
+use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
+use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult};
+use cgka_traits::error::PeelerError;
+use cgka_traits::group_context::GroupContextSnapshot;
+use cgka_traits::ingest::{PeeledContent, PeeledMessage};
+use cgka_traits::message::MessageState;
+use cgka_traits::peeler::TransportPeeler;
+use cgka_traits::storage::{
+    GroupStorage, MessageStorage, OutboundIntentStorage, QueuedOutboundIntent,
+};
+use cgka_traits::transport::{
+    EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
+};
+use cgka_traits::types::{EpochId, GroupId, MemberId, MessageId};
+use sha2::{Digest, Sha256};
+use storage_sqlite::{SqlCipherKey, SqliteAccountStorage};
+
+mod support;
+use support::proof_signer;
+
+const CHILD_ENV: &str = "MDK_CGKA_CRASH_CHILD";
+const DATABASE_ENV: &str = "MDK_CGKA_CRASH_DATABASE";
+const CRASH_POINT_ENV: &str = "MDK_CGKA_TEST_CRASH_POINT";
+const DATABASE_KEY: &str = "cgka convergence crash recovery key";
+const READY_PREFIX: &str = "MDK_CGKA_TEST_CRASH_READY:";
+const H5_POINT: &str = "historical-apply-before-commit";
+const H6_POINT: &str = "retained-anchor-after-rewind";
+const CAROL_SEED: &[u8] = b"carol-crash";
+const QUEUED_INTENT_ID: &[u8] = b"crash-queued-intent";
+
+struct MockPeeler;
+
+#[async_trait]
+impl TransportPeeler for MockPeeler {
+    async fn peel_group_message(
+        &self,
+        msg: &TransportMessage,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<PeeledMessage, PeelerError> {
+        Ok(PeeledMessage {
+            id: msg.id.clone(),
+            group_id: None,
+            sender: None,
+            content: PeeledContent::MlsMessage {
+                bytes: msg.payload.clone(),
+            },
+            origin: msg.clone(),
+        })
+    }
+
+    async fn peel_welcome(&self, msg: &TransportMessage) -> Result<PeeledMessage, PeelerError> {
+        Ok(PeeledMessage {
+            id: msg.id.clone(),
+            group_id: None,
+            sender: None,
+            content: PeeledContent::Welcome {
+                bytes: msg.payload.clone(),
+            },
+            origin: msg.clone(),
+        })
+    }
+
+    async fn wrap_group_message(
+        &self,
+        payload: &EncryptedPayload,
+        _ctx: &GroupContextSnapshot,
+    ) -> Result<TransportMessage, PeelerError> {
+        Ok(TransportMessage {
+            id: hash_id(&payload.ciphertext),
+            payload: payload.ciphertext.clone(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("crash-test".into()),
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: vec![],
+            },
+        })
+    }
+
+    async fn wrap_welcome(
+        &self,
+        payload: &EncryptedPayload,
+        recipient: &MemberId,
+    ) -> Result<TransportMessage, PeelerError> {
+        Ok(TransportMessage {
+            id: hash_id(&payload.ciphertext),
+            payload: payload.ciphertext.clone(),
+            timestamp: Timestamp(0),
+            causal_deps: vec![],
+            source: TransportSource("crash-test".into()),
+            envelope: TransportEnvelope::Welcome {
+                recipient: recipient.clone(),
+            },
+        })
+    }
+}
+
+#[test]
+fn h5_kill_before_historical_apply_commit_preserves_live_inputs() {
+    run_parent_case(H5_POINT, EpochId(2), "openmls-apply-");
+}
+
+#[test]
+fn h6_kill_after_retained_anchor_rewind_recovers_live_snapshot() {
+    run_parent_case(H6_POINT, EpochId(1), "openmls-retained-probe-");
+}
+
+#[tokio::test]
+#[ignore = "spawned by the parent crash-recovery tests"]
+async fn crash_child_runs_late_commit_convergence() {
+    if std::env::var(CHILD_ENV).as_deref() != Ok("1") {
+        return;
+    }
+    let path = PathBuf::from(std::env::var_os(DATABASE_ENV).expect("child database path"));
+    run_child_case(&path).await;
+    panic!("selected crash point was not reached");
+}
+
+fn run_parent_case(point: &str, stranded_epoch: EpochId, snapshot_prefix: &str) {
+    let dir = tempfile::tempdir().expect("parent temp directory");
+    let database = dir.path().join("carol.sqlite3");
+    let mut child = Command::new(std::env::current_exe().expect("current test executable"))
+        .args([
+            "--ignored",
+            "--exact",
+            "crash_child_runs_late_commit_convergence",
+            "--nocapture",
+        ])
+        .env(CHILD_ENV, "1")
+        .env(DATABASE_ENV, &database)
+        .env(CRASH_POINT_ENV, point)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn crash child");
+
+    let stdout = child.stdout.take().expect("child stdout");
+    let (line_tx, line_rx) = mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            if line_tx.send(line).is_err() {
+                return;
+            }
+        }
+    });
+
+    let expected_ready = format!("{READY_PREFIX}{point}");
+    let mut child_output = Vec::new();
+    let ready = loop {
+        match line_rx.recv_timeout(Duration::from_secs(30)) {
+            Ok(Ok(line)) => {
+                let is_ready = line == expected_ready;
+                child_output.push(line);
+                if is_ready {
+                    break true;
+                }
+            }
+            Ok(Err(err)) => {
+                child_output.push(format!("stdout error: {err}"));
+                break false;
+            }
+            Err(_) => break false,
+        }
+    };
+    if !ready {
+        let _ = child.kill();
+        let _ = child.wait();
+        drop(line_rx);
+        let _ = reader.join();
+        panic!(
+            "child did not reach {point}; stdout:\n{}",
+            child_output.join("\n")
+        );
+    }
+
+    child.kill().expect("kill child at crash point");
+    let status = child.wait().expect("wait for killed child");
+    assert!(!status.success(), "killed child must not exit successfully");
+    drop(line_rx);
+    reader.join().expect("stdout reader exits");
+
+    let mut stderr = String::new();
+    child
+        .stderr
+        .take()
+        .expect("child stderr")
+        .read_to_string(&mut stderr)
+        .expect("read child stderr");
+    assert!(
+        database.exists(),
+        "child database missing after kill; stderr:\n{stderr}"
+    );
+    assert!(
+        wal_path(&database).exists(),
+        "WAL must survive the abrupt process stop"
+    );
+
+    let key = SqlCipherKey::new(DATABASE_KEY).expect("parent SQLCipher key");
+    let storage =
+        SqliteAccountStorage::open_encrypted(&database, &key).expect("reopen killed database");
+    let group_ids = storage.list_groups().expect("list persisted groups");
+    assert_eq!(group_ids.len(), 1, "crash fixture owns one group");
+    let group_id = group_ids[0].clone();
+    let stranded_group = storage.get_group(&group_id).expect("stranded group");
+    assert_eq!(stranded_group.epoch, stranded_epoch);
+    if point == H6_POINT {
+        assert!(
+            !stranded_group
+                .members
+                .iter()
+                .any(|member| member.id == MemberId::new(identity(b"david-crash"))),
+            "retained-anchor crash must expose the historical membership before hydration"
+        );
+    }
+    assert!(
+        storage
+            .list_group_snapshots(&group_id)
+            .expect("list stranded snapshots")
+            .iter()
+            .any(|name| name.starts_with(snapshot_prefix)),
+        "expected stranded snapshot prefix {snapshot_prefix}"
+    );
+    if point == H5_POINT {
+        assert_eq!(
+            storage
+                .list_queued_outbound_intents(&group_id)
+                .expect("list stranded queued work")
+                .len(),
+            1,
+            "the uncommitted historical rewrite must not discard queued work"
+        );
+        assert!(
+            storage
+                .list_messages(&group_id, EpochId(0))
+                .expect("list stranded convergence inputs")
+                .iter()
+                .any(|record| record.state == MessageState::Created),
+            "the uncommitted historical rewrite must not discard its convergence input"
+        );
+    }
+
+    let mut reopened = build_client_with_storage(CAROL_SEED, storage.clone());
+    reopened
+        .hydrate_stable_groups_from_storage()
+        .expect("hydrate killed database");
+
+    assert_eq!(
+        reopened.epoch(&group_id).expect("recovered epoch"),
+        EpochId(2)
+    );
+    let recovered_group = storage.get_group(&group_id).expect("recovered group");
+    assert_eq!(recovered_group.name, "crash-recovery");
+    assert!(
+        recovered_group
+            .members
+            .iter()
+            .any(|member| member.id == MemberId::new(identity(b"david-crash"))),
+        "hydration must restore the live incumbent membership"
+    );
+    assert!(
+        !recovered_group
+            .members
+            .iter()
+            .any(|member| member.id == MemberId::new(identity(b"eve-crash"))),
+        "the uncommitted late rewrite must not replace the live membership"
+    );
+    assert!(
+        storage
+            .list_group_snapshots(&group_id)
+            .expect("list recovered snapshots")
+            .iter()
+            .all(|name| !name.starts_with(snapshot_prefix)),
+        "hydrate must release the interrupted snapshot"
+    );
+    let queued = storage
+        .list_queued_outbound_intents(&group_id)
+        .expect("list recovered queued work");
+    assert_eq!(queued.len(), 1, "queued work must survive the crash");
+    assert_eq!(queued[0].id, MessageId::new(QUEUED_INTENT_ID.to_vec()));
+    assert!(
+        storage
+            .list_messages(&group_id, EpochId(0))
+            .expect("list recovered convergence inputs")
+            .iter()
+            .any(|record| record.state == MessageState::Created),
+        "the late convergence input must remain durable for replay"
+    );
+}
+
+async fn run_child_case(database: &Path) {
+    let (first, _first_storage) = build_memory_client(b"admin-a");
+    let (second, _second_storage) = build_memory_client(b"admin-b");
+    let ((mut alice, alice_seed), (mut bob, bob_seed)) =
+        if first.self_id().as_slice() > second.self_id().as_slice() {
+            (
+                (first, b"admin-a".as_slice()),
+                (second, b"admin-b".as_slice()),
+            )
+        } else {
+            (
+                (second, b"admin-b".as_slice()),
+                (first, b"admin-a".as_slice()),
+            )
+        };
+    assert!(
+        bob.self_id().as_slice() < alice.self_id().as_slice(),
+        "late challenger must win the deterministic tiebreak"
+    );
+    let (mut david, _david_storage) = build_memory_client(b"david-crash");
+    let (mut eve, _eve_storage) = build_memory_client(b"eve-crash");
+
+    let key = SqlCipherKey::new(DATABASE_KEY).expect("child SQLCipher key");
+    let carol_storage =
+        SqliteAccountStorage::open_encrypted(database, &key).expect("open child database");
+    let mut carol = build_client_with_storage(CAROL_SEED, carol_storage.clone());
+
+    let bob_kp = bob.fresh_key_package().await.expect("bob key package");
+    let carol_kp = carol.fresh_key_package().await.expect("carol key package");
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "crash-recovery".into(),
+            description: String::new(),
+            members: vec![bob_kp, carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .expect("create crash group");
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice
+        .confirm_published(pending)
+        .await
+        .expect("confirm group");
+    bob.join_welcome(welcome_for(&welcomes, bob_seed))
+        .await
+        .expect("bob joins");
+    carol
+        .join_welcome(welcome_for(&welcomes, CAROL_SEED))
+        .await
+        .expect("carol joins");
+
+    let david_kp = david.fresh_key_package().await.expect("david key package");
+    let (alice_commit, _) = evolution(
+        alice
+            .send(SendIntent::Invite {
+                group_id: group_id.clone(),
+                key_packages: vec![david_kp],
+            })
+            .await
+            .expect("alice invite"),
+    );
+    carol
+        .buffer_openmls_convergence_message(&group_id, route(alice_commit, &group_id), 1_000)
+        .expect("buffer incumbent commit");
+    carol
+        .converge_stored_openmls_messages(&group_id, 1_000_000)
+        .expect("settle incumbent branch");
+    assert_eq!(carol.epoch(&group_id).expect("live epoch"), EpochId(2));
+    assert_eq!(
+        carol_storage
+            .get_group(&group_id)
+            .expect("persisted live group")
+            .epoch,
+        EpochId(2)
+    );
+
+    let eve_kp = eve.fresh_key_package().await.expect("eve key package");
+    let (bob_commit, _) = evolution(
+        bob.send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+        })
+        .await
+        .expect("bob invite"),
+    );
+    carol
+        .buffer_openmls_convergence_message(&group_id, route(bob_commit, &group_id), 2_000)
+        .expect("buffer late winning commit");
+    carol_storage
+        .put_queued_outbound_intent(&QueuedOutboundIntent {
+            id: MessageId::new(QUEUED_INTENT_ID.to_vec()),
+            group_id: group_id.clone(),
+            intent: SendIntent::AppMessage {
+                group_id: group_id.clone(),
+                payload: app_payload_for(&carol, b"queued across crash"),
+            },
+            created_at_ms: 2_100,
+        })
+        .expect("persist queued work");
+
+    let _ = alice_seed;
+    if std::env::var(CRASH_POINT_ENV).as_deref() == Ok(H5_POINT) {
+        let policy = CanonicalizationPolicy::default();
+        let state = CanonicalizationState {
+            current_tip_epoch: 2,
+            retained_anchor_epoch: 0,
+            last_convergence_relevant_input_ms: 3_000_000 - policy.settlement_quiescence_ms,
+            seen_message_ids: BTreeSet::new(),
+        };
+        let result = canonicalize_stored_openmls_messages(
+            &carol_storage,
+            &group_id,
+            state,
+            vec![],
+            policy.clone(),
+            3_000_000,
+        )
+        .expect("canonicalize late historical branch");
+        apply_openmls_canonicalization_result(
+            &carol_storage,
+            &group_id,
+            &result,
+            policy.convergence.max_rewind_commits,
+        )
+        .expect("historical apply reaches selected crash point");
+    } else {
+        carol
+            .converge_stored_openmls_messages(&group_id, 3_000_000)
+            .expect("late branch convergence reaches selected crash point");
+    }
+}
+
+fn build_memory_client(seed: &[u8]) -> (Engine<SqliteAccountStorage>, SqliteAccountStorage) {
+    let storage = SqliteAccountStorage::in_memory().expect("in-memory storage");
+    let engine = build_client_with_storage(seed, storage.clone());
+    (engine, storage)
+}
+
+fn build_client_with_storage(
+    seed: &[u8],
+    storage: SqliteAccountStorage,
+) -> Engine<SqliteAccountStorage> {
+    EngineBuilder::new(storage)
+        .legacy_compatibility_profile()
+        .identity(identity(seed))
+        .account_identity_proof_signer(proof_signer(seed))
+        .feature_registry(self_remove_registry())
+        .peeler(Box::new(MockPeeler))
+        .build()
+        .expect("build crash-test engine")
+}
+
+fn self_remove_registry() -> FeatureRegistry {
+    let mut registry = FeatureRegistry::new();
+    registry.register(
+        Feature("self-remove"),
+        CapabilityRequirement {
+            requires: Capability::Proposal(10),
+            level: RequirementLevel::Required,
+            description: "MIP-03",
+        },
+    );
+    registry
+}
+
+fn identity(seed: &[u8]) -> Vec<u8> {
+    use k256::schnorr::SigningKey;
+
+    let mut counter = 0_u64;
+    loop {
+        let mut material = [0_u8; 32];
+        let mut hasher = Sha256::new();
+        hasher.update(b"cgka-engine-test-identity-v1");
+        hasher.update(seed);
+        hasher.update(counter.to_be_bytes());
+        material.copy_from_slice(&hasher.finalize());
+        if let Ok(key) = SigningKey::from_bytes(&material) {
+            return key.verifying_key().to_bytes().to_vec();
+        }
+        counter = counter.checked_add(1).expect("identity search exhausted");
+    }
+}
+
+fn hash_id(bytes: &[u8]) -> MessageId {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    MessageId::new(hasher.finish().to_be_bytes().to_vec())
+}
+
+fn route(msg: TransportMessage, group_id: &GroupId) -> TransportMessage {
+    match msg.envelope {
+        TransportEnvelope::Welcome { .. } => msg,
+        TransportEnvelope::GroupMessage { .. } => TransportMessage {
+            envelope: TransportEnvelope::GroupMessage {
+                transport_group_id: group_id.as_slice().to_vec(),
+            },
+            ..msg
+        },
+    }
+}
+
+fn evolution(result: SendResult) -> (TransportMessage, cgka_traits::engine_state::PendingStateRef) {
+    match result {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    }
+}
+
+fn welcome_for(welcomes: &[TransportMessage], seed: &[u8]) -> TransportMessage {
+    let recipient = MemberId::new(identity(seed));
+    welcomes
+        .iter()
+        .find(|message| {
+            matches!(
+                &message.envelope,
+                TransportEnvelope::Welcome { recipient: actual } if *actual == recipient
+            )
+        })
+        .expect("welcome exists")
+        .clone()
+}
+
+fn app_payload_for(engine: &Engine<SqliteAccountStorage>, payload: &[u8]) -> Vec<u8> {
+    MarmotAppEvent::new(
+        hex::encode(engine.self_id().as_slice()),
+        1_700_000_000,
+        MARMOT_APP_EVENT_KIND_CHAT,
+        vec![],
+        String::from_utf8(payload.to_vec()).expect("test payload is UTF-8"),
+    )
+    .encode()
+    .expect("encode app event")
+}
+
+fn wal_path(database: &Path) -> PathBuf {
+    let mut path = database.as_os_str().to_os_string();
+    path.push("-wal");
+    PathBuf::from(path)
+}


### PR DESCRIPTION
## Summary

- add explicit `--storage memory|file` selection to the conformance report runner and record the resolved backend in report metadata
- make file-backed harness restarts fully close and reopen encrypted SQLite before hydration
- exercise encrypted headers, production WAL defaults, and busy-writer retry behavior in the simulator storage-mode tests
- add debug-only H5/H6 crash hooks plus subprocess-kill recovery tests over file-backed SQLCipher storage
- run every portable vector in encrypted file-backed mode on pull requests and verify the reported backend

## Why

The encrypted file-backed simulator path existed, but CI did not exercise it and harness restarts rebuilt over an existing open connection. That left close/reopen durability and the former H5/H6 process-crash windows untested even though the production fixes were already merged.

This change hardens the test harness and CI without changing production convergence policy or storage behavior. The crash hooks are inactive unless both the test-only feature and debug assertions are enabled.

## Validation

- `cargo test -p storage-sqlite` (278 passed)
- `cargo test -p cgka-conformance-simulator`
- `cargo test -p cgka-conformance-simulator --test sqlite_storage_modes` (3 passed)
- all 19 portable vectors with `--storage file --strict-oracle`, with every report identifying `encrypted-file-sqlite`
- `cargo nextest run -p cgka-engine --test crash_recovery_sqlite --features test-crash-hooks` (2 passed)
- `just fast-ci`
- `actionlint .github/workflows/ci.yml`

Fixes #1025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional file-backed encrypted SQLite storage for conformance runs via `--storage file`.
  * Reports now identify the selected storage backend.
  * File-backed sessions support database close/reopen and state hydration.

* **Bug Fixes**
  * Improved recovery and retry behavior during database restarts, crashes, and busy-writer conditions.

* **Documentation**
  * Updated simulator guidance for storage selection, report generation, durability coverage, and recovery limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->