### PR TITLE
fix(incident-replay): fail-close format detection on manifest-less NDJSON streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,6 +2633,7 @@ dependencies = [
  "fs-private",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -22,8 +22,9 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
     `complete: true`, per-section counts matching what arrived, and no in-band
     `error` line — the server's only failure surface once the HTTP status is
     committed), which replaces the `has_more` truncation signal of the document
-    shape. `is_stream` detects the format from the contract's manifest-first
-    rule, so the CLI needs no format flag.
+    shape. `is_stream` detects any first-line `t` discriminator and routes it
+    through that fail-closed contract, so a malformed or manifest-less stream
+    cannot fall back to the document parser and the CLI needs no format flag.
 - **Module:** `src/classify.rs`
   - **Role:** The `classify` gate → `Verdict`: `Healthy | ForkRecovery |
     ConvergenceSelected | Quarantine { reason }`. Everything downstream is gated

--- a/crates/incident-replay/Cargo.toml
+++ b/crates/incident-replay/Cargo.toml
@@ -14,6 +14,9 @@ cgka-conformance-simulator.workspace = true
 fs-private.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [[bin]]
 name = "incident-replay"
 path = "src/main.rs"

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -432,16 +432,14 @@ impl EventKind {
 
 /// Parse a Goggles `agent-state.json` export.
 pub fn parse(json: &str) -> Result<AgentStateExport, ParseError> {
-    #[derive(Deserialize)]
-    struct StreamDiscriminatorProbe {
-        t: Option<String>,
-    }
-    if let Ok(StreamDiscriminatorProbe { t: Some(t) }) =
-        serde_json::from_str::<StreamDiscriminatorProbe>(json)
+    let value: serde_json::Value = serde_json::from_str(json)?;
+    if value
+        .as_object()
+        .is_some_and(|object| object.contains_key("t"))
     {
-        return Err(ParseError::StreamDiscriminator { t });
+        return Err(ParseError::StreamDiscriminator);
     }
-    Ok(serde_json::from_str(json)?)
+    Ok(serde_json::from_value(value)?)
 }
 
 /// Why an export could not be parsed.
@@ -449,8 +447,6 @@ pub fn parse(json: &str) -> Result<AgentStateExport, ParseError> {
 pub enum ParseError {
     #[error("agent-state export does not match the expected schema: {0}")]
     Json(#[from] serde_json::Error),
-    #[error(
-        "input is a streamed NDJSON line (discriminator `t` = `{t}`), not an agent-state document"
-    )]
-    StreamDiscriminator { t: String },
+    #[error("input carries the streamed NDJSON `t` discriminator, not an agent-state document")]
+    StreamDiscriminator,
 }

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -432,14 +432,11 @@ impl EventKind {
 
 /// Parse a Goggles `agent-state.json` export.
 pub fn parse(json: &str) -> Result<AgentStateExport, ParseError> {
-    let value: serde_json::Value = serde_json::from_str(json)?;
-    if value
-        .as_object()
-        .is_some_and(|object| object.contains_key("t"))
-    {
+    let probe = serde_json::from_str::<BTreeMap<String, serde::de::IgnoredAny>>(json);
+    if probe.is_ok_and(|object| object.contains_key("t")) {
         return Err(ParseError::StreamDiscriminator);
     }
-    Ok(serde_json::from_value(value)?)
+    Ok(serde_json::from_str(json)?)
 }
 
 /// Why an export could not be parsed.

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -432,6 +432,15 @@ impl EventKind {
 
 /// Parse a Goggles `agent-state.json` export.
 pub fn parse(json: &str) -> Result<AgentStateExport, ParseError> {
+    #[derive(Deserialize)]
+    struct StreamDiscriminatorProbe {
+        t: Option<String>,
+    }
+    if let Ok(StreamDiscriminatorProbe { t: Some(t) }) =
+        serde_json::from_str::<StreamDiscriminatorProbe>(json)
+    {
+        return Err(ParseError::StreamDiscriminator { t });
+    }
     Ok(serde_json::from_str(json)?)
 }
 
@@ -440,4 +449,8 @@ pub fn parse(json: &str) -> Result<AgentStateExport, ParseError> {
 pub enum ParseError {
     #[error("agent-state export does not match the expected schema: {0}")]
     Json(#[from] serde_json::Error),
+    #[error(
+        "input is a streamed NDJSON line (discriminator `t` = `{t}`), not an agent-state document"
+    )]
+    StreamDiscriminator { t: String },
 }

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -1,9 +1,10 @@
 //! `incident-replay` CLI: classify a Goggles export — either an
 //! `agent-state.json` document or a streamed NDJSON group export — and, for a
 //! fork-recovery or convergence incident, synthesize and verify a conformance
-//! vector. The format is recognised from the content: a stream leads with its
-//! `manifest` line (the `goggles-group-export/v1` contract), anything else is
-//! parsed as `agent-state.json`.
+//! vector. The format is recognised from the content: any first line carrying
+//! the stream's `t` discriminator is parsed under the fail-closed
+//! `goggles-group-export/v1` contract; anything else is parsed as
+//! `agent-state.json`.
 //!
 //! Reading, format detection, and printing live here; everything about *which*
 //! route an export takes is [`incident_replay::route`].

--- a/crates/incident-replay/src/ndjson.rs
+++ b/crates/incident-replay/src/ndjson.rs
@@ -43,10 +43,8 @@ pub fn is_stream(input: &str) -> bool {
     let Some(first_line) = input.lines().find(|line| !line.trim().is_empty()) else {
         return false;
     };
-    serde_json::from_str::<serde_json::Value>(first_line)
-        .ok()
-        .and_then(|value| value.as_object().map(|object| object.contains_key("t")))
-        .unwrap_or(false)
+    serde_json::from_str::<BTreeMap<String, serde::de::IgnoredAny>>(first_line)
+        .is_ok_and(|object| object.contains_key("t"))
 }
 
 /// Parse a streamed group export into the same [`AgentStateExport`] the rest of

--- a/crates/incident-replay/src/ndjson.rs
+++ b/crates/incident-replay/src/ndjson.rs
@@ -35,18 +35,15 @@ const EVENT: &str = "event";
 /// terminal `{"t":"error","complete":false}` line with no `eof`.
 const ERROR: &str = "error";
 
-/// Whether `input` is a Goggles NDJSON group-export stream. The v1 contract
-/// requires the first line to be the manifest, so this checks exactly that; an
-/// `agent-state.json` document (one JSON object, no `t` discriminator) is never
-/// mistaken for a stream.
+/// Whether `input` is a Goggles NDJSON group-export stream. A stream line is
+/// discriminated by a `t` field; checking whether the first non-empty line
+/// carries a `t` discriminator prevents a manifest-less or corrupt stream from
+/// falling back to the document parser and fail-opening as a healthy export.
 pub fn is_stream(input: &str) -> bool {
     let Some(first_line) = input.lines().find(|line| !line.trim().is_empty()) else {
         return false;
     };
-    matches!(
-        serde_json::from_str::<TagProbe>(first_line),
-        Ok(TagProbe { t }) if t == MANIFEST
-    )
+    serde_json::from_str::<TagProbe>(first_line).is_ok()
 }
 
 /// Parse a streamed group export into the same [`AgentStateExport`] the rest of
@@ -77,6 +74,9 @@ pub fn parse_stream(input: &str) -> Result<AgentStateExport, StreamParseError> {
             })?;
 
         if !saw_manifest {
+            if t == ERROR {
+                return Err(StreamParseError::ServerReportedError { line: number });
+            }
             if t != MANIFEST {
                 return Err(StreamParseError::MissingManifest);
             }

--- a/crates/incident-replay/src/ndjson.rs
+++ b/crates/incident-replay/src/ndjson.rs
@@ -43,7 +43,10 @@ pub fn is_stream(input: &str) -> bool {
     let Some(first_line) = input.lines().find(|line| !line.trim().is_empty()) else {
         return false;
     };
-    serde_json::from_str::<TagProbe>(first_line).is_ok()
+    serde_json::from_str::<serde_json::Value>(first_line)
+        .ok()
+        .and_then(|value| value.as_object().map(|object| object.contains_key("t")))
+        .unwrap_or(false)
 }
 
 /// Parse a streamed group export into the same [`AgentStateExport`] the rest of

--- a/crates/incident-replay/tests/cli.rs
+++ b/crates/incident-replay/tests/cli.rs
@@ -1,0 +1,34 @@
+//! End-to-end CLI coverage for fail-closed format detection.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+#[test]
+fn malformed_stream_discriminators_never_classify_as_healthy() {
+    for input in [
+        r#"{"t": null}"#,
+        r#"{"t": 0}"#,
+        r#"{"t": {}}"#,
+        r#"{"t": []}"#,
+        r#"{"t": "error", "t": null}"#,
+    ] {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_incident-replay"))
+            .arg("/dev/stdin")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("launch incident-replay");
+        child
+            .stdin
+            .take()
+            .expect("capture stdin")
+            .write_all(input.as_bytes())
+            .expect("write export");
+        let output = child.wait_with_output().expect("wait for incident-replay");
+        let stdout = String::from_utf8(output.stdout).expect("stdout is utf-8");
+
+        assert_eq!(output.status.code(), Some(2), "input: {input}");
+        assert!(!stdout.contains("healthy:"), "input: {input}");
+    }
+}

--- a/crates/incident-replay/tests/cli.rs
+++ b/crates/incident-replay/tests/cli.rs
@@ -1,34 +1,22 @@
 //! End-to-end CLI coverage for fail-closed format detection.
 
 use std::io::Write;
-use std::process::{Command, Stdio};
+use std::process::Command;
+
+use tempfile::NamedTempFile;
 
 #[test]
-fn malformed_stream_discriminators_never_classify_as_healthy() {
-    for input in [
-        r#"{"t": null}"#,
-        r#"{"t": 0}"#,
-        r#"{"t": {}}"#,
-        r#"{"t": []}"#,
-        r#"{"t": "error", "t": null}"#,
-    ] {
-        let mut child = Command::new(env!("CARGO_BIN_EXE_incident-replay"))
-            .arg("/dev/stdin")
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("launch incident-replay");
-        child
-            .stdin
-            .take()
-            .expect("capture stdin")
-            .write_all(input.as_bytes())
-            .expect("write export");
-        let output = child.wait_with_output().expect("wait for incident-replay");
-        let stdout = String::from_utf8(output.stdout).expect("stdout is utf-8");
+fn a_manifest_less_error_remnant_never_classifies_as_healthy() {
+    let mut input = NamedTempFile::new().expect("create export");
+    input
+        .write_all(br#"{"t":"error","complete":false}"#)
+        .expect("write export");
+    let output = Command::new(env!("CARGO_BIN_EXE_incident-replay"))
+        .arg(input.path())
+        .output()
+        .expect("run incident-replay");
+    let stdout = String::from_utf8(output.stdout).expect("stdout is utf-8");
 
-        assert_eq!(output.status.code(), Some(2), "input: {input}");
-        assert!(!stdout.contains("healthy:"), "input: {input}");
-    }
+    assert_eq!(output.status.code(), Some(2));
+    assert!(!stdout.contains("healthy:"));
 }

--- a/crates/incident-replay/tests/ndjson.rs
+++ b/crates/incident-replay/tests/ndjson.rs
@@ -78,10 +78,24 @@ fn a_stream_reporting_a_mid_stream_failure_is_rejected() {
 #[test]
 fn a_stream_without_a_leading_manifest_is_rejected() {
     let input = r#"{"t": "event", "kind": {"type": "epoch_confirmed", "epoch": 1}}"#;
-    assert!(!is_stream(input));
+    assert!(is_stream(input));
     assert!(matches!(
         parse_stream(input),
         Err(StreamParseError::MissingManifest)
+    ));
+}
+
+#[test]
+fn a_manifest_less_error_remnant_is_detected_as_a_stream_and_rejected() {
+    // A stream truncated to just its terminal in-band error line (e.g. after an
+    // immediate server abort) carries a `t` discriminator and must be classified
+    // as a stream so it fail-closes with ServerReportedError instead of reading
+    // as a healthy document.
+    let input = r#"{"t": "error", "complete": false}"#;
+    assert!(is_stream(input));
+    assert!(matches!(
+        parse_stream(input),
+        Err(StreamParseError::ServerReportedError { line: 1 })
     ));
 }
 

--- a/crates/incident-replay/tests/ndjson.rs
+++ b/crates/incident-replay/tests/ndjson.rs
@@ -100,6 +100,23 @@ fn a_manifest_less_error_remnant_is_detected_as_a_stream_and_rejected() {
 }
 
 #[test]
+fn malformed_stream_discriminators_never_fall_back_to_the_document_parser() {
+    for input in [
+        r#"{"t": null}"#,
+        r#"{"t": 0}"#,
+        r#"{"t": {}}"#,
+        r#"{"t": []}"#,
+        r#"{"t": "error", "t": null}"#,
+    ] {
+        assert!(is_stream(input), "stream-shaped input was missed: {input}");
+        assert!(
+            parse_stream(input).is_err(),
+            "malformed stream unexpectedly parsed: {input}"
+        );
+    }
+}
+
+#[test]
 fn a_stream_without_a_terminal_eof_is_rejected() {
     let input = concat!(
         r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#,

--- a/crates/incident-replay/tests/parse.rs
+++ b/crates/incident-replay/tests/parse.rs
@@ -8,6 +8,15 @@ fn invalid_json_is_a_parse_error() {
 }
 
 #[test]
+fn invalid_document_errors_keep_the_source_position() {
+    let Err(ParseError::Json(source)) = parse("{\n  \"events\": [\n}") else {
+        panic!("invalid document did not return its JSON error");
+    };
+    assert_eq!(source.line(), 3);
+    assert_eq!(source.column(), 1);
+}
+
+#[test]
 fn unknown_event_kinds_and_absent_projections_are_tolerated() {
     // Real exports carry ~40 event kinds and many fields this adapter ignores;
     // unknown kinds map to a no-op and an absent derived_projections defaults

--- a/crates/incident-replay/tests/parse.rs
+++ b/crates/incident-replay/tests/parse.rs
@@ -17,3 +17,11 @@ fn unknown_event_kinds_and_absent_projections_are_tolerated() {
             .expect("unknown kinds and absent derived_projections parse");
     assert_eq!(classify(&export), Verdict::Healthy);
 }
+
+#[test]
+fn stream_shaped_lines_are_rejected_as_documents() {
+    // A stream line carrying a `t` discriminator must never be adopted by the
+    // document parser as an empty (healthy) export.
+    assert!(parse(r#"{"t": "error", "complete": false}"#).is_err());
+    assert!(parse(r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#).is_err());
+}

--- a/crates/incident-replay/tests/parse.rs
+++ b/crates/incident-replay/tests/parse.rs
@@ -1,6 +1,6 @@
 //! Parser behaviour: lenient to unknown shapes, loud on invalid input.
 
-use incident_replay::{Verdict, classify, parse};
+use incident_replay::{ParseError, Verdict, classify, parse};
 
 #[test]
 fn invalid_json_is_a_parse_error() {
@@ -22,6 +22,18 @@ fn unknown_event_kinds_and_absent_projections_are_tolerated() {
 fn stream_shaped_lines_are_rejected_as_documents() {
     // A stream line carrying a `t` discriminator must never be adopted by the
     // document parser as an empty (healthy) export.
-    assert!(parse(r#"{"t": "error", "complete": false}"#).is_err());
-    assert!(parse(r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#).is_err());
+    for input in [
+        r#"{"t": "error", "complete": false}"#,
+        r#"{"t": "manifest", "schema_version": "goggles-group-export/v1"}"#,
+        r#"{"t": null}"#,
+        r#"{"t": 0}"#,
+        r#"{"t": {}}"#,
+        r#"{"t": []}"#,
+        r#"{"t": "error", "t": null}"#,
+    ] {
+        assert!(
+            matches!(parse(input), Err(ParseError::StreamDiscriminator)),
+            "stream-shaped input was not rejected: {input}"
+        );
+    }
 }


### PR DESCRIPTION
### Summary

Previously, `is_stream` required the first non-empty line of an export to be a valid `manifest` line. When an NDJSON stream was truncated to a single JSON object without a leading manifest (for example, after an immediate server abort reporting only an in-band error line `{"t":"error","complete":false}`), format detection returned `false` and routed the input to the document parser `export::parse`. Because all document fields default cleanly, the remnant was silently adopted as an empty export and classified as healthy (`healthy: 0 vectors`).

This PR fixes this fail-open behavior by updating `is_stream` to recognize any line carrying a `t` discriminator as a stream. This ensures that manifest-less or corrupt streams fail closed with a `StreamParseError` instead of falling back to the document parser. As an additional layer of defense against accidental adoption, `export::parse` now explicitly rejects top-level objects carrying a `t` discriminator.

Fixes #1037

### Verification

- Added reproduction regression tests in `crates/incident-replay/tests/ndjson.rs` and `crates/incident-replay/tests/parse.rs` verifying that manifest-less stream remnants and stream-shaped lines are rejected and fail closed.
- Confirmed all existing `incident-replay` unit and integration tests pass without regression.
- Ran workspace-wide formatting and clippy checks (`just fast-ci` equivalents).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of NDJSON streams, including streams without a manifest.
  - Reports server-sent errors immediately during stream parsing.
  - Prevents streamed data from being misinterpreted as complete agent-state documents.
  - Provides clearer errors for malformed or stream-shaped JSON input.

- **Documentation**
  - Clarified stream detection rules and the supported stream format.

- **Tests**
  - Added coverage for manifest-less streams, terminal errors, malformed discriminators, and CLI parsing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->