### PR TITLE
fix(openclaw): route replies through the source channel

### DIFF
--- a/.github/workflows/wn-agent-binaries.yml
+++ b/.github/workflows/wn-agent-binaries.yml
@@ -388,7 +388,13 @@ jobs:
           # Build dist/ before packing: package.json#files ships dist (which is
           # gitignored), and the gateway requires compiled runtime output rather
           # than the TypeScript sources.
-          ( cd integrations/openclaw/marmot && pnpm install --frozen-lockfile && pnpm build )
+          (
+            cd integrations/openclaw/marmot
+            pnpm install --frozen-lockfile
+            pnpm typecheck
+            pnpm test
+            pnpm build
+          )
           # Provenance manifest (release.md requires one in each artifact); ships
           # via package.json#files alongside the built plugin.
           cat > integrations/openclaw/marmot/manifest.json <<EOF

--- a/integrations/openclaw/marmot/AGENTS.md
+++ b/integrations/openclaw/marmot/AGENTS.md
@@ -21,7 +21,8 @@ The OpenClaw counterpart of `integrations/hermes/marmot`. Read `README.md` first
 - `src/append-only.ts` — append-only suffix tracker for progressive updates.
 - `src/live.ts` — live-preview state machine → `stream_begin`/`append`/`finalize`/`cancel`.
 - `src/inbound.ts` — inbound subscription bridge (reconnect, dedupe, resync).
-- `src/inbound-runtime.ts` — `registerFull` wiring + the inbound→agent dispatch seam.
+- `src/gateway.ts` — OpenClaw-owned account lifecycle and inbound subscription.
+- `src/inbound-runtime.ts` — the inbound→agent dispatch seam.
 - `src/bounded-keyed-async-queue.ts` — per-group inbound dispatch with a depth cap.
 - `src/outbound.ts` — `defineChannelMessageAdapter` durable send → `send_final`.
 - `src/messaging.ts` — `messaging` target-resolution adapter so the shared `message` tool can resolve a Marmot conversation (group id hex).
@@ -37,7 +38,9 @@ The OpenClaw counterpart of `integrations/hermes/marmot`. Read `README.md` first
 - Regenerate `test/vectors/transcript-vectors.json` from the Rust
   `AgentTextStreamTranscriptV1` if the Rust transcript hashing ever changes.
 - Keep the `openclaw` dependency pinned; before bumping, verify the
-  `openclaw/plugin-sdk/*` subpath exports against the new version's types.
+  `openclaw/plugin-sdk/*` subpath exports against the new version's types, and
+  re-verify the deliberate test-only `dist/plugins/loader.js` import used by the
+  connector E2E (the pinned SDK exposes no supported plugin-loader subpath).
 - The inbound→agent and live-preview-pipeline seams use OpenClaw gateway runtime
   internals and are validated by the deterministic connector E2E plus the docker
   phone test, not the unit tests alone.

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -206,6 +206,9 @@ advanced shared deployment can point both gateways at one `wn-agent`:
 | `profileNameOnboarding` | `MARMOT_PROFILE_NAME_ONBOARDING` | `true` |
 | `dm.policy` / `dm.allowFrom` | — | `allowlist` |
 
+The QUIC/streaming settings are still accepted for configuration compatibility,
+but inbound agent replies are currently delivered final-only.
+
 `accountIdHex` is the Marmot/wn-agent account id. It is intentionally distinct
 from OpenClaw's channel account id (`default`, or a key under
 `channels.marmot.accounts`) used for routing, session metadata, and message-tool
@@ -220,11 +223,14 @@ The token grants the full connector API for every hosted account, not only the
 configured OpenClaw channel account. Use a separate connector home/socket/token
 for any plugin or tenant that is not in the same trust boundary.
 
-- **Inbound → agent turn** (`src/dispatch.ts`): the inbound bridge feeds each
-  received Marmot message (`chatId` = Marmot group id, `userId` = sender) into
-  OpenClaw's turn kernel via `runChannelInboundEvent` + `dispatchReplyWithBufferedBlockDispatcher`,
-  **modeled on the bundled Telegram channel**. The agent's reply is delivered
-  back through the message adapter and threads to the triggering message.
+- **Inbound → agent turn** (`src/dispatch.ts`): the gateway-owned inbound bridge
+  feeds each received Marmot message (`chatId` = Marmot group id, `userId` =
+  sender) into OpenClaw's turn kernel via `runChannelInboundEvent` +
+  `dispatchReplyWithBufferedBlockDispatcher`. The trusted inbound context owns
+  the destination. A normal assistant final is passed to
+  `deliverInboundReplyWithMessageSendContext`, which invokes the registered
+  Marmot message adapter and threads the reply to the triggering message. The
+  model never has to reconstruct or select the source group.
   Dispatch is serialized per group (distinct groups run concurrently, each group
   stays FIFO), so a slow turn in one group never blocks inbound for others; set
   `debounceMs` to coalesce rapid same-sender bursts into one turn.
@@ -245,16 +251,11 @@ for any plugin or tenant that is not in the same trust boundary.
   unrecallable barge-in there is worse than dropping a single reply in a true
   two-party DM (where the user can re-send or address the agent explicitly). The
   error is not cached, so the next message retries the lookup.
-- **Durable replies** are sent verbatim as `kind: 9` messages via `send_final`;
-  the adapter never merges or rewrites text across sends. Each durable reply is
-  **idempotent + retried**: the sink generates one `idempotency_key` per reply
-  and retries the send a few times (with a short backoff) on retryable errors,
-  reusing the same key so `wn-agent` dedups instead of double-posting. A repeated
-  key returns the original message ids without a second send, so a retry after a
-  post-write timeout cannot double-post an unrecallable encrypted message.
-  Live-preview `stream_finalize` uses the same posture: one idempotency key per
-  preview stream, bounded retry on retryable failures, and connector-side cached
-  final message ids for post-success retries.
+- **Durable replies** are sent verbatim as `kind: 9` messages via the registered
+  message adapter's `send.text` → `wn-agent send_final` mapping. The adapter
+  never merges or rewrites text across sends. A bounded retry reuses one
+  per-send idempotency key so a transient control-socket failure does not create
+  a second Marmot message.
 - **`message`-tool target resolution** (`src/messaging.ts`): a Marmot reply is
   delivered automatically from the assistant's final text, so the agent does not
   need the shared `message` tool to answer. When it *does* call
@@ -296,18 +297,11 @@ for any plugin or tenant that is not in the same trust boundary.
   non-regular files. `wn-agent` encrypts + uploads to Blossom; the content key
   never leaves it. The vision model actually
   receiving the image is confirmed on the docker harness.
-- **Live QUIC previews** (`src/live.ts`): progressive agent reply blocks drive an
-  append-only preview (`stream_begin`/`append`/`finalize`); a non-append-only
-  update cancels the preview and sends the final verbatim. The transcript hash +
-  chunk count match `wn-agent` byte-for-byte (Rust-anchored parity test in
-  `test/transcript.test.ts`). Previews run whenever `streaming.mode` is not
-  `off` and `quicCandidates` are set, and OpenClaw is emitting progressive
-  blocks. Marmot enables OpenClaw block delivery automatically when
-  `quicCandidates` are configured and `streaming.mode` is not `off`; operators
-  can override it with `blockStreaming`, `streaming.block.enabled`, or
-  `MARMOT_BLOCK_STREAMING`. Like a Telegram preview,
-  this is driven by the channel's reply `deliver` callback, not a core-driven
-  live adapter (that SDK seam does not exist yet).
+- **Live QUIC previews** (`src/live.ts`) are temporarily not wired into inbound
+  agent turns. Those turns are final-only so durable delivery has one owner: the
+  registered OpenClaw message adapter. The transcript and preview primitives
+  remain tested for a later reintroduction through OpenClaw's standard live
+  message-adapter lifecycle.
   The plugin keeps one stable request id across retries of the initial
   `stream_begin`, retains the returned v2 stream capability in memory, and
   presents it on every later operation. It never logs or persists that bearer.

--- a/integrations/openclaw/marmot/index.ts
+++ b/integrations/openclaw/marmot/index.ts
@@ -1,113 +1,13 @@
-// OpenClaw plugin runtime entry. Registers the Marmot channel, syncs the
-// welcomer allowlist, and starts the inbound subscription that drives the agent
-// turn (modeled on the bundled Telegram channel). See README.md for setup.
+// OpenClaw plugin runtime entry. Account lifecycle, including the inbound
+// subscription, is owned by the channel's `gateway.startAccount` adapter.
 
-import {
-  defineChannelPluginEntry,
-  type OpenClawPluginApi,
-} from "openclaw/plugin-sdk/channel-core";
+import { defineChannelPluginEntry } from "openclaw/plugin-sdk/channel-core";
 
-import {
-  createMarmotChannelPlugin,
-  MARMOT_CHANNEL_ID,
-  resolveMarmotChannelAccount,
-} from "./src/channel.js";
-import { clientForAccount } from "./src/config.js";
-import { createMarmotInboundDispatcher, type OpenClawChannelRuntime } from "./src/dispatch.js";
-import {
-  startMarmotInbound,
-  syncMarmotAllowlist,
-  type MarmotAmbientSurfacer,
-} from "./src/inbound-runtime.js";
-import { DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID } from "./src/runtime-state.js";
+import { createMarmotChannelPlugin, MARMOT_CHANNEL_ID } from "./src/channel.js";
 
 export default defineChannelPluginEntry({
   id: MARMOT_CHANNEL_ID,
   name: "Marmot",
   description: "End-to-end encrypted Marmot groups through the local wn-agent connector.",
   plugin: createMarmotChannelPlugin(),
-  registerFull(api: OpenClawPluginApi) {
-    api.logger.info(
-      `marmot: registerFull invoked (registrationMode=${String(
-        (api as { registrationMode?: unknown }).registrationMode ?? "unknown",
-      )})`,
-    );
-    void (async () => {
-      try {
-        // Mirror configured dm.allowFrom welcomers into wn-agent before consuming
-        // inbound, so the welcomer policy is in place when the agent goes live.
-        // (syncMarmotAllowlist is self-guarded and never rejects.)
-        await syncMarmotAllowlist(api);
-
-        const resolved = resolveMarmotChannelAccount(api.config, null);
-
-        // Inherit the configured OpenClaw agent name (if any): it seeds the
-        // profile-name onboarding flow and, as a trigger phrase, lets the agent
-        // recognize being addressed by name in a group.
-        const agents = (api.config as {
-          agents?: { list?: Array<{ name?: string; default?: boolean }> };
-        }).agents;
-        const agentList = agents?.list ?? [];
-        const configuredAgentName =
-          agentList.find((entry) => entry.default)?.name ?? agentList[0]?.name ?? null;
-        const mentionPatterns = [...resolved.mentionPatterns, configuredAgentName].filter(
-          (pattern): pattern is string => typeof pattern === "string" && pattern.trim().length > 0,
-        );
-
-        // Inbound -> agent turn dispatch (Telegram-modeled): the bridge feeds each
-        // received Marmot message into runChannelInboundEvent, and the agent's
-        // reply is delivered back through send_final / live QUIC previews.
-        const dispatch = createMarmotInboundDispatcher({
-          cfg: api.config,
-          runtimeChannel: api.runtime.channel as unknown as OpenClawChannelRuntime,
-          client: clientForAccount(resolved),
-          channelAccountId: resolved.accountId ?? DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID,
-          streamMode: resolved.streamMode,
-          blockStreaming: resolved.blockStreaming,
-          quicCandidates: resolved.quicCandidates,
-          groupActivation: resolved.groupActivation,
-          mentionPatterns,
-          log: (message) => api.logger.info(message),
-        });
-
-        // Ambient surfacer: route a passive group event to the agent's session as
-        // quiet next-turn context. Built here (over the full `api`) because it
-        // needs `api.runtime.channel.routing` + `api.runtime.system`, which the
-        // narrowed inbound api does not expose. Feature-detected at runtime so it
-        // degrades to a no-op on a host without the system-event surface.
-        const channelAccountId = resolved.accountId ?? DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID;
-        const surfaceAmbientEvent: MarmotAmbientSurfacer = ({ groupIdHex, text, contextKey }) => {
-          const enqueue = api.runtime?.system?.enqueueSystemEvent;
-          if (typeof enqueue !== "function") {
-            api.logger.warn(
-              "marmot: runtime has no system-event surface; ambient event not delivered",
-            );
-            return;
-          }
-          const route = api.runtime.channel.routing.resolveAgentRoute({
-            cfg: api.config,
-            channel: MARMOT_CHANNEL_ID,
-            accountId: channelAccountId,
-            peer: { kind: "group", id: groupIdHex },
-          });
-          enqueue(text, { sessionKey: route.sessionKey, contextKey: contextKey ?? null });
-        };
-
-        startMarmotInbound(api, dispatch, {
-          configuredAgentName,
-          surfaceAmbientEvent,
-          invalidateGroupActivation: dispatch.invalidateGroupActivation,
-          clearGroupActivationCache: dispatch.clearGroupActivationCache,
-        });
-      } catch {
-        // This runs in a fire-and-forget IIFE, so an unguarded throw (e.g. a
-        // malformed channels.marmot config that fails account resolution) would
-        // surface as an unhandledRejection — and OpenClaw's handler process.exit(1)s
-        // the whole gateway on a non-transient rejection, taking sibling channels
-        // down with it. Contain it: log a privacy-safe notice and leave the Marmot
-        // channel inert instead of crashing the gateway.
-        api.logger.warn("marmot: inbound startup failed; channel is inactive");
-      }
-    })();
-  },
 });

--- a/integrations/openclaw/marmot/src/channel.ts
+++ b/integrations/openclaw/marmot/src/channel.ts
@@ -2,9 +2,8 @@
 //
 // Composed with `createChatChannelPlugin`: meta + capabilities + a config
 // adapter that resolves a Marmot account from the `channels.marmot` config (or
-// MARMOT_* env), the durable/live message adapter, DM allowlist security, and
-// reply threading. Outbound (durable send + live preview) flows through the
-// message adapter; inbound is driven by src/inbound-runtime.ts.
+// MARMOT_* env), the durable message adapter, gateway-owned inbound lifecycle,
+// DM allowlist security, and reply threading.
 
 import { jsonResult } from "openclaw/plugin-sdk/channel-actions";
 import type {
@@ -29,6 +28,7 @@ import {
   type MarmotChannelAccountConfig,
   type ResolvedMarmotAccount,
 } from "./config.js";
+import { startMarmotGatewayAccount } from "./gateway.js";
 import { createMarmotMessagingAdapter } from "./messaging.js";
 import { createMarmotMessageAdapter } from "./outbound.js";
 import {
@@ -98,7 +98,7 @@ function accountSnapshot(
     lastInboundAt: inbound.lastInboundAt ?? runtime?.lastInboundAt ?? null,
     lastOutboundAt: inbound.lastOutboundAt ?? runtime?.lastOutboundAt ?? null,
     reconnectAttempts: inbound.reconnectAttempts ?? runtime?.reconnectAttempts,
-    mode: account.streamMode,
+    mode: "off",
     dmPolicy: account.dmPolicy ?? "allowlist",
     allowFrom: account.allowFrom.map(String),
     probe,
@@ -207,7 +207,7 @@ export function createMarmotChannelPlugin() {
         chatTypes: ["direct", "group"],
         reply: true,
         media: true,
-        blockStreaming: true,
+        blockStreaming: false,
         // Marmot supports deleting (unsending) a previously-sent message; gates
         // the agent-facing `delete` message action's visibility.
         unsend: true,
@@ -248,6 +248,9 @@ export function createMarmotChannelPlugin() {
         ],
       },
       actions,
+      gateway: {
+        startAccount: startMarmotGatewayAccount,
+      },
     },
     security: {
       dm: {

--- a/integrations/openclaw/marmot/src/dispatch.ts
+++ b/integrations/openclaw/marmot/src/dispatch.ts
@@ -1,16 +1,12 @@
-// Inbound -> agent turn dispatch, modeled on the bundled OpenClaw Telegram
-// channel (node_modules/openclaw/dist/bot-*.js): the channel owns its inbound
-// loop and calls `runChannelInboundEvent` itself, with a `resolveTurn` whose
-// `runDispatch` drives `dispatchReplyWithBufferedBlockDispatcher`. The agent's
-// reply arrives as progressive `block` deliveries + a `final` via a
-// `deliver(payload, info)` callback, which we map onto Marmot sends.
+// Inbound -> agent turn dispatch. The channel builds one authoritative OpenClaw
+// route from the received Marmot group, runs the agent turn, and sends its final
+// through OpenClaw's durable message context. That context invokes the channel's
+// registered Marmot message adapter, which is the only durable wn-agent send path.
 //
 // The turn assembly (runChannelInboundEvent / buildChannelInboundEventContext /
-// api.runtime.channel) is typechecked against the SDK but is validated
-// end-to-end against the `openclaw-gateway` docker harness (it needs a running
-// gateway + a model). The MarmotReplySink mapping below is unit-tested.
+// api.runtime.channel) is typechecked against the SDK and validated by the
+// connector E2E. Inbound production turns are deliberately final-only for now.
 
-import { randomUUID } from "node:crypto";
 import { readFile, unlink } from "node:fs/promises";
 
 import {
@@ -18,431 +14,45 @@ import {
   runChannelInboundEvent,
   type InboundMediaFacts,
 } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  deliverInboundReplyWithMessageSendContext,
+  type DurableInboundReplyDeliveryResult,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 
-import { NonAppendOnlyUpdateError } from "./append-only.js";
-import { isRetryable, type MarmotAgentControlClient } from "./client.js";
-import type { GroupActivation, StreamMode } from "./config.js";
+import type { MarmotAgentControlClient } from "./client.js";
+import type { GroupActivation } from "./config.js";
 import type { MarmotInboundMessage } from "./inbound.js";
-import { MarmotLivePreview, type StreamControlClient } from "./live.js";
 import { DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID } from "./runtime-state.js";
-import { resolveLatestAssistantTextFromSessionStore } from "./session-transcript.js";
 
-// --- reply sink (unit-tested) -----------------------------------------------
+// --- inbound turn dispatch (SDK-coupled; harness-validated) ------------------
 
-/** Kind of a streamed reply delivery from the OpenClaw reply dispatcher. */
+/** Kind of reply delivery emitted by OpenClaw's buffered dispatcher. */
 export interface ReplyDelivery {
   kind: "final" | "block" | "tool";
 }
 
-/** The subset of the reply payload the Marmot sink reads. */
-export interface ReplyPayloadLike {
-  text?: string;
-}
+/** Reply payload emitted by OpenClaw's buffered reply dispatcher. */
+export type ReplyPayloadLike = ReplyPayload;
 
-/** Partial assistant preview payload emitted before the durable reply dispatcher settles. */
-export interface PartialReplyPayloadLike {
-  text?: string;
-  delta?: string;
-  replace?: true;
-}
-
-export type MarmotSinkClient = Pick<MarmotAgentControlClient, "sendFinal"> & StreamControlClient;
-
-export interface MarmotReplySinkOptions {
-  client: MarmotSinkClient;
-  accountIdHex: string;
-  groupIdHex: string;
-  replyToMessageIdHex?: string | null;
-  streamMode: StreamMode;
-  quicCandidates: string[];
-  chunkBytes?: number;
-  resolveFinalText?: () => Promise<string | undefined> | string | undefined;
-  /** Optional privacy-safe lifecycle logger (kinds + lengths only, no content/ids). */
-  log?: (message: string) => void;
-}
-
-const MIN_TRUNCATED_FINAL_PREFIX_CHARS = 48;
-const MIN_TRUNCATED_FINAL_CONTINUATION_CHARS = 24;
-
-function stripTrailingEllipsis(text: string): string {
-  return text.replace(/(?:\s*(?:\.{3}|…))+$/u, "").trimEnd();
-}
-
-function isPotentialTruncatedFinal(text: string): boolean {
-  const trimmed = text.trimEnd();
-  const untruncated = stripTrailingEllipsis(trimmed);
-  return untruncated.length >= MIN_TRUNCATED_FINAL_PREFIX_CHARS && untruncated !== trimmed;
-}
-
-function selectLongerFinalText(current: string, candidate: string | undefined): string | undefined {
-  const candidateText = candidate?.trimEnd();
-  if (!candidateText) {
-    return undefined;
-  }
-  const currentText = current.trimEnd();
-  if (!currentText) {
-    return candidateText;
-  }
-  if (candidateText === currentText) {
-    return currentText;
-  }
-  if (candidateText.length > currentText.length && candidateText.startsWith(currentText)) {
-    return candidateText;
-  }
-  if (!isPotentialTruncatedFinal(currentText)) {
-    return undefined;
-  }
-  const untruncated = stripTrailingEllipsis(currentText);
-  if (candidateText.length <= currentText.length || !candidateText.startsWith(untruncated)) {
-    return undefined;
-  }
-  const continuation = candidateText.slice(untruncated.length).trimStart();
-  return continuation.length >= MIN_TRUNCATED_FINAL_CONTINUATION_CHARS && /^[\p{L}\p{N}]/u.test(continuation)
-    ? candidateText
-    : undefined;
-}
+const MARMOT_TURN_DENIED_TOOLS = ["sessions_send"] as const;
 
 /**
- * Maps the agent's streamed reply onto Marmot sends: progressive `block`
- * deliveries drive an append-only live QUIC preview; the `final` is committed
- * via `stream_finalize` when a preview is active and the final extends it, else
- * a plain `send_final`. A non-append-only update cancels the preview and falls
- * back to a verbatim `send_final` (mirrors the Hermes shim's behavior).
+ * Keep cross-session coordination out of a source-bound Marmot reply turn.
+ * `sessions_send` does not deliver to a human-facing channel; normal final text
+ * and the shared `message` tool already use the authoritative source route.
  */
-export class MarmotReplySink {
-  private preview: MarmotLivePreview | null = null;
-  private previewAbandoned = false;
-  /** Reply deliveries received from the dispatcher this turn (diagnostic). */
-  deliveries = 0;
-  /** Latest reconstructed answer text; used to commit a blocks-only turn at flush(). */
-  private latestAnswerText = "";
-  /** True once lower-latency partial snapshots, not delayed block chunks, own the preview. */
-  private partialPreviewActive = false;
-  /** True once OpenClaw has emitted any partial reply callback for this turn. */
-  private sawPartialPreview = false;
-  private partialDeliveries = 0;
-  private partialAppendEvents = 0;
-  private partialAppendedChars = 0;
-  private loggedPartialStart = false;
-  private loggedPartialAppendStart = false;
-  private loggedPartialSummary = false;
-  /** Whether the durable reply has been committed (stream_finalize or send_final). */
-  private finalized = false;
-
-  constructor(private readonly options: MarmotReplySinkOptions) {}
-
-  private log(message: string): void {
-    this.options.log?.(message);
-  }
-
-  private get streamingEnabled(): boolean {
-    return this.options.streamMode !== "off" && this.options.quicCandidates.length > 0;
-  }
-
-  private ensurePreview(): MarmotLivePreview {
-    if (!this.preview) {
-      this.preview = new MarmotLivePreview(this.options.client, {
-        accountIdHex: this.options.accountIdHex,
-        groupIdHex: this.options.groupIdHex,
-        parentMessageIdHex: this.options.replyToMessageIdHex,
-        quicCandidates: this.options.quicCandidates,
-        chunkBytes: this.options.chunkBytes,
-      });
-    }
-    return this.preview;
-  }
-
-  private async abandonPreview(reason: string): Promise<void> {
-    this.previewAbandoned = true;
-    if (this.preview) {
-      // Best effort: if the QUIC stream is already unhealthy, cancel may also
-      // fail — we still fall back to a plain durable send.
-      await this.preview.cancel(reason).catch(() => undefined);
-    }
-  }
-
-  private nextAnswerTextFromBlock(text: string): string {
-    if (!this.latestAnswerText) {
-      return text;
-    }
-    if (text.startsWith(this.latestAnswerText)) {
-      return text;
-    }
-    if (this.latestAnswerText.endsWith(text)) {
-      return this.latestAnswerText;
-    }
-    return `${this.latestAnswerText}${text}`;
-  }
-
-  private async bestFinalText(fallback: string): Promise<string> {
-    let candidate: string | undefined;
-    try {
-      candidate = await this.options.resolveFinalText?.();
-    } catch {
-      this.log("marmot: transcript final recovery lookup failed");
-    }
-    if (!candidate?.trim()) {
-      return fallback;
-    }
-    if (this.options.streamMode === "partial" || this.options.streamMode === "progress" || this.sawPartialPreview) {
-      return candidate.trimEnd();
-    }
-    return selectLongerFinalText(fallback, candidate) ?? fallback;
-  }
-
-  private async sendProgress(text: string): Promise<void> {
-    const progressText = text.trim();
-    if (!progressText || !this.streamingEnabled || this.previewAbandoned) {
-      return;
-    }
-    try {
-      await this.ensurePreview().progress(progressText);
-    } catch {
-      this.log("marmot: live progress abandoned (preview_error); will send the final durably");
-      await this.abandonPreview("preview_progress_error");
-    }
-  }
-
-  async prewarm(): Promise<void> {
-    if (!this.streamingEnabled || this.previewAbandoned) {
-      return;
-    }
-    try {
-      await this.ensurePreview().begin();
-      this.log("marmot: live preview stream started");
-    } catch {
-      this.log("marmot: live preview start failed; will send the final durably");
-      await this.abandonPreview("preview_begin_error");
-    }
-  }
-
-  async status(status: string): Promise<void> {
-    const statusText = status.trim();
-    if (!statusText || !this.streamingEnabled || this.previewAbandoned) {
-      return;
-    }
-    try {
-      await this.ensurePreview().status(statusText);
-    } catch {
-      this.log("marmot: live status abandoned (preview_error); will send the final durably");
-      await this.abandonPreview("preview_status_error");
-    }
-  }
-
-  async progress(text: string): Promise<void> {
-    await this.sendProgress(text);
-  }
-
-  async partial(payload: PartialReplyPayloadLike): Promise<void> {
-    const text = String(payload.text ?? "");
-    const delta = payload.replace === true ? "" : String(payload.delta ?? "");
-    if (!text.trim() && delta.length === 0) {
-      return;
-    }
-    this.sawPartialPreview = true;
-    this.partialDeliveries += 1;
-    if (!this.loggedPartialStart) {
-      this.loggedPartialStart = true;
-      this.log(
-        `marmot: partial reply streaming started chars=${text.length} delta_chars=${delta.length} streaming=${this.streamingEnabled}`,
-      );
-    }
-    if (!this.streamingEnabled || this.previewAbandoned) {
-      this.latestAnswerText = text || `${this.latestAnswerText}${delta}`;
-      return;
-    }
-    try {
-      const preview = this.ensurePreview();
-      if (delta.length > 0) {
-        await preview.appendDelta(delta);
-        this.partialPreviewActive = true;
-        this.latestAnswerText = text || preview.currentText;
-        this.notePartialAppend("delta", delta.length);
-        return;
-      }
-      if (payload.replace === true) {
-        this.log("marmot: skipped replacement partial without append delta");
-        this.partialPreviewActive = false;
-        return;
-      }
-      const previousLength = preview.currentText.length;
-      await preview.update(text);
-      this.partialPreviewActive = true;
-      this.latestAnswerText = text;
-      const appendedChars = preview.currentText.length - previousLength;
-      if (appendedChars > 0) {
-        this.notePartialAppend("snapshot", appendedChars);
-      }
-    } catch (error) {
-      if (error instanceof NonAppendOnlyUpdateError) {
-        this.log("marmot: skipped non-append partial without append delta");
-        this.partialPreviewActive = false;
-        return;
-      }
-      const reason = "preview_partial_error";
-      this.log(`marmot: live partial preview abandoned (${reason}); will send the final durably`);
-      this.partialPreviewActive = false;
-      this.latestAnswerText = "";
-      await this.abandonPreview(reason);
-    }
-  }
-
-  private notePartialAppend(kind: "delta" | "snapshot", chars: number): void {
-    this.partialAppendEvents += 1;
-    this.partialAppendedChars += chars;
-    if (!this.loggedPartialAppendStart) {
-      this.loggedPartialAppendStart = true;
-      this.log(`marmot: partial reply append started kind=${kind} chars=${chars}`);
-    }
-  }
-
-  private logPartialSummary(): void {
-    if (!this.sawPartialPreview || this.loggedPartialSummary) {
-      return;
-    }
-    this.loggedPartialSummary = true;
-    this.log(
-      `marmot: partial reply summary deliveries=${this.partialDeliveries} appends=${this.partialAppendEvents} appended_chars=${this.partialAppendedChars}`,
-    );
-  }
-
-  private async sendFinal(text: string): Promise<void> {
-    this.log(`marmot: sending durable final (${text.length} chars)`);
-    // One idempotency key for all attempts of THIS durable reply: a retry after a
-    // post-write timeout reuses the key so the connector dedups instead of
-    // double-posting an unrecallable encrypted message. Bounded retries with a
-    // tiny backoff cover the transient/timeout window; non-retryable errors fail
-    // fast and the last error is rethrown.
-    const idempotencyKey = randomUUID();
-    const backoffMs = [100, 300];
-    let attempt = 0;
-    for (;;) {
-      try {
-        await this.options.client.sendFinal(
-          this.options.accountIdHex,
-          this.options.groupIdHex,
-          text,
-          this.options.replyToMessageIdHex ?? null,
-          idempotencyKey,
-        );
-        this.log("marmot: durable final sent");
-        return;
-      } catch (err) {
-        if (attempt >= backoffMs.length || !isRetryable(err)) {
-          throw err;
-        }
-        this.log(`marmot: durable final send failed; retrying (attempt ${attempt + 1})`);
-        await new Promise((resolve) => setTimeout(resolve, backoffMs[attempt]));
-        attempt += 1;
-      }
-    }
-  }
-
-  async deliver(payload: ReplyPayloadLike, info: ReplyDelivery): Promise<void> {
-    const text = payload?.text ?? "";
-    this.deliveries += 1;
-    this.log(
-      `marmot: reply delivery kind=${info.kind} chars=${text.length} streaming=${this.streamingEnabled}`,
-    );
-
-    if (info.kind === "tool") {
-      await this.sendProgress(text);
-      return;
-    }
-
-    if (info.kind === "block") {
-      if (this.partialPreviewActive) {
-        // OpenClaw emits delayed block chunks after earlier partial snapshots.
-        // Once partials own the live preview, blocks are only a durable fallback;
-        // appending them would replay or reorder already-streamed text.
-        return;
-      }
-      this.latestAnswerText = this.nextAnswerTextFromBlock(text);
-      if (!this.streamingEnabled || this.previewAbandoned) {
-        return; // recorded in latestAnswerText; committed by the final delivery or flush()
-      }
-      try {
-        await this.ensurePreview().update(this.latestAnswerText);
-      } catch (error) {
-        // Any preview failure — non-append-only text, or a QUIC/broker error —
-        // abandons the live preview. The full text is still delivered durably by
-        // the final delivery or flush(), so a streaming hiccup never drops it.
-        const reason =
-          error instanceof NonAppendOnlyUpdateError ? "non_append_only" : "preview_error";
-        this.log(`marmot: live preview abandoned (${reason}); will send the final durably`);
-        await this.abandonPreview(reason);
-      }
-      return;
-    }
-
-    this.latestAnswerText = text || this.latestAnswerText;
-    await this.commit(this.latestAnswerText);
-  }
-
-  /**
-   * Commit the durable reply exactly once: finalize an active live preview into
-   * a stream-final, otherwise send a plain durable final.
-   */
-  private async commit(text: string): Promise<boolean> {
-    if (this.finalized) {
-      return true;
-    }
-    const finalText = await this.bestFinalText(text);
-    if (!finalText) {
-      return false;
-    }
-    this.finalized = true;
-    this.logPartialSummary();
-    if (this.preview && this.preview.isActive && !this.previewAbandoned) {
-      try {
-        await this.preview.finalize(finalText);
-        this.log(`marmot: live preview finalized (${finalText.length} chars)`);
-        return true;
-      } catch (error) {
-        const reason =
-          error instanceof NonAppendOnlyUpdateError ? "final_not_append_only" : "finalize_error";
-        this.log(`marmot: preview finalize failed (${reason}); falling back to a durable send`);
-        await this.abandonPreview(reason);
-      }
-    }
-    await this.sendFinal(finalText);
-    return true;
-  }
-
-  /**
-   * Commit the reply once the agent turn has finished. Block streaming can
-   * deliver the whole reply as `block`s with no trailing `final`; without this
-   * the live preview would never be finalized and no durable kind:9 would land.
-   * A no-op once a `final` delivery already committed, or if the turn produced
-   * no text at all.
-   */
-  async flush(): Promise<void> {
-    if (this.finalized) {
-      return;
-    }
-    this.log("marmot: no explicit final delivery; committing the streamed reply at turn end");
-    if (this.options.streamMode === "block" && this.sawPartialPreview && this.deliveries === 0) {
-      this.log("marmot: no block/final reply deliveries; abandoning partial-only block preview");
-      if (this.preview?.isActive) {
-        await this.abandonPreview("no_deliverable_reply");
-      }
-      return;
-    }
-    if (await this.commit(this.latestAnswerText)) {
-      return;
-    }
-    if (!this.latestAnswerText) {
-      this.log("marmot: turn produced no deliverable reply");
-      if (this.preview?.isActive) {
-        await this.abandonPreview("no_deliverable_reply");
-      }
-      return;
-    }
-  }
+export function buildMarmotTurnConfig(baseCfg: unknown): Record<string, unknown> {
+  const cfg = baseCfg as { tools?: { deny?: string[] } };
+  return {
+    ...cfg,
+    tools: {
+      ...cfg.tools,
+      deny: [...new Set([...(cfg.tools?.deny ?? []), ...MARMOT_TURN_DENIED_TOOLS])],
+    },
+  };
 }
-
-// --- inbound turn dispatch (SDK-coupled; harness-validated) ------------------
 
 /** Narrow view of `api.runtime.channel` (only the members we drive). */
 export interface OpenClawChannelRuntime {
@@ -463,11 +73,10 @@ export interface OpenClawChannelRuntime {
 }
 
 /**
- * Dispatcher client: the reply sink surface plus the group-info read for
- * gating and the media download used to surface inbound images to the agent.
+ * Dispatcher client: the group-info read used for activation gating and the
+ * media download used to surface inbound images to the agent.
  */
-export type MarmotDispatchClient = MarmotSinkClient &
-  Pick<MarmotAgentControlClient, "groupInfo" | "downloadMedia">;
+export type MarmotDispatchClient = Pick<MarmotAgentControlClient, "groupInfo" | "downloadMedia">;
 
 export interface MarmotDispatchDeps {
   /** Full OpenClaw config (`api.config`). */
@@ -477,16 +86,24 @@ export interface MarmotDispatchDeps {
   client: MarmotDispatchClient;
   /** OpenClaw channel account id ("default" or a configured account key), not the Marmot account hex. */
   channelAccountId?: string | null;
-  streamMode: StreamMode;
-  blockStreaming: boolean;
-  quicCandidates: string[];
-  chunkBytes?: number;
   /** When to reply in a multi-party group ("mention" gates; "always" replies to all). */
   groupActivation: GroupActivation;
   /** Case-insensitive trigger phrases that count as addressing the agent. */
   mentionPatterns: string[];
   /** Optional privacy-safe lifecycle logger. */
   log?: (message: string) => void;
+  /** Override OpenClaw durable delivery in focused tests. */
+  deliverInboundReply?: typeof deliverInboundReplyWithMessageSendContext;
+}
+
+function assertDurableReplyHandled(result: DurableInboundReplyDeliveryResult): void {
+  if (result.status === "handled_visible" || result.status === "handled_no_send") {
+    return;
+  }
+  if (result.status === "failed") {
+    throw result.error;
+  }
+  throw new Error(`marmot: OpenClaw durable reply was not handled (${result.reason})`);
 }
 
 /** Whether the message text contains any configured trigger phrase. */
@@ -664,7 +281,8 @@ export type MarmotInboundDispatcher = ((message: MarmotInboundMessage) => Promis
 /**
  * Build the inbound dispatcher: for each received Marmot message, resolve the
  * agent route, build the inbound context, and run it through the OpenClaw turn
- * kernel, delivering the agent's reply through a per-message MarmotReplySink.
+ * kernel. Final replies re-enter OpenClaw's durable message context, which uses
+ * the registered Marmot message adapter and its trusted source route.
  */
 export function createMarmotInboundDispatcher(
   deps: MarmotDispatchDeps,
@@ -715,28 +333,11 @@ export function createMarmotInboundDispatcher(
     });
 
     const storePath = deps.runtimeChannel.session.resolveStorePath();
-    const dispatchStartedAt = Date.now();
-    const sink = new MarmotReplySink({
-      client: deps.client,
-      accountIdHex: message.accountIdHex,
-      groupIdHex: message.groupIdHex,
-      // Thread both the durable reply and the live stream-start event to the
-      // inbound message that triggered this agent turn.
-      replyToMessageIdHex: message.messageIdHex,
-      streamMode: deps.streamMode,
-      quicCandidates: deps.quicCandidates,
-      chunkBytes: deps.chunkBytes,
-      resolveFinalText: () =>
-        resolveLatestAssistantTextFromSessionStore({
-          storePath,
-          sessionKey: route.sessionKey,
-          startedAtMs: dispatchStartedAt,
-        }),
-      log: deps.log,
-    });
-
+    const turnCfg = buildMarmotTurnConfig(deps.cfg);
+    const deliverInboundReply =
+      deps.deliverInboundReply ?? deliverInboundReplyWithMessageSendContext;
+    let finalDeliveries = 0;
     deps.log?.("marmot: agent turn starting");
-    await sink.prewarm();
     await runChannelInboundEvent({
       channel: "marmot",
       accountId: channelAccountId,
@@ -757,33 +358,41 @@ export function createMarmotInboundDispatcher(
           runDispatch: () =>
             deps.runtimeChannel.reply.dispatchReplyWithBufferedBlockDispatcher({
               ctx: ctxPayload,
-              cfg: deps.cfg,
+              cfg: turnCfg,
               dispatcherOptions: {
-                deliver: (payload: ReplyPayloadLike, info: ReplyDelivery) =>
-                  sink.deliver(payload, info),
+                deliver: async (payload: ReplyPayloadLike, info: ReplyDelivery) => {
+                  if (info.kind !== "final") {
+                    return;
+                  }
+                  finalDeliveries += 1;
+                  const result = await deliverInboundReply({
+                    cfg: turnCfg as never,
+                    channel: "marmot",
+                    accountId: route.accountId,
+                    agentId: route.agentId,
+                    ctxPayload,
+                    payload,
+                    info,
+                    // A normal response threads to the inbound message that
+                    // triggered this turn. The destination itself comes from
+                    // ctxPayload.OriginatingTo / ctxPayload.To.
+                    replyToId: message.messageIdHex,
+                  });
+                  assertDurableReplyHandled(result);
+                },
               },
               replyOptions: {
-                disableBlockStreaming: deps.blockStreaming ? false : true,
-                onPartialReply: (payload: PartialReplyPayloadLike) => sink.partial(payload),
-                onAssistantMessageStart: () => sink.status("Thinking..."),
-                onRunProgress: () => sink.status("Working..."),
-                onExecutionPhase: (info: { phase?: string; firstModelCallStarted?: boolean }) => {
-                  if (info.firstModelCallStarted || info.phase === "model_call_started") {
-                    return sink.status("Thinking...");
-                  }
-                  return undefined;
-                },
-                onToolStart: () => sink.progress("Working..."),
-                onCommandOutput: () => sink.progress("Working..."),
+                sourceReplyDeliveryMode: "automatic",
+                // Keep the initial contract final-only. QUIC previews can be
+                // reintroduced later through the standard message-adapter live
+                // lifecycle without creating a second durable send path.
+                disableBlockStreaming: true,
               },
             }) as never,
         }),
       },
     });
-    // Block streaming can finish a turn with only `block` deliveries; commit the
-    // accumulated reply durably if no explicit `final` did.
-    await sink.flush();
-    deps.log?.(`marmot: agent turn done (sink deliveries=${sink.deliveries})`);
+    deps.log?.(`marmot: agent turn done (final deliveries=${finalDeliveries})`);
   };
 
   return Object.assign(dispatch, {

--- a/integrations/openclaw/marmot/src/gateway.ts
+++ b/integrations/openclaw/marmot/src/gateway.ts
@@ -1,0 +1,128 @@
+// Marmot channel gateway lifecycle. OpenClaw starts one long-lived task per
+// configured channel account; that task owns exactly one wn-agent subscription.
+
+import {
+  createAccountStatusSink,
+  runPassiveAccountLifecycle,
+} from "openclaw/plugin-sdk/channel-lifecycle";
+import type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-runtime";
+import { enqueueSystemEvent } from "openclaw/plugin-sdk/channel-runtime";
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/status-helpers";
+
+import { clientForAccount, type ResolvedMarmotAccount } from "./config.js";
+import { createMarmotInboundDispatcher, type OpenClawChannelRuntime } from "./dispatch.js";
+import {
+  startMarmotInbound,
+  syncMarmotAllowlist,
+  type InboundPluginApi,
+  type MarmotAmbientSurfacer,
+} from "./inbound-runtime.js";
+import { DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID } from "./runtime-state.js";
+
+function resolveConfiguredAgentName(cfg: unknown): string | null {
+  const agents = (cfg as { agents?: { list?: Array<{ name?: string; default?: boolean }> } })
+    .agents;
+  const agentList = agents?.list ?? [];
+  return agentList.find((entry) => entry.default)?.name ?? agentList[0]?.name ?? null;
+}
+
+/** Start and own the inbound subscription for one OpenClaw Marmot account. */
+export async function startMarmotGatewayAccount(
+  ctx: ChannelGatewayContext<ResolvedMarmotAccount>,
+): Promise<void> {
+  const statusSink = createAccountStatusSink({
+    accountId: ctx.accountId,
+    setStatus: ctx.setStatus,
+  });
+  const markRunning = (patch: Partial<ChannelAccountSnapshot> = {}) => {
+    statusSink({
+      running: true,
+      connected: patch.connected ?? false,
+      lastStartAt: patch.lastStartAt ?? Date.now(),
+      lastStopAt: null,
+      lastError: null,
+      ...patch,
+    });
+  };
+  const markStopped = (lastError: string | null = null) => {
+    statusSink({
+      running: false,
+      connected: false,
+      lastStopAt: Date.now(),
+      lastError,
+    });
+  };
+
+  markRunning();
+  ctx.log?.info?.("marmot: starting inbound subscription");
+
+  try {
+    const api: InboundPluginApi = {
+      config: ctx.cfg,
+      logger: {
+        info: (message) => ctx.log?.info?.(message),
+        warn: (message) => ctx.log?.warn?.(message),
+      },
+    };
+    await syncMarmotAllowlist(api, { channelAccountId: ctx.accountId });
+
+    const channelRuntime = ctx.channelRuntime as unknown as OpenClawChannelRuntime | undefined;
+    if (!channelRuntime) {
+      throw new Error("marmot: channelRuntime is required for inbound agent dispatch");
+    }
+
+    const account = ctx.account;
+    const configuredAgentName = resolveConfiguredAgentName(ctx.cfg);
+    const mentionPatterns = [...account.mentionPatterns, configuredAgentName].filter(
+      (pattern): pattern is string => typeof pattern === "string" && pattern.trim().length > 0,
+    );
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: ctx.cfg,
+      runtimeChannel: channelRuntime,
+      client: clientForAccount(account),
+      channelAccountId: account.accountId ?? DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID,
+      groupActivation: account.groupActivation,
+      mentionPatterns,
+      log: (message) => ctx.log?.info?.(message),
+    });
+
+    const surfaceAmbientEvent: MarmotAmbientSurfacer = ({ groupIdHex, text, contextKey }) => {
+      const route = channelRuntime.routing.resolveAgentRoute({
+        cfg: ctx.cfg,
+        channel: "marmot",
+        accountId: account.accountId ?? DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID,
+        peer: { kind: "group", id: groupIdHex },
+      });
+      enqueueSystemEvent(text, {
+        sessionKey: route.sessionKey,
+        contextKey: contextKey ?? null,
+      });
+    };
+
+    await runPassiveAccountLifecycle({
+      abortSignal: ctx.abortSignal,
+      start: async () =>
+        startMarmotInbound(api, dispatch, {
+          signal: ctx.abortSignal,
+          channelAccountId: ctx.accountId,
+          configuredAgentName,
+          surfaceAmbientEvent,
+          invalidateGroupActivation: dispatch.invalidateGroupActivation,
+          clearGroupActivationCache: dispatch.clearGroupActivationCache,
+          statusSink: (patch) => {
+            statusSink({ running: true, ...patch });
+          },
+        }),
+      stop: (stopInbound) => {
+        stopInbound();
+      },
+      onStop: () => {
+        markStopped();
+      },
+    });
+  } catch (error) {
+    markStopped("inbound startup failed");
+    ctx.log?.error?.("marmot: inbound startup failed");
+    throw error;
+  }
+}

--- a/integrations/openclaw/marmot/src/inbound-runtime.ts
+++ b/integrations/openclaw/marmot/src/inbound-runtime.ts
@@ -3,14 +3,14 @@
 // `startMarmotInbound` runs the wn-agent inbound subscription and hands each
 // mapped message to a real agent dispatcher (no production no-op fallback —
 // consuming inbound without dispatching would silently swallow messages). The
-// dispatcher in `src/dispatch.ts` drives the OpenClaw turn kernel; the plugin
-// entry wires it in `registerFull`. End-to-end behavior is validated against the
-// docker `openclaw-gateway` harness (it needs a running gateway + a model).
+// dispatcher in `src/dispatch.ts` drives the OpenClaw turn kernel; the channel's
+// `gateway.startAccount` task owns this runtime for its full lifetime.
 //
 // `syncMarmotAllowlist` mirrors the configured `dm.allowFrom` welcomers into
 // wn-agent's per-account allowlist so configured welcomers are accepted.
 
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/status-helpers";
 
 import { BoundedKeyedAsyncQueue, DEFAULT_INBOUND_QUEUE_MAX_DEPTH } from "./bounded-keyed-async-queue.js";
 import { resolveSingleAccount } from "./account.js";
@@ -24,6 +24,7 @@ import {
   ProfileNameOnboardingStore,
 } from "./profile-onboarding.js";
 import {
+  DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID,
   markMarmotInboundReady,
   markMarmotInboundReceived,
   markMarmotInboundReconnect,
@@ -47,10 +48,13 @@ export interface InboundPluginApi {
 
 type ClientFactory = (resolved: ResolvedMarmotAccount) => MarmotAgentControlClient;
 
-function resolveAccount(api: InboundPluginApi): ResolvedMarmotAccount {
+function resolveAccount(
+  api: InboundPluginApi,
+  channelAccountId?: string | null,
+): ResolvedMarmotAccount {
   return resolveMarmotChannelAccount(
     api.config as Parameters<typeof resolveMarmotChannelAccount>[0],
-    null,
+    channelAccountId ?? null,
   );
 }
 
@@ -142,6 +146,10 @@ export type MarmotAmbientSurfacer = (event: {
 
 export interface StartMarmotInboundOptions {
   signal?: AbortSignal;
+  /** OpenClaw channel account id that owns this subscription. */
+  channelAccountId?: string | null;
+  /** Gateway-owned status writer. */
+  statusSink?: (patch: Partial<ChannelAccountSnapshot>) => void;
   /** Override the control-client factory (tests inject a stub). */
   clientFactory?: ClientFactory;
   /**
@@ -169,13 +177,14 @@ export interface StartMarmotInboundOptions {
   clearGroupActivationCache?: () => void;
 }
 
-// The gateway can full-load the plugin in more than one in-process context
-// (the HTTP server and the agent-runtime pre-warm each invoke `registerFull`),
-// so `startMarmotInbound` can be called more than once in a single process. A
-// second live subscription would deliver — and dispatch an agent turn for —
-// every inbound message twice, so only the first start is honored until it is
-// stopped.
-let inboundActive = false;
+// OpenClaw owns one gateway task per configured channel account. Keep one
+// subscription per account even if a host accidentally starts the same task
+// twice.
+const inboundActiveAccounts = new Set<string>();
+
+export function resetMarmotInboundAccountsForTests(): void {
+  inboundActiveAccounts.clear();
+}
 
 /**
  * Run the wn-agent inbound subscription, dispatching each mapped message to
@@ -187,21 +196,37 @@ export function startMarmotInbound(
   dispatch: InboundAgentDispatcher,
   options: StartMarmotInboundOptions = {},
 ): () => void {
-  if (inboundActive) {
+  const resolved = resolveAccount(api, options.channelAccountId);
+  const inboundAccountKey =
+    options.channelAccountId?.trim() ||
+    resolved.accountId ||
+    DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID;
+  if (inboundActiveAccounts.has(inboundAccountKey)) {
     api.logger.info("marmot: inbound subscription already active; ignoring duplicate start");
     return () => {};
   }
-  const resolved = resolveAccount(api);
-  const statusAccountId = resolved.accountId ?? null;
-  inboundActive = true;
+  const statusAccountId = resolved.accountId ?? inboundAccountKey;
+  inboundActiveAccounts.add(inboundAccountKey);
   markMarmotInboundStarting(statusAccountId);
+  options.statusSink?.({
+    running: true,
+    connected: false,
+    lastStartAt: Date.now(),
+    lastStopAt: null,
+    lastError: null,
+  });
   const controller = new AbortController();
   // Release the guard when the loop is stopped so a clean restart can re-subscribe.
   controller.signal.addEventListener(
     "abort",
     () => {
-      inboundActive = false;
+      inboundActiveAccounts.delete(inboundAccountKey);
       markMarmotInboundStopped(statusAccountId);
+      options.statusSink?.({
+        running: false,
+        connected: false,
+        lastStopAt: Date.now(),
+      });
     },
     { once: true },
   );
@@ -228,8 +253,14 @@ export function startMarmotInbound(
       accountIdHex = resolved.marmotAccountIdHex ?? (await resolveSingleAccount(client));
     } catch {
       api.logger.warn("marmot: could not resolve an agent account for the inbound subscription");
-      inboundActive = false;
+      inboundActiveAccounts.delete(inboundAccountKey);
       markMarmotInboundStopped(statusAccountId);
+      options.statusSink?.({
+        running: false,
+        connected: false,
+        lastStopAt: Date.now(),
+        lastError: "could not resolve agent account",
+      });
       return;
     }
     let readyLogged = false;
@@ -294,6 +325,13 @@ export function startMarmotInbound(
       groupIdHex: resolved.groupIdHex ?? null,
       onReady: () => {
         markMarmotInboundReady(statusAccountId);
+        options.statusSink?.({
+          running: true,
+          connected: true,
+          lastStartAt: Date.now(),
+          lastStopAt: null,
+          lastError: null,
+        });
         api.logger.info(
           readyLogged
             ? "marmot: inbound subscription re-established"
@@ -306,6 +344,7 @@ export function startMarmotInbound(
         // inbound loop keeps reading (enables cross-group concurrency). Dedupe in
         // MarmotInboundBridge.handle() already ran synchronously before this.
         markMarmotInboundReceived(statusAccountId);
+        options.statusSink?.({ lastInboundAt: Date.now() });
         submitInbound(message);
       },
       onMessageDeleted: (deletion) => {
@@ -313,6 +352,7 @@ export function startMarmotInbound(
         // (next-turn) context when a surfacer is wired; always recorded + logged
         // privacy-safely (no ids/pubkeys in the log).
         markMarmotInboundReceived(statusAccountId);
+        options.statusSink?.({ lastInboundAt: Date.now() });
         api.logger.info("marmot: inbound message deletion observed");
         void Promise.resolve(
           options.surfaceAmbientEvent?.({
@@ -329,6 +369,7 @@ export function startMarmotInbound(
         // the agent as quiet ambient context (via the surfacer) when wired. The
         // mapped sentence never carries a member pubkey.
         markMarmotInboundReceived(statusAccountId);
+        options.statusSink?.({ lastInboundAt: Date.now() });
         api.logger.info("marmot: inbound group state change observed");
         // Drop the cached is_direct activation fact for this group: a
         // membership change can flip whether the group is an effective DM, so the
@@ -348,6 +389,7 @@ export function startMarmotInbound(
       onGroupInvite: onboardingStore
         ? async ({ accountIdHex: joinedAccountIdHex, groupIdHex: joinedGroupIdHex }) => {
             markMarmotInboundReceived(statusAccountId);
+            options.statusSink?.({ lastInboundAt: Date.now() });
             // Greet on join: offer to publish a public profile name (once).
             await maybeSendProfilePromptOnJoin({
               store: onboardingStore,
@@ -361,6 +403,7 @@ export function startMarmotInbound(
         : undefined,
       onResync: ({ droppedEvents }) => {
         markMarmotInboundReceived(statusAccountId);
+        options.statusSink?.({ lastInboundAt: Date.now() });
         api.logger.warn(
           `marmot: inbound resync required (${droppedEvents} broadcast slots dropped)`,
         );
@@ -370,6 +413,11 @@ export function startMarmotInbound(
       },
       onError: () => {
         markMarmotInboundReconnect(statusAccountId);
+        options.statusSink?.({
+          running: true,
+          connected: false,
+          lastError: "inbound subscription dropped",
+        });
         api.logger.warn("marmot: inbound subscription dropped; reconnecting");
       },
     });
@@ -381,6 +429,8 @@ export function startMarmotInbound(
 
 export interface SyncAllowlistOptions {
   clientFactory?: ClientFactory;
+  /** OpenClaw channel account id whose allowlist should be mirrored. */
+  channelAccountId?: string | null;
 }
 
 /**
@@ -393,7 +443,7 @@ export async function syncMarmotAllowlist(
   options: SyncAllowlistOptions = {},
 ): Promise<void> {
   try {
-    const resolved = resolveAccount(api);
+    const resolved = resolveAccount(api, options.channelAccountId);
     if (resolved.allowFrom.length === 0) {
       return;
     }

--- a/integrations/openclaw/marmot/src/outbound.ts
+++ b/integrations/openclaw/marmot/src/outbound.ts
@@ -307,7 +307,12 @@ export function createMarmotMessageAdapter(deps: MarmotMessageAdapterDeps) {
     durableFinal: {
       // Marmot durable sends are plain encrypted kind-9 text or media with an
       // optional reply.
-      capabilities: { text: true, media: true, replyTo: true },
+      capabilities: {
+        text: true,
+        media: true,
+        replyTo: true,
+        messageSendingHooks: true,
+      },
     },
     send: {
       text: async (ctx: ChannelMessageSendTextContext) => {

--- a/integrations/openclaw/marmot/src/runtime-state.ts
+++ b/integrations/openclaw/marmot/src/runtime-state.ts
@@ -1,9 +1,8 @@
 // Process-local runtime status for the Marmot channel subscription.
 //
-// OpenClaw's channel health policy evaluates `running` from the channel status
-// snapshot. The Marmot plugin owns its inbound subscription from registerFull
-// rather than a core-managed gateway adapter, so it records that lifecycle here
-// and exposes it through the status adapter in channel.ts.
+// Compatibility snapshot for status tests and hosts that do not surface the
+// gateway account status directly. The primary lifecycle owner is now
+// `gateway.startAccount`.
 
 import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/status-helpers";
 

--- a/integrations/openclaw/marmot/test/channel.test.ts
+++ b/integrations/openclaw/marmot/test/channel.test.ts
@@ -96,7 +96,7 @@ describe("resolveMarmotChannelAccount", () => {
       connected: true,
       enabled: true,
       configured: true,
-      mode: "block",
+      mode: "off",
       dmPolicy: "allowlist",
       probe,
     });
@@ -112,7 +112,7 @@ describe("resolveMarmotChannelAccount", () => {
       configured: true,
       running: true,
       connected: true,
-      mode: "block",
+      mode: "off",
       probe,
     });
   });

--- a/integrations/openclaw/marmot/test/dispatch.test.ts
+++ b/integrations/openclaw/marmot/test/dispatch.test.ts
@@ -1,17 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { StreamMode } from "../src/config.js";
 import { AgentControlError, type AgentControlMediaRef } from "../src/client.js";
 import type { MarmotInboundMessage } from "../src/inbound.js";
 import {
+  buildMarmotTurnConfig,
   createMarmotInboundDispatcher,
-  MarmotReplySink,
   type MarmotDispatchClient,
-  type MarmotSinkClient,
   type OpenClawChannelRuntime,
 } from "../src/dispatch.js";
 
 import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+import { deliverInboundReplyWithMessageSendContext } from "openclaw/plugin-sdk/channel-outbound";
 
 vi.mock("openclaw/plugin-sdk/channel-inbound", () => ({
   buildChannelInboundEventContext: vi.fn((params: unknown) => params),
@@ -21,6 +20,18 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", () => ({
     },
   ),
 }));
+
+vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/channel-outbound")>();
+  return {
+    ...actual,
+    deliverInboundReplyWithMessageSendContext: vi.fn(async () => ({
+      status: "handled_visible",
+      delivery: {},
+    })),
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/media-store", () => ({
   saveMediaBuffer: vi.fn(async (_buf: Buffer, ct?: string, _sub?: string, _max?: number, name?: string) => ({
@@ -37,39 +48,39 @@ vi.mock("node:fs/promises", () => ({
 }));
 
 const buildCtxMock = vi.mocked(buildChannelInboundEventContext);
+const durableDeliveryMock = vi.mocked(deliverInboundReplyWithMessageSendContext);
+
+beforeEach(() => {
+  durableDeliveryMock.mockClear();
+});
 
 const HEX32 = (b: string) => b.repeat(32);
-const STREAM_ID = HEX32("11");
-const START_ID = HEX32("22");
-const CAPABILITY = HEX32("33");
-// Rust-anchored hash for stream=0x11*32 start=0x22*32, appends "hel"/"lo"/" world".
-const INCREMENTAL_HASH = "412b9bd20aedf322174fab2b1dee909992044fa166391027f4b8fb730d5c5a81";
+
+describe("buildMarmotTurnConfig", () => {
+  it("denies sessions_send without mutating existing tool policy", () => {
+    const base = { tools: { deny: ["dangerous_tool"] }, marker: true };
+    const configured = buildMarmotTurnConfig(base);
+
+    expect(configured).toMatchObject({
+      marker: true,
+      tools: { deny: ["dangerous_tool", "sessions_send"] },
+    });
+    expect(base.tools.deny).toEqual(["dangerous_tool"]);
+  });
+});
 
 interface Calls {
   sendFinal: { accountIdHex: string; text: string; replyTo: string | null }[];
-  begin: number;
-  beginParents: (string | null)[];
-  append: string[];
-  status: string[];
-  progress: string[];
-  finalize: { hash: string; count: number }[];
-  cancel: string[];
 }
 
 function emptyCalls(): Calls {
-  return {
-    sendFinal: [],
-    begin: 0,
-    beginParents: [],
-    append: [],
-    status: [],
-    progress: [],
-    finalize: [],
-    cancel: [],
-  };
+  return { sendFinal: [] };
 }
 
-function stubClient(calls: Calls, opts: { isDirect?: boolean } = {}): MarmotSinkClient {
+function stubClient(
+  calls: Calls,
+  opts: { isDirect?: boolean } = {},
+): MarmotDispatchClient {
   return {
     async sendFinal(_account: string, _group: string, text: string, replyTo?: string | null) {
       calls.sendFinal.push({ accountIdHex: _account, text, replyTo: replyTo ?? null });
@@ -85,419 +96,10 @@ function stubClient(calls: Calls, opts: { isDirect?: boolean } = {}): MarmotSink
         subject: null,
       };
     },
-    async streamBegin(
-      _accountIdHex: string,
-      _groupIdHex: string,
-      options: { parentMessageIdHex?: string | null } = {},
-    ) {
-      calls.begin += 1;
-      calls.beginParents.push(options.parentMessageIdHex ?? null);
-      return {
-        type: "stream_begun",
-        stream_id_hex: STREAM_ID,
-        stream_capability: CAPABILITY,
-        start_message_id_hex: START_ID,
-        quic_candidates: [],
-      };
-    },
-    async streamAppend(_id: string, _capability: string, text: string) {
-      calls.append.push(text);
-      return { type: "ack" };
-    },
-    async streamStatus(_id: string, _capability: string, text: string) {
-      calls.status.push(text);
-      return { type: "ack" };
-    },
-    async streamProgress(_id: string, _capability: string, text: string) {
-      calls.progress.push(text);
-      return { type: "ack" };
-    },
-    async streamFinalize(_id: string, _capability: string, _final: string, hash: string, count: number) {
-      calls.finalize.push({ hash, count });
-      return { type: "stream_finalized", stream_id_hex: STREAM_ID, message_ids_hex: [HEX32("ab")] };
-    },
-    async streamCancel(_id: string, _capability: string, reason?: string | null) {
-      calls.cancel.push(reason ?? "");
-      return { type: "ack" };
-    },
-  } as unknown as MarmotSinkClient;
+  } as unknown as MarmotDispatchClient;
 }
-
-function makeSink(
-  calls: Calls,
-  opts: {
-    streamMode?: StreamMode;
-    quicCandidates?: string[];
-    replyToMessageIdHex?: string | null;
-    resolveFinalText?: () => Promise<string | undefined> | string | undefined;
-  } = {},
-): MarmotReplySink {
-  return new MarmotReplySink({
-    client: stubClient(calls),
-    accountIdHex: HEX32("aa"),
-    groupIdHex: HEX32("cc"),
-    replyToMessageIdHex: opts.replyToMessageIdHex,
-    streamMode: opts.streamMode ?? "block",
-    quicCandidates: opts.quicCandidates ?? ["quic://broker:4450"],
-    resolveFinalText: opts.resolveFinalText,
-  });
-}
-
-describe("MarmotReplySink", () => {
-  it("passes the triggering message id to stream_begin", async () => {
-    const calls = emptyCalls();
-    const parentMessageIdHex = HEX32("dd");
-    const sink = makeSink(calls, { replyToMessageIdHex: parentMessageIdHex });
-
-    await sink.partial({ text: "hello" });
-
-    expect(calls.beginParents).toEqual([parentMessageIdHex]);
-  });
-
-  it("sends a plain final when there were no preview blocks", async () => {
-    const calls = emptyCalls();
-    await makeSink(calls).deliver({ text: "hello world" }, { kind: "final" });
-    expect(calls.begin).toBe(0);
-    expect(calls.append).toEqual([]);
-    expect(calls.sendFinal.map((c) => c.text)).toEqual(["hello world"]);
-  });
-
-  it("streams progressive blocks as append-only deltas and finalizes", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls);
-    await sink.deliver({ text: "hel" }, { kind: "block" });
-    await sink.deliver({ text: "hello" }, { kind: "block" });
-    await sink.deliver({ text: "hello world" }, { kind: "block" });
-    await sink.deliver({ text: "hello world" }, { kind: "final" });
-
-    expect(calls.begin).toBe(1);
-    expect(calls.append).toEqual(["hel", "lo", " world"]);
-    expect(calls.finalize[0]).toEqual({ hash: INCREMENTAL_HASH, count: 3 });
-    expect(calls.sendFinal).toEqual([]);
-  });
-
-  it("streams fragment-style blocks as append-only deltas and finalizes", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls);
-    await sink.deliver({ text: "hel" }, { kind: "block" });
-    await sink.deliver({ text: "lo" }, { kind: "block" });
-    await sink.deliver({ text: " world" }, { kind: "block" });
-    await sink.deliver({ text: "hello world" }, { kind: "final" });
-
-    expect(calls.begin).toBe(1);
-    expect(calls.append).toEqual(["hel", "lo", " world"]);
-    expect(calls.finalize[0]).toEqual({ hash: INCREMENTAL_HASH, count: 3 });
-    expect(calls.sendFinal).toEqual([]);
-  });
-
-  it("streams partial snapshots before delayed block chunks and finalizes", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls);
-    await sink.partial({ text: "hel" });
-    await sink.partial({ text: "hello" });
-    await sink.partial({ text: "hello world" });
-    await sink.deliver({ text: "delayed block chunk" }, { kind: "block" });
-    await sink.deliver({ text: "hello world" }, { kind: "final" });
-
-    expect(calls.begin).toBe(1);
-    expect(calls.append).toEqual(["hel", "lo", " world"]);
-    expect(calls.finalize[0]).toEqual({ hash: INCREMENTAL_HASH, count: 3 });
-    expect(calls.cancel).toEqual([]);
-    expect(calls.sendFinal).toEqual([]);
-  });
-
-  it("streams partial append deltas even when snapshots are windowed", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls);
-    await sink.partial({ text: "hel", delta: "hel" });
-    await sink.partial({ text: "lo window", delta: "lo" });
-    await sink.partial({ text: "world window", delta: " world" });
-    await sink.deliver({ text: "delayed block chunk" }, { kind: "block" });
-    await sink.deliver({ text: "hello world" }, { kind: "final" });
-
-    expect(calls.begin).toBe(1);
-    expect(calls.append).toEqual(["hel", "lo", " world"]);
-    expect(calls.finalize[0]).toEqual({ hash: INCREMENTAL_HASH, count: 3 });
-    expect(calls.cancel).toEqual([]);
-    expect(calls.sendFinal).toEqual([]);
-  });
-
-  it("streams delta-only partial payloads", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls);
-    await sink.partial({ delta: "hel" });
-    await sink.partial({ delta: "lo" });
-    await sink.partial({ delta: " world" });
-    await sink.deliver({ text: "hello world" }, { kind: "final" });
-
-    expect(calls.begin).toBe(1);
-    expect(calls.append).toEqual(["hel", "lo", " world"]);
-    expect(calls.finalize[0]).toEqual({ hash: INCREMENTAL_HASH, count: 3 });
-    expect(calls.sendFinal).toEqual([]);
-  });
-
-  it("lets block snapshots recover after a delta-less non-append partial", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls);
-    await sink.prewarm();
-    await sink.partial({ text: "hel" });
-    await sink.partial({ text: "window shifted" });
-    await sink.deliver({ text: "hello" }, { kind: "block" });
-    await sink.deliver({ text: "hello world" }, { kind: "final" });
-
-    expect(calls.append).toEqual(["hel", "lo", " world"]);
-    expect(calls.cancel).toEqual([]);
-    expect(calls.finalize[0]).toEqual({ hash: INCREMENTAL_HASH, count: 3 });
-    expect(calls.sendFinal).toEqual([]);
-  });
-
-  it("falls back durably when partial snapshots become non-append-only", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls, {
-      streamMode: "partial",
-      resolveFinalText: () => "hello complete answer",
-    });
-    await sink.partial({ text: "hello partial answer" });
-    await sink.partial({ text: "window shifted", replace: true });
-    await sink.flush();
-
-    expect(calls.append).toEqual(["hello partial answer"]);
-    expect(calls.cancel).toHaveLength(1);
-    expect(calls.finalize).toEqual([]);
-    expect(calls.sendFinal.map((c) => c.text)).toEqual(["hello complete answer"]);
-  });
-
-  it("can prewarm a live preview before answer text arrives", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls, { streamMode: "partial" });
-    await sink.prewarm();
-    await sink.partial({ text: "done" });
-    await sink.flush();
-
-    expect(calls.begin).toBe(1);
-    expect(calls.status).toEqual([]);
-    expect(calls.append).toEqual(["done"]);
-    expect(calls.finalize[0]?.count).toBe(1);
-    expect(calls.sendFinal).toEqual([]);
-  });
-
-  it("abandons partial-only block previews instead of committing tool acknowledgements", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls, { streamMode: "block" });
-    await sink.prewarm();
-    await sink.partial({ text: "Sent." });
-    await sink.flush();
-
-    expect(calls.append).toEqual(["Sent."]);
-    expect(calls.cancel).toHaveLength(1);
-    expect(calls.finalize).toEqual([]);
-    expect(calls.sendFinal).toEqual([]);
-  });
-
-  it("streams tool deliveries as non-text progress and still finalizes answer text", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls);
-    await sink.deliver({ text: "searching" }, { kind: "tool" });
-    await sink.deliver({ text: "answer" }, { kind: "block" });
-    await sink.deliver({ text: "answer" }, { kind: "final" });
-
-    expect(calls.progress).toEqual(["searching"]);
-    expect(calls.append).toEqual(["answer"]);
-    expect(calls.finalize[0]?.count).toBe(2);
-    expect(calls.sendFinal).toEqual([]);
-  });
-
-  it("ignores blocks and sends a plain final when streaming is off", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls, { streamMode: "off" });
-    await sink.deliver({ text: "hel" }, { kind: "block" });
-    await sink.deliver({ text: "done" }, { kind: "final" });
-    expect(calls.begin).toBe(0);
-    expect(calls.sendFinal.map((c) => c.text)).toEqual(["done"]);
-  });
-
-  it("cancels the preview and falls back to send_final on a non-append-only block", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls);
-    await sink.deliver({ text: "hello" }, { kind: "block" });
-    await sink.deliver({ text: "goodbye" }, { kind: "block" }); // not an extension
-    await sink.deliver({ text: "goodbye" }, { kind: "final" });
-
-    expect(calls.append).toEqual(["hello", "goodbye"]);
-    expect(calls.cancel).toHaveLength(1);
-    expect(calls.finalize).toEqual([]);
-    expect(calls.sendFinal.map((c) => c.text)).toEqual(["goodbye"]);
-  });
-
-  it("falls back to a durable final when a preview append fails (e.g. broker unreachable)", async () => {
-    const calls = emptyCalls();
-    const client = stubClient(calls);
-    // A QUIC/broker failure surfaces as a generic error, not a non-append-only
-    // rejection — the reply must still be delivered, just without a live preview.
-    client.streamAppend = (async () => {
-      throw new Error("broker unreachable");
-    }) as typeof client.streamAppend;
-    const sink = new MarmotReplySink({
-      client,
-      accountIdHex: HEX32("aa"),
-      groupIdHex: HEX32("cc"),
-      streamMode: "block",
-      quicCandidates: ["quic://broker:4450"],
-    });
-
-    await sink.deliver({ text: "hel" }, { kind: "block" });
-    await sink.deliver({ text: "hello world" }, { kind: "final" });
-
-    expect(calls.finalize).toEqual([]);
-    expect(calls.sendFinal.map((c) => c.text)).toEqual(["hello world"]);
-  });
-
-  it("falls back to a durable final when preview finalize fails", async () => {
-    const calls = emptyCalls();
-    const client = stubClient(calls);
-    client.streamFinalize = (async () => {
-      throw new Error("finalize failed");
-    }) as typeof client.streamFinalize;
-    const sink = new MarmotReplySink({
-      client,
-      accountIdHex: HEX32("aa"),
-      groupIdHex: HEX32("cc"),
-      streamMode: "block",
-      quicCandidates: ["quic://broker:4450"],
-    });
-
-    await sink.deliver({ text: "hel" }, { kind: "block" });
-    await sink.deliver({ text: "hello" }, { kind: "block" });
-    await sink.deliver({ text: "hello world" }, { kind: "final" });
-
-    // The final suffix is appended before stream_finalize is attempted; the
-    // finalize then throws, so we abandon and re-send the whole text durably.
-    expect(calls.append).toEqual(["hel", "lo", " world"]);
-    expect(calls.sendFinal.map((c) => c.text)).toEqual(["hello world"]);
-  });
-
-  it("commits the streamed reply at flush when the turn sends blocks but no final", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls);
-    // Block streaming delivered the whole answer as one block, with no trailing
-    // `final` delivery — the live preview must still be finalized durably.
-    await sink.deliver({ text: "the full answer" }, { kind: "block" });
-    await sink.flush();
-
-    expect(calls.begin).toBe(1);
-    expect(calls.append).toEqual(["the full answer"]);
-    expect(calls.finalize).toHaveLength(1);
-    expect(calls.sendFinal).toEqual([]);
-  });
-
-  it("recovers the full transcript final for partial-mode windowed previews", async () => {
-    const calls = emptyCalls();
-    const full =
-      "This is the complete recovered answer that OpenClaw persisted to the session transcript after the turn finished.";
-    const sink = makeSink(calls, {
-      streamMode: "partial",
-      resolveFinalText: () => full,
-    });
-
-    await sink.deliver(
-      { text: "This is the complete recovered answer that OpenClaw persisted..." },
-      { kind: "block" },
-    );
-    await sink.deliver({ text: "window shifted and no longer starts at the prefix" }, { kind: "block" });
-    await sink.flush();
-
-    expect(calls.finalize).toEqual([]);
-    expect(calls.cancel).toHaveLength(1);
-    expect(calls.sendFinal.map((c) => c.text)).toEqual([full]);
-  });
-
-  it("flush sends a plain final for a blocks-only turn when streaming is off", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls, { streamMode: "off" });
-    await sink.deliver({ text: "the answer" }, { kind: "block" });
-    await sink.flush();
-
-    expect(calls.begin).toBe(0);
-    expect(calls.sendFinal.map((c) => c.text)).toEqual(["the answer"]);
-  });
-
-  it("flush is a no-op once a final delivery has committed the reply", async () => {
-    const calls = emptyCalls();
-    const sink = makeSink(calls);
-    await sink.deliver({ text: "answer" }, { kind: "final" });
-    await sink.flush();
-    expect(calls.sendFinal.map((c) => c.text)).toEqual(["answer"]);
-  });
-
-  it("flush sends nothing when the turn produced no reply", async () => {
-    const calls = emptyCalls();
-    await makeSink(calls).flush();
-    expect(calls).toEqual(emptyCalls());
-  });
-
-  it("ignores tool deliveries when streaming is off", async () => {
-    const calls = emptyCalls();
-    await makeSink(calls, { streamMode: "off" }).deliver({ text: "searching..." }, { kind: "tool" });
-    expect(calls).toEqual(emptyCalls());
-  });
-
-  it("retries a retryable durable final, reusing one idempotency key per call", async () => {
-    const keys: (string | undefined)[] = [];
-    let attempts = 0;
-    const client = {
-      async sendFinal(
-        _account: string,
-        _group: string,
-        _text: string,
-        _replyTo?: string | null,
-        idempotencyKey?: string,
-      ) {
-        keys.push(idempotencyKey);
-        attempts += 1;
-        if (attempts === 1) {
-          throw new AgentControlError("transient", { code: "io_error", retryable: true });
-        }
-        return { type: "final_sent", message_ids_hex: [HEX32("ab")] };
-      },
-    } as unknown as MarmotSinkClient;
-    const sink = new MarmotReplySink({
-      client,
-      accountIdHex: HEX32("aa"),
-      groupIdHex: HEX32("cc"),
-      streamMode: "off",
-      quicCandidates: [],
-    });
-
-    await sink.deliver({ text: "hello world" }, { kind: "final" });
-    expect(attempts).toBe(2);
-    expect(keys).toHaveLength(2);
-    expect(keys[0]).toBeTruthy();
-    expect(keys[1]).toBe(keys[0]); // same key reused across the retry
-  });
-
-  it("does not retry a non-retryable durable final and rethrows", async () => {
-    let attempts = 0;
-    const client = {
-      async sendFinal() {
-        attempts += 1;
-        throw new AgentControlError("bad request", { code: "bad_request", retryable: false });
-      },
-    } as unknown as MarmotSinkClient;
-    const sink = new MarmotReplySink({
-      client,
-      accountIdHex: HEX32("aa"),
-      groupIdHex: HEX32("cc"),
-      streamMode: "off",
-      quicCandidates: [],
-    });
-
-    await expect(sink.deliver({ text: "hello" }, { kind: "final" })).rejects.toThrow("bad request");
-    expect(attempts).toBe(1);
-  });
-});
-
 describe("createMarmotInboundDispatcher", () => {
-  it("enables OpenClaw block streaming when Marmot live block streaming is resolved on", async () => {
+  it("routes a final through OpenClaw's durable message context with streaming disabled", async () => {
     const calls = emptyCalls();
     const captured: unknown[] = [];
     const routeInputs: unknown[] = [];
@@ -533,9 +135,6 @@ describe("createMarmotInboundDispatcher", () => {
       runtimeChannel,
       client: stubClient(calls) as unknown as MarmotDispatchClient,
       channelAccountId: "default",
-      streamMode: "off",
-      blockStreaming: true,
-      quicCandidates: [],
       groupActivation: "always",
       mentionPatterns: [],
     });
@@ -561,11 +160,82 @@ describe("createMarmotInboundDispatcher", () => {
     expect(
       (captured[0] as { replyOptions: { disableBlockStreaming?: boolean } }).replyOptions
         .disableBlockStreaming,
-    ).toBe(false);
-    expect(calls.sendFinal[0]?.accountIdHex).toBe(HEX32("aa"));
-    expect(calls.sendFinal.map((c) => c.text)).toEqual(["done"]);
-    // GAP-01: the durable reply threads to the triggering message id.
-    expect(calls.sendFinal[0]?.replyTo).toBe(HEX32("dd"));
+    ).toBe(true);
+    expect(
+      (captured[0] as { replyOptions: { sourceReplyDeliveryMode?: string } }).replyOptions
+        .sourceReplyDeliveryMode,
+    ).toBe("automatic");
+    expect(calls.sendFinal).toEqual([]);
+    expect(durableDeliveryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "marmot",
+        accountId: "default",
+        agentId: "agent",
+        payload: { text: "done" },
+        replyToId: HEX32("dd"),
+        ctxPayload: expect.objectContaining({
+          reply: expect.objectContaining({ to: HEX32("cc") }),
+        }),
+      }),
+    );
+  });
+
+  it("keeps three sequential replies bound to the same Marmot group", async () => {
+    const groupIdHex = HEX32("cc");
+    const runtimeChannel: OpenClawChannelRuntime = {
+      routing: {
+        resolveAgentRoute: () => ({
+          agentId: "agent",
+          accountId: "default",
+          sessionKey: "agent:marmot",
+        }),
+      },
+      session: {
+        resolveStorePath: () => "/tmp/openclaw-marmot-sequential-test",
+        recordInboundSession: vi.fn(),
+      },
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: async (params: unknown) => {
+          const deliver = (params as {
+            dispatcherOptions: {
+              deliver: (payload: { text: string }, info: { kind: "final" }) => Promise<void>;
+            };
+          }).dispatcherOptions.deliver;
+          await deliver({ text: "reply" }, { kind: "final" });
+        },
+      },
+    };
+    const dispatch = createMarmotInboundDispatcher({
+      cfg: {},
+      runtimeChannel,
+      client: stubClient(emptyCalls()) as unknown as MarmotDispatchClient,
+      channelAccountId: "default",
+      groupActivation: "always",
+      mentionPatterns: [],
+    });
+
+    for (const byte of ["d1", "d2", "d3"]) {
+      await dispatch({
+        accountIdHex: HEX32("aa"),
+        groupIdHex,
+        messageIdHex: HEX32(byte),
+        senderAccountIdHex: HEX32("bb"),
+        text: "hello",
+      });
+    }
+
+    expect(durableDeliveryMock).toHaveBeenCalledTimes(3);
+    expect(
+      durableDeliveryMock.mock.calls.map(([params]) => ({
+        to: (params.ctxPayload as unknown as { reply: { to: string } }).reply.to,
+        replyToId: params.replyToId,
+      })),
+    ).toEqual(
+      ["d1", "d2", "d3"].map((byte) => ({
+        to: groupIdHex,
+        replyToId: HEX32(byte),
+      })),
+    );
   });
 });
 
@@ -619,9 +289,6 @@ describe("createMarmotInboundDispatcher activation gating", () => {
         isDirect: opts.isDirect,
       }) as unknown as MarmotDispatchClient,
       channelAccountId: "default",
-      streamMode: "off",
-      blockStreaming: false,
-      quicCandidates: [],
       groupActivation: opts.groupActivation,
       mentionPatterns: opts.mentionPatterns ?? [],
     });
@@ -730,9 +397,6 @@ describe("createMarmotInboundDispatcher activation cache", () => {
       runtimeChannel: cachingRuntime(turns),
       client,
       channelAccountId: "default",
-      streamMode: "off",
-      blockStreaming: false,
-      quicCandidates: [],
       groupActivation: "mention",
       mentionPatterns: [],
     });
@@ -917,9 +581,6 @@ describe("createMarmotInboundDispatcher inbound media", () => {
       runtimeChannel: mediaRuntime(),
       client,
       channelAccountId: "default",
-      streamMode: "off",
-      blockStreaming: false,
-      quicCandidates: [],
       groupActivation: "always",
       mentionPatterns: [],
     });

--- a/integrations/openclaw/marmot/test/e2e-connector.test.ts
+++ b/integrations/openclaw/marmot/test/e2e-connector.test.ts
@@ -3,6 +3,8 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
+// Deliberate test-only internal import: openclaw@2026.6.11 exposes no supported
+// plugin-loader subpath. Re-verify this path whenever the pinned SDK is bumped.
 import {
   clearActivatedPluginRuntimeState,
   clearPluginLoaderCache,

--- a/integrations/openclaw/marmot/test/e2e-connector.test.ts
+++ b/integrations/openclaw/marmot/test/e2e-connector.test.ts
@@ -5,8 +5,17 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { MarmotAgentControlClient } from "../src/client.js";
-import { startMarmotInbound, type InboundPluginApi } from "../src/inbound-runtime.js";
-import type { MarmotInboundMessage } from "../src/inbound.js";
+import {
+  createMarmotInboundDispatcher,
+  type MarmotDispatchClient,
+  type OpenClawChannelRuntime,
+} from "../src/dispatch.js";
+import {
+  resetMarmotInboundAccountsForTests,
+  startMarmotInbound,
+  type InboundPluginApi,
+} from "../src/inbound-runtime.js";
+import { createMarmotMessageAdapter } from "../src/outbound.js";
 import { resetMarmotInboundRuntimeForTests } from "../src/runtime-state.js";
 
 const RUN_CONNECTOR_E2E = process.env.MARMOT_OPENCLAW_CONNECTOR_E2E === "1";
@@ -14,10 +23,7 @@ const maybeDescribe = RUN_CONNECTOR_E2E ? describe : describe.skip;
 
 const ACCOUNT_ID_HEX = "11".repeat(32);
 const GROUP_ID_HEX = "22".repeat(32);
-const MESSAGE_ID_HEX = "33".repeat(32);
 const SENDER_ACCOUNT_ID_HEX = "44".repeat(32);
-const INBOUND_TEXT = "ping from connector";
-const DETERMINISTIC_RESPONSE = `marmot-e2e-ok: ${INBOUND_TEXT}`;
 
 interface DebugRecordedFinalSend {
   account_id_hex: string;
@@ -40,9 +46,7 @@ async function waitFor<T>(
   probe: () => Promise<T | null | undefined> | T | null | undefined,
   options: { timeoutMs?: number; intervalMs?: number; label?: string } = {},
 ): Promise<T> {
-  const timeoutMs = options.timeoutMs ?? 30_000;
-  const intervalMs = options.intervalMs ?? 50;
-  const deadline = Date.now() + timeoutMs;
+  const deadline = Date.now() + (options.timeoutMs ?? 30_000);
   let lastError: unknown;
   while (Date.now() < deadline) {
     try {
@@ -53,7 +57,7 @@ async function waitFor<T>(
     } catch (error) {
       lastError = error;
     }
-    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    await new Promise((resolve) => setTimeout(resolve, options.intervalMs ?? 50));
   }
   const suffix = lastError instanceof Error ? `: ${lastError.message}` : "";
   throw new Error(`${options.label ?? "waitFor"} timed out${suffix}`);
@@ -82,14 +86,14 @@ async function recordedFinals(
 }
 
 afterEach(() => {
+  resetMarmotInboundAccountsForTests();
   resetMarmotInboundRuntimeForTests();
 });
 
 maybeDescribe("OpenClaw Marmot connector E2E", () => {
   it(
-    "dispatches debug-injected inbound through the OpenClaw inbound runtime into real wn-agent send_final",
+    "keeps sequential and restarted inbound replies on the source Marmot group",
     async () => {
-      // Keep the Unix socket path short for macOS sockaddr_un limits.
       const tempRoot = await mkdtemp("/tmp/omce-");
       const marmotHome = join(tempRoot, "marmot-home");
       const socketPath = join(tempRoot, "a.sock");
@@ -133,14 +137,7 @@ maybeDescribe("OpenClaw Marmot connector E2E", () => {
           { timeoutMs: 60_000, label: "wn-agent debug control socket" },
         );
 
-        let resolveReady: () => void = () => {};
-        const ready = new Promise<void>((resolve) => {
-          resolveReady = resolve;
-        });
-        let resolveDispatched: (message: MarmotInboundMessage) => void = () => {};
-        const dispatched = new Promise<MarmotInboundMessage>((resolve) => {
-          resolveDispatched = resolve;
-        });
+        let readyCount = 0;
         const api: InboundPluginApi = {
           config: {
             channels: {
@@ -155,59 +152,126 @@ maybeDescribe("OpenClaw Marmot connector E2E", () => {
           logger: {
             info: (message) => {
               if (message.includes("inbound subscription established")) {
-                resolveReady();
+                readyCount += 1;
               }
             },
             warn: () => {},
           },
         };
 
-        const stopInbound = startMarmotInbound(
-          api,
-          async (message) => {
-            await client.sendFinal(
-              message.accountIdHex,
-              message.groupIdHex,
-              DETERMINISTIC_RESPONSE,
-              message.messageIdHex,
-            );
-            resolveDispatched(message);
+        const adapter = createMarmotMessageAdapter({
+          resolveTarget: async () => ({
+            client,
+            marmotAccountIdHex: ACCOUNT_ID_HEX,
+          }),
+        });
+        const runtimeChannel: OpenClawChannelRuntime = {
+          routing: {
+            resolveAgentRoute: () => ({
+              agentId: "main",
+              accountId: "default",
+              sessionKey: `agent:main:marmot:group:${GROUP_ID_HEX}`,
+            }),
           },
-          { clientFactory: () => client },
-        );
+          session: {
+            resolveStorePath: () => join(tempRoot, "sessions.json"),
+            recordInboundSession: () => {},
+          },
+          reply: {
+            dispatchReplyWithBufferedBlockDispatcher: async (params: unknown) => {
+              const typed = params as {
+                ctx: { MessageSid: string };
+                dispatcherOptions: {
+                  deliver: (
+                    payload: { text: string },
+                    info: { kind: "final" },
+                  ) => Promise<void>;
+                };
+              };
+              await typed.dispatcherOptions.deliver(
+                { text: `marmot-e2e-ok:${typed.ctx.MessageSid.slice(0, 2)}` },
+                { kind: "final" },
+              );
+            },
+          },
+        };
+        const dispatch = createMarmotInboundDispatcher({
+          cfg: api.config,
+          runtimeChannel,
+          client: client as unknown as MarmotDispatchClient,
+          channelAccountId: "default",
+          groupActivation: "always",
+          mentionPatterns: [],
+          deliverInboundReply: async (params) => {
+            const context = params.ctxPayload as {
+              OriginatingTo?: string;
+              To?: string;
+            };
+            const to = context.OriginatingTo ?? context.To;
+            if (!to) {
+              return { status: "unsupported", reason: "missing_target" };
+            }
+            await adapter.send.text({
+              cfg: params.cfg,
+              to,
+              text: params.payload.text ?? "",
+              accountId: params.accountId,
+              replyToId: params.replyToId,
+            } as never);
+            return { status: "handled_visible", delivery: {} as never };
+          },
+        });
+        const runInbound = () =>
+          startMarmotInbound(api, dispatch, {
+            channelAccountId: "default",
+            clientFactory: () => client,
+          });
 
+        let stopInbound = runInbound();
         try {
-          await ready;
+          await waitFor(() => readyCount === 1, { label: "initial inbound subscription" });
+          const messageIds = ["a1", "a2", "a3"].map((byte) => byte.repeat(32));
+          for (const messageIdHex of messageIds.slice(0, 2)) {
+            await client.request({
+              type: "debug_inject_inbound",
+              account_id_hex: ACCOUNT_ID_HEX,
+              group_id_hex: GROUP_ID_HEX,
+              message_id_hex: messageIdHex,
+              sender_account_id_hex: SENDER_ACCOUNT_ID_HEX,
+              text: "ping from connector",
+            });
+          }
+          await waitFor(async () => (await recordedFinals(client)).sends.length === 2, {
+            label: "two sequential final sends",
+          });
+
+          stopInbound();
+          stopInbound = runInbound();
+          await waitFor(() => readyCount === 2, { label: "restarted inbound subscription" });
           await client.request({
             type: "debug_inject_inbound",
             account_id_hex: ACCOUNT_ID_HEX,
             group_id_hex: GROUP_ID_HEX,
-            message_id_hex: MESSAGE_ID_HEX,
+            message_id_hex: messageIds[2]!,
             sender_account_id_hex: SENDER_ACCOUNT_ID_HEX,
-            text: INBOUND_TEXT,
+            text: "ping after restart",
           });
+          const finals = await waitFor(async () => {
+            const recorded = await recordedFinals(client);
+            return recorded.sends.length === 3 ? recorded.sends : null;
+          }, { label: "post-restart final send" });
 
-          await expect(dispatched).resolves.toMatchObject({
-            accountIdHex: ACCOUNT_ID_HEX,
-            groupIdHex: GROUP_ID_HEX,
-            messageIdHex: MESSAGE_ID_HEX,
-            senderAccountIdHex: SENDER_ACCOUNT_ID_HEX,
-            text: INBOUND_TEXT,
-          });
-          const final = await waitFor(
-            async () => {
-              const recorded = await recordedFinals(client);
-              return recorded.sends[0] ?? null;
-            },
-            { timeoutMs: 10_000, label: "recorded final send" },
+          expect(
+            finals.map((send) => ({
+              groupIdHex: send.group_id_hex,
+              replyToId: send.reply_to_message_id_hex,
+            })),
+          ).toEqual(
+            messageIds.map((messageIdHex) => ({
+              groupIdHex: GROUP_ID_HEX,
+              replyToId: messageIdHex,
+            })),
           );
-          expect(final).toMatchObject({
-            account_id_hex: ACCOUNT_ID_HEX,
-            group_id_hex: GROUP_ID_HEX,
-            text: DETERMINISTIC_RESPONSE,
-            reply_to_message_id_hex: MESSAGE_ID_HEX,
-            message_ids_hex: ["1".padStart(64, "0")],
-          });
         } finally {
           stopInbound();
         }

--- a/integrations/openclaw/marmot/test/e2e-connector.test.ts
+++ b/integrations/openclaw/marmot/test/e2e-connector.test.ts
@@ -3,6 +3,12 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearActivatedPluginRuntimeState,
+  clearPluginLoaderCache,
+  clearPluginRegistryLoadCache,
+  loadOpenClawPlugins,
+} from "../node_modules/openclaw/dist/plugins/loader.js";
 
 import { MarmotAgentControlClient } from "../src/client.js";
 import {
@@ -15,7 +21,6 @@ import {
   startMarmotInbound,
   type InboundPluginApi,
 } from "../src/inbound-runtime.js";
-import { createMarmotMessageAdapter } from "../src/outbound.js";
 import { resetMarmotInboundRuntimeForTests } from "../src/runtime-state.js";
 
 const RUN_CONNECTOR_E2E = process.env.MARMOT_OPENCLAW_CONNECTOR_E2E === "1";
@@ -88,6 +93,9 @@ async function recordedFinals(
 afterEach(() => {
   resetMarmotInboundAccountsForTests();
   resetMarmotInboundRuntimeForTests();
+  clearActivatedPluginRuntimeState();
+  clearPluginRegistryLoadCache();
+  clearPluginLoaderCache();
 });
 
 maybeDescribe("OpenClaw Marmot connector E2E", () => {
@@ -138,8 +146,14 @@ maybeDescribe("OpenClaw Marmot connector E2E", () => {
         );
 
         let readyCount = 0;
+        const pluginRoot = join(import.meta.dirname, "..");
         const api: InboundPluginApi = {
           config: {
+            plugins: {
+              allow: ["marmot"],
+              load: { paths: [pluginRoot] },
+              entries: { marmot: { enabled: true } },
+            },
             channels: {
               marmot: {
                 socketPath,
@@ -159,12 +173,23 @@ maybeDescribe("OpenClaw Marmot connector E2E", () => {
           },
         };
 
-        const adapter = createMarmotMessageAdapter({
-          resolveTarget: async () => ({
-            client,
-            marmotAccountIdHex: ACCOUNT_ID_HEX,
-          }),
+        // Load and activate the actual plugin so OpenClaw's production helper
+        // resolves the registered Marmot message adapter and checks its declared
+        // durable-final capabilities before sending.
+        const registry = loadOpenClawPlugins({
+          config: api.config as never,
+          activationSourceConfig: api.config as never,
+          workspaceDir: tempRoot,
+          onlyPluginIds: ["marmot"],
+          activate: true,
+          loadModules: true,
+          cache: false,
+          mode: "full",
+          throwOnLoadError: true,
         });
+        expect(registry.channels.find((entry) => entry.plugin.id === "marmot")?.plugin.message)
+          .toBeDefined();
+
         const runtimeChannel: OpenClawChannelRuntime = {
           routing: {
             resolveAgentRoute: () => ({
@@ -202,24 +227,6 @@ maybeDescribe("OpenClaw Marmot connector E2E", () => {
           channelAccountId: "default",
           groupActivation: "always",
           mentionPatterns: [],
-          deliverInboundReply: async (params) => {
-            const context = params.ctxPayload as {
-              OriginatingTo?: string;
-              To?: string;
-            };
-            const to = context.OriginatingTo ?? context.To;
-            if (!to) {
-              return { status: "unsupported", reason: "missing_target" };
-            }
-            await adapter.send.text({
-              cfg: params.cfg,
-              to,
-              text: params.payload.text ?? "",
-              accountId: params.accountId,
-              replyToId: params.replyToId,
-            } as never);
-            return { status: "handled_visible", delivery: {} as never };
-          },
         });
         const runInbound = () =>
           startMarmotInbound(api, dispatch, {

--- a/integrations/openclaw/marmot/test/gateway.test.ts
+++ b/integrations/openclaw/marmot/test/gateway.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-runtime";
+
+import type { ResolvedMarmotAccount } from "../src/config.js";
+import { startMarmotGatewayAccount } from "../src/gateway.js";
+import {
+  resetMarmotInboundAccountsForTests,
+  type InboundPluginApi,
+} from "../src/inbound-runtime.js";
+import { resetMarmotInboundRuntimeForTests } from "../src/runtime-state.js";
+
+const syncCalls: Array<{ channelAccountId?: string | null }> = [];
+const statusPatches: Array<Record<string, unknown>> = [];
+let lifecycleStarts = 0;
+
+vi.mock("openclaw/plugin-sdk/channel-lifecycle", () => ({
+  createAccountStatusSink: ({ setStatus }: { setStatus: (next: unknown) => void }) => {
+    return (patch: Record<string, unknown>) => {
+      statusPatches.push(patch);
+      setStatus(patch);
+    };
+  },
+  runPassiveAccountLifecycle: async (options: {
+    start: () => Promise<() => void>;
+    stop: (stopInbound: () => void) => void | Promise<void>;
+    onStop: () => void | Promise<void>;
+  }) => {
+    lifecycleStarts += 1;
+    const stopInbound = await options.start();
+    await options.stop(stopInbound);
+    await options.onStop();
+  },
+}));
+
+vi.mock("../src/inbound-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/inbound-runtime.js")>();
+  return {
+    ...actual,
+    syncMarmotAllowlist: vi.fn(async (_api: InboundPluginApi, options = {}) => {
+      syncCalls.push(options);
+    }),
+    startMarmotInbound: vi.fn(() => () => {}),
+  };
+});
+
+function account(overrides: Partial<ResolvedMarmotAccount> = {}): ResolvedMarmotAccount {
+  return {
+    accountId: "default",
+    socketPath: "/tmp/marmot.sock",
+    streamMode: "off",
+    blockStreaming: false,
+    quicCandidates: [],
+    groupActivation: "always",
+    mentionPatterns: [],
+    allowFrom: [],
+    profileNameOnboarding: false,
+    profileOnboardingStatePath: "/tmp/onboarding.json",
+    debounceMs: 0,
+    dmPolicy: "allowlist",
+    ...overrides,
+  };
+}
+
+function gatewayContext(
+  resolved: ResolvedMarmotAccount,
+  options: { accountId?: string; includeRuntime?: boolean } = {},
+): ChannelGatewayContext<ResolvedMarmotAccount> {
+  const accountId = options.accountId ?? resolved.accountId ?? "default";
+  return {
+    cfg: { channels: { marmot: { accounts: { [accountId]: {} } } } },
+    accountId,
+    account: resolved,
+    runtime: {} as never,
+    abortSignal: AbortSignal.timeout(5_000),
+    getStatus: () => ({ accountId, running: false, connected: false }),
+    setStatus: () => {},
+    channelRuntime:
+      options.includeRuntime === false
+        ? undefined
+        : ({
+            routing: {
+              resolveAgentRoute: () => ({
+                agentId: "main",
+                accountId,
+                sessionKey: "agent:main:marmot:group:test",
+              }),
+            },
+            session: {
+              resolveStorePath: () => "/tmp/openclaw-marmot-gateway-test",
+              recordInboundSession: vi.fn(),
+            },
+            reply: {
+              dispatchReplyWithBufferedBlockDispatcher: vi.fn(),
+            },
+          } as never),
+    log: { info: () => {}, warn: () => {}, error: () => {} },
+  };
+}
+
+afterEach(() => {
+  resetMarmotInboundAccountsForTests();
+  resetMarmotInboundRuntimeForTests();
+  syncCalls.length = 0;
+  statusPatches.length = 0;
+  lifecycleStarts = 0;
+  vi.clearAllMocks();
+});
+
+describe("startMarmotGatewayAccount", () => {
+  it("owns one passive inbound lifecycle for the configured channel account", async () => {
+    await startMarmotGatewayAccount(gatewayContext(account(), { accountId: "acct-a" }));
+
+    expect(syncCalls).toEqual([{ channelAccountId: "acct-a" }]);
+    expect(lifecycleStarts).toBe(1);
+    expect(statusPatches.some((patch) => patch.running === true)).toBe(true);
+    expect(statusPatches.at(-1)).toMatchObject({ running: false, connected: false });
+  });
+
+  it("marks startup failure stopped instead of leaving the account running", async () => {
+    await expect(
+      startMarmotGatewayAccount(
+        gatewayContext(account(), { accountId: "acct-a", includeRuntime: false }),
+      ),
+    ).rejects.toThrow(/channelRuntime is required/);
+
+    expect(lifecycleStarts).toBe(0);
+    expect(statusPatches.at(-1)).toMatchObject({
+      running: false,
+      connected: false,
+      lastError: "inbound startup failed",
+    });
+  });
+});

--- a/integrations/openclaw/marmot/test/inbound-runtime.test.ts
+++ b/integrations/openclaw/marmot/test/inbound-runtime.test.ts
@@ -6,6 +6,7 @@ import type {
   MarmotAgentControlClient,
 } from "../src/client.js";
 import {
+  resetMarmotInboundAccountsForTests,
   startMarmotInbound,
   syncMarmotAllowlist,
   type InboundPluginApi,
@@ -77,6 +78,7 @@ async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void
 }
 
 afterEach(() => {
+  resetMarmotInboundAccountsForTests();
   resetMarmotInboundRuntimeForTests();
 });
 

--- a/integrations/openclaw/marmot/test/outbound.test.ts
+++ b/integrations/openclaw/marmot/test/outbound.test.ts
@@ -3,9 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
-import type {
-  ChannelMessageSendMediaContext,
-  ChannelMessageSendTextContext,
+import {
+  deriveDurableFinalDeliveryRequirements,
+  type ChannelMessageSendMediaContext,
+  type ChannelMessageSendTextContext,
 } from "openclaw/plugin-sdk/channel-outbound";
 
 import type {
@@ -121,6 +122,16 @@ describe("createMarmotMessageAdapter", () => {
       replyTo: true,
       messageSendingHooks: true,
     });
+    const required = deriveDurableFinalDeliveryRequirements({
+      payload: { text: "done" },
+      replyToId: HEX32("dd"),
+    });
+    expect(required).toEqual({
+      text: true,
+      replyTo: true,
+      messageSendingHooks: true,
+    });
+    expect(adapter.durableFinal?.capabilities).toMatchObject(required);
     expect(Object.prototype.hasOwnProperty.call(adapter, "live")).toBe(false);
   });
 

--- a/integrations/openclaw/marmot/test/outbound.test.ts
+++ b/integrations/openclaw/marmot/test/outbound.test.ts
@@ -111,11 +111,16 @@ describe("createMarmotMessageAdapter", () => {
     expect(result.receipt.sentAt).toBe(1234);
   });
 
-  it("declares durable text + media + replyTo capabilities (no unproven live caps)", () => {
+  it("declares the capabilities required by OpenClaw durable inbound delivery", () => {
     const adapter = createMarmotMessageAdapter({
       resolveTarget: () => ({ client: stubClient(emptyClientCalls()), marmotAccountIdHex: HEX32("aa") }),
     });
-    expect(adapter.durableFinal?.capabilities).toEqual({ text: true, media: true, replyTo: true });
+    expect(adapter.durableFinal?.capabilities).toEqual({
+      text: true,
+      media: true,
+      replyTo: true,
+      messageSendingHooks: true,
+    });
     expect(Object.prototype.hasOwnProperty.call(adapter, "live")).toBe(false);
   });
 

--- a/scripts/openclaw_marmot_connector_e2e.sh
+++ b/scripts/openclaw_marmot_connector_e2e.sh
@@ -44,4 +44,5 @@ fi
 source "$dev_root/env.sh"
 
 cd "$OPENCLAW_PLUGIN_SRC"
+pnpm build
 exec env MARMOT_OPENCLAW_CONNECTOR_E2E=1 pnpm exec vitest run test/e2e-connector.test.ts


### PR DESCRIPTION
## What changed

- make OpenClaw's `gateway.startAccount` own exactly one long-lived Marmot inbound subscription per configured account
- build the trusted inbound context from the received Marmot group and route normal assistant finals through `deliverInboundReplyWithMessageSendContext`
- let OpenClaw invoke the registered Marmot message adapter, which maps the trusted destination to `wn-agent send_final`
- deny `sessions_send` during source-bound Marmot turns because it targets another agent session, not the originating external channel
- disable inbound reply streaming for now so there is one durable delivery owner
- remove the obsolete custom reply/preview sink and fire-and-forget `registerFull` startup path

## Why

The previous connector had two competing durable reply paths. Normal inbound turns could send directly to `wn-agent`, while OpenClaw's shared message path used the registered channel adapter. A model could also choose `sessions_send`, which does not reply to the human-facing Marmot channel. That made destination ownership ambiguous and caused received messages to produce no reply on their source group.

This change follows OpenClaw's standard channel contract: the inbound context owns `OriginatingTo`/`To`, and a normal final goes back through the registered channel adapter to that same Marmot group. The model never reconstructs or selects the group id.

## User impact

A message received from a Marmot group now produces its automatic final on that same group and threads it to the triggering message. Sequential messages and a restarted inbound subscription preserve the same routing contract. QUIC preview primitives remain available for a future standard live-adapter integration, but inbound turns are final-only today.

## Validation

- `pnpm typecheck`
- `pnpm build`
- `pnpm test` — 187 passed, 1 skipped
- `MARMOT_OPENCLAW_CONNECTOR_E2E=1 pnpm exec vitest run test/e2e-connector.test.ts --reporter=verbose` — real `wn-agent`, sequential replies plus subscription restart
- `just openclaw-dev-script-test`
- `just fast-ci`

Supersedes #1137.

Fixes #1125.