### PR TITLE
Retire consumed self-remove proposal work

### DIFF
--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -1699,11 +1699,6 @@ async fn strict_chaos_boundary_retains_known_reliability_failures() {
             "rolled-back transported commit",
         ),
         (
-            3usize,
-            "pending_work_remaining",
-            "self-remove proposal work",
-        ),
-        (
             4usize,
             "pending_work_remaining",
             "pre-join deferred application object",
@@ -1723,6 +1718,15 @@ async fn strict_chaos_boundary_retains_known_reliability_failures() {
             report.expectation_failures
         );
     }
+
+    let self_remove_report = run_generated_case_report(&cases[3], None)
+        .await
+        .expect("strict self-remove case reports");
+    assert!(
+        self_remove_report.expectation_failures.is_empty(),
+        "strict self-remove case must retire consumed proposal work: {:?}",
+        self_remove_report.expectation_failures
+    );
 }
 
 #[tokio::test]

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -1322,29 +1322,12 @@ async fn send_leave_family_records_seed_and_runs_generated_cases() {
         let report = run_generated_case_report(&case, None)
             .await
             .expect("strict send/leave case report runs");
-        let includes_leave = case
-            .scenario
-            .steps
-            .iter()
-            .any(|step| matches!(step, ScenarioStep::Leave { .. }));
-        if includes_leave {
-            assert!(
-                report
-                    .expectation_failures
-                    .iter()
-                    .any(|failure| failure.kind == "pending_work_remaining"),
-                "leave case {} must retain the strict pending-work regression until proposal work is retired: {:?}",
-                case.case_index,
-                report.expectation_failures
-            );
-        } else {
-            assert!(
-                report.expectation_failures.is_empty(),
-                "non-leave case {} failed strict expectations: {:?}",
-                case.case_index,
-                report.expectation_failures
-            );
-        }
+        assert!(
+            report.expectation_failures.is_empty(),
+            "send/leave case {} failed strict expectations: {:?}",
+            case.case_index,
+            report.expectation_failures
+        );
     }
 }
 

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -201,17 +201,14 @@ async fn report_runner_writes_send_leave_json_reports() {
     .await
     .expect("runner writes reports");
     assert_eq!(summary.total(), 2);
-    assert_eq!(summary.failed(), 1);
-    assert!(summary.scenarios[0].failures.is_empty());
-    // Seed 42 case 1 deliberately retains the self-remove proposal/scheduler
-    // work exposed by the strict final observation. Keep the named finding
-    // visible until the engine lifecycle defect is fixed; it is not a generic
-    // report-runner failure.
+    assert_eq!(summary.failed(), 0);
     assert!(
-        summary.scenarios[1]
-            .failures
+        summary
+            .scenarios
             .iter()
-            .any(|failure| failure.kind == "pending_work_remaining")
+            .all(|scenario| scenario.failures.is_empty()),
+        "consumed self-remove proposals must not leave failed send/leave reports: {:?}",
+        summary.scenarios
     );
 
     let case0 = out_dir.join("send-leave-v1-seed-42-case-0.json");

--- a/crates/cgka-engine/src/distributed_convergence.rs
+++ b/crates/cgka-engine/src/distributed_convergence.rs
@@ -1272,6 +1272,11 @@ impl<S: StorageProvider> Engine<S> {
             },
         );
 
+        // A successful settled pass has acted on the proposal-arrival edge.
+        // Keeping the one-bit per-group signal after this point can only
+        // request redundant scheduling; any later proposal ingress recreates
+        // it normally.
+        self.valid_proposal_groups.remove(group_id);
         self.remember_canonicalization_result_messages(&result);
         Ok(result)
     }

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1296,6 +1296,10 @@ impl<S: StorageProvider> Engine<S> {
                     // Update our per-group state machine + storage mirror.
                     self.epoch_manager.set_stable(group_id.clone(), after);
                     self.drop_self_remove_auto_commit_schedules_for_group(&group_id);
+                    // Proposal-arrival schedule signals are source-epoch
+                    // scoped. An accepted commit advances the group, so every
+                    // such signal from the prior epoch is obsolete.
+                    self.valid_proposal_groups.remove(&group_id);
                     self.record_applied_commit_for_recovery(
                         group_id.clone(),
                         before,

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -431,6 +431,65 @@ pub(crate) fn own_commit_stamp(
     })
 }
 
+/// Give retained proposal rows the same terminal disposition when a local
+/// commit is confirmed that stored convergence assigns when it selects that
+/// commit. The staged commit records consumed proposal references, while
+/// MessageStorage is keyed by content-derived message ids, so re-project the
+/// current-epoch proposal rows against the pre-merge group and match the exact
+/// authenticated references.
+pub(crate) fn mark_consumed_proposal_records_processed<S: StorageProvider>(
+    storage: &S,
+    crypto: &RustCrypto,
+    mls_group: &mut MlsGroup,
+    group_id: &GroupId,
+    source_epoch: EpochId,
+    consumed_proposal_refs: &[String],
+) -> Result<(), cgka_traits::error::EngineError> {
+    if consumed_proposal_refs.is_empty() {
+        return Ok(());
+    }
+    let consumed: BTreeSet<&str> = consumed_proposal_refs.iter().map(String::as_str).collect();
+    let provider = EngineOpenMlsProvider::<S>::new(crypto, storage.mls_storage());
+    for record in storage.list_messages(group_id, source_epoch)? {
+        if record.epoch != source_epoch
+            || !matches!(
+                record.state,
+                MessageState::Created | MessageState::Retryable
+            )
+        {
+            continue;
+        }
+        let Ok(payload) = StoredMessagePayload::decode(&record.payload) else {
+            continue;
+        };
+        let Some(message) = payload.as_openmls_wire() else {
+            continue;
+        };
+        let Ok(Some(protocol)) = protocol_message_from_bytes(&message.payload) else {
+            continue;
+        };
+        // Marmot's current handshake wire-format policy is public. Do not
+        // replay a future private proposal here: OpenMLS decryption advances
+        // the persisted secret tree, which is not an acceptable side effect
+        // for disposition matching.
+        if !matches!(&protocol, ProtocolMessage::PublicMessage(_)) {
+            continue;
+        }
+        let Ok(processed) = mls_group.process_message(&provider, protocol) else {
+            continue;
+        };
+        let ProcessedMessageContent::ProposalMessage(queued) = processed.into_content() else {
+            continue;
+        };
+        let proposal_ref = tls_hex(queued.proposal_reference_ref())
+            .map_err(|error| cgka_traits::error::EngineError::Serialize(error.to_string()))?;
+        if consumed.contains(proposal_ref.as_str()) {
+            storage.update_message_state(&record.id, MessageState::Processed)?;
+        }
+    }
+    Ok(())
+}
+
 /// Mark the origin commit record `Processed` and, when a confirm-time stamp is
 /// available, enrich its stored wire payload to `OwnCommitWire` in the same
 /// write, so stored convergence can later rebuild this commit's branch as a

--- a/crates/cgka-engine/src/publish.rs
+++ b/crates/cgka-engine/src/publish.rs
@@ -141,6 +141,18 @@ impl<S: StorageProvider> Engine<S> {
                             self.identity.self_id().clone(),
                         )?);
                     }
+                    let source_epoch = EpochId(mls_group.epoch().as_u64());
+                    crate::openmls_projection::mark_consumed_proposal_records_processed(
+                        storage,
+                        &self.crypto,
+                        &mut mls_group,
+                        &group_id,
+                        source_epoch,
+                        &own_commit_stamp
+                            .as_ref()
+                            .expect("pending commit produced a stamp")
+                            .consumed_proposal_refs,
+                    )?;
                     let tx_provider =
                         EngineOpenMlsProvider::<S>::new(&self.crypto, storage.mls_storage());
                     mls_group
@@ -222,6 +234,12 @@ impl<S: StorageProvider> Engine<S> {
             *fanout = confirmed;
         }
         self.queued_intent_by_pending.remove(&pending);
+        if has_pending_commit {
+            // A proposal-arrival signal only resets scheduling for its source
+            // epoch. Confirming any commit crosses that boundary, so no
+            // signal from the prior epoch remains actionable.
+            self.valid_proposal_groups.remove(&group_id);
+        }
         self.audit_with_context(
             Some(&group_id),
             audit_context.clone(),

--- a/crates/cgka-engine/tests/distributed_convergence.rs
+++ b/crates/cgka-engine/tests/distributed_convergence.rs
@@ -4909,7 +4909,7 @@ async fn rebuilt_engine_emits_losing_branch_app_invalidation_after_convergence()
 
 #[tokio::test]
 async fn engine_ingest_retains_proposal_until_canonical_commit_consumes_it() {
-    let (mut alice, _alice_storage) = build_client(b"alice");
+    let (mut alice, alice_storage) = build_client(b"alice");
     let (mut bob, _bob_storage) = build_client(b"bob");
     let (mut carol, carol_storage) = build_client(b"carol");
 
@@ -4988,6 +4988,23 @@ async fn engine_ingest_retains_proposal_until_canonical_commit_consumes_it() {
         .next()
         .expect("alice auto-commits bob's self-remove");
     alice.confirm_published(auto_commit.pending).await.unwrap();
+    assert_message_state(&alice_storage, &proposal, MessageState::Processed);
+    assert!(
+        !alice.drain_valid_proposal_groups().contains(&group_id),
+        "confirming the proposal-consuming commit retires the obsolete proposal schedule signal"
+    );
+
+    let mut restarted_alice = build_client_with_storage(b"alice", alice_storage.clone());
+    restarted_alice
+        .hydrate_stable_groups_from_storage()
+        .expect("rebuild after proposal-consuming commit");
+    assert_message_state(&alice_storage, &proposal, MessageState::Processed);
+    assert!(
+        restarted_alice
+            .drain_pending_convergence_groups()
+            .is_empty(),
+        "processed consumed proposals must not recreate convergence scheduling work after restart"
+    );
 
     let commit = route(auto_commit.msg, &group_id);
     let commit_outcome = carol.ingest(commit.clone()).await.unwrap();


### PR DESCRIPTION
## What changed

- Mark durable proposal message rows `Processed` when a locally confirmed commit consumed their exact authenticated proposal references.
- Clear the epoch-scoped in-memory proposal scheduling signal after local confirmation, accepted direct commits, and successful settled convergence passes.
- Tighten the send/leave simulator regression and add restart coverage proving consumed proposals do not recreate pending convergence work.

## Why

After a member removed itself, the auto-committer could consume the retained `SelfRemove` proposal while leaving its durable `cgka_messages` row in `Created` and its in-memory `valid_proposal_groups` signal set. The stale row survived restart and could recreate pending convergence work; the stale signal could request redundant scheduling in the current process. This residual work did not represent an actionable proposal after the epoch advanced.

The fix gives locally consumed proposal rows the same terminal disposition used by stored convergence. It matches the staged commit's consumed proposal references against current-epoch public proposal records before merging, within the existing confirmation transaction. It does not replay private handshake messages or mutate the secret tree.

## Impact

Self-removal now completes with no residual durable proposal or scheduler signal. Restart remains quiescent, and strict send/leave convergence checks no longer need a known-failure exception.

## Validation

- `cargo test -p cgka-engine --features test-policy-overrides`
- `cargo test -p cgka-conformance-simulator send_leave_family_records_seed_and_runs_generated_cases -- --nocapture`
- `just fast-ci`

A plain `cargo test -p cgka-engine` still has seven pre-existing deferred-peel failures because those tests request the test-only policy override without enabling `test-policy-overrides`; the feature-enabled engine suite passes.