### PR TITLE
Retain pending sends during transport activation

### DIFF
--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -51,6 +51,12 @@ use tls_codec::{Deserialize as _, Serialize as _};
 pub const DEFAULT_CIPHERSUITE: Ciphersuite =
     Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 
+#[derive(Clone, Copy)]
+enum SendAcceptance {
+    Prepare,
+    QueueAppMessage,
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 struct SystemWallClock;
 
@@ -680,6 +686,30 @@ impl<S: StorageProvider> Engine<S> {
         intent: SendIntent,
         context: Option<AuditEventContext>,
     ) -> Result<SendResult, EngineError> {
+        self.accept_send_with_audit_context(intent, context, SendAcceptance::Prepare)
+            .await
+    }
+
+    pub async fn queue_app_message_with_audit_context(
+        &mut self,
+        group_id: GroupId,
+        payload: Vec<u8>,
+        context: Option<AuditEventContext>,
+    ) -> Result<SendResult, EngineError> {
+        self.accept_send_with_audit_context(
+            SendIntent::AppMessage { group_id, payload },
+            context,
+            SendAcceptance::QueueAppMessage,
+        )
+        .await
+    }
+
+    async fn accept_send_with_audit_context(
+        &mut self,
+        intent: SendIntent,
+        context: Option<AuditEventContext>,
+        acceptance: SendAcceptance,
+    ) -> Result<SendResult, EngineError> {
         let operation_id = self.next_audit_operation_id();
         let intent_kind = crate::audit_helpers::send_intent_kind_str(&intent).to_string();
         let group_ref = crate::audit_helpers::send_intent_group_ref(&intent);
@@ -694,7 +724,15 @@ impl<S: StorageProvider> Engine<S> {
             },
         });
         self.current_audit_context = Some(context.clone());
-        let result = self.do_send(intent).await;
+        let result = match acceptance {
+            SendAcceptance::Prepare => self.do_send(intent).await,
+            SendAcceptance::QueueAppMessage => {
+                let SendIntent::AppMessage { group_id, payload } = intent else {
+                    unreachable!("queue app-message acceptance constructs an AppMessage intent")
+                };
+                self.do_queue_app_message(group_id, payload)
+            }
+        };
         self.current_audit_context = None;
         match &result {
             Ok(send_result) => {
@@ -2355,6 +2393,15 @@ impl<S: StorageProvider + 'static> CgkaEngine for Engine<S> {
 
     async fn send(&mut self, intent: SendIntent) -> Result<SendResult, EngineError> {
         self.send_with_audit_context(intent, None).await
+    }
+
+    async fn queue_app_message(
+        &mut self,
+        group_id: GroupId,
+        payload: Vec<u8>,
+    ) -> Result<SendResult, EngineError> {
+        self.queue_app_message_with_audit_context(group_id, payload, None)
+            .await
     }
 
     async fn advance_convergence(

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -188,7 +188,48 @@ impl<S: StorageProvider> Engine<S> {
     }
 
     pub(crate) async fn do_send(&mut self, intent: SendIntent) -> Result<SendResult, EngineError> {
-        let group_id = send_intent_group_id(&intent).clone();
+        let group_id = self.validate_send_acceptance(&intent)?;
+        // Disband is an intent-persistence operation, not a Commit-preparation
+        // operation. It remains acceptable while another staged Commit owns
+        // the group and while Unrecoverable is paused.
+        if matches!(&intent, SendIntent::Disband { .. }) {
+            return self.do_request_disband(group_id);
+        }
+        if self.should_queue_outbound_intent(&group_id).await? {
+            return self.queue_outbound_intent(group_id, intent);
+        }
+
+        self.do_send_ready(intent).await
+    }
+
+    pub(crate) fn do_queue_app_message(
+        &mut self,
+        group_id: GroupId,
+        payload: Vec<u8>,
+    ) -> Result<SendResult, EngineError> {
+        let intent = SendIntent::AppMessage {
+            group_id: group_id.clone(),
+            payload,
+        };
+        self.validate_send_acceptance(&intent)?;
+        if let Some(state) = self.epoch_manager.state(&group_id)
+            && !matches!(state, EpochState::Stable { .. })
+        {
+            return Err(EngineError::InvalidTransition(
+                cgka_traits::engine_state::InvalidTransition {
+                    from: state.name(),
+                    to: "queue_app_message",
+                    reason: "queue_app_message requires Stable",
+                },
+            ));
+        }
+        let queued = self.queue_outbound_intent(group_id.clone(), intent)?;
+        self.schedule_pending_convergence_group(&group_id);
+        Ok(queued)
+    }
+
+    fn validate_send_acceptance(&mut self, intent: &SendIntent) -> Result<GroupId, EngineError> {
+        let group_id = send_intent_group_id(intent).clone();
         // Quarantine gate: a group frozen by hydration quarantine must not
         // stage, queue, or publish anything — a confirm would set_stable and
         // silently un-quarantine it out of band (mdk#364).
@@ -197,16 +238,15 @@ impl<S: StorageProvider> Engine<S> {
             return Err(EngineError::InvalidTransition(
                 cgka_traits::engine_state::InvalidTransition {
                     from: "Disbanded",
-                    to: crate::audit_helpers::send_intent_kind_str(&intent),
+                    to: crate::audit_helpers::send_intent_kind_str(intent),
                     reason: "Disbanded is terminal",
                 },
             ));
         }
-        // Disband is an intent-persistence operation, not a Commit-preparation
-        // operation. It remains acceptable while another staged Commit owns
-        // the group and while Unrecoverable is paused.
-        if matches!(&intent, SendIntent::Disband { .. }) {
-            return self.do_request_disband(group_id);
+        // Disband has its own durable acceptance gates and intentionally
+        // remains available while the ordinary send lifecycle is paused.
+        if matches!(intent, SendIntent::Disband { .. }) {
+            return Ok(group_id);
         }
         // Strict cutover freezes membership growth in legacy groups. Existing
         // members may continue messaging and applying other group changes, but
@@ -232,7 +272,7 @@ impl<S: StorageProvider> Engine<S> {
             return Err(EngineError::InvalidTransition(
                 cgka_traits::engine_state::InvalidTransition {
                     from: "Removed",
-                    to: crate::audit_helpers::send_intent_kind_str(&intent),
+                    to: crate::audit_helpers::send_intent_kind_str(intent),
                     reason: "local group copy is marked removed (self-evicted)",
                 },
             ));
@@ -243,7 +283,7 @@ impl<S: StorageProvider> Engine<S> {
             return Err(EngineError::InvalidTransition(
                 cgka_traits::engine_state::InvalidTransition {
                     from: "Unrecoverable",
-                    to: crate::audit_helpers::send_intent_kind_str(&intent),
+                    to: crate::audit_helpers::send_intent_kind_str(intent),
                     reason: "group is Unrecoverable pending verified repair",
                 },
             ));
@@ -252,7 +292,7 @@ impl<S: StorageProvider> Engine<S> {
             return Err(EngineError::InvalidTransition(
                 cgka_traits::engine_state::InvalidTransition {
                     from: "Disbanding",
-                    to: crate::audit_helpers::send_intent_kind_str(&intent),
+                    to: crate::audit_helpers::send_intent_kind_str(intent),
                     reason: "disband requested or awaiting convergence",
                 },
             ));
@@ -261,16 +301,12 @@ impl<S: StorageProvider> Engine<S> {
             return Err(EngineError::InvalidTransition(
                 cgka_traits::engine_state::InvalidTransition {
                     from: "Leaving",
-                    to: crate::audit_helpers::send_intent_kind_str(&intent),
+                    to: crate::audit_helpers::send_intent_kind_str(intent),
                     reason: "leave requested",
                 },
             ));
         }
-        if self.should_queue_outbound_intent(&group_id).await? {
-            return self.queue_outbound_intent(group_id, intent);
-        }
-
-        self.do_send_ready(intent).await
+        Ok(group_id)
     }
 
     pub async fn converge_and_drain_queued_outbound_intents(

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -1306,6 +1306,26 @@ async fn applying_removal_commit_purges_queued_outbound_intents() {
             .is_empty(),
         "marking the copy removed must discard queued outbound intents"
     );
+    let payload = app_payload_for(&bob, b"must not queue after removal");
+    let error = bob
+        .queue_app_message(group_id.clone(), payload)
+        .await
+        .expect_err("authoritative removal must reject forced local queueing");
+    assert!(
+        matches!(
+            error,
+            EngineError::InvalidTransition(ref transition)
+                if transition.from == "Removed"
+        ),
+        "removed copy should fail through the authoritative gate, got {error:?}"
+    );
+    assert!(
+        bob_storage
+            .list_queued_outbound_intents(&group_id)
+            .unwrap()
+            .is_empty(),
+        "a rejected post-removal send must not recreate queued plaintext"
+    );
 }
 
 /// #376 review follow-up: realization itself purges queued intents, and the

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -731,6 +731,24 @@ impl AccountDeviceSession {
         Ok(self.collect_effects(vec![result]))
     }
 
+    pub async fn queue_app_message_with_audit_context(
+        &mut self,
+        group_id: GroupId,
+        payload: Vec<u8>,
+        context: AuditEventContext,
+    ) -> SessionResult<SessionEffects> {
+        tracing::debug!(
+            target: TRACE_TARGET,
+            method = "queue_app_message_with_audit_context",
+            "durably queueing local application-message intent"
+        );
+        let result = self
+            .engine
+            .queue_app_message_with_audit_context(group_id, payload, Some(context))
+            .await?;
+        Ok(self.collect_effects(vec![result]))
+    }
+
     pub async fn ingest(&mut self, msg: TransportMessage) -> SessionResult<IngestEffects> {
         tracing::debug!(
             target: TRACE_TARGET,

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -1427,6 +1427,26 @@ where
         Ok(output)
     }
 
+    pub async fn queue_app_message_with_audit_context(
+        &mut self,
+        group_id: GroupId,
+        payload: Vec<u8>,
+        context: AuditEventContext,
+    ) -> AccountResult<AccountDeviceEffects> {
+        let effects = self
+            .session
+            .queue_app_message_with_audit_context(group_id.clone(), payload, context.clone())
+            .await?;
+        let mut output = self
+            .publish_session_effects_with_audit_context(effects, Some(context))
+            .await?;
+        if self.post_join_rotation_pending(&group_id)? {
+            output.maintenance_disposition =
+                SendMaintenanceDisposition::PostJoinRotationPendingRetryable;
+        }
+        Ok(output)
+    }
+
     fn post_join_rotation_pending(&self, group_id: &GroupId) -> AccountResult<bool> {
         Ok(self
             .session

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1675,20 +1675,31 @@ impl AppClient {
         }
 
         let effects = match async {
-            self.sync_runtime_groups().await?;
-            let send_intent = SendIntent::AppMessage {
-                group_id: group_id.clone(),
-                payload,
-            };
-            // Thread the human-action context through the engine so the send's
-            // audit rows carry `human_action`, matching create_group/invite/etc.
-            let effects = match &audit_context {
-                Some(context) => {
+            let effects = match self.sync_runtime_groups().await {
+                Ok(()) => {
+                    let send_intent = SendIntent::AppMessage {
+                        group_id: group_id.clone(),
+                        payload,
+                    };
+                    // Thread the human-action context through the engine so the
+                    // send's audit rows carry `human_action`, matching
+                    // create_group/invite/etc.
+                    match &audit_context {
+                        Some(context) => {
+                            self.runtime
+                                .send_with_audit_context(send_intent, context.clone())
+                                .await?
+                        }
+                        None => self.runtime.send(send_intent).await?,
+                    }
+                }
+                Err(error) if error.is_account_not_active() => {
+                    let context = audit_context.clone().unwrap_or_default();
                     self.runtime
-                        .send_with_audit_context(send_intent, context.clone())
+                        .queue_app_message_with_audit_context(group_id.clone(), payload, context)
                         .await?
                 }
-                None => self.runtime.send(send_intent).await?,
+                Err(error) => return Err(error),
             };
             fail_if_publish_failed(&effects)?;
             Ok::<_, AppError>(effects)
@@ -1747,7 +1758,7 @@ impl AppClient {
         }
         self.app.save_state(&self.state)?;
         self.queue_own_group_system_projection_updates(&effects);
-        if notification_trigger_for_intent(&intent).is_some() {
+        if published.is_some() && notification_trigger_for_intent(&intent).is_some() {
             self.publish_notification_trigger_best_effort(
                 group_id,
                 notifications::NotificationTrigger::NewMessage,

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -511,6 +511,19 @@ impl AppClient {
         self.remember_pending_convergence_effects(&effects);
         self.remember_published_reports(&effects);
         let finalize_updates = self.finalize_published_app_message_source_retention(&effects)?;
+        let publish_new_message_notification =
+            effects.published_app_messages.iter().any(|published| {
+                let group_id_hex = hex::encode(published.group_id.as_slice());
+                self.app
+                    .reaction_target(&self.state.label, &group_id_hex, &published.app_event_id)
+                    .ok()
+                    .flatten()
+                    .is_some_and(|message| {
+                        message.kind == MARMOT_APP_EVENT_KIND_CHAT
+                            && !message.deleted
+                            && !message.invalidated
+                    })
+            });
         self.refresh_group(group_id);
 
         let display_names = self.app.display_names_by_id()?;
@@ -534,6 +547,13 @@ impl AppClient {
         }
         self.prune_plaintext_retention_for_group(group_id)?;
         self.app.save_state(&self.state)?;
+        if publish_new_message_notification {
+            self.publish_notification_trigger_best_effort(
+                group_id,
+                notifications::NotificationTrigger::NewMessage,
+            )
+            .await;
+        }
         Ok(summary)
     }
 

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -123,6 +123,16 @@ impl From<TransportAdapterError> for AppError {
 }
 
 impl AppError {
+    pub(crate) fn is_account_not_active(&self) -> bool {
+        matches!(
+            self,
+            Self::Transport(TransportAdapterError::AccountNotActive(_))
+                | Self::Account(AccountError::Transport(
+                    TransportAdapterError::AccountNotActive(_)
+                ))
+        )
+    }
+
     pub(crate) fn privacy_safe_kind(&self) -> &'static str {
         match self {
             Self::Account(error) => account_error_kind(error),

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -561,6 +561,28 @@ async fn run_app_runtime_account_worker(
                 &account_label,
                 message.clone(),
             );
+            // Hydration may already have scheduled durable queued intents from
+            // a prior process. Initial transport activation failed before the
+            // normal sync path could drain those engine effects, so transfer
+            // their scheduling edge into the app client now. Queued intents do
+            // not require transport merely to drain; any incidental fanout
+            // failure remains retryable and is reported separately.
+            match client.drain_pending_session_events().await {
+                Ok(summary) => {
+                    publish_app_runtime_summary(&events, &account_id_hex, &account_label, &summary);
+                }
+                Err(drain_error) => {
+                    publish_app_runtime_account_error(
+                        &events,
+                        &account_id_hex,
+                        &account_label,
+                        account_error_message(
+                            "runtime startup queued-work wake failed",
+                            &drain_error,
+                        ),
+                    );
+                }
+            }
             Err(message)
         }
     };
@@ -650,6 +672,7 @@ async fn run_app_runtime_account_worker(
                         }
                     }
                     Err(err) => {
+                        let account_inactive = err.is_account_not_active();
                         scheduled_convergence.schedule_retry_groups(groups);
                         publish_app_runtime_account_error(
                             &events,
@@ -657,6 +680,19 @@ async fn run_app_runtime_account_worker(
                             &account_label,
                             account_error_message("scheduled convergence sync failed", &err),
                         );
+                        if account_inactive
+                            && let Err(activation_error) = client.prepare_transport().await
+                        {
+                            publish_app_runtime_account_error(
+                                &events,
+                                &account_id_hex,
+                                &account_label,
+                                account_error_message(
+                                    "scheduled convergence transport reactivation failed",
+                                    &activation_error,
+                                ),
+                            );
+                        }
                     }
                 }
             }
@@ -770,11 +806,36 @@ async fn run_app_runtime_account_worker(
                                 }
                                 app.finish_client_open_network_maintenance(&mut reopened)
                                     .await;
+                                match reopened.drain_pending_session_events().await {
+                                    Ok(summary) => {
+                                        publish_app_runtime_summary(
+                                            &events,
+                                            &account_id_hex,
+                                            &account_label,
+                                            &summary,
+                                        );
+                                    }
+                                    Err(error) => {
+                                        publish_app_runtime_account_error(
+                                            &events,
+                                            &account_id_hex,
+                                            &account_label,
+                                            account_error_message(
+                                                "runtime restart queued-work wake failed",
+                                                &error,
+                                            ),
+                                        );
+                                    }
+                                }
                                 let pending = reopened
                                     .retry_pending_push_registration_shares_best_effort()
                                     .await;
                                 scheduled_push_retry.schedule_after_attempt(pending, &command_tx);
                                 client = reopened;
+                                schedule_pending_convergence_groups(
+                                    &mut scheduled_convergence,
+                                    &mut client,
+                                );
                             }
                             Err(setup_err) => {
                                 publish_app_runtime_account_error(

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -36,7 +36,9 @@ use crate::messages::{AppMessageIntent, build_inner_event};
 #[derive(Default)]
 struct ScriptedPushRelayClient {
     publish_results: std::sync::Mutex<std::collections::VecDeque<bool>>,
+    published_events: std::sync::Mutex<Vec<NostrTransportEvent>>,
     block_next_subscribe: std::sync::atomic::AtomicBool,
+    fail_blocked_subscribe: std::sync::atomic::AtomicBool,
     block_next_publish: std::sync::atomic::AtomicBool,
     zero_ack_next_publish: std::sync::atomic::AtomicBool,
     batch_calls: std::sync::atomic::AtomicUsize,
@@ -51,6 +53,15 @@ impl ScriptedPushRelayClient {
         *self.publish_results.lock().unwrap() = results.into_iter().collect();
     }
 
+    fn published_event_ids(&self) -> Vec<String> {
+        self.published_events
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|event| event.id.clone())
+            .collect()
+    }
+
     fn block_next_publish(&self) {
         self.block_next_publish
             .store(true, std::sync::atomic::Ordering::SeqCst);
@@ -59,6 +70,12 @@ impl ScriptedPushRelayClient {
     fn block_next_subscribe(&self) {
         self.block_next_subscribe
             .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    fn block_and_fail_next_subscribe(&self) {
+        self.fail_blocked_subscribe
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.block_next_subscribe();
     }
 
     async fn wait_for_blocked_subscribe(&self) {
@@ -89,12 +106,20 @@ impl NostrRelayClient for ScriptedPushRelayClient {
         &self,
         _subscription: NostrSubscription,
     ) -> Result<(), cgka_traits::TransportAdapterError> {
-        if self
+        let blocked = self
             .block_next_subscribe
-            .swap(false, std::sync::atomic::Ordering::SeqCst)
-        {
+            .swap(false, std::sync::atomic::Ordering::SeqCst);
+        if blocked {
             self.subscribe_started.notify_one();
             self.subscribe_release.notified().await;
+            if self
+                .fail_blocked_subscribe
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(cgka_traits::TransportAdapterError::Subscription(
+                    "injected startup activation failure".to_owned(),
+                ));
+            }
         }
         Ok(())
     }
@@ -116,7 +141,7 @@ impl NostrRelayClient for ScriptedPushRelayClient {
     async fn publish_event(
         &self,
         endpoints: &[TransportEndpoint],
-        _event: &NostrTransportEvent,
+        event: &NostrTransportEvent,
         _required_acks: usize,
     ) -> Result<NostrPublishOutcome, cgka_traits::TransportAdapterError> {
         if self
@@ -139,6 +164,7 @@ impl NostrRelayClient for ScriptedPushRelayClient {
             .pop_front()
             .unwrap_or(true)
         {
+            self.published_events.lock().unwrap().push(event.clone());
             Ok(NostrPublishOutcome::accepted(endpoints.to_vec()))
         } else {
             Err(cgka_traits::TransportAdapterError::Publish(
@@ -199,6 +225,30 @@ fn account_reconcile_returns_local_readiness_before_relay_subscription_registrat
     run_composed_app_runtime_test(
         "account-local-ready-before-subscribe",
         account_local_ready_before_subscribe_body,
+    );
+}
+
+#[test]
+fn local_ready_send_remains_pending_when_transport_activation_fails() {
+    run_composed_app_runtime_test(
+        "local-ready-send-pending-on-activation-failure",
+        local_ready_send_pending_on_activation_failure_body,
+    );
+}
+
+#[test]
+fn local_ready_queued_sends_publish_once_in_order_after_activation_recovers() {
+    run_composed_app_runtime_test(
+        "local-ready-queued-send-ordering",
+        local_ready_queued_send_ordering_body,
+    );
+}
+
+#[test]
+fn locally_queued_send_survives_runtime_restart_and_failed_reactivation() {
+    run_composed_app_runtime_test(
+        "local-ready-queued-send-restart",
+        locally_queued_send_restart_body,
     );
 }
 
@@ -380,6 +430,375 @@ async fn account_local_ready_before_subscribe_body() {
     assert_eq!(telemetry.account_transport_activation.successes, 1);
     assert_eq!(telemetry.account_subscription_registration.successes, 1);
     runtime.shutdown().await;
+}
+
+async fn local_ready_send_pending_on_activation_failure_body() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+        .with_test_relay_client(relay.clone());
+
+    // Seed the persisted conversation using an independently activated client.
+    // The runtime below receives a fresh relay plane and must activate it after
+    // reporting local readiness.
+    let mut setup_client = app.client("alice").await.unwrap();
+    let group_id = setup_client
+        .create_group("local-ready send", &[])
+        .await
+        .unwrap();
+    drop(setup_client);
+    let publishes_before_runtime = relay.published_event_ids().len();
+
+    relay.block_and_fail_next_subscribe();
+    let runtime = MarmotAppRuntime::new(app.clone());
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        runtime.reconcile_accounts(),
+    )
+    .await
+    .expect("local readiness must not wait for transport activation")
+    .unwrap();
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        relay.wait_for_blocked_subscribe(),
+    )
+    .await
+    .expect("transport activation should continue after local readiness");
+
+    let send_runtime = runtime.clone();
+    let send_group_id = group_id.clone();
+    let mut send = tokio::spawn(async move {
+        send_runtime
+            .send_message(
+                "alice",
+                &send_group_id,
+                b"retain while transport activates".to_vec(),
+            )
+            .await
+    });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(100), &mut send)
+            .await
+            .is_err(),
+        "the send should remain deferred while initial activation is blocked"
+    );
+
+    // Hold the reconnect activation too, so the test can observe the accepted
+    // local row before background convergence publishes it.
+    relay.block_next_subscribe();
+    relay.release_subscribe();
+    let send_result = tokio::time::timeout(std::time::Duration::from_secs(5), send)
+        .await
+        .expect("deferred send should settle after activation failure")
+        .expect("send task should not panic");
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        relay.wait_for_blocked_subscribe(),
+    )
+    .await
+    .expect("transport reconnect should continue in the background");
+    let timeline = app
+        .timeline_messages_with_query(
+            "alice",
+            TimelineMessageQuery {
+                group_id_hex: Some(hex::encode(group_id.as_slice())),
+                ..TimelineMessageQuery::default()
+            },
+        )
+        .unwrap();
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let chat_list = app.chat_list("alice", false).unwrap();
+    let chat_row = chat_list
+        .iter()
+        .find(|row| row.group_id_hex == group_id_hex)
+        .expect("persisted conversation should remain in the chat list");
+    let last_message = chat_row
+        .last_message
+        .as_ref()
+        .expect("the locally accepted send should remain projected");
+
+    assert_eq!(timeline.messages.len(), 1);
+    assert_eq!(
+        timeline.messages[0].plaintext,
+        "retain while transport activates"
+    );
+    assert_eq!(
+        last_message.delivery_state,
+        ChatListMessageDeliveryState::Pending,
+        "the app-facing projection must stay pending while activation recovers; \
+         invalidation: {:?}; send result: {send_result:?}",
+        timeline.messages[0].invalidation_status
+    );
+    assert_eq!(
+        timeline.messages[0].invalidation_status, None,
+        "a locally accepted send must remain pending while activation recovers; send result: {send_result:?}"
+    );
+    assert!(
+        send_result.is_ok(),
+        "transport lifecycle state must not become a terminal send error: {send_result:?}"
+    );
+
+    relay.release_subscribe();
+    tokio::time::timeout(std::time::Duration::from_secs(8), async {
+        loop {
+            let timeline = app
+                .timeline_messages_with_query(
+                    "alice",
+                    TimelineMessageQuery {
+                        group_id_hex: Some(group_id_hex.clone()),
+                        ..TimelineMessageQuery::default()
+                    },
+                )
+                .unwrap();
+            if timeline.messages.len() == 1 && timeline.messages[0].source_message_id_hex.is_some()
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("reconnect should publish and finalize the queued row");
+    let recovered_timeline = app
+        .timeline_messages_with_query(
+            "alice",
+            TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex),
+                ..TimelineMessageQuery::default()
+            },
+        )
+        .unwrap();
+    let published_ids = relay.published_event_ids();
+    assert_eq!(
+        published_ids.len() - publishes_before_runtime,
+        1,
+        "recovery must publish exactly one transport event"
+    );
+    assert_eq!(
+        recovered_timeline.messages[0]
+            .source_message_id_hex
+            .as_deref(),
+        published_ids.last().map(String::as_str),
+        "the pending row must finalize with the one recovered transport event"
+    );
+
+    runtime.shutdown().await;
+}
+
+async fn local_ready_queued_send_ordering_body() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+        .with_test_relay_client(relay.clone());
+    let mut setup_client = app.client("alice").await.unwrap();
+    let group_id = setup_client
+        .create_group("local-ready ordering", &[])
+        .await
+        .unwrap();
+    drop(setup_client);
+    let publishes_before_runtime = relay.published_event_ids().len();
+
+    relay.block_and_fail_next_subscribe();
+    let runtime = MarmotAppRuntime::new(app.clone());
+    runtime.reconcile_accounts().await.unwrap();
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        relay.wait_for_blocked_subscribe(),
+    )
+    .await
+    .expect("initial activation should be in flight");
+
+    let first_runtime = runtime.clone();
+    let first_group = group_id.clone();
+    let first = tokio::spawn(async move {
+        first_runtime
+            .send_message("alice", &first_group, b"first queued".to_vec())
+            .await
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    let second_runtime = runtime.clone();
+    let second_group = group_id.clone();
+    let second = tokio::spawn(async move {
+        second_runtime
+            .send_message("alice", &second_group, b"second queued".to_vec())
+            .await
+    });
+
+    relay.block_next_subscribe();
+    relay.release_subscribe();
+    assert!(first.await.unwrap().is_ok());
+    assert!(second.await.unwrap().is_ok());
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        relay.wait_for_blocked_subscribe(),
+    )
+    .await
+    .expect("background transport reactivation should be attempted");
+
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let pending = app
+        .timeline_messages_with_query(
+            "alice",
+            TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex.clone()),
+                ..TimelineMessageQuery::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(pending.messages.len(), 2);
+    assert!(
+        pending
+            .messages
+            .iter()
+            .all(|message| message.source_message_id_hex.is_none()
+                && message.invalidation_status.is_none()),
+        "both accepted sends must remain pending before activation recovers"
+    );
+
+    relay.release_subscribe();
+    tokio::time::timeout(std::time::Duration::from_secs(8), async {
+        loop {
+            let timeline = app
+                .timeline_messages_with_query(
+                    "alice",
+                    TimelineMessageQuery {
+                        group_id_hex: Some(group_id_hex.clone()),
+                        ..TimelineMessageQuery::default()
+                    },
+                )
+                .unwrap();
+            if timeline.messages.len() == 2
+                && timeline
+                    .messages
+                    .iter()
+                    .all(|message| message.source_message_id_hex.is_some())
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("both queued sends should finalize after activation");
+
+    let delivered = app
+        .timeline_messages_with_query(
+            "alice",
+            TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex),
+                ..TimelineMessageQuery::default()
+            },
+        )
+        .unwrap();
+    let source_for = |plaintext: &str| {
+        delivered
+            .messages
+            .iter()
+            .find(|message| message.plaintext == plaintext)
+            .and_then(|message| message.source_message_id_hex.clone())
+            .expect("queued message should have one finalized source id")
+    };
+    let first_source = source_for("first queued");
+    let second_source = source_for("second queued");
+    assert_ne!(first_source, second_source);
+    let published_ids = relay.published_event_ids();
+    let recovered_ids = &published_ids[publishes_before_runtime..];
+    assert_eq!(
+        recovered_ids,
+        &[first_source, second_source],
+        "durable queue insertion order must be transport publication order"
+    );
+
+    runtime.shutdown().await;
+}
+
+async fn locally_queued_send_restart_body() {
+    let dir = tempfile::tempdir().unwrap();
+    AccountHome::open(dir.path())
+        .create_account("alice")
+        .unwrap();
+    let relay = Arc::new(ScriptedPushRelayClient::default());
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+        .with_test_relay_client(relay.clone());
+    let mut setup_client = app.client("alice").await.unwrap();
+    let group_id = setup_client
+        .create_group("local-ready restart", &[])
+        .await
+        .unwrap();
+    drop(setup_client);
+
+    relay.block_and_fail_next_subscribe();
+    let first_runtime = MarmotAppRuntime::new(app.clone());
+    first_runtime.reconcile_accounts().await.unwrap();
+    relay.wait_for_blocked_subscribe().await;
+    let send_runtime = first_runtime.clone();
+    let send_group = group_id.clone();
+    let send = tokio::spawn(async move {
+        send_runtime
+            .send_message("alice", &send_group, b"survives restart".to_vec())
+            .await
+    });
+    relay.release_subscribe();
+    assert!(send.await.unwrap().is_ok());
+    first_runtime.shutdown().await;
+
+    let group_id_hex = hex::encode(group_id.as_slice());
+    let pending = app
+        .timeline_messages_with_query(
+            "alice",
+            TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex.clone()),
+                ..TimelineMessageQuery::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(pending.messages.len(), 1);
+    assert!(pending.messages[0].source_message_id_hex.is_none());
+    assert!(pending.messages[0].invalidation_status.is_none());
+    let publishes_before_restart = relay.published_event_ids().len();
+
+    // Fail the restarted worker's first activation too. Hydration must still
+    // wake the durable queue, and its convergence timer must reactivate the
+    // account without any new user command or inbound event.
+    relay.block_and_fail_next_subscribe();
+    let restarted_runtime = MarmotAppRuntime::new(app.clone());
+    restarted_runtime.reconcile_accounts().await.unwrap();
+    relay.wait_for_blocked_subscribe().await;
+    relay.release_subscribe();
+
+    tokio::time::timeout(std::time::Duration::from_secs(8), async {
+        loop {
+            let timeline = app
+                .timeline_messages_with_query(
+                    "alice",
+                    TimelineMessageQuery {
+                        group_id_hex: Some(group_id_hex.clone()),
+                        ..TimelineMessageQuery::default()
+                    },
+                )
+                .unwrap();
+            if timeline.messages.len() == 1 && timeline.messages[0].source_message_id_hex.is_some()
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("hydrated queue should publish after background reactivation");
+    assert_eq!(
+        relay.published_event_ids().len() - publishes_before_restart,
+        1,
+        "restart recovery must publish the logical message exactly once"
+    );
+
+    restarted_runtime.shutdown().await;
 }
 
 async fn disable_native_push_removal_body() {

--- a/crates/traits/src/engine.rs
+++ b/crates/traits/src/engine.rs
@@ -654,6 +654,21 @@ pub trait CgkaEngine: Send + Sync {
     /// `PendingPublish` / `Merging`.
     async fn send(&mut self, intent: SendIntent) -> Result<SendResult, EngineError>;
 
+    /// Durably accept an application-message intent without preparing MLS or
+    /// transport bytes yet.
+    ///
+    /// This is the transport-lifecycle fallback for a locally ready signing
+    /// account whose transport is not active. The same authoritative
+    /// quarantine, disband, removal, unrecoverable, leave, and epoch-state
+    /// gates as [`Self::send`] still apply. On success the group is scheduled
+    /// for convergence so the intent is regenerated from current canonical
+    /// state before publication.
+    async fn queue_app_message(
+        &mut self,
+        group_id: GroupId,
+        payload: Vec<u8>,
+    ) -> Result<SendResult, EngineError>;
+
     /// Advance convergence for a group and release any queued outbound work
     /// that is now safe to regenerate from the selected canonical state.
     /// Accepted inbound application messages from the canonical branch are


### PR DESCRIPTION
## Summary

- accept application-message sends locally when a hydrated signing account is temporarily transport-inactive
- persist those sends in the existing durable outbound-intent queue and re-drive them after activation, reconnect, or restart
- retain and finalize the same optimistic projection, preserve queue order, and delay notification triggers until actual publication
- keep authoritative removal and other terminal engine gates intact

## Root cause

PR #1134 intentionally moved runtime readiness ahead of transport activation and catch-up. When initial activation failed, deferred sends were replayed against an inactive adapter. `send_app_event_with_local_projection` then treated `TransportAdapterError::AccountNotActive` as terminal and retracted the optimistic row.

The convergence scheduler also retried group synchronization without reactivating the account, and failed startup/reconnect paths could leave hydrated queued work unscheduled.

## User impact

A message sent immediately after local readiness now remains as one pending row instead of becoming “Send failed.” When transport activation recovers, MDK publishes that same logical event once and finalizes the existing row without creating a duplicate.

Closes #1151.

## Validation

- `just fast-ci`
- `cargo test -p marmot-app local_ready -- --nocapture`
- `cargo test -p marmot-app locally_queued_send_survives_runtime_restart_and_failed_reactivation -- --nocapture`
- `cargo test -p cgka-engine applying_removal_commit_purges_queued_outbound_intents -- --exact`