### PR TITLE
Feat/tui picker viewport

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,14 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Added
+
+- `wn tui` group detail now has a lowercase `a` that searches for a member to
+  add, for when you do not have the pubkey to hand (`A` remains the paste-a-pubkey
+  path). The search it opens is aimed at that group: `a` on a result confirms
+  against it directly instead of asking which chat, `Esc` returns to the group
+  detail, and a completed add reopens and reloads it.
+
 ### Changed
 
 - Encrypted media and Hermes/WN Agent file delivery now accept blobs up to
@@ -209,7 +217,7 @@ versioning through the workspace version in the root `Cargo.toml`.
   observer-side resolution, branch-depth reversal, encrypted-SQLite restart,
   exact canonical agreement, durable input dispositions, and all twelve
   directed application-decryptability probes.
-  
+
 ### Fixed
 
 - Group creation now performs member KeyPackage lookup and founding Welcome

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -94,6 +94,11 @@ versioning through the workspace version in the root `Cargo.toml`.
 - The Nostr SDK failed-signature regression test now observes EOSE under one
   bounded CI-safe window, avoiding sharded CI flakes without weakening
   failed-event non-emission and non-caching assertions.
+- `wn tui` now scrolls the highlighted row into view on the account picker, the
+  profile, group-detail, and user-search panes, and the picker popup. Past
+  roughly a screenful of rows the highlight fell outside the drawn area, which
+  made the selection invisible rather than merely awkward — the marker and the
+  highlight are drawn inside each row.
 
 ## [0.9.11] - 2026-08-09
 

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -639,8 +639,12 @@ Main view controls:
 - `?`: open the help popup.
 - `Esc`: clear an armed message-interaction prefill (`/react`, `/reply`, or `/delete`, whether untouched or after you
   have typed into it); a hand-typed draft is left intact so `Esc` never destroys text you wrote — use `Ctrl-U` to
-  clear a hand-typed draft. With a popup open, `Esc` closes it.
+  clear a hand-typed draft. With no armed prefill, `Esc` is spatial back: composer → messages → chats, and a no-op
+  from the chat list. Leaving the composer this way keeps the draft for when focus returns. With a popup open, `Esc`
+  closes it.
 - `Ctrl-U`: clear the whole composer (readline kill-line), whatever it holds. Also clears the masked nsec-entry field.
+- `q`: quit, from the chat list or the messages pane and only while the composer is empty. In the composer it is a
+  literal `q`, and with a draft already typed it does nothing at all — so quitting can never discard text you wrote.
 - `Ctrl-C`: quit.
 
 Popups are modal: while one is open it captures every key and the screen behind it is inert. A text-entry popup
@@ -650,7 +654,9 @@ key. Because the help card is a popup, `q` under it closes the card instead of q
 
 Group detail (`g` from the chat list) shows the selected group's members with admin badges (and a `(you)` marker),
 its relay hints, and its name and description; `Esc` returns to the main view. Its keys: `j`/`k` move the member
-selection; `A` adds a member by npub/hex (text popup → `groups add-members`); `x` removes the selected member
+selection (the pane scrolls to keep the highlighted member on screen); `a` searches for someone to add (see user
+search below) for when you do not have their pubkey to hand; `A` adds a member by npub/hex (text popup →
+`groups add-members`); `x` removes the selected member
 (confirm → `groups remove-members`); `P` promotes the selected member to admin (confirm → `groups promote`); `R`
 renames the group (text popup prefilled with the current name → `groups rename`); `L` leaves the group. An admin
 cannot leave: `L` shows a "Cannot Leave Group" info card (sole admins are told to promote another member first,
@@ -677,13 +683,19 @@ worker with in-flight feedback and fold into a per-row
 `[following]` badge; rows you already follow are badged up front from a `follows list` snapshot taken with each
 search. `i` returns to the query, and
 `Esc` returns to the main view. Result rows show the display name/name, a shortened npub, and the `matched_field · match_quality · radius`
-attribution the search returns.
+attribution the search returns, and the list scrolls to keep the highlighted result (both of its lines) on screen.
+
+Opened from group detail with `a`, the same screen is aimed at that group: the hints line names it, `a` on a result
+skips the chat picker and confirms straight against that group, and `Esc` returns to the group detail rather than the
+main view. After the add lands, the group detail reopens and reloads, so the new member shows in the list you started
+from.
 
 Profile (`p` from the chat list) shows your own profile — name, display name, about, picture URL (as literal text; no
 avatar is fetched), nip05, lud16, and npub — from `profile show`, plus your follows from `follows list`. `j`/`k` move a
 single cursor over the six fields then the follows; `Enter` on a field opens a text popup prefilled with the current
 value and, on submit, publishes only that one field (`profile update --<field>`, which merges over the current profile
-so the other fields survive); `f` follows a user by npub/hex (`follows add`), and `x` unfollows the selected follow
+so the other fields survive); the pane scrolls to keep the highlighted field or follow on screen. `f` follows a user
+by npub/hex (`follows add`), and `x` unfollows the selected follow
 (confirm → `follows remove`). There is no nsec export anywhere. `Esc` returns to the main view.
 
 Relay health (`h` from the chat list) is a redacted, device-local telemetry dashboard from `relay-stats` (which reads

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -1711,10 +1711,16 @@ impl TuiApp {
     pub(crate) fn handle_user_search_key(&mut self, key: KeyEvent) -> TuiResult<()> {
         if key.code == KeyCode::Esc {
             // A search opened from group detail goes back there rather than to the
-            // main view, so `Esc` undoes the step that opened it.
+            // main view, so `Esc` undoes the step that opened it. The refresh that
+            // return schedules can fail its account precondition, and a key handler
+            // reports rather than propagates: a `?` here would leave `run()` and end
+            // the session over a status-line error. One assignment covers both
+            // outcomes so the report cannot be overwritten by the settled status.
             if let Some(group_id) = self.search_add_target().map(str::to_owned) {
-                self.return_to_group_detail(&group_id)?;
-                self.status = "group detail".to_owned();
+                self.status = match self.return_to_group_detail(&group_id) {
+                    Ok(()) => "group detail".to_owned(),
+                    Err(err) => format!("error: {err}"),
+                };
                 return Ok(());
             }
             self.leave_screen();

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -1421,6 +1421,12 @@ impl TuiApp {
             }
             PopupSubmit::AddUserToChat { group_id, pubkey } => {
                 self.add_group_member(&group_id, pubkey)?;
+                // A search opened from group detail returns there, because the
+                // point of adding from that screen is to watch the member land in
+                // its list. A browse search instead reveals the chat it changed.
+                if self.search_add_target().is_some() {
+                    return self.return_to_group_detail(&group_id);
+                }
                 self.select_chat_by_group_id(&group_id)?;
                 self.reveal_chat_from_search();
                 Ok(())
@@ -1462,6 +1468,7 @@ impl TuiApp {
                     view.select_down();
                 }
             }
+            KeyCode::Char('a') => self.search_for_member_to_add(),
             KeyCode::Char('A') => self.open_add_member_popup(),
             KeyCode::Char('R') => self.open_rename_group_popup(),
             KeyCode::Char('x') => self.open_remove_member_popup(),
@@ -1492,6 +1499,29 @@ impl TuiApp {
         }
         self.screen = Screen::Main;
         self.focus = Focus::Chats;
+    }
+
+    /// The group an open user search was opened to add someone to, if that is why
+    /// it is open. `None` for a browse search, which has to ask.
+    fn search_add_target(&self) -> Option<&str> {
+        match &self.user_search.as_ref()?.purpose {
+            UserSearchPurpose::AddToGroup { group_id, .. } => Some(group_id),
+            UserSearchPurpose::Browse => None,
+        }
+    }
+
+    /// Search for someone to add to the open group (`a`), for when the pubkey is
+    /// not already in hand — `A` is the paste-a-pubkey path. The group-detail
+    /// view is left loaded, so returning to it needs no reload.
+    fn search_for_member_to_add(&mut self) {
+        let Some(view) = &self.group_detail else {
+            return;
+        };
+        let purpose = UserSearchPurpose::AddToGroup {
+            group_id: view.group_id.clone(),
+            group_name: view.name.clone(),
+        };
+        self.open_user_search_with(None, purpose);
     }
 
     fn open_add_member_popup(&mut self) {
@@ -1680,6 +1710,13 @@ impl TuiApp {
     /// query field or the result list handles the key per the screen's focus.
     pub(crate) fn handle_user_search_key(&mut self, key: KeyEvent) -> TuiResult<()> {
         if key.code == KeyCode::Esc {
+            // A search opened from group detail goes back there rather than to the
+            // main view, so `Esc` undoes the step that opened it.
+            if let Some(group_id) = self.search_add_target().map(str::to_owned) {
+                self.return_to_group_detail(&group_id)?;
+                self.status = "group detail".to_owned();
+                return Ok(());
+            }
             self.leave_screen();
             return Ok(());
         }
@@ -1794,16 +1831,28 @@ impl TuiApp {
     /// preselecting the open chat when one is loaded. `Enter` chains into the
     /// add-user confirm for the highlighted chat; `Esc` closes with no side
     /// effects. With no chats a status-line notice explains.
+    ///
+    /// A search opened from group detail already has its target, so it skips the
+    /// picker and confirms against that group directly.
     fn open_add_user_to_chat_popup(&mut self) {
-        let Some(result) = self
-            .user_search
-            .as_ref()
-            .and_then(UserSearchView::selected_result)
-        else {
+        let Some(view) = self.user_search.as_ref() else {
+            return;
+        };
+        let Some(result) = view.selected_result() else {
             return;
         };
         let pubkey = result.pubkey.clone();
         let label = result.display_label();
+        if let UserSearchPurpose::AddToGroup {
+            group_id,
+            group_name,
+        } = &view.purpose
+        {
+            self.popup = Some(Popup::confirm_add_user_to_chat(
+                group_id, group_name, &pubkey, &label,
+            ));
+            return;
+        }
         if self.chats.is_empty() {
             self.status = "no chats to add a user to; c starts a new chat".to_owned();
             return;

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -1425,7 +1425,15 @@ impl TuiApp {
                 // point of adding from that screen is to watch the member land in
                 // its list. A browse search instead reveals the chat it changed.
                 if self.search_add_target().is_some() {
-                    return self.return_to_group_detail(&group_id);
+                    // The add has already published, so a failed refresh annotates
+                    // its confirmation instead of replacing it: a completed add
+                    // reported as an error would send the user to re-add a member
+                    // who is already in the group.
+                    if let Err(err) = self.return_to_group_detail(&group_id) {
+                        self.status =
+                            format!("{}; group detail refresh failed: {err}", self.status);
+                    }
+                    return Ok(());
                 }
                 self.select_chat_by_group_id(&group_id)?;
                 self.reveal_chat_from_search();

--- a/crates/cli/src/tui/client.rs
+++ b/crates/cli/src/tui/client.rs
@@ -999,6 +999,30 @@ impl TuiApp {
         Ok(())
     }
 
+    /// Return from a search opened by group-detail `a` to that group's detail,
+    /// refreshing it so a membership change made from the search is visible. The
+    /// cached view renders at once, so the refresh only shows if it changed
+    /// something. The status is left as the caller set it, because it carries the
+    /// outcome of whatever the search just did.
+    ///
+    /// Falls back to the main view when the group-detail view is gone: a disband
+    /// or a leave can clear it while the search is open, and returning to a
+    /// screen with nothing to show would strand the reader on a loading notice.
+    pub(crate) fn return_to_group_detail(&mut self, group_id: &str) -> TuiResult<()> {
+        // Dropping the in-flight anchor makes a late search result a no-op at fold
+        // time, so the screen we return to cannot be repopulated by the abandoned
+        // query — the same guard `leave_screen` applies on `Esc`.
+        self.searching_users = None;
+        self.user_search = None;
+        if self.group_detail.is_none() {
+            self.screen = Screen::Main;
+            self.focus = Focus::Chats;
+            return Ok(());
+        }
+        self.screen = Screen::GroupDetail;
+        self.load_group_detail(group_id)
+    }
+
     /// Load (or reload) the group-detail view off the event loop: members with
     /// admin badges (`groups members` + `groups admins`), relay hints
     /// (`groups relays`), and name/description (`groups show`). The member
@@ -1285,10 +1309,27 @@ impl TuiApp {
 
     // ---- Phase 5b: user search, profile, and relay health ----
 
-    /// Enter the user-search screen. A query (from `/users <query>`) runs
-    /// immediately; an empty open lands on the query field awaiting input.
+    /// Enter the user-search screen to browse. A query (from `/users <query>`)
+    /// runs immediately; an empty open lands on the query field awaiting input.
     pub(crate) fn open_user_search(&mut self, query: Option<String>) {
-        let mut view = UserSearchView::default();
+        self.open_user_search_with(query, UserSearchPurpose::Browse);
+    }
+
+    /// Enter the user-search screen for a specific purpose. The purpose travels
+    /// on the view, so it is dropped with the screen and cannot outlive it.
+    pub(crate) fn open_user_search_with(
+        &mut self,
+        query: Option<String>,
+        purpose: UserSearchPurpose,
+    ) {
+        let status = match &purpose {
+            UserSearchPurpose::Browse => "user search",
+            UserSearchPurpose::AddToGroup { .. } => "search a user to add",
+        };
+        let mut view = UserSearchView {
+            purpose,
+            ..UserSearchView::default()
+        };
         if let Some(query) = query
             .map(|query| query.trim().to_owned())
             .filter(|q| !q.is_empty())
@@ -1298,7 +1339,7 @@ impl TuiApp {
         let run_now = !view.query.is_empty();
         self.user_search = Some(view);
         self.screen = Screen::UserSearch;
-        self.status = "user search".to_owned();
+        self.status = status.to_owned();
         if run_now && let Err(err) = self.run_user_search() {
             self.status = format!("error: {err}");
         }

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -846,9 +846,9 @@ impl Popup {
         }
     }
 
-    /// The add-user-to-chat confirm. Built by the group picker's `Enter` (which
-    /// chose the target chat), so the guarding step and its wording live in one
-    /// place.
+    /// The add-user-to-chat confirm, so the guarding step and its wording live in
+    /// one place however the target was chosen: the group picker's `Enter` in a
+    /// browse search, or the group a group-detail search was aimed at.
     pub(crate) fn confirm_add_user_to_chat(
         group_id: &str,
         chat_label: &str,
@@ -1080,8 +1080,9 @@ pub(crate) fn help_card_lines() -> Vec<String> {
         "Messages: j/k or arrows move; PageUp/PageDown page; G/g newest/oldest.",
         "On the selected message: r react (Enter sends +), u unreact, d delete, R reply.",
         "Composer: cursor editing (arrows/Home/End, Backspace/Delete); Enter sends.",
-        "Group detail: j/k move; A add member; x remove; P promote; R rename; L leave.",
+        "Group detail: j/k move; a search for a member to add; A add by pubkey; x remove; P promote; R rename; L leave.",
         "User search: type + Enter searches; Enter opens a card; c chat; a add to a chat; f follow; x unfollow.",
+        "A search opened by group-detail a adds to that group and Esc returns to it.",
         "Profile: j/k move; Enter edits a field; f follow; x unfollow. Relay health: r refresh.",
         "Popups capture every key; Esc or the shown key closes them.",
         "",
@@ -1318,15 +1319,34 @@ impl UserSearchResultRow {
     }
 }
 
+/// Why the user-search screen was opened. `Browse` is the standalone search
+/// (`s` on the main view, `/users <query>`), where `a` still has to ask which
+/// chat to add the found user to. `AddToGroup` is the group-detail `a` flow: the
+/// target group is already known, so `a` confirms against it directly and the
+/// screen returns to that group's detail when the flow ends.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) enum UserSearchPurpose {
+    #[default]
+    Browse,
+    AddToGroup {
+        group_id: String,
+        /// Carried so the confirm can name the group without the group-detail
+        /// view still being loaded.
+        group_name: String,
+    },
+}
+
 /// The user-search screen state: a reusable query [`Input`], the one-shot
-/// results, the selection, and which region has focus. `users search` is a
-/// one-shot call (no streaming), so the results only change on `Enter`.
+/// results, the selection, which region has focus, and why the screen was
+/// opened. `users search` is a one-shot call (no streaming), so the results only
+/// change on `Enter`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct UserSearchView {
     pub(crate) query: Input,
     pub(crate) results: Vec<UserSearchResultRow>,
     pub(crate) selected: usize,
     pub(crate) focus: UserSearchFocus,
+    pub(crate) purpose: UserSearchPurpose,
 }
 
 impl Default for UserSearchView {
@@ -1336,6 +1356,7 @@ impl Default for UserSearchView {
             results: Vec::new(),
             selected: 0,
             focus: UserSearchFocus::Query,
+            purpose: UserSearchPurpose::Browse,
         }
     }
 }
@@ -1778,14 +1799,40 @@ fn build_relay_health_rows(spread: &Value, sync: &Value) -> Vec<RelayHealthRow> 
 }
 
 /// The user-search hints line, keyed by the screen's internal focus (the shared
-/// `hints_line` cannot see it, so `render_hints` calls this for the search screen).
-pub(crate) fn user_search_hint(focus: UserSearchFocus) -> &'static str {
-    match focus {
-        UserSearchFocus::Query => "type query  Enter search  Down results  Esc back",
-        UserSearchFocus::Results => {
+/// `hints_line` cannot see it, so `render_hints` calls this for the search
+/// screen) and by why the screen was opened. A search aimed at a group names that
+/// group, because `a` adds to it directly instead of asking which chat, and
+/// nothing else on the screen says which group that is.
+pub(crate) fn user_search_hint(focus: UserSearchFocus, purpose: &UserSearchPurpose) -> String {
+    match (focus, purpose) {
+        (UserSearchFocus::Query, _) => USER_SEARCH_QUERY_HINT.to_owned(),
+        (UserSearchFocus::Results, UserSearchPurpose::Browse) => {
             "j/k move  Enter profile  f follow  x unfollow  c chat  a add  i query  Esc back"
+                .to_owned()
         }
+        // The add segment leads, so it survives truncation on a narrow terminal.
+        (UserSearchFocus::Results, UserSearchPurpose::AddToGroup { group_name, .. }) => format!(
+            "j/k move  a add to {}  Enter profile  f follow  x unfollow  c chat  i query  Esc back",
+            hint_safe_name(group_name)
+        ),
     }
+}
+
+/// The query-focus search hint, shared so `hints_line`'s fallback arm and
+/// `user_search_hint` cannot drift apart.
+const USER_SEARCH_QUERY_HINT: &str = "type query  Enter search  Down results  Esc back";
+
+/// A name made safe to interpolate into a keymap hint: terminal-safe, collapsed
+/// to single spaces, and shortened. The collapse matters as much as the
+/// filtering — `keymap_hint_spans` splits segments on a double space and boxes a
+/// segment's leading token when it looks like a key, so a group named
+/// `"Ops  Esc quit"` would otherwise render a convincing fake `Esc` keycap.
+fn hint_safe_name(name: &str) -> String {
+    let collapsed = terminal_safe_text(name)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    shorten(&collapsed, 16)
 }
 
 /// The three states of the login screen: the create/login menu (no accounts),
@@ -2053,12 +2100,12 @@ pub(crate) fn hints_line(screen: Screen, focus: Focus, entered_main: bool) -> &'
         }
         Screen::Login(LoginMode::NsecEntry) => "Enter submit  Esc back",
         Screen::GroupDetail => {
-            "j/k move  A add  x remove  P promote  R rename  L leave  I invites  ? help  Esc back"
+            "j/k move  a search+add  A add  x remove  P promote  R rename  L leave  I invites  ? help  Esc back"
         }
         // The search screen has an internal focus the shared signature cannot
         // carry; `render_hints` calls `user_search_hint` instead. This arm keeps
         // `hints_line` total and returns the query-focus hint as the fallback.
-        Screen::UserSearch => user_search_hint(UserSearchFocus::Query),
+        Screen::UserSearch => USER_SEARCH_QUERY_HINT,
         Screen::Profile => "j/k move  Enter edit  f follow  x unfollow  Esc back",
         Screen::RelayHealth => "r refresh  j/k scroll  Esc back",
         Screen::Main => match focus {
@@ -2200,8 +2247,9 @@ fn looks_like_key(token: &str) -> bool {
 /// Render a per-focus keymap hint string (`"j/k move  Enter open  ..."`) as
 /// keycap+label spans: each `"  "`-separated segment becomes a boxed keycap for
 /// its leading key token followed by a dim label. A segment whose leading token
-/// is prose (not a key) renders entirely dim. The hint strings are trusted
-/// static keymaps, so no terminal-safe filtering is needed.
+/// is prose (not a key) renders entirely dim. The hint strings are keymaps this
+/// crate writes; the one interpolated value (the group a search is adding to)
+/// goes through `hint_safe_name` first, so nothing here has to filter.
 pub(crate) fn keymap_hint_spans(text: &str) -> Vec<Span<'static>> {
     let mut spans = Vec::new();
     for (index, segment) in text.split("  ").filter(|s| !s.is_empty()).enumerate() {

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -11381,6 +11381,14 @@ fn adding_a_found_user_from_group_detail_adds_them_and_returns_to_the_group() {
         Some("g1"),
         "the group detail reloads so the new member shows"
     );
+    // The add published, so the status must report that and not be displaced by
+    // the return that follows it. A completed add reported as anything else
+    // would send the user to re-add a member who is already in the group.
+    assert!(
+        app.status.contains("added member(s)"),
+        "the completed add is what the status reports; got: {:?}",
+        app.status
+    );
 }
 
 #[cfg(unix)]

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -7374,6 +7374,31 @@ fn esc_from_a_group_aimed_search_returns_to_the_group_not_the_main_view() {
 }
 
 #[test]
+fn a_failing_return_from_a_group_aimed_search_reports_and_keeps_the_session_up() {
+    // The return schedules a group-detail refresh, whose account precondition can
+    // fail. A key handler reports such a failure on the status line; propagating it
+    // would exit `run()` and end the whole session over a recoverable error.
+    let mut app = app_on_group_detail(test_unused_client());
+    app.handle_key(char_key('a')).expect("a on group detail");
+    // A public-only account cannot sign, so `require_selected_local_account` — the
+    // refresh's precondition — fails.
+    app.accounts[0].local_signing = false;
+
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .expect("Esc reports the failure instead of tearing down the session");
+
+    assert!(
+        app.status.starts_with("error:"),
+        "the failure reaches the status line; got: {:?}",
+        app.status
+    );
+    // The navigation the user asked for still applied: only the refresh failed, and
+    // the cached group-detail view is what renders.
+    assert_eq!(app.screen, Screen::GroupDetail);
+    assert!(app.user_search.is_none(), "the search view is cleared");
+}
+
+#[test]
 fn group_detail_add_and_rename_open_text_popups_with_expected_prefill() {
     let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
     app.screen = Screen::GroupDetail;

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -7587,6 +7587,39 @@ fn group_detail_frame_shows_members_with_badges_and_relays() {
 }
 
 #[test]
+fn group_detail_pane_scrolls_the_selected_member_into_view() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::GroupDetail;
+    // A member list far taller than the pane, with the selection at the bottom.
+    let mut members: Vec<GroupMemberRow> = (0..40)
+        .map(|index| GroupMemberRow {
+            member_id: format!("id{index:02}"),
+            npub: format!("npubmember{index:02}"),
+            is_admin: false,
+            is_self: false,
+        })
+        .collect();
+    members[39].npub = "npubLASTMEMBER".to_owned();
+    let selected = members.len() - 1;
+    app.group_detail = Some(GroupDetailView {
+        group_id: "g1".to_owned(),
+        name: "Ops Room".to_owned(),
+        description: "the ops".to_owned(),
+        members,
+        relays: vec!["wss://relay.example".to_owned()],
+        account_is_admin: true,
+        admin_count: 1,
+        selected,
+    });
+
+    let rendered = rendered_buffer(&mut app);
+    assert!(
+        rendered.contains("npubLASTMEMBER"),
+        "the selected member renders inside the pane"
+    );
+}
+
+#[test]
 fn daemon_start_args_forward_first_run_relays() {
     assert_eq!(
         daemon_start_args(&[], &[]),
@@ -7939,6 +7972,32 @@ fn start_opens_the_account_picker_with_several_accounts() {
     assert!(
         !app.entered_main,
         "the startup picker has no active main yet"
+    );
+}
+
+#[test]
+fn account_picker_scrolls_the_selected_account_into_view() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::Login(LoginMode::AccountSelect);
+    // More accounts than the picker card can show, with the selection last.
+    app.accounts = (0..40)
+        .map(|index| AccountRow {
+            account_id: format!("{index:064}"),
+            npub: format!("npubaccount{index:02}"),
+            display_name: Some(if index == 39 {
+                "LASTACCOUNT".to_owned()
+            } else {
+                format!("account{index:02}")
+            }),
+            local_signing: true,
+        })
+        .collect();
+    app.picker_selection = app.accounts.len() - 1;
+
+    let rendered = rendered_buffer(&mut app);
+    assert!(
+        rendered.contains("LASTACCOUNT"),
+        "the highlighted account renders inside the picker card"
     );
 }
 
@@ -8677,6 +8736,37 @@ fn popup_rect_clamps_to_a_small_area() {
 }
 
 #[test]
+fn picker_popup_scrolls_the_selected_row_into_view() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::Main;
+    // More rows than the screen can hold, so the popup clamps to the area and
+    // the highlighted row falls outside the drawn body without a scroll offset.
+    let items: Vec<PickerItem> = (0..40)
+        .map(|index| PickerItem {
+            id: format!("id{index:02}"),
+            label: if index == 39 {
+                "LASTCHOICE".to_owned()
+            } else {
+                format!("choice{index:02}")
+            },
+        })
+        .collect();
+    let selected = items.len() - 1;
+    app.popup = Some(Popup::Picker {
+        purpose: PickerPurpose::Invites,
+        title: "Pending Invites".to_owned(),
+        items,
+        selected,
+    });
+
+    let rendered = rendered_buffer(&mut app);
+    assert!(
+        rendered.contains("LASTCHOICE"),
+        "the selected picker row renders inside the popup"
+    );
+}
+
+#[test]
 fn popup_body_lines_color_confirm_yellow_and_logout_red() {
     let confirm = Popup::Confirm {
         purpose: ConfirmPurpose::LeaveGroup {
@@ -8685,7 +8775,7 @@ fn popup_body_lines_color_confirm_yellow_and_logout_red() {
         title: "Leave Group".to_owned(),
         body: vec!["Leave ops-room?".to_owned()],
     };
-    let lines = popup_body_lines(&confirm);
+    let lines = popup_body_lines(&confirm).lines;
     assert_eq!(
         lines[0].spans[0].style.fg,
         Some(Color::Yellow),
@@ -8701,7 +8791,7 @@ fn popup_body_lines_color_confirm_yellow_and_logout_red() {
         body: vec!["This permanently destroys the signing key.".to_owned()],
         input: Input::default(),
     };
-    let lines = popup_body_lines(&logout);
+    let lines = popup_body_lines(&logout).lines;
     assert_eq!(
         lines[0].spans[0].style.fg,
         Some(Color::Red),
@@ -10276,6 +10366,7 @@ fn a_user_search_fold_badges_the_rows_the_account_already_follows() {
     );
 
     let rendered = user_search_lines(view, false)
+        .lines
         .iter()
         .map(|line| {
             line.spans
@@ -10293,6 +10384,46 @@ fn a_user_search_fold_badges_the_rows_the_account_already_follows() {
         rendered.matches("[following]").count(),
         1,
         "only the followed row is badged; got:\n{rendered}"
+    );
+}
+
+#[test]
+fn user_search_pane_scrolls_the_whole_selected_row_into_view() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::UserSearch;
+    // Two lines per result, so a result list far taller than the pane needs the
+    // attribution line visible too — not just the label the marker sits on.
+    let results: Vec<UserSearchResultRow> = (0..30)
+        .map(|index| UserSearchResultRow {
+            pubkey: format!("{index:064}"),
+            npub: format!("npubresult{index:02}"),
+            display_name: Some(if index == 29 {
+                "LASTRESULT".to_owned()
+            } else {
+                format!("result{index:02}")
+            }),
+            matched_field: "name".to_owned(),
+            match_quality: "prefix".to_owned(),
+            radius: 2,
+            following: false,
+        })
+        .collect();
+    let selected = results.len() - 1;
+    app.user_search = Some(UserSearchView {
+        query: Input::default(),
+        results,
+        selected,
+        focus: UserSearchFocus::Results,
+    });
+
+    let rendered = rendered_buffer(&mut app);
+    assert!(
+        rendered.contains("LASTRESULT"),
+        "the selected result renders inside the pane"
+    );
+    assert!(
+        rendered.contains("name · prefix · radius 2"),
+        "the selected result's attribution line renders with it"
     );
 }
 
@@ -10771,6 +10902,30 @@ fn profile_frame_shows_fields_and_follows() {
     assert!(rendered.contains("Follows"), "follows section present");
     assert!(rendered.contains("npubBOB"), "follow present");
     assert!(rendered.contains("(unset)"), "unset field rendered");
+}
+
+#[test]
+fn profile_pane_scrolls_the_selected_follow_into_view() {
+    let mut app = test_tui_app(test_unused_client(), &"aa".repeat(32));
+    app.screen = Screen::Profile;
+    // A follow list far taller than the pane, with the selection at the bottom.
+    let mut follows: Vec<String> = (0..60)
+        .map(|index| format!("npubfollow{index:02}"))
+        .collect();
+    follows[59] = "npubLASTFOLLOW".to_owned();
+    let mut view = ProfileView {
+        npub: "npubSELF".to_owned(),
+        follows,
+        ..ProfileView::default()
+    };
+    view.selected = view.row_count() - 1;
+    app.profile_view = Some(view);
+
+    let rendered = rendered_buffer(&mut app);
+    assert!(
+        rendered.contains("npubLASTFOLLOW"),
+        "the selected follow renders inside the pane"
+    );
 }
 
 #[test]

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -6796,13 +6796,14 @@ fn hints_line_matches_the_keymap_per_screen_and_focus() {
         hints_line(Screen::RelayHealth, Focus::Chats, true),
         "r refresh  j/k scroll  Esc back"
     );
-    // The user-search screen's hint is focus-aware (rendered via `user_search_hint`).
+    // The user-search screen's hint is focus- and purpose-aware (rendered via
+    // `user_search_hint`).
     assert_eq!(
-        user_search_hint(UserSearchFocus::Query),
+        user_search_hint(UserSearchFocus::Query, &UserSearchPurpose::Browse),
         "type query  Enter search  Down results  Esc back"
     );
     assert_eq!(
-        user_search_hint(UserSearchFocus::Results),
+        user_search_hint(UserSearchFocus::Results, &UserSearchPurpose::Browse),
         "j/k move  Enter profile  f follow  x unfollow  c chat  a add  i query  Esc back"
     );
     assert_eq!(
@@ -6811,7 +6812,7 @@ fn hints_line_matches_the_keymap_per_screen_and_focus() {
     );
     assert_eq!(
         hints_line(Screen::GroupDetail, Focus::Chats, true),
-        "j/k move  A add  x remove  P promote  R rename  L leave  I invites  ? help  Esc back"
+        "j/k move  a search+add  A add  x remove  P promote  R rename  L leave  I invites  ? help  Esc back"
     );
     assert_eq!(
         hints_line(Screen::Main, Focus::Composer, true),
@@ -7230,6 +7231,146 @@ fn group_detail_leave_guard_blocks_admins_and_confirms_non_admins() {
             ..
         })
     ));
+}
+
+/// A group-detail view with two members, for the search-and-add flow.
+fn app_on_group_detail(client: WnClient) -> TuiApp {
+    let mut app = test_tui_app(client, &"aa".repeat(32));
+    app.screen = Screen::GroupDetail;
+    app.group_detail = Some(GroupDetailView {
+        group_id: "g1".to_owned(),
+        name: "Ops Room".to_owned(),
+        description: String::new(),
+        members: vec![GroupMemberRow {
+            member_id: "aa".to_owned(),
+            npub: "npubself".to_owned(),
+            is_admin: true,
+            is_self: true,
+        }],
+        relays: Vec::new(),
+        account_is_admin: true,
+        admin_count: 1,
+        selected: 0,
+    });
+    app
+}
+
+#[test]
+fn a_on_group_detail_opens_a_user_search_aimed_at_that_group() {
+    let mut app = app_on_group_detail(test_unused_client());
+
+    app.handle_key(char_key('a')).expect("a on group detail");
+
+    assert_eq!(app.screen, Screen::UserSearch);
+    assert_eq!(
+        app.user_search.as_ref().map(|view| view.purpose.clone()),
+        Some(UserSearchPurpose::AddToGroup {
+            group_id: "g1".to_owned(),
+            group_name: "Ops Room".to_owned(),
+        }),
+        "the search knows the group it was opened to add to"
+    );
+}
+
+/// A result row for the search-and-add flow.
+fn search_result_row(npub: &str, label: &str) -> UserSearchResultRow {
+    UserSearchResultRow {
+        pubkey: "bb".repeat(32),
+        npub: npub.to_owned(),
+        display_name: Some(label.to_owned()),
+        matched_field: "name".to_owned(),
+        match_quality: "exact".to_owned(),
+        radius: 1,
+        following: false,
+    }
+}
+
+#[test]
+fn a_on_a_result_confirms_against_the_group_the_search_was_opened_for() {
+    let mut app = app_on_group_detail(test_unused_client());
+    app.handle_key(char_key('a')).expect("a on group detail");
+    app.user_search.as_mut().expect("search view").results =
+        vec![search_result_row("npubbob", "Bob")];
+    app.user_search.as_mut().expect("search view").focus = UserSearchFocus::Results;
+
+    app.handle_key(char_key('a')).expect("a on the result");
+
+    // Straight to the confirm: the target group is already known, so the chat
+    // picker that the browse flow needs would be a dead step here.
+    match &app.popup {
+        Some(Popup::Confirm {
+            purpose: ConfirmPurpose::AddUserToChat { group_id, pubkey },
+            body,
+            ..
+        }) => {
+            assert_eq!(group_id, "g1");
+            assert_eq!(pubkey, &"bb".repeat(32));
+            assert!(
+                body[0].contains("Bob") && body[0].contains("Ops Room"),
+                "the confirm names the user and the group; got: {body:?}"
+            );
+        }
+        other => panic!("expected the add-to-group confirm, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_group_aimed_search_hint_names_the_group_and_the_help_card_names_the_key() {
+    let purpose = UserSearchPurpose::AddToGroup {
+        group_id: "g1".to_owned(),
+        group_name: "Ops Room".to_owned(),
+    };
+    let hint = user_search_hint(UserSearchFocus::Results, &purpose);
+    assert!(
+        hint.contains("a add to Ops Room"),
+        "the aimed search names its target, since `a` no longer asks; got: {hint}"
+    );
+    let help = help_card_lines().join("\n");
+    assert!(
+        help.contains("a search for a member to add"),
+        "the help card names the group-detail search key; got:\n{help}"
+    );
+}
+
+#[test]
+fn a_group_name_cannot_fabricate_a_keycap_in_the_search_hint() {
+    // `keymap_hint_spans` splits hint segments on a double space and boxes a
+    // leading key-shaped token, so an unsanitized name could paint a convincing
+    // fake `Esc` keycap into the hint line.
+    let purpose = UserSearchPurpose::AddToGroup {
+        group_id: "g1".to_owned(),
+        group_name: "Ops  Esc quit".to_owned(),
+    };
+    let hint = user_search_hint(UserSearchFocus::Results, &purpose);
+    assert!(
+        hint.contains("a add to Ops Esc quit"),
+        "the name stays one segment; got: {hint}"
+    );
+    let keycaps = keymap_hint_spans(&hint)
+        .into_iter()
+        .filter(|span| span.content.as_ref() == " Esc ")
+        .count();
+    assert_eq!(keycaps, 1, "only the real `Esc back` renders as a keycap");
+}
+
+#[test]
+fn esc_from_a_group_aimed_search_returns_to_the_group_not_the_main_view() {
+    let mut app = app_on_group_detail(test_unused_client());
+    app.handle_key(char_key('a')).expect("a on group detail");
+
+    app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+        .expect("Esc from the search");
+
+    assert_eq!(
+        app.screen,
+        Screen::GroupDetail,
+        "back where `a` was pressed"
+    );
+    assert!(app.user_search.is_none(), "the search view is cleared");
+    assert!(
+        app.group_detail.is_some(),
+        "the group-detail view was kept, so the return needs no reload to render"
+    );
 }
 
 #[test]
@@ -10410,10 +10551,10 @@ fn user_search_pane_scrolls_the_whole_selected_row_into_view() {
         .collect();
     let selected = results.len() - 1;
     app.user_search = Some(UserSearchView {
-        query: Input::default(),
         results,
         selected,
         focus: UserSearchFocus::Results,
+        ..UserSearchView::default()
     });
 
     let rendered = rendered_buffer(&mut app);
@@ -11172,6 +11313,48 @@ fn add_to_open_chat_from_search_navigates_into_that_chat() {
         app.selected_chat_row().map(|chat| chat.group_id.as_str()),
         Some("g1"),
         "the affected chat is selected"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn adding_a_found_user_from_group_detail_adds_them_and_returns_to_the_group() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let (exe, args_file) =
+        test_appending_arg_executable(tempdir.path(), r#"{"ok":true,"result":{}}"#);
+    let client = WnClient {
+        exe,
+        home: None,
+        socket: None,
+        relay: None,
+        discovery_relays: Vec::new(),
+        default_account_relays: Vec::new(),
+        secret_store: None,
+        keychain_service: None,
+    };
+    let mut app = app_on_group_detail(client);
+    app.handle_key(char_key('a')).expect("a on group detail");
+    app.user_search.as_mut().expect("search view").results =
+        vec![search_result_row("npubbob", "Bob")];
+    app.user_search.as_mut().expect("search view").focus = UserSearchFocus::Results;
+    app.handle_key(char_key('a')).expect("a on the result");
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .expect("confirm the add");
+
+    let recorded = std::fs::read_to_string(&args_file).expect("recorded args");
+    assert!(
+        recorded.contains(&format!("groups add-members g1 {}", "bb".repeat(32))),
+        "the member is added to the group the search was opened for; got:\n{recorded}"
+    );
+    // Back where the flow started, not on the main view: the point of adding
+    // from group detail is to see the member land in that list.
+    assert_eq!(app.screen, Screen::GroupDetail);
+    assert!(app.user_search.is_none(), "the search view is cleared");
+    assert_eq!(
+        app.loading_group_detail.as_deref(),
+        Some("g1"),
+        "the group detail reloads so the new member shows"
     );
 }
 
@@ -12239,7 +12422,7 @@ fn a_stale_follow_fold_reports_but_never_badges_a_left_or_changed_search() {
 
 #[test]
 fn the_search_results_hints_and_help_card_name_the_follow_keys() {
-    let hint = user_search_hint(UserSearchFocus::Results);
+    let hint = user_search_hint(UserSearchFocus::Results, &UserSearchPurpose::Browse);
     assert!(
         hint.contains("f follow  x unfollow"),
         "the results-focus hints name the follow keys; got: {hint}"

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -966,7 +966,9 @@ impl TuiApp {
         // static keymap with a persistent "what Enter does, Esc clears" hint,
         // recomputed here each frame so it survives later status events.
         let spans = match (self.screen, self.user_search.as_ref()) {
-            (Screen::UserSearch, Some(view)) => keymap_hint_spans(user_search_hint(view.focus)),
+            (Screen::UserSearch, Some(view)) => {
+                keymap_hint_spans(&user_search_hint(view.focus, &view.purpose))
+            }
             (Screen::Main, _) => {
                 match armed_interaction_hint(self.input.value(), self.selected_timeline_row()) {
                     Some(armed) => armed_hint_spans(&armed),

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -363,6 +363,83 @@ pub(crate) fn row_label_style(selected: bool, color: Color) -> Style {
     }
 }
 
+/// A pane body together with the index of the body line a viewport has to keep
+/// visible: the *last* line of the selected row, since a row can span several
+/// lines. `None` when the body carries no selection at all.
+///
+/// Bodies are built at full length regardless of the pane's height, so without
+/// this anchor a pane silently hides its own selection once the body outgrows
+/// the area — the marker and the highlight both live inside the row.
+pub(crate) struct PaneBody {
+    pub(crate) lines: Vec<Line<'static>>,
+    pub(crate) anchor: Option<usize>,
+}
+
+impl PaneBody {
+    /// Record the line about to be pushed as the selection anchor. Called at the
+    /// point a row is emitted, so the anchor cannot drift out of step with the
+    /// layout the way a recomputed index would.
+    fn anchor_next(&mut self) {
+        self.anchor = Some(self.lines.len());
+    }
+
+    fn push(&mut self, line: Line<'static>) {
+        self.lines.push(line);
+    }
+
+    fn extend(&mut self, lines: impl IntoIterator<Item = Line<'static>>) {
+        self.lines.extend(lines);
+    }
+}
+
+/// The vertical scroll offset, in post-wrap rows, that a `height`-row viewport
+/// `width` cells wide needs for `anchor` to be its last visible row. Zero
+/// whenever the content through the anchor already fits, so a pane that fits
+/// never scrolls, and moving the selection back up unwinds the offset.
+///
+/// The measurement runs through the same word wrapper the renderer uses and
+/// `Paragraph::scroll` counts post-wrap rows, so the offset cannot disagree with
+/// what actually gets drawn — which is the failure mode a hand-rolled row count
+/// would have.
+fn selection_scroll_offset(
+    lines: &[Line<'static>],
+    anchor: Option<usize>,
+    width: u16,
+    height: u16,
+) -> u16 {
+    let Some(anchor) = anchor else {
+        return 0;
+    };
+    let Some(through_anchor) = lines.get(..=anchor) else {
+        return 0;
+    };
+    let rows = Paragraph::new(through_anchor.to_vec())
+        .wrap(Wrap { trim: false })
+        .line_count(width);
+    u16::try_from(rows)
+        .unwrap_or(u16::MAX)
+        .saturating_sub(height)
+}
+
+/// A wrapped body paragraph scrolled so its selection anchor stays visible in an
+/// `inner`-sized viewport. Selection-bearing bodies go through here rather than
+/// building a `Paragraph` directly, because an unscrolled render pins the offset
+/// at 0 and draws the selection off the bottom of the viewport.
+fn selection_paragraph(body: PaneBody, inner: Rect) -> Paragraph<'static> {
+    let offset = selection_scroll_offset(&body.lines, body.anchor, inner.width, inner.height);
+    Paragraph::new(body.lines)
+        .wrap(Wrap { trim: false })
+        .scroll((offset, 0))
+}
+
+/// Render a selection-bearing pane body inside `block`, scrolled to its
+/// selection. The viewport is the block's inner rect, so the borders are
+/// accounted for wherever this is called.
+fn render_selection_pane(frame: &mut Frame, area: Rect, block: Block<'_>, body: PaneBody) {
+    let inner = block.inner(area);
+    frame.render_widget(selection_paragraph(body, inner).block(block), area);
+}
+
 pub(crate) fn panel_block(title: &str, focused: bool) -> Block<'_> {
     let style = if focused {
         Style::default().fg(FOCUS_ACCENT)
@@ -401,8 +478,11 @@ pub(crate) fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect 
 /// typed-token logout body renders red (irreversible key destruction); other
 /// bodies keep the default foreground. The `Image` variant renders through
 /// `render_image_popup`, so it has no body here.
-pub(crate) fn popup_body_lines(popup: &Popup) -> Vec<Line<'static>> {
-    let mut lines: Vec<Line<'static>> = Vec::new();
+pub(crate) fn popup_body_lines(popup: &Popup) -> PaneBody {
+    let mut pane = PaneBody {
+        lines: Vec::new(),
+        anchor: None,
+    };
     match popup {
         Popup::Text {
             purpose,
@@ -415,20 +495,20 @@ pub(crate) fn popup_body_lines(popup: &Popup) -> Vec<Line<'static>> {
             } else {
                 Style::default()
             };
-            lines.extend(
+            pane.extend(
                 body.iter()
                     .map(|line| Line::from(Span::styled(terminal_safe_text(line), style))),
             );
-            lines.push(input_cursor_line("> ", input));
+            pane.push(input_cursor_line("> ", input));
         }
-        Popup::Confirm { body, .. } => lines.extend(body.iter().map(|line| {
+        Popup::Confirm { body, .. } => pane.extend(body.iter().map(|line| {
             Line::from(Span::styled(
                 terminal_safe_text(line),
                 Style::default().fg(Color::Yellow),
             ))
         })),
         Popup::Card { body, .. } => {
-            lines.extend(body.iter().map(|line| Line::from(terminal_safe_text(line))))
+            pane.extend(body.iter().map(|line| Line::from(terminal_safe_text(line))))
         }
         Popup::Picker {
             items, selected, ..
@@ -436,7 +516,10 @@ pub(crate) fn popup_body_lines(popup: &Popup) -> Vec<Line<'static>> {
             for (index, item) in items.iter().enumerate() {
                 let is_selected = index == *selected;
                 let marker = if is_selected { ">" } else { " " };
-                lines.push(Line::from(vec![
+                if is_selected {
+                    pane.anchor_next();
+                }
+                pane.push(Line::from(vec![
                     Span::raw(format!("{marker} ")),
                     Span::styled(
                         shorten(&terminal_safe_text(&item.label), 40),
@@ -448,7 +531,7 @@ pub(crate) fn popup_body_lines(popup: &Popup) -> Vec<Line<'static>> {
         // Rendered by `render_image_popup`, not here.
         Popup::Image { .. } => {}
     }
-    lines
+    pane
 }
 
 /// The content-sized, exactly-centered rect for a popup: a per-variant width
@@ -459,7 +542,7 @@ pub(crate) fn popup_body_lines(popup: &Popup) -> Vec<Line<'static>> {
 pub(crate) fn popup_rect(popup: &Popup, area: Rect) -> Rect {
     let width = popup_width(popup).min(area.width);
     let inner_width = width.saturating_sub(2).max(1);
-    let body_rows = Paragraph::new(popup_body_lines(popup))
+    let body_rows = Paragraph::new(popup_body_lines(popup).lines)
         .wrap(Wrap { trim: false })
         .line_count(inner_width);
     let body_rows = u16::try_from(body_rows).unwrap_or(u16::MAX);
@@ -1176,8 +1259,10 @@ impl TuiApp {
             .direction(Direction::Vertical)
             .constraints([Constraint::Min(0), Constraint::Length(1)])
             .split(inner);
+        // The rect is content-sized, so this only scrolls when the body could not
+        // fit the screen — a picker with more rows than the terminal is tall.
         frame.render_widget(
-            Paragraph::new(popup_body_lines(popup)).wrap(Wrap { trim: false }),
+            selection_paragraph(popup_body_lines(popup), rows[0]),
             rows[0],
         );
         frame.render_widget(
@@ -1197,11 +1282,11 @@ impl TuiApp {
             ])
             .split(area);
         match self.group_detail.as_ref() {
-            Some(view) => frame.render_widget(
-                Paragraph::new(group_detail_lines(Some(view)))
-                    .block(panel_block("Group Detail", true))
-                    .wrap(Wrap { trim: false }),
+            Some(view) => render_selection_pane(
+                frame,
                 root[0],
+                panel_block("Group Detail", true),
+                group_detail_lines(Some(view)),
             ),
             None => {
                 render_loading_screen(frame, root[0], "Group Detail", "loading group detail...")
@@ -1214,11 +1299,11 @@ impl TuiApp {
     fn render_user_search(&self, frame: &mut Frame) {
         let root = screen_body_layout(frame.area());
         match self.user_search.as_ref() {
-            Some(view) => frame.render_widget(
-                Paragraph::new(user_search_lines(view, self.searching_users.is_some()))
-                    .block(panel_block("User Search", true))
-                    .wrap(Wrap { trim: false }),
+            Some(view) => render_selection_pane(
+                frame,
                 root[0],
+                panel_block("User Search", true),
+                user_search_lines(view, self.searching_users.is_some()),
             ),
             None => render_loading_screen(frame, root[0], "User Search", "loading user search..."),
         }
@@ -1229,11 +1314,11 @@ impl TuiApp {
     fn render_profile(&self, frame: &mut Frame) {
         let root = screen_body_layout(frame.area());
         match self.profile_view.as_ref() {
-            Some(view) => frame.render_widget(
-                Paragraph::new(profile_lines(view))
-                    .block(panel_block("Profile", true))
-                    .wrap(Wrap { trim: false }),
+            Some(view) => render_selection_pane(
+                frame,
                 root[0],
+                panel_block("Profile", true),
+                profile_lines(view),
             ),
             None => render_loading_screen(frame, root[0], "Profile", "loading profile..."),
         }
@@ -1334,25 +1419,31 @@ pub(crate) fn input_cursor_line(prefix: &str, input: &Input) -> Line<'static> {
 /// The group-detail screen body: name and description header, the member list
 /// with admin/you badges and a selection highlight, then the relay hints. Every
 /// name, npub, and relay passes through `terminal_safe_text`.
-pub(crate) fn group_detail_lines(view: Option<&GroupDetailView>) -> Vec<Line<'static>> {
+pub(crate) fn group_detail_lines(view: Option<&GroupDetailView>) -> PaneBody {
     let Some(view) = view else {
-        return vec![Line::from("loading group detail...")];
+        return PaneBody {
+            lines: vec![Line::from("loading group detail...")],
+            anchor: None,
+        };
     };
-    let mut lines = vec![Line::from(vec![
-        Span::styled("Group ", Style::default().fg(Color::DarkGray)),
-        Span::styled(
-            shorten(&terminal_safe_text(&view.name), 48),
-            Style::default().add_modifier(Modifier::BOLD),
-        ),
-    ])];
+    let mut body = PaneBody {
+        lines: vec![Line::from(vec![
+            Span::styled("Group ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                shorten(&terminal_safe_text(&view.name), 48),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+        ])],
+        anchor: None,
+    };
     if !view.description.is_empty() {
-        lines.push(Line::from(Span::styled(
+        body.push(Line::from(Span::styled(
             terminal_safe_text(&view.description),
             Style::default().fg(Color::DarkGray),
         )));
     }
-    lines.push(Line::from(""));
-    lines.push(Line::from(format!("Members ({})", view.members.len())));
+    body.push(Line::from(""));
+    body.push(Line::from(format!("Members ({})", view.members.len())));
     for (index, member) in view.members.iter().enumerate() {
         let is_selected = index == view.selected;
         let marker = if is_selected { ">" } else { " " };
@@ -1369,29 +1460,35 @@ pub(crate) fn group_detail_lines(view: Option<&GroupDetailView>) -> Vec<Line<'st
         if member.is_self {
             spans.push(Span::styled(" (you)", Style::default().fg(Color::DarkGray)));
         }
-        lines.push(Line::from(spans));
+        if is_selected {
+            body.anchor_next();
+        }
+        body.push(Line::from(spans));
     }
-    lines.push(Line::from(""));
-    lines.push(Line::from(format!("Relays ({})", view.relays.len())));
+    body.push(Line::from(""));
+    body.push(Line::from(format!("Relays ({})", view.relays.len())));
     for relay in &view.relays {
-        lines.push(Line::from(format!("  {}", terminal_safe_text(relay))));
+        body.push(Line::from(format!("  {}", terminal_safe_text(relay))));
     }
-    lines
+    body
 }
 
 /// The user-search screen body: the query field (with the cursor cell in query
 /// focus) then the result rows, each showing the display label, a shortened
 /// npub, and the `matched_field · match_quality · provenance` attribution. Every
 /// name and npub passes through `terminal_safe_text`.
-pub(crate) fn user_search_lines(view: &UserSearchView, searching: bool) -> Vec<Line<'static>> {
+pub(crate) fn user_search_lines(view: &UserSearchView, searching: bool) -> PaneBody {
     let query_focused = view.focus == UserSearchFocus::Query;
-    let mut lines = input_field_lines(
-        &view.query.display(),
-        view.query.cursor(),
-        query_focused,
-        Some(Span::styled("search ", Style::default().fg(FOCUS_ACCENT))),
-    );
-    lines.push(Line::from(""));
+    let mut body = PaneBody {
+        lines: input_field_lines(
+            &view.query.display(),
+            view.query.cursor(),
+            query_focused,
+            Some(Span::styled("search ", Style::default().fg(FOCUS_ACCENT))),
+        ),
+        anchor: None,
+    };
+    body.push(Line::from(""));
     if view.results.is_empty() {
         // Distinguish an in-flight search (yellow) from a settled empty result
         // (dark gray), keyed off the async search flag.
@@ -1400,10 +1497,10 @@ pub(crate) fn user_search_lines(view: &UserSearchView, searching: bool) -> Vec<L
         } else {
             ("no results — type a query and press Enter", Color::DarkGray)
         };
-        lines.push(Line::from(Span::styled(text, Style::default().fg(color))));
-        return lines;
+        body.push(Line::from(Span::styled(text, Style::default().fg(color))));
+        return body;
     }
-    lines.push(Line::from(format!("Results ({})", view.results.len())));
+    body.push(Line::from(format!("Results ({})", view.results.len())));
     let results_focused = view.focus == UserSearchFocus::Results;
     for (index, result) in view.results.iter().enumerate() {
         let is_selected = results_focused && index == view.selected;
@@ -1427,13 +1524,18 @@ pub(crate) fn user_search_lines(view: &UserSearchView, searching: bool) -> Vec<L
                 Style::default().fg(Color::DarkGray),
             ));
         }
-        lines.push(Line::from(spans));
+        body.push(Line::from(spans));
         let provenance = if result.radius == OFF_GRAPH_SEARCH_RADIUS {
             "discovery".to_owned()
         } else {
             format!("radius {}", result.radius)
         };
-        lines.push(Line::from(Span::styled(
+        // Anchor on the attribution line rather than the label above it, so
+        // scrolling to the last result brings the whole two-line row into view.
+        if is_selected {
+            body.anchor_next();
+        }
+        body.push(Line::from(Span::styled(
             format!(
                 "    {} · {} · {provenance}",
                 terminal_safe_text(&result.matched_field),
@@ -1442,24 +1544,28 @@ pub(crate) fn user_search_lines(view: &UserSearchView, searching: bool) -> Vec<L
             Style::default().fg(Color::DarkGray),
         )));
     }
-    lines
+    body
 }
 
 /// The own-profile screen body: the npub header, the six editable fields with a
 /// selection highlight (unset fields dimmed), then the follow list. Every value
 /// passes through `terminal_safe_text`; picture URLs render as literal text.
-pub(crate) fn profile_lines(view: &ProfileView) -> Vec<Line<'static>> {
-    let mut lines = vec![
-        Line::from(vec![
-            Span::styled("Profile ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                shorten(&terminal_safe_text(&view.npub), 32),
-                Style::default().add_modifier(Modifier::BOLD),
-            ),
-        ]),
-        Line::from(""),
-        Line::from("Fields"),
-    ];
+/// Fields and follows share one selection index, so both can be the anchor.
+pub(crate) fn profile_lines(view: &ProfileView) -> PaneBody {
+    let mut body = PaneBody {
+        lines: vec![
+            Line::from(vec![
+                Span::styled("Profile ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    shorten(&terminal_safe_text(&view.npub), 32),
+                    Style::default().add_modifier(Modifier::BOLD),
+                ),
+            ]),
+            Line::from(""),
+            Line::from("Fields"),
+        ],
+        anchor: None,
+    };
     for (index, field) in ProfileField::ALL.iter().enumerate() {
         let is_selected = index == view.selected;
         let marker = if is_selected { ">" } else { " " };
@@ -1467,7 +1573,10 @@ pub(crate) fn profile_lines(view: &ProfileView) -> Vec<Line<'static>> {
             Some(value) => Span::raw(terminal_safe_text(value)),
             None => Span::styled("(unset)".to_owned(), Style::default().fg(Color::DarkGray)),
         };
-        lines.push(Line::from(vec![
+        if is_selected {
+            body.anchor_next();
+        }
+        body.push(Line::from(vec![
             Span::raw(format!("{marker} ")),
             Span::styled(
                 format!("{}: ", field.label()),
@@ -1476,12 +1585,15 @@ pub(crate) fn profile_lines(view: &ProfileView) -> Vec<Line<'static>> {
             value_span,
         ]));
     }
-    lines.push(Line::from(""));
-    lines.push(Line::from(format!("Follows ({})", view.follows.len())));
+    body.push(Line::from(""));
+    body.push(Line::from(format!("Follows ({})", view.follows.len())));
     for (index, follow) in view.follows.iter().enumerate() {
         let is_selected = ProfileField::ALL.len() + index == view.selected;
         let marker = if is_selected { ">" } else { " " };
-        lines.push(Line::from(vec![
+        if is_selected {
+            body.anchor_next();
+        }
+        body.push(Line::from(vec![
             Span::raw(format!("{marker} ")),
             Span::styled(
                 shorten(&terminal_safe_text(follow), 28),
@@ -1489,7 +1601,7 @@ pub(crate) fn profile_lines(view: &ProfileView) -> Vec<Line<'static>> {
             ),
         ]));
     }
-    lines
+    body
 }
 
 /// The relay-health screen body: a daemon-state and health-summary header, then

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -830,9 +830,18 @@ impl TuiApp {
                 })
                 .collect()
         };
-        frame.render_widget(
+        // Drive the list with a ListState synced to the selection so the
+        // highlighted account always scrolls into view, exactly as the chats
+        // sidebar does. A plain `render_widget` pins the offset at 0, which
+        // hides the marker once the account list outgrows the card.
+        let mut state = ListState::default();
+        if !self.accounts.is_empty() {
+            state.select(Some(self.picker_selection.min(self.accounts.len() - 1)));
+        }
+        frame.render_stateful_widget(
             List::new(items).block(panel_block("Select Account", true)),
             area,
+            &mut state,
         );
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a group-scoped “add member” flow from Group Detail (`a`) that performs a targeted user search and confirms against the selected group.
  - Returning from the add-member flow now reloads and reopens Group Detail so the new membership is immediately reflected.

- **Bug Fixes**
  - Highlighted selection now reliably scrolls into view across the account picker, popups, user search, group detail, and profile/follows.
  - Prevented multiple concurrent live in-memory engine sessions per account.

- **Documentation**
  - Updated `wn tui` help/keybinding guidance for the new `a` flow, `Esc` behavior, and `q` quit semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->