### PR TITLE
Add convergence subject boundary

### DIFF
--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -74,6 +74,13 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
     into the canonical snapshot and scenario-input ledger while legacy `Observe` remains stable for existing fixtures.
     `ProbeBidirectionalDecryptability` actively exercises send, transport peel, MLS decrypt, and application delivery.
 
+- **Module:** `src/subject.rs`
+  - **Role:** Simulator-owned `ConvergenceSubject` boundary and the built-in `EngineHarnessSubject` adapter. The
+    scenario runner owns step semantics and stable action ids; subjects implement semantic group, publication,
+    application, delivery, observation, and restart operations. Every adapter declares a versioned capability set that
+    is checked before execution. Queue/partition mutation is available only through the separately named
+    `ConvergenceFaultSubject` white-box interface.
+
 - **Module:** `src/vector.rs`
   - **Role:** `ScenarioTrace`, observations, and semantic `TraceExpectation` checks. Records final epoch/member/payload
     facts plus member additions/removals, client convergence, epoch changes, app invalidations, exact canonical state,

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -17,6 +17,9 @@ welcomes use NIP-59 gift wraps before the bus delivers them.
 - `TransportBus` — an in-memory message bus with seeded scheduling, partition support, broadcast and addressed
   delivery for welcomes, and replay hooks.
 - `HarnessClient` — wraps `Engine<SqliteAccountStorage>` and the real Nostr transport peeler while keeping delivery in memory.
+- `ConvergenceSubject` — a capability-declared semantic boundary between scenario execution and the implementation
+  under test. `EngineHarnessSubject` is the in-process adapter; queue and partition mutation live on a separate,
+  explicitly white-box fault interface.
 - `ScenarioSpec` — a serializable v1 input contract for deterministic scripted scenarios, including explicit queue
   faults and partitions.
 - `VectorFixture` — portable JSON fixtures pairing runnable scenario input with exact traces or semantic expected
@@ -85,8 +88,9 @@ through encrypted file-backed storage. Use the report command when you want save
 pass/fail summary outside the test harness.
 
 The report command exits non-zero when any fixture expectation fails. Each report includes the exact scenario input,
-selected storage backend, observed trace, flattened recovery and epoch observations, and the mismatched expected/actual
-JSON.
+selected subject adapter, declared capabilities, storage backend, observed trace, flattened recovery and epoch
+observations, and the mismatched expected/actual JSON. A subject that lacks any capability required by a scenario is
+rejected before the first scenario action executes.
 
 ## Exact state oracle
 

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -32,6 +32,7 @@ pub mod proptest_support;
 pub mod report;
 pub mod scenario;
 mod scenario_input_ledger;
+pub mod subject;
 pub mod vector;
 
 pub use bus::{ClientId, DeliveryPolicy, TransportBus};
@@ -68,10 +69,17 @@ pub use scenario::{
     ScenarioStep, ScenarioStepLogEntry, ScenarioStepStatus, VectorFixtureMetadata,
     run_scenario_report, run_scenario_report_with_outcomes,
     run_scenario_report_with_outcomes_and_storage_mode, run_scenario_report_with_storage_mode,
-    run_scenario_spec, run_vector_fixture_report, run_vector_fixture_report_with_storage_mode,
+    run_scenario_report_with_subject, run_scenario_spec, run_scenario_spec_with_subject,
+    run_vector_fixture_report, run_vector_fixture_report_with_storage_mode,
+    validate_scenario_for_subject,
 };
 pub use scenario_input_ledger::{
     ScenarioInputDisposition, ScenarioInputKind, ScenarioInputLedgerEntry,
+};
+pub use subject::{
+    ConvergenceFaultSubject, ConvergenceSubject, EngineHarnessSubject, SubjectCapability,
+    SubjectCreateGroup, SubjectDescriptor, SubjectError, SubjectInviteMembers,
+    SubjectSendApplication, SubjectUpdateAdminPolicy, SubjectUpdateGroupData, required_capability,
 };
 pub use vector::{
     AppInvalidationObservation, ApplicationProfileContract, ClientEventCounts, ClientObservation,

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -429,6 +429,7 @@ mod tests {
                 spec_version: "1".into(),
                 step_count: 0,
                 storage_backend: "in-memory-sqlite".into(),
+                subject: None,
                 generated: None,
                 fixture: None,
             },

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -5,21 +5,16 @@
 //! their observed trace to exact or semantic fixture expectations.
 
 use crate::{
-    BidirectionalDecryptabilityObservation, ClientBuilder, DecryptabilityProbeSendStatus,
-    DirectionalDecryptabilityProbe, ExpectationFailure, HarnessClient, HarnessStorageMode,
-    PendingResolutionObservation, ScenarioAdminPolicyObservation, ScenarioErrorObservation,
-    ScenarioOracleReport, ScenarioTrace, TraceExpectation, TransportBus, VectorFixture,
-    build_scenario_oracle_report, compare_trace_expectations, observe_client, observe_client_exact,
+    ConvergenceFaultSubject, ConvergenceSubject, EngineHarnessSubject, ExpectationFailure,
+    HarnessStorageMode, PendingResolutionObservation, ScenarioErrorObservation,
+    ScenarioOracleReport, ScenarioTrace, SubjectCreateGroup, SubjectDescriptor, SubjectError,
+    SubjectInviteMembers, SubjectSendApplication, SubjectUpdateAdminPolicy, SubjectUpdateGroupData,
+    TraceExpectation, VectorFixture, build_scenario_oracle_report, compare_trace_expectations,
+    required_capability,
 };
-use cgka_engine::feature_registry::FeatureRegistry;
-use cgka_traits::EngineError;
-use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
-use cgka_traits::engine::KeyPackage;
-use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::group::ProtocolProfile;
-use cgka_traits::types::MemberId;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeSet;
 use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -200,6 +195,8 @@ pub struct ScenarioReportMetadata {
     pub spec_version: String,
     pub step_count: usize,
     pub storage_backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<SubjectDescriptor>,
     pub generated: Option<GeneratedScenarioMetadata>,
     pub fixture: Option<VectorFixtureMetadata>,
 }
@@ -271,6 +268,17 @@ pub async fn run_scenario_spec(spec: &ScenarioSpec) -> Result<ScenarioTrace, Sce
         .expect("successful report always includes an observed trace"))
 }
 
+/// Run ScenarioSpec v1 through an explicitly supplied convergence subject.
+pub async fn run_scenario_spec_with_subject(
+    spec: &ScenarioSpec,
+    subject: &mut dyn ConvergenceSubject,
+) -> Result<ScenarioTrace, ScenarioRunError> {
+    let report = run_scenario_report_with_subject(spec, None, Vec::new(), subject).await?;
+    Ok(report
+        .observed_trace
+        .expect("successful report always includes an observed trace"))
+}
+
 pub async fn run_scenario_report(
     spec: &ScenarioSpec,
     expected_trace: Option<ScenarioTrace>,
@@ -284,15 +292,10 @@ pub async fn run_scenario_report_with_storage_mode(
     expected_trace: Option<ScenarioTrace>,
     storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    run_scenario_report_inner(
-        spec,
-        expected_trace,
-        vec![],
-        None,
-        ProtocolProfile::Legacy,
-        storage_mode,
-    )
-    .await
+    let mut subject =
+        EngineHarnessSubject::new(&spec.clients, ProtocolProfile::Legacy, storage_mode)
+            .map_err(subject_setup_error)?;
+    run_scenario_report_inner(spec, expected_trace, vec![], None, &mut subject).await
 }
 
 pub async fn run_scenario_report_with_outcomes(
@@ -315,15 +318,22 @@ pub async fn run_scenario_report_with_outcomes_and_storage_mode(
     expected_outcomes: Vec<TraceExpectation>,
     storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    run_scenario_report_inner(
-        spec,
-        expected_trace,
-        expected_outcomes,
-        None,
-        ProtocolProfile::Legacy,
-        storage_mode,
-    )
-    .await
+    let mut subject =
+        EngineHarnessSubject::new(&spec.clients, ProtocolProfile::Legacy, storage_mode)
+            .map_err(subject_setup_error)?;
+    run_scenario_report_inner(spec, expected_trace, expected_outcomes, None, &mut subject).await
+}
+
+/// Build a complete report using an explicitly supplied adapter.
+///
+/// Capability validation runs before the subject receives any action.
+pub async fn run_scenario_report_with_subject(
+    spec: &ScenarioSpec,
+    expected_trace: Option<ScenarioTrace>,
+    expected_outcomes: Vec<TraceExpectation>,
+    subject: &mut dyn ConvergenceSubject,
+) -> Result<ScenarioReport, ScenarioRunError> {
+    run_scenario_report_inner(spec, expected_trace, expected_outcomes, None, subject).await
 }
 
 pub async fn run_vector_fixture_report(
@@ -350,6 +360,9 @@ pub async fn run_vector_fixture_report_with_storage_mode(
             });
         }
     };
+    let mut subject =
+        EngineHarnessSubject::new(&fixture.scenario.clients, protocol_profile, storage_mode)
+            .map_err(subject_setup_error)?;
     run_scenario_report_inner(
         &fixture.scenario,
         fixture.expected_trace.clone(),
@@ -360,8 +373,7 @@ pub async fn run_vector_fixture_report_with_storage_mode(
             conformance_version: fixture.conformance_version.clone(),
             seed: fixture.seed,
         }),
-        protocol_profile,
-        storage_mode,
+        &mut subject,
     )
     .await
 }
@@ -371,33 +383,10 @@ async fn run_scenario_report_inner(
     expected_trace: Option<ScenarioTrace>,
     expected_outcomes: Vec<TraceExpectation>,
     fixture: Option<VectorFixtureMetadata>,
-    protocol_profile: ProtocolProfile,
-    storage_mode: HarnessStorageMode,
+    subject: &mut dyn ConvergenceSubject,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    if spec.spec_version != "1" {
-        return Err(ScenarioRunError {
-            step_index: None,
-            message: format!("unsupported ScenarioSpec version {}", spec.spec_version),
-        });
-    }
-    let bus = TransportBus::ordered();
-    let mut clients = BTreeMap::new();
-    for label in &spec.clients {
-        if clients.contains_key(label) {
-            return Err(ScenarioRunError {
-                step_index: None,
-                message: format!("duplicate client label {label}"),
-            });
-        }
-        let client = ClientBuilder::new(pad32(label.as_bytes()))
-            .registry(scenario_registry())
-            .protocol_profile(protocol_profile)
-            .storage_mode(storage_mode)
-            .attach(&bus);
-        clients.insert(label.clone(), client);
-    }
-
-    let mut pending_refs = HashMap::new();
+    let descriptor = subject.descriptor();
+    validate_scenario_for_subject(spec, &descriptor)?;
     let mut pending_resolutions = Vec::new();
     let mut observations = Vec::new();
     let mut decryptability_probes = Vec::new();
@@ -406,6 +395,7 @@ async fn run_scenario_report_inner(
     let mut step_log = Vec::new();
 
     for (step_index, step) in spec.steps.iter().enumerate() {
+        let action_id = scenario_input_id(step_index, step);
         match step {
             ScenarioStep::CreateGroup {
                 creator,
@@ -418,69 +408,83 @@ async fn run_scenario_report_inner(
                 let initial_admin_labels = initial_admins
                     .clone()
                     .unwrap_or_else(|| scenario_initial_admins(spec, step_index, invitees));
-                let initial_admins = member_ids(&clients, &initial_admin_labels, step_index)?;
-                let key_packages = fresh_key_packages(&mut clients, invitees, step_index).await?;
-                let required_features =
-                    required_features_from_names(required_features, step_index)?;
-                let creator = client_mut(&mut clients, creator, step_index)?;
-                let (_group_id, pending_ref) = creator
-                    .create_group_with_admins_maybe_pending(
+                subject
+                    .create_group(SubjectCreateGroup {
+                        creator,
                         name,
-                        key_packages,
+                        invitees,
                         required_features,
-                        initial_admins,
-                    )
-                    .await;
-                if let Some(pending_ref) = pending_ref {
-                    insert_pending(&mut pending_refs, pending, pending_ref, step_index)?;
-                }
+                        initial_admins: &initial_admin_labels,
+                        pending,
+                    })
+                    .await
+                    .map_err(|error| subject_step_error(step_index, error))?;
             }
             ScenarioStep::InviteMembers {
                 inviter,
                 invitees,
                 pending,
             } => {
-                let key_packages = fresh_key_packages(&mut clients, invitees, step_index).await?;
-                let inviter = client_mut(&mut clients, inviter, step_index)?;
-                inviter.name_next_scenario_input(scenario_input_id(step_index, step));
-                let pending_ref = inviter.invite(key_packages).await;
-                insert_pending(&mut pending_refs, pending, pending_ref, step_index)?;
+                subject
+                    .invite_members(SubjectInviteMembers {
+                        action_id: &action_id,
+                        inviter,
+                        invitees,
+                        pending,
+                    })
+                    .await
+                    .map_err(|error| subject_step_error(step_index, error))?;
             }
             ScenarioStep::UpdateGroupData {
                 client,
                 name,
                 pending,
             } => {
-                let client = client_mut(&mut clients, client, step_index)?;
-                client.name_next_scenario_input(scenario_input_id(step_index, step));
-                let pending_ref = client.update_group_data(name.clone()).await;
-                insert_pending(&mut pending_refs, pending, pending_ref, step_index)?;
+                subject
+                    .update_group_data(SubjectUpdateGroupData {
+                        action_id: &action_id,
+                        client,
+                        name,
+                        pending,
+                    })
+                    .await
+                    .map_err(|error| subject_step_error(step_index, error))?;
             }
             ScenarioStep::UpdateAdminPolicy {
                 client,
                 admins,
                 pending,
             } => {
-                let admin_ids = member_ids(&clients, admins, step_index)?;
-                let client = client_mut(&mut clients, client, step_index)?;
-                client.name_next_scenario_input(scenario_input_id(step_index, step));
-                let pending_ref = client.update_admin_policy(admin_ids).await.map_err(|e| {
-                    err(
-                        step_index,
-                        format!("update_admin_policy unexpectedly failed: {e}"),
-                    )
-                })?;
-                insert_pending(&mut pending_refs, pending, pending_ref, step_index)?;
+                subject
+                    .update_admin_policy(SubjectUpdateAdminPolicy {
+                        action_id: Some(&action_id),
+                        client,
+                        admins,
+                        pending: Some(pending),
+                    })
+                    .await
+                    .map_err(|error| {
+                        err(
+                            step_index,
+                            format!("update_admin_policy unexpectedly failed: {error}"),
+                        )
+                    })?;
             }
             ScenarioStep::ExpectUpdateAdminPolicyError {
                 client,
                 admins,
                 error,
             } => {
-                let admin_ids = member_ids(&clients, admins, step_index)?;
                 let client_label = client.clone();
-                let client = client_mut(&mut clients, client, step_index)?;
-                match client.update_admin_policy(admin_ids).await {
+                match subject
+                    .update_admin_policy(SubjectUpdateAdminPolicy {
+                        action_id: None,
+                        client,
+                        admins,
+                        pending: None,
+                    })
+                    .await
+                {
                     Ok(_) => {
                         return Err(err(
                             step_index,
@@ -488,12 +492,12 @@ async fn run_scenario_report_inner(
                         ));
                     }
                     Err(actual) => {
-                        let actual = observe_engine_error(&actual);
-                        if &actual != error {
+                        if &actual.code != error {
                             return Err(err(
                                 step_index,
                                 format!(
-                                    "update_admin_policy failed with {actual}; expected {error}"
+                                    "update_admin_policy failed with {}; expected {error}",
+                                    actual.code
                                 ),
                             ));
                         }
@@ -501,16 +505,17 @@ async fn run_scenario_report_inner(
                             step_index,
                             client: client_label,
                             operation: "update_admin_policy".into(),
-                            error: actual,
+                            error: actual.code,
                         });
                     }
                 }
             }
             ScenarioStep::ConfirmPending { client, pending } => {
-                let pending_ref = take_pending(&mut pending_refs, pending, step_index)?;
                 let client_label = client.clone();
-                let client = client_mut(&mut clients, client, step_index)?;
-                client.confirm(pending_ref).await;
+                subject
+                    .confirm_pending(client, pending)
+                    .await
+                    .map_err(|error| subject_step_error(step_index, error))?;
                 pending_resolutions.push(PendingResolutionObservation {
                     step_index,
                     client: client_label,
@@ -519,10 +524,11 @@ async fn run_scenario_report_inner(
                 });
             }
             ScenarioStep::FailPending { client, pending } => {
-                let pending_ref = take_pending(&mut pending_refs, pending, step_index)?;
                 let client_label = client.clone();
-                let client = client_mut(&mut clients, client, step_index)?;
-                client.fail(pending_ref).await;
+                subject
+                    .fail_pending(client, pending)
+                    .await
+                    .map_err(|error| subject_step_error(step_index, error))?;
                 pending_resolutions.push(PendingResolutionObservation {
                     step_index,
                     client: client_label,
@@ -531,107 +537,101 @@ async fn run_scenario_report_inner(
                 });
             }
             ScenarioStep::SendAppMessage { sender, payload } => {
-                let sender = client_mut(&mut clients, sender, step_index)?;
-                sender.name_next_scenario_input(scenario_input_id(step_index, step));
-                sender.send_app(payload.clone().into_bytes()).await;
+                subject
+                    .send_application(SubjectSendApplication {
+                        action_id: &action_id,
+                        sender,
+                        payload,
+                    })
+                    .await
+                    .map_err(|error| subject_step_error(step_index, error))?;
             }
             ScenarioStep::Leave { client } => {
-                let client = client_mut(&mut clients, client, step_index)?;
-                client.name_next_scenario_input(scenario_input_id(step_index, step));
-                client.leave().await;
+                subject
+                    .leave(&action_id, client)
+                    .await
+                    .map_err(|error| subject_step_error(step_index, error))?;
             }
-            ScenarioStep::DeliverAll => bus.deliver_all(),
+            ScenarioStep::DeliverAll => subject
+                .deliver_all()
+                .map_err(|error| subject_step_error(step_index, error))?,
             ScenarioStep::Tick { clients: labels } => {
-                for label in labels {
-                    let client = client_mut(&mut clients, label, step_index)?;
-                    client.tick().await;
-                }
+                subject
+                    .tick(labels)
+                    .await
+                    .map_err(|error| subject_step_error(step_index, error))?;
             }
             ScenarioStep::Observe { clients: labels } => {
-                for label in labels {
-                    let client = client_mut(&mut clients, label, step_index)?;
-                    observations.push(observe_client(label.clone(), client));
-                }
+                observations.extend(
+                    subject
+                        .observe(labels)
+                        .map_err(|error| subject_step_error(step_index, error))?,
+                );
             }
             ScenarioStep::ObserveExact { clients: labels } => {
-                for label in labels {
-                    let client = client_mut(&mut clients, label, step_index)?;
-                    observations.push(observe_client_exact(label.clone(), client));
-                }
+                observations.extend(
+                    subject
+                        .observe_exact(labels)
+                        .map_err(|error| subject_step_error(step_index, error))?,
+                );
             }
             ScenarioStep::ProbeBidirectionalDecryptability { clients: labels } => {
                 decryptability_probes.push(
-                    run_bidirectional_decryptability_probe(&mut clients, &bus, labels, step_index)
-                        .await?,
+                    subject
+                        .probe_bidirectional_decryptability(labels, step_index)
+                        .await
+                        .map_err(|error| subject_step_error(step_index, error))?,
                 );
             }
             ScenarioStep::ObserveAdminPolicy { clients: labels } => {
-                for label in labels {
-                    let client = client_ref(&clients, label, step_index)?;
-                    admin_policy_observations.push(ScenarioAdminPolicyObservation {
-                        client: label.clone(),
-                        admins: client.admin_labels(),
-                    });
-                }
+                admin_policy_observations.extend(
+                    subject
+                        .observe_admin_policy(labels)
+                        .map_err(|error| subject_step_error(step_index, error))?,
+                );
             }
             ScenarioStep::ClearEvents { clients: labels } => {
-                for label in labels {
-                    let client = client_mut(&mut clients, label, step_index)?;
-                    client.drain_events();
-                    client.clear_audit_capture();
-                }
+                subject
+                    .clear_events(labels)
+                    .map_err(|error| subject_step_error(step_index, error))?;
             }
             ScenarioStep::DropQueued { index } => {
-                if !bus.drop_queued(*index) {
-                    return Err(err(
-                        step_index,
-                        format!("queued message index {index} does not exist"),
-                    ));
-                }
+                subject_faults(subject, step_index)?
+                    .drop_queued(*index)
+                    .map_err(|error| subject_step_error(step_index, error))?;
             }
             ScenarioStep::DuplicateQueued { index } => {
-                if !bus.duplicate_queued(*index) {
-                    return Err(err(
-                        step_index,
-                        format!("queued message index {index} does not exist"),
-                    ));
-                }
+                subject_faults(subject, step_index)?
+                    .duplicate_queued(*index)
+                    .map_err(|error| subject_step_error(step_index, error))?;
             }
             ScenarioStep::DelayQueued { index, delayed } => {
-                if !bus.delay_queued(*index, delayed.clone()) {
-                    return Err(err(
-                        step_index,
-                        format!("queued message index {index} does not exist"),
-                    ));
-                }
+                subject_faults(subject, step_index)?
+                    .delay_queued(*index, delayed)
+                    .map_err(|error| subject_step_error(step_index, error))?;
             }
             ScenarioStep::ReleaseDelayed { delayed } => {
-                if !bus.release_delayed(delayed) {
-                    return Err(err(
-                        step_index,
-                        format!("delayed queue label {delayed} does not exist"),
-                    ));
-                }
+                subject_faults(subject, step_index)?
+                    .release_delayed(delayed)
+                    .map_err(|error| subject_step_error(step_index, error))?;
             }
             ScenarioStep::ReorderQueued { order } => {
-                if !bus.reorder_queued(order) {
-                    return Err(err(
-                        step_index,
-                        format!("invalid queue reorder permutation {order:?}"),
-                    ));
-                }
+                subject_faults(subject, step_index)?
+                    .reorder_queued(order)
+                    .map_err(|error| subject_step_error(step_index, error))?;
             }
             ScenarioStep::SetPartition { allow } => {
-                let mut allowed = Vec::with_capacity(allow.len());
-                for label in allow {
-                    allowed.push(client_ref(&clients, label, step_index)?.bus_id);
-                }
-                bus.set_partition(Some(allowed));
+                subject_faults(subject, step_index)?
+                    .set_partition(allow)
+                    .map_err(|error| subject_step_error(step_index, error))?;
             }
-            ScenarioStep::ClearPartition => bus.set_partition(None),
+            ScenarioStep::ClearPartition => subject_faults(subject, step_index)?
+                .clear_partition()
+                .map_err(|error| subject_step_error(step_index, error))?,
             ScenarioStep::RestartClient { client } => {
-                let client = client_mut(&mut clients, client, step_index)?;
-                client.restart();
+                subject
+                    .restart(client)
+                    .map_err(|error| subject_step_error(step_index, error))?;
             }
         }
         step_log.push(ScenarioStepLogEntry {
@@ -698,7 +698,8 @@ async fn run_scenario_report_inner(
             scenario_name: spec.name.clone(),
             spec_version: spec.spec_version.clone(),
             step_count: spec.steps.len(),
-            storage_backend: storage_mode.report_label().into(),
+            storage_backend: descriptor.storage_backend.clone(),
+            subject: Some(descriptor),
             generated: None,
             fixture,
         },
@@ -721,110 +722,41 @@ fn scenario_input_id(step_index: usize, step: &ScenarioStep) -> String {
     format!("step-{step_index}:{}", step.kind())
 }
 
-async fn run_bidirectional_decryptability_probe(
-    clients: &mut BTreeMap<String, HarnessClient>,
-    bus: &TransportBus,
-    labels: &[String],
-    step_index: usize,
-) -> Result<BidirectionalDecryptabilityObservation, ScenarioRunError> {
-    let mut unique_labels = labels.to_vec();
-    unique_labels.sort();
-    unique_labels.dedup();
-    if labels.len() < 2 || unique_labels.len() != labels.len() {
-        return Err(err(
-            step_index,
-            "bidirectional decryptability probe requires at least two unique clients".into(),
-        ));
+/// Validate adapter support before the first scenario action is executed.
+pub fn validate_scenario_for_subject(
+    spec: &ScenarioSpec,
+    descriptor: &SubjectDescriptor,
+) -> Result<(), ScenarioRunError> {
+    if spec.spec_version != "1" {
+        return Err(ScenarioRunError {
+            step_index: None,
+            message: format!("unsupported ScenarioSpec version {}", spec.spec_version),
+        });
     }
-    for label in labels {
-        client_ref(clients, label, step_index)?;
-    }
-
-    let mut sends = BTreeMap::new();
-    for sender in labels {
-        let payload = format!("cgka-decryptability-probe/v1/{step_index}/{sender}");
-        let status = match client_mut(clients, sender, step_index)?
-            .try_send_app(payload.clone().into_bytes())
-            .await
-        {
-            Ok((status, logical_id)) => (status, Some(logical_id)),
-            Err(error) => (
-                DecryptabilityProbeSendStatus::Failed {
-                    error: observe_engine_error(&error),
-                },
-                None,
-            ),
-        };
-        sends.insert(sender.clone(), (payload, status));
-    }
-
-    bus.deliver_all();
-    let all_clients = clients.keys().cloned().collect::<Vec<_>>();
-    for label in all_clients {
-        client_mut(clients, &label, step_index)?.tick().await;
-    }
-
-    let mut recipient_ledgers = BTreeMap::new();
-    for recipient in labels {
-        recipient_ledgers.insert(
-            recipient.clone(),
-            client_mut(clients, recipient, step_index)?.scenario_input_ledger(),
-        );
-    }
-
-    let mut probes = Vec::with_capacity(labels.len() * (labels.len() - 1));
-    for sender in labels {
-        let (payload, (send_status, logical_id)) = sends
-            .get(sender)
-            .expect("probe send result exists for every validated sender");
-        for recipient in labels {
-            if recipient == sender {
-                continue;
-            }
-            let recipient_ledger = recipient_ledgers[recipient]
-                .iter()
-                .find(|entry| entry.logical_id.as_ref() == logical_id.as_ref())
-                .cloned();
-            probes.push(DirectionalDecryptabilityProbe {
-                sender: sender.clone(),
-                recipient: recipient.clone(),
-                payload: payload.clone(),
-                logical_id: logical_id.clone(),
-                send_status: send_status.clone(),
-                recipient_ledger,
+    let mut clients = BTreeSet::new();
+    for label in &spec.clients {
+        if !clients.insert(label) {
+            return Err(ScenarioRunError {
+                step_index: None,
+                message: format!("duplicate client label {label}"),
             });
         }
     }
-
-    Ok(BidirectionalDecryptabilityObservation {
-        step_index,
-        clients: labels.to_vec(),
-        probes,
-    })
-}
-
-async fn fresh_key_packages(
-    clients: &mut BTreeMap<String, HarnessClient>,
-    labels: &[String],
-    step_index: usize,
-) -> Result<Vec<KeyPackage>, ScenarioRunError> {
-    let mut key_packages = Vec::with_capacity(labels.len());
-    for label in labels {
-        let client = client_mut(clients, label, step_index)?;
-        key_packages.push(client.fresh_key_package().await);
+    for (step_index, step) in spec.steps.iter().enumerate() {
+        let capability = required_capability(step);
+        if !descriptor.supports(capability) {
+            return Err(err(
+                step_index,
+                format!(
+                    "subject {} does not support capability {} required by {}",
+                    descriptor.adapter,
+                    capability,
+                    step.kind()
+                ),
+            ));
+        }
     }
-    Ok(key_packages)
-}
-
-fn member_ids(
-    clients: &BTreeMap<String, HarnessClient>,
-    labels: &[String],
-    step_index: usize,
-) -> Result<Vec<MemberId>, ScenarioRunError> {
-    labels
-        .iter()
-        .map(|label| client_ref(clients, label, step_index).map(HarnessClient::member_id))
-        .collect()
+    Ok(())
 }
 
 fn scenario_initial_admins(
@@ -853,82 +785,16 @@ fn admin_gated_actor(step: &ScenarioStep) -> Option<&str> {
     }
 }
 
-fn insert_pending(
-    pending_refs: &mut HashMap<String, PendingStateRef>,
-    label: &str,
-    pending_ref: PendingStateRef,
+fn subject_faults(
+    subject: &mut dyn ConvergenceSubject,
     step_index: usize,
-) -> Result<(), ScenarioRunError> {
-    if pending_refs
-        .insert(label.to_string(), pending_ref)
-        .is_some()
-    {
-        return Err(err(step_index, format!("duplicate pending label {label}")));
-    }
-    Ok(())
-}
-
-fn take_pending(
-    pending_refs: &mut HashMap<String, PendingStateRef>,
-    label: &str,
-    step_index: usize,
-) -> Result<PendingStateRef, ScenarioRunError> {
-    pending_refs
-        .remove(label)
-        .ok_or_else(|| err(step_index, format!("unknown pending label {label}")))
-}
-
-fn client_ref<'a>(
-    clients: &'a BTreeMap<String, HarnessClient>,
-    label: &str,
-    step_index: usize,
-) -> Result<&'a HarnessClient, ScenarioRunError> {
-    clients
-        .get(label)
-        .ok_or_else(|| err(step_index, format!("unknown client {label}")))
-}
-
-fn client_mut<'a>(
-    clients: &'a mut BTreeMap<String, HarnessClient>,
-    label: &str,
-    step_index: usize,
-) -> Result<&'a mut HarnessClient, ScenarioRunError> {
-    clients
-        .get_mut(label)
-        .ok_or_else(|| err(step_index, format!("unknown client {label}")))
-}
-
-fn required_features_from_names(
-    names: &[String],
-    step_index: usize,
-) -> Result<Vec<Feature>, ScenarioRunError> {
-    names
-        .iter()
-        .map(|name| match name.as_str() {
-            "self-remove" => Ok(Feature("self-remove")),
-            _ => Err(err(step_index, format!("unknown required feature {name}"))),
-        })
-        .collect()
-}
-
-fn scenario_registry() -> FeatureRegistry {
-    let mut registry = FeatureRegistry::new();
-    registry.register(
-        Feature("self-remove"),
-        CapabilityRequirement {
-            requires: Capability::Proposal(10),
-            level: RequirementLevel::Required,
-            description: "MIP-03",
-        },
-    );
-    registry
-}
-
-fn pad32(name: &[u8]) -> Vec<u8> {
-    let mut out = vec![0u8; 32];
-    let n = name.len().min(32);
-    out[..n].copy_from_slice(&name[..n]);
-    out
+) -> Result<&mut dyn ConvergenceFaultSubject, ScenarioRunError> {
+    subject.fault_injection().ok_or_else(|| {
+        err(
+            step_index,
+            "subject declared a white-box fault capability without a fault interface".into(),
+        )
+    })
 }
 
 fn err(step_index: usize, message: String) -> ScenarioRunError {
@@ -938,36 +804,15 @@ fn err(step_index: usize, message: String) -> ScenarioRunError {
     }
 }
 
-fn observe_engine_error(error: &EngineError) -> String {
-    match error {
-        EngineError::NotGroupAdmin { .. } => "not_group_admin",
-        EngineError::AdminCannotSelfRemove { .. } | EngineError::AdminDepletion { .. } => {
-            "admin_policy"
-        }
-        EngineError::LeaveAlreadyRequested { .. } => "leave_already_requested",
-        EngineError::Serialize(_) => "invalid_admin_policy",
-        EngineError::InvalidWelcome => "invalid_welcome",
-        EngineError::WelcomeAlreadyProcessed => "welcome_already_processed",
-        EngineError::InvalidTransition(_) => "invalid_transition",
-        EngineError::UnknownGroup(_) => "unknown_group",
-        EngineError::UnknownMember { .. } => "unknown_member",
-        EngineError::NotAMember { .. } => "not_a_member",
-        EngineError::Other(_) => "other",
-        EngineError::Backend(_) => "backend",
-        EngineError::Storage(_) => "storage",
-        EngineError::Peeler(_) => "peeler",
-        EngineError::ForkedEpoch { .. } => "forked_epoch",
-        EngineError::MissingRequiredCapabilities { .. } => "missing_required_capabilities",
-        EngineError::DisbandingUnsupportedMembers { .. } => "disbanding_unsupported_members",
-        EngineError::DisbandingNotEnabled { .. } => "disbanding_not_enabled",
-        EngineError::InvalidCredentialIdentity(_) => "invalid_credential_identity",
-        EngineError::InvalidAccountIdentityProof(_) => "invalid_account_identity_proof",
-        EngineError::InvalidKeyPackageLifetime { .. } => "invalid_key_package_lifetime",
-        EngineError::UnsupportedCiphersuite { .. } => "unsupported_ciphersuite",
-        EngineError::InvalidAppMessagePayload(_) => "invalid_app_message_payload",
-        EngineError::UnknownPending => "unknown_pending",
+fn subject_setup_error(error: SubjectError) -> ScenarioRunError {
+    ScenarioRunError {
+        step_index: None,
+        message: error.to_string(),
     }
-    .into()
+}
+
+fn subject_step_error(step_index: usize, error: SubjectError) -> ScenarioRunError {
+    err(step_index, error.to_string())
 }
 
 fn invariant_failures(expectation_failures: &[ExpectationFailure]) -> Vec<InvariantFailure> {
@@ -983,6 +828,28 @@ fn invariant_failures(expectation_failures: &[ExpectationFailure]) -> Vec<Invari
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{SubjectCapability, SubjectSendApplication};
+    use async_trait::async_trait;
+
+    struct RecordingSubject {
+        descriptor: SubjectDescriptor,
+        send_called: bool,
+    }
+
+    #[async_trait]
+    impl ConvergenceSubject for RecordingSubject {
+        fn descriptor(&self) -> SubjectDescriptor {
+            self.descriptor.clone()
+        }
+
+        async fn send_application(
+            &mut self,
+            _action: SubjectSendApplication<'_>,
+        ) -> Result<(), SubjectError> {
+            self.send_called = true;
+            Ok(())
+        }
+    }
 
     #[test]
     fn fallback_initial_admins_include_future_admin_policy_actors() {
@@ -1011,5 +878,93 @@ mod tests {
             scenario_initial_admins(&spec, 0, &["bob".to_owned(), "carol".to_owned()]),
             vec!["bob".to_owned()]
         );
+    }
+
+    #[tokio::test]
+    async fn unsupported_capability_is_rejected_before_subject_action() {
+        let spec = ScenarioSpec {
+            name: "unsupported-subject-capability/v1".to_owned(),
+            spec_version: "1".to_owned(),
+            clients: vec!["alice".to_owned()],
+            steps: vec![
+                ScenarioStep::SendAppMessage {
+                    sender: "alice".to_owned(),
+                    payload: "hello".to_owned(),
+                },
+                ScenarioStep::RestartClient {
+                    client: "alice".to_owned(),
+                },
+            ],
+        };
+        let mut subject = RecordingSubject {
+            descriptor: SubjectDescriptor {
+                adapter: "recording-subject".to_owned(),
+                adapter_version: "1".to_owned(),
+                storage_backend: "none".to_owned(),
+                capabilities: BTreeSet::from([SubjectCapability::ApplicationMessaging]),
+            },
+            send_called: false,
+        };
+
+        let error = run_scenario_spec_with_subject(&spec, &mut subject)
+            .await
+            .expect_err("unsupported scenario must fail preflight");
+
+        assert_eq!(error.step_index, Some(1));
+        assert!(error.message.contains("crash_reopen"));
+        assert!(!subject.send_called);
+    }
+
+    #[test]
+    fn queue_fault_steps_require_explicit_white_box_capability() {
+        let capability = required_capability(&ScenarioStep::DropQueued { index: 0 });
+
+        assert_eq!(capability, SubjectCapability::WhiteBoxTransportQueueFaults);
+        assert!(capability.is_white_box());
+    }
+
+    #[tokio::test]
+    async fn explicit_engine_subject_preserves_default_runner_trace() {
+        let spec = ScenarioSpec {
+            name: "subject-boundary-smoke/v1".to_owned(),
+            spec_version: "1".to_owned(),
+            clients: vec!["alice".to_owned(), "bob".to_owned()],
+            steps: vec![
+                ScenarioStep::CreateGroup {
+                    creator: "alice".to_owned(),
+                    name: "subject-boundary".to_owned(),
+                    invitees: vec!["bob".to_owned()],
+                    required_features: Vec::new(),
+                    initial_admins: None,
+                    pending: "create".to_owned(),
+                },
+                ScenarioStep::ConfirmPending {
+                    client: "alice".to_owned(),
+                    pending: "create".to_owned(),
+                },
+                ScenarioStep::DeliverAll,
+                ScenarioStep::Tick {
+                    clients: vec!["bob".to_owned()],
+                },
+                ScenarioStep::Observe {
+                    clients: vec!["alice".to_owned(), "bob".to_owned()],
+                },
+            ],
+        };
+
+        let default_trace = run_scenario_spec(&spec)
+            .await
+            .expect("default engine runner succeeds");
+        let mut subject = EngineHarnessSubject::new(
+            &spec.clients,
+            ProtocolProfile::Legacy,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        let explicit_trace = run_scenario_spec_with_subject(&spec, &mut subject)
+            .await
+            .expect("explicit engine subject succeeds");
+
+        assert_eq!(explicit_trace, default_trace);
     }
 }

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -1,0 +1,826 @@
+//! Adapter boundary between scenario semantics and a convergence implementation.
+//!
+//! The scenario runner owns step ordering, stable action ids, and report
+//! construction. A [`ConvergenceSubject`] implements semantic operations using
+//! only the public behavior available at its layer. Harness-only transport
+//! mutation is exposed separately through [`ConvergenceFaultSubject`].
+
+use crate::{
+    BidirectionalDecryptabilityObservation, ClientBuilder, ClientObservation,
+    DecryptabilityProbeSendStatus, DirectionalDecryptabilityProbe, HarnessClient,
+    HarnessStorageMode, ScenarioAdminPolicyObservation, ScenarioStep, TransportBus, observe_client,
+    observe_client_exact,
+};
+use async_trait::async_trait;
+use cgka_engine::feature_registry::FeatureRegistry;
+use cgka_traits::EngineError;
+use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
+use cgka_traits::engine::KeyPackage;
+use cgka_traits::engine_state::PendingStateRef;
+use cgka_traits::group::ProtocolProfile;
+use cgka_traits::types::MemberId;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt;
+
+/// A semantic or explicitly white-box operation an adapter can execute.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubjectCapability {
+    GroupMutation,
+    PublicationLifecycle,
+    ApplicationMessaging,
+    TransportDelivery,
+    EventObservation,
+    ExactConformanceObservation,
+    ActiveDecryptabilityProbe,
+    AdminPolicyObservation,
+    CrashReopen,
+    VirtualTime,
+    WhiteBoxTransportQueueFaults,
+    WhiteBoxTransportPartition,
+    WhiteBoxStorageFaults,
+}
+
+impl SubjectCapability {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::GroupMutation => "group_mutation",
+            Self::PublicationLifecycle => "publication_lifecycle",
+            Self::ApplicationMessaging => "application_messaging",
+            Self::TransportDelivery => "transport_delivery",
+            Self::EventObservation => "event_observation",
+            Self::ExactConformanceObservation => "exact_conformance_observation",
+            Self::ActiveDecryptabilityProbe => "active_decryptability_probe",
+            Self::AdminPolicyObservation => "admin_policy_observation",
+            Self::CrashReopen => "crash_reopen",
+            Self::VirtualTime => "virtual_time",
+            Self::WhiteBoxTransportQueueFaults => "white_box_transport_queue_faults",
+            Self::WhiteBoxTransportPartition => "white_box_transport_partition",
+            Self::WhiteBoxStorageFaults => "white_box_storage_faults",
+        }
+    }
+
+    pub const fn is_white_box(self) -> bool {
+        matches!(
+            self,
+            Self::WhiteBoxTransportQueueFaults
+                | Self::WhiteBoxTransportPartition
+                | Self::WhiteBoxStorageFaults
+        )
+    }
+}
+
+impl fmt::Display for SubjectCapability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Stable adapter identity and its declared executable surface.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubjectDescriptor {
+    pub adapter: String,
+    pub adapter_version: String,
+    pub storage_backend: String,
+    pub capabilities: BTreeSet<SubjectCapability>,
+}
+
+impl SubjectDescriptor {
+    pub fn supports(&self, capability: SubjectCapability) -> bool {
+        self.capabilities.contains(&capability)
+    }
+}
+
+/// Adapter-level failure with a normalized code suitable for expectations.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SubjectError {
+    pub code: String,
+    pub message: String,
+}
+
+impl SubjectError {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    fn unsupported(capability: SubjectCapability) -> Self {
+        Self::new(
+            "unsupported_capability",
+            format!("subject does not support {capability}"),
+        )
+    }
+}
+
+impl fmt::Display for SubjectError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for SubjectError {}
+
+pub struct SubjectCreateGroup<'a> {
+    pub creator: &'a str,
+    pub name: &'a str,
+    pub invitees: &'a [String],
+    pub required_features: &'a [String],
+    pub initial_admins: &'a [String],
+    pub pending: &'a str,
+}
+
+pub struct SubjectInviteMembers<'a> {
+    pub action_id: &'a str,
+    pub inviter: &'a str,
+    pub invitees: &'a [String],
+    pub pending: &'a str,
+}
+
+pub struct SubjectUpdateGroupData<'a> {
+    pub action_id: &'a str,
+    pub client: &'a str,
+    pub name: &'a str,
+    pub pending: &'a str,
+}
+
+pub struct SubjectUpdateAdminPolicy<'a> {
+    /// Stable input id for operations expected to produce protocol input.
+    /// Expected validation failures leave this unset because no input should
+    /// be produced or entered into the scenario-input ledger.
+    pub action_id: Option<&'a str>,
+    pub client: &'a str,
+    pub admins: &'a [String],
+    pub pending: Option<&'a str>,
+}
+
+pub struct SubjectSendApplication<'a> {
+    pub action_id: &'a str,
+    pub sender: &'a str,
+    pub payload: &'a str,
+}
+
+/// Normal convergence operations available to a scenario executor.
+///
+/// Default methods fail closed. A partial adapter can therefore declare only
+/// the capabilities it truly supports; preflight rejects the scenario before
+/// any method is invoked.
+#[async_trait]
+pub trait ConvergenceSubject: Send {
+    fn descriptor(&self) -> SubjectDescriptor;
+
+    async fn create_group(&mut self, _action: SubjectCreateGroup<'_>) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(SubjectCapability::GroupMutation))
+    }
+
+    async fn invite_members(
+        &mut self,
+        _action: SubjectInviteMembers<'_>,
+    ) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(SubjectCapability::GroupMutation))
+    }
+
+    async fn update_group_data(
+        &mut self,
+        _action: SubjectUpdateGroupData<'_>,
+    ) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(SubjectCapability::GroupMutation))
+    }
+
+    async fn update_admin_policy(
+        &mut self,
+        _action: SubjectUpdateAdminPolicy<'_>,
+    ) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(SubjectCapability::GroupMutation))
+    }
+
+    async fn confirm_pending(&mut self, _client: &str, _pending: &str) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(
+            SubjectCapability::PublicationLifecycle,
+        ))
+    }
+
+    async fn fail_pending(&mut self, _client: &str, _pending: &str) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(
+            SubjectCapability::PublicationLifecycle,
+        ))
+    }
+
+    async fn send_application(
+        &mut self,
+        _action: SubjectSendApplication<'_>,
+    ) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(
+            SubjectCapability::ApplicationMessaging,
+        ))
+    }
+
+    async fn leave(&mut self, _action_id: &str, _client: &str) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(SubjectCapability::GroupMutation))
+    }
+
+    fn deliver_all(&mut self) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(
+            SubjectCapability::TransportDelivery,
+        ))
+    }
+
+    async fn tick(&mut self, _clients: &[String]) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(
+            SubjectCapability::TransportDelivery,
+        ))
+    }
+
+    fn observe(&mut self, _clients: &[String]) -> Result<Vec<ClientObservation>, SubjectError> {
+        Err(SubjectError::unsupported(
+            SubjectCapability::EventObservation,
+        ))
+    }
+
+    fn observe_exact(
+        &mut self,
+        _clients: &[String],
+    ) -> Result<Vec<ClientObservation>, SubjectError> {
+        Err(SubjectError::unsupported(
+            SubjectCapability::ExactConformanceObservation,
+        ))
+    }
+
+    async fn probe_bidirectional_decryptability(
+        &mut self,
+        _clients: &[String],
+        _step_index: usize,
+    ) -> Result<BidirectionalDecryptabilityObservation, SubjectError> {
+        Err(SubjectError::unsupported(
+            SubjectCapability::ActiveDecryptabilityProbe,
+        ))
+    }
+
+    fn observe_admin_policy(
+        &self,
+        _clients: &[String],
+    ) -> Result<Vec<ScenarioAdminPolicyObservation>, SubjectError> {
+        Err(SubjectError::unsupported(
+            SubjectCapability::AdminPolicyObservation,
+        ))
+    }
+
+    fn clear_events(&mut self, _clients: &[String]) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(
+            SubjectCapability::EventObservation,
+        ))
+    }
+
+    fn restart(&mut self, _client: &str) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(SubjectCapability::CrashReopen))
+    }
+
+    fn fault_injection(&mut self) -> Option<&mut dyn ConvergenceFaultSubject> {
+        None
+    }
+}
+
+/// Explicit harness-only transport mutation. Normal subjects need not expose it.
+pub trait ConvergenceFaultSubject {
+    fn drop_queued(&mut self, index: usize) -> Result<(), SubjectError>;
+    fn duplicate_queued(&mut self, index: usize) -> Result<(), SubjectError>;
+    fn delay_queued(&mut self, index: usize, delayed: &str) -> Result<(), SubjectError>;
+    fn release_delayed(&mut self, delayed: &str) -> Result<(), SubjectError>;
+    fn reorder_queued(&mut self, order: &[usize]) -> Result<(), SubjectError>;
+    fn set_partition(&mut self, allow: &[String]) -> Result<(), SubjectError>;
+    fn clear_partition(&mut self) -> Result<(), SubjectError>;
+}
+
+/// Capability required for one ScenarioSpec v1 step.
+pub fn required_capability(step: &ScenarioStep) -> SubjectCapability {
+    match step {
+        ScenarioStep::CreateGroup { .. }
+        | ScenarioStep::InviteMembers { .. }
+        | ScenarioStep::UpdateGroupData { .. }
+        | ScenarioStep::UpdateAdminPolicy { .. }
+        | ScenarioStep::ExpectUpdateAdminPolicyError { .. }
+        | ScenarioStep::Leave { .. } => SubjectCapability::GroupMutation,
+        ScenarioStep::ConfirmPending { .. } | ScenarioStep::FailPending { .. } => {
+            SubjectCapability::PublicationLifecycle
+        }
+        ScenarioStep::SendAppMessage { .. } => SubjectCapability::ApplicationMessaging,
+        ScenarioStep::DeliverAll | ScenarioStep::Tick { .. } => {
+            SubjectCapability::TransportDelivery
+        }
+        ScenarioStep::Observe { .. } | ScenarioStep::ClearEvents { .. } => {
+            SubjectCapability::EventObservation
+        }
+        ScenarioStep::ObserveExact { .. } => SubjectCapability::ExactConformanceObservation,
+        ScenarioStep::ProbeBidirectionalDecryptability { .. } => {
+            SubjectCapability::ActiveDecryptabilityProbe
+        }
+        ScenarioStep::ObserveAdminPolicy { .. } => SubjectCapability::AdminPolicyObservation,
+        ScenarioStep::RestartClient { .. } => SubjectCapability::CrashReopen,
+        ScenarioStep::DropQueued { .. }
+        | ScenarioStep::DuplicateQueued { .. }
+        | ScenarioStep::DelayQueued { .. }
+        | ScenarioStep::ReleaseDelayed { .. }
+        | ScenarioStep::ReorderQueued { .. } => SubjectCapability::WhiteBoxTransportQueueFaults,
+        ScenarioStep::SetPartition { .. } | ScenarioStep::ClearPartition => {
+            SubjectCapability::WhiteBoxTransportPartition
+        }
+    }
+}
+
+/// Current in-process OpenMLS/SQLite/Nostr-peeler subject.
+pub struct EngineHarnessSubject {
+    descriptor: SubjectDescriptor,
+    bus: TransportBus,
+    clients: BTreeMap<String, HarnessClient>,
+    pending_refs: HashMap<String, PendingStateRef>,
+}
+
+impl EngineHarnessSubject {
+    pub fn new(
+        clients: &[String],
+        protocol_profile: ProtocolProfile,
+        storage_mode: HarnessStorageMode,
+    ) -> Result<Self, SubjectError> {
+        let bus = TransportBus::ordered();
+        let mut attached = BTreeMap::new();
+        for label in clients {
+            if attached.contains_key(label) {
+                return Err(SubjectError::new(
+                    "duplicate_client",
+                    format!("duplicate client label {label}"),
+                ));
+            }
+            let client = ClientBuilder::new(pad32(label.as_bytes()))
+                .registry(scenario_registry())
+                .protocol_profile(protocol_profile)
+                .storage_mode(storage_mode)
+                .attach(&bus);
+            attached.insert(label.clone(), client);
+        }
+        let capabilities = [
+            SubjectCapability::GroupMutation,
+            SubjectCapability::PublicationLifecycle,
+            SubjectCapability::ApplicationMessaging,
+            SubjectCapability::TransportDelivery,
+            SubjectCapability::EventObservation,
+            SubjectCapability::ExactConformanceObservation,
+            SubjectCapability::ActiveDecryptabilityProbe,
+            SubjectCapability::AdminPolicyObservation,
+            SubjectCapability::CrashReopen,
+            SubjectCapability::WhiteBoxTransportQueueFaults,
+            SubjectCapability::WhiteBoxTransportPartition,
+        ]
+        .into_iter()
+        .collect();
+        Ok(Self {
+            descriptor: SubjectDescriptor {
+                adapter: "mdk-engine-harness".into(),
+                adapter_version: env!("CARGO_PKG_VERSION").into(),
+                storage_backend: storage_mode.report_label().into(),
+                capabilities,
+            },
+            bus,
+            clients: attached,
+            pending_refs: HashMap::new(),
+        })
+    }
+
+    fn client(&self, label: &str) -> Result<&HarnessClient, SubjectError> {
+        self.clients
+            .get(label)
+            .ok_or_else(|| SubjectError::new("unknown_client", format!("unknown client {label}")))
+    }
+
+    fn client_mut(&mut self, label: &str) -> Result<&mut HarnessClient, SubjectError> {
+        self.clients
+            .get_mut(label)
+            .ok_or_else(|| SubjectError::new("unknown_client", format!("unknown client {label}")))
+    }
+
+    async fn fresh_key_packages(
+        &mut self,
+        labels: &[String],
+    ) -> Result<Vec<KeyPackage>, SubjectError> {
+        let mut key_packages = Vec::with_capacity(labels.len());
+        for label in labels {
+            key_packages.push(self.client_mut(label)?.fresh_key_package().await);
+        }
+        Ok(key_packages)
+    }
+
+    fn member_ids(&self, labels: &[String]) -> Result<Vec<MemberId>, SubjectError> {
+        labels
+            .iter()
+            .map(|label| self.client(label).map(HarnessClient::member_id))
+            .collect()
+    }
+
+    fn insert_pending(
+        &mut self,
+        label: &str,
+        pending_ref: PendingStateRef,
+    ) -> Result<(), SubjectError> {
+        if self
+            .pending_refs
+            .insert(label.to_string(), pending_ref)
+            .is_some()
+        {
+            return Err(SubjectError::new(
+                "duplicate_pending",
+                format!("duplicate pending label {label}"),
+            ));
+        }
+        Ok(())
+    }
+
+    fn take_pending(&mut self, label: &str) -> Result<PendingStateRef, SubjectError> {
+        self.pending_refs.remove(label).ok_or_else(|| {
+            SubjectError::new("unknown_pending", format!("unknown pending label {label}"))
+        })
+    }
+}
+
+#[async_trait]
+impl ConvergenceSubject for EngineHarnessSubject {
+    fn descriptor(&self) -> SubjectDescriptor {
+        self.descriptor.clone()
+    }
+
+    async fn create_group(&mut self, action: SubjectCreateGroup<'_>) -> Result<(), SubjectError> {
+        let initial_admins = self.member_ids(action.initial_admins)?;
+        let key_packages = self.fresh_key_packages(action.invitees).await?;
+        let required_features = required_features_from_names(action.required_features)?;
+        let creator = self.client_mut(action.creator)?;
+        let (_, pending_ref) = creator
+            .create_group_with_admins_maybe_pending(
+                action.name,
+                key_packages,
+                required_features,
+                initial_admins,
+            )
+            .await;
+        if let Some(pending_ref) = pending_ref {
+            self.insert_pending(action.pending, pending_ref)?;
+        }
+        Ok(())
+    }
+
+    async fn invite_members(
+        &mut self,
+        action: SubjectInviteMembers<'_>,
+    ) -> Result<(), SubjectError> {
+        let key_packages = self.fresh_key_packages(action.invitees).await?;
+        let inviter = self.client_mut(action.inviter)?;
+        inviter.name_next_scenario_input(action.action_id);
+        let pending_ref = inviter.invite(key_packages).await;
+        self.insert_pending(action.pending, pending_ref)
+    }
+
+    async fn update_group_data(
+        &mut self,
+        action: SubjectUpdateGroupData<'_>,
+    ) -> Result<(), SubjectError> {
+        let client = self.client_mut(action.client)?;
+        client.name_next_scenario_input(action.action_id);
+        let pending_ref = client.update_group_data(action.name.to_owned()).await;
+        self.insert_pending(action.pending, pending_ref)
+    }
+
+    async fn update_admin_policy(
+        &mut self,
+        action: SubjectUpdateAdminPolicy<'_>,
+    ) -> Result<(), SubjectError> {
+        let admin_ids = self.member_ids(action.admins)?;
+        let client = self.client_mut(action.client)?;
+        if let Some(action_id) = action.action_id {
+            client.name_next_scenario_input(action_id);
+        }
+        let pending_ref = client
+            .update_admin_policy(admin_ids)
+            .await
+            .map_err(subject_engine_error)?;
+        if let Some(pending) = action.pending {
+            self.insert_pending(pending, pending_ref)?;
+        }
+        Ok(())
+    }
+
+    async fn confirm_pending(&mut self, client: &str, pending: &str) -> Result<(), SubjectError> {
+        let pending_ref = self.take_pending(pending)?;
+        self.client_mut(client)?.confirm(pending_ref).await;
+        Ok(())
+    }
+
+    async fn fail_pending(&mut self, client: &str, pending: &str) -> Result<(), SubjectError> {
+        let pending_ref = self.take_pending(pending)?;
+        self.client_mut(client)?.fail(pending_ref).await;
+        Ok(())
+    }
+
+    async fn send_application(
+        &mut self,
+        action: SubjectSendApplication<'_>,
+    ) -> Result<(), SubjectError> {
+        let sender = self.client_mut(action.sender)?;
+        sender.name_next_scenario_input(action.action_id);
+        sender.send_app(action.payload.as_bytes().to_vec()).await;
+        Ok(())
+    }
+
+    async fn leave(&mut self, action_id: &str, client: &str) -> Result<(), SubjectError> {
+        let client = self.client_mut(client)?;
+        client.name_next_scenario_input(action_id);
+        client.leave().await;
+        Ok(())
+    }
+
+    fn deliver_all(&mut self) -> Result<(), SubjectError> {
+        self.bus.deliver_all();
+        Ok(())
+    }
+
+    async fn tick(&mut self, clients: &[String]) -> Result<(), SubjectError> {
+        for label in clients {
+            self.client_mut(label)?.tick().await;
+        }
+        Ok(())
+    }
+
+    fn observe(&mut self, clients: &[String]) -> Result<Vec<ClientObservation>, SubjectError> {
+        clients
+            .iter()
+            .map(|label| {
+                let client = self.client_mut(label)?;
+                Ok(observe_client(label.clone(), client))
+            })
+            .collect()
+    }
+
+    fn observe_exact(
+        &mut self,
+        clients: &[String],
+    ) -> Result<Vec<ClientObservation>, SubjectError> {
+        clients
+            .iter()
+            .map(|label| {
+                let client = self.client_mut(label)?;
+                Ok(observe_client_exact(label.clone(), client))
+            })
+            .collect()
+    }
+
+    async fn probe_bidirectional_decryptability(
+        &mut self,
+        labels: &[String],
+        step_index: usize,
+    ) -> Result<BidirectionalDecryptabilityObservation, SubjectError> {
+        let mut unique_labels = labels.to_vec();
+        unique_labels.sort();
+        unique_labels.dedup();
+        if labels.len() < 2 || unique_labels.len() != labels.len() {
+            return Err(SubjectError::new(
+                "invalid_probe_clients",
+                "bidirectional decryptability probe requires at least two unique clients",
+            ));
+        }
+        for label in labels {
+            self.client(label)?;
+        }
+
+        let mut sends = BTreeMap::new();
+        for sender in labels {
+            let payload = format!("cgka-decryptability-probe/v1/{step_index}/{sender}");
+            let status = match self
+                .client_mut(sender)?
+                .try_send_app(payload.clone().into_bytes())
+                .await
+            {
+                Ok((status, logical_id)) => (status, Some(logical_id)),
+                Err(error) => (
+                    DecryptabilityProbeSendStatus::Failed {
+                        error: observe_engine_error(&error),
+                    },
+                    None,
+                ),
+            };
+            sends.insert(sender.clone(), (payload, status));
+        }
+
+        self.bus.deliver_all();
+        let all_clients = self.clients.keys().cloned().collect::<Vec<_>>();
+        self.tick(&all_clients).await?;
+
+        let mut recipient_ledgers = BTreeMap::new();
+        for recipient in labels {
+            recipient_ledgers.insert(
+                recipient.clone(),
+                self.client_mut(recipient)?.scenario_input_ledger(),
+            );
+        }
+
+        let mut probes = Vec::with_capacity(labels.len() * (labels.len() - 1));
+        for sender in labels {
+            let (payload, (send_status, logical_id)) = sends
+                .get(sender)
+                .expect("probe send result exists for every validated sender");
+            for recipient in labels {
+                if recipient == sender {
+                    continue;
+                }
+                let recipient_ledger = recipient_ledgers[recipient]
+                    .iter()
+                    .find(|entry| entry.logical_id.as_ref() == logical_id.as_ref())
+                    .cloned();
+                probes.push(DirectionalDecryptabilityProbe {
+                    sender: sender.clone(),
+                    recipient: recipient.clone(),
+                    payload: payload.clone(),
+                    logical_id: logical_id.clone(),
+                    send_status: send_status.clone(),
+                    recipient_ledger,
+                });
+            }
+        }
+
+        Ok(BidirectionalDecryptabilityObservation {
+            step_index,
+            clients: labels.to_vec(),
+            probes,
+        })
+    }
+
+    fn observe_admin_policy(
+        &self,
+        clients: &[String],
+    ) -> Result<Vec<ScenarioAdminPolicyObservation>, SubjectError> {
+        clients
+            .iter()
+            .map(|label| {
+                Ok(ScenarioAdminPolicyObservation {
+                    client: label.clone(),
+                    admins: self.client(label)?.admin_labels(),
+                })
+            })
+            .collect()
+    }
+
+    fn clear_events(&mut self, clients: &[String]) -> Result<(), SubjectError> {
+        for label in clients {
+            let client = self.client_mut(label)?;
+            client.drain_events();
+            client.clear_audit_capture();
+        }
+        Ok(())
+    }
+
+    fn restart(&mut self, client: &str) -> Result<(), SubjectError> {
+        self.client_mut(client)?.restart();
+        Ok(())
+    }
+
+    fn fault_injection(&mut self) -> Option<&mut dyn ConvergenceFaultSubject> {
+        Some(self)
+    }
+}
+
+impl ConvergenceFaultSubject for EngineHarnessSubject {
+    fn drop_queued(&mut self, index: usize) -> Result<(), SubjectError> {
+        if self.bus.drop_queued(index) {
+            Ok(())
+        } else {
+            Err(SubjectError::new(
+                "unknown_queued_message",
+                format!("queued message index {index} does not exist"),
+            ))
+        }
+    }
+
+    fn duplicate_queued(&mut self, index: usize) -> Result<(), SubjectError> {
+        if self.bus.duplicate_queued(index) {
+            Ok(())
+        } else {
+            Err(SubjectError::new(
+                "unknown_queued_message",
+                format!("queued message index {index} does not exist"),
+            ))
+        }
+    }
+
+    fn delay_queued(&mut self, index: usize, delayed: &str) -> Result<(), SubjectError> {
+        if self.bus.delay_queued(index, delayed.to_owned()) {
+            Ok(())
+        } else {
+            Err(SubjectError::new(
+                "unknown_queued_message",
+                format!("queued message index {index} does not exist"),
+            ))
+        }
+    }
+
+    fn release_delayed(&mut self, delayed: &str) -> Result<(), SubjectError> {
+        if self.bus.release_delayed(delayed) {
+            Ok(())
+        } else {
+            Err(SubjectError::new(
+                "unknown_delayed_queue",
+                format!("delayed queue label {delayed} does not exist"),
+            ))
+        }
+    }
+
+    fn reorder_queued(&mut self, order: &[usize]) -> Result<(), SubjectError> {
+        if self.bus.reorder_queued(order) {
+            Ok(())
+        } else {
+            Err(SubjectError::new(
+                "invalid_queue_order",
+                format!("invalid queue reorder permutation {order:?}"),
+            ))
+        }
+    }
+
+    fn set_partition(&mut self, allow: &[String]) -> Result<(), SubjectError> {
+        let allowed = allow
+            .iter()
+            .map(|label| self.client(label).map(|client| client.bus_id))
+            .collect::<Result<Vec<_>, _>>()?;
+        self.bus.set_partition(Some(allowed));
+        Ok(())
+    }
+
+    fn clear_partition(&mut self) -> Result<(), SubjectError> {
+        self.bus.set_partition(None);
+        Ok(())
+    }
+}
+
+fn required_features_from_names(names: &[String]) -> Result<Vec<Feature>, SubjectError> {
+    names
+        .iter()
+        .map(|name| match name.as_str() {
+            "self-remove" => Ok(Feature("self-remove")),
+            _ => Err(SubjectError::new(
+                "unknown_required_feature",
+                format!("unknown required feature {name}"),
+            )),
+        })
+        .collect()
+}
+
+fn scenario_registry() -> FeatureRegistry {
+    let mut registry = FeatureRegistry::new();
+    registry.register(
+        Feature("self-remove"),
+        CapabilityRequirement {
+            requires: Capability::Proposal(10),
+            level: RequirementLevel::Required,
+            description: "MIP-03",
+        },
+    );
+    registry
+}
+
+fn pad32(name: &[u8]) -> Vec<u8> {
+    let mut out = vec![0u8; 32];
+    let n = name.len().min(32);
+    out[..n].copy_from_slice(&name[..n]);
+    out
+}
+
+fn subject_engine_error(error: EngineError) -> SubjectError {
+    SubjectError::new(observe_engine_error(&error), error.to_string())
+}
+
+fn observe_engine_error(error: &EngineError) -> String {
+    match error {
+        EngineError::NotGroupAdmin { .. } => "not_group_admin",
+        EngineError::AdminCannotSelfRemove { .. } | EngineError::AdminDepletion { .. } => {
+            "admin_policy"
+        }
+        EngineError::LeaveAlreadyRequested { .. } => "leave_already_requested",
+        EngineError::Serialize(_) => "invalid_admin_policy",
+        EngineError::InvalidWelcome => "invalid_welcome",
+        EngineError::WelcomeAlreadyProcessed => "welcome_already_processed",
+        EngineError::InvalidTransition(_) => "invalid_transition",
+        EngineError::UnknownGroup(_) => "unknown_group",
+        EngineError::UnknownMember { .. } => "unknown_member",
+        EngineError::NotAMember { .. } => "not_a_member",
+        EngineError::Other(_) => "other",
+        EngineError::Backend(_) => "backend",
+        EngineError::Storage(_) => "storage",
+        EngineError::Peeler(_) => "peeler",
+        EngineError::ForkedEpoch { .. } => "forked_epoch",
+        EngineError::MissingRequiredCapabilities { .. } => "missing_required_capabilities",
+        EngineError::DisbandingUnsupportedMembers { .. } => "disbanding_unsupported_members",
+        EngineError::DisbandingNotEnabled { .. } => "disbanding_not_enabled",
+        EngineError::InvalidCredentialIdentity(_) => "invalid_credential_identity",
+        EngineError::InvalidAccountIdentityProof(_) => "invalid_account_identity_proof",
+        EngineError::InvalidKeyPackageLifetime { .. } => "invalid_key_package_lifetime",
+        EngineError::UnsupportedCiphersuite { .. } => "unsupported_ciphersuite",
+        EngineError::InvalidAppMessagePayload(_) => "invalid_app_message_payload",
+        EngineError::UnknownPending => "unknown_pending",
+    }
+    .into()
+}

--- a/crates/cgka-conformance-simulator/tests/report_runner.rs
+++ b/crates/cgka-conformance-simulator/tests/report_runner.rs
@@ -229,6 +229,17 @@ async fn report_runner_writes_send_leave_json_reports() {
     assert_eq!(report["metadata"]["generated"]["seed"], 42);
     assert_eq!(report["metadata"]["generated"]["case_index"], 0);
     assert_eq!(report["metadata"]["storage_backend"], "in-memory-sqlite");
+    assert_eq!(
+        report["metadata"]["subject"]["adapter"],
+        "mdk-engine-harness"
+    );
+    assert!(
+        report["metadata"]["subject"]["capabilities"]
+            .as_array()
+            .is_some_and(|capabilities| capabilities
+                .iter()
+                .any(|capability| capability == "application_messaging"))
+    );
     assert!(
         report["observed_trace"]["observations"]
             .as_array()

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -437,11 +437,15 @@ gap, distinct from the three engine-state failures.
 
 ### 1.2 Public subject boundary
 
-- [ ] Define a simulator-owned `ConvergenceSubject` interface using public engine behavior.
-- [ ] Implement create/mutate, ingest, virtual-time advance, public event/outbound polling, crash/reopen, and sanitized
-  observation.
-- [ ] Split normal black-box execution from explicitly named white-box storage/fault capabilities.
-- [ ] Reject scenarios that require unsupported subject capabilities before execution.
+- [x] Define a simulator-owned `ConvergenceSubject` interface that keeps scenario semantics in the runner and exposes
+  semantic engine operations through declared adapter capabilities.
+- [x] Implement the first engine-adapter vertical slice: create/mutate, publication confirmation/failure, application
+  send, transport delivery/ingest, event/exact/admin observation, active decryptability probing, and crash/reopen.
+- [ ] Add virtual-time advance plus explicit public outbound polling/acknowledgement; coordinate this with the dual-clock
+  and full-quiescence work rather than encoding real-time waits in the subject.
+- [x] Split normal black-box execution from the explicitly named `ConvergenceFaultSubject` queue/partition mutation
+  capability; reserve a named white-box storage-fault capability for a future adapter.
+- [x] Reject scenarios that require unsupported subject capabilities before execution.
 - [ ] Refresh the local canonicalization contract against the adopted protocol before freezing the public observation
   schema; keep normative behavior in the protocol repo and implementation/diagnostic detail here.
 
@@ -766,3 +770,4 @@ incorrect result.
 | 2026-07-30 | 1.1 bidirectional decryptability probe | Added an active exact-ID application-message matrix; settled members pass every directed edge, a missed commit exposes future-epoch deferral in only one direction, and a named nonmember cannot pass | `cargo test -p cgka-conformance-simulator bidirectional_decryptability` |
 | 2026-07-30 | 1.1 terminal disband projection | Added a shared-fact-only canonical tombstone projection; terminal state passes exact/no-pending observation across restart, while device-local authorship and roster ordering cannot split equality | `cargo test -p cgka-conformance-simulator exact_oracle_projects_terminal_disband_tombstone_across_restart`; `cargo test -p cgka-engine --features test-conformance-snapshot disband_projection_excludes_device_local_authorship_and_canonicalizes_roster` |
 | 2026-07-30 | 1.1 strict reliability campaigns | Made report oracle coverage strict by default, added `--allow-weak-oracle`, and appended final global drain/exact/no-pending checks to send-leave and chaos cases. The stronger boundary exposed rollback divergence, pre-join deferred work, unretired leave proposal work, and an unasserted mixed-storm application phase rather than masking them | `strict_chaos_boundary_retains_known_reliability_failures`; focused generator/report tests; generated JSON reports |
+| 2026-07-30 | 1.2a public convergence subject | Extracted scenario execution behind a capability-declared `ConvergenceSubject`, added the in-process engine adapter, separated queue/partition mutation behind `ConvergenceFaultSubject`, rejected unsupported scenarios before actions, and recorded adapter identity/capabilities in reports | Subject preflight/fault-classification tests; default-versus-explicit engine subject trace equivalence; report metadata test |


### PR DESCRIPTION
## Summary

- add a simulator-owned, capability-declared `ConvergenceSubject` interface and an in-process `EngineHarnessSubject` adapter
- keep scenario semantics and stable action scheduling in the runner while moving engine, transport, observation, restart, and pending-publication mechanics behind the adapter
- separate queue and partition mutation behind the explicitly white-box `ConvergenceFaultSubject` interface
- reject unsupported scenarios before any scenario action runs and record adapter identity/capabilities in every report
- update the convergence reliability plan to mark the 1.2a vertical slice complete while leaving virtual time, outbound polling/acknowledgement, and the canonicalization-contract refresh open

## Why

Milestone 1.2 needs one scenario corpus to run against increasingly production-shaped implementations without duplicating or reinterpreting scenario semantics in every adapter. This establishes that boundary around the existing engine harness while preserving current vector and trace behavior.

## Verification

- `cargo test -p cgka-conformance-simulator`
- `cargo test -p cgka-conformance-simulator scenario::tests --lib`
- `cargo test -p cgka-conformance-simulator --test canonical_scenarios canonical_vector_fixtures_match_generated_traces`
- `cargo clippy -p cgka-conformance-simulator --all-targets -- -D warnings`
- `just fast-ci`