### PR TITLE
feat: support www bare autolinks

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -9,6 +9,13 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 ## [Unreleased]
 
+### Added
+
+- `marmot-markdown` now recognizes bare `www.example.com/path` text as web
+  autolinks. The AST preserves the displayed `www.` source while exposing an
+  explicit `Www` autolink kind so renderers can synthesize `https://`
+  destinations without a second client-side URL parser.
+
 ## [0.9.10] - 2026-07-29
 
 ### Added

--- a/crates/marmot-markdown/src/ast.rs
+++ b/crates/marmot-markdown/src/ast.rs
@@ -125,6 +125,9 @@ pub enum Inline {
 pub enum AutolinkKind {
     Uri,
     Email,
+    /// Bare `www.` host/path text. Renderers synthesize an `https://` launch
+    /// destination while displaying the original source text.
+    Www,
 }
 
 /// Security-relevant classification of an untrusted Markdown destination.

--- a/crates/marmot-markdown/src/destination.rs
+++ b/crates/marmot-markdown/src/destination.rs
@@ -50,6 +50,7 @@ pub(crate) fn classify_autolink_destination(
 ) -> LinkDestinationKind {
     match kind {
         AutolinkKind::Email => LinkDestinationKind::Contact,
+        AutolinkKind::Www => LinkDestinationKind::Web,
         AutolinkKind::Uri => classify_link_destination(destination),
     }
 }

--- a/crates/marmot-markdown/src/inline.rs
+++ b/crates/marmot-markdown/src/inline.rs
@@ -21,10 +21,10 @@ use crate::scanner;
 /// Keep in sync with the explicit match arms — used as the exit condition
 /// for the plain-byte fast-scan in the `_` wildcard arm.
 ///
-/// `h`, `m`, `t`, `w` are tripwires for bare-URL schemes (`http(s)://`,
-/// `mailto:`, `marmot://`, `tel:`, `whitenoise:`); the bulk-scan rescue below keeps the
-/// fast path for the overwhelmingly common case of ordinary prose containing
-/// those letters.
+/// `h`, `m`, `t`, `w` are tripwires for bare-URL prefixes (`http(s)://`,
+/// `mailto:`, `marmot://`, `tel:`, `whitenoise:`, `www.`); the bulk-scan rescue
+/// below keeps the fast path for the overwhelmingly common case of ordinary
+/// prose containing those letters.
 const INLINE_SPECIAL: [bool; 128] = {
     let mut t = [false; 128];
     let chars = b"\\`$&[!*_~]<@nhmtw\n";
@@ -439,12 +439,12 @@ pub(crate) fn tokenize(raw: &str, refs: &HashMap<String, LinkRef>) -> Vec<Inline
                 }
             }
             b'h' | b'm' | b't' | b'w' => {
-                if let Some((url, end)) = try_bare_url(bytes, i) {
+                if let Some((url, kind, end)) = try_bare_url(bytes, i) {
                     flush_text(&mut out, &mut buf, &delims);
-                    let classification = classify_autolink_destination(&url, AutolinkKind::Uri);
+                    let classification = classify_autolink_destination(&url, kind);
                     out.push(Inline::Autolink {
                         url,
-                        kind: AutolinkKind::Uri,
+                        kind,
                         classification,
                     });
                     i = end;
@@ -506,7 +506,7 @@ pub(crate) fn tokenize(raw: &str, refs: &HashMap<String, LinkRef>) -> Vec<Inline
                                 continue;
                             }
                             // Same rescue for `h`/`m`/`t`/`w` — they're
-                            // tripwires for bare-URL schemes and most occur
+                            // tripwires for bare-URL prefixes and most occur
                             // mid-word in prose.
                             if matches!(cc, b'h' | b'm' | b't' | b'w')
                                 && !looks_like_bare_url_start(bytes, i)
@@ -1066,38 +1066,39 @@ fn absorb_link(
 // Autolinks + raw HTML
 // ---------------------------------------------------------------------------
 
-/// Schemes recognized as bare (unbracketed) URLs.
+/// Prefixes recognized as bare (unbracketed) URLs.
 ///
 /// **Order matters:** `whitenoise-staging://` must come before `whitenoise://`
 /// because the `find(..)` lookup is first-match-wins, and the latter is a
 /// strict prefix of the former. With them in the wrong order
 /// `whitenoise-staging://x` would parse as `whitenoise:` + literal
 /// `-staging://x`.
-const BARE_URL_SCHEMES: &[&[u8]] = &[
-    b"https://",
-    b"http://",
-    b"mailto:",
-    b"tel:",
-    b"marmot://",
-    b"whitenoise-staging://",
-    b"whitenoise://",
+const BARE_URL_PREFIXES: &[(&[u8], AutolinkKind)] = &[
+    (b"https://", AutolinkKind::Uri),
+    (b"http://", AutolinkKind::Uri),
+    (b"mailto:", AutolinkKind::Uri),
+    (b"tel:", AutolinkKind::Uri),
+    (b"marmot://", AutolinkKind::Uri),
+    (b"whitenoise-staging://", AutolinkKind::Uri),
+    (b"whitenoise://", AutolinkKind::Uri),
+    (b"www.", AutolinkKind::Www),
 ];
 
 /// True if the bytes starting at `i` begin with one of the recognized bare-URL
-/// scheme prefixes. Used by the bulk-scan tripwire to keep ordinary text
+/// prefixes. Used by the bulk-scan tripwire to keep ordinary text
 /// (every `d`/`h`/`m`/`t`/`w` byte in prose) on the fast path.
 fn looks_like_bare_url_start(bytes: &[u8], i: usize) -> bool {
-    BARE_URL_SCHEMES
+    BARE_URL_PREFIXES
         .iter()
-        .any(|s| bytes.get(i..i + s.len()) == Some(s))
+        .any(|(prefix, _)| bytes.get(i..i + prefix.len()) == Some(*prefix))
 }
 
 /// Try to consume a bare URL (no surrounding `<>`) starting at `i`. Matches
-/// `https://`, `http://`, `mailto:`, `tel:`, or an app deep-link authority form
-/// followed by a non-empty run of non-whitespace, non-`<` bytes. Trailing
-/// punctuation is stripped per the GFM extended-autolink rules (`.,;:!?*_~`
-/// always; `)` only when it would unbalance the URL body).
-fn try_bare_url(bytes: &[u8], i: usize) -> Option<(String, usize)> {
+/// a recognized scheme or `www.` prefix followed by a non-empty run of
+/// non-whitespace, non-`<` bytes. Trailing punctuation is stripped per the GFM
+/// extended-autolink rules (`.,;:!?*_~` always; `)` only when it would
+/// unbalance the URL body).
+fn try_bare_url(bytes: &[u8], i: usize) -> Option<(String, AutolinkKind, usize)> {
     let prev = if i == 0 { None } else { Some(bytes[i - 1]) };
     if !nostr::left_boundary_ok(prev) {
         return None;
@@ -1109,10 +1110,11 @@ fn try_bare_url(bytes: &[u8], i: usize) -> Option<(String, usize)> {
     if prev == Some(b'<') {
         return None;
     }
-    let scheme = BARE_URL_SCHEMES
+    let (prefix, kind) = BARE_URL_PREFIXES
         .iter()
-        .find(|s| bytes.get(i..i + s.len()) == Some(**s))?;
-    let body_start = i + scheme.len();
+        .copied()
+        .find(|(prefix, _)| bytes.get(i..i + prefix.len()) == Some(*prefix))?;
+    let body_start = i + prefix.len();
     let mut j = body_start;
     while j < bytes.len() {
         let c = bytes[j];
@@ -1137,7 +1139,7 @@ fn try_bare_url(bytes: &[u8], i: usize) -> Option<(String, usize)> {
         return None;
     }
     let url = std::str::from_utf8(&bytes[i..j]).ok()?.to_string();
-    Some((url, j))
+    Some((url, kind, j))
 }
 
 /// Trim trailing punctuation from a bare-URL body per GFM:

--- a/crates/marmot-markdown/src/lib.rs
+++ b/crates/marmot-markdown/src/lib.rs
@@ -87,10 +87,12 @@ pub use destination::classify_link_destination;
 /// - GFM task-list items (`- [ ]`, `- [x]`).
 /// - Bare URLs (GFM-style extended autolinks) for the schemes `http://`,
 ///   `https://`, `mailto:`, `tel:`, `marmot://`, `whitenoise://`, and
-///   `whitenoise-staging://`. Recognized at word boundaries; trailing
-///   punctuation (`.,;:!?*_~` and unbalanced `)`) is excluded from the
-///   matched URL. Opaque app-scheme forms like `marmot:foo` and
-///   `whitenoise:foo` (no `//`) stay literal.
+///   `whitenoise-staging://`, plus bare `www.` host/path forms. `www.`
+///   autolinks preserve their source text; renderers synthesize an `https://`
+///   launch destination. Recognized at word boundaries; trailing punctuation
+///   (`.,;:!?*_~` and unbalanced `)`) is excluded from the matched URL. Opaque
+///   app-scheme forms like `marmot:foo` and `whitenoise:foo` (no `//`) stay
+///   literal.
 /// - Math: inline `$…$` and block `$$ … $$` (content is opaque — recognized
 ///   but never parsed as LaTeX).
 /// - Nostr bare mentions (`@npub1…`) and URIs (`nostr:<hrp>1…`) for the

--- a/crates/marmot-markdown/tests/common/render.rs
+++ b/crates/marmot-markdown/tests/common/render.rs
@@ -199,6 +199,7 @@ fn render_inline(i: &Inline, out: &mut String) {
             let href = match kind {
                 AutolinkKind::Uri => url.clone(),
                 AutolinkKind::Email => format!("mailto:{url}"),
+                AutolinkKind::Www => format!("https://{url}"),
             };
             out.push_str(&format!("<a href=\"{}\">", escape_attr(&href)));
             out.push_str(&escape(url));

--- a/crates/marmot-markdown/tests/golden/bare_urls.json
+++ b/crates/marmot-markdown/tests/golden/bare_urls.json
@@ -228,6 +228,41 @@
       "Paragraph": {
         "inlines": [
           {
+            "Text": "Bare www: "
+          },
+          {
+            "Autolink": {
+              "url": "www.example.com/path",
+              "kind": "Www",
+              "classification": "Web"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "Paragraph": {
+        "inlines": [
+          {
+            "Text": "Sentence www: See "
+          },
+          {
+            "Autolink": {
+              "url": "www.example.com/path",
+              "kind": "Www",
+              "classification": "Web"
+            }
+          },
+          {
+            "Text": "."
+          }
+        ]
+      }
+    },
+    {
+      "Paragraph": {
+        "inlines": [
+          {
             "Text": "Trailing-punct stripping: visit "
           },
           {
@@ -557,6 +592,8 @@
   ],
   "blank_lines_before": [
     0,
+    1,
+    1,
     1,
     1,
     1,

--- a/crates/marmot-markdown/tests/golden/bare_urls.md
+++ b/crates/marmot-markdown/tests/golden/bare_urls.md
@@ -12,6 +12,10 @@ All seven recognized schemes, bare (no `<>`):
 
 Mid-sentence: see https://example.com for details.
 
+Bare www: www.example.com/path
+
+Sentence www: See www.example.com/path.
+
 Trailing-punct stripping: visit https://example.com.
 
 Trailing-punct cluster: really?! https://example.com?!

--- a/crates/marmot-markdown/tests/spec.rs
+++ b/crates/marmot-markdown/tests/spec.rs
@@ -88,6 +88,22 @@ fn email_autolink() {
     );
 }
 
+#[test]
+fn bare_www_autolink() {
+    check(
+        "www.example.com/path",
+        "<p><a href=\"https://www.example.com/path\">www.example.com/path</a></p>\n",
+    );
+}
+
+#[test]
+fn bare_www_autolink_strips_sentence_period() {
+    check(
+        "See www.example.com/path.",
+        "<p>See <a href=\"https://www.example.com/path\">www.example.com/path</a>.</p>\n",
+    );
+}
+
 // ----- Block quote + lists ----------------------------------------------
 
 #[test]

--- a/crates/marmot-markdown/tests/unit_autolinks.rs
+++ b/crates/marmot-markdown/tests/unit_autolinks.rs
@@ -17,6 +17,13 @@ fn email(addr: &str) -> Inline {
         classification: LinkDestinationKind::Contact,
     }
 }
+fn www(url: &str) -> Inline {
+    Inline::Autolink {
+        url: url.to_string(),
+        kind: AutolinkKind::Www,
+        classification: LinkDestinationKind::Web,
+    }
+}
 
 // HTML is NOT parsed: tag-like sequences are literal text in both the
 // block pass (no HTML blocks) and the inline pass (no raw-HTML inline).
@@ -166,6 +173,22 @@ fn dangerous_uri_autolinks_are_preserved_and_classified() {
 }
 
 // ----- Bare URLs (GFM-style extended autolinks) ------------------------
+
+#[test]
+fn bare_www() {
+    assert_eq!(
+        parse_inlines("www.example.com/path"),
+        vec![www("www.example.com/path")]
+    );
+}
+
+#[test]
+fn bare_www_strips_trailing_period() {
+    assert_eq!(
+        parse_inlines("See www.example.com/path."),
+        vec![t("See "), www("www.example.com/path"), t(".")]
+    );
+}
 
 #[test]
 fn bare_https() {

--- a/crates/marmot-uniffi/src/markdown.rs
+++ b/crates/marmot-uniffi/src/markdown.rs
@@ -156,6 +156,8 @@ pub enum MarkdownInlineFfi {
 pub enum MarkdownAutolinkKindFfi {
     Uri,
     Email,
+    /// Bare `www.` host/path text. Hosts synthesize `https://` for navigation.
+    Www,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, uniffi::Enum)]
@@ -454,6 +456,7 @@ impl From<MdAutolinkKind> for MarkdownAutolinkKindFfi {
         match value {
             MdAutolinkKind::Uri => Self::Uri,
             MdAutolinkKind::Email => Self::Email,
+            MdAutolinkKind::Www => Self::Www,
         }
     }
 }
@@ -621,6 +624,30 @@ mod tests {
                 classification: MarkdownLinkDestinationKindFfi::App,
                 ..
             } if url == "marmot://profile/npub1abc"
+        ));
+    }
+
+    #[test]
+    fn bridges_www_autolink_kind() {
+        let document = parse_markdown_document("See www.example.com/path.");
+        let MarkdownBlockFfi::Paragraph { inlines } = &document.blocks[0] else {
+            panic!("expected paragraph");
+        };
+        assert!(matches!(
+            inlines[0],
+            MarkdownInlineFfi::Text { ref content } if content == "See "
+        ));
+        assert!(matches!(
+            inlines[1],
+            MarkdownInlineFfi::Autolink {
+                ref url,
+                kind: MarkdownAutolinkKindFfi::Www,
+                classification: MarkdownLinkDestinationKindFfi::Web,
+            } if url == "www.example.com/path"
+        ));
+        assert!(matches!(
+            inlines[2],
+            MarkdownInlineFfi::Text { ref content } if content == "."
         ));
     }
 


### PR DESCRIPTION
Fixes #1175

## Summary
- recognize bare `www.example.com/path` text through the existing bare-URL scanner
- preserve the authored `www.` display text while exposing `AutolinkKind::Www` so renderers synthesize a launchable `https://` destination
- carry the typed contract through UniFFI and classify it as `Web`
- retain the existing left-boundary and trailing-punctuation behavior, with unit, HTML-spec, golden AST, and FFI coverage

## Verification
- `cargo test -p marmot-markdown --locked`
- `cargo test -p marmot-uniffi --locked`
- `cargo fmt --all --check`
- `RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --locked`
- `RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`

## TDD
The initial `bare_www` regression test failed before production changes because `AutolinkKind::Www` and `www.` recognition did not exist, then passed after the implementation.

## Release hygiene
- updated `crates/cli/CHANGELOG.md` under `Unreleased`
- no version, conformance, fixture-cohort, dependency, or lockfile changes

## Sensitive paths
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bare `www.example.com/path` is now automatically recognized as a web link.
  * Rendered links use secure `https://` while preserving the visible `www.` text.
  * The structured Markdown interface now exposes a dedicated `www.` link type.
* **Bug Fixes**
  * Faster settling of group state when outgoing messages are queued, with improved updates to runtime chat/group subscribers.
* **Changed**
  * Updated bundled SQLite/SQLCipher components (including the WAL reset corruption fix).
* **Tests**
  * Added coverage for standalone and in-sentence `www.` links, rendering, and trailing punctuation handling.
* **Documentation**
  * Updated changelog and URL-autolink documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->