### PR TITLE
fix(cgka-engine): reopen a stale convergence pass at the current tip instead of halting the group

### DIFF
--- a/crates/cgka-engine/src/convergence_input.rs
+++ b/crates/cgka-engine/src/convergence_input.rs
@@ -255,6 +255,35 @@ mod tests {
     }
 
     #[test]
+    fn no_input_opens_a_pass_without_a_commit_edge_to_gate_outbound_work() {
+        // The reachability premise behind `discard_stale_convergence_pass`: an
+        // open pass always holds at least one `CommitEdge` member, and a
+        // `CommitEdge` member gates outbound work unconditionally (pinned by
+        // `processed_commit_still_gates_while_its_durable_pass_is_active`).
+        // Together those mean the tip cannot advance underneath an open pass, so
+        // a pass whose base epoch disagrees with the tip is inherited scheduling
+        // state rather than a live transition.
+        for role in [
+            ConvergencePassMemberRole::ProposalDependency,
+            ConvergencePassMemberRole::AppWitnessCandidate,
+        ] {
+            for state in [
+                MessageState::Sent,
+                MessageState::Created,
+                MessageState::Retryable,
+            ] {
+                let non_edge = input(role, 3, state, 1);
+                let context = ConvergenceInputContext::from_inputs([non_edge]);
+
+                assert!(
+                    !context.opens_pass(non_edge),
+                    "{role:?}/{state:?} opened a pass with no commit edge to gate outbound work"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn processed_commit_still_gates_while_its_durable_pass_is_active() {
         let commit = input(
             ConvergencePassMemberRole::CommitEdge,

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -473,15 +473,24 @@ impl<S: StorageProvider> Engine<S> {
         }
     }
 
-    /// Discard a pass whose base epoch the device has already left behind, so the
-    /// caller reopens one at the current tip.
+    /// Discard a pass whose base epoch disagrees with the current tip, so the
+    /// caller reopens one at the tip.
     ///
-    /// A pass is local scheduling state for a single base epoch; the tip
-    /// legitimately moves while one is open (a device catching up applies
-    /// commits). The stale batch is therefore benign, not evidence of corruption,
-    /// and it carries no canonical state of its own — its members are retained
-    /// stored messages that reseed into the next pass. Same rule as the discarded
-    /// local copy in `do_join_welcome`.
+    /// This is a repair path, not a steady-state transition. The tip does not
+    /// move forward underneath an open pass: an active pass gates outbound work
+    /// (every trigger that opens one admits at least one `CommitEdge` member, and
+    /// a `CommitEdge` member gates unconditionally), and an inbound commit inside
+    /// the rewind horizon re-enters convergence instead of applying directly.
+    /// What this repairs is inherited scheduling state — before
+    /// [`Self::convergence_tip_epoch`] there were two authorities for one epoch,
+    /// because `base_epoch` was stamped from the durable group record while the
+    /// halt compared the epoch manager, and those two stores can split across a
+    /// restart. A base inherited from an older binary can therefore sit behind or
+    /// ahead of the tip, so both directions are discarded.
+    ///
+    /// The stale batch is benign either way: a pass carries no canonical state of
+    /// its own, and its members are retained stored messages that reseed into the
+    /// next pass. Same rule as the discarded local copy in `do_join_welcome`.
     fn discard_stale_convergence_pass(
         &self,
         pass: &DurableConvergencePass,

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -118,8 +118,9 @@ impl<S: StorageProvider> Engine<S> {
     /// remaining process-local cutoff delay.
     ///
     /// This is intentionally a command, not a diagnostic query: when eligible
-    /// retained input exists it may open a pass, consume a dormant fairness
-    /// slot, or persist restart deadline rebasing before returning the delay.
+    /// retained input exists it may open a pass, discard one left behind by an
+    /// advanced tip, consume a dormant fairness slot, or persist restart deadline
+    /// rebasing before returning the delay.
     pub fn prepare_convergence_cutoff_delay_ms(
         &mut self,
         group_id: &GroupId,
@@ -127,13 +128,10 @@ impl<S: StorageProvider> Engine<S> {
         if self.ensure_group_live(group_id).is_err() {
             return Ok(None);
         }
-        let group = self
-            .storage
-            .get_group(group_id)
-            .map_err(storage_projection_error)?;
+        let tip = self.convergence_tip_epoch(group_id)?;
         let policy = self.convergence_policy_for_group(group_id)?;
         let now_ms = self.convergence_now_ms();
-        let pass = self.load_or_open_convergence_pass(group_id, group.epoch, &policy, now_ms)?;
+        let pass = self.load_or_open_convergence_pass(group_id, tip, &policy, now_ms)?;
         Ok(match pass {
             Some(pass) if pass.phase == ConvergencePassPhase::Collecting => {
                 Some(pass.cutoff_monotonic_ms().saturating_sub(now_ms))
@@ -352,11 +350,7 @@ impl<S: StorageProvider> Engine<S> {
                 .get_group(group_id)
                 .map_err(storage_projection_error)?
                 .epoch;
-            self.realize_group_unrecoverable_for_convergence_pass(
-                group_id,
-                epoch,
-                "frozen_member_integrity",
-            );
+            self.realize_group_unrecoverable_for_frozen_pass(group_id, epoch);
         }
         Ok(())
     }
@@ -375,13 +369,9 @@ impl<S: StorageProvider> Engine<S> {
             // first stable scheduler run opens a pass and seeds retained work.
             return Ok(ConvergenceAdmissionOutcome::Retained);
         }
-        let group = self
-            .storage
-            .get_group(group_id)
-            .map_err(storage_projection_error)?;
+        let tip = self.convergence_tip_epoch(group_id)?;
         let policy = self.convergence_policy_for_group(group_id)?;
-        let Some(mut pass) =
-            self.load_or_open_convergence_pass(group_id, group.epoch, &policy, now_ms)?
+        let Some(mut pass) = self.load_or_open_convergence_pass(group_id, tip, &policy, now_ms)?
         else {
             return Ok(ConvergenceAdmissionOutcome::Retained);
         };
@@ -466,6 +456,51 @@ impl<S: StorageProvider> Engine<S> {
         Ok(())
     }
 
+    /// The epoch a convergence pass is scheduled against.
+    ///
+    /// One authority for the tip: the epoch manager owns it, and the durable
+    /// group record is only the pre-hydration fallback. Reading the two stores at
+    /// different call sites let a pass be stamped against an epoch the rest of
+    /// convergence disagreed with.
+    fn convergence_tip_epoch(&self, group_id: &GroupId) -> Result<EpochId, OpenMlsProjectionError> {
+        match self.epoch_manager.epoch(group_id) {
+            Some(epoch) => Ok(epoch),
+            None => Ok(self
+                .storage
+                .get_group(group_id)
+                .map_err(storage_projection_error)?
+                .epoch),
+        }
+    }
+
+    /// Discard a pass whose base epoch the device has already left behind, so the
+    /// caller reopens one at the current tip.
+    ///
+    /// A pass is local scheduling state for a single base epoch; the tip
+    /// legitimately moves while one is open (a device catching up applies
+    /// commits). The stale batch is therefore benign, not evidence of corruption,
+    /// and it carries no canonical state of its own — its members are retained
+    /// stored messages that reseed into the next pass. Same rule as the discarded
+    /// local copy in `do_join_welcome`.
+    fn discard_stale_convergence_pass(
+        &self,
+        pass: &DurableConvergencePass,
+        tip: EpochId,
+    ) -> Result<(), OpenMlsProjectionError> {
+        self.storage
+            .delete_convergence_pass(&pass.group_id)
+            .map_err(storage_projection_error)?;
+        self.audit_group(
+            &pass.group_id,
+            marmot_forensics::AuditEventKind::ConvergencePassReopened {
+                stale_base_epoch: pass.base_epoch.0,
+                current_tip_epoch: tip.0,
+                generation: pass.generation,
+            },
+        );
+        Ok(())
+    }
+
     fn load_or_open_convergence_pass(
         &self,
         group_id: &GroupId,
@@ -502,7 +537,13 @@ impl<S: StorageProvider> Engine<S> {
                 .put_convergence_pass(&consumed)
                 .map_err(storage_projection_error)?;
         }
-        if let Some(mut pass) = previous.clone()
+        if let Some(stale) = previous.as_ref()
+            && stale.is_active()
+            && stale.base_epoch != base_epoch
+        {
+            // Reopen below, at the tip this call asks for.
+            self.discard_stale_convergence_pass(stale, base_epoch)?;
+        } else if let Some(mut pass) = previous.clone()
             && pass.is_active()
         {
             #[cfg(feature = "test-policy-overrides")]
@@ -766,19 +807,6 @@ impl<S: StorageProvider> Engine<S> {
         group_id: &GroupId,
         epoch: EpochId,
     ) -> Result<(), OpenMlsProjectionError> {
-        self.mark_group_unrecoverable_for_convergence_pass(
-            group_id,
-            epoch,
-            "frozen_member_integrity",
-        )
-    }
-
-    fn mark_group_unrecoverable_for_convergence_pass(
-        &mut self,
-        group_id: &GroupId,
-        epoch: EpochId,
-        error_kind: &'static str,
-    ) -> Result<(), OpenMlsProjectionError> {
         let mut group = self
             .storage
             .get_group(group_id)
@@ -789,16 +817,14 @@ impl<S: StorageProvider> Engine<S> {
                 .put_group(&group)
                 .map_err(storage_projection_error)?;
         }
-        self.realize_group_unrecoverable_for_convergence_pass(group_id, epoch, error_kind);
+        self.realize_group_unrecoverable_for_frozen_pass(group_id, epoch);
         Ok(())
     }
 
-    fn realize_group_unrecoverable_for_convergence_pass(
-        &mut self,
-        group_id: &GroupId,
-        epoch: EpochId,
-        error_kind: &'static str,
-    ) {
+    /// A frozen pass member that no longer matches the record it was admitted
+    /// from is a real integrity failure: the batch this group already committed
+    /// to resolving cannot be reconstructed, so the group halts.
+    fn realize_group_unrecoverable_for_frozen_pass(&mut self, group_id: &GroupId, epoch: EpochId) {
         self.epoch_manager.mark_unrecoverable(group_id);
         self.events_buf.push_back(GroupEvent::GroupUnrecoverable {
             group_id: group_id.clone(),
@@ -809,15 +835,8 @@ impl<S: StorageProvider> Engine<S> {
                 phase: ConvergencePhase::Unrecoverable,
                 current_tip_epoch: Some(epoch.0),
                 retained_anchor_horizon: None,
-                reason: Some(
-                    if error_kind == "base_epoch_mismatch" {
-                        "convergence_pass_base_changed"
-                    } else {
-                        "frozen_pass_integrity_failure"
-                    }
-                    .to_string(),
-                ),
-                error_kind: Some(error_kind.to_string()),
+                reason: Some("frozen_pass_integrity_failure".to_string()),
+                error_kind: Some("frozen_member_integrity".to_string()),
             },
         );
     }
@@ -893,10 +912,7 @@ impl<S: StorageProvider> Engine<S> {
         // MLS state isn't loadable just skips those diffs.
         let previous_components = self.reorg_component_snapshot(group_id);
         let previous_name = previous_group.name.clone();
-        let previous_tip = self
-            .epoch_manager
-            .epoch(group_id)
-            .unwrap_or(previous_group.epoch);
+        let previous_tip = self.convergence_tip_epoch(group_id)?;
         let policy = self.convergence_policy_for_group(group_id)?;
         let Some(mut pass) =
             self.load_or_open_convergence_pass(group_id, previous_tip, &policy, now_ms)?
@@ -932,14 +948,6 @@ impl<S: StorageProvider> Engine<S> {
             );
             return Ok(settled_empty_result(previous_tip.0));
         };
-        if pass.is_active() && pass.base_epoch != previous_tip {
-            self.mark_group_unrecoverable_for_convergence_pass(
-                group_id,
-                previous_tip,
-                "base_epoch_mismatch",
-            )?;
-            return Ok(unrecoverable_result(previous_tip.0));
-        }
         let mut just_frozen = false;
         if pass.phase == ConvergencePassPhase::Collecting {
             let cutoff = pass.cutoff_monotonic_ms();

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -492,7 +492,7 @@ impl<S: StorageProvider> Engine<S> {
             .map_err(storage_projection_error)?;
         self.audit_group(
             &pass.group_id,
-            marmot_forensics::AuditEventKind::ConvergencePassReopened {
+            marmot_forensics::AuditEventKind::ConvergencePassDiscarded {
                 stale_base_epoch: pass.base_epoch.0,
                 current_tip_epoch: tip.0,
                 generation: pass.generation,

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -5576,11 +5576,16 @@ async fn input_at_effective_cutoff_is_retained_for_the_next_generation() {
 
 #[tokio::test]
 async fn stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting() {
-    // A device catching up advances its tip while a durable pass stays open at
-    // the epoch it was scheduled from. That is stale local scheduling state, not
-    // corruption: convergence must discard the pass, reopen at the tip, and keep
-    // converging. Halting here durably wedged a field device that was six epochs
-    // behind, and every later send failed against the halt.
+    // A durable pass whose base epoch disagrees with the tip is stale local
+    // scheduling state, not corruption: convergence must discard it, reopen at
+    // the tip, and keep converging. The disagreement is inherited rather than
+    // reachable live — a base epoch stamped from the durable group record while
+    // the tip was read from the epoch manager, two stores that can split across a
+    // restart — so the test installs that shape on the durable record directly.
+    // The live engine cannot produce it: an open pass gates outbound work and
+    // re-routes inbound commits back through convergence. Halting on it durably
+    // wedged a field device six epochs behind, and every later send failed
+    // against the halt.
     use marmot_forensics::{AuditEvent, AuditEventKind, JsonlRecorder};
 
     let audit_dir = tempfile::tempdir().unwrap();
@@ -5639,8 +5644,8 @@ async fn stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting() {
     let stale_base = EpochId(tip.0.checked_sub(1).expect("the tip is past epoch zero"));
     let mut stale = carol_storage.convergence_pass(&group_id).unwrap().unwrap();
     assert_eq!(stale.base_epoch, tip, "pass opens at the current tip");
-    // The durable pass outlives the tip it was scheduled from, so its base epoch
-    // falls behind as the device catches up.
+    // Install the inherited shape: a durable pass whose base epoch trails the
+    // tip the rest of convergence reads.
     stale.base_epoch = stale_base;
     carol_storage.put_convergence_pass(&stale).unwrap();
 

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -5686,7 +5686,7 @@ async fn stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting() {
     assert!(
         events.iter().any(|event| matches!(
             &event.kind,
-            AuditEventKind::ConvergencePassReopened {
+            AuditEventKind::ConvergencePassDiscarded {
                 stale_base_epoch,
                 current_tip_epoch,
                 generation,

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -5574,26 +5574,66 @@ async fn input_at_effective_cutoff_is_retained_for_the_next_generation() {
     );
 }
 
-#[tokio::test]
-async fn stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting() {
-    // A durable pass whose base epoch disagrees with the tip is stale local
-    // scheduling state, not corruption: convergence must discard it, reopen at
-    // the tip, and keep converging. The disagreement is inherited rather than
-    // reachable live — a base epoch stamped from the durable group record while
-    // the tip was read from the epoch manager, two stores that can split across a
-    // restart — so the test installs that shape on the durable record directly.
-    // The live engine cannot produce it: an open pass gates outbound work and
-    // re-routes inbound commits back through convergence. Halting on it durably
-    // wedged a field device six epochs behind, and every later send failed
-    // against the halt.
-    use marmot_forensics::{AuditEvent, AuditEventKind, JsonlRecorder};
+/// One buffered inbound commit on `carol`, so she holds an active convergence
+/// pass opened at her current tip, with a forensic recorder attached.
+///
+/// The base-epoch discard tests differ only in the shape they then stamp onto
+/// that durable pass, so they share the arrival path.
+struct BufferedPassFixture {
+    carol: Engine<SqliteAccountStorage>,
+    storage: SqliteAccountStorage,
+    group_id: GroupId,
+    commit: TransportMessage,
+    tip: EpochId,
+    audit_path: std::path::PathBuf,
+    /// Owns the audit file for the lifetime of the fixture.
+    _audit_dir: tempfile::TempDir,
+}
+
+impl BufferedPassFixture {
+    /// The durable pass as convergence last persisted it.
+    fn pass(&self) -> cgka_traits::convergence_pass::DurableConvergencePass {
+        self.storage
+            .convergence_pass(&self.group_id)
+            .unwrap()
+            .expect("a buffered commit leaves a durable pass")
+    }
+
+    fn put_pass(&self, pass: &cgka_traits::convergence_pass::DurableConvergencePass) {
+        self.storage.put_convergence_pass(pass).unwrap();
+    }
+
+    /// Every `convergence_pass_discarded` row the recorder wrote. Consumes the
+    /// engine so the recorder flushes first.
+    fn discard_audit_rows(self) -> Vec<(u64, u64, u64)> {
+        use marmot_forensics::{AuditEvent, AuditEventKind};
+
+        drop(self.carol);
+        std::fs::read_to_string(&self.audit_path)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str::<AuditEvent>(line).unwrap())
+            .filter_map(|event| match event.kind {
+                AuditEventKind::ConvergencePassDiscarded {
+                    stale_base_epoch,
+                    current_tip_epoch,
+                    generation,
+                } => Some((stale_base_epoch, current_tip_epoch, generation)),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+async fn buffered_convergence_pass_fixture(group_name: &str) -> BufferedPassFixture {
+    use marmot_forensics::JsonlRecorder;
 
     let audit_dir = tempfile::tempdir().unwrap();
     let audit_path = audit_dir.path().join("audit.jsonl");
     let (mut alice, _alice_storage) = build_client(b"alice");
     let (mut david, _david_storage) = build_client(b"david");
-    let carol_storage = SqliteAccountStorage::in_memory().unwrap();
-    let mut carol = EngineBuilder::new(carol_storage.clone())
+    let storage = SqliteAccountStorage::in_memory().unwrap();
+    let mut carol = EngineBuilder::new(storage.clone())
         .legacy_compatibility_profile()
         .identity(pad32(b"carol"))
         .account_identity_proof_signer(proof_signer(b"carol"))
@@ -5608,7 +5648,7 @@ async fn stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting() {
     let carol_kp = carol.fresh_key_package().await.unwrap();
     let (group_id, create) = alice
         .create_group(CreateGroupRequest {
-            name: "engine-convergence-stale-pass-base".into(),
+            name: group_name.into(),
             description: "".into(),
             members: vec![carol_kp],
             required_features: vec![],
@@ -5641,16 +5681,47 @@ async fn stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting() {
         .unwrap();
 
     let tip = carol.epoch(&group_id).unwrap();
+    let fixture = BufferedPassFixture {
+        carol,
+        storage,
+        group_id,
+        commit,
+        tip,
+        audit_path,
+        _audit_dir: audit_dir,
+    };
+    assert_eq!(
+        fixture.pass().base_epoch,
+        tip,
+        "pass opens at the current tip"
+    );
+    fixture
+}
+
+#[tokio::test]
+async fn stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting() {
+    // A durable pass whose base epoch disagrees with the tip is stale local
+    // scheduling state, not corruption: convergence must discard it, reopen at
+    // the tip, and keep converging. The disagreement is inherited rather than
+    // reachable live — a base epoch stamped from the durable group record while
+    // the tip was read from the epoch manager, two stores that can split across a
+    // restart — so the test installs that shape on the durable record directly.
+    // The live engine cannot produce it: an open pass gates outbound work and
+    // re-routes inbound commits back through convergence. Halting on it durably
+    // wedged a field device six epochs behind, and every later send failed
+    // against the halt.
+    let mut fixture = buffered_convergence_pass_fixture("engine-convergence-stale-pass-base").await;
+    let tip = fixture.tip;
     let stale_base = EpochId(tip.0.checked_sub(1).expect("the tip is past epoch zero"));
-    let mut stale = carol_storage.convergence_pass(&group_id).unwrap().unwrap();
-    assert_eq!(stale.base_epoch, tip, "pass opens at the current tip");
+    let mut stale = fixture.pass();
     // Install the inherited shape: a durable pass whose base epoch trails the
     // tip the rest of convergence reads.
     stale.base_epoch = stale_base;
-    carol_storage.put_convergence_pass(&stale).unwrap();
+    fixture.put_pass(&stale);
 
-    let compensated = carol
-        .converge_stored_openmls_messages(&group_id, 2_000)
+    let compensated = fixture
+        .carol
+        .converge_stored_openmls_messages(&fixture.group_id, 2_000)
         .expect("a stale pass base is compensated, not fatal");
     assert_ne!(
         compensated.convergence_status,
@@ -5658,48 +5729,180 @@ async fn stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting() {
         "a stale pass base must not block the run"
     );
     assert!(
-        !carol_storage.get_group(&group_id).unwrap().unrecoverable,
+        !fixture
+            .storage
+            .get_group(&fixture.group_id)
+            .unwrap()
+            .unrecoverable,
         "a stale pass base must not durably wedge the group"
     );
     assert!(
-        !carol
+        !fixture
+            .carol
             .drain_events()
             .iter()
             .any(|event| matches!(event, GroupEvent::GroupUnrecoverable { .. }))
     );
 
-    let reopened = carol_storage
-        .convergence_pass(&group_id)
-        .unwrap()
-        .expect("the discarded pass is replaced by one at the current tip");
+    let reopened = fixture.pass();
     assert_eq!(reopened.base_epoch, tip);
     assert_eq!(reopened.generation, stale.generation + 1);
 
-    let settled = carol
-        .converge_stored_openmls_messages(&group_id, 3_000)
+    let settled = fixture
+        .carol
+        .converge_stored_openmls_messages(&fixture.group_id, 3_000)
         .expect("the reopened pass converges at the current tip");
     assert_eq!(settled.convergence_status, ConvergenceStatus::Settled);
-    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(tip.0 + 1));
-    assert_message_state(&carol_storage, &commit, MessageState::Processed);
+    assert_eq!(
+        fixture.carol.epoch(&fixture.group_id).unwrap(),
+        EpochId(tip.0 + 1)
+    );
+    assert_message_state(&fixture.storage, &fixture.commit, MessageState::Processed);
 
-    drop(carol);
-    let events: Vec<AuditEvent> = std::fs::read_to_string(&audit_path)
-        .unwrap()
-        .lines()
-        .map(|line| serde_json::from_str(line).unwrap())
-        .collect();
+    assert_eq!(
+        fixture.discard_audit_rows(),
+        vec![(stale_base.0, tip.0, stale.generation)],
+        "the compensation is diagnosable from a forensic export, exactly once"
+    );
+}
+
+#[tokio::test]
+async fn frozen_stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting() {
+    // Frozen passes are deliberately inside the discard, not carved out of it. A
+    // frozen batch has fixed its membership, but it is still scheduling state for
+    // one base epoch, and an inherited base epoch is no more trustworthy frozen
+    // than collecting. The frozen-member integrity check remains the only thing
+    // that halts, and it only ever runs against a pass convergence keeps — never
+    // against one it is about to drop.
+    let mut fixture =
+        buffered_convergence_pass_fixture("engine-convergence-frozen-stale-pass-base").await;
+    let tip = fixture.tip;
+    let stale_base = EpochId(tip.0.checked_sub(1).expect("the tip is past epoch zero"));
+    let mut stale = fixture.pass();
+    stale.base_epoch = stale_base;
+    stale.phase = cgka_traits::ConvergencePassPhase::Frozen;
+    stale.frozen_at_wall_ms = Some(1_500);
+    stale.cutoff_cause = Some(cgka_traits::ConvergenceCutoffCause::Quiescence);
+    assert!(stale.is_active(), "a frozen pass is still an active pass");
+    fixture.put_pass(&stale);
+
+    let compensated = fixture
+        .carol
+        .converge_stored_openmls_messages(&fixture.group_id, 2_000)
+        .expect("a frozen stale pass base is compensated, not fatal");
+    assert_ne!(
+        compensated.convergence_status,
+        ConvergenceStatus::Blocked,
+        "a frozen stale pass base must not block the run"
+    );
     assert!(
-        events.iter().any(|event| matches!(
-            &event.kind,
-            AuditEventKind::ConvergencePassDiscarded {
-                stale_base_epoch,
-                current_tip_epoch,
-                generation,
-            } if *stale_base_epoch == stale_base.0
-                && *current_tip_epoch == tip.0
-                && *generation == stale.generation
-        )),
-        "the compensation is diagnosable from a forensic export"
+        !fixture
+            .storage
+            .get_group(&fixture.group_id)
+            .unwrap()
+            .unrecoverable,
+        "a frozen stale pass base must not durably wedge the group"
+    );
+    assert!(
+        !fixture
+            .carol
+            .drain_events()
+            .iter()
+            .any(|event| matches!(event, GroupEvent::GroupUnrecoverable { .. })),
+        "the frozen phase must not route the discard into the integrity halt"
+    );
+
+    let reopened = fixture.pass();
+    assert_eq!(reopened.base_epoch, tip);
+    assert_eq!(reopened.generation, stale.generation + 1);
+    assert_eq!(
+        reopened.phase,
+        cgka_traits::ConvergencePassPhase::Collecting,
+        "the replacement pass collects afresh rather than inheriting the frozen batch"
+    );
+
+    let settled = fixture
+        .carol
+        .converge_stored_openmls_messages(&fixture.group_id, 3_000)
+        .expect("the reopened pass converges at the current tip");
+    assert_eq!(settled.convergence_status, ConvergenceStatus::Settled);
+    assert_eq!(
+        fixture.carol.epoch(&fixture.group_id).unwrap(),
+        EpochId(tip.0 + 1)
+    );
+    assert_message_state(&fixture.storage, &fixture.commit, MessageState::Processed);
+
+    assert_eq!(
+        fixture.discard_audit_rows(),
+        vec![(stale_base.0, tip.0, stale.generation)],
+        "one discard row, reporting the frozen pass that was dropped"
+    );
+}
+
+#[tokio::test]
+async fn future_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting() {
+    // The other direction of the same inherited split: a base epoch *ahead* of
+    // the tip. Fork rollback reaches this shape on shipped code, because
+    // recovering to a pre-commit snapshot moves the in-memory tip backwards while
+    // the durable pass keeps the base it was stamped with. It is exactly as
+    // benign as a trailing base — the pass still holds no canonical state — so
+    // discarding on `!=` rather than `<` is load-bearing. A directional guard
+    // would leave this direction halting the group.
+    let mut fixture =
+        buffered_convergence_pass_fixture("engine-convergence-future-pass-base").await;
+    let tip = fixture.tip;
+    let future_base = EpochId(tip.0 + 1);
+    let mut stale = fixture.pass();
+    stale.base_epoch = future_base;
+    fixture.put_pass(&stale);
+
+    let compensated = fixture
+        .carol
+        .converge_stored_openmls_messages(&fixture.group_id, 2_000)
+        .expect("a future pass base is compensated, not fatal");
+    assert_ne!(
+        compensated.convergence_status,
+        ConvergenceStatus::Blocked,
+        "a future pass base must not block the run"
+    );
+    assert!(
+        !fixture
+            .storage
+            .get_group(&fixture.group_id)
+            .unwrap()
+            .unrecoverable,
+        "a future pass base must not durably wedge the group"
+    );
+    assert!(
+        !fixture
+            .carol
+            .drain_events()
+            .iter()
+            .any(|event| matches!(event, GroupEvent::GroupUnrecoverable { .. }))
+    );
+
+    let reopened = fixture.pass();
+    assert_eq!(
+        reopened.base_epoch, tip,
+        "the replacement pass is scheduled at the tip, not at the base it inherited"
+    );
+    assert_eq!(reopened.generation, stale.generation + 1);
+
+    let settled = fixture
+        .carol
+        .converge_stored_openmls_messages(&fixture.group_id, 3_000)
+        .expect("the reopened pass converges at the current tip");
+    assert_eq!(settled.convergence_status, ConvergenceStatus::Settled);
+    assert_eq!(
+        fixture.carol.epoch(&fixture.group_id).unwrap(),
+        EpochId(tip.0 + 1)
+    );
+    assert_message_state(&fixture.storage, &fixture.commit, MessageState::Processed);
+
+    assert_eq!(
+        fixture.discard_audit_rows(),
+        vec![(future_base.0, tip.0, stale.generation)],
+        "one discard row, reporting a base epoch ahead of the tip"
     );
 }
 

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -5575,6 +5575,128 @@ async fn input_at_effective_cutoff_is_retained_for_the_next_generation() {
 }
 
 #[tokio::test]
+async fn stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting() {
+    // A device catching up advances its tip while a durable pass stays open at
+    // the epoch it was scheduled from. That is stale local scheduling state, not
+    // corruption: convergence must discard the pass, reopen at the tip, and keep
+    // converging. Halting here durably wedged a field device that was six epochs
+    // behind, and every later send failed against the halt.
+    use marmot_forensics::{AuditEvent, AuditEventKind, JsonlRecorder};
+
+    let audit_dir = tempfile::tempdir().unwrap();
+    let audit_path = audit_dir.path().join("audit.jsonl");
+    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut david, _david_storage) = build_client(b"david");
+    let carol_storage = SqliteAccountStorage::in_memory().unwrap();
+    let mut carol = EngineBuilder::new(carol_storage.clone())
+        .legacy_compatibility_profile()
+        .identity(pad32(b"carol"))
+        .account_identity_proof_signer(proof_signer(b"carol"))
+        .feature_registry(selfremove_registry())
+        .peeler(Box::new(MockPeeler))
+        .recorder(Box::new(
+            JsonlRecorder::open(&audit_path, "carol-engine".to_string()).unwrap(),
+        ))
+        .build()
+        .unwrap();
+
+    let carol_kp = carol.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "engine-convergence-stale-pass-base".into(),
+            description: "".into(),
+            members: vec![carol_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![],
+        })
+        .await
+        .unwrap();
+    let (pending, welcomes) = match create {
+        SendResult::GroupCreated { pending, welcomes } => (pending, welcomes),
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    alice.confirm_published(pending).await.unwrap();
+    carol
+        .join_welcome(welcome_for(&welcomes, b"carol"))
+        .await
+        .unwrap();
+
+    let invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david.fresh_key_package().await.unwrap()],
+        })
+        .await
+        .unwrap();
+    let (commit, _) = evolution(invite);
+    let commit = route(commit, &group_id);
+    carol
+        .buffer_openmls_convergence_message(&group_id, commit.clone(), 1_000)
+        .unwrap();
+
+    let tip = carol.epoch(&group_id).unwrap();
+    let stale_base = EpochId(tip.0.checked_sub(1).expect("the tip is past epoch zero"));
+    let mut stale = carol_storage.convergence_pass(&group_id).unwrap().unwrap();
+    assert_eq!(stale.base_epoch, tip, "pass opens at the current tip");
+    // The durable pass outlives the tip it was scheduled from, so its base epoch
+    // falls behind as the device catches up.
+    stale.base_epoch = stale_base;
+    carol_storage.put_convergence_pass(&stale).unwrap();
+
+    let compensated = carol
+        .converge_stored_openmls_messages(&group_id, 2_000)
+        .expect("a stale pass base is compensated, not fatal");
+    assert_ne!(
+        compensated.convergence_status,
+        ConvergenceStatus::Blocked,
+        "a stale pass base must not block the run"
+    );
+    assert!(
+        !carol_storage.get_group(&group_id).unwrap().unrecoverable,
+        "a stale pass base must not durably wedge the group"
+    );
+    assert!(
+        !carol
+            .drain_events()
+            .iter()
+            .any(|event| matches!(event, GroupEvent::GroupUnrecoverable { .. }))
+    );
+
+    let reopened = carol_storage
+        .convergence_pass(&group_id)
+        .unwrap()
+        .expect("the discarded pass is replaced by one at the current tip");
+    assert_eq!(reopened.base_epoch, tip);
+    assert_eq!(reopened.generation, stale.generation + 1);
+
+    let settled = carol
+        .converge_stored_openmls_messages(&group_id, 3_000)
+        .expect("the reopened pass converges at the current tip");
+    assert_eq!(settled.convergence_status, ConvergenceStatus::Settled);
+    assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(tip.0 + 1));
+    assert_message_state(&carol_storage, &commit, MessageState::Processed);
+
+    drop(carol);
+    let events: Vec<AuditEvent> = std::fs::read_to_string(&audit_path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert!(
+        events.iter().any(|event| matches!(
+            &event.kind,
+            AuditEventKind::ConvergencePassReopened {
+                stale_base_epoch,
+                current_tip_epoch,
+                ..
+            } if *stale_base_epoch == stale_base.0 && *current_tip_epoch == tip.0
+        )),
+        "the compensation is diagnosable from a forensic export"
+    );
+}
+
+#[tokio::test]
 async fn frozen_pass_member_tampering_fails_closed_to_unrecoverable() {
     let (mut alice, _alice_storage) = build_client(b"alice");
     let (mut carol, carol_storage) = build_client(b"carol");

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -5689,8 +5689,10 @@ async fn stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting() {
             AuditEventKind::ConvergencePassReopened {
                 stale_base_epoch,
                 current_tip_epoch,
-                ..
-            } if *stale_base_epoch == stale_base.0 && *current_tip_epoch == tip.0
+                generation,
+            } if *stale_base_epoch == stale_base.0
+                && *current_tip_epoch == tip.0
+                && *generation == stale.generation
         )),
         "the compensation is diagnosable from a forensic export"
     );

--- a/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
+++ b/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
@@ -1675,7 +1675,7 @@
           ],
           "properties": {
             "type": {
-              "const": "convergence_pass_reopened"
+              "const": "convergence_pass_discarded"
             },
             "stale_base_epoch": {
               "$ref": "#/$defs/u64"

--- a/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
+++ b/crates/marmot-forensics/schema/audit-log-event.v2.schema.json
@@ -1663,6 +1663,30 @@
               "$ref": "#/$defs/u64"
             }
           }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "stale_base_epoch",
+            "current_tip_epoch",
+            "generation"
+          ],
+          "properties": {
+            "type": {
+              "const": "convergence_pass_reopened"
+            },
+            "stale_base_epoch": {
+              "$ref": "#/$defs/u64"
+            },
+            "current_tip_epoch": {
+              "$ref": "#/$defs/u64"
+            },
+            "generation": {
+              "$ref": "#/$defs/u64"
+            }
+          }
         }
       ]
     }

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -1021,6 +1021,22 @@ pub enum AuditEventKind {
     /// Privacy: two scalar counts only — no ids, relay URLs, message ids, or
     /// payloads — so nothing here needs scrubbing in either [`AuditDataMode`].
     EpochStallBackfillArmed { stalled_epoch: u64, threshold: u64 },
+    /// A durable convergence pass was scheduled against an epoch the device has
+    /// since left behind — it caught up while the pass stayed open — so the pass
+    /// was discarded and convergence reopened at the current tip. Non-terminal by
+    /// construction: it records the compensation that keeps a catching-up device
+    /// converging. `stale_base_epoch` is the epoch the discarded pass was
+    /// scheduled from and `generation` is its pass generation, so an export shows
+    /// how far behind the discarded scheduling state was.
+    ///
+    /// Group-scoped through the enclosing [`AuditEvent::group_ref`]; three scalar
+    /// epochs/counters only, so nothing here needs scrubbing in either
+    /// [`AuditDataMode`].
+    ConvergencePassReopened {
+        stale_base_epoch: u64,
+        current_tip_epoch: u64,
+        generation: u64,
+    },
 }
 
 impl AuditEventKind {
@@ -1072,6 +1088,7 @@ impl AuditEventKind {
             AuditEventKind::SubscriptionRebuild { .. } => "subscription_rebuild",
             AuditEventKind::SyncDrain { .. } => "sync_drain",
             AuditEventKind::EpochStallBackfillArmed { .. } => "epoch_stall_backfill_armed",
+            AuditEventKind::ConvergencePassReopened { .. } => "convergence_pass_reopened",
         }
     }
 }

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -1021,13 +1021,15 @@ pub enum AuditEventKind {
     /// Privacy: two scalar counts only — no ids, relay URLs, message ids, or
     /// payloads — so nothing here needs scrubbing in either [`AuditDataMode`].
     EpochStallBackfillArmed { stalled_epoch: u64, threshold: u64 },
-    /// A durable convergence pass was scheduled against an epoch the device has
-    /// since left behind — it caught up while the pass stayed open — so the pass
-    /// was discarded and convergence reopened at the current tip. Non-terminal by
-    /// construction: it records the compensation that keeps a catching-up device
-    /// converging. `stale_base_epoch` is the epoch the discarded pass was
-    /// scheduled from and `generation` is its pass generation, so an export shows
-    /// how far behind the discarded scheduling state was.
+    /// A durable convergence pass whose base epoch disagreed with the device's
+    /// current tip was discarded, freeing convergence to reopen at the tip.
+    /// Non-terminal by construction: it records a repair, not a fault. The
+    /// disagreement is inherited scheduling state — an older binary stamped a
+    /// pass's base epoch from the durable group record while convergence compared
+    /// the epoch manager, and those two stores can split across a restart — so
+    /// `stale_base_epoch` may sit either behind or ahead of `current_tip_epoch`.
+    /// `generation` is the discarded pass's generation, so an export shows which
+    /// scheduling state was dropped.
     ///
     /// Group-scoped through the enclosing [`AuditEvent::group_ref`]; three scalar
     /// epochs/counters only, so nothing here needs scrubbing in either

--- a/crates/marmot-forensics/src/audit.rs
+++ b/crates/marmot-forensics/src/audit.rs
@@ -1032,7 +1032,7 @@ pub enum AuditEventKind {
     /// Group-scoped through the enclosing [`AuditEvent::group_ref`]; three scalar
     /// epochs/counters only, so nothing here needs scrubbing in either
     /// [`AuditDataMode`].
-    ConvergencePassReopened {
+    ConvergencePassDiscarded {
         stale_base_epoch: u64,
         current_tip_epoch: u64,
         generation: u64,
@@ -1088,7 +1088,7 @@ impl AuditEventKind {
             AuditEventKind::SubscriptionRebuild { .. } => "subscription_rebuild",
             AuditEventKind::SyncDrain { .. } => "sync_drain",
             AuditEventKind::EpochStallBackfillArmed { .. } => "epoch_stall_backfill_armed",
-            AuditEventKind::ConvergencePassReopened { .. } => "convergence_pass_reopened",
+            AuditEventKind::ConvergencePassDiscarded { .. } => "convergence_pass_discarded",
         }
     }
 }

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -835,7 +835,7 @@ fn sample_audit_event_kinds() -> Vec<AuditEventKind> {
             stalled_epoch: 19,
             threshold: 8,
         },
-        AuditEventKind::ConvergencePassReopened {
+        AuditEventKind::ConvergencePassDiscarded {
             stale_base_epoch: 7,
             current_tip_epoch: 13,
             generation: 4,

--- a/crates/marmot-forensics/src/audit/tests.rs
+++ b/crates/marmot-forensics/src/audit/tests.rs
@@ -835,6 +835,11 @@ fn sample_audit_event_kinds() -> Vec<AuditEventKind> {
             stalled_epoch: 19,
             threshold: 8,
         },
+        AuditEventKind::ConvergencePassReopened {
+            stale_base_epoch: 7,
+            current_tip_epoch: 13,
+            generation: 4,
+        },
     ]
 }
 

--- a/docs/marmot-architecture/distributed-convergence.md
+++ b/docs/marmot-architecture/distributed-convergence.md
@@ -138,11 +138,18 @@ millisecond wall deadlines. An elapsed deadline becomes immediately due, and a b
 fails closed to an immediate cutoff. Frozen and resolving passes resume their exact persisted membership without
 re-enumerating storage.
 
-A pass is scheduling state for one base epoch. When the group's tip has moved past that epoch — a device catching up
-applies commits while a pass is open — the stale pass is discarded and the next generation opens at the current tip
-(`convergence_pass_discarded`). The pass holds no canonical state of its own, so its members reseed from retained
-storage. `stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting` pins that rule. Only a frozen member
-that no longer matches the record it was admitted from is an integrity failure, and that alone halts the group
+A pass is scheduling state for one base epoch. A pass whose base epoch disagrees with the current tip is discarded, and
+the next generation opens at the tip (`convergence_pass_discarded`). This is a repair path, not a steady-state
+transition: the tip does not move forward underneath an open pass, because an active pass gates outbound work and an
+inbound commit inside the rewind horizon re-enters convergence instead of applying directly. What it repairs is
+inherited scheduling state — a base epoch stamped from the durable group record while the tip was read from the epoch
+manager, two authorities for one epoch that can split across a restart — so an inherited base can sit either behind or
+ahead of the tip, and both directions are discarded regardless of pass phase. The pass holds no canonical state of its
+own, so its members reseed from retained storage.
+`stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting`,
+`frozen_stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting`, and
+`future_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting` pin that rule. Only a frozen member that no
+longer matches the record it was admitted from is an integrity failure, and that alone halts the group
 `Unrecoverable`.
 
 The runtime arms one timer deadline per group. Scheduling traffic for one group cannot postpone another group's earlier

--- a/docs/marmot-architecture/distributed-convergence.md
+++ b/docs/marmot-architecture/distributed-convergence.md
@@ -140,7 +140,7 @@ re-enumerating storage.
 
 A pass is scheduling state for one base epoch. When the group's tip has moved past that epoch — a device catching up
 applies commits while a pass is open — the stale pass is discarded and the next generation opens at the current tip
-(`convergence_pass_reopened`). The pass holds no canonical state of its own, so its members reseed from retained
+(`convergence_pass_discarded`). The pass holds no canonical state of its own, so its members reseed from retained
 storage. `stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting` pins that rule. Only a frozen member
 that no longer matches the record it was admitted from is an integrity failure, and that alone halts the group
 `Unrecoverable`.

--- a/docs/marmot-architecture/distributed-convergence.md
+++ b/docs/marmot-architecture/distributed-convergence.md
@@ -141,8 +141,9 @@ re-enumerating storage.
 A pass is scheduling state for one base epoch. When the group's tip has moved past that epoch — a device catching up
 applies commits while a pass is open — the stale pass is discarded and the next generation opens at the current tip
 (`convergence_pass_reopened`). The pass holds no canonical state of its own, so its members reseed from retained
-storage. Only a frozen member that no longer matches the record it was admitted from is an integrity failure, and that
-alone halts the group `Unrecoverable`.
+storage. `stale_pass_base_epoch_reopens_at_the_current_tip_instead_of_halting` pins that rule. Only a frozen member
+that no longer matches the record it was admitted from is an integrity failure, and that alone halts the group
+`Unrecoverable`.
 
 The runtime arms one timer deadline per group. Scheduling traffic for one group cannot postpone another group's earlier
 cutoff. After a completed pass, one persisted, already-queued admin group-state intent receives one preparation attempt

--- a/docs/marmot-architecture/distributed-convergence.md
+++ b/docs/marmot-architecture/distributed-convergence.md
@@ -138,6 +138,12 @@ millisecond wall deadlines. An elapsed deadline becomes immediately due, and a b
 fails closed to an immediate cutoff. Frozen and resolving passes resume their exact persisted membership without
 re-enumerating storage.
 
+A pass is scheduling state for one base epoch. When the group's tip has moved past that epoch — a device catching up
+applies commits while a pass is open — the stale pass is discarded and the next generation opens at the current tip
+(`convergence_pass_reopened`). The pass holds no canonical state of its own, so its members reseed from retained
+storage. Only a frozen member that no longer matches the record it was admitted from is an integrity failure, and that
+alone halts the group `Unrecoverable`.
+
 The runtime arms one timer deadline per group. Scheduling traffic for one group cannot postpone another group's earlier
 cutoff. After a completed pass, one persisted, already-queued admin group-state intent receives one preparation attempt
 before an inbound-only follow-up generation. App messages, leave work, and automatic maintenance do not consume that


### PR DESCRIPTION
A durable convergence pass records local scheduling state for one base epoch. On a real field device, a pass whose base epoch disagreed with the live tip was treated as a pass-integrity failure and marked the group durably Unrecoverable — whose only exit is a verified re-join — so a device six epochs behind was wedged at epoch 7 and every later send failed against the halt. The mismatch does not come from a live transition (the tip cannot move while a pass is open: every active pass gates outbound, and inbound commits route through convergence). It comes from dual authority: the pass's base_epoch was stamped from the durable group record while the halt compared the epoch manager's live epoch. Those two stores can split — behind the tip via the record lagging across a restart, or ahead of it via a fork rollback that moves the in-memory tip backwards without writing the record — so an inherited pass can sit on either side of the tip, benignly.

Give passes a single epoch authority instead (convergence_tip_epoch: the epoch manager, with the durable record only as the pre-hydration fallback), and maintain the invariant where passes are handed out: load_or_open_convergence_pass discards an active pass whose base epoch differs from the tip — behind or ahead, any active phase — and reopens at the tip, the same rule do_join_welcome already applies to a discarded local copy. A pass carries no canonical state of its own (members are id references into retained rows), so discarding drops a batch boundary and two deadlines and the members reseed. A frozen member that no longer matches the record it was admitted from is still a real integrity failure and still halts.

The compensation is diagnosable from a forensic export: a non-terminal convergence_pass_discarded audit row (named for the discard it records — the reopen is a separate decision, observable as the next generation's pass) carrying the stale base epoch, the current tip, and the discarded generation.

Review round: the mechanism prose was corrected at five sites (this description included — the original text claimed the catching-up transition), the audit kind was renamed from convergence_pass_reopened, and the discard is now pinned in both directions and the frozen phase by mutation-verified regressions, plus a unit test pinning that every pass trigger admits a commit edge that gates outbound work.

Stacked on this PR: #1184 makes the inbound-commit epoch mirror transactional instead of best-effort, closing the production source of the group-record/epoch-manager split that stamped stale bases in the first place — this PR repairs the records such splits leave behind. Rebased on master with #1173 in; will rebase again once #1174 lands, per review agreement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **Improvements**
  * Hardened stored-message convergence: stale durable convergence passes are discarded and re-opened at the current tip epoch, improving repair behavior for behind/ahead base-epoch mismatches.
  * Removed incorrect unrecoverable marking for certain base-epoch mismatches; normal convergence flow now proceeds.
  * Frozen-pass integrity failure handling is now more consistent, with tighter repair/rejection behavior.

* **Audit & Documentation**
  * Added `convergence_pass_discarded` audit event (stale base epoch, current tip epoch, generation), including schema and documentation updates.

* **Tests**
  * Added integration and unit tests covering pass reopening/compensation and commit-edge gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->