### PR TITLE
chore(release): prepare 0.9.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-connector"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "agent-control",
  "agent-stream-compose",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agent-control"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agent-stream-compose"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "cgka-traits",
  "hex",
@@ -853,7 +853,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgka-conformance-simulator"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-engine"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-session"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "cgka-traits"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "hex",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "fs-private"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "libc",
  "tempfile",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "incident-replay"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "cgka-conformance-simulator",
  "serde",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-account"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-app"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "cgka-engine",
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-forensics"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "fs-private",
  "serde",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-markdown"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "marmot-uniffi"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "cgka-engine",
  "cgka-traits",
@@ -5441,7 +5441,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-sqlite"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "cgka-traits",
  "fs-private",
@@ -6035,7 +6035,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-adapter"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6054,7 +6054,7 @@ dependencies = [
 
 [[package]]
 name = "transport-nostr-peeler"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "async-trait",
  "cgka-traits",
@@ -6071,7 +6071,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-broker"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "cgka-traits",
  "clap",
@@ -6091,7 +6091,7 @@ dependencies = [
 
 [[package]]
 name = "transport-quic-stream"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "cgka-traits",
  "chacha20poly1305",
@@ -7146,7 +7146,7 @@ dependencies = [
 
 [[package]]
 name = "wn-cli"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "agent-stream-compose",
  "cgka-session",
@@ -7179,7 +7179,7 @@ dependencies = [
 
 [[package]]
 name = "wn-opencode"
-version = "0.9.10"
+version = "0.9.9"
 dependencies = [
  "agent-control",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-version = "0.9.10"
+version = "0.9.9"
 license = "MIT"
 publish = false
 

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "admin-policy-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "concurrent-invite-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-committer-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-witness-selected/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "current-profile-required-set/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "application_profile": {
     "name": "current",

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "delayed-past-epoch-app-message/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "drop-queued/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-fork-recovery/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "group-data-update/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "convergence-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "membership-fork-recovery-incident/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-member/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "invite-publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "partition-clear-leave/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "publish-fail/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "queue-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "restart-delivery-faults/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -1,7 +1,7 @@
 {
   "scenario_name": "three-client-message-exchange/v1",
   "vector_version": "1",
-  "conformance_version": "0.9.10",
+  "conformance_version": "0.9.9",
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,45 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+## [0.9.9] - 2026-07-28
+
+### Added
+
+- MarmotKit now supports durable, device-local chat pinning. Chat-list rows
+  expose normalized pin state and position, new commands pin, unpin, and
+  transactionally replace the complete pinned order, and chat-list
+  subscriptions publish atomic snapshots when pin order changes.
+- MDK now implements lifecycle-v1 terminal group disbanding. Current-profile
+  groups can durably request and converge on an authenticated disband Commit,
+  transactionally erase live MLS state, retain a terminal tombstone and local
+  history, block later group activity, recover safely after restart, and expose
+  lifecycle, request, support, and management state through MarmotKit.
+- WN Agent inbound delivery now carries structured actor, message, media, reply,
+  edit, delete, and reaction context. Durable mutation events are normalized,
+  deduplicated, privacy-filtered, and delivered through the native OpenClaw and
+  Hermes context surfaces; OpenCode decodes the new schema while intentionally
+  ignoring ambient mutations.
+
+### Changed
+
+- The `marmot.agent-control.v2` inbound schema replaces the former flat message
+  shape. This is the final unversioned wire break: deploy the `0.9.9` WN Agent,
+  Hermes plugin, OpenClaw plugin, and OpenCode harness as one cohort. Future
+  breaking changes require a new protocol label or explicit negotiation.
+- Chat-list consumers must handle the new snapshot and pin-order subscription
+  cases and the required pin fields. Group consumers gain terminal lifecycle
+  and disband-request fields, typed disband errors, and disband commands.
+- The supported integration baselines are now Hermes Agent 0.19.0 and OpenClaw
+  2026.7.1. Release installers validate an existing host but never install or
+  upgrade Hermes or OpenClaw.
+
+### Fixed
+
+- WN Agent now preserves ambient edits, deletes, and reactions that arrive
+  while an agent turn is already in flight, so the bounded context is attached
+  to the next triggering message instead of being lost when the current turn
+  finishes.
+
 ## [0.9.8] - 2026-07-27
 
 ### Added
@@ -959,7 +998,8 @@ Initial release of the `dm` command-line app, the `dmd` background daemon, and t
 - Local installation docs for `cargo install --path crates/cli --locked --bins`.
 - Homebrew release checklist and namespaced tap packaging path for `marmot-protocol/tap/darkmatter`.
 
-[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.8...HEAD
+[Unreleased]: https://github.com/marmot-protocol/mdk/compare/v0.9.9...HEAD
+[0.9.9]: https://github.com/marmot-protocol/mdk/compare/v0.9.8...v0.9.9
 [0.9.8]: https://github.com/marmot-protocol/mdk/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/marmot-protocol/mdk/compare/v0.9.6...v0.9.7
 [0.9.6]: https://github.com/marmot-protocol/mdk/compare/v0.9.5...v0.9.6

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -56,7 +56,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 `0600`, then use a pinned release URL:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.8/install-hermes-marmot.sh" | \
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.9/install-hermes-marmot.sh" | \
   bash -s -- \
     --yes \
     --existing-identity-file "$HOME/.config/example/hermes-agent.nsec" \

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -53,7 +53,7 @@ with `--generate-identity`). To preserve an existing Nostr identity, place its
 `0600`, then use a pinned release URL:
 
 ```sh
-curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.8/install-openclaw-marmot.sh" | \
+curl -fsSL "https://github.com/marmot-protocol/mdk/releases/download/wn-agent-v0.9.9/install-openclaw-marmot.sh" | \
   bash -s -- \
     --yes \
     --existing-identity-file "$HOME/.config/example/openclaw-agent.nsec" \


### PR DESCRIPTION
## Summary

- restore the intended workspace release version from the accidental `0.9.10` bump to `0.9.9`
- align every workspace package in `Cargo.lock` and every canonical conformance fixture stamp with `0.9.9`
- publish a `0.9.9` changelog covering chat pinning, terminal group disbanding, and rich agent inbound context
- document the `marmot.agent-control.v2` lockstep upgrade requirement and current Hermes/OpenClaw host baselines
- update pinned Hermes and OpenClaw installer examples to `wn-agent-v0.9.9`

## Release impact

This prepares one compatibility cohort across `v0.9.9`, `wn-agent-v0.9.9`, and `marmotkit-v0.9.9`. The agent-control inbound schema is a deliberate final unversioned wire break, so WN Agent and all in-repo integrations must be deployed together.

## Validation

- `just fast-ci`
- `cargo test -p cgka-conformance-simulator canonical_vector_fixtures_match_generated_traces`
- `just release-all-dry-run 0.9.9`
- `git diff --check`