### PR TITLE
Expose pinned retention metadata in timeline bindings

### DIFF
--- a/crates/cli/src/commands/messages.rs
+++ b/crates/cli/src/commands/messages.rs
@@ -821,6 +821,8 @@ mod tests {
             message_id_hex: "system-1".to_owned(),
             source_message_id_hex: None,
             source_epoch: Some(3),
+            retention_seconds: None,
+            retention_expires_at: None,
             direction: "system".to_owned(),
             group_id_hex: "11".repeat(32),
             sender: actor.clone(),

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -263,6 +263,8 @@ fn timeline_test_record(message_id_hex: &str, timeline_at: u64) -> TimelineMessa
         message_id_hex: message_id_hex.to_owned(),
         source_message_id_hex: None,
         source_epoch: None,
+        retention_seconds: None,
+        retention_expires_at: None,
         group_id_hex: "group-1".to_owned(),
         direction: "inbound".to_owned(),
         sender: "sender-1".to_owned(),

--- a/crates/marmot-uniffi/src/conversions/mod.rs
+++ b/crates/marmot-uniffi/src/conversions/mod.rs
@@ -289,6 +289,8 @@ mod tests {
             message_id_hex: "message-1".to_owned(),
             source_message_id_hex: Some("source-1".to_owned()),
             source_epoch: Some(7),
+            retention_seconds: Some(300),
+            retention_expires_at: Some(310),
             direction: "received".to_owned(),
             group_id_hex: "11".repeat(32),
             sender: "aa".repeat(32),
@@ -341,6 +343,9 @@ mod tests {
         let message = &page.messages[0];
         assert_eq!(message.message_id_hex, "message-1");
         assert_eq!(message.source_message_id_hex.as_deref(), Some("source-1"));
+        assert_eq!(message.source_epoch, Some(7));
+        assert_eq!(message.retention_seconds, Some(300));
+        assert_eq!(message.retention_expires_at, Some(310));
         assert_eq!(message.reply_to_message_id_hex.as_deref(), Some("parent"));
         assert!(matches!(
             &message.content_tokens.blocks[0],
@@ -407,6 +412,8 @@ mod tests {
             message_id_hex: "system-1".to_owned(),
             source_message_id_hex: None,
             source_epoch: Some(4),
+            retention_seconds: None,
+            retention_expires_at: None,
             direction: "system".to_owned(),
             group_id_hex: "11".repeat(32),
             sender: "aa".repeat(32),
@@ -451,6 +458,8 @@ mod tests {
             message_id_hex: "system-bad".to_owned(),
             source_message_id_hex: None,
             source_epoch: Some(4),
+            retention_seconds: None,
+            retention_expires_at: None,
             direction: "system".to_owned(),
             group_id_hex: "11".repeat(32),
             sender: "aa".repeat(32),

--- a/crates/marmot-uniffi/src/conversions/timeline.rs
+++ b/crates/marmot-uniffi/src/conversions/timeline.rs
@@ -168,6 +168,15 @@ pub struct TimelineMessageRecordFfi {
     /// re-sending the text. For received messages this is the originating event
     /// id and is always `Some(..)`.
     pub source_message_id_hex: Option<String>,
+    /// Authenticated MLS source epoch used to resolve this message's pinned
+    /// retention and encrypted-media decisions.
+    pub source_epoch: Option<u64>,
+    /// `None` means no recoverable source-epoch decision (legacy/safe retain).
+    /// `Some(0)` means retention was explicitly disabled for this message.
+    pub retention_seconds: Option<u64>,
+    /// Exact pinned expiration timestamp. A positive retention duration can
+    /// still have no finite expiry when timestamp addition overflowed.
+    pub retention_expires_at: Option<u64>,
     pub direction: String,
     pub group_id_hex: String,
     pub sender: String,
@@ -212,6 +221,9 @@ impl From<TimelineMessageRecord> for TimelineMessageRecordFfi {
         Self {
             message_id_hex: value.message_id_hex,
             source_message_id_hex: value.source_message_id_hex,
+            source_epoch: value.source_epoch,
+            retention_seconds: value.retention_seconds,
+            retention_expires_at: value.retention_expires_at,
             direction: value.direction,
             group_id_hex: value.group_id_hex,
             sender: value.sender,
@@ -474,6 +486,8 @@ mod tests {
             message_id_hex: "msg".to_owned(),
             source_message_id_hex: None,
             source_epoch,
+            retention_seconds: None,
+            retention_expires_at: None,
             direction: "received".to_owned(),
             group_id_hex: "11".repeat(32),
             sender: "alice".to_owned(),
@@ -519,6 +533,28 @@ mod tests {
     fn timeline_message_record_ffi_with_no_media_yields_empty() {
         let record: TimelineMessageRecordFfi = record_with_media(Some(7), None, None).into();
         assert!(record.media.is_empty());
+    }
+
+    #[test]
+    fn timeline_message_record_ffi_preserves_retention_states_without_recomputation() {
+        let legacy: TimelineMessageRecordFfi = record_with_media(Some(7), None, None).into();
+        assert_eq!(legacy.source_epoch, Some(7));
+        assert_eq!(legacy.retention_seconds, None);
+        assert_eq!(legacy.retention_expires_at, None);
+
+        let mut disabled = record_with_media(Some(8), None, None);
+        disabled.retention_seconds = Some(0);
+        let disabled = TimelineMessageRecordFfi::from(disabled);
+        assert_eq!(disabled.source_epoch, Some(8));
+        assert_eq!(disabled.retention_seconds, Some(0));
+        assert_eq!(disabled.retention_expires_at, None);
+
+        let mut unbounded = record_with_media(Some(9), None, None);
+        unbounded.retention_seconds = Some(300);
+        let unbounded = TimelineMessageRecordFfi::from(unbounded);
+        assert_eq!(unbounded.source_epoch, Some(9));
+        assert_eq!(unbounded.retention_seconds, Some(300));
+        assert_eq!(unbounded.retention_expires_at, None);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -28,12 +28,13 @@ use serde_json::{Value, json};
 /// (`AppEventReplayCursor`, which additionally tie-breaks on the LOCAL
 /// `insert_order` and is used only for lag-recovery watermark/suppression). Keep
 /// the two distinct: the replay cursor MUST NOT be applied to timeline
-/// pagination. Non-aliased `ORDER BY` sites reference these; a few aliased
-/// subquery lookups and the keyset-pagination predicates express the SAME order
-/// inline (they carry a table alias / bind placeholders that don't fit a plain
-/// fragment).
-pub(crate) const TIMELINE_ORDER_BY_ASC: &str = "ORDER BY timeline_at ASC, message_id_hex ASC";
-pub(crate) const TIMELINE_ORDER_BY_DESC: &str = "ORDER BY timeline_at DESC, message_id_hex DESC";
+/// pagination. Timeline record queries alias the materialized table as
+/// `timeline` and reference these constants; a few other lookups and the
+/// keyset-pagination predicates express the SAME order inline.
+pub(crate) const TIMELINE_ORDER_BY_ASC: &str =
+    "ORDER BY timeline.timeline_at ASC, timeline.message_id_hex ASC";
+pub(crate) const TIMELINE_ORDER_BY_DESC: &str =
+    "ORDER BY timeline.timeline_at DESC, timeline.message_id_hex DESC";
 
 const DEFAULT_TIMELINE_LIMIT: usize = 50;
 /// Largest number of rows a single timeline cursor query returns. A
@@ -99,6 +100,13 @@ pub struct TimelineMessageRecord {
     pub message_id_hex: String,
     pub source_message_id_hex: Option<String>,
     pub source_epoch: Option<u64>,
+    /// Retention decision pinned from the message's authenticated source epoch.
+    /// `None` means no recoverable decision; `Some(0)` means retention was
+    /// explicitly disabled for this message.
+    pub retention_seconds: Option<u64>,
+    /// Exact pinned expiration timestamp. A positive retention duration can
+    /// still have no finite expiry when timestamp addition overflowed.
+    pub retention_expires_at: Option<u64>,
     pub direction: String,
     pub group_id_hex: String,
     pub sender: String,
@@ -2243,12 +2251,19 @@ fn timeline_records_by_ids_tx(
             .collect::<Vec<_>>()
             .join(", ");
         let sql = format!(
-            "SELECT message_id_hex, source_message_id_hex, source_epoch, direction, group_id_hex, sender,
-                plaintext, kind, tags_json, timeline_at, received_at,
-                reply_to_message_id_hex, media_json, agent_stream_json, reactions_json,
-                deleted, deleted_by_message_id_hex, invalidation_status
-             FROM message_timeline
-             WHERE group_id_hex = ? AND message_id_hex IN ({placeholders})"
+            "SELECT timeline.message_id_hex, timeline.source_message_id_hex, timeline.source_epoch,
+                    source.retention_seconds, source.retention_expires_at,
+                    timeline.direction, timeline.group_id_hex, timeline.sender,
+                    timeline.plaintext, timeline.kind, timeline.tags_json, timeline.timeline_at,
+                    timeline.received_at, timeline.reply_to_message_id_hex, timeline.media_json,
+                    timeline.agent_stream_json, timeline.reactions_json, timeline.deleted,
+                    timeline.deleted_by_message_id_hex, timeline.invalidation_status
+             FROM message_timeline AS timeline
+             LEFT JOIN app_events AS source
+               ON source.group_id_hex = timeline.group_id_hex
+              AND source.message_id_hex = timeline.message_id_hex
+             WHERE timeline.group_id_hex = ?
+               AND timeline.message_id_hex IN ({placeholders})"
         );
         let mut params = Vec::<rusqlite::types::Value>::with_capacity(chunk.len() + 1);
         params.push(rusqlite::types::Value::Text(group_id_hex.to_owned()));
@@ -2316,7 +2331,7 @@ fn timeline_query_sql(
     let mut clauses = Vec::new();
     let mut params = Vec::new();
     if let Some(group_id_hex) = &query.group_id_hex {
-        clauses.push("group_id_hex = ?".to_owned());
+        clauses.push("timeline.group_id_hex = ?".to_owned());
         params.push(rusqlite::types::Value::Text(group_id_hex.clone()));
     }
     if let Some(search) = query
@@ -2325,7 +2340,7 @@ fn timeline_query_sql(
         .map(|value| value.trim())
         .filter(|value| !value.is_empty())
     {
-        clauses.push("plaintext LIKE ? ESCAPE '\\' COLLATE NOCASE".to_owned());
+        clauses.push("timeline.plaintext LIKE ? ESCAPE '\\' COLLATE NOCASE".to_owned());
         params.push(rusqlite::types::Value::Text(format!(
             "%{}%",
             escape_like_literal(search)
@@ -2337,7 +2352,7 @@ fn timeline_query_sql(
             // tie-break comparison flips from `<` to `<=`.
             let id_comparison = if pagination.inclusive { "<=" } else { "<" };
             clauses.push(format!(
-                "(timeline_at < ? OR (timeline_at = ? AND message_id_hex {id_comparison} ?))"
+                "(timeline.timeline_at < ? OR (timeline.timeline_at = ? AND timeline.message_id_hex {id_comparison} ?))"
             ));
             let cursor_at = u64_to_i64(pagination.cursor_at.unwrap_or_default())?;
             params.push(rusqlite::types::Value::Integer(cursor_at));
@@ -2347,8 +2362,10 @@ fn timeline_query_sql(
             ));
         }
         CursorDirection::After => {
-            clauses
-                .push("(timeline_at > ? OR (timeline_at = ? AND message_id_hex > ?))".to_owned());
+            clauses.push(
+                "(timeline.timeline_at > ? OR (timeline.timeline_at = ? AND timeline.message_id_hex > ?))"
+                    .to_owned(),
+            );
             let cursor_at = u64_to_i64(pagination.cursor_at.unwrap_or_default())?;
             params.push(rusqlite::types::Value::Integer(cursor_at));
             params.push(rusqlite::types::Value::Integer(cursor_at));
@@ -2372,11 +2389,17 @@ fn timeline_query_sql(
     };
     Ok((
         format!(
-            "SELECT message_id_hex, source_message_id_hex, source_epoch, direction, group_id_hex, sender,
-                    plaintext, kind, tags_json, timeline_at, received_at,
-                    reply_to_message_id_hex, media_json, agent_stream_json, reactions_json,
-                    deleted, deleted_by_message_id_hex, invalidation_status
-             FROM message_timeline
+            "SELECT timeline.message_id_hex, timeline.source_message_id_hex, timeline.source_epoch,
+                    source.retention_seconds, source.retention_expires_at,
+                    timeline.direction, timeline.group_id_hex, timeline.sender,
+                    timeline.plaintext, timeline.kind, timeline.tags_json, timeline.timeline_at,
+                    timeline.received_at, timeline.reply_to_message_id_hex, timeline.media_json,
+                    timeline.agent_stream_json, timeline.reactions_json, timeline.deleted,
+                    timeline.deleted_by_message_id_hex, timeline.invalidation_status
+             FROM message_timeline AS timeline
+             LEFT JOIN app_events AS source
+               ON source.group_id_hex = timeline.group_id_hex
+              AND source.message_id_hex = timeline.message_id_hex
              {where_sql}
              {order_sql}
              LIMIT ?"
@@ -2696,44 +2719,54 @@ fn timeline_record_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Timelin
         source_epoch: row
             .get::<_, Option<i64>>(2)?
             .and_then(|value| value.try_into().ok()),
-        direction: row.get(3)?,
-        group_id_hex: row.get(4)?,
-        sender: row.get(5)?,
-        plaintext: row.get(6)?,
-        kind: row.get::<_, i64>(7)?.try_into().unwrap_or_default(),
-        tags: tags_from_json(row.get::<_, String>(8)?).map_err(|err| {
-            rusqlite::Error::FromSqlConversionFailure(8, rusqlite::types::Type::Text, Box::new(err))
-        })?,
-        timeline_at: row.get::<_, i64>(9)?.try_into().unwrap_or_default(),
-        received_at: row.get::<_, i64>(10)?.try_into().unwrap_or_default(),
-        reply_to_message_id_hex: row.get(11)?,
-        reply_preview: None,
-        media: optional_value_from_json(row.get::<_, Option<String>>(12)?).map_err(|err| {
+        retention_seconds: row
+            .get::<_, Option<i64>>(3)?
+            .and_then(|value| value.try_into().ok()),
+        retention_expires_at: row
+            .get::<_, Option<i64>>(4)?
+            .and_then(|value| value.try_into().ok()),
+        direction: row.get(5)?,
+        group_id_hex: row.get(6)?,
+        sender: row.get(7)?,
+        plaintext: row.get(8)?,
+        kind: row.get::<_, i64>(9)?.try_into().unwrap_or_default(),
+        tags: tags_from_json(row.get::<_, String>(10)?).map_err(|err| {
             rusqlite::Error::FromSqlConversionFailure(
-                12,
+                10,
                 rusqlite::types::Type::Text,
                 Box::new(err),
             )
         })?,
-        agent_text_stream: optional_value_from_json(row.get::<_, Option<String>>(13)?).map_err(
-            |err| {
-                rusqlite::Error::FromSqlConversionFailure(
-                    13,
-                    rusqlite::types::Type::Text,
-                    Box::new(err),
-                )
-            },
-        )?,
-        reactions: reaction_summary_from_json(row.get::<_, String>(14)?).map_err(|err| {
+        timeline_at: row.get::<_, i64>(11)?.try_into().unwrap_or_default(),
+        received_at: row.get::<_, i64>(12)?.try_into().unwrap_or_default(),
+        reply_to_message_id_hex: row.get(13)?,
+        reply_preview: None,
+        media: optional_value_from_json(row.get::<_, Option<String>>(14)?).map_err(|err| {
             rusqlite::Error::FromSqlConversionFailure(
                 14,
                 rusqlite::types::Type::Text,
                 Box::new(err),
             )
         })?,
-        deleted: row.get::<_, i64>(15)? != 0,
-        deleted_by_message_id_hex: row.get(16)?,
-        invalidation_status: row.get(17)?,
+        agent_text_stream: optional_value_from_json(row.get::<_, Option<String>>(15)?).map_err(
+            |err| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    15,
+                    rusqlite::types::Type::Text,
+                    Box::new(err),
+                )
+            },
+        )?,
+        reactions: reaction_summary_from_json(row.get::<_, String>(16)?).map_err(|err| {
+            rusqlite::Error::FromSqlConversionFailure(
+                16,
+                rusqlite::types::Type::Text,
+                Box::new(err),
+            )
+        })?,
+        deleted: row.get::<_, i64>(17)? != 0,
+        deleted_by_message_id_hex: row.get(18)?,
+        invalidation_status: row.get(19)?,
     })
 }
 

--- a/crates/storage-sqlite/src/timeline/tests.rs
+++ b/crates/storage-sqlite/src/timeline/tests.rs
@@ -272,6 +272,122 @@ fn list(store: &SqliteAccountStorage) -> Vec<TimelineMessageRecord> {
         .messages
 }
 
+#[test]
+fn timeline_reads_preserve_every_pinned_retention_state() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let group_id = "11".repeat(32);
+
+    let mut finite = chat("finite", "alice", 10, "expires");
+    finite.source_epoch = Some(4);
+    let finite_update = store
+        .record_app_event_with_retention(
+            &finite,
+            Some(AppMessageRetentionDecision::new(finite.recorded_at, 300)),
+        )
+        .unwrap();
+    assert_eq!(finite_update.messages[0].source_epoch, Some(4));
+    assert_eq!(finite_update.messages[0].retention_seconds, Some(300));
+    assert_eq!(finite_update.messages[0].retention_expires_at, Some(310));
+
+    let disabled = chat("disabled", "alice", 20, "kept");
+    store
+        .record_app_event_with_retention(
+            &disabled,
+            Some(AppMessageRetentionDecision::new(disabled.recorded_at, 0)),
+        )
+        .unwrap();
+    store
+        .record_app_event(&chat("legacy", "alice", 30, "safe retain"))
+        .unwrap();
+    let overflow = chat("overflow", "alice", 40, "no finite expiry");
+    store
+        .record_app_event_with_retention(
+            &overflow,
+            Some(AppMessageRetentionDecision::new(u64::MAX, 1)),
+        )
+        .unwrap();
+
+    let paginated = store
+        .message_timeline(TimelineMessageQuery {
+            group_id_hex: Some(group_id.clone()),
+            pagination: TimelinePagination {
+                after: Some(0),
+                after_message_id: Some(String::new()),
+                limit: Some(10),
+                ..TimelinePagination::default()
+            },
+            ..TimelineMessageQuery::default()
+        })
+        .unwrap()
+        .messages;
+    let ids = paginated
+        .iter()
+        .map(|record| record.message_id_hex.clone())
+        .collect::<BTreeSet<_>>();
+    let by_id = timeline_records_by_ids_tx(&store.lock().unwrap(), &group_id, ids).unwrap();
+
+    let retention_by_id = |records: &[TimelineMessageRecord]| {
+        records
+            .iter()
+            .map(|record| {
+                (
+                    record.message_id_hex.clone(),
+                    (record.retention_seconds, record.retention_expires_at),
+                )
+            })
+            .collect::<BTreeMap<_, _>>()
+    };
+    let expected = BTreeMap::from([
+        ("disabled".to_owned(), (Some(0), None)),
+        ("finite".to_owned(), (Some(300), Some(310))),
+        ("legacy".to_owned(), (None, None)),
+        ("overflow".to_owned(), (Some(1), None)),
+    ]);
+    assert_eq!(retention_by_id(&paginated), expected);
+    assert_eq!(retention_by_id(&by_id), expected);
+
+    store.rebuild_message_timeline_for_group(&group_id).unwrap();
+    assert_eq!(retention_by_id(&list(&store)), expected);
+}
+
+#[test]
+fn incremental_retention_finalization_is_visible_without_stale_projection_data() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let group_id = "11".repeat(32);
+    let optimistic = chat("optimistic", "alice", 50, "pending");
+
+    let initial = store.record_app_event(&optimistic).unwrap();
+    assert_eq!(initial.messages[0].source_epoch, None);
+    assert_eq!(initial.messages[0].retention_seconds, None);
+    assert_eq!(initial.messages[0].retention_expires_at, None);
+
+    let finalized = store
+        .finalize_app_event_source_retention(
+            &group_id,
+            "optimistic",
+            Some("source-optimistic"),
+            9,
+            AppMessageRetentionDecision::new(50, 300),
+        )
+        .unwrap()
+        .expect("retention finalization update");
+    assert_eq!(finalized.messages[0].source_epoch, Some(9));
+    assert_eq!(finalized.messages[0].retention_seconds, Some(300));
+    assert_eq!(finalized.messages[0].retention_expires_at, Some(350));
+
+    let mut reprojected = optimistic;
+    reprojected.plaintext = "updated projection".to_owned();
+    let update = store.record_app_event(&reprojected).unwrap();
+    assert_eq!(update.messages[0].source_epoch, Some(9));
+    assert_eq!(update.messages[0].retention_seconds, Some(300));
+    assert_eq!(update.messages[0].retention_expires_at, Some(350));
+
+    let page = list(&store);
+    assert_eq!(page[0].source_epoch, Some(9));
+    assert_eq!(page[0].retention_seconds, Some(300));
+    assert_eq!(page[0].retention_expires_at, Some(350));
+}
+
 fn group_system_from_commit(
     id: &str,
     system_type: &str,


### PR DESCRIPTION
## Summary

- expose `source_epoch`, `retention_seconds`, and `retention_expires_at` on timeline message records and UniFFI bindings
- load pinned retention metadata from the authoritative `app_events` row for paginated and by-ID timeline reads
- preserve legacy `None`, explicit `Some(0)`, finite expiry, and positive-duration-without-expiry states exactly
- cover rebuild and incremental finalization paths with storage and conversion regression tests

## Root cause

`app_events` already persisted the retention decision pinned to the message's authenticated source epoch, but `TimelineMessageRecord` was populated only from `message_timeline`. The timeline conversion therefore dropped that metadata before Swift and Kotlin consumers could receive it.

Timeline reads now `LEFT JOIN` the authoritative source event by group and message ID. The values are not denormalized into `message_timeline`, so no schema migration or backfill is required and reads cannot become stale relative to retention finalization.

## Consumer impact

Generated bindings add these nullable fields to `TimelineMessageRecordFfi`:

- Swift: `sourceEpoch`, `retentionSeconds`, `retentionExpiresAt` as `UInt64?`
- Kotlin: `sourceEpoch`, `retentionSeconds`, `retentionExpiresAt` as `ULong?`

Consumers that construct the record explicitly must update their initializers after regenerating or vendoring the bindings. This remains part of the unreleased `0.9.8` API cohort.

## Validation

- `cargo fmt --check`
- `cargo test -p storage-sqlite` — 288 passed
- `cargo test -p marmot-uniffi`
- `cargo check -p marmot-uniffi --features otlp-export`
- `just fast-ci`
- `./crates/marmot-uniffi/xcframework.sh`
- `./crates/marmot-uniffi/kotlin-bindings.sh` — all four Android JNI ABIs
- `cargo test -p marmot-app` — all 467 unit tests passed; five `relay_runtime` integration tests failed identically when rerun from a clean worktree at the exact current `origin/master`, confirming pre-existing baseline failures unrelated to this diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timeline messages now expose retention duration and expiration details.
  * Retention states—including disabled, unspecified, finite, and unknown expiration—are preserved accurately.
* **Bug Fixes**
  * Fixed timeline reads and message lookups so retention information remains consistent across pagination and timeline rebuilds.
  * Updated projections to display finalized retention settings immediately without reverting to outdated values.
* **Tests**
  * Added coverage for retention states, timeline rebuilding, and incremental retention updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->