### PR TITLE
Supervise relay notification forwarding and recover inbound delivery

### DIFF
--- a/crates/cli/src/commands/relay_stats.rs
+++ b/crates/cli/src/commands/relay_stats.rs
@@ -109,6 +109,15 @@ pub(crate) fn relay_stats_plain(snapshot: &RelayTelemetrySnapshot) -> String {
         health.connection_attempts,
         health.connection_successes,
     ));
+    lines.push(format!(
+        "notification forwarder: running={} restarts={} lag_incidents={} lagged_notifications={} panics={} unexpected_exits={}",
+        health.notification_forwarder_running,
+        health.notification_forwarder_restarts,
+        health.notification_forwarder_lag_incidents,
+        health.notification_forwarder_lagged_notifications,
+        health.notification_forwarder_panics,
+        health.notification_forwarder_unexpected_exits,
+    ));
     lines.join("\n")
 }
 

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -1575,6 +1575,12 @@ pub(crate) struct RelayHealthData {
     pub(crate) disconnected: u64,
     pub(crate) connection_attempts: u64,
     pub(crate) connection_successes: u64,
+    pub(crate) notification_forwarder_running: bool,
+    pub(crate) notification_forwarder_restarts: u64,
+    pub(crate) notification_forwarder_lag_incidents: u64,
+    pub(crate) notification_forwarder_lagged_notifications: u64,
+    pub(crate) notification_forwarder_panics: u64,
+    pub(crate) notification_forwarder_unexpected_exits: u64,
     pub(crate) per_relay: Vec<RelayHealthRow>,
 }
 
@@ -1686,6 +1692,24 @@ pub(crate) fn parse_relay_health(result: &Value, daemon_running: bool) -> RelayH
         disconnected: u64_at(&health, "disconnected"),
         connection_attempts: u64_at(&health, "connection_attempts"),
         connection_successes: u64_at(&health, "connection_successes"),
+        notification_forwarder_running: health
+            .get("notification_forwarder_running")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        notification_forwarder_restarts: u64_at(&health, "notification_forwarder_restarts"),
+        notification_forwarder_lag_incidents: u64_at(
+            &health,
+            "notification_forwarder_lag_incidents",
+        ),
+        notification_forwarder_lagged_notifications: u64_at(
+            &health,
+            "notification_forwarder_lagged_notifications",
+        ),
+        notification_forwarder_panics: u64_at(&health, "notification_forwarder_panics"),
+        notification_forwarder_unexpected_exits: u64_at(
+            &health,
+            "notification_forwarder_unexpected_exits",
+        ),
         per_relay,
     }
 }

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -10600,12 +10600,32 @@ fn parse_relay_health_reads_counters_histograms_and_per_relay() {
             "eose": {"buckets": [{"upper_bound_ms": 300, "count": 2}], "overflow_count": 0},
             "per_relay": [{"relay_index": 0, "first_event": {"buckets": [{"upper_bound_ms": 100, "count": 2}], "overflow_count": 0}, "eose": {"buckets": [{"upper_bound_ms": 300, "count": 1}], "overflow_count": 0}}]
         },
-        "health": {"sdk_backed": true, "total_relays": 3, "connected": 2, "connecting": 0, "disconnected": 1, "connection_attempts": 5, "connection_successes": 4}
+        "health": {
+            "sdk_backed": true,
+            "total_relays": 3,
+            "connected": 2,
+            "connecting": 0,
+            "disconnected": 1,
+            "connection_attempts": 5,
+            "connection_successes": 4,
+            "notification_forwarder_running": true,
+            "notification_forwarder_restarts": 2,
+            "notification_forwarder_lag_incidents": 1,
+            "notification_forwarder_lagged_notifications": 17,
+            "notification_forwarder_panics": 1,
+            "notification_forwarder_unexpected_exits": 1
+        }
     });
     let data = parse_relay_health(&snapshot, true);
     assert_eq!(data.inbound_seen, 10);
     assert_eq!(data.total_relays, 3);
     assert_eq!(data.connected, 2);
+    assert!(data.notification_forwarder_running);
+    assert_eq!(data.notification_forwarder_restarts, 2);
+    assert_eq!(data.notification_forwarder_lag_incidents, 1);
+    assert_eq!(data.notification_forwarder_lagged_notifications, 17);
+    assert_eq!(data.notification_forwarder_panics, 1);
+    assert_eq!(data.notification_forwarder_unexpected_exits, 1);
     assert_eq!(data.observed, 5);
     assert_eq!(data.spread_samples, 4);
     // p50 of 4 samples: ceil(0.5*4)=2 falls in the first (<=50ms) bucket.

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -1503,6 +1503,15 @@ pub(crate) fn relay_health_lines(data: &RelayHealthData) -> Vec<Line<'static>> {
             data.connection_attempts,
             data.connection_successes,
         )),
+        Line::from(format!(
+            "forwarder: running={} restarts={} lag_incidents={} lagged={} panics={} unexpected_exits={}",
+            data.notification_forwarder_running,
+            data.notification_forwarder_restarts,
+            data.notification_forwarder_lag_incidents,
+            data.notification_forwarder_lagged_notifications,
+            data.notification_forwarder_panics,
+            data.notification_forwarder_unexpected_exits,
+        )),
         Line::from(""),
         Line::from("counters"),
         Line::from(format!(

--- a/crates/marmot-app/src/directory/sync.rs
+++ b/crates/marmot-app/src/directory/sync.rs
@@ -233,7 +233,7 @@ async fn run_directory_sync_worker(
     relay_plane: MarmotRelayPlane,
     mut commands: mpsc::Receiver<DirectorySyncCommand>,
     mut directory_events: tokio::sync::broadcast::Receiver<
-        crate::relay_plane::DirectoryRelayEventRecord,
+        crate::relay_plane::DirectoryRelayPlaneEvent,
     >,
     rebuild_queued: Arc<AtomicBool>,
 ) {
@@ -243,7 +243,8 @@ async fn run_directory_sync_worker(
                 match command {
                     Some(DirectorySyncCommand::Rebuild { respond }) => {
                         rebuild_queued.store(false, Ordering::SeqCst);
-                        let result = run_directory_sync_once(app.clone(), relay_plane.clone()).await;
+                        let result =
+                            run_directory_sync_once(app.clone(), relay_plane.clone(), false).await;
                         if let Some(respond) = respond {
                             let _ = respond.send(result.map_err(|err| err.to_string()));
                         }
@@ -253,11 +254,23 @@ async fn run_directory_sync_worker(
             }
             event = directory_events.recv() => {
                 match event {
-                    Ok(record) => {
+                    Ok(crate::relay_plane::DirectoryRelayPlaneEvent::Record(record)) => {
                         let app = app.clone();
                         let _ = blocking_app_task(move || app.ingest_directory_relay_event(record)).await;
                     }
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Ok(crate::relay_plane::DirectoryRelayPlaneEvent::RecoveryRequired)
+                    | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                        if run_directory_sync_once(app.clone(), relay_plane.clone(), true)
+                            .await
+                            .is_err()
+                        {
+                            tracing::warn!(
+                                target: "marmot_app::directory",
+                                method = "run_directory_sync_worker",
+                                "directory subscription recovery rebuild failed",
+                            );
+                        }
+                    }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
                 }
             }
@@ -268,11 +281,12 @@ async fn run_directory_sync_worker(
 async fn run_directory_sync_once(
     app: MarmotApp,
     relay_plane: MarmotRelayPlane,
+    force_rebuild: bool,
 ) -> Result<DirectorySyncRunSummary, AppError> {
     let plan = blocking_app_task(move || app.directory_sync_plan()).await?;
     let watched_user_count = plan.watched_user_count;
     let subscriptions = relay_plane
-        .sync_directory_user_subscriptions(plan)
+        .sync_directory_user_subscriptions(plan, force_rebuild)
         .await
         .map_err(AppError::RelayDirectory)?;
     Ok(DirectorySyncRunSummary {

--- a/crates/marmot-app/src/directory/sync.rs
+++ b/crates/marmot-app/src/directory/sync.rs
@@ -7,7 +7,7 @@ use sha2::{Digest, Sha256};
 
 use cgka_traits::TransportEndpoint;
 use tokio::sync::{mpsc, oneshot};
-use tokio::task::AbortHandle;
+use tokio::task::{AbortHandle, JoinHandle};
 
 use crate::{
     AppError, KIND_MARMOT_INBOX_RELAY_LIST, KIND_MARMOT_KEY_PACKAGE, KIND_NIP65_RELAY_LIST,
@@ -75,6 +75,47 @@ enum DirectorySyncCommand {
         respond: Option<oneshot::Sender<Result<DirectorySyncRunSummary, String>>>,
     },
     Shutdown,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct DirectoryRecoveryRebuildQueue {
+    active: bool,
+    pending: bool,
+}
+
+struct DirectoryRecoveryRebuildTask(JoinHandle<Result<DirectorySyncRunSummary, AppError>>);
+
+impl Drop for DirectoryRecoveryRebuildTask {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+impl DirectoryRecoveryRebuildQueue {
+    /// Queue one recovery rebuild, coalescing any further requests while a
+    /// rebuild is active into at most one follow-up pass.
+    fn request(&mut self) -> bool {
+        if self.active {
+            self.pending = true;
+            false
+        } else {
+            self.active = true;
+            true
+        }
+    }
+
+    /// Complete the active pass and report whether one coalesced follow-up
+    /// pass must start.
+    fn complete(&mut self) -> bool {
+        debug_assert!(self.active);
+        if self.pending {
+            self.pending = false;
+            true
+        } else {
+            self.active = false;
+            false
+        }
+    }
 }
 
 impl DirectorySyncPlan {
@@ -237,6 +278,8 @@ async fn run_directory_sync_worker(
     >,
     rebuild_queued: Arc<AtomicBool>,
 ) {
+    let mut recovery_rebuilds = DirectoryRecoveryRebuildQueue::default();
+    let mut recovery_task: Option<DirectoryRecoveryRebuildTask> = None;
     loop {
         tokio::select! {
             command = commands.recv() => {
@@ -249,7 +292,31 @@ async fn run_directory_sync_worker(
                             let _ = respond.send(result.map_err(|err| err.to_string()));
                         }
                     }
-                    Some(DirectorySyncCommand::Shutdown) | None => return,
+                    Some(DirectorySyncCommand::Shutdown) | None => {
+                        drop(recovery_task.take());
+                        return;
+                    }
+                }
+            }
+            recovery_result = async {
+                let task = recovery_task
+                    .as_mut()
+                    .expect("recovery task is present when this select arm is enabled");
+                (&mut task.0).await
+            }, if recovery_task.is_some() => {
+                recovery_task = None;
+                if !matches!(recovery_result, Ok(Ok(_))) {
+                    tracing::warn!(
+                        target: "marmot_app::directory",
+                        method = "run_directory_sync_worker",
+                        "directory subscription recovery rebuild failed",
+                    );
+                }
+                if recovery_rebuilds.complete() {
+                    recovery_task = Some(spawn_directory_recovery_rebuild(
+                        app.clone(),
+                        relay_plane.clone(),
+                    ));
                 }
             }
             event = directory_events.recv() => {
@@ -260,22 +327,32 @@ async fn run_directory_sync_worker(
                     }
                     Ok(crate::relay_plane::DirectoryRelayPlaneEvent::RecoveryRequired)
                     | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                        if run_directory_sync_once(app.clone(), relay_plane.clone(), true)
-                            .await
-                            .is_err()
-                        {
-                            tracing::warn!(
-                                target: "marmot_app::directory",
-                                method = "run_directory_sync_worker",
-                                "directory subscription recovery rebuild failed",
-                            );
+                        if recovery_rebuilds.request() {
+                            recovery_task = Some(spawn_directory_recovery_rebuild(
+                                app.clone(),
+                                relay_plane.clone(),
+                            ));
                         }
                     }
-                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        drop(recovery_task.take());
+                        return;
+                    }
                 }
             }
         }
     }
+}
+
+fn spawn_directory_recovery_rebuild(
+    app: MarmotApp,
+    relay_plane: MarmotRelayPlane,
+) -> DirectoryRecoveryRebuildTask {
+    DirectoryRecoveryRebuildTask(tokio::spawn(run_directory_sync_once(
+        app,
+        relay_plane,
+        true,
+    )))
 }
 
 async fn run_directory_sync_once(
@@ -401,6 +478,27 @@ mod tests {
                 .filter(|batch| batch.authors.contains(&local))
                 .count(),
             1
+        );
+    }
+
+    #[test]
+    fn recovery_rebuild_queue_coalesces_to_one_follow_up_pass() {
+        let mut rebuilds = DirectoryRecoveryRebuildQueue::default();
+
+        assert!(rebuilds.request(), "the first request starts a rebuild");
+        assert!(!rebuilds.request(), "an active rebuild absorbs a request");
+        assert!(!rebuilds.request(), "more requests stay coalesced");
+        assert!(
+            rebuilds.complete(),
+            "completion starts exactly one coalesced follow-up"
+        );
+        assert!(
+            !rebuilds.complete(),
+            "the follow-up completes without another queued pass"
+        );
+        assert!(
+            rebuilds.request(),
+            "a later independent recovery can start normally"
         );
     }
 

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -1,5 +1,8 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{
+    Arc, RwLock, RwLockReadGuard, RwLockWriteGuard,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
@@ -75,10 +78,38 @@ struct MarmotRelayPlaneInner {
 struct RelayPlaneTransport {
     adapter: NostrTransportAdapter,
     sdk_relay_client: Option<NostrSdkRelayClient>,
-    directory_events: broadcast::Sender<DirectoryRelayEventRecord>,
+    directory_events: broadcast::Sender<DirectoryRelayPlaneEvent>,
     account_deliveries: RwLock<HashMap<MemberId, mpsc::Sender<TransportDelivery>>>,
     router: Mutex<Option<JoinHandle<()>>>,
     notification_forwarder: Mutex<Option<JoinHandle<()>>>,
+    notification_forwarder_health: Arc<RelayNotificationForwarderHealth>,
+    shutting_down: AtomicBool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum DirectoryRelayPlaneEvent {
+    Record(DirectoryRelayEventRecord),
+    RecoveryRequired,
+}
+
+#[derive(Default)]
+struct RelayNotificationForwarderHealth {
+    running: AtomicBool,
+    restarts: AtomicU64,
+    lag_incidents: AtomicU64,
+    lagged_notifications: AtomicU64,
+    panics: AtomicU64,
+    unexpected_exits: AtomicU64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct RelayNotificationForwarderHealthSnapshot {
+    running: bool,
+    restarts: u64,
+    lag_incidents: u64,
+    lagged_notifications: u64,
+    panics: u64,
+    unexpected_exits: u64,
 }
 
 #[derive(Clone)]
@@ -103,6 +134,12 @@ pub struct RelayPlaneHealth {
     pub sleeping: usize,
     pub connection_attempts: usize,
     pub connection_successes: usize,
+    pub notification_forwarder_running: bool,
+    pub notification_forwarder_restarts: u64,
+    pub notification_forwarder_lag_incidents: u64,
+    pub notification_forwarder_lagged_notifications: u64,
+    pub notification_forwarder_panics: u64,
+    pub notification_forwarder_unexpected_exits: u64,
     pub directory_inflight_fetches: usize,
     pub directory_active_subscriptions: usize,
     pub directory_completed_fetches: usize,
@@ -195,6 +232,8 @@ impl MarmotRelayPlane {
             account_deliveries: RwLock::new(HashMap::new()),
             router: Mutex::new(None),
             notification_forwarder: Mutex::new(notification_forwarder),
+            notification_forwarder_health: Arc::new(RelayNotificationForwarderHealth::default()),
+            shutting_down: AtomicBool::new(false),
         });
         let this = Self {
             inner: Arc::new(MarmotRelayPlaneInner {
@@ -320,8 +359,17 @@ impl MarmotRelayPlane {
 
     pub async fn relay_health(&self) -> RelayPlaneHealth {
         let directory = self.inner.directory.stats().await;
+        let forwarder = self
+            .inner
+            .transport
+            .notification_forwarder_health
+            .snapshot();
         if let Some(sdk_relay_client) = &self.inner.transport.sdk_relay_client {
-            return RelayPlaneHealth::from_sdk(sdk_relay_client.relay_health().await, directory);
+            return RelayPlaneHealth::from_sdk(
+                sdk_relay_client.relay_health().await,
+                directory,
+                forwarder,
+            );
         }
         RelayPlaneHealth::from_directory(directory)
     }
@@ -408,13 +456,14 @@ impl MarmotRelayPlane {
 
     pub(crate) fn subscribe_directory_events(
         &self,
-    ) -> broadcast::Receiver<DirectoryRelayEventRecord> {
+    ) -> broadcast::Receiver<DirectoryRelayPlaneEvent> {
         self.inner.transport.directory_events.subscribe()
     }
 
     pub(crate) async fn sync_directory_user_subscriptions(
         &self,
         plan: DirectorySyncPlan,
+        force_rebuild: bool,
     ) -> Result<DirectorySubscriptionSyncSummary, String> {
         self.spawn_router();
         let endpoints = self
@@ -461,7 +510,10 @@ impl MarmotRelayPlane {
             .iter()
             .map(|batch| batch.subscription_id.clone())
             .collect::<HashSet<_>>();
-        let (to_add, to_remove) = self.inner.directory.subscription_diff(&desired_ids).await;
+        let (mut to_add, to_remove) = self.inner.directory.subscription_diff(&desired_ids).await;
+        if force_rebuild {
+            to_add = desired_ids;
+        }
         for subscription_id in &to_remove {
             sdk_relay_client
                 .client()
@@ -522,6 +574,10 @@ impl MarmotRelayPlane {
     }
 
     pub async fn shutdown(&self) {
+        self.inner
+            .transport
+            .shutting_down
+            .store(true, Ordering::SeqCst);
         if let Some(sdk_relay_client) = &self.inner.transport.sdk_relay_client {
             let timed_out = timeout(
                 RELAY_PLANE_SHUTDOWN_WAIT,
@@ -555,29 +611,48 @@ impl MarmotRelayPlane {
             handle.abort();
             let _ = timeout(RELAY_PLANE_TASK_ABORT_WAIT, &mut handle).await;
         }
+        self.inner
+            .transport
+            .notification_forwarder_health
+            .running
+            .store(false, Ordering::SeqCst);
     }
 
     fn spawn_router(&self) {
+        if self.inner.transport.shutting_down.load(Ordering::SeqCst) {
+            return;
+        }
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
             return;
         };
+        if let Ok(mut notification_forwarder) =
+            self.inner.transport.notification_forwarder.try_lock()
+        {
+            let needs_forwarder = match notification_forwarder.as_ref() {
+                None => true,
+                Some(forwarder) => forwarder.is_finished(),
+            };
+            if needs_forwarder
+                && let Some(sdk_relay_client) = &self.inner.transport.sdk_relay_client
+            {
+                if notification_forwarder.take().is_some() {
+                    recover_relay_notification_forwarder(
+                        &self.inner.transport,
+                        RelayNotificationConsumerExit::Closed,
+                    );
+                }
+                *notification_forwarder = Some(spawn_relay_notification_forwarder(
+                    sdk_relay_client.clone(),
+                    self.inner.transport.clone(),
+                    self.inner.directory.clone(),
+                ));
+            }
+        }
         let Ok(mut router) = self.inner.transport.router.try_lock() else {
             return;
         };
         if router.is_some() {
             return;
-        }
-        if let Ok(mut notification_forwarder) =
-            self.inner.transport.notification_forwarder.try_lock()
-            && notification_forwarder.is_none()
-            && let Some(sdk_relay_client) = &self.inner.transport.sdk_relay_client
-        {
-            *notification_forwarder = Some(spawn_relay_notification_forwarder(
-                sdk_relay_client.clone(),
-                self.inner.transport.adapter.clone(),
-                self.inner.transport.directory_events.clone(),
-                self.inner.directory.clone(),
-            ));
         }
         let transport = self.inner.transport.clone();
         let adapter = transport.adapter.clone();
@@ -624,7 +699,11 @@ impl MarmotRelayPlane {
 }
 
 impl RelayPlaneHealth {
-    fn from_sdk(health: NostrSdkRelayHealth, directory: DirectoryRelayStats) -> Self {
+    fn from_sdk(
+        health: NostrSdkRelayHealth,
+        directory: DirectoryRelayStats,
+        forwarder: RelayNotificationForwarderHealthSnapshot,
+    ) -> Self {
         Self {
             sdk_backed: true,
             total_relays: health.total_relays,
@@ -638,6 +717,12 @@ impl RelayPlaneHealth {
             sleeping: health.sleeping,
             connection_attempts: health.connection_attempts,
             connection_successes: health.connection_successes,
+            notification_forwarder_running: forwarder.running,
+            notification_forwarder_restarts: forwarder.restarts,
+            notification_forwarder_lag_incidents: forwarder.lag_incidents,
+            notification_forwarder_lagged_notifications: forwarder.lagged_notifications,
+            notification_forwarder_panics: forwarder.panics,
+            notification_forwarder_unexpected_exits: forwarder.unexpected_exits,
             directory_inflight_fetches: directory.inflight_fetches,
             directory_active_subscriptions: directory.active_subscriptions,
             directory_completed_fetches: directory.completed_fetches,
@@ -664,132 +749,336 @@ impl RelayPlaneHealth {
     }
 }
 
+impl RelayNotificationForwarderHealth {
+    fn snapshot(&self) -> RelayNotificationForwarderHealthSnapshot {
+        RelayNotificationForwarderHealthSnapshot {
+            running: self.running.load(Ordering::Relaxed),
+            restarts: self.restarts.load(Ordering::Relaxed),
+            lag_incidents: self.lag_incidents.load(Ordering::Relaxed),
+            lagged_notifications: self.lagged_notifications.load(Ordering::Relaxed),
+            panics: self.panics.load(Ordering::Relaxed),
+            unexpected_exits: self.unexpected_exits.load(Ordering::Relaxed),
+        }
+    }
+
+    fn increment(counter: &AtomicU64, value: u64) {
+        let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            Some(current.saturating_add(value))
+        });
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RelayNotificationConsumerExit {
+    Shutdown,
+    Lagged(u64),
+    Closed,
+}
+
+struct RelayNotificationConsumerOutcome {
+    receiver: broadcast::Receiver<RelayPoolNotification>,
+    exit: RelayNotificationConsumerExit,
+}
+
+trait RelayNotificationSource: Send + Sync {
+    fn notifications(&self) -> broadcast::Receiver<RelayPoolNotification>;
+    fn is_shutdown(&self) -> bool;
+}
+
+struct SdkRelayNotificationSource {
+    client: NostrSdkClient,
+}
+
+impl RelayNotificationSource for SdkRelayNotificationSource {
+    fn notifications(&self) -> broadcast::Receiver<RelayPoolNotification> {
+        self.client.notifications()
+    }
+
+    fn is_shutdown(&self) -> bool {
+        self.client.pool().is_shutdown()
+    }
+}
+
 fn spawn_relay_notification_forwarder(
     sdk_relay_client: NostrSdkRelayClient,
-    adapter: NostrTransportAdapter,
-    directory_events: broadcast::Sender<DirectoryRelayEventRecord>,
+    transport: Arc<RelayPlaneTransport>,
     directory: DirectoryRelayPlane,
 ) -> JoinHandle<()> {
-    let client = sdk_relay_client.client().clone();
+    let source: Arc<dyn RelayNotificationSource> = Arc::new(SdkRelayNotificationSource {
+        client: sdk_relay_client.client().clone(),
+    });
+    spawn_relay_notification_supervisor(source, transport, directory)
+}
+
+fn spawn_relay_notification_supervisor(
+    source: Arc<dyn RelayNotificationSource>,
+    transport: Arc<RelayPlaneTransport>,
+    directory: DirectoryRelayPlane,
+) -> JoinHandle<()> {
     tokio::spawn(async move {
-        let _ = client
-            .handle_notifications(move |notification| {
-                let adapter = adapter.clone();
-                let directory_events = directory_events.clone();
-                let directory = directory.clone();
-                async move {
-                    match notification {
-                        RelayPoolNotification::Event {
-                            relay_url,
-                            subscription_id,
-                            event,
-                        } => {
-                            if let Ok(event) = NostrTransportEvent::from_nostr_event(&event) {
-                                tracing::trace!(
-                                    target: "marmot_app::relay_plane",
-                                    method = "spawn_relay_notification_forwarder",
-                                    "forwarding SDK relay event"
-                                );
-                                let endpoint = TransportEndpoint(relay_url.to_string());
-                                let subscription_id = subscription_id.to_string();
-                                let relay_event = transport_nostr_adapter::NostrRelayEvent {
-                                    endpoint: endpoint.clone(),
-                                    subscription_id: Some(subscription_id.clone()),
-                                    event: event.clone(),
-                                };
-                                // The transport adapter path is unchanged: every
-                                // SDK event still feeds account/group delivery
-                                // and telemetry. Only the directory cache path is
-                                // gated, so an unsolicited or filter-mismatched
-                                // event from a malicious or buggy relay cannot
-                                // create persistent directory search-graph writes
-                                // (mdk#709).
-                                let _ = adapter.handle_relay_event(relay_event).await;
-                                if directory
-                                    .accepts_live_event(
-                                        &subscription_id,
-                                        &event.pubkey,
-                                        event.kind,
-                                    )
-                                    .await
-                                {
-                                    let _ = directory_events.send(DirectoryRelayEventRecord {
-                                        endpoints: vec![endpoint],
-                                        event,
-                                    });
-                                } else {
-                                    tracing::trace!(
-                                        target: "marmot_app::relay_plane",
-                                        method = "spawn_relay_notification_forwarder",
-                                        "dropping directory relay event: no matching active directory subscription"
-                                    );
-                                }
-                            }
-                            Ok(false)
-                        }
-                        RelayPoolNotification::Message {
-                            relay_url,
-                            message:
-                                RelayMessage::Event {
-                                    subscription_id,
-                                    event,
-                                },
-                        } => {
-                            // Raw per-relay copy (not deduplicated): telemetry
-                            // only, so cross-relay arrival spread and per-relay
-                            // first-event timing see every relay's copy. Delivery
-                            // happens on the deduplicated `Event` arm above. Keep
-                            // this in sync with the relay plane's own tap; the
-                            // SDK client's standalone forwarder is unused here.
-                            if let Ok(event) = NostrTransportEvent::from_nostr_event(&event) {
-                                tracing::trace!(
-                                    target: "marmot_app::relay_plane",
-                                    method = "spawn_relay_notification_forwarder",
-                                    "observing per-relay event copy"
-                                );
-                                adapter
-                                    .observe_relay_event(transport_nostr_adapter::NostrRelayEvent {
-                                        endpoint: TransportEndpoint(relay_url.to_string()),
-                                        subscription_id: Some(subscription_id.to_string()),
-                                        event,
-                                    })
-                                    .await;
-                            }
-                            Ok(false)
-                        }
-                        RelayPoolNotification::Message {
-                            relay_url,
-                            message: RelayMessage::EndOfStoredEvents(subscription_id),
-                        } => {
-                            // EOSE tap: advances the per-relay initial-sync gate
-                            // and records EOSE latency. No delivery.
-                            tracing::trace!(
-                                target: "marmot_app::relay_plane",
-                                method = "spawn_relay_notification_forwarder",
-                                "forwarding SDK relay end-of-stored-events"
-                            );
-                            adapter
-                                .handle_relay_eose(
-                                    TransportEndpoint(relay_url.to_string()),
-                                    subscription_id.to_string(),
-                                )
-                                .await;
-                            Ok(false)
-                        }
-                        RelayPoolNotification::Shutdown => {
-                            tracing::debug!(
-                                target: "marmot_app::relay_plane",
-                                method = "spawn_relay_notification_forwarder",
-                                "SDK relay pool shutdown observed"
-                            );
-                            Ok(true)
-                        }
-                        _ => Ok(false),
+        transport
+            .notification_forwarder_health
+            .running
+            .store(true, Ordering::SeqCst);
+        let mut receiver = None;
+        loop {
+            let adapter = transport.adapter.clone();
+            let directory_events = transport.directory_events.clone();
+            let directory = directory.clone();
+            let source_for_consumer = source.clone();
+            let next_receiver = receiver.take();
+            let mut consumer = tokio::spawn(async move {
+                let receiver = next_receiver.unwrap_or_else(|| source_for_consumer.notifications());
+                run_relay_notification_consumer(receiver, adapter, directory_events, directory)
+                    .await
+            });
+            let abort_on_drop = AbortTaskOnDrop(consumer.abort_handle());
+            match (&mut consumer).await {
+                Ok(outcome) => {
+                    drop(abort_on_drop);
+                    receiver = Some(outcome.receiver);
+                    if outcome.exit == RelayNotificationConsumerExit::Shutdown
+                        || transport.shutting_down.load(Ordering::SeqCst)
+                        || source.is_shutdown()
+                    {
+                        break;
+                    }
+                    recover_relay_notification_forwarder(&transport, outcome.exit);
+                    if outcome.exit == RelayNotificationConsumerExit::Closed {
+                        receiver = None;
+                        tokio::time::sleep(Duration::from_millis(100)).await;
                     }
                 }
-            })
-            .await;
+                Err(join_error) => {
+                    drop(abort_on_drop);
+                    if transport.shutting_down.load(Ordering::SeqCst) || source.is_shutdown() {
+                        break;
+                    }
+                    RelayNotificationForwarderHealth::increment(
+                        &transport.notification_forwarder_health.panics,
+                        u64::from(join_error.is_panic()),
+                    );
+                    receiver = None;
+                    recover_relay_notification_forwarder(
+                        &transport,
+                        RelayNotificationConsumerExit::Closed,
+                    );
+                }
+            }
+        }
+        transport
+            .notification_forwarder_health
+            .running
+            .store(false, Ordering::SeqCst);
     })
+}
+
+struct AbortTaskOnDrop(tokio::task::AbortHandle);
+
+impl Drop for AbortTaskOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+async fn run_relay_notification_consumer(
+    mut receiver: broadcast::Receiver<RelayPoolNotification>,
+    adapter: NostrTransportAdapter,
+    directory_events: broadcast::Sender<DirectoryRelayPlaneEvent>,
+    directory: DirectoryRelayPlane,
+) -> RelayNotificationConsumerOutcome {
+    loop {
+        match receiver.recv().await {
+            Ok(notification) => {
+                let should_shutdown = handle_relay_notification(
+                    notification,
+                    &adapter,
+                    &directory_events,
+                    &directory,
+                )
+                .await;
+                if should_shutdown {
+                    return RelayNotificationConsumerOutcome {
+                        receiver,
+                        exit: RelayNotificationConsumerExit::Shutdown,
+                    };
+                }
+            }
+            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                return RelayNotificationConsumerOutcome {
+                    receiver,
+                    exit: RelayNotificationConsumerExit::Lagged(skipped),
+                };
+            }
+            Err(broadcast::error::RecvError::Closed) => {
+                return RelayNotificationConsumerOutcome {
+                    receiver,
+                    exit: RelayNotificationConsumerExit::Closed,
+                };
+            }
+        }
+    }
+}
+
+async fn handle_relay_notification(
+    notification: RelayPoolNotification,
+    adapter: &NostrTransportAdapter,
+    directory_events: &broadcast::Sender<DirectoryRelayPlaneEvent>,
+    directory: &DirectoryRelayPlane,
+) -> bool {
+    match notification {
+        RelayPoolNotification::Event {
+            relay_url,
+            subscription_id,
+            event,
+        } => {
+            if let Ok(event) = NostrTransportEvent::from_nostr_event(&event) {
+                tracing::trace!(
+                    target: "marmot_app::relay_plane",
+                    method = "spawn_relay_notification_forwarder",
+                    "forwarding SDK relay event"
+                );
+                let endpoint = TransportEndpoint(relay_url.to_string());
+                let subscription_id = subscription_id.to_string();
+                let relay_event = transport_nostr_adapter::NostrRelayEvent {
+                    endpoint: endpoint.clone(),
+                    subscription_id: Some(subscription_id.clone()),
+                    event: event.clone(),
+                };
+                // The transport adapter path is unchanged: every
+                // SDK event still feeds account/group delivery
+                // and telemetry. Only the directory cache path is
+                // gated, so an unsolicited or filter-mismatched
+                // event from a malicious or buggy relay cannot
+                // create persistent directory search-graph writes
+                // (mdk#709).
+                let _ = adapter.handle_relay_event(relay_event).await;
+                if directory
+                    .accepts_live_event(&subscription_id, &event.pubkey, event.kind)
+                    .await
+                {
+                    let _ = directory_events.send(DirectoryRelayPlaneEvent::Record(
+                        DirectoryRelayEventRecord {
+                            endpoints: vec![endpoint],
+                            event,
+                        },
+                    ));
+                } else {
+                    tracing::trace!(
+                        target: "marmot_app::relay_plane",
+                        method = "spawn_relay_notification_forwarder",
+                        "dropping directory relay event: no matching active directory subscription"
+                    );
+                }
+            }
+            false
+        }
+        RelayPoolNotification::Message {
+            relay_url,
+            message:
+                RelayMessage::Event {
+                    subscription_id,
+                    event,
+                },
+        } => {
+            // Raw per-relay copy (not deduplicated): telemetry
+            // only, so cross-relay arrival spread and per-relay
+            // first-event timing see every relay's copy. Delivery
+            // happens on the deduplicated `Event` arm above. Keep
+            // this in sync with the relay plane's own tap; the
+            // SDK client's standalone forwarder is unused here.
+            if let Ok(event) = NostrTransportEvent::from_nostr_event(&event) {
+                tracing::trace!(
+                    target: "marmot_app::relay_plane",
+                    method = "spawn_relay_notification_forwarder",
+                    "observing per-relay event copy"
+                );
+                adapter
+                    .observe_relay_event(transport_nostr_adapter::NostrRelayEvent {
+                        endpoint: TransportEndpoint(relay_url.to_string()),
+                        subscription_id: Some(subscription_id.to_string()),
+                        event,
+                    })
+                    .await;
+            }
+            false
+        }
+        RelayPoolNotification::Message {
+            relay_url,
+            message: RelayMessage::EndOfStoredEvents(subscription_id),
+        } => {
+            // EOSE tap: advances the per-relay initial-sync gate
+            // and records EOSE latency. No delivery.
+            tracing::trace!(
+                target: "marmot_app::relay_plane",
+                method = "spawn_relay_notification_forwarder",
+                "forwarding SDK relay end-of-stored-events"
+            );
+            adapter
+                .handle_relay_eose(
+                    TransportEndpoint(relay_url.to_string()),
+                    subscription_id.to_string(),
+                )
+                .await;
+            false
+        }
+        RelayPoolNotification::Shutdown => {
+            tracing::debug!(
+                target: "marmot_app::relay_plane",
+                method = "spawn_relay_notification_forwarder",
+                "SDK relay pool shutdown observed"
+            );
+            true
+        }
+        _ => false,
+    }
+}
+
+fn recover_relay_notification_forwarder(
+    transport: &RelayPlaneTransport,
+    exit: RelayNotificationConsumerExit,
+) {
+    let account_count = account_deliveries_read(&transport.account_deliveries).len();
+    account_deliveries_write(&transport.account_deliveries).clear();
+    let _ = transport
+        .directory_events
+        .send(DirectoryRelayPlaneEvent::RecoveryRequired);
+    RelayNotificationForwarderHealth::increment(
+        &transport.notification_forwarder_health.restarts,
+        1,
+    );
+    match exit {
+        RelayNotificationConsumerExit::Lagged(skipped) => {
+            RelayNotificationForwarderHealth::increment(
+                &transport.notification_forwarder_health.lag_incidents,
+                1,
+            );
+            RelayNotificationForwarderHealth::increment(
+                &transport.notification_forwarder_health.lagged_notifications,
+                skipped,
+            );
+            tracing::warn!(
+                target: "marmot_app::relay_plane",
+                method = "recover_relay_notification_forwarder",
+                skipped_notifications = skipped,
+                affected_accounts = account_count,
+                "relay notification consumer lagged; restarting inbound delivery",
+            );
+        }
+        RelayNotificationConsumerExit::Closed => {
+            RelayNotificationForwarderHealth::increment(
+                &transport.notification_forwarder_health.unexpected_exits,
+                1,
+            );
+            tracing::warn!(
+                target: "marmot_app::relay_plane",
+                method = "recover_relay_notification_forwarder",
+                affected_accounts = account_count,
+                "relay notification consumer exited unexpectedly; restarting inbound delivery",
+            );
+        }
+        RelayNotificationConsumerExit::Shutdown => {}
+    }
 }
 
 impl MarmotRelayPlaneAccountAdapter {

--- a/crates/marmot-app/src/relay_plane/mod.rs
+++ b/crates/marmot-app/src/relay_plane/mod.rs
@@ -3,7 +3,7 @@ use std::sync::{
     Arc, RwLock, RwLockReadGuard, RwLockWriteGuard,
     atomic::{AtomicBool, AtomicU64, Ordering},
 };
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use cgka_traits::transport::Timestamp;
@@ -62,6 +62,9 @@ const DIRECTORY_EVENT_BUFFER: usize = 1024;
 pub(crate) const DIRECTORY_RELAY_CONNECT_WAIT: Duration = Duration::from_secs(5);
 const RELAY_PLANE_SHUTDOWN_WAIT: Duration = Duration::from_secs(2);
 const RELAY_PLANE_TASK_ABORT_WAIT: Duration = Duration::from_millis(250);
+const RELAY_NOTIFICATION_RESTART_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
+const RELAY_NOTIFICATION_RESTART_MAX_BACKOFF: Duration = Duration::from_secs(30);
+const RELAY_NOTIFICATION_RESTART_HEALTHY_RUNTIME: Duration = Duration::from_secs(5);
 
 #[derive(Clone)]
 pub struct MarmotRelayPlane {
@@ -73,6 +76,7 @@ struct MarmotRelayPlaneInner {
     relay_safety: RelaySafetyPolicy,
     transport: Arc<RelayPlaneTransport>,
     directory: DirectoryRelayPlane,
+    directory_subscription_sync: Mutex<()>,
 }
 
 struct RelayPlaneTransport {
@@ -241,6 +245,7 @@ impl MarmotRelayPlane {
                 relay_safety: RelaySafetyPolicy::with_allow_loopback(allow_loopback),
                 transport,
                 directory: DirectoryRelayPlane::new(directory_fetcher),
+                directory_subscription_sync: Mutex::new(()),
             }),
         };
         this.spawn_router();
@@ -465,6 +470,7 @@ impl MarmotRelayPlane {
         plan: DirectorySyncPlan,
         force_rebuild: bool,
     ) -> Result<DirectorySubscriptionSyncSummary, String> {
+        let _sync_guard = self.inner.directory_subscription_sync.lock().await;
         self.spawn_router();
         let endpoints = self
             .inner
@@ -635,17 +641,21 @@ impl MarmotRelayPlane {
             if needs_forwarder
                 && let Some(sdk_relay_client) = &self.inner.transport.sdk_relay_client
             {
-                if notification_forwarder.take().is_some() {
-                    recover_relay_notification_forwarder(
-                        &self.inner.transport,
-                        RelayNotificationConsumerExit::Closed,
-                    );
+                if sdk_relay_client.client().pool().is_shutdown() {
+                    notification_forwarder.take();
+                } else {
+                    if notification_forwarder.take().is_some() {
+                        recover_relay_notification_forwarder(
+                            &self.inner.transport,
+                            RelayNotificationConsumerExit::Closed,
+                        );
+                    }
+                    *notification_forwarder = Some(spawn_relay_notification_forwarder(
+                        sdk_relay_client.clone(),
+                        self.inner.transport.clone(),
+                        self.inner.directory.clone(),
+                    ));
                 }
-                *notification_forwarder = Some(spawn_relay_notification_forwarder(
-                    sdk_relay_client.clone(),
-                    self.inner.transport.clone(),
-                    self.inner.directory.clone(),
-                ));
             }
         }
         let Ok(mut router) = self.inner.transport.router.try_lock() else {
@@ -780,6 +790,33 @@ struct RelayNotificationConsumerOutcome {
     exit: RelayNotificationConsumerExit,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct RelayNotificationRestartBackoff {
+    next: Duration,
+}
+
+impl Default for RelayNotificationRestartBackoff {
+    fn default() -> Self {
+        Self {
+            next: RELAY_NOTIFICATION_RESTART_INITIAL_BACKOFF,
+        }
+    }
+}
+
+impl RelayNotificationRestartBackoff {
+    fn delay_after_failure(&mut self, consumer_runtime: Duration) -> Duration {
+        if consumer_runtime >= RELAY_NOTIFICATION_RESTART_HEALTHY_RUNTIME {
+            self.next = RELAY_NOTIFICATION_RESTART_INITIAL_BACKOFF;
+        }
+        let delay = self.next;
+        self.next = self
+            .next
+            .saturating_mul(2)
+            .min(RELAY_NOTIFICATION_RESTART_MAX_BACKOFF);
+        delay
+    }
+}
+
 trait RelayNotificationSource: Send + Sync {
     fn notifications(&self) -> broadcast::Receiver<RelayPoolNotification>;
     fn is_shutdown(&self) -> bool;
@@ -821,12 +858,14 @@ fn spawn_relay_notification_supervisor(
             .running
             .store(true, Ordering::SeqCst);
         let mut receiver = None;
+        let mut restart_backoff = RelayNotificationRestartBackoff::default();
         loop {
             let adapter = transport.adapter.clone();
             let directory_events = transport.directory_events.clone();
             let directory = directory.clone();
             let source_for_consumer = source.clone();
             let next_receiver = receiver.take();
+            let consumer_started_at = Instant::now();
             let mut consumer = tokio::spawn(async move {
                 let receiver = next_receiver.unwrap_or_else(|| source_for_consumer.notifications());
                 run_relay_notification_consumer(receiver, adapter, directory_events, directory)
@@ -846,7 +885,10 @@ fn spawn_relay_notification_supervisor(
                     recover_relay_notification_forwarder(&transport, outcome.exit);
                     if outcome.exit == RelayNotificationConsumerExit::Closed {
                         receiver = None;
-                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        tokio::time::sleep(
+                            restart_backoff.delay_after_failure(consumer_started_at.elapsed()),
+                        )
+                        .await;
                     }
                 }
                 Err(join_error) => {
@@ -863,6 +905,10 @@ fn spawn_relay_notification_supervisor(
                         &transport,
                         RelayNotificationConsumerExit::Closed,
                     );
+                    tokio::time::sleep(
+                        restart_backoff.delay_after_failure(consumer_started_at.elapsed()),
+                    )
+                    .await;
                 }
             }
         }
@@ -935,7 +981,7 @@ async fn handle_relay_notification(
             if let Ok(event) = NostrTransportEvent::from_nostr_event(&event) {
                 tracing::trace!(
                     target: "marmot_app::relay_plane",
-                    method = "spawn_relay_notification_forwarder",
+                    method = "handle_relay_notification",
                     "forwarding SDK relay event"
                 );
                 let endpoint = TransportEndpoint(relay_url.to_string());
@@ -966,7 +1012,7 @@ async fn handle_relay_notification(
                 } else {
                     tracing::trace!(
                         target: "marmot_app::relay_plane",
-                        method = "spawn_relay_notification_forwarder",
+                        method = "handle_relay_notification",
                         "dropping directory relay event: no matching active directory subscription"
                     );
                 }
@@ -990,7 +1036,7 @@ async fn handle_relay_notification(
             if let Ok(event) = NostrTransportEvent::from_nostr_event(&event) {
                 tracing::trace!(
                     target: "marmot_app::relay_plane",
-                    method = "spawn_relay_notification_forwarder",
+                    method = "handle_relay_notification",
                     "observing per-relay event copy"
                 );
                 adapter
@@ -1011,7 +1057,7 @@ async fn handle_relay_notification(
             // and records EOSE latency. No delivery.
             tracing::trace!(
                 target: "marmot_app::relay_plane",
-                method = "spawn_relay_notification_forwarder",
+                method = "handle_relay_notification",
                 "forwarding SDK relay end-of-stored-events"
             );
             adapter
@@ -1025,7 +1071,7 @@ async fn handle_relay_notification(
         RelayPoolNotification::Shutdown => {
             tracing::debug!(
                 target: "marmot_app::relay_plane",
-                method = "spawn_relay_notification_forwarder",
+                method = "handle_relay_notification",
                 "SDK relay pool shutdown observed"
             );
             true

--- a/crates/marmot-app/src/relay_plane/tests.rs
+++ b/crates/marmot-app/src/relay_plane/tests.rs
@@ -118,6 +118,31 @@ fn account_deliveries_lock_helpers_recover_from_poisoned_guard() {
     assert_eq!(account_deliveries_read(&deliveries).len(), 1);
 }
 
+#[test]
+fn notification_restart_backoff_caps_and_resets_after_healthy_runtime() {
+    let mut backoff = RelayNotificationRestartBackoff::default();
+
+    assert_eq!(
+        backoff.delay_after_failure(Duration::ZERO),
+        RELAY_NOTIFICATION_RESTART_INITIAL_BACKOFF
+    );
+    assert_eq!(
+        backoff.delay_after_failure(Duration::ZERO),
+        RELAY_NOTIFICATION_RESTART_INITIAL_BACKOFF.saturating_mul(2)
+    );
+    for _ in 0..16 {
+        let _ = backoff.delay_after_failure(Duration::ZERO);
+    }
+    assert_eq!(
+        backoff.delay_after_failure(Duration::ZERO),
+        RELAY_NOTIFICATION_RESTART_MAX_BACKOFF
+    );
+    assert_eq!(
+        backoff.delay_after_failure(RELAY_NOTIFICATION_RESTART_HEALTHY_RUNTIME),
+        RELAY_NOTIFICATION_RESTART_INITIAL_BACKOFF
+    );
+}
+
 #[tokio::test]
 async fn notification_consumer_reports_lag_without_silently_ending() {
     let relay = Arc::new(RecordingRelayClient::default());
@@ -392,6 +417,89 @@ async fn notification_supervisor_restarts_after_consumer_panic() {
         stopped.restarts, 1,
         "normal shutdown must not be counted as another restart"
     );
+}
+
+#[tokio::test]
+async fn clean_sdk_shutdown_stays_terminal_across_spawn_router_reentry() {
+    let relay_plane = MarmotRelayPlane::with_subscription_rebuild_lookback(Duration::from_secs(30));
+    let relay = Arc::new(RecordingRelayClient::default());
+    let existing_adapter =
+        relay_plane.account_adapter(MemberId::new(vec![0xA1; 32]), relay.clone());
+
+    timeout(Duration::from_secs(1), async {
+        while !relay_plane
+            .inner
+            .transport
+            .notification_forwarder_health
+            .snapshot()
+            .running
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("SDK notification supervisor should start");
+
+    relay_plane
+        .inner
+        .transport
+        .sdk_relay_client
+        .as_ref()
+        .unwrap()
+        .client()
+        .shutdown()
+        .await;
+    timeout(Duration::from_secs(1), async {
+        loop {
+            let forwarder = relay_plane
+                .inner
+                .transport
+                .notification_forwarder
+                .lock()
+                .await;
+            if forwarder.as_ref().is_some_and(JoinHandle::is_finished) {
+                break;
+            }
+            drop(forwarder);
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("supervisor should finish after clean pool shutdown");
+
+    let before = relay_plane
+        .inner
+        .transport
+        .notification_forwarder_health
+        .snapshot();
+    relay_plane.account_adapter(MemberId::new(vec![0xB2; 32]), relay);
+    let after = relay_plane
+        .inner
+        .transport
+        .notification_forwarder_health
+        .snapshot();
+
+    assert_eq!(before.unexpected_exits, 0);
+    assert_eq!(after.unexpected_exits, 0);
+    assert_eq!(after.restarts, 0);
+    assert!(
+        relay_plane
+            .inner
+            .transport
+            .notification_forwarder
+            .lock()
+            .await
+            .is_none(),
+        "a terminal SDK pool must not be respawned"
+    );
+    assert!(
+        timeout(Duration::from_millis(50), existing_adapter.receive())
+            .await
+            .is_err(),
+        "re-entering spawn_router after clean shutdown must not close existing account senders"
+    );
+
+    relay_plane.shutdown().await;
 }
 
 #[async_trait]

--- a/crates/marmot-app/src/relay_plane/tests.rs
+++ b/crates/marmot-app/src/relay_plane/tests.rs
@@ -118,11 +118,280 @@ fn account_deliveries_lock_helpers_recover_from_poisoned_guard() {
     assert_eq!(account_deliveries_read(&deliveries).len(), 1);
 }
 
+#[tokio::test]
+async fn notification_consumer_reports_lag_without_silently_ending() {
+    let relay = Arc::new(RecordingRelayClient::default());
+    let relay_plane = MarmotRelayPlane::new(Some(Duration::from_secs(30)), relay);
+    let (notifications, receiver) = broadcast::channel(1);
+    let _ = notifications.send(RelayPoolNotification::Shutdown);
+    let _ = notifications.send(RelayPoolNotification::Shutdown);
+
+    let outcome = run_relay_notification_consumer(
+        receiver,
+        relay_plane.inner.transport.adapter.clone(),
+        relay_plane.inner.transport.directory_events.clone(),
+        relay_plane.inner.directory.clone(),
+    )
+    .await;
+
+    assert_eq!(
+        outcome.exit,
+        RelayNotificationConsumerExit::Lagged(1),
+        "a broadcast overrun must be an explicit recovery trigger"
+    );
+
+    let resumed = run_relay_notification_consumer(
+        outcome.receiver,
+        relay_plane.inner.transport.adapter.clone(),
+        relay_plane.inner.transport.directory_events.clone(),
+        relay_plane.inner.directory.clone(),
+    )
+    .await;
+    assert_eq!(
+        resumed.exit,
+        RelayNotificationConsumerExit::Shutdown,
+        "the retained notification after the lag must still be consumed"
+    );
+}
+
+#[tokio::test]
+async fn notification_recovery_closes_account_delivery_and_signals_directory_rebuild() {
+    let relay = Arc::new(RecordingRelayClient::default());
+    let relay_plane = MarmotRelayPlane::new(Some(Duration::from_secs(30)), relay.clone());
+    let account = MemberId::new(vec![0xA1; 32]);
+    let account_adapter = relay_plane.account_adapter(account, relay.clone());
+    let mut directory_events = relay_plane.subscribe_directory_events();
+
+    recover_relay_notification_forwarder(
+        &relay_plane.inner.transport,
+        RelayNotificationConsumerExit::Lagged(7),
+    );
+
+    assert!(
+        timeout(Duration::from_secs(1), account_adapter.receive())
+            .await
+            .expect("account receiver should close promptly")
+            .expect("closed account receiver is not an adapter error")
+            .is_none(),
+        "closing the producer must drive the account worker into its existing reconnect path"
+    );
+    assert!(matches!(
+        directory_events.recv().await,
+        Ok(DirectoryRelayPlaneEvent::RecoveryRequired)
+    ));
+
+    let health = relay_plane
+        .inner
+        .transport
+        .notification_forwarder_health
+        .snapshot();
+    assert_eq!(health.restarts, 1);
+    assert_eq!(health.lag_incidents, 1);
+    assert_eq!(health.lagged_notifications, 7);
+
+    let message = group_event("outbound-during-recovery", &[0xD4; 32])
+        .to_transport_message()
+        .unwrap();
+    account_adapter
+        .publish(TransportPublishRequest {
+            account_id: MemberId::new(vec![0xA1; 32]),
+            message,
+            target: TransportPublishTarget::Group {
+                group_id: GroupId::new(vec![0xC3; 32]),
+                transport_group_id: vec![0xD4; 32],
+                endpoints: vec![TransportEndpoint("wss://relay.example".into())],
+            },
+            required_acks: 0,
+        })
+        .await
+        .expect("inbound recovery must not take the outbound publisher down");
+}
+
+#[tokio::test]
+async fn managed_account_worker_reopens_transport_after_notification_recovery() {
+    let dir = tempfile::tempdir().unwrap();
+    marmot_account::AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(RecordingRelayClient::default());
+    let app = crate::MarmotApp::with_relay(dir.path(), "wss://relay.example")
+        .with_test_relay_client(relay.clone());
+    let relay_plane = app.relay_plane.clone();
+    let runtime = crate::MarmotAppRuntime::new(app);
+
+    runtime.reconcile_accounts().await.unwrap();
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let inbox_subscriptions = relay
+                .subscriptions
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|subscription| {
+                    matches!(subscription, NostrSubscription::AccountInbox { .. })
+                })
+                .count();
+            if inbox_subscriptions >= 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the managed account worker should activate its initial inbox subscription");
+
+    recover_relay_notification_forwarder(
+        &relay_plane.inner.transport,
+        RelayNotificationConsumerExit::Lagged(3),
+    );
+
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let inbox_subscriptions = relay
+                .subscriptions
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|subscription| {
+                    matches!(subscription, NostrSubscription::AccountInbox { .. })
+                })
+                .count();
+            if inbox_subscriptions >= 2 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("producer death should make the managed account worker reopen and resubscribe");
+
+    runtime.shutdown().await;
+}
+
 #[derive(Default)]
 struct RecordingRelayClient {
     subscriptions: StdMutex<Vec<NostrSubscription>>,
     unsubscribed: StdMutex<Vec<NostrSubscription>>,
     unsubscribed_accounts: StdMutex<Vec<MemberId>>,
+}
+
+struct TestNotificationSource {
+    sender: broadcast::Sender<RelayPoolNotification>,
+    subscriptions: AtomicUsize,
+    preload_lag: bool,
+    panic_first: AtomicBool,
+}
+
+impl TestNotificationSource {
+    fn lag_once() -> Self {
+        Self {
+            sender: broadcast::channel(1).0,
+            subscriptions: AtomicUsize::new(0),
+            preload_lag: true,
+            panic_first: AtomicBool::new(false),
+        }
+    }
+
+    fn panic_once() -> Self {
+        Self {
+            sender: broadcast::channel(1).0,
+            subscriptions: AtomicUsize::new(0),
+            preload_lag: false,
+            panic_first: AtomicBool::new(true),
+        }
+    }
+
+    fn send(&self, notification: RelayPoolNotification) {
+        self.sender
+            .send(notification)
+            .expect("test supervisor should have an active notification receiver");
+    }
+}
+
+impl RelayNotificationSource for TestNotificationSource {
+    fn notifications(&self) -> broadcast::Receiver<RelayPoolNotification> {
+        if self.panic_first.swap(false, Ordering::SeqCst) {
+            panic!("injected notification consumer panic");
+        }
+        let receiver = self.sender.subscribe();
+        if self.subscriptions.fetch_add(1, Ordering::SeqCst) == 0 && self.preload_lag {
+            let relay_url = RelayUrl::parse("wss://relay.example").unwrap();
+            let notice = || RelayPoolNotification::Message {
+                relay_url: relay_url.clone(),
+                message: RelayMessage::Notice("preloaded notification".into()),
+            };
+            let _ = self.sender.send(notice());
+            let _ = self.sender.send(notice());
+        }
+        receiver
+    }
+
+    fn is_shutdown(&self) -> bool {
+        false
+    }
+}
+
+#[tokio::test]
+async fn notification_supervisor_restarts_after_consumer_panic() {
+    let relay = Arc::new(RecordingRelayClient::default());
+    let relay_plane = MarmotRelayPlane::new(Some(Duration::from_secs(30)), relay.clone());
+    let account_adapter = relay_plane.account_adapter(MemberId::new(vec![0xA1; 32]), relay);
+    let source = Arc::new(TestNotificationSource::panic_once());
+    let supervisor = spawn_relay_notification_supervisor(
+        source.clone(),
+        relay_plane.inner.transport.clone(),
+        relay_plane.inner.directory.clone(),
+    );
+
+    timeout(Duration::from_secs(2), async {
+        loop {
+            let health = relay_plane
+                .inner
+                .transport
+                .notification_forwarder_health
+                .snapshot();
+            if health.panics == 1 && source.subscriptions.load(Ordering::SeqCst) == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("a panicked consumer should be observed and replaced");
+
+    assert!(
+        timeout(Duration::from_secs(1), account_adapter.receive())
+            .await
+            .unwrap()
+            .unwrap()
+            .is_none(),
+        "panic recovery must propagate producer death to the account receiver"
+    );
+    let recovered = relay_plane
+        .inner
+        .transport
+        .notification_forwarder_health
+        .snapshot();
+    assert!(recovered.running);
+    assert_eq!(recovered.restarts, 1);
+    assert_eq!(recovered.panics, 1);
+    assert_eq!(recovered.unexpected_exits, 1);
+
+    source.send(RelayPoolNotification::Shutdown);
+    timeout(Duration::from_secs(1), supervisor)
+        .await
+        .expect("normal shutdown should stop the replacement consumer")
+        .unwrap();
+    let stopped = relay_plane
+        .inner
+        .transport
+        .notification_forwarder_health
+        .snapshot();
+    assert!(!stopped.running);
+    assert_eq!(
+        stopped.restarts, 1,
+        "normal shutdown must not be counted as another restart"
+    );
 }
 
 #[async_trait]
@@ -996,6 +1265,177 @@ fn group_event(id_prefix: &str, transport_group_id: &[u8]) -> NostrTransportEven
     };
     event.id = event.computed_id();
     event
+}
+
+fn relay_pool_group_notification(
+    id_prefix: &str,
+    transport_group_id: &[u8],
+) -> RelayPoolNotification {
+    use nostr_sdk::prelude::{Alphabet, EventBuilder, Keys, SingleLetterTag, Tag, TagKind};
+
+    let signed = EventBuilder::new(
+        Kind::MlsGroupMessage,
+        format!("encrypted recovery {id_prefix}"),
+    )
+    .tags([Tag::custom(
+        TagKind::SingleLetter(SingleLetterTag::lowercase(Alphabet::H)),
+        [hex::encode(transport_group_id)],
+    )])
+    .custom_created_at(NostrTimestamp::from_secs(1_700_000_001))
+    .sign_with_keys(&Keys::generate())
+    .expect("sign test group event");
+    RelayPoolNotification::Event {
+        relay_url: RelayUrl::parse("wss://relay.example").unwrap(),
+        subscription_id: SubscriptionId::new("group-sub"),
+        event: Box::new(signed),
+    }
+}
+
+#[tokio::test]
+async fn supervised_notification_lag_recovers_later_inbound_exactly_once() {
+    let relay = Arc::new(RecordingRelayClient::default());
+    let relay_plane = MarmotRelayPlane::new(Some(Duration::from_secs(30)), relay.clone());
+    let account = MemberId::new(vec![0xA1; 32]);
+    let group_id = GroupId::new(vec![0xC3; 32]);
+    let transport_group_id = vec![0xD4; 32];
+    let endpoint = TransportEndpoint("wss://relay.example".into());
+    let old_adapter = relay_plane.account_adapter(account.clone(), relay.clone());
+    old_adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account.clone(),
+            inbox_endpoints: vec![endpoint.clone()],
+            group_subscriptions: vec![TransportGroupSubscription {
+                group_id: group_id.clone(),
+                transport_group_id: transport_group_id.clone(),
+                endpoints: vec![endpoint.clone()],
+            }],
+            since: None,
+        })
+        .await
+        .unwrap();
+
+    let source = Arc::new(TestNotificationSource::lag_once());
+    let supervisor = spawn_relay_notification_supervisor(
+        source.clone(),
+        relay_plane.inner.transport.clone(),
+        relay_plane.inner.directory.clone(),
+    );
+
+    timeout(Duration::from_secs(2), async {
+        while relay_plane
+            .inner
+            .transport
+            .notification_forwarder_health
+            .snapshot()
+            .lag_incidents
+            == 0
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the deterministic overrun should trigger recovery");
+    assert!(
+        timeout(Duration::from_secs(1), old_adapter.receive())
+            .await
+            .unwrap()
+            .unwrap()
+            .is_none(),
+        "the old account delivery stream must terminate"
+    );
+
+    let outbound = group_event("outbound-still-available", &transport_group_id)
+        .to_transport_message()
+        .unwrap();
+    old_adapter
+        .publish(TransportPublishRequest {
+            account_id: account.clone(),
+            message: outbound,
+            target: TransportPublishTarget::Group {
+                group_id: group_id.clone(),
+                transport_group_id: transport_group_id.clone(),
+                endpoints: vec![endpoint.clone()],
+            },
+            required_acks: 0,
+        })
+        .await
+        .expect("outbound publishing remains available during inbound recovery");
+
+    let recovered_adapter = relay_plane.account_adapter(account.clone(), relay.clone());
+    recovered_adapter
+        .activate_account(TransportAccountActivation {
+            account_id: account.clone(),
+            inbox_endpoints: vec![endpoint.clone()],
+            group_subscriptions: vec![TransportGroupSubscription {
+                group_id: group_id.clone(),
+                transport_group_id: transport_group_id.clone(),
+                endpoints: vec![endpoint],
+            }],
+            since: Some(Timestamp(1_699_999_999)),
+        })
+        .await
+        .unwrap();
+    assert!(
+        relay
+            .subscriptions
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|subscription| matches!(
+                subscription,
+                NostrSubscription::Group {
+                    account_id: subscribed_account,
+                    transport_group_id: subscribed_group,
+                    since: Some(Timestamp(1_699_999_999)),
+                    ..
+                } if subscribed_account == &account && subscribed_group == &transport_group_id
+            )),
+        "recovery must reinstall a cursor-bounded group subscription"
+    );
+
+    let replayed_backlog = relay_pool_group_notification("replayed-backlog", &transport_group_id);
+    let expected_message_id = match &replayed_backlog {
+        RelayPoolNotification::Event { event, .. } => {
+            NostrTransportEvent::from_nostr_event(event)
+                .unwrap()
+                .to_transport_message()
+                .unwrap()
+                .id
+        }
+        _ => unreachable!(),
+    };
+    source.send(replayed_backlog);
+    let first_delivery = timeout(Duration::from_secs(1), recovered_adapter.receive())
+        .await
+        .expect("the restarted consumer should deliver later inbound")
+        .unwrap()
+        .unwrap();
+    let mut deliveries = vec![first_delivery];
+    loop {
+        match timeout(Duration::from_millis(50), recovered_adapter.receive()).await {
+            Err(_) => break,
+            Ok(Ok(Some(delivery))) => deliveries.push(delivery),
+            Ok(Ok(None)) => panic!("recovered account delivery stream closed unexpectedly"),
+            Ok(Err(error)) => panic!("recovered account delivery stream failed: {error}"),
+        }
+    }
+    let matching = deliveries
+        .iter()
+        .filter(|delivery| delivery.message.id == expected_message_id)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        matching.len(),
+        1,
+        "the recovered inbound event must be projected exactly once"
+    );
+    assert_eq!(matching[0].account_id, account);
+    assert_eq!(matching[0].group_id_hint, Some(group_id));
+
+    source.send(RelayPoolNotification::Shutdown);
+    timeout(Duration::from_secs(1), supervisor)
+        .await
+        .expect("supervisor should stop on normal SDK shutdown")
+        .unwrap();
 }
 
 #[test]

--- a/crates/marmot-uniffi/src/conversions/relay.rs
+++ b/crates/marmot-uniffi/src/conversions/relay.rs
@@ -162,6 +162,12 @@ pub struct RelayHealthFfi {
     pub sleeping: u32,
     pub connection_attempts: u32,
     pub connection_successes: u32,
+    pub notification_forwarder_running: bool,
+    pub notification_forwarder_restarts: u64,
+    pub notification_forwarder_lag_incidents: u64,
+    pub notification_forwarder_lagged_notifications: u64,
+    pub notification_forwarder_panics: u64,
+    pub notification_forwarder_unexpected_exits: u64,
 }
 
 impl From<RelayPlaneHealth> for RelayHealthFfi {
@@ -179,6 +185,13 @@ impl From<RelayPlaneHealth> for RelayHealthFfi {
             sleeping: super::saturating_u32(value.sleeping),
             connection_attempts: super::saturating_u32(value.connection_attempts),
             connection_successes: super::saturating_u32(value.connection_successes),
+            notification_forwarder_running: value.notification_forwarder_running,
+            notification_forwarder_restarts: value.notification_forwarder_restarts,
+            notification_forwarder_lag_incidents: value.notification_forwarder_lag_incidents,
+            notification_forwarder_lagged_notifications: value
+                .notification_forwarder_lagged_notifications,
+            notification_forwarder_panics: value.notification_forwarder_panics,
+            notification_forwarder_unexpected_exits: value.notification_forwarder_unexpected_exits,
         }
     }
 }


### PR DESCRIPTION
## Summary

- replace the fire-and-forget SDK notification callback with a supervised consumer that distinguishes shutdown, lag, closure, and panic
- restart failed consumers and close per-account delivery producers so managed account workers enter their existing reconnect path
- force directory subscription rebuilds after notification-pipeline recovery
- expose aggregate, privacy-safe forwarder liveness counters through relay health, UniFFI, CLI, and TUI diagnostics
- add deterministic lag, panic, managed-worker reconnect, bounded replay, outbound-availability, and exactly-once recovery coverage

## Root cause

`nostr-relay-pool`'s `handle_notifications` loop returns successfully whenever its broadcast receiver reports `Lagged` or `Closed`. MDK discarded that terminal result and retained the finished task's `JoinHandle`, while the adapter and account delivery channels remained open. Inbound receivers could therefore stay parked forever even though outbound publishing continued through the independent SDK publish path.

## Recovery behavior

The supervisor now consumes the broadcast receiver directly so lag is observable. On lag, unexpected closure, or consumer panic it records redacted counters, retains buffered notifications when possible, replaces the consumer, closes current account delivery senders, and signals directory recovery. Managed account workers reopen their transport adapters and reinstall subscriptions through the existing durable-cursor lookback path. Normal SDK shutdown remains terminal and does not count as a restart.

## Validation

- `just fast-ci`
- `cargo test -p marmot-app --lib --locked` (474 passed before the final targeted managed-worker regression was added)
- `cargo test -p marmot-app relay_plane --lib --locked` (39 passed)
- `cargo test -p wn-cli relay_stats --locked`
- `cargo test -p wn-cli parse_relay_health --lib --locked`
- `cargo test -p marmot-uniffi conversions::relay --lib --locked`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #1156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added notification-forwarder health details to relay health reports, including running status, restarts, lag, panics, and unexpected exits.
  - Added automatic recovery and subscription rebuilding after notification lag, consumer failures, or relay-plane recovery events.
  - Improved notification delivery resilience by restarting failed consumers and replaying missed notifications safely.

- **Bug Fixes**
  - Prevented notification failures and broadcast lag from silently stopping delivery.
  - Ensured recovered account streams resume subscriptions and deliver subsequent notifications correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->