### PR TITLE
fix(cgka-engine): mirror the inbound-commit epoch inside the merge transaction instead of best-effort

### DIFF
--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -365,7 +365,12 @@ shapes. Tests: `tests/fork_detection.rs` plus the harness `deliberate_fork_via_h
   MLS state change it projects, and every mirror failure propagates — never best-effort. Write the record inside the
   transaction that merges the commit (`publish::do_confirm_published`, the inbound apply in `message_processor/ingest.rs`)
   or compensate the in-memory transition explicitly (`stage_auto_commit_for_queued_proposals`). A swallowed mirror error
-  splits the two stores silently and the split resurfaces as a wrong epoch on the next session open.
+  splits the two stores silently and the split resurfaces as a wrong epoch on the next session open. Undoing the apply
+  is only half the obligation: where the failing seam sits behind fork resolution — whose side effects (released
+  incumbent snapshot, `EpochInvalidated` incumbent commit) cannot be compensated — it must also release the recovery
+  snapshot it created and hand the still-retained winning commit back to stored convergence via
+  `schedule_pending_convergence_group`. Otherwise the group parks one epoch behind holding a durable winner nothing
+  will ever apply.
 - **Only `EpochManager` may construct non-`Stable` `EpochState` variants.** This is enforced by visibility — the
   variants' fields are private. Don't add a public constructor for `Recovering` etc. somewhere else.
 - **No Nostr library/SDK dependency.** These crates do not depend on any Nostr crate and use no Nostr SDK types. They

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -360,6 +360,12 @@ shapes. Tests: `tests/fork_detection.rs` plus the harness `deliberate_fork_via_h
   path that reads group state, add the gate — a path that bypasses it can silently un-quarantine a group via
   `set_stable`. Quarantine clears only through `retry_hydrate_quarantined_group` or an authenticated re-join welcome,
   both of which schedule retained input for replay.
+- **The durable `Group::epoch` is a mirror of the epoch manager, and hydration seeds the epoch manager from it.**
+  Because those two stores read each other across a restart, every mirror write belongs to the same durable unit as the
+  MLS state change it projects, and every mirror failure propagates — never best-effort. Write the record inside the
+  transaction that merges the commit (`publish::do_confirm_published`, the inbound apply in `message_processor/ingest.rs`)
+  or compensate the in-memory transition explicitly (`stage_auto_commit_for_queued_proposals`). A swallowed mirror error
+  splits the two stores silently and the split resurfaces as a wrong epoch on the next session open.
 - **Only `EpochManager` may construct non-`Stable` `EpochState` variants.** This is enforced by visibility — the
   variants' fields are private. Don't add a public constructor for `Recovering` etc. somewhere else.
 - **No Nostr library/SDK dependency.** These crates do not depend on any Nostr crate and use no Nostr SDK types. They

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -55,6 +55,17 @@ struct RetainedSelfRemoveProposal {
     queued: QueuedProposal,
 }
 
+/// What an applied inbound commit changed, derived from the merged group state.
+///
+/// Produced inside the apply transaction because the durable record mirror is
+/// written from the same values the post-apply events are synthesized from.
+struct AppliedCommitProjection {
+    epoch: EpochId,
+    remaining_member_ids: std::collections::HashSet<MemberId>,
+    removed_member_ids: Vec<MemberId>,
+    message_retention_seconds: Option<u64>,
+}
+
 enum ScheduledAutoCommitReplay {
     Staged,
     NotApplicable,
@@ -1272,34 +1283,84 @@ impl<S: StorageProvider> Engine<S> {
                         &group_id,
                         &staged,
                     )?;
-                    self.storage.with_transaction(|storage| {
-                        let tx_provider =
-                            EngineOpenMlsProvider::<S>::new(&self.crypto, storage.mls_storage());
-                        mls_group
-                            .merge_staged_commit(&tx_provider, *staged)
-                            .map_err(|e| {
-                                EngineError::Backend(format!("merge_staged_commit: {e:?}"))
-                            })?;
-                        crate::app_components::validate_current_profile_group_invariants(&mls_group)
-                    })?;
-                    let after = EpochId(mls_group.epoch().as_u64());
-                    let after_members = group_lifecycle::marmot_members(&mls_group);
+                    // Merge and mirror the Marmot record in one durable unit, the
+                    // same rule `do_confirm_published` applies to its own merge.
+                    // Session open seeds the epoch state machine FROM that
+                    // record, so a failed mirror must undo the merge instead of
+                    // leaving the two stores at different epochs. Nothing between
+                    // this transaction and `set_stable` below is fallible, so the
+                    // in-memory epoch authority can only advance over a committed
+                    // mirror.
+                    let AppliedCommitProjection {
+                        epoch: after,
+                        remaining_member_ids: after_ids,
+                        removed_member_ids: removed,
+                        message_retention_seconds: after_message_retention,
+                    } = self.storage.with_transaction(
+                        |storage| -> Result<AppliedCommitProjection, EngineError> {
+                            let tx_provider = EngineOpenMlsProvider::<S>::new(
+                                &self.crypto,
+                                storage.mls_storage(),
+                            );
+                            mls_group
+                                .merge_staged_commit(&tx_provider, *staged)
+                                .map_err(|e| {
+                                    EngineError::Backend(format!("merge_staged_commit: {e:?}"))
+                                })?;
+                            crate::app_components::validate_current_profile_group_invariants(
+                                &mls_group,
+                            )?;
+                            let after = EpochId(mls_group.epoch().as_u64());
+                            let after_members = group_lifecycle::marmot_members(&mls_group);
+                            let after_ids: std::collections::HashSet<MemberId> =
+                                after_members.iter().map(|m| m.id.clone()).collect();
+                            let removed: Vec<MemberId> = before_members
+                                .into_iter()
+                                .filter_map(|m| (!after_ids.contains(&m.id)).then_some(m.id))
+                                .collect();
+                            let mut g = storage.get_group(&group_id)?;
+                            g.epoch = after;
+                            g.members = after_members;
+                            g.required_capabilities =
+                                crate::capability_manager::required_capabilities_from_group(
+                                    &mls_group,
+                                );
+                            crate::group_lifecycle::mirror_app_components_into_record(
+                                &mls_group, &mut g,
+                            );
+                            // This commit removed our own leaf: mark the local
+                            // copy removed (member-departure.md, "Realizing
+                            // removal") in the same record write. The departure
+                            // notification for self is emitted with the roster
+                            // diff below, so the marker and the notification stay
+                            // coupled and later `SelfEvicted` input does not
+                            // re-emit it.
+                            if removed
+                                .iter()
+                                .any(|member| member == self.identity.self_id())
+                            {
+                                g.removed = true;
+                            }
+                            storage.put_group(&g)?;
+                            Ok(AppliedCommitProjection {
+                                epoch: after,
+                                remaining_member_ids: after_ids,
+                                removed_member_ids: removed,
+                                message_retention_seconds:
+                                    crate::app_components::message_retention_seconds_of_group(
+                                        &mls_group,
+                                    )?,
+                            })
+                        },
+                    )?;
                     let after_admins =
                         crate::app_components::admins_of_group(&mls_group).unwrap_or_default();
                     let after_profile = crate::app_components::group_profile_of_group(&mls_group)
                         .ok()
                         .flatten();
                     let after_avatar = avatar_component_snapshot(&mls_group);
-                    let after_message_retention =
-                        crate::app_components::message_retention_seconds_of_group(&mls_group)?;
-                    let after_ids: std::collections::HashSet<MemberId> =
-                        after_members.iter().map(|m| m.id.clone()).collect();
-                    let removed: Vec<MemberId> = before_members
-                        .into_iter()
-                        .filter_map(|m| (!after_ids.contains(&m.id)).then_some(m.id))
-                        .collect();
 
-                    // Update our per-group state machine + storage mirror.
+                    // Update our per-group state machine.
                     self.epoch_manager.set_stable(group_id.clone(), after);
                     self.drop_self_remove_auto_commit_schedules_for_group(&group_id);
                     // Proposal-arrival schedule signals are source-epoch
@@ -1318,29 +1379,6 @@ impl<S: StorageProvider> Engine<S> {
                         ),
                         recovery_snapshot,
                     );
-                    if let Ok(mut g) = self.storage.get_group(&group_id) {
-                        g.epoch = after;
-                        g.members = after_members;
-                        g.required_capabilities =
-                            crate::capability_manager::required_capabilities_from_group(&mls_group);
-                        crate::group_lifecycle::mirror_app_components_into_record(
-                            &mls_group, &mut g,
-                        );
-                        // This commit removed our own leaf: mark the local
-                        // copy removed (member-departure.md, "Realizing
-                        // removal") in the same record write. The departure
-                        // notification for self is emitted with the roster
-                        // diff below, so the marker and the notification stay
-                        // coupled and later `SelfEvicted` input does not
-                        // re-emit it.
-                        if removed
-                            .iter()
-                            .any(|member| member == self.identity.self_id())
-                        {
-                            g.removed = true;
-                        }
-                        self.storage.put_group(&g)?;
-                    }
                     // #740 rotation: a peer's applied commit may have changed the
                     // Nostr routing component; additively refresh the transport-id
                     // index so the new nostr_group_id resolves (prior id retained

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1296,7 +1296,7 @@ impl<S: StorageProvider> Engine<S> {
                         remaining_member_ids: after_ids,
                         removed_member_ids: removed,
                         message_retention_seconds: after_message_retention,
-                    } = self.storage.with_transaction(
+                    } = match self.storage.with_transaction(
                         |storage| -> Result<AppliedCommitProjection, EngineError> {
                             let tx_provider = EngineOpenMlsProvider::<S>::new(
                                 &self.crypto,
@@ -1352,7 +1352,36 @@ impl<S: StorageProvider> Engine<S> {
                                     )?,
                             })
                         },
-                    )?;
+                    ) {
+                        Ok(projection) => projection,
+                        Err(error) => {
+                            // The snapshot above guards an apply that is now
+                            // abandoned; only `record_applied_commit_for_recovery`
+                            // below takes ownership of it. Release it here, and
+                            // do not let a release failure mask the original
+                            // error.
+                            match self
+                                .storage
+                                .release_group_snapshot(&group_id, &recovery_snapshot)
+                            {
+                                Ok(()) | Err(StorageError::SnapshotMissing(_)) => {}
+                                Err(_) => tracing::warn!(
+                                    target: "cgka_engine::message_processor",
+                                    method = "ingest_group_message",
+                                    "failed to release the recovery snapshot of an abandoned inbound apply"
+                                ),
+                            }
+                            // Fork resolution already consumed side effects this
+                            // seam cannot compensate: the incumbent's snapshot is
+                            // released and its commit is `EpochInvalidated`. The
+                            // winning commit is durably retained as a `Created`
+                            // wire row, so hand the group back to stored
+                            // convergence — that pass is the repair path, and
+                            // without the schedule nothing would ever apply it.
+                            self.schedule_pending_convergence_group(&group_id);
+                            return Err(error);
+                        }
+                    };
                     let after_admins =
                         crate::app_components::admins_of_group(&mls_group).unwrap_or_default();
                     let after_profile = crate::app_components::group_profile_of_group(&mls_group)

--- a/crates/cgka-engine/tests/AGENTS.md
+++ b/crates/cgka-engine/tests/AGENTS.md
@@ -67,8 +67,10 @@ backend on the same rail.
     `PendingCommit`, clears it, and surfaces `GroupEvent::PendingCommitRecovered` (mdk#150)
 
 - **File:** `auto_commit_atomicity.rs`
-  - **Owns:** Auto-commit staging atomicity (mdk#333) — an injected `put_group` failure during staging leaves no torn
-    group record, no orphaned pending publish, no leaked snapshot, and no stale stored proposal; the group stays usable
+  - **Owns:** Group-record write atomicity under an injected `put_group` failure (mdk#333), one test per seam that
+    projects the record: auto-commit staging, Welcome join, group-profile staging, and inbound commit apply. No torn
+    record, no orphaned pending publish, no leaked snapshot, no stale stored proposal, no epoch split between the
+    record and the epoch manager; the group stays usable
 
 - **File:** `hydration_quarantine.rs`
   - **Owns:** Group hydration-quarantine path — `GroupHydrationQuarantineReason` classification on session open

--- a/crates/cgka-engine/tests/AGENTS.md
+++ b/crates/cgka-engine/tests/AGENTS.md
@@ -70,7 +70,8 @@ backend on the same rail.
   - **Owns:** Group-record write atomicity under an injected `put_group` failure (mdk#333), one test per seam that
     projects the record: auto-commit staging, Welcome join, group-profile staging, and inbound commit apply. No torn
     record, no orphaned pending publish, no leaked snapshot, no stale stored proposal, no epoch split between the
-    record and the epoch manager; the group stays usable
+    record and the epoch manager; the group stays usable, and an apply the fault abandoned hands its still-retained
+    winning commit back to stored convergence so it is eventually applied
 
 - **File:** `hydration_quarantine.rs`
   - **Owns:** Group hydration-quarantine path — `GroupHydrationQuarantineReason` classification on session open

--- a/crates/cgka-engine/tests/auto_commit_atomicity.rs
+++ b/crates/cgka-engine/tests/auto_commit_atomicity.rs
@@ -1,17 +1,17 @@
-//! Auto-commit staging atomicity (mdk#333).
+//! Group-record write atomicity under an injected storage fault (mdk#333).
 //!
-//! `stage_auto_commit_for_queued_proposal` projects the post-merge group
-//! record (epoch N+1, leaver dropped) as part of staging. If any fallible
-//! staging step fails after durable state has advanced, the record must not
-//! be left torn — epoch/membership disagreeing with the MLS group and the
-//! epoch state machine strands auto-commit replay (which bails on any epoch
-//! mismatch) and forks the rendered member list from reality.
+//! Every seam that advances durable group state projects the Marmot record as
+//! part of the same logical step. If the record write fails after other durable
+//! state has advanced, the record must not be left torn — an epoch or roster
+//! disagreeing with the MLS group and the epoch state machine strands replay
+//! (which bails on any epoch mismatch), forks the rendered member list from
+//! reality, and survives into the next session because hydration reads the
+//! record.
 //!
-//! The staging path orders the record write after `begin_pending` and
-//! compensates a failed `put_group` by rewinding the state machine, with the
-//! armed `PendingCommitCleanupGuard` clearing the staged OpenMLS commit on
-//! the early return. This test injects a one-shot `put_group` failure at
-//! exactly that point and asserts nothing is torn and the group stays usable.
+//! Each test here arms a one-shot `put_group` failure at exactly one seam's
+//! projection — auto-commit staging, Welcome join, group-profile staging,
+//! inbound commit apply — and asserts nothing is torn and the group stays
+//! usable.
 
 use async_trait::async_trait;
 use cgka_engine::EngineBuilder;
@@ -20,7 +20,10 @@ use cgka_traits::OutboundFanout;
 use cgka_traits::capabilities::{
     Capability, CapabilityRequirement, Feature, GroupCapabilities, RequirementLevel,
 };
-use cgka_traits::engine::{CgkaEngine, CreateGroupRequest, SendIntent, SendResult};
+use cgka_traits::engine::{
+    CgkaEngine, CommitOrderingKey, CommitOrderingPriority, CreateGroupRequest, SendIntent,
+    SendResult,
+};
 use cgka_traits::error::{EngineError, PeelerError};
 use cgka_traits::group::{Group, Member};
 use cgka_traits::group_context::GroupContextSnapshot;
@@ -677,6 +680,134 @@ async fn auto_commit_record_write_failure_leaves_no_torn_group_record() {
     assert_eq!(record.epoch, EpochId(2));
     assert_eq!(record.members.len(), 2);
     assert!(!record.members.iter().any(|m| m.id == bob_member_id));
+}
+
+/// Fork recovery rolls the losing side back to its pre-commit snapshot and
+/// re-applies the winning commit through the inbound apply seam, which mirrors
+/// the recovered epoch into the durable group record. A storage fault at that
+/// mirror must not leave the engine reporting the recovered epoch while the
+/// record still holds the pre-fork one: hydration seeds the in-memory epoch
+/// FROM that record, so an in-process split becomes a wrong epoch on the next
+/// session open.
+#[tokio::test]
+async fn inbound_apply_record_mirror_failure_does_not_split_epoch_state() {
+    let alice_fault = PutGroupFault::default();
+    let bob_fault = PutGroupFault::default();
+    let (mut alice, alice_handle) =
+        build_fault_selfremove_client(b"alice-mirror", alice_fault.clone());
+    let (mut bob, bob_handle) = build_fault_selfremove_client(b"bob-mirror", bob_fault.clone());
+    let mut david = build_selfremove_client(b"david-mirror");
+    let mut eve = build_selfremove_client(b"eve-mirror");
+
+    // Alice and bob are co-admins at epoch 1, so both can publish a privileged
+    // invite commit from the same epoch.
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "mirror".into(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let welcome = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            welcomes.remove(0)
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(welcome).await.unwrap();
+
+    // Concurrent invites at epoch 1: neither admin has seen the other's commit.
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let alice_invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david_kp],
+        })
+        .await
+        .unwrap();
+    let bob_invite = bob
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+        })
+        .await
+        .unwrap();
+    let alice_commit = match alice_invite {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            alice.confirm_published(pending).await.unwrap();
+            msg
+        }
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    let bob_commit = match bob_invite {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            bob.confirm_published(pending).await.unwrap();
+            msg
+        }
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+
+    // The authenticated ordering key decides which side rolls back; both sides
+    // are fault-injectable so the test never depends on which one that is.
+    let ordering_key = |committer: MemberId, commit: &TransportMessage| {
+        CommitOrderingKey::from_commit_bytes(
+            EpochId(1),
+            CommitOrderingPriority::Privileged,
+            committer,
+            &commit.payload,
+        )
+    };
+    let bob_wins =
+        ordering_key(bob.self_id(), &bob_commit) < ordering_key(alice.self_id(), &alice_commit);
+    let (loser, loser_handle, loser_fault, winning_commit) = if bob_wins {
+        (&mut alice, &alice_handle, &alice_fault, bob_commit)
+    } else {
+        (&mut bob, &bob_handle, &bob_fault, alice_commit)
+    };
+    assert_eq!(loser.epoch(&group_id).unwrap(), EpochId(2));
+
+    // Fail exactly the epoch mirror's record write on the fork-recovery apply
+    // (no other `put_group` runs on this ingest path).
+    loser_fault.arm(1);
+    let routed_winner = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..winning_commit
+    };
+    let ingested = loser.ingest(routed_winner).await;
+
+    let record = loser_handle.get_group(&group_id).unwrap();
+    assert_eq!(
+        loser.epoch(&group_id).unwrap(),
+        record.epoch,
+        "the engine's epoch and the durable record must never split"
+    );
+    assert_eq!(
+        record.epoch,
+        EpochId(1),
+        "a failed mirror must undo the apply, not half-commit it"
+    );
+    assert!(
+        matches!(ingested, Err(EngineError::Storage(StorageError::Busy(_)))),
+        "the storage fault must surface as a retryable error, got {ingested:?}"
+    );
+
+    // Both stores are consistent at the rolled-back epoch, roster included:
+    // neither forked invitee is present, and the group stays live.
+    let members = loser.members(&group_id).expect("group must stay live");
+    assert_eq!(members.len(), 2, "both forked invites are rolled back");
+    assert_eq!(record.members.len(), 2);
 }
 
 /// A profile projection failure occurs after the MLS commit is staged. It must

--- a/crates/cgka-engine/tests/auto_commit_atomicity.rs
+++ b/crates/cgka-engine/tests/auto_commit_atomicity.rs
@@ -27,7 +27,7 @@ use cgka_traits::engine::{
 use cgka_traits::error::{EngineError, PeelerError};
 use cgka_traits::group::{Group, Member};
 use cgka_traits::group_context::GroupContextSnapshot;
-use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage};
+use cgka_traits::ingest::{IngestOutcome, InputRejectionCategory, PeeledContent, PeeledMessage};
 use cgka_traits::message::{MessageRecord, MessageState};
 use cgka_traits::peeler::TransportPeeler;
 use cgka_traits::storage::{
@@ -66,6 +66,14 @@ fn pad32(name: &[u8]) -> Vec<u8> {
         }
         counter += 1;
     }
+}
+
+/// Hex form of a group message's content-derived dedup id, for comparing
+/// against canonicalization-result message ids. Under the pass-through
+/// `MockPeeler` the recovered MLS bytes are exactly `msg.payload`.
+fn content_hex(msg: &TransportMessage) -> String {
+    use sha2::{Digest, Sha256};
+    hex::encode(Sha256::digest(&msg.payload))
 }
 
 fn hash_id(bytes: &[u8]) -> MessageId {
@@ -689,6 +697,15 @@ async fn auto_commit_record_write_failure_leaves_no_torn_group_record() {
 /// record still holds the pre-fork one: hydration seeds the in-memory epoch
 /// FROM that record, so an in-process split becomes a wrong epoch on the next
 /// session open.
+///
+/// Undoing the apply is only half the obligation. Fork resolution already
+/// consumed side effects this seam cannot compensate (the incumbent snapshot is
+/// released, the incumbent commit is `EpochInvalidated`), and the winning commit
+/// stays durably retained. So the failure must also release the recovery
+/// snapshot it created for the apply it abandoned and hand the retained winner
+/// back to stored convergence — otherwise the group is parked one epoch behind
+/// with a durable winner nothing will ever apply, and redelivery answers
+/// `Buffered` forever.
 #[tokio::test]
 async fn inbound_apply_record_mirror_failure_does_not_split_epoch_state() {
     let alice_fault = PutGroupFault::default();
@@ -775,6 +792,11 @@ async fn inbound_apply_record_mirror_failure_does_not_split_epoch_state() {
         (&mut bob, &bob_handle, &bob_fault, alice_commit)
     };
     assert_eq!(loser.epoch(&group_id).unwrap(), EpochId(2));
+    let snapshots_before: std::collections::HashSet<String> = loser_handle
+        .list_group_snapshots(&group_id)
+        .unwrap()
+        .into_iter()
+        .collect();
 
     // Fail exactly the epoch mirror's record write on the fork-recovery apply
     // (no other `put_group` runs on this ingest path).
@@ -785,7 +807,7 @@ async fn inbound_apply_record_mirror_failure_does_not_split_epoch_state() {
         },
         ..winning_commit
     };
-    let ingested = loser.ingest(routed_winner).await;
+    let ingested = loser.ingest(routed_winner.clone()).await;
 
     let record = loser_handle.get_group(&group_id).unwrap();
     assert_eq!(
@@ -808,6 +830,78 @@ async fn inbound_apply_record_mirror_failure_does_not_split_epoch_state() {
     let members = loser.members(&group_id).expect("group must stay live");
     assert_eq!(members.len(), 2, "both forked invites are rolled back");
     assert_eq!(record.members.len(), 2);
+
+    // Fork resolution legitimately releases the incumbent's snapshot, so the
+    // retained set may shrink — but the abandoned apply must not add its own
+    // recovery snapshot to it.
+    let snapshots_after: std::collections::HashSet<String> = loser_handle
+        .list_group_snapshots(&group_id)
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert!(
+        snapshots_after.is_subset(&snapshots_before),
+        "the failed apply leaked its recovery snapshot: {:?}",
+        snapshots_after
+            .difference(&snapshots_before)
+            .collect::<Vec<_>>()
+    );
+
+    // The winning commit is durably retained but unapplied, and the consumed
+    // fork-resolution side effects cannot be undone. The only repair left is
+    // stored convergence, so the failure must schedule it.
+    let scheduled = loser.drain_pending_convergence_groups();
+    assert!(
+        scheduled.contains(&group_id),
+        "a failed apply must reschedule the retained winner for convergence"
+    );
+
+    // Drive recovery only through what the drain scheduled: the first pass
+    // opens on the retained commit edge, the second settles it past quiescence.
+    let mut recovered = None;
+    for g in &scheduled {
+        loser.converge_stored_openmls_messages_at(g, 0).unwrap();
+        let settled = loser
+            .converge_stored_openmls_messages_at(g, 60_000)
+            .unwrap();
+        if g == &group_id {
+            recovered = Some(settled);
+        }
+    }
+    let recovered = recovered.expect("the faulted group is scheduled");
+    assert!(
+        recovered
+            .accepted_commits
+            .contains(&content_hex(&routed_winner)),
+        "convergence must accept the retained winning commit, got {:?}",
+        recovered.accepted_commits
+    );
+    assert_eq!(
+        loser.epoch(&group_id).unwrap(),
+        EpochId(2),
+        "the scheduled convergence pass must eventually apply the winner"
+    );
+    let record = loser_handle.get_group(&group_id).unwrap();
+    assert_eq!(record.epoch, EpochId(2));
+    assert_eq!(
+        loser.members(&group_id).expect("group stays live").len(),
+        3,
+        "the winner's invitee joins the roster"
+    );
+    assert_eq!(record.members.len(), 3);
+
+    // With the winner applied, redelivery is a plain duplicate — not a
+    // `Buffered` promise of a replay that would never come.
+    let redelivered = loser.ingest(routed_winner).await;
+    assert!(
+        matches!(
+            redelivered,
+            Ok(IngestOutcome::Ignored {
+                category: InputRejectionCategory::Duplicate
+            })
+        ),
+        "redelivery after recovery must be a duplicate, got {redelivered:?}"
+    );
 }
 
 /// A profile projection failure occurs after the MLS commit is staged. It must

--- a/crates/traits/src/ingest.rs
+++ b/crates/traits/src/ingest.rs
@@ -17,6 +17,13 @@ pub enum IngestOutcome {
     /// the group is temporarily not ingestible, usually during a local
     /// publish-before-apply transition. The engine replays buffered messages
     /// when the group returns to `Stable`.
+    ///
+    /// That replay is owned by the application's convergence drain
+    /// (`drain_pending_convergence_groups` →
+    /// `converge_stored_openmls_messages`), not by `replay_buffered_messages`,
+    /// which only re-ingests retained raw transport rows. So an engine seam that
+    /// leaves a retained content row unapplied MUST schedule the group for
+    /// convergence; otherwise this outcome promises a replay that never happens.
     Buffered { group_id: GroupId, epoch: EpochId },
     /// Rejected before convergence admission because routing or deduplication
     /// proved the input cannot affect this account-device's canonical state.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inbound commit processing so durable group “mirror” updates (epoch, membership changes, and mirrored components) and in-memory progression are applied together atomically.
  * Storage mirror-write failures now properly fail the operation so epochs and roster state can’t diverge after a restart.

* **Documentation**
  * Added durability/hydration guidance requiring the group epoch to mirror the epoch manager, with consistent durable write behavior.

* **Tests**
  * Added a failure-injection test ensuring concurrent privileged invites don’t split epoch state when mirror/recovery writes fail.
  * Broadened atomicity test documentation to cover multiple record-projection seams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->