### PR TITLE
fix: republish current KeyPackage event

### DIFF
--- a/crates/cli/tests/cli.rs
+++ b/crates/cli/tests/cli.rs
@@ -2701,7 +2701,7 @@ fn key_package_fetches_latest_package_via_relay_list_discovery() {
 }
 
 #[test]
-fn keys_publish_replaces_create_identity_key_package_under_stable_slot() {
+fn keys_publish_republishes_create_identity_key_package_under_stable_slot() {
     let home = tempfile::tempdir().expect("tempdir");
     let relay = test_relay_url();
 
@@ -2721,7 +2721,11 @@ fn keys_publish_replaces_create_identity_key_package_under_stable_slot() {
     assert_eq!(republished["key_package_bytes"], first["key_package_bytes"]);
     assert_eq!(second["key_package_bytes"], first["key_package_bytes"]);
     assert_eq!(second["key_package_id"], first["key_package_id"]);
-    assert_ne!(second["key_package_ref"], first["key_package_ref"]);
+    assert_eq!(second["key_package_ref"], first["key_package_ref"]);
+    assert_eq!(
+        second["key_package_event_id"],
+        first["key_package_event_id"]
+    );
     assert!(
         first["key_package_id"]
             .as_str()
@@ -2735,7 +2739,7 @@ fn keys_publish_replaces_create_identity_key_package_under_stable_slot() {
 }
 
 #[test]
-fn keys_rotate_and_publish_each_replace_under_the_stable_slot() {
+fn keys_rotate_changes_ref_and_publish_republishes_current_ref() {
     let home = tempfile::tempdir().expect("tempdir");
     let relay = test_relay_url();
 
@@ -2760,10 +2764,18 @@ fn keys_rotate_and_publish_each_replace_under_the_stable_slot() {
 
     assert_eq!(second["key_package_id"], first["key_package_id"]);
     assert_ne!(second["key_package_ref"], first["key_package_ref"]);
+    assert_ne!(
+        second["key_package_event_id"],
+        first["key_package_event_id"]
+    );
     assert_eq!(second["key_package_bytes"], rotated["key_package_bytes"]);
     assert_eq!(third["key_package_bytes"], second["key_package_bytes"]);
     assert_eq!(third["key_package_id"], second["key_package_id"]);
-    assert_ne!(third["key_package_ref"], second["key_package_ref"]);
+    assert_eq!(third["key_package_ref"], second["key_package_ref"]);
+    assert_eq!(
+        third["key_package_event_id"],
+        second["key_package_event_id"]
+    );
     assert!(
         third["key_package_id"]
             .as_str()
@@ -2845,25 +2857,17 @@ fn keys_list_reports_published_key_package() {
     run_json(home.path(), &["--account", &account_id, "keys", "publish"]);
 
     // With a published KeyPackage on the reachable relay, `keys list` must
-    // surface it rather than returning an empty list.
+    // surface the merged local+relay row for the current package rather than
+    // returning an empty list or a separate retained duplicate.
     let listed = run_json(home.path(), &["--account", &account_id, "keys", "list"]);
     assert_eq!(listed["account_id"], account_id);
     let keys = listed["keys"].as_array().expect("keys array");
     assert_eq!(
         keys.len(),
-        2,
-        "expected the current relay-visible package and retained local package, got {keys:?}"
-    );
-    let relay_keys = keys
-        .iter()
-        .filter(|key| key["relay"] == true)
-        .collect::<Vec<_>>();
-    assert_eq!(
-        relay_keys.len(),
         1,
-        "expected the published key package, got {keys:?}"
+        "expected one merged current key package inventory row, got {keys:?}"
     );
-    let published = relay_keys[0];
+    let published = &keys[0];
     assert_eq!(published["account_id"], account_id);
     assert!(
         published["key_package_event_id"]
@@ -2905,7 +2909,9 @@ fn keys_delete_and_delete_all_use_runtime_relay_deletion() {
             .is_some_and(|count| count > 0)
     );
 
-    run_json(home.path(), &["--account", &account_id, "keys", "publish"]);
+    // NIP-09 prevents republishing the deleted authored event. Mint the
+    // explicit replacement before exercising delete-all.
+    run_json(home.path(), &["--account", &account_id, "keys", "rotate"]);
     let delete_all = run_json(
         home.path(),
         &["--account", &account_id, "keys", "delete-all", "--confirm"],

--- a/crates/marmot-account/src/error.rs
+++ b/crates/marmot-account/src/error.rs
@@ -66,6 +66,8 @@ pub enum AccountError {
     KeyPackage(#[from] KeyPackagePublishError),
     #[error("key package replacement is blocked by local clock skew")]
     ClockSkewBlocked,
+    #[error("key package rotation is already in progress")]
+    KeyPackageRotationInProgress,
     #[error("transport delivery was addressed to a different account")]
     WrongAccountDelivery,
 }

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -264,6 +264,141 @@ where
         Ok(())
     }
 
+    /// Re-send the exact current durable authored KeyPackage event to the
+    /// current authoritative publication targets without staging a replacement.
+    ///
+    /// When no usable current package or signed artifact exists, this falls back to
+    /// [`Self::publish_fresh_key_package`].
+    pub async fn republish_key_package(&mut self) -> AccountResult<KeyPackage> {
+        let Some(mut lifecycle) = self.session.key_package_lifecycle()? else {
+            tracing::debug!(
+                target: TRACE_TARGET,
+                method = "republish_key_package",
+                fallback_reason = "no_lifecycle_state",
+                "no republishable current key package artifact; falling back to fresh publication"
+            );
+            return self.publish_fresh_key_package().await;
+        };
+        if lifecycle.pending_replacement.is_some() {
+            return Err(AccountError::KeyPackageRotationInProgress);
+        }
+        if lifecycle.stable_slot_id.is_empty() {
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "key package lifecycle is migration-blocked because the stable replaceable-event slot is unavailable",
+            )
+            .into());
+        }
+        let now = self.wall_clock.now();
+        if !current_key_package_republishable(&lifecycle, now) {
+            tracing::debug!(
+                target: TRACE_TARGET,
+                method = "republish_key_package",
+                fallback_reason = current_key_package_republish_fallback_reason(&lifecycle, now),
+                "no republishable current key package artifact; falling back to fresh publication"
+            );
+            return self.publish_fresh_key_package().await;
+        }
+
+        tracing::debug!(
+            target: TRACE_TARGET,
+            method = "republish_key_package",
+            endpoint_count = self.routing.key_package_endpoints().len(),
+            "republishing current key package"
+        );
+
+        let current_endpoints = self.routing.key_package_endpoints();
+        merge_republish_publication_targets(&mut lifecycle.publication_targets, &current_endpoints);
+        let endpoints = current_endpoints.to_vec();
+        if endpoints.is_empty() {
+            self.session.put_key_package_lifecycle(&lifecycle)?;
+            return Err(crate::key_package::KeyPackagePublishError::unexposed(
+                "no KeyPackage publication endpoints are configured",
+            )
+            .into());
+        }
+
+        let Some(artifact) = lifecycle.authored_signed_event.clone() else {
+            tracing::debug!(
+                target: TRACE_TARGET,
+                method = "republish_key_package",
+                fallback_reason = "missing_authored_signed_event",
+                "no republishable current key package artifact; falling back to fresh publication"
+            );
+            return self.publish_fresh_key_package().await;
+        };
+        let Some(key_package) = lifecycle.current_key_package.clone() else {
+            tracing::debug!(
+                target: TRACE_TARGET,
+                method = "republish_key_package",
+                fallback_reason = "missing_current_key_package",
+                "no republishable current key package artifact; falling back to fresh publication"
+            );
+            return self.publish_fresh_key_package().await;
+        };
+
+        lifecycle.phase = cgka_traits::MaintenancePhase::Fanout;
+        self.session.put_key_package_lifecycle(&lifecycle)?;
+        let publication = KeyPackagePublication {
+            account_id: self.session.self_id().clone(),
+            key_package: key_package.clone(),
+            slot_id: lifecycle.stable_slot_id.clone(),
+            created_at: artifact.created_at,
+            endpoints: endpoints.clone(),
+        };
+        match self
+            .key_packages
+            .publish_prepared_key_package(&publication, &artifact)
+            .await
+        {
+            Ok(receipt) => {
+                note_key_package_attempt(
+                    &mut lifecycle.publication_targets,
+                    &publication.endpoints,
+                    &receipt.accepted,
+                    &receipt.failed,
+                    self.wall_clock.now(),
+                );
+                if receipt.accepted.is_empty() {
+                    lifecycle.phase = cgka_traits::MaintenancePhase::Retry;
+                    self.session.put_key_package_lifecycle(&lifecycle)?;
+                    return Err(crate::key_package::KeyPackagePublishError::exposed(
+                        "no KeyPackage relay acknowledged the republication",
+                    )
+                    .into());
+                }
+                lifecycle.phase = if lifecycle.publication_targets.iter().all(|target| {
+                    matches!(
+                        target.state,
+                        TransportFanoutAttemptState::Accepted
+                            | TransportFanoutAttemptState::PolicyProhibited
+                    )
+                }) {
+                    cgka_traits::MaintenancePhase::Complete
+                } else {
+                    cgka_traits::MaintenancePhase::Fanout
+                };
+                self.session.put_key_package_lifecycle(&lifecycle)?;
+                Ok(key_package)
+            }
+            Err(error) => {
+                note_key_package_attempt(
+                    &mut lifecycle.publication_targets,
+                    &publication.endpoints,
+                    &[],
+                    &[],
+                    self.wall_clock.now(),
+                );
+                lifecycle.phase = if error.externally_exposed {
+                    cgka_traits::MaintenancePhase::Fanout
+                } else {
+                    cgka_traits::MaintenancePhase::Retry
+                };
+                self.session.put_key_package_lifecycle(&lifecycle)?;
+                Err(error.into())
+            }
+        }
+    }
+
     pub async fn publish_fresh_key_package(&mut self) -> AccountResult<KeyPackage> {
         tracing::debug!(
             target: TRACE_TARGET,
@@ -2971,6 +3106,100 @@ fn apply_report_to_fanout(
                 .into(),
             );
         }
+    }
+}
+
+fn current_key_package_republishable(lifecycle: &KeyPackageLifecycleState, now: Timestamp) -> bool {
+    lifecycle.current_key_package.is_some()
+        && lifecycle.current_key_package_ref.is_some()
+        && lifecycle
+            .current_not_before
+            .is_some_and(|not_before| not_before <= now)
+        && lifecycle
+            .current_not_after
+            .is_some_and(|not_after| not_after > now)
+        && lifecycle.authored_event_id.is_some()
+        && lifecycle.authored_event_created_at.is_some()
+        && lifecycle.authored_signed_event.is_some()
+        && lifecycle.last_consumed_key_package_ref != lifecycle.current_key_package_ref
+        && lifecycle
+            .refresh_at
+            .is_some_and(|refresh_at| refresh_at > now)
+        && lifecycle.upgrade_rotation_recorded
+}
+
+fn current_key_package_republish_fallback_reason(
+    lifecycle: &KeyPackageLifecycleState,
+    now: Timestamp,
+) -> &'static str {
+    if lifecycle.current_key_package.is_none() {
+        "missing_current_key_package"
+    } else if lifecycle.current_key_package_ref.is_none() {
+        "missing_current_key_package_ref"
+    } else if lifecycle
+        .current_not_before
+        .is_none_or(|not_before| not_before > now)
+    {
+        "current_not_before_unreached"
+    } else if lifecycle
+        .current_not_after
+        .is_none_or(|not_after| not_after <= now)
+    {
+        "current_not_after_expired"
+    } else if lifecycle.authored_event_id.is_none() {
+        "missing_authored_event_id"
+    } else if lifecycle.authored_event_created_at.is_none() {
+        "missing_authored_event_created_at"
+    } else if lifecycle.authored_signed_event.is_none() {
+        "missing_authored_signed_event"
+    } else if lifecycle.last_consumed_key_package_ref == lifecycle.current_key_package_ref {
+        "current_key_package_ref_consumed"
+    } else if lifecycle
+        .refresh_at
+        .is_none_or(|refresh_at| refresh_at <= now)
+    {
+        "refresh_due"
+    } else if !lifecycle.upgrade_rotation_recorded {
+        "upgrade_rotation_required"
+    } else {
+        "republishable"
+    }
+}
+
+fn merge_republish_publication_targets(
+    targets: &mut Vec<TransportFanoutTarget>,
+    current_endpoints: &[TransportEndpoint],
+) {
+    for endpoint in current_endpoints {
+        if let Some(target) = targets
+            .iter_mut()
+            .find(|target| target.endpoint == *endpoint)
+        {
+            if target.state == TransportFanoutAttemptState::PolicyProhibited {
+                target.state = TransportFanoutAttemptState::Unattempted;
+                target.attempt_count = 0;
+                target.last_attempt_at = None;
+                target.failure_code = None;
+            }
+            continue;
+        }
+        targets.push(TransportFanoutTarget {
+            endpoint: endpoint.clone(),
+            state: TransportFanoutAttemptState::Unattempted,
+            attempt_count: 0,
+            last_attempt_at: None,
+            failure_code: None,
+        });
+    }
+    for target in targets.iter_mut() {
+        if current_endpoints.contains(&target.endpoint) {
+            continue;
+        }
+        if target.state == TransportFanoutAttemptState::PolicyProhibited {
+            continue;
+        }
+        target.state = TransportFanoutAttemptState::PolicyProhibited;
+        target.failure_code = Some("endpoint_removed_from_policy".into());
     }
 }
 

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -3122,9 +3122,6 @@ fn current_key_package_republishable(lifecycle: &KeyPackageLifecycleState, now: 
         && lifecycle.authored_event_created_at.is_some()
         && lifecycle.authored_signed_event.is_some()
         && lifecycle.last_consumed_key_package_ref != lifecycle.current_key_package_ref
-        && lifecycle
-            .refresh_at
-            .is_some_and(|refresh_at| refresh_at > now)
         && lifecycle.upgrade_rotation_recorded
 }
 
@@ -3154,11 +3151,6 @@ fn current_key_package_republish_fallback_reason(
         "missing_authored_signed_event"
     } else if lifecycle.last_consumed_key_package_ref == lifecycle.current_key_package_ref {
         "current_key_package_ref_consumed"
-    } else if lifecycle
-        .refresh_at
-        .is_none_or(|refresh_at| refresh_at <= now)
-    {
-        "refresh_due"
     } else if !lifecycle.upgrade_rotation_recorded {
         "upgrade_rotation_required"
     } else {

--- a/crates/marmot-account/src/runtime.rs
+++ b/crates/marmot-account/src/runtime.rs
@@ -289,11 +289,11 @@ where
             .into());
         }
         let now = self.wall_clock.now();
-        if !current_key_package_republishable(&lifecycle, now) {
+        if let Some(fallback_reason) = current_key_package_republish_blocker(&lifecycle, now) {
             tracing::debug!(
                 target: TRACE_TARGET,
                 method = "republish_key_package",
-                fallback_reason = current_key_package_republish_fallback_reason(&lifecycle, now),
+                fallback_reason,
                 "no republishable current key package artifact; falling back to fresh publication"
             );
             return self.publish_fresh_key_package().await;
@@ -3109,52 +3109,36 @@ fn apply_report_to_fanout(
     }
 }
 
-fn current_key_package_republishable(lifecycle: &KeyPackageLifecycleState, now: Timestamp) -> bool {
-    lifecycle.current_key_package.is_some()
-        && lifecycle.current_key_package_ref.is_some()
-        && lifecycle
-            .current_not_before
-            .is_some_and(|not_before| not_before <= now)
-        && lifecycle
-            .current_not_after
-            .is_some_and(|not_after| not_after > now)
-        && lifecycle.authored_event_id.is_some()
-        && lifecycle.authored_event_created_at.is_some()
-        && lifecycle.authored_signed_event.is_some()
-        && lifecycle.last_consumed_key_package_ref != lifecycle.current_key_package_ref
-        && lifecycle.upgrade_rotation_recorded
-}
-
-fn current_key_package_republish_fallback_reason(
+fn current_key_package_republish_blocker(
     lifecycle: &KeyPackageLifecycleState,
     now: Timestamp,
-) -> &'static str {
+) -> Option<&'static str> {
     if lifecycle.current_key_package.is_none() {
-        "missing_current_key_package"
+        Some("missing_current_key_package")
     } else if lifecycle.current_key_package_ref.is_none() {
-        "missing_current_key_package_ref"
+        Some("missing_current_key_package_ref")
     } else if lifecycle
         .current_not_before
         .is_none_or(|not_before| not_before > now)
     {
-        "current_not_before_unreached"
+        Some("current_not_before_unreached")
     } else if lifecycle
         .current_not_after
         .is_none_or(|not_after| not_after <= now)
     {
-        "current_not_after_expired"
+        Some("current_not_after_expired")
     } else if lifecycle.authored_event_id.is_none() {
-        "missing_authored_event_id"
+        Some("missing_authored_event_id")
     } else if lifecycle.authored_event_created_at.is_none() {
-        "missing_authored_event_created_at"
+        Some("missing_authored_event_created_at")
     } else if lifecycle.authored_signed_event.is_none() {
-        "missing_authored_signed_event"
+        Some("missing_authored_signed_event")
     } else if lifecycle.last_consumed_key_package_ref == lifecycle.current_key_package_ref {
-        "current_key_package_ref_consumed"
+        Some("current_key_package_ref_consumed")
     } else if !lifecycle.upgrade_rotation_recorded {
-        "upgrade_rotation_required"
+        Some("upgrade_rotation_required")
     } else {
-        "republishable"
+        None
     }
 }
 

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -1220,6 +1220,538 @@ async fn key_package_first_ack_promotes_then_paused_maintenance_finishes_exact_f
 }
 
 #[tokio::test]
+async fn republish_key_package_resends_exact_authored_event_and_finishes_partial_fanout() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot kp republish key").unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let publisher = PartialFanoutKeyPackages::default();
+    let wall = Arc::new(TestWallClock::new(70_000));
+    let routing = StaticTransportRouting::new(vec![]).key_package_endpoints(vec![
+        TransportEndpoint("wss://keys-a.example".into()),
+        TransportEndpoint("wss://keys-b.example".into()),
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        routing.clone(),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(23)),
+    );
+
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect("initial rotation promotes a current package");
+    let promoted = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let authored_event = promoted.authored_signed_event.clone().unwrap();
+    let current_ref = promoted.current_key_package_ref.clone().unwrap();
+    let durable_bundle_count = runtime.durably_owned_key_packages().unwrap().len();
+    wall.set(promoted.current_not_before.unwrap().0);
+
+    runtime
+        .republish_key_package()
+        .await
+        .expect("explicit republish must reuse the current authored event");
+    let after_republish = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(after_republish.stable_slot_id, promoted.stable_slot_id);
+    assert_eq!(
+        after_republish.authored_signed_event,
+        Some(authored_event.clone())
+    );
+    assert_eq!(
+        after_republish.authored_event_id,
+        promoted.authored_event_id
+    );
+    assert_eq!(
+        after_republish.authored_event_created_at,
+        promoted.authored_event_created_at
+    );
+    assert_eq!(
+        after_republish.current_key_package_ref,
+        Some(current_ref.clone())
+    );
+    assert!(after_republish.pending_replacement.is_none());
+    assert_eq!(
+        after_republish.retained_private_material,
+        promoted.retained_private_material
+    );
+    assert_eq!(
+        runtime.durably_owned_key_packages().unwrap().len(),
+        durable_bundle_count,
+        "republish must not mint or prune durable private bundles"
+    );
+
+    let calls = publisher.publications();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].1, calls[1].1);
+    assert_eq!(calls[0].0.slot_id, calls[1].0.slot_id);
+    assert_eq!(calls[0].0.created_at, calls[1].0.created_at);
+    assert_eq!(
+        calls[1].0.endpoints,
+        vec![
+            TransportEndpoint("wss://keys-a.example".into()),
+            TransportEndpoint("wss://keys-b.example".into()),
+        ]
+    );
+    let completed = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(completed.phase, cgka_traits::MaintenancePhase::Complete);
+    assert!(
+        completed
+            .publication_targets
+            .iter()
+            .all(|target| { target.state == cgka_traits::TransportFanoutAttemptState::Accepted })
+    );
+
+    drop(runtime);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        routing,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(23)),
+    );
+    restarted
+        .republish_key_package()
+        .await
+        .expect("restart republish must reuse the durable authored event");
+    let calls = publisher.publications();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[2].1, authored_event);
+    assert_eq!(
+        calls[2].0.endpoints,
+        vec![
+            TransportEndpoint("wss://keys-a.example".into()),
+            TransportEndpoint("wss://keys-b.example".into()),
+        ]
+    );
+    let after_restart = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(after_restart.stable_slot_id, promoted.stable_slot_id);
+    assert_eq!(after_restart.authored_signed_event, Some(authored_event));
+    assert_eq!(after_restart.authored_event_id, promoted.authored_event_id);
+    assert_eq!(
+        after_restart.authored_event_created_at,
+        promoted.authored_event_created_at
+    );
+    assert_eq!(after_restart.current_key_package_ref, Some(current_ref));
+    assert_eq!(
+        after_restart.retained_private_material,
+        promoted.retained_private_material
+    );
+    assert_eq!(
+        restarted.durably_owned_key_packages().unwrap().len(),
+        durable_bundle_count,
+        "restart republish must not mint or prune durable private bundles"
+    );
+}
+
+#[tokio::test]
+async fn republish_key_package_rejects_pending_replacement_without_publishing() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot kp pending republish key").unwrap();
+    let policy = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]);
+    let initial_publisher = RecordingKeyPackages::default();
+    let mut initial = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        policy.clone(),
+        initial_publisher,
+    );
+    initial.publish_fresh_key_package().await.unwrap();
+    drop(initial);
+
+    let flaky = FlakyKeyPackages::new(1);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        policy,
+        flaky.clone(),
+    );
+    runtime
+        .publish_fresh_key_package()
+        .await
+        .expect_err("replacement attempt must fail before acknowledgement");
+    let before = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert!(before.pending_replacement.is_some());
+    let durable_before = runtime.durably_owned_key_packages().unwrap();
+
+    let error = runtime
+        .republish_key_package()
+        .await
+        .expect_err("republish must not advance a pending replacement");
+    assert!(matches!(error, AccountError::KeyPackageRotationInProgress));
+    assert_eq!(
+        flaky.publications().len(),
+        1,
+        "only the failed rotation attempt may publish"
+    );
+    let after = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(after, before);
+    assert_eq!(
+        runtime.durably_owned_key_packages().unwrap(),
+        durable_before
+    );
+}
+
+#[tokio::test]
+async fn republish_key_package_falls_back_when_no_current_artifact_exists() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let key = SqlCipherKey::new("marmot kp no artifact republish key").unwrap();
+    let publisher = RecordingKeyPackages::default();
+    let policy = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]);
+    let session = session(database, &key, b"alice");
+    let slot = publisher
+        .legacy_slot_id(&session.self_id())
+        .unwrap()
+        .unwrap();
+    session
+        .put_key_package_lifecycle(&cgka_traits::KeyPackageLifecycleState::slot_only(slot))
+        .unwrap();
+    let mut runtime = AccountDeviceRuntime::new(
+        session,
+        RecordingAdapter::default(),
+        policy,
+        publisher.clone(),
+    );
+
+    let key_package = runtime
+        .republish_key_package()
+        .await
+        .expect("republish must fall back to fresh publication");
+    assert!(!key_package.bytes().is_empty());
+    let publications = publisher.publications();
+    assert_eq!(publications.len(), 1);
+    let lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(
+        lifecycle.current_key_package_ref,
+        Some(
+            hex::decode(
+                cgka_engine::key_package::key_package_metadata(&key_package)
+                    .unwrap()
+                    .key_package_ref_hex
+            )
+            .unwrap()
+        )
+    );
+    assert!(lifecycle.pending_replacement.is_none());
+    assert!(lifecycle.authored_signed_event.is_some());
+}
+
+#[tokio::test]
+async fn republish_key_package_falls_back_when_refresh_is_due() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot kp refresh due republish key").unwrap();
+    let publisher = RecordingKeyPackages::default();
+    let wall = Arc::new(TestWallClock::new(90_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![])
+            .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(17)),
+    );
+
+    let first = runtime.publish_fresh_key_package().await.unwrap();
+    let refresh_at = runtime
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .refresh_at
+        .unwrap();
+    wall.set(refresh_at.0);
+
+    let second = runtime.republish_key_package().await.unwrap();
+    let publications = publisher.publications();
+    assert_eq!(publications.len(), 2);
+    assert_ne!(first, second);
+    assert_ne!(
+        publications[0].created_at, publications[1].created_at,
+        "refresh-due fallback must rotate via a new authored event"
+    );
+    let lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(lifecycle.retained_private_material.len(), 1);
+    assert_eq!(
+        lifecycle.retained_private_material[0].key_package,
+        publications[0].key_package
+    );
+}
+
+#[tokio::test]
+async fn republish_key_package_falls_back_when_current_ref_is_consumed() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot kp consumed republish key").unwrap();
+    let publisher = RecordingKeyPackages::default();
+    let wall = Arc::new(TestWallClock::new(90_000));
+    let mut runtime = AccountDeviceRuntime::new(
+        session(dir.path().join("alice.sqlite"), &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![])
+            .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(17)),
+    );
+
+    let first = runtime.publish_fresh_key_package().await.unwrap();
+    let mut lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let consumed_ref = lifecycle.current_key_package_ref.clone().unwrap();
+    lifecycle.last_consumed_key_package_ref = Some(consumed_ref.clone());
+    lifecycle.last_consumed_at = Some(Timestamp(42));
+    runtime
+        .session()
+        .put_key_package_lifecycle(&lifecycle)
+        .unwrap();
+    wall.set(lifecycle.current_not_before.unwrap().0);
+
+    let second = runtime.republish_key_package().await.unwrap();
+    let publications = publisher.publications();
+    assert_eq!(publications.len(), 2);
+    assert_ne!(first, second);
+    let after = runtime.key_package_maintenance_status().unwrap().unwrap();
+    assert_ne!(after.current_key_package_ref, Some(consumed_ref));
+    assert!(after.last_consumed_key_package_ref.is_none());
+    assert_eq!(after.retained_private_material.len(), 0);
+}
+
+#[tokio::test]
+async fn republish_key_package_reconciles_authoritative_targets_across_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot kp routing reconcile key").unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let publisher = PartialFanoutKeyPackages::default();
+    let wall = Arc::new(TestWallClock::new(70_000));
+    let initial_routing = StaticTransportRouting::new(vec![]).key_package_endpoints(vec![
+        TransportEndpoint("wss://keys-a.example".into()),
+        TransportEndpoint("wss://keys-b.example".into()),
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        initial_routing,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(23)),
+    );
+
+    runtime.publish_fresh_key_package().await.unwrap();
+    let promoted = runtime.key_package_maintenance_status().unwrap().unwrap();
+    wall.set(promoted.current_not_before.unwrap().0);
+    let authored_event = promoted.authored_signed_event.clone().unwrap();
+    drop(runtime);
+
+    let updated_routing = StaticTransportRouting::new(vec![]).key_package_endpoints(vec![
+        TransportEndpoint("wss://keys-a.example".into()),
+        TransportEndpoint("wss://keys-c.example".into()),
+    ]);
+    let mut restarted = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        updated_routing,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(23)),
+    );
+    restarted.republish_key_package().await.unwrap();
+
+    let calls = publisher.publications();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[1].1, authored_event);
+    assert_eq!(
+        calls[1].0.endpoints,
+        vec![
+            TransportEndpoint("wss://keys-a.example".into()),
+            TransportEndpoint("wss://keys-c.example".into()),
+        ]
+    );
+    let completed = restarted.key_package_maintenance_status().unwrap().unwrap();
+    assert_eq!(completed.phase, cgka_traits::MaintenancePhase::Complete);
+    let removed = completed
+        .publication_targets
+        .iter()
+        .find(|target| target.endpoint == TransportEndpoint("wss://keys-b.example".into()))
+        .expect("removed endpoint history must be retained");
+    assert_eq!(
+        removed.state,
+        cgka_traits::TransportFanoutAttemptState::PolicyProhibited
+    );
+    let reauthorized = completed
+        .publication_targets
+        .iter()
+        .find(|target| target.endpoint == TransportEndpoint("wss://keys-c.example".into()))
+        .expect("new authoritative endpoint must be tracked");
+    assert_eq!(
+        reauthorized.state,
+        cgka_traits::TransportFanoutAttemptState::Accepted
+    );
+}
+
+#[tokio::test]
+async fn republish_key_package_reauthorizes_previously_removed_endpoint() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot kp routing reauthorize key").unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let publisher = RecordingKeyPackages::default();
+    let wall = Arc::new(TestWallClock::new(70_000));
+    let two_targets = StaticTransportRouting::new(vec![]).key_package_endpoints(vec![
+        TransportEndpoint("wss://keys-a.example".into()),
+        TransportEndpoint("wss://keys-b.example".into()),
+    ]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        two_targets,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(23)),
+    );
+    runtime.publish_fresh_key_package().await.unwrap();
+    let promoted = runtime.key_package_maintenance_status().unwrap().unwrap();
+    wall.set(promoted.current_not_before.unwrap().0);
+    drop(runtime);
+
+    let one_target = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![TransportEndpoint("wss://keys-a.example".into())]);
+    let mut removed = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        one_target,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(23)),
+    );
+    removed.republish_key_package().await.unwrap();
+    let prohibited = removed
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap()
+        .publication_targets
+        .iter()
+        .find(|target| target.endpoint == TransportEndpoint("wss://keys-b.example".into()))
+        .expect("removed endpoint must remain durable")
+        .state;
+    assert_eq!(
+        prohibited,
+        cgka_traits::TransportFanoutAttemptState::PolicyProhibited
+    );
+    drop(removed);
+
+    let mut restored = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![
+            TransportEndpoint("wss://keys-a.example".into()),
+            TransportEndpoint("wss://keys-b.example".into()),
+        ]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(23)),
+    );
+    restored.republish_key_package().await.unwrap();
+    let restored_lifecycle = restored.key_package_maintenance_status().unwrap().unwrap();
+    let reauthorized = restored_lifecycle
+        .publication_targets
+        .iter()
+        .find(|target| target.endpoint == TransportEndpoint("wss://keys-b.example".into()))
+        .expect("reauthorized endpoint must be retained");
+    assert_eq!(
+        reauthorized.state,
+        cgka_traits::TransportFanoutAttemptState::Accepted
+    );
+    assert_eq!(reauthorized.attempt_count, 1);
+    assert!(reauthorized.failure_code.is_none());
+}
+
+#[tokio::test]
+async fn republish_key_package_persists_policy_removal_when_no_targets_remain() {
+    let dir = tempfile::tempdir().unwrap();
+    let key = SqlCipherKey::new("marmot kp empty routing republish key").unwrap();
+    let database = dir.path().join("alice.sqlite");
+    let publisher = RecordingKeyPackages::default();
+    let wall = Arc::new(TestWallClock::new(70_000));
+    let initial_routing = StaticTransportRouting::new(vec![])
+        .key_package_endpoints(vec![TransportEndpoint("wss://keys.example".into())]);
+    let mut runtime = AccountDeviceRuntime::new(
+        session(database.clone(), &key, b"alice"),
+        RecordingAdapter::default(),
+        initial_routing,
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall.clone(),
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(23)),
+    );
+    runtime.publish_fresh_key_package().await.unwrap();
+    let promoted = runtime.key_package_maintenance_status().unwrap().unwrap();
+    wall.set(promoted.current_not_before.unwrap().0);
+    drop(runtime);
+
+    let mut no_targets = AccountDeviceRuntime::new(
+        session(database, &key, b"alice"),
+        RecordingAdapter::default(),
+        StaticTransportRouting::new(vec![]).key_package_endpoints(vec![]),
+        publisher.clone(),
+    )
+    .with_maintenance_sources(
+        wall,
+        Arc::new(TestMonotonicClock::default()),
+        Arc::new(TestRandom::new(23)),
+    );
+
+    no_targets
+        .republish_key_package()
+        .await
+        .expect_err("republish without authoritative targets must fail");
+    assert_eq!(
+        publisher.publications().len(),
+        1,
+        "empty policy must not trigger a publication"
+    );
+    let lifecycle = no_targets
+        .key_package_maintenance_status()
+        .unwrap()
+        .unwrap();
+    assert!(lifecycle.publication_targets.iter().all(|target| {
+        target.state == cgka_traits::TransportFanoutAttemptState::PolicyProhibited
+            && target.failure_code.as_deref() == Some("endpoint_removed_from_policy")
+    }));
+}
+
+#[tokio::test]
 async fn key_package_expiry_sweep_deletes_private_material_while_network_maintenance_is_paused() {
     let dir = tempfile::tempdir().unwrap();
     let key = SqlCipherKey::new("marmot kp paused expiry key").unwrap();

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -1449,7 +1449,7 @@ async fn republish_key_package_falls_back_when_no_current_artifact_exists() {
 }
 
 #[tokio::test]
-async fn republish_key_package_falls_back_when_refresh_is_due() {
+async fn republish_key_package_reuses_current_artifact_when_refresh_is_due() {
     let dir = tempfile::tempdir().unwrap();
     let key = SqlCipherKey::new("marmot kp refresh due republish key").unwrap();
     let publisher = RecordingKeyPackages::default();
@@ -1468,27 +1468,35 @@ async fn republish_key_package_falls_back_when_refresh_is_due() {
     );
 
     let first = runtime.publish_fresh_key_package().await.unwrap();
-    let refresh_at = runtime
-        .key_package_maintenance_status()
-        .unwrap()
-        .unwrap()
-        .refresh_at
-        .unwrap();
+    let before = runtime.key_package_maintenance_status().unwrap().unwrap();
+    let durable_before = runtime.durably_owned_key_packages().unwrap();
+    let refresh_at = before.refresh_at.unwrap();
     wall.set(refresh_at.0);
 
     let second = runtime.republish_key_package().await.unwrap();
     let publications = publisher.publications();
     assert_eq!(publications.len(), 2);
-    assert_ne!(first, second);
-    assert_ne!(
-        publications[0].created_at, publications[1].created_at,
-        "refresh-due fallback must rotate via a new authored event"
-    );
-    let lifecycle = runtime.key_package_maintenance_status().unwrap().unwrap();
-    assert_eq!(lifecycle.retained_private_material.len(), 1);
+    assert_eq!(first, second);
+    assert_eq!(publications[0], publications[1]);
+    let after = runtime.key_package_maintenance_status().unwrap().unwrap();
     assert_eq!(
-        lifecycle.retained_private_material[0].key_package,
-        publications[0].key_package
+        after.current_key_package_ref,
+        before.current_key_package_ref
+    );
+    assert_eq!(after.authored_event_id, before.authored_event_id);
+    assert_eq!(
+        after.authored_event_created_at,
+        before.authored_event_created_at
+    );
+    assert_eq!(after.authored_signed_event, before.authored_signed_event);
+    assert_eq!(
+        after.retained_private_material,
+        before.retained_private_material
+    );
+    assert_eq!(
+        runtime.durably_owned_key_packages().unwrap(),
+        durable_before,
+        "refresh-due republish must not mint or prune durable private bundles"
     );
 }
 

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -238,10 +238,7 @@ impl AppClient {
             .await?;
         self.refresh_routing()?;
         self.runtime.activate_transport(None).await?;
-        // SQLCipher lifecycle state is authoritative. On first rollout the
-        // publisher imports only the legacy JSON `d` slot, then performs the
-        // recorded upgrade replacement under that same slot.
-        Ok(self.runtime.publish_fresh_key_package().await?)
+        Ok(self.runtime.republish_key_package().await?)
     }
 
     pub fn maintenance_status(
@@ -492,7 +489,15 @@ impl AppClient {
     }
 
     pub async fn rotate_key_package(&mut self) -> Result<KeyPackage, AppError> {
-        self.publish_key_package().await
+        self.app
+            .ensure_local_account_relay_lists(&self.state.label)
+            .await?;
+        self.refresh_routing()?;
+        self.runtime.activate_transport(None).await?;
+        // SQLCipher lifecycle state is authoritative. On first rollout the
+        // publisher imports only the legacy JSON `d` slot, then performs the
+        // recorded upgrade replacement under that same slot.
+        Ok(self.runtime.publish_fresh_key_package().await?)
     }
 
     /// Create a locally canonical group and attempt each founding Welcome.

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -208,6 +208,7 @@ fn account_error_kind(error: &AccountError) -> &'static str {
         AccountError::TransportRouting(_) => "account_transport_routing",
         AccountError::KeyPackage(_) => "account_key_package",
         AccountError::ClockSkewBlocked => "account_clock_skew_blocked",
+        AccountError::KeyPackageRotationInProgress => "account_key_package_rotation_in_progress",
         AccountError::WrongAccountDelivery => "account_wrong_delivery",
         _ => "account_unknown",
     }

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -2083,6 +2083,13 @@ impl MarmotAppRuntime {
             .await
     }
 
+    pub async fn durably_owned_key_packages(
+        &self,
+        account_ref: &str,
+    ) -> Result<Vec<cgka_traits::engine::KeyPackage>, AppError> {
+        self.accounts.durably_owned_key_packages(account_ref).await
+    }
+
     pub async fn publish_new_key_package(&self, account_ref: &str) -> Result<usize, AppError> {
         self.rotate_key_package(account_ref).await
     }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -926,7 +926,7 @@ async fn runtime_profile_publish_preserves_unknown_kind0_fields() {
 }
 
 #[tokio::test]
-async fn app_runtime_routine_key_package_publish_replaces_under_stable_slot() {
+async fn app_runtime_republish_key_package_resends_exact_current_event() {
     let dir = tempfile::tempdir().unwrap();
     let (_relay, app, url) = mock_app(&dir).await;
     let runtime = MarmotAppRuntime::new(app.clone());
@@ -947,12 +947,27 @@ async fn app_runtime_routine_key_package_publish_replaces_under_stable_slot() {
         )
         .await
         .unwrap();
+    let before = runtime
+        .key_package_maintenance_status(&created.account.account_id_hex)
+        .await
+        .unwrap()
+        .expect("initial publication must promote lifecycle state");
+    let durable_before = runtime
+        .durably_owned_key_packages(&created.account.account_id_hex)
+        .await
+        .unwrap()
+        .len();
 
     let republished_bytes = runtime
         .publish_key_package(&created.account.account_id_hex)
         .await
         .unwrap();
-    let second = app
+    let after_republish = runtime
+        .key_package_maintenance_status(&created.account.account_id_hex)
+        .await
+        .unwrap()
+        .expect("republish must keep lifecycle state");
+    let relay_after_republish = app
         .fetch_latest_key_package_for_account_id(
             &created.account.account_id_hex,
             vec![endpoint(&url)],
@@ -961,17 +976,157 @@ async fn app_runtime_routine_key_package_publish_replaces_under_stable_slot() {
         .unwrap();
 
     assert_eq!(republished_bytes, first.key_package.bytes().len());
-    assert_ne!(second.key_package.bytes(), first.key_package.bytes());
-    assert_eq!(second.key_package_id, first.key_package_id);
-    assert_ne!(second.key_package_ref_hex, first.key_package_ref_hex);
-    assert!(!first.key_package_id.is_empty());
-    assert!(!second.key_package_id.is_empty());
-    assert!(!first.key_package_ref_hex.is_empty());
-    assert!(!second.key_package_ref_hex.is_empty());
-    assert!(!first.key_package_event_id.is_empty());
-    assert!(!second.key_package_event_id.is_empty());
+    assert_eq!(
+        relay_after_republish.key_package.bytes(),
+        first.key_package.bytes()
+    );
+    assert_eq!(
+        relay_after_republish.key_package_ref_hex,
+        first.key_package_ref_hex
+    );
+    assert_eq!(
+        relay_after_republish.key_package_event_id,
+        first.key_package_event_id
+    );
+    assert_eq!(after_republish.stable_slot_id, before.stable_slot_id);
+    assert_eq!(
+        after_republish.current_key_package_ref,
+        before.current_key_package_ref
+    );
+    assert_eq!(after_republish.authored_event_id, before.authored_event_id);
+    assert_eq!(
+        after_republish.authored_event_created_at,
+        before.authored_event_created_at
+    );
+    assert_eq!(
+        after_republish.authored_signed_event,
+        before.authored_signed_event
+    );
+    assert_eq!(after_republish.phase, before.phase);
+    assert_eq!(
+        after_republish.retained_private_material.len(),
+        before.retained_private_material.len()
+    );
+    assert!(after_republish.pending_replacement.is_none());
+    assert_eq!(
+        runtime
+            .durably_owned_key_packages(&created.account.account_id_hex)
+            .await
+            .unwrap()
+            .len(),
+        durable_before,
+        "republish must not mint or prune durable private bundles"
+    );
 
     runtime.shutdown().await;
+    drop(runtime);
+    drop(app);
+
+    let restarted_app = MarmotApp::with_relay_and_config(
+        dir.path(),
+        url.clone(),
+        MarmotAppConfig::default()
+            .with_allow_loopback_blob_endpoints(true)
+            .with_allow_loopback_relay_endpoints(true),
+    );
+    let restarted = MarmotAppRuntime::new(restarted_app.clone());
+    restarted.reconcile_accounts().await.unwrap();
+
+    let republished_after_restart_bytes = restarted
+        .publish_key_package(&created.account.account_id_hex)
+        .await
+        .unwrap();
+    let after_restart = restarted
+        .key_package_maintenance_status(&created.account.account_id_hex)
+        .await
+        .unwrap()
+        .expect("restart must retain lifecycle state");
+    let relay_after_restart = restarted_app
+        .fetch_latest_key_package_for_account_id(
+            &created.account.account_id_hex,
+            vec![endpoint(&url)],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        republished_after_restart_bytes,
+        first.key_package.bytes().len()
+    );
+    assert_eq!(
+        relay_after_restart.key_package.bytes(),
+        first.key_package.bytes()
+    );
+    assert_eq!(
+        relay_after_restart.key_package_ref_hex,
+        first.key_package_ref_hex
+    );
+    assert_eq!(
+        relay_after_restart.key_package_event_id,
+        first.key_package_event_id
+    );
+    assert_eq!(after_restart.stable_slot_id, before.stable_slot_id);
+    assert_eq!(
+        after_restart.current_key_package_ref,
+        before.current_key_package_ref
+    );
+    assert_eq!(after_restart.authored_event_id, before.authored_event_id);
+    assert_eq!(
+        after_restart.authored_signed_event,
+        before.authored_signed_event
+    );
+    assert_eq!(
+        after_restart.retained_private_material.len(),
+        before.retained_private_material.len()
+    );
+    assert_eq!(
+        restarted
+            .durably_owned_key_packages(&created.account.account_id_hex)
+            .await
+            .unwrap()
+            .len(),
+        durable_before,
+        "restart republish must not mint or prune durable private bundles"
+    );
+
+    let rotated_bytes = restarted
+        .rotate_key_package(&created.account.account_id_hex)
+        .await
+        .unwrap();
+    let after_rotation = restarted
+        .key_package_maintenance_status(&created.account.account_id_hex)
+        .await
+        .unwrap()
+        .expect("rotation must promote lifecycle state");
+    let relay_after_rotation = restarted_app
+        .fetch_latest_key_package_for_account_id(
+            &created.account.account_id_hex,
+            vec![endpoint(&url)],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        rotated_bytes,
+        relay_after_rotation.key_package.bytes().len()
+    );
+    assert_eq!(after_rotation.stable_slot_id, before.stable_slot_id);
+    assert_ne!(
+        after_rotation.current_key_package_ref,
+        before.current_key_package_ref
+    );
+    assert_ne!(after_rotation.authored_event_id, before.authored_event_id);
+    assert_ne!(
+        relay_after_rotation.key_package.bytes(),
+        first.key_package.bytes()
+    );
+    assert_eq!(
+        after_rotation.retained_private_material.len(),
+        before.retained_private_material.len() + 1,
+        "explicit rotation must retain the prior unconsumed private bundle"
+    );
+
+    restarted.shutdown().await;
 }
 
 #[tokio::test]
@@ -1076,9 +1231,9 @@ async fn app_runtime_can_rotate_key_package_on_request() {
     assert_eq!(rotated_bytes, rotated.key_package.bytes().len());
     assert_eq!(rotated.key_package_id, first.key_package_id);
     assert_ne!(rotated.key_package_ref_hex, first.key_package_ref_hex);
-    assert_ne!(republished.key_package.bytes(), rotated.key_package.bytes());
+    assert_eq!(republished.key_package.bytes(), rotated.key_package.bytes());
     assert_eq!(republished.key_package_id, rotated.key_package_id);
-    assert_ne!(republished.key_package_ref_hex, rotated.key_package_ref_hex);
+    assert_eq!(republished.key_package_ref_hex, rotated.key_package_ref_hex);
     assert!(!rotated.key_package_id.is_empty());
     assert!(!republished.key_package_id.is_empty());
     assert!(!rotated.key_package_ref_hex.is_empty());

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -482,7 +482,12 @@ impl NostrSdkRelayClient {
             )
             .await
             {
-                Ok(Ok(output)) if output.success.contains(&endpoint) => {
+                Ok(Ok(output))
+                    if relay_endpoint_publish_accepted(
+                        output.success.contains(&endpoint),
+                        output.failed.get(&endpoint).map(String::as_str),
+                    ) =>
+                {
                     return Ok(TransportEndpointReceipt {
                         endpoint: transport_endpoint,
                         accepted_at: None,
@@ -1146,6 +1151,19 @@ fn merge_registration_log(
     }
 }
 
+/// A relay `OK:false` with the NIP-01 `duplicate:` machine prefix proves the
+/// exact event is already stored and counts as idempotent publication success.
+fn relay_duplicate_acknowledgement(relay_failure: &str) -> bool {
+    matches!(
+        nostr::message::MachineReadablePrefix::parse(relay_failure),
+        Some(nostr::message::MachineReadablePrefix::Duplicate)
+    )
+}
+
+fn relay_endpoint_publish_accepted(success: bool, failure_reason: Option<&str>) -> bool {
+    success || failure_reason.is_some_and(relay_duplicate_acknowledgement)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1153,7 +1171,7 @@ mod tests {
     use cgka_traits::Timestamp;
     use cgka_traits::engine::KeyPackage;
     use nostr_relay_builder::MockRelay;
-    use nostr_sdk::prelude::Keys;
+    use nostr_sdk::prelude::{EventBuilder, Keys, Kind, Tag};
     use tokio::net::TcpListener;
     use tokio::time::{Duration, advance, timeout};
     use transport_nostr_peeler::KIND_MARMOT_GROUP_MESSAGE;
@@ -1172,6 +1190,33 @@ mod tests {
             .sign_with_keys(&ephemeral)
             .expect("sign ephemeral 445");
         NostrTransportEvent::from_nostr_event(&signed).expect("dto from signed event")
+    }
+
+    #[test]
+    fn relay_duplicate_acknowledgement_accepts_only_duplicate_prefix() {
+        assert!(relay_duplicate_acknowledgement(
+            "duplicate: already have this event"
+        ));
+        assert!(!relay_duplicate_acknowledgement("blocked: policy"));
+        assert!(!relay_duplicate_acknowledgement("relay rejected event"));
+        assert!(!relay_duplicate_acknowledgement(""));
+    }
+
+    #[test]
+    fn relay_endpoint_publish_accepted_treats_duplicate_failure_as_success() {
+        assert!(relay_endpoint_publish_accepted(
+            false,
+            Some("duplicate: already have this event")
+        ));
+        assert!(!relay_endpoint_publish_accepted(
+            false,
+            Some("blocked: policy")
+        ));
+        assert!(!relay_endpoint_publish_accepted(
+            false,
+            Some("error: unknown")
+        ));
+        assert!(relay_endpoint_publish_accepted(true, None));
     }
 
     #[test]
@@ -1713,6 +1758,47 @@ mod tests {
 
         assert!(err.to_string().contains("publish timed out"));
         assert_eq!(sdk.relay_health().await.total_relays, 1);
+    }
+
+    #[tokio::test]
+    async fn publish_event_accepts_duplicate_relay_ack_for_same_signed_event() {
+        let relay = MockRelay::run().await.unwrap();
+        let endpoint = TransportEndpoint(relay.url().await.to_string());
+        let keys = Keys::generate();
+        let client = Client::builder().signer(keys.clone()).build();
+        let sdk = NostrSdkRelayClient::new(client);
+        let dto = NostrKeyPackagePublication {
+            account_id: MemberId::new(keys.public_key().to_bytes().to_vec()),
+            key_package: KeyPackage::new(vec![1, 2, 3, 4]),
+            key_package_slot_id: "slot-1".into(),
+            key_package_ref: "bb".repeat(32),
+            mls_ciphersuite: "0x0001".into(),
+            mls_extensions: vec!["0x0006".into(), "0xf2f1".into(), "0x000a".into()],
+            mls_proposals: vec!["0x0008".into(), "0x000a".into()],
+            app_components: vec!["0x8001".into(), "0x8003".into(), "0x8004".into()],
+            publish_endpoints: vec![endpoint.clone()],
+        }
+        .to_event()
+        .expect("key package event");
+
+        timeout(
+            Duration::from_secs(2),
+            sdk.publish_event(std::slice::from_ref(&endpoint), &dto, 1),
+        )
+        .await
+        .expect("first publish should complete")
+        .expect("first publish should succeed");
+
+        let republish = timeout(
+            Duration::from_secs(2),
+            sdk.publish_event(std::slice::from_ref(&endpoint), &dto, 1),
+        )
+        .await
+        .expect("adapter republish should complete")
+        .expect("republishing the exact signed key package must be accepted");
+
+        assert_eq!(republish.accepted.len(), 1);
+        assert_eq!(republish.accepted[0].endpoint, endpoint);
     }
 
     #[tokio::test]

--- a/crates/transport-nostr-adapter/src/sdk_client.rs
+++ b/crates/transport-nostr-adapter/src/sdk_client.rs
@@ -1216,6 +1216,7 @@ mod tests {
             false,
             Some("error: unknown")
         ));
+        assert!(!relay_endpoint_publish_accepted(false, None));
         assert!(relay_endpoint_publish_accepted(true, None));
     }
 
@@ -1761,7 +1762,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn publish_event_accepts_duplicate_relay_ack_for_same_signed_event() {
+    async fn publish_event_accepts_republishing_same_signed_replaceable_event() {
         let relay = MockRelay::run().await.unwrap();
         let endpoint = TransportEndpoint(relay.url().await.to_string());
         let keys = Keys::generate();


### PR DESCRIPTION
Fixes #1163

## Summary
- Change explicit KeyPackage publish/republish to resend the exact durable current signed event and KeyPackage instead of staging a replacement.
- Preserve explicit rotation as the only path that mints a new KeyPackage, while retaining fallback rotation for missing, consumed, expired/refresh-due, or otherwise unusable current artifacts.
- Reconcile current authoritative publication targets across restart and policy churn, reject republish while a replacement is pending, and preserve lifecycle/private-material identity on normal republish.
- Treat a NIP-01 `duplicate:` relay acknowledgement as idempotent publication success without exposing relay-controlled rejection text.
- Update app/client/CLI wiring and add account, app-runtime, transport, and CLI regressions.

## Verification
- `cargo fmt --all --check`
- `./scripts/check_legacy_naming.sh`
- `cargo test -p marmot-account --locked -- --test-threads=1` — 89 passed
- `cargo test -p marmot-app --test relay_runtime --features test-policy-overrides --locked -- --test-threads=1` — 81 passed
- `cargo test -p transport-nostr-adapter --features sdk --locked -- --test-threads=1` — 85 passed
- `cargo nextest run -p wn-cli --test cli --features test-policy-overrides --locked --profile ci` — 88 passed
- `RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --locked`
- `RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test -p cgka-engine --test convergence_policy_pin --locked` — 5 passed
- Independent adversarial review: PASS, no blocking findings

## Sensitive paths
- `crates/marmot-account/src/runtime.rs` — KeyPackage lifecycle, signed artifact reuse, publication-target state
- `crates/marmot-app/src/client/mod.rs`
- `crates/marmot-app/src/runtime/mod.rs`
- `crates/transport-nostr-adapter/src/sdk_client.rs` — relay publication acknowledgement handling

Sensitive code touched. Explicit human approval is required at the merge gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Key package publishing now republishes the current package when appropriate, preserving its identity and durable state.
  - Added explicit key package rotation for creating a fresh package.
  - Added access to durably owned key packages.
- **Bug Fixes**
  - Republish operations now reconcile relay changes and retry incomplete distribution.
  - Duplicate relay acknowledgements are treated as successful, avoiding false publication failures.
  - Added clearer handling when key package rotation is already in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->