### PR TITLE
Add exact convergence oracle and scenario input ledger

### DIFF
--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -22,6 +22,22 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
     and hydrates it. `tick().await` drains pending inbound for one client. `confirm(pending).await` finishes a
     `GroupEvolution`.
 
+- **Module:** `src/scenario_input_ledger.rs`
+  - **Role:** Simulator-owned per-client application-message accounting. Joins the inner Marmot event id to outer
+    transport and peeled MLS content ids, then records send/queue/publication, ingest/defer/resource outcomes,
+    delivery/deduplication/expiry/invalidation, and pending state without adding production engine hooks.
+
+- **Module:** `src/pending_work.rs`
+  - **Role:** Instantaneous strict progress observation combining the conformance engine snapshot, global bus
+    queue/delay/mailbox counts, and per-client logical pending entries. It reports blockers for `NoPendingWork`; it does
+    not implement virtual-time quiescence waiting.
+
+- **Module:** `src/decryptability.rs`
+  - **Role:** Serializable active application-message probe results. A
+    `ProbeBidirectionalDecryptability` scenario step sends one logical event per named client, drains every attached
+    client, and records each directed sender-to-recipient edge by exact logical event id and recipient ledger
+    disposition. This is a mutating probe, not a passive observation.
+
 - **Module:** `cgka_engine::convergence`
   - **Role:** Candidate-state graph scoring rules for the distributed convergence design, re-exported by this crate for
     tests. These tests pin selector policy independently from OpenMLS replay.
@@ -30,7 +46,9 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
   - **Role:** Deterministic generated scenario families. `generate_send_leave_family`,
     `generate_convergence_e2e_delivery_family`, and `generate_convergence_chaos_family` record family name, generator
     version, seed, case index, runnable `ScenarioSpec`, and optional semantic expectations. `run_generated_case_report`
-    adds generated metadata to report artifacts.
+    adds generated metadata to report artifacts. Reliability families append a final global drain, exact canonical
+    observation, and pending-work assertion; do not remove a red strict result merely because an earlier legacy
+    observation passed.
 
 - **Module:** `src/oracle.rs`
   - **Role:** Scenario oracle and coverage evidence. Computes scenario stimuli, expected behavior classes, observed
@@ -51,11 +69,14 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
   - **Role:** Serializable `ScenarioSpec` v1 plus `run_scenario_spec` / `run_scenario_report` /
     `run_vector_fixture_report`. Drives ordered client operations from JSON-shaped scenario data and returns either a
     `ScenarioTrace` or a serializable report with the executed scenario, metadata, step log, flattened epoch changes,
-    app invalidations, recoveries, expectation failures, and invariant failures.
+    app invalidations, recoveries, expectation failures, and invariant failures. `ObserveExact` opts a portable scenario
+    into the canonical snapshot and scenario-input ledger while legacy `Observe` remains stable for existing fixtures.
+    `ProbeBidirectionalDecryptability` actively exercises send, transport peel, MLS decrypt, and application delivery.
 
 - **Module:** `src/vector.rs`
   - **Role:** `ScenarioTrace`, observations, and semantic `TraceExpectation` checks. Records final epoch/member/payload
-    facts plus member additions/removals, client convergence, epoch changes, app invalidations, and
+    facts plus member additions/removals, client convergence, epoch changes, app invalidations, exact canonical state,
+    commit/proposal/application input dispositions, pending-work blockers, active decryptability matrices, and
     `ForkRecoveryObservation` entries from `GroupEvent::ForkRecovered`.
 
 - **Module:** `src/policy_cases.rs`
@@ -171,7 +192,8 @@ cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report 
 ```
 
 Generated-family runs write both `*-case-N.json` reports and `*-case-N-fixture.v1.json` candidates that can be promoted
-into `vectors/` after review.
+into `vectors/` after review. Oracle coverage is strict by default; use `--allow-weak-oracle` only for an explicitly
+exploratory run.
 
 Run portable vector fixtures:
 

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -23,14 +23,15 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
     `GroupEvolution`.
 
 - **Module:** `src/scenario_input_ledger.rs`
-  - **Role:** Simulator-owned per-client application-message accounting. Joins the inner Marmot event id to outer
-    transport and peeled MLS content ids, then records send/queue/publication, ingest/defer/resource outcomes,
-    delivery/deduplication/expiry/invalidation, and pending state without adding production engine hooks.
+  - **Role:** Simulator-owned per-client commit, proposal, and application-input accounting. Joins stable scenario
+    action ids to outer transport and peeled MLS content ids; application entries also retain the inner Marmot event id.
+    It records send/queue/publication, ingest/defer/resource outcomes, delivery/deduplication/expiry/invalidation, and
+    pending state without adding production engine hooks.
 
 - **Module:** `src/pending_work.rs`
-  - **Role:** Instantaneous strict progress observation combining the conformance engine snapshot, global bus
-    queue/delay/mailbox counts, and per-client logical pending entries. It reports blockers for `NoPendingWork`; it does
-    not implement virtual-time quiescence waiting.
+  - **Role:** Instantaneous strict local-progress observation combining a group-scoped conformance engine snapshot,
+    client-addressed bus queue/delay/mailbox counts, and per-client logical pending entries. It reports blockers for
+    `NoPendingWork`; it does not claim end-to-end delivery or implement virtual-time quiescence waiting.
 
 - **Module:** `src/decryptability.rs`
   - **Role:** Serializable active application-message probe results. A

--- a/crates/cgka-conformance-simulator/Cargo.toml
+++ b/crates/cgka-conformance-simulator/Cargo.toml
@@ -13,7 +13,7 @@ conformance-slow = []
 
 [dependencies]
 cgka-traits.workspace = true
-cgka-engine.workspace = true
+cgka-engine = { workspace = true, features = ["test-conformance-snapshot"] }
 marmot-forensics.workspace = true
 storage-sqlite.workspace = true
 transport-nostr-peeler.workspace = true

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -107,11 +107,13 @@ work. In particular,
 `TransportDeferred` remains pending but is not mislabeled as application acceptance: until peeling succeeds, the engine
 cannot make a logical validity or branch claim about that object.
 
-`NoPendingWork` is the strict instantaneous progress assertion. An `observe_exact` step captures aggregate engine work
-(publish lifecycle, convergence pass/input, queued outbound, deferred/retryable storage, and scheduling buffers), the
-bus queue/delayed/mailbox counts, and pending scenario-input ledger entries. The expectation fails with the blocking subsystem
-names. It does not yet wait for quiescence: virtual-time advancement, two unchanged observations, timeout policy, and
-retry-timer coverage belong to Milestone 1.3.
+`NoPendingWork` is the strict instantaneous local-progress assertion. An `observe_exact` step captures group-scoped
+engine work (publish lifecycle, convergence pass/input, queued outbound, deferred/retryable storage, and scheduling
+buffers), bus queue/delayed/mailbox work addressed to that client, and that client's pending scenario-input ledger
+entries. The expectation fails with the blocking subsystem names. It is deliberately not an end-to-end delivery claim
+for an application object that a transport fault dropped; scenarios that require delivery must assert the recipient's
+ledger or output separately. It does not yet wait for quiescence: virtual-time advancement, structural progress tokens,
+timeout policy, and retry-timer coverage belong to Milestone 1.3.
 
 `probe_bidirectional_decryptability` is the active cryptographic-reachability check. Each named client sends one
 uniquely identified application event through the normal engine and transport path; the runner delivers the resulting
@@ -234,9 +236,10 @@ without inventing a separate execution path. We promote a case only when it shou
 as a regression fixture or the smallest readable example of a semantic edge.
 
 Send/leave and convergence-chaos reliability cases finish with a global transport/mailbox drain, an exact observation,
-and a `NoPendingWork` expectation. Multi-client settled claims also require `ClientsExactlyEquivalent`. These checks are
-intentionally capable of making a generated campaign red even when its earlier legacy observation passed; that is how
-hidden unread input, branch divergence, and retained work become visible.
+and a per-client `NoPendingWork` expectation. Multi-client settled claims also require `ClientsExactlyEquivalent`, and
+delivery-sensitive cases assert recipient ledgers or outputs. These checks are intentionally capable of making a
+generated campaign red even when its earlier legacy observation passed; that is how hidden unread input, branch
+divergence, and retained work become visible.
 
 `generate_convergence_e2e_delivery_family(seed, cases)` produces deterministic variants of
 `convergence-e2e-group-events/v1`. Each variant keeps the logical branch race stable but mutates queued delivery with

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -23,6 +23,9 @@ welcomes use NIP-59 gift wraps before the bus delivers them.
   outcomes.
 - `ScenarioReport` — serializable run artifacts with metadata, expected and observed traces, oracle coverage evidence,
   step logs, recoveries, and expectation failures.
+- `ConformanceGroupSnapshot` — a feature-gated synthetic-test projection of exact canonical group state: leaf identities
+  and capabilities, required/application state, lifecycle/profile/admin state, a GroupContext hash, and the adopted
+  domain-separated exporter commitment. Raw exporter material is never serialized.
 - `cgka-conformance-simulator-report` — a small CLI that runs generated scenario families, writes JSON reports, and
   emits fixture candidates for generated cases.
 - `proptest_support` — strategies that generate arbitrary typed `SendIntent` sequences for property-based tests.
@@ -73,8 +76,7 @@ To run every portable vector fixture and write a report for each one:
 cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report -- \
   --vectors crates/cgka-conformance-simulator/vectors \
   --out target/cgka-conformance-simulator-reports \
-  --storage file \
-  --strict-oracle
+  --storage file
 ```
 
 The normal `cargo test -p cgka-conformance-simulator` run already validates the top-level vector fixtures and checks the
@@ -85,6 +87,38 @@ pass/fail summary outside the test harness.
 The report command exits non-zero when any fixture expectation fails. Each report includes the exact scenario input,
 selected storage backend, observed trace, flattened recovery and epoch observations, and the mismatched expected/actual
 JSON.
+
+## Exact state oracle
+
+Legacy `observe_client` traces retain the portable epoch/member-count/group-name observation used by existing vectors.
+Reliability scenarios call `observe_client_exact` (or use the serializable `observe_exact` step) and assert
+`ClientsExactlyEquivalent` plus `ScenarioInputLedger`. The canonical-state expectation compares a tagged
+`ConformanceCanonicalStateSnapshot`: either the complete live-group `ConformanceGroupSnapshot` or the authenticated
+terminal disband tombstone. Equal member counts cannot hide different member identities, equal public metadata cannot
+hide different exporter state, and device-local `local_was_committer_leaf` metadata cannot split otherwise equivalent
+terminal clients. The engine interface is enabled only for this simulator through `test-conformance-snapshot`; it
+exposes the commitment, never the raw exporter secret.
+
+The scenario-input ledger gives every commit, proposal, and application action a stable scenario id, then joins it to
+the outer transport id and content-derived MLS id; application entries also retain the inner Marmot event id for
+delivery correlation. Per client it distinguishes send attempt/acceptance/queue/publication, protocol acceptance,
+transport deferral, application delivery, deduplication, expiry, invalidation, resource refusal, rejection, and pending
+work. In particular,
+`TransportDeferred` remains pending but is not mislabeled as application acceptance: until peeling succeeds, the engine
+cannot make a logical validity or branch claim about that object.
+
+`NoPendingWork` is the strict instantaneous progress assertion. An `observe_exact` step captures aggregate engine work
+(publish lifecycle, convergence pass/input, queued outbound, deferred/retryable storage, and scheduling buffers), the
+bus queue/delayed/mailbox counts, and pending scenario-input ledger entries. The expectation fails with the blocking subsystem
+names. It does not yet wait for quiescence: virtual-time advancement, two unchanged observations, timeout policy, and
+retry-timer coverage belong to Milestone 1.3.
+
+`probe_bidirectional_decryptability` is the active cryptographic-reachability check. Each named client sends one
+uniquely identified application event through the normal engine and transport path; the runner delivers the resulting
+objects, ticks every attached client, and records every directed sender-to-recipient edge. The
+`ClientsBidirectionallyDecryptable` expectation requires every edge to reach application delivery and preserves queued,
+failed, deferred, rejected, expired, and invalidated ledger evidence when it does not. The probe mutates the scenario by
+sending application messages, so place it after the state whose decryptability is being tested.
 
 ## Property tests
 
@@ -164,6 +198,8 @@ recovery without pinning which invite branch wins.
 - `deliver_all`
 - `tick`
 - `observe`
+- `observe_exact`
+- `probe_bidirectional_decryptability`
 - `clear_events`
 - `drop_queued`
 - `duplicate_queued`
@@ -183,7 +219,8 @@ label's messages to the end of the queue.
 
 ## Generated scenario families
 
-`generate_send_leave_family(seed, cases)` produces deterministic `GeneratedScenarioCase` values. Each case records:
+`generate_send_leave_family(seed, cases)` produces deterministic `GeneratedScenarioCase` values (generator version
+`2`). Each case records:
 
 - `family_name`
 - `generator_version`
@@ -196,6 +233,11 @@ The generated `scenario` is a normal `ScenarioSpec`, so a selected generated cas
 without inventing a separate execution path. We promote a case only when it should become a stable named contract, such
 as a regression fixture or the smallest readable example of a semantic edge.
 
+Send/leave and convergence-chaos reliability cases finish with a global transport/mailbox drain, an exact observation,
+and a `NoPendingWork` expectation. Multi-client settled claims also require `ClientsExactlyEquivalent`. These checks are
+intentionally capable of making a generated campaign red even when its earlier legacy observation passed; that is how
+hidden unread input, branch divergence, and retained work become visible.
+
 `generate_convergence_e2e_delivery_family(seed, cases)` produces deterministic variants of
 `convergence-e2e-group-events/v1`. Each variant keeps the logical branch race stable but mutates queued delivery with
 duplicate, delay/release, and reorder steps before observer clients tick. Under the real Nostr peeler the settled
@@ -207,7 +249,7 @@ trace includes exactly the selected branch application payload.
 semantic expectations. The generator rotates through invite forks, group-data forks, publish rollback plus delayed app
 duplicates, partition/heal/leave, delayed past-epoch app delivery, stable duplicate/delay/reorder queue faults, 20+
 client message storms, partitioned large-group delivery storms, multi-committer group-data storms, mixed large
-message/commit storms, and restart plus duplicate delivery faults. Generator version `3` draws the delivery schedule of
+message/commit storms, and restart plus duplicate delivery faults. Generator version `4` draws the delivery schedule of
 the rollback and storm shapes from the seed, so distinct seeds exercise distinct adversarial orderings while the
 schedule-invariant convergence, rollback, and payload-set expectations stay fixed. These cases are ordinary
 `ScenarioSpec`s, so the same runner and report path can turn selected generated cases into fixed vectors when that makes
@@ -272,8 +314,9 @@ cargo run -p cgka-conformance-simulator --bin cgka-conformance-simulator-report 
 Reports are written as one file per case, for example
 `target/cgka-conformance-simulator-reports/send-leave-v1-seed-42-case-0.json`. Generated family runs also write fixture
 candidates such as `target/cgka-conformance-simulator-reports/convergence-chaos-v1-seed-42-case-0-fixture.v1.json`.
-Pass `--strict-oracle` when a report run should fail on oracle coverage problems (`weak_oracle_warnings` or
-`missing_observed_behaviors`) instead of treating them as advisory metadata.
+Report runs are strict by default: oracle coverage problems (`weak_oracle_warnings` or
+`missing_observed_behaviors`) count as failures. `--strict-oracle` remains accepted for explicit scripts. Use
+`--allow-weak-oracle` only for exploratory legacy or diagnostic runs where advisory coverage is intentional.
 
 File-backed restart tests and the engine subprocess-kill tests cover durability when the encrypted database and WAL are
 intact: handles are closed or the process is killed, the database is reopened, and hydration reconciles interrupted

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -269,6 +269,15 @@ These are real simulator scenarios that are still tied to Rust harness details.
 - Pressure: exact observation while the engine remains in `PendingPublish`.
 - Expected: `NoPendingWork` fails with an engine blocker even if public epoch/member facts otherwise look coherent.
 
+### `no_pending_work_does_not_claim_delivery_of_dropped_application_input`
+
+- Setup: Alice sends an application event to Bob after a stable two-member join, then a transport fault drops the queued
+  object before Bob receives it.
+- Pressure: compare each client's local pending-work snapshot with Bob's exact recipient ledger/output observation.
+- Expected: `NoPendingWork` passes for both clients once their local work is empty, while the independent delivery
+  expectation fails because Bob never observed the application input. This sentinel keeps local quiescence distinct
+  from end-to-end delivery.
+
 ### `convergence_e2e_from_peeler_ingest_to_group_events`
 
 - Setup: two admins create competing invite branches and each sends an application event on its branch; two passive

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -122,7 +122,9 @@ These are the scenarios another implementation should be able to load from JSON 
 - File: `vectors/queue-faults.v1.json`
 - Setup: Alice creates a group with Bob and Carol. Bob and Carol send app messages.
 - Pressure: the bus duplicates, delays, releases, and reorders queued messages.
-- Expected: Alice receives each valid payload once in the expected observed order.
+- Expected: Alice receives each valid payload once in the expected observed order. The Rust mechanics regression for
+  this shape additionally captures the strict scenario-input ledger: two ingest attempts for the duplicated Bob event, one
+  application acceptance, one delivery, one deduplication, and no remaining work for that event.
 
 ### `partition-clear-leave/v1`
 
@@ -195,6 +197,86 @@ These are real simulator scenarios that are still tied to Rust harness details.
 - Expected: all clients converge and each receives the other two messages.
 - Reason: this duplicates the smoke vector at direct harness level.
 
+### `exact_oracle_matches_full_canonical_state_after_join`
+
+- Setup: Alice creates a group with Bob and Bob joins from the Welcome.
+- Pressure: the strict conformance projection is captured independently from both live engines.
+- Expected: every exact leaf/capability, required and application component, lifecycle/profile/admin field, GroupContext
+  hash, and exporter commitment matches. Sentinel unit tests separately prove that different member identities or
+  exporter commitments fail `ClientsExactlyEquivalent` even when epoch and member count match. Both joined clients
+  also pass `NoPendingWork`.
+
+### `exact_observation_ledgers_commit_proposal_and_application_dispositions`
+
+- Setup: Alice and Bob settle a group, Alice publishes a group-data commit and application event, and Bob publishes a
+  self-remove proposal.
+- Pressure: the exact observation correlates each action through randomized transport and content-derived ids after the
+  commit sender has already advanced MLS state.
+- Expected: the ledger contains stable scenario ids for all three input classes, the confirmed commit and published
+  application event are accepted, and the proposal exposes its exact current pending-or-accepted disposition.
+
+### `exact_oracle_projects_terminal_disband_tombstone_across_restart`
+
+- Setup: a current-profile solo member creates a group, requests disband, and advances the normal convergence path
+  until the authenticated disband commit terminalizes the group.
+- Pressure: live MLS state is deleted; exact observation must use only the durable tombstone, then survive a full
+  engine/storage restart.
+- Expected: the tagged terminal canonical state preserves group id, epoch, actor, origin commit, commit digest, and the
+  canonical former-member roster; it passes `NoPendingWork` and is byte-for-byte unchanged after restart.
+- Sentinel: an engine unit test proves that device-local committer-leaf status, roster order, and duplicate roster rows
+  do not change terminal equality.
+
+### `bidirectional_decryptability_probe_passes_for_settled_members`
+
+- Setup: Alice creates a settled three-member group with Bob and Carol.
+- Pressure: the active probe sends one exact logical application event from each member and exercises all six directed
+  sender-to-recipient edges through normal send, Nostr transport peel, MLS decrypt, and application delivery.
+- Expected: all six edges deliver, the exact canonical snapshots remain equivalent, and the probe leaves no pending
+  work.
+
+### `bidirectional_decryptability_probe_exposes_asymmetric_epoch_reachability`
+
+- Setup: Alice and Bob begin settled; Alice confirms a group-data commit whose transport object is then dropped, leaving
+  Alice one epoch ahead of Bob.
+- Pressure: the active probe runs in both directions.
+- Expected: Bob's past-epoch event still decrypts at Alice, while Alice's future-epoch event remains
+  `transport_deferred` at Bob. `ClientsBidirectionallyDecryptable` reports only the failed Alice-to-Bob edge.
+
+### `bidirectional_decryptability_probe_rejects_a_named_nonmember`
+
+- Setup: Alice and Bob form a group while attached client Carol is deliberately not invited.
+- Pressure: Carol is included in the active probe client set.
+- Expected: Carol's send is recorded as a typed failed probe and the complete directed matrix cannot pass.
+
+### `no_pending_work_rejects_bus_queue_and_unread_mailbox`
+
+- Setup: Bob sends an application event to Alice after a stable two-member join.
+- Pressure: observe once while the transport object remains queued, then again after delivery but before Alice ingests
+  her mailbox.
+- Expected: the progress snapshot names `bus_queue` and `bus_mailboxes` as blockers; after Alice ticks, the exact
+  snapshot is empty.
+
+### `no_pending_work_rejects_delayed_transport_then_accepts_drained_delivery`
+
+- Setup: Bob sends an application event to Alice and the bus moves it into a named delayed queue.
+- Pressure: assert before and after release/delivery/ingest.
+- Expected: `NoPendingWork` initially fails with `bus_delayed`, then passes after the logical event is delivered and all
+  transport work drains.
+
+### `no_pending_work_rejects_unconfirmed_publish`
+
+- Setup: a stable group stages an invite without confirming publication.
+- Pressure: exact observation while the engine remains in `PendingPublish`.
+- Expected: `NoPendingWork` fails with an engine blocker even if public epoch/member facts otherwise look coherent.
+
+### `convergence_e2e_from_peeler_ingest_to_group_events`
+
+- Setup: two admins create competing invite branches and each sends an application event on its branch; two passive
+  observers ingest the real Nostr-wrapped transport objects.
+- Expected: each observer delivers the selected branch event exactly once and never projects the losing event. If the
+  losing transport object never peels, its ledger entry remains explicitly `transport_deferred` and pending rather than
+  being falsely labeled application-accepted or losing-branch-invalidated.
+
 ### `delayed_past_epoch_app_message_peels_from_retained_anchor`
 
 - Setup: Bob sends an epoch-1 app message. Alice advances the group by inviting David. The old app message arrives late.
@@ -247,9 +329,10 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 
 ### `send-leave/v1`
 
-- Generator: `generate_send_leave_family`
+- Generator: `generate_send_leave_family` (generator version `2`)
 - Setup: three clients start in one group. The generator emits app sends and self-remove leaves.
-- Expected: remaining live members converge on the same epoch and member set.
+- Expected: remaining live members converge on exact canonical state after a final global drain and report no pending
+  work. The current leave shapes intentionally expose retained proposal/schedule work as a strict failure.
 
 ### `convergence-e2e-delivery/v1`
 
@@ -260,9 +343,10 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 
 ### `convergence-chaos/v1`
 
-- Generator: `generate_convergence_chaos_family` (generator version `3`).
+- Generator: `generate_convergence_chaos_family` (generator version `4`).
 - Setup: the family rotates through the case classes below.
-- Expected: each case carries semantic expectations for convergence, rollback, payload delivery, or recovery.
+- Expected: each case carries semantic expectations for convergence, rollback, payload delivery, or recovery, then
+  performs a final global drain with exact-state and pending-work assertions.
 - Seed behavior: the rollback (`2`) and storm shapes (`6`, `7`, `8`, `9`) draw their delivery schedule from the seed,
   so distinct seeds exercise distinct adversarial orderings. Convergence, rollback, and payload-set expectations are
   invariant under delivery schedule, so they stay fixed while coverage grows with the seed. The remaining shapes are
@@ -286,7 +370,8 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 - Pressure: a seed-driven delivery reorder of the post-rollback messages, plus a duplicated and delayed copy of one app
   message released after Alice has already processed the original.
 - Expected: Alice remains at epoch 1 and receives Bob's post-rollback payloads once each, in the seed-driven delivery
-  order (the released app duplicate is deduped).
+  order (the released app duplicate is deduped). The strict final drain currently demonstrates that Bob can apply the
+  already-transported rolled-back commit and diverge from Alice.
 
 #### Chaos Class `3`: Partition Leave
 
@@ -298,7 +383,8 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 
 - Setup: Bob's epoch-1 app message is delayed while Alice invites David.
 - Pressure: late app delivery after an epoch advance.
-- Expected: Carol accepts the late app payload from retained context.
+- Expected: Carol accepts the late app payload from retained context. The strict pending-work boundary currently also
+  exposes that post-invite David retains the pre-join object as deferred logical work.
 
 #### Chaos Class `5`: Stable Queue Faults
 
@@ -331,7 +417,8 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 - Setup: Alice creates a 21-member group. Members send app messages, then eight members race group-data commits.
 - Pressure: large app-message load (seed-driven reorder) followed by a commit storm with a seed-driven duplicate and reorder.
 - Expected: the committers converge at epoch 2 with 21 members and the same branch-sensitive group name (see Chaos Class
-  `8`).
+  `8`). Strict oracle coverage currently also reports that the cleared application phase lacks a delivery or
+  invalidation expectation; this is a tracked oracle gap, not an engine-state failure.
 
 #### Chaos Class `10`: Restart Delivery Faults
 

--- a/crates/cgka-conformance-simulator/src/bus.rs
+++ b/crates/cgka-conformance-simulator/src/bus.rs
@@ -20,8 +20,10 @@
 //! broadcast welcomes (then the engine's `NotForThisClient` filter kicks
 //! in client-side).
 
+use crate::pending_work::BusPendingWorkSnapshot;
+use crate::scenario_input_ledger::ScenarioInputMetadata;
 use cgka_traits::transport::{TransportEnvelope, TransportMessage};
-use cgka_traits::types::MemberId;
+use cgka_traits::types::{MemberId, MessageId};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -62,6 +64,8 @@ struct Inner {
     /// If Some, only deliver to clients in this allowlist (partition).
     partition_allowed: Option<std::collections::HashSet<ClientId>>,
     delayed: HashMap<String, Vec<InFlight>>,
+    scenario_input_by_transport_id: HashMap<MessageId, ScenarioInputMetadata>,
+    scenario_input_by_content_id: HashMap<MessageId, ScenarioInputMetadata>,
 }
 
 impl TransportBus {
@@ -81,6 +85,8 @@ impl TransportBus {
                 mailboxes: HashMap::new(),
                 partition_allowed: None,
                 delayed: HashMap::new(),
+                scenario_input_by_transport_id: HashMap::new(),
+                scenario_input_by_content_id: HashMap::new(),
             })),
         }
     }
@@ -100,6 +106,46 @@ impl TransportBus {
     pub fn send(&self, sender: ClientId, msg: TransportMessage) {
         let mut inner = self.inner.lock().unwrap();
         inner.queue.push(InFlight { sender, msg });
+    }
+
+    pub(crate) fn register_scenario_input(
+        &self,
+        transport_id: MessageId,
+        content_id: MessageId,
+        mut metadata: ScenarioInputMetadata,
+    ) {
+        metadata.aliases = vec![transport_id.clone(), content_id.clone()];
+        let mut inner = self.inner.lock().unwrap();
+        inner
+            .scenario_input_by_transport_id
+            .insert(transport_id, metadata.clone());
+        inner
+            .scenario_input_by_content_id
+            .insert(content_id, metadata);
+    }
+
+    pub(crate) fn scenario_input_for_transport(
+        &self,
+        message_id: &MessageId,
+    ) -> Option<ScenarioInputMetadata> {
+        self.inner
+            .lock()
+            .unwrap()
+            .scenario_input_by_transport_id
+            .get(message_id)
+            .cloned()
+    }
+
+    pub(crate) fn scenario_input_for_content(
+        &self,
+        message_id: &MessageId,
+    ) -> Option<ScenarioInputMetadata> {
+        self.inner
+            .lock()
+            .unwrap()
+            .scenario_input_by_content_id
+            .get(message_id)
+            .cloned()
     }
 
     /// Deliver up to `n` messages from the queue into per-client mailboxes,
@@ -187,6 +233,15 @@ impl TransportBus {
     /// Number of queued (not yet delivered) messages.
     pub fn queued_len(&self) -> usize {
         self.inner.lock().unwrap().queue.len()
+    }
+
+    pub(crate) fn pending_work_snapshot(&self) -> BusPendingWorkSnapshot {
+        let inner = self.inner.lock().unwrap();
+        BusPendingWorkSnapshot {
+            queued_messages: inner.queue.len(),
+            delayed_messages: inner.delayed.values().map(Vec::len).sum(),
+            mailbox_messages: inner.mailboxes.values().map(Vec::len).sum(),
+        }
     }
 
     /// Snapshot queued messages without altering delivery order.

--- a/crates/cgka-conformance-simulator/src/bus.rs
+++ b/crates/cgka-conformance-simulator/src/bus.rs
@@ -235,12 +235,25 @@ impl TransportBus {
         self.inner.lock().unwrap().queue.len()
     }
 
-    pub(crate) fn pending_work_snapshot(&self) -> BusPendingWorkSnapshot {
+    pub(crate) fn pending_work_snapshot(&self, client: ClientId) -> BusPendingWorkSnapshot {
         let inner = self.inner.lock().unwrap();
+        let identity = inner
+            .clients
+            .get(&client)
+            .expect("pending-work client is attached");
         BusPendingWorkSnapshot {
-            queued_messages: inner.queue.len(),
-            delayed_messages: inner.delayed.values().map(Vec::len).sum(),
-            mailbox_messages: inner.mailboxes.values().map(Vec::len).sum(),
+            queued_messages: inner
+                .queue
+                .iter()
+                .filter(|in_flight| targets_client(&inner.policy, identity, client, in_flight))
+                .count(),
+            delayed_messages: inner
+                .delayed
+                .values()
+                .flatten()
+                .filter(|in_flight| targets_client(&inner.policy, identity, client, in_flight))
+                .count(),
+            mailbox_messages: inner.mailboxes.get(&client).map_or(0, Vec::len),
         }
     }
 
@@ -322,6 +335,28 @@ impl TransportBus {
     /// when a test wants to inspect ordering before stepping.
     pub fn peek_policy(&self) -> DeliveryPolicy {
         self.inner.lock().unwrap().policy.clone()
+    }
+}
+
+fn targets_client(
+    policy: &DeliveryPolicy,
+    identity: &MemberId,
+    client: ClientId,
+    in_flight: &InFlight,
+) -> bool {
+    if in_flight.sender == client {
+        return false;
+    }
+    match &in_flight.msg.envelope {
+        TransportEnvelope::GroupMessage { .. } => true,
+        TransportEnvelope::Welcome { recipient } => {
+            matches!(
+                policy,
+                DeliveryPolicy::Ordered {
+                    broadcast_welcomes: true
+                }
+            ) || recipient == identity
+        }
     }
 }
 

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -697,20 +697,11 @@ impl HarnessClient {
                 welcomes,
                 pending,
             } => {
-                let scenario_input =
-                    self.next_scenario_input_metadata(ScenarioInputKind::Commit, None, None);
-                self.scenario_input_tracker
-                    .record_send_attempt(&scenario_input);
-                self.scenario_input_tracker
-                    .record_send_accepted(&scenario_input, false);
                 for w in welcomes {
                     self.bus.send(self.bus_id, w);
                 }
                 let routed = route(msg, &gid);
-                let scenario_input = self
-                    .register_published_scenario_input(&routed, scenario_input)
-                    .await;
-                self.remember_pending_scenario_input(pending, &scenario_input);
+                self.publish_commit_scenario_input(&routed, pending).await;
                 self.bus.send(self.bus_id, routed);
                 pending
             }
@@ -739,17 +730,8 @@ impl HarnessClient {
                     welcomes.is_empty(),
                     "group-data update should not create welcomes"
                 );
-                let scenario_input =
-                    self.next_scenario_input_metadata(ScenarioInputKind::Commit, None, None);
-                self.scenario_input_tracker
-                    .record_send_attempt(&scenario_input);
-                self.scenario_input_tracker
-                    .record_send_accepted(&scenario_input, false);
                 let routed = route(msg, &gid);
-                let scenario_input = self
-                    .register_published_scenario_input(&routed, scenario_input)
-                    .await;
-                self.remember_pending_scenario_input(pending, &scenario_input);
+                self.publish_commit_scenario_input(&routed, pending).await;
                 self.bus.send(self.bus_id, routed);
                 pending
             }
@@ -783,17 +765,8 @@ impl HarnessClient {
                     welcomes.is_empty(),
                     "admin policy update should not create welcomes"
                 );
-                let scenario_input =
-                    self.next_scenario_input_metadata(ScenarioInputKind::Commit, None, None);
-                self.scenario_input_tracker
-                    .record_send_attempt(&scenario_input);
-                self.scenario_input_tracker
-                    .record_send_accepted(&scenario_input, false);
                 let routed = route(msg, &gid);
-                let scenario_input = self
-                    .register_published_scenario_input(&routed, scenario_input)
-                    .await;
-                self.remember_pending_scenario_input(pending, &scenario_input);
+                self.publish_commit_scenario_input(&routed, pending).await;
                 self.bus.send(self.bus_id, routed);
                 Ok(pending)
             }
@@ -952,17 +925,8 @@ impl HarnessClient {
                 for w in welcomes {
                     self.bus.send(self.bus_id, w);
                 }
-                let scenario_input =
-                    self.next_scenario_input_metadata(ScenarioInputKind::Commit, None, None);
-                self.scenario_input_tracker
-                    .record_send_attempt(&scenario_input);
-                self.scenario_input_tracker
-                    .record_send_accepted(&scenario_input, false);
                 let routed = route(msg, &gid);
-                let scenario_input = self
-                    .register_published_scenario_input(&routed, scenario_input)
-                    .await;
-                self.remember_pending_scenario_input(pending, &scenario_input);
+                self.publish_commit_scenario_input(&routed, pending).await;
                 self.bus.send(self.bus_id, routed);
                 Ok(pending)
             }
@@ -1207,16 +1171,7 @@ impl HarnessClient {
                 } else {
                     msg
                 };
-                let scenario_input =
-                    self.next_scenario_input_metadata(ScenarioInputKind::Commit, None, None);
-                self.scenario_input_tracker
-                    .record_send_attempt(&scenario_input);
-                self.scenario_input_tracker
-                    .record_send_accepted(&scenario_input, false);
-                let scenario_input = self
-                    .register_published_scenario_input(&routed, scenario_input)
-                    .await;
-                self.remember_pending_scenario_input(pending, &scenario_input);
+                self.publish_commit_scenario_input(&routed, pending).await;
                 self.bus.send(self.bus_id, routed);
                 self.try_confirm(pending).await?;
                 self.capture_engine_events();
@@ -1251,18 +1206,15 @@ impl HarnessClient {
             } else {
                 auto.msg
             };
-            let scenario_input =
-                self.next_scenario_input_metadata(ScenarioInputKind::Commit, None, None);
-            self.scenario_input_tracker
-                .record_send_attempt(&scenario_input);
-            self.scenario_input_tracker
-                .record_send_accepted(&scenario_input, false);
-            let scenario_input = self
-                .register_published_scenario_input(&routed, scenario_input)
+            self.publish_commit_scenario_input(&routed, auto.pending)
                 .await;
-            self.remember_pending_scenario_input(auto.pending, &scenario_input);
             self.bus.send(self.bus_id, routed);
             if let Err(e) = self.try_confirm(auto.pending).await {
+                // A confirmation error is not evidence that the engine rolled
+                // back the staged state. Keep the mapping pending so the
+                // strict oracle exposes the unresolved publish lifecycle; an
+                // actual rollback is recorded only through publish_failed or
+                // the corresponding engine event.
                 outcomes.push(Err(e));
                 continue;
             }
@@ -1380,7 +1332,7 @@ impl HarnessClient {
             .engine()
             .conformance_pending_work_snapshot(&group_id)
             .expect("capture conformance pending work");
-        let bus = self.bus.pending_work_snapshot();
+        let bus = self.bus.pending_work_snapshot(self.bus_id);
         PendingWorkObservation {
             engine,
             bus_queued_messages: bus.queued_messages,
@@ -1397,6 +1349,23 @@ impl HarnessClient {
             .checked_add(1)
             .expect("app event counter exhausted");
         encode_harness_app_payload(&self.engine().self_id(), seq, payload)
+    }
+
+    async fn publish_commit_scenario_input(
+        &mut self,
+        message: &TransportMessage,
+        pending: PendingStateRef,
+    ) {
+        let scenario_input =
+            self.next_scenario_input_metadata(ScenarioInputKind::Commit, None, None);
+        self.scenario_input_tracker
+            .record_send_attempt(&scenario_input);
+        self.scenario_input_tracker
+            .record_send_accepted(&scenario_input, false);
+        let scenario_input = self
+            .register_published_scenario_input(message, scenario_input)
+            .await;
+        self.remember_pending_scenario_input(pending, &scenario_input);
     }
 
     async fn register_published_scenario_input(
@@ -1522,12 +1491,17 @@ impl HarnessClient {
                 GroupEvent::ForkRecovered {
                     invalidated_commit_id,
                     ..
+                } => {
+                    if let Some(scenario_input) = self
+                        .bus
+                        .scenario_input_for_transport(invalidated_commit_id)
+                        .or_else(|| self.bus.scenario_input_for_content(invalidated_commit_id))
+                    {
+                        self.scenario_input_tracker
+                            .record_commit_invalidated(&scenario_input, "fork_recovered");
+                    }
                 }
-                | GroupEvent::CommitRolledBack {
-                    invalidated_commit_id,
-                    ..
-                }
-                | GroupEvent::GroupStateInvalidated {
+                GroupEvent::CommitRolledBack {
                     invalidated_commit_id,
                     ..
                 } => {
@@ -1537,7 +1511,22 @@ impl HarnessClient {
                         .or_else(|| self.bus.scenario_input_for_content(invalidated_commit_id))
                     {
                         self.scenario_input_tracker
-                            .record_commit_invalidated(&scenario_input, "superseded");
+                            .record_commit_invalidated(&scenario_input, "commit_rolled_back");
+                    }
+                }
+                GroupEvent::GroupStateInvalidated {
+                    invalidated_commit_id,
+                    ..
+                } => {
+                    if let Some(scenario_input) = self
+                        .bus
+                        .scenario_input_for_transport(invalidated_commit_id)
+                        .or_else(|| self.bus.scenario_input_for_content(invalidated_commit_id))
+                    {
+                        self.scenario_input_tracker.record_commit_invalidated(
+                            &scenario_input,
+                            "group_state_invalidated_superseded",
+                        );
                     }
                 }
                 _ => {}

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -4,6 +4,11 @@
 
 use crate::audit_capture::{AuditCapture, CapturingRecorder};
 use crate::bus::{ClientId, TransportBus};
+use crate::decryptability::DecryptabilityProbeSendStatus;
+use crate::pending_work::PendingWorkObservation;
+use crate::scenario_input_ledger::{
+    ScenarioInputKind, ScenarioInputLedgerEntry, ScenarioInputMetadata, ScenarioInputTracker,
+};
 use cgka_engine::account_identity_proof::{
     AccountIdentityProofRequest, AccountIdentityProofSigner,
 };
@@ -56,6 +61,10 @@ pub struct HarnessClient {
     /// automatically after the first create/join.
     default_group: Option<GroupId>,
     app_event_counter: u64,
+    scenario_input_counter: u64,
+    next_scenario_input_id: Option<String>,
+    scenario_input_tracker: ScenarioInputTracker,
+    pending_scenario_inputs: HashMap<PendingStateRef, String>,
     /// Shared in-memory capture of the engine's forensic audit events, used to
     /// observe decisions no `GroupEvent` exposes (e.g. `convergence_decision`).
     audit_capture: AuditCapture,
@@ -252,6 +261,10 @@ impl ClientBuilder {
             pending_events: Vec::new(),
             default_group: None,
             app_event_counter: 0,
+            scenario_input_counter: 0,
+            next_scenario_input_id: None,
+            scenario_input_tracker: ScenarioInputTracker::default(),
+            pending_scenario_inputs: HashMap::new(),
             audit_capture,
             convergence_checkpoints: HashMap::new(),
         }
@@ -524,6 +537,16 @@ impl HarnessClient {
         self.engine().self_id()
     }
 
+    /// Assign the stable synthetic id consumed by the next commit, proposal, or
+    /// application input this client produces.
+    pub fn name_next_scenario_input(&mut self, scenario_id: impl Into<String>) {
+        assert!(
+            self.next_scenario_input_id.is_none(),
+            "previous scenario input id was not consumed"
+        );
+        self.next_scenario_input_id = Some(scenario_id.into());
+    }
+
     pub async fn fresh_key_package(&mut self) -> KeyPackage {
         let key_package = self.engine_mut().fresh_key_package().await.expect("kp");
         key_package_with_harness_source(key_package)
@@ -634,10 +657,15 @@ impl HarnessClient {
     /// action (create, invite, upgrade) when the simulated transport
     /// "succeeds."
     pub async fn confirm(&mut self, pending: PendingStateRef) {
-        self.engine_mut()
-            .confirm_published(pending)
-            .await
-            .expect("confirm_published");
+        self.try_confirm(pending).await.expect("confirm_published");
+    }
+
+    async fn try_confirm(&mut self, pending: PendingStateRef) -> Result<(), EngineError> {
+        self.engine_mut().confirm_published(pending).await?;
+        if let Some(scenario_id) = self.pending_scenario_inputs.remove(&pending) {
+            self.scenario_input_tracker.record_confirmed(&scenario_id);
+        }
+        Ok(())
     }
 
     /// Report a publish failure for a pending operation. The engine
@@ -648,6 +676,9 @@ impl HarnessClient {
             .publish_failed(pending)
             .await
             .expect("publish_failed");
+        if let Some(scenario_id) = self.pending_scenario_inputs.remove(&pending) {
+            self.scenario_input_tracker.record_rolled_back(&scenario_id);
+        }
     }
 
     /// Issue a `SendIntent::UpgradeCapabilities` for the default group
@@ -666,10 +697,21 @@ impl HarnessClient {
                 welcomes,
                 pending,
             } => {
+                let scenario_input =
+                    self.next_scenario_input_metadata(ScenarioInputKind::Commit, None, None);
+                self.scenario_input_tracker
+                    .record_send_attempt(&scenario_input);
+                self.scenario_input_tracker
+                    .record_send_accepted(&scenario_input, false);
                 for w in welcomes {
                     self.bus.send(self.bus_id, w);
                 }
-                self.bus.send(self.bus_id, route(msg, &gid));
+                let routed = route(msg, &gid);
+                let scenario_input = self
+                    .register_published_scenario_input(&routed, scenario_input)
+                    .await;
+                self.remember_pending_scenario_input(pending, &scenario_input);
+                self.bus.send(self.bus_id, routed);
                 pending
             }
             other => panic!("expected GroupEvolution from upgrade, got {other:?}"),
@@ -697,7 +739,18 @@ impl HarnessClient {
                     welcomes.is_empty(),
                     "group-data update should not create welcomes"
                 );
-                self.bus.send(self.bus_id, route(msg, &gid));
+                let scenario_input =
+                    self.next_scenario_input_metadata(ScenarioInputKind::Commit, None, None);
+                self.scenario_input_tracker
+                    .record_send_attempt(&scenario_input);
+                self.scenario_input_tracker
+                    .record_send_accepted(&scenario_input, false);
+                let routed = route(msg, &gid);
+                let scenario_input = self
+                    .register_published_scenario_input(&routed, scenario_input)
+                    .await;
+                self.remember_pending_scenario_input(pending, &scenario_input);
+                self.bus.send(self.bus_id, routed);
                 pending
             }
             other => panic!("expected GroupEvolution from update_group_data, got {other:?}"),
@@ -730,7 +783,18 @@ impl HarnessClient {
                     welcomes.is_empty(),
                     "admin policy update should not create welcomes"
                 );
-                self.bus.send(self.bus_id, route(msg, &gid));
+                let scenario_input =
+                    self.next_scenario_input_metadata(ScenarioInputKind::Commit, None, None);
+                self.scenario_input_tracker
+                    .record_send_attempt(&scenario_input);
+                self.scenario_input_tracker
+                    .record_send_accepted(&scenario_input, false);
+                let routed = route(msg, &gid);
+                let scenario_input = self
+                    .register_published_scenario_input(&routed, scenario_input)
+                    .await;
+                self.remember_pending_scenario_input(pending, &scenario_input);
+                self.bus.send(self.bus_id, routed);
                 Ok(pending)
             }
             other => Err(EngineError::Backend(format!(
@@ -758,6 +822,14 @@ impl HarnessClient {
             .clone()
             .expect("must create or join a group first");
         let payload = self.next_app_payload(payload.into());
+        let (logical_id, logical_payload) = logical_message_fields(&payload);
+        let scenario_input = self.next_scenario_input_metadata(
+            ScenarioInputKind::Application,
+            Some(logical_id),
+            Some(logical_payload),
+        );
+        self.scenario_input_tracker
+            .record_send_attempt(&scenario_input);
         let res = self
             .engine_mut()
             .send(SendIntent::AppMessage {
@@ -768,7 +840,11 @@ impl HarnessClient {
             .expect("send app");
         match res {
             SendResult::ApplicationMessage { msg, .. } => {
+                self.scenario_input_tracker
+                    .record_send_accepted(&scenario_input, false);
                 let routed = route(msg, &gid);
+                self.register_published_scenario_input(&routed, scenario_input)
+                    .await;
                 self.bus.send(self.bus_id, routed.clone());
                 routed
             }
@@ -778,23 +854,68 @@ impl HarnessClient {
 
     /// Send an application message to the default group.
     pub async fn send_app(&mut self, payload: impl Into<Vec<u8>>) {
+        let _ = self
+            .try_send_app(payload)
+            .await
+            .expect("send app message through harness");
+    }
+
+    pub async fn request_disband(&mut self) -> Result<(), EngineError> {
+        let group_id = self.default_group.clone().expect("group");
+        match self
+            .engine_mut()
+            .send(SendIntent::Disband { group_id })
+            .await?
+        {
+            SendResult::DisbandRequested { .. } => Ok(()),
+            other => Err(EngineError::Backend(format!(
+                "expected DisbandRequested, got {other:?}"
+            ))),
+        }
+    }
+
+    pub(crate) async fn try_send_app(
+        &mut self,
+        payload: impl Into<Vec<u8>>,
+    ) -> Result<(DecryptabilityProbeSendStatus, String), EngineError> {
         let gid = self
             .default_group
             .clone()
-            .expect("must create or join a group first");
+            .ok_or_else(|| EngineError::Other("must create or join a group first".into()))?;
         let payload = self.next_app_payload(payload.into());
+        let (logical_id, logical_payload) = logical_message_fields(&payload);
+        let scenario_input = self.next_scenario_input_metadata(
+            ScenarioInputKind::Application,
+            Some(logical_id.clone()),
+            Some(logical_payload),
+        );
+        self.scenario_input_tracker
+            .record_send_attempt(&scenario_input);
         let res = self
             .engine_mut()
             .send(SendIntent::AppMessage {
                 group_id: gid.clone(),
                 payload,
             })
-            .await
-            .expect("send app");
-        if let SendResult::ApplicationMessage { msg, .. } = res {
-            self.bus.send(self.bus_id, route(msg, &gid));
-        } else {
-            panic!("expected ApplicationMessage");
+            .await?;
+        match res {
+            SendResult::ApplicationMessage { msg, .. } => {
+                self.scenario_input_tracker
+                    .record_send_accepted(&scenario_input, false);
+                let routed = route(msg, &gid);
+                self.register_published_scenario_input(&routed, scenario_input)
+                    .await;
+                self.bus.send(self.bus_id, routed);
+                Ok((DecryptabilityProbeSendStatus::Published, logical_id))
+            }
+            SendResult::Queued { .. } => {
+                self.scenario_input_tracker
+                    .record_send_accepted(&scenario_input, true);
+                Ok((DecryptabilityProbeSendStatus::Queued, logical_id))
+            }
+            other => Err(EngineError::Backend(format!(
+                "expected ApplicationMessage or Queued, got {other:?}"
+            ))),
         }
     }
 
@@ -831,7 +952,18 @@ impl HarnessClient {
                 for w in welcomes {
                     self.bus.send(self.bus_id, w);
                 }
-                self.bus.send(self.bus_id, route(msg, &gid));
+                let scenario_input =
+                    self.next_scenario_input_metadata(ScenarioInputKind::Commit, None, None);
+                self.scenario_input_tracker
+                    .record_send_attempt(&scenario_input);
+                self.scenario_input_tracker
+                    .record_send_accepted(&scenario_input, false);
+                let routed = route(msg, &gid);
+                let scenario_input = self
+                    .register_published_scenario_input(&routed, scenario_input)
+                    .await;
+                self.remember_pending_scenario_input(pending, &scenario_input);
+                self.bus.send(self.bus_id, routed);
                 Ok(pending)
             }
             other => Err(EngineError::Other(format!(
@@ -856,7 +988,15 @@ impl HarnessClient {
             .await
             .expect("send leave");
         if let SendResult::Proposal { msg } = res {
+            let scenario_input =
+                self.next_scenario_input_metadata(ScenarioInputKind::Proposal, None, None);
+            self.scenario_input_tracker
+                .record_send_attempt(&scenario_input);
+            self.scenario_input_tracker
+                .record_send_accepted(&scenario_input, false);
             let routed = route(msg, &gid);
+            self.register_published_scenario_input(&routed, scenario_input)
+                .await;
             self.bus.send(self.bus_id, routed.clone());
             routed
         } else {
@@ -897,7 +1037,12 @@ impl HarnessClient {
         let inbound = self.bus.mailbox(self.bus_id);
         let mut outcomes = Vec::with_capacity(inbound.len());
         for msg in inbound {
+            let scenario_input = self.bus.scenario_input_for_transport(&msg.id);
             let result = self.engine_mut().ingest(msg).await;
+            if let Some(scenario_input) = scenario_input {
+                self.scenario_input_tracker
+                    .record_ingest(&scenario_input, result.as_ref().map_err(|_| ()));
+            }
             if result.is_ok() {
                 self.capture_engine_events();
             }
@@ -1013,12 +1158,40 @@ impl HarnessClient {
     async fn publish_send_result(&mut self, result: SendResult) -> Result<(), EngineError> {
         let gid = self.default_group.clone();
         match result {
-            SendResult::ApplicationMessage { msg, .. } | SendResult::Proposal { msg } => {
+            SendResult::ApplicationMessage {
+                msg, app_event_id, ..
+            } => {
                 let routed = if let Some(gid) = &gid {
                     route(msg, gid)
                 } else {
                     msg
                 };
+                let scenario_input = self
+                    .scenario_input_tracker
+                    .metadata_for_logical(&app_event_id)
+                    .ok_or_else(|| {
+                        EngineError::Backend(format!(
+                            "missing scenario-input metadata for regenerated app event {app_event_id}"
+                        ))
+                    })?;
+                self.register_published_scenario_input(&routed, scenario_input)
+                    .await;
+                self.bus.send(self.bus_id, routed);
+            }
+            SendResult::Proposal { msg } => {
+                let routed = if let Some(gid) = &gid {
+                    route(msg, gid)
+                } else {
+                    msg
+                };
+                let scenario_input =
+                    self.next_scenario_input_metadata(ScenarioInputKind::Proposal, None, None);
+                self.scenario_input_tracker
+                    .record_send_attempt(&scenario_input);
+                self.scenario_input_tracker
+                    .record_send_accepted(&scenario_input, false);
+                self.register_published_scenario_input(&routed, scenario_input)
+                    .await;
                 self.bus.send(self.bus_id, routed);
             }
             SendResult::GroupEvolution {
@@ -1034,8 +1207,18 @@ impl HarnessClient {
                 } else {
                     msg
                 };
+                let scenario_input =
+                    self.next_scenario_input_metadata(ScenarioInputKind::Commit, None, None);
+                self.scenario_input_tracker
+                    .record_send_attempt(&scenario_input);
+                self.scenario_input_tracker
+                    .record_send_accepted(&scenario_input, false);
+                let scenario_input = self
+                    .register_published_scenario_input(&routed, scenario_input)
+                    .await;
+                self.remember_pending_scenario_input(pending, &scenario_input);
                 self.bus.send(self.bus_id, routed);
-                self.engine_mut().confirm_published(pending).await?;
+                self.try_confirm(pending).await?;
                 self.capture_engine_events();
             }
             SendResult::GroupCreated { welcomes, pending } => {
@@ -1068,8 +1251,18 @@ impl HarnessClient {
             } else {
                 auto.msg
             };
+            let scenario_input =
+                self.next_scenario_input_metadata(ScenarioInputKind::Commit, None, None);
+            self.scenario_input_tracker
+                .record_send_attempt(&scenario_input);
+            self.scenario_input_tracker
+                .record_send_accepted(&scenario_input, false);
+            let scenario_input = self
+                .register_published_scenario_input(&routed, scenario_input)
+                .await;
+            self.remember_pending_scenario_input(auto.pending, &scenario_input);
             self.bus.send(self.bus_id, routed);
-            if let Err(e) = self.engine_mut().confirm_published(auto.pending).await {
+            if let Err(e) = self.try_confirm(auto.pending).await {
                 outcomes.push(Err(e));
                 continue;
             }
@@ -1082,6 +1275,14 @@ impl HarnessClient {
             } else {
                 msg
             };
+            let scenario_input =
+                self.next_scenario_input_metadata(ScenarioInputKind::Proposal, None, None);
+            self.scenario_input_tracker
+                .record_send_attempt(&scenario_input);
+            self.scenario_input_tracker
+                .record_send_accepted(&scenario_input, false);
+            self.register_published_scenario_input(&routed, scenario_input)
+                .await;
             self.bus.send(self.bus_id, routed);
         }
         outcomes
@@ -1099,7 +1300,19 @@ impl HarnessClient {
 
     pub fn members(&self) -> Vec<cgka_traits::group::Member> {
         let gid = self.default_group.clone().expect("group");
-        self.engine().members(&gid).expect("members")
+        match self.engine().members(&gid) {
+            Ok(members) => members,
+            Err(error) => {
+                let record = self.engine().group_record(&gid).unwrap_or_else(|_| {
+                    panic!("members unavailable without terminal group record: {error}")
+                });
+                assert!(
+                    record.disbanded.is_some(),
+                    "members unavailable for non-disbanded group: {error}"
+                );
+                record.members
+            }
+        }
     }
 
     /// Current app-facing group name mirrored from signed group-profile state.
@@ -1119,6 +1332,64 @@ impl HarnessClient {
         self.default_group.clone().expect("group")
     }
 
+    /// Capture the conformance-only canonical state projection for the default
+    /// group without exposing the wrapped engine to scenario code.
+    pub fn canonical_group_snapshot(
+        &self,
+    ) -> cgka_engine::conformance_snapshot::ConformanceGroupSnapshot {
+        let group_id = self.default_group.clone().expect("group");
+        self.engine()
+            .conformance_group_snapshot(&group_id)
+            .expect("capture canonical group snapshot")
+    }
+
+    pub fn canonical_state_snapshot(
+        &self,
+    ) -> cgka_engine::conformance_snapshot::ConformanceCanonicalStateSnapshot {
+        let group_id = self.default_group.clone().expect("group");
+        self.engine()
+            .conformance_canonical_state_snapshot(&group_id)
+            .expect("capture canonical state snapshot")
+    }
+
+    pub fn scenario_input_ledger(&mut self) -> Vec<ScenarioInputLedgerEntry> {
+        let observed_states = self
+            .scenario_input_tracker
+            .state_queries()
+            .into_iter()
+            .map(|(scenario_id, kind, aliases)| {
+                let state = self
+                    .engine()
+                    .conformance_message_state(&aliases)
+                    .expect("capture conformance message state");
+                (scenario_id, kind, state)
+            })
+            .collect::<Vec<_>>();
+        for (scenario_id, kind, state) in observed_states {
+            if let Some(state) = state {
+                self.scenario_input_tracker
+                    .record_storage_state(&scenario_id, kind, state);
+            }
+        }
+        self.scenario_input_tracker.snapshot()
+    }
+
+    pub fn pending_work_observation(&self) -> PendingWorkObservation {
+        let group_id = self.default_group.clone().expect("group");
+        let engine = self
+            .engine()
+            .conformance_pending_work_snapshot(&group_id)
+            .expect("capture conformance pending work");
+        let bus = self.bus.pending_work_snapshot();
+        PendingWorkObservation {
+            engine,
+            bus_queued_messages: bus.queued_messages,
+            bus_delayed_messages: bus.delayed_messages,
+            bus_mailbox_messages: bus.mailbox_messages,
+            scenario_inputs_pending: self.scenario_input_tracker.pending_count(),
+        }
+    }
+
     fn next_app_payload(&mut self, payload: Vec<u8>) -> Vec<u8> {
         let seq = self.app_event_counter;
         self.app_event_counter = self
@@ -1126,6 +1397,63 @@ impl HarnessClient {
             .checked_add(1)
             .expect("app event counter exhausted");
         encode_harness_app_payload(&self.engine().self_id(), seq, payload)
+    }
+
+    async fn register_published_scenario_input(
+        &mut self,
+        message: &TransportMessage,
+        mut metadata: ScenarioInputMetadata,
+    ) -> ScenarioInputMetadata {
+        metadata.aliases = self
+            .engine()
+            .conformance_message_aliases(&message.id)
+            .expect("sender exposes durable scenario-input aliases");
+        let content_id = metadata
+            .aliases
+            .iter()
+            .find(|alias| **alias != message.id)
+            .cloned()
+            .unwrap_or_else(|| message.id.clone());
+        self.bus
+            .register_scenario_input(message.id.clone(), content_id, metadata.clone());
+        self.scenario_input_tracker.record_published(&metadata);
+        metadata
+    }
+
+    fn next_scenario_input_metadata(
+        &mut self,
+        kind: ScenarioInputKind,
+        logical_id: Option<String>,
+        payload: Option<String>,
+    ) -> ScenarioInputMetadata {
+        let sequence = self.scenario_input_counter;
+        self.scenario_input_counter = self
+            .scenario_input_counter
+            .checked_add(1)
+            .expect("scenario input counter exhausted");
+        let sender = logical_label_for_member_id(&self.identity)
+            .unwrap_or_else(|| hex::encode(&self.identity));
+        let scenario_id = self
+            .next_scenario_input_id
+            .take()
+            .unwrap_or_else(|| format!("{sender}/{}-{sequence}", kind.label()));
+        ScenarioInputMetadata {
+            scenario_id,
+            kind,
+            sender,
+            logical_id,
+            payload,
+            aliases: Vec::new(),
+        }
+    }
+
+    fn remember_pending_scenario_input(
+        &mut self,
+        pending: PendingStateRef,
+        metadata: &ScenarioInputMetadata,
+    ) {
+        self.pending_scenario_inputs
+            .insert(pending, metadata.scenario_id.clone());
     }
 
     /// Return a clone of `msg` whose payload is the peeled MLS wire bytes.
@@ -1170,15 +1498,61 @@ impl HarnessClient {
 
 impl HarnessClient {
     fn capture_engine_events(&mut self) {
-        for event in self.engine_mut().drain_events() {
+        let events = self.engine_mut().drain_events();
+        for event in events {
             if let GroupEvent::GroupJoined { group_id, .. } = &event
                 && self.default_group.is_none()
             {
                 self.default_group = Some(group_id.clone());
             }
+            match &event {
+                GroupEvent::MessageReceived { payload, .. } => {
+                    let (logical_id, _) = logical_message_fields(payload);
+                    self.scenario_input_tracker
+                        .record_delivered_logical(&logical_id);
+                }
+                GroupEvent::AppMessageInvalidated {
+                    message_id, reason, ..
+                } => {
+                    if let Some(scenario_input) = self.bus.scenario_input_for_content(message_id) {
+                        self.scenario_input_tracker
+                            .record_app_invalidated(&scenario_input, *reason);
+                    }
+                }
+                GroupEvent::ForkRecovered {
+                    invalidated_commit_id,
+                    ..
+                }
+                | GroupEvent::CommitRolledBack {
+                    invalidated_commit_id,
+                    ..
+                }
+                | GroupEvent::GroupStateInvalidated {
+                    invalidated_commit_id,
+                    ..
+                } => {
+                    if let Some(scenario_input) = self
+                        .bus
+                        .scenario_input_for_transport(invalidated_commit_id)
+                        .or_else(|| self.bus.scenario_input_for_content(invalidated_commit_id))
+                    {
+                        self.scenario_input_tracker
+                            .record_commit_invalidated(&scenario_input, "superseded");
+                    }
+                }
+                _ => {}
+            }
             self.pending_events.push(event);
         }
     }
+}
+
+fn logical_message_fields(payload: &[u8]) -> (String, String) {
+    let event = MarmotAppEvent::decode(payload).expect("harness application payload decodes");
+    (
+        event.id,
+        String::from_utf8_lossy(&decode_harness_app_payload(payload)).into_owned(),
+    )
 }
 
 pub fn encode_harness_app_payload(sender: &MemberId, sequence: u64, payload: Vec<u8>) -> Vec<u8> {

--- a/crates/cgka-conformance-simulator/src/decryptability.rs
+++ b/crates/cgka-conformance-simulator/src/decryptability.rs
@@ -1,0 +1,93 @@
+//! Active application-message probes for cryptographic reachability.
+//!
+//! Exact group snapshots can establish that two clients expose the same
+//! canonical state, but they do not exercise the normal send, transport peel,
+//! MLS decrypt, and application delivery path. These observations record that
+//! end-to-end evidence for every directed pair in a selected client set.
+
+use crate::ScenarioInputLedgerEntry;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum DecryptabilityProbeSendStatus {
+    Published,
+    Queued,
+    Failed { error: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirectionalDecryptabilityProbe {
+    pub sender: String,
+    pub recipient: String,
+    pub payload: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logical_id: Option<String>,
+    pub send_status: DecryptabilityProbeSendStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recipient_ledger: Option<ScenarioInputLedgerEntry>,
+}
+
+impl DirectionalDecryptabilityProbe {
+    pub fn succeeded(&self) -> bool {
+        matches!(self.send_status, DecryptabilityProbeSendStatus::Published)
+            && self.recipient_ledger.as_ref().is_some_and(|entry| {
+                self.logical_id.as_ref() == entry.logical_id.as_ref()
+                    && entry.sender == self.sender
+                    && entry.payload == self.payload
+                    && entry.delivered > 0
+            })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BidirectionalDecryptabilityObservation {
+    pub step_index: usize,
+    pub clients: Vec<String>,
+    pub probes: Vec<DirectionalDecryptabilityProbe>,
+}
+
+impl BidirectionalDecryptabilityObservation {
+    pub fn succeeded(&self) -> bool {
+        let unique_clients = self.clients.iter().collect::<BTreeSet<_>>();
+        let expected_edges = self
+            .clients
+            .iter()
+            .flat_map(|sender| {
+                self.clients
+                    .iter()
+                    .filter(move |recipient| *recipient != sender)
+                    .map(move |recipient| (sender, recipient))
+            })
+            .collect::<BTreeSet<_>>();
+        let observed_edges = self
+            .probes
+            .iter()
+            .map(|probe| (&probe.sender, &probe.recipient))
+            .collect::<BTreeSet<_>>();
+        self.clients.len() >= 2
+            && unique_clients.len() == self.clients.len()
+            && observed_edges == expected_edges
+            && self.probes.len() == expected_edges.len()
+            && self
+                .probes
+                .iter()
+                .all(DirectionalDecryptabilityProbe::succeeded)
+    }
+
+    pub fn failed_edges(&self) -> Vec<&DirectionalDecryptabilityProbe> {
+        self.probes
+            .iter()
+            .filter(|probe| !probe.succeeded())
+            .collect()
+    }
+
+    pub(crate) fn matches_clients(&self, clients: &[String]) -> bool {
+        let mut observed = self.clients.clone();
+        observed.sort();
+        let mut expected = clients.to_vec();
+        expected.sort();
+        observed == expected
+    }
+}

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -557,13 +557,18 @@ fn convergence_chaos_delayed_past_epoch_app(
             },
             ScenarioStep::DeliverAll,
             tick(["carol"]),
-            observe(["carol"]),
+            observe(["carol", "david"]),
         ],
     };
     let expected = vec![
         confirmed(1, "alice", "create"),
         confirmed(8, "alice", "invite-david"),
         client_state("carol", 2, 4, vec![payload]),
+        // David joined after the application input was authored and therefore
+        // does not claim historical delivery. Naming his state explicitly
+        // also makes him part of the strict exact/pending-work boundary,
+        // where the retained pre-join transport object remains visible.
+        client_state("david", 2, 4, vec![]),
     ];
     (scenario, expected)
 }
@@ -1315,31 +1320,14 @@ fn add_strict_reliability_oracle(
 ) {
     let exact_clients = expected
         .iter()
-        .find_map(|expectation| match expectation {
-            TraceExpectation::ClientsConverged { clients, .. } => Some(clients.clone()),
-            _ => None,
+        .flat_map(|expectation| match expectation {
+            TraceExpectation::ClientsConverged { clients, .. } => clients.clone(),
+            TraceExpectation::ClientState { client, .. } => vec![client.clone()],
+            _ => Vec::new(),
         })
-        .or_else(|| {
-            expected.iter().find_map(|expectation| match expectation {
-                TraceExpectation::ClientState { member_count, .. }
-                    if *member_count == scenario.clients.len() =>
-                {
-                    Some(scenario.clients.clone())
-                }
-                _ => None,
-            })
-        })
-        .unwrap_or_else(|| {
-            expected
-                .iter()
-                .filter_map(|expectation| match expectation {
-                    TraceExpectation::ClientState { client, .. } => Some(client.clone()),
-                    _ => None,
-                })
-                .collect::<BTreeSet<_>>()
-                .into_iter()
-                .collect()
-        });
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
 
     if exact_clients.is_empty() {
         return;

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -47,13 +47,15 @@ pub fn generate_send_leave_family(seed: u64, cases: usize) -> Vec<GeneratedScena
     let mut out = Vec::with_capacity(cases);
     for case_index in 0..cases {
         let mut rng = StdRng::seed_from_u64(seed ^ ((case_index as u64) << 32));
+        let (mut scenario, mut expected_outcomes) = send_leave_case(&mut rng, case_index as u64);
+        add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
         out.push(GeneratedScenarioCase {
             family_name: "send-leave/v1".into(),
-            generator_version: "1".into(),
+            generator_version: "2".into(),
             seed,
             case_index: case_index as u64,
-            scenario: send_leave_case(&mut rng, case_index as u64),
-            expected_outcomes: vec![],
+            scenario,
+            expected_outcomes,
         });
     }
     out
@@ -82,10 +84,12 @@ pub fn generate_convergence_chaos_family(seed: u64, cases: usize) -> Vec<Generat
     let mut out = Vec::with_capacity(cases);
     for case_index in 0..cases {
         let mut rng = StdRng::seed_from_u64(seed ^ 0xC0A7_1CE5 ^ ((case_index as u64) << 32));
-        let (scenario, expected_outcomes) = convergence_chaos_case(&mut rng, case_index as u64);
+        let (mut scenario, mut expected_outcomes) =
+            convergence_chaos_case(&mut rng, case_index as u64);
+        add_strict_reliability_oracle(&mut scenario, &mut expected_outcomes);
         out.push(GeneratedScenarioCase {
             family_name: "convergence-chaos/v1".into(),
-            generator_version: "3".into(),
+            generator_version: "4".into(),
             seed,
             case_index: case_index as u64,
             scenario,
@@ -1198,7 +1202,7 @@ fn shuffled_order(rng: &mut StdRng, len: usize) -> Vec<usize> {
     order
 }
 
-fn send_leave_case(rng: &mut StdRng, case_index: u64) -> ScenarioSpec {
+fn send_leave_case(rng: &mut StdRng, case_index: u64) -> (ScenarioSpec, Vec<TraceExpectation>) {
     let clients = vec!["alice".to_string(), "bob".to_string(), "carol".to_string()];
     let mut steps = vec![
         ScenarioStep::CreateGroup {
@@ -1220,19 +1224,23 @@ fn send_leave_case(rng: &mut StdRng, case_index: u64) -> ScenarioSpec {
     ];
 
     let send_count = 2 + rng.gen_range(0..=2);
+    let mut sends = Vec::with_capacity(send_count);
     for send_index in 0..send_count {
         let sender = clients[rng.gen_range(0..clients.len())].clone();
         let marker: u16 = rng.r#gen();
+        let payload = format!("case-{case_index}:send-{send_index}:{sender}:{marker}");
         steps.push(ScenarioStep::SendAppMessage {
             sender: sender.clone(),
-            payload: format!("case-{case_index}:send-{send_index}:{sender}:{marker}"),
+            payload: payload.clone(),
         });
+        sends.push((sender, payload));
     }
 
     if send_count > 1 && rng.gen_bool(0.5) {
         steps.push(ScenarioStep::ReorderQueued {
             order: (0..send_count).rev().collect(),
         });
+        sends.reverse();
     }
     steps.push(ScenarioStep::DeliverAll);
     steps.push(ScenarioStep::Tick {
@@ -1267,13 +1275,94 @@ fn send_leave_case(rng: &mut StdRng, case_index: u64) -> ScenarioSpec {
     };
 
     steps.push(ScenarioStep::Observe {
-        clients: observe_clients,
+        clients: observe_clients.clone(),
     });
 
-    ScenarioSpec {
-        name: format!("send-leave/v1/case-{case_index}"),
-        spec_version: "1".into(),
-        clients,
-        steps,
+    let epoch = u64::from(leaver.is_some()) + 1;
+    let member_count = clients.len() - usize::from(leaver.is_some());
+    let mut expected = vec![confirmed(1, "alice", "create")];
+    for client in &observe_clients {
+        expected.push(client_state(
+            client,
+            epoch,
+            member_count,
+            sends
+                .iter()
+                .filter(|(sender, _)| sender != client)
+                .map(|(_, payload)| payload.clone())
+                .collect(),
+        ));
     }
+
+    (
+        ScenarioSpec {
+            name: format!("send-leave/v1/case-{case_index}"),
+            spec_version: "1".into(),
+            clients,
+            steps,
+        },
+        expected,
+    )
+}
+
+/// Turn a generated reliability scenario's claimed settled state into a
+/// strict black-box assertion. The extra drain is deliberate: exact state and
+/// quiescence are sampled only after every attached client has had a final
+/// chance to consume retained transport.
+fn add_strict_reliability_oracle(
+    scenario: &mut ScenarioSpec,
+    expected: &mut Vec<TraceExpectation>,
+) {
+    let exact_clients = expected
+        .iter()
+        .find_map(|expectation| match expectation {
+            TraceExpectation::ClientsConverged { clients, .. } => Some(clients.clone()),
+            _ => None,
+        })
+        .or_else(|| {
+            expected.iter().find_map(|expectation| match expectation {
+                TraceExpectation::ClientState { member_count, .. }
+                    if *member_count == scenario.clients.len() =>
+                {
+                    Some(scenario.clients.clone())
+                }
+                _ => None,
+            })
+        })
+        .unwrap_or_else(|| {
+            expected
+                .iter()
+                .filter_map(|expectation| match expectation {
+                    TraceExpectation::ClientState { client, .. } => Some(client.clone()),
+                    _ => None,
+                })
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect()
+        });
+
+    if exact_clients.is_empty() {
+        return;
+    }
+
+    scenario.steps.push(ScenarioStep::DeliverAll);
+    scenario.steps.push(ScenarioStep::Tick {
+        clients: scenario.clients.clone(),
+    });
+    scenario.steps.push(ScenarioStep::DeliverAll);
+    scenario.steps.push(ScenarioStep::Tick {
+        clients: scenario.clients.clone(),
+    });
+    scenario.steps.push(ScenarioStep::ObserveExact {
+        clients: exact_clients.clone(),
+    });
+
+    if exact_clients.len() >= 2 {
+        expected.push(TraceExpectation::ClientsExactlyEquivalent {
+            clients: exact_clients.clone(),
+        });
+    }
+    expected.push(TraceExpectation::NoPendingWork {
+        clients: exact_clients,
+    });
 }

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -9,6 +9,8 @@
 //!   partition support, broadcast / addressed delivery for welcomes.
 //! - [`client`] - [`client::HarnessClient`] wrapping `Engine<SqliteAccountStorage>`
 //!   plus the real Nostr transport peeler over the in-memory bus.
+//! - active bidirectional decryptability probes that exercise the complete
+//!   application-message path and retain per-edge ledger evidence.
 //! - [`canonicalization`] - executable model of the CGKA canonicalization
 //!   contract above the branch selector, re-exported from `cgka-engine`.
 //! - [`convergence`] - candidate-state graph scoring rules, re-exported
@@ -21,17 +23,29 @@
 mod audit_capture;
 pub mod bus;
 pub mod client;
+mod decryptability;
 pub mod family;
 pub mod oracle;
+mod pending_work;
 pub mod policy_cases;
 pub mod proptest_support;
 pub mod report;
 pub mod scenario;
+mod scenario_input_ledger;
 pub mod vector;
 
 pub use bus::{ClientId, DeliveryPolicy, TransportBus};
+pub use cgka_engine::conformance_snapshot::{
+    ConformanceAppComponent, ConformanceCanonicalStateSnapshot, ConformanceDisbandedGroupSnapshot,
+    ConformanceGroupSnapshot, ConformanceLeafCapabilities, ConformanceLeafSnapshot,
+    ConformancePendingWorkSnapshot, ConformanceRequiredCapabilities,
+};
 pub use cgka_engine::{canonicalization, convergence, openmls_projection};
 pub use client::{ClientBuilder, HarnessClient, HarnessStorageMode};
+pub use decryptability::{
+    BidirectionalDecryptabilityObservation, DecryptabilityProbeSendStatus,
+    DirectionalDecryptabilityProbe,
+};
 pub use family::{
     GeneratedScenarioCase, generate_convergence_chaos_family,
     generate_convergence_e2e_delivery_family, generate_send_leave_family,
@@ -43,6 +57,7 @@ pub use oracle::{
     coverage_matrix_entry, expected_behaviors, property_test_coverage_entries, scenario_stimuli,
     trace_behaviors,
 };
+pub use pending_work::PendingWorkObservation;
 pub use report::{
     ReportArgs, ReportCommand, ReportFailureSummary, ReportInput, ReportRunSummary,
     ScenarioReportSummary, parse_report_command, report_usage, run_report,
@@ -55,10 +70,14 @@ pub use scenario::{
     run_scenario_report_with_outcomes_and_storage_mode, run_scenario_report_with_storage_mode,
     run_scenario_spec, run_vector_fixture_report, run_vector_fixture_report_with_storage_mode,
 };
+pub use scenario_input_ledger::{
+    ScenarioInputDisposition, ScenarioInputKind, ScenarioInputLedgerEntry,
+};
 pub use vector::{
     AppInvalidationObservation, ApplicationProfileContract, ClientEventCounts, ClientObservation,
     ConvergenceDecisionObservation, EpochChangeObservation, ExpectationFailure,
     ForkRecoveryObservation, PendingResolutionObservation, RecoveryOrderingKeyObservation,
     ScenarioAdminPolicyObservation, ScenarioErrorObservation, ScenarioTrace, TraceExpectation,
     VectorFixture, VectorMismatch, compare_trace_expectations, observe_client,
+    observe_client_exact,
 };

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -17,6 +17,7 @@ pub enum ScenarioStimulus {
     PublishConfirm,
     PublishFail,
     AppMessage,
+    BidirectionalDecryptabilityProbe,
     Leave,
     QueueDrop,
     QueueDuplicate,
@@ -47,6 +48,10 @@ pub enum OracleBehavior {
     AdminPolicyObserved,
     ClientState,
     ClientConvergence,
+    ExactStateEquivalence,
+    ScenarioInputDisposition,
+    NoPendingWorkObserved,
+    BidirectionalDecryptabilityObserved,
     DeliveredPayload,
     MemberAdded,
     MemberRemoved,
@@ -80,6 +85,12 @@ pub struct BehaviorEvidenceSummary {
     pub app_invalidations: usize,
     pub recoveries: usize,
     pub convergence_decisions: usize,
+    pub scenario_input_entries: usize,
+    pub scenario_inputs_deduplicated: usize,
+    pub no_pending_work_observations: usize,
+    pub decryptability_probe_edges: usize,
+    pub decryptability_probe_edges_delivered: usize,
+    pub bidirectional_decryptability_observations: usize,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -281,6 +292,11 @@ pub fn scenario_stimuli(spec: &ScenarioSpec) -> Vec<ScenarioStimulus> {
                 stimuli.insert(ScenarioStimulus::AppMessage);
                 sends += 1;
             }
+            ScenarioStep::ProbeBidirectionalDecryptability { clients } => {
+                stimuli.insert(ScenarioStimulus::AppMessage);
+                stimuli.insert(ScenarioStimulus::BidirectionalDecryptabilityProbe);
+                sends += clients.len();
+            }
             ScenarioStep::Leave { .. } => {
                 stimuli.insert(ScenarioStimulus::Leave);
             }
@@ -305,6 +321,7 @@ pub fn scenario_stimuli(spec: &ScenarioSpec) -> Vec<ScenarioStimulus> {
             ScenarioStep::DeliverAll
             | ScenarioStep::Tick { .. }
             | ScenarioStep::Observe { .. }
+            | ScenarioStep::ObserveExact { .. }
             | ScenarioStep::ObserveAdminPolicy { .. }
             | ScenarioStep::ClearEvents { .. } => {}
         }
@@ -377,6 +394,18 @@ pub fn trace_behaviors(trace: &ScenarioTrace) -> Vec<OracleBehavior> {
     if evidence.convergence_decisions > 0 {
         behaviors.insert(OracleBehavior::ConvergenceDecisionObserved);
     }
+    if evidence.scenario_input_entries > 0 {
+        behaviors.insert(OracleBehavior::ScenarioInputDisposition);
+    }
+    if evidence.scenario_inputs_deduplicated > 0 {
+        behaviors.insert(OracleBehavior::ReplayDeduplication);
+    }
+    if evidence.no_pending_work_observations > 0 {
+        behaviors.insert(OracleBehavior::NoPendingWorkObserved);
+    }
+    if evidence.bidirectional_decryptability_observations > 0 {
+        behaviors.insert(OracleBehavior::BidirectionalDecryptabilityObserved);
+    }
     if evidence.max_member_count >= 20 {
         behaviors.insert(OracleBehavior::LargeGroupObserved);
     }
@@ -390,6 +419,18 @@ pub fn trace_behaviors(trace: &ScenarioTrace) -> Vec<OracleBehavior> {
                 && &observation.group_name == first_group_name
         }) {
             behaviors.insert(OracleBehavior::ClientConvergence);
+        }
+        let exact_states = trace
+            .observations
+            .iter()
+            .filter_map(|observation| observation.canonical_state.as_ref())
+            .collect::<Vec<_>>();
+        if exact_states.len() >= 2
+            && exact_states
+                .iter()
+                .all(|snapshot| *snapshot == exact_states[0])
+        {
+            behaviors.insert(OracleBehavior::ExactStateEquivalence);
         }
     }
     behaviors.into_iter().collect()
@@ -409,6 +450,17 @@ pub fn behavior_evidence(trace: &ScenarioTrace) -> BehaviorEvidenceSummary {
     }
     evidence.expected_errors += trace.errors.len();
     evidence.admin_policy_observations += trace.admin_policies.len();
+    for observation in &trace.decryptability_probes {
+        evidence.decryptability_probe_edges += observation.probes.len();
+        evidence.decryptability_probe_edges_delivered += observation
+            .probes
+            .iter()
+            .filter(|probe| probe.succeeded())
+            .count();
+        if observation.succeeded() {
+            evidence.bidirectional_decryptability_observations += 1;
+        }
+    }
     for observation in &trace.observations {
         evidence.max_member_count = evidence.max_member_count.max(observation.member_count);
         evidence.delivered_payloads += observation.received_payloads.len();
@@ -418,6 +470,19 @@ pub fn behavior_evidence(trace: &ScenarioTrace) -> BehaviorEvidenceSummary {
         evidence.app_invalidations += observation.app_invalidations.len();
         evidence.recoveries += observation.recoveries.len();
         evidence.convergence_decisions += observation.convergence_decisions.len();
+        evidence.scenario_input_entries += observation.scenario_input_ledger.len();
+        evidence.scenario_inputs_deduplicated += observation
+            .scenario_input_ledger
+            .iter()
+            .map(|entry| entry.deduplicated)
+            .sum::<usize>();
+        if observation
+            .pending_work
+            .as_ref()
+            .is_some_and(|pending| pending.is_empty())
+        {
+            evidence.no_pending_work_observations += 1;
+        }
     }
     evidence
 }
@@ -477,6 +542,28 @@ fn expectation_behaviors(expectation: &TraceExpectation) -> BTreeSet<OracleBehav
             if member_count.is_some_and(|count| count >= 20) {
                 behaviors.insert(OracleBehavior::LargeGroupObserved);
             }
+        }
+        TraceExpectation::ClientsExactlyEquivalent { .. } => {
+            behaviors.insert(OracleBehavior::ClientConvergence);
+            behaviors.insert(OracleBehavior::ExactStateEquivalence);
+        }
+        TraceExpectation::ScenarioInputLedger { entries, .. } => {
+            behaviors.insert(OracleBehavior::ScenarioInputDisposition);
+            if entries.iter().any(|entry| entry.delivered > 0) {
+                behaviors.insert(OracleBehavior::DeliveredPayload);
+            }
+            if entries.iter().any(|entry| entry.deduplicated > 0) {
+                behaviors.insert(OracleBehavior::ReplayDeduplication);
+            }
+            if entries.iter().any(|entry| !entry.invalidated.is_empty()) {
+                behaviors.insert(OracleBehavior::AppInvalidated);
+            }
+        }
+        TraceExpectation::NoPendingWork { .. } => {
+            behaviors.insert(OracleBehavior::NoPendingWorkObserved);
+        }
+        TraceExpectation::ClientsBidirectionallyDecryptable { .. } => {
+            behaviors.insert(OracleBehavior::BidirectionalDecryptabilityObserved);
         }
         TraceExpectation::ClientEpochChanges { .. } => {
             behaviors.insert(OracleBehavior::EpochChanged);
@@ -553,6 +640,9 @@ fn recommended_behaviors(stimulus: ScenarioStimulus) -> Vec<OracleBehavior> {
                 OracleBehavior::AppInvalidated,
             ]
         }
+        ScenarioStimulus::BidirectionalDecryptabilityProbe => {
+            vec![OracleBehavior::BidirectionalDecryptabilityObserved]
+        }
         ScenarioStimulus::Leave => vec![
             OracleBehavior::MemberRemoved,
             OracleBehavior::ClientConvergence,
@@ -603,7 +693,7 @@ fn recommended_behaviors(stimulus: ScenarioStimulus) -> Vec<OracleBehavior> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ClientEventCounts, ClientObservation};
+    use crate::{ClientEventCounts, ClientObservation, ConformanceCanonicalStateSnapshot};
 
     fn observation(
         client: &str,
@@ -616,6 +706,9 @@ mod tests {
             epoch,
             member_count,
             group_name: group_name.into(),
+            canonical_state: None,
+            scenario_input_ledger: Vec::new(),
+            pending_work: None,
             event_counts: ClientEventCounts::default(),
             received_payloads: Vec::new(),
             added_members: Vec::new(),
@@ -633,6 +726,7 @@ mod tests {
             pending_resolutions: Vec::new(),
             errors: Vec::new(),
             admin_policies: Vec::new(),
+            decryptability_probes: Vec::new(),
             observations,
         }
     }
@@ -664,6 +758,25 @@ mod tests {
         assert!(
             behaviors.contains(&OracleBehavior::ClientConvergence),
             "same epoch/member_count/group_name should count as convergence: {behaviors:#?}"
+        );
+    }
+
+    #[test]
+    fn trace_behaviors_finds_exact_equivalence_after_legacy_observations() {
+        let mut alice_exact = observation("alice", 2, 2, "winner");
+        alice_exact.canonical_state = Some(ConformanceCanonicalStateSnapshot::Live(Box::default()));
+        let mut bob_exact = observation("bob", 2, 2, "winner");
+        bob_exact.canonical_state = alice_exact.canonical_state.clone();
+        let observed = trace(vec![
+            observation("alice", 2, 2, "winner"),
+            observation("bob", 2, 2, "winner"),
+            alice_exact,
+            bob_exact,
+        ]);
+
+        assert!(
+            trace_behaviors(&observed).contains(&OracleBehavior::ExactStateEquivalence),
+            "legacy observations must not hide a later equivalent exact sample"
         );
     }
 }

--- a/crates/cgka-conformance-simulator/src/pending_work.rs
+++ b/crates/cgka-conformance-simulator/src/pending_work.rs
@@ -1,8 +1,10 @@
 //! Instantaneous pending-work observations for strict simulator assertions.
 //!
 //! This deliberately does not decide quiescence over time. It captures one
-//! privacy-safe progress boundary; Milestone 1.3 will add virtual-time waiting
-//! and repeated stable observations.
+//! privacy-safe, client-scoped local execution boundary; Milestone 1.3 will
+//! add structural progress tokens and bounded virtual-time fixed-point
+//! evaluation. It does not assert end-to-end delivery of transport objects
+//! that a scenario dropped.
 
 use cgka_engine::conformance_snapshot::ConformancePendingWorkSnapshot;
 use serde::{Deserialize, Serialize};

--- a/crates/cgka-conformance-simulator/src/pending_work.rs
+++ b/crates/cgka-conformance-simulator/src/pending_work.rs
@@ -1,0 +1,54 @@
+//! Instantaneous pending-work observations for strict simulator assertions.
+//!
+//! This deliberately does not decide quiescence over time. It captures one
+//! privacy-safe progress boundary; Milestone 1.3 will add virtual-time waiting
+//! and repeated stable observations.
+
+use cgka_engine::conformance_snapshot::ConformancePendingWorkSnapshot;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct BusPendingWorkSnapshot {
+    pub queued_messages: usize,
+    pub delayed_messages: usize,
+    pub mailbox_messages: usize,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingWorkObservation {
+    pub engine: ConformancePendingWorkSnapshot,
+    pub bus_queued_messages: usize,
+    pub bus_delayed_messages: usize,
+    pub bus_mailbox_messages: usize,
+    pub scenario_inputs_pending: usize,
+}
+
+impl PendingWorkObservation {
+    pub fn is_empty(&self) -> bool {
+        self.engine.is_empty()
+            && self.bus_queued_messages == 0
+            && self.bus_delayed_messages == 0
+            && self.bus_mailbox_messages == 0
+            && self.scenario_inputs_pending == 0
+    }
+
+    pub fn blocking_subsystems(&self) -> Vec<&'static str> {
+        let mut blockers = Vec::new();
+        if !self.engine.is_empty() {
+            blockers.push("engine");
+        }
+        if self.bus_queued_messages > 0 {
+            blockers.push("bus_queue");
+        }
+        if self.bus_delayed_messages > 0 {
+            blockers.push("bus_delayed");
+        }
+        if self.bus_mailbox_messages > 0 {
+            blockers.push("bus_mailboxes");
+        }
+        if self.scenario_inputs_pending > 0 {
+            blockers.push("scenario_inputs");
+        }
+        blockers
+    }
+}

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -360,7 +360,7 @@ pub fn parse_report_command(
     let mut cases = 1usize;
     let mut vectors = Vec::new();
     let mut out = PathBuf::from("target/cgka-conformance-simulator-reports");
-    let mut strict_oracle = false;
+    let mut strict_oracle = true;
     let mut storage_mode = None;
 
     let mut args = args.into_iter();
@@ -378,6 +378,7 @@ pub fn parse_report_command(
                 )?)?)
             }
             "--strict-oracle" => strict_oracle = true,
+            "--allow-weak-oracle" => strict_oracle = false,
             "--help" | "-h" => return Ok(ReportCommand::Help),
             other => return Err(format!("unknown argument {other}").into()),
         }
@@ -410,7 +411,7 @@ fn next_value(
 }
 
 pub fn report_usage() -> &'static str {
-    "Usage: cgka-conformance-simulator-report [--vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle]"
+    "Usage: cgka-conformance-simulator-report [--vectors FILE_OR_DIR ... | --family send-leave/v1|convergence-e2e-delivery/v1|convergence-chaos/v1 --seed N --cases N] [--out DIR] [--storage memory|file] [--strict-oracle|--allow-weak-oracle]"
 }
 
 #[cfg(test)]

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -764,6 +764,14 @@ async fn run_bidirectional_decryptability_probe(
         client_mut(clients, &label, step_index)?.tick().await;
     }
 
+    let mut recipient_ledgers = BTreeMap::new();
+    for recipient in labels {
+        recipient_ledgers.insert(
+            recipient.clone(),
+            client_mut(clients, recipient, step_index)?.scenario_input_ledger(),
+        );
+    }
+
     let mut probes = Vec::with_capacity(labels.len() * (labels.len() - 1));
     for sender in labels {
         let (payload, (send_status, logical_id)) = sends
@@ -773,10 +781,10 @@ async fn run_bidirectional_decryptability_probe(
             if recipient == sender {
                 continue;
             }
-            let recipient_ledger = client_mut(clients, recipient, step_index)?
-                .scenario_input_ledger()
-                .into_iter()
-                .find(|entry| entry.logical_id.as_ref() == logical_id.as_ref());
+            let recipient_ledger = recipient_ledgers[recipient]
+                .iter()
+                .find(|entry| entry.logical_id.as_ref() == logical_id.as_ref())
+                .cloned();
             probes.push(DirectionalDecryptabilityProbe {
                 sender: sender.clone(),
                 recipient: recipient.clone(),

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -5,10 +5,11 @@
 //! their observed trace to exact or semantic fixture expectations.
 
 use crate::{
-    ClientBuilder, ExpectationFailure, HarnessClient, HarnessStorageMode,
+    BidirectionalDecryptabilityObservation, ClientBuilder, DecryptabilityProbeSendStatus,
+    DirectionalDecryptabilityProbe, ExpectationFailure, HarnessClient, HarnessStorageMode,
     PendingResolutionObservation, ScenarioAdminPolicyObservation, ScenarioErrorObservation,
     ScenarioOracleReport, ScenarioTrace, TraceExpectation, TransportBus, VectorFixture,
-    build_scenario_oracle_report, compare_trace_expectations, observe_client,
+    build_scenario_oracle_report, compare_trace_expectations, observe_client, observe_client_exact,
 };
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_traits::EngineError;
@@ -84,6 +85,16 @@ pub enum ScenarioStep {
     Observe {
         clients: Vec<String>,
     },
+    /// Capture the exact canonical state and scenario-input ledger used by
+    /// reliability expectations.
+    ObserveExact {
+        clients: Vec<String>,
+    },
+    /// Actively prove the application-message path in every direction between
+    /// the named clients.
+    ProbeBidirectionalDecryptability {
+        clients: Vec<String>,
+    },
     ObserveAdminPolicy {
         clients: Vec<String>,
     },
@@ -130,6 +141,10 @@ impl ScenarioStep {
             ScenarioStep::DeliverAll => "deliver_all",
             ScenarioStep::Tick { .. } => "tick",
             ScenarioStep::Observe { .. } => "observe",
+            ScenarioStep::ObserveExact { .. } => "observe_exact",
+            ScenarioStep::ProbeBidirectionalDecryptability { .. } => {
+                "probe_bidirectional_decryptability"
+            }
             ScenarioStep::ObserveAdminPolicy { .. } => "observe_admin_policy",
             ScenarioStep::ClearEvents { .. } => "clear_events",
             ScenarioStep::DropQueued { .. } => "drop_queued",
@@ -385,6 +400,7 @@ async fn run_scenario_report_inner(
     let mut pending_refs = HashMap::new();
     let mut pending_resolutions = Vec::new();
     let mut observations = Vec::new();
+    let mut decryptability_probes = Vec::new();
     let mut admin_policy_observations = Vec::new();
     let mut error_observations = Vec::new();
     let mut step_log = Vec::new();
@@ -426,6 +442,7 @@ async fn run_scenario_report_inner(
             } => {
                 let key_packages = fresh_key_packages(&mut clients, invitees, step_index).await?;
                 let inviter = client_mut(&mut clients, inviter, step_index)?;
+                inviter.name_next_scenario_input(scenario_input_id(step_index, step));
                 let pending_ref = inviter.invite(key_packages).await;
                 insert_pending(&mut pending_refs, pending, pending_ref, step_index)?;
             }
@@ -435,6 +452,7 @@ async fn run_scenario_report_inner(
                 pending,
             } => {
                 let client = client_mut(&mut clients, client, step_index)?;
+                client.name_next_scenario_input(scenario_input_id(step_index, step));
                 let pending_ref = client.update_group_data(name.clone()).await;
                 insert_pending(&mut pending_refs, pending, pending_ref, step_index)?;
             }
@@ -445,6 +463,7 @@ async fn run_scenario_report_inner(
             } => {
                 let admin_ids = member_ids(&clients, admins, step_index)?;
                 let client = client_mut(&mut clients, client, step_index)?;
+                client.name_next_scenario_input(scenario_input_id(step_index, step));
                 let pending_ref = client.update_admin_policy(admin_ids).await.map_err(|e| {
                     err(
                         step_index,
@@ -513,10 +532,12 @@ async fn run_scenario_report_inner(
             }
             ScenarioStep::SendAppMessage { sender, payload } => {
                 let sender = client_mut(&mut clients, sender, step_index)?;
+                sender.name_next_scenario_input(scenario_input_id(step_index, step));
                 sender.send_app(payload.clone().into_bytes()).await;
             }
             ScenarioStep::Leave { client } => {
                 let client = client_mut(&mut clients, client, step_index)?;
+                client.name_next_scenario_input(scenario_input_id(step_index, step));
                 client.leave().await;
             }
             ScenarioStep::DeliverAll => bus.deliver_all(),
@@ -531,6 +552,18 @@ async fn run_scenario_report_inner(
                     let client = client_mut(&mut clients, label, step_index)?;
                     observations.push(observe_client(label.clone(), client));
                 }
+            }
+            ScenarioStep::ObserveExact { clients: labels } => {
+                for label in labels {
+                    let client = client_mut(&mut clients, label, step_index)?;
+                    observations.push(observe_client_exact(label.clone(), client));
+                }
+            }
+            ScenarioStep::ProbeBidirectionalDecryptability { clients: labels } => {
+                decryptability_probes.push(
+                    run_bidirectional_decryptability_probe(&mut clients, &bus, labels, step_index)
+                        .await?,
+                );
             }
             ScenarioStep::ObserveAdminPolicy { clients: labels } => {
                 for label in labels {
@@ -613,6 +646,7 @@ async fn run_scenario_report_inner(
         pending_resolutions,
         errors: error_observations,
         admin_policies: admin_policy_observations,
+        decryptability_probes,
         observations,
     };
     let pending_resolution_observations = observed_trace.pending_resolutions.clone();
@@ -680,6 +714,84 @@ async fn run_scenario_report_inner(
         app_invalidation_observations,
         expectation_failures,
         invariant_failures,
+    })
+}
+
+fn scenario_input_id(step_index: usize, step: &ScenarioStep) -> String {
+    format!("step-{step_index}:{}", step.kind())
+}
+
+async fn run_bidirectional_decryptability_probe(
+    clients: &mut BTreeMap<String, HarnessClient>,
+    bus: &TransportBus,
+    labels: &[String],
+    step_index: usize,
+) -> Result<BidirectionalDecryptabilityObservation, ScenarioRunError> {
+    let mut unique_labels = labels.to_vec();
+    unique_labels.sort();
+    unique_labels.dedup();
+    if labels.len() < 2 || unique_labels.len() != labels.len() {
+        return Err(err(
+            step_index,
+            "bidirectional decryptability probe requires at least two unique clients".into(),
+        ));
+    }
+    for label in labels {
+        client_ref(clients, label, step_index)?;
+    }
+
+    let mut sends = BTreeMap::new();
+    for sender in labels {
+        let payload = format!("cgka-decryptability-probe/v1/{step_index}/{sender}");
+        let status = match client_mut(clients, sender, step_index)?
+            .try_send_app(payload.clone().into_bytes())
+            .await
+        {
+            Ok((status, logical_id)) => (status, Some(logical_id)),
+            Err(error) => (
+                DecryptabilityProbeSendStatus::Failed {
+                    error: observe_engine_error(&error),
+                },
+                None,
+            ),
+        };
+        sends.insert(sender.clone(), (payload, status));
+    }
+
+    bus.deliver_all();
+    let all_clients = clients.keys().cloned().collect::<Vec<_>>();
+    for label in all_clients {
+        client_mut(clients, &label, step_index)?.tick().await;
+    }
+
+    let mut probes = Vec::with_capacity(labels.len() * (labels.len() - 1));
+    for sender in labels {
+        let (payload, (send_status, logical_id)) = sends
+            .get(sender)
+            .expect("probe send result exists for every validated sender");
+        for recipient in labels {
+            if recipient == sender {
+                continue;
+            }
+            let recipient_ledger = client_mut(clients, recipient, step_index)?
+                .scenario_input_ledger()
+                .into_iter()
+                .find(|entry| entry.logical_id.as_ref() == logical_id.as_ref());
+            probes.push(DirectionalDecryptabilityProbe {
+                sender: sender.clone(),
+                recipient: recipient.clone(),
+                payload: payload.clone(),
+                logical_id: logical_id.clone(),
+                send_status: send_status.clone(),
+                recipient_ledger,
+            });
+        }
+    }
+
+    Ok(BidirectionalDecryptabilityObservation {
+        step_index,
+        clients: labels.to_vec(),
+        probes,
     })
 }
 

--- a/crates/cgka-conformance-simulator/src/scenario_input_ledger.rs
+++ b/crates/cgka-conformance-simulator/src/scenario_input_ledger.rs
@@ -284,8 +284,9 @@ impl ScenarioInputTracker {
         };
         match state {
             MessageState::Processed => {
-                if kind != ScenarioInputKind::Application
-                    || entry.disposition != ScenarioInputDisposition::Delivered
+                if !is_terminal(&entry.disposition)
+                    && (kind != ScenarioInputKind::Application
+                        || entry.disposition != ScenarioInputDisposition::Delivered)
                 {
                     entry.disposition = ScenarioInputDisposition::Accepted;
                 }
@@ -512,5 +513,37 @@ mod tests {
         assert_eq!(entry.transport_deferred, 1);
         assert_eq!(entry.disposition, ScenarioInputDisposition::Pending);
         assert!(entry.pending);
+    }
+
+    #[test]
+    fn processed_storage_does_not_overwrite_terminal_semantic_disposition() {
+        let terminal_dispositions = [
+            ScenarioInputDisposition::Delivered,
+            ScenarioInputDisposition::Expired,
+            ScenarioInputDisposition::Invalidated,
+            ScenarioInputDisposition::Rejected,
+            ScenarioInputDisposition::Stale,
+            ScenarioInputDisposition::Ignored,
+            ScenarioInputDisposition::ResourceRefused,
+            ScenarioInputDisposition::RolledBack,
+        ];
+        for disposition in terminal_dispositions {
+            let mut tracker = ScenarioInputTracker::default();
+            let metadata = metadata(ScenarioInputKind::Application);
+            tracker.record_send_attempt(&metadata);
+            let entry = tracker.entries.get_mut(&metadata.scenario_id).unwrap();
+            entry.disposition = disposition.clone();
+            entry.pending = false;
+
+            tracker.record_storage_state(
+                &metadata.scenario_id,
+                ScenarioInputKind::Application,
+                MessageState::Processed,
+            );
+
+            let entry = &tracker.snapshot()[0];
+            assert_eq!(entry.disposition, disposition);
+            assert!(!entry.pending);
+        }
     }
 }

--- a/crates/cgka-conformance-simulator/src/scenario_input_ledger.rs
+++ b/crates/cgka-conformance-simulator/src/scenario_input_ledger.rs
@@ -1,0 +1,516 @@
+//! Simulator-owned accounting for every convergence-relevant scenario input.
+//!
+//! The engine deliberately works in transport/content ids, while scenarios use
+//! stable action ids. This ledger joins those layers without exposing ids in
+//! reports: the harness registers commit, proposal, and application inputs at
+//! send time, records public `IngestOutcome`s and `GroupEvent`s, then refreshes
+//! the final durable disposition through the feature-gated conformance view.
+
+use cgka_traits::engine::AppMessageInvalidationReason;
+use cgka_traits::ingest::{IngestOutcome, InputRejectionCategory, StaleReason};
+use cgka_traits::message::MessageState;
+use cgka_traits::types::MessageId;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScenarioInputKind {
+    Commit,
+    Proposal,
+    #[default]
+    Application,
+}
+
+impl ScenarioInputKind {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Commit => "commit",
+            Self::Proposal => "proposal",
+            Self::Application => "application",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScenarioInputDisposition {
+    #[default]
+    Pending,
+    Accepted,
+    Delivered,
+    Deduplicated,
+    Expired,
+    Invalidated,
+    Rejected,
+    Stale,
+    Ignored,
+    ResourceRefused,
+    RolledBack,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ScenarioInputMetadata {
+    pub scenario_id: String,
+    pub kind: ScenarioInputKind,
+    pub sender: String,
+    pub logical_id: Option<String>,
+    pub payload: Option<String>,
+    pub aliases: Vec<MessageId>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScenarioInputLedgerEntry {
+    /// Stable synthetic action id, never a transport or randomized MLS id.
+    pub scenario_id: String,
+    pub kind: ScenarioInputKind,
+    /// Stable scenario label when known, otherwise the sender identity hex.
+    pub sender: String,
+    /// Deterministic inner application-event id used only to correlate delivery.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logical_id: Option<String>,
+    /// Harness-decoded logical application payload. Commits and proposals omit it.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub payload: String,
+    /// Current semantic disposition at the observation boundary.
+    pub disposition: ScenarioInputDisposition,
+    pub send_attempts: usize,
+    pub send_accepted: usize,
+    pub send_queued: usize,
+    pub published: usize,
+    pub ingest_attempts: usize,
+    pub ingest_accepted: usize,
+    pub transport_deferred: usize,
+    pub resource_refused: usize,
+    pub ignored: usize,
+    pub local_state: usize,
+    pub rejected: usize,
+    pub ingest_errors: usize,
+    pub delivered: usize,
+    pub deduplicated: usize,
+    pub expired: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub invalidated: Vec<String>,
+    /// True while accepted or retained work lacks a terminal/current outcome.
+    pub pending: bool,
+}
+
+#[derive(Default)]
+pub(crate) struct ScenarioInputTracker {
+    entries: BTreeMap<String, ScenarioInputLedgerEntry>,
+    metadata: BTreeMap<String, ScenarioInputMetadata>,
+    scenario_by_logical_id: BTreeMap<String, String>,
+}
+
+impl ScenarioInputTracker {
+    pub(crate) fn record_send_attempt(&mut self, metadata: &ScenarioInputMetadata) {
+        self.remember_metadata(metadata);
+        let entry = self.entry(metadata);
+        entry.send_attempts += 1;
+        entry.disposition = ScenarioInputDisposition::Pending;
+        entry.pending = true;
+    }
+
+    pub(crate) fn record_send_accepted(&mut self, metadata: &ScenarioInputMetadata, queued: bool) {
+        self.remember_metadata(metadata);
+        let entry = self.entry(metadata);
+        entry.send_accepted += 1;
+        if queued {
+            entry.send_queued += 1;
+        }
+        entry.disposition = ScenarioInputDisposition::Pending;
+        entry.pending = true;
+    }
+
+    pub(crate) fn record_published(&mut self, metadata: &ScenarioInputMetadata) {
+        self.remember_metadata(metadata);
+        let entry = self.entry(metadata);
+        entry.published += 1;
+        if metadata.kind == ScenarioInputKind::Application {
+            entry.disposition = ScenarioInputDisposition::Accepted;
+            entry.pending = false;
+        }
+    }
+
+    pub(crate) fn record_confirmed(&mut self, scenario_id: &str) {
+        if let Some(entry) = self.entries.get_mut(scenario_id) {
+            entry.disposition = ScenarioInputDisposition::Accepted;
+            entry.pending = false;
+        }
+    }
+
+    pub(crate) fn record_rolled_back(&mut self, scenario_id: &str) {
+        if let Some(entry) = self.entries.get_mut(scenario_id) {
+            entry.disposition = ScenarioInputDisposition::RolledBack;
+            push_unique(&mut entry.invalidated, "publish_rolled_back");
+            entry.pending = false;
+        }
+    }
+
+    pub(crate) fn record_ingest(
+        &mut self,
+        metadata: &ScenarioInputMetadata,
+        outcome: Result<&IngestOutcome, ()>,
+    ) {
+        self.remember_metadata(metadata);
+        let entry = self.entry(metadata);
+        entry.ingest_attempts += 1;
+        match outcome {
+            Ok(IngestOutcome::Processed) => {
+                entry.ingest_accepted += 1;
+                entry.disposition = ScenarioInputDisposition::Accepted;
+                entry.pending = false;
+            }
+            Ok(IngestOutcome::Buffered { .. }) => {
+                entry.ingest_accepted += 1;
+                entry.disposition = ScenarioInputDisposition::Pending;
+                entry.pending = true;
+            }
+            Ok(IngestOutcome::TransportDeferred { .. }) => {
+                entry.transport_deferred += 1;
+                entry.disposition = ScenarioInputDisposition::Pending;
+                entry.pending = true;
+            }
+            Ok(IngestOutcome::Ignored {
+                category: InputRejectionCategory::Duplicate,
+            }) => {
+                entry.deduplicated += 1;
+                if entry.pending {
+                    entry.disposition = ScenarioInputDisposition::Deduplicated;
+                }
+            }
+            Ok(IngestOutcome::Stale {
+                reason: StaleReason::BeyondAppRetention,
+            }) => {
+                entry.expired = 1;
+                entry.disposition = ScenarioInputDisposition::Expired;
+                entry.pending = false;
+            }
+            Ok(IngestOutcome::Stale { reason }) => {
+                push_unique(&mut entry.invalidated, stale_reason(reason));
+                entry.disposition = ScenarioInputDisposition::Stale;
+                entry.pending = false;
+            }
+            Ok(IngestOutcome::Ignored { .. }) => {
+                entry.ignored += 1;
+                entry.disposition = ScenarioInputDisposition::Ignored;
+                entry.pending = false;
+            }
+            Ok(IngestOutcome::LocalState { .. }) => {
+                entry.local_state += 1;
+                entry.disposition = ScenarioInputDisposition::Ignored;
+                entry.pending = false;
+            }
+            Ok(IngestOutcome::ResourceRefused { .. }) => {
+                entry.resource_refused += 1;
+                entry.disposition = ScenarioInputDisposition::ResourceRefused;
+                entry.pending = false;
+            }
+            Ok(IngestOutcome::Rejected { category }) => {
+                entry.rejected += 1;
+                push_unique_owned(&mut entry.invalidated, format!("{category:?}"));
+                entry.disposition = ScenarioInputDisposition::Rejected;
+                entry.pending = false;
+            }
+            Err(()) => {
+                entry.ingest_errors += 1;
+            }
+        }
+    }
+
+    pub(crate) fn record_delivered_logical(&mut self, logical_id: &str) {
+        let Some(scenario_id) = self.scenario_by_logical_id.get(logical_id).cloned() else {
+            return;
+        };
+        let Some(entry) = self.entries.get_mut(&scenario_id) else {
+            return;
+        };
+        entry.delivered += 1;
+        entry.disposition = ScenarioInputDisposition::Delivered;
+        entry.pending = false;
+    }
+
+    pub(crate) fn record_app_invalidated(
+        &mut self,
+        metadata: &ScenarioInputMetadata,
+        reason: AppMessageInvalidationReason,
+    ) {
+        self.remember_metadata(metadata);
+        let entry = self.entry(metadata);
+        let reason = invalidation_reason(reason).to_owned();
+        if reason == "beyond_app_retention" {
+            entry.expired = 1;
+            entry.disposition = ScenarioInputDisposition::Expired;
+        } else {
+            entry.disposition = ScenarioInputDisposition::Invalidated;
+        }
+        push_unique_owned(&mut entry.invalidated, reason);
+        entry.pending = false;
+    }
+
+    pub(crate) fn record_commit_invalidated(
+        &mut self,
+        metadata: &ScenarioInputMetadata,
+        reason: &'static str,
+    ) {
+        self.remember_metadata(metadata);
+        let entry = self.entry(metadata);
+        push_unique(&mut entry.invalidated, reason);
+        entry.disposition = ScenarioInputDisposition::Invalidated;
+        entry.pending = false;
+    }
+
+    pub(crate) fn state_queries(&self) -> Vec<(String, ScenarioInputKind, Vec<MessageId>)> {
+        self.metadata
+            .values()
+            .map(|metadata| {
+                (
+                    metadata.scenario_id.clone(),
+                    metadata.kind,
+                    metadata.aliases.clone(),
+                )
+            })
+            .collect()
+    }
+
+    pub(crate) fn record_storage_state(
+        &mut self,
+        scenario_id: &str,
+        kind: ScenarioInputKind,
+        state: MessageState,
+    ) {
+        let Some(entry) = self.entries.get_mut(scenario_id) else {
+            return;
+        };
+        match state {
+            MessageState::Processed => {
+                if kind != ScenarioInputKind::Application
+                    || entry.disposition != ScenarioInputDisposition::Delivered
+                {
+                    entry.disposition = ScenarioInputDisposition::Accepted;
+                }
+                entry.pending = false;
+            }
+            MessageState::Created | MessageState::Retryable | MessageState::PeelDeferred => {
+                if !is_terminal(&entry.disposition) {
+                    entry.disposition = ScenarioInputDisposition::Pending;
+                    entry.pending = true;
+                }
+            }
+            MessageState::Sent => {
+                if kind == ScenarioInputKind::Application {
+                    entry.disposition = ScenarioInputDisposition::Accepted;
+                    entry.pending = false;
+                }
+            }
+            MessageState::Failed => {
+                if !is_terminal(&entry.disposition) {
+                    entry.disposition = ScenarioInputDisposition::Rejected;
+                    entry.pending = false;
+                }
+            }
+            MessageState::EpochInvalidated => {
+                if !matches!(
+                    entry.disposition,
+                    ScenarioInputDisposition::Expired | ScenarioInputDisposition::RolledBack
+                ) {
+                    entry.disposition = ScenarioInputDisposition::Invalidated;
+                }
+                entry.pending = false;
+            }
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> Vec<ScenarioInputLedgerEntry> {
+        self.entries.values().cloned().collect()
+    }
+
+    pub(crate) fn pending_count(&self) -> usize {
+        self.entries.values().filter(|entry| entry.pending).count()
+    }
+
+    pub(crate) fn metadata_for_logical(&self, logical_id: &str) -> Option<ScenarioInputMetadata> {
+        self.scenario_by_logical_id
+            .get(logical_id)
+            .and_then(|scenario_id| self.metadata.get(scenario_id))
+            .cloned()
+    }
+
+    fn remember_metadata(&mut self, metadata: &ScenarioInputMetadata) {
+        if let Some(logical_id) = &metadata.logical_id {
+            self.scenario_by_logical_id
+                .insert(logical_id.clone(), metadata.scenario_id.clone());
+        }
+        self.metadata
+            .entry(metadata.scenario_id.clone())
+            .and_modify(|existing| {
+                for alias in &metadata.aliases {
+                    if !existing.aliases.contains(alias) {
+                        existing.aliases.push(alias.clone());
+                    }
+                }
+            })
+            .or_insert_with(|| metadata.clone());
+    }
+
+    fn entry(&mut self, metadata: &ScenarioInputMetadata) -> &mut ScenarioInputLedgerEntry {
+        self.entries
+            .entry(metadata.scenario_id.clone())
+            .or_insert_with(|| ScenarioInputLedgerEntry {
+                scenario_id: metadata.scenario_id.clone(),
+                kind: metadata.kind,
+                sender: metadata.sender.clone(),
+                logical_id: metadata.logical_id.clone(),
+                payload: metadata.payload.clone().unwrap_or_default(),
+                disposition: ScenarioInputDisposition::Pending,
+                ..Default::default()
+            })
+    }
+}
+
+fn is_terminal(disposition: &ScenarioInputDisposition) -> bool {
+    matches!(
+        disposition,
+        ScenarioInputDisposition::Delivered
+            | ScenarioInputDisposition::Expired
+            | ScenarioInputDisposition::Invalidated
+            | ScenarioInputDisposition::Rejected
+            | ScenarioInputDisposition::Stale
+            | ScenarioInputDisposition::Ignored
+            | ScenarioInputDisposition::ResourceRefused
+            | ScenarioInputDisposition::RolledBack
+    )
+}
+
+fn push_unique(values: &mut Vec<String>, value: &str) {
+    if !values.iter().any(|existing| existing == value) {
+        values.push(value.to_owned());
+    }
+}
+
+fn push_unique_owned(values: &mut Vec<String>, value: String) {
+    if !values.contains(&value) {
+        values.push(value);
+    }
+}
+
+fn invalidation_reason(reason: AppMessageInvalidationReason) -> &'static str {
+    match reason {
+        AppMessageInvalidationReason::LosingBranch => "losing_branch",
+        AppMessageInvalidationReason::BeyondAnchor => "beyond_anchor",
+        AppMessageInvalidationReason::BeyondAppRetention => "beyond_app_retention",
+        AppMessageInvalidationReason::UndecryptableInCanonicalState => {
+            "undecryptable_in_canonical_state"
+        }
+    }
+}
+
+fn stale_reason(reason: &StaleReason) -> &'static str {
+    #[allow(deprecated)]
+    match reason {
+        StaleReason::AlreadySeen => "already_seen",
+        StaleReason::AlreadyAtEpoch { .. } => "already_at_epoch",
+        StaleReason::NotForThisClient => "not_for_this_client",
+        StaleReason::UnknownGroup => "unknown_group",
+        StaleReason::OwnEcho => "own_echo",
+        StaleReason::PreMembership => "pre_membership",
+        StaleReason::BeyondAnchor => "beyond_anchor",
+        StaleReason::BeyondRollbackHorizon => "beyond_rollback_horizon",
+        StaleReason::BeyondAppRetention => "beyond_app_retention",
+        StaleReason::LosingBranch => "losing_branch",
+        StaleReason::InvalidAgainstCanonicalState => "invalid_against_canonical_state",
+        StaleReason::SelfEvicted => "self_evicted",
+        StaleReason::Quarantined => "quarantined",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgka_traits::types::{EpochId, GroupId};
+
+    fn metadata(kind: ScenarioInputKind) -> ScenarioInputMetadata {
+        ScenarioInputMetadata {
+            scenario_id: format!("step-4:{}", kind.label()),
+            kind,
+            sender: "alice".into(),
+            logical_id: (kind == ScenarioInputKind::Application).then(|| "event-id".into()),
+            payload: (kind == ScenarioInputKind::Application).then(|| "hello".into()),
+            aliases: vec![MessageId::new(vec![1])],
+        }
+    }
+
+    #[test]
+    fn duplicate_attempt_does_not_hide_the_single_delivery() {
+        let mut tracker = ScenarioInputTracker::default();
+        let metadata = metadata(ScenarioInputKind::Application);
+        tracker.record_ingest(&metadata, Ok(&IngestOutcome::Processed));
+        tracker.record_delivered_logical("event-id");
+        tracker.record_ingest(
+            &metadata,
+            Ok(&IngestOutcome::Ignored {
+                category: InputRejectionCategory::Duplicate,
+            }),
+        );
+
+        let entry = &tracker.snapshot()[0];
+        assert_eq!(entry.ingest_attempts, 2);
+        assert_eq!(entry.ingest_accepted, 1);
+        assert_eq!(entry.delivered, 1);
+        assert_eq!(entry.deduplicated, 1);
+        assert_eq!(entry.disposition, ScenarioInputDisposition::Delivered);
+        assert!(!entry.pending);
+    }
+
+    #[test]
+    fn buffered_commit_and_proposal_are_pending_until_storage_accepts_them() {
+        let mut tracker = ScenarioInputTracker::default();
+        for kind in [ScenarioInputKind::Commit, ScenarioInputKind::Proposal] {
+            let metadata = metadata(kind);
+            tracker.record_ingest(
+                &metadata,
+                Ok(&IngestOutcome::Buffered {
+                    group_id: GroupId::new(vec![1]),
+                    epoch: EpochId(1),
+                }),
+            );
+            assert_eq!(
+                tracker
+                    .snapshot()
+                    .into_iter()
+                    .find(|entry| entry.scenario_id == metadata.scenario_id)
+                    .unwrap()
+                    .disposition,
+                ScenarioInputDisposition::Pending
+            );
+            tracker.record_storage_state(&metadata.scenario_id, kind, MessageState::Processed);
+            assert_eq!(
+                tracker
+                    .snapshot()
+                    .into_iter()
+                    .find(|entry| entry.scenario_id == metadata.scenario_id)
+                    .unwrap()
+                    .disposition,
+                ScenarioInputDisposition::Accepted
+            );
+        }
+    }
+
+    #[test]
+    fn transport_deferred_is_pending_but_not_accepted() {
+        let mut tracker = ScenarioInputTracker::default();
+        let metadata = metadata(ScenarioInputKind::Application);
+        tracker.record_ingest(
+            &metadata,
+            Ok(&IngestOutcome::TransportDeferred {
+                group_id: GroupId::new(vec![1]),
+            }),
+        );
+
+        let entry = &tracker.snapshot()[0];
+        assert_eq!(entry.ingest_accepted, 0);
+        assert_eq!(entry.transport_deferred, 1);
+        assert_eq!(entry.disposition, ScenarioInputDisposition::Pending);
+        assert!(entry.pending);
+    }
+}

--- a/crates/cgka-conformance-simulator/src/vector.rs
+++ b/crates/cgka-conformance-simulator/src/vector.rs
@@ -4,7 +4,11 @@
 //! ids. They capture the deterministic observable outcome a conforming engine
 //! should produce after running the same scripted scenario.
 
-use crate::{HarnessClient, ScenarioSpec};
+use crate::{
+    BidirectionalDecryptabilityObservation, HarnessClient, PendingWorkObservation,
+    ScenarioInputLedgerEntry, ScenarioSpec,
+};
+use cgka_engine::conformance_snapshot::ConformanceCanonicalStateSnapshot;
 use cgka_traits::engine::{
     AppMessageInvalidationReason, CommitOrderingKey, CommitOrderingPriority, GroupEvent,
     GroupStateChange,
@@ -122,6 +126,31 @@ pub enum TraceExpectation {
         epoch: Option<u64>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         member_count: Option<usize>,
+    },
+    /// Require the adopted canonical live-group projection to match exactly.
+    ///
+    /// Unlike `ClientsConverged`, this compares exact leaf identities and
+    /// capabilities, required capabilities, application profile/state,
+    /// lifecycle, GroupContext hash, and the conformance exporter commitment.
+    /// Scenario-input dispositions are asserted separately through
+    /// `ScenarioInputLedger`.
+    ClientsExactlyEquivalent {
+        clients: Vec<String>,
+    },
+    /// Require the complete per-client commit/proposal/application input ledger.
+    ScenarioInputLedger {
+        client: String,
+        entries: Vec<ScenarioInputLedgerEntry>,
+    },
+    /// Require every named client's exact progress snapshot to contain no
+    /// outstanding engine, transport, or logical-message work.
+    NoPendingWork {
+        clients: Vec<String>,
+    },
+    /// Require a completed active application-message probe in every direction
+    /// between the named clients.
+    ClientsBidirectionallyDecryptable {
+        clients: Vec<String>,
     },
     ClientEpochChanges {
         client: String,
@@ -253,7 +282,7 @@ impl TraceExpectation {
                 received_payloads,
                 added_members,
                 removed_members,
-            } => match client_observation(observed, client) {
+            } => match client_legacy_observation(observed, client) {
                 Some(observation)
                     if observation.epoch == *epoch
                         && observation.member_count == *member_count
@@ -295,7 +324,7 @@ impl TraceExpectation {
             } => {
                 let mut observations = Vec::with_capacity(clients.len());
                 for client in clients {
-                    match client_observation(observed, client) {
+                    match client_legacy_observation(observed, client) {
                         Some(observation) => observations.push(observation),
                         None => {
                             missing_client(client, self, mismatches);
@@ -344,6 +373,163 @@ impl TraceExpectation {
                             "member_count": member_count,
                         }),
                         actual: json!(observations),
+                    });
+                }
+            }
+            TraceExpectation::ClientsExactlyEquivalent { clients } => {
+                let mut snapshots = Vec::with_capacity(clients.len());
+                for client in clients {
+                    let Some(observation) = client_observation(observed, client) else {
+                        missing_client(client, self, mismatches);
+                        return;
+                    };
+                    let Some(snapshot) = observation.canonical_state.as_ref() else {
+                        mismatches.push(ExpectationFailure {
+                            kind: "missing_canonical_state".into(),
+                            message: format!(
+                                "client {client} was not observed with observe_client_exact"
+                            ),
+                            expected: json!(self),
+                            actual: json!(observation),
+                        });
+                        return;
+                    };
+                    snapshots.push((client, snapshot));
+                }
+                if snapshots.is_empty() {
+                    mismatches.push(ExpectationFailure {
+                        kind: "empty_exact_equivalence_expectation".into(),
+                        message: "clients_exactly_equivalent did not name any clients".into(),
+                        expected: json!(self),
+                        actual: json!(observed.observations),
+                    });
+                    return;
+                }
+                let first = snapshots[0].1;
+                if snapshots.iter().any(|(_, snapshot)| *snapshot != first) {
+                    mismatches.push(ExpectationFailure {
+                        kind: "clients_not_exactly_equivalent".into(),
+                        message: format!(
+                            "clients {clients:?} have different canonical group snapshots"
+                        ),
+                        expected: json!({
+                            "clients": clients,
+                            "canonical_state": first,
+                        }),
+                        actual: json!(
+                            snapshots
+                                .into_iter()
+                                .map(|(client, snapshot)| json!({
+                                    "client": client,
+                                    "canonical_state": snapshot,
+                                }))
+                                .collect::<Vec<_>>()
+                        ),
+                    });
+                }
+            }
+            TraceExpectation::ScenarioInputLedger { client, entries } => {
+                match client_observation(observed, client) {
+                    Some(observation) if &observation.scenario_input_ledger == entries => {}
+                    Some(observation) => mismatches.push(ExpectationFailure {
+                        kind: "scenario_input_ledger_mismatch".into(),
+                        message: format!(
+                            "client {client} scenario-input disposition ledger did not match"
+                        ),
+                        expected: json!(entries),
+                        actual: json!(observation.scenario_input_ledger),
+                    }),
+                    None => missing_client(client, self, mismatches),
+                }
+            }
+            TraceExpectation::NoPendingWork { clients } => {
+                if clients.is_empty() {
+                    mismatches.push(ExpectationFailure {
+                        kind: "empty_no_pending_work_expectation".into(),
+                        message: "no_pending_work did not name any clients".into(),
+                        expected: json!(self),
+                        actual: json!(observed.observations),
+                    });
+                    return;
+                }
+                for client in clients {
+                    let Some(observation) = client_observation(observed, client) else {
+                        missing_client(client, self, mismatches);
+                        return;
+                    };
+                    let Some(pending_work) = observation.pending_work.as_ref() else {
+                        mismatches.push(ExpectationFailure {
+                            kind: "missing_pending_work_observation".into(),
+                            message: format!(
+                                "client {client} was not observed with observe_client_exact"
+                            ),
+                            expected: json!(self),
+                            actual: json!(observation),
+                        });
+                        continue;
+                    };
+                    if !pending_work.is_empty() {
+                        mismatches.push(ExpectationFailure {
+                            kind: "pending_work_remaining".into(),
+                            message: format!(
+                                "client {client} still has pending work in {:?}",
+                                pending_work.blocking_subsystems()
+                            ),
+                            expected: json!({
+                                "client": client,
+                                "pending_work": PendingWorkObservation::default(),
+                            }),
+                            actual: json!(pending_work),
+                        });
+                    }
+                }
+            }
+            TraceExpectation::ClientsBidirectionallyDecryptable { clients } => {
+                let mut unique_clients = clients.clone();
+                unique_clients.sort();
+                unique_clients.dedup();
+                if clients.len() < 2 || unique_clients.len() != clients.len() {
+                    mismatches.push(ExpectationFailure {
+                        kind: "invalid_bidirectional_decryptability_expectation".into(),
+                        message: "clients_bidirectionally_decryptable requires at least two unique clients"
+                            .into(),
+                        expected: json!(self),
+                        actual: json!(observed.decryptability_probes),
+                    });
+                    return;
+                }
+                let Some(probe) = observed
+                    .decryptability_probes
+                    .iter()
+                    .rev()
+                    .find(|probe| probe.matches_clients(clients))
+                else {
+                    mismatches.push(ExpectationFailure {
+                        kind: "missing_bidirectional_decryptability_probe".into(),
+                        message: format!(
+                            "no bidirectional decryptability probe was run for clients {clients:?}"
+                        ),
+                        expected: json!(self),
+                        actual: json!(observed.decryptability_probes),
+                    });
+                    return;
+                };
+                if !probe.succeeded() {
+                    let failed_edges = probe
+                        .failed_edges()
+                        .into_iter()
+                        .map(|edge| format!("{}->{}", edge.sender, edge.recipient))
+                        .collect::<Vec<_>>();
+                    mismatches.push(ExpectationFailure {
+                        kind: "bidirectional_decryptability_failed".into(),
+                        message: format!(
+                            "application-message decryptability failed for directed edges {failed_edges:?}"
+                        ),
+                        expected: json!({
+                            "clients": clients,
+                            "all_directional_probes_delivered": true,
+                        }),
+                        actual: json!(probe),
                     });
                 }
             }
@@ -610,6 +796,8 @@ pub struct ScenarioTrace {
     pub errors: Vec<ScenarioErrorObservation>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub admin_policies: Vec<ScenarioAdminPolicyObservation>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub decryptability_probes: Vec<BidirectionalDecryptabilityObservation>,
     pub observations: Vec<ClientObservation>,
 }
 
@@ -650,6 +838,18 @@ pub struct ClientObservation {
     /// that predate the field.
     #[serde(default)]
     pub group_name: String,
+    /// Adopted canonical live-group projection. Legacy observations leave this
+    /// absent; strict reliability scenarios opt in through
+    /// [`observe_client_exact`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_state: Option<ConformanceCanonicalStateSnapshot>,
+    /// Application-message dispositions observed through public simulator
+    /// send, ingest, and event boundaries.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scenario_input_ledger: Vec<ScenarioInputLedgerEntry>,
+    /// Instantaneous progress snapshot used only by strict observations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_work: Option<PendingWorkObservation>,
     #[serde(default)]
     pub event_counts: ClientEventCounts,
     pub received_payloads: Vec<String>,
@@ -687,6 +887,23 @@ fn client_observation<'a>(
         .iter()
         .rev()
         .find(|observation| observation.client == client)
+}
+
+/// Legacy semantic expectations describe the event window captured by an
+/// `observe` step. A later `observe_exact` intentionally drains a fresh event
+/// window, so it must not replace the earlier observation for payload/member
+/// assertions. Fall back to any observation for fixtures that only use the
+/// exact step but still carry a legacy state expectation.
+fn client_legacy_observation<'a>(
+    observed: &'a ScenarioTrace,
+    client: &str,
+) -> Option<&'a ClientObservation> {
+    observed
+        .observations
+        .iter()
+        .rev()
+        .find(|observation| observation.client == client && observation.canonical_state.is_none())
+        .or_else(|| client_observation(observed, client))
 }
 
 fn missing_client(
@@ -842,6 +1059,9 @@ pub fn observe_client(label: impl Into<String>, client: &mut HarnessClient) -> C
         epoch: client.epoch().0,
         member_count: client.members().len(),
         group_name: client.group_name(),
+        canonical_state: None,
+        scenario_input_ledger: Vec::new(),
+        pending_work: None,
         event_counts,
         received_payloads: events
             .iter()
@@ -926,6 +1146,19 @@ pub fn observe_client(label: impl Into<String>, client: &mut HarnessClient) -> C
     }
 }
 
+/// Capture the normal application/event observation plus the adopted exact
+/// canonical group-state projection.
+pub fn observe_client_exact(
+    label: impl Into<String>,
+    client: &mut HarnessClient,
+) -> ClientObservation {
+    let mut observation = observe_client(label, client);
+    observation.canonical_state = Some(client.canonical_state_snapshot());
+    observation.scenario_input_ledger = client.scenario_input_ledger();
+    observation.pending_work = Some(client.pending_work_observation());
+    observation
+}
+
 fn observe_member_id(bytes: &[u8]) -> String {
     if let Some(label) = crate::client::logical_label_for_member_id(bytes) {
         return label;
@@ -967,6 +1200,7 @@ fn observe_key(key: &CommitOrderingKey) -> RecoveryOrderingKeyObservation {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cgka_engine::conformance_snapshot::{ConformanceGroupSnapshot, ConformanceLeafSnapshot};
 
     fn observation(client: &str, epoch: u64, member_count: usize) -> ClientObservation {
         ClientObservation {
@@ -974,6 +1208,9 @@ mod tests {
             epoch,
             member_count,
             group_name: String::new(),
+            canonical_state: None,
+            scenario_input_ledger: Vec::new(),
+            pending_work: None,
             event_counts: ClientEventCounts::default(),
             received_payloads: Vec::new(),
             added_members: Vec::new(),
@@ -991,8 +1228,31 @@ mod tests {
             pending_resolutions: Vec::new(),
             errors: Vec::new(),
             admin_policies: Vec::new(),
+            decryptability_probes: Vec::new(),
             observations,
         }
+    }
+
+    fn exact_snapshot(
+        member_identity: &str,
+        exporter_commitment: &str,
+    ) -> ConformanceCanonicalStateSnapshot {
+        ConformanceCanonicalStateSnapshot::Live(Box::new(ConformanceGroupSnapshot {
+            group_id_hex: "0102".into(),
+            epoch: 7,
+            group_context_sha256: "group-context".into(),
+            selected_branch_id: "group-context".into(),
+            exporter_commitment_sha256: exporter_commitment.into(),
+            leaves: vec![ConformanceLeafSnapshot {
+                leaf_index: 0,
+                account_identity_hex: member_identity.into(),
+                signature_public_key_hex: "shared-signature-key".into(),
+                ..Default::default()
+            }],
+            sorted_member_identities_hex: vec![member_identity.into()],
+            group_name: "group".into(),
+            ..Default::default()
+        }))
     }
 
     fn convergence_decision(
@@ -1058,6 +1318,173 @@ mod tests {
     }
 
     #[test]
+    fn scenario_input_ledger_expectation_is_exact() {
+        let mut alice = observation("alice", 1, 2);
+        alice.scenario_input_ledger = vec![ScenarioInputLedgerEntry {
+            scenario_id: "step-4:send_app_message".into(),
+            logical_id: Some("event-id".into()),
+            sender: "bob".into(),
+            payload: "hello".into(),
+            ingest_attempts: 2,
+            ingest_accepted: 1,
+            delivered: 1,
+            deduplicated: 1,
+            ..Default::default()
+        }];
+        let expected = alice.scenario_input_ledger.clone();
+
+        let failures = compare_trace_expectations(
+            None,
+            &[TraceExpectation::ScenarioInputLedger {
+                client: "alice".into(),
+                entries: expected,
+            }],
+            &trace(vec![alice.clone()]),
+        );
+        assert!(failures.is_empty(), "unexpected failures: {failures:#?}");
+
+        alice.scenario_input_ledger[0].delivered = 2;
+        let failures = compare_trace_expectations(
+            None,
+            &[TraceExpectation::ScenarioInputLedger {
+                client: "alice".into(),
+                entries: vec![ScenarioInputLedgerEntry {
+                    scenario_id: "step-4:send_app_message".into(),
+                    logical_id: Some("event-id".into()),
+                    sender: "bob".into(),
+                    payload: "hello".into(),
+                    ingest_attempts: 2,
+                    ingest_accepted: 1,
+                    delivered: 1,
+                    deduplicated: 1,
+                    ..Default::default()
+                }],
+            }],
+            &trace(vec![alice]),
+        );
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].kind, "scenario_input_ledger_mismatch");
+    }
+
+    #[test]
+    fn no_pending_work_requires_an_empty_exact_progress_snapshot() {
+        let mut alice = observation("alice", 1, 2);
+        alice.pending_work = Some(PendingWorkObservation::default());
+        let expectation = TraceExpectation::NoPendingWork {
+            clients: vec!["alice".into()],
+        };
+
+        let failures = compare_trace_expectations(
+            None,
+            std::slice::from_ref(&expectation),
+            &trace(vec![alice.clone()]),
+        );
+        assert!(failures.is_empty(), "unexpected failures: {failures:#?}");
+
+        alice
+            .pending_work
+            .as_mut()
+            .expect("pending snapshot")
+            .bus_delayed_messages = 1;
+        let failures = compare_trace_expectations(None, &[expectation], &trace(vec![alice]));
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].kind, "pending_work_remaining");
+        assert!(
+            failures[0].message.contains("bus_delayed"),
+            "failure should name the blocking subsystem: {failures:#?}"
+        );
+    }
+
+    #[test]
+    fn no_pending_work_rejects_legacy_observation_without_progress_snapshot() {
+        let failures = compare_trace_expectations(
+            None,
+            &[TraceExpectation::NoPendingWork {
+                clients: vec!["alice".into()],
+            }],
+            &trace(vec![observation("alice", 1, 2)]),
+        );
+
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].kind, "missing_pending_work_observation");
+    }
+
+    #[test]
+    fn bidirectional_decryptability_requires_every_directed_edge() {
+        let mut observed = trace(Vec::new());
+        observed.decryptability_probes = vec![BidirectionalDecryptabilityObservation {
+            step_index: 7,
+            clients: vec!["alice".into(), "bob".into()],
+            probes: vec![
+                crate::DirectionalDecryptabilityProbe {
+                    sender: "alice".into(),
+                    recipient: "bob".into(),
+                    payload: "alice-probe".into(),
+                    logical_id: Some("alice-id".into()),
+                    send_status: crate::DecryptabilityProbeSendStatus::Published,
+                    recipient_ledger: Some(ScenarioInputLedgerEntry {
+                        scenario_id: "probe:alice".into(),
+                        logical_id: Some("alice-id".into()),
+                        sender: "alice".into(),
+                        payload: "alice-probe".into(),
+                        delivered: 1,
+                        ..Default::default()
+                    }),
+                },
+                crate::DirectionalDecryptabilityProbe {
+                    sender: "bob".into(),
+                    recipient: "alice".into(),
+                    payload: "bob-probe".into(),
+                    logical_id: Some("bob-id".into()),
+                    send_status: crate::DecryptabilityProbeSendStatus::Published,
+                    recipient_ledger: Some(ScenarioInputLedgerEntry {
+                        scenario_id: "probe:bob".into(),
+                        logical_id: Some("bob-id".into()),
+                        sender: "bob".into(),
+                        payload: "bob-probe".into(),
+                        delivered: 1,
+                        ..Default::default()
+                    }),
+                },
+            ],
+        }];
+        let expectation = TraceExpectation::ClientsBidirectionallyDecryptable {
+            clients: vec!["alice".into(), "bob".into()],
+        };
+
+        let failures =
+            compare_trace_expectations(None, std::slice::from_ref(&expectation), &observed);
+        assert!(failures.is_empty(), "unexpected failures: {failures:#?}");
+
+        observed.decryptability_probes[0].probes[0]
+            .recipient_ledger
+            .as_mut()
+            .expect("ledger")
+            .delivered = 0;
+        let failures = compare_trace_expectations(None, &[expectation], &observed);
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].kind, "bidirectional_decryptability_failed");
+        assert!(failures[0].message.contains("alice->bob"));
+    }
+
+    #[test]
+    fn bidirectional_decryptability_requires_a_matching_active_probe() {
+        let failures = compare_trace_expectations(
+            None,
+            &[TraceExpectation::ClientsBidirectionallyDecryptable {
+                clients: vec!["alice".into(), "bob".into()],
+            }],
+            &trace(Vec::new()),
+        );
+
+        assert_eq!(failures.len(), 1);
+        assert_eq!(
+            failures[0].kind,
+            "missing_bidirectional_decryptability_probe"
+        );
+    }
+
+    #[test]
     fn clients_converged_expectation_rejects_group_data_branch_fork() {
         // Regression for mdk#162: a multi-committer group-data storm fork
         // leaves the committers on competing branches that share an epoch and
@@ -1100,6 +1527,63 @@ mod tests {
                 member_count: Some(21),
             }],
             &observed,
+        );
+
+        assert!(failures.is_empty(), "unexpected failures: {failures:#?}");
+    }
+
+    #[test]
+    fn exact_equivalence_rejects_same_count_with_different_member_identities() {
+        let mut alice = observation("alice", 7, 1);
+        alice.canonical_state = Some(exact_snapshot("alice-id", "commitment"));
+        let mut bob = observation("bob", 7, 1);
+        bob.canonical_state = Some(exact_snapshot("bob-id", "commitment"));
+
+        let failures = compare_trace_expectations(
+            None,
+            &[TraceExpectation::ClientsExactlyEquivalent {
+                clients: vec!["alice".into(), "bob".into()],
+            }],
+            &trace(vec![alice, bob]),
+        );
+
+        assert_eq!(failures.len(), 1, "expected one failure: {failures:#?}");
+        assert_eq!(failures[0].kind, "clients_not_exactly_equivalent");
+    }
+
+    #[test]
+    fn exact_equivalence_rejects_different_exporter_commitments() {
+        let mut alice = observation("alice", 7, 1);
+        alice.canonical_state = Some(exact_snapshot("shared-id", "alice-commitment"));
+        let mut bob = observation("bob", 7, 1);
+        bob.canonical_state = Some(exact_snapshot("shared-id", "bob-commitment"));
+
+        let failures = compare_trace_expectations(
+            None,
+            &[TraceExpectation::ClientsExactlyEquivalent {
+                clients: vec!["alice".into(), "bob".into()],
+            }],
+            &trace(vec![alice, bob]),
+        );
+
+        assert_eq!(failures.len(), 1, "expected one failure: {failures:#?}");
+        assert_eq!(failures[0].kind, "clients_not_exactly_equivalent");
+    }
+
+    #[test]
+    fn exact_equivalence_accepts_identical_canonical_snapshots() {
+        let snapshot = exact_snapshot("shared-id", "shared-commitment");
+        let mut alice = observation("alice", 7, 1);
+        alice.canonical_state = Some(snapshot.clone());
+        let mut bob = observation("bob", 7, 1);
+        bob.canonical_state = Some(snapshot);
+
+        let failures = compare_trace_expectations(
+            None,
+            &[TraceExpectation::ClientsExactlyEquivalent {
+                clients: vec!["alice".into(), "bob".into()],
+            }],
+            &trace(vec![alice, bob]),
         );
 
         assert!(failures.is_empty(), "unexpected failures: {failures:#?}");

--- a/crates/cgka-conformance-simulator/src/vector.rs
+++ b/crates/cgka-conformance-simulator/src/vector.rs
@@ -143,7 +143,12 @@ pub enum TraceExpectation {
         entries: Vec<ScenarioInputLedgerEntry>,
     },
     /// Require every named client's exact progress snapshot to contain no
-    /// outstanding engine, transport, or logical-message work.
+    /// outstanding local engine, client-addressed transport, or logical-input
+    /// work.
+    ///
+    /// This is not an end-to-end delivery assertion for transport objects that
+    /// a fault policy dropped. Assert recipient ledger/output dispositions
+    /// separately when delivery is required.
     NoPendingWork {
         clients: Vec<String>,
     },
@@ -379,21 +384,25 @@ impl TraceExpectation {
             TraceExpectation::ClientsExactlyEquivalent { clients } => {
                 let mut snapshots = Vec::with_capacity(clients.len());
                 for client in clients {
-                    let Some(observation) = client_observation(observed, client) else {
+                    let Some(latest_observation) = client_observation(observed, client) else {
                         missing_client(client, self, mismatches);
                         return;
                     };
-                    let Some(snapshot) = observation.canonical_state.as_ref() else {
+                    let Some(observation) = client_canonical_observation(observed, client) else {
                         mismatches.push(ExpectationFailure {
                             kind: "missing_canonical_state".into(),
                             message: format!(
                                 "client {client} was not observed with observe_client_exact"
                             ),
                             expected: json!(self),
-                            actual: json!(observation),
+                            actual: json!(latest_observation),
                         });
                         return;
                     };
+                    let snapshot = observation
+                        .canonical_state
+                        .as_ref()
+                        .expect("canonical observation carries canonical state");
                     snapshots.push((client, snapshot));
                 }
                 if snapshots.is_empty() {
@@ -429,7 +438,9 @@ impl TraceExpectation {
                 }
             }
             TraceExpectation::ScenarioInputLedger { client, entries } => {
-                match client_observation(observed, client) {
+                match client_canonical_observation(observed, client)
+                    .or_else(|| client_observation(observed, client))
+                {
                     Some(observation) if &observation.scenario_input_ledger == entries => {}
                     Some(observation) => mismatches.push(ExpectationFailure {
                         kind: "scenario_input_ledger_mismatch".into(),
@@ -453,21 +464,25 @@ impl TraceExpectation {
                     return;
                 }
                 for client in clients {
-                    let Some(observation) = client_observation(observed, client) else {
+                    let Some(latest_observation) = client_observation(observed, client) else {
                         missing_client(client, self, mismatches);
                         return;
                     };
-                    let Some(pending_work) = observation.pending_work.as_ref() else {
+                    let Some(observation) = client_pending_work_observation(observed, client) else {
                         mismatches.push(ExpectationFailure {
                             kind: "missing_pending_work_observation".into(),
                             message: format!(
                                 "client {client} was not observed with observe_client_exact"
                             ),
                             expected: json!(self),
-                            actual: json!(observation),
+                            actual: json!(latest_observation),
                         });
                         continue;
                     };
+                    let pending_work = observation
+                        .pending_work
+                        .as_ref()
+                        .expect("pending-work observation carries pending work");
                     if !pending_work.is_empty() {
                         mismatches.push(ExpectationFailure {
                             kind: "pending_work_remaining".into(),
@@ -889,6 +904,28 @@ fn client_observation<'a>(
         .find(|observation| observation.client == client)
 }
 
+fn client_canonical_observation<'a>(
+    observed: &'a ScenarioTrace,
+    client: &str,
+) -> Option<&'a ClientObservation> {
+    observed
+        .observations
+        .iter()
+        .rev()
+        .find(|observation| observation.client == client && observation.canonical_state.is_some())
+}
+
+fn client_pending_work_observation<'a>(
+    observed: &'a ScenarioTrace,
+    client: &str,
+) -> Option<&'a ClientObservation> {
+    observed
+        .observations
+        .iter()
+        .rev()
+        .find(|observation| observation.client == client && observation.pending_work.is_some())
+}
+
 /// Legacy semantic expectations describe the event window captured by an
 /// `observe` step. A later `observe_exact` intentionally drains a fresh event
 /// window, so it must not replace the earlier observation for payload/member
@@ -1200,6 +1237,7 @@ fn observe_key(key: &CommitOrderingKey) -> RecoveryOrderingKeyObservation {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ScenarioInputDisposition;
     use cgka_engine::conformance_snapshot::{ConformanceGroupSnapshot, ConformanceLeafSnapshot};
 
     fn observation(client: &str, epoch: u64, member_count: usize) -> ClientObservation {
@@ -1587,6 +1625,53 @@ mod tests {
         );
 
         assert!(failures.is_empty(), "unexpected failures: {failures:#?}");
+    }
+
+    #[test]
+    fn exact_expectations_use_latest_qualifying_sample_before_later_legacy_observation() {
+        let snapshot = exact_snapshot("shared-id", "shared-commitment");
+        let mut alice_exact = observation("alice", 7, 1);
+        alice_exact.canonical_state = Some(snapshot.clone());
+        alice_exact.pending_work = Some(PendingWorkObservation::default());
+        alice_exact.scenario_input_ledger = vec![ScenarioInputLedgerEntry {
+            scenario_id: "step-4:send_app_message".into(),
+            disposition: ScenarioInputDisposition::Delivered,
+            delivered: 1,
+            ..Default::default()
+        }];
+        let expected_ledger = alice_exact.scenario_input_ledger.clone();
+
+        let mut bob_exact = observation("bob", 7, 1);
+        bob_exact.canonical_state = Some(snapshot);
+        bob_exact.pending_work = Some(PendingWorkObservation::default());
+
+        let observed = trace(vec![
+            alice_exact,
+            bob_exact,
+            observation("alice", 7, 1),
+            observation("bob", 7, 1),
+        ]);
+        let failures = compare_trace_expectations(
+            None,
+            &[
+                TraceExpectation::ClientsExactlyEquivalent {
+                    clients: vec!["alice".into(), "bob".into()],
+                },
+                TraceExpectation::ScenarioInputLedger {
+                    client: "alice".into(),
+                    entries: expected_ledger,
+                },
+                TraceExpectation::NoPendingWork {
+                    clients: vec!["alice".into(), "bob".into()],
+                },
+            ],
+            &observed,
+        );
+
+        assert!(
+            failures.is_empty(),
+            "later legacy observations must not hide exact evidence: {failures:#?}"
+        );
     }
 
     #[test]

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -184,6 +184,11 @@ async fn exact_oracle_projects_terminal_disband_tombstone_across_restart() {
     alice.drain_events();
 
     alice.request_disband().await.expect("request disband");
+    // Milestone 1.3 replaces this production-clock wait with the simulator's
+    // injected monotonic/wall clocks. Until that subject boundary exists, run
+    // the real pinned-v1 quiescence policy rather than weakening its constants
+    // just for this terminal-projection test.
+    let mut reached_terminal = false;
     for _ in 0..24 {
         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         alice
@@ -194,9 +199,14 @@ async fn exact_oracle_projects_terminal_disband_tombstone_across_restart() {
             alice.canonical_state_snapshot(),
             ConformanceCanonicalStateSnapshot::Disbanded(_)
         ) {
+            reached_terminal = true;
             break;
         }
     }
+    assert!(
+        reached_terminal,
+        "disband did not reach terminal state within the 6-second pinned-v1 test budget"
+    );
     bus.deliver_all();
 
     let before_restart = alice.canonical_state_snapshot();
@@ -513,25 +523,43 @@ async fn no_pending_work_rejects_bus_queue_and_unread_mailbox() {
     bob.drain_events();
 
     bob.send_app(b"queued".to_vec()).await;
-    let queued = observe_client_exact("alice", &mut alice);
+    let queued_for_alice = observe_client_exact("alice", &mut alice);
     assert_eq!(
-        queued
+        queued_for_alice
             .pending_work
             .as_ref()
             .expect("exact pending snapshot")
             .bus_queued_messages,
         1
     );
+    let sender_does_not_own_queued_delivery = observe_client_exact("bob", &mut bob);
+    assert_eq!(
+        sender_does_not_own_queued_delivery
+            .pending_work
+            .as_ref()
+            .expect("exact pending snapshot")
+            .bus_queued_messages,
+        0
+    );
 
     bus.deliver_all();
-    let unread = observe_client_exact("bob", &mut bob);
+    let unread_for_alice = observe_client_exact("alice", &mut alice);
     assert_eq!(
-        unread
+        unread_for_alice
             .pending_work
             .as_ref()
             .expect("exact pending snapshot")
             .bus_mailbox_messages,
         1
+    );
+    let sender_mailbox_remains_empty = observe_client_exact("bob", &mut bob);
+    assert_eq!(
+        sender_mailbox_remains_empty
+            .pending_work
+            .as_ref()
+            .expect("exact pending snapshot")
+            .bus_mailbox_messages,
+        0
     );
 
     alice.tick().await;
@@ -543,6 +571,82 @@ async fn no_pending_work_rejects_bus_queue_and_unread_mailbox() {
             .expect("exact pending snapshot")
             .is_empty(),
         "all transport and engine work should be drained: {drained:#?}"
+    );
+}
+
+#[tokio::test]
+async fn no_pending_work_does_not_claim_delivery_of_dropped_application_input() {
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice")).attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob")).attach(&bus);
+    let bob_key_package = bob.fresh_key_package().await;
+
+    let (_group_id, pending) = alice
+        .create_group("dropped-is-not-pending", vec![bob_key_package], vec![])
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+    alice.drain_events();
+    bob.drain_events();
+
+    alice.send_app(b"intentionally-dropped".to_vec()).await;
+    assert!(bus.drop_queued(0), "drop the application transport object");
+
+    let alice_observation = observe_client_exact("alice", &mut alice);
+    let bob_observation = observe_client_exact("bob", &mut bob);
+    let sender_entry = alice_observation
+        .scenario_input_ledger
+        .iter()
+        .find(|entry| entry.payload == "intentionally-dropped")
+        .expect("sender records the published application input");
+    assert_eq!(
+        sender_entry.disposition,
+        ScenarioInputDisposition::Accepted,
+        "sender acceptance is not an end-to-end delivery claim"
+    );
+    assert!(
+        bob_observation.scenario_input_ledger.is_empty(),
+        "a recipient cannot classify an object the scenario removed before delivery"
+    );
+
+    let trace = ScenarioTrace {
+        name: "dropped-is-not-pending".into(),
+        pending_resolutions: vec![],
+        errors: vec![],
+        admin_policies: vec![],
+        decryptability_probes: vec![],
+        observations: vec![alice_observation, bob_observation],
+    };
+    let no_pending_failures = compare_trace_expectations(
+        None,
+        &[TraceExpectation::NoPendingWork {
+            clients: vec!["alice".into(), "bob".into()],
+        }],
+        &trace,
+    );
+    assert!(
+        no_pending_failures.is_empty(),
+        "NoPendingWork is local execution quiescence, not transport completeness: \
+         {no_pending_failures:#?}"
+    );
+
+    let delivery_failures = compare_trace_expectations(
+        None,
+        &[TraceExpectation::ClientState {
+            client: "bob".into(),
+            epoch: 1,
+            member_count: 2,
+            received_payloads: Some(vec!["intentionally-dropped".into()]),
+            added_members: None,
+            removed_members: None,
+        }],
+        &trace,
+    );
+    assert_eq!(
+        delivery_failures.len(),
+        1,
+        "delivery must be asserted independently from local quiescence"
     );
 }
 

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -5,17 +5,20 @@
 //! behavior into seeded random send/leave sequences.
 
 use cgka_conformance_simulator::{
-    ClientBuilder, EpochChangeObservation, GeneratedScenarioCase, HarnessClient,
-    PendingResolutionObservation, ScenarioReport, ScenarioSpec, ScenarioStep, ScenarioTrace,
-    TraceExpectation, TransportBus, VectorFixture, compare_trace_expectations,
+    ClientBuilder, ConformanceCanonicalStateSnapshot, EpochChangeObservation,
+    GeneratedScenarioCase, HarnessClient, PendingResolutionObservation, ScenarioInputDisposition,
+    ScenarioInputKind, ScenarioInputLedgerEntry, ScenarioReport, ScenarioSpec, ScenarioStep,
+    ScenarioTrace, TraceExpectation, TransportBus, VectorFixture, compare_trace_expectations,
     generate_convergence_chaos_family, generate_convergence_e2e_delivery_family,
-    generate_send_leave_family, observe_client, run_generated_case_report, run_scenario_report,
-    run_scenario_report_with_outcomes, run_scenario_spec, run_vector_fixture_report,
+    generate_send_leave_family, observe_client, observe_client_exact, run_generated_case_report,
+    run_scenario_report, run_scenario_report_with_outcomes, run_scenario_spec,
+    run_vector_fixture_report,
 };
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_engine::openmls_projection::{OpenMlsContentKind, project_mls_message};
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
 use cgka_traits::engine::GroupEvent;
+use cgka_traits::group::ProtocolProfile;
 use cgka_traits::ingest::IngestOutcome;
 use cgka_traits::message::MessageState;
 use cgka_traits::storage::MessageStorage;
@@ -115,6 +118,484 @@ async fn three_client_happy_path_via_harness() {
     // Convergence: same epoch, same member set across all clients.
     assert_eq!(alice.epoch(), bob.epoch());
     assert_eq!(alice.epoch(), carol.epoch());
+}
+
+#[tokio::test]
+async fn exact_oracle_matches_full_canonical_state_after_join() {
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice")).attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob")).attach(&bus);
+    let bob_key_package = bob.fresh_key_package().await;
+
+    let (_group_id, pending) = alice
+        .create_group("exact-state", vec![bob_key_package], vec![])
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+
+    let alice_snapshot = alice.canonical_group_snapshot();
+    let bob_snapshot = bob.canonical_group_snapshot();
+    assert_eq!(alice_snapshot, bob_snapshot);
+    assert_eq!(alice_snapshot.leaves.len(), 2);
+    assert_eq!(alice_snapshot.sorted_member_identities_hex.len(), 2);
+    assert_eq!(alice_snapshot.exporter_commitment_sha256.len(), 64);
+    assert_eq!(alice_snapshot.group_context_sha256.len(), 64);
+
+    let trace = ScenarioTrace {
+        name: "exact-state-after-join/v1".into(),
+        pending_resolutions: vec![],
+        errors: vec![],
+        admin_policies: vec![],
+        decryptability_probes: vec![],
+        observations: vec![
+            observe_client_exact("alice", &mut alice),
+            observe_client_exact("bob", &mut bob),
+        ],
+    };
+    let failures = compare_trace_expectations(
+        None,
+        &[
+            TraceExpectation::ClientsExactlyEquivalent {
+                clients: vec!["alice".into(), "bob".into()],
+            },
+            TraceExpectation::NoPendingWork {
+                clients: vec!["alice".into(), "bob".into()],
+            },
+        ],
+        &trace,
+    );
+    assert!(failures.is_empty(), "unexpected failures: {failures:#?}");
+}
+
+#[tokio::test]
+async fn exact_oracle_projects_terminal_disband_tombstone_across_restart() {
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice"))
+        .protocol_profile(ProtocolProfile::Current)
+        .attach(&bus);
+    let (_group_id, pending) = alice
+        .create_group_with_admins_maybe_pending("terminal", vec![], vec![], vec![])
+        .await;
+    assert!(
+        pending.is_none(),
+        "current founding group is immediately live"
+    );
+    alice.drain_events();
+
+    alice.request_disband().await.expect("request disband");
+    for _ in 0..24 {
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        alice
+            .advance_convergence()
+            .await
+            .expect("advance disband convergence");
+        if matches!(
+            alice.canonical_state_snapshot(),
+            ConformanceCanonicalStateSnapshot::Disbanded(_)
+        ) {
+            break;
+        }
+    }
+    bus.deliver_all();
+
+    let before_restart = alice.canonical_state_snapshot();
+    let ConformanceCanonicalStateSnapshot::Disbanded(tombstone) = &before_restart else {
+        panic!("expected terminal tombstone, got {before_restart:#?}");
+    };
+    assert_eq!(tombstone.epoch, 1);
+    assert_eq!(tombstone.former_member_identities_hex.len(), 1);
+    assert_eq!(tombstone.commit_digest_hex.len(), 64);
+
+    let trace = ScenarioTrace {
+        name: "exact-disband-tombstone".into(),
+        pending_resolutions: vec![],
+        errors: vec![],
+        admin_policies: vec![],
+        decryptability_probes: vec![],
+        observations: vec![observe_client_exact("alice", &mut alice)],
+    };
+    let failures = compare_trace_expectations(
+        None,
+        &[
+            TraceExpectation::ClientsExactlyEquivalent {
+                clients: vec!["alice".into()],
+            },
+            TraceExpectation::NoPendingWork {
+                clients: vec!["alice".into()],
+            },
+        ],
+        &trace,
+    );
+    assert!(failures.is_empty(), "unexpected failures: {failures:#?}");
+
+    alice.restart();
+    assert_eq!(alice.canonical_state_snapshot(), before_restart);
+}
+
+#[tokio::test]
+async fn bidirectional_decryptability_probe_passes_for_settled_members() {
+    let spec = ScenarioSpec {
+        name: "bidirectional-decryptability/settled".into(),
+        spec_version: "1".into(),
+        clients: vec!["alice".into(), "bob".into(), "carol".into()],
+        steps: vec![
+            ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "decryptability".into(),
+                invitees: vec!["bob".into(), "carol".into()],
+                required_features: vec![],
+                initial_admins: None,
+                pending: "create".into(),
+            },
+            ScenarioStep::ConfirmPending {
+                client: "alice".into(),
+                pending: "create".into(),
+            },
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into(), "carol".into()],
+            },
+            ScenarioStep::ProbeBidirectionalDecryptability {
+                clients: vec!["alice".into(), "bob".into(), "carol".into()],
+            },
+            ScenarioStep::ObserveExact {
+                clients: vec!["alice".into(), "bob".into(), "carol".into()],
+            },
+        ],
+    };
+    let report = run_scenario_report_with_outcomes(
+        &spec,
+        None,
+        vec![
+            TraceExpectation::ClientsExactlyEquivalent {
+                clients: vec!["alice".into(), "bob".into(), "carol".into()],
+            },
+            TraceExpectation::ClientsBidirectionallyDecryptable {
+                clients: vec!["alice".into(), "bob".into(), "carol".into()],
+            },
+            TraceExpectation::NoPendingWork {
+                clients: vec!["alice".into(), "bob".into(), "carol".into()],
+            },
+        ],
+    )
+    .await
+    .expect("run settled decryptability probe");
+
+    assert!(
+        report.expectation_failures.is_empty(),
+        "unexpected failures: {:#?}",
+        report.expectation_failures
+    );
+    let probe = &report
+        .observed_trace
+        .as_ref()
+        .expect("trace")
+        .decryptability_probes[0];
+    assert!(probe.succeeded());
+    assert_eq!(probe.probes.len(), 6);
+}
+
+#[tokio::test]
+async fn bidirectional_decryptability_probe_exposes_asymmetric_epoch_reachability() {
+    let spec = ScenarioSpec {
+        name: "bidirectional-decryptability/asymmetric-epoch".into(),
+        spec_version: "1".into(),
+        clients: vec!["alice".into(), "bob".into()],
+        steps: vec![
+            ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "decryptability".into(),
+                invitees: vec!["bob".into()],
+                required_features: vec![],
+                initial_admins: None,
+                pending: "create".into(),
+            },
+            ScenarioStep::ConfirmPending {
+                client: "alice".into(),
+                pending: "create".into(),
+            },
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            ScenarioStep::UpdateGroupData {
+                client: "alice".into(),
+                name: "advanced-without-bob".into(),
+                pending: "advance".into(),
+            },
+            ScenarioStep::ConfirmPending {
+                client: "alice".into(),
+                pending: "advance".into(),
+            },
+            ScenarioStep::DropQueued { index: 0 },
+            ScenarioStep::ProbeBidirectionalDecryptability {
+                clients: vec!["alice".into(), "bob".into()],
+            },
+        ],
+    };
+    let report = run_scenario_report_with_outcomes(
+        &spec,
+        None,
+        vec![TraceExpectation::ClientsBidirectionallyDecryptable {
+            clients: vec!["alice".into(), "bob".into()],
+        }],
+    )
+    .await
+    .expect("run asymmetric decryptability probe");
+
+    assert_eq!(report.expectation_failures.len(), 1);
+    assert_eq!(
+        report.expectation_failures[0].kind,
+        "bidirectional_decryptability_failed"
+    );
+    let probe = &report
+        .observed_trace
+        .as_ref()
+        .expect("trace")
+        .decryptability_probes[0];
+    let alice_to_bob = probe
+        .probes
+        .iter()
+        .find(|edge| edge.sender == "alice" && edge.recipient == "bob")
+        .expect("alice to bob edge");
+    assert!(!alice_to_bob.succeeded());
+    assert_eq!(
+        alice_to_bob
+            .recipient_ledger
+            .as_ref()
+            .expect("deferred ledger")
+            .transport_deferred,
+        1
+    );
+    assert!(
+        probe
+            .probes
+            .iter()
+            .find(|edge| edge.sender == "bob" && edge.recipient == "alice")
+            .expect("bob to alice edge")
+            .succeeded()
+    );
+}
+
+#[tokio::test]
+async fn bidirectional_decryptability_probe_rejects_a_named_nonmember() {
+    let spec = ScenarioSpec {
+        name: "bidirectional-decryptability/nonmember".into(),
+        spec_version: "1".into(),
+        clients: vec!["alice".into(), "bob".into(), "carol".into()],
+        steps: vec![
+            ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "decryptability".into(),
+                invitees: vec!["bob".into()],
+                required_features: vec![],
+                initial_admins: None,
+                pending: "create".into(),
+            },
+            ScenarioStep::ConfirmPending {
+                client: "alice".into(),
+                pending: "create".into(),
+            },
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            ScenarioStep::ProbeBidirectionalDecryptability {
+                clients: vec!["alice".into(), "bob".into(), "carol".into()],
+            },
+        ],
+    };
+    let report = run_scenario_report_with_outcomes(
+        &spec,
+        None,
+        vec![TraceExpectation::ClientsBidirectionallyDecryptable {
+            clients: vec!["alice".into(), "bob".into(), "carol".into()],
+        }],
+    )
+    .await
+    .expect("run nonmember decryptability probe");
+
+    assert_eq!(report.expectation_failures.len(), 1);
+    let probe = &report
+        .observed_trace
+        .as_ref()
+        .expect("trace")
+        .decryptability_probes[0];
+    assert!(!probe.succeeded());
+    assert!(probe.probes.iter().any(|edge| {
+        edge.sender == "carol"
+            && matches!(
+                edge.send_status,
+                cgka_conformance_simulator::DecryptabilityProbeSendStatus::Failed { .. }
+            )
+    }));
+}
+
+#[tokio::test]
+async fn no_pending_work_rejects_delayed_transport_then_accepts_drained_delivery() {
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice")).attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob")).attach(&bus);
+    let bob_key_package = bob.fresh_key_package().await;
+
+    let (_group_id, pending) = alice
+        .create_group("pending-delayed", vec![bob_key_package], vec![])
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+    alice.drain_events();
+    bob.drain_events();
+
+    bob.send_app(b"held".to_vec()).await;
+    assert!(bus.delay_queued(0, "held-message"));
+    let held_trace = ScenarioTrace {
+        name: "pending-delayed/held".into(),
+        pending_resolutions: vec![],
+        errors: vec![],
+        admin_policies: vec![],
+        decryptability_probes: vec![],
+        observations: vec![observe_client_exact("alice", &mut alice)],
+    };
+    let failures = compare_trace_expectations(
+        None,
+        &[TraceExpectation::NoPendingWork {
+            clients: vec!["alice".into()],
+        }],
+        &held_trace,
+    );
+    assert_eq!(failures.len(), 1, "expected delayed blocker: {failures:#?}");
+    assert_eq!(failures[0].kind, "pending_work_remaining");
+    assert!(
+        failures[0].message.contains("bus_delayed"),
+        "delayed subsystem should be named: {failures:#?}"
+    );
+
+    assert!(bus.release_delayed("held-message"));
+    bus.deliver_all();
+    alice.tick().await;
+    let drained_trace = ScenarioTrace {
+        name: "pending-delayed/drained".into(),
+        pending_resolutions: vec![],
+        errors: vec![],
+        admin_policies: vec![],
+        decryptability_probes: vec![],
+        observations: vec![observe_client_exact("alice", &mut alice)],
+    };
+    let failures = compare_trace_expectations(
+        None,
+        &[TraceExpectation::NoPendingWork {
+            clients: vec!["alice".into()],
+        }],
+        &drained_trace,
+    );
+    assert!(
+        failures.is_empty(),
+        "unexpected pending work: {failures:#?}"
+    );
+}
+
+#[tokio::test]
+async fn no_pending_work_rejects_bus_queue_and_unread_mailbox() {
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice")).attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob")).attach(&bus);
+    let bob_key_package = bob.fresh_key_package().await;
+
+    let (_group_id, pending) = alice
+        .create_group("pending-bus", vec![bob_key_package], vec![])
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+    alice.drain_events();
+    bob.drain_events();
+
+    bob.send_app(b"queued".to_vec()).await;
+    let queued = observe_client_exact("alice", &mut alice);
+    assert_eq!(
+        queued
+            .pending_work
+            .as_ref()
+            .expect("exact pending snapshot")
+            .bus_queued_messages,
+        1
+    );
+
+    bus.deliver_all();
+    let unread = observe_client_exact("bob", &mut bob);
+    assert_eq!(
+        unread
+            .pending_work
+            .as_ref()
+            .expect("exact pending snapshot")
+            .bus_mailbox_messages,
+        1
+    );
+
+    alice.tick().await;
+    let drained = observe_client_exact("alice", &mut alice);
+    assert!(
+        drained
+            .pending_work
+            .as_ref()
+            .expect("exact pending snapshot")
+            .is_empty(),
+        "all transport and engine work should be drained: {drained:#?}"
+    );
+}
+
+#[tokio::test]
+async fn no_pending_work_rejects_unconfirmed_publish() {
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice")).attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob")).attach(&bus);
+    let mut carol = ClientBuilder::new(pad32(b"carol")).attach(&bus);
+    let bob_key_package = bob.fresh_key_package().await;
+
+    let (_group_id, pending) = alice
+        .create_group("pending-publish", vec![bob_key_package], vec![])
+        .await;
+    alice.confirm(pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+    alice.drain_events();
+    bob.drain_events();
+
+    let pending_invite = alice.invite(vec![carol.fresh_key_package().await]).await;
+    let observation = observe_client_exact("alice", &mut alice);
+    assert_eq!(
+        observation
+            .pending_work
+            .as_ref()
+            .expect("exact pending snapshot")
+            .engine
+            .non_stable_epoch_state,
+        1
+    );
+    let trace = ScenarioTrace {
+        name: "pending-publish/unconfirmed".into(),
+        pending_resolutions: vec![],
+        errors: vec![],
+        admin_policies: vec![],
+        decryptability_probes: vec![],
+        observations: vec![observation],
+    };
+    let failures = compare_trace_expectations(
+        None,
+        &[TraceExpectation::NoPendingWork {
+            clients: vec!["alice".into()],
+        }],
+        &trace,
+    );
+    assert_eq!(failures.len(), 1, "expected publish blocker: {failures:#?}");
+    assert!(
+        failures[0].message.contains("engine"),
+        "engine subsystem should be named: {failures:#?}"
+    );
+
+    alice.fail(pending_invite).await;
 }
 
 #[tokio::test]
@@ -242,6 +723,7 @@ async fn three_client_message_exchange_vector_is_stable() {
         }],
         errors: vec![],
         admin_policies: vec![],
+        decryptability_probes: vec![],
         observations: vec![
             observe_client("alice", &mut alice),
             observe_client("bob", &mut bob),
@@ -261,12 +743,16 @@ async fn three_client_message_exchange_vector_is_stable() {
             }],
             errors: vec![],
             admin_policies: vec![],
+            decryptability_probes: vec![],
             observations: vec![
                 cgka_conformance_simulator::ClientObservation {
                     client: "alice".into(),
                     epoch: 1,
                     member_count: 3,
                     group_name: "vector-smoke".into(),
+                    canonical_state: None,
+                    scenario_input_ledger: vec![],
+                    pending_work: None,
                     event_counts: cgka_conformance_simulator::ClientEventCounts {
                         message_received: 2,
                         ..Default::default()
@@ -284,6 +770,9 @@ async fn three_client_message_exchange_vector_is_stable() {
                     epoch: 1,
                     member_count: 3,
                     group_name: "vector-smoke".into(),
+                    canonical_state: None,
+                    scenario_input_ledger: vec![],
+                    pending_work: None,
                     event_counts: cgka_conformance_simulator::ClientEventCounts {
                         message_received: 2,
                         ..Default::default()
@@ -301,6 +790,9 @@ async fn three_client_message_exchange_vector_is_stable() {
                     epoch: 1,
                     member_count: 3,
                     group_name: "vector-smoke".into(),
+                    canonical_state: None,
+                    scenario_input_ledger: vec![],
+                    pending_work: None,
                     event_counts: cgka_conformance_simulator::ClientEventCounts {
                         message_received: 2,
                         ..Default::default()
@@ -571,7 +1063,7 @@ async fn scenario_spec_can_duplicate_delay_and_reorder_queued_messages() {
             ScenarioStep::Tick {
                 clients: vec!["alice".into()],
             },
-            ScenarioStep::Observe {
+            ScenarioStep::ObserveExact {
                 clients: vec!["alice".into()],
             },
         ],
@@ -583,6 +1075,105 @@ async fn scenario_spec_can_duplicate_delay_and_reorder_queued_messages() {
         trace.observations[0].received_payloads,
         vec!["carol:second", "bob:first"]
     );
+    let bob_message = trace.observations[0]
+        .scenario_input_ledger
+        .iter()
+        .find(|entry| entry.payload == "bob:first")
+        .expect("bob's logical message is tracked");
+    assert_eq!(bob_message.ingest_attempts, 2);
+    assert_eq!(bob_message.ingest_accepted, 1);
+    assert_eq!(bob_message.delivered, 1);
+    assert_eq!(bob_message.deduplicated, 1);
+    assert!(!bob_message.pending);
+}
+
+#[tokio::test]
+async fn exact_observation_ledgers_commit_proposal_and_application_dispositions() {
+    let spec = ScenarioSpec {
+        name: "generalized-scenario-input-ledger/v1".into(),
+        spec_version: "1".into(),
+        clients: vec!["alice".into(), "bob".into()],
+        steps: vec![
+            ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "ledger".into(),
+                invitees: vec!["bob".into()],
+                required_features: vec![],
+                initial_admins: None,
+                pending: "create".into(),
+            },
+            ScenarioStep::ConfirmPending {
+                client: "alice".into(),
+                pending: "create".into(),
+            },
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            ScenarioStep::UpdateGroupData {
+                client: "alice".into(),
+                name: "ledger-updated".into(),
+                pending: "rename".into(),
+            },
+            ScenarioStep::ConfirmPending {
+                client: "alice".into(),
+                pending: "rename".into(),
+            },
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            ScenarioStep::SendAppMessage {
+                sender: "alice".into(),
+                payload: "ledger-message".into(),
+            },
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            ScenarioStep::Leave {
+                client: "bob".into(),
+            },
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["alice".into()],
+            },
+            ScenarioStep::ObserveExact {
+                clients: vec!["alice".into()],
+            },
+        ],
+    };
+
+    let trace = run_scenario_spec(&spec).await.expect("scenario runs");
+    let ledger = &trace.observations[0].scenario_input_ledger;
+
+    let commit = ledger
+        .iter()
+        .find(|entry| entry.scenario_id == "step-4:update_group_data")
+        .expect("named commit input");
+    assert_eq!(commit.kind, ScenarioInputKind::Commit);
+    assert_eq!(commit.disposition, ScenarioInputDisposition::Accepted);
+
+    let application = ledger
+        .iter()
+        .find(|entry| entry.scenario_id == "step-8:send_app_message")
+        .expect("named application input");
+    assert_eq!(application.kind, ScenarioInputKind::Application);
+    assert_eq!(application.payload, "ledger-message");
+    assert_eq!(application.disposition, ScenarioInputDisposition::Accepted);
+
+    let proposal = ledger
+        .iter()
+        .find(|entry| entry.scenario_id == "step-11:leave")
+        .expect("named proposal input");
+    assert_eq!(proposal.kind, ScenarioInputKind::Proposal);
+    assert!(
+        matches!(
+            proposal.disposition,
+            ScenarioInputDisposition::Pending | ScenarioInputDisposition::Accepted
+        ),
+        "the ledger must expose the proposal's current durable disposition: {proposal:?}"
+    );
 }
 
 #[tokio::test]
@@ -593,7 +1184,7 @@ async fn send_leave_family_records_seed_and_runs_generated_cases() {
     assert_eq!(cases.len(), 3);
     for (case_index, case) in cases.iter().enumerate() {
         assert_eq!(case.family_name, "send-leave/v1");
-        assert_eq!(case.generator_version, "1");
+        assert_eq!(case.generator_version, "2");
         assert_eq!(case.seed, 42);
         assert_eq!(case.case_index, case_index as u64);
 
@@ -606,7 +1197,51 @@ async fn send_leave_family_records_seed_and_runs_generated_cases() {
 
     let json = serde_json::to_value(&cases[0]).expect("case serializes");
     assert_eq!(json["seed"], 42);
-    assert_eq!(json["generator_version"], "1");
+    assert_eq!(json["generator_version"], "2");
+
+    for case in cases {
+        assert!(
+            case.scenario
+                .steps
+                .iter()
+                .any(|step| matches!(step, ScenarioStep::ObserveExact { .. }))
+        );
+        assert!(case.expected_outcomes.iter().any(|expectation| matches!(
+            expectation,
+            TraceExpectation::ClientsExactlyEquivalent { .. }
+        )));
+        assert!(
+            case.expected_outcomes
+                .iter()
+                .any(|expectation| matches!(expectation, TraceExpectation::NoPendingWork { .. }))
+        );
+        let report = run_generated_case_report(&case, None)
+            .await
+            .expect("strict send/leave case report runs");
+        let includes_leave = case
+            .scenario
+            .steps
+            .iter()
+            .any(|step| matches!(step, ScenarioStep::Leave { .. }));
+        if includes_leave {
+            assert!(
+                report
+                    .expectation_failures
+                    .iter()
+                    .any(|failure| failure.kind == "pending_work_remaining"),
+                "leave case {} must retain the strict pending-work regression until proposal work is retired: {:?}",
+                case.case_index,
+                report.expectation_failures
+            );
+        } else {
+            assert!(
+                report.expectation_failures.is_empty(),
+                "non-leave case {} failed strict expectations: {:?}",
+                case.case_index,
+                report.expectation_failures
+            );
+        }
+    }
 }
 
 #[tokio::test]
@@ -692,6 +1327,17 @@ where
     }
 }
 
+fn without_strict_reliability_outcomes(mut case: GeneratedScenarioCase) -> GeneratedScenarioCase {
+    case.expected_outcomes.retain(|expectation| {
+        !matches!(
+            expectation,
+            TraceExpectation::ClientsExactlyEquivalent { .. }
+                | TraceExpectation::NoPendingWork { .. }
+        )
+    });
+    case
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn convergence_chaos_family_generates_specs_with_semantic_expectations() {
     let cases = generate_convergence_chaos_family(123, 24);
@@ -702,6 +1348,17 @@ async fn convergence_chaos_family_generates_specs_with_semantic_expectations() {
         cases.iter().all(|case| !case.expected_outcomes.is_empty()),
         "chaos cases should carry semantic expectations"
     );
+    assert!(cases.iter().all(|case| {
+        case.scenario
+            .steps
+            .iter()
+            .any(|step| matches!(step, ScenarioStep::ObserveExact { .. }))
+    }));
+    assert!(cases.iter().all(|case| {
+        case.expected_outcomes
+            .iter()
+            .any(|expectation| matches!(expectation, TraceExpectation::NoPendingWork { .. }))
+    }));
     assert!(
         cases.iter().any(|case| case
             .scenario
@@ -800,12 +1457,16 @@ async fn convergence_chaos_family_generates_specs_with_semantic_expectations() {
 
     for (case_index, case) in cases.iter().enumerate() {
         assert_eq!(case.family_name, "convergence-chaos/v1");
-        assert_eq!(case.generator_version, "3");
+        assert_eq!(case.generator_version, "4");
         assert_eq!(case.seed, 123);
         assert_eq!(case.case_index, case_index as u64);
     }
 
-    for_each_chaos_case_concurrently(cases, |case, report| {
+    let baseline_cases = cases
+        .into_iter()
+        .map(without_strict_reliability_outcomes)
+        .collect();
+    for_each_chaos_case_concurrently(baseline_cases, |case, report| {
         assert_eq!(report.expected_outcomes, case.expected_outcomes);
         assert!(
             report.expectation_failures.is_empty(),
@@ -865,8 +1526,12 @@ async fn convergence_chaos_family_seed_changes_scenarios() {
 
     // Every seed-driven scenario must still satisfy its pinned expectations,
     // so the divergence reflects real behavior variation, not breakage.
-    let seeded_cases: Vec<GeneratedScenarioCase> =
-        seed_a.iter().chain(seed_b.iter()).cloned().collect();
+    let seeded_cases: Vec<GeneratedScenarioCase> = seed_a
+        .iter()
+        .chain(seed_b.iter())
+        .cloned()
+        .map(without_strict_reliability_outcomes)
+        .collect();
     for_each_chaos_case_concurrently(seeded_cases, |case, report| {
         assert!(
             report.expectation_failures.is_empty(),
@@ -913,7 +1578,8 @@ async fn convergence_chaos_rollback_fault_duplicates_post_rollback_app_message()
         .expect("rollback arm should delay the duplicate copy");
     assert_eq!(delayed_copy, (2, "duplicate-app"));
 
-    let report = run_generated_case_report(case, None)
+    let baseline_case = without_strict_reliability_outcomes(case.clone());
+    let report = run_generated_case_report(&baseline_case, None)
         .await
         .expect("rollback duplicate-app case reports");
     assert!(
@@ -934,6 +1600,42 @@ async fn convergence_chaos_rollback_fault_duplicates_post_rollback_app_message()
         6,
         "Alice should receive the six unique post-rollback app payloads; the released duplicate must not emit a seventh",
     );
+}
+
+#[tokio::test]
+async fn strict_chaos_boundary_retains_known_reliability_failures() {
+    let cases = generate_convergence_chaos_family(123, 5);
+    let expected_failures = [
+        (
+            2usize,
+            "clients_not_exactly_equivalent",
+            "rolled-back transported commit",
+        ),
+        (
+            3usize,
+            "pending_work_remaining",
+            "self-remove proposal work",
+        ),
+        (
+            4usize,
+            "pending_work_remaining",
+            "pre-join deferred application object",
+        ),
+    ];
+
+    for (case_index, failure_kind, description) in expected_failures {
+        let report = run_generated_case_report(&cases[case_index], None)
+            .await
+            .expect("strict known-gap case reports");
+        assert!(
+            report
+                .expectation_failures
+                .iter()
+                .any(|failure| failure.kind == failure_kind),
+            "strict case {case_index} must retain the {description} regression until the engine behavior is fixed: {:?}",
+            report.expectation_failures
+        );
+    }
 }
 
 #[tokio::test]
@@ -1267,6 +1969,7 @@ async fn scenario_report_records_mismatch_as_invariant_failure() {
         pending_resolutions: vec![],
         errors: vec![],
         admin_policies: vec![],
+        decryptability_probes: vec![],
         observations: vec![],
     };
 
@@ -1280,7 +1983,7 @@ async fn scenario_report_records_mismatch_as_invariant_failure() {
 
 #[tokio::test]
 async fn generated_case_report_records_generator_metadata() {
-    let case = generate_send_leave_family(7, 1).remove(0);
+    let case = generate_send_leave_family(42, 1).remove(0);
 
     let report = run_generated_case_report(&case, None)
         .await
@@ -1292,8 +1995,8 @@ async fn generated_case_report_records_generator_metadata() {
         .expect("generated metadata");
 
     assert_eq!(generated.family_name, "send-leave/v1");
-    assert_eq!(generated.generator_version, "1");
-    assert_eq!(generated.seed, 7);
+    assert_eq!(generated.generator_version, "2");
+    assert_eq!(generated.seed, 42);
     assert_eq!(generated.case_index, 0);
     assert!(generated.minimized_case.is_none());
 }
@@ -1341,6 +2044,7 @@ async fn three_client_message_exchange_trace() -> ScenarioTrace {
         }],
         errors: vec![],
         admin_policies: vec![],
+        decryptability_probes: vec![],
         observations: vec![
             observe_client("alice", &mut alice),
             observe_client("bob", &mut bob),
@@ -1486,6 +2190,7 @@ async fn deliberate_fork_via_harness() {
         pending_resolutions: vec![],
         errors: vec![],
         admin_policies: vec![],
+        decryptability_probes: vec![],
         observations: vec![
             observe_client("alice", &mut alice),
             observe_client("bob", &mut bob),
@@ -1612,6 +2317,18 @@ async fn convergence_e2e_from_peeler_ingest_to_group_events() {
     let frank_outcomes = frank.tick().await;
     assert_tick_reached_convergence("carol", &carol_outcomes);
     assert_tick_reached_convergence("frank", &frank_outcomes);
+    assert_canonical_scenario_input_ledger(
+        "carol",
+        &carol.scenario_input_ledger(),
+        &expected_payload,
+        &losing_payload,
+    );
+    assert_canonical_scenario_input_ledger(
+        "frank",
+        &frank.scenario_input_ledger(),
+        &expected_payload,
+        &losing_payload,
+    );
 
     assert_canonical_application_event(
         "carol",
@@ -1637,6 +2354,51 @@ async fn convergence_e2e_from_peeler_ingest_to_group_events() {
             "{name} should not contain the losing branch invitee"
         );
     }
+
+    let deferred_trace = ScenarioTrace {
+        name: "convergence-e2e/deferred-losing-transport".into(),
+        pending_resolutions: vec![],
+        errors: vec![],
+        admin_policies: vec![],
+        decryptability_probes: vec![],
+        observations: vec![
+            observe_client_exact("carol", &mut carol),
+            observe_client_exact("frank", &mut frank),
+        ],
+    };
+    for observation in &deferred_trace.observations {
+        let pending = observation
+            .pending_work
+            .as_ref()
+            .expect("exact pending snapshot");
+        assert!(
+            pending.engine.stored_transport_deferred_messages > 0,
+            "{} should expose the retained unpeeled transport object: {pending:#?}",
+            observation.client
+        );
+        assert!(
+            pending.scenario_inputs_pending > 0,
+            "{} should expose the unresolved scenario input: {pending:#?}",
+            observation.client
+        );
+    }
+    let failures = compare_trace_expectations(
+        None,
+        &[TraceExpectation::NoPendingWork {
+            clients: vec!["carol".into(), "frank".into()],
+        }],
+        &deferred_trace,
+    );
+    assert_eq!(
+        failures.len(),
+        2,
+        "each observer should fail quiescence while transport work remains: {failures:#?}"
+    );
+    assert!(
+        failures
+            .iter()
+            .all(|failure| failure.kind == "pending_work_remaining")
+    );
 }
 
 #[tokio::test]
@@ -1782,6 +2544,42 @@ fn convergence_e2e_group_events_spec() -> ScenarioSpec {
             },
         ],
     }
+}
+
+fn assert_canonical_scenario_input_ledger(
+    client: &str,
+    ledger: &[ScenarioInputLedgerEntry],
+    expected_payload: &[u8],
+    losing_payload: &[u8],
+) {
+    let expected_payload = String::from_utf8_lossy(expected_payload);
+    let losing_payload = String::from_utf8_lossy(losing_payload);
+    let expected = ledger
+        .iter()
+        .find(|entry| entry.payload == expected_payload)
+        .unwrap_or_else(|| panic!("{client} missing selected logical message: {ledger:#?}"));
+    let losing = ledger
+        .iter()
+        .find(|entry| entry.payload == losing_payload)
+        .unwrap_or_else(|| panic!("{client} missing losing logical message: {ledger:#?}"));
+
+    assert_eq!(
+        expected.delivered, 1,
+        "{client} must deliver the selected branch exactly once: {ledger:#?}"
+    );
+    assert_eq!(
+        losing.delivered, 0,
+        "{client} must not project losing-branch application output: {ledger:#?}"
+    );
+    assert!(
+        losing
+            .invalidated
+            .iter()
+            .any(|reason| reason == "losing_branch")
+            || (losing.transport_deferred > 0 && losing.pending),
+        "{client} must classify losing output as invalidated or visibly transport-pending: \
+         {ledger:#?}"
+    );
 }
 
 fn assert_tick_reached_convergence(
@@ -2033,6 +2831,7 @@ async fn harness_captures_and_asserts_convergence_decision() {
         pending_resolutions: Vec::new(),
         errors: Vec::new(),
         admin_policies: Vec::new(),
+        decryptability_probes: Vec::new(),
         observations: vec![observe_client("carol", &mut carol)],
     };
     let failures = compare_trace_expectations(

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -18,7 +18,7 @@ fn parse_defaults_to_send_leave_family() {
                 cases: 1,
             },
             out: PathBuf::from("target/cgka-conformance-simulator-reports"),
-            strict_oracle: false,
+            strict_oracle: true,
             storage_mode: HarnessStorageMode::InMemorySqlite,
         })
     );
@@ -47,7 +47,7 @@ fn parse_custom_report_args() {
                 cases: 3,
             },
             out: PathBuf::from("target/custom"),
-            strict_oracle: false,
+            strict_oracle: true,
             storage_mode: HarnessStorageMode::InMemorySqlite,
         })
     );
@@ -80,7 +80,7 @@ fn parse_vector_fixture_report_args() {
                 paths: vec![PathBuf::from("crates/cgka-conformance-simulator/vectors")],
             },
             out: PathBuf::from("target/vector-reports"),
-            strict_oracle: false,
+            strict_oracle: true,
             storage_mode: HarnessStorageMode::InMemorySqlite,
         })
     );
@@ -108,6 +108,21 @@ fn parse_strict_oracle_report_args() {
             storage_mode: HarnessStorageMode::InMemorySqlite,
         })
     );
+}
+
+#[test]
+fn parse_allow_weak_oracle_report_args() {
+    let command = parse_report_command([
+        "--family".into(),
+        "send-leave/v1".into(),
+        "--allow-weak-oracle".into(),
+    ])
+    .expect("weak oracle opt-out args parse");
+
+    let ReportCommand::Run(args) = command else {
+        panic!("expected run command");
+    };
+    assert!(!args.strict_oracle);
 }
 
 #[test]
@@ -186,7 +201,14 @@ async fn report_runner_writes_send_leave_json_reports() {
     .await
     .expect("runner writes reports");
     assert_eq!(summary.total(), 2);
-    assert_eq!(summary.failed(), 0);
+    assert_eq!(summary.failed(), 1);
+    assert!(summary.scenarios[0].failures.is_empty());
+    assert!(
+        summary.scenarios[1]
+            .failures
+            .iter()
+            .any(|failure| failure.kind == "pending_work_remaining")
+    );
 
     let case0 = out_dir.join("send-leave-v1-seed-42-case-0.json");
     let case1 = out_dir.join("send-leave-v1-seed-42-case-1.json");
@@ -224,7 +246,7 @@ async fn report_runner_strict_oracle_counts_weak_warnings_as_failures() {
 
     let summary = run_report(&ReportArgs {
         input: ReportInput::GeneratedFamily {
-            family: "send-leave/v1".into(),
+            family: "convergence-e2e-delivery/v1".into(),
             seed: 42,
             cases: 1,
         },

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -203,6 +203,10 @@ async fn report_runner_writes_send_leave_json_reports() {
     assert_eq!(summary.total(), 2);
     assert_eq!(summary.failed(), 1);
     assert!(summary.scenarios[0].failures.is_empty());
+    // Seed 42 case 1 deliberately retains the self-remove proposal/scheduler
+    // work exposed by the strict final observation. Keep the named finding
+    // visible until the engine lifecycle defect is fixed; it is not a generic
+    // report-runner failure.
     assert!(
         summary.scenarios[1]
             .failures

--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -142,6 +142,11 @@ realises. Read those rustdocs as the source of truth — this table is just an i
   - **Owns:** role-aware convergence scheduling classification that distinguishes commit edges, proposal
     dependencies, and potential application-message witnesses for pass opening, quiescence, and outbound gating
 
+- **Module:** `conformance_snapshot.rs` (feature `test-conformance-snapshot`)
+  - **Owns:** privacy-safe exact canonical-state (live MLS state or authenticated terminal disband tombstone) and
+    aggregate pending-work projections consumed only by the conformance simulator. Terminal equality excludes
+    device-local authorship metadata. These diagnostics never feed protocol selection or production telemetry.
+
 - **Module:** `distributed_convergence.rs`
   - **Owns:** the engine entry point for stored-message distributed convergence
 

--- a/crates/cgka-engine/Cargo.toml
+++ b/crates/cgka-engine/Cargo.toml
@@ -14,6 +14,10 @@ test-policy-overrides = []
 # Debug-only subprocess crash points used by the SQLCipher durability tests.
 # Production/app consumers must not enable this feature.
 test-crash-hooks = []
+# Synthetic conformance-only state projection. This exposes commitments and
+# public protocol state, never raw exporter material, and must not be enabled by
+# production/app consumers.
+test-conformance-snapshot = []
 
 [dependencies]
 cgka-traits.workspace = true

--- a/crates/cgka-engine/src/conformance_snapshot.rs
+++ b/crates/cgka-engine/src/conformance_snapshot.rs
@@ -10,7 +10,7 @@ use cgka_traits::engine_state::{EpochState, GroupLifecycleState};
 use cgka_traits::error::EngineError;
 use cgka_traits::group::ProtocolProfile;
 use cgka_traits::message::MessageState;
-use cgka_traits::storage::StorageProvider;
+use cgka_traits::storage::{StorageError, StorageProvider};
 use cgka_traits::types::{EpochId, GroupId};
 use openmls::group::MlsGroup;
 use openmls::prelude::ProtocolVersion;
@@ -368,10 +368,8 @@ pub(crate) fn capture_pending_work_snapshot<S: StorageProvider>(
     engine: &crate::Engine<S>,
     group_id: &GroupId,
 ) -> Result<ConformancePendingWorkSnapshot, EngineError> {
+    engine.ensure_group_live(group_id)?;
     let disbanded = engine.storage.disband_tombstone(group_id)?.is_some();
-    if !disbanded {
-        engine.ensure_group_live(group_id)?;
-    }
     let epoch_state = engine
         .epoch_manager
         .state(group_id)
@@ -417,11 +415,33 @@ pub(crate) fn capture_pending_work_snapshot<S: StorageProvider>(
         stored_created_messages,
         stored_retryable_messages,
         stored_transport_deferred_messages,
-        pending_engine_events: engine.events_buf.len(),
-        pending_auto_publish: engine.auto_publish_buf.len(),
-        pending_auto_proposals: engine.auto_proposal_buf.len(),
-        valid_proposal_schedule_signals: engine.valid_proposal_groups.len(),
-        pending_state_changes: engine.pending_state_changes.len(),
+        pending_engine_events: engine
+            .events_buf
+            .iter()
+            .filter(|event| event_group_id(event) == group_id)
+            .count(),
+        pending_auto_publish: engine
+            .auto_publish_buf
+            .iter()
+            .filter(|auto| {
+                engine
+                    .epoch_manager
+                    .group_for_pending(auto.pending)
+                    .as_ref()
+                    == Some(group_id)
+            })
+            .count(),
+        pending_auto_proposals: pending_auto_proposals_for_group(engine, group_id)?,
+        valid_proposal_schedule_signals: usize::from(
+            engine.valid_proposal_groups.contains(group_id),
+        ),
+        pending_state_changes: engine
+            .pending_state_changes
+            .keys()
+            .filter(|pending| {
+                engine.epoch_manager.group_for_pending(**pending).as_ref() == Some(group_id)
+            })
+            .count(),
         pending_leave_requests: usize::from(engine.leave_requests.contains_key(group_id)),
         scheduled_self_remove_auto_commits: engine
             .scheduled_self_remove_auto_commits
@@ -442,6 +462,46 @@ pub(crate) fn capture_pending_work_snapshot<S: StorageProvider>(
             .filter(|(queued_group_id, _)| queued_group_id == group_id)
             .count(),
     })
+}
+
+fn pending_auto_proposals_for_group<S: StorageProvider>(
+    engine: &crate::Engine<S>,
+    group_id: &GroupId,
+) -> Result<usize, EngineError> {
+    let mut count = 0;
+    for proposal in &engine.auto_proposal_buf {
+        match engine.storage.get_message(&proposal.id) {
+            Ok(record) if record.group_id == *group_id => count += 1,
+            Ok(_) => {}
+            Err(StorageError::NotFound) => {
+                return Err(EngineError::Backend(
+                    "conformance auto-proposal buffer references a missing durable row".into(),
+                ));
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(count)
+}
+
+fn event_group_id(event: &cgka_traits::engine::GroupEvent) -> &GroupId {
+    use cgka_traits::engine::GroupEvent;
+
+    match event {
+        GroupEvent::GroupCreated { group_id }
+        | GroupEvent::GroupJoined { group_id, .. }
+        | GroupEvent::MessageReceived { group_id, .. }
+        | GroupEvent::AppMessageInvalidated { group_id, .. }
+        | GroupEvent::GroupStateChanged { group_id, .. }
+        | GroupEvent::GroupHydrationQuarantined { group_id, .. }
+        | GroupEvent::EpochChanged { group_id, .. }
+        | GroupEvent::ForkRecovered { group_id, .. }
+        | GroupEvent::CommitRolledBack { group_id, .. }
+        | GroupEvent::GroupStateInvalidated { group_id, .. }
+        | GroupEvent::GroupUnrecoverable { group_id }
+        | GroupEvent::PendingCommitRecovered { group_id, .. }
+        | GroupEvent::GroupHydrationRecovered { group_id, .. } => group_id,
+    }
 }
 
 fn protocol_version_u16(version: &ProtocolVersion) -> Result<u16, EngineError> {

--- a/crates/cgka-engine/src/conformance_snapshot.rs
+++ b/crates/cgka-engine/src/conformance_snapshot.rs
@@ -1,0 +1,502 @@
+//! Synthetic conformance-only projection of canonical group state.
+//!
+//! This module is available only with the `test-conformance-snapshot` feature.
+//! It deliberately returns a domain-separated commitment to MLS exporter state,
+//! never the exporter secret itself. Production telemetry and application
+//! surfaces must not enable or consume this interface.
+
+use cgka_traits::app_components::GroupLifecycleV1;
+use cgka_traits::engine_state::{EpochState, GroupLifecycleState};
+use cgka_traits::error::EngineError;
+use cgka_traits::group::ProtocolProfile;
+use cgka_traits::message::MessageState;
+use cgka_traits::storage::StorageProvider;
+use cgka_traits::types::{EpochId, GroupId};
+use openmls::group::MlsGroup;
+use openmls::prelude::ProtocolVersion;
+use openmls::treesync::Node;
+use openmls_rust_crypto::RustCrypto;
+use openmls_traits::storage::{CURRENT_VERSION, StorageProvider as OpenMlsStorageProvider};
+use openmls_traits::types::VerifiableCiphersuite;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tls_codec::Serialize as _;
+
+/// MLS-Exporter label adopted by Marmot's conformance-state contract.
+pub const CONFORMANCE_EXPORTER_LABEL: &str = "marmot";
+/// MLS-Exporter context adopted by Marmot's conformance-state contract.
+pub const CONFORMANCE_EXPORTER_CONTEXT: &[u8] = b"convergence-conformance-v1";
+/// Domain separator applied before committing to the exporter secret.
+pub const CONFORMANCE_COMMITMENT_DOMAIN: &[u8] = b"marmot-convergence-conformance-v1";
+const CONFORMANCE_EXPORTER_LENGTH: usize = 32;
+
+const _: [(); 33] = [(); CONFORMANCE_COMMITMENT_DOMAIN.len()];
+
+/// Exact, implementation-neutral capability projection for one leaf.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConformanceLeafCapabilities {
+    pub versions: Vec<u16>,
+    pub ciphersuites: Vec<u16>,
+    pub extensions: Vec<u16>,
+    pub proposals: Vec<u16>,
+    pub credentials: Vec<u16>,
+    pub app_components: Vec<u16>,
+}
+
+/// One nonblank MLS leaf, retained in leaf-index order.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConformanceLeafSnapshot {
+    pub leaf_index: u32,
+    pub account_identity_hex: String,
+    pub signature_public_key_hex: String,
+    pub capabilities: ConformanceLeafCapabilities,
+}
+
+/// Group-required capabilities from MLS and Marmot app-component state.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConformanceRequiredCapabilities {
+    pub extensions: Vec<u16>,
+    pub proposals: Vec<u16>,
+    pub credentials: Vec<u16>,
+    pub app_components: Vec<u16>,
+}
+
+/// One exact `app_data_dictionary` entry in ascending component-id order.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConformanceAppComponent {
+    pub component_id: u16,
+    pub data_hex: String,
+}
+
+/// Canonical live-group state needed by the engine simulator's exact oracle.
+///
+/// Hashes and public protocol values are safe to serialize into synthetic test
+/// artifacts. The raw exporter secret is never stored in this value.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConformanceGroupSnapshot {
+    pub group_id_hex: String,
+    pub epoch: u64,
+    pub group_context_sha256: String,
+    /// The GroupContext hash is also the branch identity used by this local
+    /// black-box oracle. It names selected protocol state, not a transport row.
+    pub selected_branch_id: String,
+    pub exporter_commitment_sha256: String,
+    pub leaves: Vec<ConformanceLeafSnapshot>,
+    pub sorted_member_identities_hex: Vec<String>,
+    pub required_capabilities: ConformanceRequiredCapabilities,
+    pub app_components: Vec<ConformanceAppComponent>,
+    pub protocol_lifecycle: Option<GroupLifecycleV1>,
+    pub convergence_status: GroupLifecycleState,
+    pub protocol_profile: ProtocolProfile,
+    pub group_name: String,
+    pub group_description: String,
+    pub admin_identities_hex: Vec<String>,
+}
+
+/// Canonical terminal evidence retained after live MLS state is deleted.
+///
+/// Only cross-client protocol facts belong here. Device-local facts such as
+/// whether this exact leaf authored the selected commit are deliberately
+/// excluded so equivalent account devices compare equal.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConformanceDisbandedGroupSnapshot {
+    pub group_id_hex: String,
+    pub epoch: u64,
+    pub actor_identity_hex: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_commit_id_hex: Option<String>,
+    pub commit_digest_hex: String,
+    pub former_member_identities_hex: Vec<String>,
+    pub protocol_lifecycle: GroupLifecycleV1,
+    pub convergence_status: GroupLifecycleState,
+}
+
+/// Exact canonical state for either a live MLS group or its terminal
+/// authenticated disband tombstone.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", content = "snapshot", rename_all = "snake_case")]
+pub enum ConformanceCanonicalStateSnapshot {
+    Live(Box<ConformanceGroupSnapshot>),
+    Disbanded(ConformanceDisbandedGroupSnapshot),
+}
+
+/// Aggregate work that must be resolved before a simulator may call one
+/// account-device quiescent.
+///
+/// This is diagnostic state, not protocol input. Counts are intentionally
+/// payload- and identity-free so failure artifacts explain the blocking
+/// subsystem without exposing message contents or group identifiers.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConformancePendingWorkSnapshot {
+    pub non_stable_epoch_state: usize,
+    pub recovering_buffered_messages: usize,
+    pub active_convergence_passes: usize,
+    pub active_convergence_pass_members: usize,
+    pub unresolved_convergence_inputs: usize,
+    pub queued_outbound_intents: usize,
+    pub stored_created_messages: usize,
+    pub stored_retryable_messages: usize,
+    pub stored_transport_deferred_messages: usize,
+    pub pending_engine_events: usize,
+    pub pending_auto_publish: usize,
+    pub pending_auto_proposals: usize,
+    pub valid_proposal_schedule_signals: usize,
+    pub pending_state_changes: usize,
+    pub pending_leave_requests: usize,
+    pub scheduled_self_remove_auto_commits: usize,
+    pub scheduled_convergence_groups: usize,
+    pub regenerated_standalone_publishes: usize,
+    pub regenerated_pending_publishes: usize,
+}
+
+impl ConformancePendingWorkSnapshot {
+    pub fn is_empty(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
+pub(crate) fn capture_group_snapshot<S: StorageProvider>(
+    storage: &S,
+    crypto: &RustCrypto,
+    group_id: &GroupId,
+    epoch_state: &EpochState,
+) -> Result<ConformanceGroupSnapshot, EngineError> {
+    let mls_group_id = openmls::group::GroupId::from_slice(group_id.as_slice());
+    let mls_group = MlsGroup::load(storage.mls_storage(), &mls_group_id)
+        .map_err(|error| EngineError::Backend(format!("load conformance group: {error:?}")))?
+        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+    let group_context: openmls::group::GroupContext = <S::Mls as OpenMlsStorageProvider<
+        CURRENT_VERSION,
+    >>::group_context(
+        storage.mls_storage(), &mls_group_id
+    )
+    .map_err(|error| EngineError::Backend(format!("load conformance group context: {error:?}")))?
+    .ok_or_else(|| {
+        EngineError::Backend("conformance group context is missing from storage".into())
+    })?;
+
+    let group_context_bytes = group_context
+        .tls_serialize_detached()
+        .map_err(|error| EngineError::Serialize(format!("serialize group context: {error}")))?;
+    let group_context_sha256 = hex::encode(Sha256::digest(group_context_bytes));
+
+    let exporter_secret = mls_group
+        .export_secret(
+            crypto,
+            CONFORMANCE_EXPORTER_LABEL,
+            CONFORMANCE_EXPORTER_CONTEXT,
+            CONFORMANCE_EXPORTER_LENGTH,
+        )
+        .map_err(|error| EngineError::Backend(format!("derive conformance exporter: {error:?}")))?;
+    let mut commitment = Sha256::new();
+    commitment.update(CONFORMANCE_COMMITMENT_DOMAIN);
+    commitment.update([0]);
+    commitment.update(&exporter_secret);
+    let exporter_commitment_sha256 = hex::encode(commitment.finalize());
+    drop(exporter_secret);
+
+    let nodes = crate::app_components::ratchet_tree_nodes(mls_group.export_ratchet_tree())?;
+    let mut leaves = Vec::new();
+    for (node_index, node) in nodes.into_iter().enumerate() {
+        let Some(Node::LeafNode(leaf)) = node else {
+            continue;
+        };
+        let leaf_index = u32::try_from(node_index / 2)
+            .map_err(|_| EngineError::Backend("conformance leaf index overflow".into()))?;
+        let account_identity = crate::identity::validated_member_id_of_leaf(&leaf)?;
+        let capabilities = leaf.capabilities();
+        let mut app_components = crate::app_components::app_components_of_leaf(&leaf)?
+            .ids
+            .into_iter()
+            .collect::<Vec<_>>();
+        app_components.sort_unstable();
+        leaves.push(ConformanceLeafSnapshot {
+            leaf_index,
+            account_identity_hex: hex::encode(account_identity.as_slice()),
+            signature_public_key_hex: hex::encode(leaf.signature_key().as_slice()),
+            capabilities: ConformanceLeafCapabilities {
+                versions: capabilities
+                    .versions()
+                    .iter()
+                    .map(protocol_version_u16)
+                    .collect::<Result<_, _>>()?,
+                ciphersuites: capabilities
+                    .ciphersuites()
+                    .iter()
+                    .map(VerifiableCiphersuite::value)
+                    .collect(),
+                extensions: capabilities
+                    .extensions()
+                    .iter()
+                    .copied()
+                    .map(u16::from)
+                    .collect(),
+                proposals: capabilities
+                    .proposals()
+                    .iter()
+                    .copied()
+                    .map(u16::from)
+                    .collect(),
+                credentials: capabilities
+                    .credentials()
+                    .iter()
+                    .copied()
+                    .map(u16::from)
+                    .collect(),
+                app_components,
+            },
+        });
+    }
+
+    let mut sorted_member_identities_hex = leaves
+        .iter()
+        .map(|leaf| leaf.account_identity_hex.clone())
+        .collect::<Vec<_>>();
+    sorted_member_identities_hex.sort();
+
+    let required = group_context.required_capabilities();
+    let mut required_app_components =
+        crate::app_components::required_app_components_of_group(&mls_group)?
+            .ids
+            .into_iter()
+            .collect::<Vec<_>>();
+    required_app_components.sort_unstable();
+    let required_capabilities = ConformanceRequiredCapabilities {
+        extensions: required
+            .map(|required| {
+                required
+                    .extension_types()
+                    .iter()
+                    .copied()
+                    .map(u16::from)
+                    .collect()
+            })
+            .unwrap_or_default(),
+        proposals: required
+            .map(|required| {
+                required
+                    .proposal_types()
+                    .iter()
+                    .copied()
+                    .map(u16::from)
+                    .collect()
+            })
+            .unwrap_or_default(),
+        credentials: required
+            .map(|required| {
+                required
+                    .credential_types()
+                    .iter()
+                    .copied()
+                    .map(u16::from)
+                    .collect()
+            })
+            .unwrap_or_default(),
+        app_components: required_app_components,
+    };
+
+    let app_components = group_context
+        .extensions()
+        .app_data_dictionary()
+        .map(|dictionary| {
+            dictionary
+                .dictionary()
+                .entries()
+                .map(|entry| ConformanceAppComponent {
+                    component_id: entry.id(),
+                    data_hex: hex::encode(entry.data()),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let group = storage.get_group(group_id)?;
+    let mut admin_identities_hex = crate::app_components::admins_of_group(&mls_group)?
+        .into_iter()
+        .map(hex::encode)
+        .collect::<Vec<_>>();
+    admin_identities_hex.sort();
+    admin_identities_hex.dedup();
+
+    Ok(ConformanceGroupSnapshot {
+        group_id_hex: hex::encode(group_id.as_slice()),
+        epoch: group_context.epoch().as_u64(),
+        selected_branch_id: group_context_sha256.clone(),
+        group_context_sha256,
+        exporter_commitment_sha256,
+        leaves,
+        sorted_member_identities_hex,
+        required_capabilities,
+        app_components,
+        protocol_lifecycle: crate::app_components::lifecycle_of_group(&mls_group)?,
+        convergence_status: GroupLifecycleState::from(epoch_state),
+        protocol_profile: group.protocol_profile,
+        group_name: group.name,
+        group_description: group.description,
+        admin_identities_hex,
+    })
+}
+
+pub(crate) fn capture_disbanded_group_snapshot(
+    group_id: &GroupId,
+    tombstone: &cgka_traits::DisbandTombstone,
+) -> ConformanceDisbandedGroupSnapshot {
+    let mut former_member_identities_hex = tombstone
+        .former_members
+        .iter()
+        .map(|member| hex::encode(member.id.as_slice()))
+        .collect::<Vec<_>>();
+    former_member_identities_hex.sort();
+    former_member_identities_hex.dedup();
+
+    ConformanceDisbandedGroupSnapshot {
+        group_id_hex: hex::encode(group_id.as_slice()),
+        epoch: tombstone.epoch.0,
+        actor_identity_hex: hex::encode(tombstone.actor.as_slice()),
+        origin_commit_id_hex: tombstone
+            .origin_commit_id
+            .as_ref()
+            .map(|message_id| hex::encode(message_id.as_slice())),
+        commit_digest_hex: hex::encode(tombstone.commit_digest),
+        former_member_identities_hex,
+        protocol_lifecycle: GroupLifecycleV1::Disbanded,
+        convergence_status: GroupLifecycleState::Disbanded,
+    }
+}
+
+pub(crate) fn capture_pending_work_snapshot<S: StorageProvider>(
+    engine: &crate::Engine<S>,
+    group_id: &GroupId,
+) -> Result<ConformancePendingWorkSnapshot, EngineError> {
+    let disbanded = engine.storage.disband_tombstone(group_id)?.is_some();
+    if !disbanded {
+        engine.ensure_group_live(group_id)?;
+    }
+    let epoch_state = engine
+        .epoch_manager
+        .state(group_id)
+        .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+    let lifecycle = GroupLifecycleState::from(epoch_state);
+    let recovering_buffered_messages = match epoch_state {
+        EpochState::Recovering(recovering) => recovering.buffered().len(),
+        _ => 0,
+    };
+
+    let pass = engine.storage.convergence_pass(group_id)?;
+    let active_pass = pass.as_ref().filter(|pass| pass.is_active());
+    let messages = engine.storage.list_messages(group_id, EpochId(0))?;
+    let mut stored_created_messages = 0;
+    let mut stored_retryable_messages = 0;
+    let mut stored_transport_deferred_messages = 0;
+    for message in messages {
+        match message.state {
+            MessageState::Created => stored_created_messages += 1,
+            MessageState::Retryable => stored_retryable_messages += 1,
+            MessageState::PeelDeferred => stored_transport_deferred_messages += 1,
+            MessageState::Sent
+            | MessageState::Processed
+            | MessageState::Failed
+            | MessageState::EpochInvalidated => {}
+        }
+    }
+
+    Ok(ConformancePendingWorkSnapshot {
+        non_stable_epoch_state: usize::from(!matches!(
+            lifecycle,
+            GroupLifecycleState::Stable | GroupLifecycleState::Disbanded
+        )),
+        recovering_buffered_messages,
+        active_convergence_passes: usize::from(active_pass.is_some()),
+        active_convergence_pass_members: active_pass.map_or(0, |pass| pass.members.len()),
+        unresolved_convergence_inputs: usize::from(if disbanded {
+            false
+        } else {
+            engine.has_pending_convergence_inputs(group_id)?
+        }),
+        queued_outbound_intents: engine.storage.list_queued_outbound_intents(group_id)?.len(),
+        stored_created_messages,
+        stored_retryable_messages,
+        stored_transport_deferred_messages,
+        pending_engine_events: engine.events_buf.len(),
+        pending_auto_publish: engine.auto_publish_buf.len(),
+        pending_auto_proposals: engine.auto_proposal_buf.len(),
+        valid_proposal_schedule_signals: engine.valid_proposal_groups.len(),
+        pending_state_changes: engine.pending_state_changes.len(),
+        pending_leave_requests: usize::from(engine.leave_requests.contains_key(group_id)),
+        scheduled_self_remove_auto_commits: engine
+            .scheduled_self_remove_auto_commits
+            .values()
+            .filter(|scheduled| scheduled.group_id == *group_id)
+            .count(),
+        scheduled_convergence_groups: usize::from(
+            engine.pending_convergence_groups.contains(group_id),
+        ),
+        regenerated_standalone_publishes: engine
+            .queued_intent_by_message
+            .values()
+            .filter(|(queued_group_id, _)| queued_group_id == group_id)
+            .count(),
+        regenerated_pending_publishes: engine
+            .queued_intent_by_pending
+            .values()
+            .filter(|(queued_group_id, _)| queued_group_id == group_id)
+            .count(),
+    })
+}
+
+fn protocol_version_u16(version: &ProtocolVersion) -> Result<u16, EngineError> {
+    let bytes = version
+        .tls_serialize_detached()
+        .map_err(|error| EngineError::Serialize(format!("serialize protocol version: {error}")))?;
+    let bytes: [u8; 2] = bytes.try_into().map_err(|_| {
+        EngineError::Serialize("protocol version did not serialize to two bytes".into())
+    })?;
+    Ok(u16::from_be_bytes(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cgka_traits::{DisbandTombstone, Member, MemberId, MessageId};
+
+    #[test]
+    fn commitment_domain_is_the_adopted_33_byte_value() {
+        assert_eq!(CONFORMANCE_COMMITMENT_DOMAIN.len(), 33);
+        assert_eq!(
+            CONFORMANCE_COMMITMENT_DOMAIN,
+            b"marmot-convergence-conformance-v1"
+        );
+    }
+
+    #[test]
+    fn disband_projection_excludes_device_local_authorship_and_canonicalizes_roster() {
+        let group_id = GroupId::new(vec![0x10, 0x20]);
+        let alice = Member {
+            id: MemberId::new(vec![0xa1]),
+            credential: vec![0x01],
+        };
+        let bob = Member {
+            id: MemberId::new(vec![0xb2]),
+            credential: vec![0x02],
+        };
+        let base = DisbandTombstone {
+            epoch: EpochId(7),
+            actor: alice.id.clone(),
+            origin_commit_id: Some(MessageId::new(vec![0xc3])),
+            commit_digest: [0xd4; 32],
+            local_was_committer_leaf: true,
+            former_members: vec![bob.clone(), alice.clone(), bob],
+        };
+        let sibling_device = DisbandTombstone {
+            local_was_committer_leaf: false,
+            former_members: vec![alice, base.former_members[0].clone()],
+            ..base.clone()
+        };
+
+        assert_eq!(
+            capture_disbanded_group_snapshot(&group_id, &base),
+            capture_disbanded_group_snapshot(&group_id, &sibling_device),
+            "device-local authorship and roster order/duplicates must not split canonical state"
+        );
+    }
+}

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -538,6 +538,109 @@ impl<S: StorageProvider> Engine<S> {
         self.epoch_manager.state(group_id).cloned()
     }
 
+    /// Capture the adopted Marmot conformance projection for one live group.
+    ///
+    /// This synthetic-test interface is deliberately feature-gated. It returns
+    /// public protocol state and a domain-separated exporter commitment, never
+    /// the raw exporter secret. Production telemetry and app surfaces must not
+    /// enable `test-conformance-snapshot`.
+    #[cfg(feature = "test-conformance-snapshot")]
+    pub fn conformance_group_snapshot(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<crate::conformance_snapshot::ConformanceGroupSnapshot, EngineError> {
+        self.ensure_group_live(group_id)?;
+        let epoch_state = self
+            .epoch_manager
+            .state(group_id)
+            .ok_or_else(|| EngineError::UnknownGroup(group_id.clone()))?;
+        crate::conformance_snapshot::capture_group_snapshot(
+            &self.storage,
+            &self.crypto,
+            group_id,
+            epoch_state,
+        )
+    }
+
+    /// Capture exact canonical state for either a live group or an
+    /// authenticated terminal disband tombstone.
+    #[cfg(feature = "test-conformance-snapshot")]
+    pub fn conformance_canonical_state_snapshot(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<crate::conformance_snapshot::ConformanceCanonicalStateSnapshot, EngineError> {
+        if let Some(tombstone) = self.storage.disband_tombstone(group_id)? {
+            return Ok(
+                crate::conformance_snapshot::ConformanceCanonicalStateSnapshot::Disbanded(
+                    crate::conformance_snapshot::capture_disbanded_group_snapshot(
+                        group_id, &tombstone,
+                    ),
+                ),
+            );
+        }
+        self.conformance_group_snapshot(group_id)
+            .map(Box::new)
+            .map(crate::conformance_snapshot::ConformanceCanonicalStateSnapshot::Live)
+    }
+
+    /// Capture aggregate outstanding work for the synthetic conformance
+    /// simulator. This is an oracle diagnostic only and never affects engine
+    /// scheduling or protocol decisions.
+    #[cfg(feature = "test-conformance-snapshot")]
+    pub fn conformance_pending_work_snapshot(
+        &self,
+        group_id: &GroupId,
+    ) -> Result<crate::conformance_snapshot::ConformancePendingWorkSnapshot, EngineError> {
+        crate::conformance_snapshot::capture_pending_work_snapshot(self, group_id)
+    }
+
+    /// Read the durable state of one synthetic scenario input under either its
+    /// transport or content-derived id.
+    ///
+    /// The simulator supplies both aliases because outbound and inbound copies
+    /// of the same MLS bytes can use different storage keys. This observation is
+    /// feature-gated, exposes no payload bytes, and never affects processing.
+    #[cfg(feature = "test-conformance-snapshot")]
+    pub fn conformance_message_state(
+        &self,
+        aliases: &[MessageId],
+    ) -> Result<Option<cgka_traits::MessageState>, EngineError> {
+        for alias in aliases {
+            match self.storage.get_message(alias) {
+                Ok(record) => return Ok(Some(record.state)),
+                Err(cgka_traits::storage::StorageError::NotFound) => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Ok(None)
+    }
+
+    /// Return the transport and content-derived ids for a durable synthetic
+    /// scenario input without exposing its wire bytes.
+    ///
+    /// Locally produced OpenMLS messages are retained under the exact
+    /// transport id and a content marker. The simulator needs both aliases to
+    /// correlate a re-wrapped inbound copy and later invalidation events, but
+    /// must not re-peel a commit after the sender has already advanced state.
+    #[cfg(feature = "test-conformance-snapshot")]
+    pub fn conformance_message_aliases(
+        &self,
+        transport_id: &MessageId,
+    ) -> Result<Vec<MessageId>, EngineError> {
+        let record = self.storage.get_message(transport_id)?;
+        let mut aliases = vec![transport_id.clone()];
+        if let Ok(payload) = StoredMessagePayload::decode(&record.payload)
+            && let Some(openmls_message) = payload.as_openmls_wire()
+        {
+            let content_id =
+                MessageId::new(Sha256::digest(openmls_message.payload.as_slice()).to_vec());
+            if content_id != *transport_id {
+                aliases.push(content_id);
+            }
+        }
+        Ok(aliases)
+    }
+
     /// Persist a frozen transport fanout before or after one lifecycle edge.
     pub fn put_outbound_fanout(&self, fanout: &OutboundFanout) -> Result<(), EngineError> {
         if let Some(group_id) = fanout.group_id() {

--- a/crates/cgka-engine/src/engine.rs
+++ b/crates/cgka-engine/src/engine.rs
@@ -569,6 +569,7 @@ impl<S: StorageProvider> Engine<S> {
         &self,
         group_id: &GroupId,
     ) -> Result<crate::conformance_snapshot::ConformanceCanonicalStateSnapshot, EngineError> {
+        self.ensure_group_live(group_id)?;
         if let Some(tombstone) = self.storage.disband_tombstone(group_id)? {
             return Ok(
                 crate::conformance_snapshot::ConformanceCanonicalStateSnapshot::Disbanded(

--- a/crates/cgka-engine/src/lib.rs
+++ b/crates/cgka-engine/src/lib.rs
@@ -42,6 +42,8 @@ pub(crate) mod bounded_id_set;
 pub mod canonicalization;
 pub mod capabilities;
 pub mod capability_manager;
+#[cfg(feature = "test-conformance-snapshot")]
+pub mod conformance_snapshot;
 pub mod convergence;
 pub(crate) mod convergence_input;
 pub mod disband;

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -31,8 +31,9 @@ The program is successful when the following statement is justified by specifica
 bounded models, and repeatable campaign evidence:
 
 > Under explicit delivery, input-closure, policy-version, participant, and resource assumptions, every nonfaulty client
-> either reaches exactly equivalent cryptographic and application state within a measured bound or reaches the same
-> explicit, deterministic, diagnosable, and replayable terminal outcome.
+> either reaches exactly equivalent cryptographic and application state within the scenario's declared observation
+> budget, with convergence latency characterized separately, or reaches the same explicit, deterministic, diagnosable,
+> replayable, and durably recoverable non-progress outcome.
 
 This statement deliberately does not promise prompt convergence under permanent message suppression, an unbounded
 stream of valid competing commits, or exhausted resources. Those cases require an explicit availability or fairness
@@ -102,13 +103,18 @@ The baseline is useful scaffolding, but it is not yet the target reliability lab
 10. **Privacy-safe evidence.** Committed fixtures are synthetic. Reports and telemetry follow the repository
     observability rules and never emit identifiers, relay URLs, payloads, ciphertext, plaintext, or key material into
     production tracing.
+11. **Clocks are dependencies.** Engine campaigns inject advancing monotonic and wall clocks. Process adapters define
+    their own observable quiescence contract rather than pretending an in-process progress snapshot is universal.
+12. **Equivalence is layered.** Shared protocol state, scenario-input/application-output dispositions, and local
+    operational/resource diagnostics are compared separately. Local diagnostic differences cannot silently weaken
+    shared-state or output equality.
 
 ## Milestone Summary
 
 | Milestone | Outcome | Status | Exit gate |
 | --- | --- | --- | --- |
 | 0. Assurance foundation | Guarantees, assumptions, constants, and formal gate are explicit | complete | Every constant is classified; formal warnings fail CI; protocol decisions are named |
-| 1. Trustworthy engine black box | Exact oracle, public subject boundary, full quiescence, replay capsules | not-started | Known semantic mutations fail and captured failures replay |
+| 1. Trustworthy engine black box | Exact oracle, public subject boundary, full quiescence, replay capsules | in-progress | Known semantic mutations fail and captured failures replay |
 | 2. Scenario IR and retained relays | One adapter-neutral DSL/IR plus realistic offline/history sync | not-started | One compiled case runs against reference, engine, and retained-relay adapters |
 | 3. Adversarial campaigns | Sustained real-world workloads, resource sweeps, incident import | not-started | Headline workload families produce bounded, diagnosable results |
 | 4. Independent verification | Reference model, liveness model, mutation adequacy, protocol decision gate | not-started | Model and tests detect seeded policy/lifecycle defects |
@@ -127,17 +133,19 @@ The initial assurance matrix is below. “Required verification” names the min
 | ID | Claim | Required assumptions | Required verification | Status |
 | --- | --- | --- | --- | --- |
 | S1 | Same retained anchor, authenticated input closure, policy version, and engine version produce the same canonical branch and exact state | Finite relevant input set; every compared client possesses the same validated dependency closure | Independent reference comparison; schedule/restart metamorphic tests; bounded model | specified |
-| S2 | Application output after settlement is exactly the payload/state-change projection of the selected branch | MLS and Marmot payload authentication succeeds; invalidations reach projection | Exact logical ledger; losing-branch and superseded-state scenarios; Tamarin output lemmas | partially-covered |
+| S2 | Application output after settlement is exactly the payload/state-change projection of the selected branch | MLS and Marmot payload authentication succeeds; invalidations reach projection | Exact scenario-input/output ledger; losing-branch and superseded-state scenarios; Tamarin output lemmas | partially-covered |
 | S3 | Missing retained state, invalid policy, corrupt frozen input, and exhausted replay budget never apply a partial candidate result | Storage reports failures accurately; fail-closed errors are durable or retryable by contract | Engine tests, crash matrix, resource campaigns, seeded mutations | partially-covered |
 | S4 | Publish-before-apply and convergence lifecycle changes are torn-write-free | Storage transaction contract holds; external publication results are accurately reported | Storage/engine lifecycle tests; kill/restart at each durable transition | partially-covered |
-| S5 | Operational scheduler timing does not change the eventual canonical result after authenticated input closure | All pending passes are eventually revisited; required retained state remains available | Virtual-time metamorphic tests across scheduler margin, retry, and re-arm values | unverified |
-| L1 | After relevant input closes and all required history is locally available, convergence reaches `Settled` or a named terminal failure | Client continues executing; resource policy admits the workload | Bounded state-machine liveness model; engine and retained-relay scenarios | unverified |
+| S5 | For one retained authenticated input set and fixed horizon eligibility, changing delivery partitioning across convergence passes or scheduler timing does not change the eventual canonical result | All pending passes are eventually revisited; required retained state remains available; no compared run crosses a semantic retention/eligibility boundary | Controlled pass-partition and virtual-time metamorphic tests; separately classified horizon-assumption violations | unverified |
+| L1 | After relevant input closes and all required history is locally available, convergence reaches `Settled` or a named durable fail-closed/non-progress state with an explicit repair path | Client continues executing; resource policy admits the workload | Bounded state-machine liveness model; engine and retained-relay scenarios; repair-path tests | unverified |
 | L2 | Outbound work blocked by convergence is eventually released, regenerated, or terminated with an explicit outcome | L1 assumptions; publication path eventually returns a result | Scheduler/outbound ledger assertions; crash/restart scenarios | partially-covered |
 | L3 | Marmot does not guarantee that a privileged administrative transition becomes canonical while valid selection-relevant input, including ordinary self-updates, continues without bound | The bounded post-settlement preparation opportunity remains enforced; stronger progress requires eventual relevant-input closure | Adversarial model and sustained simulator family; bounded preparation-opportunity tests | specified |
 | S6 | Clients are exactly equivalent only when the canonical conformance projection, including its domain-separated exporter commitment, matches | Synthetic/local conformance execution; raw exporter secret never leaves the test process | M1.1 exact snapshot comparison; mismatched-member, component, disposition, output, and commitment sentinels | specified |
+| S7 | Shared protocol state, exact scenario-input/application-output dispositions, and local operational diagnostics remain distinct comparison layers | Every scenario input has a stable action id; adapters declare observable capabilities | M1.1 disposition ledger; M2 adapter schema; M5 projection comparison | partially-covered |
 | R1 | Crash/reopen from any durable convergence phase is equivalent to uninterrupted execution | Database and required WAL/sidecars remain intact; no storage corruption unless scenario declares it | File-backed crash matrix and process-kill replay | partially-covered |
 | R2 | Clients with unequal relay histories converge after the histories reconcile | Relevant events remain retained and are eventually fetched; same policy/version | Retained multi-relay scenarios with EOSE, backfill, and set equality | unverified |
-| D1 | Every failure is attributable to a stable action, policy, state transition, or resource bound and can be replayed | Failure artifact completes successfully; sensitive evidence remains local | Failure-capsule self-replay and schema tests | unverified |
+| R3 | A runtime can determine the completeness claim it is making for acquired relay history and can invoke a stronger reconciliation path when incremental cursors are insufficient | Relay EOSE and query completion are observable; at least one full-history/set-reconciliation mechanism is available | Since-floor/EOSE matrix; full-history backstop tests; retained-relay adapter | unverified |
+| D1 | Every observed failure is attributable to a stable action, policy, state transition, or resource bound and can be replayed; silent input absence requires the separate R3 completeness signal | Failure manifests in an observable layer; failure artifact completes successfully; sensitive evidence remains local | Failure-capsule self-replay and schema tests; R3 absence detection | unverified |
 
 #### Assurance verification ownership
 
@@ -147,17 +155,19 @@ test is evidence for only the behavior in its name; it does not establish the la
 | ID | Normative/architecture source | Current evidence | Missing evidence owner |
 | --- | --- | --- | --- |
 | S1 | Protocol `convergence.md` branch selection; local canonicalization contract “Determinism and convergence” | Tamarin `same_input_set_converges`; `prop_candidate_graph_selection_is_order_invariant`; `prop_stored_convergence_restart_equivalence` | M1.1 exact-state oracle; M4.1 independent reference model; M4.2 arbitrary schedule/lifecycle model |
-| S2 | Protocol `convergence.md` “Applying the selected branch”; local canonicalization output contract | Tamarin application-output/invalidation lemmas; `engine_emits_only_canonical_branch_app_messages_after_convergence`; `rebuilt_engine_emits_losing_branch_app_invalidation_after_convergence` | M1.1 exact logical ledger and projection equivalence; M5.1 app projection adapter |
+| S2 | Protocol `convergence.md` “Applying the selected branch”; local canonicalization output contract | Tamarin application-output/invalidation lemmas; `engine_emits_only_canonical_branch_app_messages_after_convergence`; `rebuilt_engine_emits_losing_branch_app_invalidation_after_convergence` | M1.1 exact scenario-input/output ledger; M5.1 app projection adapter |
 | S3 | Protocol retained-anchor error rules; local canonicalization errors and fail-closed replay contract | Tamarin missing/beyond-anchor lemmas; `frozen_pass_member_tampering_fails_closed_to_unrecoverable`; `missing_frozen_pass_member_fails_closed_to_unrecoverable`; replay-budget unit tests | M3.1 end-to-end resource exhaustion; M4.3 mutations |
 | S4 | Protocol publish lifecycle and bounded-pass persistence; local multi-step-state-change rules | `convergence_pass_round_trips_updates_and_cascades`; `collecting_pass_restart_preserves_remaining_window_and_backward_clock_fails_closed`; `reopen_after_crash_during_publish_recovers_stranded_pending_commit`; crash-recovery SQLite tests | M3.1 complete durable-transition kill matrix; M5.1 runtime crash matrix |
-| S5 | Protocol bounded collection window; relay telemetry claim that quiescence is not a correctness boundary | `prop_quiescence_gate_controls_settlement`; cutoff and scheduler unit tests | M3.2 cross-value metamorphic campaign; M4.2 scheduler model |
-| L1 | Protocol pass freeze and completion rules; group convergence status | Individual settle/fail-closed integration tests | M4.2 TLA+/TLC liveness specification; M2.3 retained-relay scenarios |
+| S5 | Protocol pass-partition invariance and bounded collection window; relay telemetry claim that quiescence is not a correctness boundary | `prop_quiescence_gate_controls_settlement`; cutoff and scheduler unit tests | M1.3 controlled partition metamorphic test; M3.2 cross-value campaign; M4.2 scheduler model |
+| L1 | Protocol pass freeze and completion rules; group convergence status | Individual settle/fail-closed integration tests | M4.2 TLA+/TLC liveness specification; M2.3 retained-relay scenarios; named repair tests for every durable non-progress state |
 | L2 | Protocol outbound gating; local queued-intent lifecycle | Tamarin queued-outbound lemmas; `engine_queues_app_send_until_convergence_is_settled`; `trait_advance_convergence_drains_queued_outbound_intent`; scheduler tests | M1.3 complete quiescence; M3.1 crash/failure workload |
 | L3 | Protocol same-epoch priority and depth rules; no sustained-progress guarantee currently stated | `convergence_privileged_remove_beats_grinding_ordinary_self_update`; `continuous_inbound_cannot_starve_admin_attempt` | M3.1 sustained self-update family; M4.2 fairness model; protocol decision PDR-2 below |
 | S6 | Protocol `foundation/conformance.md`, adopted by [marmot#410](https://github.com/marmot-protocol/marmot/pull/410) | Domain separation and 33-byte commitment prefix checked in the protocol PR | M1.1 public snapshot API and exact-equivalence sentinels |
+| S7 | Protocol conformance projection and input-disposition requirements | M1.1 exact canonical snapshot plus commit/proposal/application disposition ledger | M2.2 common adapter observation schema; M5.1 app projection layer |
 | R1 | Protocol durable pass wall/monotonic deadline rules; local storage/restart contract | `collecting_pass_restart_preserves_remaining_window_and_backward_clock_fails_closed`; `h5_kill_before_historical_apply_commit_preserves_live_inputs`; `h6_kill_after_retained_anchor_rewind_recovers_live_snapshot` | M3.1 every-phase crash matrix; M5.3 process kill/reopen |
 | R2 | Relay telemetry EOSE/backfill/reconciliation architecture; protocol requires equalized relevant history for equivalent selection | `stalled_epoch_backfill_recovers_below_floor_backlog_when_armed`; `next_event_returns_when_a_live_delivery_arms_the_epoch_backfill` | M2.3 retained multi-relay model; M3.1 unequal-history family |
-| D1 | Local forensic audit/report contracts and privacy rules | Generated reports, oracle coverage, conservative minimizer, incident archetype synthesis | M1.4 failure capsule and self-replay; M3.3 exact incident import |
+| R3 | Relay sync/backfill architecture; incremental cursors do not establish full offline history | Existing since-floor regressions expose the blind spot; epoch-stall backfill is armed only after qualifying live evidence | M2.3 EOSE/completeness policy and full-history/set-reconciliation backstop; M5.1 production runtime adapter |
+| D1 | Local forensic audit/report contracts and privacy rules | Generated reports, oracle coverage, conservative minimizer, incident archetype synthesis | M1.4 failure capsule and self-replay; M3.3 exact incident import; R3 silent-absence detection |
 
 Milestone 0 work:
 
@@ -184,6 +194,9 @@ protocol guarantees:
 | PDR-3 | State the interoperable outcome when local resource policy drops, defers, or refuses otherwise valid input; distinguish fail-closed local availability from canonical branch selection | adopted-protocol-pr-410; MDK-aligned | M3.1 resource campaigns |
 | PDR-4 | Define the portable notion of exact cryptographic/application state equivalence without exposing secrets | adopted-protocol-pr-410 | M1.1 exporter commitment and cross-implementation vectors |
 | PDR-5 | Keep quiescence/pass cutoffs explicitly outside final-state correctness after input closure, or revise the guarantee if metamorphic tests find a counterexample | adopted-protocol-pr-410; evidence-required | S5 and P4/P5 verification |
+| PDR-6 | Distinguish deterministic processing of one frozen batch from invariance under different pass partitions of the same retained input; classify runs that cross anchor/app-retention eligibility as assumption violations, not scheduler counterexamples | test-method-required | M1.3 controlled metamorphic harness; M3.2 witness-expiry/deferred-commit/anchor-pruning matrix; M4.2 model |
+| PDR-7 | Define the supported repair outcome for a joiner/invite/device-add that lands only on a losing branch | protocol-decision-required | M3.1 workload; M4.2 lifecycle model; M5.1 user-visible repair projection |
+| PDR-8 | Define what relay-history completeness claim implementations make after EOSE, cursor rebuild, and long offline intervals, including the full-history or set-reconciliation backstop | architecture/protocol-decision-required | R2/R3; M2.3 retained relay; M5.1 runtime |
 
 This MDK branch records and tests the implementation implications. The implementation-neutral wording is adopted in
 `marmot-protocol/marmot` through [marmot#410](https://github.com/marmot-protocol/marmot/pull/410).
@@ -210,8 +223,8 @@ Categories:
 | P1 | `V1_MAX_REWIND_COMMITS` | 5 commits | semantic, security-retention | Bounds eligible fork depth and retained anchors | Too low rejects recoverable late history; too high increases reorg, storage, replay, and secret-retention exposure | yes, by policy version | Eligibility boundaries, delayed-history sweep, retention/security review |
 | P2 | `V1_APP_MESSAGE_PAST_EPOCH_LIMIT` | 5 epochs | semantic, security-retention | Bounds delayed app delivery and witness eligibility | Too low expires realistic offline traffic; too high retains old message secrets and increases work | yes, by policy version | Multi-commit offline flood, exact app ledger, six-advance boundary |
 | P3 | `DEFAULT_MAX_PAST_EPOCHS` | 5 epochs | security-retention | Configures OpenMLS decryptable history; must equal P2 | Drift causes messages to be policy-eligible but cryptographically undecryptable, or retains unusable secrets | must be identical to P2 | Pin/alignment tests and delayed decryption sweep |
-| P4 | `V1_SETTLEMENT_QUIESCENCE_MS` | 1,000 ms | semantic scheduling policy | Closes a live-input window after delivery jitter | Too low raises post-settle reorgs; too high stalls outbound work | intended no after input closure; may change intermediate passes | Virtual-time sweep, post-settle reorg metrics, retained-relay spread |
-| P5 | `V1_MAX_CONVERGENCE_PASS_MS` | 5,000 ms | semantic scheduling policy | Guarantees a collecting pass freezes under sustained relevant input | Too low fragments ordinary bursts; too high lets a flood hold the group collecting | intended no after all follow-up passes; may change pass membership | Sustained-flood test, cutoff restart matrix, eventual fixed-point comparison |
+| P4 | `V1_SETTLEMENT_QUIESCENCE_MS` | 1,000 ms | semantic, scheduler | Closes a live-input window after delivery jitter | Too low raises post-settle reorgs; too high stalls outbound work | intended no after input closure; may change intermediate passes | Virtual-time sweep, post-settle reorg metrics, retained-relay spread |
+| P5 | `V1_MAX_CONVERGENCE_PASS_MS` | 5,000 ms | semantic, scheduler | Guarantees a collecting pass freezes under sustained relevant input | Too low fragments ordinary bursts; too high lets a flood hold the group collecting | intended no after all follow-up passes; may change pass membership | Sustained-flood test, cutoff restart matrix, controlled pass-partition fixed-point comparison |
 | P6 | `V1_WITNESS_QUORUM_SENDERS_PER_EPOCH` | 2 senders | semantic | Defines per-epoch corroboration | Too low lets one identity dominate; too high makes evidence unavailable in small/offline groups | yes, by policy version | Group-size/device-topology sweep and Sybil/account dedupe model |
 | P7 | `V1_WITNESS_QUORUM_EPOCHS` | 1 epoch | semantic | Defines how many branch epochs require quorum | Too low gives brief activity more weight; too high suppresses witnesses on short branches | yes, by policy version | Branch-length and traffic-duration sweep |
 | P8 | `V1_MAX_WITNESS_OVERRIDE_DEPTH` | 1 commit | semantic | Caps witness-derived effective-depth boost | Too low makes witnesses irrelevant; too high lets traffic outrank much longer commit history | yes, by policy version | Bound proof, depth-difference matrix, adversarial witness flood |
@@ -226,7 +239,7 @@ Categories:
 | E4 | `MAX_DEFERRED_ROWS_PER_SWEEP` | 64 rows | resource, scheduler | Prevents old deferred history monopolizing a pass | Fair cursor progress eventually visits every row | intended no | Backlog fairness and restart tests |
 | E5 | `CANDIDATE_REPLAY_BUDGET_SLACK` | 4× | resource | Scales replay budget over linear commit/rewind estimate | `ReplayBudgetExceeded` fails closed without partial selection | intended no | Branch-explosion campaign and recovery policy test |
 | E6 | `CANDIDATE_REPLAY_BUDGET_FLOOR` | 32 probes | resource | Gives small passes minimum replay headroom | Same as E5 | intended no | Small/large boundary matrix |
-| E7 | self-remove auto-commit jitter | 10 ms + [0, 40) ms | scheduler | Reduces synchronized automatic self-remove commits | Jitter changes ordering only, not admissible final behavior after closure | intended no | Seeded schedule invariance and collision tests |
+| E7 | self-remove auto-commit jitter | 10 ms + [0, 40] ms (10–50 ms inclusive) | scheduler | Reduces synchronized automatic self-remove commits | Jitter changes ordering only, not admissible final behavior after closure | intended no | Seeded schedule invariance and collision tests |
 
 #### App scheduler and input-recovery bounds
 
@@ -251,7 +264,9 @@ because they can delay a process.
 The machine-readable
 [`convergence-constant-inventory.txt`](./convergence-constant-inventory.txt) maps every ledger ID to its current Rust
 declaration. `just convergence-ledger-gate` verifies those declarations, requires every P/E/A ID below, and scans the
-named source families for newly introduced constants that have not been reviewed into this ledger.
+named source families for newly introduced constants that have not been reviewed into this ledger. It currently checks
+declaration presence and coverage, not literal values; production-value drift remains guarded by policy pin tests, and a
+future inventory revision should encode machine-checked expected values where the Rust expression is stable enough.
 
 | IDs | Current source/test owner | Remaining verification owner |
 | --- | --- | --- |
@@ -331,7 +346,7 @@ row without terminal deduplication, while E3 returns typed `ResourceRefused`; ex
 remain eligible, and the app runtime immediately arms history backfill for resource refusal. The normative availability
 and liveness wording is adopted through
 [marmot#410](https://github.com/marmot-protocol/marmot/pull/410). With that dependency merged, Milestone 0 is complete;
-the exact state/message oracle is the first Milestone 1 slice.
+the exact state/scenario-input oracle is the first Milestone 1 slice.
 
 Milestone 0 verification:
 
@@ -352,22 +367,64 @@ git diff --check
 
 ## Milestone 1: Trustworthy Engine Black Box
 
-### 1.1 Exact state and logical-message oracle
+### 1.1 Exact state and scenario-input oracle
 
-- [ ] Add exact sorted member identities to portable observations.
-- [ ] Include epoch, selected branch, admin policy, application profile, required capabilities, and group state.
-- [ ] Record a logical message ledger: sent, accepted, delivered, deduplicated, expired, invalidated, and pending.
-- [ ] Add a test-only privacy-safe cryptographic state commitment based on MLS exporter state.
-- [ ] Prove bidirectional decryptability after apparent convergence.
-- [ ] Add `ClientsExactlyEquivalent`, `LogicalMessageLedger`, and `NoPendingWork` expectations.
-- [ ] Make strict oracle behavior the default for reliability campaigns.
+- [x] Add exact sorted member identities to strict observations, while also preserving nonblank leaves in MLS leaf-index
+  order.
+- [x] Include epoch, selected branch commitment, admin policy, application profile, required capabilities, exact
+  app-component state, and group lifecycle/convergence state.
+- [x] Record a generalized scenario-input disposition ledger for commits, proposals, and application messages, keyed by
+  stable scenario action id and distinguishing sent, accepted, delivered, deduplicated, expired, invalidated, rejected,
+  resource-refused, rolled-back, and pending outcomes.
+- [x] Add a test-only privacy-safe cryptographic state commitment based on MLS exporter state.
+- [x] Prove bidirectional decryptability after apparent convergence.
+- [x] Add strict expectations for `ClientsExactlyEquivalent`, `ScenarioInputLedger`, `NoPendingWork`, and
+  `ClientsBidirectionallyDecryptable`.
+- [x] Project terminal disband tombstones into exact canonical state without device-local authorship metadata.
+- [x] Make strict oracle behavior the default for reliability campaigns, with an explicit exploratory opt-out.
 
 Verification:
 
 - same member count but different member identities fails;
 - same public metadata but different exporter commitment fails;
-- duplicate delivery appears once in the logical ledger;
-- losing-branch payload/state output is absent or explicitly invalidated.
+- duplicate application delivery appears once in the scenario-input ledger;
+- commit, proposal, and application actions retain stable scenario ids and exact current dispositions;
+- losing-branch payload/state output is absent or explicitly invalidated;
+- queued, delayed, unread, unconfirmed-publish, and retained transport-deferred work fail `NoPendingWork`;
+- every directed application-message edge succeeds after settled convergence; a deliberately missed commit produces a
+  visible one-way decryptability failure while the reverse past-epoch edge succeeds;
+- terminal disband state survives restart and compares independently of device-local committer-leaf metadata;
+- generated reliability cases finish with a global drain, exact observation, and `NoPendingWork`; report runs fail on
+  weak-oracle coverage unless explicitly invoked with `--allow-weak-oracle`.
+
+The exact-state interface is feature-gated to the simulator. Legacy observations remain unchanged for existing vectors;
+strict scenarios opt in with `observe_client_exact` / `observe_exact`, `ClientsExactlyEquivalent`, and
+`ScenarioInputLedger`. The ledger names every commit, proposal, and application action independently of randomized
+transport/MLS ids, correlates aliases through the feature-gated durable conformance view, and uses the deterministic
+inner application event only for delivery correlation. It preserves the protocol distinction between authenticated
+acceptance and pre-admission `TransportDeferred`. `NoPendingWork` adds an instantaneous aggregate progress snapshot
+across engine, bus, and scenario-input ledger state; it deliberately does not replace Milestone 1.3's repeated
+virtual-time quiescence test. The active
+decryptability probe sends one exact logical event per client, correlates every directed delivery by logical event id,
+and retains the recipient ledger disposition for failed edges. Exact canonical state is a tagged live-or-disbanded
+projection; the terminal form is derived from the durable authenticated tombstone and excludes
+`local_was_committer_leaf`, which is device-local rather than a shared protocol fact.
+
+The strict campaign migration deliberately exposed three pre-existing reliability failures that the legacy observation
+point hid:
+
+1. a locally rolled-back but already transported group-data commit can later advance another member, splitting exact
+   state after the final mailbox drain;
+2. a member invited after an old application event can retain that pre-join object as transport/scenario-input pending
+   work;
+3. after self-remove convergence, selected remaining members can retain a created proposal row and valid-proposal
+   schedule signal.
+
+These remain red strict-campaign evidence, not relaxed oracle rules. The ordinary generated-family regression tests keep
+checking their original semantic observation windows and explicitly retain the leave pending-work sentinel; report
+campaigns run the complete strict expectations by default. Strict coverage also flags the mixed large storm because its
+application phase is cleared before any delivery-or-invalidation expectation accounts for it; that is an oracle coverage
+gap, distinct from the three engine-state failures.
 
 ### 1.2 Public subject boundary
 
@@ -376,20 +433,26 @@ Verification:
   observation.
 - [ ] Split normal black-box execution from explicitly named white-box storage/fault capabilities.
 - [ ] Reject scenarios that require unsupported subject capabilities before execution.
+- [ ] Refresh the local canonicalization contract against the adopted protocol before freezing the public observation
+  schema; keep normative behavior in the protocol repo and implementation/diagnostic detail here.
 
 ### 1.3 Full-system quiescence
 
 - [ ] Include deliverable input, inbox, delayed messages, pass phase, deferred replay, outbound publication, retry
   timers, and durable transitions in a progress snapshot.
+- [ ] Inject an advancing monotonic clock plus a controlled wall clock; do not infer time progress from repeated calls
+  at one synthetic timestamp.
 - [ ] Require two stable virtual-time observations with no state or ledger progress.
 - [ ] Report which subsystem prevents quiescence.
 - [ ] Bound quiescence waiting by scenario policy and emit a terminal timeout artifact.
+- [ ] Add controlled metamorphic runs that preserve retained input and horizon eligibility while varying delivery across
+  one frozen batch versus multiple convergence passes; report retention/anchor assumption violations separately.
 
 ### 1.4 Deterministic failure capsules
 
 - [ ] Define a versioned capsule schema.
 - [ ] Save original scenario, canonical IR, seeds, expanded schedule, policy/constant snapshot, adapter/binary versions,
-  captured wire bytes, virtual time, logical ledger, state commitments, and resource measurements.
+  captured wire bytes, virtual time, scenario-input/output ledger, state commitments, and resource measurements.
 - [ ] Replay a capsule without regenerating MLS bytes.
 - [ ] Keep real incident artifacts local and restrictive-by-construction.
 - [ ] Promote minimized synthetic failures into portable vectors when they define durable behavior.
@@ -401,15 +464,20 @@ Verification:
 - [ ] Hidden pending work prevents quiescence.
 - [ ] A captured byte-level failure replays with the same outcome.
 - [ ] Targeted semantic mutations are detected.
+- [ ] Every durable fail-closed/non-progress state names a tested repair or terminal user-visible outcome.
 
 ## Milestone 2: Scenario IR And Retained Relays
 
 ### 2.1 Scenario IR v2 and authoring DSL
 
-- [ ] Define adapter-neutral, versioned JSON IR and JSON Schema.
-- [ ] Add human YAML authoring that compiles to canonical JSON; execute only canonical JSON.
+- [ ] Land a minimal vertical slice first: versioned action/assertion IR, deterministic executor, stable action ids, and
+  one engine-adapter scenario that round-trips through JSON.
+- [ ] Define the complete adapter-neutral JSON IR and JSON Schema.
+- [ ] Specify deterministic expansion and rate semantics (`repeat`, `parallel`, `rate`, `burst`, barriers, and virtual
+  time) before adding authoring sugar.
+- [ ] Add human YAML authoring only after the canonical JSON IR/executor is stable; execute only canonical JSON.
 - [ ] Model accounts, devices, processes, roles, groups, relays, and policy/binary versions explicitly.
-- [ ] Add `repeat`, `parallel`, `rate`, `burst`, barriers, and virtual time.
+- [ ] Add `repeat`, `parallel`, `rate`, `burst`, barriers, and virtual time with a recorded expanded schedule.
 - [ ] Add create, invite, remove, leave, self-update, group/admin state update, and application send.
 - [ ] Add offline/reconnect, delay, duplicate, omit, withhold/release, crash/restart, and declared storage faults.
 - [ ] Replace queue indices with semantic action/message selectors.
@@ -427,8 +495,14 @@ Verification:
 
 - [ ] Maintain a durable event history per relay.
 - [ ] Model publish fanout, subscriptions, query filters, EOSE, reconnect, since floors, and full backfill.
+- [ ] Make query completion explicit: distinguish relay EOSE from proven relevant-history completeness and record the
+  completeness claim in every run.
 - [ ] Model relay-specific duplicate/order/visibility/omission behavior.
 - [ ] Model unequal client relay sets and later history reconciliation.
+- [ ] Add a set/full-history reconciliation backstop for the case where no qualifying live event arms the existing
+  epoch-stall recovery path; evaluate NIP-77-like set reconciliation without making it a prerequisite.
+- [ ] Make quiet-group diagnosis explicit: a lack of new traffic must not be mistaken for complete history or healthy
+  convergence, and reports must identify which reconciliation path was or was not attempted.
 - [ ] Keep the existing in-memory packet bus as a fast unit-test adapter, not offline-sync evidence.
 
 ### Milestone 2 Exit Gate
@@ -445,12 +519,17 @@ Verification:
 - [ ] Offline retained-history flood with application traffic spanning many membership/state commits.
 - [ ] Sustained application traffic interspersed with proposals and commits.
 - [ ] Sequential self-update adversary racing privileged administrative changes.
+- [ ] Losing-branch joiner/invite/device-add, including an explicit successful repair, re-invite, or named unrecoverable
+  user-visible outcome.
 - [ ] Unequal relay histories followed by reconciliation.
 - [ ] Crash/restart at every durable convergence transition.
 - [ ] Multi-group noisy-neighbor and per-group fairness.
 - [ ] Candidate graph/replay budget/resource exhaustion.
 - [ ] Multi-device account identity and witness deduplication.
-- [ ] Mixed binary and policy versions.
+- [ ] App-message witness value: compare selection with/without witnesses, include proposal expiry and multi-parent
+  commit cases, and decide whether the speculative mechanism earns its complexity.
+- [ ] Mixed binary and policy versions as controlled negative/compatibility tests. Do not require a production policy
+  stamp before Scenario IR v2 can carry explicit policy versions.
 - [ ] Clock movement, scheduler delay, and timestamp/cursor attacks.
 
 Each family varies schedule, storage mode, participant count, rates, restart placement, relay topology, and applicable
@@ -460,9 +539,11 @@ test-only constants while preserving a stable semantic oracle.
 
 - [ ] Record convergence latency and blocked-send duration.
 - [ ] Record pass count, reorg count/depth/lateness, and unresolved outcomes.
-- [ ] Record logical delivery/expiry/invalidation results.
+- [ ] Record commit/proposal/application dispositions and logical delivery/expiry/invalidation results.
 - [ ] Record CPU time, peak memory, database size/writes, queue depth, and replay probes.
 - [ ] Sweep constants around the pinned value in explicit test-policy builds.
+- [ ] For P4/P5, preserve one retained input set and fixed eligibility horizons while varying pass partitioning; keep
+  witness expiry, deferred commits, and anchor pruning as explicit boundary cases rather than accidental confounders.
 - [ ] Produce curves and boundary failures; never auto-tune production policy from simulator output.
 
 ### 3.3 Incident replay
@@ -475,7 +556,7 @@ test-only constants while preserving a stable semantic oracle.
 ### Milestone 3 Exit Gate
 
 - [ ] The three headline workloads run both as small regressions and sustained campaigns.
-- [ ] Every resource exhaustion reaches a named fail-closed or retryable outcome.
+- [ ] Every resource exhaustion reaches a named fail-closed or retryable outcome with a tested repair path.
 - [ ] Campaign reports identify the first failing action and limiting resource.
 - [ ] Selected incident histories reproduce or clearly state why exact replay is impossible.
 
@@ -485,6 +566,8 @@ test-only constants while preserving a stable semantic oracle.
 
 - [ ] Implement symbolic authenticated candidates, authorization, dependency closure, witness scoring, selection, and
   dispositions without calling production selector/canonicalization code.
+- [ ] Include proposal expiry and multi-parent commit sentinels, and keep an app-message-witness-free reference variant
+  so the witness mechanism's marginal effect is measurable.
 - [ ] Differentially compare reference model, production selector, and full engine.
 - [ ] Keep model inputs small and shrinkable.
 
@@ -492,6 +575,8 @@ test-only constants while preserving a stable semantic oracle.
 
 - [ ] Prototype the self-update/admin-progress case in TLA+/TLC and Stateright, then record the tool decision.
 - [ ] Model unequal histories, eventual input closure, pass freeze/settle, crash/restart, fairness, and resource failure.
+- [ ] Model joiner/invite/device-add state that becomes stranded on a losing branch and its permitted repair transitions.
+- [ ] Emit model traces that preserve enough action identity to compile into Scenario IR regression cases.
 - [ ] Produce minimal counterexample traces consumable by Scenario IR where practical.
 - [ ] Keep Tamarin focused on symbolic safety/security and executable bounded policy cases.
 
@@ -499,6 +584,7 @@ test-only constants while preserving a stable semantic oracle.
 
 - [ ] Mutate selector comparison order.
 - [ ] Mutate witness sender/epoch deduplication.
+- [ ] Mutate app-message witness admission/removal to determine which scenarios actually depend on it.
 - [ ] Mutate cutoff admission and frozen-member persistence.
 - [ ] Mutate scheduler deadlines and re-arm classification.
 - [ ] Mutate output invalidation and publication acknowledgement.
@@ -527,7 +613,11 @@ test-only constants while preserving a stable semantic oracle.
 - [ ] Drive only public app-runtime operations.
 - [ ] Exercise real account/device lifecycle, projections, outbound publication, relay sync/backfill, and retries.
 - [ ] Compare engine state commitments and user-visible chat/member/admin/message projections.
+- [ ] Compare the three equivalence layers independently: shared protocol state, scenario-input/application projection,
+  and local operational diagnostics.
 - [ ] Crash/reopen the complete runtime.
+- [ ] Exercise long-offline sync where no live message arms epoch-stall backfill, and prove the selected EOSE/full-history
+  completeness policy closes the gap.
 
 ### 5.2 Simulator node process
 
@@ -535,6 +625,8 @@ test-only constants while preserving a stable semantic oracle.
 - [ ] Define a versioned JSONL control and observation protocol.
 - [ ] Keep engine/storage internals unavailable through the process protocol.
 - [ ] Emit privacy-safe structured diagnostics and failure capsules.
+- [ ] Define process-adapter quiescence from observable inbox/outbox, relay-query completion, retry timers, projection
+  checkpoints, and stable state commitments; do not reuse engine-private counters as the contract.
 
 ### 5.3 Process orchestrator
 
@@ -612,7 +704,7 @@ adapter capabilities and versions
 policy and constant snapshot
 captured transport artifacts
 virtual and wall-clock timeline
-logical input/output/disposition ledger
+scenario-input/application-output disposition ledger
 exact state commitments
 resource observations
 assertion failures
@@ -629,7 +721,7 @@ The first implementation series is deliberately ordered:
 
 1. strict Tamarin warning/derivation gate;
 2. assurance contract and constant-ledger review against the canonical protocol;
-3. exact state/message oracle;
+3. exact state/scenario-input oracle;
 4. public subject boundary and complete quiescence;
 5. failure capsule;
 6. Scenario IR v2;
@@ -657,3 +749,9 @@ incorrect result.
 | 2026-07-30 | 0.1 typed deferred/resource outcomes | Replaced ambiguous `Stale(PeelFailed)` results with typed transport availability, protocol rejection, and stale-disposition categories; retry-budget release no longer terminally deduplicates exact-ID redelivery | `cargo test -p cgka-engine --features test-policy-overrides --test deferred_peel_lifecycle`; `--test ingest`; `--test fork_detection` |
 | 2026-07-30 | 0.1 resource-refusal recovery signal | Resource refusal immediately arms one account-wide history backfill per group epoch; ordinary transport deferral retains the existing evidence threshold | `cargo test -p marmot-app client::epoch_stall --lib` |
 | 2026-07-30 | Milestone 0 completion verification | Rebased onto MDK `master` at `1b949655`; fast CI, the full feature-enabled engine suite, full simulator suite, session suite, focused app deferral/backfill coverage, and all 76 strict Tamarin lemmas passed | `just fast-ci`; `cargo test -p cgka-engine --features test-policy-overrides`; `cargo test -p cgka-conformance-simulator`; `cargo test -p cgka-session --features test-policy-overrides`; focused `marmot-app` tests; `just tamarin` |
+| 2026-07-30 | 1.1 exact live-group state oracle | Added a conformance-only canonical snapshot and strict equivalence expectation; exact member and exporter semantic mutations now fail while two independently joined clients match | `cargo test -p cgka-conformance-simulator`; `cargo test -p cgka-engine --features "test-conformance-snapshot test-policy-overrides"` |
+| 2026-07-30 | 1.1 generalized scenario-input disposition ledger | Added strict per-client commit, proposal, and application dispositions keyed by stable scenario action ids and joined to outer transport/content aliases; duplicate application delivery is one delivery plus one dedup, and unpeeled input remains visibly transport-pending | `cargo test -p cgka-conformance-simulator exact_observation_ledgers_commit_proposal_and_application_dispositions`; full simulator suite |
+| 2026-07-30 | 1.1 instantaneous pending-work oracle | Added `NoPendingWork` over aggregate engine, bus, and scenario-input-ledger progress; queued, delayed, unread, unconfirmed-publish, and transport-deferred sentinels fail while a drained joined group passes | `cargo test -p cgka-conformance-simulator` |
+| 2026-07-30 | 1.1 bidirectional decryptability probe | Added an active exact-ID application-message matrix; settled members pass every directed edge, a missed commit exposes future-epoch deferral in only one direction, and a named nonmember cannot pass | `cargo test -p cgka-conformance-simulator bidirectional_decryptability` |
+| 2026-07-30 | 1.1 terminal disband projection | Added a shared-fact-only canonical tombstone projection; terminal state passes exact/no-pending observation across restart, while device-local authorship and roster ordering cannot split equality | `cargo test -p cgka-conformance-simulator exact_oracle_projects_terminal_disband_tombstone_across_restart`; `cargo test -p cgka-engine --features test-conformance-snapshot disband_projection_excludes_device_local_authorship_and_canonicalizes_roster` |
+| 2026-07-30 | 1.1 strict reliability campaigns | Made report oracle coverage strict by default, added `--allow-weak-oracle`, and appended final global drain/exact/no-pending checks to send-leave and chaos cases. The stronger boundary exposed rollback divergence, pre-join deferred work, unretired leave proposal work, and an unasserted mixed-storm application phase rather than masking them | `strict_chaos_boundary_retains_known_reliability_failures`; focused generator/report tests; generated JSON reports |

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -390,7 +390,9 @@ Verification:
 - duplicate application delivery appears once in the scenario-input ledger;
 - commit, proposal, and application actions retain stable scenario ids and exact current dispositions;
 - losing-branch payload/state output is absent or explicitly invalidated;
-- queued, delayed, unread, unconfirmed-publish, and retained transport-deferred work fail `NoPendingWork`;
+- queued, delayed, unread, unconfirmed-publish, and retained transport-deferred work addressed to the observed client
+  fail `NoPendingWork`; a deliberately dropped object does not masquerade as local pending work, and its missing
+  recipient delivery fails an independent ledger/output assertion;
 - every directed application-message edge succeeds after settled convergence; a deliberately missed commit produces a
   visible one-way decryptability failure while the reverse past-epoch edge succeeds;
 - terminal disband state survives restart and compares independently of device-local committer-leaf metadata;
@@ -402,13 +404,20 @@ strict scenarios opt in with `observe_client_exact` / `observe_exact`, `ClientsE
 `ScenarioInputLedger`. The ledger names every commit, proposal, and application action independently of randomized
 transport/MLS ids, correlates aliases through the feature-gated durable conformance view, and uses the deterministic
 inner application event only for delivery correlation. It preserves the protocol distinction between authenticated
-acceptance and pre-admission `TransportDeferred`. `NoPendingWork` adds an instantaneous aggregate progress snapshot
-across engine, bus, and scenario-input ledger state; it deliberately does not replace Milestone 1.3's repeated
-virtual-time quiescence test. The active
+acceptance and pre-admission `TransportDeferred`. `NoPendingWork` adds an instantaneous, client-scoped local-progress
+snapshot across group-scoped engine state, client-addressed bus state, and the client's scenario-input ledger. It is not
+an end-to-end delivery assertion for objects removed by an explicit transport fault; required delivery is checked
+through recipient ledger/output expectations. It deliberately does not replace Milestone 1.3's structural virtual-time
+quiescence test. The active
 decryptability probe sends one exact logical event per client, correlates every directed delivery by logical event id,
 and retains the recipient ledger disposition for failed edges. Exact canonical state is a tagged live-or-disbanded
 projection; the terminal form is derived from the durable authenticated tombstone and excludes
 `local_was_committer_leaf`, which is device-local rather than a shared protocol fact.
+
+This Milestone 1.1 slice supplies exact engine observations and sentinels; it does not close the cross-layer Scenario IR
+operational-semantics and adapter-refinement acceptance criteria tracked in
+[#1189](https://github.com/marmot-protocol/mdk/issues/1189). Those remain owned by Milestones 2.1 and 2.2 before
+campaign/process expansion relies on equivalence across adapters.
 
 The strict campaign migration deliberately exposed three pre-existing reliability failures that the legacy observation
 point hid:
@@ -438,11 +447,13 @@ gap, distinct from the three engine-state failures.
 
 ### 1.3 Full-system quiescence
 
-- [ ] Include deliverable input, inbox, delayed messages, pass phase, deferred replay, outbound publication, retry
-  timers, and durable transitions in a progress snapshot.
-- [ ] Inject an advancing monotonic clock plus a controlled wall clock; do not infer time progress from repeated calls
-  at one synthetic timestamp.
-- [ ] Require two stable virtual-time observations with no state or ledger progress.
+- [ ] Expose a sanitized structural progress token, runnable work, earliest next wake-up, deferred/retry work, outbound
+  work awaiting acknowledgement, and terminal blockers; include inbox, delayed messages, pass phase, and durable
+  transitions.
+- [ ] Inject an advancing monotonic clock plus a controlled wall clock throughout the subject and its tests; do not
+  infer time progress from repeated calls at one synthetic timestamp or wait on real wall time.
+- [ ] Compute a bounded virtual-time fixed point from structural work and the earliest next wake-up. Treat step, time,
+  and work limits only as watchdog/performance evidence, not as the definition of quiescence.
 - [ ] Report which subsystem prevents quiescence.
 - [ ] Bound quiescence waiting by scenario policy and emit a terminal timeout artifact.
 - [ ] Add controlled metamorphic runs that preserve retained input and horizon eligibility while varying delivery across
@@ -751,7 +762,7 @@ incorrect result.
 | 2026-07-30 | Milestone 0 completion verification | Rebased onto MDK `master` at `1b949655`; fast CI, the full feature-enabled engine suite, full simulator suite, session suite, focused app deferral/backfill coverage, and all 76 strict Tamarin lemmas passed | `just fast-ci`; `cargo test -p cgka-engine --features test-policy-overrides`; `cargo test -p cgka-conformance-simulator`; `cargo test -p cgka-session --features test-policy-overrides`; focused `marmot-app` tests; `just tamarin` |
 | 2026-07-30 | 1.1 exact live-group state oracle | Added a conformance-only canonical snapshot and strict equivalence expectation; exact member and exporter semantic mutations now fail while two independently joined clients match | `cargo test -p cgka-conformance-simulator`; `cargo test -p cgka-engine --features "test-conformance-snapshot test-policy-overrides"` |
 | 2026-07-30 | 1.1 generalized scenario-input disposition ledger | Added strict per-client commit, proposal, and application dispositions keyed by stable scenario action ids and joined to outer transport/content aliases; duplicate application delivery is one delivery plus one dedup, and unpeeled input remains visibly transport-pending | `cargo test -p cgka-conformance-simulator exact_observation_ledgers_commit_proposal_and_application_dispositions`; full simulator suite |
-| 2026-07-30 | 1.1 instantaneous pending-work oracle | Added `NoPendingWork` over aggregate engine, bus, and scenario-input-ledger progress; queued, delayed, unread, unconfirmed-publish, and transport-deferred sentinels fail while a drained joined group passes | `cargo test -p cgka-conformance-simulator` |
+| 2026-07-30 | 1.1 instantaneous pending-work oracle | Added client-scoped `NoPendingWork` over group-scoped engine, client-addressed bus, and per-client scenario-input-ledger progress; queued, delayed, unread, unconfirmed-publish, and transport-deferred sentinels fail, while a dropped-object sentinel proves delivery remains an independent recipient assertion | `cargo test -p cgka-conformance-simulator` |
 | 2026-07-30 | 1.1 bidirectional decryptability probe | Added an active exact-ID application-message matrix; settled members pass every directed edge, a missed commit exposes future-epoch deferral in only one direction, and a named nonmember cannot pass | `cargo test -p cgka-conformance-simulator bidirectional_decryptability` |
 | 2026-07-30 | 1.1 terminal disband projection | Added a shared-fact-only canonical tombstone projection; terminal state passes exact/no-pending observation across restart, while device-local authorship and roster ordering cannot split equality | `cargo test -p cgka-conformance-simulator exact_oracle_projects_terminal_disband_tombstone_across_restart`; `cargo test -p cgka-engine --features test-conformance-snapshot disband_projection_excludes_device_local_authorship_and_canonicalizes_roster` |
 | 2026-07-30 | 1.1 strict reliability campaigns | Made report oracle coverage strict by default, added `--allow-weak-oracle`, and appended final global drain/exact/no-pending checks to send-leave and chaos cases. The stronger boundary exposed rollback divergence, pre-join deferred work, unretired leave proposal work, and an unasserted mixed-storm application phase rather than masking them | `strict_chaos_boundary_retains_known_reliability_failures`; focused generator/report tests; generated JSON reports |


### PR DESCRIPTION
## Summary

- add a feature-gated, privacy-safe canonical engine projection for live and disbanded groups, including a domain-separated exporter commitment
- add exact simulator expectations for canonical equivalence, generalized commit/proposal/application dispositions, instantaneous pending work, and bidirectional decryptability
- make strict oracle coverage the default for reliability report campaigns while preserving an explicit exploratory opt-out
- update the convergence reliability plan with pass-partition methodology, relay-history completeness and EOSE work, durable repair outcomes, clock injection, staged Scenario IR delivery, and adapter-specific quiescence

## Generalized disposition ledger

Every convergence-relevant scenario action now receives a stable scenario id. The harness correlates that action with outer transport and content-derived ids through the conformance-only durable view, so commit senders do not need to re-peel their own post-advance commit. The ledger records current dispositions and counts for commits, proposals, and application messages without exposing transport ids in reports.

## Known strict findings retained

The stronger final boundary intentionally continues to expose pre-existing reliability findings instead of relaxing the oracle:

- a transported commit that is locally rolled back can still advance another member
- pre-membership transport input can remain pending after a later join
- self-remove convergence can leave proposal/scheduler work behind
- the mixed large storm has an application phase with weak outcome coverage

Regression tests pin these as known red campaign evidence while the ordinary test suite remains green.

## Verification

- cargo test -p cgka-conformance-simulator
- cargo test -p cgka-engine --features "test-conformance-snapshot test-policy-overrides"
- just fast-ci
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exact canonical-state observations for more precise scenario comparisons.
  * Added scenario-input tracking for sends, delivery, deduplication, invalidation, and pending status.
  * Added bidirectional decryptability probes with per-direction results.
  * Added pending-work reporting to identify remaining queued or deferred activity.
* **Bug Fixes**
  * Improved handling and reporting of disbanded group state and retained membership data.
* **Documentation**
  * Expanded simulator scenario, reporting, and reliability verification guidance.
* **Chores**
  * Reports now enforce strict oracle coverage by default; exploratory runs can opt into weaker validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->