### PR TITLE
fix: broadcast group events applied inside an outbound send

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -16,7 +16,13 @@ versioning through the workspace version in the root `Cargo.toml`.
   pass (only an admin group-state change may briefly hold that boundary, as
   the protocol requires), and busy groups are no longer demoted to retry
   backoff while convergence is legitimately still collecting.
-  
+
+- Runtime chat-list and group-state subscriptions now observe group state
+  changes (for example a group rename) that a member's own outbound send
+  applied by folding retained convergence commits. Previously those events were
+  dropped on the send path, so storage showed the new state while live
+  subscribers were never notified.
+
 ### Added
 
 - MarmotKit and the agent connector now acquire a nonblocking, kernel-released

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1738,7 +1738,8 @@ impl AppClient {
             // folded are durably applied — broadcast them before surfacing the
             // publish failure, best-effort so a projection error cannot mask
             // the primary error.
-            self.observe_send_applied_effects_best_effort(&effects).await;
+            self.observe_send_applied_effects_best_effort(&effects)
+                .await;
             if let Err(_save_err) = self.app.save_state(&self.state) {
                 tracing::warn!(
                     target: "marmot_app::messages",
@@ -1788,7 +1789,8 @@ impl AppClient {
         // for the account worker to broadcast; dropping the events here leaves
         // storage renamed while chat-list/group-state subscribers never wake.
         // Best-effort: a projection failure must not fail a completed publish.
-        self.observe_send_applied_effects_best_effort(&effects).await;
+        self.observe_send_applied_effects_best_effort(&effects)
+            .await;
         self.app.save_state(&self.state)?;
         if published.is_some() && notification_trigger_for_intent(&intent).is_some() {
             self.publish_notification_trigger_best_effort(

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -1688,64 +1688,73 @@ impl AppClient {
             on_local_projection(update);
         }
 
-        let effects = match async {
-            let effects = match self.sync_runtime_groups().await {
-                Ok(()) => {
-                    let send_intent = SendIntent::AppMessage {
-                        group_id: group_id.clone(),
-                        payload,
-                    };
-                    // Thread the human-action context through the engine so the
-                    // send's audit rows carry `human_action`, matching
-                    // create_group/invite/etc.
-                    match &audit_context {
-                        Some(context) => {
-                            self.runtime
-                                .send_with_audit_context(send_intent, context.clone())
-                                .await?
-                        }
-                        None => self.runtime.send(send_intent).await?,
+        let send_result = match self.sync_runtime_groups().await {
+            Ok(()) => {
+                let send_intent = SendIntent::AppMessage {
+                    group_id: group_id.clone(),
+                    payload,
+                };
+                // Thread the human-action context through the engine so the
+                // send's audit rows carry `human_action`, matching
+                // create_group/invite/etc.
+                match &audit_context {
+                    Some(context) => {
+                        self.runtime
+                            .send_with_audit_context(send_intent, context.clone())
+                            .await
                     }
+                    None => self.runtime.send(send_intent).await,
                 }
-                Err(error) if error.is_account_not_active() => {
-                    let context = audit_context.clone().unwrap_or_default();
-                    self.runtime
-                        .queue_app_message_with_audit_context(group_id.clone(), payload, context)
-                        .await?
-                }
-                Err(error) => return Err(error),
-            };
-            fail_if_publish_failed(&effects)?;
-            Ok::<_, AppError>(effects)
-        }
-        .await
-        {
+                .map_err(AppError::from)
+            }
+            Err(error) if error.is_account_not_active() => {
+                let context = audit_context.clone().unwrap_or_default();
+                self.runtime
+                    .queue_app_message_with_audit_context(group_id.clone(), payload, context)
+                    .await
+                    .map_err(AppError::from)
+            }
+            Err(error) => Err(error),
+        };
+        // The publish-status gate is applied separately from obtaining the
+        // effects: even when the outbound publish hard-fails, the engine may
+        // already have folded retained peer commits into this send, and those
+        // applied `GroupStateChanged` / `EpochChanged` events must still be
+        // observed and broadcast — only the local message is retracted.
+        let effects = match send_result {
             Ok(effects) => effects,
             Err(err) => {
-                if should_project_locally {
-                    // No read-marker rollback needed: the marker only advances
-                    // in the post-publish success projection below.
-                    match self.app.invalidate_timeline_app_event(
-                        &self.state.label,
-                        &group_id_hex,
-                        &app_event_id,
-                        "local_publish_failed",
-                    ) {
-                        Ok(Some(update)) => on_local_projection(update),
-                        Ok(None) => {}
-                        Err(_) => {
-                            tracing::warn!(
-                                target: "marmot_app::messages",
-                                method = "send_app_event_with_local_projection",
-                                error_code = "local_projection_retract_failed",
-                                "failed to retract local projection after publish failure"
-                            );
-                        }
-                    }
-                }
+                self.retract_failed_local_projection(
+                    should_project_locally,
+                    &group_id_hex,
+                    &app_event_id,
+                    &mut on_local_projection,
+                );
                 return Err(err);
             }
         };
+        if let Err(publish_err) = fail_if_publish_failed(&effects) {
+            // The send itself failed to reach anyone, but any peer commits it
+            // folded are durably applied — broadcast them before surfacing the
+            // publish failure, best-effort so a projection error cannot mask
+            // the primary error.
+            self.observe_send_applied_effects_best_effort(&effects).await;
+            if let Err(_save_err) = self.app.save_state(&self.state) {
+                tracing::warn!(
+                    target: "marmot_app::messages",
+                    method = "send_app_event_with_local_projection",
+                    error_code = "send_applied_state_save_failed",
+                    "failed to persist state observed from a failed send"
+                );
+            }
+            self.retract_failed_local_projection(
+                should_project_locally,
+                &group_id_hex,
+                &app_event_id,
+                &mut on_local_projection,
+            );
+            return Err(publish_err);
+        }
         if let Some(context) = &audit_context {
             self.record_human_action_succeeded(group_id, context, &effects);
         }
@@ -1778,7 +1787,8 @@ impl AppClient {
         // `queue_own_group_system_projection_updates`) — and buffer the summary
         // for the account worker to broadcast; dropping the events here leaves
         // storage renamed while chat-list/group-state subscribers never wake.
-        self.observe_send_applied_effects(&effects).await?;
+        // Best-effort: a projection failure must not fail a completed publish.
+        self.observe_send_applied_effects_best_effort(&effects).await;
         self.app.save_state(&self.state)?;
         if published.is_some() && notification_trigger_for_intent(&intent).is_some() {
             self.publish_notification_trigger_best_effort(
@@ -1795,6 +1805,40 @@ impl AppClient {
                 maintenance_disposition: effects.maintenance_disposition,
             },
         ))
+    }
+
+    /// Retract the optimistic local timeline row for a send that failed. No
+    /// read-marker rollback is needed: the marker only advances in the
+    /// post-publish success projection.
+    fn retract_failed_local_projection<F>(
+        &mut self,
+        should_project_locally: bool,
+        group_id_hex: &str,
+        app_event_id: &str,
+        on_local_projection: &mut F,
+    ) where
+        F: FnMut(crate::AppProjectionUpdate),
+    {
+        if !should_project_locally {
+            return;
+        }
+        match self.app.invalidate_timeline_app_event(
+            &self.state.label,
+            group_id_hex,
+            app_event_id,
+            "local_publish_failed",
+        ) {
+            Ok(Some(update)) => on_local_projection(update),
+            Ok(None) => {}
+            Err(_) => {
+                tracing::warn!(
+                    target: "marmot_app::messages",
+                    method = "send_app_event_with_local_projection",
+                    error_code = "local_projection_retract_failed",
+                    "failed to retract local projection after publish failure"
+                );
+            }
+        }
     }
 
     /// Most recent kind-7 reaction this account authored that targets

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -76,6 +76,14 @@ pub struct AppClient {
     /// path. The runtime account worker drains this after each command and
     /// broadcasts `ProjectionUpdated` so live timeline subscriptions refresh.
     pub(crate) pending_projection_updates: Vec<crate::AppProjectionUpdate>,
+    /// Sync summary for group events the engine applied as a side effect of an
+    /// outbound send: a send that lands while inbound convergence input is
+    /// retained folds those commits before publishing, so its effects can carry
+    /// peer `GroupStateChanged` / `EpochChanged` events. The runtime account
+    /// worker drains this after each command and broadcasts it like an inbound
+    /// sync summary so live chat-list/group-state subscriptions observe the
+    /// applied commits.
+    pub(crate) pending_applied_sync_summary: crate::SyncSummary,
     pub(crate) pending_convergence_groups: HashSet<GroupId>,
     /// Welcomes queued for re-delivery during the most recent create/invite.
     /// The runtime account worker drains this after the command and broadcasts a
@@ -1762,8 +1770,16 @@ impl AppClient {
             on_local_projection(update);
             self.prune_plaintext_retention_for_group(group_id)?;
         }
+        // A send that lands while inbound convergence input is retained folds
+        // those commits before publishing, so `effects.events` can carry peer
+        // state changes (e.g. a mid-window group rename). Observe them through
+        // the same pipeline as inbound deliveries — state group refresh plus
+        // kind-1210 system-row synthesis (replacing the narrower
+        // `queue_own_group_system_projection_updates`) — and buffer the summary
+        // for the account worker to broadcast; dropping the events here leaves
+        // storage renamed while chat-list/group-state subscribers never wake.
+        self.observe_send_applied_effects(&effects).await?;
         self.app.save_state(&self.state)?;
-        self.queue_own_group_system_projection_updates(&effects);
         if published.is_some() && notification_trigger_for_intent(&intent).is_some() {
             self.publish_notification_trigger_best_effort(
                 group_id,

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -303,6 +303,24 @@ impl AppClient {
         Ok(())
     }
 
+    /// Best-effort wrapper over [`Self::observe_send_applied_effects`] for the
+    /// outbound send paths: a projection or route-refresh failure here must
+    /// not fail a publish that already completed (or mask a publish error on
+    /// the failure path), so it is logged rather than propagated.
+    pub(crate) async fn observe_send_applied_effects_best_effort(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) {
+        if let Err(_err) = self.observe_send_applied_effects(effects).await {
+            tracing::warn!(
+                target: "marmot_app::messages",
+                method = "observe_send_applied_effects",
+                error_code = "send_applied_observe_failed",
+                "failed to observe group events applied during a send"
+            );
+        }
+    }
+
     /// Drain the buffered summary of send-applied group events. Called by the
     /// account worker after each command so the events broadcast on the same
     /// seam that published the command's response.

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -259,6 +259,57 @@ impl AppClient {
         Ok(summary)
     }
 
+    /// Observe group events the engine applied as a side effect of an outbound
+    /// send and buffer them for the account worker to broadcast.
+    ///
+    /// A send that lands while inbound convergence input is retained folds the
+    /// retained commits before publishing, so its effects can carry peer
+    /// `GroupStateChanged` / `EpochChanged` events (e.g. a group rename applied
+    /// mid-window). Those events never pass through the inbound ingest or
+    /// scheduled-convergence seams, so without this pass they reach no runtime
+    /// subscriber: storage shows the new state while chat-list and group-state
+    /// subscriptions stay silent. Runs the same observe pipeline as those seams
+    /// — state group refresh, push-gossip handling, kind-1210 system-row
+    /// synthesis (a deterministic upsert) — and merges the result into
+    /// `pending_applied_sync_summary`. The caller persists state afterwards.
+    pub(crate) async fn observe_send_applied_effects(
+        &mut self,
+        effects: &marmot_account::AccountDeviceEffects,
+    ) -> Result<(), AppError> {
+        if effects.events.is_empty() {
+            return Ok(());
+        }
+        let display_names = self.app.display_names_by_id()?;
+        let mut summary = SyncSummary::default();
+        // Synthetic source identity: these events have no single inbound
+        // transport message (see `drain_pending_session_events`).
+        let source_message_id_hex = String::new();
+        let source_received_at = unix_now_seconds();
+        let routes_dirty = self
+            .observe_account_device_effects(
+                effects,
+                &display_names,
+                &mut summary,
+                &source_message_id_hex,
+                source_received_at,
+                None,
+            )
+            .await?;
+        let routes_changed = self.refresh_group_routes()?;
+        if routes_dirty || routes_changed {
+            self.sync_runtime_groups().await?;
+        }
+        self.pending_applied_sync_summary.merge(summary);
+        Ok(())
+    }
+
+    /// Drain the buffered summary of send-applied group events. Called by the
+    /// account worker after each command so the events broadcast on the same
+    /// seam that published the command's response.
+    pub(crate) fn take_pending_applied_sync_summary(&mut self) -> SyncSummary {
+        std::mem::take(&mut self.pending_applied_sync_summary)
+    }
+
     /// Build an [`EventGroupProjection`] for `group_id`, returning `None` if any
     /// component lookup fails (e.g. the group is quarantined and not live).
     /// Used by the no-inbound drain path where a missing projection must not

--- a/crates/marmot-app/src/config.rs
+++ b/crates/marmot-app/src/config.rs
@@ -80,6 +80,12 @@ pub struct MarmotAppConfig {
     /// `test-policy-overrides` feature is enabled; normal debug and release
     /// builds ignore it so hosts cannot fork the pinned v1 baseline (mdk#970).
     pub dev_settlement_quiescence_ms: Option<u64>,
+    /// Dev/test-only delay added after the engine-reported convergence cutoff
+    /// before the account worker runs scheduled convergence. `None` (the
+    /// default) adds no delay. Honored only with `test-policy-overrides`; this
+    /// lets integration tests hold the precise post-cutoff/pre-scheduler state
+    /// without changing protocol timing in normal builds.
+    pub dev_scheduled_convergence_delay_ms: Option<u64>,
     /// Accounts to search outward from when the searcher's own web of trust is
     /// empty, as pubkey hex.
     ///
@@ -130,6 +136,7 @@ impl Default for MarmotAppConfig {
             allow_loopback_blob_endpoints: false,
             allow_loopback_relay_endpoints: false,
             dev_settlement_quiescence_ms: None,
+            dev_scheduled_convergence_delay_ms: None,
             directory_search_fallback_seeds: Vec::new(),
         }
     }
@@ -200,6 +207,13 @@ impl MarmotAppConfig {
     /// ignore this field; explicit test harnesses set `0` for instant settlement.
     pub fn with_dev_settlement_quiescence_ms(mut self, ms: u64) -> Self {
         self.dev_settlement_quiescence_ms = Some(ms);
+        self
+    }
+
+    /// Add a test-only delay between the engine cutoff and the account
+    /// worker's scheduled convergence pass. Normal builds ignore this field.
+    pub fn with_dev_scheduled_convergence_delay_ms(mut self, ms: u64) -> Self {
+        self.dev_scheduled_convergence_delay_ms = Some(ms);
         self
     }
 }

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1295,6 +1295,7 @@ impl MarmotApp {
             transport_signer: open.signer,
             state: open.state,
             pending_projection_updates: Vec::new(),
+            pending_applied_sync_summary: SyncSummary::default(),
             pending_convergence_groups: std::collections::HashSet::new(),
             pending_welcome_delivery_events: Vec::new(),
             epoch_stall: Default::default(),

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -439,7 +439,10 @@ async fn run_app_runtime_account_worker(
             return;
         }
     };
-    let mut scheduled_convergence = ScheduledConvergence::new(convergence_settlement_delay(&app));
+    let mut scheduled_convergence = ScheduledConvergence::with_test_delay(
+        convergence_settlement_delay(&app),
+        scheduled_convergence_test_delay(&app),
+    );
     let mut scheduled_push_retry = ScheduledPushRegistrationRetry::new();
 
     // The session is hydrated. Capture a read snapshot and signal
@@ -852,6 +855,12 @@ async fn run_app_runtime_account_worker(
                                     .retry_pending_push_registration_shares_best_effort()
                                     .await;
                                 scheduled_push_retry.schedule_after_attempt(pending, &command_tx);
+                                publish_client_pending_applied_summary(
+                                    &mut reopened,
+                                    &events,
+                                    &account_id_hex,
+                                    &account_label,
+                                );
                                 client = reopened;
                                 schedule_pending_convergence_groups(
                                     &mut scheduled_convergence,
@@ -1895,6 +1904,7 @@ const CONVERGENCE_UNSETTLED_MAX_REARMS: u32 = 10;
 
 struct ScheduledConvergence {
     delay: Duration,
+    test_delay: Duration,
     deadlines: HashMap<GroupId, TokioInstant>,
     retry_attempts: HashMap<GroupId, u32>,
     unsettled_rearm_attempts: HashMap<GroupId, u32>,
@@ -1902,9 +1912,15 @@ struct ScheduledConvergence {
 }
 
 impl ScheduledConvergence {
+    #[cfg(test)]
     fn new(delay: Duration) -> Self {
+        Self::with_test_delay(delay, Duration::ZERO)
+    }
+
+    fn with_test_delay(delay: Duration, test_delay: Duration) -> Self {
         Self {
             delay,
+            test_delay,
             deadlines: HashMap::new(),
             retry_attempts: HashMap::new(),
             unsettled_rearm_attempts: HashMap::new(),
@@ -1926,7 +1942,8 @@ impl ScheduledConvergence {
                 self.unsettled_rearm_attempts.remove(group_id);
                 let delay = Duration::from_millis(
                     remaining_ms.saturating_add(CONVERGENCE_SETTLEMENT_SCHEDULE_MARGIN_MS),
-                );
+                )
+                .saturating_add(self.test_delay);
                 self.arm_no_later(group_id.clone(), TokioInstant::now() + delay);
                 self.reset_timer_to_earliest();
             }
@@ -1935,7 +1952,8 @@ impl ScheduledConvergence {
                 self.unsettled_rearm_attempts.remove(group_id);
                 self.arm_no_later(
                     group_id.clone(),
-                    TokioInstant::now() + MIN_CONVERGENCE_SETTLEMENT_DELAY,
+                    TokioInstant::now()
+                        + MIN_CONVERGENCE_SETTLEMENT_DELAY.saturating_add(self.test_delay),
                 );
                 self.reset_timer_to_earliest();
             }
@@ -2104,6 +2122,18 @@ fn convergence_settlement_delay(app: &MarmotApp) -> Duration {
         cgka_engine::canonicalization::V1_SETTLEMENT_QUIESCENCE_MS
     };
     Duration::from_millis(quiescence_ms.saturating_add(CONVERGENCE_SETTLEMENT_SCHEDULE_MARGIN_MS))
+}
+
+fn scheduled_convergence_test_delay(app: &MarmotApp) -> Duration {
+    if cfg!(feature = "test-policy-overrides") {
+        Duration::from_millis(
+            app.config
+                .dev_scheduled_convergence_delay_ms
+                .unwrap_or_default(),
+        )
+    } else {
+        Duration::ZERO
+    }
 }
 
 fn retry_delay_for_attempt(attempt: u32) -> Duration {

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -615,6 +615,7 @@ async fn run_app_runtime_account_worker(
         .retry_pending_push_registration_shares_best_effort()
         .await;
     scheduled_push_retry.schedule_after_attempt(push_work_pending, &command_tx);
+    publish_client_pending_applied_summary(&mut client, &events, &account_id_hex, &account_label);
 
     // #637: mutations replayed during deferred startup (e.g. a queued SendMessage
     // / InviteMembers) can buffer convergence groups. The steady-state arms below
@@ -771,6 +772,12 @@ async fn run_app_runtime_account_worker(
                                 .retry_pending_push_registration_shares_best_effort()
                                 .await;
                             scheduled_push_retry.schedule_after_attempt(pending, &command_tx);
+                            publish_client_pending_applied_summary(
+                                &mut client,
+                                &events,
+                                &account_id_hex,
+                                &account_label,
+                            );
                         }
                     }
                     Err(err) => {
@@ -921,6 +928,12 @@ async fn run_app_runtime_account_worker(
                     Ok(summary) => {
                         let _ = summary;
                         publish_client_pending_projection_updates(
+                            &mut client,
+                            &events,
+                            &account_id_hex,
+                            &account_label,
+                        );
+                        publish_client_pending_applied_summary(
                             &mut client,
                             &events,
                             &account_id_hex,
@@ -1714,6 +1727,10 @@ async fn handle_account_worker_command(
             let _ = respond.send(Ok(()));
         }
     }
+    // Publishing from this seam — rather than inside each send arm — keeps
+    // every command path covered; the summary is empty for commands that
+    // applied nothing.
+    publish_client_pending_applied_summary(client, events, account_id_hex, account_label);
 }
 
 #[derive(Debug, Clone)]
@@ -2197,6 +2214,22 @@ fn publish_client_pending_projection_updates(
     for update in client.take_pending_projection_updates() {
         publish_app_runtime_projection_update(events, account_id_hex, account_label, update);
     }
+}
+
+/// Broadcast group events a send applied as a side effect (retained inbound
+/// convergence commits folded before publishing). Called from every worker seam
+/// that can run a send — the command chokepoint, the receive arm's post-join
+/// push retry, the maintenance tick, and startup — so the applied events reach
+/// chat-list/group-state subscribers instead of buffering indefinitely. A no-op
+/// when the buffered summary is empty.
+fn publish_client_pending_applied_summary(
+    client: &mut AppClient,
+    events: &broadcast::Sender<MarmotAppEvent>,
+    account_id_hex: &str,
+    account_label: &str,
+) {
+    let summary = client.take_pending_applied_sync_summary();
+    publish_app_runtime_summary(events, account_id_hex, account_label, &summary);
 }
 
 pub(crate) fn publish_app_runtime_group_state_updated(

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -3428,10 +3428,26 @@ async fn app_runtime_chat_and_group_state_subscriptions_stream_projection_update
 /// ingest or scheduled-convergence seams. The runtime must still broadcast
 /// them: bob's group-state subscription has to observe the rename even though
 /// his own send — not a receive — applied it.
+///
+/// The collection window is pinned wide open (10s; the knob is honored under
+/// `test-policy-overrides`, and normal builds keep the pinned ~1s window) so
+/// scheduled convergence cannot apply the rename first, and bob keeps sending
+/// until his chat row shows the rename — the durable witness that a send
+/// folded the commit. The subscription must then deliver well inside the
+/// still-open window; on a build that drops send-applied events it stays
+/// silent here even though storage already shows the new name.
 #[tokio::test]
 async fn group_state_subscription_observes_rename_applied_during_interleaved_send() {
     let dir = tempfile::tempdir().unwrap();
-    let (_relay, app, url) = mock_app(&dir).await;
+    let (_relay, url) = mock_relay().await;
+    let app = MarmotApp::with_relay_and_config(
+        dir.path(),
+        url.clone(),
+        MarmotAppConfig::default()
+            .with_allow_loopback_blob_endpoints(true)
+            .with_allow_loopback_relay_endpoints(true)
+            .with_dev_settlement_quiescence_ms(10_000),
+    );
     let runtime = MarmotAppRuntime::new(app.clone());
     let setup = AccountSetupRequest {
         default_relays: vec![endpoint(&url)],
@@ -3477,17 +3493,37 @@ async fn group_state_subscription_observes_rename_applied_during_interleaved_sen
         )
         .await
         .unwrap();
-    // Give the rename commit time to reach bob's collection window, then send
-    // from bob while the window is still open so the send folds the commit.
-    // If timing shifts and convergence applies the commit first, the rename
-    // still broadcasts through the scheduled-convergence seam — either way the
-    // subscription must deliver it.
-    sleep(Duration::from_millis(300)).await;
-    runtime
-        .send_message(&bob_id, &group_id, b"bob interleaved".to_vec())
-        .await
-        .unwrap();
+    // Send from bob until his chat row shows the rename: a send only folds the
+    // retained commit once bob's worker has ingested it, and relay delivery
+    // timing varies, so retry rather than guess with one sleep. The row flip
+    // is the durable witness that the commit applied inside a send — the
+    // 10s collection window keeps scheduled convergence from applying it.
+    let mut rename_applied = false;
+    'sends: for round in 0..5u32 {
+        runtime
+            .send_message(
+                &bob_id,
+                &group_id,
+                format!("bob interleaved {round}").into_bytes(),
+            )
+            .await
+            .unwrap();
+        for _ in 0..20 {
+            let row = app.chat_list_row(&bob.account.label, &group_id_hex).unwrap();
+            if row.is_some_and(|row| row.title == "renamed mid send") {
+                rename_applied = true;
+                break 'sends;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+    }
+    assert!(
+        rename_applied,
+        "a send from bob should fold and apply the retained rename commit"
+    );
 
+    // Storage shows the rename; the subscription must now deliver it well
+    // inside the still-open collection window (5s timeout vs 10s quiescence).
     let updated = wait_for_group_state_update(&mut group_state, |group| {
         group.profile.name == "renamed mid send"
     })

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -3456,15 +3456,11 @@ async fn app_runtime_chat_and_group_state_subscriptions_stream_projection_update
 /// default (a zero window would let scheduled convergence apply the rename
 /// before the send), and normal builds ignore the knob but keep the pinned
 /// ~1s production window — so both build modes run the same interleaving.
-/// Empirically a send ~300ms after the rename folds the retained commit
-/// (`published > 0`) and flips bob's chat row instantly; the row flip is the
-/// durable witness that the rename applied, and only then is the subscription
-/// required to deliver. On a build that drops send-applied events the
-/// subscription stays silent here even though storage already shows the new
-/// name; if timing shifts and the send queues or misses the window instead,
-/// the rename applies through the scheduled-convergence/drain seam, which
-/// broadcasts on its own — the test never false-fails, it only fails when
-/// events are dropped.
+/// Each round demands a strict fold witness (pre-send old row, published
+/// send, immediate post-send renamed row) before the subscription assertion
+/// runs, so a round where scheduled convergence preempts the fold or the
+/// send queues is discarded and retried with a fresh rename rather than
+/// passing through an alternate broadcasting seam.
 #[tokio::test]
 async fn group_state_subscription_observes_rename_applied_during_interleaved_send() {
     let dir = tempfile::tempdir().unwrap();
@@ -3513,24 +3509,30 @@ async fn group_state_subscription_observes_rename_applied_during_interleaved_sen
         .subscribe_group_state(&bob_id, &group_id_hex)
         .unwrap();
 
-    runtime
-        .update_group_profile(
-            &alice_id,
-            &group_id,
-            Some("renamed mid send".to_owned()),
-            None,
-        )
-        .await
-        .unwrap();
-    // Land the send mid-window: ~300ms is enough for bob to have ingested and
-    // retained the rename commit, and observed timing folds the commit into
-    // the send at that offset. Retry with fresh sends if the first round
-    // neither folds nor sees the convergence apply — a stalled runner shifts
-    // timing but every path below still requires the subscription to deliver.
-    sleep(Duration::from_millis(300)).await;
-    let mut rename_applied = false;
-    'sends: for round in 0..5u32 {
+    // Witness the fold strictly, retrying with a fresh rename when timing
+    // spoils a round: immediately before the send bob's row must still show
+    // the previous name (scheduled convergence has not applied the rename),
+    // the send must publish (`published > 0`; a queued send never folds), and
+    // immediately after the send returns the row must show the new name (the
+    // fold is synchronous inside the send, and the chat-list projection
+    // rebuilds on read). Only a send-folded commit satisfies all three.
+    let mut witnessed = None;
+    for round in 0..8u32 {
+        let renamed = format!("renamed mid send {round}");
         runtime
+            .update_group_profile(&alice_id, &group_id, Some(renamed.clone()), None)
+            .await
+            .unwrap();
+        // ~300ms lands the send mid-window, after bob ingested and retained
+        // the commit; observed timing folds it into the send at that offset.
+        sleep(Duration::from_millis(300)).await;
+        let pre_send = row_title(&app, &bob.account.label, &group_id_hex);
+        if pre_send.as_deref() == Some(renamed.as_str()) {
+            // Scheduled convergence preempted the fold on this runner; this
+            // round cannot witness the interleaving. Rename again.
+            continue;
+        }
+        let summary = runtime
             .send_message(
                 &bob_id,
                 &group_id,
@@ -3538,27 +3540,25 @@ async fn group_state_subscription_observes_rename_applied_during_interleaved_sen
             )
             .await
             .unwrap();
-        for _ in 0..20 {
-            let row = app
-                .chat_list_row(&bob.account.label, &group_id_hex)
-                .unwrap();
-            if row.is_some_and(|row| row.title == "renamed mid send") {
-                rename_applied = true;
-                break 'sends;
-            }
-            sleep(Duration::from_millis(50)).await;
+        let post = row_title(&app, &bob.account.label, &group_id_hex);
+        if summary.published == 0 {
+            // Queued: the send never reached the fold; the queued drain
+            // broadcasts on its own seam. Retry with a fresh rename.
+            continue;
+        }
+        if post.as_deref() == Some(renamed.as_str()) {
+            witnessed = Some(renamed);
+            break;
         }
     }
-    assert!(
-        rename_applied,
-        "a send from bob should fold and apply the retained rename commit"
-    );
+    let renamed =
+        witnessed.expect("a mid-window send from bob should fold the retained rename commit");
 
-    // Storage shows the rename; the subscription must now deliver it.
-    let updated = wait_for_group_state_update(&mut group_state, |group| {
-        group.profile.name == "renamed mid send"
-    })
-    .await;
+    // After a witnessed fold the retained input is consumed, so scheduled
+    // convergence has nothing left to broadcast for this rename: only the
+    // send-path observe/broadcast can satisfy this assertion.
+    let updated =
+        wait_for_group_state_update(&mut group_state, |group| group.profile.name == renamed).await;
     assert_eq!(updated.group_id_hex, group_id_hex);
 
     runtime.shutdown().await;
@@ -3569,10 +3569,13 @@ async fn group_state_subscription_observes_rename_applied_during_interleaved_sen
 /// but bob's own outbound publish is rejected by the relay. A send that folds
 /// the retained rename commit has durably applied it before the publish
 /// attempt, so the commit's group events must reach the subscription even
-/// when the message itself hard-fails (the send returns the publish error and
-/// retracts only the local message). If timing shifts the send onto the
-/// queued path instead, the rename applies through the scheduled drain once
-/// the relay accepts again — the subscription must deliver either way.
+/// when the message itself hard-fails: the witnessed round requires the
+/// injected publish error plus the immediate post-send row flip, and the
+/// subscription assertion runs while the relay still rejects bob's publishes,
+/// so the queued-drain seam stays blocked and cannot deliver the rename on a
+/// build that drops send-applied events. Rounds where the send queued or a
+/// plain (unfolded) publish was rejected are discarded and retried with a
+/// fresh rename after letting the relay accept again.
 #[tokio::test]
 async fn group_state_subscription_observes_rename_applied_during_failed_send() {
     let dir = tempfile::tempdir().unwrap();
@@ -3626,41 +3629,57 @@ async fn group_state_subscription_observes_rename_applied_during_failed_send() {
         .subscribe_group_state(&bob_id, &group_id_hex)
         .unwrap();
 
-    runtime
-        .update_group_profile(
-            &alice_id,
-            &group_id,
-            Some("renamed mid failed send".to_owned()),
-            None,
-        )
-        .await
-        .unwrap();
-    // Land the send mid-window as in the success-path test, but with the
-    // relay rejecting bob's publish.
-    sleep(Duration::from_millis(300)).await;
-    reject_armed.store(true, Ordering::Relaxed);
-    let send_result = runtime
-        .send_message(&bob_id, &group_id, b"bob rejected".to_vec())
-        .await;
-    // Disarm before asserting so drain/retry publishes can proceed on runners
-    // where the send took the queued path instead of failing outright.
-    reject_armed.store(false, Ordering::Relaxed);
-    // A folded send surfaces the injected rejection as a hard error; a queued
-    // send returns Ok with `published == 0`. The subscription contract below
-    // holds for both.
-    if let Ok(summary) = &send_result {
-        assert_eq!(
-            summary.published, 0,
-            "a send that neither folded-and-failed nor queued should not exist \
-             while the relay rejects group messages"
-        );
+    // Witness a fold whose own publish hard-fails: pre-send the row must
+    // still show the previous name, the send (with the relay rejecting bob's
+    // kind-445 publishes) must return the injected publish error, and the row
+    // must show the new name immediately after — the fold applied durably
+    // even though the message reached no one. Rounds where the send queued
+    // (`Ok`, nothing published) or a plain unfolded publish was rejected (an
+    // error without the row flip) are retried with a fresh rename after
+    // letting the relay accept again.
+    let mut witnessed = None;
+    for round in 0..8u32 {
+        let renamed = format!("renamed mid failed send {round}");
+        runtime
+            .update_group_profile(&alice_id, &group_id, Some(renamed.clone()), None)
+            .await
+            .unwrap();
+        sleep(Duration::from_millis(300)).await;
+        let pre_send = row_title(&app, &bob.account.label, &group_id_hex);
+        if pre_send.as_deref() == Some(renamed.as_str()) {
+            continue;
+        }
+        reject_armed.store(true, Ordering::Relaxed);
+        let send_result = runtime
+            .send_message(
+                &bob_id,
+                &group_id,
+                format!("bob rejected {round}").into_bytes(),
+            )
+            .await;
+        let folded_and_failed = matches!(send_result, Err(AppError::Publish(_)))
+            && row_title(&app, &bob.account.label, &group_id_hex).as_deref()
+                == Some(renamed.as_str());
+        if folded_and_failed {
+            witnessed = Some(renamed);
+            break;
+        }
+        // Let queued drains and the next round's rename publish again.
+        reject_armed.store(false, Ordering::Relaxed);
+        sleep(Duration::from_millis(200)).await;
     }
+    let renamed = witnessed.expect(
+        "a mid-window send from bob should fold the retained rename commit and \
+         fail its own publish",
+    );
 
-    let updated = wait_for_group_state_update(&mut group_state, |group| {
-        group.profile.name == "renamed mid failed send"
-    })
-    .await;
+    // The relay still rejects bob's publishes here, so the queued-drain seam
+    // cannot rescue the rename: only the send-path observe/broadcast of the
+    // failed send can satisfy this assertion.
+    let updated =
+        wait_for_group_state_update(&mut group_state, |group| group.profile.name == renamed).await;
     assert_eq!(updated.group_id_hex, group_id_hex);
+    reject_armed.store(false, Ordering::Relaxed);
 
     runtime.shutdown().await;
 }
@@ -3864,6 +3883,15 @@ where
     })
     .await
     .expect("runtime chat update")
+}
+
+/// Current chat-list row title for one group, read fresh from the projection
+/// (rebuilt on read after any state save). Used as the durable witness that a
+/// group-state commit has been applied locally.
+fn row_title(app: &MarmotApp, label: &str, group_id_hex: &str) -> Option<String> {
+    app.chat_list_row(label, group_id_hex)
+        .unwrap()
+        .map(|row| row.title)
 }
 
 async fn wait_for_group_state_update<F>(

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::Path;
+#[cfg(feature = "test-policy-overrides")]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Once};
 
@@ -76,9 +77,11 @@ fn install_mock_keyring() {
 
 /// Rejects kind-445 group messages while armed. Lets a test accept setup
 /// traffic normally, then fail exactly one member's outbound publish window.
+#[cfg(feature = "test-policy-overrides")]
 #[derive(Debug)]
 struct RejectGroupMessagesWhileArmed(Arc<AtomicBool>);
 
+#[cfg(feature = "test-policy-overrides")]
 impl WritePolicy for RejectGroupMessagesWhileArmed {
     fn admit_event<'a>(
         &'a self,
@@ -3451,16 +3454,15 @@ async fn app_runtime_chat_and_group_state_subscriptions_stream_projection_update
 /// them: bob's group-state subscription has to observe the rename even though
 /// his own send — not a receive — applied it.
 ///
-/// The collection window is pinned to 1s explicitly: under
-/// `test-policy-overrides` the dev knob replaces the instant-settlement
-/// default (a zero window would let scheduled convergence apply the rename
-/// before the send), and normal builds ignore the knob but keep the pinned
-/// ~1s production window — so both build modes run the same interleaving.
-/// Each round demands a strict fold witness (pre-send old row, published
-/// send, immediate post-send renamed row) before the subscription assertion
-/// runs, so a round where scheduled convergence preempts the fold or the
-/// send queues is discarded and retried with a fresh rename rather than
-/// passing through an alternate broadcasting seam.
+/// This regression uses explicit test-policy overrides to create the precise
+/// post-cutoff/pre-scheduler state. `update_group_profile` completes its
+/// cross-account catch-up before returning, proving bob has ingested the
+/// rename. The test then lets the 100ms engine cutoff elapse while holding the
+/// scheduled worker for 60s. The send is therefore the only operation that can
+/// move bob's durable row from the old name to the new one, and the
+/// subscription must update within 5s, well before scheduled convergence can
+/// provide an alternate broadcasting seam.
+#[cfg(feature = "test-policy-overrides")]
 #[tokio::test]
 async fn group_state_subscription_observes_rename_applied_during_interleaved_send() {
     let dir = tempfile::tempdir().unwrap();
@@ -3471,7 +3473,8 @@ async fn group_state_subscription_observes_rename_applied_during_interleaved_sen
         MarmotAppConfig::default()
             .with_allow_loopback_blob_endpoints(true)
             .with_allow_loopback_relay_endpoints(true)
-            .with_dev_settlement_quiescence_ms(1_000),
+            .with_dev_settlement_quiescence_ms(100)
+            .with_dev_scheduled_convergence_delay_ms(60_000),
     );
     let runtime = MarmotAppRuntime::new(app.clone());
     let setup = AccountSetupRequest {
@@ -3509,50 +3512,36 @@ async fn group_state_subscription_observes_rename_applied_during_interleaved_sen
         .subscribe_group_state(&bob_id, &group_id_hex)
         .unwrap();
 
-    // Witness the fold strictly, retrying with a fresh rename when timing
-    // spoils a round: immediately before the send bob's row must still show
-    // the previous name (scheduled convergence has not applied the rename),
-    // the send must publish (`published > 0`; a queued send never folds), and
-    // immediately after the send returns the row must show the new name (the
-    // fold is synchronous inside the send, and the chat-list projection
-    // rebuilds on read). Only a send-folded commit satisfies all three.
-    let mut witnessed = None;
-    for round in 0..8u32 {
-        let renamed = format!("renamed mid send {round}");
-        runtime
-            .update_group_profile(&alice_id, &group_id, Some(renamed.clone()), None)
-            .await
-            .unwrap();
-        // ~300ms lands the send mid-window, after bob ingested and retained
-        // the commit; observed timing folds it into the send at that offset.
-        sleep(Duration::from_millis(300)).await;
-        let pre_send = row_title(&app, &bob.account.label, &group_id_hex);
-        if pre_send.as_deref() == Some(renamed.as_str()) {
-            // Scheduled convergence preempted the fold on this runner; this
-            // round cannot witness the interleaving. Rename again.
-            continue;
-        }
-        let summary = runtime
-            .send_message(
-                &bob_id,
-                &group_id,
-                format!("bob interleaved {round}").into_bytes(),
-            )
-            .await
-            .unwrap();
-        let post = row_title(&app, &bob.account.label, &group_id_hex);
-        if summary.published == 0 {
-            // Queued: the send never reached the fold; the queued drain
-            // broadcasts on its own seam. Retry with a fresh rename.
-            continue;
-        }
-        if post.as_deref() == Some(renamed.as_str()) {
-            witnessed = Some(renamed);
-            break;
-        }
-    }
-    let renamed =
-        witnessed.expect("a mid-window send from bob should fold the retained rename commit");
+    let renamed = "renamed during retained send".to_owned();
+    runtime
+        .update_group_profile(&alice_id, &group_id, Some(renamed.clone()), None)
+        .await
+        .unwrap();
+    assert_ne!(
+        row_title(&app, &bob.account.label, &group_id_hex).as_deref(),
+        Some(renamed.as_str()),
+        "bob's completed catch-up must retain the rename without applying it"
+    );
+    sleep(Duration::from_millis(250)).await;
+    assert_ne!(
+        row_title(&app, &bob.account.label, &group_id_hex).as_deref(),
+        Some(renamed.as_str()),
+        "the test scheduler delay must hold the post-cutoff rename"
+    );
+
+    let summary = runtime
+        .send_message(&bob_id, &group_id, b"bob interleaved".to_vec())
+        .await
+        .unwrap();
+    assert!(
+        summary.published > 0,
+        "the interleaved send must publish rather than queue"
+    );
+    assert_eq!(
+        row_title(&app, &bob.account.label, &group_id_hex).as_deref(),
+        Some(renamed.as_str()),
+        "the send must synchronously fold the retained rename"
+    );
 
     // After a witnessed fold the retained input is consumed, so scheduled
     // convergence has nothing left to broadcast for this rename: only the
@@ -3573,9 +3562,8 @@ async fn group_state_subscription_observes_rename_applied_during_interleaved_sen
 /// injected publish error plus the immediate post-send row flip, and the
 /// subscription assertion runs while the relay still rejects bob's publishes,
 /// so the queued-drain seam stays blocked and cannot deliver the rename on a
-/// build that drops send-applied events. Rounds where the send queued or a
-/// plain (unfolded) publish was rejected are discarded and retried with a
-/// fresh rename after letting the relay accept again.
+/// build that drops send-applied events.
+#[cfg(feature = "test-policy-overrides")]
 #[tokio::test]
 async fn group_state_subscription_observes_rename_applied_during_failed_send() {
     let dir = tempfile::tempdir().unwrap();
@@ -3591,7 +3579,8 @@ async fn group_state_subscription_observes_rename_applied_during_failed_send() {
         MarmotAppConfig::default()
             .with_allow_loopback_blob_endpoints(true)
             .with_allow_loopback_relay_endpoints(true)
-            .with_dev_settlement_quiescence_ms(1_000),
+            .with_dev_settlement_quiescence_ms(100)
+            .with_dev_scheduled_convergence_delay_ms(60_000),
     );
     let runtime = MarmotAppRuntime::new(app.clone());
     let setup = AccountSetupRequest {
@@ -3629,48 +3618,35 @@ async fn group_state_subscription_observes_rename_applied_during_failed_send() {
         .subscribe_group_state(&bob_id, &group_id_hex)
         .unwrap();
 
-    // Witness a fold whose own publish hard-fails: pre-send the row must
-    // still show the previous name, the send (with the relay rejecting bob's
-    // kind-445 publishes) must return the injected publish error, and the row
-    // must show the new name immediately after — the fold applied durably
-    // even though the message reached no one. Rounds where the send queued
-    // (`Ok`, nothing published) or a plain unfolded publish was rejected (an
-    // error without the row flip) are retried with a fresh rename after
-    // letting the relay accept again.
-    let mut witnessed = None;
-    for round in 0..8u32 {
-        let renamed = format!("renamed mid failed send {round}");
-        runtime
-            .update_group_profile(&alice_id, &group_id, Some(renamed.clone()), None)
-            .await
-            .unwrap();
-        sleep(Duration::from_millis(300)).await;
-        let pre_send = row_title(&app, &bob.account.label, &group_id_hex);
-        if pre_send.as_deref() == Some(renamed.as_str()) {
-            continue;
-        }
-        reject_armed.store(true, Ordering::Relaxed);
-        let send_result = runtime
-            .send_message(
-                &bob_id,
-                &group_id,
-                format!("bob rejected {round}").into_bytes(),
-            )
-            .await;
-        let folded_and_failed = matches!(send_result, Err(AppError::Publish(_)))
-            && row_title(&app, &bob.account.label, &group_id_hex).as_deref()
-                == Some(renamed.as_str());
-        if folded_and_failed {
-            witnessed = Some(renamed);
-            break;
-        }
-        // Let queued drains and the next round's rename publish again.
-        reject_armed.store(false, Ordering::Relaxed);
-        sleep(Duration::from_millis(200)).await;
-    }
-    let renamed = witnessed.expect(
-        "a mid-window send from bob should fold the retained rename commit and \
-         fail its own publish",
+    let renamed = "renamed during rejected send".to_owned();
+    runtime
+        .update_group_profile(&alice_id, &group_id, Some(renamed.clone()), None)
+        .await
+        .unwrap();
+    assert_ne!(
+        row_title(&app, &bob.account.label, &group_id_hex).as_deref(),
+        Some(renamed.as_str()),
+        "bob's completed catch-up must retain the rename without applying it"
+    );
+    sleep(Duration::from_millis(250)).await;
+    assert_ne!(
+        row_title(&app, &bob.account.label, &group_id_hex).as_deref(),
+        Some(renamed.as_str()),
+        "the test scheduler delay must hold the post-cutoff rename"
+    );
+
+    reject_armed.store(true, Ordering::Relaxed);
+    let send_result = runtime
+        .send_message(&bob_id, &group_id, b"bob rejected".to_vec())
+        .await;
+    assert!(
+        matches!(send_result, Err(AppError::Publish(_))),
+        "the folded send must reach the injected hard-publish failure"
+    );
+    assert_eq!(
+        row_title(&app, &bob.account.label, &group_id_hex).as_deref(),
+        Some(renamed.as_str()),
+        "the failed send must still synchronously fold the retained rename"
     );
 
     // The relay still rejects bob's publishes here, so the queued-drain seam
@@ -3888,6 +3864,7 @@ where
 /// Current chat-list row title for one group, read fresh from the projection
 /// (rebuilt on read after any state save). Used as the durable witness that a
 /// group-state commit has been applied locally.
+#[cfg(feature = "test-policy-overrides")]
 fn row_title(app: &MarmotApp, label: &str, group_id_hex: &str) -> Option<String> {
     app.chat_list_row(label, group_id_hex)
         .unwrap()

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Once};
 
 use cgka_engine::account_identity_proof::ACCOUNT_IDENTITY_PROOF_EXTENSION_TYPE;
@@ -71,6 +72,27 @@ fn install_mock_keyring() {
             keyring_core::set_default_store(store);
         }
     });
+}
+
+/// Rejects kind-445 group messages while armed. Lets a test accept setup
+/// traffic normally, then fail exactly one member's outbound publish window.
+#[derive(Debug)]
+struct RejectGroupMessagesWhileArmed(Arc<AtomicBool>);
+
+impl WritePolicy for RejectGroupMessagesWhileArmed {
+    fn admit_event<'a>(
+        &'a self,
+        event: &'a nostr::Event,
+        _addr: &'a SocketAddr,
+    ) -> BoxedFuture<'a, PolicyResult> {
+        Box::pin(async move {
+            if self.0.load(Ordering::Relaxed) && event.kind == Kind::MlsGroupMessage {
+                PolicyResult::Reject("injected group-message rejection".into())
+            } else {
+                PolicyResult::Accept
+            }
+        })
+    }
 }
 
 #[derive(Debug)]
@@ -3429,13 +3451,20 @@ async fn app_runtime_chat_and_group_state_subscriptions_stream_projection_update
 /// them: bob's group-state subscription has to observe the rename even though
 /// his own send — not a receive — applied it.
 ///
-/// The collection window is pinned wide open (10s; the knob is honored under
-/// `test-policy-overrides`, and normal builds keep the pinned ~1s window) so
-/// scheduled convergence cannot apply the rename first, and bob keeps sending
-/// until his chat row shows the rename — the durable witness that a send
-/// folded the commit. The subscription must then deliver well inside the
-/// still-open window; on a build that drops send-applied events it stays
-/// silent here even though storage already shows the new name.
+/// The collection window is pinned to 1s explicitly: under
+/// `test-policy-overrides` the dev knob replaces the instant-settlement
+/// default (a zero window would let scheduled convergence apply the rename
+/// before the send), and normal builds ignore the knob but keep the pinned
+/// ~1s production window — so both build modes run the same interleaving.
+/// Empirically a send ~300ms after the rename folds the retained commit
+/// (`published > 0`) and flips bob's chat row instantly; the row flip is the
+/// durable witness that the rename applied, and only then is the subscription
+/// required to deliver. On a build that drops send-applied events the
+/// subscription stays silent here even though storage already shows the new
+/// name; if timing shifts and the send queues or misses the window instead,
+/// the rename applies through the scheduled-convergence/drain seam, which
+/// broadcasts on its own — the test never false-fails, it only fails when
+/// events are dropped.
 #[tokio::test]
 async fn group_state_subscription_observes_rename_applied_during_interleaved_send() {
     let dir = tempfile::tempdir().unwrap();
@@ -3446,7 +3475,7 @@ async fn group_state_subscription_observes_rename_applied_during_interleaved_sen
         MarmotAppConfig::default()
             .with_allow_loopback_blob_endpoints(true)
             .with_allow_loopback_relay_endpoints(true)
-            .with_dev_settlement_quiescence_ms(10_000),
+            .with_dev_settlement_quiescence_ms(1_000),
     );
     let runtime = MarmotAppRuntime::new(app.clone());
     let setup = AccountSetupRequest {
@@ -3493,11 +3522,12 @@ async fn group_state_subscription_observes_rename_applied_during_interleaved_sen
         )
         .await
         .unwrap();
-    // Send from bob until his chat row shows the rename: a send only folds the
-    // retained commit once bob's worker has ingested it, and relay delivery
-    // timing varies, so retry rather than guess with one sleep. The row flip
-    // is the durable witness that the commit applied inside a send — the
-    // 10s collection window keeps scheduled convergence from applying it.
+    // Land the send mid-window: ~300ms is enough for bob to have ingested and
+    // retained the rename commit, and observed timing folds the commit into
+    // the send at that offset. Retry with fresh sends if the first round
+    // neither folds nor sees the convergence apply — a stalled runner shifts
+    // timing but every path below still requires the subscription to deliver.
+    sleep(Duration::from_millis(300)).await;
     let mut rename_applied = false;
     'sends: for round in 0..5u32 {
         runtime
@@ -3509,7 +3539,9 @@ async fn group_state_subscription_observes_rename_applied_during_interleaved_sen
             .await
             .unwrap();
         for _ in 0..20 {
-            let row = app.chat_list_row(&bob.account.label, &group_id_hex).unwrap();
+            let row = app
+                .chat_list_row(&bob.account.label, &group_id_hex)
+                .unwrap();
             if row.is_some_and(|row| row.title == "renamed mid send") {
                 rename_applied = true;
                 break 'sends;
@@ -3522,10 +3554,110 @@ async fn group_state_subscription_observes_rename_applied_during_interleaved_sen
         "a send from bob should fold and apply the retained rename commit"
     );
 
-    // Storage shows the rename; the subscription must now deliver it well
-    // inside the still-open collection window (5s timeout vs 10s quiescence).
+    // Storage shows the rename; the subscription must now deliver it.
     let updated = wait_for_group_state_update(&mut group_state, |group| {
         group.profile.name == "renamed mid send"
+    })
+    .await;
+    assert_eq!(updated.group_id_hex, group_id_hex);
+
+    runtime.shutdown().await;
+}
+
+/// Same interleaving as
+/// `group_state_subscription_observes_rename_applied_during_interleaved_send`,
+/// but bob's own outbound publish is rejected by the relay. A send that folds
+/// the retained rename commit has durably applied it before the publish
+/// attempt, so the commit's group events must reach the subscription even
+/// when the message itself hard-fails (the send returns the publish error and
+/// retracts only the local message). If timing shifts the send onto the
+/// queued path instead, the rename applies through the scheduled drain once
+/// the relay accepts again — the subscription must deliver either way.
+#[tokio::test]
+async fn group_state_subscription_observes_rename_applied_during_failed_send() {
+    let dir = tempfile::tempdir().unwrap();
+    let reject_armed = Arc::new(AtomicBool::new(false));
+    let relay = LocalRelay::new(
+        RelayBuilder::default().write_policy(RejectGroupMessagesWhileArmed(reject_armed.clone())),
+    );
+    relay.run().await.unwrap();
+    let url = relay.url().await.to_string();
+    let app = MarmotApp::with_relay_and_config(
+        dir.path(),
+        url.clone(),
+        MarmotAppConfig::default()
+            .with_allow_loopback_blob_endpoints(true)
+            .with_allow_loopback_relay_endpoints(true)
+            .with_dev_settlement_quiescence_ms(1_000),
+    );
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let bob = runtime.create_identity(setup).await.unwrap();
+    let alice_id = alice.account.account_id_hex.clone();
+    let bob_id = bob.account.account_id_hex.clone();
+    let mut events = runtime.subscribe();
+
+    let group_id = runtime
+        .create_group(
+            &alice_id,
+            "failed send fold",
+            std::slice::from_ref(&bob_id),
+            None,
+        )
+        .await
+        .unwrap();
+    wait_for_event(&mut events, |event| {
+        matches!(
+            event,
+            MarmotAppEvent::GroupJoined { account_id_hex, group_id: joined, .. }
+                if account_id_hex == &bob_id && joined == &group_id
+        )
+    })
+    .await;
+    let group_id_hex = hex::encode(group_id.as_slice());
+
+    let mut group_state = runtime
+        .subscribe_group_state(&bob_id, &group_id_hex)
+        .unwrap();
+
+    runtime
+        .update_group_profile(
+            &alice_id,
+            &group_id,
+            Some("renamed mid failed send".to_owned()),
+            None,
+        )
+        .await
+        .unwrap();
+    // Land the send mid-window as in the success-path test, but with the
+    // relay rejecting bob's publish.
+    sleep(Duration::from_millis(300)).await;
+    reject_armed.store(true, Ordering::Relaxed);
+    let send_result = runtime
+        .send_message(&bob_id, &group_id, b"bob rejected".to_vec())
+        .await;
+    // Disarm before asserting so drain/retry publishes can proceed on runners
+    // where the send took the queued path instead of failing outright.
+    reject_armed.store(false, Ordering::Relaxed);
+    // A folded send surfaces the injected rejection as a hard error; a queued
+    // send returns Ok with `published == 0`. The subscription contract below
+    // holds for both.
+    if let Ok(summary) = &send_result {
+        assert_eq!(
+            summary.published, 0,
+            "a send that neither folded-and-failed nor queued should not exist \
+             while the relay rejects group messages"
+        );
+    }
+
+    let updated = wait_for_group_state_update(&mut group_state, |group| {
+        group.profile.name == "renamed mid failed send"
     })
     .await;
     assert_eq!(updated.group_id_hex, group_id_hex);

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -3422,6 +3422,81 @@ async fn app_runtime_chat_and_group_state_subscriptions_stream_projection_update
     runtime.shutdown().await;
 }
 
+/// A member send that lands while a peer's rename commit sits in the
+/// convergence collection window folds that commit inside the send, so its
+/// group events surface through the send's effects rather than the inbound
+/// ingest or scheduled-convergence seams. The runtime must still broadcast
+/// them: bob's group-state subscription has to observe the rename even though
+/// his own send — not a receive — applied it.
+#[tokio::test]
+async fn group_state_subscription_observes_rename_applied_during_interleaved_send() {
+    let dir = tempfile::tempdir().unwrap();
+    let (_relay, app, url) = mock_app(&dir).await;
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let setup = AccountSetupRequest {
+        default_relays: vec![endpoint(&url)],
+        bootstrap_relays: vec![endpoint(&url)],
+        publish_initial_key_package: true,
+        ..AccountSetupRequest::default()
+    };
+    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let bob = runtime.create_identity(setup).await.unwrap();
+    let alice_id = alice.account.account_id_hex.clone();
+    let bob_id = bob.account.account_id_hex.clone();
+    let mut events = runtime.subscribe();
+
+    let group_id = runtime
+        .create_group(
+            &alice_id,
+            "interleaved send",
+            std::slice::from_ref(&bob_id),
+            None,
+        )
+        .await
+        .unwrap();
+    wait_for_event(&mut events, |event| {
+        matches!(
+            event,
+            MarmotAppEvent::GroupJoined { account_id_hex, group_id: joined, .. }
+                if account_id_hex == &bob_id && joined == &group_id
+        )
+    })
+    .await;
+    let group_id_hex = hex::encode(group_id.as_slice());
+
+    let mut group_state = runtime
+        .subscribe_group_state(&bob_id, &group_id_hex)
+        .unwrap();
+
+    runtime
+        .update_group_profile(
+            &alice_id,
+            &group_id,
+            Some("renamed mid send".to_owned()),
+            None,
+        )
+        .await
+        .unwrap();
+    // Give the rename commit time to reach bob's collection window, then send
+    // from bob while the window is still open so the send folds the commit.
+    // If timing shifts and convergence applies the commit first, the rename
+    // still broadcasts through the scheduled-convergence seam — either way the
+    // subscription must deliver it.
+    sleep(Duration::from_millis(300)).await;
+    runtime
+        .send_message(&bob_id, &group_id, b"bob interleaved".to_vec())
+        .await
+        .unwrap();
+
+    let updated = wait_for_group_state_update(&mut group_state, |group| {
+        group.profile.name == "renamed mid send"
+    })
+    .await;
+    assert_eq!(updated.group_id_hex, group_id_hex);
+
+    runtime.shutdown().await;
+}
+
 #[tokio::test]
 async fn app_runtime_timeline_subscription_reopen_keeps_local_sent_message() {
     let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Problem

When a member's outbound send lands while a peer's commit sits retained in the convergence collection window, the engine folds that commit inside the send. The resulting `GroupStateChanged` / `EpochChanged` events surface only through the send's `AccountDeviceEffects` — and `send_app_event_with_local_projection` dropped them. Storage and projections showed the new group state, but `MarmotAppEvent::GroupEvent` was never broadcast, so runtime chat-list and group-state subscriptions stayed silent forever.

Repro (probed while hardening `convergence_settles_across_generations_with_mid_window_queued_sends` on #1174): alice renames the group, bob sends a message ~300 ms later. Bob's `chat_list_row` title and `app.group()` record flip to the new name within ~1.3 s, but `subscribe_group_state` / `subscribe_chats` never deliver an update. Instrumentation shows bob's send effects carry `[GroupStateChanged, EpochChanged]` from the folded rename commit, and no later seam re-emits them (the subsequent scheduled-convergence pass finds nothing left to apply).

This is pre-existing on master — the same repro fails identically at 82f3e2f3 — and is not introduced by #1174's scheduling changes (that PR's test carries a "subscription can stay silent … tracked separately" comment for exactly this).

## Fix

- `AppClient::observe_send_applied_effects` routes send-applied effects through the same observe pipeline as the inbound-ingest and scheduled-convergence seams (`observe_account_device_effects`: state group refresh, push-gossip handling, kind-1210 system-row synthesis — a deterministic upsert), and merges the resulting `SyncSummary` into a new `pending_applied_sync_summary` buffer. It replaces the narrower `queue_own_group_system_projection_updates` call in the message/app-event send path only; the own-commit command paths (rename, invite, retention, …) are unchanged — their worker arms already publish `GroupStateUpdated`.
- The account worker broadcasts the buffered summary via `publish_app_runtime_summary` from every seam that can run a send: the command chokepoint at the end of `handle_account_worker_command`, the receive arm's post-join push retry, the maintenance tick, and startup. Empty summaries are no-ops.

Subscribers then wake through the existing `runtime_group_event_route` / fingerprint machinery and re-read the (already refreshed) group record.

## Tests

- New regression test `group_state_subscription_observes_rename_applied_during_interleaved_send`: rename from alice, 300 ms later a send from bob, then require bob's group-state subscription to deliver the new name. Fails on master (times out with zero updates), passes with the fix. If CI timing shifts the send outside the collection window, the rename broadcasts through the scheduled-convergence seam instead and the test still passes — it only fails when events are dropped.
- `just fast-ci` clean.
- `cargo test -p marmot-app`: all targets pass except five `relay_runtime` tests (`encrypted_media_*`, `retained_media_rehydrates_*`, `relay_app_runtime_synthesizes_system_row_for_retention_change`, `self_removal_suppresses_account_unread_*`) that fail identically on clean master in this environment — pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime chat-list and group-state subscriptions now reliably reflect group state changes (such as renames), even when updates originate from send-side effects or are folded through convergence.
  * Subscription updates remain visible even if an outgoing publish attempt fails, avoiding gaps between persisted state and live notifications.
  * Improved timing so “send applied” updates are broadcast promptly after relevant events.
* **Tests**
  * Updated and expanded relay runtime regression tests for deterministic scheduling, including rename retention across interleaved sends and publish failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->