### PR TITLE
Add UniFFI follow management

### DIFF
--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -559,6 +559,7 @@ fn read_marker_error_code(error: &AppError) -> &'static str {
         AppError::Publish(_) => "read_marker_failed:publish",
         AppError::MissingDefaultRelays => "read_marker_failed:missing_default_relays",
         AppError::MissingRelayLists(_) => "read_marker_failed:missing_relay_lists",
+        AppError::FollowListUnavailable => "read_marker_failed:follow_list_unavailable",
         AppError::RelayDirectory(_) => "read_marker_failed:relay_directory",
         AppError::AccountCatchUp(_) => "read_marker_failed:account_catch_up",
         AppError::InvalidPublicKey => "read_marker_failed:invalid_public_key",

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -379,14 +379,14 @@ impl MarmotApp {
             &account.account_id_hex,
             publish_endpoints_from_bootstrap(&bootstrap),
         );
-        let tags = follows
+        let cached_follows =
+            normalize_account_ids(follows.iter().map(|follow| (*follow).to_owned()).collect())?;
+        let tags = cached_follows
             .iter()
-            .map(|follow| {
-                parse_account_id_hex(follow).map(|account_id| vec!["p".to_owned(), account_id])
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+            .map(|account_id| vec!["p".to_owned(), account_id.clone()])
+            .collect();
         let event = NostrTransportEvent::new_unsigned(
-            account.account_id_hex,
+            account.account_id_hex.clone(),
             KIND_NOSTR_CONTACT_LIST,
             tags,
             String::new(),
@@ -394,6 +394,19 @@ impl MarmotApp {
         self.relay_client_for_endpoints(signer.as_nostr_signer(), &endpoints)
             .publish_event(&endpoints, &event, 1)
             .await?;
+        // Publishing a local kind-3 list must make its own cached edge set
+        // immediately available to the bindings, without admitting every
+        // followed account as a watched directory entry.
+        self.remember_directory_follow_edges_for_search(
+            &account.account_id_hex,
+            &FetchedFollowList {
+                follows: cached_follows,
+                source_relays: endpoints
+                    .iter()
+                    .map(|endpoint| endpoint.0.clone())
+                    .collect(),
+            },
+        )?;
         Ok(())
     }
 

--- a/crates/marmot-app/src/directory/methods.rs
+++ b/crates/marmot-app/src/directory/methods.rs
@@ -397,7 +397,7 @@ impl MarmotApp {
         // Publishing a local kind-3 list must make its own cached edge set
         // immediately available to the bindings, without admitting every
         // followed account as a watched directory entry.
-        self.remember_directory_follow_edges_for_search(
+        if let Err(error) = self.remember_directory_follow_edges_for_search(
             &account.account_id_hex,
             &FetchedFollowList {
                 follows: cached_follows,
@@ -406,7 +406,14 @@ impl MarmotApp {
                     .map(|endpoint| endpoint.0.clone())
                     .collect(),
             },
-        )?;
+        ) {
+            tracing::warn!(
+                target: "marmot_app::directory",
+                method = "publish_account_follow_list",
+                error_kind = error.privacy_safe_kind(),
+                "follow list published but local cache update failed"
+            );
+        }
         Ok(())
     }
 

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -50,6 +50,12 @@ pub enum AppError {
     MissingDefaultRelays,
     #[error("missing account relay lists: {0:?}")]
     MissingRelayLists(Vec<MissingRelayListKind>),
+    /// The selected relay set returned no current kind-3 contact-list event.
+    ///
+    /// Follow updates replace the entire list, so treating an absent event as
+    /// an empty list could silently erase follows published elsewhere.
+    #[error("current account follow list is unavailable")]
+    FollowListUnavailable,
     #[error("relay directory fetch failed: {0}")]
     RelayDirectory(String),
     /// An account worker's transport catch-up failed (sync error or timeout).
@@ -157,6 +163,7 @@ impl AppError {
             Self::Publish(_) => "publish",
             Self::MissingDefaultRelays => "missing_default_relays",
             Self::MissingRelayLists(_) => "missing_relay_lists",
+            Self::FollowListUnavailable => "follow_list_unavailable",
             Self::RelayDirectory(_) => "relay_directory",
             Self::AccountCatchUp(_) => "account_catch_up",
             Self::InvalidPublicKey => "invalid_public_key",

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -106,6 +106,7 @@ pub struct MarmotAppRuntime {
     events: broadcast::Sender<MarmotAppEvent>,
     shared: RuntimeSharedServices,
     accounts: AccountManager,
+    follow_list_updates: Arc<Mutex<()>>,
     directory_sync: Arc<Mutex<Option<DirectorySyncHandle>>>,
     initial_directory_sync: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
@@ -820,6 +821,7 @@ impl MarmotAppRuntime {
             events,
             shared,
             accounts,
+            follow_list_updates: Arc::new(Mutex::new(())),
             directory_sync: Arc::new(Mutex::new(None)),
             initial_directory_sync: Arc::new(Mutex::new(None)),
         }
@@ -2585,6 +2587,118 @@ impl MarmotAppRuntime {
             .app
             .publish_account_follow_list(&account.label, &follow_refs, bootstrap)
             .await
+    }
+
+    /// Return the locally cached kind-3 follow list for a local account.
+    ///
+    /// This is intentionally network-free for profile/search-row rendering.
+    /// Successful directory refreshes and follow-list publishes update the
+    /// cache before returning.
+    pub fn account_follows(&self, account_ref: &str) -> Result<Vec<String>, AppError> {
+        let account = self.accounts.resolve(account_ref)?;
+        let mut follows = self
+            .accounts
+            .app
+            .directory_entry_for_account_id(&account.account_id_hex)?
+            .map(|entry| entry.follows)
+            .unwrap_or_default();
+        follows.sort();
+        follows.dedup();
+        Ok(follows)
+    }
+
+    /// Fast, network-free membership check against [`Self::account_follows`].
+    pub fn is_following(
+        &self,
+        account_ref: &str,
+        user_account_id_hex: &str,
+    ) -> Result<bool, AppError> {
+        Ok(self
+            .account_follows(account_ref)?
+            .binary_search_by(|follow| follow.as_str().cmp(user_account_id_hex))
+            .is_ok())
+    }
+
+    /// Add one account to the current kind-3 list without replacing unrelated
+    /// follows.
+    pub async fn follow_user(
+        &self,
+        account_ref: &str,
+        user_account_id_hex: &str,
+    ) -> Result<Vec<String>, AppError> {
+        self.set_following(account_ref, user_account_id_hex, true)
+            .await
+    }
+
+    /// Remove one account from the current kind-3 list without replacing
+    /// unrelated follows.
+    pub async fn unfollow_user(
+        &self,
+        account_ref: &str,
+        user_account_id_hex: &str,
+    ) -> Result<Vec<String>, AppError> {
+        self.set_following(account_ref, user_account_id_hex, false)
+            .await
+    }
+
+    async fn set_following(
+        &self,
+        account_ref: &str,
+        user_account_id_hex: &str,
+        following: bool,
+    ) -> Result<Vec<String>, AppError> {
+        // Kind-3 is a whole-list replaceable event. Serialize updates made
+        // through this runtime so two local UI actions cannot both fetch the
+        // same snapshot and then overwrite one another.
+        let _update_guard = self.follow_list_updates.lock().await;
+        let account = self.accounts.resolve(account_ref)?;
+        let status = self
+            .accounts
+            .app
+            .account_relay_list_status_for_account_id(&account.account_id_hex)?;
+        let mut source_relays = status
+            .nip65
+            .relays
+            .into_iter()
+            .map(TransportEndpoint)
+            .collect::<Vec<_>>();
+        for endpoint in self.accounts.app.directory_source_relays(&[]) {
+            if !source_relays.contains(&endpoint) {
+                source_relays.push(endpoint);
+            }
+        }
+        let mut follows = self
+            .accounts
+            .app
+            .fetch_current_follow_list_for_account_id(&account.account_id_hex, source_relays)
+            .await?
+            .ok_or(AppError::FollowListUnavailable)?;
+
+        let changed = if following {
+            if follows.iter().any(|follow| follow == user_account_id_hex) {
+                false
+            } else {
+                follows.push(user_account_id_hex.to_owned());
+                true
+            }
+        } else {
+            let previous_len = follows.len();
+            follows.retain(|follow| follow != user_account_id_hex);
+            follows.len() != previous_len
+        };
+        follows.sort();
+        follows.dedup();
+
+        if changed {
+            let fallback = self.accounts.app.directory_source_relays(&[]);
+            self.publish_account_follow_list(
+                &account.label,
+                &follows,
+                AccountRelayListBootstrap::new(fallback.clone(), fallback),
+            )
+            .await?;
+        }
+        Ok(follows)
     }
 
     pub async fn refresh_user_directory_for_account_id(

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -106,7 +106,7 @@ pub struct MarmotAppRuntime {
     events: broadcast::Sender<MarmotAppEvent>,
     shared: RuntimeSharedServices,
     accounts: AccountManager,
-    follow_list_updates: Arc<Mutex<()>>,
+    follow_list_updates: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
     directory_sync: Arc<Mutex<Option<DirectorySyncHandle>>>,
     initial_directory_sync: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
@@ -821,7 +821,7 @@ impl MarmotAppRuntime {
             events,
             shared,
             accounts,
-            follow_list_updates: Arc::new(Mutex::new(())),
+            follow_list_updates: Arc::new(Mutex::new(HashMap::new())),
             directory_sync: Arc::new(Mutex::new(None)),
             initial_directory_sync: Arc::new(Mutex::new(None)),
         }
@@ -2582,6 +2582,18 @@ impl MarmotAppRuntime {
         bootstrap: AccountRelayListBootstrap,
     ) -> Result<(), AppError> {
         let account = self.accounts.resolve(account_ref)?;
+        let update_lock = self.follow_list_update_lock(&account.account_id_hex).await;
+        let _update_guard = update_lock.lock().await;
+        self.publish_account_follow_list_unlocked(&account, follows, bootstrap)
+            .await
+    }
+
+    async fn publish_account_follow_list_unlocked(
+        &self,
+        account: &AccountSummary,
+        follows: &[String],
+        bootstrap: AccountRelayListBootstrap,
+    ) -> Result<(), AppError> {
         let follow_refs = follows.iter().map(String::as_str).collect::<Vec<_>>();
         self.accounts
             .app
@@ -2647,11 +2659,12 @@ impl MarmotAppRuntime {
         user_account_id_hex: &str,
         following: bool,
     ) -> Result<Vec<String>, AppError> {
-        // Kind-3 is a whole-list replaceable event. Serialize updates made
-        // through this runtime so two local UI actions cannot both fetch the
-        // same snapshot and then overwrite one another.
-        let _update_guard = self.follow_list_updates.lock().await;
         let account = self.accounts.resolve(account_ref)?;
+        // Kind-3 is a whole-list replaceable event. Serialize updates for
+        // this account so two local actions cannot both fetch the same
+        // snapshot and then overwrite one another.
+        let update_lock = self.follow_list_update_lock(&account.account_id_hex).await;
+        let _update_guard = update_lock.lock().await;
         let status = self
             .accounts
             .app
@@ -2691,14 +2704,22 @@ impl MarmotAppRuntime {
 
         if changed {
             let fallback = self.accounts.app.directory_source_relays(&[]);
-            self.publish_account_follow_list(
-                &account.label,
+            self.publish_account_follow_list_unlocked(
+                &account,
                 &follows,
                 AccountRelayListBootstrap::new(fallback.clone(), fallback),
             )
             .await?;
         }
         Ok(follows)
+    }
+
+    async fn follow_list_update_lock(&self, account_id_hex: &str) -> Arc<Mutex<()>> {
+        let mut locks = self.follow_list_updates.lock().await;
+        locks
+            .entry(account_id_hex.to_owned())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
     }
 
     pub async fn refresh_user_directory_for_account_id(

--- a/crates/marmot-uniffi/src/commands/account.rs
+++ b/crates/marmot-uniffi/src/commands/account.rs
@@ -3,7 +3,7 @@
 use cgka_traits::TransportEndpoint;
 use marmot_app::{AccountSetupRequest, UserProfileMetadata, default_directory_discovery_relays};
 
-use crate::conversions::{AccountSummaryFfi, UserProfileMetadataFfi};
+use crate::conversions::{AccountSummaryFfi, UserProfileMetadataFfi, normalize_member_ref_ffi};
 use crate::errors::MarmotKitError;
 use crate::external_signer::{ExternalAccountSignerAdapter, ExternalAccountSignerFfi};
 use crate::{Marmot, conversions, endpoints};
@@ -326,6 +326,67 @@ impl Marmot {
         Ok(status.into())
     }
 
+    // -----------------------------------------------------------------------
+    // Follows
+    // -----------------------------------------------------------------------
+
+    /// Return the complete locally cached kind-3 follow list for `account_ref`
+    /// as canonical lowercase public-key hex strings.
+    ///
+    /// This is a synchronous, network-free read intended for profile screens
+    /// and bulk membership checks. Follow/unfollow and directory refreshes
+    /// update the cache before returning.
+    pub fn account_follows(&self, account_ref: String) -> Result<Vec<String>, MarmotKitError> {
+        Ok(self.runtime.account_follows(&account_ref)?)
+    }
+
+    /// Return whether `account_ref` currently follows `user_ref`, using the
+    /// same local cache as [`Self::account_follows`]. `user_ref` accepts npub,
+    /// hex, `nostr:npub…`, and Marmot profile links.
+    pub fn is_following(
+        &self,
+        account_ref: String,
+        user_ref: String,
+    ) -> Result<bool, MarmotKitError> {
+        let user = normalize_member_ref_ffi(&user_ref)?;
+        Ok(self
+            .runtime
+            .is_following(&account_ref, &user.account_id_hex)?)
+    }
+
+    /// Follow `user_ref` while preserving every other entry in the account's
+    /// current kind-3 contact list. Returns the complete updated list.
+    ///
+    /// This fetches the current replaceable event from the account's known
+    /// outbox/default relays before publishing. If no current event can be
+    /// established, it returns `FollowListUnavailable` rather than risking a
+    /// destructive replacement.
+    pub async fn follow_user(
+        &self,
+        account_ref: String,
+        user_ref: String,
+    ) -> Result<Vec<String>, MarmotKitError> {
+        let user = normalize_member_ref_ffi(&user_ref)?;
+        Ok(self
+            .runtime
+            .follow_user(&account_ref, &user.account_id_hex)
+            .await?)
+    }
+
+    /// Unfollow `user_ref` while preserving every other entry in the account's
+    /// current kind-3 contact list. Returns the complete updated list.
+    pub async fn unfollow_user(
+        &self,
+        account_ref: String,
+        user_ref: String,
+    ) -> Result<Vec<String>, MarmotKitError> {
+        let user = normalize_member_ref_ffi(&user_ref)?;
+        Ok(self
+            .runtime
+            .unfollow_user(&account_ref, &user.account_id_hex)
+            .await?)
+    }
+
     /// Export the active account's raw private key in canonical `nsec1...`
     /// bech32 form for an in-app key-backup display (mdk#543).
     ///
@@ -411,4 +472,100 @@ fn ffi_discovery_relays(bootstrap_relays: &[String]) -> Vec<TransportEndpoint> {
         }
     }
     relays
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use marmot_account::AccountHome;
+    use marmot_app::{AccountRelayListBootstrap, MarmotApp, npub_for_account_id};
+    use nostr_relay_builder::MockRelay;
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn follow_bindings_preserve_the_list_and_refresh_fast_reads() {
+        let relay = MockRelay::run().await.expect("start mock relay");
+        let relay_url = relay.url().await.to_string();
+        let root = tempfile::tempdir().expect("tempdir");
+        let home = AccountHome::open(root.path());
+        let alice = home.create_account("alice").expect("create alice");
+        let bob = home.create_account("bob").expect("create bob");
+        let carol = home.create_account("carol").expect("create carol");
+        let app = MarmotApp::with_relay(root.path(), relay_url.clone());
+        let endpoint = TransportEndpoint(relay_url);
+        let bootstrap =
+            AccountRelayListBootstrap::new(vec![endpoint.clone()], vec![endpoint.clone()]);
+        app.publish_account_follow_list(&alice.label, &[bob.account_id_hex.as_str()], bootstrap)
+            .await
+            .expect("seed follow list");
+
+        // Kind-3 is replaceable at second granularity. Keep each update in a
+        // distinct timestamp so this test exercises deterministic relay state
+        // rather than the event-id tie-breaker.
+        tokio::time::sleep(Duration::from_millis(1_050)).await;
+
+        let runtime = app.runtime();
+        let kit = Marmot { app, runtime };
+        let bob_npub = npub_for_account_id(&bob.account_id_hex).expect("bob npub");
+        let carol_npub = npub_for_account_id(&carol.account_id_hex).expect("carol npub");
+
+        let followed = kit
+            .follow_user(alice.label.clone(), carol_npub)
+            .await
+            .expect("follow carol");
+        let mut expected_follows = vec![bob.account_id_hex.clone(), carol.account_id_hex.clone()];
+        expected_follows.sort();
+        assert_eq!(followed, expected_follows);
+        assert_eq!(
+            kit.account_follows(alice.label.clone())
+                .expect("cached follows"),
+            followed
+        );
+        assert!(
+            kit.is_following(alice.label.clone(), bob_npub.clone())
+                .expect("bob membership")
+        );
+        assert!(
+            kit.is_following(alice.label.clone(), carol.account_id_hex.clone())
+                .expect("carol membership")
+        );
+
+        tokio::time::sleep(Duration::from_millis(1_050)).await;
+
+        let remaining = kit
+            .unfollow_user(alice.label.clone(), bob_npub)
+            .await
+            .expect("unfollow bob");
+        assert_eq!(remaining, vec![carol.account_id_hex.clone()]);
+        assert_eq!(
+            kit.account_follows(alice.label.clone())
+                .expect("updated cached follows"),
+            remaining
+        );
+        assert!(
+            !kit.is_following(alice.label, bob.account_id_hex)
+                .expect("removed membership")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn follow_binding_refuses_to_replace_an_unknown_list() {
+        let relay = MockRelay::run().await.expect("start mock relay");
+        let relay_url = relay.url().await.to_string();
+        let root = tempfile::tempdir().expect("tempdir");
+        let home = AccountHome::open(root.path());
+        let alice = home.create_account("alice").expect("create alice");
+        let bob = home.create_account("bob").expect("create bob");
+        let app = MarmotApp::with_relay(root.path(), relay_url);
+        let runtime = app.runtime();
+        let kit = Marmot { app, runtime };
+
+        let error = kit
+            .follow_user(alice.label, bob.account_id_hex)
+            .await
+            .expect_err("missing current kind-3 must not be treated as empty");
+        assert!(matches!(error, MarmotKitError::FollowListUnavailable));
+    }
 }

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -32,6 +32,11 @@ pub enum MarmotKitError {
     MissingKeyPackage { account: String },
     #[error("publish failed: {details}")]
     Publish { details: String },
+    /// No current kind-3 event was found on the account's known outbox/default
+    /// relays. Retrying after directory/relay recovery is safe; publishing from
+    /// an assumed empty list is not.
+    #[error("current account follow list is unavailable")]
+    FollowListUnavailable,
     #[error("transport closed")]
     TransportClosed,
     #[error("marmot runtime is shutting down")]
@@ -196,6 +201,7 @@ impl From<AppError> for MarmotKitError {
             },
             AppError::InvalidKeyPackageEvent(details) => Self::InvalidKeyPackageEvent { details },
             AppError::Publish(details) => Self::Publish { details },
+            AppError::FollowListUnavailable => Self::FollowListUnavailable,
             AppError::TransportClosed => Self::TransportClosed,
             AppError::RuntimeStopping => Self::RuntimeStopping,
             AppError::AccountCatchUp(details) => Self::AccountCatchUp { details },


### PR DESCRIPTION
## Summary

Adds UniFFI APIs for following and unfollowing users, checking follow membership, and retrieving an account's full follow list.

The write operations preserve the current kind-3 list through a serialized read-modify-publish flow. If no current list is available, they return a typed error instead of publishing an unintended replacement. Cached directory data is refreshed immediately so the read APIs remain fast and local.

## Validation

- `just fast-ci`
- `cargo test -p marmot-uniffi`
- `./crates/marmot-uniffi/xcframework.sh`
- `./crates/marmot-uniffi/kotlin-bindings.sh`
- `git diff --check`

`cargo test -p marmot-app` completed 514 unit tests, but five unrelated existing `relay_runtime` integration failures remain reproducible in media, retention, and group-removal paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cached follow-list viewing and following-status checks.
  * Added follow and unfollow actions that preserve and return the updated follow list.
  * Follow-list updates are synchronized and published only when changes occur.

* **Bug Fixes**
  * Follow lists now normalize account identifiers and remain available after publishing.
  * Added a specific error when the current follow list is unavailable.

* **Chores**
  * Updated the application version to 0.9.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->