### PR TITLE
Add durable agent reply and conversation history

### DIFF
--- a/crates/agent-connector/src/bootstrap.rs
+++ b/crates/agent-connector/src/bootstrap.rs
@@ -463,6 +463,8 @@ fn response_type_name(response: &AgentControlResponse) -> &'static str {
         AgentControlResponse::Ack => "ack",
         AgentControlResponse::Error { .. } => "error",
         AgentControlResponse::AccountList { .. } => "account_list",
+        AgentControlResponse::TimelineMessage { .. } => "timeline_message",
+        AgentControlResponse::TimelinePage { .. } => "timeline_page",
         AgentControlResponse::AccountCreated { .. } => "account_created",
         AgentControlResponse::KeyPackagePublished { .. } => "key_package_published",
         AgentControlResponse::ProfilePublished { .. } => "profile_published",

--- a/crates/agent-connector/src/connection.rs
+++ b/crates/agent-connector/src/connection.rs
@@ -174,6 +174,26 @@ impl AgentConnector {
     ) -> Result<AgentControlResponse, ConnectorError> {
         match request {
             AgentControlRequest::AccountList => self.account_list_response(),
+            AgentControlRequest::TimelineMessageGet {
+                account_id_hex,
+                group_id_hex,
+                message_id_hex,
+            } => self.timeline_message_response(&account_id_hex, &group_id_hex, &message_id_hex),
+            AgentControlRequest::TimelineList {
+                account_id_hex,
+                group_id_hex,
+                before,
+                after,
+                before_inclusive,
+                limit,
+            } => self.timeline_list_response(
+                &account_id_hex,
+                &group_id_hex,
+                before,
+                after,
+                before_inclusive,
+                limit,
+            ),
             AgentControlRequest::AllowlistList { account_id_hex } => {
                 self.allowlist_response(&account_id_hex)
             }

--- a/crates/agent-connector/src/connection.rs
+++ b/crates/agent-connector/src/connection.rs
@@ -187,6 +187,7 @@ impl AgentConnector {
                 before_inclusive,
                 limit,
             } => self.timeline_list_response(
+                request_id,
                 &account_id_hex,
                 &group_id_hex,
                 before,

--- a/crates/agent-connector/src/event_projection.rs
+++ b/crates/agent-connector/src/event_projection.rs
@@ -282,7 +282,7 @@ use tokio::sync::{Mutex as AsyncMutex, broadcast};
 use crate::INBOUND_CATCH_UP_INTERVAL;
 use crate::validation::normalize_hex;
 
-fn control_actor(
+pub(crate) fn control_actor(
     account_id_hex: impl Into<String>,
     display_name: Option<String>,
     self_account_id_hex: &str,
@@ -295,7 +295,7 @@ fn control_actor(
     }
 }
 
-fn attachment_summaries_from_tags(
+pub(crate) fn attachment_summaries_from_tags(
     tags: &[Vec<String>],
     source_epoch: Option<u64>,
 ) -> (Vec<AgentControlAttachmentSummary>, bool) {

--- a/crates/agent-connector/src/lib.rs
+++ b/crates/agent-connector/src/lib.rs
@@ -17,6 +17,7 @@ mod quic;
 mod socket;
 mod stream;
 mod stream_session;
+mod timeline;
 mod validation;
 
 #[cfg(test)]

--- a/crates/agent-connector/src/timeline.rs
+++ b/crates/agent-connector/src/timeline.rs
@@ -1,0 +1,284 @@
+//! Read-only materialized-timeline projection for agent-control clients.
+
+use agent_control::{
+    AGENT_CONTROL_TIMELINE_DEFAULT_LIMIT, AGENT_CONTROL_TIMELINE_MAX_LIMIT,
+    AGENT_CONTROL_TIMELINE_REACTIONS_MAX, AGENT_CONTROL_TIMELINE_TEXT_MAX_CHARS,
+    AgentControlEnvelope, AgentControlResponse, AgentControlTimelineCursor,
+    AgentControlTimelineMessage, AgentControlTimelineMessageAvailability,
+    AgentControlTimelineReaction, MAX_AGENT_CONTROL_FRAME_BYTES,
+};
+use marmot_app::{TimelineMessageQuery, TimelineMessageRecord, TimelinePagination};
+
+use crate::AgentConnector;
+use crate::error::ConnectorError;
+use crate::event_projection::{attachment_summaries_from_tags, control_actor};
+use crate::validation::normalize_hex;
+
+const TIMELINE_ATTACHMENT_FIELD_MAX_CHARS: usize = 512;
+const TIMELINE_REACTION_EMOJI_MAX_CHARS: usize = 64;
+
+impl AgentConnector {
+    pub(crate) fn timeline_message_response(
+        &self,
+        account_id_hex: &str,
+        group_id_hex: &str,
+        message_id_hex: &str,
+    ) -> Result<AgentControlResponse, ConnectorError> {
+        let account = self.local_account_for_account_id(account_id_hex)?;
+        let group_id_hex = normalize_hex(group_id_hex)?;
+        let message_id_hex = normalize_hex(message_id_hex)?;
+        let message = self
+            .runtime
+            .timeline_message(&account.label, &group_id_hex, &message_id_hex)?
+            .map(|record| timeline_message(record, &account.account_id_hex));
+        Ok(AgentControlResponse::TimelineMessage {
+            account_id_hex: account.account_id_hex,
+            group_id_hex,
+            message_id_hex,
+            message,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn timeline_list_response(
+        &self,
+        account_id_hex: &str,
+        group_id_hex: &str,
+        before: Option<AgentControlTimelineCursor>,
+        after: Option<AgentControlTimelineCursor>,
+        before_inclusive: bool,
+        limit: Option<u32>,
+    ) -> Result<AgentControlResponse, ConnectorError> {
+        let account = self.local_account_for_account_id(account_id_hex)?;
+        let group_id_hex = normalize_hex(group_id_hex)?;
+        let before = before.map(normalize_cursor).transpose()?;
+        let after = after.map(normalize_cursor).transpose()?;
+        let limit = limit
+            .unwrap_or(AGENT_CONTROL_TIMELINE_DEFAULT_LIMIT)
+            .clamp(1, AGENT_CONTROL_TIMELINE_MAX_LIMIT);
+        let page = self.runtime.timeline_messages_with_query(
+            &account.label,
+            TimelineMessageQuery {
+                group_id_hex: Some(group_id_hex.clone()),
+                search: None,
+                pagination: TimelinePagination {
+                    before: before.as_ref().map(|cursor| cursor.recorded_at),
+                    before_message_id: before.as_ref().map(|cursor| cursor.message_id_hex.clone()),
+                    before_inclusive,
+                    after: after.as_ref().map(|cursor| cursor.recorded_at),
+                    after_message_id: after.as_ref().map(|cursor| cursor.message_id_hex.clone()),
+                    limit: Some(limit as usize),
+                },
+            },
+        )?;
+        let mut messages = page
+            .messages
+            .into_iter()
+            .map(|record| timeline_message(record, &account.account_id_hex))
+            .collect::<Vec<_>>();
+        let mut has_more_before = page.has_more_before;
+        let mut has_more_after = page.has_more_after;
+
+        loop {
+            let response = AgentControlResponse::TimelinePage {
+                account_id_hex: account.account_id_hex.clone(),
+                group_id_hex: group_id_hex.clone(),
+                messages: messages.clone(),
+                has_more_before,
+                has_more_after,
+            };
+            // Keep a complete response envelope below the protocol frame cap. When a
+            // requested page is too large, preserve the messages nearest the cursor
+            // and expose the omitted side through the existing pagination flags.
+            let sizing_envelope = AgentControlEnvelope::new(Some("0".repeat(64)), response.clone());
+            if serde_json::to_vec(&sizing_envelope)?.len() < MAX_AGENT_CONTROL_FRAME_BYTES
+                || messages.len() <= 1
+            {
+                return Ok(response);
+            }
+            if after.is_some() {
+                messages.pop();
+                has_more_after = true;
+            } else {
+                messages.remove(0);
+                has_more_before = true;
+            }
+        }
+    }
+}
+
+fn normalize_cursor(
+    mut cursor: AgentControlTimelineCursor,
+) -> Result<AgentControlTimelineCursor, ConnectorError> {
+    cursor.message_id_hex = normalize_hex(&cursor.message_id_hex)?;
+    Ok(cursor)
+}
+
+fn timeline_message(
+    record: TimelineMessageRecord,
+    self_account_id_hex: &str,
+) -> AgentControlTimelineMessage {
+    let availability = if record.invalidation_status.is_some() {
+        AgentControlTimelineMessageAvailability::Invalidated
+    } else if record.deleted {
+        AgentControlTimelineMessageAvailability::Deleted
+    } else {
+        AgentControlTimelineMessageAvailability::Available
+    };
+    let available = availability == AgentControlTimelineMessageAvailability::Available;
+    let (text, text_truncated, attachments, attachments_truncated) = if available {
+        let (text, text_truncated) = bounded_timeline_text(&record.plaintext);
+        let (mut attachments, mut attachments_truncated) =
+            attachment_summaries_from_tags(&record.tags, record.source_epoch);
+        for attachment in &mut attachments {
+            let (media_type, media_type_truncated) =
+                bounded_string(&attachment.media_type, TIMELINE_ATTACHMENT_FIELD_MAX_CHARS);
+            attachment.media_type = media_type;
+            let (file_name, file_name_truncated) =
+                bounded_string(&attachment.file_name, TIMELINE_ATTACHMENT_FIELD_MAX_CHARS);
+            attachment.file_name = file_name;
+            attachments_truncated |= file_name_truncated;
+            if let Some(dim) = attachment.dim.as_deref() {
+                let (dim, dim_truncated) = bounded_string(dim, TIMELINE_ATTACHMENT_FIELD_MAX_CHARS);
+                attachment.dim = Some(dim);
+                attachments_truncated |= dim_truncated;
+            }
+            attachments_truncated |= media_type_truncated;
+        }
+        (
+            Some(text),
+            text_truncated,
+            attachments,
+            attachments_truncated,
+        )
+    } else {
+        (None, false, Vec::new(), false)
+    };
+    let reactions_len = record.reactions.user_reactions.len();
+    let reactions = if available {
+        record
+            .reactions
+            .user_reactions
+            .into_iter()
+            .take(AGENT_CONTROL_TIMELINE_REACTIONS_MAX)
+            .map(|reaction| AgentControlTimelineReaction {
+                reaction_message_id_hex: reaction.reaction_message_id_hex,
+                actor: control_actor(reaction.sender, None, self_account_id_hex),
+                emoji: bounded_string(&reaction.emoji, TIMELINE_REACTION_EMOJI_MAX_CHARS).0,
+                reacted_at: reaction.reacted_at,
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    AgentControlTimelineMessage {
+        message_id_hex: record.message_id_hex,
+        sender: control_actor(record.sender, None, self_account_id_hex),
+        direction: record.direction,
+        kind: record.kind,
+        recorded_at: record.timeline_at,
+        observed_at: record.received_at,
+        availability,
+        text,
+        text_truncated,
+        reply_to_message_id_hex: record.reply_to_message_id_hex,
+        attachments,
+        attachments_truncated,
+        reactions,
+        reactions_truncated: available && reactions_len > AGENT_CONTROL_TIMELINE_REACTIONS_MAX,
+    }
+}
+
+fn bounded_timeline_text(text: &str) -> (String, bool) {
+    bounded_string(text, AGENT_CONTROL_TIMELINE_TEXT_MAX_CHARS)
+}
+
+fn bounded_string(text: &str, max_chars: usize) -> (String, bool) {
+    let mut chars = text.chars();
+    let excerpt = chars.by_ref().take(max_chars).collect::<String>();
+    (excerpt, chars.next().is_some())
+}
+
+#[cfg(test)]
+mod tests {
+    use marmot_app::{TimelineMessageRecord, TimelineReactionSummary, TimelineUserReaction};
+
+    use super::*;
+
+    fn record() -> TimelineMessageRecord {
+        TimelineMessageRecord {
+            message_id_hex: "11".repeat(32),
+            source_message_id_hex: Some("22".repeat(32)),
+            source_epoch: Some(7),
+            retention_seconds: None,
+            retention_expires_at: None,
+            direction: "received".to_owned(),
+            group_id_hex: "33".repeat(32),
+            sender: "44".repeat(32),
+            plaintext: "hello".to_owned(),
+            kind: 9,
+            tags: Vec::new(),
+            timeline_at: 42,
+            received_at: 43,
+            reply_to_message_id_hex: Some("55".repeat(32)),
+            reply_preview: None,
+            media: None,
+            agent_text_stream: None,
+            reactions: TimelineReactionSummary {
+                by_emoji: Default::default(),
+                user_reactions: vec![TimelineUserReaction {
+                    reaction_message_id_hex: "66".repeat(32),
+                    target_message_id_hex: "11".repeat(32),
+                    sender: "77".repeat(32),
+                    emoji: "👍".to_owned(),
+                    reacted_at: 44,
+                }],
+            },
+            deleted: false,
+            deleted_by_message_id_hex: None,
+            invalidation_status: None,
+        }
+    }
+
+    #[test]
+    fn available_timeline_message_keeps_durable_identity_and_reactions() {
+        let message = timeline_message(record(), &"77".repeat(32));
+        assert_eq!(
+            message.availability,
+            AgentControlTimelineMessageAvailability::Available
+        );
+        assert_eq!(message.text.as_deref(), Some("hello"));
+        assert_eq!(message.reply_to_message_id_hex, Some("55".repeat(32)));
+        assert_eq!(message.reactions.len(), 1);
+        assert!(message.reactions[0].actor.is_self);
+        assert_eq!(
+            message.reactions[0].reaction_message_id_hex,
+            "66".repeat(32)
+        );
+    }
+
+    #[test]
+    fn deleted_and_invalidated_timeline_messages_never_expose_content() {
+        let mut deleted = record();
+        deleted.deleted = true;
+        deleted.tags = vec![vec!["imeta".to_owned(), "m image/png".to_owned()]];
+        let deleted = timeline_message(deleted, &"aa".repeat(32));
+        assert_eq!(
+            deleted.availability,
+            AgentControlTimelineMessageAvailability::Deleted
+        );
+        assert_eq!(deleted.text, None);
+        assert!(deleted.attachments.is_empty());
+        assert!(deleted.reactions.is_empty());
+
+        let mut invalidated = record();
+        invalidated.invalidation_status = Some("LosingBranch".to_owned());
+        let invalidated = timeline_message(invalidated, &"aa".repeat(32));
+        assert_eq!(
+            invalidated.availability,
+            AgentControlTimelineMessageAvailability::Invalidated
+        );
+        assert_eq!(invalidated.text, None);
+        assert!(invalidated.reactions.is_empty());
+    }
+}

--- a/crates/agent-connector/src/timeline.rs
+++ b/crates/agent-connector/src/timeline.rs
@@ -42,6 +42,7 @@ impl AgentConnector {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn timeline_list_response(
         &self,
+        request_id: Option<&str>,
         account_id_hex: &str,
         group_id_hex: &str,
         before: Option<AgentControlTimelineCursor>,
@@ -71,38 +72,60 @@ impl AgentConnector {
                 },
             },
         )?;
-        let mut messages = page
-            .messages
-            .into_iter()
-            .map(|record| timeline_message(record, &account.account_id_hex))
-            .collect::<Vec<_>>();
-        let mut has_more_before = page.has_more_before;
-        let mut has_more_after = page.has_more_after;
-
-        loop {
-            let response = AgentControlResponse::TimelinePage {
+        bounded_timeline_page_response(
+            request_id,
+            AgentControlResponse::TimelinePage {
                 account_id_hex: account.account_id_hex.clone(),
                 group_id_hex: group_id_hex.clone(),
-                messages: messages.clone(),
-                has_more_before,
-                has_more_after,
-            };
-            // Keep a complete response envelope below the protocol frame cap. When a
-            // requested page is too large, preserve the messages nearest the cursor
-            // and expose the omitted side through the existing pagination flags.
-            let sizing_envelope = AgentControlEnvelope::new(Some("0".repeat(64)), response.clone());
-            if serde_json::to_vec(&sizing_envelope)?.len() < MAX_AGENT_CONTROL_FRAME_BYTES
-                || messages.len() <= 1
-            {
-                return Ok(response);
-            }
-            if after.is_some() {
-                messages.pop();
-                has_more_after = true;
-            } else {
-                messages.remove(0);
-                has_more_before = true;
-            }
+                messages: page
+                    .messages
+                    .into_iter()
+                    .map(|record| timeline_message(record, &account.account_id_hex))
+                    .collect(),
+                has_more_before: page.has_more_before,
+                has_more_after: page.has_more_after,
+            },
+            after.is_some(),
+        )
+    }
+}
+
+fn bounded_timeline_page_response(
+    request_id: Option<&str>,
+    mut response: AgentControlResponse,
+    trim_from_back: bool,
+) -> Result<AgentControlResponse, ConnectorError> {
+    loop {
+        // Size the exact envelope that handle_connection will write, including
+        // the caller-supplied correlation id.
+        let sizing_envelope =
+            AgentControlEnvelope::new(request_id.map(str::to_owned), response.clone());
+        let frame_len = serde_json::to_vec(&sizing_envelope)?.len() + 1;
+        if frame_len <= MAX_AGENT_CONTROL_FRAME_BYTES {
+            return Ok(response);
+        }
+
+        let AgentControlResponse::TimelinePage {
+            messages,
+            has_more_before,
+            has_more_after,
+            ..
+        } = &mut response
+        else {
+            unreachable!("timeline page bounder requires a timeline_page response");
+        };
+        if messages.is_empty() {
+            return Err(agent_control::AgentControlError::FrameTooLarge(frame_len).into());
+        }
+        // Storage returns rows in chronological order. For an `after` page,
+        // discard the newest tail; otherwise discard the oldest head. This
+        // preserves the rows nearest the requested cursor.
+        if trim_from_back {
+            messages.pop();
+            *has_more_after = true;
+        } else {
+            messages.remove(0);
+            *has_more_before = true;
         }
     }
 }
@@ -201,6 +224,10 @@ fn bounded_string(text: &str, max_chars: usize) -> (String, bool) {
 
 #[cfg(test)]
 mod tests {
+    use agent_control::{
+        AGENT_CONTROL_REFERENCED_ATTACHMENTS_MAX, AgentControlActor, AgentControlAttachmentSummary,
+        encode_frame,
+    };
     use marmot_app::{TimelineMessageRecord, TimelineReactionSummary, TimelineUserReaction};
 
     use super::*;
@@ -280,5 +307,144 @@ mod tests {
         );
         assert_eq!(invalidated.text, None);
         assert!(invalidated.reactions.is_empty());
+    }
+
+    fn large_timeline_message(index: usize) -> AgentControlTimelineMessage {
+        let actor = AgentControlActor {
+            account_id_hex: "44".repeat(32),
+            display_name: None,
+            is_self: false,
+        };
+        AgentControlTimelineMessage {
+            message_id_hex: format!("{index:064x}"),
+            sender: actor.clone(),
+            direction: "received".to_owned(),
+            kind: 9,
+            recorded_at: index as u64,
+            observed_at: index as u64,
+            availability: AgentControlTimelineMessageAvailability::Available,
+            text: Some("t".repeat(AGENT_CONTROL_TIMELINE_TEXT_MAX_CHARS)),
+            text_truncated: true,
+            reply_to_message_id_hex: None,
+            attachments: (0..AGENT_CONTROL_REFERENCED_ATTACHMENTS_MAX)
+                .map(|_| AgentControlAttachmentSummary {
+                    media_type: "m".repeat(TIMELINE_ATTACHMENT_FIELD_MAX_CHARS),
+                    file_name: "f".repeat(TIMELINE_ATTACHMENT_FIELD_MAX_CHARS),
+                    dim: Some("d".repeat(TIMELINE_ATTACHMENT_FIELD_MAX_CHARS)),
+                })
+                .collect(),
+            attachments_truncated: true,
+            reactions: (0..AGENT_CONTROL_TIMELINE_REACTIONS_MAX)
+                .map(|reaction| AgentControlTimelineReaction {
+                    reaction_message_id_hex: format!("{reaction:064x}"),
+                    actor: actor.clone(),
+                    emoji: "e".repeat(TIMELINE_REACTION_EMOJI_MAX_CHARS),
+                    reacted_at: reaction as u64,
+                })
+                .collect(),
+            reactions_truncated: true,
+        }
+    }
+
+    fn oversized_page() -> AgentControlResponse {
+        AgentControlResponse::TimelinePage {
+            account_id_hex: "11".repeat(32),
+            group_id_hex: "22".repeat(32),
+            messages: (0..AGENT_CONTROL_TIMELINE_MAX_LIMIT as usize)
+                .map(large_timeline_message)
+                .collect(),
+            has_more_before: false,
+            has_more_after: false,
+        }
+    }
+
+    fn page_messages(response: &AgentControlResponse) -> &[AgentControlTimelineMessage] {
+        let AgentControlResponse::TimelinePage { messages, .. } = response else {
+            panic!("expected timeline_page response");
+        };
+        messages
+    }
+
+    #[test]
+    fn oversized_before_page_keeps_newest_rows_nearest_cursor() {
+        let response =
+            bounded_timeline_page_response(Some("request-before"), oversized_page(), false)
+                .unwrap();
+        let messages = page_messages(&response);
+        assert!(!messages.is_empty());
+        assert!(messages.len() < AGENT_CONTROL_TIMELINE_MAX_LIMIT as usize);
+        assert_ne!(messages[0].message_id_hex, format!("{:064x}", 0));
+        assert_eq!(
+            messages.last().unwrap().message_id_hex,
+            format!("{:064x}", AGENT_CONTROL_TIMELINE_MAX_LIMIT - 1)
+        );
+        let AgentControlResponse::TimelinePage {
+            has_more_before,
+            has_more_after,
+            ..
+        } = &response
+        else {
+            unreachable!()
+        };
+        assert!(*has_more_before);
+        assert!(!*has_more_after);
+        assert!(
+            encode_frame(&AgentControlEnvelope::new(
+                Some("request-before".to_owned()),
+                response
+            ))
+            .unwrap()
+            .len()
+                <= MAX_AGENT_CONTROL_FRAME_BYTES
+        );
+    }
+
+    #[test]
+    fn oversized_after_page_keeps_oldest_rows_nearest_cursor() {
+        let response =
+            bounded_timeline_page_response(Some("request-after"), oversized_page(), true).unwrap();
+        let messages = page_messages(&response);
+        assert!(!messages.is_empty());
+        assert!(messages.len() < AGENT_CONTROL_TIMELINE_MAX_LIMIT as usize);
+        assert_eq!(messages[0].message_id_hex, format!("{:064x}", 0));
+        assert_ne!(
+            messages.last().unwrap().message_id_hex,
+            format!("{:064x}", AGENT_CONTROL_TIMELINE_MAX_LIMIT - 1)
+        );
+        let AgentControlResponse::TimelinePage {
+            has_more_before,
+            has_more_after,
+            ..
+        } = &response
+        else {
+            unreachable!()
+        };
+        assert!(!*has_more_before);
+        assert!(*has_more_after);
+        assert!(
+            encode_frame(&AgentControlEnvelope::new(
+                Some("request-after".to_owned()),
+                response
+            ))
+            .unwrap()
+            .len()
+                <= MAX_AGENT_CONTROL_FRAME_BYTES
+        );
+    }
+
+    #[test]
+    fn page_budget_accounts_for_actual_request_id() {
+        let short = bounded_timeline_page_response(Some("short"), oversized_page(), false).unwrap();
+        let long_request_id = "r".repeat(100_000);
+        let long = bounded_timeline_page_response(Some(&long_request_id), oversized_page(), false)
+            .unwrap();
+
+        assert!(page_messages(&long).len() < page_messages(&short).len());
+        assert!(
+            encode_frame(&AgentControlEnvelope::new(Some(long_request_id), long))
+                .unwrap()
+                .len()
+                <= MAX_AGENT_CONTROL_FRAME_BYTES
+        );
     }
 }

--- a/crates/agent-connector/src/validation.rs
+++ b/crates/agent-connector/src/validation.rs
@@ -102,6 +102,8 @@ pub(crate) fn unsupported_request_message(request: &AgentControlRequest) -> &'st
 pub(crate) fn agent_control_request_type(request: &AgentControlRequest) -> &'static str {
     match request {
         AgentControlRequest::SubscribeInbound { .. } => "subscribe_inbound",
+        AgentControlRequest::TimelineMessageGet { .. } => "timeline_message_get",
+        AgentControlRequest::TimelineList { .. } => "timeline_list",
         AgentControlRequest::SendFinal { .. } => "send_final",
         AgentControlRequest::DeleteMessage { .. } => "delete_message",
         AgentControlRequest::StreamBegin { .. } => "stream_begin",

--- a/crates/agent-control/README.md
+++ b/crates/agent-control/README.md
@@ -22,9 +22,25 @@ begin inputs is an error, and trying to begin another active stream with an occu
 
 ## What this crate does
 
-- Owns `AgentControlEnvelope` and the typed control DTOs (bootstrap, send, subscribe, stream compose, allowlists, etc.).
+- Owns `AgentControlEnvelope` and the typed control DTOs (bootstrap, send, subscribe, timeline history, stream compose,
+  allowlists, etc.).
 - Provides newline-delimited JSON framing with a 1 MiB per-frame cap.
 - Stays dependency-light: `serde` and Tokio IO only.
+
+## Materialized timeline reads
+
+`timeline_message_get` resolves one durable message id and `timeline_list` pages a
+group's current materialized timeline with a stable `(recorded_at,
+message_id_hex)` cursor. These are read-only views of current message state:
+edits are reflected, reactions are aggregated, and deleted or invalidated
+messages retain identity/attribution but never expose plaintext or attachment
+metadata. Responses bound text, attachments, reactions, page size, and total
+frame size.
+
+Connectors use the same API both to attach a recent ID-bearing chat window to an
+inbound turn and to expose an on-demand history tool. This is also the recovery
+path after `resync_required`; clients should re-page the materialized timeline
+rather than attempting to reconstruct history from the lossy event stream.
 
 ## What it does not do
 

--- a/crates/agent-control/src/lib.rs
+++ b/crates/agent-control/src/lib.rs
@@ -10,6 +10,10 @@ pub const MAX_AGENT_CONTROL_FRAME_BYTES: usize = 1024 * 1024;
 pub const AGENT_CONTROL_STREAM_STATUS_STARTED: &str = "started";
 pub const AGENT_CONTROL_REFERENCED_TEXT_MAX_CHARS: usize = 2_000;
 pub const AGENT_CONTROL_REFERENCED_ATTACHMENTS_MAX: usize = 16;
+pub const AGENT_CONTROL_TIMELINE_DEFAULT_LIMIT: u32 = 20;
+pub const AGENT_CONTROL_TIMELINE_MAX_LIMIT: u32 = 50;
+pub const AGENT_CONTROL_TIMELINE_TEXT_MAX_CHARS: usize = 8_192;
+pub const AGENT_CONTROL_TIMELINE_REACTIONS_MAX: usize = 64;
 
 #[derive(Debug, thiserror::Error)]
 pub enum AgentControlError {
@@ -72,6 +76,27 @@ pub enum AgentControlRequest {
     SubscribeInbound {
         account_id_hex: Option<String>,
         group_id_hex: Option<String>,
+    },
+    /// Resolve one row from the materialized, user-visible timeline.
+    TimelineMessageGet {
+        account_id_hex: String,
+        group_id_hex: String,
+        message_id_hex: String,
+    },
+    /// Page through the materialized, user-visible timeline in stable
+    /// `(recorded_at, message_id_hex)` order. `before` and `after` are mutually
+    /// exclusive; an omitted cursor returns the newest page.
+    TimelineList {
+        account_id_hex: String,
+        group_id_hex: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        before: Option<AgentControlTimelineCursor>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        after: Option<AgentControlTimelineCursor>,
+        #[serde(default)]
+        before_inclusive: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        limit: Option<u32>,
     },
     SendFinal {
         account_id_hex: String,
@@ -306,6 +331,20 @@ pub enum AgentControlResponse {
     AccountList {
         accounts: Vec<AgentControlAccount>,
     },
+    TimelineMessage {
+        account_id_hex: String,
+        group_id_hex: String,
+        message_id_hex: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<AgentControlTimelineMessage>,
+    },
+    TimelinePage {
+        account_id_hex: String,
+        group_id_hex: String,
+        messages: Vec<AgentControlTimelineMessage>,
+        has_more_before: bool,
+        has_more_after: bool,
+    },
     AccountCreated {
         account: AgentControlAccount,
     },
@@ -433,6 +472,58 @@ pub struct AgentControlActor {
     pub display_name: Option<String>,
     #[serde(default)]
     pub is_self: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentControlTimelineCursor {
+    pub recorded_at: u64,
+    pub message_id_hex: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentControlTimelineMessageAvailability {
+    Available,
+    Deleted,
+    Invalidated,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentControlTimelineReaction {
+    pub reaction_message_id_hex: String,
+    pub actor: AgentControlActor,
+    pub emoji: String,
+    pub reacted_at: u64,
+}
+
+/// A bounded, privacy-aware view of one materialized timeline row. Deleted and
+/// invalidated rows retain identity/attribution but never carry plaintext or
+/// attachment summaries.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentControlTimelineMessage {
+    pub message_id_hex: String,
+    pub sender: AgentControlActor,
+    pub direction: String,
+    pub kind: u64,
+    /// Sender-authenticated timeline time in Unix seconds.
+    pub recorded_at: u64,
+    /// Local observation/creation time in Unix seconds.
+    pub observed_at: u64,
+    pub availability: AgentControlTimelineMessageAvailability,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub text_truncated: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_to_message_id_hex: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<AgentControlAttachmentSummary>,
+    #[serde(default)]
+    pub attachments_truncated: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reactions: Vec<AgentControlTimelineReaction>,
+    #[serde(default)]
+    pub reactions_truncated: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -735,8 +826,9 @@ mod tests {
     use crate::{
         AgentControlEnvelope, AgentControlError, AgentControlEvent,
         AgentControlProfileLookupStatus, AgentControlRequest, AgentControlResponse,
-        AgentControlSendMaintenanceDisposition, MAX_AGENT_CONTROL_FRAME_BYTES, decode_envelope,
-        encode_frame, read_envelope, read_frame, write_frame,
+        AgentControlSendMaintenanceDisposition, AgentControlTimelineCursor,
+        MAX_AGENT_CONTROL_FRAME_BYTES, decode_envelope, encode_frame, read_envelope, read_frame,
+        write_frame,
     };
 
     #[test]
@@ -1094,6 +1186,28 @@ mod tests {
                     group_id_hex: None,
                 },
                 "subscribe_inbound",
+            ),
+            (
+                AgentControlRequest::TimelineMessageGet {
+                    account_id_hex: account(),
+                    group_id_hex: group(),
+                    message_id_hex: message(),
+                },
+                "timeline_message_get",
+            ),
+            (
+                AgentControlRequest::TimelineList {
+                    account_id_hex: account(),
+                    group_id_hex: group(),
+                    before: Some(AgentControlTimelineCursor {
+                        recorded_at: 42,
+                        message_id_hex: message(),
+                    }),
+                    after: None,
+                    before_inclusive: false,
+                    limit: Some(20),
+                },
+                "timeline_list",
             ),
             (
                 AgentControlRequest::SendFinal {

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,14 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Added
+
+- WN Agent now exposes exact-message and stable cursor-paginated materialized
+  timeline reads. OpenClaw and Hermes attach bounded recent history with durable
+  message ids to inbound turns and provide a `marmot_history` tool for older or
+  exact transcript lookup; complete referenced-message sender and text context
+  is preserved, including self-authored OpenClaw reply targets.
+
 ## [0.9.9] - 2026-07-28
 
 ### Added

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1698,6 +1698,18 @@ impl MarmotApp {
         Ok(self.account_storage(label)?.message_timeline(query)?)
     }
 
+    pub fn timeline_message(
+        &self,
+        label: &str,
+        group_id_hex: &str,
+        message_id_hex: &str,
+    ) -> Result<Option<TimelineMessageRecord>, AppError> {
+        self.ensure_account_state(label)?;
+        Ok(self
+            .account_storage(label)?
+            .timeline_message(group_id_hex, message_id_hex)?)
+    }
+
     pub fn chat_list(
         &self,
         label: &str,

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -42,8 +42,8 @@ use crate::{
     PushPlatform, PushRegistration, PushRegistrationShareOutcome, PushRegistrationSyncResult,
     ReceivedMessage, RelayTelemetryExportConfig, RelayTelemetryRuntimeConfig,
     RelayTelemetrySettings, RetentionSweepReport, SecureDeleteExpiredResult, SendSummary,
-    TimelineMessageQuery, TimelinePage, UserDirectoryRefresh, UserProfileMetadata,
-    default_profile_pseudonym, unix_now_seconds,
+    TimelineMessageQuery, TimelineMessageRecord, TimelinePage, UserDirectoryRefresh,
+    UserProfileMetadata, default_profile_pseudonym, unix_now_seconds,
 };
 
 mod account_worker;
@@ -93,9 +93,9 @@ pub(crate) use subscriptions::{
 // External items `runtime/tests.rs` reaches through `super::*` that the
 // orchestration core itself no longer references after the split.
 #[cfg(test)]
-use crate::messages::STREAM_ROUTE_QUIC;
+use crate::TimelineMessageChange;
 #[cfg(test)]
-use crate::{TimelineMessageChange, TimelineMessageRecord};
+use crate::messages::STREAM_ROUTE_QUIC;
 #[cfg(test)]
 use cgka_traits::app_event::{
     MARMOT_APP_EVENT_KIND_AGENT_STREAM_START, STREAM_ROUTE_TAG, STREAM_TAG,
@@ -2692,6 +2692,18 @@ impl MarmotAppRuntime {
         self.accounts
             .app
             .timeline_messages_with_query(&account.label, query)
+    }
+
+    pub fn timeline_message(
+        &self,
+        account_ref: &str,
+        group_id_hex: &str,
+        message_id_hex: &str,
+    ) -> Result<Option<TimelineMessageRecord>, AppError> {
+        let account = self.accounts.resolve(account_ref)?;
+        self.accounts
+            .app
+            .timeline_message(&account.label, group_id_hex, message_id_hex)
     }
 
     pub fn chat_list(

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -840,6 +840,42 @@ impl SqliteAccountStorage {
         })
     }
 
+    /// Resolve one complete materialized-timeline row by group + message id.
+    /// This reads the user-visible projection (including current edit,
+    /// reaction, delete, and invalidation state), not the raw app-event row.
+    pub fn timeline_message(
+        &self,
+        group_id_hex: &str,
+        message_id_hex: &str,
+    ) -> StorageResult<Option<TimelineMessageRecord>> {
+        let conn = self.lock()?;
+        let mut message = conn
+            .query_row(
+                "SELECT timeline.message_id_hex, timeline.source_message_id_hex, timeline.source_epoch,
+                        source.retention_seconds, source.retention_expires_at,
+                        timeline.direction, timeline.group_id_hex, timeline.sender,
+                        timeline.plaintext, timeline.kind, timeline.tags_json, timeline.timeline_at,
+                        timeline.received_at, timeline.reply_to_message_id_hex, timeline.media_json,
+                        timeline.agent_stream_json, timeline.reactions_json, timeline.deleted,
+                        timeline.deleted_by_message_id_hex, timeline.invalidation_status
+                 FROM message_timeline AS timeline
+                 LEFT JOIN app_events AS source
+                   ON source.group_id_hex = timeline.group_id_hex
+                  AND source.message_id_hex = timeline.message_id_hex
+                 WHERE timeline.group_id_hex = ?1
+                   AND timeline.message_id_hex = ?2
+                 LIMIT 1",
+                params![group_id_hex, message_id_hex],
+                timeline_record_from_row,
+            )
+            .optional()
+            .storage()?;
+        if let Some(message) = message.as_mut() {
+            attach_reply_previews(&conn, std::slice::from_mut(message))?;
+        }
+        Ok(message)
+    }
+
     /// Resolve a single materialized-timeline row by `(group_id_hex,
     /// message_id_hex)` without scanning the timeline. Returns the small
     /// [`TimelineMessageTarget`] view (sender, plaintext, kind, deleted,

--- a/crates/storage-sqlite/src/timeline/tests.rs
+++ b/crates/storage-sqlite/src/timeline/tests.rs
@@ -1652,6 +1652,15 @@ fn timeline_message_target_resolves_single_row_and_reflects_state() {
     assert!(!found.deleted);
     assert!(!found.invalidated);
 
+    let full = store
+        .timeline_message(&"11".repeat(32), "target")
+        .unwrap()
+        .expect("complete target row");
+    assert_eq!(full.message_id_hex, "target");
+    assert_eq!(full.sender, "alice");
+    assert_eq!(full.plaintext, "hello");
+    assert_eq!(full.timeline_at, 1);
+
     // Absent id in the same group → None.
     assert!(
         store

--- a/integrations/hermes/marmot/README.md
+++ b/integrations/hermes/marmot/README.md
@@ -4,6 +4,15 @@ This directory is a Hermes platform plugin for the local `wn-agent` connector.
 Hermes runs the agent and tools. `wn-agent` owns the Marmot account, MLS state,
 Nostr transport, final encrypted sends, and QUIC live-preview stream records.
 
+For each activated inbound turn, the plugin asks `wn-agent` for a bounded recent
+materialized chat window and supplies Hermes with durable message ids, senders,
+timestamps, reply links, current reaction summaries, and
+delete/invalidation state. Reply context includes both Hermes's native reply
+fields and a complete structured referenced-message payload. The
+model-callable `marmot_history` tool can fetch one exact message id or page older
+messages using a `(recorded_at, message_id_hex)` cursor. Automatic history
+lookup is best-effort and never drops the current inbound message if it fails.
+
 For live previews, the plugin retries `stream_begin` with one stable v2 request
 id and retains the returned stream capability in memory for subsequent append,
 status, finalize, and cancel calls. The capability is a bearer secret and must

--- a/integrations/hermes/marmot/adapter.py
+++ b/integrations/hermes/marmot/adapter.py
@@ -438,17 +438,30 @@ def _normalize_inbound_message_event(event: Dict[str, Any]) -> Dict[str, Any]:
 def _referenced_channel_context(reply: Any) -> Optional[str]:
     if not isinstance(reply, dict):
         return None
-    attachments = reply.get("attachments")
-    if not isinstance(attachments, list) or not attachments:
-        return None
     fact = {
-        "type": "quoted_attachments",
-        "message_id": reply.get("message_id_hex"),
+        "type": "referenced_message",
+        "message_id_hex": reply.get("message_id_hex"),
         "availability": reply.get("availability"),
-        "attachments": attachments,
+        "sender": reply.get("sender"),
+        "recorded_at": reply.get("recorded_at"),
+        "text_excerpt": reply.get("text_excerpt"),
+        "text_truncated": bool(reply.get("text_truncated")),
+        "attachments": reply.get("attachments") or [],
         "attachments_truncated": bool(reply.get("attachments_truncated")),
     }
-    return f"Marmot quoted attachment context (untrusted): {json.dumps(fact, separators=(',', ':'))}"
+    return f"Marmot referenced-message context (untrusted): {json.dumps(fact, separators=(',', ':'))}"
+
+
+def _timeline_channel_context(messages: Any) -> Optional[str]:
+    if not isinstance(messages, list) or not messages:
+        return None
+    fact = {
+        "type": "chat_window",
+        "order": "chronological",
+        "relation": "before_current_message",
+        "messages": messages,
+    }
+    return f"Marmot conversation history (untrusted): {json.dumps(fact, separators=(',', ':'))}"
 
 
 def _mutation_channel_context(event: Dict[str, Any]) -> str:
@@ -1003,6 +1016,54 @@ class MarmotAgentControlClient:
 
     async def account_list(self) -> Dict[str, Any]:
         return await self.request({"type": "account_list"})
+
+    async def timeline_message_get(
+        self,
+        account_id_hex: str,
+        group_id_hex: str,
+        message_id_hex: str,
+    ) -> Dict[str, Any]:
+        return await self.request(
+            {
+                "type": "timeline_message_get",
+                "account_id_hex": _normalize_hex(account_id_hex, "account_id_hex"),
+                "group_id_hex": _normalize_hex(group_id_hex, "group_id_hex"),
+                "message_id_hex": _normalize_hex(message_id_hex, "message_id_hex"),
+            }
+        )
+
+    async def timeline_list(
+        self,
+        account_id_hex: str,
+        group_id_hex: str,
+        *,
+        before: Optional[Dict[str, Any]] = None,
+        after: Optional[Dict[str, Any]] = None,
+        before_inclusive: bool = False,
+        limit: int = 20,
+    ) -> Dict[str, Any]:
+        def normalize_cursor(cursor: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+            if cursor is None:
+                return None
+            return {
+                "recorded_at": max(0, int(cursor.get("recorded_at") or 0)),
+                "message_id_hex": _normalize_hex(
+                    cursor.get("message_id_hex"),
+                    "timeline cursor message_id_hex",
+                ),
+            }
+
+        return await self.request(
+            {
+                "type": "timeline_list",
+                "account_id_hex": _normalize_hex(account_id_hex, "account_id_hex"),
+                "group_id_hex": _normalize_hex(group_id_hex, "group_id_hex"),
+                "before": normalize_cursor(before),
+                "after": normalize_cursor(after),
+                "before_inclusive": bool(before_inclusive),
+                "limit": max(1, min(50, int(limit))),
+            }
+        )
 
     async def account_lookup_profile(self, account_id_hex: str) -> Dict[str, Any]:
         response = await self.request(
@@ -2794,6 +2855,26 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             if media_urls:
                 hermes_event.media_urls = media_urls
                 hermes_event.media_types = media_types
+            history_context = None
+            try:
+                history_page = await self.client.timeline_list(
+                    event["account_id_hex"],
+                    group_id_hex,
+                    before={
+                        "recorded_at": int(event.get("recorded_at") or 0),
+                        "message_id_hex": message_id_hex,
+                    },
+                    limit=20,
+                )
+                history_context = _timeline_channel_context(
+                    history_page.get("messages")
+                    if history_page.get("type") == "timeline_page"
+                    else None
+                )
+            except Exception:
+                logger.debug(
+                    "Marmot conversation history lookup failed; continuing without history"
+                )
             # Attach any buffered quiet ambient context (a deletion / group-state
             # change observed since the last turn) as channel_context. The runner
             # prepends channel_context to the trigger text as context without it
@@ -2806,6 +2887,7 @@ class MarmotPlatformAdapter(BasePlatformAdapter):
             contexts = [
                 context
                 for context in (
+                    history_context,
                     ambient_context,
                     _referenced_channel_context(reply),
                 )
@@ -3316,6 +3398,69 @@ def _delete_marmot_message_tool(args: Dict[str, Any]) -> str:
         return json.dumps({"ok": False, "error": str(exc)})
 
 
+def _marmot_history_tool(args: Dict[str, Any]) -> str:
+    group_id_hex = str(args.get("group_id_hex") or "").strip()
+    if not group_id_hex:
+        return json.dumps({"ok": False, "error": "group_id_hex required"})
+    message_id_hex = str(args.get("message_id_hex") or "").strip()
+    before_recorded_at = args.get("before_recorded_at")
+    before_message_id_hex = str(args.get("before_message_id_hex") or "").strip()
+    if (before_recorded_at is None) != (not before_message_id_hex):
+        return json.dumps(
+            {
+                "ok": False,
+                "error": (
+                    "before_recorded_at and before_message_id_hex "
+                    "must be supplied together"
+                ),
+            }
+        )
+
+    try:
+        from gateway.config import Platform
+        from gateway.run import _gateway_runner_ref
+        from model_tools import _run_async
+
+        runner = _gateway_runner_ref()
+        adapter = runner.adapters.get(Platform("marmot")) if runner is not None else None
+        if adapter is None:
+            return json.dumps(
+                {
+                    "ok": False,
+                    "error": "marmot_history requires a live Marmot adapter",
+                }
+            )
+        account_id_hex = _run_async(adapter._ensure_account_id())
+        if message_id_hex:
+            response = _run_async(
+                adapter.client.timeline_message_get(
+                    account_id_hex,
+                    group_id_hex,
+                    message_id_hex,
+                )
+            )
+        else:
+            before = (
+                {
+                    "recorded_at": before_recorded_at,
+                    "message_id_hex": before_message_id_hex,
+                }
+                if before_recorded_at is not None
+                else None
+            )
+            response = _run_async(
+                adapter.client.timeline_list(
+                    account_id_hex,
+                    group_id_hex,
+                    before=before,
+                    limit=max(1, min(50, int(args.get("limit") or 20))),
+                )
+            )
+        return json.dumps({"ok": True, **response})
+    except Exception as exc:
+        return json.dumps({"ok": False, "error": str(exc)})
+
+
 def register(ctx):
     """Hermes plugin entry point."""
     ctx.register_platform(
@@ -3334,7 +3479,8 @@ def register(ctx):
         platform_hint=(
             "You are chatting through Marmot, an end-to-end encrypted group "
             "messaging protocol. Chat ids are Marmot group ids and user ids "
-            "are Marmot account pubkeys."
+            "are Marmot account pubkeys. Use marmot_history with the current "
+            "chat id for exact durable message ids or older transcript pages."
         ),
         emoji="",
     )
@@ -3361,6 +3507,39 @@ def register(ctx):
                 "required": ["message_id"],
             },
             handler=_delete_marmot_message_tool,
+        )
+        register_tool(
+            name="marmot_history",
+            toolset="platform",
+            schema={
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "group_id_hex": {
+                        "type": "string",
+                        "description": "Marmot group id hex from the current conversation.",
+                    },
+                    "message_id_hex": {
+                        "type": "string",
+                        "description": "Optional exact durable message id to fetch.",
+                    },
+                    "before_recorded_at": {
+                        "type": "number",
+                        "description": "Optional Unix-time cursor for paging older messages.",
+                    },
+                    "before_message_id_hex": {
+                        "type": "string",
+                        "description": "Message id paired with before_recorded_at.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 50,
+                    },
+                },
+                "required": ["group_id_hex"],
+            },
+            handler=_marmot_history_tool,
         )
 
 

--- a/integrations/hermes/marmot/tests/test_adapter.py
+++ b/integrations/hermes/marmot/tests/test_adapter.py
@@ -265,6 +265,60 @@ class AgentControlClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("idempotency_key", requests[1])
         self.assertNotIn("idempotency_key", requests[2])
 
+    async def test_timeline_reads_write_exact_message_and_cursor_requests(self):
+        requests = []
+
+        async def handler(reader, writer):
+            request = await read_json_line(reader)
+            requests.append(request)
+            if request["type"] == "timeline_message_get":
+                response = {
+                    "type": "timeline_message",
+                    "account_id_hex": request["account_id_hex"],
+                    "group_id_hex": request["group_id_hex"],
+                    "message_id_hex": request["message_id_hex"],
+                    "message": None,
+                }
+            else:
+                response = {
+                    "type": "timeline_page",
+                    "account_id_hex": request["account_id_hex"],
+                    "group_id_hex": request["group_id_hex"],
+                    "messages": [],
+                    "has_more_before": False,
+                    "has_more_after": False,
+                }
+            await write_json_line(
+                writer,
+                {
+                    "marmot_agent_control": "marmot.agent-control.v2",
+                    "id": request["id"],
+                    **response,
+                },
+            )
+            writer.close()
+
+        await self.start_server(handler)
+        client = self.adapter.MarmotAgentControlClient(self.socket_path)
+        await client.timeline_message_get("11" * 32, "22" * 32, "33" * 32)
+        await client.timeline_list(
+            "11" * 32,
+            "22" * 32,
+            before={"recorded_at": 42, "message_id_hex": "44" * 32},
+            limit=500,
+        )
+
+        self.assertEqual(requests[0]["type"], "timeline_message_get")
+        self.assertEqual(requests[0]["message_id_hex"], "33" * 32)
+        self.assertEqual(requests[1]["type"], "timeline_list")
+        self.assertEqual(
+            requests[1]["before"],
+            {"recorded_at": 42, "message_id_hex": "44" * 32},
+        )
+        self.assertIsNone(requests[1]["after"])
+        self.assertFalse(requests[1]["before_inclusive"])
+        self.assertEqual(requests[1]["limit"], 50)
+
     async def test_stream_begin_includes_parent_message_id_only_when_supplied(self):
         requests = []
 
@@ -3202,6 +3256,34 @@ class ParityBehaviorTests(unittest.IsolatedAsyncioTestCase):
             async def inbound_events(self, account_id_hex=None, group_id_hex=None):
                 yield wire_event(event)
 
+            async def timeline_list(self, account_id_hex, group_id_hex, **kwargs):
+                return {
+                    "type": "timeline_page",
+                    "account_id_hex": account_id_hex,
+                    "group_id_hex": group_id_hex,
+                    "messages": [
+                        {
+                            "message_id_hex": "88" * 32,
+                            "sender": {
+                                "account_id_hex": "44" * 32,
+                                "display_name": "Alice",
+                                "is_self": False,
+                            },
+                            "direction": "received",
+                            "kind": 9,
+                            "recorded_at": 1_720_999_800,
+                            "observed_at": 1_720_999_801,
+                            "availability": "available",
+                            "text": "earlier question",
+                            "text_truncated": False,
+                            "attachments_truncated": False,
+                            "reactions_truncated": False,
+                        }
+                    ],
+                    "has_more_before": False,
+                    "has_more_after": False,
+                }
+
         adapter = self._adapter(FakeClient())
         await adapter._consume_inbound_once(drain=True)
 
@@ -3220,6 +3302,11 @@ class ParityBehaviorTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(delivered.reply_to_is_own_message)
         # The internal normalized shape retains the routing id as well.
         self.assertEqual(delivered.raw_message.get("reply_to_message_id_hex"), "99" * 32)
+        self.assertIn('"type":"chat_window"', delivered.channel_context)
+        self.assertIn('"message_id_hex":"' + ("88" * 32) + '"', delivered.channel_context)
+        self.assertIn('"type":"referenced_message"', delivered.channel_context)
+        self.assertIn('"text_excerpt":"earlier answer"', delivered.channel_context)
+        self.assertIn('"display_name":"Hermes Agent"', delivered.channel_context)
 
     async def test_inbound_falls_back_to_marmot_name_without_display_name(self):
         event = {
@@ -4384,6 +4471,82 @@ class ProfilePromptTests(unittest.TestCase):
         action, name, _ = self.adapter_module.parse_profile_name_reply("yes")
         self.assertEqual(action, "affirm")
         self.assertIsNone(name)
+
+
+class PluginRegistrationTests(unittest.TestCase):
+    def setUp(self):
+        self.adapter_module = load_adapter_module()
+
+    def test_register_exposes_marmot_history_as_a_platform_tool(self):
+        class FakeContext:
+            def __init__(self):
+                self.platforms = []
+                self.tools = []
+
+            def register_platform(self, **kwargs):
+                self.platforms.append(kwargs)
+
+            def register_tool(self, **kwargs):
+                self.tools.append(kwargs)
+
+        ctx = FakeContext()
+        self.adapter_module.register(ctx)
+
+        self.assertEqual([platform["name"] for platform in ctx.platforms], ["marmot"])
+        history = next(tool for tool in ctx.tools if tool["name"] == "marmot_history")
+        self.assertEqual(history["toolset"], "platform")
+        self.assertEqual(history["schema"]["required"], ["group_id_hex"])
+        self.assertIs(history["handler"], self.adapter_module._marmot_history_tool)
+
+    def test_marmot_history_fetches_one_exact_materialized_message(self):
+        calls = []
+
+        class FakeClient:
+            async def timeline_message_get(
+                self, account_id_hex, group_id_hex, message_id_hex
+            ):
+                calls.append((account_id_hex, group_id_hex, message_id_hex))
+                return {
+                    "type": "timeline_message",
+                    "message_id_hex": message_id_hex,
+                    "message": None,
+                }
+
+        class FakeAdapter:
+            client = FakeClient()
+
+            async def _ensure_account_id(self):
+                return "11" * 32
+
+        class AdapterMap:
+            def get(self, _platform):
+                return FakeAdapter()
+
+        gateway_run = types.ModuleType("gateway.run")
+        gateway_run._gateway_runner_ref = lambda: types.SimpleNamespace(
+            adapters=AdapterMap()
+        )
+        model_tools = types.ModuleType("model_tools")
+        model_tools._run_async = asyncio.run
+        sys.modules["gateway.run"] = gateway_run
+        sys.modules["model_tools"] = model_tools
+
+        try:
+            result = json.loads(
+                self.adapter_module._marmot_history_tool(
+                    {
+                        "group_id_hex": "22" * 32,
+                        "message_id_hex": "33" * 32,
+                    }
+                )
+            )
+        finally:
+            sys.modules.pop("gateway.run", None)
+            sys.modules.pop("model_tools", None)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["type"], "timeline_message")
+        self.assertEqual(calls, [("11" * 32, "22" * 32, "33" * 32)])
 
 
 class KeyedAsyncQueueDepthTests(unittest.IsolatedAsyncioTestCase):

--- a/integrations/hermes/marmot/tests/test_rich_context_golden.py
+++ b/integrations/hermes/marmot/tests/test_rich_context_golden.py
@@ -27,7 +27,8 @@ class RichContextGoldenTests(unittest.TestCase):
             and event["reply_to"]["availability"] == "available"
         )
         quoted_context = adapter._referenced_channel_context(available_reply)
-        self.assertIn('"type":"quoted_attachments"', quoted_context)
+        self.assertIn('"type":"referenced_message"', quoted_context)
+        self.assertIn('"text_excerpt":', quoted_context)
         self.assertIn('"file_name":"diagram.png"', quoted_context)
 
         mutations = [

--- a/integrations/openclaw/marmot/README.md
+++ b/integrations/openclaw/marmot/README.md
@@ -11,6 +11,16 @@ local Unix socket. It never opens a QUIC connection, encrypts a record, or talks
 to a relay — all of that stays in `wn-agent`. It is the OpenClaw counterpart of
 the Python Hermes plugin in [`../../hermes/marmot/`](../../hermes/marmot).
 
+For each activated inbound turn, the plugin asks `wn-agent` for a bounded recent
+materialized chat window and supplies it to OpenClaw with durable message ids,
+senders, timestamps, reply links, current reaction summaries, and
+delete/invalidation state. Reply context is supplied through both OpenClaw's
+native quote fields and a complete structured referenced-message payload.
+The model-callable `marmot_history` tool can fetch one exact message id or page
+older messages using the returned `(recorded_at, message_id_hex)` cursor.
+History reads are best-effort for turn activation, so a temporary read failure
+does not suppress the new inbound message.
+
 - Pinned OpenClaw development SDK: **`openclaw@2026.7.1-2`**.
 - Toolchain: TypeScript, pnpm, Node ≥ 22.19, Vitest.
 

--- a/integrations/openclaw/marmot/index.ts
+++ b/integrations/openclaw/marmot/index.ts
@@ -4,10 +4,12 @@
 import { defineChannelPluginEntry } from "openclaw/plugin-sdk/channel-core";
 
 import { createMarmotChannelPlugin, MARMOT_CHANNEL_ID } from "./src/channel.js";
+import { registerMarmotHistoryTool } from "./src/history-tool.js";
 
 export default defineChannelPluginEntry({
   id: MARMOT_CHANNEL_ID,
   name: "Marmot",
   description: "End-to-end encrypted Marmot groups through the local wn-agent connector.",
   plugin: createMarmotChannelPlugin(),
+  registerFull: registerMarmotHistoryTool,
 });

--- a/integrations/openclaw/marmot/src/channel.ts
+++ b/integrations/openclaw/marmot/src/channel.ts
@@ -245,6 +245,7 @@ export function createMarmotChannelPlugin() {
         messageToolHints: () => [
           "- Marmot replies: to answer the current conversation, just write your reply as normal assistant text — it is delivered to the Marmot group automatically. You do not need the `message` tool to reply.",
           "- Marmot `message` targets: a Marmot conversation is addressed by its group id hex (optionally prefixed `marmot:`). There are no @handles or #channels.",
+          "- Marmot history: use `marmot_history` with the conversation group id when you need an exact durable message id, one referenced message, or an older transcript page.",
         ],
       },
       actions,

--- a/integrations/openclaw/marmot/src/client.ts
+++ b/integrations/openclaw/marmot/src/client.ts
@@ -176,6 +176,57 @@ export interface AgentControlReferencedMessage {
   attachments_truncated: boolean;
 }
 
+export interface AgentControlTimelineCursor {
+  recorded_at: number;
+  message_id_hex: string;
+}
+
+export type AgentControlTimelineMessageAvailability =
+  | "available"
+  | "deleted"
+  | "invalidated";
+
+export interface AgentControlTimelineReaction {
+  reaction_message_id_hex: string;
+  actor: AgentControlActor;
+  emoji: string;
+  reacted_at: number;
+}
+
+export interface AgentControlTimelineMessage {
+  message_id_hex: string;
+  sender: AgentControlActor;
+  direction: string;
+  kind: number;
+  recorded_at: number;
+  observed_at: number;
+  availability: AgentControlTimelineMessageAvailability;
+  text?: string | null;
+  text_truncated: boolean;
+  reply_to_message_id_hex?: string | null;
+  attachments?: AgentControlAttachmentSummary[];
+  attachments_truncated: boolean;
+  reactions?: AgentControlTimelineReaction[];
+  reactions_truncated: boolean;
+}
+
+export interface TimelineMessageResponse {
+  type: "timeline_message";
+  account_id_hex: string;
+  group_id_hex: string;
+  message_id_hex: string;
+  message?: AgentControlTimelineMessage | null;
+}
+
+export interface TimelinePageResponse {
+  type: "timeline_page";
+  account_id_hex: string;
+  group_id_hex: string;
+  messages: AgentControlTimelineMessage[];
+  has_more_before: boolean;
+  has_more_after: boolean;
+}
+
 export interface MediaDownloadedResponse {
   type: "media_downloaded";
   /** Host-local path on the `wn-agent` machine where the plaintext was written. */
@@ -445,6 +496,52 @@ export class MarmotAgentControlClient {
 
   async accountList(): Promise<AccountListResponse> {
     return (await this.request({ type: "account_list" })) as unknown as AccountListResponse;
+  }
+
+  async timelineMessageGet(
+    accountIdHex: string,
+    groupIdHex: string,
+    messageIdHex: string,
+  ): Promise<TimelineMessageResponse> {
+    return (await this.request({
+      type: "timeline_message_get",
+      account_id_hex: normalizeHex(accountIdHex, "account_id_hex"),
+      group_id_hex: normalizeHex(groupIdHex, "group_id_hex"),
+      message_id_hex: normalizeHex(messageIdHex, "message_id_hex"),
+    })) as unknown as TimelineMessageResponse;
+  }
+
+  async timelineList(
+    accountIdHex: string,
+    groupIdHex: string,
+    options: {
+      before?: AgentControlTimelineCursor | null;
+      after?: AgentControlTimelineCursor | null;
+      beforeInclusive?: boolean;
+      limit?: number;
+    } = {},
+  ): Promise<TimelinePageResponse> {
+    const normalizeCursor = (
+      cursor: AgentControlTimelineCursor | null | undefined,
+    ): AgentControlTimelineCursor | undefined =>
+      cursor
+        ? {
+            recorded_at: Math.max(0, Math.trunc(cursor.recorded_at)),
+            message_id_hex: normalizeHex(cursor.message_id_hex, "timeline cursor message_id_hex"),
+          }
+        : undefined;
+    return (await this.request({
+      type: "timeline_list",
+      account_id_hex: normalizeHex(accountIdHex, "account_id_hex"),
+      group_id_hex: normalizeHex(groupIdHex, "group_id_hex"),
+      before: normalizeCursor(options.before),
+      after: normalizeCursor(options.after),
+      before_inclusive: options.beforeInclusive === true,
+      limit:
+        options.limit === undefined
+          ? undefined
+          : Math.max(1, Math.min(50, Math.trunc(options.limit))),
+    })) as unknown as TimelinePageResponse;
   }
 
   async accountLookupProfile(accountIdHex: string): Promise<{

--- a/integrations/openclaw/marmot/src/dispatch.ts
+++ b/integrations/openclaw/marmot/src/dispatch.ts
@@ -21,7 +21,10 @@ import {
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 
-import type { MarmotAgentControlClient } from "./client.js";
+import type {
+  AgentControlTimelineMessage,
+  MarmotAgentControlClient,
+} from "./client.js";
 import type { GroupActivation } from "./config.js";
 import type { MarmotInboundMessage } from "./inbound.js";
 import { DEFAULT_MARMOT_CHANNEL_ACCOUNT_ID } from "./runtime-state.js";
@@ -76,7 +79,10 @@ export interface OpenClawChannelRuntime {
  * Dispatcher client: the group-info read used for activation gating and the
  * media download used to surface inbound images to the agent.
  */
-export type MarmotDispatchClient = Pick<MarmotAgentControlClient, "groupInfo" | "downloadMedia">;
+export type MarmotDispatchClient = Pick<
+  MarmotAgentControlClient,
+  "groupInfo" | "downloadMedia" | "timelineList"
+>;
 
 export interface MarmotDispatchDeps {
   /** Full OpenClaw config (`api.config`). */
@@ -233,7 +239,10 @@ function replyFallbackBody(availability: string): string {
  * native, explicitly-untrusted supplemental context. None of this data enters a
  * system prompt, and ambient events never invoke this dispatcher themselves.
  */
-function inboundSupplemental(message: MarmotInboundMessage) {
+function inboundSupplemental(
+  message: MarmotInboundMessage,
+  history: AgentControlTimelineMessage[] = [],
+) {
   const reply = message.replyTo;
   const untrustedContext: Array<{
     label: string;
@@ -247,10 +256,26 @@ function inboundSupplemental(message: MarmotInboundMessage) {
       source: "marmot",
       type: "referenced_message",
       payload: {
+        message_id_hex: reply.message_id_hex,
         availability: reply.availability,
+        sender: reply.sender,
+        recorded_at: reply.recorded_at,
+        text_excerpt: reply.text_excerpt,
         attachments: reply.attachments ?? [],
         attachments_truncated: reply.attachments_truncated,
         text_truncated: reply.text_truncated,
+      },
+    });
+  }
+  if (history.length > 0) {
+    untrustedContext.push({
+      label: "Marmot conversation history",
+      source: "marmot",
+      type: "chat_window",
+      payload: {
+        order: "chronological",
+        relation: "before_current_message",
+        messages: history,
       },
     });
   }
@@ -377,9 +402,26 @@ export function createMarmotInboundDispatcher(
     // local path (wn-agent decrypts; the content key never leaves it) and hand
     // the local file facts to OpenClaw, which reads + base64-encodes them.
     const media = await downloadInboundMedia(deps.client, message, deps.log);
-    const supplemental = inboundSupplemental(message);
+    let history: AgentControlTimelineMessage[] = [];
+    try {
+      const page = await deps.client.timelineList(
+        message.accountIdHex,
+        message.groupIdHex,
+        {
+          before: {
+            recorded_at: message.recordedAt ?? 0,
+            message_id_hex: message.messageIdHex,
+          },
+          limit: 20,
+        },
+      );
+      history = page.messages;
+    } catch {
+      deps.log?.("marmot: conversation history lookup failed; continuing without history");
+    }
+    const supplemental = inboundSupplemental(message, history);
 
-    const ctxPayload = buildChannelInboundEventContext({
+    const ctxPayload = await buildChannelInboundEventContext({
       channel: "marmot",
       accountId: channelAccountId,
       messageId: message.messageIdHex,
@@ -402,6 +444,8 @@ export function createMarmotInboundDispatcher(
       message: { rawBody: message.text, bodyForAgent: message.text },
       ...(media ? { media } : {}),
       ...(supplemental ? { supplemental } : {}),
+      resolveSupplementalMedia: true,
+      suppressSelfQuoteBody: false,
     });
 
     const storePath = deps.runtimeChannel.session.resolveStorePath();

--- a/integrations/openclaw/marmot/src/history-tool.ts
+++ b/integrations/openclaw/marmot/src/history-tool.ts
@@ -1,0 +1,130 @@
+import type {
+  OpenClawPluginApi,
+  OpenClawPluginToolContext,
+} from "openclaw/plugin-sdk/core";
+
+import { resolveSingleAccount } from "./account.js";
+import { resolveMarmotChannelAccount } from "./channel.js";
+import { clientForAccount } from "./config.js";
+
+type HistoryToolArgs = {
+  group_id_hex?: string;
+  message_id_hex?: string;
+  before_recorded_at?: number;
+  before_message_id_hex?: string;
+  limit?: number;
+};
+
+function textResult(details: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(details) }],
+    details,
+  };
+}
+
+export function createMarmotHistoryTool(
+  ctx: OpenClawPluginToolContext,
+  fallbackConfig: unknown,
+) {
+  const cfg =
+    ctx.getRuntimeConfig?.() ??
+    ctx.runtimeConfig ??
+    ctx.config ??
+    fallbackConfig;
+  const deliveryAccountId =
+    ctx.deliveryContext?.channel === "marmot"
+      ? ctx.deliveryContext.accountId
+      : undefined;
+  const resolved = resolveMarmotChannelAccount(
+    cfg as Parameters<typeof resolveMarmotChannelAccount>[0],
+    deliveryAccountId ?? ctx.agentAccountId ?? null,
+  );
+  const client = clientForAccount(resolved);
+
+  return {
+    name: "marmot_history",
+    label: "Marmot History",
+    description:
+      "Read authoritative Marmot conversation history with durable message ids. " +
+      "Use message_id_hex for one message, or page older messages with a before cursor.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        group_id_hex: {
+          type: "string",
+          description: "Marmot group id hex from the current conversation metadata.",
+        },
+        message_id_hex: {
+          type: "string",
+          description: "Optional exact Marmot message id hex to fetch.",
+        },
+        before_recorded_at: {
+          type: "number",
+          description: "Optional timeline cursor Unix time for paging older messages.",
+        },
+        before_message_id_hex: {
+          type: "string",
+          description: "Message id paired with before_recorded_at.",
+        },
+        limit: {
+          type: "number",
+          minimum: 1,
+          maximum: 50,
+          description: "Maximum messages to return (default 20, maximum 50).",
+        },
+      },
+      required: ["group_id_hex"],
+    },
+    async execute(_toolCallId: string, rawArgs: HistoryToolArgs) {
+      const groupIdHex = String(rawArgs.group_id_hex ?? "").trim();
+      if (!groupIdHex) {
+        return textResult({ ok: false, error: "group_id_hex required" });
+      }
+      const accountIdHex =
+        resolved.marmotAccountIdHex ?? (await resolveSingleAccount(client));
+      const messageIdHex = String(rawArgs.message_id_hex ?? "").trim();
+      if (messageIdHex) {
+        const response = await client.timelineMessageGet(
+          accountIdHex,
+          groupIdHex,
+          messageIdHex,
+        );
+        return textResult({ ok: true, ...response });
+      }
+      const beforeRecordedAt = rawArgs.before_recorded_at;
+      const beforeMessageIdHex = String(
+        rawArgs.before_message_id_hex ?? "",
+      ).trim();
+      if (
+        (beforeRecordedAt === undefined) !==
+        (beforeMessageIdHex.length === 0)
+      ) {
+        return textResult({
+          ok: false,
+          error:
+            "before_recorded_at and before_message_id_hex must be supplied together",
+        });
+      }
+      const response = await client.timelineList(accountIdHex, groupIdHex, {
+        ...(beforeRecordedAt !== undefined
+          ? {
+              before: {
+                recorded_at: beforeRecordedAt,
+                message_id_hex: beforeMessageIdHex,
+              },
+            }
+          : {}),
+        limit: rawArgs.limit,
+      });
+      return textResult({ ok: true, ...response });
+    },
+  };
+}
+
+export function registerMarmotHistoryTool(api: OpenClawPluginApi): void {
+  api.registerTool(
+    (ctx) => createMarmotHistoryTool(ctx, api.config) as never,
+    { name: "marmot_history" },
+  );
+}

--- a/integrations/openclaw/marmot/test/client.test.ts
+++ b/integrations/openclaw/marmot/test/client.test.ts
@@ -28,6 +28,39 @@ function handleRequest(socket: Socket, req: Record<string, unknown>): void {
         accounts: [{ account_id_hex: HEX32("aa"), label: "agent", local_signing: true }],
       });
       break;
+    case "timeline_message_get":
+      send(socket, id, {
+        type: "timeline_message",
+        account_id_hex: req.account_id_hex,
+        group_id_hex: req.group_id_hex,
+        message_id_hex: req.message_id_hex,
+        message: {
+          message_id_hex: req.message_id_hex,
+          sender: { account_id_hex: HEX32("bb"), is_self: false },
+          direction: "received",
+          kind: 9,
+          recorded_at: 10,
+          observed_at: 11,
+          availability: "available",
+          text: "earlier",
+          text_truncated: false,
+          attachments_truncated: false,
+          reactions_truncated: false,
+        },
+      });
+      break;
+    case "timeline_list":
+      send(socket, id, {
+        type: "timeline_page",
+        account_id_hex: req.account_id_hex,
+        group_id_hex: req.group_id_hex,
+        messages: [],
+        has_more_before: true,
+        has_more_after: false,
+        echoed_before: req.before ?? null,
+        echoed_limit: req.limit,
+      });
+      break;
     case "account_profile_lookup":
       send(socket, id, {
         type: "profile_lookup",
@@ -189,6 +222,32 @@ describe("MarmotAgentControlClient", () => {
       status: "profile_found",
       retryable: false,
     });
+  });
+
+  it("fetches one durable timeline message and pages by stable cursor", async () => {
+    const one = await client.timelineMessageGet(
+      HEX32("aa"),
+      HEX32("cc"),
+      HEX32("dd"),
+    );
+    expect(one.message).toMatchObject({
+      message_id_hex: HEX32("dd"),
+      text: "earlier",
+      availability: "available",
+    });
+
+    const page = (await client.timelineList(HEX32("aa"), HEX32("cc"), {
+      before: { recorded_at: 10, message_id_hex: HEX32("dd") },
+      limit: 500,
+    })) as unknown as {
+      echoed_before: { recorded_at: number; message_id_hex: string };
+      echoed_limit: number;
+    };
+    expect(page.echoed_before).toEqual({
+      recorded_at: 10,
+      message_id_hex: HEX32("dd"),
+    });
+    expect(page.echoed_limit).toBe(50);
   });
 
   it("returns durable message ids from send_final", async () => {

--- a/integrations/openclaw/marmot/test/dispatch.test.ts
+++ b/integrations/openclaw/marmot/test/dispatch.test.ts
@@ -79,7 +79,7 @@ function emptyCalls(): Calls {
 
 function stubClient(
   calls: Calls,
-  opts: { isDirect?: boolean } = {},
+  opts: { isDirect?: boolean; history?: unknown[] } = {},
 ): MarmotDispatchClient {
   return {
     async sendFinal(_account: string, _group: string, text: string, replyTo?: string | null) {
@@ -94,6 +94,16 @@ function stubClient(
         member_count: opts.isDirect ? 2 : 5,
         is_direct: opts.isDirect ?? false,
         subject: null,
+      };
+    },
+    async timelineList(accountIdHex: string, groupIdHex: string) {
+      return {
+        type: "timeline_page",
+        account_id_hex: accountIdHex,
+        group_id_hex: groupIdHex,
+        messages: opts.history ?? [],
+        has_more_before: false,
+        has_more_after: false,
       };
     },
   } as unknown as MarmotDispatchClient;
@@ -201,7 +211,30 @@ describe("createMarmotInboundDispatcher", () => {
     const dispatch = createMarmotInboundDispatcher({
       cfg: {},
       runtimeChannel,
-      client: stubClient(emptyCalls()) as unknown as MarmotDispatchClient,
+      client: stubClient(emptyCalls(), {
+        history: [
+          {
+            message_id_hex: HEX32("10"),
+            sender: {
+              account_id_hex: HEX32("bb"),
+              display_name: "Alice",
+              is_self: false,
+            },
+            direction: "received",
+            kind: 9,
+            recorded_at: 1_720_999_800,
+            observed_at: 1_720_999_801,
+            availability: "available",
+            text: "earlier question",
+            text_truncated: false,
+            reply_to_message_id_hex: null,
+            attachments: [],
+            attachments_truncated: false,
+            reactions: [],
+            reactions_truncated: false,
+          },
+        ],
+      }) as unknown as MarmotDispatchClient,
       channelAccountId: "default",
       groupActivation: "always",
       mentionPatterns: [],
@@ -254,9 +287,10 @@ describe("createMarmotInboundDispatcher", () => {
       ],
     });
 
-    const context = buildCtxMock.mock.calls.at(-1)?.[0] as {
+    const context = buildCtxMock.mock.calls.at(-1)?.[0] as unknown as {
       timestamp: number;
       reply: { replyToId: string };
+      suppressSelfQuoteBody: boolean;
       supplemental: {
         quote: {
           id: string;
@@ -270,6 +304,7 @@ describe("createMarmotInboundDispatcher", () => {
     };
     expect(context.timestamp).toBe(1_721_000_000_000);
     expect(context.reply.replyToId).toBe(HEX32("11"));
+    expect(context.suppressSelfQuoteBody).toBe(false);
     expect(context.supplemental.quote).toEqual({
       id: HEX32("11"),
       body: "quoted body",
@@ -281,7 +316,23 @@ describe("createMarmotInboundDispatcher", () => {
       expect.objectContaining({
         type: "referenced_message",
         payload: expect.objectContaining({
+          message_id_hex: HEX32("11"),
+          sender: expect.objectContaining({ account_id_hex: HEX32("aa") }),
+          text_excerpt: "quoted body",
           attachments: [{ media_type: "image/png", file_name: "quote.png" }],
+        }),
+      }),
+      expect.objectContaining({
+        type: "chat_window",
+        payload: expect.objectContaining({
+          relation: "before_current_message",
+          messages: [
+            expect.objectContaining({
+              message_id_hex: HEX32("10"),
+              sender: expect.objectContaining({ display_name: "Alice" }),
+              text: "earlier question",
+            }),
+          ],
         }),
       }),
       expect.objectContaining({ type: "reaction_added" }),

--- a/integrations/openclaw/marmot/test/history-tool.test.ts
+++ b/integrations/openclaw/marmot/test/history-tool.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  timelineMessageGet: vi.fn(),
+  timelineList: vi.fn(),
+  resolveMarmotChannelAccount: vi.fn(() => ({
+    accountId: "named",
+    marmotAccountIdHex: "11".repeat(32),
+  })),
+}));
+
+vi.mock("../src/account.js", () => ({
+  resolveSingleAccount: vi.fn(),
+}));
+vi.mock("../src/channel.js", () => ({
+  resolveMarmotChannelAccount: mocks.resolveMarmotChannelAccount,
+}));
+vi.mock("../src/config.js", () => ({
+  clientForAccount: () => ({
+    timelineMessageGet: mocks.timelineMessageGet,
+    timelineList: mocks.timelineList,
+  }),
+}));
+
+import {
+  createMarmotHistoryTool,
+  registerMarmotHistoryTool,
+} from "../src/history-tool.js";
+
+describe("marmot_history tool registration", () => {
+  it("registers one model-callable history tool during full plugin registration", () => {
+    const registerTool = vi.fn();
+    registerMarmotHistoryTool({
+      config: {},
+      registerTool,
+    } as never);
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    const [factory, options] = registerTool.mock.calls[0]!;
+    expect(typeof factory).toBe("function");
+    expect(options).toEqual({ name: "marmot_history" });
+  });
+
+  it("uses the active Marmot delivery account and fetches one exact message", async () => {
+    mocks.timelineMessageGet.mockResolvedValueOnce({
+      type: "timeline_message",
+      message_id_hex: "22".repeat(32),
+      message: null,
+    });
+    const tool = createMarmotHistoryTool(
+      {
+        config: {},
+        agentAccountId: "wrong-agent-account",
+        deliveryContext: { channel: "marmot", accountId: "named" },
+      } as never,
+      {},
+    );
+    const result = await tool.execute("call-1", {
+      group_id_hex: "33".repeat(32),
+      message_id_hex: "22".repeat(32),
+    });
+
+    expect(mocks.resolveMarmotChannelAccount).toHaveBeenCalledWith({}, "named");
+    expect(mocks.timelineMessageGet).toHaveBeenCalledWith(
+      "11".repeat(32),
+      "33".repeat(32),
+      "22".repeat(32),
+    );
+    expect(result.details).toEqual(
+      expect.objectContaining({ ok: true, type: "timeline_message" }),
+    );
+  });
+
+  it("pages older messages with a paired stable cursor", async () => {
+    mocks.timelineList.mockResolvedValueOnce({
+      type: "timeline_page",
+      messages: [],
+      has_more_before: false,
+      has_more_after: false,
+    });
+    const tool = createMarmotHistoryTool({ config: {} } as never, {});
+    await tool.execute("call-2", {
+      group_id_hex: "33".repeat(32),
+      before_recorded_at: 42,
+      before_message_id_hex: "44".repeat(32),
+      limit: 20,
+    });
+
+    expect(mocks.timelineList).toHaveBeenCalledWith(
+      "11".repeat(32),
+      "33".repeat(32),
+      {
+        before: {
+          recorded_at: 42,
+          message_id_hex: "44".repeat(32),
+        },
+        limit: 20,
+      },
+    );
+  });
+});

--- a/integrations/openclaw/marmot/test/reply-context-sdk.test.ts
+++ b/integrations/openclaw/marmot/test/reply-context-sdk.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+
+const HEX32 = (byte: string) => byte.repeat(32);
+
+describe("pinned OpenClaw reply context", () => {
+  it("keeps a self-authored quote body when the channel explicitly opts in", async () => {
+    const context = await buildChannelInboundEventContext({
+      channel: "marmot",
+      accountId: "default",
+      messageId: HEX32("dd"),
+      timestamp: 1_721_000_000_000,
+      from: HEX32("bb"),
+      sender: { id: HEX32("bb"), name: "Alice" },
+      conversation: { kind: "group", id: HEX32("cc") },
+      route: {
+        agentId: "agent",
+        accountId: "default",
+        routeSessionKey: "agent:marmot",
+      },
+      reply: { to: HEX32("cc"), replyToId: HEX32("11") },
+      message: { rawBody: "new message", bodyForAgent: "new message" },
+      supplemental: {
+        quote: {
+          id: HEX32("11"),
+          body: "quoted body",
+          sender: "Marmot Agent",
+          isQuote: true,
+          isSelf: true,
+        },
+      },
+      resolveSupplementalMedia: true,
+      suppressSelfQuoteBody: false,
+    });
+
+    expect(context.ReplyToId).toBe(HEX32("11"));
+    expect(context.ReplyToBody).toBe("quoted body");
+    expect(context.ReplyToSender).toBe("Marmot Agent");
+  });
+});

--- a/integrations/opencode/marmot/src/control.rs
+++ b/integrations/opencode/marmot/src/control.rs
@@ -299,6 +299,8 @@ fn response_name(response: &AgentControlResponse) -> &'static str {
         AgentControlResponse::Ack => "ack",
         AgentControlResponse::Error { .. } => "error",
         AgentControlResponse::AccountList { .. } => "account_list",
+        AgentControlResponse::TimelineMessage { .. } => "timeline_message",
+        AgentControlResponse::TimelinePage { .. } => "timeline_page",
         AgentControlResponse::AccountCreated { .. } => "account_created",
         AgentControlResponse::KeyPackagePublished { .. } => "key_package_published",
         AgentControlResponse::ProfilePublished { .. } => "profile_published",


### PR DESCRIPTION
## Summary

- add exact-message and stable cursor-paginated materialized timeline reads to `marmot.agent-control.v2`
- project bounded, privacy-aware timeline DTOs through `wn-agent`, including sender identity, timestamps, reply links, attachments, current reactions, and durable message ids
- attach complete referenced-message context and a recent canonical chat window to activated OpenClaw and Hermes turns
- add model-callable `marmot_history` tools to both integrations for exact lookup and older transcript pages
- document the history/recovery contract and keep the OpenCode harness exhaustive over the additive response variants

## Root cause

`wn-agent` already hydrated reply targets, but OpenClaw split that information between native quote fields and an incomplete untrusted payload. The pinned OpenClaw SDK also suppresses the body of self-authored quotes by default, producing the observed state where the reply id and `availability: available` survived but text and sender context did not reach the model reliably.

Hermes preserved more fields in its adapter object, but its prompt-facing context did not retain the full durable message identity and author metadata. More broadly, neither integration had an authoritative, on-demand transcript API; the inbound event stream was being asked to serve as both notification transport and history.

## Behavior and compatibility

Timeline reads use the current materialized user-visible projection rather than replaying raw events, so edits and current reactions are reflected. Deleted and invalidated rows retain identity and attribution while plaintext and attachment metadata remain redacted. Text, attachments, reactions, page size, and total response size are bounded.

This is additive at the wire and storage layers and requires no database migration or capability negotiation. `wn-agent` and its connectors are expected to ship together. Automatic history lookup is best-effort and never suppresses the current inbound turn if it fails.

## Validation

- `just fast-ci`
- `cargo test -p agent-control -p agent-connector --no-fail-fast`
- `cargo test -p agent-control -p agent-connector -p storage-sqlite timeline --no-fail-fast`
- OpenClaw: `pnpm typecheck && pnpm test` — 199 passed, 1 skipped
- Hermes: `python3 -m unittest discover -s integrations/hermes/marmot/tests -p 'test_*.py'` — 163 passed
- `cargo test -p wn-opencode` — 49 passed, process-spawning E2E ignored