### PR TITLE
Enforce per-account session ownership

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -24,6 +24,12 @@ versioning through the workspace version in the root `Cargo.toml`.
   
 ### Fixed
 
+- `MarmotApp` now permits only one live in-memory engine session per account
+  across direct clients and managed workers. Concurrent opens return the typed
+  `AccountSessionBusy` error, and worker reconnect drops the failed session
+  before reopening, preventing two engines over one session database from
+  staging conflicting epoch work.
+
 - Group state changes settle promptly again when messages are queued for
   sending: a queued ordinary message no longer delays the next convergence
   pass (only an admin group-state change may briefly hold that boundary, as

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -67,6 +67,8 @@ pub(crate) use sync::is_own_relay_echo;
 pub struct AppClient {
     pub(crate) app: MarmotApp,
     pub(crate) runtime: AppRuntime,
+    // Struct fields drop in declaration order. Keep the engine-owning runtime
+    // before this guard so ownership is released only after engine teardown.
     pub(crate) _session_guard: crate::AppAccountSessionGuard,
     pub(crate) adapter: MarmotRelayPlaneAccountAdapter,
     pub(crate) routing: AppTransportRouting,

--- a/crates/marmot-app/src/client/mod.rs
+++ b/crates/marmot-app/src/client/mod.rs
@@ -67,6 +67,7 @@ pub(crate) use sync::is_own_relay_echo;
 pub struct AppClient {
     pub(crate) app: MarmotApp,
     pub(crate) runtime: AppRuntime,
+    pub(crate) _session_guard: crate::AppAccountSessionGuard,
     pub(crate) adapter: MarmotRelayPlaneAccountAdapter,
     pub(crate) routing: AppTransportRouting,
     pub(crate) relay_plane: MarmotRelayPlane,

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -590,6 +590,7 @@ fn read_marker_error_code(error: &AppError) -> &'static str {
         AppError::SqlcipherKeyDerivation(_) => "read_marker_failed:sqlcipher_key_derivation",
         AppError::BlockingTask(_) => "read_marker_failed:blocking_task",
         AppError::RuntimeBusy => "read_marker_failed:runtime_busy",
+        AppError::AccountSessionBusy => "read_marker_failed:account_session_busy",
         AppError::RuntimeStopping => "read_marker_failed:runtime_stopping",
         AppError::ReactionNotFound => "read_marker_failed:reaction_not_found",
         AppError::TransportClosed => "read_marker_failed:transport_closed",

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -115,6 +115,10 @@ pub enum AppError {
     /// iOS notification extension can take its bounded fallback path.
     #[error("marmot runtime root is already in use")]
     RuntimeBusy,
+    /// Another [`crate::AppClient`] from this [`crate::MarmotApp`] currently
+    /// owns the account's in-memory engine session.
+    #[error("marmot account session is already in use")]
+    AccountSessionBusy,
     #[error("marmot runtime is shutting down")]
     RuntimeStopping,
     #[error("no matching reaction by this account to retract")]
@@ -195,6 +199,7 @@ impl AppError {
             Self::SqlcipherKeyDerivation(_) => "sqlcipher_key_derivation",
             Self::BlockingTask(_) => "blocking_task",
             Self::RuntimeBusy => "runtime_busy",
+            Self::AccountSessionBusy => "account_session_busy",
             Self::RuntimeStopping => "runtime_stopping",
             Self::ReactionNotFound => "reaction_not_found",
             Self::TransportClosed => "transport_closed",

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -440,6 +440,7 @@ pub struct MarmotApp {
     config: MarmotAppConfig,
     directory_sync: Arc<RwLock<Option<DirectorySyncHandle>>>,
     account_storages: Arc<Mutex<HashMap<String, SqliteAccountStorage>>>,
+    account_session_owners: Arc<Mutex<HashSet<String>>>,
     directory_caches: Arc<Mutex<HashMap<String, DirectoryCache>>>,
     legacy_directory_cache_checked: Arc<Mutex<bool>>,
     #[cfg(test)]
@@ -971,10 +972,25 @@ struct KeyPackageRecord {
 
 struct OpenAppAccount {
     runtime: AppRuntime,
+    session_guard: AppAccountSessionGuard,
     adapter: MarmotRelayPlaneAccountAdapter,
     routing: AppTransportRouting,
     state: AccountState,
     signer: Arc<dyn nostr::NostrSigner>,
+}
+
+struct AppAccountSessionGuard {
+    label: String,
+    owners: Arc<Mutex<HashSet<String>>>,
+}
+
+impl Drop for AppAccountSessionGuard {
+    fn drop(&mut self) {
+        self.owners
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&self.label);
+    }
 }
 
 impl MarmotApp {
@@ -1109,6 +1125,7 @@ impl MarmotApp {
             config,
             directory_sync: Arc::new(RwLock::new(None)),
             account_storages: Arc::new(Mutex::new(HashMap::new())),
+            account_session_owners: Arc::new(Mutex::new(HashSet::new())),
             directory_caches: Arc::new(Mutex::new(HashMap::new())),
             legacy_directory_cache_checked: Arc::new(Mutex::new(false)),
             #[cfg(test)]
@@ -1169,6 +1186,7 @@ impl MarmotApp {
             config,
             directory_sync: Arc::new(RwLock::new(None)),
             account_storages: Arc::new(Mutex::new(HashMap::new())),
+            account_session_owners: Arc::new(Mutex::new(HashSet::new())),
             directory_caches: Arc::new(Mutex::new(HashMap::new())),
             legacy_directory_cache_checked: Arc::new(Mutex::new(false)),
             #[cfg(test)]
@@ -1217,6 +1235,12 @@ impl MarmotApp {
             .contains_key(label)
     }
 
+    /// Open the account's exclusive in-memory engine session.
+    ///
+    /// Only one [`AppClient`] for an account may exist within a [`MarmotApp`]
+    /// (including its clones and managed runtime workers). A concurrent open
+    /// returns [`AppError::AccountSessionBusy`]. Drop the owning client before
+    /// retrying.
     pub async fn client(&self, label: &str) -> Result<AppClient, AppError> {
         #[cfg(test)]
         let relay_plane = self
@@ -1289,6 +1313,7 @@ impl MarmotApp {
         let mut client = AppClient {
             app: self.clone(),
             runtime: open.runtime,
+            _session_guard: open.session_guard,
             adapter: open.adapter,
             routing: open.routing,
             relay_plane: relay_plane.clone(),
@@ -2591,6 +2616,7 @@ impl MarmotApp {
         label: &str,
         relay_plane: &MarmotRelayPlane,
     ) -> Result<OpenAppAccount, AppError> {
+        let session_guard = self.acquire_account_session(label)?;
         let state = self.load_state(label)?;
         let account = self.account_home().account(label)?;
         let signer = self.account_signer_for_summary(&account)?;
@@ -2672,10 +2698,25 @@ impl MarmotApp {
             AccountDeviceRuntime::new(session, adapter.clone(), routing.clone(), key_packages);
         Ok(OpenAppAccount {
             runtime,
+            session_guard,
             adapter,
             routing,
             state,
             signer: nostr_signer,
+        })
+    }
+
+    fn acquire_account_session(&self, label: &str) -> Result<AppAccountSessionGuard, AppError> {
+        let mut owners = self
+            .account_session_owners
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !owners.insert(label.to_owned()) {
+            return Err(AppError::AccountSessionBusy);
+        }
+        Ok(AppAccountSessionGuard {
+            label: label.to_owned(),
+            owners: self.account_session_owners.clone(),
         })
     }
 

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -1295,7 +1295,9 @@ impl MarmotApp {
         lifecycle: Option<runtime::RuntimeLifecycle>,
     ) -> Result<AppClient, AppError> {
         let app = self.clone();
-        let label = label.to_owned();
+        // Resolve every supported account ref before touching label-keyed
+        // caches or the session-owner registry.
+        let label = self.account_home().account(label)?.label;
         let relay_plane_for_open = relay_plane.clone();
         let permit = lifecycle
             .as_ref()
@@ -2616,9 +2618,12 @@ impl MarmotApp {
         label: &str,
         relay_plane: &MarmotRelayPlane,
     ) -> Result<OpenAppAccount, AppError> {
+        let account = self.account_home().account(label)?;
+        // Account refs may be labels, hex pubkeys, or npubs. Ownership is keyed
+        // by the canonical stored label so aliases cannot open a second engine.
+        let label = account.label.as_str();
         let session_guard = self.acquire_account_session(label)?;
         let state = self.load_state(label)?;
-        let account = self.account_home().account(label)?;
         let signer = self.account_signer_for_summary(&account)?;
         let account_id = MemberId::new(hex::decode(&account.account_id_hex)?);
         let nostr_signer = signer.as_nostr_signer();

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -43,11 +43,6 @@ pub(crate) struct ManagedAccountWorker {
 }
 
 impl ManagedAccountWorker {
-    pub(crate) fn stop(self) {
-        let _ = self.shutdown.send(());
-        self.handle.abort();
-    }
-
     pub(crate) async fn shutdown(self) {
         self.shutdown_with_timeout(APP_RUNTIME_ACCOUNT_SHUTDOWN_WAIT)
             .await;
@@ -74,7 +69,11 @@ impl ManagedAccountWorker {
                     "managed account worker shutdown timed out; aborting",
                 );
                 handle.abort();
-                let _ = timeout(Duration::from_millis(250), &mut handle).await;
+                // Reaping is the ownership handoff: the task owns AppClient,
+                // whose drop releases the account-session guard. Do not return
+                // until cancellation has run its destructors, or a replacement
+                // worker could race the still-live engine.
+                let _ = handle.await;
             }
         }
     }
@@ -383,7 +382,7 @@ pub(crate) fn spawn_app_runtime_account_worker(
     runtime: AccountWorkerRuntime,
     command_tx: mpsc::Sender<AccountWorkerCommand>,
     commands: mpsc::Receiver<AccountWorkerCommand>,
-    ready: oneshot::Sender<Result<(), String>>,
+    ready: oneshot::Sender<Result<(), AppError>>,
     shutdown: oneshot::Receiver<()>,
 ) -> JoinHandle<()> {
     tokio::spawn(run_app_runtime_account_worker(
@@ -395,7 +394,7 @@ async fn run_app_runtime_account_worker(
     runtime: AccountWorkerRuntime,
     command_tx: mpsc::Sender<AccountWorkerCommand>,
     mut commands: mpsc::Receiver<AccountWorkerCommand>,
-    ready: oneshot::Sender<Result<(), String>>,
+    ready: oneshot::Sender<Result<(), AppError>>,
     mut shutdown: oneshot::Receiver<()>,
 ) {
     let mut ready = Some(ready);
@@ -412,13 +411,17 @@ async fn run_app_runtime_account_worker(
     let mut client = match tokio::select! {
         _ = &mut shutdown => {
             if let Some(ready) = ready.take() {
-                let _ = ready.send(Err("runtime startup cancelled".into()));
+                let _ = ready.send(Err(AppError::BlockingTask(
+                    "runtime startup cancelled".into(),
+                )));
             }
             return;
         }
         _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => {
             if let Some(ready) = ready.take() {
-                let _ = ready.send(Err("runtime startup cancelled".into()));
+                let _ = ready.send(Err(AppError::BlockingTask(
+                    "runtime startup cancelled".into(),
+                )));
             }
             return;
         }
@@ -434,7 +437,7 @@ async fn run_app_runtime_account_worker(
                 message.clone(),
             );
             if let Some(ready) = ready.take() {
-                let _ = ready.send(Err(message));
+                let _ = ready.send(Err(err));
             }
             return;
         }
@@ -473,7 +476,7 @@ async fn run_app_runtime_account_worker(
                 message.clone(),
             );
             if let Some(ready) = ready.take() {
-                let _ = ready.send(Err(message));
+                let _ = ready.send(Err(err));
             }
             return;
         }
@@ -633,7 +636,7 @@ async fn run_app_runtime_account_worker(
     let mut maintenance_tick = interval(Duration::from_secs(15));
     maintenance_tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-    loop {
+    'worker: loop {
         tokio::select! {
             biased;
             _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => {
@@ -790,18 +793,35 @@ async fn run_app_runtime_account_worker(
                             &account_label,
                             account_error_message("runtime receive failed", &err),
                         );
-                        tokio::select! {
-                            _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
-                            _ = &mut shutdown => return,
-                            _ = sleep(reconnect_backoff.next_delay()) => {}
-                        }
                         // The account-session ownership guard is held by
-                        // `AppClient`.
-                        // Destroy the failed engine before attempting to
-                        // hydrate its replacement; otherwise reconnect would
-                        // create two independent engines over one session DB.
+                        // `AppClient`. Destroy the failed engine before the
+                        // backoff as well as before hydrating its replacement;
+                        // this leaves room for a one-shot client during a
+                        // prolonged transport outage.
                         drop(client);
                         client = loop {
+                            let mut retry_delay =
+                                std::pin::pin!(sleep(reconnect_backoff.next_delay()));
+                            loop {
+                                tokio::select! {
+                                    _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
+                                    _ = &mut shutdown => return,
+                                    _ = &mut retry_delay => break,
+                                    command = commands.recv() => {
+                                        match command {
+                                            // There is deliberately no engine
+                                            // session during this backoff.
+                                            // Poll the bounded channel and
+                                            // reject callers promptly by
+                                            // dropping their response sender
+                                            // instead of letting the queue fill
+                                            // until host-side timeouts fire.
+                                            Some(command) => drop(command),
+                                            None => return,
+                                        }
+                                    }
+                                }
+                            }
                             match tokio::select! {
                                 _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
                                 _ = &mut shutdown => return,
@@ -829,11 +849,6 @@ async fn run_app_runtime_account_worker(
                                                 &transport_err,
                                             ),
                                         );
-                                        tokio::select! {
-                                            _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
-                                            _ = &mut shutdown => return,
-                                            _ = sleep(reconnect_backoff.next_delay()) => {}
-                                        }
                                         drop(reopened);
                                         continue;
                                     }
@@ -880,11 +895,6 @@ async fn run_app_runtime_account_worker(
                                         &account_label,
                                         account_error_message("runtime restart failed", &setup_err),
                                     );
-                                    tokio::select! {
-                                        _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
-                                        _ = &mut shutdown => return,
-                                        _ = sleep(reconnect_backoff.next_delay()) => {}
-                                    }
                                 }
                             }
                         };
@@ -892,6 +902,7 @@ async fn run_app_runtime_account_worker(
                             &mut scheduled_convergence,
                             &mut client,
                         );
+                        continue 'worker;
                     }
                 }
             }

--- a/crates/marmot-app/src/runtime/account_worker.rs
+++ b/crates/marmot-app/src/runtime/account_worker.rs
@@ -795,92 +795,103 @@ async fn run_app_runtime_account_worker(
                             _ = &mut shutdown => return,
                             _ = sleep(reconnect_backoff.next_delay()) => {}
                         }
-                        match tokio::select! {
-                            _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
-                            _ = &mut shutdown => return,
-                            result = app.runtime_local_client(&account_label, &relay_plane, lifecycle.clone()) => result,
-                        } {
-                            Ok(mut reopened) => {
-                                // Reconnect restores transport activation and
-                                // subscriptions, then resumes the live receive
-                                // tail. Do not block the command loop on a full
-                                // catch-up; the maintenance path performs
-                                // bounded repair syncs when required.
-                                let prepare_transport = tokio::select! {
-                                    _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
-                                    _ = &mut shutdown => return,
-                                    result = reopened.prepare_transport() => result,
-                                };
-                                if let Err(transport_err) = prepare_transport {
+                        // The account-session ownership guard is held by
+                        // `AppClient`.
+                        // Destroy the failed engine before attempting to
+                        // hydrate its replacement; otherwise reconnect would
+                        // create two independent engines over one session DB.
+                        drop(client);
+                        client = loop {
+                            match tokio::select! {
+                                _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
+                                _ = &mut shutdown => return,
+                                result = app.runtime_local_client(&account_label, &relay_plane, lifecycle.clone()) => result,
+                            } {
+                                Ok(mut reopened) => {
+                                    // Reconnect restores transport activation
+                                    // and subscriptions, then resumes the live
+                                    // receive tail. Do not block the command
+                                    // loop on a full catch-up; the maintenance
+                                    // path performs bounded repair syncs when
+                                    // required.
+                                    let prepare_transport = tokio::select! {
+                                        _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
+                                        _ = &mut shutdown => return,
+                                        result = reopened.prepare_transport() => result,
+                                    };
+                                    if let Err(transport_err) = prepare_transport {
+                                        publish_app_runtime_account_error(
+                                            &events,
+                                            &account_id_hex,
+                                            &account_label,
+                                            account_error_message(
+                                                "runtime restart transport failed",
+                                                &transport_err,
+                                            ),
+                                        );
+                                        tokio::select! {
+                                            _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
+                                            _ = &mut shutdown => return,
+                                            _ = sleep(reconnect_backoff.next_delay()) => {}
+                                        }
+                                        drop(reopened);
+                                        continue;
+                                    }
+                                    app.finish_client_open_network_maintenance(&mut reopened)
+                                        .await;
+                                    match reopened.drain_pending_session_events().await {
+                                        Ok(summary) => {
+                                            publish_app_runtime_summary(
+                                                &events,
+                                                &account_id_hex,
+                                                &account_label,
+                                                &summary,
+                                            );
+                                        }
+                                        Err(error) => {
+                                            publish_app_runtime_account_error(
+                                                &events,
+                                                &account_id_hex,
+                                                &account_label,
+                                                account_error_message(
+                                                    "runtime restart queued-work wake failed",
+                                                    &error,
+                                                ),
+                                            );
+                                        }
+                                    }
+                                    let pending = reopened
+                                        .retry_pending_push_registration_shares_best_effort()
+                                        .await;
+                                    scheduled_push_retry
+                                        .schedule_after_attempt(pending, &command_tx);
+                                    publish_client_pending_applied_summary(
+                                        &mut reopened,
+                                        &events,
+                                        &account_id_hex,
+                                        &account_label,
+                                    );
+                                    break reopened;
+                                }
+                                Err(setup_err) => {
                                     publish_app_runtime_account_error(
                                         &events,
                                         &account_id_hex,
                                         &account_label,
-                                        account_error_message(
-                                            "runtime restart transport failed",
-                                            &transport_err,
-                                        ),
+                                        account_error_message("runtime restart failed", &setup_err),
                                     );
                                     tokio::select! {
                                         _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
                                         _ = &mut shutdown => return,
                                         _ = sleep(reconnect_backoff.next_delay()) => {}
                                     }
-                                    continue;
-                                }
-                                app.finish_client_open_network_maintenance(&mut reopened)
-                                    .await;
-                                match reopened.drain_pending_session_events().await {
-                                    Ok(summary) => {
-                                        publish_app_runtime_summary(
-                                            &events,
-                                            &account_id_hex,
-                                            &account_label,
-                                            &summary,
-                                        );
-                                    }
-                                    Err(error) => {
-                                        publish_app_runtime_account_error(
-                                            &events,
-                                            &account_id_hex,
-                                            &account_label,
-                                            account_error_message(
-                                                "runtime restart queued-work wake failed",
-                                                &error,
-                                            ),
-                                        );
-                                    }
-                                }
-                                let pending = reopened
-                                    .retry_pending_push_registration_shares_best_effort()
-                                    .await;
-                                scheduled_push_retry.schedule_after_attempt(pending, &command_tx);
-                                publish_client_pending_applied_summary(
-                                    &mut reopened,
-                                    &events,
-                                    &account_id_hex,
-                                    &account_label,
-                                );
-                                client = reopened;
-                                schedule_pending_convergence_groups(
-                                    &mut scheduled_convergence,
-                                    &mut client,
-                                );
-                            }
-                            Err(setup_err) => {
-                                publish_app_runtime_account_error(
-                                    &events,
-                                    &account_id_hex,
-                                    &account_label,
-                                    account_error_message("runtime restart failed", &setup_err),
-                                );
-                                tokio::select! {
-                                    _ = wait_for_runtime_shutdown(&mut lifecycle_shutdown) => return,
-                                    _ = &mut shutdown => return,
-                                    _ = sleep(reconnect_backoff.next_delay()) => {}
                                 }
                             }
-                        }
+                        };
+                        schedule_pending_convergence_groups(
+                            &mut scheduled_convergence,
+                            &mut client,
+                        );
                     }
                 }
             }

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -3356,7 +3356,7 @@ impl AccountManager {
                 .map(|account| account.account_id_hex.clone())
                 .collect::<HashSet<_>>();
 
-            let existing_account_ids = {
+            let (existing_account_ids, stale_workers) = {
                 let mut workers = self.workers.lock().await;
                 let stale_account_ids = workers
                     .iter()
@@ -3368,13 +3368,20 @@ impl AccountManager {
                         }
                     })
                     .collect::<Vec<_>>();
-                for account_id in stale_account_ids {
-                    if let Some(worker) = workers.remove(&account_id) {
-                        worker.stop();
-                    }
-                }
-                workers.keys().cloned().collect::<HashSet<_>>()
+                let stale_workers = stale_account_ids
+                    .into_iter()
+                    .filter_map(|account_id| workers.remove(&account_id))
+                    .collect::<Vec<_>>();
+                (
+                    workers.keys().cloned().collect::<HashSet<_>>(),
+                    stale_workers,
+                )
             };
+            // Worker task teardown releases AppClient's account-session guard.
+            // Reap stale tasks before opening replacements for the same labels.
+            for worker in stale_workers {
+                worker.shutdown().await;
+            }
 
             let pending = accounts
                 .into_iter()
@@ -3437,7 +3444,7 @@ impl AccountManager {
                 );
                 match ready_result {
                     Ok(Ok(Ok(()))) => {}
-                    Ok(Ok(Err(message))) => return Err(AppError::BlockingTask(message)),
+                    Ok(Ok(Err(error))) => return Err(error),
                     Ok(Err(_closed)) => return Err(AppError::TransportClosed),
                     Err(_elapsed) => {
                         return Err(AppError::BlockingTask(
@@ -3459,11 +3466,11 @@ impl AccountManager {
 
     pub async fn restart_account(&self, account_id_hex: &str) -> Result<(), AppError> {
         self.shared.lifecycle().ensure_running()?;
-        {
-            let mut workers = self.workers.lock().await;
-            if let Some(worker) = workers.remove(account_id_hex) {
-                worker.stop();
-            }
+        let worker = self.workers.lock().await.remove(account_id_hex);
+        if let Some(worker) = worker {
+            // The worker owns the AppClient and its account-session guard.
+            // Await teardown before reconcile opens the replacement.
+            worker.shutdown().await;
         }
         self.reconcile().await
     }

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -240,9 +240,20 @@ fn newest_user_profile_keeps_newer_cached_extra_fields() {
 
 #[tokio::test]
 async fn managed_account_worker_shutdown_aborts_unresponsive_task_after_timeout() {
+    struct DropSignal(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
     let (commands, _commands_rx) = mpsc::channel(1);
     let (shutdown, _shutdown_rx) = oneshot::channel();
-    let handle = tokio::spawn(async {
+    let dropped = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let drop_signal = DropSignal(dropped.clone());
+    let handle = tokio::spawn(async move {
+        let _drop_signal = drop_signal;
         std::future::pending::<()>().await;
     });
     let worker = ManagedAccountWorker {
@@ -257,6 +268,7 @@ async fn managed_account_worker_shutdown_aborts_unresponsive_task_after_timeout(
         .await;
 
     assert!(started.elapsed() < Duration::from_secs(1));
+    assert!(dropped.load(std::sync::atomic::Ordering::SeqCst));
 }
 
 #[tokio::test]

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -219,6 +219,8 @@ fn account_session_guard_is_exclusive_until_client_drop() {
         let home = AccountHome::open(dir.path());
         home.create_account("alice").unwrap();
         home.create_account("bob").unwrap();
+        let alice_account_id = home.account("alice").unwrap().account_id_hex;
+        let canonical_account = home.create_nostr_account().unwrap();
         let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
             .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
 
@@ -228,15 +230,47 @@ fn account_session_guard_is_exclusive_until_client_drop() {
             Err(AppError::AccountSessionBusy)
         ));
 
+        // Hex labels and npub refs for the same account share one canonical
+        // ownership key.
+        let canonical = app.client(&canonical_account.label).await.unwrap();
+        let alias_open = app
+            .client(&npub_for_account_id_lossy(
+                &canonical_account.account_id_hex,
+            ))
+            .await;
+        assert!(
+            matches!(alias_open, Err(AppError::AccountSessionBusy)),
+            "{:?}",
+            alias_open.err()
+        );
+        drop(canonical);
+
         // Ownership is scoped per account, not across the whole app.
         let bob = app.client("bob").await.unwrap();
         drop(bob);
+
+        // Managed-worker startup preserves the typed contention error instead
+        // of flattening it into BlockingTask.
+        let contended_runtime = MarmotAppRuntime::new(app.clone());
+        assert!(matches!(
+            contended_runtime.reconcile_accounts().await,
+            Err(AppError::AccountSessionBusy)
+        ));
+        contended_runtime.shutdown().await;
 
         // One-shot operations can release their client and managed workers can
         // then hydrate the accounts normally.
         drop(alice);
         let runtime = MarmotAppRuntime::new(app.clone());
         runtime.start().await.unwrap();
+        assert!(matches!(
+            app.client("alice").await,
+            Err(AppError::AccountSessionBusy)
+        ));
+
+        // Restart waits for the previous worker to release ownership before
+        // opening its replacement.
+        runtime.restart_account(&alice_account_id).await.unwrap();
         assert!(matches!(
             app.client("alice").await,
             Err(AppError::AccountSessionBusy)

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -213,6 +213,43 @@ where
 }
 
 #[test]
+fn account_session_guard_is_exclusive_until_client_drop() {
+    run_composed_app_runtime_test("account-session-guard", || async {
+        let dir = tempfile::tempdir().unwrap();
+        let home = AccountHome::open(dir.path());
+        home.create_account("alice").unwrap();
+        home.create_account("bob").unwrap();
+        let app = MarmotApp::with_relay(dir.path(), "wss://relay.example")
+            .with_test_relay_client(Arc::new(ScriptedPushRelayClient::default()));
+
+        let alice = app.client("alice").await.unwrap();
+        assert!(matches!(
+            app.client("alice").await,
+            Err(AppError::AccountSessionBusy)
+        ));
+
+        // Ownership is scoped per account, not across the whole app.
+        let bob = app.client("bob").await.unwrap();
+        drop(bob);
+
+        // One-shot operations can release their client and managed workers can
+        // then hydrate the accounts normally.
+        drop(alice);
+        let runtime = MarmotAppRuntime::new(app.clone());
+        runtime.start().await.unwrap();
+        assert!(matches!(
+            app.client("alice").await,
+            Err(AppError::AccountSessionBusy)
+        ));
+
+        // Worker shutdown releases the same guard for a later one-shot open.
+        runtime.shutdown().await;
+        let reopened = app.client("alice").await.unwrap();
+        drop(reopened);
+    });
+}
+
+#[test]
 fn disabling_native_push_persists_removal_before_returning_without_waiting_for_relay() {
     run_composed_app_runtime_test(
         "disable-native-push-removal",

--- a/crates/marmot-app/tests/audit_logs.rs
+++ b/crates/marmot-app/tests/audit_logs.rs
@@ -473,11 +473,12 @@ async fn audit_log_setting_enables_jsonl_recorder_for_opened_accounts() {
     let account = home.create_account("alice").unwrap();
     let app = MarmotApp::with_relay(tmp.path(), "wss://relay.example");
 
-    let _client = app.client(&account.label).await.unwrap();
+    let client = app.client(&account.label).await.unwrap();
     assert!(
         app.audit_log_files().unwrap().is_empty(),
         "audit logs should be off by default"
     );
+    drop(client);
 
     app.set_audit_log_settings(AuditLogSettings {
         enabled: true,

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -2020,9 +2020,8 @@ async fn app_runtime_schedules_audit_tracker_update_after_inbound_welcome() {
         .unwrap();
     runtime.start().await.unwrap();
 
-    let mut alice = app.client("alice").await.unwrap();
-    let group_id = alice
-        .create_group("runtime inbound audit", &["bob"])
+    let group_id = runtime
+        .create_group("alice", "runtime inbound audit", &["bob".to_owned()], None)
         .await
         .unwrap();
     wait_for_event(&mut events, |event| {
@@ -2096,9 +2095,13 @@ async fn app_runtime_uploads_armed_backfill_row_without_visible_activity() {
 
     // bob's managed worker joins the group so it holds a live subscription on
     // which the undecryptable probes below are delivered.
-    let mut alice = app.client("alice").await.unwrap();
-    let group_id = alice
-        .create_group("runtime epoch backfill arm", &["bob"])
+    let group_id = runtime
+        .create_group(
+            "alice",
+            "runtime epoch backfill arm",
+            &["bob".to_owned()],
+            None,
+        )
         .await
         .unwrap();
     wait_for_event(&mut events, |event| {
@@ -3075,8 +3078,10 @@ async fn app_runtime_emits_live_messages_for_local_accounts_without_manual_sync(
     let mut events = runtime.subscribe();
     runtime.start().await.unwrap();
 
-    let mut alice = app.client("alice").await.unwrap();
-    let group_id = alice.create_group("live", &["bob"]).await.unwrap();
+    let group_id = runtime
+        .create_group("alice", "live", &["bob".to_owned()], None)
+        .await
+        .unwrap();
     wait_for_event(&mut events, |event| {
         matches!(
             event,
@@ -3086,8 +3091,12 @@ async fn app_runtime_emits_live_messages_for_local_accounts_without_manual_sync(
     })
     .await;
 
-    alice
-        .send(&group_id, b"hello through the app runtime")
+    runtime
+        .send_message(
+            "alice",
+            &group_id,
+            b"hello through the app runtime".to_vec(),
+        )
         .await
         .unwrap();
     let received = wait_for_event(&mut events, |event| {

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -44,6 +44,10 @@ pub enum MarmotKitError {
     /// host should open an unleased runtime after receiving it.
     #[error("marmot runtime root is already in use")]
     RuntimeBusy,
+    /// Another client or managed worker in this runtime currently owns the
+    /// account's in-memory engine session. Retry only after that owner closes.
+    #[error("marmot account session is already in use")]
+    AccountSessionBusy,
     #[error("marmot runtime is shutting down")]
     RuntimeStopping,
     /// An account worker's transport catch-up failed (sync error or timeout).
@@ -209,6 +213,7 @@ impl From<AppError> for MarmotKitError {
             AppError::FollowListUnavailable => Self::FollowListUnavailable,
             AppError::TransportClosed => Self::TransportClosed,
             AppError::RuntimeBusy => Self::RuntimeBusy,
+            AppError::AccountSessionBusy => Self::AccountSessionBusy,
             AppError::RuntimeStopping => Self::RuntimeStopping,
             AppError::AccountCatchUp(details) => Self::AccountCatchUp { details },
             // #484: a transient storage busy error can also surface directly at
@@ -319,6 +324,15 @@ mod tests {
         assert!(
             matches!(ffi, MarmotKitError::RuntimeBusy),
             "exclusive-root contention must remain distinguishable at the host boundary"
+        );
+    }
+
+    #[test]
+    fn account_session_busy_crosses_ffi_as_typed_variant() {
+        let ffi: MarmotKitError = AppError::AccountSessionBusy.into();
+        assert!(
+            matches!(ffi, MarmotKitError::AccountSessionBusy),
+            "in-process account-session contention must remain distinguishable at the host boundary"
         );
     }
 


### PR DESCRIPTION
## Summary

- add an in-process per-account ownership guard so a `MarmotApp` and its clones cannot hydrate two independent engine sessions over the same account database
- hold ownership for the `AppClient` lifetime and return typed `AccountSessionBusy` contention through MarmotKit
- drop a failed worker client before reconnect opens its replacement
- route runtime integration tests through the managed worker and document the change in the Unreleased changelog

## Root cause

The root runtime lease prevents separate processes or independently constructed production runtimes from sharing an app root, but it does not distinguish multiple `AccountDeviceSession` instances created inside one `MarmotApp`. Each session owns private in-memory pending, deduplication, and epoch state, so two sessions over one `session.sqlite` could stage conflicting next-epoch work even though the database itself remained transaction-safe.

This change adds only an in-process ownership guard: no additional file lock, OS lease, or lifetime-held mutex. `MarmotApp` clones share a small account-owner registry, while each `AppClient` holds one non-clonable guard that unregisters on drop.

## Validation

- `just fast-ci`
- `cargo test -p marmot-uniffi`
- focused account ownership, worker lifecycle, FFI mapping, audit-log reopen, and affected relay-runtime tests

The full `cargo test -p marmot-app` command also reports five relay-runtime failures outside this change. `encrypted_media_endpoint_updates_are_full_replacement_and_admin_only` was reproduced unchanged on base commit `1985d9a8`.

Closes #998