### PR TITLE
Fix orphaned Keychain account import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3192,6 +3192,7 @@ dependencies = [
  "hex",
  "hkdf 0.12.4",
  "image",
+ "keyring-core",
  "marmot-account",
  "marmot-forensics",
  "marmot-markdown",

--- a/crates/marmot-account/src/home.rs
+++ b/crates/marmot-account/src/home.rs
@@ -84,6 +84,23 @@ pub struct AccountSummary {
     pub signed_out: bool,
 }
 
+/// Provenance for a strict Nostr private-key import used by account setup.
+///
+/// A live account record is never treated as idempotent by this flow. The
+/// only reusable state is an exact account-id-keyed signing credential whose
+/// filesystem account record is absent.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NostrAccountImport {
+    account: AccountSummary,
+    reused_account_id_credential: bool,
+}
+
+impl NostrAccountImport {
+    pub fn account(&self) -> &AccountSummary {
+        &self.account
+    }
+}
+
 impl AccountSummary {
     pub fn can_sign(&self) -> bool {
         self.local_signing || self.external_signing
@@ -235,6 +252,65 @@ impl AccountHome {
         let keys =
             nostr::Keys::parse(secret_key).map_err(|_| AccountHomeError::InvalidSecretKey)?;
         self.write_signing_account(&keys)
+    }
+
+    /// Import a Nostr private key for runtime account setup, recovering only an
+    /// exact orphaned account-id-keyed credential.
+    ///
+    /// Existing account records remain duplicates and are rejected. This is
+    /// narrower than [`Self::import_account_idempotent`]: it exists for
+    /// uninstall/reinstall recovery where an app's filesystem home was removed
+    /// while its Keychain entry survived.
+    pub fn import_nostr_account_idempotent(
+        &self,
+        secret_key: &str,
+    ) -> AccountHomeResult<NostrAccountImport> {
+        let keys =
+            nostr::Keys::parse(secret_key).map_err(|_| AccountHomeError::InvalidSecretKey)?;
+        let account_id_hex = keys.public_key().to_hex();
+        let _guard = self
+            .mutation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        validate_account_label(&account_id_hex)?;
+
+        if self.account_record_path(&account_id_hex).exists()
+            || self.secret_store.has_secret_for_label(&account_id_hex)?
+        {
+            return Err(AccountHomeError::AccountExists(account_id_hex));
+        }
+        if self
+            .accounts()?
+            .iter()
+            .any(|account| account.local_signing && account.account_id_hex == account_id_hex)
+        {
+            return Err(AccountHomeError::AccountIdInUse(account_id_hex));
+        }
+
+        let account = AccountSummary {
+            label: account_id_hex.clone(),
+            account_id_hex,
+            local_signing: true,
+            external_signing: false,
+            signed_out: false,
+        };
+        let reused_account_id_credential = self
+            .secret_store
+            .has_secret_for_account_id(&account.account_id_hex)?;
+        if reused_account_id_credential {
+            let stored_keys = self.secret_store.load_secret(&account)?;
+            if stored_keys.public_key() != keys.public_key() {
+                return Err(AccountHomeError::AccountIdMismatch);
+            }
+            self.write_account_record(&account)?;
+        } else {
+            self.write_new_signing_account(&account, &keys)?;
+        }
+
+        Ok(NostrAccountImport {
+            account,
+            reused_account_id_credential,
+        })
     }
 
     pub fn add_public_account(&self, public_key: &str) -> AccountHomeResult<AccountSummary> {
@@ -410,6 +486,32 @@ impl AccountHome {
     /// live account, so the call still reports success rather than a forbidden
     /// partial-live state.
     pub fn remove_account(&self, account_ref: &str) -> AccountHomeResult<()> {
+        self.remove_account_inner(account_ref, None, false)
+    }
+
+    /// Roll back a runtime setup import using the provenance captured when the
+    /// account record was created.
+    ///
+    /// If the import recovered an account-id-keyed credential, the filesystem
+    /// account state is removed while that pre-existing credential is retained.
+    /// Newly created credentials are removed with the account as usual.
+    pub fn rollback_nostr_account_import(
+        &self,
+        imported: &NostrAccountImport,
+    ) -> AccountHomeResult<()> {
+        self.remove_account_inner(
+            &imported.account.label,
+            Some(&imported.account),
+            imported.reused_account_id_credential,
+        )
+    }
+
+    fn remove_account_inner(
+        &self,
+        account_ref: &str,
+        expected: Option<&AccountSummary>,
+        preserve_account_id_credential: bool,
+    ) -> AccountHomeResult<()> {
         // Hold the mutation lock across the shared-credential check and
         // the matching `remove_secret` call so two concurrent removals on
         // twin records cannot both observe the other as still present,
@@ -420,6 +522,23 @@ impl AccountHome {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let account = self.account(account_ref)?;
+        if expected.is_some_and(|expected| expected != &account) {
+            return Err(AccountHomeError::AccountExists(account.label));
+        }
+        if preserve_account_id_credential {
+            if !self
+                .secret_store
+                .has_secret_for_account_id(&account.account_id_hex)?
+            {
+                return Err(AccountHomeError::SecretNotFound(
+                    account.account_id_hex.clone(),
+                ));
+            }
+            let stored_keys = self.secret_store.load_secret(&account)?;
+            if stored_keys.public_key().to_hex() != account.account_id_hex {
+                return Err(AccountHomeError::AccountIdMismatch);
+            }
+        }
 
         // Commit point: atomically move the live account directory into the
         // tombstone namespace. After this returns Ok the account is no longer a
@@ -434,7 +553,7 @@ impl AccountHome {
         // a no-op (NotFound -> Ok); the tombstoned secret file is scrubbed below
         // before recursive directory deletion. For the keychain store the entry
         // is independent of the directory and is removed here.
-        if !self.secret_shared_with_other_record(&account)? {
+        if !preserve_account_id_credential && !self.secret_shared_with_other_record(&account)? {
             self.secret_store.remove_secret(&account)?;
         }
 

--- a/crates/marmot-account/src/lib.rs
+++ b/crates/marmot-account/src/lib.rs
@@ -18,6 +18,7 @@ mod time;
 pub use error::{AccountError, AccountHomeError, AccountHomeResult, AccountResult};
 pub use home::{
     AccountHome, AccountSummary, DEFAULT_KEYCHAIN_SERVICE_NAME, EXTERNAL_SQLCIPHER_SECRET_FILE,
+    NostrAccountImport,
 };
 pub use key_package::{
     KeyPackagePublication, KeyPackagePublishError, KeyPackagePublishReceipt, KeyPackagePublisher,

--- a/crates/marmot-account/tests/home.rs
+++ b/crates/marmot-account/tests/home.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
-use std::sync::{Mutex, Once};
+use std::sync::{Arc, Mutex, Once};
 
 use marmot_account::{
     AccountHome, AccountHomeError, AccountHomeResult, AccountSecretStore, AccountSummary,
+    KeychainSecretStore,
 };
 use nostr::nips::nip19::FromBech32;
 use nostr::nips::nip49::{EncryptedSecretKey, KeySecurity};
@@ -442,6 +443,36 @@ fn account_home_idempotent_import_recovers_orphaned_keychain_credential() {
     assert_eq!(
         home.load_signing_keys("agent").unwrap().public_key(),
         keys.public_key()
+    );
+}
+
+#[test]
+fn account_home_runtime_import_does_not_capture_mismatched_keychain_credential() {
+    install_mock_keyring();
+    let dir = tempfile::tempdir().unwrap();
+    let requested_keys = nostr::Keys::generate();
+    let unrelated_keys = nostr::Keys::generate();
+    let account_id = requested_keys.public_key().to_hex();
+    let account = AccountSummary {
+        label: account_id.clone(),
+        account_id_hex: account_id.clone(),
+        local_signing: true,
+        external_signing: false,
+        signed_out: false,
+    };
+    let store =
+        KeychainSecretStore::new(format!("com.marmot.test.runtime-mismatch-{account_id}")).unwrap();
+    store.write_secret(&account, &unrelated_keys).unwrap();
+    let home = AccountHome::open_with_secret_store(dir.path(), Arc::new(store.clone()));
+
+    assert!(matches!(
+        home.import_nostr_account_idempotent(&requested_keys.secret_key().to_secret_hex()),
+        Err(AccountHomeError::AccountIdMismatch)
+    ));
+    assert!(home.accounts().unwrap().is_empty());
+    assert_eq!(
+        store.load_secret(&account).unwrap().public_key(),
+        unrelated_keys.public_key()
     );
 }
 

--- a/crates/marmot-app/Cargo.toml
+++ b/crates/marmot-app/Cargo.toml
@@ -54,5 +54,6 @@ url.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
+keyring-core.workspace = true
 nostr-relay-builder.workspace = true
 tempfile.workspace = true

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -11,7 +11,7 @@ use cgka_traits::agent_text_stream::AGENT_TEXT_STREAM_EXPORTER_CACHE_KEY;
 use cgka_traits::app_event::MarmotAppEvent as MarmotInnerEvent;
 use cgka_traits::engine::GroupEvent;
 use cgka_traits::{GroupId, SecretBytes, TransportEndpoint};
-use marmot_account::{AccountHome, AccountHomeError, AccountSummary};
+use marmot_account::{AccountHome, AccountHomeError, AccountSummary, NostrAccountImport};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, Notify, broadcast, mpsc, oneshot, watch};
 use tokio::task::{JoinHandle, JoinSet};
@@ -3518,9 +3518,9 @@ impl AccountManager {
         let imports_private_key = request.identity.as_deref().is_some_and(is_nostr_secret);
         let creates_new_private_key = request.identity.is_none();
         let directory_bootstrap_relays = directory_bootstrap_relays_for_setup(&request);
-        let mut account = match request.identity.as_deref() {
+        let (mut account, private_key_import) = match request.identity.as_deref() {
             Some(identity) => match self.signed_out_account_for_identity(identity)? {
-                Some(account) => account,
+                Some(account) => (account, None),
                 None => self.create_nostr_account(request.identity.clone())?,
             },
             None => self.create_nostr_account(None)?,
@@ -3559,7 +3559,11 @@ impl AccountManager {
             Ok(relay_lists) => relay_lists,
             Err(err) => {
                 if rollback_on_setup_failure {
-                    return self.rollback_account_after_setup_failure(&account.label, err);
+                    return self.rollback_import_after_setup_failure(
+                        &account,
+                        private_key_import.as_ref(),
+                        err,
+                    );
                 }
                 return Err(err);
             }
@@ -3574,7 +3578,11 @@ impl AccountManager {
                 Ok(profile) => Some(profile),
                 Err(err) => {
                     if rollback_on_setup_failure {
-                        return self.rollback_account_after_setup_failure(&account.label, err);
+                        return self.rollback_import_after_setup_failure(
+                            &account,
+                            private_key_import.as_ref(),
+                            err,
+                        );
                     }
                     return Err(err);
                 }
@@ -3589,7 +3597,11 @@ impl AccountManager {
                 Ok(bytes) => Some(bytes),
                 Err(err) => {
                     if rollback_on_setup_failure {
-                        return self.rollback_account_after_setup_failure(&account.label, err);
+                        return self.rollback_import_after_setup_failure(
+                            &account,
+                            private_key_import.as_ref(),
+                            err,
+                        );
                     }
                     return Err(err);
                 }
@@ -3967,14 +3979,18 @@ impl AccountManager {
         }
     }
 
-    fn create_nostr_account(&self, identity: Option<String>) -> Result<AccountSummary, AppError> {
+    fn create_nostr_account(
+        &self,
+        identity: Option<String>,
+    ) -> Result<(AccountSummary, Option<NostrAccountImport>), AppError> {
         let account_home = self.app.account_home();
         match identity {
             Some(value) if is_nostr_secret(&value) => {
-                Ok(account_home.import_nostr_account(&value)?)
+                let imported = account_home.import_nostr_account_idempotent(&value)?;
+                Ok((imported.account().clone(), Some(imported)))
             }
-            Some(value) => Ok(account_home.add_public_account(&value)?),
-            None => Ok(account_home.create_nostr_account()?),
+            Some(value) => Ok((account_home.add_public_account(&value)?, None)),
+            None => Ok((account_home.create_nostr_account()?, None)),
         }
     }
 
@@ -4013,6 +4029,29 @@ impl AccountManager {
         // inode. See `drop_account_caches` and mdk#220.
         self.app.drop_account_caches(account);
         match self.app.account_home().remove_account(account) {
+            Ok(()) => Err(source),
+            Err(rollback) => Err(AppError::RelayDirectory(format!(
+                "failed to roll back account after setup failure: {source}; rollback error: {rollback}"
+            ))),
+        }
+    }
+
+    fn rollback_import_after_setup_failure<T>(
+        &self,
+        account: &AccountSummary,
+        private_key_import: Option<&NostrAccountImport>,
+        source: AppError,
+    ) -> Result<T, AppError> {
+        let Some(imported) = private_key_import else {
+            return self.rollback_account_after_setup_failure(&account.label, source);
+        };
+
+        self.app.drop_account_caches(&account.label);
+        match self
+            .app
+            .account_home()
+            .rollback_nostr_account_import(imported)
+        {
             Ok(()) => Err(source),
             Err(rollback) => Err(AppError::RelayDirectory(format!(
                 "failed to roll back account after setup failure: {source}; rollback error: {rollback}"

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Once};
 
 use cgka_engine::account_identity_proof::ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE;
 use cgka_engine::key_package::key_package_metadata;
@@ -12,9 +12,9 @@ use cgka_traits::app_event::{
     STREAM_TAG,
 };
 use cgka_traits::engine::KeyPackage;
-use marmot_account::AccountHome;
+use marmot_account::{AccountHome, AccountHomeError, AccountSecretStore, KeychainSecretStore};
 use marmot_app::{
-    AccountRelayListBootstrap, AccountSetupRequest, AppMessageQuery, AuditDataMode,
+    AccountRelayListBootstrap, AccountSetupRequest, AppError, AppMessageQuery, AuditDataMode,
     AuditLogSettings, AuditLogTrackerConfig, AuditLogUploadSource, MarmotApp, MarmotAppConfig,
     MarmotAppEvent, MarmotAppRuntime, MediaAttachmentReference, MediaLocator,
     MediaUploadAttachmentRequest, MediaUploadRequest, MissingRelayListKind, NotificationWakeSource,
@@ -61,6 +61,16 @@ async fn mock_app(dir: &tempfile::TempDir) -> (MockRelay, MarmotApp, String) {
             .with_allow_loopback_relay_endpoints(true),
     );
     (relay, app, url)
+}
+
+fn install_mock_keyring() {
+    static KEYRING_INIT: Once = Once::new();
+    KEYRING_INIT.call_once(|| {
+        if keyring_core::get_default_store().is_none() {
+            let store = keyring_core::mock::Store::new().expect("create mock keyring store");
+            keyring_core::set_default_store(store);
+        }
+    });
 }
 
 #[derive(Debug)]
@@ -591,6 +601,185 @@ async fn import_with_stalled_discovery_endpoint_completes_within_the_advisory_ca
     .expect("import must not hang on a stalled discovery endpoint")
     .expect("import should succeed without the advisory preflight");
     assert!(imported.account.local_signing);
+}
+
+#[tokio::test]
+async fn app_runtime_private_key_import_recovers_orphaned_keychain_credential() {
+    use nostr::prelude::ToBech32;
+
+    install_mock_keyring();
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, url) = mock_relay().await;
+    let keys = Keys::generate();
+    let account_id = keys.public_key().to_hex();
+    let secret = keys.secret_key().to_bech32().unwrap();
+    let service_name = format!("com.marmot.test.runtime-orphan-{account_id}");
+    let setup = AccountSetupRequest {
+        identity: Some(secret),
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_missing_relay_lists: true,
+        ..AccountSetupRequest::default()
+    };
+    let config = MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true);
+
+    let first_home = AccountHome::open_with_keychain(dir.path(), service_name.clone()).unwrap();
+    let first_app = MarmotApp::with_relays_and_account_home_and_config(
+        dir.path(),
+        vec![url.clone()],
+        first_home,
+        config.clone(),
+    );
+    let first_runtime = MarmotAppRuntime::new(first_app.clone());
+    let first = first_runtime
+        .create_or_import_account(setup.clone())
+        .await
+        .unwrap();
+    assert_eq!(first.account.account_id_hex, account_id);
+    assert!(matches!(
+        first_runtime
+            .create_or_import_account(setup.clone())
+            .await,
+        Err(AppError::AccountHome(AccountHomeError::AccountExists(
+            duplicate
+        ))) if duplicate == account_id
+    ));
+    first_runtime.shutdown().await;
+    drop(first_runtime);
+    drop(first_app);
+
+    std::fs::remove_dir_all(dir.path()).unwrap();
+    std::fs::create_dir_all(dir.path()).unwrap();
+
+    let recovered_home = AccountHome::open_with_keychain(dir.path(), service_name).unwrap();
+    let recovered_app = MarmotApp::with_relays_and_account_home_and_config(
+        dir.path(),
+        vec![url],
+        recovered_home.clone(),
+        config,
+    );
+    let recovered_runtime = MarmotAppRuntime::new(recovered_app.clone());
+    let recovered = recovered_runtime
+        .create_or_import_account(setup)
+        .await
+        .expect("runtime import should recover the matching orphaned Keychain credential");
+
+    assert_eq!(recovered.account.account_id_hex, account_id);
+    assert_eq!(
+        recovered_home.account(&account_id).unwrap(),
+        recovered.account
+    );
+    assert_eq!(
+        recovered_home
+            .load_signing_keys(&account_id)
+            .unwrap()
+            .public_key(),
+        keys.public_key()
+    );
+
+    recovered_runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn app_runtime_private_key_setup_rollback_preserves_only_recovered_keychain_secret() {
+    use nostr::prelude::ToBech32;
+
+    install_mock_keyring();
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, url) = mock_relay().await;
+    let recovered_keys = Keys::generate();
+    let recovered_account_id = recovered_keys.public_key().to_hex();
+    let recovered_secret = recovered_keys.secret_key().to_bech32().unwrap();
+    let recovered_service =
+        format!("com.marmot.test.runtime-rollback-recovered-{recovered_account_id}");
+    let config = MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true);
+    let successful_setup = AccountSetupRequest {
+        identity: Some(recovered_secret.clone()),
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_missing_relay_lists: true,
+        ..AccountSetupRequest::default()
+    };
+
+    let first_home =
+        AccountHome::open_with_keychain(dir.path(), recovered_service.clone()).unwrap();
+    let first_app = MarmotApp::with_relays_and_account_home_and_config(
+        dir.path(),
+        vec![url.clone()],
+        first_home,
+        config.clone(),
+    );
+    let first_runtime = MarmotAppRuntime::new(first_app.clone());
+    first_runtime
+        .create_or_import_account(successful_setup.clone())
+        .await
+        .unwrap();
+    first_runtime.shutdown().await;
+    drop(first_runtime);
+    drop(first_app);
+
+    std::fs::remove_dir_all(dir.path()).unwrap();
+    std::fs::create_dir_all(dir.path()).unwrap();
+
+    let recovered_home =
+        AccountHome::open_with_keychain(dir.path(), recovered_service.clone()).unwrap();
+    let recovered_app = MarmotApp::with_relays_and_account_home_and_config(
+        dir.path(),
+        vec![url.clone()],
+        recovered_home.clone(),
+        config.clone(),
+    );
+    let recovered_runtime = MarmotAppRuntime::new(recovered_app);
+    assert!(matches!(
+        recovered_runtime
+            .create_or_import_account(AccountSetupRequest {
+                identity: Some(recovered_secret),
+                ..AccountSetupRequest::default()
+            })
+            .await,
+        Err(AppError::MissingDefaultRelays)
+    ));
+    assert!(recovered_home.accounts().unwrap().is_empty());
+    assert!(
+        KeychainSecretStore::new(recovered_service)
+            .unwrap()
+            .has_secret_for_account_id(&recovered_account_id)
+            .unwrap(),
+        "rollback must retain the exact Keychain credential that predated setup"
+    );
+
+    let new_keys = Keys::generate();
+    let new_account_id = new_keys.public_key().to_hex();
+    let new_service = format!("com.marmot.test.runtime-rollback-new-{new_account_id}");
+    let new_dir = tempfile::tempdir().unwrap();
+    let new_home = AccountHome::open_with_keychain(new_dir.path(), new_service.clone()).unwrap();
+    let new_app = MarmotApp::with_relays_and_account_home_and_config(
+        new_dir.path(),
+        vec![url],
+        new_home.clone(),
+        config,
+    );
+    let new_runtime = MarmotAppRuntime::new(new_app);
+    assert!(matches!(
+        new_runtime
+            .create_or_import_account(AccountSetupRequest {
+                identity: Some(new_keys.secret_key().to_bech32().unwrap()),
+                ..AccountSetupRequest::default()
+            })
+            .await,
+        Err(AppError::MissingDefaultRelays)
+    ));
+    assert!(new_home.accounts().unwrap().is_empty());
+    assert!(
+        !KeychainSecretStore::new(new_service)
+            .unwrap()
+            .has_secret_for_account_id(&new_account_id)
+            .unwrap(),
+        "rollback must still delete a signing credential created by failed setup"
+    );
+
+    recovered_runtime.shutdown().await;
+    new_runtime.shutdown().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- recover a matching account-ID-keyed signing credential when private-key login finds no filesystem account record
- keep live-record and duplicate-account protections fail-closed, including verification that the stored credential matches the supplied nsec
- carry import provenance through runtime setup so rollback preserves a pre-existing Keychain credential while still deleting a newly created credential

## Root cause

iOS can remove the App Group account home during uninstall while retaining the signing credential in Keychain. The UniFFI-backed runtime login path continued to call the strict `import_nostr_account` path, so the surviving credential triggered `AccountIdInUse` before the account record could be recreated. The lower-level recovery behavior existed for repeatable installer bootstrap, but it was not wired into the production Marmot runtime path.

## Safety

The recovery path remains strict:

- any live account record is still a duplicate
- another local-signing record for the same account ID is still rejected
- an orphaned credential is loaded and matched to the imported nsec before recreating the record
- a mismatched credential remains untouched and returns `AccountIdMismatch`
- rollback revalidates the imported record and credential before preserving a secret that predates setup

Generated-key creation, signed-out reactivation, public-only identities, external signers, and normal duplicate imports retain their existing paths.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p marmot-app --test relay_runtime app_runtime_private_key -- --nocapture` — 2 passed
- `cargo test -p marmot-account` — 81 passed across the crate suites
- `cargo test -p marmot-app --lib register_external_signer_requires_matching_external_account` — 1 passed

The broader `cargo test -p marmot-app --test relay_runtime` run completed 76 tests and hit 5 unrelated failures in existing media/timeline tests. Each failure was reproduced individually on clean `master` at `b2919f15`, confirming they are baseline failures rather than regressions from this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added idempotent Nostr private-key account imports, including recovery of previously orphaned credentials.
  * Added rollback handling for failed account setup while preserving valid recovered credentials.
* **Bug Fixes**
  * Prevented mismatched stored credentials from being captured or overwritten.
  * Improved cleanup so failed setup removes newly created credentials without deleting recovered ones.
* **Tests**
  * Added coverage for credential mismatch protection, orphaned-account recovery, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->