### PR TITLE
Fix simulator rollback publication semantics

### DIFF
--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -130,6 +130,11 @@ to be a group member yet.
 `drop_queued`, `duplicate_queued`, `delay_queued`, `release_delayed`, and `reorder_queued`. `set_partition` and
 `clear_partition` remain the partition/heal operations.
 
+`fail_pending` means definite non-publication. Before invoking the engine rollback, the harness retracts every matching
+undelivered commit and Welcome from the queue and delayed sets. It returns a scenario error instead of rolling back if
+any matching artifact has already reached a recipient mailbox; model that case as ambiguous exposure at an adapter-aware
+boundary rather than as `fail_pending`.
+
 Use `clear_events` after setup when a scenario wants the final trace to describe only the behavior under test. The
 convergence E2E scenario does this after the initial welcome joins so its trace focuses on the peeler-ingest epoch
 change and selected branch outputs. Delayed past-epoch app messages are covered via retained epoch contexts.

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -218,7 +218,9 @@ recovery without pinning which invite branch wins.
 
 Pending operations are referenced by string labels chosen inside the scenario. Client labels are stable logical names;
 the Rust harness maps them to deterministic Nostr keys so welcome routing and NIP-59 decryption exercise the same
-identity shape as production. Queue fault steps select messages by the current zero-based queue index at that step.
+identity shape as production. `fail_pending` represents a definite publication failure: it retracts all matching
+undelivered commit/Welcome artifacts before local rollback and fails the scenario if any matching artifact has already
+reached a recipient mailbox. Queue fault steps select messages by the current zero-based queue index at that step.
 `reorder_queued.order` is a full permutation of current queue indices; each entry names which old queue slot moves into
 the next position. `delay_queued` stores selected messages under a string label, and `release_delayed` returns that
 label's messages to the end of the queue.

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -379,8 +379,8 @@ regression, covers a new semantic edge, or is the smallest readable example of a
 - Pressure: a seed-driven delivery reorder of the post-rollback messages, plus a duplicated and delayed copy of one app
   message released after Alice has already processed the original.
 - Expected: Alice remains at epoch 1 and receives Bob's post-rollback payloads once each, in the seed-driven delivery
-  order (the released app duplicate is deduped). The strict final drain currently demonstrates that Bob can apply the
-  already-transported rolled-back commit and diverge from Alice.
+  order (the released app duplicate is deduped). Definite publication failure retracts the undelivered commit before
+  local rollback, so Bob remains at epoch 1 and the strict final drain observes exact equivalence.
 
 #### Chaos Class `3`: Partition Leave
 

--- a/crates/cgka-conformance-simulator/src/bus.rs
+++ b/crates/cgka-conformance-simulator/src/bus.rs
@@ -66,6 +66,7 @@ struct Inner {
     delayed: HashMap<String, Vec<InFlight>>,
     scenario_input_by_transport_id: HashMap<MessageId, ScenarioInputMetadata>,
     scenario_input_by_content_id: HashMap<MessageId, ScenarioInputMetadata>,
+    exposed_recipient_counts: HashMap<MessageId, usize>,
 }
 
 impl TransportBus {
@@ -87,6 +88,7 @@ impl TransportBus {
                 delayed: HashMap::new(),
                 scenario_input_by_transport_id: HashMap::new(),
                 scenario_input_by_content_id: HashMap::new(),
+                exposed_recipient_counts: HashMap::new(),
             })),
         }
     }
@@ -106,6 +108,50 @@ impl TransportBus {
     pub fn send(&self, sender: ClientId, msg: TransportMessage) {
         let mut inner = self.inner.lock().unwrap();
         inner.queue.push(InFlight { sender, msg });
+    }
+
+    /// Retract every still-undelivered artifact for one pending publication.
+    ///
+    /// A definite publication failure is valid only while none of the
+    /// artifacts has reached a recipient mailbox. Check that precondition
+    /// before mutating the queue or delayed sets so a caller cannot partially
+    /// retract an already-exposed publication.
+    pub(crate) fn retract_undelivered_publication(
+        &self,
+        sender: ClientId,
+        message_ids: &[MessageId],
+    ) -> Result<usize, usize> {
+        let mut inner = self.inner.lock().unwrap();
+        let delivered = message_ids
+            .iter()
+            .map(|message_id| {
+                inner
+                    .exposed_recipient_counts
+                    .get(message_id)
+                    .copied()
+                    .unwrap_or_default()
+            })
+            .sum();
+        if delivered > 0 {
+            return Err(delivered);
+        }
+
+        let queued_before = inner.queue.len();
+        inner.queue.retain(|in_flight| {
+            in_flight.sender != sender || !message_ids.contains(&in_flight.msg.id)
+        });
+        let mut retracted = queued_before - inner.queue.len();
+
+        for delayed in inner.delayed.values_mut() {
+            let delayed_before = delayed.len();
+            delayed.retain(|in_flight| {
+                in_flight.sender != sender || !message_ids.contains(&in_flight.msg.id)
+            });
+            retracted += delayed_before - delayed.len();
+        }
+        inner.delayed.retain(|_, messages| !messages.is_empty());
+
+        Ok(retracted)
     }
 
     pub(crate) fn register_scenario_input(
@@ -186,6 +232,10 @@ impl TransportBus {
                 };
                 if deliver {
                     inner.mailboxes.get_mut(cid).unwrap().push(msg.clone());
+                    *inner
+                        .exposed_recipient_counts
+                        .entry(msg.id.clone())
+                        .or_default() += 1;
                 }
             }
         }
@@ -226,7 +276,8 @@ impl TransportBus {
     pub fn inject(&self, client: ClientId, msg: TransportMessage) {
         let mut inner = self.inner.lock().unwrap();
         if let Some(mb) = inner.mailboxes.get_mut(&client) {
-            mb.push(msg);
+            mb.push(msg.clone());
+            *inner.exposed_recipient_counts.entry(msg.id).or_default() += 1;
         }
     }
 

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -66,6 +66,7 @@ pub struct HarnessClient {
     next_scenario_input_id: Option<String>,
     scenario_input_tracker: ScenarioInputTracker,
     pending_scenario_inputs: HashMap<PendingStateRef, String>,
+    pending_publication_artifacts: HashMap<PendingStateRef, Vec<MessageId>>,
     /// Shared in-memory capture of the engine's forensic audit events, used to
     /// observe decisions no `GroupEvent` exposes (e.g. `convergence_decision`).
     audit_capture: AuditCapture,
@@ -275,6 +276,7 @@ impl ClientBuilder {
             next_scenario_input_id: None,
             scenario_input_tracker: ScenarioInputTracker::default(),
             pending_scenario_inputs: HashMap::new(),
+            pending_publication_artifacts: HashMap::new(),
             audit_capture,
             convergence_checkpoints: HashMap::new(),
         }
@@ -658,6 +660,12 @@ impl HarnessClient {
                 )));
             }
         };
+        if let Some(pending) = pending {
+            self.remember_pending_publication(
+                pending,
+                welcomes.iter().map(|welcome| welcome.id.clone()),
+            );
+        }
         for w in welcomes {
             self.bus.send(self.bus_id, w);
         }
@@ -677,6 +685,7 @@ impl HarnessClient {
 
     async fn try_confirm(&mut self, pending: PendingStateRef) -> Result<(), EngineError> {
         self.engine_mut().confirm_published(pending).await?;
+        self.pending_publication_artifacts.remove(&pending);
         if let Some(scenario_id) = self.pending_scenario_inputs.remove(&pending) {
             self.scenario_input_tracker.record_confirmed(&scenario_id);
         }
@@ -687,13 +696,28 @@ impl HarnessClient {
     /// discards the staged commit and rewinds to `Stable` at the prior
     /// epoch. Used by the rollback proptest property.
     pub async fn fail(&mut self, pending: PendingStateRef) {
-        self.engine_mut()
-            .publish_failed(pending)
-            .await
-            .expect("publish_failed");
+        self.try_fail(pending).await.expect("publish_failed");
+    }
+
+    pub async fn try_fail(&mut self, pending: PendingStateRef) -> Result<(), EngineError> {
+        let message_ids = self
+            .pending_publication_artifacts
+            .get(&pending)
+            .cloned()
+            .unwrap_or_default();
+        self.bus
+            .retract_undelivered_publication(self.bus_id, &message_ids)
+            .map_err(|delivered| {
+                EngineError::Other(format!(
+                    "cannot report definite publication failure after {delivered} matching artifact(s) reached a recipient mailbox"
+                ))
+            })?;
+        self.engine_mut().publish_failed(pending).await?;
+        self.pending_publication_artifacts.remove(&pending);
         if let Some(scenario_id) = self.pending_scenario_inputs.remove(&pending) {
             self.scenario_input_tracker.record_rolled_back(&scenario_id);
         }
+        Ok(())
     }
 
     /// Issue a `SendIntent::UpgradeCapabilities` for the default group
@@ -712,10 +736,17 @@ impl HarnessClient {
                 welcomes,
                 pending,
             } => {
+                let routed = route(msg, &gid);
+                self.remember_pending_publication(
+                    pending,
+                    welcomes
+                        .iter()
+                        .map(|welcome| welcome.id.clone())
+                        .chain(std::iter::once(routed.id.clone())),
+                );
                 for w in welcomes {
                     self.bus.send(self.bus_id, w);
                 }
-                let routed = route(msg, &gid);
                 self.publish_commit_scenario_input(&routed, pending).await;
                 self.bus.send(self.bus_id, routed);
                 pending
@@ -746,6 +777,7 @@ impl HarnessClient {
                     "group-data update should not create welcomes"
                 );
                 let routed = route(msg, &gid);
+                self.remember_pending_publication(pending, std::iter::once(routed.id.clone()));
                 self.publish_commit_scenario_input(&routed, pending).await;
                 self.bus.send(self.bus_id, routed);
                 pending
@@ -781,6 +813,7 @@ impl HarnessClient {
                     "admin policy update should not create welcomes"
                 );
                 let routed = route(msg, &gid);
+                self.remember_pending_publication(pending, std::iter::once(routed.id.clone()));
                 self.publish_commit_scenario_input(&routed, pending).await;
                 self.bus.send(self.bus_id, routed);
                 Ok(pending)
@@ -937,10 +970,17 @@ impl HarnessClient {
                 // Send welcomes before the commit so new members join via
                 // welcome and only then classify the commit echo as
                 // AlreadyAtEpoch.
+                let routed = route(msg, &gid);
+                self.remember_pending_publication(
+                    pending,
+                    welcomes
+                        .iter()
+                        .map(|welcome| welcome.id.clone())
+                        .chain(std::iter::once(routed.id.clone())),
+                );
                 for w in welcomes {
                     self.bus.send(self.bus_id, w);
                 }
-                let routed = route(msg, &gid);
                 self.publish_commit_scenario_input(&routed, pending).await;
                 self.bus.send(self.bus_id, routed);
                 Ok(pending)
@@ -1438,6 +1478,17 @@ impl HarnessClient {
     ) {
         self.pending_scenario_inputs
             .insert(pending, metadata.scenario_id.clone());
+    }
+
+    fn remember_pending_publication(
+        &mut self,
+        pending: PendingStateRef,
+        message_ids: impl IntoIterator<Item = MessageId>,
+    ) {
+        self.pending_publication_artifacts
+            .entry(pending)
+            .or_default()
+            .extend(message_ids);
     }
 
     /// Return a clone of `msg` whose payload is the peeled MLS wire bytes.

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -328,16 +328,13 @@ fn convergence_chaos_rollback_queue_faults(
     rng: &mut StdRng,
     case_index: u64,
 ) -> (ScenarioSpec, Vec<TraceExpectation>) {
-    // After alice's group-data update rolls back, alice's own commit stays on
-    // the bus queue (FailPending only retracts the local pending state) and bob
-    // sends several app messages behind it. Drive the delivery schedule of those
-    // app messages from the seed so distinct seeds exercise distinct adversarial
-    // orderings of the post-rollback queue, not just a different payload string.
+    // A definite publish failure retracts alice's undelivered group-data commit
+    // before rolling back local pending state. Bob then sends several app
+    // messages. Drive their delivery schedule from the seed so distinct seeds
+    // exercise distinct adversarial orderings, not just a different payload
+    // string.
     // FIFO delivery makes the observed payload order the permuted queue order,
-    // so recompute the expectation from the same permutation. The rolled-back
-    // commit is pinned at queue head so the duplicate/delay/release still pins
-    // dedup of the redelivered commit across the rollback (the shape's reason
-    // for existing) regardless of the seeded app order.
+    // so recompute the expectation from the same permutation.
     let payloads = (0..6)
         .map(|index| format!("bob-after-rollback-{case_index}-{index}"))
         .collect::<Vec<_>>();
@@ -346,11 +343,7 @@ fn convergence_chaos_rollback_queue_faults(
         .iter()
         .map(|index| payloads[*index].clone())
         .collect::<Vec<_>>();
-    // Full-queue permutation: the rolled-back commit stays at index 0, the app
-    // messages (queue indices 1..) are permuted per the seed.
-    let order = std::iter::once(0)
-        .chain(app_order.iter().map(|index| index + 1))
-        .collect::<Vec<_>>();
+    let order = app_order.clone();
 
     let mut steps = vec![
         create_group(
@@ -381,13 +374,12 @@ fn convergence_chaos_rollback_queue_faults(
     }
     // Seed-driven delivery schedule for the post-rollback messages.
     steps.push(ScenarioStep::ReorderQueued { order });
-    // Duplicate the first post-rollback app message, not the rolled-back commit
-    // pinned at queue head. The original reaches alice in the first delivery
-    // pass; the delayed copy is released and ticked separately, so this shape
-    // exercises duplicate app-message handling under a rollback-tainted queue.
-    steps.push(ScenarioStep::DuplicateQueued { index: 1 });
+    // The original reaches alice in the first delivery pass; the delayed copy
+    // is released and ticked separately, so this shape exercises duplicate
+    // app-message handling after a definite publish rollback.
+    steps.push(ScenarioStep::DuplicateQueued { index: 0 });
     steps.push(ScenarioStep::DelayQueued {
-        index: 2,
+        index: 1,
         delayed: "duplicate-app".into(),
     });
     steps.push(ScenarioStep::DeliverAll);

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -514,8 +514,17 @@ impl ConvergenceSubject for EngineHarnessSubject {
     }
 
     async fn fail_pending(&mut self, client: &str, pending: &str) -> Result<(), SubjectError> {
-        let pending_ref = self.take_pending(pending)?;
-        self.client_mut(client)?.fail(pending_ref).await;
+        let pending_ref = self.pending_refs.get(pending).cloned().ok_or_else(|| {
+            SubjectError::new(
+                "unknown_pending",
+                format!("unknown pending label {pending}"),
+            )
+        })?;
+        self.client_mut(client)?
+            .try_fail(pending_ref)
+            .await
+            .map_err(subject_engine_error)?;
+        self.pending_refs.remove(pending);
         Ok(())
     }
 

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -1006,6 +1006,173 @@ async fn scenario_spec_supports_publish_fail() {
 }
 
 #[tokio::test]
+async fn definite_publish_failure_retracts_commit_before_local_rollback() {
+    let spec = ScenarioSpec {
+        name: "transported-commit-after-local-rollback/minimal/v1".into(),
+        spec_version: "1".into(),
+        clients: vec!["alice".into(), "bob".into()],
+        steps: vec![
+            ScenarioStep::CreateGroup {
+                creator: "alice".into(),
+                name: "before".into(),
+                invitees: vec!["bob".into()],
+                required_features: vec![],
+                initial_admins: None,
+                pending: "create".into(),
+            },
+            ScenarioStep::ConfirmPending {
+                client: "alice".into(),
+                pending: "create".into(),
+            },
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            ScenarioStep::UpdateGroupData {
+                client: "alice".into(),
+                name: "after".into(),
+                pending: "update".into(),
+            },
+            ScenarioStep::FailPending {
+                client: "alice".into(),
+                pending: "update".into(),
+            },
+            ScenarioStep::DeliverAll,
+            ScenarioStep::Tick {
+                clients: vec!["bob".into()],
+            },
+            ScenarioStep::ObserveExact {
+                clients: vec!["alice".into(), "bob".into()],
+            },
+        ],
+    };
+
+    let report = run_scenario_report_with_outcomes(
+        &spec,
+        None,
+        vec![
+            TraceExpectation::PendingResolution {
+                step_index: 1,
+                client: "alice".into(),
+                pending: "create".into(),
+                resolution: "confirmed".into(),
+            },
+            TraceExpectation::PendingResolution {
+                step_index: 5,
+                client: "alice".into(),
+                pending: "update".into(),
+                resolution: "rolled_back".into(),
+            },
+            TraceExpectation::ClientsExactlyEquivalent {
+                clients: vec!["alice".into(), "bob".into()],
+            },
+            TraceExpectation::NoPendingWork {
+                clients: vec!["alice".into(), "bob".into()],
+            },
+        ],
+    )
+    .await
+    .expect("definite-failure scenario reports");
+
+    assert!(
+        report.expectation_failures.is_empty(),
+        "definite failure must leave no transported commit: {:?}",
+        report.expectation_failures
+    );
+    let trace = report.observed_trace.as_ref().expect("observed trace");
+    assert!(
+        trace
+            .observations
+            .iter()
+            .all(|observation| observation.epoch == 1),
+        "both clients must remain at the pre-publish epoch"
+    );
+    let bob = trace
+        .observations
+        .iter()
+        .find(|observation| observation.client == "bob")
+        .expect("bob observation");
+    assert!(
+        bob.scenario_input_ledger.is_empty(),
+        "bob must never observe the retracted commit"
+    );
+}
+
+#[tokio::test]
+async fn definite_publish_failure_retracts_commit_and_welcome() {
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice")).attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob")).attach(&bus);
+    let mut carol = ClientBuilder::new(pad32(b"carol")).attach(&bus);
+    let (_group_id, create_pending) = alice
+        .create_group(
+            "retract-invite-artifacts",
+            vec![bob.fresh_key_package().await],
+            vec![],
+        )
+        .await;
+    alice.confirm(create_pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+
+    let invite_pending = alice.invite(vec![carol.fresh_key_package().await]).await;
+    assert_eq!(bus.queued_len(), 2, "invite commit and Welcome are queued");
+    assert!(
+        bus.delay_queued(0, "pending-welcome"),
+        "hold the Welcome in the delayed set"
+    );
+    alice.fail(invite_pending).await;
+    assert_eq!(
+        bus.queued_len(),
+        0,
+        "definite failure must retract the complete publication"
+    );
+    assert!(
+        !bus.release_delayed("pending-welcome"),
+        "definite failure must retract delayed publication artifacts too"
+    );
+    bus.deliver_all();
+    carol.tick().await;
+    assert_eq!(alice.epoch(), EpochId(1));
+    assert_eq!(alice.members().len(), 2);
+}
+
+#[tokio::test]
+async fn fail_pending_rejects_artifact_that_already_reached_a_recipient() {
+    let bus = TransportBus::ordered();
+    let mut alice = ClientBuilder::new(pad32(b"alice")).attach(&bus);
+    let mut bob = ClientBuilder::new(pad32(b"bob")).attach(&bus);
+    let (_group_id, create_pending) = alice
+        .create_group(
+            "ambiguous-exposure-guard",
+            vec![bob.fresh_key_package().await],
+            vec![],
+        )
+        .await;
+    alice.confirm(create_pending).await;
+    bus.deliver_all();
+    bob.tick().await;
+
+    let pending = alice.update_group_data("after").await;
+    bus.deliver_all();
+    bob.tick().await;
+    let error = alice
+        .try_fail(pending)
+        .await
+        .expect_err("mailbox exposure is not a definite failure");
+    assert!(
+        error.to_string().contains("reached a recipient mailbox"),
+        "unexpected error: {error}"
+    );
+
+    alice.confirm(pending).await;
+    assert_eq!(alice.epoch(), EpochId(2));
+    assert_eq!(bob.epoch(), EpochId(2));
+    assert_eq!(alice.group_name(), "after");
+    assert_eq!(bob.group_name(), "after");
+}
+
+#[tokio::test]
 async fn scenario_spec_supports_leave_and_clear_partition() {
     let spec = ScenarioSpec {
         name: "leave-and-clear-partition/v1".into(),
@@ -1635,8 +1802,8 @@ async fn convergence_chaos_family_seed_changes_scenarios() {
 #[tokio::test]
 async fn convergence_chaos_rollback_fault_duplicates_post_rollback_app_message() {
     // Regression for mdk#163: the rollback arm must duplicate and delay
-    // a Bob app message that Alice actually ticks, not the rolled-back commit
-    // pinned at queue index 0 and addressed to Bob.
+    // a Bob app message that Alice actually ticks. The definitely failed
+    // group-data commit must already have been retracted from the bus.
     let cases = generate_convergence_chaos_family(123, 3);
     let case = &cases[2];
 
@@ -1649,10 +1816,7 @@ async fn convergence_chaos_rollback_fault_duplicates_post_rollback_app_message()
             _ => None,
         })
         .expect("rollback arm should duplicate a queued message");
-    assert_eq!(
-        duplicate_index, 1,
-        "queue index 0 is Alice's rolled-back commit to Bob; duplicate the first post-rollback app message instead",
-    );
+    assert_eq!(duplicate_index, 0);
 
     let delayed_copy = case
         .scenario
@@ -1663,10 +1827,9 @@ async fn convergence_chaos_rollback_fault_duplicates_post_rollback_app_message()
             _ => None,
         })
         .expect("rollback arm should delay the duplicate copy");
-    assert_eq!(delayed_copy, (2, "duplicate-app"));
+    assert_eq!(delayed_copy, (1, "duplicate-app"));
 
-    let baseline_case = without_strict_reliability_outcomes(case.clone());
-    let report = run_generated_case_report(&baseline_case, None)
+    let report = run_generated_case_report(case, None)
         .await
         .expect("rollback duplicate-app case reports");
     assert!(
@@ -1692,18 +1855,20 @@ async fn convergence_chaos_rollback_fault_duplicates_post_rollback_app_message()
 #[tokio::test]
 async fn strict_chaos_boundary_retains_known_reliability_failures() {
     let cases = generate_convergence_chaos_family(123, 5);
-    let expected_failures = [
-        (
-            2usize,
-            "clients_not_exactly_equivalent",
-            "rolled-back transported commit",
-        ),
-        (
-            4usize,
-            "pending_work_remaining",
-            "pre-join deferred application object",
-        ),
-    ];
+    let expected_failures = [(
+        4usize,
+        "pending_work_remaining",
+        "pre-join deferred application object",
+    )];
+
+    let repaired = run_generated_case_report(&cases[2], None)
+        .await
+        .expect("repaired rollback case reports");
+    assert!(
+        repaired.expectation_failures.is_empty(),
+        "definite publish rollback must retract transport artifacts before the strict drain: {:?}",
+        repaired.expectation_failures
+    );
 
     for (case_index, failure_kind, description) in expected_failures {
         let report = run_generated_case_report(&cases[case_index], None)

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -420,20 +420,20 @@ operational-semantics and adapter-refinement acceptance criteria tracked in
 campaign/process expansion relies on equivalence across adapters.
 
 The strict campaign migration deliberately exposed three pre-existing reliability failures that the legacy observation
-point hid:
+point hid. The transported-commit case is now resolved by making simulator `FailPending` mean definite
+non-publication: it atomically retracts every matching undelivered commit/Welcome before local rollback and refuses the
+operation after any artifact reaches a recipient mailbox. Two engine-state failures remain:
 
-1. a locally rolled-back but already transported group-data commit can later advance another member, splitting exact
-   state after the final mailbox drain;
-2. a member invited after an old application event can retain that pre-join object as transport/scenario-input pending
+1. a member invited after an old application event can retain that pre-join object as transport/scenario-input pending
    work;
-3. after self-remove convergence, selected remaining members can retain a created proposal row and valid-proposal
+2. after self-remove convergence, selected remaining members can retain a created proposal row and valid-proposal
    schedule signal.
 
 These remain red strict-campaign evidence, not relaxed oracle rules. The ordinary generated-family regression tests keep
 checking their original semantic observation windows and explicitly retain the leave pending-work sentinel; report
 campaigns run the complete strict expectations by default. Strict coverage also flags the mixed large storm because its
 application phase is cleared before any delivery-or-invalidation expectation accounts for it; that is an oracle coverage
-gap, distinct from the three engine-state failures.
+gap, distinct from the two remaining engine-state failures.
 
 ### 1.2 Public subject boundary
 
@@ -771,3 +771,4 @@ incorrect result.
 | 2026-07-30 | 1.1 terminal disband projection | Added a shared-fact-only canonical tombstone projection; terminal state passes exact/no-pending observation across restart, while device-local authorship and roster ordering cannot split equality | `cargo test -p cgka-conformance-simulator exact_oracle_projects_terminal_disband_tombstone_across_restart`; `cargo test -p cgka-engine --features test-conformance-snapshot disband_projection_excludes_device_local_authorship_and_canonicalizes_roster` |
 | 2026-07-30 | 1.1 strict reliability campaigns | Made report oracle coverage strict by default, added `--allow-weak-oracle`, and appended final global drain/exact/no-pending checks to send-leave and chaos cases. The stronger boundary exposed rollback divergence, pre-join deferred work, unretired leave proposal work, and an unasserted mixed-storm application phase rather than masking them | `strict_chaos_boundary_retains_known_reliability_failures`; focused generator/report tests; generated JSON reports |
 | 2026-07-30 | 1.2a public convergence subject | Extracted scenario execution behind a capability-declared `ConvergenceSubject`, added the in-process engine adapter, separated queue/partition mutation behind `ConvergenceFaultSubject`, rejected unsupported scenarios before actions, and recorded adapter identity/capabilities in reports | Subject preflight/fault-classification tests; default-versus-explicit engine subject trace equivalence; report metadata test |
+| 2026-07-30 | 1.1 definite publish-failure semantics | Minimized the transported-commit rollback split to nine steps; made simulator `FailPending` retract the complete undelivered commit/Welcome artifact set and reject artifacts that already reached any recipient, restoring strict exact equivalence without changing production lifecycle behavior | `definite_publish_failure_retracts_commit_before_local_rollback`; `definite_publish_failure_retracts_commit_and_welcome`; `fail_pending_rejects_artifact_that_already_reached_a_recipient`; full simulator suite |


### PR DESCRIPTION
## Summary

- retract every undelivered artifact belonging to a simulator publication before applying `FailPending`
- reject definite-failure rollback after any commit or Welcome has reached a recipient, preserving the pending state for confirmation
- make the transported-commit-after-local-rollback strict-oracle case deterministic and green
- document the simulator fault boundary and retain the two unrelated engine-state chaos failures

## Root cause

The conformance simulator modeled `FailPending` as a local engine rollback only. The associated commit remained queued (or delayed) on the simulated transport, so a peer could subsequently ingest a commit that the sender had already rolled back. Production publication lifecycle code already distinguishes acknowledged acceptance, definite zero-acceptance failure, and ambiguous exposure; the failure was in simulator fault semantics rather than the engine publish lifecycle.

## Protocol implications

A definite publication failure may roll back only when the harness can establish that no publication artifact reached a recipient. Once exposure is possible, treating publication as definitely failed is unsafe: peers may already have advanced, so the sender must retain pending state for confirmation/reconciliation.

## Validation

- `cargo test -p cgka-conformance-simulator`
- `cargo fmt --all -- --check`
- `git diff --check`

No production engine, transport-adapter, or account-runtime behavior is changed.