### PR TITLE
Establish the convergence assurance foundation

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -295,6 +295,11 @@ dead-code-audit:
 naming-gate:
     ./scripts/check_legacy_naming.sh
 
+# Keep convergence policy, resource, scheduler, and history-recovery constants
+# attached to reviewed Milestone 0 ledger entries.
+convergence-ledger-gate:
+    ./scripts/check_convergence_constant_ledger.sh
+
 # Prove the normal-build convergence policy pin (mdk#970). The broader test
 # matrix explicitly enables test-policy-overrides; this target must not.
 test-convergence-policy-pin:
@@ -302,6 +307,6 @@ test-convergence-policy-pin:
 
 # Fast local pre-push gate: mechanical/static checks plus the release pin proof.
 # GitHub CI runs the full `just ci` suite (including the workspace test matrix).
-fast-ci: fmt-check naming-gate check clippy test-convergence-policy-pin
+fast-ci: fmt-check naming-gate convergence-ledger-gate check clippy test-convergence-policy-pin
 
-ci: fmt-check naming-gate check clippy test-convergence-policy-pin test
+ci: fmt-check naming-gate convergence-ledger-gate check clippy test-convergence-policy-pin test

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -16,7 +16,7 @@ use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::openmls_projection::{OpenMlsContentKind, project_mls_message};
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::GroupEvent;
-use cgka_traits::ingest::{IngestOutcome, StaleReason};
+use cgka_traits::ingest::IngestOutcome;
 use cgka_traits::message::MessageState;
 use cgka_traits::storage::MessageStorage;
 use cgka_traits::transport::TransportMessage;
@@ -158,14 +158,9 @@ async fn delayed_past_epoch_app_message_peels_from_retained_anchor() {
     let outcomes = carol.tick().await;
 
     assert!(
-        outcomes.iter().all(|outcome| {
-            !matches!(
-                outcome,
-                Ok(IngestOutcome::Stale {
-                    reason: StaleReason::PeelFailed
-                })
-            )
-        }),
+        outcomes
+            .iter()
+            .all(|outcome| { !matches!(outcome, Ok(IngestOutcome::TransportDeferred { .. })) }),
         "past-epoch app should peel from the retained epoch context: {outcomes:?}"
     );
     // The delayed past-epoch app message is stored under its content-derived
@@ -1949,26 +1944,27 @@ async fn welcome_before_commit_rejects_commit_echo_cleanly_via_harness() {
     alice.confirm(invite_pending).await;
 
     // Both arrive in the same delivery. Carol processes the welcome, then
-    // treats the group-message echo as a stale peel failure because the
+    // treats the group-message echo as transport-deferred because the
     // outer wrapper was encrypted for the pre-join epoch.
     bus.deliver_all();
     let outcomes = carol.tick().await;
     let saw_welcome = outcomes
         .iter()
         .any(|o| matches!(o, Ok(cgka_traits::ingest::IngestOutcome::Processed)));
-    let saw_peel_failed = outcomes.iter().any(|o| {
+    let saw_transport_deferred = outcomes.iter().any(|o| {
         matches!(
             o,
-            Ok(cgka_traits::ingest::IngestOutcome::Stale {
-                reason: cgka_traits::ingest::StaleReason::PeelFailed,
-            })
+            Ok(cgka_traits::ingest::IngestOutcome::TransportDeferred { .. })
         )
     });
     assert!(
         saw_welcome,
         "expected welcome to be processed: {outcomes:?}"
     );
-    assert!(saw_peel_failed, "expected stale peel failure: {outcomes:?}");
+    assert!(
+        saw_transport_deferred,
+        "expected transport-deferred commit echo: {outcomes:?}"
+    );
 }
 
 /// End-to-end proof of the convergence assert surface: an observer's engine

--- a/crates/cgka-engine/src/audit_helpers.rs
+++ b/crates/cgka-engine/src/audit_helpers.rs
@@ -12,7 +12,9 @@ use cgka_traits::app_components::{
 use cgka_traits::engine::{GroupStateChange, SendIntent, SendResult};
 use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::error::{EngineError, PeelerError};
-use cgka_traits::ingest::{IngestOutcome, InputRejectionCategory, LocalIngestState, StaleReason};
+use cgka_traits::ingest::{
+    InboundResourceLimit, IngestOutcome, InputRejectionCategory, LocalIngestState, StaleReason,
+};
 use cgka_traits::message::MessageState;
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
 use cgka_traits::types::{EpochId, MemberId, MessageId};
@@ -68,6 +70,8 @@ pub(crate) fn ingest_outcome_kind_str(outcome: &IngestOutcome) -> &'static str {
         IngestOutcome::Buffered { .. } => "buffered",
         IngestOutcome::Ignored { .. } => "ignored",
         IngestOutcome::LocalState { .. } => "local_state",
+        IngestOutcome::TransportDeferred { .. } => "transport_deferred",
+        IngestOutcome::ResourceRefused { .. } => "resource_refused",
         IngestOutcome::Stale { .. } => "stale",
         IngestOutcome::Rejected { .. } => "rejected",
     }
@@ -81,7 +85,12 @@ pub(crate) fn stale_reason_str(reason: &StaleReason) -> &'static str {
         StaleReason::NotForThisClient => "not_for_this_client",
         StaleReason::UnknownGroup => "unknown_group",
         StaleReason::OwnEcho => "own_echo",
-        StaleReason::PeelFailed => "peel_failed",
+        StaleReason::PreMembership => "pre_membership",
+        StaleReason::BeyondAnchor => "beyond_anchor",
+        StaleReason::BeyondRollbackHorizon => "beyond_rollback_horizon",
+        StaleReason::BeyondAppRetention => "beyond_app_retention",
+        StaleReason::LosingBranch => "losing_branch",
+        StaleReason::InvalidAgainstCanonicalState => "invalid_against_canonical_state",
         StaleReason::SelfEvicted => "self_evicted",
         StaleReason::Quarantined => "quarantined",
     }
@@ -99,7 +108,9 @@ pub(crate) fn ingest_outcome_epoch(outcome: &IngestOutcome) -> Option<u64> {
 
 pub(crate) fn ingest_outcome_group_ref(outcome: &IngestOutcome) -> Option<String> {
     match outcome {
-        IngestOutcome::Buffered { group_id, .. } => Some(hex::encode(group_id.as_slice())),
+        IngestOutcome::Buffered { group_id, .. }
+        | IngestOutcome::TransportDeferred { group_id }
+        | IngestOutcome::ResourceRefused { group_id, .. } => Some(hex::encode(group_id.as_slice())),
         _ => None,
     }
 }
@@ -465,6 +476,12 @@ pub(crate) fn ingest_outcome_event(
                     InputRejectionCategory::OwnEcho => "own_echo",
                     InputRejectionCategory::WrongRecipient => "wrong_recipient",
                     InputRejectionCategory::UnknownGroup => "unknown_group",
+                    InputRejectionCategory::InvalidEncoding => "invalid_encoding",
+                    InputRejectionCategory::InvalidSignature => "invalid_signature",
+                    InputRejectionCategory::UnsupportedRequiredFeature => {
+                        "unsupported_required_feature"
+                    }
+                    InputRejectionCategory::AuthorizationFailed => "authorization_failed",
                 }
                 .to_string(),
             ),
@@ -478,6 +495,18 @@ pub(crate) fn ingest_outcome_event(
             IngestOutcome::Rejected { category } => {
                 Some(crate::app_components::proposal_rejection_category_tag(*category).to_string())
             }
+            IngestOutcome::TransportDeferred { .. } => Some("transport_deferred".to_string()),
+            IngestOutcome::ResourceRefused { resource, .. } => Some(
+                match resource {
+                    InboundResourceLimit::TransportDeferredCapacity => {
+                        "resource_refused_deferred_capacity"
+                    }
+                    InboundResourceLimit::TransportDeferredRetryBudget => {
+                        "resource_refused_retry_budget"
+                    }
+                }
+                .to_string(),
+            ),
             _ => None,
         },
         epoch: ingest_outcome_epoch(outcome),
@@ -521,11 +550,12 @@ pub(crate) fn message_state_transition_event(
     }
 }
 
-/// Terminal transition of a deferred-peel row, carrying the lifecycle's
-/// per-row telemetry: how many re-peel attempts it consumed and how many
-/// retry sweeps it waited between first attempt and this transition
-/// (mdk#339).
-pub(crate) fn deferred_peel_terminal_event(
+/// Resource-refusal release of a deferred-peel row, carrying the lifecycle's
+/// per-row telemetry: how many re-peel attempts it consumed and how many retry
+/// sweeps it waited before release (mdk#339). `released` deliberately does not
+/// claim a terminal message state; the row no longer exists and same-id
+/// redelivery remains eligible.
+pub(crate) fn deferred_peel_resource_refused_event(
     msg_id_hex: MessageRefHex,
     epoch: Option<EpochId>,
     reason: &str,
@@ -536,7 +566,7 @@ pub(crate) fn deferred_peel_terminal_event(
         msg_id: msg_id_hex,
         artifact_kind: None,
         previous_state: Some(message_state_str(MessageState::PeelDeferred).to_string()),
-        new_state: message_state_str(MessageState::Failed).to_string(),
+        new_state: "released".to_string(),
         epoch: epoch.map(|epoch| epoch.0),
         reason: reason.to_string(),
         retry_count: Some(retry_count),

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -309,12 +309,12 @@ pub struct Engine<S: StorageProvider> {
     /// context-fingerprint sweep gate, per-row attempt/first-seen bookkeeping,
     /// bounded-sweep cursor, and the cached `PeelDeferred` row count backing
     /// the per-group flood cap. In-memory by design — a restart costs one free
-    /// re-sweep and a count rescan; terminal decisions are durable via
-    /// `MessageState::Failed`.
+    /// re-sweep and a count rescan; protocol-terminal decisions remain
+    /// durable, while resource-refused rows are released for redelivery.
     pub(crate) deferred_peel: HashMap<GroupId, crate::message_processor::DeferredPeelGroupState>,
 
-    /// Retry budget before a `PeelDeferred` row transitions to terminal
-    /// `Failed` (`permanently_undecryptable`). Field (not a const) so tests
+    /// Retry budget before a `PeelDeferred` row is resource-refused and
+    /// released without terminal deduplication. Field (not a const) so tests
     /// can exhaust it quickly via [`Self::set_deferred_peel_retry_budget`].
     pub(crate) deferred_peel_retry_budget: u32,
 }
@@ -2040,8 +2040,8 @@ impl<S: StorageProvider> Engine<S> {
     }
 
     /// Override the deferred-peel retry budget (mdk#339). Rows that
-    /// exceed it without ever peeling transition to terminal `Failed`
-    /// (`permanently_undecryptable`). Exposed so tests can exhaust the budget
+    /// exceed it without ever peeling are resource-refused and released.
+    /// Exposed so tests can exhaust the budget
     /// quickly; production uses the default.
     pub fn set_deferred_peel_retry_budget(&mut self, budget: u32) {
         self.deferred_peel_retry_budget = budget.max(1);

--- a/crates/cgka-engine/src/fork_recovery.rs
+++ b/crates/cgka-engine/src/fork_recovery.rs
@@ -426,6 +426,10 @@ mod tests {
             unused()
         }
 
+        fn delete_message(&self, _id: &MessageId) -> StorageResult<()> {
+            unused()
+        }
+
         fn update_message_state(
             &self,
             _id: &MessageId,

--- a/crates/cgka-engine/src/message_disposition.rs
+++ b/crates/cgka-engine/src/message_disposition.rs
@@ -12,23 +12,22 @@ pub(crate) enum MessageDisposition {
     /// (`Group::join_epoch`). Permanently undecryptable by design — terminal,
     /// never retried.
     PreMembershipEvent,
-    /// The device was (or may have been) a member at the message's epoch, but
-    /// no retained snapshot or past-epoch secret can decrypt it anymore.
-    /// Terminal for this device; content-level redelivery is the recovery
-    /// path.
-    ValidHistorySnapshotMissing,
+    /// The device was a member at the application message's source epoch, but
+    /// that epoch is now outside the retained app-payload decryption window.
+    /// Terminal under the active convergence policy.
+    AppPayloadRetentionExpired,
     /// The transport bytes failed to peel against the current epoch context
     /// and every retained snapshot. Retained as `PeelDeferred`; retried only
     /// when the (epoch, snapshot-set) peel context actually changes.
     RetryPending,
-    /// A retained `PeelDeferred` row exhausted its retry budget without ever
-    /// peeling. Terminal: indistinguishable from garbage; a legitimate
-    /// message re-delivered under a fresh transport id starts over.
-    PermanentlyUndecryptable,
+    /// A retained `PeelDeferred` row exhausted its changed-context retry
+    /// budget without peeling. The row is released as a local resource
+    /// refusal; the same transport id remains eligible on later redelivery.
+    RetryBudgetRefused,
     /// The per-group cap on retained `PeelDeferred` rows is reached; the
     /// message was dropped without being persisted so a flood of
     /// undecryptable input cannot grow the durable store unboundedly.
-    DeferredCapExceeded,
+    DeferredCapacityRefused,
     /// The group is under hydration quarantine; input is retained for
     /// post-repair replay (see `LocalIngestState::Quarantined`).
     Quarantined,
@@ -39,11 +38,11 @@ impl MessageDisposition {
     pub(crate) fn tag(self) -> &'static str {
         match self {
             Self::PreMembershipEvent => "pre_membership_event",
-            Self::ValidHistorySnapshotMissing => "valid_history_snapshot_missing",
+            Self::AppPayloadRetentionExpired => "app_payload_retention_expired",
             // Historical audit string, kept for dashboard continuity.
             Self::RetryPending => "peel_failed_no_snapshot",
-            Self::PermanentlyUndecryptable => "permanently_undecryptable",
-            Self::DeferredCapExceeded => "peel_deferred_cap_exceeded",
+            Self::RetryBudgetRefused => "resource_refused_retry_budget",
+            Self::DeferredCapacityRefused => "resource_refused_deferred_capacity",
             Self::Quarantined => "quarantined_group_input_deferred",
         }
     }

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -25,7 +25,7 @@ use cgka_traits::engine::{
 };
 use cgka_traits::error::{EngineError, PeelerError};
 use cgka_traits::ingest::{
-    IngestOutcome, InputRejectionCategory, LocalIngestState, PeeledContent,
+    InboundResourceLimit, IngestOutcome, InputRejectionCategory, LocalIngestState, PeeledContent,
     ProposalRejectionCategory, StaleReason,
 };
 use cgka_traits::message::{MessageState, StoredMessagePayload};
@@ -128,9 +128,21 @@ impl<S: StorageProvider> Engine<S> {
             }
             Err(error) if group_lifecycle::terminal_welcome_error(&error) => {
                 self.storage.put_ingress_dedup_marker(&msg.id)?;
-                Ok(IngestOutcome::Stale {
-                    reason: StaleReason::PeelFailed,
-                })
+                let category = match error {
+                    EngineError::Peeler(PeelerError::InvalidSignature)
+                    | EngineError::InvalidCredentialIdentity(_)
+                    | EngineError::InvalidAccountIdentityProof(_) => {
+                        InputRejectionCategory::InvalidSignature
+                    }
+                    EngineError::MissingRequiredCapabilities { .. } => {
+                        InputRejectionCategory::UnsupportedRequiredFeature
+                    }
+                    EngineError::NotGroupAdmin { .. } => {
+                        InputRejectionCategory::AuthorizationFailed
+                    }
+                    _ => InputRejectionCategory::InvalidEncoding,
+                };
+                Ok(IngestOutcome::Ignored { category })
             }
             Err(other) => Err(other),
         }
@@ -183,20 +195,27 @@ impl<S: StorageProvider> Engine<S> {
                         crate::message_disposition::MessageDisposition::Quarantined.tag(),
                     ),
                 );
-            } else if self.should_audit_peel_deferred_cap_rejection(&group_id) {
-                // Same flood cap as the deferral seam (mdk#339): a
-                // quarantined group's replay buffer must not grow unboundedly
-                // either. Audited once per cap-full episode so a flood does
-                // not emit one write per rejected message.
-                self.audit_group(
-                    &group_id,
-                    marmot_forensics::AuditEventKind::Rejection {
-                        msg_id: hex::encode(msg.id.as_slice()),
-                        reason: crate::message_disposition::MessageDisposition::DeferredCapExceeded
-                            .tag()
-                            .to_string(),
-                    },
-                );
+            } else {
+                self.retryable_unpersisted_ingest_id = Some(msg.id.clone());
+                if self.should_audit_peel_deferred_cap_rejection(&group_id) {
+                    // Same flood cap as the deferral seam (mdk#339): a
+                    // quarantined group's replay buffer must not grow
+                    // unboundedly either. Audited once per cap-full episode so
+                    // a flood does not emit one write per rejected message.
+                    self.audit_group(
+                        &group_id,
+                        marmot_forensics::AuditEventKind::Rejection {
+                            msg_id: hex::encode(msg.id.as_slice()),
+                            reason: crate::message_disposition::MessageDisposition::DeferredCapacityRefused
+                                .tag()
+                                .to_string(),
+                        },
+                    );
+                }
+                return Ok(IngestOutcome::ResourceRefused {
+                    group_id,
+                    resource: InboundResourceLimit::TransportDeferredCapacity,
+                });
             }
             return Ok(IngestOutcome::LocalState {
                 state: LocalIngestState::Quarantined,
@@ -352,13 +371,18 @@ impl<S: StorageProvider> Engine<S> {
                         // storage errors keep propagating as genuine engine
                         // faults.
                         Err(EngineError::Peeler(
-                            PeelerError::Malformed(_) | PeelerError::InvalidSignature,
+                            rejection @ (PeelerError::Malformed(_) | PeelerError::InvalidSignature),
                         )) => {
-                            return self.terminal_peel_rejection_stale(
+                            let category = if matches!(rejection, PeelerError::InvalidSignature) {
+                                InputRejectionCategory::InvalidSignature
+                            } else {
+                                InputRejectionCategory::InvalidEncoding
+                            };
+                            return self.terminal_peel_rejection_ignored(
                                 &raw_msg_id,
                                 &msg.id,
                                 "malformed_payload_snapshot_fallback",
-                                StaleReason::PeelFailed,
+                                category,
                             );
                         }
                         Err(EngineError::Peeler(PeelerError::WrongRecipient)) => {
@@ -406,7 +430,7 @@ impl<S: StorageProvider> Engine<S> {
                                     &group_id,
                                     marmot_forensics::AuditEventKind::Rejection {
                                         msg_id: msg_id_hex.clone(),
-                                        reason: crate::message_disposition::MessageDisposition::DeferredCapExceeded
+                                        reason: crate::message_disposition::MessageDisposition::DeferredCapacityRefused
                                             .tag()
                                             .to_string(),
                                     },
@@ -417,8 +441,9 @@ impl<S: StorageProvider> Engine<S> {
                                 method = "ingest_group_message",
                                 "peel-deferred row cap reached; dropping undecryptable input unpersisted"
                             );
-                            return Ok(IngestOutcome::Stale {
-                                reason: StaleReason::PeelFailed,
+                            return Ok(IngestOutcome::ResourceRefused {
+                                group_id,
+                                resource: InboundResourceLimit::TransportDeferredCapacity,
                             });
                         }
                         self.persist_transport_message(
@@ -438,12 +463,13 @@ impl<S: StorageProvider> Engine<S> {
                                 crate::message_disposition::MessageDisposition::RetryPending.tag(),
                             ),
                         );
-                        return Ok(IngestOutcome::Stale {
-                            reason: StaleReason::PeelFailed,
-                        });
+                        return Ok(IngestOutcome::TransportDeferred { group_id });
                     }
                 }
-                Err(PeelerError::StaleEpoch { .. }) => {
+                Err(PeelerError::StaleEpoch {
+                    message_epoch,
+                    context_epoch,
+                }) => {
                     let recovered = match self
                         .try_peel_group_message_from_available_snapshots(
                             msg,
@@ -463,13 +489,18 @@ impl<S: StorageProvider> Engine<S> {
                         // storage errors keep propagating as genuine engine
                         // faults.
                         Err(EngineError::Peeler(
-                            PeelerError::Malformed(_) | PeelerError::InvalidSignature,
+                            rejection @ (PeelerError::Malformed(_) | PeelerError::InvalidSignature),
                         )) => {
-                            return self.terminal_peel_rejection_stale(
+                            let category = if matches!(rejection, PeelerError::InvalidSignature) {
+                                InputRejectionCategory::InvalidSignature
+                            } else {
+                                InputRejectionCategory::InvalidEncoding
+                            };
+                            return self.terminal_peel_rejection_ignored(
                                 &raw_msg_id,
                                 &msg.id,
                                 "malformed_payload_snapshot_fallback",
-                                StaleReason::PeelFailed,
+                                category,
                             );
                         }
                         Err(EngineError::Peeler(PeelerError::WrongRecipient)) => {
@@ -524,7 +555,10 @@ impl<S: StorageProvider> Engine<S> {
                             ),
                         );
                         return Ok(IngestOutcome::Stale {
-                            reason: StaleReason::PeelFailed,
+                            reason: StaleReason::AlreadyAtEpoch {
+                                current: context_epoch,
+                                msg_epoch: message_epoch,
+                            },
                         });
                     }
                 }
@@ -546,11 +580,16 @@ impl<S: StorageProvider> Engine<S> {
                     } else {
                         "malformed_payload"
                     };
-                    return self.terminal_peel_rejection_stale(
+                    let category = if matches!(rejection, PeelerError::InvalidSignature) {
+                        InputRejectionCategory::InvalidSignature
+                    } else {
+                        InputRejectionCategory::InvalidEncoding
+                    };
+                    return self.terminal_peel_rejection_ignored(
                         &raw_msg_id,
                         &msg.id,
                         reason,
-                        StaleReason::PeelFailed,
+                        category,
                     );
                 }
                 Err(PeelerError::WrongRecipient) => {
@@ -579,8 +618,8 @@ impl<S: StorageProvider> Engine<S> {
                         current_epoch,
                         MessageState::Failed,
                     )?;
-                    return Ok(IngestOutcome::Stale {
-                        reason: StaleReason::PeelFailed,
+                    return Ok(IngestOutcome::Ignored {
+                        category: InputRejectionCategory::InvalidEncoding,
                     });
                 }
             };
@@ -644,8 +683,8 @@ impl<S: StorageProvider> Engine<S> {
                         &raw_msg_id,
                         "malformed_mls_message",
                     )?;
-                    return Ok(IngestOutcome::Stale {
-                        reason: StaleReason::PeelFailed,
+                    return Ok(IngestOutcome::Ignored {
+                        category: InputRejectionCategory::InvalidEncoding,
                     });
                 }
             };
@@ -667,8 +706,8 @@ impl<S: StorageProvider> Engine<S> {
                         &raw_msg_id,
                         "non_mls_message_body",
                     )?;
-                    return Ok(IngestOutcome::Stale {
-                        reason: StaleReason::PeelFailed,
+                    return Ok(IngestOutcome::Ignored {
+                        category: InputRejectionCategory::InvalidEncoding,
                     });
                 }
             };
@@ -702,7 +741,7 @@ impl<S: StorageProvider> Engine<S> {
                 );
                 self.mark_raw_transport_message_failed_if_awaiting_retry(&raw_msg_id, tag)?;
                 return Ok(IngestOutcome::Stale {
-                    reason: StaleReason::PeelFailed,
+                    reason: StaleReason::PreMembership,
                 });
             }
 
@@ -777,16 +816,21 @@ impl<S: StorageProvider> Engine<S> {
                     // before the join epoch the message was never decryptable
                     // here by design; at or after it, this device was a
                     // member but the past-epoch secrets are gone.
-                    let tag = if self.msg_is_pre_membership(&group_id, msg_epoch) {
+                    let pre_membership = self.msg_is_pre_membership(&group_id, msg_epoch);
+                    let tag = if pre_membership {
                         crate::message_disposition::MessageDisposition::PreMembershipEvent.tag()
                     } else {
-                        crate::message_disposition::MessageDisposition::ValidHistorySnapshotMissing
+                        crate::message_disposition::MessageDisposition::AppPayloadRetentionExpired
                             .tag()
                     };
                     self.update_stored_message_state(&msg.id, MessageState::Failed)?;
                     self.mark_raw_transport_message_failed_if_awaiting_retry(&raw_msg_id, tag)?;
                     return Ok(IngestOutcome::Stale {
-                        reason: StaleReason::PeelFailed,
+                        reason: if pre_membership {
+                            StaleReason::PreMembership
+                        } else {
+                            StaleReason::BeyondAppRetention
+                        },
                     });
                 }
                 Err(ProcessMessageError::ValidationError(ValidationError::WrongEpoch)) => {
@@ -856,7 +900,7 @@ impl<S: StorageProvider> Engine<S> {
                                     "invalid_fork_candidate_probe",
                                 )?;
                                 return Ok(IngestOutcome::Stale {
-                                    reason: StaleReason::PeelFailed,
+                                    reason: StaleReason::InvalidAgainstCanonicalState,
                                 });
                             }
                             Err(ForkProbeError::Engine(error)) => return Err(error),
@@ -982,8 +1026,8 @@ impl<S: StorageProvider> Engine<S> {
                             &raw_msg_id,
                             "unattributable_sender",
                         )?;
-                        return Ok(IngestOutcome::Stale {
-                            reason: StaleReason::PeelFailed,
+                        return Ok(IngestOutcome::Ignored {
+                            category: InputRejectionCategory::InvalidSignature,
                         });
                     };
                     let payload = bytes.into_bytes();
@@ -1004,8 +1048,8 @@ impl<S: StorageProvider> Engine<S> {
                                 &raw_msg_id,
                                 "invalid_app_payload",
                             )?;
-                            return Ok(IngestOutcome::Stale {
-                                reason: StaleReason::PeelFailed,
+                            return Ok(IngestOutcome::Ignored {
+                                category: InputRejectionCategory::InvalidEncoding,
                             });
                         }
                     };
@@ -2041,27 +2085,6 @@ impl<S: StorageProvider> Engine<S> {
         Ok(())
     }
 
-    /// Terminal disposition for malformed, unauthenticated, or misaddressed
-    /// transport input: retire the awaiting-retry raw transport row (a no-op on
-    /// the direct path, where no deferred row exists), mark the id seen so a
-    /// redelivery short-circuits, and classify the input with the supplied
-    /// typed stale reason. Shared by the direct peel and both
-    /// snapshot-fallback seams so the terminal behavior has a single
-    /// definition — a guard living on one seam only is a bug (mdk#707).
-    fn terminal_peel_rejection_stale(
-        &mut self,
-        raw_msg_id: &MessageId,
-        msg_id: &MessageId,
-        reason: &'static str,
-        stale_reason: StaleReason,
-    ) -> Result<IngestOutcome, EngineError> {
-        self.mark_raw_transport_message_failed_if_awaiting_retry(raw_msg_id, reason)?;
-        self.seen_message_ids.insert(msg_id.clone());
-        Ok(IngestOutcome::Stale {
-            reason: stale_reason,
-        })
-    }
-
     fn terminal_peel_rejection_ignored(
         &mut self,
         raw_msg_id: &MessageId,
@@ -2510,8 +2533,26 @@ fn convergence_ingest_outcome(
         if let Some(category) = dropped.rejection_category {
             return IngestOutcome::Rejected { category };
         }
-        return IngestOutcome::Stale {
-            reason: StaleReason::PeelFailed,
+        use crate::canonicalization::DroppedMessageReason;
+        return match dropped.reason {
+            DroppedMessageReason::BeyondRollbackHorizon => IngestOutcome::Stale {
+                reason: StaleReason::BeyondRollbackHorizon,
+            },
+            DroppedMessageReason::BeyondAnchor => IngestOutcome::Stale {
+                reason: StaleReason::BeyondAnchor,
+            },
+            DroppedMessageReason::BeyondAppRetention => IngestOutcome::Stale {
+                reason: StaleReason::BeyondAppRetention,
+            },
+            DroppedMessageReason::InvalidAgainstCandidateState => IngestOutcome::Stale {
+                reason: StaleReason::InvalidAgainstCanonicalState,
+            },
+            DroppedMessageReason::UnsupportedPolicy => IngestOutcome::Ignored {
+                category: InputRejectionCategory::UnsupportedRequiredFeature,
+            },
+            DroppedMessageReason::Malformed => IngestOutcome::Ignored {
+                category: InputRejectionCategory::InvalidEncoding,
+            },
         };
     }
     if let Some(inv) = result
@@ -2526,11 +2567,19 @@ fn convergence_ingest_outcome(
                 // Buffered so the application keeps the message and
                 // waits for branch selection to advance.
             }
-            InvalidatedAppMessageReason::LosingBranch
-            | InvalidatedAppMessageReason::BeyondAnchor
-            | InvalidatedAppMessageReason::BeyondAppRetention => {
+            InvalidatedAppMessageReason::LosingBranch => {
                 return IngestOutcome::Stale {
-                    reason: StaleReason::PeelFailed,
+                    reason: StaleReason::LosingBranch,
+                };
+            }
+            InvalidatedAppMessageReason::BeyondAnchor => {
+                return IngestOutcome::Stale {
+                    reason: StaleReason::BeyondAnchor,
+                };
+            }
+            InvalidatedAppMessageReason::BeyondAppRetention => {
+                return IngestOutcome::Stale {
+                    reason: StaleReason::BeyondAppRetention,
                 };
             }
         }

--- a/crates/cgka-engine/src/message_processor/mod.rs
+++ b/crates/cgka-engine/src/message_processor/mod.rs
@@ -21,7 +21,9 @@ use crate::openmls_projection::decode_openmls_wire_projection;
 use cgka_traits::engine::{GroupEvent, GroupStateChange, SendIntent, SendResult};
 use cgka_traits::engine_state::EpochState;
 use cgka_traits::error::EngineError;
-use cgka_traits::ingest::{IngestOutcome, InputRejectionCategory, LocalIngestState, StaleReason};
+use cgka_traits::ingest::{
+    InboundResourceLimit, IngestOutcome, InputRejectionCategory, LocalIngestState,
+};
 use cgka_traits::message::{MessageState, StoredMessagePayload};
 use cgka_traits::storage::{QueuedOutboundIntent, StorageError, StorageProvider};
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
@@ -36,8 +38,8 @@ const SELF_REMOVE_AUTO_COMMIT_JITTER_SPAN_MS: u64 = 40;
 /// actual re-peel attempt under a *changed* peel context (the fingerprint
 /// gate skips unchanged contexts entirely), so a legitimate future-epoch
 /// message would need to trail the group by this many context changes before
-/// its retained row goes terminal — and content-level redelivery under a
-/// fresh transport id still recovers it afterwards.
+/// its retained row is resource-refused and released. The same transport id
+/// remains eligible if the transport delivers it again afterwards.
 pub const MAX_DEFERRED_PEEL_ATTEMPTS: u32 = 32;
 
 /// Per-group cap on retained `PeelDeferred` rows (mdk#339). Raw
@@ -889,8 +891,8 @@ impl<S: StorageProvider> Engine<S> {
     ///   unproductive cycle over the backlog the context fingerprint gates
     ///   whole sweeps until the context actually changes.
     /// - **Budgeted**: a row that exhausts its retry budget without ever
-    ///   peeling goes terminal `Failed` (`permanently_undecryptable`) instead
-    ///   of retrying forever.
+    ///   peeling is resource-refused and released without terminal
+    ///   deduplication instead of retrying forever.
     /// - **Bounded**: at most [`MAX_DEFERRED_ROWS_PER_SWEEP`] rows are
     ///   attempted per sweep (cursor resumes next pass) so a large historical
     ///   backlog never starves current-event processing.
@@ -958,8 +960,10 @@ impl<S: StorageProvider> Engine<S> {
         let mut progressed = 0usize;
         let mut terminal = 0usize;
         for record in &deferred[start..end] {
-            // Budget check first: bump this row's attempt count and go
-            // terminal once it exceeds the budget without ever peeling.
+            // Budget check first: bump this row's attempt count and release it
+            // as resource-refused once it exceeds the budget without peeling.
+            // Deleting the row is intentional: retaining it as `Failed` would
+            // turn a later same-id delivery into a terminal duplicate.
             let (attempts, first_seen_sweep) = {
                 let state = self.deferred_peel.entry(group_id.clone()).or_default();
                 let entry =
@@ -974,14 +978,13 @@ impl<S: StorageProvider> Engine<S> {
                 (entry.attempts, entry.first_seen_sweep)
             };
             if attempts > retry_budget {
-                self.update_stored_message_state(&record.id, MessageState::Failed)?;
+                self.storage.delete_message(&record.id)?;
                 self.audit_group(
                     group_id,
-                    crate::audit_helpers::deferred_peel_terminal_event(
+                    crate::audit_helpers::deferred_peel_resource_refused_event(
                         hex::encode(record.id.as_slice()),
                         Some(record.epoch),
-                        crate::message_disposition::MessageDisposition::PermanentlyUndecryptable
-                            .tag(),
+                        crate::message_disposition::MessageDisposition::RetryBudgetRefused.tag(),
                         u64::from(attempts.saturating_sub(1)),
                         sweep_index.saturating_sub(first_seen_sweep),
                     ),
@@ -1000,8 +1003,10 @@ impl<S: StorageProvider> Engine<S> {
                 .ingest_group_message(&msg, group_id.as_slice().to_vec())
                 .await
             {
-                Ok(IngestOutcome::Stale {
-                    reason: StaleReason::PeelFailed,
+                Ok(IngestOutcome::TransportDeferred { .. }) => {}
+                Ok(IngestOutcome::ResourceRefused {
+                    resource: InboundResourceLimit::TransportDeferredCapacity,
+                    ..
                 }) => {}
                 Ok(IngestOutcome::LocalState {
                     state: LocalIngestState::Quarantined,
@@ -1036,6 +1041,7 @@ impl<S: StorageProvider> Engine<S> {
                     IngestOutcome::Stale { .. }
                     | IngestOutcome::Ignored { .. }
                     | IngestOutcome::LocalState { .. }
+                    | IngestOutcome::ResourceRefused { .. }
                     | IngestOutcome::Rejected { .. },
                 ) => {
                     // Terminal stale classifications are still successful
@@ -1333,9 +1339,7 @@ impl<S: StorageProvider> Engine<S> {
                     }
                 }
                 Ok(
-                    IngestOutcome::Stale {
-                        reason: StaleReason::PeelFailed,
-                    }
+                    IngestOutcome::TransportDeferred { .. }
                     | IngestOutcome::LocalState {
                         state: LocalIngestState::Quarantined,
                     }
@@ -1344,9 +1348,8 @@ impl<S: StorageProvider> Engine<S> {
                     },
                 ) => {
                     // Leave the row in its retry state so a later pass re-attempts
-                    // it. `PeelFailed`: still un-peelable, or already retired to
-                    // `Failed` by a terminal-after-peel path inside
-                    // `ingest_group_message`
+                    // it. `TransportDeferred`: still un-peelable.
+                    // A terminal-after-peel path inside `ingest_group_message`
                     // (`mark_raw_transport_message_failed_if_awaiting_retry`,
                     // `PeelDeferred`/`Retryable` alike). `Quarantined`: the group
                     // is frozen; the row replays once repair clears it.

--- a/crates/cgka-engine/tests/auto_commit_atomicity.rs
+++ b/crates/cgka-engine/tests/auto_commit_atomicity.rs
@@ -207,6 +207,9 @@ impl MessageStorage for FaultStorage {
     fn get_message(&self, id: &MessageId) -> StorageResult<MessageRecord> {
         self.inner.get_message(id)
     }
+    fn delete_message(&self, id: &MessageId) -> StorageResult<()> {
+        self.inner.delete_message(id)
+    }
     fn update_message_state(&self, id: &MessageId, new_state: MessageState) -> StorageResult<()> {
         self.inner.update_message_state(id, new_state)
     }

--- a/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
+++ b/crates/cgka-engine/tests/deferred_peel_lifecycle.rs
@@ -347,9 +347,7 @@ async fn deferred_peel_not_retried_while_context_unchanged() {
     // The epoch-3 commit does not peel at carol's epoch 1: deferred.
     assert!(matches!(
         carol.ingest(commit3.clone()).await.unwrap(),
-        IngestOutcome::Stale {
-            reason: StaleReason::PeelFailed
-        }
+        IngestOutcome::TransportDeferred { .. }
     ));
     assert_eq!(
         carol_storage.get_message(&commit3.id).unwrap().state,
@@ -420,11 +418,11 @@ async fn deferred_peel_retries_after_epoch_advance() {
     );
 }
 
-/// A row that exhausts its retry budget without ever peeling goes terminal
-/// `Failed` (`permanently_undecryptable`) and is never attempted again.
+/// A row that exhausts its retry budget is resource-refused and released
+/// without poisoning same-id redelivery as a terminal duplicate.
 #[tokio::test]
-async fn deferred_peel_terminal_after_attempt_budget() {
-    let (mut alice, mut carol, carol_storage, carol_peeler, group_id, commit2, _commit3) =
+async fn deferred_peel_retry_budget_refuses_without_terminal_dedup() {
+    let (mut alice, mut carol, carol_storage, carol_peeler, group_id, commit2, commit3) =
         carol_behind_two_epochs().await;
     carol.set_deferred_peel_retry_budget(1);
 
@@ -433,9 +431,7 @@ async fn deferred_peel_terminal_after_attempt_budget() {
     let stuck_app = send_app(&mut alice, &group_id, "forever ahead").await;
     assert!(matches!(
         carol.ingest(stuck_app.clone()).await.unwrap(),
-        IngestOutcome::Stale {
-            reason: StaleReason::PeelFailed
-        }
+        IngestOutcome::TransportDeferred { .. }
     ));
 
     // Sweep 1 (context: epoch 1) consumes the single budgeted attempt.
@@ -449,28 +445,41 @@ async fn deferred_peel_terminal_after_attempt_budget() {
     );
 
     // The epoch-2 commit changes the context; the next sweep finds the row
-    // over budget and goes terminal without another peel attempt.
+    // over budget and releases it without another peel attempt.
     carol.ingest(commit2.clone()).await.unwrap();
     carol
         .converge_and_drain_queued_outbound_intents(&group_id, 1_000_001)
         .await
         .unwrap();
-    assert_eq!(
-        carol_storage.get_message(&stuck_app.id).unwrap().state,
-        MessageState::Failed,
-        "budget-exhausted deferred row must go terminal"
+    assert!(
+        matches!(
+            carol_storage.get_message(&stuck_app.id),
+            Err(StorageError::NotFound)
+        ),
+        "budget-exhausted deferred row must be released, not terminally retained"
     );
 
-    // Terminal rows are out of the lifecycle: further context changes do not
-    // re-peel them.
-    let attempts_at_terminal = carol_peeler.attempts_for(&stuck_app.id);
+    // The same transport id remains eligible and is retained again rather
+    // than short-circuiting as a duplicate.
+    let attempts_at_refusal = carol_peeler.attempts_for(&stuck_app.id);
+    assert!(matches!(
+        carol.ingest(stuck_app.clone()).await.unwrap(),
+        IngestOutcome::TransportDeferred { .. }
+    ));
+    assert!(
+        carol_peeler.attempts_for(&stuck_app.id) > attempts_at_refusal,
+        "same-id redelivery must reach the peeler again"
+    );
+
+    // Once the missing commit arrives, the redelivered row peels and applies.
+    carol.ingest(commit3).await.unwrap();
     carol
         .converge_and_drain_queued_outbound_intents(&group_id, 1_000_002)
         .await
         .unwrap();
     assert_eq!(
-        carol_peeler.attempts_for(&stuck_app.id),
-        attempts_at_terminal
+        carol_storage.get_message(&stuck_app.id).unwrap().state,
+        MessageState::Processed
     );
 }
 
@@ -494,12 +503,7 @@ async fn peel_deferred_rows_capped_per_group_under_flood() {
         };
         let outcome = carol.ingest(wrapped.clone()).await.unwrap();
         assert!(
-            matches!(
-                outcome,
-                IngestOutcome::Stale {
-                    reason: StaleReason::PeelFailed
-                }
-            ),
+            matches!(outcome, IngestOutcome::TransportDeferred { .. }),
             "flood message {i} classified unexpectedly: {outcome:?}"
         );
     }
@@ -511,8 +515,9 @@ async fn peel_deferred_rows_capped_per_group_under_flood() {
     };
     assert!(matches!(
         carol.ingest(overflow.clone()).await.unwrap(),
-        IngestOutcome::Stale {
-            reason: StaleReason::PeelFailed
+        IngestOutcome::ResourceRefused {
+            resource: cgka_traits::ingest::InboundResourceLimit::TransportDeferredCapacity,
+            ..
         }
     ));
 
@@ -539,8 +544,9 @@ async fn peel_deferred_rows_capped_per_group_under_flood() {
     let attempts_before_redelivery = carol_peeler.attempts_for(&overflow.id);
     assert!(matches!(
         carol.ingest(overflow.clone()).await.unwrap(),
-        IngestOutcome::Stale {
-            reason: StaleReason::PeelFailed
+        IngestOutcome::ResourceRefused {
+            resource: cgka_traits::ingest::InboundResourceLimit::TransportDeferredCapacity,
+            ..
         }
     ));
     assert_eq!(
@@ -625,7 +631,7 @@ async fn pre_membership_application_message_is_terminal_not_deferred() {
     assert!(matches!(
         outcome,
         IngestOutcome::Stale {
-            reason: StaleReason::PeelFailed
+            reason: StaleReason::PreMembership
         }
     ));
     let record = carol_storage
@@ -768,9 +774,7 @@ async fn deferred_peel_self_evicted_row_stays_failed_not_swept_processed() {
     // Carol (epoch 1) ingests the future commit: undecryptable → PeelDeferred.
     assert!(matches!(
         carol.ingest(future_commit.clone()).await.unwrap(),
-        IngestOutcome::Stale {
-            reason: StaleReason::PeelFailed
-        }
+        IngestOutcome::TransportDeferred { .. }
     ));
     assert_eq!(
         carol_storage.get_message(&future_commit.id).unwrap().state,

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -6277,9 +6277,7 @@ async fn send_preflight_retries_deferred_peels_after_convergence_apply() {
     ));
     assert!(matches!(
         carol.ingest(commit_to_epoch3.clone()).await.unwrap(),
-        IngestOutcome::Stale {
-            reason: cgka_traits::ingest::StaleReason::PeelFailed
-        }
+        IngestOutcome::TransportDeferred { .. }
     ));
     assert_eq!(carol.epoch(&group_id).unwrap(), EpochId(1));
     assert_eq!(
@@ -6330,7 +6328,7 @@ async fn send_preflight_retries_deferred_peels_after_convergence_apply() {
 /// forged, unattributable application payload) must be retired from the
 /// deferred queue — marked terminal and released from the retry lifecycle —
 /// not left durably `PeelDeferred` holding a per-group cap slot. Without the
-/// fix, `retry_deferred_peels` treats the post-peel terminal `PeelFailed`
+/// fix, `retry_deferred_peels` treats the post-peel terminal rejection
 /// like "still cannot peel" and leaves the raw row deferred forever.
 #[tokio::test]
 async fn deferred_row_terminally_rejected_after_peel_leaves_the_deferred_queue() {
@@ -6390,9 +6388,7 @@ async fn deferred_row_terminally_rejected_after_peel_leaves_the_deferred_queue()
     // message, so it is retained as a PeelDeferred raw row.
     assert!(matches!(
         carol.ingest(forged.clone()).await.unwrap(),
-        IngestOutcome::Stale {
-            reason: cgka_traits::ingest::StaleReason::PeelFailed
-        }
+        IngestOutcome::TransportDeferred { .. }
     ));
     assert_eq!(
         carol_storage.get_message(&forged.id).unwrap().state,

--- a/crates/cgka-engine/tests/fork_detection.rs
+++ b/crates/cgka-engine/tests/fork_detection.rs
@@ -507,7 +507,7 @@ async fn strict_cutover_legacy_add_cannot_displace_valid_fork_incumbent() {
         matches!(
             outcome,
             IngestOutcome::Stale {
-                reason: StaleReason::PeelFailed
+                reason: StaleReason::InvalidAgainstCanonicalState
             }
         ),
         "probe-time strict cutover must reject the candidate before selection, got {outcome:?}"

--- a/crates/cgka-engine/tests/hydration_quarantine.rs
+++ b/crates/cgka-engine/tests/hydration_quarantine.rs
@@ -395,6 +395,9 @@ impl MessageStorage for FlakyGroupRecordStorage {
     fn get_message(&self, id: &MessageId) -> StorageResult<MessageRecord> {
         self.inner.get_message(id)
     }
+    fn delete_message(&self, id: &MessageId) -> StorageResult<()> {
+        self.inner.delete_message(id)
+    }
     fn update_message_state(&self, id: &MessageId, new_state: MessageState) -> StorageResult<()> {
         self.inner.update_message_state(id, new_state)
     }

--- a/crates/cgka-engine/tests/ingest.rs
+++ b/crates/cgka-engine/tests/ingest.rs
@@ -656,11 +656,11 @@ async fn malformed_peeled_welcome_is_terminal_and_restart_deduplicated() {
     let outcome = engine
         .ingest(msg.clone())
         .await
-        .expect("malformed welcome is a per-message stale outcome");
+        .expect("malformed welcome is a per-message rejection outcome");
     assert!(matches!(
         outcome,
-        IngestOutcome::Stale {
-            reason: StaleReason::PeelFailed
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::InvalidEncoding
         }
     ));
     assert!(storage.has_ingress_dedup_marker(&message_id).unwrap());
@@ -774,12 +774,7 @@ async fn peel_deferred_message_retries_instead_of_short_circuiting() {
     };
 
     let first = bob.ingest(msg.clone()).await.unwrap();
-    assert!(matches!(
-        first,
-        IngestOutcome::Stale {
-            reason: StaleReason::PeelFailed
-        }
-    ));
+    assert!(matches!(first, IngestOutcome::TransportDeferred { .. }));
 
     let second = bob.ingest(msg).await.unwrap();
     assert!(matches!(second, IngestOutcome::Processed));
@@ -793,7 +788,7 @@ async fn peel_deferred_message_retries_instead_of_short_circuiting() {
 }
 
 #[tokio::test]
-async fn malformed_group_message_is_stale_and_does_not_wedge_ingest() {
+async fn malformed_group_message_is_rejected_and_does_not_wedge_ingest() {
     let mut alice = build_client(b"alice");
     let mut bob = build_client_with_peeler(b"bob", Box::new(MalformedShortPayloadPeeler));
     let bob_kp = bob.fresh_key_package().await.unwrap();
@@ -821,7 +816,7 @@ async fn malformed_group_message_is_stale_and_does_not_wedge_ingest() {
 
     // Anyone can publish to a group's cleartext routing tag without being a
     // member, so structurally-invalid content is ordinary hostile input. It
-    // must classify as stale — never abort ingest, or one garbage event
+    // must classify as invalid encoding — never abort ingest, or one garbage event
     // starves every message queued behind it in a transport drain.
     let garbage = TransportMessage {
         id: hash_id(b"malformed garbage"),
@@ -836,15 +831,15 @@ async fn malformed_group_message_is_stale_and_does_not_wedge_ingest() {
     let outcome = bob
         .ingest(garbage)
         .await
-        .expect("malformed input must classify as stale, not abort ingest");
+        .expect("malformed input must classify as rejected, not abort ingest");
     assert!(
         matches!(
             outcome,
-            IngestOutcome::Stale {
-                reason: StaleReason::PeelFailed
+            IngestOutcome::Ignored {
+                category: InputRejectionCategory::InvalidEncoding
             }
         ),
-        "expected terminal PeelFailed for malformed content, got {outcome:?}"
+        "expected invalid encoding for malformed content, got {outcome:?}"
     );
 
     let msg = match alice
@@ -1036,8 +1031,8 @@ async fn assert_snapshot_fallback_terminal_transport_rejection(
 async fn invalid_transport_signature_is_typed_terminal_input() {
     assert_typed_terminal_transport_rejection(
         BoundaryRejection::InvalidSignature,
-        IngestOutcome::Stale {
-            reason: StaleReason::PeelFailed,
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::InvalidSignature,
         },
     )
     .await;
@@ -1102,8 +1097,8 @@ async fn invalid_transport_signature_after_decrypt_failed_fallback_is_terminal()
     assert_snapshot_fallback_terminal_transport_rejection(
         BoundaryRejection::InvalidSignature,
         InitialPeelFailure::DecryptFailed,
-        IngestOutcome::Stale {
-            reason: StaleReason::PeelFailed,
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::InvalidSignature,
         },
     )
     .await;
@@ -1169,8 +1164,8 @@ async fn post_peel_malformed_mls_message_is_terminal_and_does_not_wedge_ingest()
         .expect("malformed post-peel MLS bytes must not abort ingest");
     assert!(matches!(
         outcome,
-        IngestOutcome::Stale {
-            reason: StaleReason::PeelFailed
+        IngestOutcome::Ignored {
+            category: InputRejectionCategory::InvalidEncoding
         }
     ));
     assert_eq!(
@@ -1279,7 +1274,7 @@ async fn malformed_message_buffered_during_pending_publish_lands_terminal_after_
 }
 
 #[tokio::test]
-async fn malformed_via_snapshot_fallback_is_stale_and_does_not_wedge_ingest() {
+async fn malformed_via_snapshot_fallback_is_rejected_and_does_not_wedge_ingest() {
     // Simulates a trait-permitted non-Nostr peeler whose `Malformed` verdict is
     // context-dependent: the direct peel at the live epoch returns
     // `DecryptFailed`, driving ingest into the retained-snapshot fallback, where
@@ -1361,7 +1356,7 @@ async fn malformed_via_snapshot_fallback_is_stale_and_does_not_wedge_ingest() {
 
     // Garbage arrives: direct peel `DecryptFailed` -> snapshot fallback peels
     // `Malformed`. The terminal contract must hold on this seam too — classify
-    // stale, do not abort the drain.
+    // invalid encoding, do not abort the drain.
     let garbage = TransportMessage {
         id: hash_id(b"malformed via snapshot fallback"),
         payload: SNAPSHOT_FALLBACK_GARBAGE.to_vec(),
@@ -1375,15 +1370,15 @@ async fn malformed_via_snapshot_fallback_is_stale_and_does_not_wedge_ingest() {
     let outcome = bob
         .ingest(garbage)
         .await
-        .expect("malformed snapshot-fallback peel must classify stale, not abort ingest");
+        .expect("malformed snapshot-fallback peel must classify, not abort ingest");
     assert!(
         matches!(
             outcome,
-            IngestOutcome::Stale {
-                reason: StaleReason::PeelFailed
+            IngestOutcome::Ignored {
+                category: InputRejectionCategory::InvalidEncoding
             }
         ),
-        "expected terminal PeelFailed for a malformed snapshot-fallback peel, got {outcome:?}"
+        "expected invalid encoding for a malformed snapshot-fallback peel, got {outcome:?}"
     );
 
     // The drain is not wedged: a well-formed message queued behind the garbage

--- a/crates/cgka-engine/tests/invite_leave.rs
+++ b/crates/cgka-engine/tests/invite_leave.rs
@@ -1094,7 +1094,7 @@ async fn removed_member_applying_removal_commit_marks_local_copy_removed() {
 /// `Stale {{ SelfEvicted }}` and performs "realizing removal"
 /// (member-departure.md) when the local copy is not yet marked removed —
 /// emitting the self-removed notification and marking the copy removed —
-/// instead of failing silently as generic `PeelFailed` stale traffic.
+/// instead of failing silently as generic stale traffic.
 #[tokio::test]
 async fn post_eviction_message_realizes_self_removal_and_returns_self_evicted() {
     let (mut alice, mut bob, bob_storage, group_id, routed_commit) =

--- a/crates/cgka-engine/tests/publish_lifecycle.rs
+++ b/crates/cgka-engine/tests/publish_lifecycle.rs
@@ -979,6 +979,9 @@ impl MessageStorage for FaultStorage {
     fn get_message(&self, id: &MessageId) -> StorageResult<MessageRecord> {
         self.inner.get_message(id)
     }
+    fn delete_message(&self, id: &MessageId) -> StorageResult<()> {
+        self.inner.delete_message(id)
+    }
     fn update_message_state(&self, id: &MessageId, new_state: MessageState) -> StorageResult<()> {
         if new_state == MessageState::Processed && self.fault.should_fail() {
             return Err(StorageError::Busy("injected confirm-path lock".into()));

--- a/crates/cgka-session/src/lib.rs
+++ b/crates/cgka-session/src/lib.rs
@@ -1177,6 +1177,8 @@ fn ingest_outcome_kind(outcome: &IngestOutcome) -> &'static str {
         IngestOutcome::Buffered { .. } => "buffered",
         IngestOutcome::Ignored { .. } => "ignored",
         IngestOutcome::LocalState { .. } => "local_state",
+        IngestOutcome::TransportDeferred { .. } => "transport_deferred",
+        IngestOutcome::ResourceRefused { .. } => "resource_refused",
         IngestOutcome::Stale { .. } => "stale",
         IngestOutcome::Rejected { .. } => "rejected",
     }

--- a/crates/cgka-session/tests/nostr_stack_chaos.rs
+++ b/crates/cgka-session/tests/nostr_stack_chaos.rs
@@ -147,7 +147,7 @@ async fn invite_lifecycle_chaos_handles_wrong_routes_replays_and_welcome_before_
     assert_eq!(bob.session.members(&group_id).unwrap().len(), 3);
 
     let carol_late_commit = take_effect_for(&mut commit_deliveries, &carol_account_id);
-    assert_peel_failed(&carol_late_commit);
+    assert_transport_deferred(&carol_late_commit);
 
     let mut replay_deliveries = stack
         .deliver_event_to_sessions(
@@ -264,7 +264,7 @@ async fn invite_lifecycle_chaos_handles_commit_before_welcome_and_shared_replay(
     assert_already_seen(&bob_shared_replay);
 
     let carol_late_commit = take_effect_for(&mut shared_replay, &carol_account_id);
-    assert_peel_failed(&carol_late_commit);
+    assert_transport_deferred(&carol_late_commit);
 }
 
 #[derive(Clone, Debug)]
@@ -877,8 +877,8 @@ fn assert_already_seen(effects: &IngestEffects) {
             IngestOutcome::Ignored {
                 category: InputRejectionCategory::Duplicate
             } | IngestOutcome::Stale {
-                reason: StaleReason::AlreadyAtEpoch { .. } | StaleReason::PeelFailed
-            }
+                reason: StaleReason::AlreadyAtEpoch { .. }
+            } | IngestOutcome::TransportDeferred { .. }
         ),
         "expected duplicate/stale epoch outcome, got {:?}",
         effects.outcome
@@ -886,15 +886,10 @@ fn assert_already_seen(effects: &IngestEffects) {
     assert!(effects.effects.events.is_empty());
 }
 
-fn assert_peel_failed(effects: &IngestEffects) {
+fn assert_transport_deferred(effects: &IngestEffects) {
     assert!(
-        matches!(
-            effects.outcome,
-            IngestOutcome::Stale {
-                reason: StaleReason::PeelFailed
-            }
-        ),
-        "unexpected peel failure outcome: {:?}",
+        matches!(effects.outcome, IngestOutcome::TransportDeferred { .. }),
+        "unexpected transport-deferred outcome: {:?}",
         effects.outcome
     );
     assert!(effects.effects.events.is_empty());

--- a/crates/marmot-account/tests/runtime.rs
+++ b/crates/marmot-account/tests/runtime.rs
@@ -1912,11 +1912,11 @@ async fn consumed_last_resort_private_material_survives_pending_replacement_then
         .session_mut()
         .ingest(dave_welcome)
         .await
-        .expect("missing private material is a classified stale ingest");
+        .expect("missing private material is a classified rejection");
     assert!(matches!(
         rejected.outcome,
-        cgka_traits::IngestOutcome::Stale {
-            reason: cgka_traits::ingest::StaleReason::PeelFailed
+        cgka_traits::IngestOutcome::Ignored {
+            category: cgka_traits::ingest::InputRejectionCategory::InvalidEncoding
         }
     ));
 }

--- a/crates/marmot-app/src/client/epoch_stall.rs
+++ b/crates/marmot-app/src/client/epoch_stall.rs
@@ -115,6 +115,30 @@ impl EpochStallDetector {
             false
         }
     }
+
+    /// A resource refusal proves that at least one object in the fetched
+    /// history was not retained. Signal a replay immediately (once per epoch)
+    /// instead of waiting for the undecryptable-message threshold: the
+    /// threshold detects a likely gap, while this outcome is direct evidence
+    /// of one.
+    pub(crate) fn observe_resource_refusal(&mut self, group: GroupId, epoch: EpochId) -> bool {
+        let stall = self.groups.entry(group).or_insert_with(|| GroupStall {
+            epoch,
+            undecryptable: HashSet::new(),
+            fired_at_epoch: None,
+        });
+        if stall.epoch != epoch {
+            stall.epoch = epoch;
+            stall.undecryptable.clear();
+            stall.fired_at_epoch = None;
+        }
+        if stall.fired_at_epoch == Some(epoch) {
+            false
+        } else {
+            stall.fired_at_epoch = Some(epoch);
+            true
+        }
+    }
 }
 
 impl Default for EpochStallDetector {
@@ -159,6 +183,16 @@ mod tests {
         // would let a burst (or a spray of attacker-minted ids) trigger a storm.
         assert!(!detector.observe_undecryptable(g.clone(), "m4".into(), e));
         assert!(!detector.observe_undecryptable(g.clone(), "m5".into(), e));
+    }
+
+    #[test]
+    fn resource_refusal_signals_immediately_once_per_epoch() {
+        let mut detector = EpochStallDetector::new(8);
+        let g = group(0x01);
+
+        assert!(detector.observe_resource_refusal(g.clone(), EpochId(19)));
+        assert!(!detector.observe_resource_refusal(g.clone(), EpochId(19)));
+        assert!(detector.observe_resource_refusal(g, EpochId(20)));
     }
 
     #[test]

--- a/crates/marmot-app/src/client/sync.rs
+++ b/crates/marmot-app/src/client/sync.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 
 use cgka_traits::TransportAdapter;
 use cgka_traits::app_event::{MARMOT_APP_EVENT_KIND_CHAT, MARMOT_APP_EVENT_KIND_DELETE};
-use cgka_traits::ingest::{IngestOutcome, StaleReason};
+use cgka_traits::ingest::IngestOutcome;
 use storage_sqlite::clamp_to_max_future_skew;
 use tokio::time::timeout;
 use transport_nostr_peeler::NostrTransportEvent;
@@ -539,11 +539,13 @@ impl AppClient {
         Ok(routes_dirty)
     }
 
-    /// Feed an undecryptable group delivery to the epoch-stall detector, arming a
-    /// backfill once a group has accumulated enough undecryptable traffic at a
-    /// stalled epoch (see [`super::epoch_stall`]). Only observed under
-    /// `CursorPersistence::Advance`: a `Frozen` wake-collection pass must not own
-    /// recovery, and the main app sees the same evidence on its own next sync.
+    /// Feed an unavailable group delivery to the epoch-stall detector.
+    /// Transport-deferred input arms a backfill after the stalled-epoch
+    /// threshold; resource refusal arms it immediately because it directly
+    /// proves the fetched history was not fully retained. Only observed under
+    /// `CursorPersistence::Advance`: a `Frozen` wake-collection pass must not
+    /// own recovery, and the main app sees the same evidence on its own next
+    /// sync.
     fn detect_epoch_stall(
         &mut self,
         group_id_hint: Option<cgka_traits::GroupId>,
@@ -551,14 +553,6 @@ impl AppClient {
         outcome: &IngestOutcome,
     ) {
         if self.app.cursor_persistence() != CursorPersistence::Advance {
-            return;
-        }
-        if !matches!(
-            outcome,
-            IngestOutcome::Stale {
-                reason: StaleReason::PeelFailed
-            }
-        ) {
             return;
         }
         let Some(group_id) = group_id_hint else {
@@ -569,11 +563,18 @@ impl AppClient {
         let Ok(record) = self.runtime.group_record(&group_id) else {
             return;
         };
-        if self.epoch_stall.observe_undecryptable(
-            group_id.clone(),
-            message_id_hex.to_owned(),
-            record.epoch,
-        ) {
+        let should_backfill = match outcome {
+            IngestOutcome::TransportDeferred { .. } => self.epoch_stall.observe_undecryptable(
+                group_id.clone(),
+                message_id_hex.to_owned(),
+                record.epoch,
+            ),
+            IngestOutcome::ResourceRefused { .. } => self
+                .epoch_stall
+                .observe_resource_refusal(group_id.clone(), record.epoch),
+            _ => false,
+        };
+        if should_backfill {
             // Record the arm decision before the replay side effect runs (the
             // worker seam calls run_pending_epoch_backfill after this returns).
             // Best-effort, fire-and-forget: recording can never block or fail

--- a/crates/marmot-app/tests/epoch_stall_backfill_audit.rs
+++ b/crates/marmot-app/tests/epoch_stall_backfill_audit.rs
@@ -74,7 +74,7 @@ fn test_unix_now_seconds() -> u64 {
 /// ephemeral key and a caller-chosen `created_at`, h-tagged to
 /// `nostr_group_id_hex`. Copied from `next_event_backfill.rs`: real kind-445
 /// senders are always a fresh per-event key, and a zero-nonce marker body peels
-/// to a clean `PeelerError::DecryptFailed`, the `IngestOutcome::Stale { PeelFailed }`
+/// to a clean `PeelerError::DecryptFailed`, the `IngestOutcome::TransportDeferred`
 /// shape the epoch-stall detector counts.
 async fn publish_garbage_group_message_at(
     relay_url: &str,

--- a/crates/marmot-app/tests/malformed_445_drain.rs
+++ b/crates/marmot-app/tests/malformed_445_drain.rs
@@ -197,7 +197,7 @@ async fn malformed_group_message_does_not_starve_messages_behind_it() {
     assert_eq!(
         account_sync_failures(&runtime_bob_boot2),
         0,
-        "hostile wire input must classify as stale inside the engine, never \
+        "hostile wire input must classify as rejected inside the engine, never \
          surface as a sync failure",
     );
     runtime_bob_boot2.shutdown().await;

--- a/crates/marmot-app/tests/next_event_backfill.rs
+++ b/crates/marmot-app/tests/next_event_backfill.rs
@@ -3,7 +3,7 @@
 //! When a *live* delivery arms the epoch-gap backfill — a run of undecryptable
 //! traffic at a stalled epoch crossing `EPOCH_STALL_BACKFILL_THRESHOLD` — the
 //! arming produces no visible `SyncSummary` content (an undecryptable kind-445
-//! yields `IngestOutcome::Stale`, no `MarmotAppEvent`). `next_event` must still
+//! yields `IngestOutcome::TransportDeferred`, no `MarmotAppEvent`). `next_event` must still
 //! RETURN so the worker's post-`next_event`
 //! `run_pending_epoch_backfill` seam (`runtime/account_worker.rs`) runs. If the
 //! empty-summary guard does not also check `epoch_backfill_pending`, the call
@@ -75,7 +75,7 @@ fn test_unix_now_seconds() -> u64 {
 /// ephemeral key and a caller-chosen `created_at`, h-tagged to
 /// `nostr_group_id_hex`. Copied from `since_floor.rs`: real kind-445 senders are
 /// always a fresh per-event key, and a zero-nonce marker body peels to a clean
-/// `PeelerError::DecryptFailed`, the `IngestOutcome::Stale { PeelFailed }` shape
+/// `PeelerError::DecryptFailed`, the `IngestOutcome::TransportDeferred` shape
 /// the epoch-stall detector counts.
 async fn publish_garbage_group_message_at(
     relay_url: &str,

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -431,7 +431,7 @@ async fn publish_nostr_event_at(
 /// ephemeral key, h-tagged to `nostr_group_id_hex`. Mirrors the probe publisher
 /// in `next_event_backfill.rs`: real kind-445 senders always sign with a fresh
 /// per-event key, and a zero-nonce marker body peels to a clean
-/// `PeelFailed` — the `IngestOutcome::Stale` shape the epoch-stall detector
+/// `TransportDeferred` — the typed availability outcome the epoch-stall detector
 /// counts toward arming a backfill. Distinct `marker`s yield distinct event ids,
 /// hence distinct undecryptables at the group's one stalled epoch.
 async fn publish_garbage_group_message(

--- a/crates/marmot-app/tests/since_floor.rs
+++ b/crates/marmot-app/tests/since_floor.rs
@@ -72,7 +72,7 @@
 //! this: kind-445 senders are always a fresh per-event key, unrelated to any
 //! account identity, and this test exercises *delivery*, not decryption). An
 //! undecryptable delivery produces no `MarmotAppEvent` — decrypt failure
-//! yields `IngestOutcome::Stale` with no observable side effect at the
+//! yields `IngestOutcome::TransportDeferred` with no observable side effect at the
 //! `MarmotAppRuntime` event-stream layer. The chosen observable is instead
 //! `MarmotApp::relay_telemetry().metrics.inbound_events_delivered`
 //! (`transport-nostr-adapter`'s `NostrAdapterMetrics`, already public,
@@ -244,7 +244,7 @@ async fn wait_for_inbound_delivered(app: &MarmotApp, target: usize) {
 /// authenticate under no key, so the recipient peels it to a clean
 /// `PeelerError::DecryptFailed` — the same shape as real traffic sealed under
 /// an exporter secret this device does not hold, and the shape the epoch-stall
-/// detector counts as `IngestOutcome::Stale { reason: PeelFailed }`. (A
+/// detector counts as `IngestOutcome::TransportDeferred`. (A
 /// shorter-than-envelope body would instead be `Malformed`, a hard ingest
 /// error rather than an undecryptable-message observation.)
 async fn publish_garbage_group_message_at(

--- a/crates/storage-sqlite/src/storage/messages.rs
+++ b/crates/storage-sqlite/src/storage/messages.rs
@@ -59,6 +59,23 @@ impl MessageStorage for SqliteAccountStorage {
         deserialize(&record)
     }
 
+    fn delete_message(&self, id: &MessageId) -> StorageResult<()> {
+        let delete = || {
+            self.lock()?
+                .execute(
+                    "DELETE FROM cgka_messages WHERE id = ?1",
+                    params![id.as_slice()],
+                )
+                .storage()?;
+            Ok(())
+        };
+        if self.connection.is_current_thread_transaction_owner() {
+            delete()
+        } else {
+            retry_on_busy(delete)
+        }
+    }
+
     fn update_message_state(&self, id: &MessageId, new_state: MessageState) -> StorageResult<()> {
         // #424: when this runs inside an engine `with_transaction` (convergence
         // apply path), the outer SQL transaction is already open and owns
@@ -200,7 +217,7 @@ mod tests {
     use crate::SqliteAccountStorage;
     use crate::storage::test_support::{gid, mid, sample_group, sample_message};
     use cgka_traits::message::MessageState;
-    use cgka_traits::storage::{GroupStorage, MessageStorage};
+    use cgka_traits::storage::{GroupStorage, MessageStorage, StorageError};
     use cgka_traits::types::EpochId;
 
     #[test]
@@ -232,6 +249,23 @@ mod tests {
     }
 
     #[test]
+    fn deleted_message_id_can_be_inserted_again() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        store.put_group(&sample_group(gid(1), 0, 0)).unwrap();
+        let message = sample_message(mid(1), gid(1), 0);
+        store.put_message(&message).unwrap();
+
+        store.delete_message(&message.id).unwrap();
+        assert!(matches!(
+            store.get_message(&message.id),
+            Err(StorageError::NotFound)
+        ));
+
+        store.put_message(&message).unwrap();
+        assert_eq!(store.get_message(&message.id).unwrap(), message);
+    }
+
+    #[test]
     fn ingress_dedup_markers_are_group_independent_and_idempotent() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         let id = mid(42);
@@ -259,7 +293,7 @@ mod tests {
         // writes inside an engine `with_transaction`, `update_message_state`
         // must reuse the open transaction instead of opening a nested one
         // ("cannot start a transaction within a transaction").
-        use cgka_traits::storage::{StorageError, StorageProvider};
+        use cgka_traits::storage::StorageProvider;
 
         let store = SqliteAccountStorage::in_memory().unwrap();
         store.put_group(&sample_group(gid(1), 0, 0)).unwrap();

--- a/crates/traits/src/ingest.rs
+++ b/crates/traits/src/ingest.rs
@@ -24,6 +24,18 @@ pub enum IngestOutcome {
     /// A canonical local condition blocked processing. This is deliberately
     /// separate from convergence dispositions.
     LocalState { state: LocalIngestState },
+    /// The transport object could not be decoded or decrypted with the
+    /// currently available transport context, but a later canonical epoch,
+    /// retained candidate, staged state, or repair may make it recoverable.
+    /// The object remains outside convergence until peeling succeeds.
+    TransportDeferred { group_id: GroupId },
+    /// A local resource bound prevented the engine from retaining or
+    /// processing an otherwise unclassified transport object. This is not a
+    /// protocol rejection and must not make same-id redelivery a duplicate.
+    ResourceRefused {
+        group_id: GroupId,
+        resource: InboundResourceLimit,
+    },
     /// Message was not applied. The variant names why — callers log by
     /// category rather than pattern-matching error strings.
     Stale { reason: StaleReason },
@@ -38,6 +50,19 @@ pub enum InputRejectionCategory {
     OwnEcho,
     WrongRecipient,
     UnknownGroup,
+    InvalidEncoding,
+    InvalidSignature,
+    UnsupportedRequiredFeature,
+    AuthorizationFailed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum InboundResourceLimit {
+    /// The per-group durable transport-deferred row cap is full.
+    TransportDeferredCapacity,
+    /// A retained transport object exhausted its changed-context retry budget
+    /// and was retired without a terminal validity claim.
+    TransportDeferredRetryBudget,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -88,10 +113,20 @@ pub enum StaleReason {
     /// The message is our own commit echoed back by the transport.
     #[deprecated(note = "use IngestOutcome::Ignored { category: OwnEcho }")]
     OwnEcho,
-    /// The peeler rejected the message. The stored message may be terminal or
-    /// retryable depending on whether the engine has evidence that another
-    /// epoch context could later peel it.
-    PeelFailed,
+    /// The message predates this account-device's membership and can never
+    /// decrypt on this local copy.
+    PreMembership,
+    /// Convergence excluded the input below the retained anchor.
+    BeyondAnchor,
+    /// Convergence excluded the input beyond the rollback horizon.
+    BeyondRollbackHorizon,
+    /// The application-message decryption window no longer retains its
+    /// source epoch.
+    BeyondAppRetention,
+    /// The message belongs only to a losing canonical branch.
+    LosingBranch,
+    /// Authenticated input is invalid against the selected candidate state.
+    InvalidAgainstCanonicalState,
     /// The local retained canonical state records our own removal from this
     /// group, so later group input can never be processed here. Terminal for
     /// the group on this client. Processing input that classifies as

--- a/crates/traits/src/message.rs
+++ b/crates/traits/src/message.rs
@@ -196,6 +196,7 @@ pub struct MessageRecord {
 ///   `Created` → `PeelDeferred` (transport bytes retained for later peel)
 ///   `Retryable` → `Processed` (retry succeeded)
 ///   `PeelDeferred` → `Created` (peel succeeded and MLS bytes are buffered)
+///   `PeelDeferred` → deleted (local retry budget exhausted; redelivery remains eligible)
 ///   any → `EpochInvalidated` (group forked past; message will never apply)
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MessageState {

--- a/crates/traits/src/peeler.rs
+++ b/crates/traits/src/peeler.rs
@@ -97,8 +97,9 @@ impl GroupMessageMetadata {
 ///   when that hint is older than the supplied context; transports without
 ///   such a hint (e.g. the Nostr binding, whose kind-445 content is opaque
 ///   `base64(nonce || ciphertext)`) simply return `DecryptFailed`. The engine
-///   maps both to `StaleReason::PeelFailed`, choosing retry or terminal
-///   storage from the available epoch evidence.
+///   maps a potentially recoverable miss to
+///   `IngestOutcome::TransportDeferred`; authenticated epoch evidence can
+///   instead establish a terminal stale classification.
 /// - `peel_welcome` MUST fail cleanly for welcomes not addressed to the
 ///   local identity — the engine maps that to
 ///   `InputRejectionCategory::WrongRecipient`.

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -88,6 +88,7 @@ pub trait GroupStorage {
 pub trait MessageStorage {
     fn put_message(&self, record: &MessageRecord) -> StorageResult<()>;
     fn get_message(&self, id: &MessageId) -> StorageResult<MessageRecord>;
+    fn delete_message(&self, id: &MessageId) -> StorageResult<()>;
     fn update_message_state(&self, id: &MessageId, new_state: MessageState) -> StorageResult<()>;
     fn list_messages(
         &self,

--- a/crates/traits/tests/snapshots.rs
+++ b/crates/traits/tests/snapshots.rs
@@ -19,7 +19,9 @@ use cgka_traits::engine::{
 };
 use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::group::{Group, Member, ProtocolProfile};
-use cgka_traits::ingest::{IngestOutcome, PeeledContent, PeeledMessage, StaleReason};
+use cgka_traits::ingest::{
+    InboundResourceLimit, IngestOutcome, PeeledContent, PeeledMessage, StaleReason,
+};
 use cgka_traits::message::StoredMessagePayload;
 use cgka_traits::transport::{
     EncryptedPayload, Timestamp, TransportEnvelope, TransportMessage, TransportSource,
@@ -395,9 +397,57 @@ fn snapshot_ingest_outcomes() {
         }
     );
     insta::assert_json_snapshot!(
-        "stale_peel_failed",
+        "transport_deferred",
+        IngestOutcome::TransportDeferred { group_id: gid() }
+    );
+    insta::assert_json_snapshot!(
+        "resource_refused_deferred_capacity",
+        IngestOutcome::ResourceRefused {
+            group_id: gid(),
+            resource: InboundResourceLimit::TransportDeferredCapacity
+        }
+    );
+    insta::assert_json_snapshot!(
+        "resource_refused_retry_budget",
+        IngestOutcome::ResourceRefused {
+            group_id: gid(),
+            resource: InboundResourceLimit::TransportDeferredRetryBudget
+        }
+    );
+    insta::assert_json_snapshot!(
+        "stale_pre_membership",
         IngestOutcome::Stale {
-            reason: StaleReason::PeelFailed
+            reason: StaleReason::PreMembership
+        }
+    );
+    insta::assert_json_snapshot!(
+        "stale_beyond_anchor",
+        IngestOutcome::Stale {
+            reason: StaleReason::BeyondAnchor
+        }
+    );
+    insta::assert_json_snapshot!(
+        "stale_beyond_rollback_horizon",
+        IngestOutcome::Stale {
+            reason: StaleReason::BeyondRollbackHorizon
+        }
+    );
+    insta::assert_json_snapshot!(
+        "stale_beyond_app_retention",
+        IngestOutcome::Stale {
+            reason: StaleReason::BeyondAppRetention
+        }
+    );
+    insta::assert_json_snapshot!(
+        "stale_losing_branch",
+        IngestOutcome::Stale {
+            reason: StaleReason::LosingBranch
+        }
+    );
+    insta::assert_json_snapshot!(
+        "stale_invalid_against_canonical_state",
+        IngestOutcome::Stale {
+            reason: StaleReason::InvalidAgainstCanonicalState
         }
     );
     insta::assert_json_snapshot!(

--- a/crates/traits/tests/snapshots/snapshots__resource_refused_deferred_capacity.snap
+++ b/crates/traits/tests/snapshots/snapshots__resource_refused_deferred_capacity.snap
@@ -1,0 +1,15 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::ResourceRefused\n{ group_id: gid(), resource: InboundResourceLimit::TransportDeferredCapacity }"
+---
+{
+  "ResourceRefused": {
+    "group_id": [
+      170,
+      170,
+      170,
+      170
+    ],
+    "resource": "TransportDeferredCapacity"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__resource_refused_retry_budget.snap
+++ b/crates/traits/tests/snapshots/snapshots__resource_refused_retry_budget.snap
@@ -1,0 +1,15 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::ResourceRefused\n{\n    group_id: gid(), resource:\n    InboundResourceLimit::TransportDeferredRetryBudget\n}"
+---
+{
+  "ResourceRefused": {
+    "group_id": [
+      170,
+      170,
+      170,
+      170
+    ],
+    "resource": "TransportDeferredRetryBudget"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__stale_beyond_anchor.snap
+++ b/crates/traits/tests/snapshots/snapshots__stale_beyond_anchor.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Stale { reason: StaleReason::BeyondAnchor }"
+---
+{
+  "Stale": {
+    "reason": "BeyondAnchor"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__stale_beyond_app_retention.snap
+++ b/crates/traits/tests/snapshots/snapshots__stale_beyond_app_retention.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Stale { reason: StaleReason::BeyondAppRetention }"
+---
+{
+  "Stale": {
+    "reason": "BeyondAppRetention"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__stale_beyond_rollback_horizon.snap
+++ b/crates/traits/tests/snapshots/snapshots__stale_beyond_rollback_horizon.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Stale { reason: StaleReason::BeyondRollbackHorizon }"
+---
+{
+  "Stale": {
+    "reason": "BeyondRollbackHorizon"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__stale_invalid_against_canonical_state.snap
+++ b/crates/traits/tests/snapshots/snapshots__stale_invalid_against_canonical_state.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Stale { reason: StaleReason::InvalidAgainstCanonicalState }"
+---
+{
+  "Stale": {
+    "reason": "InvalidAgainstCanonicalState"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__stale_losing_branch.snap
+++ b/crates/traits/tests/snapshots/snapshots__stale_losing_branch.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Stale { reason: StaleReason::LosingBranch }"
+---
+{
+  "Stale": {
+    "reason": "LosingBranch"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__stale_peel_failed.snap
+++ b/crates/traits/tests/snapshots/snapshots__stale_peel_failed.snap
@@ -1,9 +1,0 @@
----
-source: crates/traits/tests/snapshots.rs
-expression: "IngestOutcome::Stale { reason: StaleReason::PeelFailed }"
----
-{
-  "Stale": {
-    "reason": "PeelFailed"
-  }
-}

--- a/crates/traits/tests/snapshots/snapshots__stale_pre_membership.snap
+++ b/crates/traits/tests/snapshots/snapshots__stale_pre_membership.snap
@@ -1,0 +1,9 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::Stale { reason: StaleReason::PreMembership }"
+---
+{
+  "Stale": {
+    "reason": "PreMembership"
+  }
+}

--- a/crates/traits/tests/snapshots/snapshots__transport_deferred.snap
+++ b/crates/traits/tests/snapshots/snapshots__transport_deferred.snap
@@ -1,0 +1,14 @@
+---
+source: crates/traits/tests/snapshots.rs
+expression: "IngestOutcome::TransportDeferred { group_id: gid() }"
+---
+{
+  "TransportDeferred": {
+    "group_id": [
+      170,
+      170,
+      170,
+      170
+    ]
+  }
+}

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -303,9 +303,10 @@ shortcuts.
 
 **5. Relay backlog causes spurious peeler decrypt errors.** Any subscription without a `since` filter receives
 historical events encrypted with old-epoch secrets that the new joiner doesn't have. Fix in spike:
-`Filter::new()...since(Timestamp::now())`. The deeper fix was to treat peel-decrypt failures as `IngestOutcome::Stale`
-rather than hard errors. Current code uses `StaleReason::PeelFailed`, and stale source-epoch group envelopes can be
-terminal when no retained snapshot can peel them.
+`Filter::new()...since(Timestamp::now())`. The spike's deeper fix was to make peel-decrypt failures ordinary typed
+outcomes rather than hard errors. That taxonomy has since been refined: potentially recoverable misses are
+`IngestOutcome::TransportDeferred`, while terminal protocol rejection and stale reasons are explicit and resource
+limits return `ResourceRefused`.
 
 **6. Forked commit recovery is out of scope for the spike, but real.** When a commit race _does_ produce a fork (e.g.
 two admins committing concurrent adds), some members end up at irreconcilable epoch-N-alpha / epoch-N-beta states. The
@@ -349,8 +350,9 @@ walks; retains caps for removed members for audit/replay) — just not the _work
 ### What I would still change from the early spike
 
 - Add `EngineError::MissingRequiredCapabilities { required, had }` typed variant (see finding 9).
-- Add `StaleReason::PeelFailed` to distinguish peel-level stale from MLS-level stale. Superseded: this now exists, and
-  the Nostr group envelope carries a source-epoch hint so pre-join stale messages can be terminal.
+- Add a typed peel-failure outcome to distinguish transport availability from MLS stale state. Superseded:
+  `TransportDeferred` and `ResourceRefused` now cover availability; the Nostr group envelope intentionally carries no
+  clear source-epoch hint.
 - Fix the auto-commit race properly — the "lowest-index" rule is a shortcut that breaks when the lowest-index member is
   offline. Real fix: short randomized delay + observer-of-commit suppression.
 - Store members' advertised capabilities in a local index so `feature_status()` can give real

--- a/docs/marmot-architecture/AGENTS.md
+++ b/docs/marmot-architecture/AGENTS.md
@@ -12,10 +12,11 @@ Agent map for the Marmot architecture docs.
 6. `overview/whitenoise-integration-map.md`
 7. `cgka-engine-spec.md`
 8. `cgka-engine-canonicalization-contract.md`
-9. `distributed-convergence.md`
-10. `relay-delivery-telemetry.md`
-11. `relay-observability.md`
-12. `github.com/marmot-protocol/marmot` when the task touches the Marmot protocol specification.
+9. `convergence-reliability-plan.md`
+10. `distributed-convergence.md`
+11. `relay-delivery-telemetry.md`
+12. `relay-observability.md`
+13. `github.com/marmot-protocol/marmot` when the task touches the Marmot protocol specification.
 
 ## Document roles
 
@@ -51,6 +52,10 @@ Agent map for the Marmot architecture docs.
 
 - **Path:** `cgka-engine-canonicalization-contract.md`
   - **Role:** Detailed post-peeling convergence contract.
+
+- **Path:** `convergence-reliability-plan.md`
+  - **Role:** Tracked convergence assurance, constant classification, simulator roadmap, verification gates, and
+    campaign evidence.
 
 - **Path:** `distributed-convergence.md`
   - **Role:** Branch selection, retained anchors, and convergence model.
@@ -91,3 +96,6 @@ Agent map for the Marmot architecture docs.
   components in `github.com/marmot-protocol/marmot`.
 - If Tamarin or Rust tests add a named scenario, mirror the name in the docs when that scenario becomes part of the
   contract.
+- When adding or changing a convergence policy, resource, scheduler, or history-recovery constant, update
+  `convergence-reliability-plan.md` and `convergence-constant-inventory.txt`, then run
+  `just convergence-ledger-gate`.

--- a/docs/marmot-architecture/audit-logging.md
+++ b/docs/marmot-architecture/audit-logging.md
@@ -36,8 +36,8 @@ treated like telemetry.
 | Engine audit call sites | [`engine.rs`](../../crates/cgka-engine/src/engine.rs), [`message_processor/`](../../crates/cgka-engine/src/message_processor), [`publish.rs`](../../crates/cgka-engine/src/publish.rs), [`fork_recovery.rs`](../../crates/cgka-engine/src/fork_recovery.rs), [`distributed_convergence.rs`](../../crates/cgka-engine/src/distributed_convergence.rs), [`update_group_data.rs`](../../crates/cgka-engine/src/update_group_data.rs), [`upgrade.rs`](../../crates/cgka-engine/src/upgrade.rs), [`group_lifecycle.rs`](../../crates/cgka-engine/src/group_lifecycle.rs) |
 | Account publish audit call sites | [`crates/marmot-account/src/lib.rs`](../../crates/marmot-account/src/lib.rs) |
 | App settings, file identities, listing, upload | [`crates/marmot-app/src/lib.rs`](../../crates/marmot-app/src/lib.rs), [`crates/marmot-app/src/config.rs`](../../crates/marmot-app/src/config.rs), [`crates/storage-sqlite/src/shared.rs`](../../crates/storage-sqlite/src/shared.rs) |
-| Runtime tracker scheduling | [`crates/marmot-app/src/runtime.rs`](../../crates/marmot-app/src/runtime.rs) |
-| UniFFI bridge | [`crates/marmot-uniffi/src/lib.rs`](../../crates/marmot-uniffi/src/lib.rs), [`crates/marmot-uniffi/src/conversions.rs`](../../crates/marmot-uniffi/src/conversions.rs) |
+| Runtime tracker scheduling | [`crates/marmot-app/src/runtime/`](../../crates/marmot-app/src/runtime) |
+| UniFFI bridge | [`crates/marmot-uniffi/src/lib.rs`](../../crates/marmot-uniffi/src/lib.rs), [`crates/marmot-uniffi/src/conversions/`](../../crates/marmot-uniffi/src/conversions) |
 | Tests | [`crates/marmot-forensics/src/audit.rs`](../../crates/marmot-forensics/src/audit.rs), [`crates/cgka-engine/tests/audit_log.rs`](../../crates/cgka-engine/tests/audit_log.rs), [`crates/marmot-app/tests/audit_logs.rs`](../../crates/marmot-app/tests/audit_logs.rs) |
 
 ## Enablement and lifecycle
@@ -328,7 +328,7 @@ Emitted after `do_ingest()` returns `Ok(outcome)`.
 | Field | Meaning |
 | --- | --- |
 | `msg_id` | Hex `MessageId` of the inbound message. |
-| `outcome_kind` | `processed`, `buffered`, `ignored`, `local_state`, `stale`, or `rejected`. |
+| `outcome_kind` | `processed`, `buffered`, `ignored`, `local_state`, `transport_deferred`, `resource_refused`, `stale`, or `rejected`. |
 | `stale_reason` | Legacy optional category field used by non-processed outcomes. |
 | `epoch` | Present for buffered outcomes and `already_at_epoch` stale outcomes. |
 
@@ -341,14 +341,27 @@ Emitted after `do_ingest()` returns `Ok(outcome)`.
 | `wrong_recipient` | Welcome/inbox message was not addressed to this client. |
 | `unknown_group` | Message referenced a group the engine does not know. |
 | `own_echo` | Message was produced by this engine and bounced back through ingest. |
-| `peel_failed` | MLS/transport peeling failed or could not be recovered. |
+| `invalid_encoding` | Transport or recovered protocol bytes failed structural validation. |
+| `invalid_signature` | A required transport or protocol signature failed validation. |
+| `unsupported_required_feature` | The input requires a feature the engine does not support. |
+| `authorization_failed` | Authenticated input was not authorized in the applicable state. |
+| `transport_deferred` | Current transport context cannot decrypt the object; a changed context may recover it. |
+| `resource_refused_deferred_capacity` | The per-group retained transport-deferred row cap was full. |
+| `resource_refused_retry_budget` | A retained transport object exhausted its changed-context retry budget and was released. |
+| `pre_membership` | The message predates this account-device's membership. |
+| `beyond_anchor` | Convergence excluded input below the retained anchor. |
+| `beyond_rollback_horizon` | Convergence excluded input beyond the rollback horizon. |
+| `beyond_app_retention` | The application-message source epoch is outside retained decryption history. |
+| `losing_branch` | The message belongs only to a losing branch. |
+| `invalid_against_canonical_state` | Authenticated input is invalid against the selected candidate state. |
 | `removed` | Authenticated canonical state records this local member's removal. |
 | `quarantined` | Hydration validation froze the local group pending repair. |
 
 Metadata notes:
 
 - This event is not emitted if `do_ingest()` returns an `Err`.
-- It has `group_ref` when the outcome is `buffered`, because that outcome carries the group id.
+- It has `group_ref` when the outcome is `buffered`, `transport_deferred`, or `resource_refused`, because those
+  outcomes carry the group id.
 - The JSON field remains named `stale_reason` for v1/v2 schema compatibility. Its type and required-field set did not
   change, so this additive outcome taxonomy does not require a forensic schema-version bump.
 
@@ -779,9 +792,11 @@ Current `reason` values found in production call sites:
 | `state_update` | Generic `update_stored_message_state` path updates a stored message. |
 | `publish_confirmed` | A pending commit message is promoted to processed after publish confirmation. |
 | `fork_loser` | A same-epoch incumbent branch loses fork resolution and its message is invalidated. |
-| `peel_failed_no_snapshot` | Group-message peel failed and no fallback snapshot could recover it; state becomes `peel_deferred`. |
+| `peel_failed_no_snapshot` | Historical stable tag: group-message peel failed and no fallback snapshot could recover it; the outcome is `transport_deferred` and state becomes `peel_deferred`. |
+| `resource_refused_deferred_capacity` | The retained transport-deferred row cap refused an additional object without persisting it. |
+| `resource_refused_retry_budget` | A retained transport-deferred row exhausted its changed-context retry budget; the row is deleted and the audit transition's `new_state` is `released`. |
 | `stale_epoch_no_snapshot` | Stale-epoch peel failed and no fallback snapshot could recover it; state becomes `failed`. |
-| `too_distant_in_the_past` | A deferred raw transport message peeled to MLS bytes, but OpenMLS proved the application ciphertext is outside the retained past-epoch window; state becomes `failed`. |
+| `app_payload_retention_expired` | A message peeled to MLS bytes, but OpenMLS proved the application ciphertext is outside the retained app-payload window; state becomes `failed`. |
 
 Metadata notes:
 
@@ -813,8 +828,8 @@ metadata keys for indexing.
 | Category | Values |
 | --- | --- |
 | `envelope_kind` | `welcome`, `group_message` |
-| `outcome_kind` | `processed`, `buffered`, `ignored`, `local_state`, `stale`, `rejected` |
-| `stale_reason` | `duplicate`, `already_at_epoch`, `wrong_recipient`, `unknown_group`, `own_echo`, `peel_failed`, `removed`, `quarantined` |
+| `outcome_kind` | `processed`, `buffered`, `ignored`, `local_state`, `transport_deferred`, `resource_refused`, `stale`, `rejected` |
+| `stale_reason` | `duplicate`, `already_at_epoch`, `wrong_recipient`, `unknown_group`, `own_echo`, `invalid_encoding`, `invalid_signature`, `unsupported_required_feature`, `authorization_failed`, `transport_deferred`, `resource_refused_deferred_capacity`, `resource_refused_retry_budget`, `pre_membership`, `beyond_anchor`, `beyond_rollback_horizon`, `beyond_app_retention`, `losing_branch`, `invalid_against_canonical_state`, `removed`, `quarantined` |
 | `engine error_kind` | `unknown_group`, `unknown_pending`, `not_a_member`, `not_group_admin`, `unknown_member`, `invalid_credential_identity`, `admin_cannot_self_remove`, `admin_depletion`, `missing_required_capabilities`, `unsupported_ciphersuite`, `invalid_app_message_payload`, `invalid_account_identity_proof`, `forked_epoch`, `invalid_transition`, `storage`, `peeler`, `serialize`, `backend`, `other` |
 | `peeler error_kind` | `malformed`, `decrypt_failed`, `stale_epoch`, `missing_context`, `wrap_failed`, `backend` |
 | `intent_kind` | `app_message`, `invite`, `remove_members`, `leave`, `update_app_components`, `update_group_data` |

--- a/docs/marmot-architecture/cgka-engine-spec.md
+++ b/docs/marmot-architecture/cgka-engine-spec.md
@@ -127,13 +127,13 @@ Stored message payloads are typed:
 
 For group messages, the engine MUST first peel with the current MLS exporter context. If that fails and retained epoch
 snapshots are available, it SHOULD try those retained contexts newest-to-oldest within the retention window before
-classifying the message as `PeelDeferred`.
+returning `IngestOutcome::TransportDeferred` and retaining it as `PeelDeferred`.
 
-Transport group envelopes SHOULD carry a clear source-epoch hint. If the peeler reports that the source epoch is older
-than the current local context and no retained snapshot can peel the message, the engine MUST classify the message as a
-terminal `PeelFailed`, not `PeelDeferred`. This is the expected path for an invitee who joined via welcome and later
-receives the invite commit that created that welcome: the invitee never had the pre-welcome epoch secret. Future-epoch
-group messages, or group messages without a usable source-epoch hint, MAY remain `PeelDeferred`.
+When a transport supplies authenticated source-epoch evidence and no retained snapshot can peel the object, the engine
+MAY establish a specific stale outcome such as `AlreadyAtEpoch`. The Nostr group envelope has no clear source-epoch
+hint, so a decrypt miss remains `TransportDeferred`: it might be a future-epoch object whose missing commit will later
+change the peel context. A local row or retry cap returns typed `ResourceRefused`, does not establish invalidity or
+permanent unreadability, and MUST leave exact-ID redelivery eligible.
 
 When convergence reaches a settled selected branch, the engine MUST retry `PeelDeferred` raw group messages for that
 group. A retry that peels into OpenMLS wire bytes promotes the stored payload from `RawTransport` to `OpenMlsWire`; it
@@ -366,8 +366,7 @@ Application-message rules:
 - A message that decrypts on the selected branch and is within the MLS past-epoch decryption limit MUST be emitted as
   `GroupEvent::MessageReceived`.
 - A transport-wrapped application message for a past epoch SHOULD be retried against retained epoch contexts before it
-  is left in `PeelDeferred` or, when source-epoch metadata proves it is older than every retained context, terminally
-  classified as `PeelFailed`.
+  returns `TransportDeferred`; authenticated source-epoch evidence can instead establish a specific stale outcome.
 - A transport-wrapped application message for a future candidate epoch SHOULD stay in `PeelDeferred` until branch
   selection advances the local MLS context; then it MUST be retried and emitted only if it decrypts on the selected
   branch.

--- a/docs/marmot-architecture/convergence-constant-inventory.txt
+++ b/docs/marmot-architecture/convergence-constant-inventory.txt
@@ -1,0 +1,31 @@
+# Machine-checked convergence constant inventory.
+#
+# Format: ledger-id|repository-relative Rust source path|Rust constant name
+# Keep this aligned with convergence-reliability-plan.md. The gate in
+# scripts/check_convergence_constant_ledger.sh verifies the declarations,
+# the documented IDs, and the scoped source-name families.
+P1|crates/cgka-engine/src/convergence.rs|V1_MAX_REWIND_COMMITS
+P2|crates/cgka-engine/src/canonicalization.rs|V1_APP_MESSAGE_PAST_EPOCH_LIMIT
+P3|crates/cgka-engine/src/wire_format.rs|DEFAULT_MAX_PAST_EPOCHS
+P4|crates/cgka-engine/src/canonicalization.rs|V1_SETTLEMENT_QUIESCENCE_MS
+P5|crates/cgka-engine/src/canonicalization.rs|V1_MAX_CONVERGENCE_PASS_MS
+P6|crates/cgka-engine/src/convergence.rs|V1_WITNESS_QUORUM_SENDERS_PER_EPOCH
+P7|crates/cgka-engine/src/convergence.rs|V1_WITNESS_QUORUM_EPOCHS
+P8|crates/cgka-engine/src/convergence.rs|V1_MAX_WITNESS_OVERRIDE_DEPTH
+E1|crates/cgka-engine/src/message_processor/mod.rs|MAX_CONVERGENCE_REPROCESSING_PASSES
+E2|crates/cgka-engine/src/message_processor/mod.rs|MAX_DEFERRED_PEEL_ATTEMPTS
+E3|crates/cgka-engine/src/message_processor/mod.rs|MAX_PEEL_DEFERRED_ROWS_PER_GROUP
+E4|crates/cgka-engine/src/message_processor/mod.rs|MAX_DEFERRED_ROWS_PER_SWEEP
+E5|crates/cgka-engine/src/openmls_projection.rs|CANDIDATE_REPLAY_BUDGET_SLACK
+E6|crates/cgka-engine/src/openmls_projection.rs|CANDIDATE_REPLAY_BUDGET_FLOOR
+E7|crates/cgka-engine/src/message_processor/mod.rs|SELF_REMOVE_AUTO_COMMIT_JITTER_MIN_MS
+E7|crates/cgka-engine/src/message_processor/mod.rs|SELF_REMOVE_AUTO_COMMIT_JITTER_SPAN_MS
+A1|crates/marmot-app/src/runtime/account_worker.rs|CONVERGENCE_SETTLEMENT_SCHEDULE_MARGIN_MS
+A2|crates/marmot-app/src/runtime/account_worker.rs|MIN_CONVERGENCE_SETTLEMENT_DELAY
+A3|crates/marmot-app/src/runtime/account_worker.rs|CONVERGENCE_RETRY_BASE_DELAY
+A3|crates/marmot-app/src/runtime/account_worker.rs|CONVERGENCE_RETRY_MAX_DELAY
+A4|crates/marmot-app/src/runtime/account_worker.rs|CONVERGENCE_UNSETTLED_MAX_REARMS
+A5|crates/marmot-app/src/runtime/account_worker.rs|IDLE_CONVERGENCE_TIMER_DELAY
+A6|crates/marmot-app/src/client/epoch_stall.rs|EPOCH_STALL_BACKFILL_THRESHOLD
+A7|crates/marmot-app/src/lib.rs|APP_RUNTIME_RELAY_REBUILD_LOOKBACK
+A8|crates/marmot-app/src/lib.rs|TRANSPORT_CURSOR_MAX_FUTURE_SKEW

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -1,0 +1,659 @@
+---
+title: "Convergence Reliability And Simulation Plan"
+created: 2026-07-30
+updated: 2026-07-30
+tags: [marmot, cgka, convergence, simulation, verification, reliability]
+status: working-plan
+---
+
+# Convergence Reliability And Simulation Plan
+
+This is the tracking plan for making Marmot convergence predictable, testable, diagnosable, and durable from the
+standalone CGKA engine through full application and multi-process deployments.
+
+The plan has two related goals:
+
+1. establish a precise assurance case for the convergence protocol and its constants; and
+2. build one versioned scenario corpus that can run against increasingly production-shaped subjects without changing
+   what the scenario means.
+
+This document owns sequencing, work-item status, exit gates, and verification evidence. Detailed protocol behavior
+continues to live in
+[`cgka-engine-canonicalization-contract.md`](./cgka-engine-canonicalization-contract.md),
+[`distributed-convergence.md`](./distributed-convergence.md), and the adopted Marmot
+[`protocol-core/convergence.md`](https://github.com/marmot-protocol/marmot/blob/master/protocol-core/convergence.md).
+Implementation-specific relay measurement remains in
+[`relay-delivery-telemetry.md`](./relay-delivery-telemetry.md).
+
+## Target Assurance Statement
+
+The program is successful when the following statement is justified by specification, executable tests, formal or
+bounded models, and repeatable campaign evidence:
+
+> Under explicit delivery, input-closure, policy-version, participant, and resource assumptions, every nonfaulty client
+> either reaches exactly equivalent cryptographic and application state within a measured bound or reaches the same
+> explicit, deterministic, diagnosable, and replayable terminal outcome.
+
+This statement deliberately does not promise prompt convergence under permanent message suppression, an unbounded
+stream of valid competing commits, or exhausted resources. Those cases require an explicit availability or fairness
+policy; timers and retries cannot manufacture the missing assumptions.
+
+## Status And Tracking Conventions
+
+Work-item states:
+
+- `not-started`: scoped below but no implementation has landed;
+- `in-progress`: implementation or design work is active;
+- `blocked`: a named dependency or protocol decision prevents progress;
+- `complete`: implementation and every listed verification step have evidence;
+- `deferred`: deliberately outside the current delivery horizon, with rationale recorded.
+
+Every completed work item records:
+
+- the issue or design decision, when one exists;
+- the implementing PR or commit;
+- exact verification commands;
+- saved report, model-check, or campaign artifacts where applicable;
+- any guarantee, constant, scenario, or adapter capability changed by the work.
+
+Checkboxes represent repository state, not intention. A checked item must have evidence in the progress log.
+
+## Current Baseline
+
+The repository already provides:
+
+- a real `Engine<SqliteAccountStorage>` harness with OpenMLS and the Nostr peeler;
+- scripted `ScenarioSpec` v1 cases and portable vectors;
+- seeded delivery schedules, generated chaos families, reports, and conservative failure minimization;
+- symbolic selector/canonicalization properties and engine integration tests;
+- encrypted file-backed restart coverage;
+- incident archetype synthesis from forensic audit exports;
+- a Tamarin model for bounded selector, lifecycle, and output-safety scenarios.
+
+The baseline is useful scaffolding, but it is not yet the target reliability lab:
+
+- portable `ClientsConverged` checks epoch/member count rather than exact member and state equivalence;
+- normal scenarios can use a harness with engine/storage access;
+- a partition drops messages instead of retaining relay history for reconnect;
+- queue emptiness does not prove all client, pass, publication, retry, deferred, or projection work is quiescent;
+- generated storms are structural tests rather than sustained rate/volume campaigns;
+- scenario seeds do not reproduce randomized MLS bytes;
+- the executable policy model used by several tests is production code, not an independent oracle;
+- Tamarin abstracts clocks, crash/restart, durable generations, resource bounds, fairness, and sustained self-updates.
+
+## Program Principles
+
+1. **Correctness before scale.** Do not build a large process fleet around an oracle that can accept the wrong state.
+2. **One scenario meaning.** Human authoring compiles to one canonical Scenario IR consumed by every adapter.
+3. **Public boundary by default.** Normal conformance scenarios use public subject behavior. White-box fault injection is
+   explicit and separately classified.
+4. **Retained history, not healed packet loss.** Offline/reconnect scenarios query durable per-relay histories and
+   observe EOSE/backfill behavior.
+5. **Independent expected behavior.** Production selector/canonicalization code cannot be the only source of expected
+   outcomes.
+6. **Timers do not define truth.** Operational scheduling may affect latency and intermediate passes, but must not
+   silently change the correct final result after input closure.
+7. **Resource failure is explicit.** A budget or cap may fail closed, defer, or report an unresolved state; it must not
+   select from partial evidence.
+8. **Logical and byte replay are distinct.** Seeds reproduce logical actions and schedules. Captured wire artifacts
+   reproduce randomized MLS bytes.
+9. **Failures become assets.** Every useful failure is minimized, captured, classified, and considered for promotion
+   into the permanent regression corpus.
+10. **Privacy-safe evidence.** Committed fixtures are synthetic. Reports and telemetry follow the repository
+    observability rules and never emit identifiers, relay URLs, payloads, ciphertext, plaintext, or key material into
+    production tracing.
+
+## Milestone Summary
+
+| Milestone | Outcome | Status | Exit gate |
+| --- | --- | --- | --- |
+| 0. Assurance foundation | Guarantees, assumptions, constants, and formal gate are explicit | complete | Every constant is classified; formal warnings fail CI; protocol decisions are named |
+| 1. Trustworthy engine black box | Exact oracle, public subject boundary, full quiescence, replay capsules | not-started | Known semantic mutations fail and captured failures replay |
+| 2. Scenario IR and retained relays | One adapter-neutral DSL/IR plus realistic offline/history sync | not-started | One compiled case runs against reference, engine, and retained-relay adapters |
+| 3. Adversarial campaigns | Sustained real-world workloads, resource sweeps, incident import | not-started | Headline workload families produce bounded, diagnosable results |
+| 4. Independent verification | Reference model, liveness model, mutation adequacy, protocol decision gate | not-started | Model and tests detect seeded policy/lifecycle defects |
+| 5. App and process simulation | Real projections and lifecycle in one or many isolated runtimes | not-started | The same case agrees in-process and across N processes |
+| 6. Distributed campaigns | Container/VM/network/disk/version hardening and campaign operations | not-started | Repeatable soak and release campaigns retain actionable artifacts |
+
+## Milestone 0: Assurance Foundation
+
+### 0.1 Guarantee And Assumption Contract
+
+Status: `complete`
+
+The initial assurance matrix is below. “Required verification” names the minimum evidence before a claim can become
+`established`.
+
+| ID | Claim | Required assumptions | Required verification | Status |
+| --- | --- | --- | --- | --- |
+| S1 | Same retained anchor, authenticated input closure, policy version, and engine version produce the same canonical branch and exact state | Finite relevant input set; every compared client possesses the same validated dependency closure | Independent reference comparison; schedule/restart metamorphic tests; bounded model | specified |
+| S2 | Application output after settlement is exactly the payload/state-change projection of the selected branch | MLS and Marmot payload authentication succeeds; invalidations reach projection | Exact logical ledger; losing-branch and superseded-state scenarios; Tamarin output lemmas | partially-covered |
+| S3 | Missing retained state, invalid policy, corrupt frozen input, and exhausted replay budget never apply a partial candidate result | Storage reports failures accurately; fail-closed errors are durable or retryable by contract | Engine tests, crash matrix, resource campaigns, seeded mutations | partially-covered |
+| S4 | Publish-before-apply and convergence lifecycle changes are torn-write-free | Storage transaction contract holds; external publication results are accurately reported | Storage/engine lifecycle tests; kill/restart at each durable transition | partially-covered |
+| S5 | Operational scheduler timing does not change the eventual canonical result after authenticated input closure | All pending passes are eventually revisited; required retained state remains available | Virtual-time metamorphic tests across scheduler margin, retry, and re-arm values | unverified |
+| L1 | After relevant input closes and all required history is locally available, convergence reaches `Settled` or a named terminal failure | Client continues executing; resource policy admits the workload | Bounded state-machine liveness model; engine and retained-relay scenarios | unverified |
+| L2 | Outbound work blocked by convergence is eventually released, regenerated, or terminated with an explicit outcome | L1 assumptions; publication path eventually returns a result | Scheduler/outbound ledger assertions; crash/restart scenarios | partially-covered |
+| L3 | Marmot does not guarantee that a privileged administrative transition becomes canonical while valid selection-relevant input, including ordinary self-updates, continues without bound | The bounded post-settlement preparation opportunity remains enforced; stronger progress requires eventual relevant-input closure | Adversarial model and sustained simulator family; bounded preparation-opportunity tests | specified |
+| S6 | Clients are exactly equivalent only when the canonical conformance projection, including its domain-separated exporter commitment, matches | Synthetic/local conformance execution; raw exporter secret never leaves the test process | M1.1 exact snapshot comparison; mismatched-member, component, disposition, output, and commitment sentinels | specified |
+| R1 | Crash/reopen from any durable convergence phase is equivalent to uninterrupted execution | Database and required WAL/sidecars remain intact; no storage corruption unless scenario declares it | File-backed crash matrix and process-kill replay | partially-covered |
+| R2 | Clients with unequal relay histories converge after the histories reconcile | Relevant events remain retained and are eventually fetched; same policy/version | Retained multi-relay scenarios with EOSE, backfill, and set equality | unverified |
+| D1 | Every failure is attributable to a stable action, policy, state transition, or resource bound and can be replayed | Failure artifact completes successfully; sensitive evidence remains local | Failure-capsule self-replay and schema tests | unverified |
+
+#### Assurance verification ownership
+
+This table assigns every claim a current evidence owner and the work item that owns the remaining gap. A named existing
+test is evidence for only the behavior in its name; it does not establish the larger claim by itself.
+
+| ID | Normative/architecture source | Current evidence | Missing evidence owner |
+| --- | --- | --- | --- |
+| S1 | Protocol `convergence.md` branch selection; local canonicalization contract “Determinism and convergence” | Tamarin `same_input_set_converges`; `prop_candidate_graph_selection_is_order_invariant`; `prop_stored_convergence_restart_equivalence` | M1.1 exact-state oracle; M4.1 independent reference model; M4.2 arbitrary schedule/lifecycle model |
+| S2 | Protocol `convergence.md` “Applying the selected branch”; local canonicalization output contract | Tamarin application-output/invalidation lemmas; `engine_emits_only_canonical_branch_app_messages_after_convergence`; `rebuilt_engine_emits_losing_branch_app_invalidation_after_convergence` | M1.1 exact logical ledger and projection equivalence; M5.1 app projection adapter |
+| S3 | Protocol retained-anchor error rules; local canonicalization errors and fail-closed replay contract | Tamarin missing/beyond-anchor lemmas; `frozen_pass_member_tampering_fails_closed_to_unrecoverable`; `missing_frozen_pass_member_fails_closed_to_unrecoverable`; replay-budget unit tests | M3.1 end-to-end resource exhaustion; M4.3 mutations |
+| S4 | Protocol publish lifecycle and bounded-pass persistence; local multi-step-state-change rules | `convergence_pass_round_trips_updates_and_cascades`; `collecting_pass_restart_preserves_remaining_window_and_backward_clock_fails_closed`; `reopen_after_crash_during_publish_recovers_stranded_pending_commit`; crash-recovery SQLite tests | M3.1 complete durable-transition kill matrix; M5.1 runtime crash matrix |
+| S5 | Protocol bounded collection window; relay telemetry claim that quiescence is not a correctness boundary | `prop_quiescence_gate_controls_settlement`; cutoff and scheduler unit tests | M3.2 cross-value metamorphic campaign; M4.2 scheduler model |
+| L1 | Protocol pass freeze and completion rules; group convergence status | Individual settle/fail-closed integration tests | M4.2 TLA+/TLC liveness specification; M2.3 retained-relay scenarios |
+| L2 | Protocol outbound gating; local queued-intent lifecycle | Tamarin queued-outbound lemmas; `engine_queues_app_send_until_convergence_is_settled`; `trait_advance_convergence_drains_queued_outbound_intent`; scheduler tests | M1.3 complete quiescence; M3.1 crash/failure workload |
+| L3 | Protocol same-epoch priority and depth rules; no sustained-progress guarantee currently stated | `convergence_privileged_remove_beats_grinding_ordinary_self_update`; `continuous_inbound_cannot_starve_admin_attempt` | M3.1 sustained self-update family; M4.2 fairness model; protocol decision PDR-2 below |
+| S6 | Protocol `foundation/conformance.md`, adopted by [marmot#410](https://github.com/marmot-protocol/marmot/pull/410) | Domain separation and 33-byte commitment prefix checked in the protocol PR | M1.1 public snapshot API and exact-equivalence sentinels |
+| R1 | Protocol durable pass wall/monotonic deadline rules; local storage/restart contract | `collecting_pass_restart_preserves_remaining_window_and_backward_clock_fails_closed`; `h5_kill_before_historical_apply_commit_preserves_live_inputs`; `h6_kill_after_retained_anchor_rewind_recovers_live_snapshot` | M3.1 every-phase crash matrix; M5.3 process kill/reopen |
+| R2 | Relay telemetry EOSE/backfill/reconciliation architecture; protocol requires equalized relevant history for equivalent selection | `stalled_epoch_backfill_recovers_below_floor_backlog_when_armed`; `next_event_returns_when_a_live_delivery_arms_the_epoch_backfill` | M2.3 retained multi-relay model; M3.1 unequal-history family |
+| D1 | Local forensic audit/report contracts and privacy rules | Generated reports, oracle coverage, conservative minimizer, incident archetype synthesis | M1.4 failure capsule and self-replay; M3.3 exact incident import |
+
+Milestone 0 work:
+
+- [x] Record the initial assurance statement, assumptions, and claim matrix in this plan.
+- [x] Review each claim against the adopted protocol text and record missing implementation-neutral assumptions or
+  outcomes.
+- [x] Open protocol PR [marmot#410](https://github.com/marmot-protocol/marmot/pull/410) for the missing
+  implementation-neutral assumptions and outcomes recorded below.
+- [x] Assign each claim an owning Rust test, formal lemma/model property, and simulator family or future work item.
+- [x] Add an explicit claim for cryptographic state equivalence using the protocol PR's test-only exporter commitment.
+- [x] Resolve L3 as an explicit non-guarantee under unbounded valid input; retain the bounded preparation opportunity.
+Follow-on rule: a claim is marked `established` only after all required evidence is linked in the progress log.
+
+#### Protocol gaps and decision register
+
+The adopted convergence specification defines policy constants, candidate validity, pass collection/freeze, branch
+selection, dispositions, and retained-history behavior. The following broader assurance statements are not yet explicit
+protocol guarantees:
+
+| ID | Required decision or protocol clarification | Status | Blocking work |
+| --- | --- | --- | --- |
+| PDR-1 | State the input-closure and execution assumptions under which eventual convergence is promised: equivalent authenticated dependency closure, same policy/version, continued client execution, and retained state availability | adopted-protocol-pr-410 | S1, L1, R2 establishment |
+| PDR-2 | Decide whether privileged administrative progress is guaranteed during an unbounded stream of valid ordinary self-updates; if not, state the eventual-quiet limitation | adopted-no-guarantee-pr-410 | M3.1/M4.2 verify the bounded opportunity and characterize adversarial behavior |
+| PDR-3 | State the interoperable outcome when local resource policy drops, defers, or refuses otherwise valid input; distinguish fail-closed local availability from canonical branch selection | adopted-protocol-pr-410; MDK-aligned | M3.1 resource campaigns |
+| PDR-4 | Define the portable notion of exact cryptographic/application state equivalence without exposing secrets | adopted-protocol-pr-410 | M1.1 exporter commitment and cross-implementation vectors |
+| PDR-5 | Keep quiescence/pass cutoffs explicitly outside final-state correctness after input closure, or revise the guarantee if metamorphic tests find a counterexample | adopted-protocol-pr-410; evidence-required | S5 and P4/P5 verification |
+
+This MDK branch records and tests the implementation implications. The implementation-neutral wording is adopted in
+`marmot-protocol/marmot` through [marmot#410](https://github.com/marmot-protocol/marmot/pull/410).
+
+### 0.2 Convergence Constant Ledger
+
+Status: `complete`
+
+Categories:
+
+- `semantic`: changes the versioned branch-selection or eligibility result;
+- `security-retention`: trades delayed processing/recovery against secret or state retention;
+- `resource`: bounds CPU, memory, durable rows, or work per pass;
+- `scheduler`: controls when equivalent work is attempted;
+- `input-recovery`: controls when or how relay history is reacquired;
+- `sentinel`: implementation mechanics that must not affect externally visible behavior.
+
+“Final-state influence” records the intended contract, not a conclusion already proved.
+
+#### Versioned convergence policy
+
+| ID | Constant | Value | Category | Intended effect | Too low / too high | Final-state influence | Required evidence |
+| --- | --- | ---: | --- | --- | --- | --- | --- |
+| P1 | `V1_MAX_REWIND_COMMITS` | 5 commits | semantic, security-retention | Bounds eligible fork depth and retained anchors | Too low rejects recoverable late history; too high increases reorg, storage, replay, and secret-retention exposure | yes, by policy version | Eligibility boundaries, delayed-history sweep, retention/security review |
+| P2 | `V1_APP_MESSAGE_PAST_EPOCH_LIMIT` | 5 epochs | semantic, security-retention | Bounds delayed app delivery and witness eligibility | Too low expires realistic offline traffic; too high retains old message secrets and increases work | yes, by policy version | Multi-commit offline flood, exact app ledger, six-advance boundary |
+| P3 | `DEFAULT_MAX_PAST_EPOCHS` | 5 epochs | security-retention | Configures OpenMLS decryptable history; must equal P2 | Drift causes messages to be policy-eligible but cryptographically undecryptable, or retains unusable secrets | must be identical to P2 | Pin/alignment tests and delayed decryption sweep |
+| P4 | `V1_SETTLEMENT_QUIESCENCE_MS` | 1,000 ms | semantic scheduling policy | Closes a live-input window after delivery jitter | Too low raises post-settle reorgs; too high stalls outbound work | intended no after input closure; may change intermediate passes | Virtual-time sweep, post-settle reorg metrics, retained-relay spread |
+| P5 | `V1_MAX_CONVERGENCE_PASS_MS` | 5,000 ms | semantic scheduling policy | Guarantees a collecting pass freezes under sustained relevant input | Too low fragments ordinary bursts; too high lets a flood hold the group collecting | intended no after all follow-up passes; may change pass membership | Sustained-flood test, cutoff restart matrix, eventual fixed-point comparison |
+| P6 | `V1_WITNESS_QUORUM_SENDERS_PER_EPOCH` | 2 senders | semantic | Defines per-epoch corroboration | Too low lets one identity dominate; too high makes evidence unavailable in small/offline groups | yes, by policy version | Group-size/device-topology sweep and Sybil/account dedupe model |
+| P7 | `V1_WITNESS_QUORUM_EPOCHS` | 1 epoch | semantic | Defines how many branch epochs require quorum | Too low gives brief activity more weight; too high suppresses witnesses on short branches | yes, by policy version | Branch-length and traffic-duration sweep |
+| P8 | `V1_MAX_WITNESS_OVERRIDE_DEPTH` | 1 commit | semantic | Caps witness-derived effective-depth boost | Too low makes witnesses irrelevant; too high lets traffic outrank much longer commit history | yes, by policy version | Bound proof, depth-difference matrix, adversarial witness flood |
+
+#### Engine resource and retry bounds
+
+| ID | Constant | Value | Category | Intended effect | Failure behavior to verify | Final-state influence | Required evidence |
+| --- | --- | ---: | --- | --- | --- | --- | --- |
+| E1 | `MAX_CONVERGENCE_REPROCESSING_PASSES` | 16 passes | resource | Bounds recursive/in-call drain work | Remaining work stays durable/retryable and no partial result is called settled | intended no | End-to-end exhaustion and later-progress test |
+| E2 | `MAX_DEFERRED_PEEL_ATTEMPTS` | 32 changed contexts | resource | Releases repeatedly undecryptable retained rows as `resource_refused_retry_budget` | Same transport id remains refetch-eligible; the limit makes no validity or permanent-unreadability claim | may affect locally available input until refetch | Changed-context exhaustion, exact-ID redelivery, and missing-commit recovery |
+| E3 | `MAX_PEEL_DEFERRED_ROWS_PER_GROUP` | 256 rows | resource | Bounds attacker-mintable undecryptable durable backlog | Over-cap input returns typed `ResourceRefused`, remains exact-ID eligible, and immediately arms history backfill | may affect locally available input until refetch | Flood, bounded-storage assertion, exact-ID recovery after drain, app backfill signal |
+| E4 | `MAX_DEFERRED_ROWS_PER_SWEEP` | 64 rows | resource, scheduler | Prevents old deferred history monopolizing a pass | Fair cursor progress eventually visits every row | intended no | Backlog fairness and restart tests |
+| E5 | `CANDIDATE_REPLAY_BUDGET_SLACK` | 4× | resource | Scales replay budget over linear commit/rewind estimate | `ReplayBudgetExceeded` fails closed without partial selection | intended no | Branch-explosion campaign and recovery policy test |
+| E6 | `CANDIDATE_REPLAY_BUDGET_FLOOR` | 32 probes | resource | Gives small passes minimum replay headroom | Same as E5 | intended no | Small/large boundary matrix |
+| E7 | self-remove auto-commit jitter | 10 ms + [0, 40) ms | scheduler | Reduces synchronized automatic self-remove commits | Jitter changes ordering only, not admissible final behavior after closure | intended no | Seeded schedule invariance and collision tests |
+
+#### App scheduler and input-recovery bounds
+
+| ID | Constant | Value | Category | Intended effect | Failure behavior to verify | Final-state influence | Required evidence |
+| --- | --- | ---: | --- | --- | --- | --- | --- |
+| A1 | `CONVERGENCE_SETTLEMENT_SCHEDULE_MARGIN_MS` | 100 ms | scheduler | Avoids firing just before an engine cutoff | Early/late wake affects latency only | intended no | Paused-time boundary tests |
+| A2 | `MIN_CONVERGENCE_SETTLEMENT_DELAY` | 10 ms | scheduler | Prevents zero-delay spin | Work remains scheduled | intended no | Timer-spin and progress tests |
+| A3 | convergence retry base/max | 1 s / 60 s | scheduler | Bounds exponential retry wakeups | Persistent error stays visible and periodically retried | intended no | Backoff sequence and eventual recovery |
+| A4 | `CONVERGENCE_UNSETTLED_MAX_REARMS` | 10 rearms | scheduler, resource | Moves persistently unopenable work to error-style backoff | Does not strand a healthy collecting pass or pending outbound work | intended no | Pending-unopenable and recovery tests |
+| A5 | `IDLE_CONVERGENCE_TIMER_DELAY` | 365 days | sentinel | Parks an empty timer | Earliest real deadline always replaces sentinel | none | Scheduler unit test |
+| A6 | `EPOCH_STALL_BACKFILL_THRESHOLD` | 8 distinct messages | input-recovery | Detects likely missed commits from undecryptable traffic | Too low causes redundant history reads; too high delays repair | can affect time/input equality, not branch choice given equality | Multi-cohort replay, relay scenario sweep, production evidence |
+| A7 | `APP_RUNTIME_RELAY_REBUILD_LOOKBACK` | 120 s | input-recovery | Rewinds relay query floor during runtime rebuild | Too low misses delayed events; too high increases replay volume | can affect acquired input set | Since-floor and long-offline retained-history tests |
+| A8 | `TRANSPORT_CURSOR_MAX_FUTURE_SKEW` | 5 min | input-recovery | Prevents sender timestamps from moving the cursor arbitrarily forward | Clamp must preserve benign skew without suppressing history | can affect acquired input set | Malicious timestamp, clock-skew, and cursor-reset tests |
+
+#### Constant verification ownership
+
+The completeness scope is constants that directly affect convergence policy, retained convergence input, convergence
+engine work bounds, dedicated convergence scheduling, or dedicated history reacquisition. Generic HTTP, relay SDK,
+account-open, and UI timeouts remain owned by their subsystem runtime policy and are not convergence constants merely
+because they can delay a process.
+
+The machine-readable
+[`convergence-constant-inventory.txt`](./convergence-constant-inventory.txt) maps every ledger ID to its current Rust
+declaration. `just convergence-ledger-gate` verifies those declarations, requires every P/E/A ID below, and scans the
+named source families for newly introduced constants that have not been reviewed into this ledger.
+
+| IDs | Current source/test owner | Remaining verification owner |
+| --- | --- | --- |
+| P1 | `convergence.rs`; Tamarin anchor/stale lemmas; `engine_replays_late_same_epoch_commit_from_retained_anchor`; `engine_prunes_retained_anchor_snapshots_to_rewind_horizon` | M3.1 delayed-history depth sweep; M4.1 reference model |
+| P2, P3 | `canonicalization.rs` and `wire_format.rs`; `app_message_window_must_match_engine_max_past_epochs`; `app_message_expired_is_relative_to_the_passed_reference_tip`; `send_preflight_terminally_retires_deferred_app_message_outside_past_epoch_window` | M3.1 multi-commit offline flood; M1.1 exact message ledger |
+| P4 | `canonicalization.rs`; `prop_quiescence_gate_controls_settlement`; `engine_duplicate_convergence_input_does_not_reset_quiescence`; `app_witness_beside_competing_commits_resets_convergence_quiescence` | M3.2 quiescence sweep; relay-spread/reorg telemetry |
+| P5 | `canonicalization.rs`; `convergence_pass_freezes_at_absolute_cap_under_continuous_selection_input`; `input_at_effective_cutoff_is_retained_for_the_next_generation`; collecting-pass restart test | M3.1 sustained flood; M3.2 eventual fixed-point comparison |
+| P6, P7, P8 | `convergence.rs`; generated policy cases; Tamarin score/bound lemmas; multi-device witness-deduplication replay probe | M3.1 group-size/device/Sybil sweeps; M4.1 independent reference |
+| E1 | `message_processor/mod.rs`; existing multi-pass integration flows | M3.1 force exhaustion, verify durable continuation and no partial settle |
+| E2, E3, E4 | `message_processor/mod.rs`; `deferred_peel_retry_budget_refuses_without_terminal_dedup`; `peel_deferred_rows_capped_per_group_under_flood`; `resource_refusal_signals_immediately_once_per_epoch`; deferred retry/context tests | M3.1 fairness/restart/redelivery campaign |
+| E5, E6 | `openmls_projection.rs`; `for_pass_scales_with_commits_and_rewind_and_keeps_a_floor`; `for_pass_saturates_instead_of_overflowing`; `consume_fails_closed_when_exhausted` | M3.1 branch-explosion end-to-end recovery; M4.3 mutation |
+| E7 | `message_processor/mod.rs`; `reopen_preserves_deferred_selfremove_auto_commit` | M3.1 deterministic jitter/collision schedules |
+| A1, A2, A4, A5 | `account_worker.rs`; clamp, re-arm, collecting, pending-outbound, cutoff-order, and backoff scheduler tests | M3.2 virtual-time scheduler invariance; M4.2 lifecycle model |
+| A3 | `account_worker.rs`; `retry_delay_for_attempt_backs_off_and_caps` | M3.1 persistent-error recovery and visibility |
+| A6 | `epoch_stall.rs`; threshold/debounce/reset tests; next-event and audit backfill tests | M3.1 retained-relay threshold sweep; additional production cohorts |
+| A7 | `marmot-app/lib.rs`; `cold_restart_since_floor_permanently_drops_backlog_below_it`; `stalled_epoch_backfill_recovers_below_floor_backlog_when_armed` | M2.3 long-offline retained-relay matrix |
+| A8 | `marmot-app/lib.rs`; since-floor malicious/future timestamp coverage | M3.1 explicit skew/cursor-reset Scenario IR family |
+
+Ledger work:
+
+- [x] Record the first code-backed classification of versioned policy, engine bounds, scheduler bounds, and
+  input-recovery heuristics.
+- [x] Mechanically audit convergence engine, storage, app scheduler, and relay-sync paths for missing constants within
+  the completeness scope above.
+- [x] Add a test or generated inventory that detects unreviewed convergence constants where practical.
+- [x] Assign every ledger row at least one named scenario/test and one current or future owner.
+Follow-on work in Milestones 3 and 4 verifies the “final-state influence” assertion for every non-semantic constant
+through metamorphic testing and records the production telemetry needed to justify future policy revisions.
+
+### 0.3 Formal Verification Gate
+
+Status: `complete`
+
+- [x] Identify that the noninteractive Make target runs `--prove` without `--quit-on-warning`.
+- [x] Make noninteractive proof runs fail on warnings and use an explicit derivation-check timeout.
+- [x] Document the strict command and override mechanism.
+- [x] Run the complete model and save the summary in the progress log.
+- [x] Add `SameInputSet` and same-policy premises to convergence lemmas where the model currently relies on
+  closed-world initializer construction.
+- [x] Classify each Tamarin lemma as safety, executability, lifecycle, delivery, or bounded-case coverage.
+- [x] Select a separate bounded state-machine tool for clock, restart, fairness, resource, and liveness properties.
+
+#### State-machine model decision
+
+TLA+/TLC is the primary independent model for Milestone 4.2:
+
+- TLA+ expresses the state machine separately from Rust production code, reducing shared-assumption risk.
+- TLC directly checks temporal liveness properties and weak/strong fairness assumptions and produces counterexample
+  behaviors.
+- The first model remains deliberately small: bounded clients, branches, messages, pass generations, crashes, and
+  resources.
+
+Stateright remains a later implementation-bridge option because it can model Rust actor systems and produce executable
+paths, but it is not the primary independent oracle. Apalache may be added if bounded safety checks encounter TLC state
+explosion; it is not required for the first liveness model.
+
+Primary references:
+
+- [TLA+ tools](https://lamport.org/tla/tools.html)
+- [TLC current tool behavior](https://github.com/tlaplus/tlaplus/blob/master/general/docs/current-tools.md)
+- [Stateright model checker](https://docs.rs/stateright/latest/stateright/)
+
+### Milestone 0 Exit Gate
+
+- [x] Every convergence-affecting constant in the declared Milestone 0 scope is in the ledger, classified, and guarded.
+- [x] Every assurance claim names its assumptions, observable outcome, and verification owner.
+- [x] The canonical protocol states the required liveness/fairness assumptions
+  ([marmot#410](https://github.com/marmot-protocol/marmot/pull/410)).
+- [x] `just tamarin` fails on warnings/timeouts and passes the current complete proof.
+- [x] No known resource or scheduler bound can silently select from partial evidence.
+- [x] The self-update administrative-progress decision is resolved as an explicit non-guarantee under unbounded valid
+  input.
+
+The implementation exits now fail visibly. E1 returns unsettled after its in-call pass limit, and E5/E6 return
+`ReplayBudgetExceeded` rather than selecting a partial candidate graph. E2 releases a retry-budget-exhausted transport
+row without terminal deduplication, while E3 returns typed `ResourceRefused`; exact-ID regression coverage proves both
+remain eligible, and the app runtime immediately arms history backfill for resource refusal. The normative availability
+and liveness wording is adopted through
+[marmot#410](https://github.com/marmot-protocol/marmot/pull/410). With that dependency merged, Milestone 0 is complete;
+the exact state/message oracle is the first Milestone 1 slice.
+
+Milestone 0 verification:
+
+```sh
+rg -n \
+  "TODO|TBD|open question|future SQLite|production storage|retry-deferred|AlreadyAtEpoch.*Peel" \
+  docs \
+  --glob '!AGENTS.md' \
+  --glob '!docs/marmot-architecture/convergence-reliability-plan.md'
+
+cargo test -p cgka-engine --test convergence_policy_pin
+cargo test -p cgka-engine --features test-policy-overrides --test distributed_convergence
+just convergence-ledger-gate
+just tamarin
+just fast-ci
+git diff --check
+```
+
+## Milestone 1: Trustworthy Engine Black Box
+
+### 1.1 Exact state and logical-message oracle
+
+- [ ] Add exact sorted member identities to portable observations.
+- [ ] Include epoch, selected branch, admin policy, application profile, required capabilities, and group state.
+- [ ] Record a logical message ledger: sent, accepted, delivered, deduplicated, expired, invalidated, and pending.
+- [ ] Add a test-only privacy-safe cryptographic state commitment based on MLS exporter state.
+- [ ] Prove bidirectional decryptability after apparent convergence.
+- [ ] Add `ClientsExactlyEquivalent`, `LogicalMessageLedger`, and `NoPendingWork` expectations.
+- [ ] Make strict oracle behavior the default for reliability campaigns.
+
+Verification:
+
+- same member count but different member identities fails;
+- same public metadata but different exporter commitment fails;
+- duplicate delivery appears once in the logical ledger;
+- losing-branch payload/state output is absent or explicitly invalidated.
+
+### 1.2 Public subject boundary
+
+- [ ] Define a simulator-owned `ConvergenceSubject` interface using public engine behavior.
+- [ ] Implement create/mutate, ingest, virtual-time advance, public event/outbound polling, crash/reopen, and sanitized
+  observation.
+- [ ] Split normal black-box execution from explicitly named white-box storage/fault capabilities.
+- [ ] Reject scenarios that require unsupported subject capabilities before execution.
+
+### 1.3 Full-system quiescence
+
+- [ ] Include deliverable input, inbox, delayed messages, pass phase, deferred replay, outbound publication, retry
+  timers, and durable transitions in a progress snapshot.
+- [ ] Require two stable virtual-time observations with no state or ledger progress.
+- [ ] Report which subsystem prevents quiescence.
+- [ ] Bound quiescence waiting by scenario policy and emit a terminal timeout artifact.
+
+### 1.4 Deterministic failure capsules
+
+- [ ] Define a versioned capsule schema.
+- [ ] Save original scenario, canonical IR, seeds, expanded schedule, policy/constant snapshot, adapter/binary versions,
+  captured wire bytes, virtual time, logical ledger, state commitments, and resource measurements.
+- [ ] Replay a capsule without regenerating MLS bytes.
+- [ ] Keep real incident artifacts local and restrictive-by-construction.
+- [ ] Promote minimized synthetic failures into portable vectors when they define durable behavior.
+
+### Milestone 1 Exit Gate
+
+- [ ] A wrong exact state cannot pass as converged.
+- [ ] A normal scenario cannot access engine/storage internals.
+- [ ] Hidden pending work prevents quiescence.
+- [ ] A captured byte-level failure replays with the same outcome.
+- [ ] Targeted semantic mutations are detected.
+
+## Milestone 2: Scenario IR And Retained Relays
+
+### 2.1 Scenario IR v2 and authoring DSL
+
+- [ ] Define adapter-neutral, versioned JSON IR and JSON Schema.
+- [ ] Add human YAML authoring that compiles to canonical JSON; execute only canonical JSON.
+- [ ] Model accounts, devices, processes, roles, groups, relays, and policy/binary versions explicitly.
+- [ ] Add `repeat`, `parallel`, `rate`, `burst`, barriers, and virtual time.
+- [ ] Add create, invite, remove, leave, self-update, group/admin state update, and application send.
+- [ ] Add offline/reconnect, delay, duplicate, omit, withhold/release, crash/restart, and declared storage faults.
+- [ ] Replace queue indices with semantic action/message selectors.
+- [ ] Add `exactly`, `eventually`, `within`, `never`, and resource assertions.
+- [ ] Compile `ScenarioSpec` v1 into v2 so existing vectors retain meaning.
+
+### 2.2 Adapter contract
+
+- [ ] Define capability discovery and compile-time rejection for unsupported operations.
+- [ ] Produce stable action ids and a deterministic expanded schedule.
+- [ ] Implement initial reference-model and engine adapters.
+- [ ] Require all adapters to emit the same observation/capsule schema.
+
+### 2.3 Retained multi-relay model
+
+- [ ] Maintain a durable event history per relay.
+- [ ] Model publish fanout, subscriptions, query filters, EOSE, reconnect, since floors, and full backfill.
+- [ ] Model relay-specific duplicate/order/visibility/omission behavior.
+- [ ] Model unequal client relay sets and later history reconciliation.
+- [ ] Keep the existing in-memory packet bus as a fast unit-test adapter, not offline-sync evidence.
+
+### Milestone 2 Exit Gate
+
+- [ ] One compiled scenario runs unchanged against the reference, engine, and retained-relay adapters.
+- [ ] Offline participants recover from relay history rather than healed packet loss.
+- [ ] Relay disagreement followed by equalized history reaches exact state equivalence.
+- [ ] Unsupported adapter behavior fails before a partial run.
+
+## Milestone 3: Adversarial Workload Campaigns
+
+### 3.1 Required workload families
+
+- [ ] Offline retained-history flood with application traffic spanning many membership/state commits.
+- [ ] Sustained application traffic interspersed with proposals and commits.
+- [ ] Sequential self-update adversary racing privileged administrative changes.
+- [ ] Unequal relay histories followed by reconciliation.
+- [ ] Crash/restart at every durable convergence transition.
+- [ ] Multi-group noisy-neighbor and per-group fairness.
+- [ ] Candidate graph/replay budget/resource exhaustion.
+- [ ] Multi-device account identity and witness deduplication.
+- [ ] Mixed binary and policy versions.
+- [ ] Clock movement, scheduler delay, and timestamp/cursor attacks.
+
+Each family varies schedule, storage mode, participant count, rates, restart placement, relay topology, and applicable
+test-only constants while preserving a stable semantic oracle.
+
+### 3.2 Resource and sensitivity measurements
+
+- [ ] Record convergence latency and blocked-send duration.
+- [ ] Record pass count, reorg count/depth/lateness, and unresolved outcomes.
+- [ ] Record logical delivery/expiry/invalidation results.
+- [ ] Record CPU time, peak memory, database size/writes, queue depth, and replay probes.
+- [ ] Sweep constants around the pinned value in explicit test-policy builds.
+- [ ] Produce curves and boundary failures; never auto-tune production policy from simulator output.
+
+### 3.3 Incident replay
+
+- [ ] Preserve normalized archetype synthesis for incomplete forensic evidence.
+- [ ] Add exact-history IR import when evidence is sufficient.
+- [ ] Carry evidence confidence and unavailable fields into the scenario artifact.
+- [ ] Keep sensitive exports and generated exact capsules out of version control.
+
+### Milestone 3 Exit Gate
+
+- [ ] The three headline workloads run both as small regressions and sustained campaigns.
+- [ ] Every resource exhaustion reaches a named fail-closed or retryable outcome.
+- [ ] Campaign reports identify the first failing action and limiting resource.
+- [ ] Selected incident histories reproduce or clearly state why exact replay is impossible.
+
+## Milestone 4: Independent Verification And Adequacy
+
+### 4.1 Independent reference model
+
+- [ ] Implement symbolic authenticated candidates, authorization, dependency closure, witness scoring, selection, and
+  dispositions without calling production selector/canonicalization code.
+- [ ] Differentially compare reference model, production selector, and full engine.
+- [ ] Keep model inputs small and shrinkable.
+
+### 4.2 Liveness and lifecycle model
+
+- [ ] Prototype the self-update/admin-progress case in TLA+/TLC and Stateright, then record the tool decision.
+- [ ] Model unequal histories, eventual input closure, pass freeze/settle, crash/restart, fairness, and resource failure.
+- [ ] Produce minimal counterexample traces consumable by Scenario IR where practical.
+- [ ] Keep Tamarin focused on symbolic safety/security and executable bounded policy cases.
+
+### 4.3 Mutation adequacy
+
+- [ ] Mutate selector comparison order.
+- [ ] Mutate witness sender/epoch deduplication.
+- [ ] Mutate cutoff admission and frozen-member persistence.
+- [ ] Mutate scheduler deadlines and re-arm classification.
+- [ ] Mutate output invalidation and publication acknowledgement.
+- [ ] Mutate retained-history and expiration boundaries.
+- [ ] Maintain a matrix showing which verification layer kills each mutation.
+
+### 4.4 Protocol decision gate
+
+- [ ] Prove bounded administrative progress under stated assumptions, add explicit fairness/admission policy, or
+  document the non-guarantee.
+- [ ] Confirm which constants are truly semantic and version them through protocol capabilities.
+- [ ] Confirm scheduler/resource constants cannot silently change a settled result after input closure.
+
+### Milestone 4 Exit Gate
+
+- [ ] The independent model and production engine agree over the bounded corpus.
+- [ ] Every targeted semantic mutation is killed or becomes a tracked verification gap.
+- [ ] Liveness counterexamples name the violated assumption.
+- [ ] The self-update/adversarial-progress decision is part of the protocol contract.
+
+## Milestone 5: Application And Multi-Process Simulation
+
+### 5.1 `MarmotAppRuntime` adapter
+
+- [ ] Give every participant a unique restrictive root and SQLCipher database.
+- [ ] Drive only public app-runtime operations.
+- [ ] Exercise real account/device lifecycle, projections, outbound publication, relay sync/backfill, and retries.
+- [ ] Compare engine state commitments and user-visible chat/member/admin/message projections.
+- [ ] Crash/reopen the complete runtime.
+
+### 5.2 Simulator node process
+
+- [ ] Add a small test binary wrapping `MarmotAppRuntime`.
+- [ ] Define a versioned JSONL control and observation protocol.
+- [ ] Keep engine/storage internals unavailable through the process protocol.
+- [ ] Emit privacy-safe structured diagnostics and failure capsules.
+
+### 5.3 Process orchestrator
+
+- [ ] Allocate one isolated root per participant.
+- [ ] Launch and barrier N participant processes.
+- [ ] Kill, pause, resume, and restart individual participants.
+- [ ] Connect all participants to controlled local relay topologies.
+- [ ] Preserve the canonical Scenario IR action schedule and observation schema.
+
+### Milestone 5 Exit Gate
+
+- [ ] The same scenario reaches equivalent results through engine, app-runtime, and process adapters.
+- [ ] Application projections contain no losing/superseded output after settlement.
+- [ ] Process kill/restart agrees with uninterrupted execution.
+- [ ] Failure capsules identify participant, action, layer, and replay instructions without sensitive production logs.
+
+## Milestone 6: Distributed Campaigns And Operations
+
+### 6.1 Container and VM execution
+
+- [ ] Add containers before VMs.
+- [ ] Add network partition, latency, bandwidth, and loss controls.
+- [ ] Add relay and participant host restarts.
+- [ ] Add slow/full disk and database contention.
+- [ ] Add mixed-build rolling upgrades.
+- [ ] Use VMs only for kernel, filesystem, network, or host-isolation behavior containers cannot represent.
+
+### 6.2 Execution lanes
+
+- [ ] PR lane: strict formal gate, fixed vectors, small engine/reference/relay cases.
+- [ ] Nightly lane: seed matrices, file-backed storage, crash matrix, retained relays, mutation subset.
+- [ ] Weekly/manual lane: process/container soak, resource and constant sweeps.
+- [ ] Release-hardening lane: mixed-version and incident-derived corpus.
+- [ ] Define wall-clock, CPU, memory, disk, artifact-retention, and flake budgets for every lane.
+
+### 6.3 Failure corpus lifecycle
+
+- [ ] Automatically save failing seeds/capsules.
+- [ ] Minimize semantically, not only by generic step removal.
+- [ ] Classify product defect, protocol ambiguity, environment failure, or expected resource refusal.
+- [ ] Promote stable synthetic regressions into vectors.
+- [ ] Track recurrence and time-to-diagnosis.
+
+### Milestone 6 Exit Gate
+
+- [ ] Campaigns are repeatable from saved configuration and artifact manifests.
+- [ ] A failing process/container run can be reduced into a smaller adapter when the defect is not layer-specific.
+- [ ] Resource and flake budgets prevent silent campaign degradation.
+- [ ] Release hardening produces a reviewed convergence evidence bundle.
+
+## Cross-Milestone Verification Matrix
+
+| Verification layer | Primary purpose | PR | Nightly | Weekly/manual |
+| --- | --- | --- | --- | --- |
+| Engine unit/integration | Local state, persistence, fail-closed outcomes | yes | yes | yes |
+| Portable vectors | Cross-implementation semantic contracts | yes | yes | yes |
+| Property/metamorphic tests | Schedule, restart, and constant invariance | bounded | expanded | expanded |
+| Independent reference model | Detect shared implementation assumptions | bounded | expanded | expanded |
+| Tamarin | Symbolic safety/security and bounded executable cases | yes | yes | yes |
+| State-machine model | Liveness, fairness, clock, crash, resource counterexamples | bounded | expanded | on protocol changes |
+| Retained-relay simulator | Input-set equality, offline sync, EOSE/backfill | smoke | expanded | sustained |
+| App-runtime adapter | Projections and orchestration | smoke after M5 | expanded | sustained |
+| Multi-process/container | OS/runtime/network failures | no by default | selected | sustained |
+| Mutation campaign | Test adequacy | small sentinel set | targeted set | full targeted set |
+
+## Standard Scenario Artifact
+
+Every adapter eventually emits the same logical envelope:
+
+```text
+scenario source
+canonical Scenario IR
+expanded action schedule
+adapter capabilities and versions
+policy and constant snapshot
+captured transport artifacts
+virtual and wall-clock timeline
+logical input/output/disposition ledger
+exact state commitments
+resource observations
+assertion failures
+quiescence or terminal-state explanation
+minimized reproducer
+```
+
+The artifact schema must distinguish synthetic shareable data from sensitive incident evidence. Local sensitive
+artifacts use restrictive creation helpers and are never committed.
+
+## Immediate Implementation Sequence
+
+The first implementation series is deliberately ordered:
+
+1. strict Tamarin warning/derivation gate;
+2. assurance contract and constant-ledger review against the canonical protocol;
+3. exact state/message oracle;
+4. public subject boundary and complete quiescence;
+5. failure capsule;
+6. Scenario IR v2;
+7. retained multi-relay model;
+8. required workload families;
+9. independent/liveness models and mutation campaign;
+10. app-runtime, process, and distributed adapters.
+
+Large-scale process or VM work does not begin before Milestone 1 establishes that the simulator can recognize an
+incorrect result.
+
+## Progress Log
+
+| Date | Work item | Result | Evidence |
+| --- | --- | --- | --- |
+| 2026-07-30 | 0.1 initial assurance contract | Recorded target statement, assumptions, and first safety/liveness/restart/diagnostic claims | This document |
+| 2026-07-30 | 0.2 initial constant ledger | Classified current versioned policy, engine resource bounds, app scheduler values, and input-recovery heuristics | This document and linked source constants |
+| 2026-07-30 | 0.3 strict formal gate | Added `--quit-on-warning` and a configurable 60-second derivation-check timeout; the strengthened full model passed with all 76 lemmas verified in 45.17 seconds | `just tamarin` |
+| 2026-07-30 | Milestone 0 baseline verification | Default policy pin passed 5 tests; distributed convergence passed 75 tests with explicit test-policy overrides; formatting, diff whitespace, and 48 local documentation links passed | Commands in “Milestone 0 verification” plus local link check |
+| 2026-07-30 | 0.1 assurance evidence ownership | Mapped every assurance claim to protocol/architecture text, current named evidence, and its remaining milestone owner; recorded five protocol decisions/gaps | Assurance verification ownership and protocol decision register |
+| 2026-07-30 | 0.2 constant audit ownership | Completed the scoped code audit and mapped every ledger row to named current tests plus remaining campaign/model ownership | Constant verification ownership |
+| 2026-07-30 | 0.3 proof scope and model decision | Added explicit input-set/run-policy premises to agreement lemmas, classified all 76 lemmas, and selected TLA+/TLC as the independent liveness/fairness model | Tamarin model/README and state-machine decision |
+| 2026-07-30 | 0.2 constant ledger drift gate | Added a 23-ID/25-declaration inventory and a fast-CI source audit for newly unreviewed convergence constants | `just convergence-ledger-gate` |
+| 2026-07-30 | 0.1 protocol assurance contract | Merged the protocol contract defining conditional liveness, pass-partition invariance, the unbounded-self-update non-guarantee, exact conformance state, and transport-deferred/resource-refused availability | [marmot#410](https://github.com/marmot-protocol/marmot/pull/410), merge `4ad4ae2` |
+| 2026-07-30 | 0.1 typed deferred/resource outcomes | Replaced ambiguous `Stale(PeelFailed)` results with typed transport availability, protocol rejection, and stale-disposition categories; retry-budget release no longer terminally deduplicates exact-ID redelivery | `cargo test -p cgka-engine --features test-policy-overrides --test deferred_peel_lifecycle`; `--test ingest`; `--test fork_detection` |
+| 2026-07-30 | 0.1 resource-refusal recovery signal | Resource refusal immediately arms one account-wide history backfill per group epoch; ordinary transport deferral retains the existing evidence threshold | `cargo test -p marmot-app client::epoch_stall --lib` |
+| 2026-07-30 | Milestone 0 completion verification | Rebased onto MDK `master` at `1b949655`; fast CI, the full feature-enabled engine suite, full simulator suite, session suite, focused app deferral/backfill coverage, and all 76 strict Tamarin lemmas passed | `just fast-ci`; `cargo test -p cgka-engine --features test-policy-overrides`; `cargo test -p cgka-conformance-simulator`; `cargo test -p cgka-session --features test-policy-overrides`; focused `marmot-app` tests; `just tamarin` |

--- a/docs/marmot-architecture/index.md
+++ b/docs/marmot-architecture/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Marmot Architecture — Index"
 created: 2026-04-15
-updated: 2026-07-04
+updated: 2026-07-30
 tags: [marmot, architecture, index]
 ---
 
@@ -69,6 +69,10 @@ Written to be readable in 5 minutes each, shareable as a package.
   - **What it covers:** Near-term engine quality target: whitenoise-rs integration, chaos coverage, scenario vectors,
     and byte-level vectors.
 
+- **Doc:** [`convergence-reliability-plan.md`](./convergence-reliability-plan.md)
+  - **What it covers:** Tracked assurance, constant review, simulator architecture, verification gates, workload
+    campaigns, and the path from an engine black box to app/process/container simulation.
+
 - **Doc:** [`overview/whitenoise-integration-map.md`](./overview/whitenoise-integration-map.md)
   - **What it covers:** First shim map from whitenoise-rs account/relay flows to the current engine/session/account
     boundary.
@@ -109,6 +113,10 @@ These are longer working documents. Go here when you need depth, not orientation
 - **Doc:** [`cgka-engine-canonicalization-contract.md`](./cgka-engine-canonicalization-contract.md)
   - **What it covers:** Draft CGKA engine canonicalization contract: post-peeling inputs, candidate-state graph, sync
     state, outputs, storage, conformance scenarios.
+
+- **Doc:** [`convergence-reliability-plan.md`](./convergence-reliability-plan.md)
+  - **What it covers:** Working program tracker for convergence assurance claims, constants, simulator milestones,
+    verification ownership, and campaign exit gates.
 
 - **Doc:** [`distributed-convergence.md`](./distributed-convergence.md)
   - **What it covers:** Draft convergence model for selecting one MLS branch from unordered multi-relay input.

--- a/docs/marmot-architecture/overview/cgka-engine-quality-and-vectors.md
+++ b/docs/marmot-architecture/overview/cgka-engine-quality-and-vectors.md
@@ -1,7 +1,7 @@
 ---
 title: "CGKA Engine Quality And Vectors"
 created: 2026-05-11
-updated: 2026-05-13
+updated: 2026-07-30
 tags: [marmot, overview, cgka, conformance, vectors]
 status: working-note
 ---
@@ -50,6 +50,11 @@ The current test stack has useful coverage at several levels:
 - Tamarin models for distributed convergence.
 
 The remaining gap is a broader byte-level vector story for encodings and transport shapes.
+
+The larger assurance and simulation program is tracked in
+[`../convergence-reliability-plan.md`](../convergence-reliability-plan.md). That plan owns the exact-state oracle,
+constant ledger, retained-relay model, sustained workload campaigns, independent verification, and progression from
+the engine harness to app-runtime and multi-process simulation.
 
 ## Scenario Vectors
 

--- a/formal/tamarin/Makefile
+++ b/formal/tamarin/Makefile
@@ -1,11 +1,13 @@
 TAMARIN ?= tamarin-prover
+DERIVCHECK_TIMEOUT ?= 60
 MODEL := distributed_convergence_v0.spthy
 
 .PHONY: prove interactive
 
 prove:
 	@tmp=$$(mktemp); \
-	$(TAMARIN) $(MODEL) --prove > "$$tmp" 2>&1; \
+	$(TAMARIN) $(MODEL) --prove --quit-on-warning \
+		--derivcheck-timeout=$(DERIVCHECK_TIMEOUT) > "$$tmp" 2>&1; \
 	status=$$?; \
 	if [ $$status -ne 0 ]; then \
 		cat "$$tmp"; \

--- a/formal/tamarin/README.md
+++ b/formal/tamarin/README.md
@@ -35,8 +35,9 @@ read that file.
 
 ## Targets
 
-- `just tamarin` runs Tamarin on the model and requires `tamarin-prover` on `PATH`. Successful runs print only Tamarin's
-  `summary of summaries`; failing runs print the full prover output.
+- `just tamarin` runs Tamarin on the model with `--quit-on-warning` and an explicit 60-second derivation-check timeout,
+  and requires `tamarin-prover` on `PATH`. Successful runs print only Tamarin's `summary of summaries`; prover errors,
+  warnings, derivation-check timeouts, or a missing summary print the full output and fail the target.
 - `just tamarin-interactive` opens the model in Tamarin's interactive UI and requires `tamarin-prover` on `PATH`.
 - `just policy-casegen` emits Tamarin seed rules and executable lemmas from `policy_cases.json`.
 
@@ -46,6 +47,12 @@ Install Tamarin separately, then run:
 
 ```sh
 just tamarin
+```
+
+To raise the derivation-check timeout on a slower machine without weakening the warning gate:
+
+```sh
+make -C formal/tamarin prove DERIVCHECK_TIMEOUT=120
 ```
 
 To inspect generated policy-case output:
@@ -109,6 +116,12 @@ visible or invalidated output disposition
 That maps to the generated `convergence-e2e-delivery/v1` variants. Tamarin proves the abstract delivery contract; the
 Rust variants check that queued delivery permutations preserve the real end-to-end group events.
 
+The agreement lemmas explicitly premise the initializer's `SameInputSet` action facts and one run-scoped
+`PolicyLoaded` action fact. Policy is global to a model run, so the latter is the model's same-policy premise for both
+clients. This makes the theorem boundary visible, but it does not turn v0 into a parametric arbitrary-set proof:
+candidate sets and policies are still supplied by the bounded initializer rules. Unequal input sets, policy mismatch,
+clock/restart behavior, and liveness remain outside this Tamarin model.
+
 The current welcome/commit handoff proof slice is:
 
 ```text
@@ -160,6 +173,21 @@ structures, OpenMLS objects, storage, and scenario harnesses.
 
 If behavior is outside the model, Tamarin says nothing about it. That behavior can still be specified in prose and
 tested in Rust, but it has no formal proof until the model includes it.
+
+## Proof Inventory
+
+Every v0 lemma belongs to exactly one verification category:
+
+| Category | Lemmas |
+| --- | --- |
+| Agreement and selector safety | `same_input_set_converges`, `selected_branches_are_eligible`, `selected_branches_require_loaded_policy`, `effective_depth_selection_requires_score_order`, `quorum_tie_selection_requires_quorum_and_bound`, `witness_score_selection_requires_score_order`, `priority_tie_selection_requires_preceding_equality_and_lower_priority`, `committer_tie_selection_requires_preceding_equality_and_lower_committer`, `digest_tie_selection_requires_lower_digest`, `opponent_ineligible_selection_requires_stale_opponent`, `duplicate_witness_dedupe_selection_uses_distinct_sender_epochs`, `three_branch_selection_requires_dominance`, `generated_bounded_case_selection_matches_expected_reason`, `no_conflicting_better_for_same_run` |
+| Lifecycle and application-output safety | `applied_branch_requires_prior_selection`, `accepted_app_output_requires_applied_branch`, `application_visible_requires_accepted_app_output`, `losing_app_invalidation_requires_applied_different_branch`, `invalidated_apps_are_never_application_visible`, `app_invalidation_disposition_requires_invalidation`, `invalidated_dispositions_are_never_application_visible`, `accepted_app_output_once_per_client_app`, `app_invalidation_disposition_once_per_app`, `welcome_acceptance_requires_matching_commit_context`, `commit_after_welcome_requires_prior_welcome`, `welcome_replayed_commit_does_not_select_branch`, `welcome_replayed_commit_does_not_detect_fork`, `fork_detection_requires_prior_local_commit`, `accepted_proposal_requires_applied_consuming_branch`, `dropped_proposal_requires_applied_different_branch`, `dropped_proposals_are_never_accepted`, `queued_outbound_requires_syncing`, `released_queued_outbound_requires_prior_queue`, `syncing_outbound_is_never_published_directly`, `settled_publish_requires_lifecycle_stable_state` |
+| Delivery safety | `released_delayed_input_requires_prior_delay`, `delivery_pending_input_requires_delivery_observation`, `delivery_pending_input_is_deduplicated`, `duplicate_delivery_requires_prior_pending_input`, `delivery_reordered_clients_select_same_branch`, `delivery_losing_app_never_application_visible` |
+| Retained-history safety | `computed_anchor_requires_loaded_policy_rewind`, `retained_anchor_replay_requires_available_anchor_and_policy`, `missing_retained_anchor_requires_missing_snapshot_and_policy`, `missing_retained_anchor_does_not_apply`, `beyond_anchor_invalidation_requires_source_before_anchor`, `beyond_anchor_invalidated_commits_are_never_selected`, `beyond_anchor_invalidated_commits_are_never_applied`, `stale_rewind_is_derived_from_anchor_and_distance`, `stale_branches_are_never_selected`, `late_withheld_rejection_requires_publish_after_anchor_and_stale` |
+| Executability and bounded-case coverage | `quorum_override_executable`, `raw_depth_lead_executable`, `witness_score_tie_executable`, `digest_tie_executable`, `stale_rewind_executable`, `duplicate_witness_dedupe_executable`, `outbound_queue_release_executable`, `outbound_settled_publish_executable`, `three_branch_permutation_executable`, `withheld_published_after_anchor_executable`, `retained_anchor_within_horizon_executable`, `missing_retained_anchor_executable`, `beyond_anchor_invalidated_executable`, `commit_application_app_output_executable`, `welcome_before_commit_handoff_executable`, `own_commit_fork_handoff_executable`, `proposal_canonical_consumption_executable`, `delivery_order_robustness_executable`, `generated_quorum_override_executable`, `generated_quorum_capped_by_depth_executable`, `generated_depth_priority_executable`, `generated_witness_priority_executable`, `generated_priority_tie_executable`, `generated_committer_tie_executable`, `generated_digest_priority_executable` |
+
+The inventory classifies proof scope; it is not a coverage claim for clocks, restart, durable pass generations,
+fairness, resource exhaustion, or unbounded self-update traffic.
 
 - **Tamarin artifact:** `Init_*` rule
   - **What it means:** A named abstract scenario.

--- a/formal/tamarin/distributed_convergence_v0.spthy
+++ b/formal/tamarin/distributed_convergence_v0.spthy
@@ -1340,8 +1340,12 @@ rule Emit_Invalidated_App_Disposition:
   []
 
 lemma same_input_set_converges:
-  "All run client_a client_b branch_a branch_b reason_a reason_b #i #j.
-      Selected(run, client_a, branch_a, reason_a) @ #i
+  "All run client_a client_b branch_a branch_b reason_a reason_b group policy
+       #inputs_a #inputs_b #policy #i #j.
+      SameInputSet(run, client_a) @ #inputs_a
+    & SameInputSet(run, client_b) @ #inputs_b
+    & PolicyLoaded(run, group, policy) @ #policy
+    & Selected(run, client_a, branch_a, reason_a) @ #i
     & Selected(run, client_b, branch_b, reason_b) @ #j
     ==> branch_a = branch_b"
 
@@ -1468,8 +1472,12 @@ lemma duplicate_delivery_requires_prior_pending_input:
     )"
 
 lemma delivery_reordered_clients_select_same_branch:
-  "All run branch_a branch_b reason_a reason_b #s #i #j.
+  "All run branch_a branch_b reason_a reason_b group policy
+       #s #inputs_carol #inputs_frank #policy #i #j.
       Scenario(run, 'delivery_order_robustness') @ #s
+    & SameInputSet(run, 'carol') @ #inputs_carol
+    & SameInputSet(run, 'frank') @ #inputs_frank
+    & PolicyLoaded(run, group, policy) @ #policy
     & Selected(run, 'carol', branch_a, reason_a) @ #i
     & Selected(run, 'frank', branch_b, reason_b) @ #j
     ==> branch_a = branch_b"

--- a/scripts/check_convergence_constant_ledger.sh
+++ b/scripts/check_convergence_constant_ledger.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep convergence-affecting policy, resource, scheduler, and input-recovery
+# constants attached to reviewed ledger IDs. This is deliberately a narrow
+# source-name audit; the scope and exclusions live in the tracking plan.
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+inventory_path="docs/marmot-architecture/convergence-constant-inventory.txt"
+plan_path="docs/marmot-architecture/convergence-reliability-plan.md"
+expected_ids=(P1 P2 P3 P4 P5 P6 P7 P8 E1 E2 E3 E4 E5 E6 E7 A1 A2 A3 A4 A5 A6 A7 A8)
+inventory_pairs=("__inventory_sentinel__")
+inventory_ids=()
+fail=0
+
+report() {
+    echo "error: $1" >&2
+    fail=1
+}
+
+contains_expected_id() {
+    local candidate="$1"
+    local expected
+    for expected in "${expected_ids[@]}"; do
+        if [[ "$candidate" == "$expected" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+contains_inventory_pair() {
+    local candidate="$1"
+    local existing
+    for existing in "${inventory_pairs[@]}"; do
+        if [[ "$candidate" == "$existing" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+while IFS='|' read -r ledger_id source_path symbol; do
+    if [[ -z "$ledger_id" || "$ledger_id" == \#* ]]; then
+        continue
+    fi
+
+    if [[ -z "$source_path" || -z "$symbol" ]]; then
+        report "malformed convergence inventory row for ${ledger_id}"
+        continue
+    fi
+    if ! contains_expected_id "$ledger_id"; then
+        report "unexpected convergence ledger id ${ledger_id}"
+    fi
+
+    pair="${source_path}|${symbol}"
+    if contains_inventory_pair "$pair"; then
+        report "duplicate convergence inventory entry ${pair}"
+    else
+        inventory_pairs+=("$pair")
+    fi
+    inventory_ids+=("$ledger_id")
+
+    if [[ ! -f "$source_path" ]]; then
+        report "convergence inventory source does not exist: ${source_path}"
+        continue
+    fi
+    if ! rg -q "^(pub(\\([^)]*\\))? )?const ${symbol}:" "$source_path"; then
+        report "convergence inventory declaration is missing: ${source_path}:${symbol}"
+    fi
+done < "$inventory_path"
+
+for expected_id in "${expected_ids[@]}"; do
+    found=0
+    for inventory_id in "${inventory_ids[@]}"; do
+        if [[ "$expected_id" == "$inventory_id" ]]; then
+            found=1
+            break
+        fi
+    done
+    if [[ "$found" -eq 0 ]]; then
+        report "convergence inventory is missing ledger id ${expected_id}"
+    fi
+    if ! rg -q "^\\| ${expected_id} \\|" "$plan_path"; then
+        report "convergence plan is missing ledger row ${expected_id}"
+    fi
+done
+
+discover_constants() {
+    local source_path="$1"
+    local name_pattern="$2"
+    local declaration
+    local symbol
+    local pair
+
+    while IFS= read -r declaration; do
+        symbol="${declaration#*const }"
+        symbol="${symbol%%:*}"
+        pair="${source_path}|${symbol}"
+        if ! contains_inventory_pair "$pair"; then
+            report "unreviewed convergence constant ${source_path}:${symbol}"
+        fi
+    done < <(
+        rg --no-filename -o \
+            "^(pub(\\([^)]*\\))? )?const (${name_pattern}):" \
+            "$source_path" || true
+    )
+}
+
+discover_constants "crates/cgka-engine/src/convergence.rs" "V1_[A-Z0-9_]+"
+discover_constants "crates/cgka-engine/src/canonicalization.rs" "V1_[A-Z0-9_]+"
+discover_constants "crates/cgka-engine/src/wire_format.rs" "DEFAULT_MAX_PAST_EPOCHS"
+discover_constants \
+    "crates/cgka-engine/src/message_processor/mod.rs" \
+    "(MAX_CONVERGENCE_[A-Z0-9_]+|MAX_DEFERRED_[A-Z0-9_]+|MAX_PEEL_DEFERRED_[A-Z0-9_]+|SELF_REMOVE_AUTO_COMMIT_[A-Z0-9_]+)"
+discover_constants \
+    "crates/cgka-engine/src/openmls_projection.rs" \
+    "CANDIDATE_REPLAY_BUDGET_[A-Z0-9_]+"
+discover_constants \
+    "crates/marmot-app/src/runtime/account_worker.rs" \
+    "(CONVERGENCE_[A-Z0-9_]+|MIN_CONVERGENCE_[A-Z0-9_]+|IDLE_CONVERGENCE_[A-Z0-9_]+)"
+discover_constants "crates/marmot-app/src/client/epoch_stall.rs" "EPOCH_STALL_[A-Z0-9_]+"
+discover_constants \
+    "crates/marmot-app/src/lib.rs" \
+    "(APP_RUNTIME_RELAY_REBUILD_LOOKBACK|TRANSPORT_CURSOR_MAX_FUTURE_SKEW)"
+
+if [[ "$fail" -ne 0 ]]; then
+    exit 1
+fi
+
+declaration_count=$((${#inventory_pairs[@]} - 1))
+echo "convergence constant ledger gate: ${#expected_ids[@]} ids, ${declaration_count} declarations"


### PR DESCRIPTION
## Summary

This completes Milestone 0 of the convergence reliability plan against the contract adopted in marmot-protocol/marmot#410.

- add the tracked assurance/simulator roadmap, verification ownership matrix, protocol decision register, and a 23-ID/25-declaration convergence-constant inventory
- make the constant inventory a `just fast-ci` / `just ci` drift gate
- make noninteractive Tamarin runs fail on warnings and derivation-check timeouts, state the same-input/same-policy premises explicitly, and inventory all 76 lemmas by assurance category
- replace ambiguous `Stale(PeelFailed)` API results with typed `TransportDeferred`, `ResourceRefused`, pre-convergence rejection categories, and specific terminal stale reasons
- release retry-budget-exhausted transport rows without terminally deduplicating the exact transport ID; preserve exact-ID redelivery after both the 32 changed-context budget and 256-row capacity refusal
- immediately arm one history backfill per group epoch when the app observes a resource refusal
- mark Milestone 0 complete now that protocol PR marmot-protocol/marmot#410 has merged; Milestone 1 begins with the exact state/message oracle

Protocol dependency: https://github.com/marmot-protocol/marmot/pull/410 (merged as `4ad4ae2`).

## Verification

Passed on top of MDK `master` at `1b949655`:

- `just fast-ci`
- `cargo test -p cgka-engine --features test-policy-overrides`
- `cargo test -p cgka-conformance-simulator`
- `cargo test -p cgka-session --features test-policy-overrides`
- `cargo test -p cgka-traits --test snapshots`
- focused `storage-sqlite`, `marmot-app` epoch-stall/backfill, account-runtime, and retained-history tests
- `just tamarin` — all 76 lemmas verified with strict warning/derivation checks
- local Markdown link check and `git diff --check`

I also ran the full `marmot-app` suite. Its 535 unit tests and the changed deferral/backfill integration tests passed; `relay_runtime` currently has five unrelated failures. I reproduced `encrypted_media_endpoint_updates_are_full_replacement_and_admin_only` with the same `left: 3, right: 1` failure on a clean detached `origin/master` at `1b949655`, so that failure is present on the PR base rather than introduced here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer ingest outcomes for transport delays, resource limits, malformed content, and specific stale conditions.
  * Deferred messages are now released when retry or capacity limits are reached, while remaining eligible for redelivery.
  * Added epoch-stall recovery signaling and improved backfill detection.
  * Added message deletion support to storage.
  * Added convergence reliability planning, constant inventory tracking, and verification gates.

* **Bug Fixes**
  * Improved audit logging and classification for rejected, deferred, and resource-refused messages.
  * Refined handling of malformed, unauthorized, and out-of-context messages to prevent processing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->