### PR TITLE
Implement terminal MLS group disbanding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -853,7 +853,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-trait",
  "hex",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "libc",
  "tempfile",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "cgka-conformance-simulator",
  "serde",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "fs-private",
  "serde",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5441,7 +5441,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6035,7 +6035,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6054,7 +6054,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6071,7 +6071,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6091,7 +6091,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7146,7 +7146,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7179,7 +7179,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "agent-control",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.9"
+version = "0.9.10"
 license = "MIT"
 publish = false
 

--- a/crates/agent-connector/src/event_projection.rs
+++ b/crates/agent-connector/src/event_projection.rs
@@ -12,7 +12,8 @@ use cgka_traits::app_event::{
     EVENT_REF_TAG, GROUP_SYSTEM_DATA_NAME, GROUP_SYSTEM_EVENT_VERSION,
     GROUP_SYSTEM_TYPE_ADMIN_ADDED, GROUP_SYSTEM_TYPE_ADMIN_REMOVED,
     GROUP_SYSTEM_TYPE_DISAPPEARING_TIMER_CHANGED, GROUP_SYSTEM_TYPE_GROUP_AVATAR_CHANGED,
-    GROUP_SYSTEM_TYPE_GROUP_RENAMED, GROUP_SYSTEM_TYPE_MEMBER_ADDED, GROUP_SYSTEM_TYPE_MEMBER_LEFT,
+    GROUP_SYSTEM_TYPE_GROUP_DISBANDED, GROUP_SYSTEM_TYPE_GROUP_RENAMED,
+    GROUP_SYSTEM_TYPE_MEMBER_ADDED, GROUP_SYSTEM_TYPE_MEMBER_LEFT,
     GROUP_SYSTEM_TYPE_MEMBER_REMOVED, GroupSystemEvent, MARMOT_APP_EVENT_KIND_AGENT_STREAM_START,
     MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_DELETE, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
     STREAM_TAG, group_system_canonical_id,
@@ -401,6 +402,7 @@ pub(crate) fn control_event_from_runtime_event(
                     GroupStateChange::MessageRetentionChanged { .. } => {
                         ("disappearing_timer_changed", None)
                     }
+                    GroupStateChange::GroupDisbanded => ("group_disbanded", None),
                 };
                 Some(AgentControlEvent::GroupStateChanged {
                     account_id_hex: group_event.account_id_hex,
@@ -469,6 +471,7 @@ fn group_system_control_parts(event: &GroupSystemEvent) -> Option<(&'static str,
         )),
         GROUP_SYSTEM_TYPE_GROUP_AVATAR_CHANGED => Some(("group_avatar_changed", None)),
         GROUP_SYSTEM_TYPE_DISAPPEARING_TIMER_CHANGED => Some(("disappearing_timer_changed", None)),
+        GROUP_SYSTEM_TYPE_GROUP_DISBANDED => Some(("group_disbanded", None)),
         _ => None,
     }
 }

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -1051,7 +1051,9 @@ impl HarnessClient {
                 }
                 self.capture_engine_events();
             }
-            SendResult::Queued { .. } => {}
+            SendResult::NoChange { .. }
+            | SendResult::DisbandRequested { .. }
+            | SendResult::Queued { .. } => {}
         }
         Ok(())
     }

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -838,6 +838,7 @@ fn observe_engine_error(error: &EngineError) -> String {
         EngineError::Peeler(_) => "peeler",
         EngineError::ForkedEpoch { .. } => "forked_epoch",
         EngineError::MissingRequiredCapabilities { .. } => "missing_required_capabilities",
+        EngineError::DisbandingUnsupportedMembers { .. } => "disbanding_unsupported_members",
         EngineError::InvalidCredentialIdentity(_) => "invalid_credential_identity",
         EngineError::InvalidAccountIdentityProof(_) => "invalid_account_identity_proof",
         EngineError::InvalidKeyPackageLifetime { .. } => "invalid_key_package_lifetime",

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -839,6 +839,7 @@ fn observe_engine_error(error: &EngineError) -> String {
         EngineError::ForkedEpoch { .. } => "forked_epoch",
         EngineError::MissingRequiredCapabilities { .. } => "missing_required_capabilities",
         EngineError::DisbandingUnsupportedMembers { .. } => "disbanding_unsupported_members",
+        EngineError::DisbandingNotEnabled { .. } => "disbanding_not_enabled",
         EngineError::InvalidCredentialIdentity(_) => "invalid_credential_identity",
         EngineError::InvalidAccountIdentityProof(_) => "invalid_account_identity_proof",
         EngineError::InvalidKeyPackageLifetime { .. } => "invalid_key_package_lifetime",

--- a/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
+++ b/crates/cgka-conformance-simulator/tests/openmls_replay_probe.rs
@@ -1848,6 +1848,7 @@ fn dummy_group(group_id: GroupId) -> Group {
         protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
         removed: false,
         unrecoverable: false,
+        disbanded: None,
         join_epoch: EpochId(0),
     }
 }

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.9",
+  "conformance_version": "0.9.10",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -7,11 +7,13 @@ use cgka_traits::app_components::{
     AppComponentId, AppComponentSet, GROUP_ADMIN_POLICY_COMPONENT_ID,
     GROUP_AVATAR_URL_COMPONENT_ID, GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
     GROUP_ENCRYPTED_MEDIA_V1_COMPONENT_ID, GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID,
-    GROUP_MESSAGE_RETENTION_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID, GroupProfileV1,
-    NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1, SAFE_AAD_COMPONENT_ID, decode_components_list,
-    decode_encrypted_media_policy_v1, decode_encrypted_media_policy_v2, decode_group_avatar_url_v1,
-    decode_group_blossom_image_v1, decode_group_profile_v1, decode_nostr_routing_v1,
-    decode_quic_varint, encode_component_vectors, encode_components_list, encode_group_profile_v1,
+    GROUP_LIFECYCLE_COMPONENT_ID, GROUP_MESSAGE_RETENTION_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID,
+    GroupLifecycleV1, GroupProfileV1, NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1,
+    SAFE_AAD_COMPONENT_ID, decode_components_list, decode_encrypted_media_policy_v1,
+    decode_encrypted_media_policy_v2, decode_group_avatar_url_v1, decode_group_blossom_image_v1,
+    decode_group_lifecycle_v1, decode_group_profile_v1, decode_nostr_routing_v1,
+    decode_quic_varint, encode_component_vectors, encode_components_list,
+    encode_group_lifecycle_v1, encode_group_profile_v1,
 };
 use cgka_traits::engine::CommitOrderingPriority;
 use cgka_traits::error::EngineError;
@@ -24,8 +26,8 @@ use openmls::group::{
 };
 use openmls::messages::proposals::{AppDataUpdateOperation, AppDataUpdateProposal, Proposal};
 use openmls::prelude::{
-    BasicCredential, ContentType, ExtensionType, LeafNode, LeafNodeIndex, ProposalType,
-    ProposalValidationError, QueuedProposal, Sender,
+    BasicCredential, ContentType, ExtensionType, LeafNode, LeafNodeIndex, ProposalOrRefType,
+    ProposalType, ProposalValidationError, QueuedProposal, Sender,
 };
 use openmls::treesync::Node;
 use std::collections::{BTreeMap, BTreeSet};
@@ -125,6 +127,12 @@ pub(crate) fn app_data_dictionary_extension_for_group(
             encode_admin_policy(&initial.admins)?,
         );
     }
+    if required.contains(GROUP_LIFECYCLE_COMPONENT_ID) {
+        dict.insert(
+            GROUP_LIFECYCLE_COMPONENT_ID,
+            encode_group_lifecycle_v1(GroupLifecycleV1::Active),
+        );
+    }
     let mut seen_initial = BTreeSet::new();
     for component in &initial.app_components {
         if !seen_initial.insert(component.component_id) {
@@ -182,6 +190,17 @@ pub(crate) fn admins_of_group(mls_group: &MlsGroup) -> Result<Vec<[u8; 32]>, Eng
         return Ok(Vec::new());
     };
     decode_admin_policy(bytes)
+}
+
+pub(crate) fn lifecycle_of_group(
+    mls_group: &MlsGroup,
+) -> Result<Option<GroupLifecycleV1>, EngineError> {
+    let Some(bytes) = app_component_bytes(mls_group, GROUP_LIFECYCLE_COMPONENT_ID) else {
+        return Ok(None);
+    };
+    decode_group_lifecycle_v1(bytes).map(Some).map_err(|error| {
+        EngineError::Serialize(format!("invalid group lifecycle component: {error}"))
+    })
 }
 
 pub(crate) fn app_component_data_of_group(
@@ -431,6 +450,13 @@ fn authorize_proposal(
             if !sender_is_admin {
                 return Err(StandaloneProposalRejection::authorization(
                     "app_data_update_sender_not_admin",
+                ));
+            }
+            if update.component_id() == GROUP_LIFECYCLE_COMPONENT_ID
+                && proposal.proposal_or_ref_type() == ProposalOrRefType::Reference
+            {
+                return Err(StandaloneProposalRejection::invalid(
+                    "group_lifecycle_update_must_be_inline",
                 ));
             }
             if validate_app_data_payload {
@@ -798,7 +824,193 @@ pub(crate) fn validate_current_profile_invariants_for_staged_commit(
     let required_components =
         validate_current_profile_group_context(extensions, "resulting group state")?;
     let leaves = conceptual_resulting_leaves(group, staged, committer_index)?;
-    validate_resulting_leaf_capabilities(leaves.iter(), extensions, &required_components)
+    validate_resulting_leaf_capabilities(leaves.iter(), extensions, &required_components)?;
+    validate_group_lifecycle_transition(group, staged, committer_index)
+}
+
+fn lifecycle_from_extensions(
+    extensions: &Extensions<GroupContext>,
+) -> Result<Option<GroupLifecycleV1>, EngineError> {
+    let Some(bytes) = extensions
+        .app_data_dictionary()
+        .and_then(|dictionary| dictionary.dictionary().get(&GROUP_LIFECYCLE_COMPONENT_ID))
+    else {
+        return Ok(None);
+    };
+    decode_group_lifecycle_v1(bytes).map(Some).map_err(|error| {
+        EngineError::Serialize(format!("invalid group lifecycle component: {error}"))
+    })
+}
+
+pub(crate) fn staged_commit_disbands(
+    group: &MlsGroup,
+    staged: &StagedCommit,
+) -> Result<bool, EngineError> {
+    Ok(
+        lifecycle_from_extensions(group.extensions())? == Some(GroupLifecycleV1::Active)
+            && lifecycle_from_extensions(staged.group_context().extensions())?
+                == Some(GroupLifecycleV1::Disbanded),
+    )
+}
+
+/// Enforce lifecycle-v1 transition and terminal Commit shape at the shared
+/// staged-Commit chokepoint used by local sends, direct ingest, convergence
+/// replay, and fork recovery.
+pub(crate) fn validate_group_lifecycle_transition(
+    group: &MlsGroup,
+    staged: &StagedCommit,
+    committer_index: LeafNodeIndex,
+) -> Result<(), EngineError> {
+    let before = lifecycle_from_extensions(group.extensions())?;
+    let after = lifecycle_from_extensions(staged.group_context().extensions())?;
+    let before_required =
+        required_app_components_of_group(group)?.contains(GROUP_LIFECYCLE_COMPONENT_ID);
+    let after_required = required_app_components_of_extensions(
+        staged.group_context().extensions(),
+        "resulting group state",
+    )?
+    .contains(GROUP_LIFECYCLE_COMPONENT_ID);
+
+    if before == Some(GroupLifecycleV1::Disbanded) {
+        return Err(EngineError::Other(
+            "commit is invalid: Disbanded has no outgoing transition".into(),
+        ));
+    }
+
+    let enabling = !before_required && after_required;
+    if enabling {
+        if after != Some(GroupLifecycleV1::Active) {
+            return Err(EngineError::Other(
+                "commit is invalid: lifecycle enablement must install Active".into(),
+            ));
+        }
+        for queued in staged.queued_proposals() {
+            if queued.proposal_or_ref_type() != ProposalOrRefType::Proposal {
+                return Err(EngineError::Other(
+                    "commit is invalid: lifecycle enablement proposals must be inline".into(),
+                ));
+            }
+            match queued.proposal() {
+                Proposal::AppDataUpdate(update)
+                    if matches!(
+                        update.component_id(),
+                        APP_COMPONENTS_COMPONENT_ID | GROUP_LIFECYCLE_COMPONENT_ID
+                    ) => {}
+                _ => {
+                    return Err(EngineError::Other(
+                        "commit is invalid: lifecycle enablement contains unrelated proposals"
+                            .into(),
+                    ));
+                }
+            }
+        }
+        return Ok(());
+    }
+
+    if before != Some(GroupLifecycleV1::Active) || after != Some(GroupLifecycleV1::Disbanded) {
+        if before != after {
+            return Err(EngineError::Other(
+                "commit is invalid: unsupported group lifecycle transition".into(),
+            ));
+        }
+        if staged.queued_proposals().any(|queued| {
+            matches!(
+                queued.proposal(),
+                Proposal::AppDataUpdate(update)
+                    if update.component_id() == GROUP_LIFECYCLE_COMPONENT_ID
+            )
+        }) {
+            return Err(EngineError::Other(
+                "commit is invalid: redundant lifecycle update".into(),
+            ));
+        }
+        return Ok(());
+    }
+
+    if !before_required || !after_required {
+        return Err(EngineError::Other(
+            "commit is invalid: disband requires lifecycle-v1 in the parent and result".into(),
+        ));
+    }
+
+    let committer = group
+        .member_at(committer_index)
+        .ok_or_else(|| EngineError::Other("commit is invalid: committer leaf is absent".into()))?;
+    let committer_id = crate::identity::validated_member_id(&committer.credential)?;
+    let committer_admin = admin_pubkey_from_member_id(&committer_id)?;
+    let mut lifecycle_updates = 0usize;
+    let mut admin_updates = 0usize;
+    let mut removed = BTreeSet::new();
+
+    for queued in staged.queued_proposals() {
+        if queued.proposal_or_ref_type() != ProposalOrRefType::Proposal {
+            return Err(EngineError::Other(
+                "commit is invalid: every disband proposal must be inline".into(),
+            ));
+        }
+        match queued.proposal() {
+            Proposal::Remove(remove) => {
+                removed.insert(remove.removed().u32());
+            }
+            Proposal::AppDataUpdate(update)
+                if update.component_id() == GROUP_LIFECYCLE_COMPONENT_ID =>
+            {
+                let AppDataUpdateOperation::Update(data) = update.operation() else {
+                    return Err(EngineError::Other(
+                        "commit is invalid: lifecycle component cannot be removed".into(),
+                    ));
+                };
+                if decode_group_lifecycle_v1(data.as_slice()).map_err(|error| {
+                    EngineError::Serialize(format!("invalid group lifecycle component: {error}"))
+                })? != GroupLifecycleV1::Disbanded
+                {
+                    return Err(EngineError::Other(
+                        "commit is invalid: terminal lifecycle update is not Disbanded".into(),
+                    ));
+                }
+                lifecycle_updates += 1;
+            }
+            Proposal::AppDataUpdate(update)
+                if update.component_id() == GROUP_ADMIN_POLICY_COMPONENT_ID =>
+            {
+                let AppDataUpdateOperation::Update(data) = update.operation() else {
+                    return Err(EngineError::Other(
+                        "commit is invalid: disband must replace the admin policy".into(),
+                    ));
+                };
+                if decode_admin_policy(data.as_slice())? != vec![committer_admin] {
+                    return Err(EngineError::Other(
+                        "commit is invalid: disband admin policy must contain only the committer"
+                            .into(),
+                    ));
+                }
+                admin_updates += 1;
+            }
+            _ => {
+                return Err(EngineError::Other(
+                    "commit is invalid: disband contains a forbidden proposal".into(),
+                ));
+            }
+        }
+    }
+    if lifecycle_updates != 1 || admin_updates != 1 {
+        return Err(EngineError::Other(
+            "commit is invalid: disband needs exactly one lifecycle and one admin-policy update"
+                .into(),
+        ));
+    }
+
+    let expected: BTreeSet<u32> = group
+        .members()
+        .filter_map(|member| (member.index != committer_index).then_some(member.index.u32()))
+        .collect();
+    if removed != expected {
+        return Err(EngineError::Other(
+            "commit is invalid: disband must remove every source-state leaf except the committer"
+                .into(),
+        ));
+    }
+    Ok(())
 }
 
 fn validate_current_profile_group_context(
@@ -939,6 +1151,7 @@ fn is_known_group_component(component_id: AppComponentId) -> bool {
             | GROUP_AVATAR_URL_COMPONENT_ID
             | GROUP_ENCRYPTED_MEDIA_V1_COMPONENT_ID
             | GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID
+            | GROUP_LIFECYCLE_COMPONENT_ID
     )
 }
 
@@ -962,6 +1175,23 @@ fn ratchet_tree_leaves(tree: openmls::treesync::RatchetTree) -> Result<Vec<LeafN
             _ => None,
         })
         .collect())
+}
+
+/// Deduplicated account identifiers for current leaves that have not yet
+/// advertised lifecycle-v1 support. The tree walk is leaf-precise, so sibling
+/// devices cannot be hidden by the account-keyed capability cache.
+pub(crate) fn lifecycle_support_blockers(group: &MlsGroup) -> Result<Vec<MemberId>, EngineError> {
+    let mut seen = std::collections::HashSet::new();
+    let mut blockers = Vec::new();
+    for leaf in ratchet_tree_leaves(group.export_ratchet_tree())? {
+        if !app_components_of_leaf(&leaf)?.contains(GROUP_LIFECYCLE_COMPONENT_ID) {
+            let member = crate::identity::validated_member_id_of_leaf(&leaf)?;
+            if seen.insert(member.clone()) {
+                blockers.push(member);
+            }
+        }
+    }
+    Ok(blockers)
 }
 
 fn indexed_ratchet_tree_leaves(
@@ -1381,6 +1611,13 @@ fn validate_app_component_bytes(
         AGENT_TEXT_STREAM_QUIC_COMPONENT_ID => validate_agent_text_stream_policy(data),
         GROUP_ENCRYPTED_MEDIA_V1_COMPONENT_ID => validate_encrypted_media_policy_v1(data),
         GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID => validate_encrypted_media_policy_v2(data),
+        GROUP_LIFECYCLE_COMPONENT_ID => {
+            decode_group_lifecycle_v1(data)
+                .map(|_| ())
+                .map_err(|error| {
+                    EngineError::Serialize(format!("invalid group lifecycle component: {error}"))
+                })
+        }
         _ => Ok(()),
     }
 }
@@ -1480,6 +1717,11 @@ fn validate_app_component_remove_against(
     if component_id == SAFE_AAD_COMPONENT_ID {
         return Err(EngineError::Other(
             "safe_aad group-component state is not supported yet".into(),
+        ));
+    }
+    if component_id == GROUP_LIFECYCLE_COMPONENT_ID {
+        return Err(EngineError::Other(
+            "group lifecycle component cannot be removed".into(),
         ));
     }
     if resulting_required.contains(component_id) {

--- a/crates/cgka-engine/src/app_components.rs
+++ b/crates/cgka-engine/src/app_components.rs
@@ -878,6 +878,11 @@ pub(crate) fn validate_group_lifecycle_transition(
     }
 
     let enabling = !before_required && after_required;
+    if before_required && !after_required {
+        return Err(EngineError::Other(
+            "commit is invalid: lifecycle-v1 cannot be un-required".into(),
+        ));
+    }
     if enabling {
         if after != Some(GroupLifecycleV1::Active) {
             return Err(EngineError::Other(

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -618,6 +618,7 @@ pub(crate) fn engine_error_kind(err: &EngineError) -> &'static str {
         EngineError::AdminDepletion { .. } => "admin_depletion",
         EngineError::MissingRequiredCapabilities { .. } => "missing_required_capabilities",
         EngineError::DisbandingUnsupportedMembers { .. } => "disbanding_unsupported_members",
+        EngineError::DisbandingNotEnabled { .. } => "disbanding_not_enabled",
         EngineError::UnsupportedCiphersuite { .. } => "unsupported_ciphersuite",
         EngineError::InvalidAppMessagePayload(_) => "invalid_app_message_payload",
         EngineError::InvalidAccountIdentityProof(_) => "invalid_account_identity_proof",

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -35,6 +35,7 @@ pub(crate) fn pending_kind_str(kind: PendingKind) -> &'static str {
     match kind {
         PendingKind::CreateGroup => "create_group",
         PendingKind::GroupEvolution => "group_evolution",
+        PendingKind::Disband => "disband",
     }
 }
 
@@ -112,6 +113,8 @@ pub(crate) fn send_intent_kind_str(intent: &SendIntent) -> &'static str {
         SendIntent::SelfUpdate { .. } => "self_update",
         SendIntent::UpdateAppComponents { .. } => "update_app_components",
         SendIntent::UpdateGroupData { .. } => "update_group_data",
+        SendIntent::EnableDisbanding { .. } => "enable_disbanding",
+        SendIntent::Disband { .. } => "disband",
     }
 }
 
@@ -128,12 +131,16 @@ pub(crate) fn send_intent_group_id(intent: &SendIntent) -> cgka_traits::GroupId 
         | SendIntent::Leave { group_id }
         | SendIntent::SelfUpdate { group_id }
         | SendIntent::UpdateAppComponents { group_id, .. }
-        | SendIntent::UpdateGroupData { group_id, .. } => group_id.clone(),
+        | SendIntent::UpdateGroupData { group_id, .. }
+        | SendIntent::EnableDisbanding { group_id }
+        | SendIntent::Disband { group_id } => group_id.clone(),
     }
 }
 
 pub(crate) fn send_result_kind_str(result: &SendResult) -> &'static str {
     match result {
+        SendResult::NoChange { .. } => "no_change",
+        SendResult::DisbandRequested { .. } => "disband_requested",
         SendResult::ApplicationMessage { .. } => "application_message",
         SendResult::Queued { .. } => "queued",
         SendResult::Proposal { .. } => "proposal",
@@ -163,6 +170,7 @@ pub(crate) fn epoch_state_name_str(name: &str) -> &'static str {
         "Merging" => "merging",
         "Recovering" => "recovering",
         "Unrecoverable" => "unrecoverable",
+        "Disbanded" => "disbanded",
         _ => "unknown",
     }
 }
@@ -192,6 +200,7 @@ pub(crate) fn group_state_change_kind_str(change: &GroupStateChange) -> &'static
         GroupStateChange::GroupRenamed { .. } => "group_renamed",
         GroupStateChange::GroupAvatarChanged => "group_avatar_changed",
         GroupStateChange::MessageRetentionChanged { .. } => "message_retention_changed",
+        GroupStateChange::GroupDisbanded => "group_disbanded",
     }
 }
 
@@ -205,6 +214,7 @@ fn group_state_change_fields(change: &GroupStateChange) -> Vec<String> {
         GroupStateChange::GroupRenamed { .. } => &["name"],
         GroupStateChange::GroupAvatarChanged => &["avatar"],
         GroupStateChange::MessageRetentionChanged { .. } => &["message_retention"],
+        GroupStateChange::GroupDisbanded => &["lifecycle"],
     };
     fields.iter().map(|field| (*field).to_string()).collect()
 }
@@ -222,6 +232,12 @@ fn group_state_change_component_ids(change: &GroupStateChange) -> Vec<u16> {
         GroupStateChange::MessageRetentionChanged { .. } => {
             vec![GROUP_MESSAGE_RETENTION_COMPONENT_ID]
         }
+        GroupStateChange::GroupDisbanded => {
+            vec![
+                cgka_traits::app_components::GROUP_LIFECYCLE_COMPONENT_ID,
+                GROUP_ADMIN_POLICY_COMPONENT_ID,
+            ]
+        }
         GroupStateChange::MemberAdded { .. }
         | GroupStateChange::MemberRemoved { .. }
         | GroupStateChange::MemberLeft { .. } => Vec::new(),
@@ -237,7 +253,8 @@ fn group_state_subject_member(change: &GroupStateChange) -> Option<&MemberId> {
         | GroupStateChange::AdminRemoved { member } => Some(member),
         GroupStateChange::GroupRenamed { .. }
         | GroupStateChange::GroupAvatarChanged
-        | GroupStateChange::MessageRetentionChanged { .. } => None,
+        | GroupStateChange::MessageRetentionChanged { .. }
+        | GroupStateChange::GroupDisbanded => None,
     }
 }
 
@@ -544,6 +561,7 @@ pub(crate) fn send_outbound_messages(result: &SendResult) -> Vec<OutboundMessage
     }
     let mut messages = Vec::new();
     match result {
+        SendResult::NoChange { .. } | SendResult::DisbandRequested { .. } => {}
         SendResult::ApplicationMessage { msg, .. } => {
             messages.push(outbound(msg, MessageArtifactKind::ApplicationMessage));
         }
@@ -599,6 +617,7 @@ pub(crate) fn engine_error_kind(err: &EngineError) -> &'static str {
         EngineError::LeaveAlreadyRequested { .. } => "leave_already_requested",
         EngineError::AdminDepletion { .. } => "admin_depletion",
         EngineError::MissingRequiredCapabilities { .. } => "missing_required_capabilities",
+        EngineError::DisbandingUnsupportedMembers { .. } => "disbanding_unsupported_members",
         EngineError::UnsupportedCiphersuite { .. } => "unsupported_ciphersuite",
         EngineError::InvalidAppMessagePayload(_) => "invalid_app_message_payload",
         EngineError::InvalidAccountIdentityProof(_) => "invalid_account_identity_proof",

--- a/crates/cgka-engine/src/disband.rs
+++ b/crates/cgka-engine/src/disband.rs
@@ -107,7 +107,7 @@ impl<S: StorageProvider> Engine<S> {
             || crate::app_components::lifecycle_of_group(&mls_group)?
                 != Some(GroupLifecycleV1::Active)
         {
-            return Err(EngineError::Other("group disbanding is not enabled".into()));
+            return Err(EngineError::DisbandingNotEnabled { group_id });
         }
         crate::app_components::require_admin(&mls_group, &group_id, self.identity.self_id())?;
 
@@ -264,6 +264,7 @@ impl<S: StorageProvider> Engine<S> {
         &self,
         group_id: &GroupId,
     ) -> Result<Vec<cgka_traits::MemberId>, EngineError> {
+        self.ensure_group_live(group_id)?;
         if self.storage.disband_tombstone(group_id)?.is_some() {
             return Ok(Vec::new());
         }

--- a/crates/cgka-engine/src/disband.rs
+++ b/crates/cgka-engine/src/disband.rs
@@ -1,0 +1,625 @@
+//! Durable terminal group-disband workflow.
+//!
+//! A user request is persisted and gates ordinary work immediately. Commit
+//! preparation happens later, after any already-staged publish and the normal
+//! bounded convergence gate have completed.
+
+use crate::engine::Engine;
+use crate::pending_commit_guard::PendingCommitCleanupGuard;
+use crate::provider::EngineOpenMlsProvider;
+use cgka_traits::app_components::{
+    APP_COMPONENTS_COMPONENT_ID, AppComponentData, GROUP_ADMIN_POLICY_COMPONENT_ID,
+    GROUP_LIFECYCLE_COMPONENT_ID, GroupLifecycleV1, encode_components_list,
+    encode_group_lifecycle_v1,
+};
+use cgka_traits::engine::{CommitOrderingKey, SendResult};
+use cgka_traits::engine_state::{EpochState, StagedCommitHandle};
+use cgka_traits::error::EngineError;
+use cgka_traits::storage::{
+    DisbandCandidate, DisbandFailureReason, DisbandRequest, DisbandRequestStatus, StorageError,
+    StorageProvider,
+};
+use cgka_traits::transport::EncryptedPayload;
+use cgka_traits::types::{EpochId, GroupId};
+use openmls::group::MlsGroup;
+use openmls::messages::proposals::{AppDataUpdateProposal, Proposal};
+use openmls::prelude::BasicCredential;
+use openmls_traits::OpenMlsProvider as _;
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use tls_codec::Serialize as _;
+
+impl<S: StorageProvider> Engine<S> {
+    pub(crate) async fn do_enable_group_disbanding(
+        &mut self,
+        group_id: GroupId,
+    ) -> Result<SendResult, EngineError> {
+        let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
+        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+        let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+            .map_err(|error| EngineError::Backend(format!("load: {error:?}")))?
+            .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+        crate::app_components::require_admin(&mls_group, &group_id, self.identity.self_id())?;
+
+        let mut required = crate::app_components::required_app_components_of_group(&mls_group)?;
+        let lifecycle = crate::app_components::lifecycle_of_group(&mls_group)?;
+        if required.contains(GROUP_LIFECYCLE_COMPONENT_ID) {
+            return match lifecycle {
+                Some(GroupLifecycleV1::Active) => Ok(SendResult::NoChange { group_id }),
+                Some(GroupLifecycleV1::Disbanded) => Err(EngineError::InvalidTransition(
+                    cgka_traits::engine_state::InvalidTransition {
+                        from: "Disbanded",
+                        to: "EnableDisbanding",
+                        reason: "Disbanded is terminal",
+                    },
+                )),
+                None => Err(EngineError::Other(
+                    "required lifecycle component has no state".into(),
+                )),
+            };
+        }
+
+        let blockers = crate::app_components::lifecycle_support_blockers(&mls_group)?;
+        if !blockers.is_empty() {
+            return Err(EngineError::DisbandingUnsupportedMembers {
+                group_id,
+                members: blockers,
+            });
+        }
+
+        required.insert(GROUP_LIFECYCLE_COMPONENT_ID);
+        let mut updates = vec![AppComponentData {
+            component_id: APP_COMPONENTS_COMPONENT_ID,
+            data: encode_components_list(&required.ids),
+        }];
+        if lifecycle.is_none() {
+            updates.push(AppComponentData {
+                component_id: GROUP_LIFECYCLE_COMPONENT_ID,
+                data: encode_group_lifecycle_v1(GroupLifecycleV1::Active),
+            });
+        }
+        self.do_send_update_app_components(group_id, updates).await
+    }
+
+    /// Persist the irreversible product intent and install its durable send
+    /// gate. This deliberately does not stage a Commit.
+    pub(crate) fn do_request_disband(
+        &mut self,
+        group_id: GroupId,
+    ) -> Result<SendResult, EngineError> {
+        if self.storage.disband_tombstone(&group_id)?.is_some() {
+            return Ok(SendResult::NoChange { group_id });
+        }
+        if let Some(request) = self.storage.disband_request(&group_id)?
+            && request.status == DisbandRequestStatus::Pending
+        {
+            self.schedule_pending_convergence_group(&group_id);
+            return Ok(SendResult::DisbandRequested { request });
+        }
+
+        let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
+        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+        let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+            .map_err(|error| EngineError::Backend(format!("load: {error:?}")))?
+            .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+        let required = crate::app_components::required_app_components_of_group(&mls_group)?;
+        if !required.contains(GROUP_LIFECYCLE_COMPONENT_ID)
+            || crate::app_components::lifecycle_of_group(&mls_group)?
+                != Some(GroupLifecycleV1::Active)
+        {
+            return Err(EngineError::Other("group disbanding is not enabled".into()));
+        }
+        crate::app_components::require_admin(&mls_group, &group_id, self.identity.self_id())?;
+
+        let request = DisbandRequest {
+            group_id: group_id.clone(),
+            requested_at_ms: self.wall_clock.now_ms(),
+            status: DisbandRequestStatus::Pending,
+            last_prepared_epoch: None,
+        };
+        let preserve_staged_publish = matches!(
+            self.epoch_manager.state(&group_id),
+            Some(EpochState::PendingPublish(_) | EpochState::Merging(_))
+        );
+        self.storage.with_transaction(|storage| {
+            storage.put_disband_request(&request)?;
+            for queued in storage.list_queued_outbound_intents(&group_id)? {
+                storage.delete_queued_outbound_intent(&queued.id)?;
+            }
+            for welcome in storage
+                .list_welcomes()?
+                .into_iter()
+                .filter(|welcome| welcome.group_id == group_id)
+            {
+                let _ = storage.take_welcome(&welcome.message_id)?;
+            }
+            if !preserve_staged_publish {
+                for fanout in storage.list_outbound_fanouts_for_group(&group_id)? {
+                    storage.delete_outbound_fanout(fanout.message_id())?;
+                }
+                if let Some(maintenance) = storage.maintenance_storage() {
+                    maintenance.delete_group_maintenance(&group_id)?;
+                    for obligation in
+                        maintenance.list_maintenance_obligations_for_group(&group_id)?
+                    {
+                        maintenance.delete_maintenance_obligation(&obligation.id)?;
+                    }
+                    for evolution in maintenance.list_group_evolutions_for_group(&group_id)? {
+                        maintenance.delete_group_evolution(&evolution.id)?;
+                    }
+                    for fanout in maintenance.list_transport_fanouts()? {
+                        if fanout.group_id.as_ref() == Some(&group_id) {
+                            maintenance.delete_transport_fanout(&fanout.id)?;
+                        }
+                    }
+                }
+            }
+            Ok::<(), StorageError>(())
+        })?;
+        self.queued_intent_by_message
+            .retain(|_, (queued_group, _)| queued_group != &group_id);
+        self.queued_intent_by_pending
+            .retain(|_, (queued_group, _)| queued_group != &group_id);
+        self.drop_self_remove_auto_commit_schedules_for_group(&group_id);
+        self.schedule_pending_convergence_group(&group_id);
+        Ok(SendResult::DisbandRequested { request })
+    }
+
+    pub(crate) fn record_inbound_disband_candidate(
+        &mut self,
+        group_id: &GroupId,
+        source_epoch: EpochId,
+        commit_id: cgka_traits::MessageId,
+        commit_bytes: &[u8],
+        actor: cgka_traits::MemberId,
+        local_was_committer_leaf: bool,
+    ) -> Result<(), EngineError> {
+        let former_members = deduplicated_roster(&self.storage.get_group(group_id)?.members);
+        let candidate = DisbandCandidate {
+            group_id: group_id.clone(),
+            source_epoch,
+            commit_id,
+            content_commit_id: crate::message_processor::content_dedup_id(commit_bytes),
+            commit_digest: Sha256::digest(commit_bytes).into(),
+            actor,
+            local_was_committer_leaf,
+            former_members,
+        };
+        self.storage.with_transaction(|storage| {
+            storage.put_disband_candidate(&candidate)?;
+            for queued in storage.list_queued_outbound_intents(group_id)? {
+                storage.delete_queued_outbound_intent(&queued.id)?;
+            }
+            for welcome in storage
+                .list_welcomes()?
+                .into_iter()
+                .filter(|welcome| &welcome.group_id == group_id)
+            {
+                let _ = storage.take_welcome(&welcome.message_id)?;
+            }
+            for fanout in storage.list_outbound_fanouts_for_group(group_id)? {
+                storage.delete_outbound_fanout(fanout.message_id())?;
+            }
+            if let Some(maintenance) = storage.maintenance_storage() {
+                maintenance.delete_group_maintenance(group_id)?;
+                for obligation in maintenance.list_maintenance_obligations_for_group(group_id)? {
+                    maintenance.delete_maintenance_obligation(&obligation.id)?;
+                }
+                for evolution in maintenance.list_group_evolutions_for_group(group_id)? {
+                    maintenance.delete_group_evolution(&evolution.id)?;
+                }
+                for fanout in maintenance.list_transport_fanouts()? {
+                    if fanout.group_id.as_ref() == Some(group_id) {
+                        maintenance.delete_transport_fanout(&fanout.id)?;
+                    }
+                }
+            }
+            Ok::<(), StorageError>(())
+        })?;
+        self.queued_intent_by_message
+            .retain(|_, (queued_group, _)| queued_group != group_id);
+        self.queued_intent_by_pending
+            .retain(|_, (queued_group, _)| queued_group != group_id);
+        self.drop_self_remove_auto_commit_schedules_for_group(group_id);
+        self.schedule_pending_convergence_group(group_id);
+        Ok(())
+    }
+
+    pub(crate) fn disband_request_pending(&self, group_id: &GroupId) -> Result<bool, EngineError> {
+        Ok(self
+            .storage
+            .disband_request(group_id)?
+            .is_some_and(|request| request.status == DisbandRequestStatus::Pending))
+    }
+
+    pub(crate) fn disband_candidate_pending(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<bool, EngineError> {
+        Ok(!self.storage.list_disband_candidates(group_id)?.is_empty())
+    }
+
+    pub fn disband_request(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Option<DisbandRequest>, EngineError> {
+        Ok(self.storage.disband_request(group_id)?)
+    }
+
+    /// Account identifiers for leaves that do not yet advertise lifecycle-v1.
+    ///
+    /// This is an advisory read. The enable commit repeats the same check under
+    /// the engine mutation lock so a concurrent roster change remains safe.
+    pub fn disbanding_support_blockers(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Vec<cgka_traits::MemberId>, EngineError> {
+        if self.storage.disband_tombstone(group_id)?.is_some() {
+            return Ok(Vec::new());
+        }
+        let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
+        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+        let mls_group = MlsGroup::load(provider.storage(), &mls_gid)
+            .map_err(|error| EngineError::Backend(format!("load: {error:?}")))?
+            .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+        crate::app_components::lifecycle_support_blockers(&mls_group)
+    }
+
+    pub fn acknowledge_disband_failure(&self, group_id: &GroupId) -> Result<bool, EngineError> {
+        let Some(request) = self.storage.disband_request(group_id)? else {
+            return Ok(false);
+        };
+        if !matches!(request.status, DisbandRequestStatus::Failed(_)) {
+            return Ok(false);
+        }
+        self.storage.clear_disband_request(group_id)?;
+        Ok(true)
+    }
+
+    fn fail_disband_request(
+        &self,
+        mut request: DisbandRequest,
+        reason: DisbandFailureReason,
+    ) -> Result<(), EngineError> {
+        request.status = DisbandRequestStatus::Failed(reason);
+        request.last_prepared_epoch = None;
+        self.storage.put_disband_request(&request)?;
+        Ok(())
+    }
+
+    /// Prepare the pending request against the currently selected active
+    /// branch. Returns `None` while another mutation owns the group, while
+    /// Unrecoverable is paused, or once a disband candidate is already in its
+    /// convergence pass.
+    pub(crate) async fn prepare_pending_disband(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<Option<SendResult>, EngineError> {
+        let Some(mut request) = self.storage.disband_request(group_id)? else {
+            return Ok(None);
+        };
+        if request.status != DisbandRequestStatus::Pending
+            || self.disband_candidate_pending(group_id)?
+        {
+            return Ok(None);
+        }
+        let Some(state) = self.epoch_manager.state(group_id) else {
+            self.fail_disband_request(request, DisbandFailureReason::NoLongerMember)?;
+            return Ok(None);
+        };
+        if matches!(state, EpochState::Unrecoverable(_)) {
+            return Ok(None);
+        }
+        if !matches!(state, EpochState::Stable { .. }) {
+            return Ok(None);
+        }
+
+        let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
+        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+        let Some(mut mls_group) = MlsGroup::load(provider.storage(), &mls_gid)
+            .map_err(|error| EngineError::Backend(format!("load: {error:?}")))?
+        else {
+            self.fail_disband_request(request, DisbandFailureReason::NoLongerMember)?;
+            return Ok(None);
+        };
+        if crate::app_components::lifecycle_of_group(&mls_group)? != Some(GroupLifecycleV1::Active)
+        {
+            return Ok(None);
+        }
+        if crate::app_components::require_admin(&mls_group, group_id, self.identity.self_id())
+            .is_err()
+        {
+            let member = mls_group.members().any(|member| {
+                BasicCredential::try_from(member.credential).is_ok_and(|credential| {
+                    credential.identity() == self.identity.self_id().as_slice()
+                })
+            });
+            self.fail_disband_request(
+                request,
+                if member {
+                    DisbandFailureReason::NoLongerAdmin
+                } else {
+                    DisbandFailureReason::NoLongerMember
+                },
+            )?;
+            return Ok(None);
+        }
+
+        let source_epoch = EpochId(mls_group.epoch().as_u64());
+        let own_leaf = mls_group.own_leaf_index();
+        let removals = mls_group
+            .members()
+            .filter_map(|member| (member.index != own_leaf).then_some(member.index))
+            .collect::<Vec<_>>();
+        let committer_admin =
+            crate::app_components::admin_pubkey_from_member_id(self.identity.self_id())?;
+        let proposals = vec![
+            Proposal::AppDataUpdate(Box::new(AppDataUpdateProposal::update(
+                GROUP_LIFECYCLE_COMPONENT_ID,
+                encode_group_lifecycle_v1(GroupLifecycleV1::Disbanded),
+            ))),
+            Proposal::AppDataUpdate(Box::new(AppDataUpdateProposal::update(
+                GROUP_ADMIN_POLICY_COMPONENT_ID,
+                crate::app_components::encode_admin_policy(&[committer_admin])?,
+            ))),
+        ];
+
+        let mut guard = PendingCommitCleanupGuard::arm(&self.storage, &provider, group_id.clone());
+        let snapshot = self
+            .fork_recovery
+            .create_snapshot(&self.storage, group_id, source_epoch)?;
+        guard.set_snapshot(snapshot.clone());
+        self.audit_snapshot_created(group_id, &snapshot, source_epoch, "pre_disband_commit");
+        let context = crate::group_lifecycle::build_group_context_snapshot(&mls_group, &provider)?;
+        let commit = self.stage_commit_with_app_data_updates(
+            &mut mls_group,
+            &provider,
+            removals,
+            proposals,
+            "disband",
+        )?;
+        let staged = mls_group
+            .pending_commit()
+            .ok_or_else(|| EngineError::Backend("disband produced no pending commit".into()))?;
+        crate::app_components::require_admin_for_staged_commit(
+            &mls_group,
+            group_id,
+            Some(self.identity.self_id()),
+            staged,
+        )?;
+        crate::app_components::validate_admin_leaf_coupling_for_staged_commit(
+            &mls_group, group_id, staged,
+        )?;
+        crate::app_components::validate_app_component_integrity_for_staged_commit(
+            &mls_group, group_id, staged,
+        )?;
+        crate::app_components::validate_current_profile_invariants_for_staged_commit(
+            &mls_group, staged, own_leaf,
+        )?;
+        let priority = crate::app_components::commit_ordering_priority_for_staged(staged);
+        let commit_bytes = commit
+            .tls_serialize_detached()
+            .map_err(|error| EngineError::Serialize(format!("{error:?}")))?;
+        let wrapped = self
+            .peeler
+            .wrap_group_message(
+                &EncryptedPayload {
+                    ciphertext: commit_bytes.clone(),
+                    aad: vec![],
+                },
+                &context,
+            )
+            .await
+            .map_err(EngineError::Peeler)?;
+        let wrapped = crate::message_processor::route_wrapped_group_message(wrapped, &context);
+        self.record_sent_openmls_message(&wrapped, &commit_bytes, group_id, source_epoch)?;
+
+        let former_members = deduplicated_roster(&self.storage.get_group(group_id)?.members);
+        let candidate = DisbandCandidate {
+            group_id: group_id.clone(),
+            source_epoch,
+            commit_id: wrapped.id.clone(),
+            content_commit_id: crate::message_processor::content_dedup_id(&commit_bytes),
+            commit_digest: Sha256::digest(&commit_bytes).into(),
+            actor: self.identity.self_id().clone(),
+            local_was_committer_leaf: true,
+            former_members,
+        };
+        request.last_prepared_epoch = Some(source_epoch);
+        self.storage.with_transaction(|storage| {
+            storage.put_disband_candidate(&candidate)?;
+            storage.put_disband_request(&request)?;
+            Ok::<(), StorageError>(())
+        })?;
+
+        let target_epoch = EpochId(source_epoch.0.saturating_add(1));
+        let pending = self.epoch_manager.next_pending_ref();
+        self.epoch_manager.begin_pending(
+            group_id.clone(),
+            source_epoch,
+            target_epoch,
+            StagedCommitHandle::from_bytes(group_id.as_slice().to_vec()),
+            pending,
+            crate::epoch_manager::PendingKind::Disband,
+            self.current_audit_context.clone(),
+        )?;
+        self.track_pending_commit_for_recovery(
+            pending,
+            group_id.clone(),
+            source_epoch,
+            wrapped.id.clone(),
+            CommitOrderingKey::from_commit_bytes(
+                source_epoch,
+                priority,
+                self.identity.self_id().clone(),
+                &commit_bytes,
+            ),
+            snapshot,
+        );
+        guard.disarm();
+        Ok(Some(SendResult::GroupEvolution {
+            msg: wrapped,
+            welcomes: vec![],
+            pending,
+        }))
+    }
+
+    /// Complete or retry a terminal intent after a frozen convergence pass has
+    /// selected and applied canonical state.
+    pub(crate) fn settle_disband_after_convergence(
+        &mut self,
+        group_id: &GroupId,
+        accepted_commit_ids: &[String],
+        origin_commit_id: Option<&cgka_traits::MessageId>,
+    ) -> Result<bool, EngineError> {
+        let candidates = self.storage.list_disband_candidates(group_id)?;
+        if candidates.is_empty() {
+            return Ok(false);
+        }
+
+        let provider = EngineOpenMlsProvider::<S>::new(&self.crypto, self.storage.mls_storage());
+        let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
+        let Some(mut mls_group) = MlsGroup::load(provider.storage(), &mls_gid)
+            .map_err(|error| EngineError::Backend(format!("load: {error:?}")))?
+        else {
+            if self.storage.disband_tombstone(group_id)?.is_some() {
+                return Ok(true);
+            }
+            return Err(EngineError::UnknownGroup(group_id.clone()));
+        };
+
+        if crate::app_components::lifecycle_of_group(&mls_group)?
+            != Some(GroupLifecycleV1::Disbanded)
+        {
+            // An active branch won. The irreversible local request survives,
+            // but every epoch-bound terminal candidate is stale.
+            self.storage.clear_disband_candidates(group_id)?;
+            if let Some(mut request) = self.storage.disband_request(group_id)?
+                && request.status == DisbandRequestStatus::Pending
+            {
+                request.last_prepared_epoch = None;
+                self.storage.put_disband_request(&request)?;
+                self.schedule_pending_convergence_group(group_id);
+            }
+            return Ok(false);
+        }
+
+        let selected = origin_commit_id
+            .and_then(|commit_id| {
+                candidates.iter().find(|candidate| {
+                    &candidate.commit_id == commit_id || &candidate.content_commit_id == commit_id
+                })
+            })
+            .or_else(|| {
+                accepted_commit_ids.iter().rev().find_map(|commit_id_hex| {
+                    candidates.iter().find(|candidate| {
+                        hex::encode(candidate.commit_id.as_slice()) == *commit_id_hex
+                            || hex::encode(candidate.content_commit_id.as_slice()) == *commit_id_hex
+                    })
+                })
+            })
+            .or_else(|| {
+                let epoch = EpochId(mls_group.epoch().as_u64());
+                let mut matching_epoch = candidates
+                    .iter()
+                    .filter(|candidate| candidate.source_epoch.0.saturating_add(1) == epoch.0);
+                let only = matching_epoch.next()?;
+                matching_epoch.next().is_none().then_some(only)
+            })
+            .cloned()
+            .ok_or_else(|| {
+                EngineError::Backend(
+                    "selected Disbanded state has no authenticated candidate evidence".into(),
+                )
+            })?;
+        let epoch = EpochId(mls_group.epoch().as_u64());
+        let tombstone = cgka_traits::DisbandTombstone {
+            epoch,
+            actor: selected.actor.clone(),
+            origin_commit_id: Some(selected.commit_id.clone()),
+            commit_digest: selected.commit_digest,
+            local_was_committer_leaf: selected.local_was_committer_leaf,
+            former_members: selected.former_members.clone(),
+        };
+
+        self.storage
+            .with_transaction(|storage| -> Result<(), EngineError> {
+                storage.put_disband_tombstone(group_id, &tombstone)?;
+                let mut group = storage.get_group(group_id)?;
+                group.epoch = epoch;
+                group.members = tombstone.former_members.clone();
+                group.removed = false;
+                group.unrecoverable = false;
+                group.disbanded = Some(tombstone.clone());
+                storage.put_group(&group)?;
+                storage.clear_disband_request(group_id)?;
+                storage.clear_disband_candidates(group_id)?;
+                storage.clear_leave_request(group_id)?;
+                for queued in storage.list_queued_outbound_intents(group_id)? {
+                    storage.delete_queued_outbound_intent(&queued.id)?;
+                }
+                for fanout in storage.list_outbound_fanouts_for_group(group_id)? {
+                    storage.delete_outbound_fanout(fanout.message_id())?;
+                }
+                for welcome in storage
+                    .list_welcomes()?
+                    .into_iter()
+                    .filter(|welcome| &welcome.group_id == group_id)
+                {
+                    let _ = storage.take_welcome(&welcome.message_id)?;
+                }
+                storage.delete_convergence_pass(group_id)?;
+                for snapshot in storage.list_group_snapshots(group_id)? {
+                    storage.release_group_snapshot(group_id, &snapshot)?;
+                }
+                if let Some(maintenance) = storage.maintenance_storage() {
+                    maintenance.delete_group_maintenance(group_id)?;
+                    for obligation in
+                        maintenance.list_maintenance_obligations_for_group(group_id)?
+                    {
+                        maintenance.delete_maintenance_obligation(&obligation.id)?;
+                    }
+                    for evolution in maintenance.list_group_evolutions_for_group(group_id)? {
+                        maintenance.delete_group_evolution(&evolution.id)?;
+                    }
+                    for fanout in maintenance.list_transport_fanouts()? {
+                        if fanout.group_id.as_ref() == Some(group_id) {
+                            maintenance.delete_transport_fanout(&fanout.id)?;
+                        }
+                    }
+                }
+                let tx_provider =
+                    EngineOpenMlsProvider::<S>::new(&self.crypto, storage.mls_storage());
+                mls_group.delete(tx_provider.storage()).map_err(|error| {
+                    EngineError::Backend(format!("delete MLS group: {error:?}"))
+                })?;
+                Ok(())
+            })?;
+
+        self.transport_group_id_index
+            .retain(|_, mapped_group| mapped_group != group_id);
+        self.pending_convergence_groups.remove(group_id);
+        self.leaving_groups.remove(group_id);
+        self.drop_self_remove_auto_commit_schedules_for_group(group_id);
+        self.epoch_manager.mark_disbanded(group_id, epoch)?;
+        self.push_group_state_change(
+            group_id,
+            epoch,
+            Some(tombstone.actor),
+            cgka_traits::GroupStateChange::GroupDisbanded,
+            tombstone.origin_commit_id,
+        );
+        Ok(true)
+    }
+}
+
+pub(crate) fn deduplicated_roster(
+    members: &[cgka_traits::group::Member],
+) -> Vec<cgka_traits::group::Member> {
+    let mut seen = HashSet::new();
+    members
+        .iter()
+        .filter(|member| seen.insert(member.id.clone()))
+        .cloned()
+        .collect()
+}

--- a/crates/cgka-engine/src/disband.rs
+++ b/crates/cgka-engine/src/disband.rs
@@ -246,6 +246,16 @@ impl<S: StorageProvider> Engine<S> {
         Ok(self.storage.disband_request(group_id)?)
     }
 
+    /// Whether outbound group work is gated while a terminal request or
+    /// authenticated terminal candidate awaits convergence.
+    ///
+    /// This deliberately differs from [`Self::disband_request`]: an inbound
+    /// disband Commit can make the group non-sendable before this account has a
+    /// local request of its own.
+    pub fn disbanding_in_progress(&self, group_id: &GroupId) -> Result<bool, EngineError> {
+        Ok(self.disband_request_pending(group_id)? || self.disband_candidate_pending(group_id)?)
+    }
+
     /// Account identifiers for leaves that do not yet advertise lifecycle-v1.
     ///
     /// This is an advisory read. The enable commit repeats the same check under

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -648,16 +648,20 @@ impl<S: StorageProvider> Engine<S> {
             .collect::<Result<Vec<_>, _>>()?;
         let context =
             ConvergenceInputContext::from_inputs(projected.iter().map(|(_, input)| *input));
-        let candidate_ids: HashSet<MessageId> = self
-            .storage
-            .list_disband_candidates(group_id)
-            .map_err(storage_projection_error)?
-            .into_iter()
-            .flat_map(|candidate| [candidate.commit_id, candidate.content_commit_id])
-            .collect();
-        let has_terminal_trigger = projected
-            .iter()
-            .any(|(member, _)| candidate_ids.contains(&member.message_id));
+        let has_terminal_trigger = if projected.is_empty() {
+            false
+        } else {
+            let candidate_ids: HashSet<MessageId> = self
+                .storage
+                .list_disband_candidates(group_id)
+                .map_err(storage_projection_error)?
+                .into_iter()
+                .flat_map(|candidate| [candidate.commit_id, candidate.content_commit_id])
+                .collect();
+            projected
+                .iter()
+                .any(|(member, _)| candidate_ids.contains(&member.message_id))
+        };
         let has_trigger = has_terminal_trigger
             || projected
                 .iter()

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -648,9 +648,20 @@ impl<S: StorageProvider> Engine<S> {
             .collect::<Result<Vec<_>, _>>()?;
         let context =
             ConvergenceInputContext::from_inputs(projected.iter().map(|(_, input)| *input));
-        let has_trigger = projected
+        let candidate_ids: HashSet<MessageId> = self
+            .storage
+            .list_disband_candidates(group_id)
+            .map_err(storage_projection_error)?
+            .into_iter()
+            .flat_map(|candidate| [candidate.commit_id, candidate.content_commit_id])
+            .collect();
+        let has_terminal_trigger = projected
             .iter()
-            .any(|(_, input)| context.opens_pass(*input));
+            .any(|(member, _)| candidate_ids.contains(&member.message_id));
+        let has_trigger = has_terminal_trigger
+            || projected
+                .iter()
+                .any(|(_, input)| context.opens_pass(*input));
         Ok((
             projected.into_iter().map(|(member, _)| member).collect(),
             has_trigger,
@@ -1164,7 +1175,7 @@ impl<S: StorageProvider> Engine<S> {
         let origin_commit_actor =
             single_accepted_commit_actor(&observations, origin_commit_id.as_ref());
 
-        if let Some(selected_tip) = result.selected_tip {
+        let terminalized = if let Some(selected_tip) = result.selected_tip {
             let selected_tip = EpochId(selected_tip);
             self.epoch_manager
                 .set_stable(group_id.clone(), selected_tip);
@@ -1186,17 +1197,34 @@ impl<S: StorageProvider> Engine<S> {
                     now_ms,
                 );
             }
-            self.emit_convergence_events(
+            let terminalized = self
+                .settle_disband_after_convergence(
+                    group_id,
+                    &result.accepted_commits,
+                    origin_commit_id.as_ref(),
+                )
+                .map_err(|error| OpenMlsProjectionError::Storage(error.to_string()))?;
+            if !terminalized {
+                self.emit_convergence_events(
+                    group_id,
+                    previous_group.members,
+                    &previous_name,
+                    previous_components,
+                    previous_tip,
+                    selected_tip,
+                    origin_commit_id,
+                    origin_commit_actor,
+                )?;
+            }
+            terminalized
+        } else {
+            self.settle_disband_after_convergence(
                 group_id,
-                previous_group.members,
-                &previous_name,
-                previous_components,
-                previous_tip,
-                selected_tip,
-                origin_commit_id,
-                origin_commit_actor,
-            )?;
-        }
+                &result.accepted_commits,
+                origin_commit_id.as_ref(),
+            )
+            .map_err(|error| OpenMlsProjectionError::Storage(error.to_string()))?
+        };
         self.emit_application_replay_events(group_id, &observations);
         self.emit_invalidated_app_events(group_id, &result)?;
         self.emit_rejected_proposal_convergence_audits(group_id, &result);
@@ -1206,7 +1234,7 @@ impl<S: StorageProvider> Engine<S> {
         // A selected branch reached the canonical state (Settled): the run is
         // applied/stable. With no selected branch the pass simply settled with
         // nothing to apply.
-        let applied_phase = if result.selected_tip.is_some() {
+        let applied_phase = if terminalized || result.selected_tip.is_some() {
             ConvergencePhase::Applied
         } else {
             ConvergencePhase::Stable

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -525,6 +525,10 @@ impl<S: StorageProvider> EngineBuilder<S> {
 }
 
 impl<S: StorageProvider> Engine<S> {
+    pub fn epoch_state(&self, group_id: &GroupId) -> Option<cgka_traits::EpochState> {
+        self.epoch_manager.state(group_id).cloned()
+    }
+
     /// Persist a frozen transport fanout before or after one lifecycle edge.
     pub fn put_outbound_fanout(&self, fanout: &OutboundFanout) -> Result<(), EngineError> {
         if let Some(group_id) = fanout.group_id() {
@@ -818,6 +822,7 @@ impl<S: StorageProvider> Engine<S> {
         let mut rows = Vec::new();
 
         let main = match result {
+            SendResult::NoChange { .. } | SendResult::DisbandRequested { .. } => None,
             SendResult::ApplicationMessage { msg, .. } => {
                 Some((msg, MessageArtifactKind::ApplicationMessage))
             }
@@ -971,9 +976,16 @@ impl<S: StorageProvider> Engine<S> {
     }
 
     pub fn hydrate_stable_groups_from_storage(&mut self) -> Result<(), EngineError> {
-        for group_id in self.storage.list_groups()? {
+        let stored_groups = self.storage.list_groups()?;
+        let stored_group_ids = stored_groups.iter().cloned().collect::<HashSet<_>>();
+        for group_id in stored_groups {
             if let Err(reason) = self.hydrate_one_stored_group(&group_id) {
                 self.quarantine_stored_group_on_hydrate(&group_id, reason);
+            }
+        }
+        for (group_id, tombstone) in self.storage.list_disband_tombstones()? {
+            if !stored_group_ids.contains(&group_id) {
+                self.restore_disband_tombstone(group_id, tombstone);
             }
         }
         Ok(())
@@ -987,14 +999,50 @@ impl<S: StorageProvider> Engine<S> {
             .storage
             .list_groups()?
             .into_iter()
-            .filter(|group_id| self.epoch_manager.state(group_id).is_some())
+            .filter(|group_id| {
+                self.epoch_manager.state(group_id).is_some_and(|state| {
+                    !matches!(state, cgka_traits::engine_state::EpochState::Disbanded(_))
+                })
+            })
             .collect())
+    }
+
+    fn restore_disband_tombstone(
+        &mut self,
+        group_id: GroupId,
+        tombstone: cgka_traits::DisbandTombstone,
+    ) {
+        self.epoch_manager
+            .restore_disbanded(group_id.clone(), tombstone.epoch);
+        self.events_buf.push_back(GroupEvent::GroupStateChanged {
+            group_id,
+            epoch: tombstone.epoch,
+            actor: Some(tombstone.actor),
+            change: GroupStateChange::GroupDisbanded,
+            origin_commit_id: tombstone.origin_commit_id,
+        });
     }
 
     fn hydrate_one_stored_group(
         &mut self,
         group_id: &GroupId,
     ) -> Result<EpochId, GroupHydrationQuarantineReason> {
+        let group = self
+            .storage
+            .get_group(group_id)
+            .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
+        let tombstone = group
+            .disbanded
+            .clone()
+            .or_else(|| self.storage.disband_tombstone(group_id).ok().flatten());
+        if let Some(tombstone) = tombstone {
+            // Reconcile the single deterministic system row after a crash. The
+            // application projection canonicalizes this event, so replaying it
+            // on open is idempotent.
+            let epoch = tombstone.epoch;
+            self.restore_disband_tombstone(group_id.clone(), tombstone);
+            return Ok(epoch);
+        }
         // A retained-anchor convergence probe durably rewinds the group while
         // it explores historical candidates. Process termination cannot run
         // the in-process rollback guard, so restore its pre-probe live snapshot

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -526,6 +526,9 @@ impl<S: StorageProvider> EngineBuilder<S> {
 
 impl<S: StorageProvider> Engine<S> {
     pub fn epoch_state(&self, group_id: &GroupId) -> Option<cgka_traits::EpochState> {
+        if self.ensure_group_live(group_id).is_err() {
+            return None;
+        }
         self.epoch_manager.state(group_id).cloned()
     }
 
@@ -985,7 +988,7 @@ impl<S: StorageProvider> Engine<S> {
         }
         for (group_id, tombstone) in self.storage.list_disband_tombstones()? {
             if !stored_group_ids.contains(&group_id) {
-                self.restore_disband_tombstone(group_id, tombstone);
+                self.restore_disband_tombstone(group_id, tombstone)?;
             }
         }
         Ok(())
@@ -1011,9 +1014,9 @@ impl<S: StorageProvider> Engine<S> {
         &mut self,
         group_id: GroupId,
         tombstone: cgka_traits::DisbandTombstone,
-    ) {
+    ) -> Result<(), EngineError> {
         self.epoch_manager
-            .restore_disbanded(group_id.clone(), tombstone.epoch);
+            .restore_disbanded(group_id.clone(), tombstone.epoch)?;
         self.events_buf.push_back(GroupEvent::GroupStateChanged {
             group_id,
             epoch: tombstone.epoch,
@@ -1021,6 +1024,7 @@ impl<S: StorageProvider> Engine<S> {
             change: GroupStateChange::GroupDisbanded,
             origin_commit_id: tombstone.origin_commit_id,
         });
+        Ok(())
     }
 
     fn hydrate_one_stored_group(
@@ -1031,16 +1035,20 @@ impl<S: StorageProvider> Engine<S> {
             .storage
             .get_group(group_id)
             .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
-        let tombstone = group
-            .disbanded
-            .clone()
-            .or_else(|| self.storage.disband_tombstone(group_id).ok().flatten());
+        let tombstone = match group.disbanded.clone() {
+            Some(tombstone) => Some(tombstone),
+            None => self
+                .storage
+                .disband_tombstone(group_id)
+                .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?,
+        };
         if let Some(tombstone) = tombstone {
             // Reconcile the single deterministic system row after a crash. The
             // application projection canonicalizes this event, so replaying it
             // on open is idempotent.
             let epoch = tombstone.epoch;
-            self.restore_disband_tombstone(group_id.clone(), tombstone);
+            self.restore_disband_tombstone(group_id.clone(), tombstone)
+                .map_err(|_| GroupHydrationQuarantineReason::GroupRecordLoadFailed)?;
             return Ok(epoch);
         }
         // A retained-anchor convergence probe durably rewinds the group while

--- a/crates/cgka-engine/src/epoch_manager.rs
+++ b/crates/cgka-engine/src/epoch_manager.rs
@@ -107,14 +107,16 @@ impl EpochManager {
     /// Set a group's state to `Stable { epoch }`. Used by the join-welcome
     /// path (no prior state) and by the merge-to-stable path post-confirm.
     ///
-    /// Refuses to overwrite `Unrecoverable`: the only legal exit is
-    /// [`Self::repair_to_stable`] after a verified repair path (mdk#971).
+    /// Refuses to overwrite `Unrecoverable` or terminal `Disbanded`: the only
+    /// legal exit from `Unrecoverable` is [`Self::repair_to_stable`] after a
+    /// verified repair path (mdk#971), while `Disbanded` has no outgoing
+    /// transition.
     pub(crate) fn set_stable(&mut self, group_id: GroupId, epoch: EpochId) {
         if self.is_unrecoverable(&group_id) || self.is_disbanded(&group_id) {
             tracing::warn!(
                 target: "cgka_engine::epoch_manager",
                 method = "set_stable",
-                "refusing set_stable while Unrecoverable; verified repair must use repair_to_stable"
+                "refusing set_stable while Unrecoverable or Disbanded; verified repair must use repair_to_stable"
             );
             return;
         }
@@ -409,11 +411,17 @@ impl EpochManager {
         Ok(())
     }
 
-    pub(crate) fn restore_disbanded(&mut self, group_id: GroupId, epoch: EpochId) {
+    pub(crate) fn restore_disbanded(
+        &mut self,
+        group_id: GroupId,
+        epoch: EpochId,
+    ) -> Result<(), EngineError> {
         let recovering = EpochState::stable(epoch).detect_fork(Vec::new());
-        if let Ok(disbanded) = recovering.settle_to_disbanded(epoch) {
-            self.states.insert(group_id, disbanded);
-        }
+        let disbanded = recovering
+            .settle_to_disbanded(epoch)
+            .map_err(EngineError::InvalidTransition)?;
+        self.states.insert(group_id, disbanded);
+        Ok(())
     }
 }
 

--- a/crates/cgka-engine/src/epoch_manager.rs
+++ b/crates/cgka-engine/src/epoch_manager.rs
@@ -52,6 +52,7 @@ struct PendingMeta {
 pub(crate) enum PendingKind {
     CreateGroup,
     GroupEvolution,
+    Disband,
 }
 
 #[derive(Default)]
@@ -109,7 +110,7 @@ impl EpochManager {
     /// Refuses to overwrite `Unrecoverable`: the only legal exit is
     /// [`Self::repair_to_stable`] after a verified repair path (mdk#971).
     pub(crate) fn set_stable(&mut self, group_id: GroupId, epoch: EpochId) {
-        if self.is_unrecoverable(&group_id) {
+        if self.is_unrecoverable(&group_id) || self.is_disbanded(&group_id) {
             tracing::warn!(
                 target: "cgka_engine::epoch_manager",
                 method = "set_stable",
@@ -382,6 +383,37 @@ impl EpochManager {
         self.states
             .get(group_id)
             .is_some_and(|s| s.is_unrecoverable())
+    }
+
+    pub(crate) fn is_disbanded(&self, group_id: &GroupId) -> bool {
+        self.states
+            .get(group_id)
+            .is_some_and(EpochState::is_disbanded)
+    }
+
+    pub(crate) fn mark_disbanded(
+        &mut self,
+        group_id: &GroupId,
+        epoch: EpochId,
+    ) -> Result<(), EngineError> {
+        let previous = self
+            .states
+            .get(group_id)
+            .cloned()
+            .unwrap_or_else(|| EpochState::stable(epoch));
+        let next = previous
+            .detect_fork(Vec::new())
+            .settle_to_disbanded(epoch)
+            .map_err(EngineError::InvalidTransition)?;
+        self.states.insert(group_id.clone(), next);
+        Ok(())
+    }
+
+    pub(crate) fn restore_disbanded(&mut self, group_id: GroupId, epoch: EpochId) {
+        let recovering = EpochState::stable(epoch).detect_fork(Vec::new());
+        if let Ok(disbanded) = recovering.settle_to_disbanded(epoch) {
+            self.states.insert(group_id, disbanded);
+        }
     }
 }
 

--- a/crates/cgka-engine/src/group_lifecycle.rs
+++ b/crates/cgka-engine/src/group_lifecycle.rs
@@ -530,6 +530,7 @@ impl<S: StorageProvider> Engine<S> {
             protocol_profile: self.new_protocol_profile,
             removed: false,
             unrecoverable: false,
+            disbanded: None,
             join_epoch: EpochId(mls_group.epoch().as_u64()),
         };
         if self.new_protocol_profile == ProtocolProfile::Legacy {
@@ -988,6 +989,9 @@ impl<S: StorageProvider> Engine<S> {
                         .as_slice()
                         .to_vec(),
                 );
+                if storage.disband_tombstone(&group_id)?.is_some() {
+                    return Err(EngineError::InvalidWelcome);
+                }
 
                 let (local_state_is_stale, repaired_unrecoverable) =
                     match storage.get_group(&group_id) {
@@ -1108,6 +1112,7 @@ impl<S: StorageProvider> Engine<S> {
                     protocol_profile,
                     removed: false,
                     unrecoverable: false,
+                    disbanded: None,
                     join_epoch: EpochId(mls_group.epoch().as_u64()),
                 };
                 mirror_app_components_into_record(&mls_group, &mut group_record);

--- a/crates/cgka-engine/src/lib.rs
+++ b/crates/cgka-engine/src/lib.rs
@@ -44,6 +44,7 @@ pub mod capabilities;
 pub mod capability_manager;
 pub mod convergence;
 pub(crate) mod convergence_input;
+pub mod disband;
 pub mod distributed_convergence;
 pub mod engine;
 pub mod engine_metrics;

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -143,6 +143,16 @@ impl<S: StorageProvider> Engine<S> {
     ) -> Result<IngestOutcome, EngineError> {
         let group_id = self.group_id_for_transport_group_id(&transport_group_id)?;
 
+        // Authenticated terminal evidence is permanent. Drop late traffic
+        // before the missing-OpenMLS fallback can retain it as retryable
+        // unknown-group input.
+        if self.storage.disband_tombstone(&group_id)?.is_some() {
+            self.storage.put_ingress_dedup_marker(&msg.id)?;
+            return Ok(IngestOutcome::Ignored {
+                category: InputRejectionCategory::UnknownGroup,
+            });
+        }
+
         // Quarantine gate (mdk#364): a group frozen by hydration
         // quarantine must not process any input — its OpenMLS state may load
         // fine (e.g. MemberValidationFailed) and a merged commit would call

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1149,6 +1149,30 @@ impl<S: StorageProvider> Engine<S> {
                         self.update_stored_message_state(&msg.id, MessageState::Failed)?;
                         return Err(err);
                     }
+                    // A valid terminal Commit never takes the direct merge
+                    // shortcut. Persist its authenticated evidence and force
+                    // the same bounded convergence pass used for competing
+                    // branches; terminal cleanup happens only after selection.
+                    if crate::app_components::staged_commit_disbands(&mls_group, &staged)? {
+                        self.record_inbound_disband_candidate(
+                            &group_id,
+                            before,
+                            msg.id.clone(),
+                            mls_bytes.as_slice(),
+                            commit_committer,
+                            committer_index == mls_group.own_leaf_index(),
+                        )?;
+                        let now_ms = self.convergence_now_ms();
+                        let result = self
+                            .converge_stored_openmls_messages(&group_id, now_ms)
+                            .map_err(|error| EngineError::Backend(format!("converge: {error}")))?;
+                        return Ok(convergence_ingest_outcome(
+                            &result,
+                            msg,
+                            group_id,
+                            current_epoch,
+                        ));
+                    }
                     // Classify departures before the merge consumes the staged
                     // commit and the leaving leaves disappear: a SelfRemove is a
                     // member leaving (attributed to themselves); a Remove is an
@@ -2180,7 +2204,11 @@ impl<S: StorageProvider> Engine<S> {
     ) -> Result<GroupId, EngineError> {
         let direct = GroupId::new(transport_group_id.to_vec());
         match self.storage.get_group(&direct) {
-            Ok(group) => return Ok(group.id),
+            Ok(group) => {
+                if self.storage.disband_tombstone(&group.id)?.is_none() {
+                    return Ok(group.id);
+                }
+            }
             Err(StorageError::NotFound) => {}
             Err(err) => return Err(EngineError::Storage(err)),
         }

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -248,7 +248,7 @@ impl<S: StorageProvider> Engine<S> {
                 },
             ));
         }
-        if self.disband_request_pending(&group_id)? || self.disband_candidate_pending(&group_id)? {
+        if self.disbanding_in_progress(&group_id)? {
             return Err(EngineError::InvalidTransition(
                 cgka_traits::engine_state::InvalidTransition {
                     from: "Disbanding",

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -193,6 +193,21 @@ impl<S: StorageProvider> Engine<S> {
         // stage, queue, or publish anything — a confirm would set_stable and
         // silently un-quarantine it out of band (mdk#364).
         self.ensure_group_live(&group_id)?;
+        if self.storage.disband_tombstone(&group_id)?.is_some() {
+            return Err(EngineError::InvalidTransition(
+                cgka_traits::engine_state::InvalidTransition {
+                    from: "Disbanded",
+                    to: crate::audit_helpers::send_intent_kind_str(&intent),
+                    reason: "Disbanded is terminal",
+                },
+            ));
+        }
+        // Disband is an intent-persistence operation, not a Commit-preparation
+        // operation. It remains acceptable while another staged Commit owns
+        // the group and while Unrecoverable is paused.
+        if matches!(&intent, SendIntent::Disband { .. }) {
+            return self.do_request_disband(group_id);
+        }
         // Strict cutover freezes membership growth in legacy groups. Existing
         // members may continue messaging and applying other group changes, but
         // no add (including a re-add) may be staged or queued.
@@ -230,6 +245,15 @@ impl<S: StorageProvider> Engine<S> {
                     from: "Unrecoverable",
                     to: crate::audit_helpers::send_intent_kind_str(&intent),
                     reason: "group is Unrecoverable pending verified repair",
+                },
+            ));
+        }
+        if self.disband_request_pending(&group_id)? || self.disband_candidate_pending(&group_id)? {
+            return Err(EngineError::InvalidTransition(
+                cgka_traits::engine_state::InvalidTransition {
+                    from: "Disbanding",
+                    to: crate::audit_helpers::send_intent_kind_str(&intent),
+                    reason: "disband requested or awaiting convergence",
                 },
             ));
         }
@@ -284,6 +308,9 @@ impl<S: StorageProvider> Engine<S> {
             .await?
         {
             return Ok(Vec::new());
+        }
+        if let Some(result) = self.prepare_pending_disband(group_id).await? {
+            return Ok(vec![result]);
         }
 
         let queued = self.storage.list_queued_outbound_intents(group_id)?;
@@ -363,6 +390,8 @@ impl<S: StorageProvider> Engine<S> {
                 }
                 SendResult::GroupCreated { .. }
                 | SendResult::FoundingGroupCreated { .. }
+                | SendResult::NoChange { .. }
+                | SendResult::DisbandRequested { .. }
                 | SendResult::Queued { .. } => {}
             }
             drained.push(result);
@@ -585,6 +614,9 @@ impl<S: StorageProvider> Engine<S> {
             && pass.is_active()
             && self.convergence_pass_gates_outbound(&pass)
         {
+            return Ok(true);
+        }
+        if self.disband_candidate_pending(group_id)? {
             return Ok(true);
         }
         // The convergence horizon is bounded on BOTH sides (mdk#736). The past
@@ -1271,7 +1303,9 @@ fn send_intent_group_id(intent: &SendIntent) -> &GroupId {
         | SendIntent::Leave { group_id }
         | SendIntent::SelfUpdate { group_id }
         | SendIntent::UpdateAppComponents { group_id, .. }
-        | SendIntent::UpdateGroupData { group_id, .. } => group_id,
+        | SendIntent::UpdateGroupData { group_id, .. }
+        | SendIntent::EnableDisbanding { group_id }
+        | SendIntent::Disband { group_id } => group_id,
     }
 }
 
@@ -1282,6 +1316,8 @@ fn is_admin_group_state_fairness_intent(intent: &SendIntent) -> bool {
             | SendIntent::RemoveMembers { .. }
             | SendIntent::UpdateAppComponents { .. }
             | SendIntent::UpdateGroupData { .. }
+            | SendIntent::EnableDisbanding { .. }
+            | SendIntent::Disband { .. }
     )
 }
 

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -65,6 +65,18 @@ impl<S: StorageProvider> Engine<S> {
                 },
             ));
         }
+        // Queued-intent drains call this method directly. A disband request or
+        // inbound terminal candidate can arrive after an ordinary intent was
+        // queued, so the durable gate must be repeated here before dispatch.
+        if self.disbanding_in_progress(&group_id)? {
+            return Err(EngineError::InvalidTransition(
+                cgka_traits::engine_state::InvalidTransition {
+                    from: "Disbanding",
+                    to: crate::audit_helpers::send_intent_kind_str(&intent),
+                    reason: "disband requested or awaiting convergence",
+                },
+            ));
+        }
         match intent {
             SendIntent::AppMessage { group_id, payload } => {
                 self.do_send_app_message(group_id, payload).await

--- a/crates/cgka-engine/src/message_processor/send.rs
+++ b/crates/cgka-engine/src/message_processor/send.rs
@@ -28,6 +28,15 @@ impl<S: StorageProvider> Engine<S> {
         intent: SendIntent,
     ) -> Result<SendResult, EngineError> {
         let group_id = super::send_intent_group_id(&intent).clone();
+        if self.storage.disband_tombstone(&group_id)?.is_some() {
+            return Err(EngineError::InvalidTransition(
+                cgka_traits::engine_state::InvalidTransition {
+                    from: "Disbanded",
+                    to: crate::audit_helpers::send_intent_kind_str(&intent),
+                    reason: "Disbanded is terminal",
+                },
+            ));
+        }
         // A local copy marked removed is terminal for outbound work: the spec
         // forbids preparing/publishing anything for it (member-departure.md,
         // "Realizing removal"), and the underlying OpenMLS state would only
@@ -80,6 +89,10 @@ impl<S: StorageProvider> Engine<S> {
                 self.do_send_update_group_data(group_id, name, description)
                     .await
             }
+            SendIntent::EnableDisbanding { group_id } => {
+                self.do_enable_group_disbanding(group_id).await
+            }
+            SendIntent::Disband { group_id } => self.do_request_disband(group_id),
         }
     }
 

--- a/crates/cgka-engine/src/message_processor/store.rs
+++ b/crates/cgka-engine/src/message_processor/store.rs
@@ -539,6 +539,7 @@ mod tests {
                 protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
                 removed: false,
                 unrecoverable: false,
+                disbanded: None,
                 join_epoch: EpochId(0),
             })
             .unwrap();

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -159,7 +159,9 @@ impl<S: StorageProvider> Engine<S> {
                 // never commit the merge + `Processed` write with a stale record.
                 let mut g = storage.get_group(&group_id)?;
                 g.epoch = EpochId(mls_group.epoch().as_u64());
-                g.members = crate::group_lifecycle::marmot_members(&mls_group);
+                if kind != crate::epoch_manager::PendingKind::Disband {
+                    g.members = crate::group_lifecycle::marmot_members(&mls_group);
+                }
                 g.required_capabilities = required_capabilities_from_group(&mls_group);
                 crate::group_lifecycle::mirror_app_components_into_record(&mls_group, &mut g);
                 storage.put_group(&g)?;
@@ -277,6 +279,11 @@ impl<S: StorageProvider> Engine<S> {
                 from: EpochId(new_epoch.0.saturating_sub(1)),
                 to: new_epoch,
             },
+            crate::epoch_manager::PendingKind::Disband => GroupEvent::EpochChanged {
+                group_id,
+                from: EpochId(new_epoch.0.saturating_sub(1)),
+                to: new_epoch,
+            },
         };
         let replay_group_id = match &event {
             GroupEvent::GroupCreated { group_id } | GroupEvent::EpochChanged { group_id, .. } => {
@@ -285,6 +292,11 @@ impl<S: StorageProvider> Engine<S> {
             _ => unreachable!("confirm only emits create/evolution events"),
         };
         self.events_buf.push_back(event.clone());
+        if kind == crate::epoch_manager::PendingKind::Disband {
+            self.pending_state_changes.remove(&pending);
+            self.schedule_pending_convergence_group(&replay_group_id);
+            return Ok(event);
+        }
         if let Some(changes) = self.pending_state_changes.remove(&pending) {
             for pending_change in changes {
                 self.push_group_state_change(
@@ -432,6 +444,14 @@ impl<S: StorageProvider> Engine<S> {
             ),
         );
         self.pending_state_changes.remove(&pending);
+        if kind == crate::epoch_manager::PendingKind::Disband {
+            self.storage.clear_disband_candidates(&group_id)?;
+            if let Some(mut request) = self.storage.disband_request(&group_id)? {
+                request.last_prepared_epoch = None;
+                self.storage.put_disband_request(&request)?;
+            }
+            self.schedule_pending_convergence_group(&group_id);
+        }
         if let Some((queued_group_id, _)) = self.queued_intent_by_pending.remove(&pending) {
             self.schedule_pending_convergence_group(&queued_group_id);
         }

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -331,6 +331,10 @@ impl<S: StorageProvider> Engine<S> {
             .epoch_manager
             .group_for_pending(pending)
             .ok_or(EngineError::UnknownPending)?;
+        let kind = self
+            .epoch_manager
+            .kind_for_pending(pending)
+            .ok_or(EngineError::UnknownPending)?;
 
         let mls_gid = openmls::group::GroupId::from_slice(group_id.as_slice());
         let mut mls_group = MlsGroup::load(provider.storage(), &mls_gid)
@@ -409,16 +413,19 @@ impl<S: StorageProvider> Engine<S> {
                     // evolution in the same transaction as the MLS clear.
                     maintenance.delete_group_evolution(&evolution.id)?;
                 }
+                if kind == crate::epoch_manager::PendingKind::Disband {
+                    storage.clear_disband_candidates(&group_id)?;
+                    if let Some(mut request) = storage.disband_request(&group_id)? {
+                        request.last_prepared_epoch = None;
+                        storage.put_disband_request(&request)?;
+                    }
+                }
                 Ok(())
             })?;
 
         if let (Some(fanout), Some(rolled_back)) = (fanout.take(), rolled_back_fanout) {
             *fanout = rolled_back;
         }
-        let kind = self
-            .epoch_manager
-            .kind_for_pending(pending)
-            .ok_or(EngineError::UnknownPending)?;
         let pending_epoch_pre = EpochId(mls_group.epoch().as_u64());
         let audit_context = self.epoch_manager.audit_context_for_pending(pending);
         let (group_id, prior_epoch) = self.epoch_manager.rollback_publish(pending)?;
@@ -445,11 +452,6 @@ impl<S: StorageProvider> Engine<S> {
         );
         self.pending_state_changes.remove(&pending);
         if kind == crate::epoch_manager::PendingKind::Disband {
-            self.storage.clear_disband_candidates(&group_id)?;
-            if let Some(mut request) = self.storage.disband_request(&group_id)? {
-                request.last_prepared_epoch = None;
-                self.storage.put_disband_request(&request)?;
-            }
             self.schedule_pending_convergence_group(&group_id);
         }
         if let Some((queued_group_id, _)) = self.queued_intent_by_pending.remove(&pending) {

--- a/crates/cgka-engine/tests/auto_commit_atomicity.rs
+++ b/crates/cgka-engine/tests/auto_commit_atomicity.rs
@@ -29,10 +29,11 @@ use cgka_traits::message::{MessageRecord, MessageState};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
-    ConvergencePassStorage, ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage,
-    LeaveRequest, LeaveRequestStorage, MemberValidationCacheStorage, MessageStorage,
-    OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent, StorageError,
-    StorageProvider, StorageResult, StoredKeyPackageBundle, WelcomeStorage,
+    ConvergencePassStorage, ConvergencePolicyStorage, DisbandCandidate, DisbandCandidateStorage,
+    DisbandRequest, DisbandRequestStorage, DisbandTombstoneStorage, GroupStorage,
+    KeyPackageBundleStorage, LeaveRequest, LeaveRequestStorage, MemberValidationCacheStorage,
+    MessageStorage, OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent,
+    StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle, WelcomeStorage,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -281,6 +282,53 @@ impl LeaveRequestStorage for FaultStorage {
     }
     fn clear_leave_request(&self, group_id: &GroupId) -> StorageResult<()> {
         self.inner.clear_leave_request(group_id)
+    }
+}
+
+impl DisbandRequestStorage for FaultStorage {
+    fn put_disband_request(&self, request: &DisbandRequest) -> StorageResult<()> {
+        self.inner.put_disband_request(request)
+    }
+    fn disband_request(&self, group_id: &GroupId) -> StorageResult<Option<DisbandRequest>> {
+        self.inner.disband_request(group_id)
+    }
+    fn clear_disband_request(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.inner.clear_disband_request(group_id)
+    }
+}
+
+impl DisbandCandidateStorage for FaultStorage {
+    fn put_disband_candidate(&self, candidate: &DisbandCandidate) -> StorageResult<()> {
+        self.inner.put_disband_candidate(candidate)
+    }
+    fn disband_candidate(
+        &self,
+        group_id: &GroupId,
+        commit_id: &MessageId,
+    ) -> StorageResult<Option<DisbandCandidate>> {
+        self.inner.disband_candidate(group_id, commit_id)
+    }
+    fn list_disband_candidates(&self, group_id: &GroupId) -> StorageResult<Vec<DisbandCandidate>> {
+        self.inner.list_disband_candidates(group_id)
+    }
+    fn clear_disband_candidates(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.inner.clear_disband_candidates(group_id)
+    }
+}
+
+impl DisbandTombstoneStorage for FaultStorage {
+    fn put_disband_tombstone(
+        &self,
+        group_id: &GroupId,
+        tombstone: &cgka_traits::DisbandTombstone,
+    ) -> StorageResult<()> {
+        self.inner.put_disband_tombstone(group_id, tombstone)
+    }
+    fn disband_tombstone(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Option<cgka_traits::DisbandTombstone>> {
+        self.inner.disband_tombstone(group_id)
     }
 }
 

--- a/crates/cgka-engine/tests/auto_commit_atomicity.rs
+++ b/crates/cgka-engine/tests/auto_commit_atomicity.rs
@@ -330,6 +330,11 @@ impl DisbandTombstoneStorage for FaultStorage {
     ) -> StorageResult<Option<cgka_traits::DisbandTombstone>> {
         self.inner.disband_tombstone(group_id)
     }
+    fn list_disband_tombstones(
+        &self,
+    ) -> StorageResult<Vec<(GroupId, cgka_traits::DisbandTombstone)>> {
+        self.inner.list_disband_tombstones()
+    }
 }
 
 impl WelcomeStorage for FaultStorage {

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -17,7 +17,8 @@ use cgka_traits::EngineError;
 use cgka_traits::app_components::{
     ACCOUNT_IDENTITY_PROOF_COMPONENT_ID, APP_COMPONENTS_COMPONENT_ID, AppComponentData,
     EncryptedMediaPolicyV2, GROUP_ADMIN_POLICY_COMPONENT_ID, GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID,
-    GROUP_PROFILE_COMPONENT_ID, NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1,
+    GROUP_LIFECYCLE_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID, GroupLifecycleV1,
+    NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1, decode_group_lifecycle_v1,
     default_group_components, encode_components_list, encode_encrypted_media_policy_v2,
     encode_nostr_routing_v1,
 };
@@ -31,7 +32,7 @@ use cgka_traits::ingest::{PeeledContent, PeeledMessage};
 use cgka_traits::message::StoredMessagePayload;
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
-    GroupStorage, KeyPackageBundleStorage, MessageStorage, StorageProvider,
+    ConvergencePassStorage, GroupStorage, KeyPackageBundleStorage, MessageStorage, StorageProvider,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -1187,6 +1188,22 @@ async fn current_solo_group_is_canonical_at_epoch_zero_without_confirmation() {
     let group = alice.group_record(&group_id).unwrap();
     assert_eq!(group.epoch, cgka_traits::types::EpochId(0));
     assert_eq!(group.members.len(), 1);
+    assert!(
+        group
+            .required_capabilities
+            .app_components
+            .contains(GROUP_LIFECYCLE_COMPONENT_ID)
+    );
+    assert_eq!(
+        decode_group_lifecycle_v1(
+            &alice
+                .app_component(&group_id, GROUP_LIFECYCLE_COMPONENT_ID)
+                .unwrap()
+                .expect("new current group has lifecycle-v1"),
+        )
+        .unwrap(),
+        GroupLifecycleV1::Active
+    );
     assert!(matches!(
         alice.drain_events().as_slice(),
         [cgka_traits::engine::GroupEvent::GroupCreated { group_id: created }]
@@ -1201,6 +1218,161 @@ async fn current_solo_group_is_canonical_at_epoch_zero_without_confirmation() {
         .await
         .expect("canonical solo group accepts work without confirm_published");
     assert!(matches!(sent, SendResult::ApplicationMessage { .. }));
+}
+
+#[tokio::test]
+async fn solo_disband_is_durable_convergent_terminal_and_restart_safe() {
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let identity = b"alice-current-solo-disband";
+    let mut alice =
+        build_profile_client_on_storage(identity, storage.clone(), ProtocolProfile::Current);
+    let (group_id, created) = alice
+        .create_group(CreateGroupRequest {
+            name: "terminal solo".into(),
+            description: String::new(),
+            members: vec![],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    assert!(matches!(
+        created,
+        SendResult::FoundingGroupCreated { ref welcomes } if welcomes.is_empty()
+    ));
+    alice.drain_events();
+
+    let requested = alice
+        .send(cgka_traits::engine::SendIntent::Disband {
+            group_id: group_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert!(matches!(requested, SendResult::DisbandRequested { .. }));
+    assert!(matches!(
+        alice.disband_request(&group_id).unwrap().unwrap().status,
+        cgka_traits::DisbandRequestStatus::Pending
+    ));
+    assert!(
+        alice
+            .send(cgka_traits::engine::SendIntent::AppMessage {
+                group_id: group_id.clone(),
+                payload: app_payload_for(&alice, "must be gated"),
+            })
+            .await
+            .is_err(),
+        "durable request acceptance gates ordinary outbound work immediately"
+    );
+
+    let prepared = alice.advance_convergence(&group_id).await.unwrap();
+    let pending = match prepared.as_slice() {
+        [
+            SendResult::GroupEvolution {
+                pending, welcomes, ..
+            },
+        ] => {
+            assert!(welcomes.is_empty());
+            *pending
+        }
+        other => panic!("expected one prepared disband commit, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    assert!(
+        !matches!(
+            alice.epoch_state(&group_id),
+            Some(cgka_traits::EpochState::Disbanded(_))
+        ),
+        "publish confirmation alone must not terminalize before convergence"
+    );
+
+    for _ in 0..24 {
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        assert!(
+            alice
+                .advance_convergence(&group_id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        if matches!(
+            alice.epoch_state(&group_id),
+            Some(cgka_traits::EpochState::Disbanded(_))
+        ) {
+            break;
+        }
+    }
+    assert!(
+        matches!(
+            alice.epoch_state(&group_id),
+            Some(cgka_traits::EpochState::Disbanded(_))
+        ),
+        "disband did not settle within the bounded convergence pass: state={:?}, pass={:?}",
+        alice.epoch_state(&group_id),
+        storage.convergence_pass(&group_id).unwrap()
+    );
+    let terminal = alice.group_record(&group_id).unwrap();
+    assert!(terminal.disbanded.is_some());
+    assert_eq!(
+        terminal.members.len(),
+        1,
+        "historical pre-disband account roster is retained"
+    );
+    assert!(alice.disband_request(&group_id).unwrap().is_none());
+    let state_changes = alice
+        .drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            cgka_traits::engine::GroupEvent::GroupStateChanged { change, .. } => Some(change),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        state_changes,
+        vec![cgka_traits::engine::GroupStateChange::GroupDisbanded],
+        "the terminal commit suppresses member/admin removal changes"
+    );
+
+    drop(alice);
+    let mut reopened =
+        build_profile_client_on_storage(identity, storage.clone(), ProtocolProfile::Current);
+    reopened.hydrate_stable_groups_from_storage().unwrap();
+    assert!(matches!(
+        reopened.epoch_state(&group_id),
+        Some(cgka_traits::EpochState::Disbanded(_))
+    ));
+    assert!(
+        reopened
+            .group_record(&group_id)
+            .unwrap()
+            .disbanded
+            .is_some()
+    );
+    assert!(reopened.quarantined_groups().is_empty());
+
+    drop(reopened);
+    assert!(
+        storage
+            .delete_local_group_data(&hex::encode(group_id.as_slice()))
+            .unwrap(),
+        "terminal local deletion should remove history and the full group row"
+    );
+    let mut tombstone_only =
+        build_profile_client_on_storage(identity, storage, ProtocolProfile::Current);
+    tombstone_only.hydrate_stable_groups_from_storage().unwrap();
+    assert!(matches!(
+        tombstone_only.epoch_state(&group_id),
+        Some(cgka_traits::EpochState::Disbanded(_))
+    ));
+    assert!(
+        tombstone_only.live_group_ids().unwrap().is_empty(),
+        "a tombstone-only group is terminal but never live/routable"
+    );
+    assert!(tombstone_only.quarantined_groups().is_empty());
+    assert!(
+        tombstone_only.group_record(&group_id).is_err(),
+        "full group metadata is optional after the user deletes local history"
+    );
 }
 
 #[tokio::test]

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -1327,6 +1327,27 @@ async fn solo_disband_is_durable_convergent_terminal_and_restart_safe() {
         !alice.disbanding_in_progress(&group_id).unwrap(),
         "terminal state is reported by the lifecycle, not as pending work"
     );
+    let late_message_id = MessageId::new(b"late-terminal-group-traffic".to_vec());
+    let late = TransportMessage {
+        id: late_message_id.clone(),
+        payload: b"never peel terminal traffic".to_vec(),
+        timestamp: Timestamp(0),
+        causal_deps: vec![],
+        source: TransportSource("mock".into()),
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+    };
+    assert!(matches!(
+        alice.ingest(late).await.unwrap(),
+        cgka_traits::ingest::IngestOutcome::Ignored {
+            category: cgka_traits::ingest::InputRejectionCategory::UnknownGroup,
+        }
+    ));
+    assert!(
+        storage.get_message(&late_message_id).is_err(),
+        "late terminal traffic must not become a retryable message row"
+    );
     let state_changes = alice
         .drain_events()
         .into_iter()

--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -1255,6 +1255,10 @@ async fn solo_disband_is_durable_convergent_terminal_and_restart_safe() {
         cgka_traits::DisbandRequestStatus::Pending
     ));
     assert!(
+        alice.disbanding_in_progress(&group_id).unwrap(),
+        "the client-facing gate becomes visible with the durable request"
+    );
+    assert!(
         alice
             .send(cgka_traits::engine::SendIntent::AppMessage {
                 group_id: group_id.clone(),
@@ -1319,6 +1323,10 @@ async fn solo_disband_is_durable_convergent_terminal_and_restart_safe() {
         "historical pre-disband account roster is retained"
     );
     assert!(alice.disband_request(&group_id).unwrap().is_none());
+    assert!(
+        !alice.disbanding_in_progress(&group_id).unwrap(),
+        "terminal state is reported by the lifecycle, not as pending work"
+    );
     let state_changes = alice
         .drain_events()
         .into_iter()

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -13,10 +13,11 @@ use cgka_traits::message::{MessageRecord, MessageState};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
-    ConvergencePassStorage, ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage,
-    LeaveRequest, LeaveRequestStorage, MemberValidationCacheStorage, MessageStorage,
-    OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent, StorageError,
-    StorageProvider, StorageResult, StoredKeyPackageBundle, WelcomeStorage,
+    ConvergencePassStorage, ConvergencePolicyStorage, DisbandCandidate, DisbandCandidateStorage,
+    DisbandRequest, DisbandRequestStorage, DisbandTombstoneStorage, GroupStorage,
+    KeyPackageBundleStorage, LeaveRequest, LeaveRequestStorage, MemberValidationCacheStorage,
+    MessageStorage, OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent,
+    StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle, WelcomeStorage,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -184,6 +185,7 @@ fn insert_marmot_group_without_openmls_state(
             protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
             removed: false,
             unrecoverable: false,
+            disbanded: None,
             join_epoch: EpochId(0),
         })
         .expect("insert marmot group record without openmls state");
@@ -470,6 +472,53 @@ impl LeaveRequestStorage for FlakyGroupRecordStorage {
     }
     fn clear_leave_request(&self, group_id: &GroupId) -> StorageResult<()> {
         self.inner.clear_leave_request(group_id)
+    }
+}
+
+impl DisbandRequestStorage for FlakyGroupRecordStorage {
+    fn put_disband_request(&self, request: &DisbandRequest) -> StorageResult<()> {
+        self.inner.put_disband_request(request)
+    }
+    fn disband_request(&self, group_id: &GroupId) -> StorageResult<Option<DisbandRequest>> {
+        self.inner.disband_request(group_id)
+    }
+    fn clear_disband_request(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.inner.clear_disband_request(group_id)
+    }
+}
+
+impl DisbandCandidateStorage for FlakyGroupRecordStorage {
+    fn put_disband_candidate(&self, candidate: &DisbandCandidate) -> StorageResult<()> {
+        self.inner.put_disband_candidate(candidate)
+    }
+    fn disband_candidate(
+        &self,
+        group_id: &GroupId,
+        commit_id: &MessageId,
+    ) -> StorageResult<Option<DisbandCandidate>> {
+        self.inner.disband_candidate(group_id, commit_id)
+    }
+    fn list_disband_candidates(&self, group_id: &GroupId) -> StorageResult<Vec<DisbandCandidate>> {
+        self.inner.list_disband_candidates(group_id)
+    }
+    fn clear_disband_candidates(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.inner.clear_disband_candidates(group_id)
+    }
+}
+
+impl DisbandTombstoneStorage for FlakyGroupRecordStorage {
+    fn put_disband_tombstone(
+        &self,
+        group_id: &GroupId,
+        tombstone: &cgka_traits::DisbandTombstone,
+    ) -> StorageResult<()> {
+        self.inner.put_disband_tombstone(group_id, tombstone)
+    }
+    fn disband_tombstone(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Option<cgka_traits::DisbandTombstone>> {
+        self.inner.disband_tombstone(group_id)
     }
 }
 

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -342,6 +342,7 @@ async fn hydration_quarantines_first_bad_group_and_continues_to_later_healthy_gr
 struct FlakyGroupRecordStorage {
     inner: SqliteAccountStorage,
     fail_get_group: Arc<AtomicBool>,
+    fail_disband_tombstone: Arc<AtomicBool>,
     fail_list_queued_outbound_intents: Arc<AtomicBool>,
 }
 
@@ -350,12 +351,17 @@ impl FlakyGroupRecordStorage {
         Self {
             inner,
             fail_get_group: Arc::new(AtomicBool::new(false)),
+            fail_disband_tombstone: Arc::new(AtomicBool::new(false)),
             fail_list_queued_outbound_intents: Arc::new(AtomicBool::new(false)),
         }
     }
 
     fn set_fail_get_group(&self, fail: bool) {
         self.fail_get_group.store(fail, Ordering::SeqCst);
+    }
+
+    fn set_fail_disband_tombstone(&self, fail: bool) {
+        self.fail_disband_tombstone.store(fail, Ordering::SeqCst);
     }
 
     fn set_fail_list_queued_outbound_intents(&self, fail: bool) {
@@ -518,7 +524,17 @@ impl DisbandTombstoneStorage for FlakyGroupRecordStorage {
         &self,
         group_id: &GroupId,
     ) -> StorageResult<Option<cgka_traits::DisbandTombstone>> {
+        if self.fail_disband_tombstone.load(Ordering::SeqCst) {
+            return Err(StorageError::Backend(
+                "injected disband_tombstone failure".into(),
+            ));
+        }
         self.inner.disband_tombstone(group_id)
+    }
+    fn list_disband_tombstones(
+        &self,
+    ) -> StorageResult<Vec<(GroupId, cgka_traits::DisbandTombstone)>> {
+        self.inner.list_disband_tombstones()
     }
 }
 
@@ -802,6 +818,36 @@ async fn retry_recovers_a_transiently_quarantined_group() {
                 if gid == &group_id && *recovered_epoch == group_epoch
         )),
         "recovery event missing or carried the wrong epoch (expected {group_epoch:?}): {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn tombstone_read_failure_quarantines_instead_of_hydrating_live_state() {
+    let storage = FlakyGroupRecordStorage::new(SqliteAccountStorage::in_memory().expect("storage"));
+    let mut initial = build_flaky_engine(storage.clone());
+    let group_id = create_confirmed_group_flaky(&mut initial).await;
+    drop(initial);
+
+    storage.set_fail_disband_tombstone(true);
+    let mut reopened = build_flaky_engine(storage.clone());
+    reopened
+        .hydrate_stable_groups_from_storage()
+        .expect("per-group tombstone failure is quarantined");
+
+    assert_eq!(
+        reopened.quarantined_groups(),
+        vec![(
+            group_id.clone(),
+            GroupHydrationQuarantineReason::GroupRecordLoadFailed,
+        )]
+    );
+    assert!(reopened.epoch_state(&group_id).is_none());
+
+    storage.set_fail_disband_tombstone(false);
+    assert!(
+        reopened
+            .retry_hydrate_quarantined_group(&group_id)
+            .expect("retry succeeds")
     );
 }
 
@@ -1190,6 +1236,10 @@ async fn quarantined_group_accessors_all_report_unknown_group() {
 
     unknown(alice.members(&group_id).map(drop), "members");
     unknown(alice.epoch(&group_id).map(drop), "epoch");
+    assert!(
+        alice.epoch_state(&group_id).is_none(),
+        "epoch_state must hide quarantined groups"
+    );
     unknown(alice.group_record(&group_id).map(drop), "group_record");
     unknown(alice.admin_pubkeys(&group_id).map(drop), "admin_pubkeys");
     unknown(alice.group_context(&group_id).map(drop), "group_context");
@@ -1206,6 +1256,10 @@ async fn quarantined_group_accessors_all_report_unknown_group() {
     unknown(
         alice.upgradeable_capabilities(&group_id).map(drop),
         "upgradeable_capabilities",
+    );
+    unknown(
+        alice.disbanding_support_blockers(&group_id).map(drop),
+        "disbanding_support_blockers",
     );
     unknown(
         alice.upgrade_group_capabilities(&group_id).await.map(drop),

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -34,10 +34,12 @@ use cgka_traits::message::{MessageRecord, MessageState, StoredMessagePayload};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
-    ConvergencePassStorage, ConvergencePolicyStorage, GroupStorage, KeyPackageBundleStorage,
-    LeaveRequest, LeaveRequestStorage, MaintenanceStorage, MemberValidationCacheStorage,
-    MessageStorage, OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent,
-    StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle, WelcomeStorage,
+    ConvergencePassStorage, ConvergencePolicyStorage, DisbandCandidate, DisbandCandidateStorage,
+    DisbandRequest, DisbandRequestStorage, DisbandTombstoneStorage, GroupStorage,
+    KeyPackageBundleStorage, LeaveRequest, LeaveRequestStorage, MaintenanceStorage,
+    MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage, OutboundIntentStorage,
+    QueuedOutboundIntent, StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle,
+    WelcomeStorage,
 };
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -1054,6 +1056,53 @@ impl LeaveRequestStorage for FaultStorage {
     }
     fn clear_leave_request(&self, group_id: &GroupId) -> StorageResult<()> {
         self.inner.clear_leave_request(group_id)
+    }
+}
+
+impl DisbandRequestStorage for FaultStorage {
+    fn put_disband_request(&self, request: &DisbandRequest) -> StorageResult<()> {
+        self.inner.put_disband_request(request)
+    }
+    fn disband_request(&self, group_id: &GroupId) -> StorageResult<Option<DisbandRequest>> {
+        self.inner.disband_request(group_id)
+    }
+    fn clear_disband_request(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.inner.clear_disband_request(group_id)
+    }
+}
+
+impl DisbandCandidateStorage for FaultStorage {
+    fn put_disband_candidate(&self, candidate: &DisbandCandidate) -> StorageResult<()> {
+        self.inner.put_disband_candidate(candidate)
+    }
+    fn disband_candidate(
+        &self,
+        group_id: &GroupId,
+        commit_id: &MessageId,
+    ) -> StorageResult<Option<DisbandCandidate>> {
+        self.inner.disband_candidate(group_id, commit_id)
+    }
+    fn list_disband_candidates(&self, group_id: &GroupId) -> StorageResult<Vec<DisbandCandidate>> {
+        self.inner.list_disband_candidates(group_id)
+    }
+    fn clear_disband_candidates(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.inner.clear_disband_candidates(group_id)
+    }
+}
+
+impl DisbandTombstoneStorage for FaultStorage {
+    fn put_disband_tombstone(
+        &self,
+        group_id: &GroupId,
+        tombstone: &cgka_traits::DisbandTombstone,
+    ) -> StorageResult<()> {
+        self.inner.put_disband_tombstone(group_id, tombstone)
+    }
+    fn disband_tombstone(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Option<cgka_traits::DisbandTombstone>> {
+        self.inner.disband_tombstone(group_id)
     }
 }
 

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -35,8 +35,8 @@ use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
     AccountDeviceSignerBinding, AccountDeviceSignerStorage, CapabilityStorage,
     ConvergencePassStorage, ConvergencePolicyStorage, DisbandCandidate, DisbandCandidateStorage,
-    DisbandRequest, DisbandRequestStorage, DisbandTombstoneStorage, GroupStorage,
-    KeyPackageBundleStorage, LeaveRequest, LeaveRequestStorage, MaintenanceStorage,
+    DisbandRequest, DisbandRequestStatus, DisbandRequestStorage, DisbandTombstoneStorage,
+    GroupStorage, KeyPackageBundleStorage, LeaveRequest, LeaveRequestStorage, MaintenanceStorage,
     MemberValidationCacheStorage, MessageStorage, OutboundFanoutStorage, OutboundIntentStorage,
     QueuedOutboundIntent, StorageError, StorageProvider, StorageResult, StoredKeyPackageBundle,
     WelcomeStorage,
@@ -951,6 +951,7 @@ struct FaultStorage {
     inner: SqliteAccountStorage,
     fault: ProcessedFault,
     lifecycle_fault: ProcessedFault,
+    disband_request_fault: ProcessedFault,
 }
 
 impl GroupStorage for FaultStorage {
@@ -1061,6 +1062,14 @@ impl LeaveRequestStorage for FaultStorage {
 
 impl DisbandRequestStorage for FaultStorage {
     fn put_disband_request(&self, request: &DisbandRequest) -> StorageResult<()> {
+        if request.status == DisbandRequestStatus::Pending
+            && request.last_prepared_epoch.is_none()
+            && self.disband_request_fault.should_fail()
+        {
+            return Err(StorageError::Busy(
+                "injected disband rollback reconciliation lock".into(),
+            ));
+        }
         self.inner.put_disband_request(request)
     }
     fn disband_request(&self, group_id: &GroupId) -> StorageResult<Option<DisbandRequest>> {
@@ -1103,6 +1112,11 @@ impl DisbandTombstoneStorage for FaultStorage {
         group_id: &GroupId,
     ) -> StorageResult<Option<cgka_traits::DisbandTombstone>> {
         self.inner.disband_tombstone(group_id)
+    }
+    fn list_disband_tombstones(
+        &self,
+    ) -> StorageResult<Vec<(GroupId, cgka_traits::DisbandTombstone)>> {
+        self.inner.list_disband_tombstones()
     }
 }
 
@@ -1357,6 +1371,7 @@ fn build_fault_engine(
         inner,
         fault,
         lifecycle_fault: ProcessedFault::default(),
+        disband_request_fault: ProcessedFault::default(),
     })
     .legacy_compatibility_profile()
     .identity(pad32(id))
@@ -1368,6 +1383,93 @@ fn build_fault_engine(
     (engine, handle)
 }
 
+#[tokio::test]
+async fn disband_publish_failure_reconciliation_is_atomic_and_retryable() {
+    let inner = SqliteAccountStorage::in_memory().unwrap();
+    let handle = inner.clone();
+    let disband_request_fault = ProcessedFault::default();
+    let mut alice = EngineBuilder::new(FaultStorage {
+        inner,
+        fault: ProcessedFault::default(),
+        lifecycle_fault: ProcessedFault::default(),
+        disband_request_fault: disband_request_fault.clone(),
+    })
+    .identity(pad32(b"alice-disband-rollback"))
+    .account_identity_proof_signer(proof_signer(b"alice-disband-rollback"))
+    .protocol_profile(cgka_traits::group::ProtocolProfile::Current)
+    .feature_registry(registry_with_reactions())
+    .peeler(Box::new(MockPeeler))
+    .build()
+    .unwrap();
+    let (group_id, created) = alice
+        .create_group(CreateGroupRequest {
+            name: "terminal rollback".into(),
+            description: String::new(),
+            members: vec![],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    assert!(matches!(
+        created,
+        SendResult::FoundingGroupCreated { ref welcomes } if welcomes.is_empty()
+    ));
+
+    assert!(matches!(
+        alice
+            .send(SendIntent::Disband {
+                group_id: group_id.clone(),
+            })
+            .await
+            .unwrap(),
+        SendResult::DisbandRequested { .. }
+    ));
+    let prepared = alice.advance_convergence(&group_id).await.unwrap();
+    let pending = match prepared.as_slice() {
+        [SendResult::GroupEvolution { pending, .. }] => *pending,
+        other => panic!("expected prepared disband commit, got {other:?}"),
+    };
+    assert!(
+        handle
+            .disband_request(&group_id)
+            .unwrap()
+            .unwrap()
+            .last_prepared_epoch
+            .is_some()
+    );
+
+    disband_request_fault.arm(1);
+    let error = alice.publish_failed(pending).await.unwrap_err();
+    assert!(error.is_transient(), "unexpected rollback error: {error:?}");
+    assert!(matches!(
+        alice.epoch_state(&group_id),
+        Some(cgka_traits::EpochState::PendingPublish(_))
+    ));
+    assert!(
+        handle
+            .disband_request(&group_id)
+            .unwrap()
+            .unwrap()
+            .last_prepared_epoch
+            .is_some(),
+        "failed transaction must retain the prepared request state"
+    );
+
+    alice
+        .publish_failed(pending)
+        .await
+        .expect("same pending slot remains retryable");
+    let request = handle.disband_request(&group_id).unwrap().unwrap();
+    assert_eq!(request.status, DisbandRequestStatus::Pending);
+    assert_eq!(request.last_prepared_epoch, None);
+    assert!(matches!(
+        alice.epoch_state(&group_id),
+        Some(cgka_traits::EpochState::Stable { .. })
+    ));
+}
+
 #[test]
 fn key_package_bundle_and_lifecycle_intent_roll_back_together() {
     let inner = SqliteAccountStorage::in_memory().unwrap();
@@ -1377,6 +1479,7 @@ fn key_package_bundle_and_lifecycle_intent_roll_back_together() {
         inner,
         fault: ProcessedFault::default(),
         lifecycle_fault: lifecycle_fault.clone(),
+        disband_request_fault: ProcessedFault::default(),
     })
     .identity(pad32(b"alice-maintenance"))
     .account_identity_proof_signer(proof_signer(b"alice-maintenance"))

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -1413,6 +1413,7 @@ async fn inbound_commit_atomically_unrequires_and_removes_optional_component() {
         GROUP_PROFILE_COMPONENT_ID,
         GROUP_ADMIN_POLICY_COMPONENT_ID,
         ACCOUNT_IDENTITY_PROOF_COMPONENT_ID,
+        GROUP_LIFECYCLE_COMPONENT_ID,
     ]
     .into_iter()
     .collect();

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -19,10 +19,10 @@ use cgka_traits::EngineError;
 use cgka_traits::app_components::{
     ACCOUNT_IDENTITY_PROOF_COMPONENT_ID, APP_COMPONENTS_COMPONENT_ID, AppComponentData,
     GROUP_ADMIN_POLICY_COMPONENT_ID, GROUP_AVATAR_URL_COMPONENT_ID,
-    GROUP_BLOSSOM_IMAGE_COMPONENT_ID, GROUP_MESSAGE_RETENTION_COMPONENT_ID,
-    GROUP_PROFILE_COMPONENT_ID, GroupAvatarUrlV1, NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1,
-    default_group_components, encode_component_vectors, encode_components_list,
-    encode_group_avatar_url_v1, encode_nostr_routing_v1,
+    GROUP_BLOSSOM_IMAGE_COMPONENT_ID, GROUP_LIFECYCLE_COMPONENT_ID,
+    GROUP_MESSAGE_RETENTION_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID, GroupAvatarUrlV1,
+    NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1, default_group_components, encode_component_vectors,
+    encode_components_list, encode_group_avatar_url_v1, encode_nostr_routing_v1,
 };
 use cgka_traits::app_event::{
     AppMessageRetentionDecision, MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent,
@@ -32,7 +32,7 @@ use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult
 use cgka_traits::error::PeelerError;
 use cgka_traits::group::ProtocolProfile;
 use cgka_traits::group_context::GroupContextSnapshot;
-use cgka_traits::ingest::{PeeledContent, PeeledMessage};
+use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage};
 use cgka_traits::message::MessageState;
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
@@ -424,7 +424,6 @@ async fn routing_rotation_reindexes_inbound_transport_group_id() {
     bob.join_welcome(welcomes.into_iter().next().unwrap())
         .await
         .unwrap();
-
     // Alice rotates the routing X -> Y and confirms locally.
     let routing_y = NostrRoutingV1::new([0x59; 32], vec!["wss://y.example".into()]).unwrap();
     let res = alice
@@ -1066,6 +1065,71 @@ async fn inbound_commit_cannot_unrequire_current_admin_policy() {
     assert_eq!(
         bob.admin_pubkeys(&gid).unwrap(),
         vec![<[u8; 32]>::try_from(pad32(b"alice")).unwrap()]
+    );
+}
+
+#[tokio::test]
+async fn current_profile_component_update_preserves_active_lifecycle_for_peer() {
+    let mut alice = build_current(b"alice-lifecycle-update");
+    let mut bob = build_current(b"bob-lifecycle-update");
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (gid, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "before".into(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let welcomes = match create {
+        SendResult::FoundingGroupCreated { welcomes } => welcomes,
+        other => panic!("expected FoundingGroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcomes.into_iter().next().unwrap())
+        .await
+        .unwrap();
+
+    let update = alice
+        .send(SendIntent::UpdateAppComponents {
+            group_id: gid.clone(),
+            updates: vec![AppComponentData {
+                component_id: GROUP_PROFILE_COMPONENT_ID,
+                data: cgka_traits::app_components::encode_group_profile_v1(
+                    &cgka_traits::app_components::GroupProfileV1 {
+                        name: "after".into(),
+                        description: String::new(),
+                    },
+                )
+                .unwrap(),
+            }],
+        })
+        .await
+        .unwrap();
+    let (commit, pending) = match update {
+        SendResult::GroupEvolution { msg, pending, .. } => (msg, pending),
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    assert!(matches!(
+        bob.ingest(commit).await.unwrap(),
+        IngestOutcome::Buffered { .. }
+    ));
+    for _ in 0..24 {
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        bob.advance_convergence(&gid).await.unwrap();
+        if bob.group_record(&gid).unwrap().name == "after" {
+            break;
+        }
+    }
+
+    assert_eq!(bob.group_record(&gid).unwrap().name, "after");
+    assert_eq!(
+        bob.app_component(&gid, GROUP_LIFECYCLE_COMPONENT_ID)
+            .unwrap(),
+        Some(vec![0])
     );
 }
 

--- a/crates/cgka-engine/tests/update_group_data.rs
+++ b/crates/cgka-engine/tests/update_group_data.rs
@@ -21,8 +21,9 @@ use cgka_traits::app_components::{
     GROUP_ADMIN_POLICY_COMPONENT_ID, GROUP_AVATAR_URL_COMPONENT_ID,
     GROUP_BLOSSOM_IMAGE_COMPONENT_ID, GROUP_LIFECYCLE_COMPONENT_ID,
     GROUP_MESSAGE_RETENTION_COMPONENT_ID, GROUP_PROFILE_COMPONENT_ID, GroupAvatarUrlV1,
-    NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1, default_group_components, encode_component_vectors,
-    encode_components_list, encode_group_avatar_url_v1, encode_nostr_routing_v1,
+    GroupLifecycleV1, NOSTR_ROUTING_COMPONENT_ID, NostrRoutingV1, decode_group_lifecycle_v1,
+    default_group_components, encode_component_vectors, encode_components_list,
+    encode_group_avatar_url_v1, encode_nostr_routing_v1,
 };
 use cgka_traits::app_event::{
     AppMessageRetentionDecision, MARMOT_APP_EVENT_KIND_CHAT, MarmotAppEvent,
@@ -1127,9 +1128,57 @@ async fn current_profile_component_update_preserves_active_lifecycle_for_peer() 
 
     assert_eq!(bob.group_record(&gid).unwrap().name, "after");
     assert_eq!(
-        bob.app_component(&gid, GROUP_LIFECYCLE_COMPONENT_ID)
-            .unwrap(),
-        Some(vec![0])
+        decode_group_lifecycle_v1(
+            &bob.app_component(&gid, GROUP_LIFECYCLE_COMPONENT_ID)
+                .unwrap()
+                .expect("lifecycle component present"),
+        )
+        .unwrap(),
+        GroupLifecycleV1::Active
+    );
+}
+
+#[tokio::test]
+async fn required_lifecycle_component_cannot_be_unrequired() {
+    let mut alice = build_current(b"alice-required-lifecycle");
+    let (gid, created) = alice
+        .create_group(CreateGroupRequest {
+            name: "required lifecycle".into(),
+            description: String::new(),
+            members: vec![],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    assert!(matches!(
+        created,
+        SendResult::FoundingGroupCreated { ref welcomes } if welcomes.is_empty()
+    ));
+    let mut required = alice
+        .group_record(&gid)
+        .unwrap()
+        .required_capabilities
+        .app_components;
+    assert!(required.ids.remove(&GROUP_LIFECYCLE_COMPONENT_ID));
+
+    let error = alice
+        .send(SendIntent::UpdateAppComponents {
+            group_id: gid,
+            updates: vec![AppComponentData {
+                component_id: APP_COMPONENTS_COMPONENT_ID,
+                data: encode_components_list(&required.ids),
+            }],
+        })
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("lifecycle-v1 cannot be un-required"),
+        "unexpected error: {error}"
     );
 }
 

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -907,6 +907,28 @@ impl AccountDeviceSession {
         self.engine.epoch(group_id)
     }
 
+    pub fn epoch_state(&self, group_id: &GroupId) -> Option<cgka_traits::EpochState> {
+        self.engine.epoch_state(group_id)
+    }
+
+    pub fn disband_request(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Option<cgka_traits::DisbandRequest>, EngineError> {
+        self.engine.disband_request(group_id)
+    }
+
+    pub fn disbanding_support_blockers(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<Vec<MemberId>, EngineError> {
+        self.engine.disbanding_support_blockers(group_id)
+    }
+
+    pub fn acknowledge_disband_failure(&self, group_id: &GroupId) -> Result<bool, EngineError> {
+        self.engine.acknowledge_disband_failure(group_id)
+    }
+
     pub fn put_outbound_fanout(&self, fanout: &OutboundFanout) -> SessionResult<()> {
         self.engine.put_outbound_fanout(fanout)?;
         Ok(())
@@ -1007,6 +1029,7 @@ impl AccountDeviceSession {
         };
         for result in results {
             match result {
+                SendResult::NoChange { .. } | SendResult::DisbandRequested { .. } => {}
                 SendResult::ApplicationMessage {
                     msg,
                     group_id,
@@ -1103,11 +1126,15 @@ fn send_intent_kind(intent: &SendIntent) -> &'static str {
         SendIntent::SelfUpdate { .. } => "self_update",
         SendIntent::UpdateAppComponents { .. } => "update_app_components",
         SendIntent::UpdateGroupData { .. } => "update_group_data",
+        SendIntent::EnableDisbanding { .. } => "enable_disbanding",
+        SendIntent::Disband { .. } => "disband",
     }
 }
 
 fn send_result_kind(result: &SendResult) -> &'static str {
     match result {
+        SendResult::NoChange { .. } => "no_change",
+        SendResult::DisbandRequested { .. } => "disband_requested",
         SendResult::ApplicationMessage { .. } => "application_message",
         SendResult::Queued { .. } => "queued",
         SendResult::Proposal { .. } => "proposal",

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -918,6 +918,10 @@ impl AccountDeviceSession {
         self.engine.disband_request(group_id)
     }
 
+    pub fn disbanding_in_progress(&self, group_id: &GroupId) -> Result<bool, EngineError> {
+        self.engine.disbanding_in_progress(group_id)
+    }
+
     pub fn disbanding_support_blockers(
         &self,
         group_id: &GroupId,

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -123,6 +123,25 @@ where
         Ok(self.session.group_record(group_id)?)
     }
 
+    pub fn epoch_state(&self, group_id: &GroupId) -> Option<cgka_traits::EpochState> {
+        self.session.epoch_state(group_id)
+    }
+
+    pub fn disband_request(
+        &self,
+        group_id: &GroupId,
+    ) -> AccountResult<Option<cgka_traits::DisbandRequest>> {
+        Ok(self.session.disband_request(group_id)?)
+    }
+
+    pub fn disbanding_support_blockers(&self, group_id: &GroupId) -> AccountResult<Vec<MemberId>> {
+        Ok(self.session.disbanding_support_blockers(group_id)?)
+    }
+
+    pub fn acknowledge_disband_failure(&self, group_id: &GroupId) -> AccountResult<bool> {
+        Ok(self.session.acknowledge_disband_failure(group_id)?)
+    }
+
     pub fn new_protocol_profile(&self) -> cgka_traits::group::ProtocolProfile {
         self.session.new_protocol_profile()
     }

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -134,6 +134,10 @@ where
         Ok(self.session.disband_request(group_id)?)
     }
 
+    pub fn disbanding_in_progress(&self, group_id: &GroupId) -> AccountResult<bool> {
+        Ok(self.session.disbanding_in_progress(group_id)?)
+    }
+
     pub fn disbanding_support_blockers(&self, group_id: &GroupId) -> AccountResult<Vec<MemberId>> {
         Ok(self.session.disbanding_support_blockers(group_id)?)
     }

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -2649,6 +2649,7 @@ async fn drain_surfaces_hydration_quarantine_without_inbound_delivery() {
                 protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
                 removed: false,
                 unrecoverable: false,
+                disbanded: None,
                 join_epoch: EpochId(0),
             })
             .unwrap();

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -762,6 +762,7 @@ impl AppClient {
                 .copied()
                 .collect(),
             disbanding_enabled,
+            disbanding: self.runtime.disbanding_in_progress(group_id)?,
             disbanding_blockers,
             disband_request: self.runtime.disband_request(group_id)?.map(Into::into),
         })
@@ -1642,7 +1643,7 @@ impl AppClient {
     where
         F: FnMut(crate::AppProjectionUpdate),
     {
-        self.ensure_group(group_id)?;
+        self.ensure_group_application_messages_allowed(group_id)?;
         // Capture the human-action descriptor before `Unreact` is rewritten to
         // `Delete` below, so the audit log records the user's actual intent.
         let audit_context = Self::message_human_action_context(&intent);
@@ -1870,7 +1871,7 @@ impl AppClient {
         attachments: Vec<MediaAttachmentReference>,
         caption: Option<String>,
     ) -> Result<SendSummary, AppError> {
-        self.ensure_group(group_id)?;
+        self.ensure_group_application_messages_allowed(group_id)?;
         self.sync_runtime_groups().await?;
         // Validate every outbound attachment against the group's exact,
         // profile-selected media version and locator policy.
@@ -1904,7 +1905,7 @@ impl AppClient {
         group_id: &GroupId,
         reference: &MediaAttachmentReference,
     ) -> Result<Vec<String>, AppError> {
-        self.ensure_group(group_id)?;
+        self.ensure_group_application_messages_allowed(group_id)?;
         self.sync_runtime_groups().await?;
         let policy = self.encrypted_media_policy_for_group(group_id)?;
         reference.build_imeta_tag(
@@ -1919,7 +1920,7 @@ impl AppClient {
         group_id: &GroupId,
         request: MediaUploadRequest,
     ) -> Result<MediaUploadResult, AppError> {
-        self.ensure_group(group_id)?;
+        self.ensure_group_application_messages_allowed(group_id)?;
         self.sync_runtime_groups().await?;
         let policy = self.encrypted_media_policy_for_group(group_id)?;
         // `upload_encrypted_media` always performs Blossom upload semantics and
@@ -2055,7 +2056,7 @@ impl AppClient {
         plaintext: Vec<u8>,
         media_type: &str,
     ) -> Result<SendSummary, AppError> {
-        self.ensure_group(group_id)?;
+        self.ensure_group_application_messages_allowed(group_id)?;
         let audit_context = Self::local_human_action_context(
             "update_group_image",
             vec!["image"],
@@ -2382,6 +2383,27 @@ impl AppClient {
         } else {
             Err(AppError::UnknownGroup(group_id_hex))
         }
+    }
+
+    /// Fail before optimistic projection, media upload, or any other
+    /// application-message preparation once terminal convergence has gated the
+    /// group. The engine repeats this check at the authoritative mutation
+    /// boundary; this app-layer preflight keeps clients from briefly rendering
+    /// a message that can only be retracted.
+    fn ensure_group_application_messages_allowed(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<(), AppError> {
+        self.ensure_group(group_id)?;
+        let terminal = self
+            .runtime
+            .group_record(group_id)
+            .map(|group| group.disbanded.is_some())
+            .unwrap_or(false);
+        if terminal || self.runtime.disbanding_in_progress(group_id)? {
+            return Err(AppError::GroupDisbanding(hex::encode(group_id.as_slice())));
+        }
+        Ok(())
     }
 
     /// Flip a group's local `archived` flag on the worker-owned in-memory

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -39,7 +39,7 @@ use crate::messages::{AppMessageIntent, build_inner_event, encode_inner_event, t
 use crate::notifications;
 use crate::{
     AccountState, AgentOperationEventRequest, AgentTextStreamFinishRequest, AppBlobEndpoint,
-    AppError, AppGroupAdminPolicyComponent, AppGroupAvatarUrlComponent,
+    AppDisbandRequest, AppError, AppGroupAdminPolicyComponent, AppGroupAvatarUrlComponent,
     AppGroupEncryptedMediaComponent, AppGroupImageComponent, AppGroupImageInput,
     AppGroupMemberRecord, AppGroupMessageRetentionComponent, AppGroupMlsState, AppGroupRecord,
     AppInitialGroupImage, AppMessageQuery, AppPerformanceTelemetry, AppQuarantinedGroup,
@@ -718,9 +718,39 @@ impl AppClient {
 
     fn group_mls_state_unchecked(&self, group_id: &GroupId) -> Result<AppGroupMlsState, AppError> {
         let group = self.runtime.group_record(group_id)?;
+        let lifecycle_state = self
+            .runtime
+            .epoch_state(group_id)
+            .as_ref()
+            .map(cgka_traits::GroupLifecycleState::from)
+            .map(Into::into)
+            .unwrap_or_else(|| {
+                if group.disbanded.is_some() {
+                    crate::AppGroupLifecycleState::Disbanded
+                } else if group.unrecoverable {
+                    crate::AppGroupLifecycleState::Unrecoverable
+                } else {
+                    crate::AppGroupLifecycleState::Stable
+                }
+            });
+        let disbanding_enabled = group
+            .required_capabilities
+            .app_components
+            .contains(cgka_traits::app_components::GROUP_LIFECYCLE_COMPONENT_ID)
+            && group.disbanded.is_none();
+        let disbanding_blockers = if disbanding_enabled || group.disbanded.is_some() {
+            Vec::new()
+        } else {
+            self.runtime
+                .disbanding_support_blockers(group_id)?
+                .into_iter()
+                .map(|member| hex::encode(member.as_slice()))
+                .collect()
+        };
         Ok(AppGroupMlsState {
             group_id_hex: hex::encode(group_id.as_slice()),
             protocol_profile: group.protocol_profile.into(),
+            lifecycle_state,
             epoch: group.epoch.0,
             member_count: group.members.len(),
             unrecoverable: group.unrecoverable,
@@ -731,6 +761,9 @@ impl AppClient {
                 .iter()
                 .copied()
                 .collect(),
+            disbanding_enabled,
+            disbanding_blockers,
+            disband_request: self.runtime.disband_request(group_id)?.map(Into::into),
         })
     }
 
@@ -1024,6 +1057,94 @@ impl AppClient {
             .await
     }
 
+    /// Atomically install lifecycle-v1 and make it required for this group.
+    pub async fn enable_group_disbanding(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<SendSummary, AppError> {
+        self.ensure_group(group_id)?;
+        let audit_context = Self::local_human_action_context(
+            "enable_group_disbanding",
+            vec!["lifecycle"],
+            vec![
+                cgka_traits::app_components::APP_COMPONENTS_COMPONENT_ID,
+                cgka_traits::app_components::GROUP_LIFECYCLE_COMPONENT_ID,
+            ],
+            None,
+        );
+        self.sync_runtime_groups().await?;
+        let effects = self
+            .runtime
+            .send_with_audit_context(
+                SendIntent::EnableDisbanding {
+                    group_id: group_id.clone(),
+                },
+                audit_context.clone(),
+            )
+            .await?;
+        fail_if_publish_failed(&effects)?;
+        self.record_human_action_succeeded(group_id, &audit_context, &effects);
+        self.remember_published_reports(&effects);
+        self.refresh_group(group_id);
+        self.app.save_state(&self.state)?;
+        self.queue_own_group_system_projection_updates(&effects);
+        Ok(send_summary_from_effects(&effects))
+    }
+
+    /// Persist the irreversible request and return without waiting for the
+    /// disband Commit or its mandatory convergence pass.
+    pub async fn disband_group(
+        &mut self,
+        group_id: &GroupId,
+    ) -> Result<AppDisbandRequest, AppError> {
+        self.ensure_group(group_id)?;
+        let audit_context = Self::local_human_action_context(
+            "disband_group",
+            vec!["lifecycle", "membership", "admins"],
+            vec![
+                cgka_traits::app_components::GROUP_LIFECYCLE_COMPONENT_ID,
+                cgka_traits::app_components::GROUP_ADMIN_POLICY_COMPONENT_ID,
+            ],
+            None,
+        );
+        self.sync_runtime_groups().await?;
+        let effects = self
+            .runtime
+            .send_with_audit_context(
+                SendIntent::Disband {
+                    group_id: group_id.clone(),
+                },
+                audit_context,
+            )
+            .await?;
+        self.remember_published_reports(&effects);
+        if let Err(error) = self
+            .app
+            .delete_message_draft(&self.state.label, &hex::encode(group_id.as_slice()))
+        {
+            // The irreversible engine request is already durable. Treat draft
+            // cleanup like the other repairable post-canonical projections:
+            // report success for the request and reconcile local UI state on
+            // the next account mutation/open rather than inviting a retry.
+            tracing::warn!(
+                target: "marmot_app::client",
+                method = "disband_group",
+                error_kind = error.privacy_safe_kind(),
+                "durable disband request outpaced composer draft cleanup"
+            );
+        }
+        self.app.save_state(&self.state)?;
+        self.runtime
+            .disband_request(group_id)?
+            .map(Into::into)
+            .ok_or_else(|| AppError::UnknownGroup(hex::encode(group_id.as_slice())))
+    }
+
+    pub fn acknowledge_disband_failure(&mut self, group_id: &GroupId) -> Result<bool, AppError> {
+        self.ensure_group(group_id)?;
+        Ok(self.runtime.acknowledge_disband_failure(group_id)?)
+    }
+
     /// Delete only this group's app-local data. This intentionally does not send
     /// an MLS leave and does not delete the stored MLS/OpenMLS group state; a
     /// future fresh group delivery can recreate the chat-list projection.
@@ -1031,6 +1152,13 @@ impl AppClient {
     /// The live transport route is removed and synced before the DB wipe so the
     /// account stops actively subscribing to the group before local rows vanish.
     pub async fn delete_group_local(&mut self, group_id: &GroupId) -> Result<bool, AppError> {
+        if self
+            .runtime
+            .disband_request(group_id)?
+            .is_some_and(|request| request.status == cgka_traits::DisbandRequestStatus::Pending)
+        {
+            return Err(AppError::GroupDisbanding(hex::encode(group_id.as_slice())));
+        }
         // A local wipe removes this group's transport route. Any already-durable
         // removal must publish first; retaining it after the route disappears
         // would preserve bytes on disk without preserving liveness.
@@ -2514,6 +2642,16 @@ impl AppClient {
                 continue;
             };
             let group_id = GroupId::new(group_id_bytes);
+            if self
+                .runtime
+                .group_record(&group_id)
+                .is_ok_and(|group| group.disbanded.is_some())
+            {
+                if self.routing.replace_group_routes(&group_id, Vec::new()) {
+                    changed = true;
+                }
+                continue;
+            }
             // Retention is epoch-derived, never process-uptime-derived. Do not
             // prune while convergence still has unresolved inputs: the
             // retained anchor is not settled yet, so conservatively keep every

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1088,7 +1088,8 @@ impl AppClient {
         self.remember_published_reports(&effects);
         self.refresh_group(group_id);
         self.app.save_state(&self.state)?;
-        self.queue_own_group_system_projection_updates(&effects);
+        // Enabling lifecycle-v1 changes eligibility, not group history. It
+        // intentionally emits no kind-1210 system row.
         Ok(send_summary_from_effects(&effects))
     }
 
@@ -1153,11 +1154,7 @@ impl AppClient {
     /// The live transport route is removed and synced before the DB wipe so the
     /// account stops actively subscribing to the group before local rows vanish.
     pub async fn delete_group_local(&mut self, group_id: &GroupId) -> Result<bool, AppError> {
-        if self
-            .runtime
-            .disband_request(group_id)?
-            .is_some_and(|request| request.status == cgka_traits::DisbandRequestStatus::Pending)
-        {
+        if self.runtime.disbanding_in_progress(group_id)? {
             return Err(AppError::GroupDisbanding(hex::encode(group_id.as_slice())));
         }
         // A local wipe removes this group's transport route. Any already-durable

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -217,6 +217,41 @@ impl AppClient {
         Ok(changed)
     }
 
+    /// Finish the app-local half of durable disband acceptance after a crash
+    /// or a transient projection write failure. The engine request/tombstone is
+    /// the source of truth, so composer drafts must not reappear on reopen.
+    pub(crate) fn reconcile_disband_drafts(&self) {
+        for projected_group in &self.state.groups {
+            let Ok(group_id_bytes) = hex::decode(&projected_group.group_id_hex) else {
+                continue;
+            };
+            let group_id = GroupId::new(group_id_bytes);
+            let request_exists = self
+                .runtime
+                .disband_request(&group_id)
+                .ok()
+                .flatten()
+                .is_some();
+            let is_disbanded = self
+                .runtime
+                .group_record(&group_id)
+                .ok()
+                .is_some_and(|group| group.disbanded.is_some());
+            if (request_exists || is_disbanded)
+                && let Err(error) = self
+                    .app
+                    .delete_message_draft(&self.state.label, &projected_group.group_id_hex)
+            {
+                tracing::warn!(
+                    target: "marmot_app::client",
+                    method = "reconcile_disband_drafts",
+                    error_kind = error.privacy_safe_kind(),
+                    "composer draft cleanup remains pending"
+                );
+            }
+        }
+    }
+
     pub(crate) fn profile_for_group(&self, group_id: &GroupId) -> AppGroupProfileComponent {
         self.runtime
             .app_component(group_id, GROUP_PROFILE_COMPONENT_ID)
@@ -506,6 +541,7 @@ fn read_marker_error_code(error: &AppError) -> &'static str {
         AppError::MissingKeyPackage(_) => "read_marker_failed:missing_key_package",
         AppError::UnknownGroup(_) => "read_marker_failed:unknown_group",
         AppError::InvalidChatPin(_) => "read_marker_failed:invalid_chat_pin",
+        AppError::GroupDisbanding(_) => "read_marker_failed:group_disbanding",
         AppError::InvalidMessageDraft(_) => "read_marker_failed:invalid_message_draft",
         AppError::AgentStreamMissingStart => "read_marker_failed:agent_stream_missing_start",
         AppError::AgentStreamStartNotConfirmed => {

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -749,6 +749,23 @@ impl AppClient {
                     )?;
                 }
             }
+            if let cgka_traits::engine::GroupEvent::GroupStateChanged {
+                group_id,
+                change: cgka_traits::engine::GroupStateChange::GroupDisbanded,
+                ..
+            } = event
+            {
+                routes_dirty = true;
+                let group_id_hex = hex::encode(group_id.as_slice());
+                // Terminal groups never advertise notification destinations
+                // again. Queue the current registration's removal and discard
+                // every cached peer token immediately; publishing the removal
+                // rumor remains restart-safe in the normal outbox.
+                let _ = self.queue_current_push_registration_removal_for_group(group_id);
+                let _ =
+                    self.app
+                        .remove_stale_group_push_tokens(&self.state.label, &group_id_hex, &[]);
+            }
             // A (re-)join or create restores the local account's membership so a
             // re-add after removal un-suppresses the group's unread count. Same
             // source-of-truth write as the departure path above: propagate the

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -29,6 +29,8 @@ pub enum AppError {
     UnknownGroup(String),
     #[error("invalid chat pin: {0}")]
     InvalidChatPin(String),
+    #[error("group disbanding is pending; local deletion is blocked")]
+    GroupDisbanding(String),
     /// Host-supplied draft attachment metadata failed validation before storage.
     #[error("invalid message draft: {0}")]
     InvalidMessageDraft(String),
@@ -135,6 +137,7 @@ impl AppError {
             Self::MissingKeyPackage(_) => "missing_key_package",
             Self::UnknownGroup(_) => "unknown_group",
             Self::InvalidChatPin(_) => "invalid_chat_pin",
+            Self::GroupDisbanding(_) => "group_disbanding",
             Self::InvalidMessageDraft(_) => "invalid_message_draft",
             Self::AgentStreamMissingStart => "agent_stream_missing_start",
             Self::AgentStreamStartNotConfirmed => "agent_stream_start_not_confirmed",

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -29,7 +29,7 @@ pub enum AppError {
     UnknownGroup(String),
     #[error("invalid chat pin: {0}")]
     InvalidChatPin(String),
-    #[error("group disbanding is pending; local deletion is blocked")]
+    #[error("group is disbanding or disbanded; outbound work is blocked")]
     GroupDisbanding(String),
     /// Host-supplied draft attachment metadata failed validation before storage.
     #[error("invalid message draft: {0}")]

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -129,6 +129,19 @@ pub struct AppGroupRecord {
     /// only way a cold launch can rediscover it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub leave_requested_at_ms: Option<u64>,
+    /// Whether ordinary outbound work is gated by a local request or an
+    /// authenticated inbound disband candidate awaiting convergence.
+    #[serde(default)]
+    pub disbanding: bool,
+    /// Local disband request outcome, when this account initiated the action.
+    /// `disbanding` can be true with no request when another admin authored the
+    /// candidate being settled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disband_request: Option<AppDisbandRequest>,
+    /// Durable terminal projection used by group-state subscribers after the
+    /// request row has been cleared.
+    #[serde(default)]
+    pub disbanded: bool,
     /// The engine has frozen this local group copy because it cannot safely
     /// select canonical state from retained material. Sending and applying
     /// group traffic remain blocked until a verified repair replaces it.
@@ -175,6 +188,10 @@ pub struct AppGroupMlsState {
     pub unrecoverable: bool,
     pub required_app_components: Vec<u16>,
     pub disbanding_enabled: bool,
+    /// True while all ordinary outbound group work, including application
+    /// messages, is blocked pending terminal convergence.
+    #[serde(default)]
+    pub disbanding: bool,
     #[serde(default)]
     pub disbanding_blockers: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -541,6 +558,9 @@ impl AppGroupRecord {
             member_count: None,
             self_membership: SelfMembership::Member,
             leave_requested_at_ms: None,
+            disbanding: false,
+            disband_request: None,
+            disbanded: false,
             unrecoverable: false,
             welcomer_account_id_hex: None,
             via_welcome_message_id_hex: None,
@@ -579,6 +599,7 @@ impl AppGroupRecord {
             record.nostr_routing_last_epoch = group.epoch.0;
             record.member_count = u64::try_from(group.members.len()).ok();
             record.unrecoverable = group.unrecoverable;
+            record.disbanded = group.disbanded.is_some();
         }
         record
     }
@@ -618,6 +639,7 @@ impl AppGroupRecord {
             self.protocol_profile = group.protocol_profile.into();
             self.member_count = u64::try_from(group.members.len()).ok();
             self.unrecoverable = group.unrecoverable;
+            self.disbanded = group.disbanded.is_some();
         }
     }
 

--- a/crates/marmot-app/src/groups.rs
+++ b/crates/marmot-app/src/groups.rs
@@ -168,11 +168,82 @@ pub struct AppGroupMemberRecord {
 pub struct AppGroupMlsState {
     pub group_id_hex: String,
     pub protocol_profile: AppProtocolProfile,
+    pub lifecycle_state: AppGroupLifecycleState,
     pub epoch: u64,
     pub member_count: usize,
     #[serde(default)]
     pub unrecoverable: bool,
     pub required_app_components: Vec<u16>,
+    pub disbanding_enabled: bool,
+    #[serde(default)]
+    pub disbanding_blockers: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disband_request: Option<AppDisbandRequest>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AppGroupLifecycleState {
+    #[default]
+    Stable,
+    PendingPublish,
+    Merging,
+    Recovering,
+    Unrecoverable,
+    Disbanded,
+}
+
+impl From<cgka_traits::GroupLifecycleState> for AppGroupLifecycleState {
+    fn from(value: cgka_traits::GroupLifecycleState) -> Self {
+        match value {
+            cgka_traits::GroupLifecycleState::Stable => Self::Stable,
+            cgka_traits::GroupLifecycleState::PendingPublish => Self::PendingPublish,
+            cgka_traits::GroupLifecycleState::Merging => Self::Merging,
+            cgka_traits::GroupLifecycleState::Recovering => Self::Recovering,
+            cgka_traits::GroupLifecycleState::Unrecoverable => Self::Unrecoverable,
+            cgka_traits::GroupLifecycleState::Disbanded => Self::Disbanded,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AppDisbandFailureReason {
+    NoLongerAdmin,
+    NoLongerMember,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AppDisbandRequest {
+    Pending {
+        requested_at_ms: u64,
+    },
+    Failed {
+        requested_at_ms: u64,
+        reason: AppDisbandFailureReason,
+    },
+}
+
+impl From<cgka_traits::DisbandRequest> for AppDisbandRequest {
+    fn from(value: cgka_traits::DisbandRequest) -> Self {
+        match value.status {
+            cgka_traits::DisbandRequestStatus::Pending => Self::Pending {
+                requested_at_ms: value.requested_at_ms,
+            },
+            cgka_traits::DisbandRequestStatus::Failed(reason) => Self::Failed {
+                requested_at_ms: value.requested_at_ms,
+                reason: match reason {
+                    cgka_traits::DisbandFailureReason::NoLongerAdmin => {
+                        AppDisbandFailureReason::NoLongerAdmin
+                    }
+                    cgka_traits::DisbandFailureReason::NoLongerMember => {
+                        AppDisbandFailureReason::NoLongerMember
+                    }
+                },
+            },
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -711,6 +782,7 @@ mod prior_nostr_route_tests {
             protocol_profile: ProtocolProfile::Current,
             removed: false,
             unrecoverable: false,
+            disbanded: None,
             join_epoch: EpochId(0),
         }
     }
@@ -1571,6 +1643,7 @@ mod delete_moderation_grant_tests {
             protocol_profile: cgka_traits::group::ProtocolProfile::Legacy,
             removed: false,
             unrecoverable: false,
+            disbanded: None,
             join_epoch: EpochId(0),
         }
     }

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -2438,6 +2438,19 @@ impl MarmotApp {
                 group.leave_requested_at_ms = pending.get(&group.group_id_hex).copied();
             }
         }
+        let storage = self.account_storage(label)?;
+        let disbanding = storage.disbanding_group_ids_hex()?;
+        let requests = storage.disband_requests_by_group_hex()?;
+        let disbanded = storage
+            .list_disband_tombstones()?
+            .into_iter()
+            .map(|(group_id, _)| hex::encode(group_id.as_slice()))
+            .collect::<HashSet<_>>();
+        for group in &mut groups {
+            group.disbanding = disbanding.contains(&group.group_id_hex);
+            group.disband_request = requests.get(&group.group_id_hex).cloned().map(Into::into);
+            group.disbanded = disbanded.contains(&group.group_id_hex);
+        }
         Ok(groups)
     }
 

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -40,7 +40,10 @@ pub use cgka_traits::app_event::AppMessageRetentionDecision;
 use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{GroupEvent, KeyPackage};
-use cgka_traits::storage::{KeyPackageBundleStorage, MaintenanceStorage};
+use cgka_traits::storage::{
+    DisbandRequestStatus, DisbandRequestStorage, DisbandTombstoneStorage, KeyPackageBundleStorage,
+    MaintenanceStorage,
+};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::{
     GroupId, MemberId, TransportEndpoint, TransportGroupSubscription, TransportPublishTarget,
@@ -142,12 +145,13 @@ pub use drafts::{
 };
 pub use error::AppError;
 pub use groups::{
-    AppAgentTextStreamComponent, AppBlobEndpoint, AppGroupAdminPolicyComponent,
-    AppGroupAvatarUrlComponent, AppGroupEncryptedMediaComponent, AppGroupHydrationQuarantineReason,
-    AppGroupImageComponent, AppGroupMemberRecord, AppGroupMessageRetentionComponent,
-    AppGroupMlsState, AppGroupNostrRoutingComponent, AppGroupOpaqueComponent,
-    AppGroupProfileComponent, AppGroupRecord, AppGroupSystemEvent, AppInitialGroupImage,
-    AppPriorNostrRoute, AppProtocolProfile, AppQuarantinedGroup, group_system_event_from_message,
+    AppAgentTextStreamComponent, AppBlobEndpoint, AppDisbandFailureReason, AppDisbandRequest,
+    AppGroupAdminPolicyComponent, AppGroupAvatarUrlComponent, AppGroupEncryptedMediaComponent,
+    AppGroupHydrationQuarantineReason, AppGroupImageComponent, AppGroupLifecycleState,
+    AppGroupMemberRecord, AppGroupMessageRetentionComponent, AppGroupMlsState,
+    AppGroupNostrRoutingComponent, AppGroupOpaqueComponent, AppGroupProfileComponent,
+    AppGroupRecord, AppGroupSystemEvent, AppInitialGroupImage, AppPriorNostrRoute,
+    AppProtocolProfile, AppQuarantinedGroup, group_system_event_from_message,
 };
 pub use ids::{
     account_id_hex_from_ref, nprofile_for_account_id, npub_for_account_id, validate_relay_urls,
@@ -1249,6 +1253,7 @@ impl MarmotApp {
             // reconciled group set when it registers subscriptions.
             client.app.save_state(&client.state)?;
         }
+        client.reconcile_disband_drafts();
         // This once-only projection migration is local SQL work and must land
         // before the host renders its first chat-list snapshot.
         client.backfill_self_membership_once()?;
@@ -2610,6 +2615,7 @@ impl MarmotApp {
         }
 
         let account = self.account_home().account(&state.label)?;
+        let account_storage = self.account_storage(&state.label)?;
         let relay_lists = self.account_relay_list_status_for_account_id(&account.account_id_hex)?;
         let mut group_routes = Vec::new();
         for group in &state.groups {
@@ -2623,6 +2629,9 @@ impl MarmotApp {
                 continue;
             };
             let group_id = GroupId::new(group_id_bytes);
+            if account_storage.disband_tombstone(&group_id)?.is_some() {
+                continue;
+            }
             match group.transport_subscriptions(&group_id) {
                 Ok(subscriptions) => group_routes.extend(subscriptions),
                 Err(_) => tracing::warn!(
@@ -3598,9 +3607,17 @@ impl MarmotApp {
         group_id_hex: &str,
     ) -> Result<bool, AppError> {
         self.ensure_account_state(label)?;
-        let deleted = self
-            .account_storage(label)?
-            .delete_local_group_data(group_id_hex)?;
+        let storage = self.account_storage(label)?;
+        let group_id = GroupId::new(hex::decode(group_id_hex)?);
+        if matches!(
+            storage
+                .disband_request(&group_id)?
+                .map(|request| request.status),
+            Some(DisbandRequestStatus::Pending)
+        ) {
+            return Err(AppError::GroupDisbanding(group_id_hex.to_owned()));
+        }
+        let deleted = storage.delete_local_group_data(group_id_hex)?;
         self.chat_list_projection_stale
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -40,10 +40,7 @@ pub use cgka_traits::app_event::AppMessageRetentionDecision;
 use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::{GroupEvent, KeyPackage};
-use cgka_traits::storage::{
-    DisbandRequestStatus, DisbandRequestStorage, DisbandTombstoneStorage, KeyPackageBundleStorage,
-    MaintenanceStorage,
-};
+use cgka_traits::storage::{DisbandTombstoneStorage, KeyPackageBundleStorage, MaintenanceStorage};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::{
     GroupId, MemberId, TransportEndpoint, TransportGroupSubscription, TransportPublishTarget,
@@ -2629,6 +2626,11 @@ impl MarmotApp {
 
         let account = self.account_home().account(&state.label)?;
         let account_storage = self.account_storage(&state.label)?;
+        let disbanded_group_ids = account_storage
+            .list_disband_tombstones()?
+            .into_iter()
+            .map(|(group_id, _)| hex::encode(group_id.as_slice()))
+            .collect::<HashSet<_>>();
         let relay_lists = self.account_relay_list_status_for_account_id(&account.account_id_hex)?;
         let mut group_routes = Vec::new();
         for group in &state.groups {
@@ -2642,7 +2644,7 @@ impl MarmotApp {
                 continue;
             };
             let group_id = GroupId::new(group_id_bytes);
-            if account_storage.disband_tombstone(&group_id)?.is_some() {
+            if disbanded_group_ids.contains(&hex::encode(group_id.as_slice())) {
                 continue;
             }
             match group.transport_subscriptions(&group_id) {
@@ -3622,12 +3624,11 @@ impl MarmotApp {
         self.ensure_account_state(label)?;
         let storage = self.account_storage(label)?;
         let group_id = GroupId::new(hex::decode(group_id_hex)?);
-        if matches!(
-            storage
-                .disband_request(&group_id)?
-                .map(|request| request.status),
-            Some(DisbandRequestStatus::Pending)
-        ) {
+        let normalized_group_id_hex = hex::encode(group_id.as_slice());
+        if storage
+            .disbanding_group_ids_hex()?
+            .contains(&normalized_group_id_hex)
+        {
             return Err(AppError::GroupDisbanding(group_id_hex.to_owned()));
         }
         let deleted = storage.delete_local_group_data(group_id_hex)?;

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -25,10 +25,10 @@ use crate::messages::AppMessageIntent;
 use crate::{
     ACCOUNT_WORKER_RECONNECT_BASE_DELAY, ACCOUNT_WORKER_RECONNECT_JITTER_MAX_MS,
     ACCOUNT_WORKER_RECONNECT_MAX_DELAY, APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT,
-    AgentTextStreamFinishRequest, AppBlobEndpoint, AppClient, AppError, AppGroupMemberRecord,
-    AppGroupMlsState, AppGroupRecord, AppInitialGroupImage, AppProjectionUpdate,
-    AppQuarantinedGroup, GroupInviteDeclineResult, MaintenanceRunSummary, MarmotApp,
-    MarmotRelayPlane, MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest,
+    AgentTextStreamFinishRequest, AppBlobEndpoint, AppClient, AppDisbandRequest, AppError,
+    AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppInitialGroupImage,
+    AppProjectionUpdate, AppQuarantinedGroup, GroupInviteDeclineResult, MaintenanceRunSummary,
+    MarmotApp, MarmotRelayPlane, MediaAttachmentReference, MediaDownloadResult, MediaUploadRequest,
     MediaUploadResult, NotificationSettings, PendingWelcomeDelivery, PushPlatform,
     PushRegistration, PushRegistrationShareOutcome, PushRegistrationSyncResult, ReceivedMessage,
     RetentionSweepReport, SecureDeleteExpiredResult, SendSummary, SyncSummary,
@@ -107,6 +107,18 @@ pub(crate) enum AccountWorkerCommand {
     GroupMlsState {
         group_id: GroupId,
         respond: oneshot::Sender<Result<AppGroupMlsState, AppError>>,
+    },
+    EnableGroupDisbanding {
+        group_id: GroupId,
+        respond: oneshot::Sender<Result<SendSummary, AppError>>,
+    },
+    DisbandGroup {
+        group_id: GroupId,
+        respond: oneshot::Sender<Result<AppDisbandRequest, AppError>>,
+    },
+    AcknowledgeDisbandFailure {
+        group_id: GroupId,
+        respond: oneshot::Sender<Result<bool, AppError>>,
     },
     QuarantinedGroups {
         respond: oneshot::Sender<Result<Vec<AppQuarantinedGroup>, AppError>>,
@@ -963,6 +975,40 @@ async fn handle_account_worker_command(
         }
         AccountWorkerCommand::GroupMlsState { group_id, respond } => {
             let result = client.group_mls_state(&group_id);
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::EnableGroupDisbanding { group_id, respond } => {
+            let result = client.enable_group_disbanding(&group_id).await;
+            if result.is_ok() {
+                publish_app_runtime_group_state_updated(
+                    events,
+                    account_id_hex,
+                    account_label,
+                    &group_id,
+                );
+            }
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::DisbandGroup { group_id, respond } => {
+            let result = client.disband_group(&group_id).await;
+            publish_app_runtime_group_state_updated(
+                events,
+                account_id_hex,
+                account_label,
+                &group_id,
+            );
+            let _ = respond.send(result);
+        }
+        AccountWorkerCommand::AcknowledgeDisbandFailure { group_id, respond } => {
+            let result = client.acknowledge_disband_failure(&group_id);
+            if matches!(result, Ok(true)) {
+                publish_app_runtime_group_state_updated(
+                    events,
+                    account_id_hex,
+                    account_label,
+                    &group_id,
+                );
+            }
             let _ = respond.send(result);
         }
         AccountWorkerCommand::QuarantinedGroups { respond } => {

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -17,8 +17,8 @@ use super::{
 use crate::app_telemetry::AppPerformanceOperation;
 use crate::messages::AppMessageIntent;
 use crate::{
-    AgentOperationEventRequest, AgentTextStreamFinishRequest, AppBlobEndpoint, AppError,
-    AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppQuarantinedGroup,
+    AgentOperationEventRequest, AgentTextStreamFinishRequest, AppBlobEndpoint, AppDisbandRequest,
+    AppError, AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppQuarantinedGroup,
     GroupInviteDeclineResult, GroupPushDebugInfo, MaintenanceRunSummary, MediaAttachmentReference,
     MediaDownloadResult, MediaUploadRequest, MediaUploadResult, NotificationSettings,
     PendingWelcomeDelivery, PushPlatform, PushRegistration, PushRegistrationShareOutcome,
@@ -123,6 +123,60 @@ impl AccountManager {
             result.is_ok(),
         );
         result
+    }
+
+    pub async fn enable_group_disbanding(
+        &self,
+        account_ref: &str,
+        group_id: &GroupId,
+    ) -> Result<SendSummary, AppError> {
+        let command = self.worker_commands(account_ref).await?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::EnableGroupDisbanding {
+                group_id: group_id.clone(),
+                respond,
+            })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        let summary = account_worker_response(response).await?;
+        self.catch_up_after_committed_mutation("enable_group_disbanding")
+            .await;
+        Ok(summary)
+    }
+
+    pub async fn disband_group(
+        &self,
+        account_ref: &str,
+        group_id: &GroupId,
+    ) -> Result<AppDisbandRequest, AppError> {
+        let command = self.worker_commands(account_ref).await?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::DisbandGroup {
+                group_id: group_id.clone(),
+                respond,
+            })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        account_worker_response(response).await
+    }
+
+    pub async fn acknowledge_disband_failure(
+        &self,
+        account_ref: &str,
+        group_id: &GroupId,
+    ) -> Result<bool, AppError> {
+        let command = self.worker_commands(account_ref).await?;
+        let (respond, response) = oneshot::channel();
+        command
+            .send(AccountWorkerCommand::AcknowledgeDisbandFailure {
+                group_id: group_id.clone(),
+                respond,
+            })
+            .await
+            .map_err(|_| AppError::TransportClosed)?;
+        account_worker_response(response).await
     }
 
     /// Stored groups that failed session-open hydration and were skipped

--- a/crates/marmot-app/src/runtime/commands.rs
+++ b/crates/marmot-app/src/runtime/commands.rs
@@ -142,6 +142,7 @@ impl AccountManager {
         let summary = account_worker_response(response).await?;
         self.catch_up_after_committed_mutation("enable_group_disbanding")
             .await;
+        self.schedule_audit_log_tracker_update("enable_group_disbanding");
         Ok(summary)
     }
 
@@ -159,7 +160,11 @@ impl AccountManager {
             })
             .await
             .map_err(|_| AppError::TransportClosed)?;
-        account_worker_response(response).await
+        let request = account_worker_response(response).await?;
+        self.catch_up_after_committed_mutation("disband_group")
+            .await;
+        self.schedule_audit_log_tracker_update("disband_group");
+        Ok(request)
     }
 
     pub async fn acknowledge_disband_failure(

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -29,10 +29,10 @@ use crate::{
     ACCOUNT_SETUP_ADVISORY_WAIT, APP_RUNTIME_ACCOUNT_READY_WAIT, APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT,
     APP_RUNTIME_RELAY_REBUILD_LOOKBACK, AccountKeyPackageRecord, AccountRelayListBootstrap,
     AccountRelayListStatus, AccountUnread, AgentOperationEventRequest,
-    AgentTextStreamFinishRequest, AppBlobEndpoint, AppError, AppGroupMemberRecord,
-    AppGroupMlsState, AppGroupRecord, AppMessageQuery, AppMessageRecord, AppProjectionUpdate,
-    AppQuarantinedGroup, AuditLogDeleteOutcome, AuditLogFile, AuditLogSettings,
-    AuditLogTrackerConfig, AuditLogTrackerUpdateResult, AuditLogUploadResult,
+    AgentTextStreamFinishRequest, AppBlobEndpoint, AppDisbandRequest, AppError,
+    AppGroupMemberRecord, AppGroupMlsState, AppGroupRecord, AppMessageQuery, AppMessageRecord,
+    AppProjectionUpdate, AppQuarantinedGroup, AuditLogDeleteOutcome, AuditLogFile,
+    AuditLogSettings, AuditLogTrackerConfig, AuditLogTrackerUpdateResult, AuditLogUploadResult,
     BackgroundNotificationCollection, ChatListRow, ChatNotificationSettings, ChatPinState,
     GroupInviteDeclineResult, GroupPushDebugInfo, KeyPackageDeletionTarget, MAX_SEEN_EVENT_IDS,
     MarmotApp, MarmotRelayPlane, MarmotServiceEndpoints, MediaAttachmentReference,
@@ -1103,6 +1103,34 @@ impl MarmotAppRuntime {
         group_id: &GroupId,
     ) -> Result<AppGroupMlsState, AppError> {
         self.accounts.group_mls_state(account_ref, group_id).await
+    }
+
+    pub async fn enable_group_disbanding(
+        &self,
+        account_ref: &str,
+        group_id: &GroupId,
+    ) -> Result<SendSummary, AppError> {
+        self.accounts
+            .enable_group_disbanding(account_ref, group_id)
+            .await
+    }
+
+    pub async fn disband_group(
+        &self,
+        account_ref: &str,
+        group_id: &GroupId,
+    ) -> Result<AppDisbandRequest, AppError> {
+        self.accounts.disband_group(account_ref, group_id).await
+    }
+
+    pub async fn acknowledge_disband_failure(
+        &self,
+        account_ref: &str,
+        group_id: &GroupId,
+    ) -> Result<bool, AppError> {
+        self.accounts
+            .acknowledge_disband_failure(account_ref, group_id)
+            .await
     }
 
     /// Stored groups that failed session-open hydration and were skipped

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -1126,6 +1126,7 @@ fn chat_list_test_row(group_id_hex: &str, title: &str) -> ChatListRow {
         updated_at: 0,
         self_membership: crate::SelfMembership::Member,
         conversation_kind: crate::ChatConversationKind::Unknown,
+        lifecycle_state: cgka_traits::GroupLifecycleState::Stable,
         muted: false,
         muted_until_ms: None,
         leave_requested_at_ms: None,

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -1059,6 +1059,13 @@ fn chat_list_fingerprint_and_expiry_tracking_include_new_interaction_state() {
         chat_list_row_fingerprint(&base),
         chat_list_row_fingerprint(&pinned)
     );
+    let mut disbanding = base.clone();
+    disbanding.disbanding = true;
+    assert_ne!(
+        chat_list_row_fingerprint(&base),
+        chat_list_row_fingerprint(&disbanding),
+        "pending disband must wake chat-list subscribers so hosts can hide the composer"
+    );
 
     let mut timed = base.clone();
     timed.muted = true;
@@ -1108,6 +1115,8 @@ fn chat_list_test_row(group_id_hex: &str, title: &str) -> ChatListRow {
         pinned_position: None,
         archived: false,
         pending_confirmation: false,
+        disbanding: false,
+        disband_request: None,
         title: title.to_owned(),
         group_name: title.to_owned(),
         avatar_url: None,

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -11,6 +11,7 @@ use cgka_traits::app_event::{
     STREAM_CHUNKS_TAG, STREAM_FINAL_KIND_TAG, STREAM_HASH_TAG, STREAM_PARENT_TAG, STREAM_START_TAG,
     STREAM_TAG, STREAM_TYPE_TAG,
 };
+use cgka_traits::storage::{DisbandCandidate, DisbandCandidateStorage};
 use marmot_account::AccountHomeError;
 use storage_sqlite::StoredRelayTelemetrySettings;
 use transport_nostr_adapter::{
@@ -207,6 +208,48 @@ fn pending_disband_is_projected_and_blocks_optimistic_application_messages() {
         "pending-disband-composer-gate",
         pending_disband_composer_gate_body,
     );
+}
+
+#[test]
+fn inbound_disband_candidate_blocks_both_local_delete_entry_points() {
+    run_composed_app_runtime_test(
+        "inbound-disband-local-delete-gate",
+        inbound_disband_candidate_blocks_local_delete_body,
+    );
+}
+
+async fn inbound_disband_candidate_blocks_local_delete_body() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+        .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client.create_group("terminal", &[]).await.unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    app.account_storage("alice")
+        .unwrap()
+        .put_disband_candidate(&DisbandCandidate {
+            group_id: group_id.clone(),
+            source_epoch: cgka_traits::EpochId(0),
+            commit_id: cgka_traits::MessageId::new(vec![0x41; 32]),
+            content_commit_id: cgka_traits::MessageId::new(vec![0x42; 32]),
+            commit_digest: [0x43; 32],
+            actor: cgka_traits::MemberId::new(vec![0x44; 32]),
+            local_was_committer_leaf: false,
+            former_members: vec![],
+        })
+        .unwrap();
+
+    assert!(matches!(
+        client.delete_group_local(&group_id).await,
+        Err(AppError::GroupDisbanding(_))
+    ));
+    assert!(matches!(
+        app.delete_group_local_data("alice", &group_id_hex),
+        Err(AppError::GroupDisbanding(_))
+    ));
 }
 
 async fn pending_disband_composer_gate_body() {

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -201,6 +201,73 @@ fn account_reconcile_returns_local_readiness_before_relay_subscription_registrat
     );
 }
 
+#[test]
+fn pending_disband_is_projected_and_blocks_optimistic_application_messages() {
+    run_composed_app_runtime_test(
+        "pending-disband-composer-gate",
+        pending_disband_composer_gate_body,
+    );
+}
+
+async fn pending_disband_composer_gate_body() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+        .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+    let mut client = app.client("alice").await.unwrap();
+    let group_id = client.create_group("terminal", &[]).await.unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+
+    let request = client.disband_group(&group_id).await.unwrap();
+    assert!(matches!(
+        request,
+        AppDisbandRequest::Pending { requested_at_ms: _ }
+    ));
+
+    let mls = client.group_mls_state(&group_id).unwrap();
+    assert!(mls.disbanding);
+    assert!(matches!(
+        mls.disband_request,
+        Some(AppDisbandRequest::Pending { .. })
+    ));
+
+    let group = app.group("alice", &group_id_hex).unwrap().unwrap();
+    assert!(group.disbanding);
+    assert!(!group.disbanded);
+    assert!(matches!(
+        group.disband_request,
+        Some(AppDisbandRequest::Pending { .. })
+    ));
+
+    let row = app
+        .chat_list_row("alice", &group_id_hex)
+        .unwrap()
+        .expect("chat-list row");
+    assert!(row.disbanding);
+    assert!(matches!(
+        row.disband_request,
+        Some(cgka_traits::DisbandRequest {
+            status: cgka_traits::DisbandRequestStatus::Pending,
+            ..
+        })
+    ));
+
+    let mut optimistic_projection_count = 0usize;
+    let error = client
+        .send_with_local_projection(&group_id, b"must not appear", |_| {
+            optimistic_projection_count += 1;
+        })
+        .await
+        .unwrap_err();
+    assert!(matches!(error, AppError::GroupDisbanding(_)));
+    assert_eq!(
+        optimistic_projection_count, 0,
+        "composer sends must fail before optimistic timeline projection"
+    );
+}
+
 async fn account_local_ready_before_subscribe_body() {
     let dir = tempfile::tempdir().unwrap();
     AccountHome::open(dir.path())

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -11,7 +11,7 @@ use cgka_traits::GroupId;
 use crate::Marmot;
 use crate::conversions::{
     AppBlobEndpointFfi, AppGroupMemberRecordFfi, AppGroupMlsStateFfi, AppGroupRecordFfi,
-    AppQuarantinedGroupFfi, GroupDetailsFfi, GroupInviteDeclineResultFfi,
+    AppQuarantinedGroupFfi, DisbandRequestFfi, GroupDetailsFfi, GroupInviteDeclineResultFfi,
     GroupMaintenanceStatusFfi, GroupManagementStateFfi, GroupMemberActionStateFfi,
     GroupMutationResultFfi, KeyPackageMaintenanceStatusFfi, MaintenanceRunSummaryFfi, MemberRefFfi,
     PeriodicMaintenancePolicyFfi, SendSummaryFfi, group_details_ffi, group_id_from_hex,
@@ -71,7 +71,18 @@ pub(crate) async fn group_details_for(
             .runtime
             .display_names_for_account_ids(&member_ids)
             .unwrap_or_default();
-        group_details_ffi(group, members, &account.account_id_hex, display_names)
+        let mls_state = kit
+            .runtime
+            .group_mls_state(account_ref, group_id)
+            .await?
+            .into();
+        group_details_ffi(
+            group,
+            members,
+            mls_state,
+            &account.account_id_hex,
+            display_names,
+        )
     }
     .await;
     kit.runtime
@@ -331,6 +342,49 @@ impl Marmot {
         let group_id = group_id_from_hex(&group_id_hex)?;
         let group_id_hex = hex::encode(group_id.as_slice());
         group_management_state_for(self, &account_ref, &group_id, &group_id_hex).await
+    }
+
+    /// Install lifecycle-v1 and require it in one admin Commit.
+    pub async fn enable_group_disbanding(
+        &self,
+        account_ref: String,
+        group_id_hex: String,
+    ) -> Result<GroupMutationResultFfi, MarmotKitError> {
+        let group_id = group_id_from_hex(&group_id_hex)?;
+        let group_id_hex = hex::encode(group_id.as_slice());
+        let state =
+            group_management_state_for(self, &account_ref, &group_id, &group_id_hex).await?;
+        ensure_group_admin(&state, &group_id_hex)?;
+        let summary = self
+            .runtime
+            .enable_group_disbanding(&account_ref, &group_id)
+            .await?;
+        group_mutation_result_for(self, &account_ref, &group_id, &group_id_hex, summary.into())
+            .await
+    }
+
+    /// Durably accept an irreversible disband request. Completion is observed
+    /// through normal group state updates after bounded convergence.
+    pub async fn disband_group(
+        &self,
+        account_ref: String,
+        group_id_hex: String,
+    ) -> Result<DisbandRequestFfi, MarmotKitError> {
+        let group_id = group_id_from_hex(&group_id_hex)?;
+        let request = self.runtime.disband_group(&account_ref, &group_id).await?;
+        Ok(request.into())
+    }
+
+    pub async fn acknowledge_disband_failure(
+        &self,
+        account_ref: String,
+        group_id_hex: String,
+    ) -> Result<bool, MarmotKitError> {
+        let group_id = group_id_from_hex(&group_id_hex)?;
+        Ok(self
+            .runtime
+            .acknowledge_disband_failure(&account_ref, &group_id)
+            .await?)
     }
 
     pub async fn invite_members(
@@ -889,6 +943,12 @@ mod tests {
             requires_self_demote_before_leave: self_admin,
             leave_request_pending: false,
             leave_requested_at_ms: None,
+            lifecycle_state: crate::conversions::GroupLifecycleStateFfi::Stable,
+            disbanding_enabled: true,
+            can_enable_disbanding: false,
+            can_disband: self_admin,
+            disband_blockers: vec![],
+            disband_request: None,
             member_actions: vec![
                 GroupMemberActionStateFfi {
                     member_id_hex: self_id.into(),

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -371,6 +371,10 @@ impl Marmot {
         group_id_hex: String,
     ) -> Result<DisbandRequestFfi, MarmotKitError> {
         let group_id = group_id_from_hex(&group_id_hex)?;
+        let group_id_hex = hex::encode(group_id.as_slice());
+        let state =
+            group_management_state_for(self, &account_ref, &group_id, &group_id_hex).await?;
+        ensure_group_admin(&state, &group_id_hex)?;
         let request = self.runtime.disband_group(&account_ref, &group_id).await?;
         Ok(request.into())
     }
@@ -948,7 +952,7 @@ mod tests {
             disbanding: false,
             can_enable_disbanding: false,
             can_disband: self_admin,
-            disband_blockers: vec![],
+            disbanding_blockers: vec![],
             disband_request: None,
             member_actions: vec![
                 GroupMemberActionStateFfi {

--- a/crates/marmot-uniffi/src/commands/group.rs
+++ b/crates/marmot-uniffi/src/commands/group.rs
@@ -945,6 +945,7 @@ mod tests {
             leave_requested_at_ms: None,
             lifecycle_state: crate::conversions::GroupLifecycleStateFfi::Stable,
             disbanding_enabled: true,
+            disbanding: false,
             can_enable_disbanding: false,
             can_disband: self_admin,
             disband_blockers: vec![],

--- a/crates/marmot-uniffi/src/conversions/chat_list.rs
+++ b/crates/marmot-uniffi/src/conversions/chat_list.rs
@@ -7,6 +7,7 @@ use marmot_app::{
 };
 
 use super::common::{SelfMembershipFfi, markdown_content_tokens};
+use super::group::GroupLifecycleStateFfi;
 use crate::markdown::MarkdownDocumentFfi;
 
 /// Group avatar reference. `image_key_hex` is the symmetric key that decrypts
@@ -149,6 +150,7 @@ pub struct ChatListRowFfi {
     pub pinned_position: Option<u32>,
     pub archived: bool,
     pub pending_confirmation: bool,
+    pub lifecycle_state: GroupLifecycleStateFfi,
     pub title: String,
     pub group_name: String,
     pub avatar_url: Option<String>,
@@ -214,6 +216,7 @@ impl From<ChatListRow> for ChatListRowFfi {
             pinned_position: value.pinned_position,
             archived: value.archived,
             pending_confirmation: value.pending_confirmation,
+            lifecycle_state: value.lifecycle_state.into(),
             title: value.title,
             group_name: value.group_name,
             avatar_url: value.avatar_url,
@@ -379,6 +382,7 @@ mod tests {
             pinned_position: None,
             archived: false,
             pending_confirmation: false,
+            lifecycle_state: cgka_traits::GroupLifecycleState::Stable,
             title: "Marmot Lab".to_owned(),
             group_name: "Marmot Lab".to_owned(),
             avatar_url: None,

--- a/crates/marmot-uniffi/src/conversions/chat_list.rs
+++ b/crates/marmot-uniffi/src/conversions/chat_list.rs
@@ -1,9 +1,9 @@
 //! Chat-list avatar, row, message-preview, and subscription-update FFI conversions.
 
 use marmot_app::{
-    ChatConversationKind, ChatListAttachmentKind, ChatListAvatar, ChatListMessageDeliveryState,
-    ChatListMessagePreview, ChatListRow, ChatNotificationSettings, ChatPinState,
-    RuntimeChatListUpdate,
+    AppDisbandRequest, ChatConversationKind, ChatListAttachmentKind, ChatListAvatar,
+    ChatListMessageDeliveryState, ChatListMessagePreview, ChatListRow, ChatNotificationSettings,
+    ChatPinState, RuntimeChatListUpdate,
 };
 
 use super::common::{SelfMembershipFfi, markdown_content_tokens};
@@ -151,6 +151,11 @@ pub struct ChatListRowFfi {
     pub archived: bool,
     pub pending_confirmation: bool,
     pub lifecycle_state: GroupLifecycleStateFfi,
+    /// Hide/disable the message composer while terminal convergence is in
+    /// progress. This also covers another admin's inbound candidate.
+    pub disbanding: bool,
+    /// This account's durable request outcome, if any.
+    pub disband_request: Option<super::group::DisbandRequestFfi>,
     pub title: String,
     pub group_name: String,
     pub avatar_url: Option<String>,
@@ -217,6 +222,11 @@ impl From<ChatListRow> for ChatListRowFfi {
             archived: value.archived,
             pending_confirmation: value.pending_confirmation,
             lifecycle_state: value.lifecycle_state.into(),
+            disbanding: value.disbanding,
+            disband_request: value
+                .disband_request
+                .map(AppDisbandRequest::from)
+                .map(Into::into),
             title: value.title,
             group_name: value.group_name,
             avatar_url: value.avatar_url,
@@ -383,6 +393,8 @@ mod tests {
             archived: false,
             pending_confirmation: false,
             lifecycle_state: cgka_traits::GroupLifecycleState::Stable,
+            disbanding: false,
+            disband_request: None,
             title: "Marmot Lab".to_owned(),
             group_name: "Marmot Lab".to_owned(),
             avatar_url: None,
@@ -480,6 +492,29 @@ mod tests {
         let ffi = ChatListRowFfi::from(sample_row());
         assert!(!ffi.leave_request_pending);
         assert_eq!(ffi.leave_requested_at_ms, None);
+    }
+
+    #[test]
+    fn chat_list_row_exports_pending_disband_for_composer_gating() {
+        let request = cgka_traits::DisbandRequest {
+            group_id: cgka_traits::GroupId::new(vec![0x11]),
+            requested_at_ms: 1_700_000_000_456,
+            status: cgka_traits::DisbandRequestStatus::Pending,
+            last_prepared_epoch: None,
+        };
+        let ffi = ChatListRowFfi::from(ChatListRow {
+            disbanding: true,
+            disband_request: Some(request),
+            ..sample_row()
+        });
+
+        assert!(ffi.disbanding);
+        assert!(matches!(
+            ffi.disband_request,
+            Some(super::super::group::DisbandRequestFfi::Pending {
+                requested_at_ms: 1_700_000_000_456
+            })
+        ));
     }
 
     #[test]

--- a/crates/marmot-uniffi/src/conversions/event.rs
+++ b/crates/marmot-uniffi/src/conversions/event.rs
@@ -163,6 +163,7 @@ fn group_state_change_tag(change: &GroupStateChange) -> &'static str {
         GroupStateChange::GroupRenamed { .. } => "group_renamed",
         GroupStateChange::GroupAvatarChanged => "group_avatar_changed",
         GroupStateChange::MessageRetentionChanged { .. } => "disappearing_timer_changed",
+        GroupStateChange::GroupDisbanded => "group_disbanded",
     }
 }
 

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -3,10 +3,11 @@
 use std::collections::{HashMap, HashSet};
 
 use marmot_app::{
-    AppBlobEndpoint, AppGroupAdminPolicyComponent, AppGroupEncryptedMediaComponent,
-    AppGroupHydrationQuarantineReason, AppGroupMemberRecord, AppGroupMlsState,
-    AppGroupNostrRoutingComponent, AppGroupProfileComponent, AppGroupRecord, AppProtocolProfile,
-    AppQuarantinedGroup, GroupInviteDeclineResult, account_id_hex_from_ref, npub_for_account_id,
+    AppBlobEndpoint, AppDisbandFailureReason, AppDisbandRequest, AppGroupAdminPolicyComponent,
+    AppGroupEncryptedMediaComponent, AppGroupHydrationQuarantineReason, AppGroupLifecycleState,
+    AppGroupMemberRecord, AppGroupMlsState, AppGroupNostrRoutingComponent,
+    AppGroupProfileComponent, AppGroupRecord, AppProtocolProfile, AppQuarantinedGroup,
+    GroupInviteDeclineResult, account_id_hex_from_ref, npub_for_account_id,
 };
 
 use super::account::SendSummaryFfi;
@@ -225,6 +226,7 @@ pub struct GroupMemberDetailsFfi {
 pub struct GroupDetailsFfi {
     pub group: AppGroupRecordFfi,
     pub members: Vec<GroupMemberDetailsFfi>,
+    pub mls_state: AppGroupMlsStateFfi,
 }
 
 #[derive(Clone, Debug, uniffi::Record)]
@@ -259,6 +261,12 @@ pub struct GroupManagementStateFfi {
     /// When the local account asked to leave, in milliseconds since the Unix
     /// epoch; `null` when no leave is pending.
     pub leave_requested_at_ms: Option<u64>,
+    pub lifecycle_state: GroupLifecycleStateFfi,
+    pub disbanding_enabled: bool,
+    pub can_enable_disbanding: bool,
+    pub can_disband: bool,
+    pub disband_blockers: Vec<String>,
+    pub disband_request: Option<DisbandRequestFfi>,
     pub member_actions: Vec<GroupMemberActionStateFfi>,
 }
 
@@ -319,6 +327,7 @@ fn canonical_member_ref_input(member_ref: &str) -> String {
 pub(crate) fn group_details_ffi(
     group: AppGroupRecordFfi,
     members: Vec<AppGroupMemberRecordFfi>,
+    mls_state: AppGroupMlsStateFfi,
     my_account_id_hex: &str,
     display_names: HashMap<String, String>,
 ) -> Result<GroupDetailsFfi, MarmotKitError> {
@@ -342,7 +351,11 @@ pub(crate) fn group_details_ffi(
             })
         })
         .collect::<Result<Vec<_>, MarmotKitError>>()?;
-    Ok(GroupDetailsFfi { group, members })
+    Ok(GroupDetailsFfi {
+        group,
+        members,
+        mls_state,
+    })
 }
 
 pub(crate) fn group_management_state_ffi(
@@ -360,7 +373,16 @@ pub(crate) fn group_management_state_ffi(
         .find(|member| member.member_id_hex == my_account_id_hex);
     let is_self_admin = self_member.is_some_and(|member| member.is_admin);
     let is_last_admin = is_self_admin && admin_count == 1;
-    let can_invite = is_self_admin;
+    let request_pending = matches!(
+        details.mls_state.disband_request,
+        Some(DisbandRequestFfi::Pending { .. })
+    );
+    let lifecycle_terminal = matches!(
+        details.mls_state.lifecycle_state,
+        GroupLifecycleStateFfi::Disbanded
+    );
+    let ordinary_actions_enabled = !request_pending && !lifecycle_terminal;
+    let can_invite = is_self_admin && ordinary_actions_enabled;
     // A leave already in flight suppresses `can_leave` so hosts do not offer a
     // second Leave that the engine would reject: the durable request is not
     // epoch-bound, but the SelfRemove proposal backing it is, and re-requesting
@@ -369,8 +391,12 @@ pub(crate) fn group_management_state_ffi(
     // the affordance keeps that error off the happy path; it does not prevent it,
     // since this state is not read atomically with the leave it guards.
     let leave_request_pending = details.group.leave_request_pending;
-    let can_leave = self_member.is_some() && !is_self_admin && !leave_request_pending;
-    let requires_self_demote_before_leave = self_member.is_some() && is_self_admin;
+    let can_leave = self_member.is_some()
+        && !is_self_admin
+        && !leave_request_pending
+        && ordinary_actions_enabled;
+    let requires_self_demote_before_leave =
+        self_member.is_some() && is_self_admin && ordinary_actions_enabled;
     let member_actions = details
         .members
         .iter()
@@ -380,9 +406,13 @@ pub(crate) fn group_management_state_ffi(
                 member_id_hex: member.member_id_hex.clone(),
                 is_self: member.is_self,
                 is_admin: member.is_admin,
-                can_remove: is_self_admin && !member.is_self && !would_remove_last_admin,
-                can_promote: is_self_admin && !member.is_admin,
+                can_remove: is_self_admin
+                    && ordinary_actions_enabled
+                    && !member.is_self
+                    && !would_remove_last_admin,
+                can_promote: is_self_admin && ordinary_actions_enabled && !member.is_admin,
                 can_demote: is_self_admin
+                    && ordinary_actions_enabled
                     && member.is_admin
                     && !member.is_self
                     && !would_remove_last_admin,
@@ -398,7 +428,94 @@ pub(crate) fn group_management_state_ffi(
         requires_self_demote_before_leave,
         leave_request_pending,
         leave_requested_at_ms: details.group.leave_requested_at_ms,
+        lifecycle_state: details.mls_state.lifecycle_state,
+        disbanding_enabled: details.mls_state.disbanding_enabled,
+        can_enable_disbanding: is_self_admin
+            && ordinary_actions_enabled
+            && matches!(
+                details.mls_state.lifecycle_state,
+                GroupLifecycleStateFfi::Stable
+            )
+            && !details.mls_state.disbanding_enabled
+            && details.mls_state.disbanding_blockers.is_empty(),
+        can_disband: is_self_admin
+            && ordinary_actions_enabled
+            && matches!(
+                details.mls_state.lifecycle_state,
+                GroupLifecycleStateFfi::Stable
+            )
+            && details.mls_state.disbanding_enabled,
+        disband_blockers: details.mls_state.disbanding_blockers.clone(),
+        disband_request: details.mls_state.disband_request.clone(),
         member_actions,
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum GroupLifecycleStateFfi {
+    Stable,
+    PendingPublish,
+    Merging,
+    Recovering,
+    Unrecoverable,
+    Disbanded,
+}
+
+impl From<AppGroupLifecycleState> for GroupLifecycleStateFfi {
+    fn from(value: AppGroupLifecycleState) -> Self {
+        match value {
+            AppGroupLifecycleState::Stable => Self::Stable,
+            AppGroupLifecycleState::PendingPublish => Self::PendingPublish,
+            AppGroupLifecycleState::Merging => Self::Merging,
+            AppGroupLifecycleState::Recovering => Self::Recovering,
+            AppGroupLifecycleState::Unrecoverable => Self::Unrecoverable,
+            AppGroupLifecycleState::Disbanded => Self::Disbanded,
+        }
+    }
+}
+
+impl From<cgka_traits::GroupLifecycleState> for GroupLifecycleStateFfi {
+    fn from(value: cgka_traits::GroupLifecycleState) -> Self {
+        AppGroupLifecycleState::from(value).into()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum DisbandFailureReasonFfi {
+    NoLongerAdmin,
+    NoLongerMember,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum DisbandRequestFfi {
+    Pending {
+        requested_at_ms: u64,
+    },
+    Failed {
+        requested_at_ms: u64,
+        reason: DisbandFailureReasonFfi,
+    },
+}
+
+impl From<AppDisbandRequest> for DisbandRequestFfi {
+    fn from(value: AppDisbandRequest) -> Self {
+        match value {
+            AppDisbandRequest::Pending { requested_at_ms } => Self::Pending { requested_at_ms },
+            AppDisbandRequest::Failed {
+                requested_at_ms,
+                reason,
+            } => Self::Failed {
+                requested_at_ms,
+                reason: match reason {
+                    AppDisbandFailureReason::NoLongerAdmin => {
+                        DisbandFailureReasonFfi::NoLongerAdmin
+                    }
+                    AppDisbandFailureReason::NoLongerMember => {
+                        DisbandFailureReasonFfi::NoLongerMember
+                    }
+                },
+            },
+        }
     }
 }
 
@@ -408,10 +525,14 @@ pub(crate) fn group_management_state_ffi(
 pub struct AppGroupMlsStateFfi {
     pub group_id_hex: String,
     pub protocol_profile: AppProtocolProfileFfi,
+    pub lifecycle_state: GroupLifecycleStateFfi,
     pub epoch: u64,
     pub member_count: u32,
     pub unrecoverable: bool,
     pub required_app_components: Vec<u16>,
+    pub disbanding_enabled: bool,
+    pub disbanding_blockers: Vec<String>,
+    pub disband_request: Option<DisbandRequestFfi>,
 }
 
 impl From<AppGroupMlsState> for AppGroupMlsStateFfi {
@@ -419,10 +540,14 @@ impl From<AppGroupMlsState> for AppGroupMlsStateFfi {
         Self {
             group_id_hex: value.group_id_hex,
             protocol_profile: value.protocol_profile.into(),
+            lifecycle_state: value.lifecycle_state.into(),
             epoch: value.epoch,
             member_count: super::saturating_u32(value.member_count),
             unrecoverable: value.unrecoverable,
             required_app_components: value.required_app_components,
+            disbanding_enabled: value.disbanding_enabled,
+            disbanding_blockers: value.disbanding_blockers,
+            disband_request: value.disband_request.map(Into::into),
         }
     }
 }

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -58,6 +58,15 @@ pub struct AppGroupRecordFfi {
     /// When the local account asked to leave, in milliseconds since the Unix
     /// epoch; `null` when no leave is pending.
     pub leave_requested_at_ms: Option<u64>,
+    /// Hide/disable the message composer while this is true. It includes both
+    /// this account's durable request and another admin's authenticated
+    /// terminal candidate awaiting convergence.
+    pub disbanding: bool,
+    /// This account's durable request outcome, if any. Another admin's pending
+    /// candidate can make `disbanding` true while this remains `null`.
+    pub disband_request: Option<DisbandRequestFfi>,
+    /// Hide the composer permanently for this group id when terminal.
+    pub disbanded: bool,
     pub welcomer_account_id_hex: Option<String>,
     pub via_welcome_message_id_hex: Option<String>,
 }
@@ -100,6 +109,9 @@ impl From<AppGroupRecord> for AppGroupRecordFfi {
             self_membership: value.self_membership.into(),
             leave_request_pending: value.leave_requested_at_ms.is_some(),
             leave_requested_at_ms: value.leave_requested_at_ms,
+            disbanding: value.disbanding,
+            disband_request: value.disband_request.map(Into::into),
+            disbanded: value.disbanded,
             welcomer_account_id_hex: value.welcomer_account_id_hex,
             via_welcome_message_id_hex: value.via_welcome_message_id_hex,
         }
@@ -263,6 +275,9 @@ pub struct GroupManagementStateFfi {
     pub leave_requested_at_ms: Option<u64>,
     pub lifecycle_state: GroupLifecycleStateFfi,
     pub disbanding_enabled: bool,
+    /// Whether terminal convergence currently blocks all ordinary outbound
+    /// group work. Hosts should hide the message composer while true.
+    pub disbanding: bool,
     pub can_enable_disbanding: bool,
     pub can_disband: bool,
     pub disband_blockers: Vec<String>,
@@ -373,15 +388,11 @@ pub(crate) fn group_management_state_ffi(
         .find(|member| member.member_id_hex == my_account_id_hex);
     let is_self_admin = self_member.is_some_and(|member| member.is_admin);
     let is_last_admin = is_self_admin && admin_count == 1;
-    let request_pending = matches!(
-        details.mls_state.disband_request,
-        Some(DisbandRequestFfi::Pending { .. })
-    );
     let lifecycle_terminal = matches!(
         details.mls_state.lifecycle_state,
         GroupLifecycleStateFfi::Disbanded
     );
-    let ordinary_actions_enabled = !request_pending && !lifecycle_terminal;
+    let ordinary_actions_enabled = !details.mls_state.disbanding && !lifecycle_terminal;
     let can_invite = is_self_admin && ordinary_actions_enabled;
     // A leave already in flight suppresses `can_leave` so hosts do not offer a
     // second Leave that the engine would reject: the durable request is not
@@ -430,6 +441,7 @@ pub(crate) fn group_management_state_ffi(
         leave_requested_at_ms: details.group.leave_requested_at_ms,
         lifecycle_state: details.mls_state.lifecycle_state,
         disbanding_enabled: details.mls_state.disbanding_enabled,
+        disbanding: details.mls_state.disbanding,
         can_enable_disbanding: is_self_admin
             && ordinary_actions_enabled
             && matches!(
@@ -531,6 +543,9 @@ pub struct AppGroupMlsStateFfi {
     pub unrecoverable: bool,
     pub required_app_components: Vec<u16>,
     pub disbanding_enabled: bool,
+    /// True while application messages and all other ordinary outbound group
+    /// work are gated pending terminal convergence.
+    pub disbanding: bool,
     pub disbanding_blockers: Vec<String>,
     pub disband_request: Option<DisbandRequestFfi>,
 }
@@ -546,6 +561,7 @@ impl From<AppGroupMlsState> for AppGroupMlsStateFfi {
             unrecoverable: value.unrecoverable,
             required_app_components: value.required_app_components,
             disbanding_enabled: value.disbanding_enabled,
+            disbanding: value.disbanding,
             disbanding_blockers: value.disbanding_blockers,
             disband_request: value.disband_request.map(Into::into),
         }

--- a/crates/marmot-uniffi/src/conversions/group.rs
+++ b/crates/marmot-uniffi/src/conversions/group.rs
@@ -262,9 +262,12 @@ pub struct GroupManagementStateFfi {
     ///
     /// When this is `false`, the reason is one of
     /// `requires_self_demote_before_leave` (demote first) or
-    /// `leave_request_pending` (already leaving) — or the account is not a member
-    /// at all. Check those before reporting an error to the user.
+    /// `leave_request_pending` (already leaving), or `disbanding` / terminal
+    /// `lifecycle_state` (ordinary group actions are unavailable) — or the
+    /// account is not a member at all. Check those before reporting an error.
     pub can_leave: bool,
+    /// Whether an admin must self-demote before leaving. Disbanding and a
+    /// terminal lifecycle take precedence and keep this false.
     pub requires_self_demote_before_leave: bool,
     /// A leave is already in flight for this group; `Marmot::leave_group` would
     /// return `MarmotKitError::LeaveAlreadyRequested`. Render progress rather
@@ -280,7 +283,7 @@ pub struct GroupManagementStateFfi {
     pub disbanding: bool,
     pub can_enable_disbanding: bool,
     pub can_disband: bool,
-    pub disband_blockers: Vec<String>,
+    pub disbanding_blockers: Vec<String>,
     pub disband_request: Option<DisbandRequestFfi>,
     pub member_actions: Vec<GroupMemberActionStateFfi>,
 }
@@ -457,7 +460,7 @@ pub(crate) fn group_management_state_ffi(
                 GroupLifecycleStateFfi::Stable
             )
             && details.mls_state.disbanding_enabled,
-        disband_blockers: details.mls_state.disbanding_blockers.clone(),
+        disbanding_blockers: details.mls_state.disbanding_blockers.clone(),
         disband_request: details.mls_state.disband_request.clone(),
         member_actions,
     }

--- a/crates/marmot-uniffi/src/conversions/mod.rs
+++ b/crates/marmot-uniffi/src/conversions/mod.rs
@@ -279,6 +279,61 @@ mod tests {
     }
 
     #[test]
+    fn disband_management_actions_require_admin_support_and_enablement() {
+        let self_id = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+        let bob_id = "bb4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+        let group = group(vec![self_id]);
+
+        let mut disabled = mls_state();
+        disabled.disbanding_enabled = false;
+        let state = group_management_state_ffi(
+            self_id,
+            &GroupDetailsFfi {
+                group: group.clone(),
+                members: vec![member(self_id, true, true), member(bob_id, false, false)],
+                mls_state: disabled.clone(),
+            },
+        );
+        assert!(state.can_enable_disbanding);
+        assert!(!state.can_disband);
+
+        disabled.disbanding_blockers = vec![bob_id.to_owned()];
+        let state = group_management_state_ffi(
+            self_id,
+            &GroupDetailsFfi {
+                group: group.clone(),
+                members: vec![member(self_id, true, true), member(bob_id, false, false)],
+                mls_state: disabled,
+            },
+        );
+        assert!(!state.can_enable_disbanding);
+        assert!(!state.can_disband);
+        assert_eq!(state.disbanding_blockers, vec![bob_id]);
+
+        let state = group_management_state_ffi(
+            self_id,
+            &GroupDetailsFfi {
+                group: group.clone(),
+                members: vec![member(self_id, true, true), member(bob_id, false, false)],
+                mls_state: mls_state(),
+            },
+        );
+        assert!(!state.can_enable_disbanding);
+        assert!(state.can_disband);
+
+        let state = group_management_state_ffi(
+            self_id,
+            &GroupDetailsFfi {
+                group,
+                members: vec![member(self_id, false, true), member(bob_id, true, false)],
+                mls_state: mls_state(),
+            },
+        );
+        assert!(!state.can_enable_disbanding);
+        assert!(!state.can_disband);
+    }
+
+    #[test]
     fn lifecycle_ffi_mapping_covers_all_six_canonical_states() {
         let cases = [
             (

--- a/crates/marmot-uniffi/src/conversions/mod.rs
+++ b/crates/marmot-uniffi/src/conversions/mod.rs
@@ -98,6 +98,9 @@ mod tests {
             self_membership: SelfMembershipFfi::Member,
             leave_request_pending: false,
             leave_requested_at_ms: None,
+            disbanding: false,
+            disband_request: None,
+            disbanded: false,
             welcomer_account_id_hex: None,
             via_welcome_message_id_hex: None,
         }
@@ -160,6 +163,7 @@ mod tests {
             unrecoverable: false,
             required_app_components: vec![],
             disbanding_enabled: true,
+            disbanding: false,
             disbanding_blockers: vec![],
             disband_request: None,
         }
@@ -246,6 +250,7 @@ mod tests {
             if terminal {
                 mls.lifecycle_state = GroupLifecycleStateFfi::Disbanded;
             } else {
+                mls.disbanding = true;
                 mls.disband_request = Some(DisbandRequestFfi::Pending {
                     requested_at_ms: 1_700_000_000_123,
                 });
@@ -264,6 +269,7 @@ mod tests {
             assert!(!state.requires_self_demote_before_leave);
             assert!(!state.can_enable_disbanding);
             assert!(!state.can_disband);
+            assert_eq!(state.disbanding, !terminal);
             assert!(
                 state.member_actions.iter().all(|action| {
                     !action.can_remove && !action.can_promote && !action.can_demote

--- a/crates/marmot-uniffi/src/conversions/mod.rs
+++ b/crates/marmot-uniffi/src/conversions/mod.rs
@@ -150,6 +150,21 @@ mod tests {
         }
     }
 
+    fn mls_state() -> AppGroupMlsStateFfi {
+        AppGroupMlsStateFfi {
+            group_id_hex: "01".repeat(16),
+            protocol_profile: AppProtocolProfileFfi::Current,
+            lifecycle_state: GroupLifecycleStateFfi::Stable,
+            epoch: 1,
+            member_count: 2,
+            unrecoverable: false,
+            required_app_components: vec![],
+            disbanding_enabled: true,
+            disbanding_blockers: vec![],
+            disband_request: None,
+        }
+    }
+
     #[test]
     fn group_management_state_marks_last_admin_self_demote_requirement() {
         let self_id = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
@@ -157,6 +172,7 @@ mod tests {
         let details = GroupDetailsFfi {
             group: group(vec![self_id]),
             members: vec![member(self_id, true, true), member(bob_id, false, false)],
+            mls_state: mls_state(),
         };
 
         let state = group_management_state_ffi(self_id, &details);
@@ -197,6 +213,7 @@ mod tests {
         let details = GroupDetailsFfi {
             group: leaving,
             members: vec![member(self_id, false, true), member(bob_id, true, false)],
+            mls_state: mls_state(),
         };
 
         let state = group_management_state_ffi(self_id, &details);
@@ -210,11 +227,82 @@ mod tests {
         let details = GroupDetailsFfi {
             group: group(vec![bob_id]),
             members: details.members,
+            mls_state: mls_state(),
         };
         let state = group_management_state_ffi(self_id, &details);
         assert!(state.can_leave);
         assert!(!state.leave_request_pending);
         assert_eq!(state.leave_requested_at_ms, None);
+    }
+
+    #[test]
+    fn disband_gate_and_terminal_state_disable_every_management_action() {
+        let self_id = "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+        let bob_id = "bb4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4";
+        let members = vec![member(self_id, true, true), member(bob_id, false, false)];
+
+        for terminal in [false, true] {
+            let mut mls = mls_state();
+            if terminal {
+                mls.lifecycle_state = GroupLifecycleStateFfi::Disbanded;
+            } else {
+                mls.disband_request = Some(DisbandRequestFfi::Pending {
+                    requested_at_ms: 1_700_000_000_123,
+                });
+            }
+            let state = group_management_state_ffi(
+                self_id,
+                &GroupDetailsFfi {
+                    group: group(vec![self_id]),
+                    members: members.clone(),
+                    mls_state: mls,
+                },
+            );
+
+            assert!(!state.can_invite);
+            assert!(!state.can_leave);
+            assert!(!state.requires_self_demote_before_leave);
+            assert!(!state.can_enable_disbanding);
+            assert!(!state.can_disband);
+            assert!(
+                state.member_actions.iter().all(|action| {
+                    !action.can_remove && !action.can_promote && !action.can_demote
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn lifecycle_ffi_mapping_covers_all_six_canonical_states() {
+        let cases = [
+            (
+                marmot_app::AppGroupLifecycleState::Stable,
+                GroupLifecycleStateFfi::Stable,
+            ),
+            (
+                marmot_app::AppGroupLifecycleState::PendingPublish,
+                GroupLifecycleStateFfi::PendingPublish,
+            ),
+            (
+                marmot_app::AppGroupLifecycleState::Merging,
+                GroupLifecycleStateFfi::Merging,
+            ),
+            (
+                marmot_app::AppGroupLifecycleState::Recovering,
+                GroupLifecycleStateFfi::Recovering,
+            ),
+            (
+                marmot_app::AppGroupLifecycleState::Unrecoverable,
+                GroupLifecycleStateFfi::Unrecoverable,
+            ),
+            (
+                marmot_app::AppGroupLifecycleState::Disbanded,
+                GroupLifecycleStateFfi::Disbanded,
+            ),
+        ];
+        for (app, ffi) in cases {
+            assert_eq!(GroupLifecycleStateFfi::from(app), ffi);
+        }
     }
 
     #[test]
@@ -516,6 +604,7 @@ mod tests {
         let details = GroupDetailsFfi {
             group: group(vec![self_id, bob_id]),
             members: vec![member(self_id, true, true), member(bob_id, true, false)],
+            mls_state: mls_state(),
         };
 
         let state = group_management_state_ffi(self_id, &details);
@@ -539,6 +628,7 @@ mod tests {
         let details = GroupDetailsFfi {
             group: group(vec![alice_id]),
             members: vec![member(self_id, false, true), member(alice_id, true, false)],
+            mls_state: mls_state(),
         };
 
         let state = group_management_state_ffi(self_id, &details);

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -60,6 +60,8 @@ pub enum MarmotKitError {
         group_id_hex: String,
         member_ids_hex: Vec<String>,
     },
+    #[error("group {group_id_hex} has not enabled disbanding")]
+    DisbandingNotEnabled { group_id_hex: String },
     #[error("group {group_id_hex} is disbanding or disbanded")]
     GroupDisbanding { group_id_hex: String },
     #[error("member {member_id_hex} is not in group {group_id_hex}")]
@@ -247,6 +249,9 @@ impl MarmotKitError {
                         .collect(),
                 }
             }
+            EngineError::DisbandingNotEnabled { group_id } => Self::DisbandingNotEnabled {
+                group_id_hex: hex::encode(group_id.as_slice()),
+            },
             EngineError::UnknownMember { group_id, member } => Self::MemberNotInGroup {
                 group_id_hex: hex::encode(group_id.as_slice()),
                 member_id_hex: hex::encode(member.as_slice()),
@@ -319,6 +324,20 @@ mod tests {
                 assert_eq!(group_id_hex, hex::encode(group_id.as_slice()));
             }
             other => panic!("expected LeaveAlreadyRequested, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disbanding_not_enabled_crosses_ffi_as_typed_variant() {
+        let group_id = cgka_traits::GroupId::new(vec![0x22; 16]);
+        let ffi = MarmotKitError::from_engine_error(&EngineError::DisbandingNotEnabled {
+            group_id: group_id.clone(),
+        });
+        match ffi {
+            MarmotKitError::DisbandingNotEnabled { group_id_hex } => {
+                assert_eq!(group_id_hex, hex::encode(group_id.as_slice()));
+            }
+            other => panic!("expected DisbandingNotEnabled, got {other:?}"),
         }
     }
 

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -55,6 +55,13 @@ pub enum MarmotKitError {
     LeaveAlreadyRequested { group_id_hex: String },
     #[error("operation would remove the last admin from group {group_id_hex}")]
     WouldRemoveLastAdmin { group_id_hex: String },
+    #[error("group {group_id_hex} cannot enable disbanding until all members support it")]
+    DisbandingUnsupportedMembers {
+        group_id_hex: String,
+        member_ids_hex: Vec<String>,
+    },
+    #[error("group {group_id_hex} has a pending disband request")]
+    GroupDisbanding { group_id_hex: String },
     #[error("member {member_id_hex} is not in group {group_id_hex}")]
     MemberNotInGroup {
         group_id_hex: String,
@@ -172,6 +179,7 @@ impl From<AppError> for MarmotKitError {
             },
             AppError::UnknownGroup(group_id_hex) => Self::UnknownGroup { group_id_hex },
             AppError::InvalidChatPin(details) => Self::InvalidChatPin { details },
+            AppError::GroupDisbanding(group_id_hex) => Self::GroupDisbanding { group_id_hex },
             AppError::InvalidMessageDraft(details) => Self::InvalidMessageDraft { details },
             // Encrypted-media validation failures are always media-boundary
             // errors; map them to the typed variant so send/upload/download
@@ -230,6 +238,15 @@ impl MarmotKitError {
             EngineError::AdminDepletion { group_id } => Self::WouldRemoveLastAdmin {
                 group_id_hex: hex::encode(group_id.as_slice()),
             },
+            EngineError::DisbandingUnsupportedMembers { group_id, members } => {
+                Self::DisbandingUnsupportedMembers {
+                    group_id_hex: hex::encode(group_id.as_slice()),
+                    member_ids_hex: members
+                        .iter()
+                        .map(|member| hex::encode(member.as_slice()))
+                        .collect(),
+                }
+            }
             EngineError::UnknownMember { group_id, member } => Self::MemberNotInGroup {
                 group_id_hex: hex::encode(group_id.as_slice()),
                 member_id_hex: hex::encode(member.as_slice()),

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -60,7 +60,7 @@ pub enum MarmotKitError {
         group_id_hex: String,
         member_ids_hex: Vec<String>,
     },
-    #[error("group {group_id_hex} has a pending disband request")]
+    #[error("group {group_id_hex} is disbanding or disbanded")]
     GroupDisbanding { group_id_hex: String },
     #[error("member {member_id_hex} is not in group {group_id_hex}")]
     MemberNotInGroup {

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -662,9 +662,12 @@ impl SqliteAccountStorage {
     /// `group_id_hex`. A metadata-only media-secret retirement barrier remains
     /// because protocol/MLS state is intentionally retained; without it that
     /// state could immediately rederive wiped key bytes. `seen_events` and
-    /// protocol/MLS tables are left intact so old relay deliveries stay
-    /// suppressed while a future fresh group message can re-create the app
-    /// projection.
+    /// protocol/MLS tables are left intact for active groups so old relay
+    /// deliveries stay suppressed while a future fresh group message can
+    /// re-create the app projection. A terminal group is different: its live
+    /// MLS state is already erased, so this transaction also removes the full
+    /// `cgka_groups` row and retains only `cgka_disband_tombstones` as the
+    /// permanent anti-resurrection guard.
     pub fn delete_local_group_data(&self, group_id_hex: &str) -> StorageResult<bool> {
         if group_id_hex.trim().is_empty() {
             return Err(StorageError::Backend(
@@ -696,6 +699,25 @@ impl SqliteAccountStorage {
                         params![group_id_hex],
                     )
                     .storage()?,
+                );
+            }
+            let group_id = hex::decode(group_id_hex).map_err(|error| {
+                StorageError::Serialization(format!("invalid local group id: {error}"))
+            })?;
+            let terminal = conn
+                .query_row(
+                    "SELECT EXISTS(
+                        SELECT 1 FROM cgka_disband_tombstones WHERE group_id = ?1
+                     )",
+                    params![&group_id],
+                    |row| row.get::<_, i64>(0),
+                )
+                .storage()?
+                != 0;
+            if terminal {
+                deleted = deleted.saturating_add(
+                    conn.execute("DELETE FROM cgka_groups WHERE id = ?1", params![group_id])
+                        .storage()?,
                 );
             }
             Ok(deleted > 0)

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -674,6 +674,9 @@ impl SqliteAccountStorage {
                 "local group delete id must not be empty".to_owned(),
             ));
         }
+        let group_id = hex::decode(group_id_hex).map_err(|error| {
+            StorageError::Serialization(format!("invalid local group id: {error}"))
+        })?;
 
         self.connection.with_transaction(|| -> StorageResult<bool> {
             let conn = self.lock()?;
@@ -701,9 +704,6 @@ impl SqliteAccountStorage {
                     .storage()?,
                 );
             }
-            let group_id = hex::decode(group_id_hex).map_err(|error| {
-                StorageError::Serialization(format!("invalid local group id: {error}"))
-            })?;
             let terminal = conn
                 .query_row(
                     "SELECT EXISTS(
@@ -716,7 +716,7 @@ impl SqliteAccountStorage {
                 != 0;
             if terminal {
                 deleted = deleted.saturating_add(
-                    conn.execute("DELETE FROM cgka_groups WHERE id = ?1", params![group_id])
+                    conn.execute("DELETE FROM cgka_groups WHERE id = ?1", params![&group_id])
                         .storage()?,
                 );
             }

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -1,4 +1,7 @@
 use crate::account_projection::chat_mute_is_effective;
+use crate::storage::disband_requests::{
+    disband_requests_by_group_hex_tx, disbanding_group_ids_hex_tx,
+};
 use crate::storage::leave_requests::pending_leave_requests_by_group_hex_tx;
 use crate::{
     SelfMembership, SqliteAccountStorage, SqliteResultExt, bool_i64, i64_to_u64,
@@ -170,6 +173,14 @@ pub struct ChatListRow {
     /// terminal Disbanded survives restarts and local history deletion.
     #[serde(default)]
     pub lifecycle_state: cgka_traits::GroupLifecycleState,
+    /// Ordinary outbound group work is gated while a local disband request or
+    /// authenticated inbound disband candidate awaits convergence.
+    #[serde(default)]
+    pub disbanding: bool,
+    /// Local request outcome, when this account initiated disbanding. An
+    /// inbound candidate can set `disbanding` without creating this request.
+    #[serde(default)]
+    pub disband_request: Option<cgka_traits::DisbandRequest>,
     pub title: String,
     pub group_name: String,
     pub avatar_url: Option<String>,
@@ -1453,6 +1464,12 @@ fn chat_list_rows_tx(tx: &Connection, query: ChatListQuery) -> StorageResult<Vec
             row.leave_requested_at_ms = pending.get(&row.group_id_hex).copied();
         }
     }
+    let disbanding = disbanding_group_ids_hex_tx(tx)?;
+    let disband_requests = disband_requests_by_group_hex_tx(tx)?;
+    for row in &mut rows {
+        row.disbanding = disbanding.contains(&row.group_id_hex);
+        row.disband_request = disband_requests.get(&row.group_id_hex).cloned();
+    }
     Ok(rows)
 }
 
@@ -1472,6 +1489,10 @@ fn chat_list_row_tx(tx: &Connection, group_id_hex: &str) -> StorageResult<Option
         row.leave_requested_at_ms = pending_leave_requests_by_group_hex_tx(tx)?
             .get(&row.group_id_hex)
             .copied();
+        row.disbanding = disbanding_group_ids_hex_tx(tx)?.contains(&row.group_id_hex);
+        row.disband_request = disband_requests_by_group_hex_tx(tx)?
+            .get(&row.group_id_hex)
+            .cloned();
         Ok(row)
     })
     .transpose()
@@ -1581,6 +1602,8 @@ fn chat_list_row_from_row(row: &rusqlite::Row<'_>, now_ms: i64) -> rusqlite::Res
         archived: row.get::<_, i64>(1)? != 0,
         pending_confirmation: row.get::<_, i64>(2)? != 0,
         lifecycle_state,
+        disbanding: false,
+        disband_request: None,
         title: row.get(3)?,
         group_name: group_name.clone(),
         avatar_url,

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -165,6 +165,11 @@ pub struct ChatListRow {
     pub pinned_position: Option<u32>,
     pub archived: bool,
     pub pending_confirmation: bool,
+    /// Durable lifecycle classification. Ephemeral merge/publish states are
+    /// exposed by the live MLS-state API; the chat-list projection guarantees
+    /// terminal Disbanded survives restarts and local history deletion.
+    #[serde(default)]
+    pub lifecycle_state: cgka_traits::GroupLifecycleState,
     pub title: String,
     pub group_name: String,
     pub avatar_url: Option<String>,
@@ -359,7 +364,11 @@ impl SqliteAccountStorage {
              FROM chat_list_rows AS row
              LEFT JOIN account_groups AS ag ON ag.group_id_hex = row.group_id_hex
              WHERE row.archived = 0
-               AND COALESCE(ag.self_membership, 'member') NOT IN ('left', 'removed')",
+               AND COALESCE(ag.self_membership, 'member') NOT IN ('left', 'removed')
+               AND NOT EXISTS (
+                   SELECT 1 FROM cgka_disband_tombstones AS tomb
+                   WHERE lower(hex(tomb.group_id)) = lower(row.group_id_hex)
+               )",
             [],
             |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
         )
@@ -1487,6 +1496,10 @@ const CHAT_LIST_ROW_SELECT_AND_JOINS: &str =
             ag.member_count,
             mute.group_id_hex IS NOT NULL,
             mute.muted_until_ms,
+            EXISTS (
+                SELECT 1 FROM cgka_disband_tombstones AS tomb
+                WHERE lower(hex(tomb.group_id)) = lower(row.group_id_hex)
+            ),
             pin.group_id_hex IS NOT NULL,
             CASE WHEN pin.ordinal IS NULL THEN NULL ELSE (
                 SELECT COUNT(*)
@@ -1551,10 +1564,15 @@ fn chat_list_row_from_row(row: &rusqlite::Row<'_>, now_ms: i64) -> rusqlite::Res
         .and_then(|value| u64::try_from(value).ok());
     let mute_row_exists = row.get::<_, i64>(30)? != 0;
     let stored_muted_until_ms = row.get::<_, Option<i64>>(31)?;
+    let lifecycle_state = if row.get::<_, i64>(32)? != 0 {
+        cgka_traits::GroupLifecycleState::Disbanded
+    } else {
+        cgka_traits::GroupLifecycleState::Stable
+    };
     let muted = chat_mute_is_effective(mute_row_exists, stored_muted_until_ms, now_ms);
-    let pinned = row.get::<_, i64>(32)? != 0;
+    let pinned = row.get::<_, i64>(33)? != 0;
     let pinned_position = row
-        .get::<_, Option<i64>>(33)?
+        .get::<_, Option<i64>>(34)?
         .and_then(|value| u32::try_from(value).ok());
     Ok(ChatListRow {
         group_id_hex: row.get(0)?,
@@ -1562,6 +1580,7 @@ fn chat_list_row_from_row(row: &rusqlite::Row<'_>, now_ms: i64) -> rusqlite::Res
         pinned_position,
         archived: row.get::<_, i64>(1)? != 0,
         pending_confirmation: row.get::<_, i64>(2)? != 0,
+        lifecycle_state,
         title: row.get(3)?,
         group_name: group_name.clone(),
         avatar_url,

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -1,6 +1,7 @@
 use crate::account_projection::chat_mute_is_effective;
 use crate::storage::disband_requests::{
     disband_requests_by_group_hex_tx, disbanding_group_ids_hex_tx,
+    disbanding_group_ids_hex_with_requests_tx,
 };
 use crate::storage::leave_requests::pending_leave_requests_by_group_hex_tx;
 use crate::{
@@ -1489,10 +1490,10 @@ fn chat_list_row_tx(tx: &Connection, group_id_hex: &str) -> StorageResult<Option
         row.leave_requested_at_ms = pending_leave_requests_by_group_hex_tx(tx)?
             .get(&row.group_id_hex)
             .copied();
-        row.disbanding = disbanding_group_ids_hex_tx(tx)?.contains(&row.group_id_hex);
-        row.disband_request = disband_requests_by_group_hex_tx(tx)?
-            .get(&row.group_id_hex)
-            .cloned();
+        let disband_requests = disband_requests_by_group_hex_tx(tx)?;
+        row.disbanding = disbanding_group_ids_hex_with_requests_tx(tx, &disband_requests)?
+            .contains(&row.group_id_hex);
+        row.disband_request = disband_requests.get(&row.group_id_hex).cloned();
         Ok(row)
     })
     .transpose()

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -76,6 +76,8 @@ mod migration_0037_chat_list_semantic_timestamps;
 mod migration_0038_chat_list_interaction_state;
 #[path = "migrations/0039_chat_pin_positions.rs"]
 mod migration_0039_chat_pin_positions;
+#[path = "migrations/0040_disband_requests.rs"]
+mod migration_0040_disband_requests;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -282,6 +284,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 39,
         name: "0039_chat_pin_positions",
         apply: migration_0039_chat_pin_positions::apply,
+    },
+    Migration {
+        version: 40,
+        name: "0040_disband_requests",
+        apply: migration_0040_disband_requests::apply,
     },
 ];
 

--- a/crates/storage-sqlite/src/migrations/0040_disband_requests.rs
+++ b/crates/storage-sqlite/src/migrations/0040_disband_requests.rs
@@ -1,0 +1,27 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE cgka_disband_requests (
+    group_id BLOB PRIMARY KEY REFERENCES cgka_groups(id) ON DELETE CASCADE,
+    record BLOB NOT NULL
+);
+
+CREATE TABLE cgka_disband_candidates (
+    group_id BLOB NOT NULL REFERENCES cgka_groups(id) ON DELETE CASCADE,
+    commit_id BLOB NOT NULL,
+    record BLOB NOT NULL,
+    PRIMARY KEY (group_id, commit_id)
+);
+
+CREATE TABLE cgka_disband_tombstones (
+    group_id BLOB PRIMARY KEY,
+    record BLOB NOT NULL
+);
+"#,
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/storage/disband_requests.rs
+++ b/crates/storage-sqlite/src/storage/disband_requests.rs
@@ -1,0 +1,243 @@
+use crate::{SqliteAccountStorage, SqliteResultExt, deserialize, serialize};
+use cgka_traits::DisbandTombstone;
+use cgka_traits::storage::{
+    DisbandCandidate, DisbandCandidateStorage, DisbandRequest, DisbandRequestStorage,
+    DisbandTombstoneStorage, StorageResult,
+};
+use cgka_traits::types::{GroupId, MessageId};
+use rusqlite::{OptionalExtension, params};
+
+impl DisbandRequestStorage for SqliteAccountStorage {
+    fn put_disband_request(&self, request: &DisbandRequest) -> StorageResult<()> {
+        let serialized = serialize(request)?;
+        self.lock()?
+            .execute(
+                "INSERT OR REPLACE INTO cgka_disband_requests (group_id, record)
+                 VALUES (?1, ?2)",
+                params![request.group_id.as_slice(), serialized],
+            )
+            .storage()?;
+        Ok(())
+    }
+
+    fn disband_request(&self, group_id: &GroupId) -> StorageResult<Option<DisbandRequest>> {
+        self.lock()?
+            .query_row(
+                "SELECT record FROM cgka_disband_requests WHERE group_id = ?1",
+                params![group_id.as_slice()],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .optional()
+            .storage()?
+            .map(|bytes| deserialize(&bytes))
+            .transpose()
+    }
+
+    fn clear_disband_request(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.lock()?
+            .execute(
+                "DELETE FROM cgka_disband_requests WHERE group_id = ?1",
+                params![group_id.as_slice()],
+            )
+            .storage()?;
+        Ok(())
+    }
+}
+
+impl DisbandCandidateStorage for SqliteAccountStorage {
+    fn put_disband_candidate(&self, candidate: &DisbandCandidate) -> StorageResult<()> {
+        self.lock()?
+            .execute(
+                "INSERT OR REPLACE INTO cgka_disband_candidates (group_id, commit_id, record)
+                 VALUES (?1, ?2, ?3)",
+                params![
+                    candidate.group_id.as_slice(),
+                    candidate.commit_id.as_slice(),
+                    serialize(candidate)?
+                ],
+            )
+            .storage()?;
+        Ok(())
+    }
+
+    fn disband_candidate(
+        &self,
+        group_id: &GroupId,
+        commit_id: &MessageId,
+    ) -> StorageResult<Option<DisbandCandidate>> {
+        self.lock()?
+            .query_row(
+                "SELECT record FROM cgka_disband_candidates
+                 WHERE group_id = ?1 AND commit_id = ?2",
+                params![group_id.as_slice(), commit_id.as_slice()],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .optional()
+            .storage()?
+            .map(|bytes| deserialize(&bytes))
+            .transpose()
+    }
+
+    fn list_disband_candidates(&self, group_id: &GroupId) -> StorageResult<Vec<DisbandCandidate>> {
+        let conn = self.lock()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT record FROM cgka_disband_candidates
+                 WHERE group_id = ?1 ORDER BY rowid",
+            )
+            .storage()?;
+        let records = stmt
+            .query_map(params![group_id.as_slice()], |row| row.get::<_, Vec<u8>>(0))
+            .storage()?
+            .collect::<Result<Vec<_>, _>>()
+            .storage()?;
+        records
+            .into_iter()
+            .map(|record| deserialize(&record))
+            .collect()
+    }
+
+    fn clear_disband_candidates(&self, group_id: &GroupId) -> StorageResult<()> {
+        self.lock()?
+            .execute(
+                "DELETE FROM cgka_disband_candidates WHERE group_id = ?1",
+                params![group_id.as_slice()],
+            )
+            .storage()?;
+        Ok(())
+    }
+}
+
+impl DisbandTombstoneStorage for SqliteAccountStorage {
+    fn put_disband_tombstone(
+        &self,
+        group_id: &GroupId,
+        tombstone: &DisbandTombstone,
+    ) -> StorageResult<()> {
+        self.lock()?
+            .execute(
+                "INSERT OR REPLACE INTO cgka_disband_tombstones (group_id, record)
+                 VALUES (?1, ?2)",
+                params![group_id.as_slice(), serialize(tombstone)?],
+            )
+            .storage()?;
+        Ok(())
+    }
+
+    fn disband_tombstone(&self, group_id: &GroupId) -> StorageResult<Option<DisbandTombstone>> {
+        self.lock()?
+            .query_row(
+                "SELECT record FROM cgka_disband_tombstones WHERE group_id = ?1",
+                params![group_id.as_slice()],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .optional()
+            .storage()?
+            .map(|bytes| deserialize(&bytes))
+            .transpose()
+    }
+
+    fn list_disband_tombstones(&self) -> StorageResult<Vec<(GroupId, DisbandTombstone)>> {
+        let conn = self.lock()?;
+        let mut stmt = conn
+            .prepare("SELECT group_id, record FROM cgka_disband_tombstones ORDER BY group_id")
+            .storage()?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?))
+            })
+            .storage()?
+            .collect::<Result<Vec<_>, _>>()
+            .storage()?;
+        rows.into_iter()
+            .map(|(group_id, record)| Ok((GroupId::new(group_id), deserialize(&record)?)))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::SqliteAccountStorage;
+    use crate::storage::test_support::{gid, member_id, mid, sample_group};
+    use cgka_traits::DisbandTombstone;
+    use cgka_traits::storage::{
+        DisbandCandidate, DisbandCandidateStorage, DisbandRequest, DisbandRequestStatus,
+        DisbandRequestStorage, DisbandTombstoneStorage, GroupStorage,
+    };
+    use cgka_traits::types::EpochId;
+
+    #[test]
+    fn disband_request_roundtrips_and_cascades_with_group() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group = sample_group(gid(1), 3, 0);
+        store.put_group(&group).unwrap();
+        let request = DisbandRequest {
+            group_id: group.id.clone(),
+            requested_at_ms: 42,
+            status: DisbandRequestStatus::Pending,
+            last_prepared_epoch: Some(EpochId(3)),
+        };
+        store.put_disband_request(&request).unwrap();
+        assert_eq!(store.disband_request(&group.id).unwrap(), Some(request));
+        store.delete_group(&group.id).unwrap();
+        assert_eq!(store.disband_request(&group.id).unwrap(), None);
+    }
+
+    #[test]
+    fn candidate_roundtrips_and_terminal_tombstone_survives_local_history_deletion() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let group = sample_group(gid(2), 7, 2);
+        store.put_group(&group).unwrap();
+        let candidate = DisbandCandidate {
+            group_id: group.id.clone(),
+            source_epoch: EpochId(7),
+            commit_id: mid(9),
+            content_commit_id: mid(10),
+            commit_digest: [0xA5; 32],
+            actor: member_id(0),
+            local_was_committer_leaf: true,
+            former_members: group.members.clone(),
+        };
+        store.put_disband_candidate(&candidate).unwrap();
+        assert_eq!(
+            store
+                .disband_candidate(&group.id, &candidate.commit_id)
+                .unwrap(),
+            Some(candidate.clone())
+        );
+        assert_eq!(
+            store.list_disband_candidates(&group.id).unwrap(),
+            vec![candidate.clone()]
+        );
+
+        let tombstone = DisbandTombstone {
+            epoch: EpochId(8),
+            actor: candidate.actor,
+            origin_commit_id: Some(candidate.commit_id),
+            commit_digest: candidate.commit_digest,
+            local_was_committer_leaf: true,
+            former_members: candidate.former_members,
+        };
+        store.put_disband_tombstone(&group.id, &tombstone).unwrap();
+        assert!(
+            store
+                .delete_local_group_data(&hex::encode(group.id.as_slice()))
+                .unwrap()
+        );
+
+        assert!(store.list_disband_candidates(&group.id).unwrap().is_empty());
+        assert!(matches!(
+            store.get_group(&group.id),
+            Err(cgka_traits::storage::StorageError::NotFound)
+        ));
+        assert_eq!(
+            store.disband_tombstone(&group.id).unwrap(),
+            Some(tombstone.clone()),
+            "minimal terminal guard must outlive optional local history"
+        );
+        assert_eq!(
+            store.list_disband_tombstones().unwrap(),
+            vec![(group.id, tombstone)]
+        );
+    }
+}

--- a/crates/storage-sqlite/src/storage/disband_requests.rs
+++ b/crates/storage-sqlite/src/storage/disband_requests.rs
@@ -34,10 +34,18 @@ pub(crate) fn disband_requests_by_group_hex_tx(
 /// Groups whose ordinary outbound work is currently gated by either a local
 /// request or an authenticated terminal candidate awaiting convergence.
 pub(crate) fn disbanding_group_ids_hex_tx(tx: &Connection) -> StorageResult<HashSet<String>> {
-    let mut group_ids = disband_requests_by_group_hex_tx(tx)?
-        .into_iter()
+    let requests = disband_requests_by_group_hex_tx(tx)?;
+    disbanding_group_ids_hex_with_requests_tx(tx, &requests)
+}
+
+pub(crate) fn disbanding_group_ids_hex_with_requests_tx(
+    tx: &Connection,
+    requests: &HashMap<String, DisbandRequest>,
+) -> StorageResult<HashSet<String>> {
+    let mut group_ids = requests
+        .iter()
         .filter_map(|(group_id, request)| {
-            (request.status == DisbandRequestStatus::Pending).then_some(group_id)
+            (request.status == DisbandRequestStatus::Pending).then_some(group_id.clone())
         })
         .collect::<HashSet<_>>();
     let mut statement = tx

--- a/crates/storage-sqlite/src/storage/disband_requests.rs
+++ b/crates/storage-sqlite/src/storage/disband_requests.rs
@@ -1,11 +1,68 @@
 use crate::{SqliteAccountStorage, SqliteResultExt, deserialize, serialize};
 use cgka_traits::DisbandTombstone;
 use cgka_traits::storage::{
-    DisbandCandidate, DisbandCandidateStorage, DisbandRequest, DisbandRequestStorage,
-    DisbandTombstoneStorage, StorageResult,
+    DisbandCandidate, DisbandCandidateStorage, DisbandRequest, DisbandRequestStatus,
+    DisbandRequestStorage, DisbandTombstoneStorage, StorageResult,
 };
 use cgka_traits::types::{GroupId, MessageId};
-use rusqlite::{OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, params};
+use std::collections::{HashMap, HashSet};
+
+/// Every durable disband request keyed by lowercase hex MLS group id.
+///
+/// Requests are read through rather than denormalized into app projections:
+/// the engine can replace or clear them during convergence without an
+/// intervening app-layer write.
+pub(crate) fn disband_requests_by_group_hex_tx(
+    tx: &Connection,
+) -> StorageResult<HashMap<String, DisbandRequest>> {
+    let mut statement = tx
+        .prepare("SELECT group_id, record FROM cgka_disband_requests")
+        .storage()?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?))
+        })
+        .storage()?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .storage()?;
+    rows.into_iter()
+        .map(|(group_id, record)| Ok((hex::encode(group_id), deserialize(&record)?)))
+        .collect()
+}
+
+/// Groups whose ordinary outbound work is currently gated by either a local
+/// request or an authenticated terminal candidate awaiting convergence.
+pub(crate) fn disbanding_group_ids_hex_tx(tx: &Connection) -> StorageResult<HashSet<String>> {
+    let mut group_ids = disband_requests_by_group_hex_tx(tx)?
+        .into_iter()
+        .filter_map(|(group_id, request)| {
+            (request.status == DisbandRequestStatus::Pending).then_some(group_id)
+        })
+        .collect::<HashSet<_>>();
+    let mut statement = tx
+        .prepare("SELECT DISTINCT group_id FROM cgka_disband_candidates")
+        .storage()?;
+    let candidate_group_ids = statement
+        .query_map([], |row| row.get::<_, Vec<u8>>(0))
+        .storage()?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .storage()?;
+    group_ids.extend(candidate_group_ids.into_iter().map(hex::encode));
+    Ok(group_ids)
+}
+
+impl SqliteAccountStorage {
+    pub fn disband_requests_by_group_hex(&self) -> StorageResult<HashMap<String, DisbandRequest>> {
+        let conn = self.lock()?;
+        disband_requests_by_group_hex_tx(&conn)
+    }
+
+    pub fn disbanding_group_ids_hex(&self) -> StorageResult<HashSet<String>> {
+        let conn = self.lock()?;
+        disbanding_group_ids_hex_tx(&conn)
+    }
+}
 
 impl DisbandRequestStorage for SqliteAccountStorage {
     fn put_disband_request(&self, request: &DisbandRequest) -> StorageResult<()> {
@@ -178,7 +235,23 @@ mod tests {
             last_prepared_epoch: Some(EpochId(3)),
         };
         store.put_disband_request(&request).unwrap();
-        assert_eq!(store.disband_request(&group.id).unwrap(), Some(request));
+        assert_eq!(
+            store.disband_request(&group.id).unwrap(),
+            Some(request.clone())
+        );
+        assert_eq!(
+            store
+                .disband_requests_by_group_hex()
+                .unwrap()
+                .get(&hex::encode(group.id.as_slice())),
+            Some(&request)
+        );
+        assert!(
+            store
+                .disbanding_group_ids_hex()
+                .unwrap()
+                .contains(&hex::encode(group.id.as_slice()))
+        );
         store.delete_group(&group.id).unwrap();
         assert_eq!(store.disband_request(&group.id).unwrap(), None);
     }
@@ -208,6 +281,13 @@ mod tests {
         assert_eq!(
             store.list_disband_candidates(&group.id).unwrap(),
             vec![candidate.clone()]
+        );
+        assert!(
+            store
+                .disbanding_group_ids_hex()
+                .unwrap()
+                .contains(&hex::encode(group.id.as_slice())),
+            "an inbound candidate gates sending without a local request"
         );
 
         let tombstone = DisbandTombstone {

--- a/crates/storage-sqlite/src/storage/mod.rs
+++ b/crates/storage-sqlite/src/storage/mod.rs
@@ -2,6 +2,7 @@ mod account_device_signer;
 mod capabilities;
 mod convergence_passes;
 mod convergence_policy;
+mod disband_requests;
 mod groups;
 /// `pub(crate)` because the chat-list projection reads durable leave requests at
 /// read time instead of denormalizing them into `chat_list_rows`.

--- a/crates/storage-sqlite/src/storage/mod.rs
+++ b/crates/storage-sqlite/src/storage/mod.rs
@@ -2,7 +2,9 @@ mod account_device_signer;
 mod capabilities;
 mod convergence_passes;
 mod convergence_policy;
-mod disband_requests;
+/// `pub(crate)` because the chat-list projection reads the durable disband gate
+/// at read time instead of denormalizing it into `chat_list_rows`.
+pub(crate) mod disband_requests;
 mod groups;
 /// `pub(crate)` because the chat-list projection reads durable leave requests at
 /// read time instead of denormalizing them into `chat_list_rows`.

--- a/crates/storage-sqlite/src/storage/test_support.rs
+++ b/crates/storage-sqlite/src/storage/test_support.rs
@@ -41,6 +41,7 @@ pub(crate) fn sample_group(id: GroupId, epoch: u64, members: usize) -> Group {
         protocol_profile: ProtocolProfile::Legacy,
         removed: false,
         unrecoverable: false,
+        disbanded: None,
         join_epoch: EpochId(0),
     }
 }

--- a/crates/traits/src/app_components/lifecycle.rs
+++ b/crates/traits/src/app_components/lifecycle.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Serialize};
+
+/// Authenticated terminal lifecycle state carried by
+/// `marmot.group.lifecycle.v1`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GroupLifecycleV1 {
+    #[default]
+    Active,
+    Disbanded,
+}
+
+/// Encode the v1 lifecycle as exactly one byte.
+pub fn encode_group_lifecycle_v1(state: GroupLifecycleV1) -> Vec<u8> {
+    vec![match state {
+        GroupLifecycleV1::Active => 0,
+        GroupLifecycleV1::Disbanded => 1,
+    }]
+}
+
+/// Decode the exact one-byte v1 lifecycle representation.
+pub fn decode_group_lifecycle_v1(bytes: &[u8]) -> Result<GroupLifecycleV1, &'static str> {
+    match bytes {
+        [0] => Ok(GroupLifecycleV1::Active),
+        [1] => Ok(GroupLifecycleV1::Disbanded),
+        [] => Err("group lifecycle state is empty"),
+        [_] => Err("group lifecycle state is unknown"),
+        _ => Err("group lifecycle state has trailing bytes"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_codec_is_exactly_one_byte() {
+        assert_eq!(encode_group_lifecycle_v1(GroupLifecycleV1::Active), [0]);
+        assert_eq!(encode_group_lifecycle_v1(GroupLifecycleV1::Disbanded), [1]);
+        assert_eq!(
+            decode_group_lifecycle_v1(&[0]),
+            Ok(GroupLifecycleV1::Active)
+        );
+        assert_eq!(
+            decode_group_lifecycle_v1(&[1]),
+            Ok(GroupLifecycleV1::Disbanded)
+        );
+        assert!(decode_group_lifecycle_v1(&[]).is_err());
+        assert!(decode_group_lifecycle_v1(&[2]).is_err());
+        assert!(decode_group_lifecycle_v1(&[0, 0]).is_err());
+    }
+}

--- a/crates/traits/src/app_components/mod.rs
+++ b/crates/traits/src/app_components/mod.rs
@@ -26,6 +26,7 @@ mod codec;
 mod encrypted_media;
 mod encrypted_media_v2;
 mod host_safety;
+mod lifecycle;
 mod profile;
 mod routing;
 
@@ -56,6 +57,7 @@ pub use host_safety::{
     is_loopback_candidate_host, is_loopback_host, is_loopback_ip, is_public_ip, is_public_ipv4,
     is_public_ipv6, reject_non_public_ip, reject_non_public_socket_addr,
 };
+pub use lifecycle::{GroupLifecycleV1, decode_group_lifecycle_v1, encode_group_lifecycle_v1};
 pub use profile::{
     GROUP_PROFILE_DESCRIPTION_MAX_LEN, GROUP_PROFILE_NAME_MAX_LEN, GroupProfileV1,
     decode_group_profile_v1, encode_group_profile_v1,
@@ -103,6 +105,7 @@ pub const GROUP_ENCRYPTED_MEDIA_COMPONENT_ID: AppComponentId =
 /// `app_components`.
 pub const ACCOUNT_IDENTITY_PROOF_COMPONENT_ID: AppComponentId = 0x8009;
 pub const GROUP_ENCRYPTED_MEDIA_V2_COMPONENT_ID: AppComponentId = 0x800b;
+pub const GROUP_LIFECYCLE_COMPONENT_ID: AppComponentId = 0x800c;
 /// Lookup key for the encrypted-media secret in the
 /// [`crate::group_context::GroupContextSnapshot`] secrets map. This is an
 /// internal cache key, NOT the MLS exporter label/context: the secret is derived
@@ -123,6 +126,7 @@ pub const GROUP_ENCRYPTED_MEDIA_V1_COMPONENT: &str = "marmot.group.encrypted-med
 pub const GROUP_ENCRYPTED_MEDIA_COMPONENT: &str = GROUP_ENCRYPTED_MEDIA_V1_COMPONENT;
 pub const ACCOUNT_IDENTITY_PROOF_COMPONENT: &str = "marmot.member.account-identity-proof.v2";
 pub const GROUP_ENCRYPTED_MEDIA_V2_COMPONENT: &str = "marmot.group.encrypted-media.v2";
+pub const GROUP_LIFECYCLE_COMPONENT: &str = "marmot.group.lifecycle.v1";
 pub const ENCRYPTED_MEDIA_FORMAT_V1: &str = "encrypted-media-v1";
 pub const ENCRYPTED_MEDIA_FORMAT_V2: &str = "encrypted-media-v2";
 pub const BLOSSOM_LOCATOR_KIND_V1: &str = "blossom-v1";
@@ -146,9 +150,13 @@ pub struct AppComponentData {
 /// The group-state components this implementation creates by default when
 /// every founding member advertises support for them.
 pub fn default_group_components() -> BTreeSet<AppComponentId> {
-    [GROUP_PROFILE_COMPONENT_ID, GROUP_ADMIN_POLICY_COMPONENT_ID]
-        .into_iter()
-        .collect()
+    [
+        GROUP_PROFILE_COMPONENT_ID,
+        GROUP_ADMIN_POLICY_COMPONENT_ID,
+        GROUP_LIFECYCLE_COMPONENT_ID,
+    ]
+    .into_iter()
+    .collect()
 }
 
 /// Sorted set of app component ids.

--- a/crates/traits/src/app_event.rs
+++ b/crates/traits/src/app_event.rs
@@ -146,6 +146,8 @@ pub enum MarmotAppEventError {
     IdMismatch { expected: String, found: String },
     #[error("marmot app event pubkey mismatch")]
     PubkeyMismatch { expected: String, found: String },
+    #[error("group-system event requires an authenticated actor")]
+    MissingAuthenticatedActor,
 }
 
 impl MarmotAppEvent {
@@ -429,6 +431,9 @@ pub fn group_system_event_material(
     actor: Option<&MemberId>,
     change: &GroupStateChange,
 ) -> Result<GroupSystemEventMaterial, MarmotAppEventError> {
+    if matches!(change, GroupStateChange::GroupDisbanded) && actor.is_none() {
+        return Err(MarmotAppEventError::MissingAuthenticatedActor);
+    }
     let parts = group_system_projection_parts(change);
     let system_type = parts.system_type;
     let actor_hex = actor.map(|id| hex::encode(id.as_slice()));
@@ -772,6 +777,18 @@ mod tests {
                 GROUP_SYSTEM_TYPE_DISAPPEARING_TIMER_CHANGED.to_owned(),
             ]]
         );
+    }
+
+    #[test]
+    fn group_disbanded_material_requires_authenticated_actor() {
+        let error = group_system_event_material(
+            &GroupId::new(vec![0x22; 32]),
+            3,
+            None,
+            &GroupStateChange::GroupDisbanded,
+        )
+        .unwrap_err();
+        assert_eq!(error, MarmotAppEventError::MissingAuthenticatedActor);
     }
 
     #[test]

--- a/crates/traits/src/app_event.rs
+++ b/crates/traits/src/app_event.rs
@@ -81,6 +81,7 @@ pub const GROUP_SYSTEM_TYPE_GROUP_AVATAR_CHANGED: &str = "group_avatar_changed";
 /// Product-facing system row for the `marmot.group.message-retention.v1` app
 /// component changing (the app calls this the disappearing-message timer).
 pub const GROUP_SYSTEM_TYPE_DISAPPEARING_TIMER_CHANGED: &str = "disappearing_timer_changed";
+pub const GROUP_SYSTEM_TYPE_GROUP_DISBANDED: &str = "group_disbanded";
 
 /// Human-readable fallback `text` for kind-1210 group system rows. These strings
 /// feed `content` → `id_preimage` → `canonical_event_id`, so they must stay in
@@ -93,6 +94,7 @@ pub const GROUP_SYSTEM_TEXT_ADMIN_REMOVED: &str = "Admin removed";
 pub const GROUP_SYSTEM_TEXT_GROUP_RENAMED: &str = "Group renamed";
 pub const GROUP_SYSTEM_TEXT_GROUP_AVATAR_CHANGED: &str = "Group avatar changed";
 pub const GROUP_SYSTEM_TEXT_DISAPPEARING_TIMER_CHANGED: &str = "Disappearing timer changed";
+pub const GROUP_SYSTEM_TEXT_GROUP_DISBANDED: &str = "Group disbanded";
 
 /// Keys inside the kind-1210 `data` object. `actor`/`subject` are lowercase-hex
 /// pubkeys, `name` is UTF-8, and retention values are seconds where `0` means
@@ -404,6 +406,15 @@ fn group_system_projection_parts(change: &GroupStateChange) -> GroupSystemProjec
             old_retention_seconds: Some(*old_seconds),
             new_retention_seconds: Some(*new_seconds),
             text: GROUP_SYSTEM_TEXT_DISAPPEARING_TIMER_CHANGED,
+        },
+        GroupStateChange::GroupDisbanded => GroupSystemProjectionParts {
+            system_type: GROUP_SYSTEM_TYPE_GROUP_DISBANDED,
+            subject: None,
+            name: None,
+            old_name: None,
+            old_retention_seconds: None,
+            new_retention_seconds: None,
+            text: GROUP_SYSTEM_TEXT_GROUP_DISBANDED,
         },
     }
 }

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -155,6 +155,13 @@ pub enum SendIntent {
         name: Option<String>,
         description: Option<String>,
     },
+    /// Install `marmot.group.lifecycle.v1 = active` and require the component
+    /// in one admin Commit for a compatible existing group.
+    EnableDisbanding { group_id: GroupId },
+    /// Persist the irreversible local intent to terminate the group. Preparing
+    /// and publishing the terminal Commit is driven asynchronously from this
+    /// durable request.
+    Disband { group_id: GroupId },
 }
 
 /// The engine's response to [`CgkaEngine::send`].
@@ -163,6 +170,15 @@ pub enum SendIntent {
 /// member additions.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SendResult {
+    /// The requested idempotent mutation was already reflected by canonical
+    /// state, so no transport publication is necessary.
+    NoChange { group_id: GroupId },
+    /// The irreversible disband request is durable. The engine prepares its
+    /// terminal Commit asynchronously after any staged publish and the
+    /// mandatory convergence gate permit it.
+    DisbandRequested {
+        request: crate::storage::DisbandRequest,
+    },
     /// Pure application message — publish once, no state advance.
     ApplicationMessage {
         msg: TransportMessage,
@@ -349,6 +365,9 @@ pub enum GroupStateChange {
     GroupAvatarChanged,
     /// The per-group disappearing-message retention changed. `0` means disabled.
     MessageRetentionChanged { old_seconds: u64, new_seconds: u64 },
+    /// The selected Commit terminalized the group. The authenticated committer
+    /// is carried as the surrounding event actor.
+    GroupDisbanded,
 }
 
 /// Why a stored group was skipped during session-open hydration.

--- a/crates/traits/src/engine_state.rs
+++ b/crates/traits/src/engine_state.rs
@@ -21,6 +21,19 @@
 use crate::ingest::PeeledMessage;
 use crate::types::EpochId;
 use serde::{Deserialize, Serialize};
+
+/// Canonical application-facing group lifecycle classification.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GroupLifecycleState {
+    #[default]
+    Stable,
+    PendingPublish,
+    Merging,
+    Recovering,
+    Unrecoverable,
+    Disbanded,
+}
 use std::fmt;
 
 /// Opaque handle to a staged MLS commit. The engine serializes its
@@ -142,6 +155,17 @@ pub struct Unrecoverable {
     last_stable_epoch: EpochId,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Disbanded {
+    epoch: EpochId,
+}
+
+impl Disbanded {
+    pub fn epoch(&self) -> EpochId {
+        self.epoch
+    }
+}
+
 impl Unrecoverable {
     pub fn last_stable_epoch(&self) -> EpochId {
         self.last_stable_epoch
@@ -206,11 +230,18 @@ pub enum EpochState {
     /// applying and ingesting group-state changes until a verified repair path.
     /// See `spec/protocol-core/group-state.md:17,54-66`.
     Unrecoverable(Unrecoverable),
+    /// A selected authenticated disband Commit terminalized the group. Live MLS
+    /// state no longer exists and there is no legal transition out.
+    Disbanded(Disbanded),
 }
 
 impl EpochState {
     pub fn stable(epoch: EpochId) -> Self {
         EpochState::Stable { epoch }
+    }
+
+    pub fn disbanded(epoch: EpochId) -> Self {
+        EpochState::Disbanded(Disbanded { epoch })
     }
 
     /// Current epoch this state reflects. For `Recovering`, returns the last
@@ -222,6 +253,7 @@ impl EpochState {
             EpochState::Merging(m) => m.epoch(),
             EpochState::Recovering(r) => r.last_stable_epoch(),
             EpochState::Unrecoverable(u) => u.last_stable_epoch(),
+            EpochState::Disbanded(d) => d.epoch(),
         }
     }
 
@@ -238,6 +270,10 @@ impl EpochState {
     /// a repair path before it may apply or ingest more group traffic.
     pub fn is_unrecoverable(&self) -> bool {
         matches!(self, EpochState::Unrecoverable(_))
+    }
+
+    pub fn is_disbanded(&self) -> bool {
+        matches!(self, EpochState::Disbanded(_))
     }
 
     /// Whether this group is in the `Stable` state — the only state from which
@@ -257,6 +293,7 @@ impl EpochState {
             EpochState::Merging(_) => "Merging",
             EpochState::Recovering(_) => "Recovering",
             EpochState::Unrecoverable(_) => "Unrecoverable",
+            EpochState::Disbanded(_) => "Disbanded",
         }
     }
 
@@ -360,6 +397,32 @@ impl EpochState {
                 to: "Stable",
                 reason: "repair_to_stable requires Unrecoverable",
             }),
+        }
+    }
+
+    /// `Recovering → Disbanded`. Terminalization is legal only after the
+    /// mandatory bounded convergence pass selects a disband branch.
+    pub fn settle_to_disbanded(self, epoch: EpochId) -> Result<Self, InvalidTransition> {
+        match self {
+            EpochState::Recovering(_) => Ok(EpochState::disbanded(epoch)),
+            other => Err(InvalidTransition {
+                from: other.name(),
+                to: "Disbanded",
+                reason: "disband terminalization requires Recovering",
+            }),
+        }
+    }
+}
+
+impl From<&EpochState> for GroupLifecycleState {
+    fn from(value: &EpochState) -> Self {
+        match value {
+            EpochState::Stable { .. } => Self::Stable,
+            EpochState::PendingPublish(_) => Self::PendingPublish,
+            EpochState::Merging(_) => Self::Merging,
+            EpochState::Recovering(_) => Self::Recovering,
+            EpochState::Unrecoverable(_) => Self::Unrecoverable,
+            EpochState::Disbanded(_) => Self::Disbanded,
         }
     }
 }

--- a/crates/traits/src/error.rs
+++ b/crates/traits/src/error.rs
@@ -76,6 +76,11 @@ pub enum EngineError {
         members: Vec<MemberId>,
     },
 
+    /// The group has not yet installed and required lifecycle-v1, so it cannot
+    /// accept a terminal disband request.
+    #[error("group disbanding is not enabled")]
+    DisbandingNotEnabled { group_id: GroupId },
+
     /// The configured MLS ciphersuite is not the Marmot mandatory-to-implement
     /// ciphersuite. Per `spec/foundation/mls-protocol.md`, Marmot requires
     /// `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519` (id `0x0001`); building an

--- a/crates/traits/src/error.rs
+++ b/crates/traits/src/error.rs
@@ -68,6 +68,14 @@ pub enum EngineError {
         had: Box<GroupCapabilities>,
     },
 
+    /// One or more current member leaves have not yet advertised lifecycle-v1
+    /// support, so the group cannot atomically require the component.
+    #[error("group disbanding is blocked by unsupported member leaves")]
+    DisbandingUnsupportedMembers {
+        group_id: GroupId,
+        members: Vec<MemberId>,
+    },
+
     /// The configured MLS ciphersuite is not the Marmot mandatory-to-implement
     /// ciphersuite. Per `spec/foundation/mls-protocol.md`, Marmot requires
     /// `MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519` (id `0x0001`); building an

--- a/crates/traits/src/group.rs
+++ b/crates/traits/src/group.rs
@@ -73,6 +73,11 @@ pub struct Group {
     /// before this field existed.
     #[serde(default)]
     pub unrecoverable: bool,
+    /// Authenticated terminal tombstone. When present, live OpenMLS state has
+    /// been deleted and the group must never hydrate, route, send, converge, or
+    /// rejoin under this group id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disbanded: Option<DisbandTombstone>,
     /// Epoch at which this device's membership began (welcome-join or group
     /// creation), refreshed on an authenticated re-join. Post-peel
     /// classification lower bound: an application message whose MLS epoch
@@ -81,6 +86,21 @@ pub struct Group {
     /// persisted before this field existed) means "unknown — no bound".
     #[serde(default)]
     pub join_epoch: EpochId,
+}
+
+/// Durable evidence and read-only projection material retained after a
+/// selected disband Commit deletes live MLS state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DisbandTombstone {
+    pub epoch: EpochId,
+    pub actor: MemberId,
+    pub origin_commit_id: Option<crate::types::MessageId>,
+    pub commit_digest: [u8; 32],
+    /// True only on the exact account-device leaf that authored the selected
+    /// Commit. Sibling leaves for the same account are removed.
+    pub local_was_committer_leaf: bool,
+    /// Deduplicated account roster captured immediately before disbanding.
+    pub former_members: Vec<Member>,
 }
 
 /// One member of a group, as storage sees it.

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -53,10 +53,10 @@ pub use app_components::{
 };
 pub use app_event::{
     AGENT_ACTIVITY_STATUS_TAG, AGENT_OPERATION_NAME_TAG, AGENT_OPERATION_STATUS_TAG,
-    AGENT_OPERATION_TYPE_TAG, AppMessageRetentionDecision, EVENT_REF_TAG, GROUP_SYSTEM_TYPE_TAG,
-    MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY, MARMOT_APP_EVENT_KIND_AGENT_OPERATION,
-    MARMOT_APP_EVENT_KIND_AGENT_STREAM_START, MARMOT_APP_EVENT_KIND_CHAT,
-    MARMOT_APP_EVENT_KIND_DELETE, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
+    AGENT_OPERATION_TYPE_TAG, AppMessageRetentionDecision, EVENT_REF_TAG,
+    GROUP_SYSTEM_TYPE_GROUP_DISBANDED, GROUP_SYSTEM_TYPE_TAG, MARMOT_APP_EVENT_KIND_AGENT_ACTIVITY,
+    MARMOT_APP_EVENT_KIND_AGENT_OPERATION, MARMOT_APP_EVENT_KIND_AGENT_STREAM_START,
+    MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_DELETE, MARMOT_APP_EVENT_KIND_GROUP_SYSTEM,
     MARMOT_APP_EVENT_KIND_REACTION, MarmotAppEvent, MarmotAppEventError, QUOTE_REF_TAG,
     STREAM_BROKER_TAG, STREAM_CHUNKS_TAG, STREAM_FINAL_KIND_TAG, STREAM_HASH_TAG,
     STREAM_PARENT_TAG, STREAM_ROUTE_TAG, STREAM_START_TAG, STREAM_TAG, STREAM_TYPE_TAG,
@@ -76,11 +76,11 @@ pub use engine::{
     WelcomeMetadata,
 };
 pub use engine_state::{
-    EpochState, InvalidTransition, Merging, PendingPublish, PendingStateRef, PendingWelcomeState,
-    Recovering, StagedCommitHandle, WelcomeState,
+    Disbanded, EpochState, GroupLifecycleState, InvalidTransition, Merging, PendingPublish,
+    PendingStateRef, PendingWelcomeState, Recovering, StagedCommitHandle, WelcomeState,
 };
 pub use error::{EngineError, PeelerError};
-pub use group::{Group, Member};
+pub use group::{DisbandTombstone, Group, Member};
 pub use group_context::{GroupContext, GroupContextSnapshot, SecretBytes};
 pub use ingest::{
     IngestOutcome, InputRejectionCategory, LocalIngestState, PeeledContent, PeeledMessage,
@@ -97,9 +97,11 @@ pub use maintenance::{
 pub use message::{MessageRecord, MessageState, OwnCommitConvergenceStamp, StoredMessagePayload};
 pub use peeler::{GroupMessageMetadata, TransportPeeler};
 pub use storage::{
-    CapabilityStorage, ConvergencePassStorage, GroupStorage, LeaveRequest, LeaveRequestStorage,
-    MaintenanceStorage, MessageStorage, OutboundFanoutStorage, OutboundIntentStorage,
-    QueuedOutboundIntent, StorageError, StorageProvider, StorageResult, WelcomeStorage,
+    CapabilityStorage, ConvergencePassStorage, DisbandCandidate, DisbandCandidateStorage,
+    DisbandFailureReason, DisbandRequest, DisbandRequestStatus, DisbandRequestStorage,
+    DisbandTombstoneStorage, GroupStorage, LeaveRequest, LeaveRequestStorage, MaintenanceStorage,
+    MessageStorage, OutboundFanoutStorage, OutboundIntentStorage, QueuedOutboundIntent,
+    StorageError, StorageProvider, StorageResult, WelcomeStorage,
 };
 pub use transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -173,6 +173,96 @@ pub trait LeaveRequestStorage {
     fn clear_leave_request(&self, group_id: &GroupId) -> StorageResult<()>;
 }
 
+// ── DisbandRequestStorage ──────────────────────────────────────────────────
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DisbandFailureReason {
+    NoLongerAdmin,
+    NoLongerMember,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DisbandRequestStatus {
+    #[default]
+    Pending,
+    Failed(DisbandFailureReason),
+}
+
+/// Durable irreversible product intent to terminate a group.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DisbandRequest {
+    pub group_id: GroupId,
+    pub requested_at_ms: u64,
+    #[serde(default)]
+    pub status: DisbandRequestStatus,
+    /// Last epoch for which this client prepared a disband Commit. The product
+    /// intent is not epoch-bound; a losing branch clears this and retries.
+    pub last_prepared_epoch: Option<EpochId>,
+}
+
+pub trait DisbandRequestStorage {
+    fn put_disband_request(&self, request: &DisbandRequest) -> StorageResult<()>;
+    fn disband_request(&self, group_id: &GroupId) -> StorageResult<Option<DisbandRequest>>;
+    fn clear_disband_request(&self, group_id: &GroupId) -> StorageResult<()>;
+}
+
+/// Authenticated terminal Commit evidence retained while the Commit competes
+/// in the mandatory bounded convergence pass.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DisbandCandidate {
+    pub group_id: GroupId,
+    pub source_epoch: EpochId,
+    /// Identifier used by the durable convergence record. Locally authored
+    /// commits use the exact signed transport id; inbound commits are already
+    /// rebound to their content-derived id by ingest.
+    pub commit_id: MessageId,
+    /// SHA-256 of the MLS commit bytes, matching convergence's canonical
+    /// cross-transport identifier.
+    pub content_commit_id: MessageId,
+    pub commit_digest: [u8; 32],
+    pub actor: crate::types::MemberId,
+    pub local_was_committer_leaf: bool,
+    /// Deduplicated account roster from the candidate parent.
+    pub former_members: Vec<crate::group::Member>,
+}
+
+pub trait DisbandCandidateStorage {
+    fn put_disband_candidate(&self, candidate: &DisbandCandidate) -> StorageResult<()>;
+    fn disband_candidate(
+        &self,
+        group_id: &GroupId,
+        commit_id: &MessageId,
+    ) -> StorageResult<Option<DisbandCandidate>>;
+    fn list_disband_candidates(&self, group_id: &GroupId) -> StorageResult<Vec<DisbandCandidate>>;
+    fn clear_disband_candidates(&self, group_id: &GroupId) -> StorageResult<()>;
+}
+
+/// Minimal authenticated terminal guard. Unlike the presentation `Group`
+/// record this row deliberately has no foreign key, so deleting local history
+/// cannot make a disbanded MLS group id joinable again.
+pub trait DisbandTombstoneStorage {
+    fn put_disband_tombstone(
+        &self,
+        group_id: &GroupId,
+        tombstone: &crate::group::DisbandTombstone,
+    ) -> StorageResult<()>;
+    fn disband_tombstone(
+        &self,
+        group_id: &GroupId,
+    ) -> StorageResult<Option<crate::group::DisbandTombstone>>;
+
+    /// Enumerate terminal guards independently from live group records. This is
+    /// required after a user deletes local history and only the anti-
+    /// resurrection tombstone remains.
+    fn list_disband_tombstones(
+        &self,
+    ) -> StorageResult<Vec<(GroupId, crate::group::DisbandTombstone)>> {
+        Ok(Vec::new())
+    }
+}
+
 // ── WelcomeStorage ──────────────────────────────────────────────────────────
 
 pub trait WelcomeStorage {
@@ -363,6 +453,9 @@ pub trait StorageProvider:
     + OutboundIntentStorage
     + OutboundFanoutStorage
     + LeaveRequestStorage
+    + DisbandRequestStorage
+    + DisbandCandidateStorage
+    + DisbandTombstoneStorage
     + WelcomeStorage
     + CapabilityStorage
     + ConvergencePolicyStorage

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -258,9 +258,7 @@ pub trait DisbandTombstoneStorage {
     /// resurrection tombstone remains.
     fn list_disband_tombstones(
         &self,
-    ) -> StorageResult<Vec<(GroupId, crate::group::DisbandTombstone)>> {
-        Ok(Vec::new())
-    }
+    ) -> StorageResult<Vec<(GroupId, crate::group::DisbandTombstone)>>;
 }
 
 // ── WelcomeStorage ──────────────────────────────────────────────────────────

--- a/crates/traits/tests/error_display.rs
+++ b/crates/traits/tests/error_display.rs
@@ -32,6 +32,10 @@ fn engine_error_display_does_not_expose_group_or_member_ids() {
             group_id: group_id.clone(),
         }
         .to_string(),
+        EngineError::DisbandingNotEnabled {
+            group_id: group_id.clone(),
+        }
+        .to_string(),
         EngineError::ForkedEpoch {
             group_id,
             last_stable: EpochId(1),

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -721,6 +721,7 @@ fn snapshot_group_and_member() {
             protocol_profile: ProtocolProfile::Current,
             removed: false,
             unrecoverable: false,
+            disbanded: None,
             join_epoch: EpochId(2),
         }
     );


### PR DESCRIPTION
## Summary

- implement lifecycle-v1 (`0x800c`) with `Active` and terminal `Disbanded` state
- add durable disband requests, authenticated convergence candidates, terminal tombstones, and migration `0040`
- validate the exact disband Commit shape, including candidate-parent admin authorization, exact committer-leaf retention, sibling-device removal, admin-policy replacement, and forbidden proposals
- route local and inbound disband Commits through normal bounded convergence without special branch dominance
- terminalize transactionally, erase live OpenMLS state, clean routes/queues/fanouts/maintenance/push state, and hydrate safely from tombstones
- expose lifecycle and request state through app/runtime/chat-list/group-details/management DTOs and UniFFI APIs
- synthesize one actor-attributed `group_disbanded` kind-1210 row and retain history/media material until local deletion
- preserve the newly landed manual chat pin ordering while composing terminal lifecycle projection into the same chat-list query

## Protocol dependency

Implements marmot-protocol/marmot#409.

## Compatibility

New current-profile groups require lifecycle-v1 and start `Active`. Existing groups remain valid without it and can be upgraded only when every current leaf advertises support. No OpenMLS fork is required.

## Validation

- `just fast-ci`
- `cargo test -p storage-sqlite` — 295 passed
- `cargo test -p cgka-engine --test group_creation solo_disband_is_durable_convergent_terminal_and_restart_safe -- --exact`
- `cargo test -p marmot-uniffi disband_gate_and_terminal_state_disable_every_management_action`
- app library, connector, lifecycle codec, canonical simulator fixture, and focused terminal/storage tests passed before the final rebase

Full `just ci` was not run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable group disbanding with lifecycle-v1 enablement, disband requests/candidates/tombstones, support blockers, failure acknowledgement, and a terminal “disbanded” state.
  * Exposed new engine/session/runtime/UniFFI APIs and surfaced disbanding state in group views (details, management, chat list), including disband lifecycle metadata and gating.
* **Bug Fixes**
  * Blocked outbound work, optimistic messaging, convergence draining/publishing side effects, unread counts, routing updates, and local deletion while disbanding or after terminal disband.
  * Added clearer event/audit and error labeling for disband-related outcomes and reconciliation behavior after restarts.
* **Tests**
  * Added/updated conformance and integration coverage for durable disbanding, hydration, and atomic failure recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->