### PR TITLE
Persist manual chat pin ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -853,7 +853,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "hex",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "libc",
  "tempfile",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "cgka-conformance-simulator",
  "serde",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "fs-private",
  "serde",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5441,7 +5441,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6035,7 +6035,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6054,7 +6054,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6071,7 +6071,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6091,7 +6091,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7146,7 +7146,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7179,7 +7179,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "agent-control",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.8"
+version = "0.9.9"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.8",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1294,6 +1294,8 @@ mod tests {
         // agrees key-for-key.
         let row: marmot_app::ChatListRow = serde_json::from_value(json!({
             "group_id_hex": "abcd",
+            "pinned": false,
+            "pinned_position": null,
             "archived": false,
             "pending_confirmation": false,
             "title": "General",
@@ -1329,6 +1331,8 @@ mod tests {
             "muted_until_ms": null
         }))
         .expect("valid chat list row");
+        assert!(!row.pinned);
+        assert_eq!(row.pinned_position, None);
 
         let mut value = json!({ "group_id": "abcd" });
         insert_chat_projection(&mut value, Some(row));

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -505,6 +505,7 @@ fn read_marker_error_code(error: &AppError) -> &'static str {
         AppError::Hex(_) => "read_marker_failed:hex",
         AppError::MissingKeyPackage(_) => "read_marker_failed:missing_key_package",
         AppError::UnknownGroup(_) => "read_marker_failed:unknown_group",
+        AppError::InvalidChatPin(_) => "read_marker_failed:invalid_chat_pin",
         AppError::InvalidMessageDraft(_) => "read_marker_failed:invalid_message_draft",
         AppError::AgentStreamMissingStart => "read_marker_failed:agent_stream_missing_start",
         AppError::AgentStreamStartNotConfirmed => {

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -27,6 +27,8 @@ pub enum AppError {
     MissingKeyPackage(String),
     #[error("unknown local group")]
     UnknownGroup(String),
+    #[error("invalid chat pin: {0}")]
+    InvalidChatPin(String),
     /// Host-supplied draft attachment metadata failed validation before storage.
     #[error("invalid message draft: {0}")]
     InvalidMessageDraft(String),
@@ -132,6 +134,7 @@ impl AppError {
             Self::Hex(_) => "hex",
             Self::MissingKeyPackage(_) => "missing_key_package",
             Self::UnknownGroup(_) => "unknown_group",
+            Self::InvalidChatPin(_) => "invalid_chat_pin",
             Self::InvalidMessageDraft(_) => "invalid_message_draft",
             Self::AgentStreamMissingStart => "agent_stream_missing_start",
             Self::AgentStreamStartNotConfirmed => "agent_stream_start_not_confirmed",

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -111,7 +111,9 @@ pub use runtime::{
     default_directory_discovery_relays,
 };
 pub(crate) use sqlcipher::{SqlcipherDatabaseKind, remove_sqlite_file_set};
-pub use storage_sqlite::{TimelineMessageChange, TimelineRemoveReason, TimelineUpdateTrigger};
+pub use storage_sqlite::{
+    ChatPinState, TimelineMessageChange, TimelineRemoveReason, TimelineUpdateTrigger,
+};
 
 pub use agent_streams::{
     AgentStreamDelta, AgentStreamUpdate, AgentStreamWatchCompletion, AgentStreamWatchManager,
@@ -191,6 +193,19 @@ pub use transport_nostr_adapter::{
     DurationHistogramSnapshot, HistogramBucket, NostrAdapterMetrics, RelayDeliverySpread,
     RelayDeliveryStats, RelayLabelResolution, RelayLatencyStats, RelaySyncSnapshot,
 };
+
+fn chat_pin_error_from_storage(error: storage_sqlite::ChatPinError) -> AppError {
+    match error {
+        storage_sqlite::ChatPinError::Storage(error) => AppError::Storage(error),
+        storage_sqlite::ChatPinError::UnknownGroup(group_id_hex) => {
+            AppError::UnknownGroup(group_id_hex)
+        }
+        storage_sqlite::ChatPinError::ArchivedChat => {
+            AppError::InvalidChatPin("archived chats cannot be pinned".to_owned())
+        }
+        storage_sqlite::ChatPinError::InvalidOrder(details) => AppError::InvalidChatPin(details),
+    }
+}
 
 use conversions::{
     account_group_push_token_from_app, account_push_registration_from_app,
@@ -1687,6 +1702,29 @@ impl MarmotApp {
             .chat_list_row(group_id_hex)?;
         self.hydrate_chat_list_row(row.as_mut())?;
         Ok(row)
+    }
+
+    pub fn set_chat_pinned(
+        &self,
+        label: &str,
+        group_id_hex: &str,
+        pinned: bool,
+    ) -> Result<ChatPinState, AppError> {
+        self.ensure_account_state(label)?;
+        self.account_storage(label)?
+            .set_chat_pinned(group_id_hex, pinned)
+            .map_err(chat_pin_error_from_storage)
+    }
+
+    pub fn set_pinned_chat_order(
+        &self,
+        label: &str,
+        ordered_group_ids: &[String],
+    ) -> Result<ChatPinState, AppError> {
+        self.ensure_account_state(label)?;
+        self.account_storage(label)?
+            .set_pinned_chat_order(ordered_group_ids)
+            .map_err(chat_pin_error_from_storage)
     }
 
     /// Per-account unread aggregate for the account-switcher badge

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1704,6 +1704,8 @@ impl MarmotApp {
         Ok(row)
     }
 
+    /// Pin or unpin one unarchived local chat and return the complete
+    /// authoritative pin order after the transaction.
     pub fn set_chat_pinned(
         &self,
         label: &str,
@@ -1716,6 +1718,9 @@ impl MarmotApp {
             .map_err(chat_pin_error_from_storage)
     }
 
+    /// Atomically replace the order of the current pinned set.
+    ///
+    /// The input must contain every currently pinned group exactly once.
     pub fn set_pinned_chat_order(
         &self,
         label: &str,

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -33,7 +33,7 @@ use crate::{
     AppGroupMlsState, AppGroupRecord, AppMessageQuery, AppMessageRecord, AppProjectionUpdate,
     AppQuarantinedGroup, AuditLogDeleteOutcome, AuditLogFile, AuditLogSettings,
     AuditLogTrackerConfig, AuditLogTrackerUpdateResult, AuditLogUploadResult,
-    BackgroundNotificationCollection, ChatListRow, ChatNotificationSettings,
+    BackgroundNotificationCollection, ChatListRow, ChatNotificationSettings, ChatPinState,
     GroupInviteDeclineResult, GroupPushDebugInfo, KeyPackageDeletionTarget, MAX_SEEN_EVENT_IDS,
     MarmotApp, MarmotRelayPlane, MarmotServiceEndpoints, MediaAttachmentReference,
     MediaDownloadResult, MediaUploadRequest, MediaUploadResult, MessageDraft,
@@ -87,7 +87,8 @@ pub(crate) use subscriptions::{
     TIMELINE_WINDOW_LIMIT, TimelineQueryFn, TimelineSubscriptionSignal, TimelineWindow,
     TimelineWindowEdge, apply_projection_to_window, chat_list_row_fingerprint,
     merge_timeline_window, messages_recovery_query, received_message_update_from_record,
-    reconcile_chat_list_snapshot, recovery_row_is_pre_subscription, send_chat_list_remove_update,
+    reconcile_chat_list_snapshot, recovery_row_is_pre_subscription, send_atomic_chat_list_snapshot,
+    send_chat_list_remove_update,
 };
 // External items `runtime/tests.rs` reaches through `super::*` that the
 // orchestration core itself no longer references after the split.
@@ -2665,6 +2666,62 @@ impl MarmotAppRuntime {
         self.accounts
             .app
             .chat_list_row(&account.label, group_id_hex)
+    }
+
+    pub fn set_chat_pinned(
+        &self,
+        account_ref: &str,
+        group_id_hex: &str,
+        pinned: bool,
+    ) -> Result<ChatPinState, AppError> {
+        let account = self.accounts.resolve(account_ref)?;
+        let group_id_hex = normalize_group_id_hex_app(group_id_hex)?;
+        let state = self
+            .accounts
+            .app
+            .set_chat_pinned(&account.label, &group_id_hex, pinned)?;
+        let row = self
+            .accounts
+            .app
+            .chat_list_row(&account.label, &group_id_hex)?;
+        self.publish_chat_list_projection_update(
+            account.account_id_hex,
+            account.label,
+            group_id_hex,
+            row,
+            ChatListUpdateTrigger::PinOrderChanged,
+        );
+        Ok(state)
+    }
+
+    pub fn set_pinned_chat_order(
+        &self,
+        account_ref: &str,
+        ordered_group_ids: Vec<String>,
+    ) -> Result<ChatPinState, AppError> {
+        let account = self.accounts.resolve(account_ref)?;
+        let ordered_group_ids = ordered_group_ids
+            .into_iter()
+            .map(|group_id_hex| normalize_group_id_hex_app(&group_id_hex))
+            .collect::<Result<Vec<_>, _>>()?;
+        let state = self
+            .accounts
+            .app
+            .set_pinned_chat_order(&account.label, &ordered_group_ids)?;
+        if let Some(group_id_hex) = ordered_group_ids.first() {
+            let row = self
+                .accounts
+                .app
+                .chat_list_row(&account.label, group_id_hex)?;
+            self.publish_chat_list_projection_update(
+                account.account_id_hex,
+                account.label,
+                group_id_hex.clone(),
+                row,
+                ChatListUpdateTrigger::PinOrderChanged,
+            );
+        }
+        Ok(state)
     }
 
     /// Per-account unread aggregate for the account-switcher badge

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -2668,6 +2668,10 @@ impl MarmotAppRuntime {
             .chat_list_row(&account.label, group_id_hex)
     }
 
+    /// Pin or unpin one unarchived chat in an account-device's local store.
+    ///
+    /// Returns the complete authoritative pin order after the transaction and
+    /// publishes an atomic chat-list snapshot to live subscribers.
     pub fn set_chat_pinned(
         &self,
         account_ref: &str,
@@ -2694,6 +2698,10 @@ impl MarmotAppRuntime {
         Ok(state)
     }
 
+    /// Atomically replace an account-device's complete pinned chat order.
+    ///
+    /// The input must contain every currently pinned group exactly once.
+    /// Successful mutations publish an atomic chat-list snapshot.
     pub fn set_pinned_chat_order(
         &self,
         account_ref: &str,

--- a/crates/marmot-app/src/runtime/subscriptions.rs
+++ b/crates/marmot-app/src/runtime/subscriptions.rs
@@ -525,6 +525,11 @@ pub enum RuntimeChatListUpdate {
         trigger: ChatListUpdateTrigger,
         group_id_hex: String,
     },
+    /// Full replacement for this subscription's visible chat list.
+    ///
+    /// Consumers must atomically replace their locally held rows with `rows`;
+    /// any previously held row absent from this value has left the subscribed
+    /// list and must be removed.
     Snapshot {
         trigger: ChatListUpdateTrigger,
         rows: Vec<ChatListRow>,

--- a/crates/marmot-app/src/runtime/subscriptions.rs
+++ b/crates/marmot-app/src/runtime/subscriptions.rs
@@ -525,6 +525,10 @@ pub enum RuntimeChatListUpdate {
         trigger: ChatListUpdateTrigger,
         group_id_hex: String,
     },
+    Snapshot {
+        trigger: ChatListUpdateTrigger,
+        rows: Vec<ChatListRow>,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -540,6 +544,7 @@ pub enum ChatListUpdateTrigger {
     MuteChanged,
     ConversationKindChanged,
     LatestMessageDeliveryChanged,
+    PinOrderChanged,
     #[default]
     SnapshotRefresh,
     Removed,
@@ -1195,6 +1200,34 @@ impl MarmotAppRuntime {
                 if let Some(update) = projection_update_from_event(&event)
                     && update.account_id_hex == account_id_hex
                 {
+                    if matches!(
+                        update.update.chat_list_trigger,
+                        ChatListUpdateTrigger::PinOrderChanged
+                            | ChatListUpdateTrigger::ArchiveChanged
+                    ) {
+                        let app_for_lookup = app.clone();
+                        let account_label_for_lookup = account_label.clone();
+                        let rows = match blocking_app_task(move || {
+                            app_for_lookup.chat_list(&account_label_for_lookup, include_archived)
+                        })
+                        .await
+                        {
+                            Ok(rows) => rows,
+                            Err(_) => continue,
+                        };
+                        mute_expiries = chat_list_mute_expiries(&rows);
+                        if !send_atomic_chat_list_snapshot(
+                            &updates_tx,
+                            &mut row_fingerprints,
+                            update.update.chat_list_trigger,
+                            rows,
+                        )
+                        .await
+                        {
+                            return;
+                        }
+                        continue;
+                    }
                     let Some(row) = update.update.chat_list_row.clone() else {
                         mute_expiries.remove(&update.update.group_id_hex);
                         if !send_chat_list_remove_update(
@@ -1644,4 +1677,21 @@ pub(crate) async fn reconcile_chat_list_snapshot(
         }
     }
     true
+}
+
+pub(crate) async fn send_atomic_chat_list_snapshot(
+    updates_tx: &mpsc::Sender<RuntimeChatListUpdate>,
+    row_fingerprints: &mut HashMap<String, String>,
+    trigger: ChatListUpdateTrigger,
+    rows: Vec<ChatListRow>,
+) -> bool {
+    row_fingerprints.clear();
+    row_fingerprints.extend(
+        rows.iter()
+            .map(|row| (row.group_id_hex.clone(), chat_list_row_fingerprint(row))),
+    );
+    updates_tx
+        .send(RuntimeChatListUpdate::Snapshot { trigger, rows })
+        .await
+        .is_ok()
 }

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -1004,6 +1004,44 @@ async fn chat_list_snapshot_reconciliation_updates_changed_rows_and_removes_miss
     ));
 }
 
+#[tokio::test]
+async fn pin_order_changes_are_sent_as_one_atomic_snapshot() {
+    let (updates_tx, mut updates_rx) = mpsc::channel(1);
+    let mut row_fingerprints = HashMap::from([("stale".to_owned(), "old".to_owned())]);
+    let mut first = chat_list_test_row("first", "First");
+    first.pinned = true;
+    first.pinned_position = Some(0);
+    let mut second = chat_list_test_row("second", "Second");
+    second.pinned = true;
+    second.pinned_position = Some(1);
+
+    assert!(
+        send_atomic_chat_list_snapshot(
+            &updates_tx,
+            &mut row_fingerprints,
+            ChatListUpdateTrigger::PinOrderChanged,
+            vec![first.clone(), second.clone()],
+        )
+        .await
+    );
+    assert_eq!(
+        updates_rx.recv().await,
+        Some(RuntimeChatListUpdate::Snapshot {
+            trigger: ChatListUpdateTrigger::PinOrderChanged,
+            rows: vec![first.clone(), second.clone()],
+        })
+    );
+    assert_eq!(row_fingerprints.len(), 2);
+    assert_eq!(
+        row_fingerprints.get("first"),
+        Some(&chat_list_row_fingerprint(&first))
+    );
+    assert_eq!(
+        row_fingerprints.get("second"),
+        Some(&chat_list_row_fingerprint(&second))
+    );
+}
+
 #[test]
 fn chat_list_fingerprint_and_expiry_tracking_include_new_interaction_state() {
     let base = chat_list_test_row("group", "title");
@@ -1013,6 +1051,13 @@ fn chat_list_fingerprint_and_expiry_tracking_include_new_interaction_state() {
     assert_ne!(
         chat_list_row_fingerprint(&base),
         chat_list_row_fingerprint(&manual)
+    );
+    let mut pinned = base.clone();
+    pinned.pinned = true;
+    pinned.pinned_position = Some(0);
+    assert_ne!(
+        chat_list_row_fingerprint(&base),
+        chat_list_row_fingerprint(&pinned)
     );
 
     let mut timed = base.clone();
@@ -1059,6 +1104,8 @@ fn latest_agent_stream_start_accepts_mixed_case_filter() {
 fn chat_list_test_row(group_id_hex: &str, title: &str) -> ChatListRow {
     ChatListRow {
         group_id_hex: group_id_hex.to_owned(),
+        pinned: false,
+        pinned_position: None,
         archived: false,
         pending_confirmation: false,
         title: title.to_owned(),

--- a/crates/marmot-uniffi/src/commands/chat_list.rs
+++ b/crates/marmot-uniffi/src/commands/chat_list.rs
@@ -1,6 +1,8 @@
 //! Durable chat-list and chat read-state commands.
 
-use crate::conversions::{ChatListRowFfi, ChatNotificationSettingsFfi, group_id_from_hex};
+use crate::conversions::{
+    ChatListRowFfi, ChatNotificationSettingsFfi, ChatPinStateFfi, group_id_from_hex,
+};
 use crate::errors::MarmotKitError;
 use crate::{Marmot, optional_message_id_hex};
 
@@ -73,6 +75,40 @@ impl Marmot {
             .map(Into::into))
     }
 
+    /// Pin or unpin one local chat. Newly pinned chats enter at the top of the
+    /// manually ordered pinned section.
+    pub fn set_chat_pinned(
+        &self,
+        account_ref: String,
+        group_id_hex: String,
+        pinned: bool,
+    ) -> Result<ChatPinStateFfi, MarmotKitError> {
+        let group_id_hex = hex::encode(group_id_from_hex(&group_id_hex)?.as_slice());
+        Ok(self
+            .runtime
+            .set_chat_pinned(&account_ref, &group_id_hex, pinned)?
+            .into())
+    }
+
+    /// Atomically replace the order of the current pinned set. The input must
+    /// contain every currently pinned group exactly once.
+    pub fn set_pinned_chat_order(
+        &self,
+        account_ref: String,
+        ordered_group_ids: Vec<String>,
+    ) -> Result<ChatPinStateFfi, MarmotKitError> {
+        let ordered_group_ids = ordered_group_ids
+            .into_iter()
+            .map(|group_id_hex| {
+                group_id_from_hex(&group_id_hex).map(|group_id| hex::encode(group_id.as_slice()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(self
+            .runtime
+            .set_pinned_chat_order(&account_ref, ordered_group_ids)?
+            .into())
+    }
+
     /// Read the current MDK timed/indefinite mute state for one chat.
     pub fn chat_notification_settings(
         &self,
@@ -112,5 +148,223 @@ impl Marmot {
             .runtime
             .clear_chat_muted(&account_ref, &group_id_hex)?
             .into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cgka_traits::TransportEndpoint;
+    use marmot_app::{AccountSetupRequest, MarmotApp};
+    use nostr_relay_builder::MockRelay;
+
+    use super::*;
+    use crate::{ChatListSubscriptionUpdateFfi, ChatListUpdateTriggerFfi};
+
+    #[test]
+    fn chat_pins_round_trip_across_runtime_and_ffi() {
+        let test_thread = std::thread::Builder::new()
+            .name("ffi-chat-pin-runtime-round-trip".to_owned())
+            .stack_size(4 * 1024 * 1024)
+            .spawn(|| {
+                let test_runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                test_runtime.block_on(chat_pins_round_trip_body());
+            })
+            .unwrap();
+        test_thread.join().unwrap();
+    }
+
+    async fn chat_pins_round_trip_body() {
+        let relay = MockRelay::run().await.expect("start mock relay");
+        let relay_url = relay.url().await.to_string();
+        let root = tempfile::tempdir().expect("tempdir");
+        let app = MarmotApp::with_relays(root.path(), vec![relay_url.clone()]);
+        let runtime = app.runtime();
+        let kit = Marmot { app, runtime };
+        let endpoint = TransportEndpoint(relay_url.clone());
+        let account = kit
+            .runtime
+            .create_identity(AccountSetupRequest {
+                default_relays: vec![endpoint.clone()],
+                bootstrap_relays: vec![endpoint],
+                publish_missing_relay_lists: true,
+                publish_initial_key_package: true,
+                ..AccountSetupRequest::default()
+            })
+            .await
+            .expect("create identity");
+        let account_ref = account.account.account_id_hex;
+        let first = kit
+            .create_group(
+                account_ref.clone(),
+                "First pin".to_owned(),
+                Vec::new(),
+                None,
+            )
+            .await
+            .expect("create first group");
+        let second = kit
+            .create_group(
+                account_ref.clone(),
+                "Second pin".to_owned(),
+                Vec::new(),
+                None,
+            )
+            .await
+            .expect("create second group");
+
+        let isolated_endpoint = TransportEndpoint(relay_url);
+        let isolated_account = kit
+            .runtime
+            .create_identity(AccountSetupRequest {
+                default_relays: vec![isolated_endpoint.clone()],
+                bootstrap_relays: vec![isolated_endpoint],
+                publish_missing_relay_lists: true,
+                publish_initial_key_package: true,
+                ..AccountSetupRequest::default()
+            })
+            .await
+            .expect("create isolated identity");
+        let isolated_account_ref = isolated_account.account.account_id_hex;
+        let isolated_group = kit
+            .create_group(
+                isolated_account_ref.clone(),
+                "Isolated pin".to_owned(),
+                Vec::new(),
+                None,
+            )
+            .await
+            .expect("create isolated group");
+        let isolated_state = kit
+            .set_chat_pinned(isolated_account_ref.clone(), isolated_group.clone(), true)
+            .expect("pin isolated group");
+        assert_eq!(
+            isolated_state.ordered_group_ids,
+            vec![isolated_group.clone()]
+        );
+
+        let subscription = kit
+            .subscribe_chat_list(account_ref.clone(), false)
+            .await
+            .expect("subscribe chat list");
+        assert_eq!(subscription.snapshot().len(), 2);
+
+        let state = kit
+            .set_chat_pinned(account_ref.clone(), first.clone(), true)
+            .expect("pin first");
+        assert_eq!(state.ordered_group_ids, vec![first.clone()]);
+        let update = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            subscription.next_update(),
+        )
+        .await
+        .expect("pin snapshot timeout")
+        .expect("pin snapshot");
+        assert!(matches!(
+            update,
+            ChatListSubscriptionUpdateFfi::Snapshot {
+                trigger: ChatListUpdateTriggerFfi::PinOrderChanged,
+                rows,
+            } if rows.first().is_some_and(|row| {
+                row.group_id_hex == first
+                    && row.pinned
+                    && row.pinned_position == Some(0)
+            })
+        ));
+
+        let state = kit
+            .set_chat_pinned(account_ref.clone(), second.clone(), true)
+            .expect("pin second");
+        assert_eq!(state.ordered_group_ids, vec![second.clone(), first.clone()]);
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            subscription.next_update(),
+        )
+        .await
+        .expect("second pin snapshot timeout")
+        .expect("second pin snapshot");
+
+        let state = kit
+            .set_chat_pinned(account_ref.clone(), second.clone(), false)
+            .expect("unpin second");
+        assert_eq!(state.ordered_group_ids, vec![first.clone()]);
+        let update = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            subscription.next_update(),
+        )
+        .await
+        .expect("unpin snapshot timeout")
+        .expect("unpin snapshot");
+        assert!(matches!(
+            update,
+            ChatListSubscriptionUpdateFfi::Snapshot {
+                trigger: ChatListUpdateTriggerFfi::PinOrderChanged,
+                rows,
+            } if rows.first().is_some_and(|row| {
+                row.group_id_hex == first
+                    && row.pinned
+                    && row.pinned_position == Some(0)
+            }) && rows.iter().any(|row| {
+                row.group_id_hex == second
+                    && !row.pinned
+                    && row.pinned_position.is_none()
+            })
+        ));
+
+        let state = kit
+            .set_chat_pinned(account_ref.clone(), second.clone(), true)
+            .expect("re-pin second");
+        assert_eq!(state.ordered_group_ids, vec![second.clone(), first.clone()]);
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            subscription.next_update(),
+        )
+        .await
+        .expect("re-pin snapshot timeout")
+        .expect("re-pin snapshot");
+
+        let state = kit
+            .set_pinned_chat_order(account_ref.clone(), vec![first.clone(), second.clone()])
+            .expect("reorder pins");
+        assert_eq!(state.ordered_group_ids, vec![first.clone(), second.clone()]);
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            subscription.next_update(),
+        )
+        .await
+        .expect("reorder snapshot timeout")
+        .expect("reorder snapshot");
+
+        let invalid = kit
+            .set_pinned_chat_order(account_ref.clone(), vec![first.clone()])
+            .expect_err("partial pinned order must be rejected");
+        assert!(matches!(invalid, MarmotKitError::InvalidChatPin { .. }));
+
+        kit.set_group_archived(account_ref.clone(), first.clone(), true)
+            .await
+            .expect("archive pinned chat");
+        let update = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            subscription.next_update(),
+        )
+        .await
+        .expect("archive snapshot timeout")
+        .expect("archive snapshot");
+        assert!(matches!(
+            update,
+            ChatListSubscriptionUpdateFfi::Snapshot {
+                trigger: ChatListUpdateTriggerFfi::ArchiveChanged,
+                rows,
+            } if rows.iter().all(|row| row.group_id_hex != first)
+                && rows.first().is_some_and(|row| {
+                    row.group_id_hex == second
+                        && row.pinned
+                        && row.pinned_position == Some(0)
+                })
+        ));
+
+        kit.runtime.shutdown().await;
     }
 }

--- a/crates/marmot-uniffi/src/conversions/chat_list.rs
+++ b/crates/marmot-uniffi/src/conversions/chat_list.rs
@@ -240,8 +240,10 @@ impl From<ChatListRow> for ChatListRowFfi {
     }
 }
 
+/// Authoritative device-local order of every currently pinned chat.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct ChatPinStateFfi {
+    /// Group ids in normalized zero-based display order.
     pub ordered_group_ids: Vec<String>,
 }
 
@@ -289,6 +291,10 @@ pub enum ChatListSubscriptionUpdateFfi {
         trigger: ChatListUpdateTriggerFfi,
         group_id_hex: String,
     },
+    /// Full replacement for the subscribed visible chat list.
+    ///
+    /// Swift and Kotlin hosts must atomically replace their locally held rows
+    /// with `rows` and drop any prior row absent from this value.
     Snapshot {
         trigger: ChatListUpdateTriggerFfi,
         rows: Vec<ChatListRowFfi>,

--- a/crates/marmot-uniffi/src/conversions/chat_list.rs
+++ b/crates/marmot-uniffi/src/conversions/chat_list.rs
@@ -2,7 +2,8 @@
 
 use marmot_app::{
     ChatConversationKind, ChatListAttachmentKind, ChatListAvatar, ChatListMessageDeliveryState,
-    ChatListMessagePreview, ChatListRow, ChatNotificationSettings, RuntimeChatListUpdate,
+    ChatListMessagePreview, ChatListRow, ChatNotificationSettings, ChatPinState,
+    RuntimeChatListUpdate,
 };
 
 use super::common::{SelfMembershipFfi, markdown_content_tokens};
@@ -144,6 +145,8 @@ impl From<ChatConversationKind> for ChatConversationKindFfi {
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct ChatListRowFfi {
     pub group_id_hex: String,
+    pub pinned: bool,
+    pub pinned_position: Option<u32>,
     pub archived: bool,
     pub pending_confirmation: bool,
     pub title: String,
@@ -207,6 +210,8 @@ impl From<ChatListRow> for ChatListRowFfi {
     fn from(value: ChatListRow) -> Self {
         Self {
             group_id_hex: value.group_id_hex,
+            pinned: value.pinned,
+            pinned_position: value.pinned_position,
             archived: value.archived,
             pending_confirmation: value.pending_confirmation,
             title: value.title,
@@ -231,6 +236,19 @@ impl From<ChatListRow> for ChatListRowFfi {
             muted_until_ms: value.muted_until_ms,
             leave_request_pending: value.leave_requested_at_ms.is_some(),
             leave_requested_at_ms: value.leave_requested_at_ms,
+        }
+    }
+}
+
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct ChatPinStateFfi {
+    pub ordered_group_ids: Vec<String>,
+}
+
+impl From<ChatPinState> for ChatPinStateFfi {
+    fn from(value: ChatPinState) -> Self {
+        Self {
+            ordered_group_ids: value.ordered_group_ids,
         }
     }
 }
@@ -271,6 +289,10 @@ pub enum ChatListSubscriptionUpdateFfi {
         trigger: ChatListUpdateTriggerFfi,
         group_id_hex: String,
     },
+    Snapshot {
+        trigger: ChatListUpdateTriggerFfi,
+        rows: Vec<ChatListRowFfi>,
+    },
 }
 
 impl From<RuntimeChatListUpdate> for ChatListSubscriptionUpdateFfi {
@@ -286,6 +308,10 @@ impl From<RuntimeChatListUpdate> for ChatListSubscriptionUpdateFfi {
             } => Self::RemoveRow {
                 trigger: trigger.into(),
                 group_id_hex,
+            },
+            RuntimeChatListUpdate::Snapshot { trigger, rows } => Self::Snapshot {
+                trigger: trigger.into(),
+                rows: rows.into_iter().map(Into::into).collect(),
             },
         }
     }
@@ -304,6 +330,7 @@ pub enum ChatListUpdateTriggerFfi {
     MuteChanged,
     ConversationKindChanged,
     LatestMessageDeliveryChanged,
+    PinOrderChanged,
     SnapshotRefresh,
     Removed,
 }
@@ -328,6 +355,7 @@ impl From<marmot_app::ChatListUpdateTrigger> for ChatListUpdateTriggerFfi {
             marmot_app::ChatListUpdateTrigger::LatestMessageDeliveryChanged => {
                 Self::LatestMessageDeliveryChanged
             }
+            marmot_app::ChatListUpdateTrigger::PinOrderChanged => Self::PinOrderChanged,
             marmot_app::ChatListUpdateTrigger::SnapshotRefresh => Self::SnapshotRefresh,
             marmot_app::ChatListUpdateTrigger::Removed => Self::Removed,
         }
@@ -341,6 +369,8 @@ mod tests {
     fn sample_row() -> ChatListRow {
         ChatListRow {
             group_id_hex: "11".to_owned(),
+            pinned: false,
+            pinned_position: None,
             archived: false,
             pending_confirmation: false,
             title: "Marmot Lab".to_owned(),

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -10,6 +10,8 @@ pub enum MarmotKitError {
     UnknownAccount { account_ref: String },
     #[error("unknown group: {group_id_hex}")]
     UnknownGroup { group_id_hex: String },
+    #[error("invalid chat pin: {details}")]
+    InvalidChatPin { details: String },
     /// Host-supplied draft attachment metadata is malformed.
     #[error("invalid message draft: {details}")]
     InvalidMessageDraft { details: String },
@@ -169,6 +171,7 @@ impl From<AppError> for MarmotKitError {
                 details: err.to_string(),
             },
             AppError::UnknownGroup(group_id_hex) => Self::UnknownGroup { group_id_hex },
+            AppError::InvalidChatPin(details) => Self::InvalidChatPin { details },
             AppError::InvalidMessageDraft(details) => Self::InvalidMessageDraft { details },
             // Encrypted-media validation failures are always media-boundary
             // errors; map them to the typed variant so send/upload/download

--- a/crates/marmot-uniffi/src/lib.rs
+++ b/crates/marmot-uniffi/src/lib.rs
@@ -50,7 +50,7 @@ pub use conversions::{
     BackgroundNotificationCollectionFfi, ChatConversationKindFfi, ChatListAttachmentKindFfi,
     ChatListAvatarFfi, ChatListMessageDeliveryStateFfi, ChatListMessagePreviewFfi, ChatListRowFfi,
     ChatListSubscriptionUpdateFfi, ChatListUpdateTriggerFfi, ChatNotificationSettingsFfi,
-    CursorPersistenceFfi, EncryptedMediaVersionFfi, GroupEvolutionStatusFfi,
+    ChatPinStateFfi, CursorPersistenceFfi, EncryptedMediaVersionFfi, GroupEvolutionStatusFfi,
     GroupMaintenanceStatusFfi, GroupPushDebugInfoFfi, GroupPushTokenDebugEntryFfi,
     GroupSystemEventFfi, HostPerformanceOperationFfi, HostPerformanceOutcomeFfi,
     KeyPackageMaintenanceStatusFfi, LocalPushRegistrationDebugFfi, MaintenanceObligationFfi,

--- a/crates/marmot-uniffi/src/subscriptions.rs
+++ b/crates/marmot-uniffi/src/subscriptions.rs
@@ -95,6 +95,16 @@ impl ChatListSubscription {
         take_snapshot(&self.snapshot).unwrap_or_default()
     }
 
+    /// Legacy row-only update stream.
+    ///
+    /// Atomic replacement snapshots are flattened into every visible row in
+    /// authoritative order so existing clients can observe changed pin fields.
+    /// This can yield many rows for one pin or archive operation and cannot
+    /// express the replacement boundary or removals. New clients that need
+    /// correct manual ordering and archive removals should use `next_update`.
+    ///
+    /// `next` and `next_update` consume the same stream and must not be mixed
+    /// for the lifetime of one subscription.
     pub async fn next(&self) -> Option<ChatListRowFfi> {
         let mut state = self.state.lock().await;
         if let Some(row) = state.pending_rows.pop_front() {
@@ -114,6 +124,11 @@ impl ChatListSubscription {
         }
     }
 
+    /// Typed update stream, including atomic full-list replacement snapshots.
+    ///
+    /// Do not mix this with `next` on the same subscription: both consume the
+    /// same underlying stream, while `next` may also hold flattened snapshot
+    /// rows in its compatibility buffer.
     pub async fn next_update(&self) -> Option<ChatListSubscriptionUpdateFfi> {
         let mut state = self.state.lock().await;
         state.inner.recv().await.map(Into::into)

--- a/crates/marmot-uniffi/src/subscriptions.rs
+++ b/crates/marmot-uniffi/src/subscriptions.rs
@@ -13,6 +13,7 @@
 //! All inner state lives behind a `tokio::sync::Mutex` because UniFFI passes
 //! these objects via `Arc<Self>` and `recv()` requires `&mut`.
 
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 
@@ -64,7 +65,12 @@ impl ChatsSubscription {
 #[derive(uniffi::Object)]
 pub struct ChatListSubscription {
     snapshot: StdMutex<Option<Vec<ChatListRowFfi>>>,
-    inner: Mutex<RuntimeChatListSubscription>,
+    state: Mutex<ChatListSubscriptionState>,
+}
+
+struct ChatListSubscriptionState {
+    inner: RuntimeChatListSubscription,
+    pending_rows: VecDeque<ChatListRowFfi>,
 }
 
 impl ChatListSubscription {
@@ -75,7 +81,10 @@ impl ChatListSubscription {
             .collect();
         Arc::new(Self {
             snapshot: StdMutex::new(Some(snapshot)),
-            inner: Mutex::new(inner),
+            state: Mutex::new(ChatListSubscriptionState {
+                inner,
+                pending_rows: VecDeque::new(),
+            }),
         })
     }
 }
@@ -87,18 +96,27 @@ impl ChatListSubscription {
     }
 
     pub async fn next(&self) -> Option<ChatListRowFfi> {
-        let mut inner = self.inner.lock().await;
+        let mut state = self.state.lock().await;
+        if let Some(row) = state.pending_rows.pop_front() {
+            return Some(row);
+        }
         loop {
-            match inner.recv().await? {
+            match state.inner.recv().await? {
                 marmot_app::RuntimeChatListUpdate::Row { row, .. } => return Some((*row).into()),
                 marmot_app::RuntimeChatListUpdate::RemoveRow { .. } => continue,
+                marmot_app::RuntimeChatListUpdate::Snapshot { rows, .. } => {
+                    state.pending_rows.extend(rows.into_iter().map(Into::into));
+                    if let Some(row) = state.pending_rows.pop_front() {
+                        return Some(row);
+                    }
+                }
             }
         }
     }
 
     pub async fn next_update(&self) -> Option<ChatListSubscriptionUpdateFfi> {
-        let mut inner = self.inner.lock().await;
-        inner.recv().await.map(Into::into)
+        let mut state = self.state.lock().await;
+        state.inner.recv().await.map(Into::into)
     }
 }
 

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -9,10 +9,28 @@ use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
 use cgka_traits::storage::StorageResult;
 use rusqlite::{Connection, OptionalExtension, Params, params};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatListQuery {
     pub include_archived: bool,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChatPinState {
+    pub ordered_group_ids: Vec<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ChatPinError {
+    #[error(transparent)]
+    Storage(#[from] cgka_traits::storage::StorageError),
+    #[error("unknown local group")]
+    UnknownGroup(String),
+    #[error("archived chats cannot be pinned")]
+    ArchivedChat,
+    #[error("invalid pinned chat order: {0}")]
+    InvalidOrder(String),
 }
 
 /// Predicate deciding whether a timeline message (by plaintext + tag set)
@@ -136,6 +154,11 @@ pub struct ChatListMessagePreview {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatListRow {
     pub group_id_hex: String,
+    pub pinned: bool,
+    /// Normalized zero-based position in the pinned section. The stored
+    /// ordinal is internal and may contain gaps after an archive-triggered
+    /// deletion.
+    pub pinned_position: Option<u32>,
     pub archived: bool,
     pub pending_confirmation: bool,
     pub title: String,
@@ -216,6 +239,89 @@ impl SqliteAccountStorage {
     pub fn chat_list_row(&self, group_id_hex: &str) -> StorageResult<Option<ChatListRow>> {
         let conn = self.lock()?;
         chat_list_row_tx(&conn, group_id_hex)
+    }
+
+    pub fn set_chat_pinned(
+        &self,
+        group_id_hex: &str,
+        pinned: bool,
+    ) -> Result<ChatPinState, ChatPinError> {
+        self.connection.with_transaction(|| {
+            let conn = self.lock()?;
+            let archived = conn
+                .query_row(
+                    "SELECT archived FROM account_groups WHERE group_id_hex = ?1",
+                    params![group_id_hex],
+                    |row| row.get::<_, i64>(0),
+                )
+                .optional()
+                .storage()?
+                .ok_or_else(|| ChatPinError::UnknownGroup(group_id_hex.to_owned()))?
+                != 0;
+            if pinned && archived {
+                return Err(ChatPinError::ArchivedChat);
+            }
+
+            let mut ordered_group_ids = pinned_chat_order_tx(&conn)?;
+            let existing = ordered_group_ids
+                .iter()
+                .position(|candidate| candidate == group_id_hex);
+            match (pinned, existing) {
+                (true, None) => {
+                    ordered_group_ids.insert(0, group_id_hex.to_owned());
+                    rewrite_pinned_chat_order_tx(&conn, &ordered_group_ids)?;
+                }
+                (false, Some(position)) => {
+                    ordered_group_ids.remove(position);
+                    rewrite_pinned_chat_order_tx(&conn, &ordered_group_ids)?;
+                }
+                _ => {}
+            }
+            Ok(ChatPinState { ordered_group_ids })
+        })
+    }
+
+    pub fn set_pinned_chat_order(
+        &self,
+        ordered_group_ids: &[String],
+    ) -> Result<ChatPinState, ChatPinError> {
+        self.connection.with_transaction(|| {
+            let conn = self.lock()?;
+            for group_id_hex in ordered_group_ids {
+                let exists = conn
+                    .query_row(
+                        "SELECT EXISTS(
+                            SELECT 1 FROM account_groups WHERE group_id_hex = ?1
+                         )",
+                        params![group_id_hex],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .storage()?;
+                if !exists {
+                    return Err(ChatPinError::UnknownGroup(group_id_hex.clone()));
+                }
+            }
+            if ordered_group_ids.iter().collect::<HashSet<_>>().len() != ordered_group_ids.len() {
+                return Err(ChatPinError::InvalidOrder(
+                    "group ids must not contain duplicates".to_owned(),
+                ));
+            }
+
+            let current = pinned_chat_order_tx(&conn)?;
+            let current_set = current.iter().collect::<HashSet<_>>();
+            let requested_set = ordered_group_ids.iter().collect::<HashSet<_>>();
+            if current_set != requested_set {
+                return Err(ChatPinError::InvalidOrder(
+                    "order must contain every currently pinned chat exactly once".to_owned(),
+                ));
+            }
+            if current != ordered_group_ids {
+                rewrite_pinned_chat_order_tx(&conn, ordered_group_ids)?;
+            }
+            Ok(ChatPinState {
+                ordered_group_ids: ordered_group_ids.to_vec(),
+            })
+        })
     }
 
     /// Cheap unread aggregate over the materialized `chat_list_rows`
@@ -459,6 +565,42 @@ impl SqliteAccountStorage {
             )
         })
     }
+}
+
+fn pinned_chat_order_tx(tx: &Connection) -> Result<Vec<String>, ChatPinError> {
+    let mut statement = tx
+        .prepare(
+            "SELECT group_id_hex
+             FROM chat_pin_positions
+             ORDER BY ordinal ASC, group_id_hex ASC",
+        )
+        .storage()?;
+    statement
+        .query_map([], |row| row.get(0))
+        .storage()?
+        .collect::<Result<Vec<_>, _>>()
+        .storage()
+        .map_err(Into::into)
+}
+
+fn rewrite_pinned_chat_order_tx(
+    tx: &Connection,
+    ordered_group_ids: &[String],
+) -> Result<(), ChatPinError> {
+    tx.execute("DELETE FROM chat_pin_positions", []).storage()?;
+    for (ordinal, group_id_hex) in ordered_group_ids.iter().enumerate() {
+        tx.execute(
+            "INSERT INTO chat_pin_positions (group_id_hex, ordinal)
+             VALUES (?1, ?2)",
+            params![
+                group_id_hex,
+                i64::try_from(ordinal)
+                    .map_err(|_| ChatPinError::InvalidOrder("too many pinned chats".to_owned()))?
+            ],
+        )
+        .storage()?;
+    }
+    Ok(())
 }
 
 fn rebuild_all_chat_list_rows_tx(
@@ -1273,12 +1415,21 @@ fn chat_list_rows_tx(tx: &Connection, query: ChatListQuery) -> StorageResult<Vec
                 row.activity_sort_at, row.updated_at, row.self_membership,
                 ag.member_count,
                 mute.group_id_hex IS NOT NULL,
-                mute.muted_until_ms
+                mute.muted_until_ms,
+                pin.group_id_hex IS NOT NULL,
+                CASE WHEN pin.ordinal IS NULL THEN NULL ELSE (
+                    SELECT COUNT(*)
+                    FROM chat_pin_positions AS earlier_pin
+                    WHERE earlier_pin.ordinal < pin.ordinal
+                ) END
          FROM chat_list_rows AS row
          LEFT JOIN account_groups AS ag ON ag.group_id_hex = row.group_id_hex
          LEFT JOIN chat_notification_settings AS mute
             ON mute.group_id_hex = row.group_id_hex
-         ORDER BY row.activity_sort_at DESC, row.group_id_hex"
+         LEFT JOIN chat_pin_positions AS pin
+            ON pin.group_id_hex = row.group_id_hex
+         ORDER BY pin.ordinal IS NULL, pin.ordinal ASC,
+                  row.activity_sort_at DESC, row.group_id_hex"
     } else {
         "SELECT row.group_id_hex, row.archived, row.pending_confirmation,
                 row.title, row.group_name, row.avatar_url,
@@ -1295,13 +1446,22 @@ fn chat_list_rows_tx(tx: &Connection, query: ChatListQuery) -> StorageResult<Vec
                 row.activity_sort_at, row.updated_at, row.self_membership,
                 ag.member_count,
                 mute.group_id_hex IS NOT NULL,
-                mute.muted_until_ms
+                mute.muted_until_ms,
+                pin.group_id_hex IS NOT NULL,
+                CASE WHEN pin.ordinal IS NULL THEN NULL ELSE (
+                    SELECT COUNT(*)
+                    FROM chat_pin_positions AS earlier_pin
+                    WHERE earlier_pin.ordinal < pin.ordinal
+                ) END
          FROM chat_list_rows AS row
          LEFT JOIN account_groups AS ag ON ag.group_id_hex = row.group_id_hex
          LEFT JOIN chat_notification_settings AS mute
             ON mute.group_id_hex = row.group_id_hex
+         LEFT JOIN chat_pin_positions AS pin
+            ON pin.group_id_hex = row.group_id_hex
          WHERE row.archived = 0
-         ORDER BY row.activity_sort_at DESC, row.group_id_hex"
+         ORDER BY pin.ordinal IS NULL, pin.ordinal ASC,
+                  row.activity_sort_at DESC, row.group_id_hex"
     };
     let now_ms = unix_now_ms();
     let mut stmt = tx.prepare(sql).storage()?;
@@ -1339,11 +1499,19 @@ fn chat_list_row_tx(tx: &Connection, group_id_hex: &str) -> StorageResult<Option
                 row.activity_sort_at, row.updated_at, row.self_membership,
                 ag.member_count,
                 mute.group_id_hex IS NOT NULL,
-                mute.muted_until_ms
+                mute.muted_until_ms,
+                pin.group_id_hex IS NOT NULL,
+                CASE WHEN pin.ordinal IS NULL THEN NULL ELSE (
+                    SELECT COUNT(*)
+                    FROM chat_pin_positions AS earlier_pin
+                    WHERE earlier_pin.ordinal < pin.ordinal
+                ) END
          FROM chat_list_rows AS row
          LEFT JOIN account_groups AS ag ON ag.group_id_hex = row.group_id_hex
          LEFT JOIN chat_notification_settings AS mute
             ON mute.group_id_hex = row.group_id_hex
+         LEFT JOIN chat_pin_positions AS pin
+            ON pin.group_id_hex = row.group_id_hex
          WHERE row.group_id_hex = ?1",
         params![group_id_hex],
         |row| chat_list_row_from_row(row, now_ms),
@@ -1412,8 +1580,14 @@ fn chat_list_row_from_row(row: &rusqlite::Row<'_>, now_ms: i64) -> rusqlite::Res
     let mute_row_exists = row.get::<_, i64>(30)? != 0;
     let stored_muted_until_ms = row.get::<_, Option<i64>>(31)?;
     let muted = chat_mute_is_effective(mute_row_exists, stored_muted_until_ms, now_ms);
+    let pinned = row.get::<_, i64>(32)? != 0;
+    let pinned_position = row
+        .get::<_, Option<i64>>(33)?
+        .and_then(|value| u32::try_from(value).ok());
     Ok(ChatListRow {
         group_id_hex: row.get(0)?,
+        pinned,
+        pinned_position,
         archived: row.get::<_, i64>(1)? != 0,
         pending_confirmation: row.get::<_, i64>(2)? != 0,
         title: row.get(3)?,

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -16,11 +16,14 @@ pub struct ChatListQuery {
     pub include_archived: bool,
 }
 
+/// Authoritative device-local order of every currently pinned chat.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatPinState {
+    /// Group ids in normalized zero-based display order.
     pub ordered_group_ids: Vec<String>,
 }
 
+/// Typed validation and persistence failures for local chat pin mutations.
 #[derive(Debug, thiserror::Error)]
 pub enum ChatPinError {
     #[error(transparent)]
@@ -154,6 +157,7 @@ pub struct ChatListMessagePreview {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ChatListRow {
     pub group_id_hex: String,
+    /// Whether this row belongs to the device-local manually ordered section.
     pub pinned: bool,
     /// Normalized zero-based position in the pinned section. The stored
     /// ordinal is internal and may contain gaps after an archive-triggered
@@ -241,6 +245,11 @@ impl SqliteAccountStorage {
         chat_list_row_tx(&conn, group_id_hex)
     }
 
+    /// Pin or unpin one unarchived local chat and return the complete
+    /// authoritative pin order after the transaction.
+    ///
+    /// A newly pinned chat is inserted at the top. Repeating the current state
+    /// is idempotent and does not move an existing pin.
     pub fn set_chat_pinned(
         &self,
         group_id_hex: &str,
@@ -281,6 +290,13 @@ impl SqliteAccountStorage {
         })
     }
 
+    /// Replace the manual order of the complete current pinned set.
+    ///
+    /// `ordered_group_ids` must contain every currently pinned group exactly
+    /// once. This strict compare-and-set contract deliberately rejects stale
+    /// client orders with [`ChatPinError::InvalidOrder`] instead of silently
+    /// merging them. A client receiving that error should refresh its chat-list
+    /// snapshot and retry from the authoritative pinned set.
     pub fn set_pinned_chat_order(
         &self,
         ordered_group_ids: &[String],
@@ -1400,71 +1416,21 @@ fn read_state_tx(
 
 fn chat_list_rows_tx(tx: &Connection, query: ChatListQuery) -> StorageResult<Vec<ChatListRow>> {
     let sql = if query.include_archived {
-        "SELECT row.group_id_hex, row.archived, row.pending_confirmation,
-                row.title, row.group_name, row.avatar_url,
-                row.avatar_image_hash_hex, row.avatar_image_key_hex,
-                row.avatar_image_nonce_hex, row.avatar_image_upload_key_hex,
-                row.avatar_media_type, row.last_message_id_hex,
-                row.last_message_sender, row.last_message_preview,
-                row.last_message_kind, row.last_message_timeline_at,
-                row.last_message_deleted, row.last_message_media_json,
-                row.last_message_delivery_state, row.unread_count,
-                row.manually_marked_unread, row.unread_mention_count,
-                row.first_unread_message_id_hex, row.last_read_message_id_hex,
-                row.last_read_timeline_at, row.conversation_created_at,
-                row.activity_sort_at, row.updated_at, row.self_membership,
-                ag.member_count,
-                mute.group_id_hex IS NOT NULL,
-                mute.muted_until_ms,
-                pin.group_id_hex IS NOT NULL,
-                CASE WHEN pin.ordinal IS NULL THEN NULL ELSE (
-                    SELECT COUNT(*)
-                    FROM chat_pin_positions AS earlier_pin
-                    WHERE earlier_pin.ordinal < pin.ordinal
-                ) END
-         FROM chat_list_rows AS row
-         LEFT JOIN account_groups AS ag ON ag.group_id_hex = row.group_id_hex
-         LEFT JOIN chat_notification_settings AS mute
-            ON mute.group_id_hex = row.group_id_hex
-         LEFT JOIN chat_pin_positions AS pin
-            ON pin.group_id_hex = row.group_id_hex
-         ORDER BY pin.ordinal IS NULL, pin.ordinal ASC,
-                  row.activity_sort_at DESC, row.group_id_hex"
+        format!(
+            "{CHAT_LIST_ROW_SELECT_AND_JOINS}
+             ORDER BY pin.ordinal IS NULL, pin.ordinal ASC,
+                      row.activity_sort_at DESC, row.group_id_hex"
+        )
     } else {
-        "SELECT row.group_id_hex, row.archived, row.pending_confirmation,
-                row.title, row.group_name, row.avatar_url,
-                row.avatar_image_hash_hex, row.avatar_image_key_hex,
-                row.avatar_image_nonce_hex, row.avatar_image_upload_key_hex,
-                row.avatar_media_type, row.last_message_id_hex,
-                row.last_message_sender, row.last_message_preview,
-                row.last_message_kind, row.last_message_timeline_at,
-                row.last_message_deleted, row.last_message_media_json,
-                row.last_message_delivery_state, row.unread_count,
-                row.manually_marked_unread, row.unread_mention_count,
-                row.first_unread_message_id_hex, row.last_read_message_id_hex,
-                row.last_read_timeline_at, row.conversation_created_at,
-                row.activity_sort_at, row.updated_at, row.self_membership,
-                ag.member_count,
-                mute.group_id_hex IS NOT NULL,
-                mute.muted_until_ms,
-                pin.group_id_hex IS NOT NULL,
-                CASE WHEN pin.ordinal IS NULL THEN NULL ELSE (
-                    SELECT COUNT(*)
-                    FROM chat_pin_positions AS earlier_pin
-                    WHERE earlier_pin.ordinal < pin.ordinal
-                ) END
-         FROM chat_list_rows AS row
-         LEFT JOIN account_groups AS ag ON ag.group_id_hex = row.group_id_hex
-         LEFT JOIN chat_notification_settings AS mute
-            ON mute.group_id_hex = row.group_id_hex
-         LEFT JOIN chat_pin_positions AS pin
-            ON pin.group_id_hex = row.group_id_hex
-         WHERE row.archived = 0
-         ORDER BY pin.ordinal IS NULL, pin.ordinal ASC,
-                  row.activity_sort_at DESC, row.group_id_hex"
+        format!(
+            "{CHAT_LIST_ROW_SELECT_AND_JOINS}
+             WHERE row.archived = 0
+             ORDER BY pin.ordinal IS NULL, pin.ordinal ASC,
+                      row.activity_sort_at DESC, row.group_id_hex"
+        )
     };
     let now_ms = unix_now_ms();
-    let mut stmt = tx.prepare(sql).storage()?;
+    let mut stmt = tx.prepare(&sql).storage()?;
     let mut rows = stmt
         .query_map([], |row| chat_list_row_from_row(row, now_ms))
         .storage()?
@@ -1483,39 +1449,13 @@ fn chat_list_rows_tx(tx: &Connection, query: ChatListQuery) -> StorageResult<Vec
 
 fn chat_list_row_tx(tx: &Connection, group_id_hex: &str) -> StorageResult<Option<ChatListRow>> {
     let now_ms = unix_now_ms();
-    tx.query_row(
-        "SELECT row.group_id_hex, row.archived, row.pending_confirmation,
-                row.title, row.group_name, row.avatar_url,
-                row.avatar_image_hash_hex, row.avatar_image_key_hex,
-                row.avatar_image_nonce_hex, row.avatar_image_upload_key_hex,
-                row.avatar_media_type, row.last_message_id_hex,
-                row.last_message_sender, row.last_message_preview,
-                row.last_message_kind, row.last_message_timeline_at,
-                row.last_message_deleted, row.last_message_media_json,
-                row.last_message_delivery_state, row.unread_count,
-                row.manually_marked_unread, row.unread_mention_count,
-                row.first_unread_message_id_hex, row.last_read_message_id_hex,
-                row.last_read_timeline_at, row.conversation_created_at,
-                row.activity_sort_at, row.updated_at, row.self_membership,
-                ag.member_count,
-                mute.group_id_hex IS NOT NULL,
-                mute.muted_until_ms,
-                pin.group_id_hex IS NOT NULL,
-                CASE WHEN pin.ordinal IS NULL THEN NULL ELSE (
-                    SELECT COUNT(*)
-                    FROM chat_pin_positions AS earlier_pin
-                    WHERE earlier_pin.ordinal < pin.ordinal
-                ) END
-         FROM chat_list_rows AS row
-         LEFT JOIN account_groups AS ag ON ag.group_id_hex = row.group_id_hex
-         LEFT JOIN chat_notification_settings AS mute
-            ON mute.group_id_hex = row.group_id_hex
-         LEFT JOIN chat_pin_positions AS pin
-            ON pin.group_id_hex = row.group_id_hex
-         WHERE row.group_id_hex = ?1",
-        params![group_id_hex],
-        |row| chat_list_row_from_row(row, now_ms),
-    )
+    let sql = format!(
+        "{CHAT_LIST_ROW_SELECT_AND_JOINS}
+         WHERE row.group_id_hex = ?1"
+    );
+    tx.query_row(&sql, params![group_id_hex], |row| {
+        chat_list_row_from_row(row, now_ms)
+    })
     .optional()
     .storage()?
     .map(|mut row| {
@@ -1527,6 +1467,38 @@ fn chat_list_row_tx(tx: &Connection, group_id_hex: &str) -> StorageResult<Option
     })
     .transpose()
 }
+
+// Keep this projection in one place: `chat_list_row_from_row` decodes it by
+// index, so list and single-row queries must never drift in column order.
+const CHAT_LIST_ROW_SELECT_AND_JOINS: &str =
+    "SELECT row.group_id_hex, row.archived, row.pending_confirmation,
+            row.title, row.group_name, row.avatar_url,
+            row.avatar_image_hash_hex, row.avatar_image_key_hex,
+            row.avatar_image_nonce_hex, row.avatar_image_upload_key_hex,
+            row.avatar_media_type, row.last_message_id_hex,
+            row.last_message_sender, row.last_message_preview,
+            row.last_message_kind, row.last_message_timeline_at,
+            row.last_message_deleted, row.last_message_media_json,
+            row.last_message_delivery_state, row.unread_count,
+            row.manually_marked_unread, row.unread_mention_count,
+            row.first_unread_message_id_hex, row.last_read_message_id_hex,
+            row.last_read_timeline_at, row.conversation_created_at,
+            row.activity_sort_at, row.updated_at, row.self_membership,
+            ag.member_count,
+            mute.group_id_hex IS NOT NULL,
+            mute.muted_until_ms,
+            pin.group_id_hex IS NOT NULL,
+            CASE WHEN pin.ordinal IS NULL THEN NULL ELSE (
+                SELECT COUNT(*)
+                FROM chat_pin_positions AS earlier_pin
+                WHERE earlier_pin.ordinal < pin.ordinal
+            ) END
+     FROM chat_list_rows AS row
+     LEFT JOIN account_groups AS ag ON ag.group_id_hex = row.group_id_hex
+     LEFT JOIN chat_notification_settings AS mute
+        ON mute.group_id_hex = row.group_id_hex
+     LEFT JOIN chat_pin_positions AS pin
+        ON pin.group_id_hex = row.group_id_hex";
 
 fn chat_list_row_from_row(row: &rusqlite::Row<'_>, now_ms: i64) -> rusqlite::Result<ChatListRow> {
     let group_name: String = row.get(4)?;

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::storage::test_support::sample_group;
 use crate::{
-    SelfMembership, StoredAccountGroup, StoredAccountGroupComponent, StoredAccountState,
-    StoredAppEvent,
+    SelfMembership, SqlCipherKey, StoredAccountGroup, StoredAccountGroupComponent,
+    StoredAccountState, StoredAppEvent,
 };
 use cgka_traits::app_components::{
     GROUP_AVATAR_URL_COMPONENT, GROUP_AVATAR_URL_COMPONENT_ID, GroupAvatarUrlV1,
@@ -1742,5 +1742,294 @@ fn chat_list_rows_report_the_durable_leave_request_at_read_time() {
             .unwrap()
             .leave_requested_at_ms,
         None
+    );
+}
+
+fn three_groups() -> Vec<StoredAccountGroup> {
+    vec![
+        group(),
+        StoredAccountGroup {
+            group_id_hex: "22".to_owned(),
+            profile_name: "Second".to_owned(),
+            ..group()
+        },
+        StoredAccountGroup {
+            group_id_hex: "33".to_owned(),
+            profile_name: "Third".to_owned(),
+            ..group()
+        },
+    ]
+}
+
+#[test]
+fn pinned_chats_are_manual_first_and_survive_projection_rebuilds() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                groups: three_groups(),
+                ..StoredAccountState::default()
+            },
+            256,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+    {
+        let conn = store.lock().unwrap();
+        conn.execute(
+            "UPDATE account_groups
+             SET conversation_created_at = CASE group_id_hex
+                 WHEN '11' THEN 100
+                 WHEN '22' THEN 300
+                 WHEN '33' THEN 200
+             END",
+            [],
+        )
+        .unwrap();
+    }
+    store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    let initial = store
+        .chat_list_rows(ChatListQuery::default())
+        .unwrap()
+        .into_iter()
+        .map(|row| row.group_id_hex)
+        .collect::<Vec<_>>();
+    assert_eq!(initial, vec!["22", "33", "11"]);
+
+    assert_eq!(
+        store.set_chat_pinned("11", true).unwrap().ordered_group_ids,
+        vec!["11"]
+    );
+    assert_eq!(
+        store.set_chat_pinned("33", true).unwrap().ordered_group_ids,
+        vec!["33", "11"]
+    );
+    // Re-pinning is idempotent and does not move an existing pin.
+    assert_eq!(
+        store.set_chat_pinned("11", true).unwrap().ordered_group_ids,
+        vec!["33", "11"]
+    );
+    assert_eq!(
+        store
+            .set_chat_pinned("11", false)
+            .unwrap()
+            .ordered_group_ids,
+        vec!["33"]
+    );
+    // Re-unpinning is also idempotent.
+    assert_eq!(
+        store
+            .set_chat_pinned("11", false)
+            .unwrap()
+            .ordered_group_ids,
+        vec!["33"]
+    );
+    assert_eq!(
+        store.set_chat_pinned("11", true).unwrap().ordered_group_ids,
+        vec!["11", "33"]
+    );
+
+    let rows = store.chat_list_rows(ChatListQuery::default()).unwrap();
+    assert_eq!(
+        rows.iter()
+            .map(|row| row.group_id_hex.as_str())
+            .collect::<Vec<_>>(),
+        vec!["11", "33", "22"]
+    );
+    assert_eq!(
+        rows.iter()
+            .map(|row| (row.pinned, row.pinned_position))
+            .collect::<Vec<_>>(),
+        vec![(true, Some(0)), (true, Some(1)), (false, None)]
+    );
+
+    store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    assert_eq!(
+        store
+            .chat_list_rows(ChatListQuery::default())
+            .unwrap()
+            .into_iter()
+            .filter(|row| row.pinned)
+            .map(|row| row.group_id_hex)
+            .collect::<Vec<_>>(),
+        vec!["11", "33"]
+    );
+
+    assert_eq!(
+        store
+            .set_pinned_chat_order(&["33".to_owned(), "11".to_owned()])
+            .unwrap()
+            .ordered_group_ids,
+        vec!["33", "11"]
+    );
+    store
+        .record_app_event(&chat("newest", REMOTE, 1_000, "new activity"))
+        .unwrap();
+    store
+        .refresh_chat_list_row(LOCAL, GROUP, &no_mentions)
+        .unwrap();
+    assert_eq!(
+        store
+            .chat_list_rows(ChatListQuery::default())
+            .unwrap()
+            .into_iter()
+            .map(|row| row.group_id_hex)
+            .collect::<Vec<_>>(),
+        vec!["33", "11", "22"]
+    );
+}
+
+#[test]
+fn pin_validation_and_unarchived_eligibility_are_explicit() {
+    let mut groups = three_groups();
+    groups[0].self_membership = SelfMembership::Left;
+    groups[1].pending_confirmation = true;
+    groups[2].self_membership = SelfMembership::Removed;
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                groups,
+                ..StoredAccountState::default()
+            },
+            256,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+
+    store.set_chat_pinned("11", true).unwrap();
+    store.set_chat_pinned("22", true).unwrap();
+    store.set_chat_pinned("33", true).unwrap();
+    assert!(matches!(
+        store.set_chat_pinned("missing", true),
+        Err(ChatPinError::UnknownGroup(_))
+    ));
+    assert!(matches!(
+        store.set_pinned_chat_order(&["33".to_owned(), "33".to_owned()]),
+        Err(ChatPinError::InvalidOrder(_))
+    ));
+    assert!(matches!(
+        store.set_pinned_chat_order(&["33".to_owned()]),
+        Err(ChatPinError::InvalidOrder(_))
+    ));
+
+    let mut archived_groups = three_groups();
+    archived_groups[0].archived = true;
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                groups: archived_groups,
+                ..StoredAccountState::default()
+            },
+            256,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+    assert!(matches!(
+        store.set_chat_pinned("11", true),
+        Err(ChatPinError::ArchivedChat)
+    ));
+}
+
+#[test]
+fn archiving_and_deleting_clear_pins_without_restoring_them() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                groups: three_groups(),
+                ..StoredAccountState::default()
+            },
+            256,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+    store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+    store.set_chat_pinned("11", true).unwrap();
+    store.set_chat_pinned("33", true).unwrap();
+
+    let mut archived_groups = three_groups();
+    archived_groups[2].archived = true;
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                groups: archived_groups,
+                ..StoredAccountState::default()
+            },
+            256,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+    let remaining = store.chat_list_row("11").unwrap().unwrap();
+    assert!(remaining.pinned);
+    assert_eq!(remaining.pinned_position, Some(0));
+    let archived = store.chat_list_row("33").unwrap().unwrap();
+    assert!(!archived.pinned);
+
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                groups: three_groups(),
+                ..StoredAccountState::default()
+            },
+            256,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+    assert!(!store.chat_list_row("33").unwrap().unwrap().pinned);
+
+    assert!(store.delete_local_group_data("11").unwrap());
+    let pin_count = {
+        let conn = store.lock().unwrap();
+        conn.query_row(
+            "SELECT COUNT(*) FROM chat_pin_positions WHERE group_id_hex = '11'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(pin_count, 0);
+}
+
+#[test]
+fn pinned_order_survives_encrypted_database_reopen() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("chat-pins.sqlite3");
+    let key = SqlCipherKey::new("chat pin persistence key").unwrap();
+    {
+        let store = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+        store
+            .save_account_projection_state(
+                &StoredAccountState {
+                    label: "alice".to_owned(),
+                    groups: three_groups(),
+                    ..StoredAccountState::default()
+                },
+                256,
+                MAX_FUTURE_SKEW_SECS,
+            )
+            .unwrap();
+        store.refresh_chat_list_rows(LOCAL, &no_mentions).unwrap();
+        store.set_chat_pinned("11", true).unwrap();
+        store.set_chat_pinned("33", true).unwrap();
+    }
+
+    let reopened = SqliteAccountStorage::open_encrypted(&path, &key).unwrap();
+    let pinned = reopened
+        .chat_list_rows(ChatListQuery::default())
+        .unwrap()
+        .into_iter()
+        .filter(|row| row.pinned)
+        .map(|row| (row.group_id_hex, row.pinned_position))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        pinned,
+        vec![("33".to_owned(), Some(0)), ("11".to_owned(), Some(1))]
     );
 }

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -28,7 +28,8 @@ pub use account_projection::{
 };
 pub use chat_list::{
     AccountUnreadTotal, ChatConversationKind, ChatListAttachmentKind, ChatListAvatar,
-    ChatListMessageDeliveryState, ChatListMessagePreview, ChatListQuery, ChatListRow,
+    ChatListMessageDeliveryState, ChatListMessagePreview, ChatListQuery, ChatListRow, ChatPinError,
+    ChatPinState,
 };
 #[allow(deprecated)]
 pub use connection::SqliteStorage;

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -74,6 +74,8 @@ mod migration_0036_agent_stream_publisher_sequences;
 mod migration_0037_chat_list_semantic_timestamps;
 #[path = "migrations/0038_chat_list_interaction_state.rs"]
 mod migration_0038_chat_list_interaction_state;
+#[path = "migrations/0039_chat_pin_positions.rs"]
+mod migration_0039_chat_pin_positions;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -275,6 +277,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 38,
         name: "0038_chat_list_interaction_state",
         apply: migration_0038_chat_list_interaction_state::apply,
+    },
+    Migration {
+        version: 39,
+        name: "0039_chat_pin_positions",
+        apply: migration_0039_chat_pin_positions::apply,
     },
 ];
 
@@ -736,6 +743,65 @@ mod tests {
             "chat_notification_settings",
             "muted_until_ms"
         ));
+    }
+
+    #[test]
+    fn chat_pin_positions_are_migrated_with_archive_cleanup() {
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.pragma_update(None, "foreign_keys", true).unwrap();
+        run(&mut conn, &MIGRATIONS[..38]).unwrap();
+        conn.execute(
+            "INSERT INTO account_groups
+                (group_id_hex, endpoint, archived, updated_at)
+             VALUES ('existing-group', 'wss://relay.example', 0, 1)",
+            [],
+        )
+        .unwrap();
+        run(&mut conn, MIGRATIONS).unwrap();
+
+        assert!(connection_has_column(
+            &conn,
+            "chat_pin_positions",
+            "ordinal"
+        ));
+        assert_eq!(
+            foreign_key(&conn, "chat_pin_positions", "group_id_hex"),
+            Some(("account_groups".to_owned(), "CASCADE".to_owned()))
+        );
+        assert!(connection_has_index(
+            &conn,
+            "chat_pin_positions",
+            "idx_chat_pin_positions_order"
+        ));
+        let trigger_exists = conn
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM sqlite_master
+                    WHERE type = 'trigger' AND name = 'unpin_chat_when_archived'
+                 )",
+                [],
+                |row| row.get::<_, bool>(0),
+            )
+            .unwrap();
+        assert!(trigger_exists);
+
+        conn.execute(
+            "INSERT INTO chat_pin_positions (group_id_hex, ordinal)
+             VALUES ('existing-group', 7)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE account_groups SET archived = 1 WHERE group_id_hex = 'existing-group'",
+            [],
+        )
+        .unwrap();
+        let pin_count = conn
+            .query_row("SELECT COUNT(*) FROM chat_pin_positions", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap();
+        assert_eq!(pin_count, 0);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/migrations/0039_chat_pin_positions.rs
+++ b/crates/storage-sqlite/src/migrations/0039_chat_pin_positions.rs
@@ -1,0 +1,32 @@
+//! Add durable, device-local manual ordering for pinned chats.
+//!
+//! Pin rows deliberately live outside the rebuildable `chat_list_rows`
+//! projection. The account database is scoped to one account-device identity,
+//! so this state remains local without entering MLS or transport state.
+
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE chat_pin_positions (
+    group_id_hex TEXT PRIMARY KEY NOT NULL,
+    ordinal INTEGER NOT NULL UNIQUE CHECK (ordinal >= 0),
+    FOREIGN KEY (group_id_hex) REFERENCES account_groups(group_id_hex) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_chat_pin_positions_order
+    ON chat_pin_positions (ordinal, group_id_hex);
+
+CREATE TRIGGER unpin_chat_when_archived
+AFTER UPDATE OF archived ON account_groups
+WHEN NEW.archived = 1
+BEGIN
+    DELETE FROM chat_pin_positions WHERE group_id_hex = NEW.group_id_hex;
+END;
+"#,
+    )
+    .storage()
+}


### PR DESCRIPTION
## Summary

- persist device-local chat pin positions in each account-device SQLCipher database
- expose transactional pin, unpin, and complete manual reorder commands through `marmot-app` and UniFFI
- keep pinned chats ahead of activity-sorted unpinned chats without allowing new messages to reorder the pinned section
- publish atomic chat-list snapshots for pin-order and archive changes while preserving the legacy flattened `next()` subscription API
- bump the workspace and MarmotKit version from `0.9.8` to `0.9.9`

## Client impact

Clients receive `pinned` and normalized zero-based `pinned_position` fields on chat-list rows. `set_chat_pinned` and `set_pinned_chat_order` return the authoritative ordered pinned group IDs after the transaction. Invalid complete-order requests return the typed `InvalidChatPin` error.

This binding change is source-breaking for clients with exhaustive Swift `switch` or Kotlin `when` expressions: hosts must handle `ChatListSubscriptionUpdateFfi::Snapshot` and `ChatListUpdateTriggerFfi::PinOrderChanged`, and construct or read the two new required `ChatListRowFfi` fields.

Pin state is deliberately local to an account-device database and does not enter MLS group state or synchronize across devices. Archiving a conversation removes its pin transactionally; unarchiving does not restore it.

## Validation

- `cargo test -p storage-sqlite` — 293 passed
- `cargo test -p marmot-uniffi` — 78 unit, 2 fixture, and 26 smoke tests passed
- pinning runtime/FFI coverage includes account isolation, pin, unpin, reorder, archive, snapshots, persistence, projection rebuilds, departed/pending eligibility, and typed errors
- `cargo test -p cgka-conformance-simulator --test canonical_scenarios` — 27 passed
- Swift XCFramework generation passed
- Kotlin binding generation and all Android ABI builds passed
- `just fast-ci` passed

## Existing test baseline

`cargo test -p marmot-app` runs all 468 unit tests successfully, then encounters five existing `relay_runtime` integration failures. A representative failure reproduces identically from clean `master`; feature-specific runtime and UniFFI tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable chat pinning and custom pinned-chat ordering.
  * Pinned chats now appear first and display pin status and position.
  * Added APIs for pinning, unpinning, and updating pinned-chat order.
  * Chat list updates now provide atomic snapshots when pin order changes.
  * Added clear validation errors for invalid pin requests and ordering.
  * Pinned settings persist across database reopen and are cleared for archived chats.

* **Bug Fixes**
  * Improved chat-list refresh behavior after pinning and archiving changes.

* **Chores**
  * Updated the release and conformance version to 0.9.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->