### PR TITLE
Add subject-level convergence virtual time

### DIFF
--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -78,8 +78,10 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
   - **Role:** Simulator-owned `ConvergenceSubject` boundary and the built-in `EngineHarnessSubject` adapter. The
     scenario runner owns step semantics and stable action ids; subjects implement semantic group, publication,
     application, delivery, observation, and restart operations. Every adapter declares a versioned capability set that
-    is checked before execution. Queue/partition mutation is available only through the separately named
-    `ConvergenceFaultSubject` white-box interface.
+    is checked before execution. The engine adapter installs one shared manual paired clock; `AdvanceTime` moves both
+    clock domains and invokes the normal scheduled-convergence entry point only for selected awake clients.
+    Queue/partition mutation is available only through the separately named `ConvergenceFaultSubject` white-box
+    interface.
 
 - **Module:** `src/vector.rs`
   - **Role:** `ScenarioTrace`, observations, and semantic `TraceExpectation` checks. Records final epoch/member/payload

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -79,9 +79,10 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
     scenario runner owns step semantics and stable action ids; subjects implement semantic group, publication,
     application, delivery, observation, and restart operations. Every adapter declares a versioned capability set that
     is checked before execution. The engine adapter installs one shared manual paired clock; `AdvanceTime` moves both
-    clock domains and invokes the normal scheduled-convergence entry point only for selected awake clients.
-    Queue/partition mutation is available only through the separately named `ConvergenceFaultSubject` white-box
-    interface.
+    clock domains without waking a runtime, activates virtual-time ticks for that subject, and `Tick` selects which
+    participants run convergence against that time. Scenarios that never call `AdvanceTime` and standalone clients
+    retain the legacy far-future `Tick` shortcut. Queue/partition mutation is available only through the separately
+    named `ConvergenceFaultSubject` white-box interface.
 
 - **Module:** `src/vector.rs`
   - **Role:** `ScenarioTrace`, observations, and semantic `TraceExpectation` checks. Records final epoch/member/payload

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -19,7 +19,8 @@ welcomes use NIP-59 gift wraps before the bus delivers them.
 - `HarnessClient` — wraps `Engine<SqliteAccountStorage>` and the real Nostr transport peeler while keeping delivery in memory.
 - `ConvergenceSubject` — a capability-declared semantic boundary between scenario execution and the implementation
   under test. `EngineHarnessSubject` is the in-process adapter; queue and partition mutation live on a separate,
-  explicitly white-box fault interface.
+  explicitly white-box fault interface. Its `virtual_time` capability advances one shared paired convergence clock and
+  runs scheduled convergence only for the selected awake participants.
 - `ScenarioSpec` — a serializable v1 input contract for deterministic scripted scenarios, including explicit queue
   faults and partitions.
 - `VectorFixture` — portable JSON fixtures pairing runnable scenario input with exact traces or semantic expected
@@ -117,8 +118,9 @@ engine work (publish lifecycle, convergence pass/input, queued outbound, deferre
 buffers), bus queue/delayed/mailbox work addressed to that client, and that client's pending scenario-input ledger
 entries. The expectation fails with the blocking subsystem names. It is deliberately not an end-to-end delivery claim
 for an application object that a transport fault dropped; scenarios that require delivery must assert the recipient's
-ledger or output separately. It does not yet wait for quiescence: virtual-time advancement, structural progress tokens,
-timeout policy, and retry-timer coverage belong to Milestone 1.3.
+ledger or output separately. The serializable `advance_time` step now controls convergence deadlines without sleeping
+and can leave selected participants paused. It does not yet wait for quiescence: structural progress tokens, a
+fixed-point driver, timeout policy, outbound acknowledgement, and retry-timer coverage remain in Milestone 1.3.
 
 `probe_bidirectional_decryptability` is the active cryptographic-reachability check. Each named client sends one
 uniquely identified application event through the normal engine and transport path; the runner delivers the resulting

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -19,8 +19,8 @@ welcomes use NIP-59 gift wraps before the bus delivers them.
 - `HarnessClient` — wraps `Engine<SqliteAccountStorage>` and the real Nostr transport peeler while keeping delivery in memory.
 - `ConvergenceSubject` — a capability-declared semantic boundary between scenario execution and the implementation
   under test. `EngineHarnessSubject` is the in-process adapter; queue and partition mutation live on a separate,
-  explicitly white-box fault interface. Its `virtual_time` capability advances one shared paired convergence clock and
-  runs scheduled convergence only for the selected awake participants.
+  explicitly white-box fault interface. Its `virtual_time` capability advances one shared paired convergence clock;
+  subsequent `tick` steps select which participant runtimes wake and observe the elapsed deadline.
 - `ScenarioSpec` — a serializable v1 input contract for deterministic scripted scenarios, including explicit queue
   faults and partitions.
 - `VectorFixture` — portable JSON fixtures pairing runnable scenario input with exact traces or semantic expected
@@ -118,8 +118,11 @@ engine work (publish lifecycle, convergence pass/input, queued outbound, deferre
 buffers), bus queue/delayed/mailbox work addressed to that client, and that client's pending scenario-input ledger
 entries. The expectation fails with the blocking subsystem names. It is deliberately not an end-to-end delivery claim
 for an application object that a transport fault dropped; scenarios that require delivery must assert the recipient's
-ledger or output separately. The serializable `advance_time` step now controls convergence deadlines without sleeping
-and can leave selected participants paused. It does not yet wait for quiescence: structural progress tokens, a
+ledger or output separately. The serializable `advance_time` step advances the shared convergence clock without
+sleeping or waking a participant; a later `tick` selects the awake runtimes and uses that same clock. Every engine
+subject carries the deterministic manual clock, but only a scenario that executes `advance_time` switches `tick` to
+that clock. Existing scenarios and standalone `HarnessClient` tests that never opt into virtual time retain the
+historical far-future `tick` shortcut. The simulator does not yet wait for quiescence: structural progress tokens, a
 fixed-point driver, timeout policy, outbound acknowledgement, and retry-timer coverage remain in Milestone 1.3.
 
 `probe_bidirectional_decryptability` is the active cryptographic-reachability check. Each named client sends one

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -446,10 +446,11 @@ These tests keep the simulator machinery honest.
 - `tests/report_runner.rs` checks CLI parsing, report JSON writing, fixture-candidate writing, and pass/fail summaries.
 - `src/oracle.rs` and `tests/report_runner.rs` check that reports name their stimuli, expected behavior classes,
   observed behavior classes, and weak-oracle warnings.
-- `virtual_time_is_capability_gated_and_dispatched_with_selected_clients` checks that `advance_time` fails preflight for
-  adapters without `virtual_time` and preserves the selected awake-client set.
-- `engine_subject_virtual_time_closes_the_real_convergence_window` checks the in-process adapter against a real durable
-  disband pass: 999 ms remains live and the final 1 ms reaches the 1,000 ms quiescence cutoff without sleeping.
+- `virtual_time_is_capability_gated_serializable_and_dispatched` checks that `advance_time` round-trips through the
+  portable scenario format, fails preflight for adapters without `virtual_time`, and dispatches the exact elapsed time.
+- `engine_subject_virtual_time_is_shared_while_participant_wakes_are_selected` checks two real durable disband passes:
+  a tick at 999 ms settles neither; at 1,000 ms Alice settles while unticked Bob stays live; Bob then settles on a later
+  tick without another time advance.
 - `failing_generated_case_records_a_minimized_reproducer` checks that a failing generated case records a smaller
   reproducer when removable delivery noise is enough to keep the same failure.
 - `tests/generated_policy_cases.rs` checks that Tamarin-derived branch selector cases match the Rust selector across

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -446,6 +446,10 @@ These tests keep the simulator machinery honest.
 - `tests/report_runner.rs` checks CLI parsing, report JSON writing, fixture-candidate writing, and pass/fail summaries.
 - `src/oracle.rs` and `tests/report_runner.rs` check that reports name their stimuli, expected behavior classes,
   observed behavior classes, and weak-oracle warnings.
+- `virtual_time_is_capability_gated_and_dispatched_with_selected_clients` checks that `advance_time` fails preflight for
+  adapters without `virtual_time` and preserves the selected awake-client set.
+- `engine_subject_virtual_time_closes_the_real_convergence_window` checks the in-process adapter against a real durable
+  disband pass: 999 ms remains live and the final 1 ms reaches the 1,000 ms quiescence cutoff without sleeping.
 - `failing_generated_case_records_a_minimized_reproducer` checks that a failing generated case records a smaller
   reproducer when removable delivery noise is enough to keep the same failure.
 - `tests/generated_policy_cases.rs` checks that Tamarin-derived branch selector cases match the Rust selector across

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -447,6 +447,10 @@ impl HarnessClient {
         self.storage_backing.database_path()
     }
 
+    pub fn has_default_group(&self) -> bool {
+        self.default_group.is_some()
+    }
+
     pub fn restart(&mut self) {
         drop(self.engine.take());
         let storage = if self.storage_backing.is_file_backed() {

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -57,6 +57,7 @@ pub struct HarnessClient {
     registry: FeatureRegistry,
     protocol_profile: ProtocolProfile,
     convergence_clock: Option<Arc<dyn ConvergenceClock>>,
+    virtual_time_tick_enabled: bool,
     pending_events: Vec<GroupEvent>,
     /// Default MLS group id used by single-group scenarios. Set
     /// automatically after the first create/join.
@@ -269,6 +270,7 @@ impl ClientBuilder {
             registry: self.registry,
             protocol_profile: self.protocol_profile,
             convergence_clock: self.convergence_clock,
+            virtual_time_tick_enabled: false,
             pending_events: Vec::new(),
             default_group: None,
             app_event_counter: 0,
@@ -447,8 +449,8 @@ impl HarnessClient {
         self.storage_backing.database_path()
     }
 
-    pub fn has_default_group(&self) -> bool {
-        self.default_group.is_some()
+    pub(crate) fn enable_virtual_time_tick(&mut self) {
+        self.virtual_time_tick_enabled = true;
     }
 
     pub fn restart(&mut self) {
@@ -1032,9 +1034,10 @@ impl HarnessClient {
     pub async fn tick(&mut self) -> Vec<Result<IngestOutcome, EngineError>> {
         let mut outcomes = self.tick_ingest_only().await;
         if let Some(gid) = self.default_group.clone() {
+            let now_ms = self.harness_convergence_now_ms();
             match self
                 .engine_mut()
-                .advance_convergence_inputs_until_settled(&gid, HARNESS_CONVERGENCE_SETTLED_AT_MS)
+                .advance_convergence_inputs_until_settled(&gid, now_ms)
                 .await
             {
                 Ok(_) => {}
@@ -1144,6 +1147,7 @@ impl HarnessClient {
         &mut self,
         outcomes: &mut Vec<Result<IngestOutcome, EngineError>>,
     ) {
+        let now_ms = self.harness_convergence_now_ms();
         for _ in 0..HARNESS_CONVERGENCE_DRAIN_PASSES {
             let groups = self.engine_mut().drain_pending_convergence_groups();
             if groups.is_empty() {
@@ -1152,10 +1156,7 @@ impl HarnessClient {
             for group_id in groups {
                 let results = match self
                     .engine_mut()
-                    .converge_and_drain_queued_outbound_intents(
-                        &group_id,
-                        HARNESS_CONVERGENCE_SETTLED_AT_MS,
-                    )
+                    .converge_and_drain_queued_outbound_intents(&group_id, now_ms)
                     .await
                 {
                     Ok(results) => results,
@@ -1176,6 +1177,20 @@ impl HarnessClient {
         outcomes.push(Err(EngineError::Backend(
             "convergence drain did not settle within harness pass limit".into(),
         )));
+    }
+
+    /// A subject switches to its injected clock on the first virtual-time
+    /// advance. Other harness clients retain the historical far-future
+    /// settlement shortcut.
+    fn harness_convergence_now_ms(&self) -> u64 {
+        if self.virtual_time_tick_enabled {
+            self.convergence_clock
+                .as_ref()
+                .map(|clock| clock.now().monotonic_ms)
+                .unwrap_or(HARNESS_CONVERGENCE_SETTLED_AT_MS)
+        } else {
+            HARNESS_CONVERGENCE_SETTLED_AT_MS
+        }
     }
 
     async fn publish_send_result(&mut self, result: SendResult) -> Result<(), EngineError> {

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -25,6 +25,7 @@ pub enum ScenarioStimulus {
     QueueReorder,
     Partition,
     Restart,
+    VirtualTimeAdvance,
     LargeGroup,
     MessageStorm,
     CommitStorm,
@@ -317,6 +318,9 @@ pub fn scenario_stimuli(spec: &ScenarioSpec) -> Vec<ScenarioStimulus> {
             }
             ScenarioStep::RestartClient { .. } => {
                 stimuli.insert(ScenarioStimulus::Restart);
+            }
+            ScenarioStep::AdvanceTime { .. } => {
+                stimuli.insert(ScenarioStimulus::VirtualTimeAdvance);
             }
             ScenarioStep::DeliverAll
             | ScenarioStep::Tick { .. }
@@ -687,6 +691,7 @@ fn recommended_behaviors(stimulus: ScenarioStimulus) -> Vec<OracleBehavior> {
             OracleBehavior::ReplayDeduplication,
         ],
         ScenarioStimulus::PublishLifecycle => vec![OracleBehavior::PublishLifecycleChecked],
+        ScenarioStimulus::VirtualTimeAdvance => vec![OracleBehavior::QuiescenceState],
     }
 }
 

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -77,11 +77,10 @@ pub enum ScenarioStep {
     Tick {
         clients: Vec<String>,
     },
-    /// Advance both convergence-clock domains and run scheduled convergence
-    /// for the selected participant runtimes.
+    /// Advance both convergence-clock domains without waking a participant.
+    /// Use `Tick` to select which participant runtimes observe elapsed time.
     AdvanceTime {
         delta_ms: u64,
-        clients: Vec<String>,
     },
     Observe {
         clients: Vec<String>,
@@ -568,12 +567,9 @@ async fn run_scenario_report_inner(
                     .await
                     .map_err(|error| subject_step_error(step_index, error))?;
             }
-            ScenarioStep::AdvanceTime {
-                delta_ms,
-                clients: labels,
-            } => {
+            ScenarioStep::AdvanceTime { delta_ms } => {
                 subject
-                    .advance_time(*delta_ms, labels)
+                    .advance_time(*delta_ms)
                     .await
                     .map_err(|error| subject_step_error(step_index, error))?;
             }
@@ -850,7 +846,7 @@ mod tests {
     struct RecordingSubject {
         descriptor: SubjectDescriptor,
         send_called: bool,
-        time_advances: Vec<(u64, Vec<String>)>,
+        time_advances: Vec<u64>,
     }
 
     #[async_trait]
@@ -867,12 +863,8 @@ mod tests {
             Ok(())
         }
 
-        async fn advance_time(
-            &mut self,
-            delta_ms: u64,
-            clients: &[String],
-        ) -> Result<(), SubjectError> {
-            self.time_advances.push((delta_ms, clients.to_vec()));
+        async fn advance_time(&mut self, delta_ms: u64) -> Result<(), SubjectError> {
+            self.time_advances.push(delta_ms);
             Ok(())
         }
     }
@@ -943,15 +935,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn virtual_time_is_capability_gated_and_dispatched_with_selected_clients() {
+    async fn virtual_time_is_capability_gated_serializable_and_dispatched() {
         let spec = ScenarioSpec {
             name: "subject-virtual-time/v1".to_owned(),
             spec_version: "1".to_owned(),
             clients: vec!["alice".to_owned(), "bob".to_owned()],
-            steps: vec![ScenarioStep::AdvanceTime {
-                delta_ms: 750,
-                clients: vec!["bob".to_owned()],
-            }],
+            steps: vec![ScenarioStep::AdvanceTime { delta_ms: 750 }],
         };
         let encoded = serde_json::to_value(&spec).expect("virtual time scenario serializes");
         assert_eq!(encoded["steps"][0]["type"], "advance_time");
@@ -984,7 +973,7 @@ mod tests {
         run_scenario_spec_with_subject(&spec, &mut subject)
             .await
             .expect("supported virtual time step succeeds");
-        assert_eq!(subject.time_advances, vec![(750, vec!["bob".to_owned()])]);
+        assert_eq!(subject.time_advances, vec![750]);
     }
 
     #[test]

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -77,6 +77,12 @@ pub enum ScenarioStep {
     Tick {
         clients: Vec<String>,
     },
+    /// Advance both convergence-clock domains and run scheduled convergence
+    /// for the selected participant runtimes.
+    AdvanceTime {
+        delta_ms: u64,
+        clients: Vec<String>,
+    },
     Observe {
         clients: Vec<String>,
     },
@@ -135,6 +141,7 @@ impl ScenarioStep {
             ScenarioStep::Leave { .. } => "leave",
             ScenarioStep::DeliverAll => "deliver_all",
             ScenarioStep::Tick { .. } => "tick",
+            ScenarioStep::AdvanceTime { .. } => "advance_time",
             ScenarioStep::Observe { .. } => "observe",
             ScenarioStep::ObserveExact { .. } => "observe_exact",
             ScenarioStep::ProbeBidirectionalDecryptability { .. } => {
@@ -561,6 +568,15 @@ async fn run_scenario_report_inner(
                     .await
                     .map_err(|error| subject_step_error(step_index, error))?;
             }
+            ScenarioStep::AdvanceTime {
+                delta_ms,
+                clients: labels,
+            } => {
+                subject
+                    .advance_time(*delta_ms, labels)
+                    .await
+                    .map_err(|error| subject_step_error(step_index, error))?;
+            }
             ScenarioStep::Observe { clients: labels } => {
                 observations.extend(
                     subject
@@ -834,6 +850,7 @@ mod tests {
     struct RecordingSubject {
         descriptor: SubjectDescriptor,
         send_called: bool,
+        time_advances: Vec<(u64, Vec<String>)>,
     }
 
     #[async_trait]
@@ -847,6 +864,15 @@ mod tests {
             _action: SubjectSendApplication<'_>,
         ) -> Result<(), SubjectError> {
             self.send_called = true;
+            Ok(())
+        }
+
+        async fn advance_time(
+            &mut self,
+            delta_ms: u64,
+            clients: &[String],
+        ) -> Result<(), SubjectError> {
+            self.time_advances.push((delta_ms, clients.to_vec()));
             Ok(())
         }
     }
@@ -904,6 +930,7 @@ mod tests {
                 capabilities: BTreeSet::from([SubjectCapability::ApplicationMessaging]),
             },
             send_called: false,
+            time_advances: Vec::new(),
         };
 
         let error = run_scenario_spec_with_subject(&spec, &mut subject)
@@ -913,6 +940,51 @@ mod tests {
         assert_eq!(error.step_index, Some(1));
         assert!(error.message.contains("crash_reopen"));
         assert!(!subject.send_called);
+    }
+
+    #[tokio::test]
+    async fn virtual_time_is_capability_gated_and_dispatched_with_selected_clients() {
+        let spec = ScenarioSpec {
+            name: "subject-virtual-time/v1".to_owned(),
+            spec_version: "1".to_owned(),
+            clients: vec!["alice".to_owned(), "bob".to_owned()],
+            steps: vec![ScenarioStep::AdvanceTime {
+                delta_ms: 750,
+                clients: vec!["bob".to_owned()],
+            }],
+        };
+        let encoded = serde_json::to_value(&spec).expect("virtual time scenario serializes");
+        assert_eq!(encoded["steps"][0]["type"], "advance_time");
+        assert_eq!(encoded["steps"][0]["delta_ms"], 750);
+        let decoded: ScenarioSpec =
+            serde_json::from_value(encoded).expect("virtual time scenario deserializes");
+        assert_eq!(decoded, spec);
+        let mut subject = RecordingSubject {
+            descriptor: SubjectDescriptor {
+                adapter: "recording-subject".to_owned(),
+                adapter_version: "1".to_owned(),
+                storage_backend: "none".to_owned(),
+                capabilities: BTreeSet::new(),
+            },
+            send_called: false,
+            time_advances: Vec::new(),
+        };
+
+        let error = run_scenario_spec_with_subject(&spec, &mut subject)
+            .await
+            .expect_err("virtual time must fail preflight when unsupported");
+        assert_eq!(error.step_index, Some(0));
+        assert!(error.message.contains("virtual_time"));
+        assert!(subject.time_advances.is_empty());
+
+        subject
+            .descriptor
+            .capabilities
+            .insert(SubjectCapability::VirtualTime);
+        run_scenario_spec_with_subject(&spec, &mut subject)
+            .await
+            .expect("supported virtual time step succeeds");
+        assert_eq!(subject.time_advances, vec![(750, vec!["bob".to_owned()])]);
     }
 
     #[test]

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -12,6 +12,7 @@ use crate::{
     observe_client_exact,
 };
 use async_trait::async_trait;
+use cgka_engine::ManualConvergenceClock;
 use cgka_engine::feature_registry::FeatureRegistry;
 use cgka_traits::EngineError;
 use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, RequirementLevel};
@@ -22,6 +23,7 @@ use cgka_traits::types::MemberId;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
+use std::sync::Arc;
 
 /// A semantic or explicitly white-box operation an adapter can execute.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -233,6 +235,19 @@ pub trait ConvergenceSubject: Send {
         ))
     }
 
+    /// Advance the subject's paired convergence clock and run the normal
+    /// scheduled-convergence entry point for the selected clients.
+    ///
+    /// Time is shared by the subject, while selecting clients models which
+    /// participant runtimes are awake to observe the elapsed deadline.
+    async fn advance_time(
+        &mut self,
+        _delta_ms: u64,
+        _clients: &[String],
+    ) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(SubjectCapability::VirtualTime))
+    }
+
     fn observe(&mut self, _clients: &[String]) -> Result<Vec<ClientObservation>, SubjectError> {
         Err(SubjectError::unsupported(
             SubjectCapability::EventObservation,
@@ -309,6 +324,7 @@ pub fn required_capability(step: &ScenarioStep) -> SubjectCapability {
         ScenarioStep::DeliverAll | ScenarioStep::Tick { .. } => {
             SubjectCapability::TransportDelivery
         }
+        ScenarioStep::AdvanceTime { .. } => SubjectCapability::VirtualTime,
         ScenarioStep::Observe { .. } | ScenarioStep::ClearEvents { .. } => {
             SubjectCapability::EventObservation
         }
@@ -335,6 +351,7 @@ pub struct EngineHarnessSubject {
     bus: TransportBus,
     clients: BTreeMap<String, HarnessClient>,
     pending_refs: HashMap<String, PendingStateRef>,
+    convergence_clock: ManualConvergenceClock,
 }
 
 impl EngineHarnessSubject {
@@ -344,6 +361,7 @@ impl EngineHarnessSubject {
         storage_mode: HarnessStorageMode,
     ) -> Result<Self, SubjectError> {
         let bus = TransportBus::ordered();
+        let convergence_clock = ManualConvergenceClock::new(0, 0);
         let mut attached = BTreeMap::new();
         for label in clients {
             if attached.contains_key(label) {
@@ -356,6 +374,7 @@ impl EngineHarnessSubject {
                 .registry(scenario_registry())
                 .protocol_profile(protocol_profile)
                 .storage_mode(storage_mode)
+                .convergence_clock(Arc::new(convergence_clock.clone()))
                 .attach(&bus);
             attached.insert(label.clone(), client);
         }
@@ -369,6 +388,7 @@ impl EngineHarnessSubject {
             SubjectCapability::ActiveDecryptabilityProbe,
             SubjectCapability::AdminPolicyObservation,
             SubjectCapability::CrashReopen,
+            SubjectCapability::VirtualTime,
             SubjectCapability::WhiteBoxTransportQueueFaults,
             SubjectCapability::WhiteBoxTransportPartition,
         ]
@@ -384,6 +404,7 @@ impl EngineHarnessSubject {
             bus,
             clients: attached,
             pending_refs: HashMap::new(),
+            convergence_clock,
         })
     }
 
@@ -553,6 +574,33 @@ impl ConvergenceSubject for EngineHarnessSubject {
     async fn tick(&mut self, clients: &[String]) -> Result<(), SubjectError> {
         for label in clients {
             self.client_mut(label)?.tick().await;
+        }
+        Ok(())
+    }
+
+    async fn advance_time(
+        &mut self,
+        delta_ms: u64,
+        clients: &[String],
+    ) -> Result<(), SubjectError> {
+        let mut selected = BTreeSet::new();
+        for label in clients {
+            self.client(label)?;
+            if !selected.insert(label) {
+                return Err(SubjectError::new(
+                    "duplicate_time_client",
+                    format!("duplicate virtual-time client {label}"),
+                ));
+            }
+        }
+        self.convergence_clock.advance_ms(delta_ms);
+        for label in clients {
+            if self.client(label)?.has_default_group() {
+                self.client_mut(label)?
+                    .advance_convergence()
+                    .await
+                    .map_err(subject_engine_error)?;
+            }
         }
         Ok(())
     }
@@ -832,4 +880,73 @@ fn observe_engine_error(error: &EngineError) -> String {
         EngineError::UnknownPending => "unknown_pending",
     }
     .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ConformanceCanonicalStateSnapshot;
+
+    #[tokio::test]
+    async fn engine_subject_virtual_time_closes_the_real_convergence_window() {
+        let labels = vec!["alice".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        assert!(
+            subject
+                .descriptor()
+                .supports(SubjectCapability::VirtualTime)
+        );
+
+        subject
+            .create_group(SubjectCreateGroup {
+                creator: "alice",
+                name: "virtual-time",
+                invitees: &[],
+                required_features: &[],
+                initial_admins: &[],
+                pending: "unused",
+            })
+            .await
+            .expect("founding group is created");
+
+        let alice = subject.client_mut("alice").expect("alice exists");
+        alice.request_disband().await.expect("request disband");
+        alice
+            .advance_convergence()
+            .await
+            .expect("prepare and confirm disband commit");
+        alice
+            .advance_convergence()
+            .await
+            .expect("open collecting pass");
+
+        subject
+            .advance_time(999, &labels)
+            .await
+            .expect("advance before cutoff");
+        assert!(matches!(
+            subject
+                .client("alice")
+                .expect("alice exists")
+                .canonical_state_snapshot(),
+            ConformanceCanonicalStateSnapshot::Live(_)
+        ));
+
+        subject
+            .advance_time(1, &labels)
+            .await
+            .expect("advance to cutoff");
+        assert!(matches!(
+            subject
+                .client("alice")
+                .expect("alice exists")
+                .canonical_state_snapshot(),
+            ConformanceCanonicalStateSnapshot::Disbanded(_)
+        ));
+    }
 }

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -235,16 +235,10 @@ pub trait ConvergenceSubject: Send {
         ))
     }
 
-    /// Advance the subject's paired convergence clock and run the normal
-    /// scheduled-convergence entry point for the selected clients.
-    ///
-    /// Time is shared by the subject, while selecting clients models which
-    /// participant runtimes are awake to observe the elapsed deadline.
-    async fn advance_time(
-        &mut self,
-        _delta_ms: u64,
-        _clients: &[String],
-    ) -> Result<(), SubjectError> {
+    /// Advance the subject's paired convergence clock without waking a
+    /// participant runtime. A later `tick` selects which participants observe
+    /// the elapsed deadline.
+    async fn advance_time(&mut self, _delta_ms: u64) -> Result<(), SubjectError> {
         Err(SubjectError::unsupported(SubjectCapability::VirtualTime))
     }
 
@@ -578,29 +572,10 @@ impl ConvergenceSubject for EngineHarnessSubject {
         Ok(())
     }
 
-    async fn advance_time(
-        &mut self,
-        delta_ms: u64,
-        clients: &[String],
-    ) -> Result<(), SubjectError> {
-        let mut selected = BTreeSet::new();
-        for label in clients {
-            self.client(label)?;
-            if !selected.insert(label) {
-                return Err(SubjectError::new(
-                    "duplicate_time_client",
-                    format!("duplicate virtual-time client {label}"),
-                ));
-            }
-        }
+    async fn advance_time(&mut self, delta_ms: u64) -> Result<(), SubjectError> {
         self.convergence_clock.advance_ms(delta_ms);
-        for label in clients {
-            if self.client(label)?.has_default_group() {
-                self.client_mut(label)?
-                    .advance_convergence()
-                    .await
-                    .map_err(subject_engine_error)?;
-            }
+        for client in self.clients.values_mut() {
+            client.enable_virtual_time_tick();
         }
         Ok(())
     }
@@ -888,8 +863,8 @@ mod tests {
     use crate::ConformanceCanonicalStateSnapshot;
 
     #[tokio::test]
-    async fn engine_subject_virtual_time_closes_the_real_convergence_window() {
-        let labels = vec!["alice".to_owned()];
+    async fn engine_subject_virtual_time_is_shared_while_participant_wakes_are_selected() {
+        let labels = vec!["alice".to_owned(), "bob".to_owned()];
         let mut subject = EngineHarnessSubject::new(
             &labels,
             ProtocolProfile::Current,
@@ -902,49 +877,76 @@ mod tests {
                 .supports(SubjectCapability::VirtualTime)
         );
 
-        subject
-            .create_group(SubjectCreateGroup {
-                creator: "alice",
-                name: "virtual-time",
-                invitees: &[],
-                required_features: &[],
-                initial_admins: &[],
-                pending: "unused",
-            })
-            .await
-            .expect("founding group is created");
+        for label in &labels {
+            subject
+                .create_group(SubjectCreateGroup {
+                    creator: label,
+                    name: "virtual-time",
+                    invitees: &[],
+                    required_features: &[],
+                    initial_admins: &[],
+                    pending: "unused",
+                })
+                .await
+                .expect("founding group is created");
+            let client = subject.client_mut(label).expect("client exists");
+            client.request_disband().await.expect("request disband");
+            client
+                .advance_convergence()
+                .await
+                .expect("prepare and confirm disband commit");
+            client
+                .advance_convergence()
+                .await
+                .expect("open collecting pass");
+        }
 
-        let alice = subject.client_mut("alice").expect("alice exists");
-        alice.request_disband().await.expect("request disband");
-        alice
-            .advance_convergence()
-            .await
-            .expect("prepare and confirm disband commit");
-        alice
-            .advance_convergence()
-            .await
-            .expect("open collecting pass");
-
         subject
-            .advance_time(999, &labels)
+            .advance_time(999)
             .await
             .expect("advance before cutoff");
+        subject
+            .tick(&["alice".to_owned()])
+            .await
+            .expect("wake alice before cutoff");
+        for label in &labels {
+            assert!(matches!(
+                subject
+                    .client(label)
+                    .expect("client exists")
+                    .canonical_state_snapshot(),
+                ConformanceCanonicalStateSnapshot::Live(_)
+            ));
+        }
+
+        subject.advance_time(1).await.expect("advance to cutoff");
+        subject
+            .tick(&["alice".to_owned()])
+            .await
+            .expect("wake alice at cutoff");
         assert!(matches!(
             subject
                 .client("alice")
                 .expect("alice exists")
                 .canonical_state_snapshot(),
+            ConformanceCanonicalStateSnapshot::Disbanded(_)
+        ));
+        assert!(matches!(
+            subject
+                .client("bob")
+                .expect("bob exists")
+                .canonical_state_snapshot(),
             ConformanceCanonicalStateSnapshot::Live(_)
         ));
 
         subject
-            .advance_time(1, &labels)
+            .tick(&["bob".to_owned()])
             .await
-            .expect("advance to cutoff");
+            .expect("wake bob without advancing time again");
         assert!(matches!(
             subject
-                .client("alice")
-                .expect("alice exists")
+                .client("bob")
+                .expect("bob exists")
                 .canonical_state_snapshot(),
             ConformanceCanonicalStateSnapshot::Disbanded(_)
         ));

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -444,8 +444,10 @@ Status: `in-progress`
   semantic engine operations through declared adapter capabilities.
 - [x] Implement the first engine-adapter vertical slice: create/mutate, publication confirmation/failure, application
   send, transport delivery/ingest, event/exact/admin observation, active decryptability probing, and crash/reopen.
-- [ ] Add virtual-time advance plus explicit public outbound polling/acknowledgement; coordinate this with the dual-clock
-  and full-quiescence work rather than encoding real-time waits in the subject.
+- [x] Add a capability-gated, serializable virtual-time advance backed by one shared paired clock; run the selected
+  awake clients through the normal scheduled-convergence entry point without sleeping.
+- [ ] Add explicit public outbound polling/acknowledgement so later adapters can model publication progress without
+  exposing harness queues.
 - [x] Split normal black-box execution from the explicitly named `ConvergenceFaultSubject` queue/partition mutation
   capability; reserve a named white-box storage-fault capability for a future adapter.
 - [x] Reject scenarios that require unsupported subject capabilities before execution.
@@ -458,8 +460,8 @@ Status: `in-progress`
 
 - [x] Add an injectable paired monotonic/wall convergence clock and use it for pass deadlines, cutoff decisions, restart
   rebasing, and deterministic engine/harness tests.
-- [ ] Expose that clock through the subject-level virtual-time capability; a clock that tests can inject is not yet a
-  portable scenario operation.
+- [x] Expose that clock through the subject-level `virtual_time` capability and portable `advance_time` scenario step;
+  allow the scenario to keep selected participant runtimes paused while global time advances.
 
 - [ ] Expose a sanitized structural progress token, runnable work, earliest next wake-up, deferred/retry work, outbound
   work awaiting acknowledgement, and terminal blockers; include inbox, delayed messages, pass phase, and durable
@@ -809,3 +811,4 @@ incorrect result.
 | 2026-07-30 | M5 app-runtime ownership prerequisite | Enforced one live account session per account within a `MarmotApp`, surfaced typed contention through UniFFI, and made worker reconnect release the failed client before replacement | [MDK #1200](https://github.com/marmot-protocol/mdk/pull/1200), merge `8dc7c12b`; ownership, worker-lifecycle, FFI, and focused runtime tests |
 | 2026-07-30 | M5 projection-maintenance prerequisite | Made large-set projection pruning bounded, preserved draft-owning groups, and made secure-delete checkpoint completion durable and explicitly observable as `erasure_pending` | [MDK #1201](https://github.com/marmot-protocol/mdk/pull/1201), merge `eec70bd9`; 307 storage tests; focused app/UniFFI retention tests; `just fast-ci` |
 | 2026-07-30 | M5 account-device modeling input | Documented a non-normative multi-device design space while deliberately leaving admission, synchronization, and repair choices unresolved; future scenarios must model account-device instances without assuming those candidate semantics | [MDK #1199](https://github.com/marmot-protocol/mdk/pull/1199), merge `aac777f3`; documentation-only |
+| 2026-07-30 | 1.2c / 1.3b subject virtual time | Added a capability-gated `advance_time` scenario operation backed by one shared paired clock across the engine subject; global time advances once while scheduled convergence runs only for selected awake participants, preserving legacy `Tick` semantics for existing vectors | Focused preflight/dispatch test; real disband pass remains live at 999 ms and settles at 1,000 ms without sleeping; full simulator suite |

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -157,14 +157,14 @@ test is evidence for only the behavior in its name; it does not establish the la
 | S1 | Protocol `convergence.md` branch selection; local canonicalization contract “Determinism and convergence” | Tamarin `same_input_set_converges`; `prop_candidate_graph_selection_is_order_invariant`; `prop_stored_convergence_restart_equivalence` | M1.1 exact-state oracle; M4.1 independent reference model; M4.2 arbitrary schedule/lifecycle model |
 | S2 | Protocol `convergence.md` “Applying the selected branch”; local canonicalization output contract | Tamarin application-output/invalidation lemmas; `engine_emits_only_canonical_branch_app_messages_after_convergence`; `rebuilt_engine_emits_losing_branch_app_invalidation_after_convergence` | M1.1 exact scenario-input/output ledger; M5.1 app projection adapter |
 | S3 | Protocol retained-anchor error rules; local canonicalization errors and fail-closed replay contract | Tamarin missing/beyond-anchor lemmas; `frozen_pass_member_tampering_fails_closed_to_unrecoverable`; `missing_frozen_pass_member_fails_closed_to_unrecoverable`; replay-budget unit tests | M3.1 end-to-end resource exhaustion; M4.3 mutations |
-| S4 | Protocol publish lifecycle and bounded-pass persistence; local multi-step-state-change rules | `convergence_pass_round_trips_updates_and_cascades`; `collecting_pass_restart_preserves_remaining_window_and_backward_clock_fails_closed`; `reopen_after_crash_during_publish_recovers_stranded_pending_commit`; crash-recovery SQLite tests | M3.1 complete durable-transition kill matrix; M5.1 runtime crash matrix |
+| S4 | Protocol publish lifecycle and bounded-pass persistence; local multi-step-state-change rules | `convergence_pass_round_trips_updates_and_cascades`; `collecting_pass_restart_preserves_remaining_window_and_backward_clock_fails_closed`; `reopen_after_crash_during_publish_recovers_stranded_pending_commit`; crash-recovery SQLite tests; transaction-boundary contention tests from [MDK #1191](https://github.com/marmot-protocol/mdk/pull/1191) | [MDK #1184](https://github.com/marmot-protocol/mdk/pull/1184) inbound commit mirror atomicity; M3.1 complete durable-transition kill matrix; M5.1 runtime crash matrix |
 | S5 | Protocol pass-partition invariance and bounded collection window; relay telemetry claim that quiescence is not a correctness boundary | `prop_quiescence_gate_controls_settlement`; cutoff and scheduler unit tests | M1.3 controlled partition metamorphic test; M3.2 cross-value campaign; M4.2 scheduler model |
-| L1 | Protocol pass freeze and completion rules; group convergence status | Individual settle/fail-closed integration tests | M4.2 TLA+/TLC liveness specification; M2.3 retained-relay scenarios; named repair tests for every durable non-progress state |
+| L1 | Protocol pass freeze and completion rules; group convergence status | Individual settle/fail-closed integration tests; stale collecting/frozen pass compensation at the current tip from [MDK #1182](https://github.com/marmot-protocol/mdk/pull/1182) | M4.2 TLA+/TLC liveness specification; M2.3 retained-relay scenarios; named repair tests for every durable non-progress state |
 | L2 | Protocol outbound gating; local queued-intent lifecycle | Tamarin queued-outbound lemmas; `engine_queues_app_send_until_convergence_is_settled`; `trait_advance_convergence_drains_queued_outbound_intent`; scheduler tests | M1.3 complete quiescence; M3.1 crash/failure workload |
 | L3 | Protocol same-epoch priority and depth rules; no sustained-progress guarantee currently stated | `convergence_privileged_remove_beats_grinding_ordinary_self_update`; `continuous_inbound_cannot_starve_admin_attempt` | M3.1 sustained self-update family; M4.2 fairness model; protocol decision PDR-2 below |
 | S6 | Protocol `foundation/conformance.md`, adopted by [marmot#410](https://github.com/marmot-protocol/marmot/pull/410) | Domain separation and 33-byte commitment prefix checked in the protocol PR | M1.1 public snapshot API and exact-equivalence sentinels |
 | S7 | Protocol conformance projection and input-disposition requirements | M1.1 exact canonical snapshot plus commit/proposal/application disposition ledger | M2.2 common adapter observation schema; M5.1 app projection layer |
-| R1 | Protocol durable pass wall/monotonic deadline rules; local storage/restart contract | `collecting_pass_restart_preserves_remaining_window_and_backward_clock_fails_closed`; `h5_kill_before_historical_apply_commit_preserves_live_inputs`; `h6_kill_after_retained_anchor_rewind_recovers_live_snapshot` | M3.1 every-phase crash matrix; M5.3 process kill/reopen |
+| R1 | Protocol durable pass wall/monotonic deadline rules; local storage/restart contract | Injectable paired convergence clocks from [MDK #1195](https://github.com/marmot-protocol/mdk/pull/1195); `collecting_pass_restart_preserves_remaining_window_and_backward_clock_fails_closed`; `h5_kill_before_historical_apply_commit_preserves_live_inputs`; `h6_kill_after_retained_anchor_rewind_recovers_live_snapshot` | M3.1 every-phase crash matrix; M5.3 process kill/reopen |
 | R2 | Relay telemetry EOSE/backfill/reconciliation architecture; protocol requires equalized relevant history for equivalent selection | `stalled_epoch_backfill_recovers_below_floor_backlog_when_armed`; `next_event_returns_when_a_live_delivery_arms_the_epoch_backfill` | M2.3 retained multi-relay model; M3.1 unequal-history family |
 | R3 | Relay sync/backfill architecture; incremental cursors do not establish full offline history | Existing since-floor regressions expose the blind spot; epoch-stall backfill is armed only after qualifying live evidence | M2.3 EOSE/completeness policy and full-history/set-reconciliation backstop; M5.1 production runtime adapter |
 | D1 | Local forensic audit/report contracts and privacy rules | Generated reports, oracle coverage, conservative minimizer, incident archetype synthesis | M1.4 failure capsule and self-replay; M3.3 exact incident import; R3 silent-absence detection |
@@ -369,6 +369,8 @@ git diff --check
 
 ### 1.1 Exact state and scenario-input oracle
 
+Status: `complete`
+
 - [x] Add exact sorted member identities to strict observations, while also preserving nonblank leaves in MLS leaf-index
   order.
 - [x] Include epoch, selected branch commitment, admin policy, application profile, required capabilities, exact
@@ -420,22 +422,23 @@ operational-semantics and adapter-refinement acceptance criteria tracked in
 campaign/process expansion relies on equivalence across adapters.
 
 The strict campaign migration deliberately exposed three pre-existing reliability failures that the legacy observation
-point hid. The transported-commit case is now resolved by making simulator `FailPending` mean definite
-non-publication: it atomically retracts every matching undelivered commit/Welcome before local rollback and refuses the
-operation after any artifact reaches a recipient mailbox. Two engine-state failures remain:
+point hid. Two are resolved without weakening the oracle:
 
-1. a member invited after an old application event can retain that pre-join object as transport/scenario-input pending
-   work;
-2. after self-remove convergence, selected remaining members can retain a created proposal row and valid-proposal
-   schedule signal.
+- [MDK #1196](https://github.com/marmot-protocol/mdk/pull/1196) made simulator `FailPending` mean definite
+  non-publication: it atomically retracts every matching undelivered commit/Welcome before local rollback and refuses
+  the operation after any artifact reaches a recipient mailbox.
+- [MDK #1192](https://github.com/marmot-protocol/mdk/pull/1192) terminally retires proposal rows and proposal-arrival
+  schedule signals consumed by a confirmed or converged commit, including across restart.
 
-These remain red strict-campaign evidence, not relaxed oracle rules. The ordinary generated-family regression tests keep
-checking their original semantic observation windows and explicitly retain the leave pending-work sentinel; report
+One engine-state failure remains: a member invited after an old application event can retain that pre-join object as
+transport/scenario-input pending work. It remains red strict-campaign evidence, not a relaxed oracle rule. Report
 campaigns run the complete strict expectations by default. Strict coverage also flags the mixed large storm because its
 application phase is cleared before any delivery-or-invalidation expectation accounts for it; that is an oracle coverage
-gap, distinct from the two remaining engine-state failures.
+gap, distinct from the remaining engine-state failure.
 
 ### 1.2 Public subject boundary
+
+Status: `in-progress`
 
 - [x] Define a simulator-owned `ConvergenceSubject` interface that keeps scenario semantics in the runner and exposes
   semantic engine operations through declared adapter capabilities.
@@ -451,10 +454,17 @@ gap, distinct from the two remaining engine-state failures.
 
 ### 1.3 Full-system quiescence
 
+Status: `in-progress`
+
+- [x] Add an injectable paired monotonic/wall convergence clock and use it for pass deadlines, cutoff decisions, restart
+  rebasing, and deterministic engine/harness tests.
+- [ ] Expose that clock through the subject-level virtual-time capability; a clock that tests can inject is not yet a
+  portable scenario operation.
+
 - [ ] Expose a sanitized structural progress token, runnable work, earliest next wake-up, deferred/retry work, outbound
   work awaiting acknowledgement, and terminal blockers; include inbox, delayed messages, pass phase, and durable
   transitions.
-- [ ] Inject an advancing monotonic clock plus a controlled wall clock throughout the subject and its tests; do not
+- [ ] Drive subject operations and scheduled wakes from the shared advancing monotonic/controlled wall clock; do not
   infer time progress from repeated calls at one synthetic timestamp or wait on real wall time.
 - [ ] Compute a bounded virtual-time fixed point from structural work and the earliest next wake-up. Treat step, time,
   and work limits only as watchdog/performance evidence, not as the definition of quiescence.
@@ -465,6 +475,8 @@ gap, distinct from the two remaining engine-state failures.
 
 ### 1.4 Deterministic failure capsules
 
+Status: `not-started`
+
 - [ ] Define a versioned capsule schema.
 - [ ] Save original scenario, canonical IR, seeds, expanded schedule, policy/constant snapshot, adapter/binary versions,
   captured wire bytes, virtual time, scenario-input/output ledger, state commitments, and resource measurements.
@@ -474,8 +486,8 @@ gap, distinct from the two remaining engine-state failures.
 
 ### Milestone 1 Exit Gate
 
-- [ ] A wrong exact state cannot pass as converged.
-- [ ] A normal scenario cannot access engine/storage internals.
+- [x] A wrong exact state cannot pass as converged.
+- [x] A normal scenario cannot access engine/storage internals.
 - [ ] Hidden pending work prevents quiescence.
 - [ ] A captured byte-level failure replays with the same outcome.
 - [ ] Targeted semantic mutations are detected.
@@ -624,6 +636,22 @@ test-only constants while preserving a stable semantic oracle.
 
 ### 5.1 `MarmotAppRuntime` adapter
 
+Recent runtime/storage hardening constrains this adapter without completing it:
+
+- [MDK #1186](https://github.com/marmot-protocol/mdk/pull/1186) fixed group-state updates applied inside an outbound
+  send reaching durable projections without waking app subscriptions. The adapter must therefore assert stored
+  projection state and notification/event delivery independently rather than treating either as evidence for the other.
+- [MDK #1200](https://github.com/marmot-protocol/mdk/pull/1200) enforces one live `AppClient`/engine session per account
+  inside a `MarmotApp`. The adapter must allocate one account-device identity per participant and classify
+  `AccountSessionBusy` as an explicit local operational outcome rather than opening a second session over the same
+  database.
+- [MDK #1201](https://github.com/marmot-protocol/mdk/pull/1201) makes projection pruning and secure deletion durable
+  and exposes `erasure_pending`. App/process comparison must keep that local maintenance outcome separate from shared
+  protocol-state and application-projection equivalence.
+- [MDK #1199](https://github.com/marmot-protocol/mdk/pull/1199) is a non-normative multi-device exploration, not an
+  adopted identity model. Scenario IR and process adapters must identify account-device instances explicitly and must
+  not assume that same-account device admission, synchronization, or repair semantics already exist.
+
 - [ ] Give every participant a unique restrictive root and SQLCipher database.
 - [ ] Drive only public app-runtime operations.
 - [ ] Exercise real account/device lifecycle, projections, outbound publication, relay sync/backfill, and retries.
@@ -764,12 +792,20 @@ incorrect result.
 | 2026-07-30 | 0.1 typed deferred/resource outcomes | Replaced ambiguous `Stale(PeelFailed)` results with typed transport availability, protocol rejection, and stale-disposition categories; retry-budget release no longer terminally deduplicates exact-ID redelivery | `cargo test -p cgka-engine --features test-policy-overrides --test deferred_peel_lifecycle`; `--test ingest`; `--test fork_detection` |
 | 2026-07-30 | 0.1 resource-refusal recovery signal | Resource refusal immediately arms one account-wide history backfill per group epoch; ordinary transport deferral retains the existing evidence threshold | `cargo test -p marmot-app client::epoch_stall --lib` |
 | 2026-07-30 | Milestone 0 completion verification | Rebased onto MDK `master` at `1b949655`; fast CI, the full feature-enabled engine suite, full simulator suite, session suite, focused app deferral/backfill coverage, and all 76 strict Tamarin lemmas passed | `just fast-ci`; `cargo test -p cgka-engine --features test-policy-overrides`; `cargo test -p cgka-conformance-simulator`; `cargo test -p cgka-session --features test-policy-overrides`; focused `marmot-app` tests; `just tamarin` |
-| 2026-07-30 | 1.1 exact live-group state oracle | Added a conformance-only canonical snapshot and strict equivalence expectation; exact member and exporter semantic mutations now fail while two independently joined clients match | `cargo test -p cgka-conformance-simulator`; `cargo test -p cgka-engine --features "test-conformance-snapshot test-policy-overrides"` |
+| 2026-07-30 | 1.1 exact live-group state oracle | Added a conformance-only canonical snapshot and strict equivalence expectation; exact member and exporter semantic mutations now fail while two independently joined clients match | [MDK #1190](https://github.com/marmot-protocol/mdk/pull/1190), merge `f4464902`; `cargo test -p cgka-conformance-simulator`; `cargo test -p cgka-engine --features "test-conformance-snapshot test-policy-overrides"` |
 | 2026-07-30 | 1.1 generalized scenario-input disposition ledger | Added strict per-client commit, proposal, and application dispositions keyed by stable scenario action ids and joined to outer transport/content aliases; duplicate application delivery is one delivery plus one dedup, and unpeeled input remains visibly transport-pending | `cargo test -p cgka-conformance-simulator exact_observation_ledgers_commit_proposal_and_application_dispositions`; full simulator suite |
 | 2026-07-30 | 1.1 instantaneous pending-work oracle | Added client-scoped `NoPendingWork` over group-scoped engine, client-addressed bus, and per-client scenario-input-ledger progress; queued, delayed, unread, unconfirmed-publish, and transport-deferred sentinels fail, while a dropped-object sentinel proves delivery remains an independent recipient assertion | `cargo test -p cgka-conformance-simulator` |
 | 2026-07-30 | 1.1 bidirectional decryptability probe | Added an active exact-ID application-message matrix; settled members pass every directed edge, a missed commit exposes future-epoch deferral in only one direction, and a named nonmember cannot pass | `cargo test -p cgka-conformance-simulator bidirectional_decryptability` |
 | 2026-07-30 | 1.1 terminal disband projection | Added a shared-fact-only canonical tombstone projection; terminal state passes exact/no-pending observation across restart, while device-local authorship and roster ordering cannot split equality | `cargo test -p cgka-conformance-simulator exact_oracle_projects_terminal_disband_tombstone_across_restart`; `cargo test -p cgka-engine --features test-conformance-snapshot disband_projection_excludes_device_local_authorship_and_canonicalizes_roster` |
 | 2026-07-30 | 1.1 strict reliability campaigns | Made report oracle coverage strict by default, added `--allow-weak-oracle`, and appended final global drain/exact/no-pending checks to send-leave and chaos cases. The stronger boundary exposed rollback divergence, pre-join deferred work, unretired leave proposal work, and an unasserted mixed-storm application phase rather than masking them | `strict_chaos_boundary_retains_known_reliability_failures`; focused generator/report tests; generated JSON reports |
-| 2026-07-30 | 1.2a public convergence subject | Extracted scenario execution behind a capability-declared `ConvergenceSubject`, added the in-process engine adapter, separated queue/partition mutation behind `ConvergenceFaultSubject`, rejected unsupported scenarios before actions, and recorded adapter identity/capabilities in reports | Subject preflight/fault-classification tests; default-versus-explicit engine subject trace equivalence; report metadata test |
-| 2026-07-30 | 1.1 definite publish-failure semantics | Minimized the transported-commit rollback split to nine steps; made simulator `FailPending` retract the complete undelivered commit/Welcome artifact set and reject artifacts that already reached any recipient, restoring strict exact equivalence without changing production lifecycle behavior | `definite_publish_failure_retracts_commit_before_local_rollback`; `definite_publish_failure_retracts_commit_and_welcome`; `fail_pending_rejects_artifact_that_already_reached_a_recipient`; full simulator suite |
-| 2026-07-30 | 1.2 adopted canonicalization contract refresh | Reconciled the executable selector, dispositions, durable message state, simulator ledger, local architecture docs, and Tamarin model with adopted Marmot convergence commit `4ad4ae2`: removed the redundant raw-depth selector step; made missing-parent, future-epoch, and eligible losing-branch outcomes explicitly deferred; and added `ConvergenceDeferred` so retained inputs can be reconsidered without immediately reopening an unchanged completed pass | canonicalization/candidate/proptest contracts; full engine/simulator/storage/traits suites; all 76 strict Tamarin lemmas |
+| 2026-07-30 | L1 stale-pass repair path | Reclassified inherited convergence-pass base/tip disagreement as recoverable local scheduling drift: collecting and frozen stale passes are discarded, audited, and reseeded at the current tip while frozen-member integrity failures remain fail-closed | [MDK #1182](https://github.com/marmot-protocol/mdk/pull/1182), merge `66c7162c`; behind-tip, ahead-tip, and frozen-phase compensation regressions |
+| 2026-07-30 | 1.2a public convergence subject | Extracted scenario execution behind a capability-declared `ConvergenceSubject`, added the in-process engine adapter, separated queue/partition mutation behind `ConvergenceFaultSubject`, rejected unsupported scenarios before actions, and recorded adapter identity/capabilities in reports | [MDK #1194](https://github.com/marmot-protocol/mdk/pull/1194), merge `2cee3f94`; subject preflight/fault-classification tests; default-versus-explicit engine subject trace equivalence; report metadata test |
+| 2026-07-30 | S4 SQLite transaction-boundary contention | Made transient `COMMIT`/`ROLLBACK` busy conditions retry in place without rerunning application closures; persistent contention remains a typed retryable error and releases a clean connection | [MDK #1191](https://github.com/marmot-protocol/mdk/pull/1191), merge `cff57a5d`; 300 storage tests; `just fast-ci` |
+| 2026-07-30 | 1.3a injectable convergence dual clock | Routed convergence deadlines, pass timestamps, cutoff decisions, and restart rebasing through paired monotonic/wall-clock samples; clock-sensitive engine and harness tests advance deterministically without sleeping | [MDK #1195](https://github.com/marmot-protocol/mdk/pull/1195), merge `5db10d68`; feature-enabled engine and simulator suites; `just fast-ci` |
+| 2026-07-30 | 1.1 consumed self-remove work retirement | Made confirmed and converged commits terminally retire exact consumed proposal rows and epoch-scoped proposal schedule signals; strict send/leave scenarios and restart now reach no-pending-work without an exception | [MDK #1192](https://github.com/marmot-protocol/mdk/pull/1192), merge `1a611eec`; feature-enabled engine suite; strict send/leave family; `just fast-ci` |
+| 2026-07-30 | 1.1 definite publish-failure semantics | Minimized the transported-commit rollback split to nine steps; made simulator `FailPending` retract the complete undelivered commit/Welcome artifact set and reject artifacts that already reached any recipient, restoring strict exact equivalence without changing production lifecycle behavior | [MDK #1196](https://github.com/marmot-protocol/mdk/pull/1196), merge `1985d9a8`; `definite_publish_failure_retracts_commit_before_local_rollback`; `definite_publish_failure_retracts_commit_and_welcome`; `fail_pending_rejects_artifact_that_already_reached_a_recipient`; full simulator suite |
+| 2026-07-30 | 1.2b adopted canonicalization contract refresh | Reconciled the executable selector, dispositions, durable message state, simulator ledger, local architecture docs, and Tamarin model with adopted Marmot convergence commit `4ad4ae2`: removed the redundant raw-depth selector step; made missing-parent, future-epoch, and eligible losing-branch outcomes explicitly deferred; added `ConvergenceDeferred` so retained inputs can be reconsidered without immediately reopening an unchanged completed pass; and terminally retires deferred commits only after they age below the retained horizon | [MDK #1198](https://github.com/marmot-protocol/mdk/pull/1198), merge `562c5d5f`; `just fast-ci`; full engine/simulator/storage/traits suites; relay runtime and simulator/vector CI; all 78 strict Tamarin lemmas |
+| 2026-07-30 | M5 projection/event-delivery prerequisite | Fixed state changes folded into outbound sends reaching stored projections without waking runtime subscriptions; established that process-level simulation must observe projection state and notification delivery as separate surfaces | [MDK #1186](https://github.com/marmot-protocol/mdk/pull/1186), merge `1b949655`; focused interleaved-send subscription regression; `just fast-ci` |
+| 2026-07-30 | M5 app-runtime ownership prerequisite | Enforced one live account session per account within a `MarmotApp`, surfaced typed contention through UniFFI, and made worker reconnect release the failed client before replacement | [MDK #1200](https://github.com/marmot-protocol/mdk/pull/1200), merge `8dc7c12b`; ownership, worker-lifecycle, FFI, and focused runtime tests |
+| 2026-07-30 | M5 projection-maintenance prerequisite | Made large-set projection pruning bounded, preserved draft-owning groups, and made secure-delete checkpoint completion durable and explicitly observable as `erasure_pending` | [MDK #1201](https://github.com/marmot-protocol/mdk/pull/1201), merge `eec70bd9`; 307 storage tests; focused app/UniFFI retention tests; `just fast-ci` |
+| 2026-07-30 | M5 account-device modeling input | Documented a non-normative multi-device design space while deliberately leaving admission, synchronization, and repair choices unresolved; future scenarios must model account-device instances without assuming those candidate semantics | [MDK #1199](https://github.com/marmot-protocol/mdk/pull/1199), merge `aac777f3`; documentation-only |

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -444,8 +444,8 @@ Status: `in-progress`
   semantic engine operations through declared adapter capabilities.
 - [x] Implement the first engine-adapter vertical slice: create/mutate, publication confirmation/failure, application
   send, transport delivery/ingest, event/exact/admin observation, active decryptability probing, and crash/reopen.
-- [x] Add a capability-gated, serializable virtual-time advance backed by one shared paired clock; run the selected
-  awake clients through the normal scheduled-convergence entry point without sleeping.
+- [x] Add a capability-gated, serializable virtual-time advance backed by one shared paired clock; keep time advancement
+  separate from `Tick`, which selects the participant runtimes that wake and observe elapsed deadlines.
 - [ ] Add explicit public outbound polling/acknowledgement so later adapters can model publication progress without
   exposing harness queues.
 - [x] Split normal black-box execution from the explicitly named `ConvergenceFaultSubject` queue/partition mutation
@@ -461,7 +461,7 @@ Status: `in-progress`
 - [x] Add an injectable paired monotonic/wall convergence clock and use it for pass deadlines, cutoff decisions, restart
   rebasing, and deterministic engine/harness tests.
 - [x] Expose that clock through the subject-level `virtual_time` capability and portable `advance_time` scenario step;
-  allow the scenario to keep selected participant runtimes paused while global time advances.
+  route subject `Tick` through the same clock so global time can advance while participant runtimes remain paused.
 
 - [ ] Expose a sanitized structural progress token, runnable work, earliest next wake-up, deferred/retry work, outbound
   work awaiting acknowledgement, and terminal blockers; include inbox, delayed messages, pass phase, and durable
@@ -811,4 +811,4 @@ incorrect result.
 | 2026-07-30 | M5 app-runtime ownership prerequisite | Enforced one live account session per account within a `MarmotApp`, surfaced typed contention through UniFFI, and made worker reconnect release the failed client before replacement | [MDK #1200](https://github.com/marmot-protocol/mdk/pull/1200), merge `8dc7c12b`; ownership, worker-lifecycle, FFI, and focused runtime tests |
 | 2026-07-30 | M5 projection-maintenance prerequisite | Made large-set projection pruning bounded, preserved draft-owning groups, and made secure-delete checkpoint completion durable and explicitly observable as `erasure_pending` | [MDK #1201](https://github.com/marmot-protocol/mdk/pull/1201), merge `eec70bd9`; 307 storage tests; focused app/UniFFI retention tests; `just fast-ci` |
 | 2026-07-30 | M5 account-device modeling input | Documented a non-normative multi-device design space while deliberately leaving admission, synchronization, and repair choices unresolved; future scenarios must model account-device instances without assuming those candidate semantics | [MDK #1199](https://github.com/marmot-protocol/mdk/pull/1199), merge `aac777f3`; documentation-only |
-| 2026-07-30 | 1.2c / 1.3b subject virtual time | Added a capability-gated `advance_time` scenario operation backed by one shared paired clock across the engine subject; global time advances once while scheduled convergence runs only for selected awake participants, preserving legacy `Tick` semantics for existing vectors | Focused preflight/dispatch test; real disband pass remains live at 999 ms and settles at 1,000 ms without sleeping; full simulator suite |
+| 2026-07-30 | 1.2c / 1.3b subject virtual time | Added a capability-gated `advance_time` scenario operation backed by one shared paired clock across the engine subject; time advancement is a separate failure-free operation and `Tick` selects which participant runtimes observe it, while standalone clients without an injected clock preserve the legacy far-future shortcut | Focused serialization/preflight/dispatch test; two real disband passes remain live at a 999 ms tick, Alice alone settles at 1,000 ms, and Bob settles on a later tick without another time advance; full simulator suite |


### PR DESCRIPTION
## Summary

- reconcile the convergence reliability tracking plan with recently merged engine, storage, and runtime hardening work
- add a capability-gated, serializable `advance_time` scenario operation
- install one shared paired monotonic/wall clock across all clients in `EngineHarnessSubject`
- keep global time advancement separate from participant execution: `advance_time` mutates only the shared clock, while `tick` selects which runtimes wake and observe it
- route opted-in subject ticks through the injected clock instead of the historical far-future settlement timestamp
- classify virtual-time advancement in oracle coverage and document the scenario surface

## Why

The merged dual-clock work made convergence deadlines injectable inside the engine, but portable simulator scenarios still could not control those deadlines through `ConvergenceSubject`. This slice closes that boundary without real sleeps or engine/storage rollback machinery.

Separating clock movement from participant execution makes the operation failure-free and models offline participants directly: global time may advance while an unticked participant remains paused.

## Behavior and compatibility

Every engine subject uses a deterministic shared manual clock. A scenario switches `tick` to that clock only after executing `advance_time`; scenarios that never opt in, and standalone `HarnessClient` tests, retain the historical far-future `tick` shortcut. Adapters that do not declare `virtual_time` fail preflight before any scenario action runs.

This does not yet implement structural quiescence, fixed-point driving, or public outbound polling/acknowledgement; those remain separate follow-up slices in the tracking plan.

## Verification

- `cargo test -p cgka-conformance-simulator`
- `cargo test -p cgka-conformance-simulator virtual_time`
- `just fast-ci`
- `git diff --check`
- documentation stale-term scan

The regression uses two independent real durable disband passes: both remain live after Alice ticks at 999 ms; Alice settles when she ticks at 1,000 ms while unticked Bob stays live; Bob then settles on a later tick without another time advance.