### PR TITLE
Publish empty follow list for new identities

### DIFF
--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -3740,6 +3740,31 @@ impl AccountManager {
             }
         };
 
+        if creates_new_private_key && account.local_signing {
+            self.shared.lifecycle().ensure_running()?;
+            if let Err(err) = self
+                .app
+                .publish_account_follow_list(
+                    &account.label,
+                    &[],
+                    AccountRelayListBootstrap::new(
+                        request.default_relays.clone(),
+                        request.bootstrap_relays.clone(),
+                    ),
+                )
+                .await
+            {
+                if rollback_on_setup_failure {
+                    return self.rollback_import_after_setup_failure(
+                        &account,
+                        private_key_import.as_ref(),
+                        err,
+                    );
+                }
+                return Err(err);
+            }
+        }
+
         let profile = if creates_new_private_key && account.local_signing {
             self.shared.lifecycle().ensure_running()?;
             match self

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -836,6 +836,16 @@ async fn app_runtime_create_identity_bootstraps_managed_account_and_key_package(
         fetched.key_package.bytes().len(),
         created.key_package_bytes.unwrap()
     );
+    assert_eq!(
+        app.fetch_current_follow_list_for_account_id(
+            &created.account.account_id_hex,
+            vec![endpoint(&url)],
+        )
+        .await
+        .unwrap(),
+        Some(Vec::new()),
+        "a new identity should publish a kind-3 event with no p tags"
+    );
 
     runtime.shutdown().await;
 }

--- a/crates/marmot-uniffi/src/commands/account.rs
+++ b/crates/marmot-uniffi/src/commands/account.rs
@@ -98,7 +98,8 @@ impl Marmot {
     }
 
     /// Create a brand-new Nostr identity, store its secret in the platform
-    /// keychain, and publish initial relay lists + key package.
+    /// keychain, and publish initial relay lists, an empty follow list, and a
+    /// key package.
     pub async fn create_identity(
         &self,
         default_relays: Vec<String>,

--- a/docs/marmot-architecture/overview/marmot-app-runtime.md
+++ b/docs/marmot-architecture/overview/marmot-app-runtime.md
@@ -172,7 +172,8 @@ The first slice now proves the architecture without filling in every product sur
 
 1. `MarmotAppRuntime::open`, `start`, and `shutdown` exist.
 2. Local signing accounts are restored into an `AccountManager`.
-3. Identity creation publishes relay lists, a profile, and a fresh KeyPackage through runtime-backed setup.
+3. Identity creation publishes relay lists, an empty follow list, a profile, and a fresh KeyPackage through
+   runtime-backed setup.
 4. Runtime events cover group joins, group-state changes, messages, and typed agent stream start/final messages.
 5. Live Nostr receive and ingest run inside `marmot-app` account workers.
 6. `wnd` hosts one runtime and forwards command intents into it.


### PR DESCRIPTION
## Summary

- publish an empty kind-3 contact list when MDK creates a brand-new local identity
- use the existing follow-list publisher so the event has empty content and no `p` tags, and the local directory records a known-empty list
- leave imported identities, existing-account logins, and external signers unchanged
- document the additional identity-setup publication

## Why

Follow and unfollow updates correctly refuse to treat a missing kind-3 event as an empty list, because kind-3 is a whole-list replaceable event and doing so could overwrite follows published elsewhere. A newly generated identity had no kind-3 event at all, so that guard also prevented its first follow update.

Publishing an explicit empty kind-3 during fresh identity setup establishes a safe relay-visible baseline: later updates can distinguish `Some([])` from a genuinely missing event (`None`) without weakening the anti-clobber guard.

## Validation

- `just fast-ci`
- `cargo test -p marmot-app --test relay_runtime app_runtime_create_identity_bootstraps_managed_account_and_key_package -- --exact`

A full `cargo test -p marmot-app` run reaches the existing `relay_runtime` failures in encrypted-media, retention-system-row, retained-media, and self-removal tests. The encrypted-media endpoint failure was reproduced unchanged from an untouched `master` worktree, independently of this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - New identities now publish an initial empty follow list during setup.
  - Follow-list publication uses the configured bootstrap and default relays.
  - Setup failures continue to support rollback when enabled.

- **Tests**
  - Added verification that newly created identities have an empty follow list.

- **Documentation**
  - Updated identity-creation documentation to include the initial follow list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->