### PR TITLE
Make inbound commit capability projections atomic

### DIFF
--- a/crates/cgka-engine/AGENTS.md
+++ b/crates/cgka-engine/AGENTS.md
@@ -350,6 +350,12 @@ shapes. Tests: `tests/fork_detection.rs` plus the harness `deliberate_fork_via_h
   terminal disposition). Fork-recovery paths fail closed with typed errors (`EngineError::ForkedEpoch` / `Backend`) —
   never `unreachable!`/`panic!` — on attacker-influenced input. When you add a guard to one seam, add it to the shared
   helper (or all seams) and extend the parity tests; a guard that exists on one seam only is a bug (see mdk#707).
+- **Commit-derived group records and capability caches are atomic with the MLS apply.** Every durable projection of
+  an accepted commit must share the transaction that mutates OpenMLS state, and every projection read/write error
+  must propagate. This includes the Marmot group record, capabilities extracted from added KeyPackages, and the
+  post-path self-capability refresh. On a failed direct apply, release its unowned recovery snapshot and schedule the
+  retained commit for stored convergence; redelivery deduplicates against the retained content row and cannot itself
+  repair the apply.
 - **Hydration quarantine is enforced through `Engine::ensure_group_live`.** A quarantined group vanishes from every
   live surface (mdk#364 / #365): every public accessor that reads durable or MLS group state (`members`,
   `group_record`, `group_context`, `admin_pubkeys`, `app_component`, `feature_status`, capability queries, the

--- a/crates/cgka-engine/src/capability_manager.rs
+++ b/crates/cgka-engine/src/capability_manager.rs
@@ -79,6 +79,33 @@ pub(crate) fn cache_self_capabilities<S: StorageProvider>(
     Ok(())
 }
 
+/// Replay-side self-cache refresh when the caller has only the materialized
+/// OpenMLS group, not the engine's declared identity.
+///
+/// The own leaf still carries the authenticated Marmot credential identity;
+/// derive that identity and route through [`cache_self_capabilities`] so replay
+/// performs the same proof/profile validation and durable write as direct
+/// ingest.
+pub(crate) fn cache_own_capabilities_from_group<S: StorageProvider>(
+    storage: &S,
+    group_id: &GroupId,
+    mls_group: &MlsGroup,
+) -> Result<(), EngineError> {
+    let Some(leaf) = mls_group.own_leaf_node() else {
+        return Ok(());
+    };
+    let credential = BasicCredential::try_from(leaf.credential().clone())
+        .map_err(|e| EngineError::Backend(format!("credential: {e:?}")))?;
+    let self_id = MemberId::new(credential.identity().to_vec());
+    cache_self_capabilities(
+        storage,
+        group_id,
+        mls_group,
+        &self_id,
+        mls_group.ciphersuite(),
+    )
+}
+
 /// Cache capabilities extracted from a validated invitee's KeyPackage.
 /// Called from create_group / invite paths after capability-check passes.
 pub(crate) fn cache_from_key_packages<S: StorageProvider>(

--- a/crates/cgka-engine/src/message_processor/ingest.rs
+++ b/crates/cgka-engine/src/message_processor/ingest.rs
@@ -1276,13 +1276,6 @@ impl<S: StorageProvider> Engine<S> {
                     let before_message_retention =
                         crate::app_components::message_retention_seconds_of_group(&mls_group)?;
                     self.retain_current_epoch_snapshot_for_group(&group_id)?;
-                    // Extract capabilities from Add proposals before the
-                    // staged commit is consumed by merge.
-                    crate::capability_manager::cache_from_staged_commit(
-                        &self.storage,
-                        &group_id,
-                        &staged,
-                    )?;
                     // Merge and mirror the Marmot record in one durable unit, the
                     // same rule `do_confirm_published` applies to its own merge.
                     // Session open seeds the epoch state machine FROM that
@@ -1298,6 +1291,13 @@ impl<S: StorageProvider> Engine<S> {
                         message_retention_seconds: after_message_retention,
                     } = match self.storage.with_transaction(
                         |storage| -> Result<AppliedCommitProjection, EngineError> {
+                            // The staged commit is the only public source for
+                            // newly added members' KeyPackage capabilities.
+                            // Cache them on the same transaction rail as the
+                            // merge and every other durable projection.
+                            crate::capability_manager::cache_from_staged_commit(
+                                storage, &group_id, &staged,
+                            )?;
                             let tx_provider = EngineOpenMlsProvider::<S>::new(
                                 &self.crypto,
                                 storage.mls_storage(),
@@ -1342,6 +1342,16 @@ impl<S: StorageProvider> Engine<S> {
                                 g.removed = true;
                             }
                             storage.put_group(&g)?;
+                            // A commit path update may change our own leaf.
+                            // Feature-status correctness requires this cache to
+                            // advance atomically with MLS and the group record.
+                            crate::capability_manager::cache_self_capabilities(
+                                storage,
+                                &group_id,
+                                &mls_group,
+                                self.identity.self_id(),
+                                self.ciphersuite,
+                            )?;
                             Ok(AppliedCommitProjection {
                                 epoch: after,
                                 remaining_member_ids: after_ids,
@@ -1413,15 +1423,6 @@ impl<S: StorageProvider> Engine<S> {
                     // index so the new nostr_group_id resolves (prior id retained
                     // for the overlap window). No-op when routing was unchanged.
                     self.reindex_transport_group_id(&group_id);
-                    // Refresh self-cache since our own leaf may have been
-                    // updated by the commit's path.
-                    crate::capability_manager::cache_self_capabilities(
-                        &self.storage,
-                        &group_id,
-                        &mls_group,
-                        self.identity.self_id(),
-                        self.ciphersuite,
-                    )?;
                     self.prune_fork_recovery_for_group(&group_id)?;
 
                     if let Some((source_epoch, winner, invalidated, invalidated_commit_id)) =

--- a/crates/cgka-engine/src/openmls_projection.rs
+++ b/crates/cgka-engine/src/openmls_projection.rs
@@ -1929,6 +1929,12 @@ fn update_group_record_from_replay<S: StorageProvider>(
     {
         group.required_capabilities = required_capabilities_from_group(&mls_group);
         crate::group_lifecycle::mirror_app_components_into_record(&mls_group, &mut group);
+        crate::capability_manager::cache_own_capabilities_from_group(storage, group_id, &mls_group)
+            .map_err(|e| {
+                OpenMlsProjectionError::Replay(format!(
+                    "refresh post-replay self capabilities: {e}"
+                ))
+            })?;
     }
 
     storage
@@ -2575,6 +2581,16 @@ fn process_openmls_messages_inner<S: StorageProvider>(
                     committer,
                     consumed_proposal_refs,
                 });
+                // Mirror direct ingest: the staged commit is the only public
+                // source for newly added members' KeyPackage capabilities.
+                // The outer canonicalization transaction rolls these writes
+                // back with the merge, record, and dispositions.
+                crate::capability_manager::cache_from_staged_commit(storage, group_id, &staged)
+                    .map_err(|e| {
+                        OpenMlsProjectionError::Replay(format!(
+                            "cache replayed Add capabilities: {e}"
+                        ))
+                    })?;
                 mls_group
                     .merge_staged_commit(&provider, *staged)
                     .map_err(|e| {

--- a/crates/cgka-engine/tests/AGENTS.md
+++ b/crates/cgka-engine/tests/AGENTS.md
@@ -67,11 +67,11 @@ backend on the same rail.
     `PendingCommit`, clears it, and surfaces `GroupEvent::PendingCommitRecovered` (mdk#150)
 
 - **File:** `auto_commit_atomicity.rs`
-  - **Owns:** Group-record write atomicity under an injected `put_group` failure (mdk#333), one test per seam that
-    projects the record: auto-commit staging, Welcome join, group-profile staging, and inbound commit apply. No torn
-    record, no orphaned pending publish, no leaked snapshot, no stale stored proposal, no epoch split between the
-    record and the epoch manager; the group stays usable, and an apply the fault abandoned hands its still-retained
-    winning commit back to stored convergence so it is eventually applied
+  - **Owns:** Group-projection atomicity under injected record/cache write failures (mdk#333, mdk#794), one test per
+    seam that projects the record plus direct-ingest capability-cache coverage. No torn record or capability cache,
+    orphaned pending publish, leaked snapshot, stale stored proposal, or epoch split between the record and the epoch
+    manager; the group stays usable, and an apply the fault abandoned hands its still-retained winning commit back to
+    stored convergence so it is eventually applied
 
 - **File:** `hydration_quarantine.rs`
   - **Owns:** Group hydration-quarantine path — `GroupHydrationQuarantineReason` classification on session open

--- a/crates/cgka-engine/tests/auto_commit_atomicity.rs
+++ b/crates/cgka-engine/tests/auto_commit_atomicity.rs
@@ -186,11 +186,37 @@ impl PutGroupFault {
     }
 }
 
+/// One-shot fault that fails the Nth capability-cache write after arming.
+///
+/// Inbound Add commits write the added member first and refresh self second,
+/// which lets the regression fail specifically at the post-merge self-cache
+/// refresh.
+#[derive(Clone, Default)]
+struct CapabilityWriteFault(Arc<AtomicUsize>);
+
+impl CapabilityWriteFault {
+    fn arm_on_call(&self, call: usize) {
+        assert!(call > 0);
+        self.0.store(call, Ordering::SeqCst);
+    }
+
+    fn should_fail(&self) -> bool {
+        matches!(
+            self.0
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    (remaining > 0).then(|| remaining - 1)
+                }),
+            Ok(1)
+        )
+    }
+}
+
 /// `SqliteAccountStorage` wrapper that injects a transient `Busy` on
-/// `put_group`. Every other call delegates unchanged.
+/// selected record/cache writes. Every other call delegates unchanged.
 struct FaultStorage {
     inner: SqliteAccountStorage,
     fault: PutGroupFault,
+    capability_fault: CapabilityWriteFault,
 }
 
 impl GroupStorage for FaultStorage {
@@ -379,6 +405,11 @@ impl CapabilityStorage for FaultStorage {
         member: &Member,
         capabilities: GroupCapabilities,
     ) -> StorageResult<()> {
+        if self.capability_fault.should_fail() {
+            return Err(StorageError::Busy(
+                "injected capability-cache write failure".into(),
+            ));
+        }
         self.inner
             .save_member_capabilities(group_id, member, capabilities)
     }
@@ -487,14 +518,39 @@ fn build_fault_selfremove_client(
 ) -> (cgka_engine::Engine<FaultStorage>, SqliteAccountStorage) {
     let inner = SqliteAccountStorage::in_memory().unwrap();
     let handle = inner.clone();
-    let engine = EngineBuilder::new(FaultStorage { inner, fault })
-        .legacy_compatibility_profile()
-        .identity(pad32(id))
-        .account_identity_proof_signer(proof_signer(id))
-        .feature_registry(selfremove_registry())
-        .peeler(Box::new(MockPeeler))
-        .build()
-        .unwrap();
+    let engine = EngineBuilder::new(FaultStorage {
+        inner,
+        fault,
+        capability_fault: CapabilityWriteFault::default(),
+    })
+    .legacy_compatibility_profile()
+    .identity(pad32(id))
+    .account_identity_proof_signer(proof_signer(id))
+    .feature_registry(selfremove_registry())
+    .peeler(Box::new(MockPeeler))
+    .build()
+    .unwrap();
+    (engine, handle)
+}
+
+fn build_capability_fault_client(
+    id: &[u8],
+    capability_fault: CapabilityWriteFault,
+) -> (cgka_engine::Engine<FaultStorage>, SqliteAccountStorage) {
+    let inner = SqliteAccountStorage::in_memory().unwrap();
+    let handle = inner.clone();
+    let engine = EngineBuilder::new(FaultStorage {
+        inner,
+        fault: PutGroupFault::default(),
+        capability_fault,
+    })
+    .legacy_compatibility_profile()
+    .identity(pad32(id))
+    .account_identity_proof_signer(proof_signer(id))
+    .feature_registry(selfremove_registry())
+    .peeler(Box::new(MockPeeler))
+    .build()
+    .unwrap();
     (engine, handle)
 }
 
@@ -901,6 +957,184 @@ async fn inbound_apply_record_mirror_failure_does_not_split_epoch_state() {
             })
         ),
         "redelivery after recovery must be a duplicate, got {redelivered:?}"
+    );
+}
+
+/// A failure refreshing self capabilities occurs after the MLS merge and group
+/// record write. All inbound projections must roll back together, and the
+/// retained commit must be handed to stored convergence for retry (mdk#794).
+#[tokio::test]
+async fn inbound_self_capability_mirror_failure_rolls_back_and_reschedules() {
+    let alice_fault = CapabilityWriteFault::default();
+    let bob_fault = CapabilityWriteFault::default();
+    let (mut alice, alice_storage) =
+        build_capability_fault_client(b"alice-inbound-cap-atomic", alice_fault.clone());
+    let (mut bob, bob_storage) =
+        build_capability_fault_client(b"bob-inbound-cap-atomic", bob_fault.clone());
+    let mut david = build_selfremove_client(b"david-inbound-cap-atomic");
+    let mut eve = build_selfremove_client(b"eve-inbound-cap-atomic");
+    let david_id = david.self_id();
+    let eve_id = eve.self_id();
+
+    // Alice and Bob are co-admins at epoch 1, so they can publish competing
+    // privileged invite commits from the same source epoch.
+    let bob_kp = bob.fresh_key_package().await.unwrap();
+    let (group_id, create) = alice
+        .create_group(CreateGroupRequest {
+            name: "inbound capability atomicity".into(),
+            description: String::new(),
+            members: vec![bob_kp],
+            required_features: vec![],
+            app_components: vec![],
+            initial_admins: vec![bob.self_id()],
+        })
+        .await
+        .unwrap();
+    let bob_welcome = match create {
+        SendResult::GroupCreated {
+            pending,
+            mut welcomes,
+        } => {
+            alice.confirm_published(pending).await.unwrap();
+            welcomes.remove(0)
+        }
+        other => panic!("expected GroupCreated, got {other:?}"),
+    };
+    bob.join_welcome(bob_welcome).await.unwrap();
+    alice.drain_pending_convergence_groups();
+    bob.drain_pending_convergence_groups();
+
+    let david_kp = david.fresh_key_package().await.unwrap();
+    let eve_kp = eve.fresh_key_package().await.unwrap();
+    let alice_invite = alice
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![david_kp],
+        })
+        .await
+        .unwrap();
+    let bob_invite = bob
+        .send(SendIntent::Invite {
+            group_id: group_id.clone(),
+            key_packages: vec![eve_kp],
+        })
+        .await
+        .unwrap();
+    let alice_commit = match alice_invite {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            alice.confirm_published(pending).await.unwrap();
+            msg
+        }
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+    let bob_commit = match bob_invite {
+        SendResult::GroupEvolution { msg, pending, .. } => {
+            bob.confirm_published(pending).await.unwrap();
+            msg
+        }
+        other => panic!("expected GroupEvolution, got {other:?}"),
+    };
+
+    let ordering_key = |committer: MemberId, commit: &TransportMessage| {
+        CommitOrderingKey::from_commit_bytes(
+            EpochId(1),
+            CommitOrderingPriority::Privileged,
+            committer,
+            &commit.payload,
+        )
+    };
+    let bob_wins =
+        ordering_key(bob.self_id(), &bob_commit) < ordering_key(alice.self_id(), &alice_commit);
+    let (loser, loser_storage, loser_fault, winning_commit, winning_invitee) = if bob_wins {
+        (&mut alice, &alice_storage, &alice_fault, bob_commit, eve_id)
+    } else {
+        (&mut bob, &bob_storage, &bob_fault, alice_commit, david_id)
+    };
+    let routed_winner = TransportMessage {
+        envelope: TransportEnvelope::GroupMessage {
+            transport_group_id: group_id.as_slice().to_vec(),
+        },
+        ..winning_commit
+    };
+
+    assert_eq!(loser.epoch(&group_id).unwrap(), EpochId(2));
+    assert!(
+        loser_storage
+            .member_capabilities(&group_id, &winning_invitee)
+            .unwrap()
+            .is_none()
+    );
+    let snapshots_before: std::collections::HashSet<String> = loser_storage
+        .list_group_snapshots(&group_id)
+        .unwrap()
+        .into_iter()
+        .collect();
+
+    // The added-member cache write is first; fail the self refresh after the
+    // merge and group-record write have both run inside the transaction.
+    loser_fault.arm_on_call(2);
+    let failed = loser.ingest(routed_winner.clone()).await;
+    assert!(
+        matches!(failed, Err(EngineError::Storage(StorageError::Busy(_)))),
+        "self-capability mirror failure must surface as retryable, got {failed:?}"
+    );
+
+    let record = loser_storage.get_group(&group_id).unwrap();
+    assert_eq!(loser.epoch(&group_id).unwrap(), EpochId(1));
+    assert_eq!(record.epoch, EpochId(1));
+    assert_eq!(loser.members(&group_id).unwrap().len(), 2);
+    assert_eq!(record.members.len(), 2);
+    assert!(
+        loser_storage
+            .member_capabilities(&group_id, &winning_invitee)
+            .unwrap()
+            .is_none(),
+        "the added-member cache write must roll back with the failed self refresh"
+    );
+    let snapshots_after: std::collections::HashSet<String> = loser_storage
+        .list_group_snapshots(&group_id)
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert!(
+        snapshots_after.is_subset(&snapshots_before),
+        "the abandoned direct apply leaked a recovery snapshot"
+    );
+
+    let scheduled = loser.drain_pending_convergence_groups();
+    assert!(
+        scheduled.contains(&group_id),
+        "the retained commit must be scheduled for stored-convergence retry"
+    );
+    loser
+        .converge_stored_openmls_messages_at(&group_id, 0)
+        .unwrap();
+    loser
+        .converge_stored_openmls_messages_at(&group_id, 60_000)
+        .unwrap();
+
+    let record = loser_storage.get_group(&group_id).unwrap();
+    assert_eq!(loser.epoch(&group_id).unwrap(), EpochId(2));
+    assert_eq!(record.epoch, EpochId(2));
+    assert_eq!(loser.members(&group_id).unwrap().len(), 3);
+    assert_eq!(record.members.len(), 3);
+    assert!(
+        loser_storage
+            .member_capabilities(&group_id, &winning_invitee)
+            .unwrap()
+            .is_some(),
+        "stored convergence must rebuild the added member's capability cache"
+    );
+
+    let redelivered = loser.ingest(routed_winner).await;
+    assert!(
+        matches!(
+            redelivered,
+            Ok(IngestOutcome::Ignored {
+                category: InputRejectionCategory::Duplicate
+            })
+        ),
+        "redelivery after convergence recovery must be a duplicate, got {redelivered:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

- move added-member and post-path self-capability cache writes onto the same transaction rail as direct inbound commit merge and group-record projection
- make stored-convergence replay rebuild added-member and self-capability projections atomically with canonical apply
- add a capability-write fault regression covering MLS/record/cache rollback, snapshot cleanup, convergence recovery, cache restoration, and duplicate redelivery
- document capability caches as commit-derived durable projections

## Relationship to #1184

While this PR was open, #1184 landed the overlapping group-record portion of #794: it made the inbound epoch/roster mirror atomic with the OpenMLS merge and added recovery scheduling after a failed record write. This branch is rebased on that implementation and keeps it intact.

The remaining gap was capability state. Direct ingest still cached newly added members before the transaction and refreshed self capabilities after it. A transient cache-write failure could therefore leave capability projections inconsistent with the MLS/group-record unit. Stored convergence also did not rebuild those caches when recovering the retained commit.

## Impact

An inbound commit now either advances MLS, the Marmot group record, and all capability projections together or rolls the complete operation back. Stored convergence can reconstruct the same capability state when it retries an abandoned direct apply.

## Validation

- `cargo test -p cgka-engine --features test-policy-overrides --test auto_commit_atomicity` — 5 passed
- `just fast-ci`
- original pre-rebase GitHub CI matrix was fully green

Fixes #794

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when applying group updates by keeping group state and capability data synchronized.
  * Failed updates now roll back cleanly, avoid leaving recovery data behind, and are automatically rescheduled for convergence.
  * Retried updates correctly rebuild capability information, while duplicate deliveries remain safely ignored.

* **Tests**
  * Added coverage for capability-cache failures during inbound group updates and subsequent recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->