### PR TITLE
Harden SQLite projection pruning and secure deletion

### DIFF
--- a/crates/cgka-engine/tests/group_creation.rs
+++ b/crates/cgka-engine/tests/group_creation.rs
@@ -1391,7 +1391,8 @@ async fn solo_disband_is_durable_convergent_terminal_and_restart_safe() {
     assert!(
         storage
             .delete_local_group_data(&hex::encode(group_id.as_slice()))
-            .unwrap(),
+            .unwrap()
+            .did_delete(),
         "terminal local deletion should remove history and the full group row"
     );
     let mut tombstone_only =

--- a/crates/marmot-app/src/client/retention.rs
+++ b/crates/marmot-app/src/client/retention.rs
@@ -561,6 +561,7 @@ mod tests {
                     pruned_messages: 2,
                     secrets_deleted: 1,
                     media_ciphertext_sha256: vec!["dd".repeat(32)],
+                    erasure_pending: false,
                 },
             ))
         });

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -792,6 +792,9 @@ pub struct SecureDeleteExpiredResult {
     /// list is sorted for deterministic output, but callers should treat it as
     /// an unordered purge set.
     pub media_ciphertext_sha256: Vec<String>,
+    /// True when logical deletion committed but secure WAL truncation remains
+    /// pending. A later retention pass will retry it.
+    pub erasure_pending: bool,
 }
 
 impl From<SecurePruneAppEventsResult> for SecureDeleteExpiredResult {
@@ -800,6 +803,7 @@ impl From<SecurePruneAppEventsResult> for SecureDeleteExpiredResult {
             pruned_messages: value.pruned_messages as u64,
             secrets_deleted: value.pruned_media_epoch_secrets as u64,
             media_ciphertext_sha256: value.media_ciphertext_sha256,
+            erasure_pending: value.erasure_pending,
         }
     }
 }

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -3715,7 +3715,7 @@ impl MarmotApp {
         {
             return Err(AppError::GroupDisbanding(group_id_hex.to_owned()));
         }
-        let deleted = storage.delete_local_group_data(group_id_hex)?;
+        let deleted = storage.delete_local_group_data(group_id_hex)?.did_delete();
         self.chat_list_projection_stale
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -4095,9 +4095,16 @@ impl MarmotApp {
         group_id_hex: &str,
         now: u64,
     ) -> Result<SecureDeleteExpiredResult, AppError> {
+        let account = self.account_home().account(label)?;
+        let classifier = Self::chat_list_mention_classifier(&account.account_id_hex);
         Ok(self
-            .account_storage(label)?
-            .secure_prune_expired_app_events(group_id_hex, now)?
+            .account_storage(&account.label)?
+            .secure_prune_expired_app_events(
+                group_id_hex,
+                now,
+                &account.account_id_hex,
+                &classifier,
+            )?
             .into())
     }
 

--- a/crates/marmot-uniffi/src/conversions/message.rs
+++ b/crates/marmot-uniffi/src/conversions/message.rs
@@ -57,6 +57,7 @@ pub struct SecureDeleteExpiredResultFfi {
     pub pruned_messages: u64,
     pub secrets_deleted: u64,
     pub media_ciphertext_sha256: Vec<String>,
+    pub erasure_pending: bool,
 }
 
 impl From<SecureDeleteExpiredResult> for SecureDeleteExpiredResultFfi {
@@ -65,6 +66,7 @@ impl From<SecureDeleteExpiredResult> for SecureDeleteExpiredResultFfi {
             pruned_messages: value.pruned_messages,
             secrets_deleted: value.secrets_deleted,
             media_ciphertext_sha256: value.media_ciphertext_sha256,
+            erasure_pending: value.erasure_pending,
         }
     }
 }

--- a/crates/marmot-uniffi/src/conversions/mod.rs
+++ b/crates/marmot-uniffi/src/conversions/mod.rs
@@ -374,6 +374,7 @@ mod tests {
             pruned_messages: 2,
             secrets_deleted: 1,
             media_ciphertext_sha256: vec!["aa".repeat(32), "bb".repeat(32)],
+            erasure_pending: true,
         });
 
         assert_eq!(ffi.pruned_messages, 2);
@@ -382,6 +383,7 @@ mod tests {
             ffi.media_ciphertext_sha256,
             vec!["aa".repeat(32), "bb".repeat(32)]
         );
+        assert!(ffi.erasure_pending);
     }
 
     #[test]

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -10,6 +10,34 @@ use rusqlite::{
 };
 use serde::{Deserialize, Serialize};
 
+/// Keep generated positive-`IN` deletes below SQLite's historical 999-variable
+/// default, including any scope parameters that precede the key list.
+const SQLITE_BIND_PARAMETER_CHUNK: usize = 900;
+const SECURE_DELETE_RETENTION_OPERATION: &str = "retention";
+const SECURE_DELETE_LOCAL_GROUP_OPERATION: &str = "local_group";
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeleteLocalGroupDataResult {
+    /// Rows removed by the logical wipe represented by this completed request.
+    /// On a retry this is recovered from the durable checkpoint intent.
+    pub deleted_rows: usize,
+    /// True when this call completed a WAL erasure checkpoint left pending by
+    /// an earlier call whose logical deletion had already committed.
+    pub completed_pending_checkpoint: bool,
+}
+
+impl DeleteLocalGroupDataResult {
+    pub fn did_delete(&self) -> bool {
+        self.deleted_rows > 0
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SecureDeleteIntent {
+    nonce: Vec<u8>,
+    result_json: String,
+}
+
 /// Whether a stored per-chat mute row is effective at `now_ms`.
 ///
 /// Missing rows are unmuted, `NULL` means an indefinite mute, and finite
@@ -461,7 +489,9 @@ impl SqliteAccountStorage {
     ///   `max_seen_events` rows, so a re-seen event outlives rows whose only
     ///   sighting is old. It only narrows cross-restart redelivery;
     ///   engine-level dedup stays the authoritative duplicate guard.
-    /// - Group and component rows are snapshot-replaced (last writer wins).
+    /// - Group and component rows are snapshot-replaced (last writer wins),
+    ///   except a group row remains while it owns an unsent draft so pruning
+    ///   re-derivable metadata cannot cascade-delete user-authored content.
     ///   Full multi-writer reconciliation is an explicit non-goal.
     ///
     /// `max_future_skew_secs` is caller policy (the app layer passes its
@@ -528,24 +558,29 @@ impl SqliteAccountStorage {
             )
             .storage()?;
 
-            if state.groups.is_empty() {
-                conn.execute("DELETE FROM account_groups", []).storage()?;
-            } else {
-                let retained_group_ids = state
-                    .groups
-                    .iter()
-                    .map(|group| Value::Text(group.group_id_hex.clone()))
-                    .collect::<Vec<_>>();
-                let placeholders = (0..retained_group_ids.len())
-                    .map(|_| "?")
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                conn.execute(
-                    &format!("DELETE FROM account_groups WHERE group_id_hex NOT IN ({placeholders})"),
-                    params_from_iter(retained_group_ids),
-                )
-                .storage()?;
-            }
+            let retained_group_ids = state
+                .groups
+                .iter()
+                .map(|group| group.group_id_hex.as_str())
+                .collect::<std::collections::HashSet<_>>();
+            // Draft text and attachment plaintext are user-authored durable data,
+            // unlike this re-derivable projection. Exclude their owning groups
+            // from stale candidates so the account_groups FK cascade cannot
+            // destroy them. Once the draft is deleted, the next save selects the
+            // group as a candidate and cleans it up normally.
+            delete_stale_text_keys(
+                &conn,
+                "SELECT group_id_hex
+                 FROM account_groups
+                 WHERE NOT EXISTS (
+                    SELECT 1 FROM message_drafts
+                    WHERE message_drafts.group_id_hex = account_groups.group_id_hex
+                 )",
+                &[],
+                "DELETE FROM account_groups WHERE group_id_hex IN",
+                &[],
+                &retained_group_ids,
+            )?;
 
             for group in &state.groups {
                 let group_was_new = !conn
@@ -676,8 +711,14 @@ impl SqliteAccountStorage {
     /// re-create the app projection. A terminal group is different: its live
     /// MLS state is already erased, so this transaction also removes the full
     /// `cgka_groups` row and retains only `cgka_disband_tombstones` as the
-    /// permanent anti-resurrection guard.
-    pub fn delete_local_group_data(&self, group_id_hex: &str) -> StorageResult<bool> {
+    /// permanent anti-resurrection guard. The logical wipe and a durable WAL
+    /// checkpoint intent commit together under `secure_delete = ON`; success is
+    /// returned only after `wal_checkpoint(TRUNCATE)` completes. A retry after
+    /// checkpoint contention recovers the original result from that intent.
+    pub fn delete_local_group_data(
+        &self,
+        group_id_hex: &str,
+    ) -> StorageResult<DeleteLocalGroupDataResult> {
         if group_id_hex.trim().is_empty() {
             return Err(StorageError::Backend(
                 "local group delete id must not be empty".to_owned(),
@@ -687,50 +728,83 @@ impl SqliteAccountStorage {
             StorageError::Serialization(format!("invalid local group id: {error}"))
         })?;
 
-        self.connection.with_transaction(|| -> StorageResult<bool> {
-            let conn = self.lock()?;
-            let mut deleted = retire_all_encrypted_media_secrets_for_group_tx(&conn, group_id_hex)?;
-            for table in [
-                "app_events",
-                "message_timeline",
-                "agent_stream_starts",
-                "conversation_read_state",
-                "chat_list_rows",
-                "account_group_app_components",
-                "group_push_tokens",
-                "group_push_token_tombstones",
-                "pending_push_registration_shares",
-                "chat_notification_settings",
-                "encrypted_media_epoch_secret_references",
-                "encrypted_media_epoch_secrets",
-                "account_groups",
-            ] {
-                deleted = deleted.saturating_add(
-                    conn.execute(
-                        &format!("DELETE FROM {table} WHERE group_id_hex = ?1"),
-                        params![group_id_hex],
-                    )
-                    .storage()?,
-                );
-            }
-            let terminal = conn
-                .query_row(
-                    "SELECT EXISTS(
-                        SELECT 1 FROM cgka_disband_tombstones WHERE group_id = ?1
-                     )",
-                    params![&group_id],
-                    |row| row.get::<_, i64>(0),
-                )
-                .storage()?
-                != 0;
-            if terminal {
-                deleted = deleted.saturating_add(
-                    conn.execute("DELETE FROM cgka_groups WHERE id = ?1", params![&group_id])
+        let newly_deleted = retry_on_busy(|| {
+            let mut conn = self.lock()?;
+            let original = secure_delete_pragma(&conn)?;
+            conn.execute_batch("PRAGMA secure_delete = ON;").storage()?;
+            let delete_result = (|| {
+                let tx = conn
+                    .transaction_with_behavior(TransactionBehavior::Immediate)
+                    .storage()?;
+                let mut deleted =
+                    retire_all_encrypted_media_secrets_for_group_tx(&tx, group_id_hex)?;
+                for table in [
+                    "app_events",
+                    "message_timeline",
+                    "agent_stream_starts",
+                    "conversation_read_state",
+                    "chat_list_rows",
+                    "account_group_app_components",
+                    "group_push_tokens",
+                    "group_push_token_tombstones",
+                    "pending_push_registration_shares",
+                    "chat_notification_settings",
+                    "encrypted_media_epoch_secret_references",
+                    "encrypted_media_epoch_secrets",
+                    "account_groups",
+                ] {
+                    deleted = deleted.saturating_add(
+                        tx.execute(
+                            &format!("DELETE FROM {table} WHERE group_id_hex = ?1"),
+                            params![group_id_hex],
+                        )
                         .storage()?,
-                );
+                    );
+                }
+                let terminal = tx
+                    .query_row(
+                        "SELECT EXISTS(
+                            SELECT 1 FROM cgka_disband_tombstones WHERE group_id = ?1
+                         )",
+                        params![&group_id],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .storage()?
+                    != 0;
+                if terminal {
+                    deleted = deleted.saturating_add(
+                        tx.execute("DELETE FROM cgka_groups WHERE id = ?1", params![&group_id])
+                            .storage()?,
+                    );
+                }
+                if deleted > 0 {
+                    merge_local_group_delete_intent_tx(&tx, group_id_hex, deleted)?;
+                }
+                tx.commit().storage()?;
+                Ok(deleted)
+            })();
+            let restore = restore_secure_delete_pragma(&conn, original);
+            combine_secure_delete_operation_and_restore(delete_result, restore)
+        })?;
+
+        match finish_secure_delete_checkpoint_intent::<DeleteLocalGroupDataResult>(
+            self,
+            SECURE_DELETE_LOCAL_GROUP_OPERATION,
+            group_id_hex,
+        )? {
+            Some(mut result) => {
+                result.completed_pending_checkpoint = newly_deleted == 0 && result.deleted_rows > 0;
+                Ok(result)
             }
-            Ok(deleted > 0)
-        })
+            // Another process may have checkpointed and consumed this intent
+            // after our logical deletion committed. In that case erasure is
+            // complete, and this caller must still report its locally known
+            // deletion instead of incorrectly returning "nothing existed".
+            None => Ok(DeleteLocalGroupDataResult {
+                deleted_rows: newly_deleted,
+                completed_pending_checkpoint: false,
+            }),
+        }
     }
 
     /// Record the local account's own membership in `group_id_hex` so the
@@ -907,36 +981,58 @@ impl SqliteAccountStorage {
         &self,
         group_id_hex: &str,
         cutoff_recorded_at: u64,
+        local_account_id_hex: &str,
+        mention_classifier: &crate::chat_list::MentionClassifier<'_>,
     ) -> StorageResult<usize> {
-        self.secure_prune_app_events_before(group_id_hex, cutoff_recorded_at)
-            .map(|outcome| outcome.pruned_messages)
+        self.secure_prune_app_events_before(
+            group_id_hex,
+            cutoff_recorded_at,
+            local_account_id_hex,
+            mention_classifier,
+        )
+        .map(|outcome| outcome.pruned_messages)
     }
 
     pub fn secure_prune_app_events_before(
         &self,
         group_id_hex: &str,
         cutoff_recorded_at: u64,
+        local_account_id_hex: &str,
+        mention_classifier: &crate::chat_list::MentionClassifier<'_>,
     ) -> StorageResult<crate::timeline::SecurePruneAppEventsResult> {
         self.secure_prune_app_events(
             group_id_hex,
             SecurePruneAppEventsMode::RecordedBefore(cutoff_recorded_at),
+            local_account_id_hex,
+            mention_classifier,
         )
     }
 
     /// Delete only app events whose durable source-epoch retention decision
-    /// has expired at or before `now`.
+    /// has expired at or before `now`. Logical deletion and its result commit
+    /// with a durable checkpoint intent, so a failed WAL truncation is surfaced
+    /// and a retry can complete erasure without losing counts or media hashes.
     pub fn secure_prune_expired_app_events(
         &self,
         group_id_hex: &str,
         now: u64,
+        local_account_id_hex: &str,
+        mention_classifier: &crate::chat_list::MentionClassifier<'_>,
     ) -> StorageResult<crate::timeline::SecurePruneAppEventsResult> {
-        self.secure_prune_app_events(group_id_hex, SecurePruneAppEventsMode::ExpiredAt(now))
+        self.secure_prune_app_events(
+            group_id_hex,
+            SecurePruneAppEventsMode::ExpiredAt(now),
+            local_account_id_hex,
+            mention_classifier,
+        )
     }
 
     fn secure_prune_app_events(
         &self,
         group_id_hex: &str,
         mode: SecurePruneAppEventsMode,
+        local_account_id_hex: &str,
+        mention_classifier: &crate::chat_list::MentionClassifier<'_>,
     ) -> StorageResult<crate::timeline::SecurePruneAppEventsResult> {
         // `secure_delete` must be ON *before* the prune transaction begins:
         // SQLite does not guarantee zero-on-free for pages freed in the same
@@ -949,9 +1045,7 @@ impl SqliteAccountStorage {
             // between those steps lets concurrent prunes save each other's
             // temporary ON value and restore the wrong configuration.
             let mut conn = self.lock()?;
-            let original = conn
-                .query_row("PRAGMA secure_delete", [], |row| row.get::<_, i64>(0))
-                .storage()?;
+            let original = secure_delete_pragma(&conn)?;
             conn.execute_batch("PRAGMA secure_delete = ON;").storage()?;
             let prune_outcome = (|| {
                 let tx = conn
@@ -963,26 +1057,33 @@ impl SqliteAccountStorage {
                             &tx,
                             group_id_hex,
                             cutoff,
+                            local_account_id_hex,
+                            mention_classifier,
                         )?
                     }
                     SecurePruneAppEventsMode::ExpiredAt(now) => {
-                        crate::timeline::secure_prune_expired_app_events_tx(&tx, group_id_hex, now)?
+                        crate::timeline::secure_prune_expired_app_events_tx(
+                            &tx,
+                            group_id_hex,
+                            now,
+                            local_account_id_hex,
+                            mention_classifier,
+                        )?
                     }
                 };
+                if outcome.pruned_messages > 0 || outcome.pruned_media_epoch_secrets > 0 {
+                    merge_secure_prune_intent_tx(&tx, group_id_hex, &outcome)?;
+                }
                 tx.commit().storage()?;
                 Ok(outcome)
             })();
-            let restore = conn
-                .execute_batch(&format!("PRAGMA secure_delete = {original};"))
-                .storage()
-                .map(|_| ());
-            match (prune_outcome, restore) {
-                (Ok(value), Ok(())) => Ok(value),
-                (Err(err), Ok(())) => Err(err),
-                (Ok(_), Err(err)) => Err(err),
-                (Err(err), Err(_)) => Err(err),
-            }
+            let restore = restore_secure_delete_pragma(&conn, original);
+            combine_secure_delete_operation_and_restore(prune_outcome, restore)
         })?;
+        let outcome = finish_secure_delete_checkpoint_intent::<
+            crate::timeline::SecurePruneAppEventsResult,
+        >(self, SECURE_DELETE_RETENTION_OPERATION, group_id_hex)?
+        .unwrap_or(outcome);
         if outcome.pruned_media_epoch_secrets > 0 {
             tracing::debug!(
                 target: "storage_sqlite::retention",
@@ -990,28 +1091,6 @@ impl SqliteAccountStorage {
                 pruned_media_epoch_secrets = outcome.pruned_media_epoch_secrets,
                 "retired encrypted-media epoch secrets after final retained references expired"
             );
-        }
-        if outcome.pruned_messages > 0 || outcome.pruned_media_epoch_secrets > 0 {
-            let conn = self.lock()?;
-            if let Err(error) = checkpoint_wal_truncate_after_secure_prune(&conn) {
-                // Log only the stable variant kind: storage error Display can
-                // embed SQL text or file paths.
-                tracing::warn!(
-                    target: "storage_sqlite::retention",
-                    method = mode.trace_method(),
-                    pruned_messages = outcome.pruned_messages,
-                    pruned_media_epoch_secrets = outcome.pruned_media_epoch_secrets,
-                    error_kind = match &error {
-                        StorageError::NotFound => "not_found",
-                        StorageError::AlreadyExists => "already_exists",
-                        StorageError::SnapshotMissing(_) => "snapshot_missing",
-                        StorageError::Busy(_) => "busy",
-                        StorageError::Backend(_) => "backend",
-                        StorageError::Serialization(_) => "serialization",
-                    },
-                    "retention secure-delete WAL checkpoint failed after committed prune"
-                );
-            }
         }
         Ok(outcome)
     }
@@ -1948,46 +2027,36 @@ impl SqliteAccountStorage {
         self.connection
             .with_transaction(|| -> StorageResult<usize> {
                 let conn = self.lock()?;
-                if active_members.is_empty() {
-                    conn.execute(
-                        "DELETE FROM group_push_token_tombstones WHERE group_id_hex = ?1",
-                        params![group_id_hex],
-                    )
-                    .storage()?;
-                    return conn
-                        .execute(
-                            "DELETE FROM group_push_tokens WHERE group_id_hex = ?1",
-                            params![group_id_hex],
-                        )
-                        .storage();
-                }
-                let placeholders = std::iter::repeat_n("?", active_members.len())
-                    .collect::<Vec<_>>()
-                    .join(",");
-                let mut values = Vec::with_capacity(active_members.len() + 1);
-                values.push(Value::Text(group_id_hex.to_owned()));
-                values.extend(active_members.iter().cloned().map(Value::Text));
+                let active_members = active_members
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<std::collections::HashSet<_>>();
+                let scope = [Value::Text(group_id_hex.to_owned())];
                 // Clear tombstones for departed members too: once a member is gone, no
                 // relayed record for them can verify against current membership, so their
                 // tombstones are no longer load-bearing.
-                conn.execute(
-                    &format!(
-                        "DELETE FROM group_push_token_tombstones
-                 WHERE group_id_hex = ?
-                   AND member_id_hex NOT IN ({placeholders})"
-                    ),
-                    params_from_iter(values.iter()),
+                delete_stale_text_keys(
+                    &conn,
+                    "SELECT DISTINCT member_id_hex
+                     FROM group_push_token_tombstones
+                     WHERE group_id_hex = ?",
+                    &scope,
+                    "DELETE FROM group_push_token_tombstones
+                     WHERE group_id_hex = ? AND member_id_hex IN",
+                    &scope,
+                    &active_members,
+                )?;
+                delete_stale_text_keys(
+                    &conn,
+                    "SELECT DISTINCT member_id_hex
+                     FROM group_push_tokens
+                     WHERE group_id_hex = ?",
+                    &scope,
+                    "DELETE FROM group_push_tokens
+                     WHERE group_id_hex = ? AND member_id_hex IN",
+                    &scope,
+                    &active_members,
                 )
-                .storage()?;
-                conn.execute(
-                    &format!(
-                        "DELETE FROM group_push_tokens
-                 WHERE group_id_hex = ?
-                   AND member_id_hex NOT IN ({placeholders})"
-                    ),
-                    params_from_iter(values.iter()),
-                )
-                .storage()
             })
     }
 
@@ -2161,7 +2230,161 @@ fn merged_transport_timestamp(
     }
 }
 
-fn checkpoint_wal_truncate_after_secure_prune(conn: &Connection) -> StorageResult<()> {
+fn secure_delete_pragma(conn: &Connection) -> StorageResult<i64> {
+    conn.query_row("PRAGMA secure_delete", [], |row| row.get(0))
+        .storage()
+}
+
+fn restore_secure_delete_pragma(conn: &Connection, original: i64) -> StorageResult<()> {
+    conn.execute_batch(&format!("PRAGMA secure_delete = {original};"))
+        .storage()
+}
+
+fn combine_secure_delete_operation_and_restore<T>(
+    operation: StorageResult<T>,
+    restore: StorageResult<()>,
+) -> StorageResult<T> {
+    match (operation, restore) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), Ok(())) | (Ok(_), Err(error)) | (Err(error), Err(_)) => Err(error),
+    }
+}
+
+fn secure_delete_intent(
+    conn: &Connection,
+    operation_kind: &str,
+    scope: &str,
+) -> StorageResult<Option<SecureDeleteIntent>> {
+    conn.query_row(
+        "SELECT intent_nonce, result_json
+         FROM secure_delete_checkpoint_intents
+         WHERE operation_kind = ?1 AND scope = ?2",
+        params![operation_kind, scope],
+        |row| {
+            Ok(SecureDeleteIntent {
+                nonce: row.get(0)?,
+                result_json: row.get(1)?,
+            })
+        },
+    )
+    .optional()
+    .storage()
+}
+
+fn upsert_secure_delete_intent_tx(
+    tx: &Connection,
+    operation_kind: &str,
+    scope: &str,
+    result_json: &str,
+) -> StorageResult<()> {
+    tx.execute(
+        "INSERT INTO secure_delete_checkpoint_intents (
+            operation_kind, scope, intent_nonce, result_json,
+            created_at_unix_seconds
+         ) VALUES (?1, ?2, randomblob(16), ?3, ?4)
+         ON CONFLICT(operation_kind, scope) DO UPDATE SET
+            intent_nonce = randomblob(16),
+            result_json = excluded.result_json,
+            created_at_unix_seconds = excluded.created_at_unix_seconds",
+        params![operation_kind, scope, result_json, unix_now_seconds_i64()],
+    )
+    .storage()?;
+    Ok(())
+}
+
+fn merge_secure_prune_intent_tx(
+    tx: &Connection,
+    group_id_hex: &str,
+    new_result: &crate::timeline::SecurePruneAppEventsResult,
+) -> StorageResult<()> {
+    let mut merged = secure_delete_intent(tx, SECURE_DELETE_RETENTION_OPERATION, group_id_hex)?
+        .map(|intent| {
+            serde_json::from_str::<crate::timeline::SecurePruneAppEventsResult>(&intent.result_json)
+                .map_err(|error| StorageError::Serialization(error.to_string()))
+        })
+        .transpose()?
+        .unwrap_or_default();
+    merged.pruned_messages = merged
+        .pruned_messages
+        .saturating_add(new_result.pruned_messages);
+    merged.pruned_media_epoch_secrets = merged
+        .pruned_media_epoch_secrets
+        .saturating_add(new_result.pruned_media_epoch_secrets);
+    let mut hashes = merged
+        .media_ciphertext_sha256
+        .into_iter()
+        .collect::<std::collections::BTreeSet<_>>();
+    hashes.extend(new_result.media_ciphertext_sha256.iter().cloned());
+    merged.media_ciphertext_sha256 = hashes.into_iter().collect();
+    let result_json = serde_json::to_string(&merged)
+        .map_err(|error| StorageError::Serialization(error.to_string()))?;
+    upsert_secure_delete_intent_tx(
+        tx,
+        SECURE_DELETE_RETENTION_OPERATION,
+        group_id_hex,
+        &result_json,
+    )
+}
+
+fn merge_local_group_delete_intent_tx(
+    tx: &Connection,
+    group_id_hex: &str,
+    deleted_rows: usize,
+) -> StorageResult<()> {
+    let mut merged = secure_delete_intent(tx, SECURE_DELETE_LOCAL_GROUP_OPERATION, group_id_hex)?
+        .map(|intent| {
+            serde_json::from_str::<DeleteLocalGroupDataResult>(&intent.result_json)
+                .map_err(|error| StorageError::Serialization(error.to_string()))
+        })
+        .transpose()?
+        .unwrap_or_default();
+    merged.deleted_rows = merged.deleted_rows.saturating_add(deleted_rows);
+    merged.completed_pending_checkpoint = false;
+    let result_json = serde_json::to_string(&merged)
+        .map_err(|error| StorageError::Serialization(error.to_string()))?;
+    upsert_secure_delete_intent_tx(
+        tx,
+        SECURE_DELETE_LOCAL_GROUP_OPERATION,
+        group_id_hex,
+        &result_json,
+    )
+}
+
+fn finish_secure_delete_checkpoint_intent<T>(
+    storage: &SqliteAccountStorage,
+    operation_kind: &str,
+    scope: &str,
+) -> StorageResult<Option<T>>
+where
+    T: serde::de::DeserializeOwned,
+{
+    for _ in 0..8 {
+        let conn = storage.lock()?;
+        let Some(intent) = secure_delete_intent(&conn, operation_kind, scope)? else {
+            return Ok(None);
+        };
+        let result = serde_json::from_str(&intent.result_json)
+            .map_err(|error| StorageError::Serialization(error.to_string()))?;
+        checkpoint_wal_truncate_after_secure_delete(&conn)?;
+        let deleted = conn
+            .execute(
+                "DELETE FROM secure_delete_checkpoint_intents
+                 WHERE operation_kind = ?1 AND scope = ?2
+                   AND intent_nonce = ?3",
+                params![operation_kind, scope, &intent.nonce],
+            )
+            .storage()?;
+        if deleted == 0 {
+            continue;
+        }
+        return Ok(Some(result));
+    }
+    Err(StorageError::Busy(
+        "secure-delete checkpoint intent changed repeatedly while completing".to_owned(),
+    ))
+}
+
+fn checkpoint_wal_truncate_after_secure_delete(conn: &Connection) -> StorageResult<()> {
     retry_on_busy(|| {
         let (busy, _log_frames, _checkpointed_frames): (i64, i64, i64) = conn
             .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
@@ -2172,7 +2395,7 @@ fn checkpoint_wal_truncate_after_secure_prune(conn: &Connection) -> StorageResul
             Ok(())
         } else {
             Err(StorageError::Busy(
-                "retention secure-delete WAL checkpoint could not truncate while readers are active"
+                "secure-delete WAL checkpoint could not truncate while readers are active"
                     .to_owned(),
             ))
         }
@@ -2212,6 +2435,51 @@ fn all_account_group_components(
         by_group.entry(group_id_hex).or_default().push(component);
     }
     Ok(by_group)
+}
+
+/// Deletes text keys that exist in a scoped query but are absent from
+/// `retained_keys`.
+///
+/// The retained set is never bound into SQL: `NOT IN` cannot be safely split
+/// into chunks because each partial statement would delete keys retained by a
+/// later chunk. Instead, this queries existing keys, computes the stale set in
+/// Rust, and chunk-deletes that stale set with positive `IN` predicates.
+fn delete_stale_text_keys(
+    conn: &Connection,
+    existing_keys_sql: &str,
+    existing_keys_params: &[Value],
+    delete_sql_prefix: &str,
+    delete_prefix_params: &[Value],
+    retained_keys: &std::collections::HashSet<&str>,
+) -> StorageResult<usize> {
+    let mut statement = conn.prepare(existing_keys_sql).storage()?;
+    let existing_keys = statement
+        .query_map(params_from_iter(existing_keys_params.iter()), |row| {
+            row.get::<_, String>(0)
+        })
+        .storage()?
+        .collect::<Result<Vec<_>, _>>()
+        .storage()?;
+    drop(statement);
+
+    let stale_keys = existing_keys
+        .into_iter()
+        .filter(|key| !retained_keys.contains(key.as_str()))
+        .collect::<Vec<_>>();
+    let mut deleted = 0;
+    for chunk in stale_keys.chunks(SQLITE_BIND_PARAMETER_CHUNK) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!("{delete_sql_prefix} ({placeholders})");
+        let mut values = Vec::with_capacity(delete_prefix_params.len() + chunk.len());
+        values.extend_from_slice(delete_prefix_params);
+        values.extend(chunk.iter().cloned().map(Value::Text));
+        deleted += conn
+            .execute(&sql, params_from_iter(values.iter()))
+            .storage()?;
+    }
+    Ok(deleted)
 }
 
 fn delete_stale_group_components(

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -1,5 +1,6 @@
 use crate::{
-    SqliteAccountStorage, SqliteResultExt, bool_i64, connection::retry_on_busy,
+    SQLITE_BIND_PARAMETER_CHUNK, SqliteAccountStorage, SqliteResultExt, bool_i64,
+    connection::retry_on_busy,
     encrypted_media_secrets::retire_all_encrypted_media_secrets_for_group_tx, i64_to_usize,
     tags_from_json, unix_now_ms, unix_now_seconds, unix_now_seconds_i64, usize_to_i64,
 };
@@ -10,20 +11,23 @@ use rusqlite::{
 };
 use serde::{Deserialize, Serialize};
 
-/// Keep generated positive-`IN` deletes below SQLite's historical 999-variable
-/// default, including any scope parameters that precede the key list.
-const SQLITE_BIND_PARAMETER_CHUNK: usize = 900;
 const SECURE_DELETE_RETENTION_OPERATION: &str = "retention";
 const SECURE_DELETE_LOCAL_GROUP_OPERATION: &str = "local_group";
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeleteLocalGroupDataResult {
-    /// Rows removed by the logical wipe represented by this completed request.
-    /// On a retry this is recovered from the durable checkpoint intent.
+    /// Rows removed by every logical wipe accumulated in the durable
+    /// checkpoint intent. If a group is re-created and wiped again before WAL
+    /// truncation succeeds, this count spans those wipes.
     pub deleted_rows: usize,
     /// True when this call completed a WAL erasure checkpoint left pending by
     /// an earlier call whose logical deletion had already committed.
     pub completed_pending_checkpoint: bool,
+    /// True when logical deletion committed but WAL truncation remains
+    /// durably pending. A later local wipe call retries the checkpoint even
+    /// when it finds no additional rows to delete.
+    #[serde(default)]
+    pub erasure_pending: bool,
 }
 
 impl DeleteLocalGroupDataResult {
@@ -36,6 +40,12 @@ impl DeleteLocalGroupDataResult {
 struct SecureDeleteIntent {
     nonce: Vec<u8>,
     result_json: String,
+}
+
+#[derive(Clone, Debug)]
+struct SecureDeleteCheckpointFinish<T> {
+    result: Option<T>,
+    erasure_pending: bool,
 }
 
 /// Whether a stored per-chat mute row is effective at `now_ms`.
@@ -492,7 +502,10 @@ impl SqliteAccountStorage {
     /// - Group and component rows are snapshot-replaced (last writer wins),
     ///   except a group row remains while it owns an unsent draft so pruning
     ///   re-derivable metadata cannot cascade-delete user-authored content.
-    ///   Full multi-writer reconciliation is an explicit non-goal.
+    ///   Consequently, a stale draft-owning group remains visible in the
+    ///   projection/chat list until its draft is removed and a later save can
+    ///   prune the group. Full multi-writer reconciliation is an explicit
+    ///   non-goal.
     ///
     /// `max_future_skew_secs` is caller policy (the app layer passes its
     /// transport-cursor skew); this crate only enforces the column merge rule.
@@ -566,8 +579,10 @@ impl SqliteAccountStorage {
             // Draft text and attachment plaintext are user-authored durable data,
             // unlike this re-derivable projection. Exclude their owning groups
             // from stale candidates so the account_groups FK cascade cannot
-            // destroy them. Once the draft is deleted, the next save selects the
-            // group as a candidate and cleans it up normally.
+            // destroy them. This intentionally keeps that stale group visible in
+            // projection/chat-list reads while its draft exists. Once the draft
+            // is deleted, the next save selects the group as a candidate and
+            // cleans it up normally.
             delete_stale_text_keys(
                 &conn,
                 "SELECT group_id_hex
@@ -712,9 +727,10 @@ impl SqliteAccountStorage {
     /// MLS state is already erased, so this transaction also removes the full
     /// `cgka_groups` row and retains only `cgka_disband_tombstones` as the
     /// permanent anti-resurrection guard. The logical wipe and a durable WAL
-    /// checkpoint intent commit together under `secure_delete = ON`; success is
-    /// returned only after `wal_checkpoint(TRUNCATE)` completes. A retry after
-    /// checkpoint contention recovers the original result from that intent.
+    /// checkpoint intent commit together under `secure_delete = ON`. If
+    /// `wal_checkpoint(TRUNCATE)` is blocked by a reader, the committed result
+    /// is returned with `erasure_pending`; a retry recovers the accumulated
+    /// result from the intent and attempts truncation again.
     pub fn delete_local_group_data(
         &self,
         group_id_hex: &str,
@@ -787,13 +803,16 @@ impl SqliteAccountStorage {
             combine_secure_delete_operation_and_restore(delete_result, restore)
         })?;
 
-        match finish_secure_delete_checkpoint_intent::<DeleteLocalGroupDataResult>(
+        let finish = finish_secure_delete_checkpoint_intent::<DeleteLocalGroupDataResult>(
             self,
             SECURE_DELETE_LOCAL_GROUP_OPERATION,
             group_id_hex,
-        )? {
+        )?;
+        match finish.result {
             Some(mut result) => {
-                result.completed_pending_checkpoint = newly_deleted == 0 && result.deleted_rows > 0;
+                result.completed_pending_checkpoint =
+                    newly_deleted == 0 && result.deleted_rows > 0 && !finish.erasure_pending;
+                result.erasure_pending = finish.erasure_pending;
                 Ok(result)
             }
             // Another process may have checkpointed and consumed this intent
@@ -803,6 +822,7 @@ impl SqliteAccountStorage {
             None => Ok(DeleteLocalGroupDataResult {
                 deleted_rows: newly_deleted,
                 completed_pending_checkpoint: false,
+                erasure_pending: false,
             }),
         }
     }
@@ -1010,8 +1030,9 @@ impl SqliteAccountStorage {
 
     /// Delete only app events whose durable source-epoch retention decision
     /// has expired at or before `now`. Logical deletion and its result commit
-    /// with a durable checkpoint intent, so a failed WAL truncation is surfaced
-    /// and a retry can complete erasure without losing counts or media hashes.
+    /// with a durable checkpoint intent. Checkpoint contention is reported as
+    /// `erasure_pending`, and a retry can complete erasure without losing
+    /// counts or media hashes.
     pub fn secure_prune_expired_app_events(
         &self,
         group_id_hex: &str,
@@ -1080,10 +1101,11 @@ impl SqliteAccountStorage {
             let restore = restore_secure_delete_pragma(&conn, original);
             combine_secure_delete_operation_and_restore(prune_outcome, restore)
         })?;
-        let outcome = finish_secure_delete_checkpoint_intent::<
+        let finish = finish_secure_delete_checkpoint_intent::<
             crate::timeline::SecurePruneAppEventsResult,
-        >(self, SECURE_DELETE_RETENTION_OPERATION, group_id_hex)?
-        .unwrap_or(outcome);
+        >(self, SECURE_DELETE_RETENTION_OPERATION, group_id_hex)?;
+        let mut outcome = finish.result.unwrap_or(outcome);
+        outcome.erasure_pending = finish.erasure_pending;
         if outcome.pruned_media_epoch_secrets > 0 {
             tracing::debug!(
                 target: "storage_sqlite::retention",
@@ -2279,14 +2301,12 @@ fn upsert_secure_delete_intent_tx(
 ) -> StorageResult<()> {
     tx.execute(
         "INSERT INTO secure_delete_checkpoint_intents (
-            operation_kind, scope, intent_nonce, result_json,
-            created_at_unix_seconds
-         ) VALUES (?1, ?2, randomblob(16), ?3, ?4)
+            operation_kind, scope, intent_nonce, result_json
+         ) VALUES (?1, ?2, randomblob(16), ?3)
          ON CONFLICT(operation_kind, scope) DO UPDATE SET
             intent_nonce = randomblob(16),
-            result_json = excluded.result_json,
-            created_at_unix_seconds = excluded.created_at_unix_seconds",
-        params![operation_kind, scope, result_json, unix_now_seconds_i64()],
+            result_json = excluded.result_json",
+        params![operation_kind, scope, result_json],
     )
     .storage()?;
     Ok(())
@@ -2316,6 +2336,7 @@ fn merge_secure_prune_intent_tx(
         .collect::<std::collections::BTreeSet<_>>();
     hashes.extend(new_result.media_ciphertext_sha256.iter().cloned());
     merged.media_ciphertext_sha256 = hashes.into_iter().collect();
+    merged.erasure_pending = false;
     let result_json = serde_json::to_string(&merged)
         .map_err(|error| StorageError::Serialization(error.to_string()))?;
     upsert_secure_delete_intent_tx(
@@ -2340,6 +2361,7 @@ fn merge_local_group_delete_intent_tx(
         .unwrap_or_default();
     merged.deleted_rows = merged.deleted_rows.saturating_add(deleted_rows);
     merged.completed_pending_checkpoint = false;
+    merged.erasure_pending = false;
     let result_json = serde_json::to_string(&merged)
         .map_err(|error| StorageError::Serialization(error.to_string()))?;
     upsert_secure_delete_intent_tx(
@@ -2354,18 +2376,31 @@ fn finish_secure_delete_checkpoint_intent<T>(
     storage: &SqliteAccountStorage,
     operation_kind: &str,
     scope: &str,
-) -> StorageResult<Option<T>>
+) -> StorageResult<SecureDeleteCheckpointFinish<T>>
 where
     T: serde::de::DeserializeOwned,
 {
+    let mut last_result = None;
     for _ in 0..8 {
         let conn = storage.lock()?;
         let Some(intent) = secure_delete_intent(&conn, operation_kind, scope)? else {
-            return Ok(None);
+            return Ok(SecureDeleteCheckpointFinish {
+                result: None,
+                erasure_pending: false,
+            });
         };
         let result = serde_json::from_str(&intent.result_json)
             .map_err(|error| StorageError::Serialization(error.to_string()))?;
-        checkpoint_wal_truncate_after_secure_delete(&conn)?;
+        match checkpoint_wal_truncate_after_secure_delete(&conn) {
+            Ok(()) => {}
+            Err(StorageError::Busy(_)) => {
+                return Ok(SecureDeleteCheckpointFinish {
+                    result: Some(result),
+                    erasure_pending: true,
+                });
+            }
+            Err(error) => return Err(error),
+        }
         let deleted = conn
             .execute(
                 "DELETE FROM secure_delete_checkpoint_intents
@@ -2375,13 +2410,18 @@ where
             )
             .storage()?;
         if deleted == 0 {
+            last_result = Some(result);
             continue;
         }
-        return Ok(Some(result));
+        return Ok(SecureDeleteCheckpointFinish {
+            result: Some(result),
+            erasure_pending: false,
+        });
     }
-    Err(StorageError::Busy(
-        "secure-delete checkpoint intent changed repeatedly while completing".to_owned(),
-    ))
+    Ok(SecureDeleteCheckpointFinish {
+        result: last_result,
+        erasure_pending: true,
+    })
 }
 
 fn checkpoint_wal_truncate_after_secure_delete(conn: &Connection) -> StorageResult<()> {
@@ -2467,7 +2507,15 @@ fn delete_stale_text_keys(
         .filter(|key| !retained_keys.contains(key.as_str()))
         .collect::<Vec<_>>();
     let mut deleted = 0;
-    for chunk in stale_keys.chunks(SQLITE_BIND_PARAMETER_CHUNK) {
+    let key_chunk_size = SQLITE_BIND_PARAMETER_CHUNK
+        .checked_sub(delete_prefix_params.len())
+        .filter(|size| *size > 0)
+        .ok_or_else(|| {
+            StorageError::Backend(
+                "stale-key delete prefix exceeds SQLite bind-parameter budget".to_owned(),
+            )
+        })?;
+    for chunk in stale_keys.chunks(key_chunk_size) {
         let placeholders = std::iter::repeat_n("?", chunk.len())
             .collect::<Vec<_>>()
             .join(",");

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -1262,11 +1262,13 @@ fn secure_prune_retry_after_reopen_recovers_committed_outcome() {
         .query_row("SELECT count(*) FROM app_events", [], |row| row.get(0))
         .unwrap();
 
-    let error = store
+    let pending = store
         .secure_prune_app_events_before("aa", 15, "local", &no_mentions)
-        .expect_err("a committed prune is not securely erased until WAL truncation succeeds");
+        .expect("checkpoint contention is a committed result with pending erasure");
 
-    assert!(matches!(error, StorageError::Busy(_)));
+    assert_eq!(pending.pruned_messages, 1);
+    assert_eq!(pending.media_ciphertext_sha256, vec![media_hash.clone()]);
+    assert!(pending.erasure_pending);
     assert_eq!(
         store.app_message_count().unwrap(),
         0,
@@ -1289,6 +1291,7 @@ fn secure_prune_retry_after_reopen_recovers_committed_outcome() {
         .expect("retry after reopen must re-drive the durable pending checkpoint");
     assert_eq!(outcome.pruned_messages, 1);
     assert_eq!(outcome.media_ciphertext_sha256, vec![media_hash]);
+    assert!(!outcome.erasure_pending);
 
     let empty = store
         .secure_prune_app_events_before("aa", 15, "local", &no_mentions)
@@ -1318,6 +1321,7 @@ fn competing_storage_handles_consume_one_checkpoint_intent_once() {
         pruned_messages: 1,
         pruned_media_epoch_secrets: 0,
         media_ciphertext_sha256: vec!["ab".repeat(32)],
+        erasure_pending: false,
     };
     {
         let conn = store_a.lock().unwrap();
@@ -1346,7 +1350,7 @@ fn competing_storage_handles_consume_one_checkpoint_intent_once() {
         )
         .unwrap()
     });
-    let outcomes = [a.join().unwrap(), b.join().unwrap()];
+    let outcomes = [a.join().unwrap().result, b.join().unwrap().result];
     assert_eq!(
         outcomes.iter().filter(|outcome| outcome.is_some()).count(),
         1,
@@ -2336,10 +2340,12 @@ fn delete_local_group_data_reopens_and_retries_a_committed_pending_checkpoint() 
         .query_row("SELECT count(*) FROM app_events", [], |row| row.get(0))
         .unwrap();
 
-    let error = store
+    let pending = store
         .delete_local_group_data(group_id_hex)
-        .expect_err("logical wipe must not report success while WAL erasure is pending");
-    assert!(matches!(error, StorageError::Busy(_)));
+        .expect("logical wipe commits while WAL erasure remains pending");
+    assert!(pending.did_delete());
+    assert!(pending.erasure_pending);
+    assert!(!pending.completed_pending_checkpoint);
     assert_eq!(store.app_message_count().unwrap(), 0);
     assert_eq!(
         secure_delete_pragma(&store),
@@ -2364,6 +2370,7 @@ fn delete_local_group_data_reopens_and_retries_a_committed_pending_checkpoint() 
         .expect("retry after reopen should finish the prior checkpoint");
     assert!(completed.did_delete());
     assert!(completed.completed_pending_checkpoint);
+    assert!(!completed.erasure_pending);
     assert!(completed.deleted_rows > 0);
     drop(store);
     for path in [

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -99,7 +99,9 @@ fn source_epoch_retention_decisions_are_frozen_and_drive_expiry() {
         None
     );
 
-    let outcome = store.secure_prune_expired_app_events("aa", 15).unwrap();
+    let outcome = store
+        .secure_prune_expired_app_events("aa", 15, "local", &no_mentions)
+        .unwrap();
     assert_eq!(outcome.pruned_messages, 1);
     let surviving_ids = store
         .app_messages(StoredAppMessageQuery {
@@ -119,7 +121,7 @@ fn source_epoch_retention_decisions_are_frozen_and_drive_expiry() {
 
     assert_eq!(
         store
-            .secure_prune_expired_app_events("aa", 16)
+            .secure_prune_expired_app_events("aa", 16, "local", &no_mentions)
             .unwrap()
             .pruned_messages,
         1
@@ -727,6 +729,81 @@ fn account_projection_state_deletes_groups_removed_from_snapshot() {
 }
 
 #[test]
+fn account_projection_group_prune_chunks_stale_keys_under_sqlite_variable_limit() {
+    const GROUP_COUNT: usize = SQLITE_BIND_PARAMETER_CHUNK + 105;
+
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    {
+        let conn = store.lock().unwrap();
+        // SAFETY: The raw handle is only used to lower this test connection's
+        // bind-parameter limit before any concurrent use; rusqlite keeps owning
+        // the connection and no pointer is retained.
+        unsafe {
+            rusqlite::ffi::sqlite3_limit(
+                conn.handle(),
+                rusqlite::ffi::SQLITE_LIMIT_VARIABLE_NUMBER,
+                1_000,
+            );
+        }
+    }
+    let groups = (0..GROUP_COUNT)
+        .map(|index| {
+            let mut stored_group = group(&format!("group-{index:04}"), "group");
+            stored_group.components.clear();
+            stored_group
+        })
+        .collect::<Vec<_>>();
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                seen_events: Vec::new(),
+                last_transport_timestamp: None,
+                groups: groups.clone(),
+            },
+            16,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+
+    let retained = StoredAccountState {
+        label: "alice".to_owned(),
+        seen_events: Vec::new(),
+        last_transport_timestamp: None,
+        groups: groups[1..].to_vec(),
+    };
+    store
+        .save_account_projection_state(&retained, 16, MAX_FUTURE_SKEW_SECS)
+        .expect("an unbounded retained set must not become SQL bind parameters");
+    assert_eq!(
+        store
+            .load_account_projection_state("alice", GROUP_COUNT)
+            .unwrap()
+            .groups
+            .len(),
+        GROUP_COUNT - 1
+    );
+
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                groups: Vec::new(),
+                ..retained
+            },
+            16,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .expect("more than one chunk of stale group keys should be deleted");
+    assert!(
+        store
+            .load_account_projection_state("alice", GROUP_COUNT)
+            .unwrap()
+            .groups
+            .is_empty()
+    );
+}
+
+#[test]
 fn account_projection_state_does_not_rewrite_unchanged_group_rows() {
     let store = SqliteAccountStorage::in_memory().unwrap();
     let state = StoredAccountState {
@@ -798,7 +875,12 @@ fn app_messages_list_raw_events_and_prune_updates_timeline() {
         .record_app_event(&app_event("old-bb", "bb", 10))
         .unwrap();
 
-    assert_eq!(store.prune_app_events_before("aa", 15).unwrap(), 1);
+    assert_eq!(
+        store
+            .prune_app_events_before("aa", 15, "local", &no_mentions)
+            .unwrap(),
+        1
+    );
 
     let aa = store
         .app_messages(StoredAppMessageQuery {
@@ -881,7 +963,12 @@ fn prune_app_events_before_scrubs_pruned_plaintext_and_media_before_deleting() {
         .unwrap();
     }
 
-    assert_eq!(store.prune_app_events_before("aa", 15).unwrap(), 1);
+    assert_eq!(
+        store
+            .prune_app_events_before("aa", 15, "local", &no_mentions)
+            .unwrap(),
+        1
+    );
 
     let conn = store.lock().unwrap();
     let rows = conn
@@ -980,7 +1067,9 @@ fn secure_prune_checkpoint_removes_plaintext_from_database_and_wal_files() {
         "fixture should place plaintext in the database file before secure prune"
     );
 
-    let outcome = store.secure_prune_app_events_before("aa", 15).unwrap();
+    let outcome = store
+        .secure_prune_app_events_before("aa", 15, "local", &no_mentions)
+        .unwrap();
     assert_eq!(outcome.pruned_messages, 1);
     assert_eq!(outcome.media_ciphertext_sha256, vec![media_hash.clone()]);
     assert!(
@@ -1056,7 +1145,9 @@ fn secure_prune_removes_pruned_plaintext_from_search_index() {
         "fixture should place indexed plaintext in the database file before secure prune"
     );
 
-    let outcome = store.secure_prune_app_events_before("aa", 15).unwrap();
+    let outcome = store
+        .secure_prune_app_events_before("aa", 15, "local", &no_mentions)
+        .unwrap();
 
     assert_eq!(outcome.pruned_messages, 1);
     drop(store);
@@ -1109,7 +1200,9 @@ fn secure_prune_clears_chat_list_preview_for_pruned_latest_message() {
         "chat list should not retain this"
     );
 
-    let outcome = store.secure_prune_app_events_before("aa", 15).unwrap();
+    let outcome = store
+        .secure_prune_app_events_before("aa", 15, "local", &no_mentions)
+        .unwrap();
 
     assert_eq!(outcome.pruned_messages, 1);
     assert!(
@@ -1134,14 +1227,16 @@ fn secure_prune_restores_caller_secure_delete_setting() {
         .record_app_event(&app_event("old-aa", "aa", 10))
         .unwrap();
 
-    let outcome = store.secure_prune_app_events_before("aa", 15).unwrap();
+    let outcome = store
+        .secure_prune_app_events_before("aa", 15, "local", &no_mentions)
+        .unwrap();
 
     assert_eq!(outcome.pruned_messages, 1);
     assert_eq!(secure_delete_pragma(&store), 0);
 }
 
 #[test]
-fn secure_prune_returns_hashes_when_wal_checkpoint_is_busy() {
+fn secure_prune_retry_after_reopen_recovers_committed_outcome() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("account.sqlite");
     let store = SqliteAccountStorage::from_connection_with_options(
@@ -1167,11 +1262,163 @@ fn secure_prune_returns_hashes_when_wal_checkpoint_is_busy() {
         .query_row("SELECT count(*) FROM app_events", [], |row| row.get(0))
         .unwrap();
 
-    let outcome = store.secure_prune_app_events_before("aa", 15).unwrap();
+    let error = store
+        .secure_prune_app_events_before("aa", 15, "local", &no_mentions)
+        .expect_err("a committed prune is not securely erased until WAL truncation succeeds");
 
+    assert!(matches!(error, StorageError::Busy(_)));
+    assert_eq!(
+        store.app_message_count().unwrap(),
+        0,
+        "logical deletion commits before the checkpoint failure is surfaced"
+    );
+    reader.execute_batch("COMMIT").unwrap();
+    drop(reader);
+    drop(store);
+
+    let store = SqliteAccountStorage::from_connection_with_options(
+        rusqlite::Connection::open(&db_path).unwrap(),
+        crate::SqliteStorageOptions {
+            busy_timeout_ms: 1,
+            ..crate::SqliteStorageOptions::default()
+        },
+    )
+    .unwrap();
+    let outcome = store
+        .secure_prune_app_events_before("aa", 15, "local", &no_mentions)
+        .expect("retry after reopen must re-drive the durable pending checkpoint");
     assert_eq!(outcome.pruned_messages, 1);
     assert_eq!(outcome.media_ciphertext_sha256, vec![media_hash]);
-    reader.execute_batch("COMMIT").unwrap();
+
+    let empty = store
+        .secure_prune_app_events_before("aa", 15, "local", &no_mentions)
+        .unwrap();
+    assert_eq!(
+        empty,
+        crate::SecurePruneAppEventsResult::default(),
+        "the committed result is consumed exactly once after checkpoint completion"
+    );
+}
+
+#[test]
+fn competing_storage_handles_consume_one_checkpoint_intent_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("competing-checkpoint.sqlite");
+    let store_a = SqliteAccountStorage::from_connection_with_options(
+        rusqlite::Connection::open(&db_path).unwrap(),
+        SqliteStorageOptions::default(),
+    )
+    .unwrap();
+    let store_b = SqliteAccountStorage::from_connection_with_options(
+        rusqlite::Connection::open(&db_path).unwrap(),
+        SqliteStorageOptions::default(),
+    )
+    .unwrap();
+    let expected = crate::SecurePruneAppEventsResult {
+        pruned_messages: 1,
+        pruned_media_epoch_secrets: 0,
+        media_ciphertext_sha256: vec!["ab".repeat(32)],
+    };
+    {
+        let conn = store_a.lock().unwrap();
+        upsert_secure_delete_intent_tx(
+            &conn,
+            SECURE_DELETE_RETENTION_OPERATION,
+            "aa",
+            &serde_json::to_string(&expected).unwrap(),
+        )
+        .unwrap();
+    }
+
+    let a = std::thread::spawn(move || {
+        finish_secure_delete_checkpoint_intent::<crate::SecurePruneAppEventsResult>(
+            &store_a,
+            SECURE_DELETE_RETENTION_OPERATION,
+            "aa",
+        )
+        .unwrap()
+    });
+    let b = std::thread::spawn(move || {
+        finish_secure_delete_checkpoint_intent::<crate::SecurePruneAppEventsResult>(
+            &store_b,
+            SECURE_DELETE_RETENTION_OPERATION,
+            "aa",
+        )
+        .unwrap()
+    });
+    let outcomes = [a.join().unwrap(), b.join().unwrap()];
+    assert_eq!(
+        outcomes.iter().filter(|outcome| outcome.is_some()).count(),
+        1,
+        "exactly one competing finisher should consume the durable result"
+    );
+    assert!(
+        outcomes
+            .into_iter()
+            .flatten()
+            .all(|outcome| outcome == expected)
+    );
+}
+
+#[test]
+fn recreated_checkpoint_intent_cannot_be_deleted_by_a_stale_nonce() {
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let first_result = crate::SecurePruneAppEventsResult {
+        pruned_messages: 1,
+        ..crate::SecurePruneAppEventsResult::default()
+    };
+    let second_result = crate::SecurePruneAppEventsResult {
+        pruned_messages: 2,
+        ..crate::SecurePruneAppEventsResult::default()
+    };
+    let conn = store.lock().unwrap();
+    upsert_secure_delete_intent_tx(
+        &conn,
+        SECURE_DELETE_RETENTION_OPERATION,
+        "aa",
+        &serde_json::to_string(&first_result).unwrap(),
+    )
+    .unwrap();
+    let first = secure_delete_intent(&conn, SECURE_DELETE_RETENTION_OPERATION, "aa")
+        .unwrap()
+        .unwrap();
+    conn.execute(
+        "DELETE FROM secure_delete_checkpoint_intents
+         WHERE operation_kind = ?1 AND scope = ?2",
+        params![SECURE_DELETE_RETENTION_OPERATION, "aa"],
+    )
+    .unwrap();
+    upsert_secure_delete_intent_tx(
+        &conn,
+        SECURE_DELETE_RETENTION_OPERATION,
+        "aa",
+        &serde_json::to_string(&second_result).unwrap(),
+    )
+    .unwrap();
+    let second = secure_delete_intent(&conn, SECURE_DELETE_RETENTION_OPERATION, "aa")
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(first.nonce.len(), 16);
+    assert_eq!(second.nonce.len(), 16);
+    assert_ne!(first.nonce, second.nonce);
+    assert_eq!(
+        conn.execute(
+            "DELETE FROM secure_delete_checkpoint_intents
+             WHERE operation_kind = ?1 AND scope = ?2 AND intent_nonce = ?3",
+            params![SECURE_DELETE_RETENTION_OPERATION, "aa", &first.nonce],
+        )
+        .unwrap(),
+        0,
+        "a stale finisher must not consume a recreated intent"
+    );
+    let remaining = secure_delete_intent(&conn, SECURE_DELETE_RETENTION_OPERATION, "aa")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        serde_json::from_str::<crate::SecurePruneAppEventsResult>(&remaining.result_json).unwrap(),
+        second_result
+    );
 }
 
 fn secure_delete_pragma(store: &SqliteAccountStorage) -> i64 {
@@ -1204,7 +1451,12 @@ fn prune_app_events_before_does_not_delete_surviving_timeline_rows() {
         .unwrap();
     }
 
-    assert_eq!(store.prune_app_events_before("aa", 15).unwrap(), 1);
+    assert_eq!(
+        store
+            .prune_app_events_before("aa", 15, "local", &no_mentions)
+            .unwrap(),
+        1
+    );
 
     let timeline = store
         .message_timeline(crate::TimelineMessageQuery {
@@ -1248,7 +1500,12 @@ fn prune_app_events_before_deletes_only_pruned_agent_stream_start_rows() {
         .unwrap();
     }
 
-    assert_eq!(store.prune_app_events_before("aa", 15).unwrap(), 1);
+    assert_eq!(
+        store
+            .prune_app_events_before("aa", 15, "local", &no_mentions)
+            .unwrap(),
+        1
+    );
 
     let conn = store.lock().unwrap();
     let stream_start_ids = conn
@@ -1286,7 +1543,9 @@ fn prune_app_events_before_chunks_projection_deletes_under_sqlite_variable_limit
     }
 
     assert_eq!(
-        store.prune_app_events_before("aa", 2_000).unwrap(),
+        store
+            .prune_app_events_before("aa", 2_000, "local", &no_mentions)
+            .unwrap(),
         EVENT_COUNT
     );
 
@@ -1329,7 +1588,12 @@ fn prune_app_events_before_does_not_reproject_replies_when_parent_is_pruned() {
         .unwrap();
     }
 
-    assert_eq!(store.prune_app_events_before("aa", 15).unwrap(), 1);
+    assert_eq!(
+        store
+            .prune_app_events_before("aa", 15, "local", &no_mentions)
+            .unwrap(),
+        1
+    );
 
     let timeline = store
         .message_timeline(crate::TimelineMessageQuery {
@@ -1366,7 +1630,12 @@ fn prune_app_events_before_reprojects_survivor_when_reaction_is_pruned() {
         .unwrap();
     }
 
-    assert_eq!(store.prune_app_events_before("aa", 15).unwrap(), 1);
+    assert_eq!(
+        store
+            .prune_app_events_before("aa", 15, "local", &no_mentions)
+            .unwrap(),
+        1
+    );
 
     let timeline = store
         .message_timeline(crate::TimelineMessageQuery {
@@ -1403,7 +1672,12 @@ fn prune_app_events_before_reprojects_survivor_when_delete_is_pruned() {
         .unwrap();
     }
 
-    assert_eq!(store.prune_app_events_before("aa", 15).unwrap(), 1);
+    assert_eq!(
+        store
+            .prune_app_events_before("aa", 15, "local", &no_mentions)
+            .unwrap(),
+        1
+    );
 
     let timeline = store
         .message_timeline(crate::TimelineMessageQuery {
@@ -1957,7 +2231,7 @@ fn delete_local_group_data_removes_app_local_rows_without_touching_protocol_stat
         .queue_push_registration_removals(&registration, 11)
         .unwrap();
 
-    assert!(store.delete_local_group_data("aa").unwrap());
+    assert!(store.delete_local_group_data("aa").unwrap().did_delete());
     store
         .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[9, 9, 9])
         .unwrap();
@@ -2012,7 +2286,99 @@ fn delete_local_group_data_removes_app_local_rows_without_touching_protocol_stat
     }
     assert_eq!(all_row_count(&store, "seen_events"), 1);
     assert_eq!(all_row_count(&store, "cgka_groups"), 1);
-    assert!(!store.delete_local_group_data("aa").unwrap());
+    assert!(!store.delete_local_group_data("aa").unwrap().did_delete());
+}
+
+#[test]
+fn delete_local_group_data_reopens_and_retries_a_committed_pending_checkpoint() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("local-wipe.sqlite");
+    let store = SqliteAccountStorage::from_connection_with_options(
+        rusqlite::Connection::open(&db_path).unwrap(),
+        crate::SqliteStorageOptions {
+            busy_timeout_ms: 1,
+            secure_delete: false,
+            ..crate::SqliteStorageOptions::default()
+        },
+    )
+    .unwrap();
+    let group_id_hex = "aa";
+    store
+        .save_account_projection_state(
+            &StoredAccountState {
+                label: "alice".to_owned(),
+                seen_events: Vec::new(),
+                last_transport_timestamp: None,
+                groups: vec![group(group_id_hex, "alpha")],
+            },
+            16,
+            MAX_FUTURE_SKEW_SECS,
+        )
+        .unwrap();
+    let secret = "local-wipe-plaintext-secret";
+    let mut message = app_event("wipe-me", group_id_hex, 10);
+    message.plaintext = secret.to_owned();
+    store.record_app_event(&message).unwrap();
+    {
+        let conn = store.lock().unwrap();
+        let (busy, _, _): (i64, i64, i64) = conn
+            .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })
+            .unwrap();
+        assert_eq!(busy, 0);
+    }
+    assert!(file_contains(&db_path, secret.as_bytes()));
+
+    let reader = rusqlite::Connection::open(&db_path).unwrap();
+    reader.execute_batch("BEGIN").unwrap();
+    let _: i64 = reader
+        .query_row("SELECT count(*) FROM app_events", [], |row| row.get(0))
+        .unwrap();
+
+    let error = store
+        .delete_local_group_data(group_id_hex)
+        .expect_err("logical wipe must not report success while WAL erasure is pending");
+    assert!(matches!(error, StorageError::Busy(_)));
+    assert_eq!(store.app_message_count().unwrap(), 0);
+    assert_eq!(
+        secure_delete_pragma(&store),
+        0,
+        "the caller's secure_delete setting must be restored after the committed wipe"
+    );
+
+    reader.execute_batch("COMMIT").unwrap();
+    drop(reader);
+    drop(store);
+    let store = SqliteAccountStorage::from_connection_with_options(
+        rusqlite::Connection::open(&db_path).unwrap(),
+        crate::SqliteStorageOptions {
+            busy_timeout_ms: 1,
+            secure_delete: false,
+            ..crate::SqliteStorageOptions::default()
+        },
+    )
+    .unwrap();
+    let completed = store
+        .delete_local_group_data(group_id_hex)
+        .expect("retry after reopen should finish the prior checkpoint");
+    assert!(completed.did_delete());
+    assert!(completed.completed_pending_checkpoint);
+    assert!(completed.deleted_rows > 0);
+    drop(store);
+    for path in [
+        db_path.clone(),
+        db_path.with_extension("sqlite-wal"),
+        db_path.with_extension("sqlite-shm"),
+    ] {
+        if path.exists() {
+            assert!(
+                !file_contains(&path, secret.as_bytes()),
+                "{} must not retain locally wiped plaintext",
+                path.display()
+            );
+        }
+    }
 }
 
 #[test]
@@ -2329,6 +2695,77 @@ fn member_cleanup_clears_tokens_and_tombstones() {
             .apply_group_push_token(&push_token(&g, &m, 10, "d1"))
             .unwrap()
     );
+}
+
+#[test]
+fn stale_push_token_cleanup_chunks_stale_keys_and_does_not_bind_retained_members() {
+    const ACTIVE_COUNT: usize = SQLITE_BIND_PARAMETER_CHUNK + 105;
+    const STALE_COUNT: usize = SQLITE_BIND_PARAMETER_CHUNK + 1;
+
+    let store = SqliteAccountStorage::in_memory().unwrap();
+    let group_id = "aa".repeat(32);
+    {
+        let conn = store.lock().unwrap();
+        // SAFETY: The raw handle is only used to lower this test connection's
+        // bind-parameter limit before any concurrent use; rusqlite keeps owning
+        // the connection and no pointer is retained.
+        unsafe {
+            rusqlite::ffi::sqlite3_limit(
+                conn.handle(),
+                rusqlite::ffi::SQLITE_LIMIT_VARIABLE_NUMBER,
+                1_000,
+            );
+        }
+        let mut token = conn
+            .prepare(
+                "INSERT INTO group_push_tokens (
+                    group_id_hex, member_id_hex, leaf_index, platform,
+                    token_fingerprint, server_pubkey_hex, relay_hint,
+                    encrypted_token, owner_ts, owner_sig, record_digest,
+                    updated_at_ms
+                 ) VALUES (?1, ?2, 0, 1, 'token', ?3, NULL, x'01', 1, 'sig', 'digest', 1)",
+            )
+            .unwrap();
+        let mut tombstone = conn
+            .prepare(
+                "INSERT INTO group_push_token_tombstones (
+                    group_id_hex, member_id_hex, leaf_index, platform,
+                    server_pubkey_hex, owner_ts, record_digest, created_at_ms
+                 ) VALUES (?1, ?2, 0, 1, ?3, 1, 'digest', 1)",
+            )
+            .unwrap();
+        for index in 0..(ACTIVE_COUNT + STALE_COUNT) {
+            let member_id = format!("member-{index:04}");
+            let server_key = "cc".repeat(32);
+            token
+                .execute(params![&group_id, &member_id, &server_key])
+                .unwrap();
+            tombstone
+                .execute(params![&group_id, &member_id, &server_key])
+                .unwrap();
+        }
+    }
+    let active_members = (0..ACTIVE_COUNT)
+        .map(|index| format!("member-{index:04}"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        store
+            .remove_stale_group_push_tokens(&group_id, &active_members)
+            .expect("retained members must not become an unbounded NOT IN bind set"),
+        STALE_COUNT
+    );
+    let conn = store.lock().unwrap();
+    for table in ["group_push_tokens", "group_push_token_tombstones"] {
+        let remaining: i64 = conn
+            .query_row(
+                &format!("SELECT count(*) FROM {table} WHERE group_id_hex = ?1"),
+                params![&group_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(remaining, ACTIVE_COUNT as i64, "{table}");
+    }
 }
 
 fn insert_group_push_token(store: &SqliteAccountStorage, group_id_hex: &str, member_id_hex: &str) {

--- a/crates/storage-sqlite/src/chat_list.rs
+++ b/crates/storage-sqlite/src/chat_list.rs
@@ -1267,6 +1267,37 @@ fn unread_summary_tx(
     })
 }
 
+pub(crate) fn refresh_chat_list_unread_after_secure_prune_tx(
+    tx: &Connection,
+    local_account_id_hex: &str,
+    group_id_hex: &str,
+    mention_classifier: &MentionClassifier<'_>,
+) -> StorageResult<()> {
+    let read_state = read_state_tx(tx, group_id_hex)?;
+    let unread = unread_summary_tx(
+        tx,
+        local_account_id_hex,
+        group_id_hex,
+        read_state.as_ref(),
+        mention_classifier,
+    )?;
+    tx.execute(
+        "UPDATE chat_list_rows
+         SET unread_count = ?2,
+             unread_mention_count = ?3,
+             first_unread_message_id_hex = ?4
+         WHERE group_id_hex = ?1",
+        params![
+            group_id_hex,
+            u64_to_i64(unread.count)?,
+            u64_to_i64(unread.mention_count)?,
+            unread.first_message_id
+        ],
+    )
+    .storage()?;
+    Ok(())
+}
+
 fn account_groups_tx(tx: &Connection) -> StorageResult<Vec<AccountGroupRow>> {
     let mut stmt = tx
         .prepare(

--- a/crates/storage-sqlite/src/chat_list/tests.rs
+++ b/crates/storage-sqlite/src/chat_list/tests.rs
@@ -554,10 +554,14 @@ fn visible_activity_survives_read_metadata_membership_and_secure_prune_updates()
         assert_eq!(row.conversation_created_at, 5);
         assert_eq!(row.activity_sort_at, 100);
 
-        store.secure_prune_app_events_before(GROUP, 101).unwrap();
+        store
+            .secure_prune_app_events_before(GROUP, 101, LOCAL, &no_mentions)
+            .unwrap();
         row = store.chat_list_row(GROUP).unwrap().expect("chat row");
         assert_eq!(row.last_message, None);
-        assert_eq!(row.unread_count, u64::from(!mark_read));
+        assert_eq!(row.unread_count, 0);
+        assert_eq!(row.unread_mention_count, 0);
+        assert_eq!(row.first_unread_message_id_hex, None);
         assert_eq!(row.activity_sort_at, 100);
 
         if mark_read {
@@ -973,6 +977,43 @@ fn unread_starts_after_first_open_and_advances_by_visible_kind9() {
         .expect("chat row");
     assert_eq!(row.unread_count, 0);
     assert_eq!(row.last_read_message_id_hex.as_deref(), Some("new"));
+}
+
+#[test]
+fn secure_prune_refreshes_unread_count_mentions_and_first_message_atomically() {
+    let store = setup_store();
+    let mentions = |plaintext: &str, _tags: &[Vec<String>]| plaintext.contains("@local");
+    store
+        .initialize_chat_read_state(LOCAL, GROUP, &mentions)
+        .unwrap();
+    store
+        .record_app_event(&chat("pruned-unread", REMOTE, 10, "hello @local"))
+        .unwrap();
+    store
+        .record_app_event(&chat("surviving-unread", REMOTE, 20, "hello"))
+        .unwrap();
+    let before = store
+        .refresh_chat_list_row(LOCAL, GROUP, &mentions)
+        .unwrap()
+        .expect("chat row");
+    assert_eq!(before.unread_count, 2);
+    assert_eq!(before.unread_mention_count, 1);
+    assert_eq!(
+        before.first_unread_message_id_hex.as_deref(),
+        Some("pruned-unread")
+    );
+
+    store
+        .secure_prune_app_events_before(GROUP, 15, LOCAL, &mentions)
+        .unwrap();
+
+    let after = store.chat_list_row(GROUP).unwrap().expect("chat row");
+    assert_eq!(after.unread_count, 1);
+    assert_eq!(after.unread_mention_count, 0);
+    assert_eq!(
+        after.first_unread_message_id_hex.as_deref(),
+        Some("surviving-unread")
+    );
 }
 
 #[test]
@@ -1984,7 +2025,7 @@ fn archiving_and_deleting_clear_pins_without_restoring_them() {
         .unwrap();
     assert!(!store.chat_list_row("33").unwrap().unwrap().pinned);
 
-    assert!(store.delete_local_group_data("11").unwrap());
+    assert!(store.delete_local_group_data("11").unwrap().did_delete());
     let pin_count = {
         let conn = store.lock().unwrap();
         conn.query_row(

--- a/crates/storage-sqlite/src/codec.rs
+++ b/crates/storage-sqlite/src/codec.rs
@@ -5,6 +5,11 @@ use cgka_traits::storage::{StorageError, StorageResult};
 use cgka_traits::types::EpochId;
 use serde::{Serialize, de::DeserializeOwned};
 
+/// Total bind-parameter budget for generated statements that use chunked
+/// positive-`IN` lists. This stays below SQLite's historical 999-variable
+/// default and includes any fixed parameters that precede the list.
+pub(crate) const SQLITE_BIND_PARAMETER_CHUNK: usize = 900;
+
 pub(crate) fn serialize<T: Serialize>(value: &T) -> StorageResult<Vec<u8>> {
     serde_json::to_vec(value).map_err(|e| StorageError::Serialization(e.to_string()))
 }

--- a/crates/storage-sqlite/src/encrypted_media_secrets.rs
+++ b/crates/storage-sqlite/src/encrypted_media_secrets.rs
@@ -415,6 +415,10 @@ mod tests {
     use crate::StoredAppEvent;
     use cgka_traits::app_event::MARMOT_APP_EVENT_KIND_CHAT;
 
+    fn no_mentions(_plaintext: &str, _tags: &[Vec<String>]) -> bool {
+        false
+    }
+
     fn media_event(id: &str, recorded_at: u64, source_epoch: u64) -> StoredAppEvent {
         media_event_with_versions(id, recorded_at, source_epoch, &[ENCRYPTED_MEDIA_FORMAT_V1])
     }
@@ -573,7 +577,9 @@ mod tests {
             .unwrap();
         store.record_app_event(&media_event("old", 10, 7)).unwrap();
 
-        let outcome = store.secure_prune_app_events_before("aa", 11).unwrap();
+        let outcome = store
+            .secure_prune_app_events_before("aa", 11, "local", &no_mentions)
+            .unwrap();
         assert_eq!(outcome.pruned_messages, 1);
         assert_eq!(outcome.pruned_media_epoch_secrets, 1);
         assert_eq!(
@@ -674,7 +680,9 @@ mod tests {
         store.record_app_event(&media_event("old", 10, 7)).unwrap();
         store.record_app_event(&media_event("new", 20, 7)).unwrap();
 
-        let partial = store.secure_prune_app_events_before("aa", 15).unwrap();
+        let partial = store
+            .secure_prune_app_events_before("aa", 15, "local", &no_mentions)
+            .unwrap();
         assert_eq!(partial.pruned_messages, 1);
         assert_eq!(partial.pruned_media_epoch_secrets, 0);
         assert!(secret_is_referenced(&store, "aa", 0x8008, 7));
@@ -683,7 +691,9 @@ mod tests {
             Some(vec![1, 2, 3])
         );
 
-        let final_sweep = store.secure_prune_app_events_before("aa", 21).unwrap();
+        let final_sweep = store
+            .secure_prune_app_events_before("aa", 21, "local", &no_mentions)
+            .unwrap();
         assert_eq!(final_sweep.pruned_messages, 1);
         assert_eq!(final_sweep.pruned_media_epoch_secrets, 1);
         assert_eq!(
@@ -724,7 +734,9 @@ mod tests {
             GROUP_ENCRYPTED_MEDIA_V1_COMPONENT_ID,
             7,
         ));
-        let outcome = store.secure_prune_app_events_before("aa", 11).unwrap();
+        let outcome = store
+            .secure_prune_app_events_before("aa", 11, "local", &no_mentions)
+            .unwrap();
         assert_eq!(outcome.pruned_media_epoch_secrets, 1);
         assert_eq!(
             store
@@ -741,7 +753,9 @@ mod tests {
             .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[1, 2, 3])
             .unwrap();
         store.record_app_event(&media_event("old", 10, 7)).unwrap();
-        store.secure_prune_app_events_before("aa", 11).unwrap();
+        store
+            .secure_prune_app_events_before("aa", 11, "local", &no_mentions)
+            .unwrap();
 
         store
             .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[9, 9, 9])
@@ -782,7 +796,9 @@ mod tests {
         store
             .record_app_event(&media_event("seven", 10, 7))
             .unwrap();
-        store.secure_prune_app_events_before("aa", 11).unwrap();
+        store
+            .secure_prune_app_events_before("aa", 11, "local", &no_mentions)
+            .unwrap();
 
         store
             .remember_encrypted_media_epoch_secret("aa", 0x8008, 6, &[6])
@@ -809,7 +825,9 @@ mod tests {
         store
             .record_app_event(&media_event("eight", 20, 8))
             .unwrap();
-        store.secure_prune_app_events_before("aa", 21).unwrap();
+        store
+            .secure_prune_app_events_before("aa", 21, "local", &no_mentions)
+            .unwrap();
         let watermark: (i64, i64) = store
             .lock()
             .unwrap()
@@ -836,7 +854,9 @@ mod tests {
             .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[1, 2, 3])
             .unwrap();
         store.record_app_event(&media_event("old", 10, 7)).unwrap();
-        store.secure_prune_app_events_before("aa", 11).unwrap();
+        store
+            .secure_prune_app_events_before("aa", 11, "local", &no_mentions)
+            .unwrap();
         drop(store);
 
         let reopened = SqliteAccountStorage::from_connection_with_options(
@@ -869,7 +889,9 @@ mod tests {
         store
             .record_app_event(&media_event("reference-only", 10, 7))
             .unwrap();
-        store.secure_prune_app_events_before("aa", 11).unwrap();
+        store
+            .secure_prune_app_events_before("aa", 11, "local", &no_mentions)
+            .unwrap();
         store
             .remember_encrypted_media_epoch_secret("aa", 0x8008, 7, &[1, 2, 3])
             .unwrap();
@@ -924,7 +946,9 @@ mod tests {
             ))
             .unwrap();
 
-        let partial = store.secure_prune_app_events_before("aa", 15).unwrap();
+        let partial = store
+            .secure_prune_app_events_before("aa", 15, "local", &no_mentions)
+            .unwrap();
         assert_eq!(partial.pruned_messages, 1);
         assert_eq!(partial.pruned_media_epoch_secrets, 0);
         assert_eq!(
@@ -935,7 +959,9 @@ mod tests {
             "a retained V2 sibling needs the same source-epoch exporter secret"
         );
 
-        let final_sweep = store.secure_prune_app_events_before("aa", 21).unwrap();
+        let final_sweep = store
+            .secure_prune_app_events_before("aa", 21, "local", &no_mentions)
+            .unwrap();
         assert_eq!(final_sweep.pruned_messages, 1);
         assert_eq!(final_sweep.pruned_media_epoch_secrets, 1);
         assert_eq!(
@@ -966,7 +992,7 @@ mod tests {
             .unwrap();
 
         let error = store
-            .secure_prune_app_events_before("aa", 11)
+            .secure_prune_app_events_before("aa", 11, "local", &no_mentions)
             .expect_err("secret-delete failure must abort the whole prune");
         assert!(format!("{error}").contains("abort media secret delete"));
         assert_eq!(store.app_message_count().unwrap(), 1);

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -22,9 +22,9 @@ mod timeline;
 pub use account_projection::{
     AccountChatNotificationSettings, AccountGroupPushToken, AccountNotificationSettings,
     AccountPendingPushRegistrationRemoval, AccountPushRegistration, AccountStoredPushRegistration,
-    AppEventReplayCursor, SelfMembership, StoredAccountGroup, StoredAccountGroupComponent,
-    StoredAccountState, StoredAppMessageQuery, StoredAppMessageRecord, StoredNostrRoute,
-    clamp_to_max_future_skew,
+    AppEventReplayCursor, DeleteLocalGroupDataResult, SelfMembership, StoredAccountGroup,
+    StoredAccountGroupComponent, StoredAccountState, StoredAppMessageQuery, StoredAppMessageRecord,
+    StoredNostrRoute, clamp_to_max_future_skew,
 };
 pub use chat_list::{
     AccountUnreadTotal, ChatConversationKind, ChatListAttachmentKind, ChatListAvatar,

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -59,7 +59,7 @@ pub use agent_stream_sequences::{
     AgentStreamPublisherState, MAX_AGENT_STREAM_PUBLISHER_CONTEXTS,
 };
 pub(crate) use codec::{
-    SqliteResultExt, bool_i64, created_at_to_i64, deserialize, epoch_to_i64, i64_to_u64,
-    i64_to_usize, message_state_to_i64, optional_u64_to_i64, serialize, tags_from_json, u64_to_i64,
-    unix_now_ms, unix_now_seconds, unix_now_seconds_i64, usize_to_i64,
+    SQLITE_BIND_PARAMETER_CHUNK, SqliteResultExt, bool_i64, created_at_to_i64, deserialize,
+    epoch_to_i64, i64_to_u64, i64_to_usize, message_state_to_i64, optional_u64_to_i64, serialize,
+    tags_from_json, u64_to_i64, unix_now_ms, unix_now_seconds, unix_now_seconds_i64, usize_to_i64,
 };

--- a/crates/storage-sqlite/src/message_drafts.rs
+++ b/crates/storage-sqlite/src/message_drafts.rs
@@ -566,7 +566,7 @@ mod tests {
     }
 
     #[test]
-    fn message_draft_round_trips_and_deletes_with_group() {
+    fn message_draft_round_trips_and_survives_projection_pruning() {
         let storage = SqliteAccountStorage::in_memory().unwrap();
         let group_id_hex = "11".repeat(16);
         storage
@@ -647,7 +647,12 @@ mod tests {
         assert!(storage.message_draft(&group_id_hex).unwrap().is_none());
 
         storage
-            .save_message_draft(&group_id_hex, "cascade", None, &[])
+            .save_message_draft(
+                &group_id_hex,
+                "protected",
+                None,
+                std::slice::from_ref(&attachment),
+            )
             .unwrap();
         storage
             .save_account_projection_state(
@@ -661,7 +666,40 @@ mod tests {
                 MAX_FUTURE_SKEW_SECS,
             )
             .unwrap();
-        assert!(storage.message_draft(&group_id_hex).unwrap().is_none());
+        let protected = storage.message_draft(&group_id_hex).unwrap().unwrap();
+        assert_eq!(protected.content, "protected");
+        assert_eq!(protected.media_attachments, vec![attachment]);
+        assert_eq!(
+            storage
+                .load_account_projection_state("alice", 100)
+                .unwrap()
+                .groups
+                .len(),
+            1,
+            "the draft-owning projection row must remain for the foreign key"
+        );
+
+        storage.delete_message_draft(&group_id_hex).unwrap();
+        storage
+            .save_account_projection_state(
+                &StoredAccountState {
+                    label: "alice".to_owned(),
+                    seen_events: vec![],
+                    last_transport_timestamp: None,
+                    groups: vec![],
+                },
+                100,
+                MAX_FUTURE_SKEW_SECS,
+            )
+            .unwrap();
+        assert!(
+            storage
+                .load_account_projection_state("alice", 100)
+                .unwrap()
+                .groups
+                .is_empty(),
+            "the formerly protected row must become stale after draft deletion"
+        );
     }
 
     #[test]

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -887,6 +887,11 @@ mod tests {
                 .iter()
                 .any(|column| column == "checkpoint_completed")
         );
+        assert!(
+            !columns
+                .iter()
+                .any(|column| column == "created_at_unix_seconds")
+        );
     }
 
     #[test]

--- a/crates/storage-sqlite/src/migrations.rs
+++ b/crates/storage-sqlite/src/migrations.rs
@@ -78,6 +78,8 @@ mod migration_0038_chat_list_interaction_state;
 mod migration_0039_chat_pin_positions;
 #[path = "migrations/0040_disband_requests.rs"]
 mod migration_0040_disband_requests;
+#[path = "migrations/0041_secure_delete_checkpoint_intents.rs"]
+mod migration_0041_secure_delete_checkpoint_intents;
 
 use crate::SqliteResultExt;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -289,6 +291,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 40,
         name: "0040_disband_requests",
         apply: migration_0040_disband_requests::apply,
+    },
+    Migration {
+        version: 41,
+        name: "0041_secure_delete_checkpoint_intents",
+        apply: migration_0041_secure_delete_checkpoint_intents::apply,
     },
 ];
 
@@ -849,6 +856,37 @@ mod tests {
             "message_draft_attachments",
             "plaintext"
         ));
+    }
+
+    #[test]
+    fn secure_delete_checkpoint_intents_table_is_migrated() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let conn = store.lock().unwrap();
+        let exists: i64 = conn
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM sqlite_master
+                    WHERE type = 'table' AND name = 'secure_delete_checkpoint_intents'
+                 )",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(exists, 1);
+        let columns = conn
+            .prepare("PRAGMA table_info(secure_delete_checkpoint_intents)")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(columns.iter().any(|column| column == "intent_nonce"));
+        assert!(!columns.iter().any(|column| column == "generation"));
+        assert!(
+            !columns
+                .iter()
+                .any(|column| column == "checkpoint_completed")
+        );
     }
 
     #[test]

--- a/crates/storage-sqlite/src/migrations/0041_secure_delete_checkpoint_intents.rs
+++ b/crates/storage-sqlite/src/migrations/0041_secure_delete_checkpoint_intents.rs
@@ -10,7 +10,6 @@ CREATE TABLE secure_delete_checkpoint_intents (
     scope TEXT NOT NULL,
     intent_nonce BLOB NOT NULL,
     result_json TEXT NOT NULL,
-    created_at_unix_seconds INTEGER NOT NULL,
     PRIMARY KEY (operation_kind, scope)
 );
 "#,

--- a/crates/storage-sqlite/src/migrations/0041_secure_delete_checkpoint_intents.rs
+++ b/crates/storage-sqlite/src/migrations/0041_secure_delete_checkpoint_intents.rs
@@ -1,0 +1,19 @@
+use crate::SqliteResultExt;
+use cgka_traits::storage::StorageResult;
+use rusqlite::Transaction;
+
+pub(crate) fn apply(tx: &Transaction<'_>) -> StorageResult<()> {
+    tx.execute_batch(
+        r#"
+CREATE TABLE secure_delete_checkpoint_intents (
+    operation_kind TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    intent_nonce BLOB NOT NULL,
+    result_json TEXT NOT NULL,
+    created_at_unix_seconds INTEGER NOT NULL,
+    PRIMARY KEY (operation_kind, scope)
+);
+"#,
+    )
+    .storage()
+}

--- a/crates/storage-sqlite/src/storage/disband_requests.rs
+++ b/crates/storage-sqlite/src/storage/disband_requests.rs
@@ -311,6 +311,7 @@ mod tests {
             store
                 .delete_local_group_data(&hex::encode(group.id.as_slice()))
                 .unwrap()
+                .did_delete()
         );
 
         assert!(store.list_disband_candidates(&group.id).unwrap().is_empty());

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use crate::{
-    SqliteAccountStorage, SqliteResultExt,
+    SQLITE_BIND_PARAMETER_CHUNK, SqliteAccountStorage, SqliteResultExt,
     encrypted_media_secrets::{
         encrypted_media_component_ids, replace_encrypted_media_secret_references_for_parts_tx,
         replace_encrypted_media_secret_references_tx,
@@ -41,8 +41,6 @@ const DEFAULT_TIMELINE_LIMIT: usize = 50;
 /// materialized window kept above this cannot be re-fetched in one query, so
 /// window owners should not exceed it.
 pub const MAX_TIMELINE_LIMIT: usize = 200;
-const SQLITE_BIND_PARAMETER_CHUNK: usize = 900;
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StoredAppEvent {
     pub group_id_hex: String,
@@ -204,6 +202,11 @@ pub struct SecurePruneAppEventsResult {
     /// Sorted set of encrypted-media blob ids referenced by pruned messages.
     /// Callers should treat this as an unordered purge set.
     pub media_ciphertext_sha256: Vec<String>,
+    /// True when logical deletion committed but WAL truncation remains
+    /// durably pending. A later prune call retries the checkpoint even when
+    /// it finds no additional rows to delete.
+    #[serde(default)]
+    pub erasure_pending: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -1054,6 +1057,7 @@ fn secure_prune_selected_app_events_tx(
         pruned_messages: pruned,
         pruned_media_epoch_secrets,
         media_ciphertext_sha256: media_ciphertext_sha256.into_iter().collect(),
+        erasure_pending: false,
     })
 }
 

--- a/crates/storage-sqlite/src/timeline.rs
+++ b/crates/storage-sqlite/src/timeline.rs
@@ -195,7 +195,7 @@ pub struct TimelineProjectionUpdate {
     pub changes: Vec<TimelineMessageChange>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SecurePruneAppEventsResult {
     pub pruned_messages: usize,
     /// Number of versioned encrypted-media epoch secrets whose final retained
@@ -943,6 +943,8 @@ pub(crate) fn secure_prune_app_events_before_tx(
     tx: &Connection,
     group_id_hex: &str,
     cutoff_recorded_at: u64,
+    local_account_id_hex: &str,
+    mention_classifier: &crate::chat_list::MentionClassifier<'_>,
 ) -> StorageResult<SecurePruneAppEventsResult> {
     debug_assert_eq!(
         tx.query_row("PRAGMA secure_delete", [], |row| row.get::<_, i64>(0))
@@ -951,7 +953,13 @@ pub(crate) fn secure_prune_app_events_before_tx(
         "secure_delete must be ON before the prune transaction is opened"
     );
     let pruned_events = app_events_before_cutoff_tx(tx, group_id_hex, cutoff_recorded_at)?;
-    secure_prune_selected_app_events_tx(tx, group_id_hex, pruned_events)
+    secure_prune_selected_app_events_tx(
+        tx,
+        group_id_hex,
+        pruned_events,
+        local_account_id_hex,
+        mention_classifier,
+    )
 }
 
 /// Securely prune only rows whose source-epoch retention decision has reached
@@ -961,6 +969,8 @@ pub(crate) fn secure_prune_expired_app_events_tx(
     tx: &Connection,
     group_id_hex: &str,
     now: u64,
+    local_account_id_hex: &str,
+    mention_classifier: &crate::chat_list::MentionClassifier<'_>,
 ) -> StorageResult<SecurePruneAppEventsResult> {
     debug_assert_eq!(
         tx.query_row("PRAGMA secure_delete", [], |row| row.get::<_, i64>(0))
@@ -969,13 +979,21 @@ pub(crate) fn secure_prune_expired_app_events_tx(
         "secure_delete must be ON before the prune transaction is opened"
     );
     let pruned_events = expired_app_events_tx(tx, group_id_hex, now)?;
-    secure_prune_selected_app_events_tx(tx, group_id_hex, pruned_events)
+    secure_prune_selected_app_events_tx(
+        tx,
+        group_id_hex,
+        pruned_events,
+        local_account_id_hex,
+        mention_classifier,
+    )
 }
 
 fn secure_prune_selected_app_events_tx(
     tx: &Connection,
     group_id_hex: &str,
     pruned_events: Vec<PrunedAppEvent>,
+    local_account_id_hex: &str,
+    mention_classifier: &crate::chat_list::MentionClassifier<'_>,
 ) -> StorageResult<SecurePruneAppEventsResult> {
     if pruned_events.is_empty() {
         return Ok(SecurePruneAppEventsResult::default());
@@ -1025,6 +1043,12 @@ fn secure_prune_selected_app_events_tx(
         upsert_message_timeline_projection_for_message_tx(tx, group_id_hex, &message_id)?;
     }
     refresh_chat_list_last_message_after_secure_prune_tx(tx, group_id_hex)?;
+    crate::chat_list::refresh_chat_list_unread_after_secure_prune_tx(
+        tx,
+        local_account_id_hex,
+        group_id_hex,
+        mention_classifier,
+    )?;
 
     Ok(SecurePruneAppEventsResult {
         pruned_messages: pruned,

--- a/crates/storage-sqlite/src/timeline/tests.rs
+++ b/crates/storage-sqlite/src/timeline/tests.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+fn no_mentions(_plaintext: &str, _tags: &[Vec<String>]) -> bool {
+    false
+}
+
 fn chat(id: &str, sender: &str, at: u64, plaintext: &str) -> StoredAppEvent {
     StoredAppEvent {
         group_id_hex: "11".repeat(32),
@@ -2005,7 +2009,9 @@ fn pruning_modifier_event_cascades_its_edges() {
         .unwrap();
     assert_eq!(modifier_edge_count(&store, "reaction-old"), 1);
 
-    store.prune_app_events_before(&"11".repeat(32), 50).unwrap();
+    store
+        .prune_app_events_before(&"11".repeat(32), 50, "local", &no_mentions)
+        .unwrap();
 
     assert_eq!(
         modifier_edge_count(&store, "reaction-old"),


### PR DESCRIPTION
## Summary

This PR fixes two related groups of SQLite storage issues:

- projection pruning now preserves draft-owning groups and avoids unbounded retained-set binds for account groups and push tokens;
- secure deletion now survives WAL checkpoint contention, applies to local group wipes, and refreshes unread projections transactionally.

## Projection pruning

The account projection and push-token cleanup paths previously deleted with `NOT IN (...)` over the retained set. Besides exceeding SQLite bind limits at scale, that shape cannot be safely chunked because an early chunk can delete values retained by a later chunk.

The shared helper:

1. queries the keys currently stored in the relevant scope;
2. computes stale keys in Rust;
3. deletes only stale keys using chunked positive `IN (...)` statements.

The shared bind budget includes fixed scope parameters as well as each key chunk. This design avoids both an unbounded retained-ID bind set and a new JSON1 runtime dependency.

Account-group pruning excludes rows that still own message drafts, preventing the foreign-key cascade from destroying unsent draft text and attachment plaintext. The resulting stale group remains visible in projection/chat-list reads while its draft exists. Once the draft is deleted, a later projection save makes the group eligible for cleanup again.

## Secure deletion

Secure retention pruning previously committed logical deletion and then hid a failed `wal_checkpoint(TRUNCATE)`. Retrying could see no rows and skip erasure, losing both the pending checkpoint and the original prune outcome.

This PR adds a durable secure-delete checkpoint intent that commits alongside logical deletion. The intent stores the accumulated result and a 128-bit nonce. Completion always retries WAL truncation and consumes the intent only when the nonce still matches, preventing stale finishers from deleting a recreated intent. The intent deliberately has no age-based garbage collection: it is cleared only after successful truncation.

Checkpoint contention after a committed delete is now a typed, non-fatal outcome. Storage, app, and UniFFI results expose `erasure_pending`; send/ingest and local-wipe callers can continue after the logical deletion while a later call retries truncation. Pre-commit writer contention remains an error.

Local group deletion uses the same contract:

- forces `PRAGMA secure_delete = ON` before beginning the transaction;
- restores the caller's prior setting;
- records a durable checkpoint intent with the wipe;
- returns the committed wipe result with `erasure_pending` when truncation is blocked;
- distinguishes a new logical deletion from completion of a previously pending checkpoint.

Its `deleted_rows` count is the accumulated count represented by one pending intent, so it can span multiple logical wipes if the group is re-created and deleted again before truncation succeeds.

Secure pruning also recomputes unread count, mention count, and first-unread message ID inside the prune transaction alongside the existing last-message refresh.

## Validation

- `cargo test -p storage-sqlite` — 307 passed
- `cargo test -p marmot-app client::retention` — 10 passed
- `cargo test -p marmot-uniffi secure_delete_expired_result_ffi_preserves_count_and_hashes`
- `just fast-ci`
- `git diff --check`

Closes #895
Closes #846
Closes #749
Closes #936
Closes #756
Closes #808