### PR TITLE
Feat/incident replay classifier parity

### DIFF
--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -28,11 +28,12 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
   - **Role:** The `classify` gate → `Verdict`: `Healthy | ForkRecovery |
     ConvergenceSelected | Quarantine { reason }`. Everything downstream is gated
     behind this, so a healthy export yields zero vectors and a clean exit. Also
-    home of the liveness gate (rule 5 below), which keeps a silently split
-    group from reading as healthy. `liveness_advisory` exposes that same rule-5
-    computation independent of the verdict, so a co-occurring liveness incident
-    that loses the single verdict to a higher-precedence incident (fork or
-    convergence) is still surfaced — the CLI prints it as a secondary advisory.
+    home of the two liveness gates (rules 5 and 6 below), which keep a halted or
+    silently split group from reading as healthy. `halt_advisory` and
+    `liveness_advisory` expose those same computations independent of the verdict,
+    so a co-occurring incident that loses the single verdict to a
+    higher-precedence one is still surfaced — the CLI prints each as a secondary
+    advisory.
 - **Module:** `src/fork.rs`
   - **Role:** `recover_fork` turns a fork-recovery export into a `RecoveredFork`
     (source epoch + commit kind), or a `ForkRecoveryError` when it cannot be
@@ -113,7 +114,25 @@ Precedence, highest first:
    `missing_snapshot` (the winning snapshot was unavailable, so it can't be
    replayed) on the fork-recovery route.
 4. **`ForkRecovery`** — any other `fork_resolution`.
-5. **Quarantine `epoch_divergence`** — an engine trails the group's epoch
+5. **Quarantine `unrecoverable_halt`** — an engine recorded halting
+   unrecoverably, so its group stays blocked until a verified repair clears the
+   marker. Two audit surfaces arm it, and the reason string from whichever fired
+   is reported per engine: `convergence_run_state` with `phase: unrecoverable`
+   (mdk#1110 — reasons `convergence_pass_base_changed` and
+   `frozen_pass_integrity_failure`, the latter from `error_kind:
+   frozen_member_integrity`), and `epoch_state_changed` with `new_state:
+   unrecoverable` (mdk#1106 — reason `hydrate_unrecoverable_group`, a durable
+   halt that survived a restart). Unlike rule 6 this is not an inference from
+   lag: the engine *stated* that it stopped, so the gate needs no timestamps to
+   order evidence and no threshold to clear noise — only an `engine_id` to
+   attribute the halt to. It therefore outranks rule 6, which it usually
+   explains: on the real 26a9f546 export the halted engine is exactly the one
+   rule 6 labelled `went dark`, and reporting the inference over the diagnosis
+   would send the operator to re-pull for a confirmation they already have.
+   A halt is a client failure, not a branch contest, so there is still nothing
+   to replay. `halt_advisory` exposes the same computation verdict-independently,
+   as `liveness_advisory` does for rule 6.
+6. **Quarantine `epoch_divergence`** — an engine trails the group's epoch
    high-water mark by ≥ 2 epochs (one epoch is routine commit propagation).
    The reason names every engine left behind with its epoch and a per-engine
    mode: **`went_dark`** (its events end before — or within one hour of — the
@@ -124,9 +143,9 @@ Precedence, highest first:
    catching up: commits are not reaching it while its other traffic flows).
    A real liveness incident, but not a branch contest, so there is nothing to
    replay — the named engines are the triage starting point.
-6. **`Healthy`** — none of the above.
+7. **`Healthy`** — none of the above.
 
-Rule 5 ranks *below* the incident routes on purpose: a reproducible contest is
+Rules 5 and 6 rank *below* the incident routes on purpose: a reproducible contest is
 worth replaying even when another engine's data is stale (recovery fail-closes
 downstream if the data it needs is missing). It fires only on positive
 evidence — no engine ids or timestamps means the gate stays unarmed — so
@@ -163,6 +182,28 @@ Gate designs evaluated against real exports and deliberately **rejected**:
   activity): a device that is merely offline while no commits land misses
   nothing and converges on return; epoch-anchored lag subsumes the cases that
   matter.
+- *Reading Goggles' `epoch_state_transition` projection* for the rule-5 halt.
+  That NDJSON section is where a halt carries `severity: error`, so it looks like
+  the obvious input, but it is a *derived* row: its `evidence_ref.event_type` is
+  `epoch_state_changed`, and on the real 26a9f546 export its 12 error rows are a
+  1:1 projection of 12 audit events that state `new_state: unrecoverable`
+  outright. Reading the audit event instead keeps the gate on primary evidence,
+  keeps it working for the `agent-state.json` shape (whose projection layout is
+  not verified here — no real document export was on hand), and keeps this model
+  decoupled from Goggles' derivation rather than only from the engine's enum.
+  No evidence is lost: every error-severity transition on that export is an
+  unrecoverable one, and every unrecoverable one is error-severity.
+- *A separate gate per halt surface.* `convergence_run_state{phase:
+  unrecoverable}` and `epoch_state_changed{new_state: unrecoverable}` are two
+  views of one incident — on the real export the same engine recorded both — so
+  they fold into one per-engine report rather than two rules that would both fire
+  and disagree about precedence. Each distinct reason is listed once: a halt is a
+  state, not a count, so repetition is not severity.
+- *Recognizing `convergence_pass_reopened`* (the non-terminal kind open PR #1182
+  adds) ahead of its merge. Its wire shape can still change; it is non-terminal,
+  so no rule would read it and the variant would be dead on arrival; and the
+  parser is already lenient — an unmodelled kind maps to `EventKind::Other`
+  harmlessly — so waiting costs nothing. Add it with the rule that needs it.
 - *Softer arming* (two variants, both refuted by the same backtest): arming only
   on `active_while_behind` would have missed the incident's genuinely-stuck
   device entirely — its uploads had stopped, so it read as dark in the export,

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -88,17 +88,43 @@ incident becomes a vector only if the simulator reproduces the recorded outcome
     reproduction. It does not independently prove action-to-event correspondence and marks unredacted imported
     Scenario IR confidential. Raw MLS bytes and the engine checkpoint remain unavailable; byte replay requires the
     separate local sensitive capsule path.
+- **Module:** `src/route.rs`
+  - **Role:** `route` composes classify → import/recover → accept into one
+    `Routing`: the primary `Outcome` (`Healthy | Accepted | Quarantine |
+    InfrastructureFailure`) plus an `Advisory` per co-occurring finding. An
+    incident verdict reads the producer's attested normalized history first
+    (`src/artifact.rs`) and only synthesizes an archetype when the export carries
+    none — the gate reads the export rather than the verdict, so it runs once,
+    ahead of route dispatch, and both incident routes ask it the same question.
+    An attested history that is rejected is fail-closed like any other route,
+    *except* when the simulator could not be run at all: that decided nothing, so
+    it is an `InfrastructureFailure` (the CLI's only non-classification exit-2)
+    rather than a quarantine nobody reached. `route` also owns the
+    **fall-through**: when the route the verdict selected fails its recovery
+    closed, the remaining lower-precedence routes are tried rather than
+    discarding a reproducible incident that shares the export (the real 26a9f546 export fail-closed on convergence
+    `WitnessBoostNotDecisive` while carrying a cleanly acceptable membership fork
+    at the same epoch). Classification precedence is untouched — fall-through runs
+    only *after* a failure — and one rule keeps it honest: a lower route may
+    override a higher route's quarantine only by producing an accepted vector. A
+    second quarantine never displaces the higher-precedence one; it becomes an
+    `advisory (fallback route):` instead. Vector names live here too: they are
+    pipeline facts, not CLI ones.
 - **Module:** `src/main.rs`
-  - **Role:** CLI — classify one export file; for a fork-recovery or convergence
-    incident, run the recover → accept → write pipeline. Exits 0 for any
+  - **Role:** CLI — read one export file, detect its format, print the `Routing`.
+    Reading and formatting only; route policy is `src/route.rs`. Exits 0 for any
     classification (healthy, quarantine, and accepted are all valid), 2 on
-    usage/IO/parse/write failure. Also prints a secondary `advisory (liveness):`
-    line whenever `liveness_advisory` fires and the primary verdict is not
-    already the epoch-divergence quarantine, so an accepted or quarantined
-    incident never masks a co-occurring engine left behind (the real e1a04e82
-    export carried both an accepted membership fork and a lag-12 stuck device). When an output directory is supplied,
-    writes both the portable vector and `incident-scenario-artifact.v1` evidence envelope owner-only; it never copies
-    the source export, transport ciphertext, or an MLS checkpoint.
+    usage/IO/parse/write failure and on an `InfrastructureFailure`. Output is one
+    primary line plus an `advisory (<label>):` line per finding that line does not
+    report: `superseded route` / `fallback route` (the fall-through above), `halt`
+    (rule 5), and `liveness` (rule 6) — the last two suppressed only when the
+    finding *is* the primary. So an accepted or quarantined incident never masks
+    a co-occurring halted or stranded engine (the real e1a04e82 export carried
+    both an accepted membership fork and a lag-12 stuck device). When an output
+    directory is supplied, writes both the portable vector and the
+    `incident-scenario-artifact.v1` evidence envelope owner-only, and refuses to
+    persist an unreproduced attested artifact; it never copies the source export,
+    transport ciphertext, or an MLS checkpoint.
 
 ## Classification rules (verified against real Goggles exports)
 

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -179,9 +179,12 @@ Precedence, highest first:
 
 Rules 5 and 6 rank *below* the incident routes on purpose: a reproducible contest is
 worth replaying even when another engine's data is stale (recovery fail-closes
-downstream if the data it needs is missing). It fires only on positive
-evidence — no engine ids or timestamps means the gate stays unarmed — so
-synthetic fixtures and older exports classify as before. Lag is measured in
+downstream if the data it needs is missing). Each fires only on positive
+evidence, with its own arming requirement: rule 5 arms on an attributable
+self-reported halt — an `engine_id` plus a halt reason, no timestamps needed —
+while rule 6 needs both an `engine_id` and `wall_time_ms` activity evidence.
+Events missing those fields leave the respective rule unarmed, so synthetic
+fixtures and older exports classify as before. Rule 6 measures lag in
 epochs, not wall-clock silence: a device that is offline while nothing is
 committed misses nothing, and an idle group never reads as stale. The ≥ 2
 threshold is derived, not tuned — lag 1 is the propagation noise floor, so 2 is

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -144,9 +144,15 @@ Precedence, highest first:
    unrecoverably, so its group stays blocked until a verified repair clears the
    marker. Two audit surfaces arm it, and the reason string from whichever fired
    is reported per engine: `convergence_run_state` with `phase: unrecoverable`
-   (mdk#1110 — reasons `convergence_pass_base_changed` and
-   `frozen_pass_integrity_failure`, the latter from `error_kind:
-   frozen_member_integrity`), and `epoch_state_changed` with `new_state:
+   (mdk#1110 — reason `frozen_pass_integrity_failure` from `error_kind:
+   frozen_member_integrity`, and the reason-less `error_kind:
+   missing_retained_anchor`, which is why the gate falls back to `error_kind`.
+   mdk#1182 retired a third, `convergence_pass_base_changed` /
+   `base_epoch_mismatch`: a pass whose base epoch disagrees with the tip is now
+   discarded and reopened, emitting the non-terminal
+   `convergence_pass_discarded`. Nothing emits the retired pair today, but the
+   gate matches no reason whitelist, so historical exports carrying it still
+   arm), and `epoch_state_changed` with `new_state:
    unrecoverable` (mdk#1106 — reason `hydrate_unrecoverable_group`, a durable
    halt that survived a restart). Unlike rule 6 this is not an inference from
    lag: the engine *stated* that it stopped, so the gate needs no timestamps to

--- a/crates/incident-replay/AGENTS.md
+++ b/crates/incident-replay/AGENTS.md
@@ -155,9 +155,28 @@ Precedence, highest first:
    arm), and `epoch_state_changed` with `new_state:
    unrecoverable` (mdk#1106 — reason `hydrate_unrecoverable_group`, a durable
    halt that survived a restart). Unlike rule 6 this is not an inference from
-   lag: the engine *stated* that it stopped, so the gate needs no timestamps to
-   order evidence and no threshold to clear noise — only an `engine_id` to
-   attribute the halt to. It therefore outranks rule 6, which it usually
+   lag: the engine *stated* that it stopped, so *arming* the gate needs no
+   timestamps to order evidence and no threshold to clear noise — only an
+   `engine_id` to attribute the halt to. **Clearing** it needs more, because
+   "until a verified repair clears the marker" is part of the rule, not a
+   footnote: an engine that halted and then completed the repair is repaired, and
+   reporting it would send the operator after a healed device. The clearing signal
+   is `epoch_state_changed` with `new_state: stable` **and** `reason:
+   join_welcome_repair` — `Engine::join_welcome` routes a halted group's re-join
+   through `EpochManager::repair_to_stable` (its only caller, and the state
+   machine's only accepted exit from `Unrecoverable`) and emits that row
+   unconditionally right after. The `reason` is the whole signal; `new_state:
+   stable` alone is the engine's ordinary healthy state (see the rejected designs
+   below). Clearing is decided per **`(engine_id, group_ref)`** — `Unrecoverable`
+   is per-group state, so a repair in one group must not clear another group's
+   halt — by **newest halt vs. newest repair**, with surviving halts folded back
+   per engine so an engine halted in two groups is still one halted engine with
+   the union of its reasons. Newest-wins needs no global event ordering because a
+   live halt is continuously re-asserted (every session open re-emits
+   `hydrate_unrecoverable_group`; every convergence attempt emits
+   `already_unrecoverable`), so a halt that outlived its repair leaves rows after
+   it. Both rows come from one engine — one clock, one recorder file — so rule 6's
+   cross-device grace does not apply here. It therefore outranks rule 6, which it usually
    explains: on the real 26a9f546 export the halted engine is exactly the one
    rule 6 labelled `went dark`, and reporting the inference over the diagnosis
    would send the operator to re-pull for a confirmation they already have.
@@ -184,7 +203,14 @@ evidence, with its own arming requirement: rule 5 arms on an attributable
 self-reported halt — an `engine_id` plus a halt reason, no timestamps needed —
 while rule 6 needs both an `engine_id` and `wall_time_ms` activity evidence.
 Events missing those fields leave the respective rule unarmed, so synthetic
-fixtures and older exports classify as before. Rule 6 measures lag in
+fixtures and older exports classify as before. Rule 5's asymmetry is deliberate:
+*arming* needs no timestamps, because a halt is self-reported and repetition
+carries no extra meaning, but *clearing* is an ordering claim about two rows and
+absent timestamps therefore fail closed — the halt stands. The same applies to a
+missing `group_ref`: `None` is its own scope, never a wildcard, so an
+unattributed repair cannot clear an attributed halt. The asymmetry is the
+fail-closed direction on purpose — a missed repair costs a re-pull, a missed halt
+costs the incident. Rule 6 measures lag in
 epochs, not wall-clock silence: a device that is offline while nothing is
 committed misses nothing, and an idle group never reads as stale. The ≥ 2
 threshold is derived, not tuned — lag 1 is the propagation noise floor, so 2 is
@@ -234,6 +260,30 @@ Gate designs evaluated against real exports and deliberately **rejected**:
   they fold into one per-engine report rather than two rules that would both fire
   and disagree about precedence. Each distinct reason is listed once: a halt is a
   state, not a count, so repetition is not severity.
+- *Clearing a halt on any `new_state: stable` row.* The obvious reading of "the
+  group returns to stable" is wrong: `stable` is the engine's ordinary state and
+  is entered from `publish_confirmed`, `publish_failed`, `join_welcome`,
+  `founding_create`, `auto_commit_stage_failed`, and
+  `update_group_data_stage_failed` — none of which repairs anything.
+  `publish_confirmed` alone is among the commonest rows in a healthy export, so
+  this rule would clear every halt on the halted engine's next successful publish
+  and delete the gate in practice. Only `reason: join_welcome_repair` marks the
+  transition that actually exited `Unrecoverable`.
+- *A presence-only downgrade* ("the engine halted but a repair row also exists ⇒
+  not halted"). It cannot tell a repaired halt from a re-halt: halt→repair and
+  repair→halt carry identical row sets and opposite meanings, and the rule gets
+  the second one wrong on the worse side, reporting a currently-halted device as
+  healthy. Ordering the newest of each is what separates them, which is why the
+  fixture set carries both orders.
+- *Ordering the two rows by `seq` or by line order.* `seq` is recorder-local and
+  restarts at `0` on every recorder open *within the same file*
+  (`docs/marmot-architecture/audit-logging.md`), so it cannot order rows across a
+  restart — precisely the boundary a durable halt survives, making it wrong exactly
+  where it matters. Line order would be an unverified server guarantee: Goggles
+  does not document the export as clock-ordered, and depending on it would put a
+  correctness claim on someone else's undocumented behaviour. `wall_time_ms` is
+  the engine's own clock, and both rows compared come from one engine, so no
+  cross-device skew enters.
 - *Recognizing `convergence_pass_reopened`* (the non-terminal kind open PR #1182
   adds) ahead of its merge. Its wire shape can still change; it is non-terminal,
   so no rule would read it and the variant would be dead on arrival; and the

--- a/crates/incident-replay/src/classify.rs
+++ b/crates/incident-replay/src/classify.rs
@@ -75,12 +75,19 @@ pub enum QuarantineReason {
     TruncatedProjections,
     /// A fork resolution's winning snapshot was missing — unreproducible.
     MissingSnapshot,
-    /// Engines recorded halting unrecoverably: the group is blocked on those
-    /// engines until a verified repair clears the marker. Unlike
+    /// Engines recorded halting unrecoverably and are *still* halted at the end
+    /// of the export: no verified repair cleared the marker afterwards. Unlike
     /// [`QuarantineReason::EpochDivergence`], this is not an inference from lag —
     /// the engine itself recorded that it stopped — so it needs no cross-pull
     /// confirmation and it is a diagnosis rather than a re-pull target. There is
     /// still nothing to replay: a halt is a client failure, not a branch contest.
+    ///
+    /// "Still halted" is decided per `(engine, group)` by comparing the newest
+    /// halt row against the newest verified-repair row
+    /// (`epoch_state_changed { new_state: "stable", reason: "join_welcome_repair"
+    /// }`); surviving halts then fold back per engine. See [`HaltLifecycle`] for
+    /// why newest-wins needs no global ordering and why missing evidence keeps the
+    /// halt.
     UnrecoverableHalt {
         /// Every engine that recorded a halt, in engine-id order.
         engines: Vec<HaltedEngine>,
@@ -285,22 +292,95 @@ pub fn halt_advisory(export: &AgentStateExport) -> Option<QuarantineReason> {
     unrecoverable_halt(export)
 }
 
+/// One group's halt lifecycle on one engine, folded from the event log.
+///
+/// `Unrecoverable` is per-group state with exactly one legal exit, so the halt
+/// and its repair are a two-event lifecycle rather than two independent facts —
+/// hence the newest of each, not a count.
+#[derive(Default)]
+struct HaltLifecycle<'a> {
+    /// Every distinct reason the engine gave for halting this group.
+    reasons: BTreeSet<&'a str>,
+    /// The newest halt row's timestamp, when the halt rows carry one.
+    last_halt_ms: Option<u64>,
+    /// The newest verified-repair row's timestamp, when it carries one.
+    last_repair_ms: Option<u64>,
+}
+
+impl HaltLifecycle<'_> {
+    /// Whether the halt still stands at the end of the export.
+    ///
+    /// Newest-repair-strictly-after-newest-halt is the whole rule, and it needs
+    /// no global event ordering because a live halt is *continuously
+    /// re-asserted*: opening a session over a durably halted group re-emits
+    /// `hydrate_unrecoverable_group` (`cgka-engine/src/engine.rs`) and every
+    /// convergence attempt against one emits `already_unrecoverable`
+    /// (`cgka-engine/src/distributed_convergence.rs`). A halt that outlived a
+    /// repair therefore leaves rows *after* it, and one that did not, does not.
+    /// Both rows also come from a single engine — one clock, one recorder file —
+    /// so none of rule 6's cross-device [`CATCH_UP_GRACE_MS`] skew allowance
+    /// applies and a strict comparison is sound. (`seq` must never be substituted
+    /// for the clock: it restarts at 0 on every recorder open *within the same
+    /// file*, so it does not order rows across a restart — the exact boundary a
+    /// durable halt survives. See `docs/marmot-architecture/audit-logging.md`.)
+    ///
+    /// Absence fails closed in both directions: an unrepaired halt keeps its
+    /// quarantine, and so does a halt whose evidence cannot be ordered. Untimed
+    /// rows never clear anything — arming rule 5 needs no timestamps, but
+    /// *clearing* it does, and guessing here would turn a real halt into a
+    /// healthy verdict. This is also why untimed fixtures and
+    /// pre-instrumentation exports classify exactly as before.
+    fn still_halted(&self) -> bool {
+        if self.reasons.is_empty() {
+            return false;
+        }
+        match (self.last_halt_ms, self.last_repair_ms) {
+            (Some(halt), Some(repair)) => repair <= halt,
+            _ => true,
+        }
+    }
+}
+
 /// The gate for engines that recorded halting unrecoverably.
 ///
 /// Like the liveness gate it fires only on positive evidence, but it needs far
-/// less of it: a halt is self-reported, so no timestamps are required to order it
-/// and no threshold is needed to distinguish it from noise. It does require an
-/// `engine_id` — the report is per-engine, and an unattributable halt could not
-/// be named — which also keeps untimed synthetic fixtures and pre-instrumentation
-/// exports classifying exactly as before.
+/// less of it to arm: a halt is self-reported, so no threshold is needed to
+/// distinguish it from noise. It does require an `engine_id` — the report is
+/// per-engine, and an unattributable halt could not be named.
+///
+/// The gate is *cleared* per `(engine_id, group_ref)` rather than per engine,
+/// because that is the granularity the halt actually has: the engine's state
+/// machine holds `Unrecoverable` for one group, and a repair in another group
+/// proves nothing about it. Surviving halts then fold back per engine, so an
+/// engine halted in two groups is still one halted engine with the union of its
+/// reasons — the report shape rule 5 has always had.
 fn unrecoverable_halt(export: &AgentStateExport) -> Option<QuarantineReason> {
-    let mut halted: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    let mut lifecycles: BTreeMap<(&str, Option<&str>), HaltLifecycle> = BTreeMap::new();
     for event in &export.events {
-        if let (Some(engine_id), Some(reason)) = (
-            event.engine_id.as_deref(),
-            event.kind.unrecoverable_halt_reason(),
-        ) {
-            halted.entry(engine_id).or_default().insert(reason);
+        let Some(engine_id) = event.engine_id.as_deref() else {
+            continue;
+        };
+        let group_scope = (engine_id, event.group_ref.as_deref());
+        if let Some(reason) = event.kind.unrecoverable_halt_reason() {
+            let lifecycle = lifecycles.entry(group_scope).or_default();
+            lifecycle.reasons.insert(reason);
+            lifecycle.last_halt_ms = lifecycle.last_halt_ms.max(event.wall_time_ms);
+        } else if event.kind.is_verified_repair() {
+            // Recorded even when no halt has been seen yet: the fold is over
+            // timestamps, not file order, so a repair may legitimately arrive
+            // before the halt it postdates.
+            let lifecycle = lifecycles.entry(group_scope).or_default();
+            lifecycle.last_repair_ms = lifecycle.last_repair_ms.max(event.wall_time_ms);
+        }
+    }
+
+    let mut halted: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    for ((engine_id, _group_ref), lifecycle) in &lifecycles {
+        if lifecycle.still_halted() {
+            halted
+                .entry(engine_id)
+                .or_default()
+                .extend(lifecycle.reasons.iter().copied());
         }
     }
 

--- a/crates/incident-replay/src/classify.rs
+++ b/crates/incident-replay/src/classify.rs
@@ -4,7 +4,7 @@
 //! this verdict, so a healthy export yields zero vectors and a clean exit rather
 //! than a crash. Built incrementally, one rule per behaviour.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 use crate::export::{AgentStateExport, EventKind};
@@ -75,6 +75,16 @@ pub enum QuarantineReason {
     TruncatedProjections,
     /// A fork resolution's winning snapshot was missing — unreproducible.
     MissingSnapshot,
+    /// Engines recorded halting unrecoverably: the group is blocked on those
+    /// engines until a verified repair clears the marker. Unlike
+    /// [`QuarantineReason::EpochDivergence`], this is not an inference from lag —
+    /// the engine itself recorded that it stopped — so it needs no cross-pull
+    /// confirmation and it is a diagnosis rather than a re-pull target. There is
+    /// still nothing to replay: a halt is a client failure, not a branch contest.
+    UnrecoverableHalt {
+        /// Every engine that recorded a halt, in engine-id order.
+        engines: Vec<HaltedEngine>,
+    },
     /// Engines trail the group's epoch high-water mark by at least
     /// [`EPOCH_DIVERGENCE_MIN_LAG`] epochs with no recorded contest explaining
     /// it. Persistent across pulls this is a silent split; on any single pull an
@@ -101,6 +111,14 @@ impl fmt::Display for QuarantineReason {
             QuarantineReason::MissingSnapshot => {
                 f.write_str("a fork resolution's winning snapshot was missing")
             }
+            QuarantineReason::UnrecoverableHalt { engines } => {
+                f.write_str("engines halted unrecoverably:")?;
+                for (index, engine) in engines.iter().enumerate() {
+                    let separator = if index == 0 { " " } else { ", " };
+                    write!(f, "{separator}{engine}")?;
+                }
+                Ok(())
+            }
             QuarantineReason::EpochDivergence {
                 group_epoch,
                 engines,
@@ -113,6 +131,21 @@ impl fmt::Display for QuarantineReason {
                 Ok(())
             }
         }
+    }
+}
+
+/// One engine that recorded halting unrecoverably.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HaltedEngine {
+    /// The engine that halted.
+    pub engine_id: String,
+    /// Every distinct halt reason it recorded, deduplicated and in sort order.
+    pub reasons: Vec<String>,
+}
+
+impl fmt::Display for HaltedEngine {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ({})", self.engine_id, self.reasons.join(", "))
     }
 }
 
@@ -201,8 +234,17 @@ pub fn classify(export: &AgentStateExport) -> Verdict {
     if kinds().any(EventKind::is_fork_resolution) {
         return Verdict::ForkRecovery;
     }
-    // No contested branch anywhere — the liveness gate now guards the healthy
-    // verdict. It ranks below the incident routes deliberately: a reproducible
+    // No contested branch anywhere. Two liveness gates now guard the healthy
+    // verdict, the better-evidenced one first: an engine that *recorded* halting
+    // unrecoverably outranks one merely *inferred* to be behind, because the halt
+    // is the engine's own statement and it usually explains the lag (on the real
+    // 26a9f546 export the halted engine is exactly the one the divergence gate
+    // labelled `went dark`). Reporting the inference over the diagnosis would
+    // send the operator to re-pull for confirmation they already have.
+    if let Some(reason) = unrecoverable_halt(export) {
+        return Verdict::Quarantine { reason };
+    }
+    // The liveness gate ranks below the incident routes deliberately: a reproducible
     // contest is worth replaying even when another engine's data is stale
     // (recovery fail-closes downstream if the data it needs is missing). It
     // exists because a stuck or dead device is only visible *across* engines:
@@ -223,12 +265,53 @@ pub fn classify(export: &AgentStateExport) -> Verdict {
 /// convergence) outranks the liveness gate on purpose — so an export that
 /// carries *both* a replayable incident and an engine left behind routes to the
 /// incident, and the liveness signal never reaches the operator. This exposes the
-/// same rule-5 computation so a caller (the CLI) can surface it as a secondary
+/// same rule-6 computation so a caller (the CLI) can surface it as a secondary
 /// advisory alongside the primary outcome. Returns `None` when no engine is left
 /// behind — the gate stays unarmed on untimed or synthetic exports, exactly as
 /// [`classify`]'s healthy path does.
 pub fn liveness_advisory(export: &AgentStateExport) -> Option<QuarantineReason> {
     epoch_divergence(export)
+}
+
+/// The unrecoverable-halt incident an export carries, independent of its routing
+/// [`Verdict`].
+///
+/// The sibling of [`liveness_advisory`], for the same reason: [`classify`]
+/// returns one verdict, so an export carrying both a replayable incident and a
+/// halted engine routes to the incident and the halt would never reach the
+/// operator. The CLI prints this as a secondary advisory alongside the primary
+/// outcome.
+pub fn halt_advisory(export: &AgentStateExport) -> Option<QuarantineReason> {
+    unrecoverable_halt(export)
+}
+
+/// The gate for engines that recorded halting unrecoverably.
+///
+/// Like the liveness gate it fires only on positive evidence, but it needs far
+/// less of it: a halt is self-reported, so no timestamps are required to order it
+/// and no threshold is needed to distinguish it from noise. It does require an
+/// `engine_id` — the report is per-engine, and an unattributable halt could not
+/// be named — which also keeps untimed synthetic fixtures and pre-instrumentation
+/// exports classifying exactly as before.
+fn unrecoverable_halt(export: &AgentStateExport) -> Option<QuarantineReason> {
+    let mut halted: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    for event in &export.events {
+        if let (Some(engine_id), Some(reason)) = (
+            event.engine_id.as_deref(),
+            event.kind.unrecoverable_halt_reason(),
+        ) {
+            halted.entry(engine_id).or_default().insert(reason);
+        }
+    }
+
+    let engines: Vec<HaltedEngine> = halted
+        .into_iter()
+        .map(|(engine_id, reasons)| HaltedEngine {
+            engine_id: engine_id.to_owned(),
+            reasons: reasons.into_iter().map(str::to_owned).collect(),
+        })
+        .collect();
+    (!engines.is_empty()).then_some(QuarantineReason::UnrecoverableHalt { engines })
 }
 
 /// Per-engine activity, folded from the event log.
@@ -240,8 +323,11 @@ struct EngineActivity {
     high_water_epoch: Option<u64>,
 }
 
-/// The gate that separates "no contested branch" from "healthy": engines left
-/// ≥ [`EPOCH_DIVERGENCE_MIN_LAG`] epochs behind the group's high-water mark.
+/// The weaker of the two gates between "no contested branch" and "healthy":
+/// engines left ≥ [`EPOCH_DIVERGENCE_MIN_LAG`] epochs behind the group's
+/// high-water mark. Weaker because it *infers* the split from lag, where
+/// [`unrecoverable_halt`] reads the engine's own report of it — hence the lower
+/// precedence and the hedged, re-pull-first framing below.
 ///
 /// It fires only on positive evidence — events without an `engine_id` or
 /// `wall_time_ms` leave it unarmed — so synthetic fixtures and older exports

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -167,6 +167,23 @@ pub enum EventKind {
         #[serde(default)]
         current_tip_epoch: Option<u64>,
     },
+    /// A durable convergence pass whose base epoch disagreed with the device's
+    /// tip was discarded so convergence could reopen at the tip (mdk #1182,
+    /// which replaced the `base_epoch_mismatch` halt this repairs). Non-terminal
+    /// by construction, so it arms no gate — but `current_tip_epoch` is read from
+    /// `convergence_tip_epoch()` at every emitting call site, making it the
+    /// engine's own materialized tip and therefore epoch evidence of the same
+    /// class as `convergence_run_state.current_tip_epoch`.
+    ///
+    /// `stale_base_epoch` is deliberately not modelled. It is inherited
+    /// scheduling state that can sit either behind *or ahead of* the tip, so it
+    /// is not an epoch any engine reached; folding it into the high-water mark
+    /// could invent a group tip nobody materialized and report every engine
+    /// behind it.
+    ConvergencePassDiscarded {
+        #[serde(default)]
+        current_tip_epoch: Option<u64>,
+    },
     /// A snapshot of the group as the engine sees it; its epoch is the
     /// engine's own current epoch.
     GroupContext {
@@ -328,7 +345,8 @@ impl EventKind {
             } => (*current_tip_epoch).max(*selected_tip_epoch),
             EventKind::ConvergenceRunState {
                 current_tip_epoch, ..
-            } => *current_tip_epoch,
+            }
+            | EventKind::ConvergencePassDiscarded { current_tip_epoch } => *current_tip_epoch,
             _ => None,
         }
     }

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -18,6 +18,27 @@ use serde::Deserialize;
 /// formats and does not depend on Goggles' severity derivation.
 const UNRECOVERABLE_STATE: &str = "unrecoverable";
 
+/// The healthy epoch-machine state. A halt clears only through a transition into
+/// it, but this state alone is *not* the clearing signal — it is by far the
+/// engine's most ordinary state, entered from `publish_confirmed`,
+/// `publish_failed`, `join_welcome`, `founding_create`,
+/// `auto_commit_stage_failed`, and `update_group_data_stage_failed`, none of
+/// which repairs anything. `publish_confirmed` alone is one of the commonest rows
+/// in a healthy export, so matching the bare state would clear every halt on the
+/// engine's next successful publish. Hence the pairing with
+/// [`VERIFIED_REPAIR_REASON`]: the reason is what identifies the repair.
+const STABLE_STATE: &str = "stable";
+
+/// The `reason` the engine stamps on the one legal exit from
+/// [`UNRECOVERABLE_STATE`]. `Engine::join_welcome` routes a halted group's
+/// re-join through `EpochManager::repair_to_stable` — the only caller, and the
+/// only transition the state machine accepts out of `Unrecoverable` — then emits
+/// this `epoch_state_changed { new_state: "stable" }` row unconditionally right
+/// after it succeeds (`cgka-engine/src/group_lifecycle.rs`). So the row is
+/// present exactly when a verified repair completed: an authenticated Welcome
+/// rebuilt the group's state and the durable `unrecoverable` marker is gone.
+const VERIFIED_REPAIR_REASON: &str = "join_welcome_repair";
+
 /// Stand-in reason for a halt whose row carried none. Every emitting surface
 /// populates a reason today; this keeps the lenient model from dropping a halt
 /// on the floor should one ever not.
@@ -54,14 +75,22 @@ pub struct Pagination {
 }
 
 /// One forensic audit event. The classifier reads `kind` plus the envelope's
-/// `engine_id` and `wall_time_ms` (the liveness gates aggregate per-engine
-/// activity from them).
+/// `engine_id`, `group_ref`, and `wall_time_ms` (the liveness gates aggregate
+/// per-engine activity from them).
 #[derive(Debug, Clone, Deserialize)]
 pub struct AuditEvent {
     #[serde(default)]
     pub account_ref: Option<String>,
     #[serde(default)]
     pub engine_id: Option<String>,
+    /// The group this row belongs to, when it is group-scoped. The halt
+    /// lifecycle keys on it: `Unrecoverable` is per-group state, so a repair in
+    /// one group says nothing about a halt in another. `None` is therefore its
+    /// own bucket and never a wildcard — an unattributed repair must not clear an
+    /// attributed halt (nor the reverse), which keeps a partially-attributed
+    /// export failing closed the way an untimed one does.
+    #[serde(default)]
+    pub group_ref: Option<String>,
     #[serde(default)]
     pub wall_time_ms: Option<u64>,
     pub kind: EventKind,
@@ -332,6 +361,25 @@ impl EventKind {
             }
             _ => None,
         }
+    }
+
+    /// The engine recorded completing the verified repair that exits
+    /// [`UNRECOVERABLE_STATE`] — the counterpart to
+    /// [`EventKind::unrecoverable_halt_reason`], and the only thing that clears a
+    /// halt.
+    ///
+    /// Both halves of the match are load-bearing: [`STABLE_STATE`] alone is the
+    /// ordinary healthy state and [`VERIFIED_REPAIR_REASON`] is what marks this
+    /// particular transition as the repair.
+    pub fn is_verified_repair(&self) -> bool {
+        matches!(
+            self,
+            EventKind::EpochStateChanged {
+                new_state: Some(new_state),
+                reason: Some(reason),
+                ..
+            } if new_state == STABLE_STATE && reason == VERIFIED_REPAIR_REASON
+        )
     }
 
     /// The group epoch this event reports the engine itself to be at, if it

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -11,6 +11,18 @@ use std::collections::BTreeMap;
 
 use serde::Deserialize;
 
+/// The epoch-machine state an engine enters when its group is blocked pending a
+/// verified repair. Goggles derives its error-severity `epoch_state_transition`
+/// projection row from exactly this state, so the classifier reads the primary
+/// audit event rather than that derived label: the event is present in both wire
+/// formats and does not depend on Goggles' severity derivation.
+const UNRECOVERABLE_STATE: &str = "unrecoverable";
+
+/// Stand-in reason for a halt whose row carried none. Every emitting surface
+/// populates a reason today; this keeps the lenient model from dropping a halt
+/// on the floor should one ever not.
+const UNSPECIFIED_HALT_REASON: &str = "unspecified";
+
 /// A parsed export, reduced to the classifier's inputs.
 #[derive(Debug, Clone, Deserialize)]
 pub struct AgentStateExport {
@@ -125,9 +137,35 @@ pub enum EventKind {
         epoch: Option<u64>,
     },
     /// The engine's epoch machine moved (commit confirmed, group hydrated, …).
+    /// `new_state` is the state it moved *into*; the classifier reads it for the
+    /// terminal [`UNRECOVERABLE_STATE`] halt, with `reason` naming the trigger
+    /// (e.g. `hydrate_unrecoverable_group`).
     EpochStateChanged {
         #[serde(default)]
         epoch: Option<u64>,
+        #[serde(default)]
+        new_state: Option<String>,
+        #[serde(default)]
+        reason: Option<String>,
+    },
+    /// A distributed-convergence run changed lifecycle phase. The classifier
+    /// reads only the terminal [`ConvergencePhase::Unrecoverable`] halt (mdk
+    /// #1110): the pass stopped and the group stays blocked until a verified
+    /// repair clears the marker. `reason` names the halt
+    /// (`convergence_pass_base_changed` / `frozen_pass_integrity_failure`) and
+    /// `error_kind` its underlying cause (e.g. `frozen_member_integrity`).
+    ConvergenceRunState {
+        #[serde(default)]
+        phase: Option<ConvergencePhase>,
+        #[serde(default)]
+        reason: Option<String>,
+        #[serde(default)]
+        error_kind: Option<String>,
+        /// The tip the run started from — an epoch the engine has locally
+        /// materialized, so it feeds the epoch high-water mark exactly as
+        /// `convergence_decision.current_tip_epoch` does.
+        #[serde(default)]
+        current_tip_epoch: Option<u64>,
     },
     /// A snapshot of the group as the engine sees it; its epoch is the
     /// engine's own current epoch.
@@ -190,6 +228,20 @@ pub struct ConvergenceRule {
     pub decisive: Option<bool>,
 }
 
+/// The lifecycle phase of a convergence run. Only the terminal halt is
+/// modelled — every other phase (`started`, `applied`, `waiting`, …) is routine
+/// and carries no verdict signal, so it maps to [`ConvergencePhase::Other`]
+/// exactly as unknown [`EventKind`]s map to [`EventKind::Other`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConvergencePhase {
+    /// The run halted and cannot continue: convergence and ingest stay blocked
+    /// for this group until a verified repair path clears the marker.
+    Unrecoverable,
+    #[serde(other)]
+    Other,
+}
+
 /// The role that won a fork resolution. `MissingSnapshot` means the winner's
 /// pre-commit snapshot was unavailable, so the incident is unreproducible.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -228,6 +280,36 @@ impl EventKind {
         matches!(self, EventKind::ForkResolution { .. })
     }
 
+    /// Why the engine recorded halting unrecoverably, or `None` when this event
+    /// is not such a halt.
+    ///
+    /// A halt is the engine's own statement that it stopped and will stay
+    /// stopped until repaired, so — unlike the inferential liveness gate — it
+    /// needs no corroborating timestamps to be believed.
+    pub fn unrecoverable_halt_reason(&self) -> Option<&str> {
+        match self {
+            EventKind::ConvergenceRunState {
+                phase: Some(ConvergencePhase::Unrecoverable),
+                reason,
+                error_kind,
+                ..
+            } => Some(
+                reason
+                    .as_deref()
+                    .or(error_kind.as_deref())
+                    .unwrap_or(UNSPECIFIED_HALT_REASON),
+            ),
+            EventKind::EpochStateChanged {
+                new_state: Some(new_state),
+                reason,
+                ..
+            } if new_state == UNRECOVERABLE_STATE => {
+                Some(reason.as_deref().unwrap_or(UNSPECIFIED_HALT_REASON))
+            }
+            _ => None,
+        }
+    }
+
     /// The group epoch this event reports the engine itself to be at, if it
     /// reports one. The liveness gates fold these into a per-engine epoch
     /// high-water mark, so only kinds that reflect the engine's *own* state
@@ -236,7 +318,7 @@ impl EventKind {
         match self {
             EventKind::GroupStateChanged { epoch, .. }
             | EventKind::MessageStateChanged { epoch }
-            | EventKind::EpochStateChanged { epoch } => *epoch,
+            | EventKind::EpochStateChanged { epoch, .. } => *epoch,
             EventKind::GroupContext { context } => context.epoch,
             EventKind::HumanAction { to_epoch } => *to_epoch,
             EventKind::ConvergenceDecision {
@@ -244,6 +326,9 @@ impl EventKind {
                 selected_tip_epoch,
                 ..
             } => (*current_tip_epoch).max(*selected_tip_epoch),
+            EventKind::ConvergenceRunState {
+                current_tip_epoch, ..
+            } => *current_tip_epoch,
             _ => None,
         }
     }

--- a/crates/incident-replay/src/export.rs
+++ b/crates/incident-replay/src/export.rs
@@ -151,9 +151,16 @@ pub enum EventKind {
     /// A distributed-convergence run changed lifecycle phase. The classifier
     /// reads only the terminal [`ConvergencePhase::Unrecoverable`] halt (mdk
     /// #1110): the pass stopped and the group stays blocked until a verified
-    /// repair clears the marker. `reason` names the halt
-    /// (`convergence_pass_base_changed` / `frozen_pass_integrity_failure`) and
-    /// `error_kind` its underlying cause (e.g. `frozen_member_integrity`).
+    /// repair clears the marker. `reason` names the halt (e.g.
+    /// `frozen_pass_integrity_failure`) and `error_kind` its underlying cause
+    /// (e.g. `frozen_member_integrity`). The `missing_retained_anchor` halt
+    /// carries only `error_kind`, hence the fallback in
+    /// [`EventKind::unrecoverable_halt_reason`].
+    ///
+    /// No reason is whitelisted, so a retired one still arms the gate on a
+    /// historical export — mdk#1182 retired `convergence_pass_base_changed` /
+    /// `base_epoch_mismatch`, which is now the non-terminal
+    /// [`EventKind::ConvergencePassDiscarded`] repair instead of a halt.
     ConvergenceRunState {
         #[serde(default)]
         phase: Option<ConvergencePhase>,

--- a/crates/incident-replay/src/lib.rs
+++ b/crates/incident-replay/src/lib.rs
@@ -47,7 +47,8 @@ pub use artifact::{
     UnavailableEvidenceV1, accept_attested_history, archetype_artifact, import_attested_history,
 };
 pub use classify::{
-    BehindEngine, BehindMode, QuarantineReason, Verdict, classify, liveness_advisory,
+    BehindEngine, BehindMode, HaltedEngine, QuarantineReason, Verdict, classify, halt_advisory,
+    liveness_advisory,
 };
 pub use convergence::{
     ConvergenceDecisionKind, ConvergenceRecoveryError, RecoveredConvergence, recover_convergence,

--- a/crates/incident-replay/src/lib.rs
+++ b/crates/incident-replay/src/lib.rs
@@ -29,6 +29,13 @@
 //!   producer-attested normalized-history import/accept gate. Archetypes never
 //!   masquerade as source-verified replay, and byte replay remains unavailable
 //!   without sensitive local state.
+//! - [`route`] — [`route::route`] composes the above into one
+//!   [`route::Routing`]: the primary [`route::Outcome`] plus the
+//!   [`route::Advisory`] lines for co-occurring findings. Every incident route
+//!   reads the producer-attested history first and only then synthesizes an
+//!   archetype, and a route whose recovery fails closed falls through to the
+//!   remaining lower-precedence ones, so a reproducible incident sharing the
+//!   export is not discarded.
 
 pub mod accept;
 pub mod artifact;
@@ -37,6 +44,7 @@ pub mod convergence;
 pub mod export;
 pub mod fork;
 pub mod ndjson;
+pub mod route;
 pub mod synth;
 
 pub use accept::{AcceptError, accept, accept_convergence};
@@ -56,4 +64,7 @@ pub use convergence::{
 pub use export::{AgentStateExport, ParseError, parse};
 pub use fork::{ForkCommitKind, ForkRecoveryError, RecoveredFork, recover_fork};
 pub use ndjson::{StreamParseError, is_stream, parse_stream};
+pub use route::{
+    Advisory, CONVERGENCE_NAME, INCIDENT_NAME, MEMBERSHIP_INCIDENT_NAME, Outcome, Routing, route,
+};
 pub use synth::{synthesize, synthesize_convergence};

--- a/crates/incident-replay/src/main.rs
+++ b/crates/incident-replay/src/main.rs
@@ -5,29 +5,28 @@
 //! `manifest` line (the `goggles-group-export/v1` contract), anything else is
 //! parsed as `agent-state.json`.
 //!
-//! Prints a human-readable outcome and exits 0 for any successful classification
-//! (healthy, quarantine, and accepted are all valid outcomes). Exits 2 on usage,
-//! I/O, or parse failure.
+//! Reading, format detection, and printing live here; everything about *which*
+//! route an export takes is [`incident_replay::route`].
+//!
+//! Output is one primary line — `healthy:`, `quarantine:`, or `accepted:` — plus
+//! an `advisory (<label>):` line for every co-occurring finding that line does
+//! not itself report. An accepted incident is written owner-only as the portable
+//! vector next to its `incident-scenario-artifact.v1` evidence envelope; the
+//! source export, transport ciphertext, and MLS checkpoints are never copied.
+//!
+//! Exits 0 for any successful classification (healthy, quarantine, and accepted
+//! are all valid outcomes). Exits 2 on usage, I/O, parse, or write failure, and
+//! on a simulator infrastructure failure that left the export unclassified.
 
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use incident_replay::{
-    AgentStateExport, ForkCommitKind, IncidentReplayFidelityV1, IncidentReproductionStatusV1,
-    IncidentScenarioArtifactV1, IncidentSourceFormatV1, NormalizedHistoryImportError,
-    QuarantineReason, Verdict, accept, accept_attested_history, accept_convergence,
-    archetype_artifact, classify, import_attested_history, is_stream, liveness_advisory, parse,
-    parse_stream, recover_convergence, recover_fork,
+    IncidentReplayFidelityV1, IncidentReproductionStatusV1, IncidentScenarioArtifactV1,
+    IncidentSourceFormatV1, Outcome, is_stream, parse, parse_stream, route,
 };
 
-/// Vector name for a group-metadata fork-recovery incident.
-const INCIDENT_NAME: &str = "fork-recovery-incident/v1";
-/// Vector name for a membership/admin fork-recovery incident (a distinct shape,
-/// so a distinct name and file — it must not overwrite the group-data vector).
-const MEMBERSHIP_INCIDENT_NAME: &str = "membership-fork-recovery-incident/v1";
-/// Vector name for a convergence incident.
-const CONVERGENCE_NAME: &str = "convergence-incident/v1";
 /// Match the workspace's audit-artifact ceiling and reject oversized forensic
 /// input before parsing can allocate from attacker-controlled JSON/NDJSON.
 const MAX_INCIDENT_EXPORT_BYTES: u64 = 64 * 1024 * 1024;
@@ -71,27 +70,27 @@ fn main() -> ExitCode {
         }
     };
 
-    let verdict = classify(&export);
-    // A co-occurring liveness incident (rule 5) loses the single verdict to any
-    // higher-precedence incident, so surface it as a secondary advisory — unless
-    // it *is* the primary verdict, where it is already printed.
-    let liveness_is_primary = matches!(
-        &verdict,
-        Verdict::Quarantine {
-            reason: QuarantineReason::EpochDivergence { .. }
-        }
-    );
-    let code = match verdict {
-        Verdict::ForkRecovery => run_fork_recovery(&export, source_format, out_dir.as_deref()),
-        Verdict::Healthy => {
-            println!("healthy: 0 vectors");
+    // One primary line, then every co-occurring finding it does not itself
+    // report. Routing policy — including which route runs, whether the export's
+    // attested history supersedes an archetype, and what happens when a route
+    // fails closed — lives in the library; this is presentation only.
+    let routing = route(&export, source_format);
+    let code = match &routing.outcome {
+        // Producing no vector is a valid outcome, so a quarantine is not an
+        // error exit.
+        Outcome::Healthy | Outcome::Quarantine { .. } => {
+            println!("{}", routing.outcome);
             ExitCode::SUCCESS
         }
-        Verdict::ConvergenceSelected => run_convergence(&export, source_format, out_dir.as_deref()),
-        Verdict::Quarantine { reason } => quarantine(&reason),
+        Outcome::Accepted(artifact) => persist_or_report(artifact, out_dir.as_deref()),
+        // The pipeline reached no verdict, so this one *is* an error exit.
+        Outcome::InfrastructureFailure { reason } => {
+            eprintln!("error: {reason}");
+            ExitCode::from(2)
+        }
     };
-    if !liveness_is_primary && let Some(reason) = liveness_advisory(&export) {
-        println!("advisory (liveness): {reason}");
+    for advisory in &routing.advisories {
+        println!("{advisory}");
     }
     code
 }
@@ -112,85 +111,6 @@ fn read_utf8_limited(reader: impl Read, max_bytes: u64) -> io::Result<String> {
         ));
     }
     String::from_utf8(bytes).map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
-}
-
-fn run_fork_recovery(
-    export: &AgentStateExport,
-    source_format: IncidentSourceFormatV1,
-    out_dir: Option<&Path>,
-) -> ExitCode {
-    match import_attested_history(export, source_format) {
-        Ok(Some(artifact)) => {
-            return match accept_attested_history(artifact) {
-                Ok(artifact) => persist_or_report(&artifact, out_dir),
-                Err(error) => normalized_history_failure(&error),
-            };
-        }
-        Ok(None) => {}
-        Err(error) => return normalized_history_failure(&error),
-    }
-    let fork = match recover_fork(export) {
-        Ok(fork) => fork,
-        Err(err) => return quarantine(&err),
-    };
-    let name = match fork.commit {
-        ForkCommitKind::GroupData => INCIDENT_NAME,
-        ForkCommitKind::Membership => MEMBERSHIP_INCIDENT_NAME,
-    };
-    match accept(&fork, name) {
-        Ok(vector) => match archetype_artifact(export, source_format, vector) {
-            Ok(artifact) => persist_or_report(&artifact, out_dir),
-            Err(error) => quarantine(&error),
-        },
-        Err(err) => quarantine(&err),
-    }
-}
-
-fn run_convergence(
-    export: &AgentStateExport,
-    source_format: IncidentSourceFormatV1,
-    out_dir: Option<&Path>,
-) -> ExitCode {
-    match import_attested_history(export, source_format) {
-        Ok(Some(artifact)) => {
-            return match accept_attested_history(artifact) {
-                Ok(artifact) => persist_or_report(&artifact, out_dir),
-                Err(error) => normalized_history_failure(&error),
-            };
-        }
-        Ok(None) => {}
-        Err(error) => return normalized_history_failure(&error),
-    }
-    let conv = match recover_convergence(export) {
-        Ok(conv) => conv,
-        Err(err) => return quarantine(&err),
-    };
-    match accept_convergence(&conv, CONVERGENCE_NAME) {
-        Ok(vector) => match archetype_artifact(export, source_format, vector) {
-            Ok(artifact) => persist_or_report(&artifact, out_dir),
-            Err(error) => quarantine(&error),
-        },
-        Err(err) => quarantine(&err),
-    }
-}
-
-/// Report a fail-closed quarantine and exit cleanly: producing no vector is a
-/// valid outcome, so it is not an error exit.
-fn quarantine(reason: &dyn std::fmt::Display) -> ExitCode {
-    println!("quarantine: {reason}");
-    ExitCode::SUCCESS
-}
-
-fn normalized_history_failure(error: &NormalizedHistoryImportError) -> ExitCode {
-    if matches!(
-        error,
-        NormalizedHistoryImportError::Run(_) | NormalizedHistoryImportError::RunTimedOut
-    ) {
-        eprintln!("error: normalized-history simulator infrastructure failed");
-        ExitCode::from(2)
-    } else {
-        quarantine(error)
-    }
 }
 
 /// Write the accepted vector plus evidence artifact to `out_dir`, or describe

--- a/crates/incident-replay/src/route.rs
+++ b/crates/incident-replay/src/route.rs
@@ -1,0 +1,318 @@
+//! Route composition: classify, then drive the chosen incident route through
+//! recover → accept, and gather the secondary advisories.
+//!
+//! This lives in the library rather than the CLI because it is pipeline policy,
+//! not presentation: which route an export takes, what happens when that route
+//! fails closed, and which co-occurring incidents must still be reported. The
+//! CLI is left with I/O and formatting.
+//!
+//! ## Attested history first
+//!
+//! Every incident route begins with the producer's own attested normalized
+//! history ([`import_attested_history`]): it is the export's account of what
+//! actually happened, so no derived archetype can improve on it. The gate reads
+//! the export, not the verdict — both incident routes ask it the same question —
+//! so it runs once, ahead of route dispatch, and only for the incident verdicts.
+//! A legacy export carries no such history, and the archetype routes below take
+//! over.
+//!
+//! ## Fall-through
+//!
+//! [`classify`] returns a single verdict and the incident routes are ordered
+//! (contested convergence outranks fork recovery), so an export carrying both
+//! used to lose the lower one entirely: on a real export the convergence
+//! recovery fail-closed while the *same* export held a cleanly reproducible
+//! membership fork, and the fork was silently discarded.
+//!
+//! Recovery failing closed is not evidence that the rest of the export is
+//! unusable, so a failed route falls through to the remaining lower-precedence
+//! ones. Classification precedence is untouched — the fall-through happens only
+//! *after* the higher route has already failed — and one rule keeps the outcome
+//! honest: **a lower route may override a higher route's quarantine only by
+//! producing an accepted vector.** A second quarantine never displaces the
+//! higher-precedence one; it is reported as an advisory instead.
+
+use std::fmt;
+
+use cgka_conformance_simulator::VectorFixture;
+
+use crate::artifact::{
+    IncidentScenarioArtifactV1, IncidentSourceFormatV1, NormalizedHistoryImportError,
+    accept_attested_history, archetype_artifact, import_attested_history,
+};
+use crate::classify::{QuarantineReason, Verdict, classify, halt_advisory, liveness_advisory};
+use crate::export::AgentStateExport;
+use crate::fork::ForkCommitKind;
+use crate::{accept, accept_convergence, recover_convergence, recover_fork};
+
+/// Vector name for a group-metadata fork-recovery incident.
+pub const INCIDENT_NAME: &str = "fork-recovery-incident/v1";
+/// Vector name for a membership/admin fork-recovery incident (a distinct shape,
+/// so a distinct name and file — it must not overwrite the group-data vector).
+pub const MEMBERSHIP_INCIDENT_NAME: &str = "membership-fork-recovery-incident/v1";
+/// Vector name for a convergence incident.
+pub const CONVERGENCE_NAME: &str = "convergence-incident/v1";
+
+/// A higher-precedence route quarantined, but a lower one reproduced an incident
+/// from the same export.
+const SUPERSEDED_ROUTE: &str = "superseded route";
+/// A higher-precedence route quarantined and the fall-through could not rescue
+/// it either.
+const FALLBACK_ROUTE: &str = "fallback route";
+/// A co-occurring unrecoverable halt (rule 5).
+const HALT: &str = "halt";
+/// A co-occurring liveness incident (rule 6).
+const LIVENESS: &str = "liveness";
+
+/// What the pipeline produced for an export: exactly one primary outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// No incident and no liveness problem. Zero vectors.
+    Healthy,
+    /// A vector the simulator reproduced, inside its evidence envelope.
+    Accepted(Box<IncidentScenarioArtifactV1>),
+    /// Fail-closed: a real or unusable incident that yields no vector.
+    Quarantine { reason: String },
+    /// The simulator machinery itself failed, so the export reached no verdict.
+    /// Distinct from [`Outcome::Quarantine`], which *is* a verdict: retrying the
+    /// same export on working infrastructure may still classify it.
+    InfrastructureFailure { reason: String },
+}
+
+/// One secondary line reported alongside the primary [`Outcome`].
+///
+/// Advisories exist because an export can carry several incidents while
+/// [`classify`] returns one verdict. Keeping them separate from the outcome
+/// preserves the one-primary-line contract: the outcome says what the pipeline
+/// produced, and each advisory names something that outcome does not cover.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Advisory {
+    /// Short category, rendered as `advisory (<label>): <detail>`.
+    pub label: &'static str,
+    /// The human-readable finding.
+    pub detail: String,
+}
+
+/// A routed export: one primary outcome plus every co-occurring finding it does
+/// not itself report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Routing {
+    pub outcome: Outcome,
+    pub advisories: Vec<Advisory>,
+}
+
+impl fmt::Display for Outcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Outcome::Healthy => f.write_str("healthy: 0 vectors"),
+            Outcome::Accepted(artifact) => {
+                write!(f, "accepted: {}", artifact.vector.scenario_name)
+            }
+            Outcome::Quarantine { reason } => write!(f, "quarantine: {reason}"),
+            Outcome::InfrastructureFailure { reason } => write!(f, "error: {reason}"),
+        }
+    }
+}
+
+impl fmt::Display for Advisory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "advisory ({}): {}", self.label, self.detail)
+    }
+}
+
+/// Classify `export` and run the route its verdict selects, falling through to
+/// lower-precedence routes if that one fails closed.
+pub fn route(export: &AgentStateExport, source_format: IncidentSourceFormatV1) -> Routing {
+    let verdict = classify(export);
+    let mut advisories = Vec::new();
+    let outcome = routed_outcome(export, source_format, &verdict, &mut advisories);
+
+    advisories.extend(co_occurring_advisories(export, &verdict));
+    Routing {
+        outcome,
+        advisories,
+    }
+}
+
+/// The primary outcome for `verdict`, appending any fall-through advisory it
+/// produced along the way.
+fn routed_outcome(
+    export: &AgentStateExport,
+    source_format: IncidentSourceFormatV1,
+    verdict: &Verdict,
+    advisories: &mut Vec<Advisory>,
+) -> Outcome {
+    if matches!(verdict, Verdict::ForkRecovery | Verdict::ConvergenceSelected)
+        && let Some(outcome) = attested_outcome(export, source_format)
+    {
+        return outcome;
+    }
+    match verdict {
+        Verdict::Healthy => Outcome::Healthy,
+        Verdict::ForkRecovery => accepted_or_quarantine(fork_route(export, source_format)),
+        // The only route with somewhere to fall through to: fork recovery sits
+        // below it (rules 3 and 4), and `fork_route` applies both.
+        Verdict::ConvergenceSelected => match convergence_route(export, source_format) {
+            Ok(artifact) => Outcome::Accepted(artifact),
+            Err(superseded) => fall_through_to_fork(export, source_format, superseded, advisories),
+        },
+        // Not an incident route: nothing to recover, so nothing to fall through
+        // to. The quarantine is the outcome.
+        Verdict::Quarantine { reason } => Outcome::Quarantine {
+            reason: reason.to_string(),
+        },
+    }
+}
+
+/// Run the producer-attested normalized history, if the export carries one.
+///
+/// `None` is the ordinary legacy-export case: no attested history, so the
+/// archetype routes decide the outcome. Anything else is already the answer —
+/// attested history is the highest fidelity available, so it neither falls
+/// through nor defers to an archetype of the same incident.
+fn attested_outcome(
+    export: &AgentStateExport,
+    source_format: IncidentSourceFormatV1,
+) -> Option<Outcome> {
+    match import_attested_history(export, source_format) {
+        Ok(None) => None,
+        Ok(Some(artifact)) => Some(match accept_attested_history(artifact) {
+            Ok(artifact) => Outcome::Accepted(Box::new(artifact)),
+            Err(error) => attested_failure(&error),
+        }),
+        Err(error) => Some(attested_failure(&error)),
+    }
+}
+
+/// A rejected attested history is fail-closed like any other route, *except*
+/// when the simulator could not be run at all: that decided nothing about the
+/// incident, so reporting a quarantine would state a verdict nobody reached.
+fn attested_failure(error: &NormalizedHistoryImportError) -> Outcome {
+    let reason = error.to_string();
+    match error {
+        NormalizedHistoryImportError::Run(_) | NormalizedHistoryImportError::RunTimedOut => {
+            Outcome::InfrastructureFailure { reason }
+        }
+        _ => Outcome::Quarantine { reason },
+    }
+}
+
+/// Rules 3 and 4: recover the fork, run it against the simulator, and wrap the
+/// accepted vector in its archetype evidence envelope. `recover_fork` reports
+/// the rule-3 missing snapshot as its own fail-closed error, so this one
+/// function is the whole fork route.
+fn fork_route(
+    export: &AgentStateExport,
+    source_format: IncidentSourceFormatV1,
+) -> Result<Box<IncidentScenarioArtifactV1>, String> {
+    let fork = recover_fork(export).map_err(|err| err.to_string())?;
+    let name = match fork.commit {
+        ForkCommitKind::GroupData => INCIDENT_NAME,
+        ForkCommitKind::Membership => MEMBERSHIP_INCIDENT_NAME,
+    };
+    let vector = accept(&fork, name).map_err(|err| err.to_string())?;
+    archetype(export, source_format, vector)
+}
+
+/// Rule 2: recover the contested convergence decision and run it.
+fn convergence_route(
+    export: &AgentStateExport,
+    source_format: IncidentSourceFormatV1,
+) -> Result<Box<IncidentScenarioArtifactV1>, String> {
+    let conv = recover_convergence(export).map_err(|err| err.to_string())?;
+    let vector = accept_convergence(&conv, CONVERGENCE_NAME).map_err(|err| err.to_string())?;
+    archetype(export, source_format, vector)
+}
+
+/// Envelope an accepted archetype vector. Failing to evidence the incident the
+/// vector stands for is fail-closed like any other route failure: an artifact
+/// that cannot point at its own source rows is not publishable evidence.
+fn archetype(
+    export: &AgentStateExport,
+    source_format: IncidentSourceFormatV1,
+    vector: VectorFixture,
+) -> Result<Box<IncidentScenarioArtifactV1>, String> {
+    archetype_artifact(export, source_format, vector)
+        .map(Box::new)
+        .map_err(|err| err.to_string())
+}
+
+/// Try the fork route after the convergence route fail-closed with `superseded`.
+///
+/// The fall-through may only *upgrade* the outcome. If the fork route also
+/// yields nothing, the convergence quarantine stays the primary — it is the
+/// higher-precedence incident, and demoting it would misreport which one the
+/// export is really about.
+fn fall_through_to_fork(
+    export: &AgentStateExport,
+    source_format: IncidentSourceFormatV1,
+    superseded: String,
+    advisories: &mut Vec<Advisory>,
+) -> Outcome {
+    // Without a fork resolution there is no lower route to enter, and saying so
+    // would be noise rather than a finding.
+    if !export
+        .events
+        .iter()
+        .any(|event| event.kind.is_fork_resolution())
+    {
+        return Outcome::Quarantine { reason: superseded };
+    }
+    match fork_route(export, source_format) {
+        Ok(artifact) => {
+            advisories.push(Advisory {
+                label: SUPERSEDED_ROUTE,
+                detail: format!("contested convergence could not be replayed: {superseded}"),
+            });
+            Outcome::Accepted(artifact)
+        }
+        Err(fallback) => {
+            advisories.push(Advisory {
+                label: FALLBACK_ROUTE,
+                detail: format!("fork recovery could not be replayed either: {fallback}"),
+            });
+            Outcome::Quarantine { reason: superseded }
+        }
+    }
+}
+
+/// The rule-5 and rule-6 incidents the primary outcome does not already report.
+///
+/// Both gates are verdict-independent, so an export routed to an incident (or
+/// quarantined for a different reason) still discloses a halted or stranded
+/// engine. Each is suppressed only when the verdict already *is* that finding,
+/// which would otherwise print it twice.
+fn co_occurring_advisories(export: &AgentStateExport, verdict: &Verdict) -> Vec<Advisory> {
+    [
+        (HALT, halt_advisory(export)),
+        (LIVENESS, liveness_advisory(export)),
+    ]
+    .into_iter()
+    .filter_map(|(label, finding)| {
+        let finding = finding?;
+        (!is_primary(verdict, &finding)).then(|| Advisory {
+            label,
+            detail: finding.to_string(),
+        })
+    })
+    .collect()
+}
+
+/// Whether `verdict` already reports `finding` as the primary outcome. Compared
+/// by variant, not value: the gate that produced the verdict and the gate that
+/// produced the advisory are the same computation, so matching variants means
+/// matching findings.
+fn is_primary(verdict: &Verdict, finding: &QuarantineReason) -> bool {
+    matches!(
+        verdict,
+        Verdict::Quarantine { reason }
+            if std::mem::discriminant(reason) == std::mem::discriminant(finding)
+    )
+}
+
+fn accepted_or_quarantine(result: Result<Box<IncidentScenarioArtifactV1>, String>) -> Outcome {
+    match result {
+        Ok(artifact) => Outcome::Accepted(artifact),
+        Err(reason) => Outcome::Quarantine { reason },
+    }
+}

--- a/crates/incident-replay/src/route.rs
+++ b/crates/incident-replay/src/route.rs
@@ -142,14 +142,20 @@ fn routed_outcome(
     verdict: &Verdict,
     advisories: &mut Vec<Advisory>,
 ) -> Outcome {
-    if matches!(verdict, Verdict::ForkRecovery | Verdict::ConvergenceSelected)
-        && let Some(outcome) = attested_outcome(export, source_format)
+    if matches!(
+        verdict,
+        Verdict::ForkRecovery | Verdict::ConvergenceSelected
+    ) && let Some(outcome) = attested_outcome(export, source_format)
     {
         return outcome;
     }
     match verdict {
         Verdict::Healthy => Outcome::Healthy,
-        Verdict::ForkRecovery => accepted_or_quarantine(fork_route(export, source_format)),
+        // The lowest incident route: nothing below it to fall through to.
+        Verdict::ForkRecovery => match fork_route(export, source_format) {
+            Ok(artifact) => Outcome::Accepted(artifact),
+            Err(reason) => Outcome::Quarantine { reason },
+        },
         // The only route with somewhere to fall through to: fork recovery sits
         // below it (rules 3 and 4), and `fork_route` applies both.
         Verdict::ConvergenceSelected => match convergence_route(export, source_format) {
@@ -308,11 +314,4 @@ fn is_primary(verdict: &Verdict, finding: &QuarantineReason) -> bool {
         Verdict::Quarantine { reason }
             if std::mem::discriminant(reason) == std::mem::discriminant(finding)
     )
-}
-
-fn accepted_or_quarantine(result: Result<Box<IncidentScenarioArtifactV1>, String>) -> Outcome {
-    match result {
-        Ok(artifact) => Outcome::Accepted(artifact),
-        Err(reason) => Outcome::Quarantine { reason },
-    }
 }

--- a/crates/incident-replay/tests/artifact.rs
+++ b/crates/incident-replay/tests/artifact.rs
@@ -1,8 +1,8 @@
 use incident_replay::{
     EvidenceConfidenceV1, ForkCommitKind, IncidentArtifactSensitivityV1, IncidentReplayFidelityV1,
     IncidentReproductionStatusV1, IncidentSourceFormatV1, NormalizedActionEvidenceV1,
-    NormalizedHistoryImportError, NormalizedScenarioHistoryV1, RecoveredFork,
-    accept_attested_history, archetype_artifact, import_attested_history, parse, synthesize,
+    NormalizedHistoryImportError, NormalizedScenarioHistoryV1, Outcome, RecoveredFork,
+    accept_attested_history, archetype_artifact, import_attested_history, parse, route, synthesize,
 };
 use std::collections::BTreeSet;
 
@@ -205,6 +205,54 @@ fn legacy_export_is_an_explicitly_inexact_archetype() {
             .unavailable_fields
             .iter()
             .any(|field| { field.field == "exact_scenario_action_history" })
+    );
+}
+
+#[test]
+fn the_attested_history_decides_the_incident_route() {
+    // The export classifies as a fork recovery, so the archetype route could
+    // synthesize a vector for it — but the producer attested its own history, and
+    // nothing derived can improve on the export's own account of the incident.
+    // `route` therefore reads the attested history before recovering anything.
+    let routing = route(
+        &export_with_history(),
+        IncidentSourceFormatV1::AgentStateDocument,
+    );
+
+    let Outcome::Accepted(artifact) = &routing.outcome else {
+        panic!("expected the attested history to be accepted, got {routing:?}");
+    };
+    assert_eq!(
+        artifact.replay_fidelity,
+        IncidentReplayFidelityV1::ProducerAttestedNormalizedHistory
+    );
+    assert_eq!(
+        artifact.reproduction_status,
+        IncidentReproductionStatusV1::Reproduced
+    );
+}
+
+#[test]
+fn a_rejected_attested_history_does_not_fall_back_to_an_archetype() {
+    // Fall-through rescues a *different*, lower-precedence incident; it does not
+    // re-tell the same incident at a lower fidelity. Silently downgrading a
+    // rejected attestation to an archetype would publish derived evidence under
+    // the producer's failed claim.
+    let mut export = export_with_history();
+    export
+        .normalized_scenario_history
+        .as_mut()
+        .expect("history present")
+        .complete = false;
+
+    let routing = route(&export, IncidentSourceFormatV1::AgentStateDocument);
+
+    let Outcome::Quarantine { reason } = &routing.outcome else {
+        panic!("expected the incomplete history to fail closed, got {routing:?}");
+    };
+    assert!(
+        reason.contains("incomplete"),
+        "quarantine must name the rejected attestation, got {reason:?}"
     );
 }
 

--- a/crates/incident-replay/tests/classify.rs
+++ b/crates/incident-replay/tests/classify.rs
@@ -238,6 +238,13 @@ fn a_convergence_pass_that_halted_unrecoverably_quarantines() {
     // blocked until a verified repair clears the marker. The engine is stating
     // outright that it stopped, so — unlike the epoch-divergence gate's
     // inferential lag — no timestamps are needed to believe it.
+    //
+    // This fixture carries the halt reason mdk#1182 retired: a pass whose base
+    // epoch disagreed with the tip now discards and reopens instead of halting,
+    // so nothing emits `convergence_pass_base_changed` today. Kept deliberately —
+    // exports already recorded it, and the gate matches no reason whitelist, so a
+    // historical export must still arm. `frozen_pass_integrity_failure` covers
+    // the reason a current engine emits (see `quarantine-repeated-halt.json`).
     let export = load("quarantine-convergence-pass-halt.json");
     assert_eq!(
         classify(&export),
@@ -246,6 +253,26 @@ fn a_convergence_pass_that_halted_unrecoverably_quarantines() {
                 engines: vec![HaltedEngine {
                     engine_id: "engine-a".into(),
                     reasons: vec!["convergence_pass_base_changed".into()],
+                }],
+            }
+        }
+    );
+}
+
+#[test]
+fn a_halt_carrying_only_an_error_kind_reports_the_error_kind() {
+    // The `missing_retained_anchor` halt is the one `unrecoverable` phase a
+    // current engine emits with `reason: None`, naming itself only through
+    // `error_kind`. Reporting the reason alone would name this engine
+    // `unspecified` and lose the single field that says what broke, so the gate
+    // falls back to `error_kind`.
+    assert_eq!(
+        classify(&load("quarantine-anchorless-halt.json")),
+        Verdict::Quarantine {
+            reason: QuarantineReason::UnrecoverableHalt {
+                engines: vec![HaltedEngine {
+                    engine_id: "engine-a".into(),
+                    reasons: vec!["missing_retained_anchor".into()],
                 }],
             }
         }

--- a/crates/incident-replay/tests/classify.rs
+++ b/crates/incident-replay/tests/classify.rs
@@ -2,7 +2,8 @@
 //! against synthetic, non-sensitive fixtures.
 
 use incident_replay::{
-    BehindEngine, BehindMode, QuarantineReason, Verdict, classify, liveness_advisory, parse,
+    BehindEngine, BehindMode, HaltedEngine, QuarantineReason, Verdict, classify, halt_advisory,
+    liveness_advisory, parse,
 };
 
 fn load(name: &str) -> incident_replay::AgentStateExport {
@@ -228,4 +229,123 @@ fn truncated_projection_quarantines_even_when_contested() {
             reason: QuarantineReason::TruncatedProjections
         }
     );
+}
+
+#[test]
+fn a_convergence_pass_that_halted_unrecoverably_quarantines() {
+    // PR #1110 made a convergence pass able to halt: it emits
+    // `convergence_run_state` with `phase: unrecoverable`, and the group stays
+    // blocked until a verified repair clears the marker. The engine is stating
+    // outright that it stopped, so — unlike the epoch-divergence gate's
+    // inferential lag — no timestamps are needed to believe it.
+    let export = load("quarantine-convergence-pass-halt.json");
+    assert_eq!(
+        classify(&export),
+        Verdict::Quarantine {
+            reason: QuarantineReason::UnrecoverableHalt {
+                engines: vec![HaltedEngine {
+                    engine_id: "engine-a".into(),
+                    reasons: vec!["convergence_pass_base_changed".into()],
+                }],
+            }
+        }
+    );
+}
+
+#[test]
+fn a_group_hydrated_into_the_unrecoverable_state_quarantines() {
+    // The other halt surface (mdk #1106): the engine's epoch machine re-entered
+    // `unrecoverable` on hydrate, so a durable halt survived a process restart.
+    // This is the shape the real 26a9f546 export carried — the row Goggles
+    // derives its error-severity `epoch_state_transition` projection from — and
+    // the classifier previously read nothing but the row's epoch, so a hard
+    // client failure surfaced only as the misleading label `went dark`.
+    let export = load("quarantine-hydrate-unrecoverable.json");
+    assert_eq!(
+        classify(&export),
+        Verdict::Quarantine {
+            reason: QuarantineReason::UnrecoverableHalt {
+                engines: vec![HaltedEngine {
+                    engine_id: "engine-b".into(),
+                    reasons: vec!["hydrate_unrecoverable_group".into()],
+                }],
+            }
+        }
+    );
+}
+
+#[test]
+fn both_halt_surfaces_on_one_engine_report_one_entry_per_reason() {
+    // An engine that halts mid-pass and then hydrates back into the halt records
+    // both surfaces, repeatedly. The report is per engine, with each distinct
+    // reason once: a halt is a state, not a count, so repetition is not severity.
+    let export = load("quarantine-repeated-halt.json");
+    assert_eq!(
+        classify(&export),
+        Verdict::Quarantine {
+            reason: QuarantineReason::UnrecoverableHalt {
+                engines: vec![HaltedEngine {
+                    engine_id: "engine-a".into(),
+                    reasons: vec![
+                        "frozen_pass_integrity_failure".into(),
+                        "hydrate_unrecoverable_group".into(),
+                    ],
+                }],
+            }
+        }
+    );
+}
+
+#[test]
+fn a_convergence_run_at_the_tip_proves_the_engine_is_not_behind() {
+    // engine-b's group-state evidence stops at epoch 4, but it went on to run a
+    // convergence pass whose canonical tip was 6 — an epoch it can only have
+    // started from by having materialized it locally. Reading only the older
+    // signal would report a healthy engine as two epochs behind. This is the same
+    // reasoning `convergence_decision.current_tip_epoch` already carries, applied
+    // to the denser of the two surfaces (a real export logs roughly twice as many
+    // run-state rows as decisions). A non-terminal phase must also leave the halt
+    // gate unarmed.
+    assert_eq!(
+        classify(&load("healthy-convergence-run-at-tip.json")),
+        Verdict::Healthy
+    );
+}
+
+#[test]
+fn halt_advisory_surfaces_behind_an_incident_verdict() {
+    // A halt is a client failure, not a branch contest, so it must not preempt a
+    // replayable incident — the fork still routes. But it must not be lost to
+    // that single verdict either, so `halt_advisory` exposes it the way
+    // `liveness_advisory` exposes rule 6.
+    let export = load("fork-with-halted-engine.json");
+    assert_eq!(classify(&export), Verdict::ForkRecovery);
+    assert_eq!(
+        halt_advisory(&export),
+        Some(QuarantineReason::UnrecoverableHalt {
+            engines: vec![HaltedEngine {
+                engine_id: "engine-b".into(),
+                reasons: vec!["hydrate_unrecoverable_group".into()],
+            }],
+        })
+    );
+}
+
+#[test]
+fn a_halt_outranks_the_epoch_divergence_it_explains() {
+    // engine-b is both halted and two epochs behind — the real 26a9f546 pairing,
+    // where the halt is *why* the engine stopped advancing. The diagnosis is the
+    // verdict; the inference stays available as the secondary advisory rather than
+    // sending the operator to re-pull for a confirmation they already have.
+    let export = load("quarantine-halt-and-divergence.json");
+    assert!(matches!(
+        classify(&export),
+        Verdict::Quarantine {
+            reason: QuarantineReason::UnrecoverableHalt { .. }
+        }
+    ));
+    assert!(matches!(
+        liveness_advisory(&export),
+        Some(QuarantineReason::EpochDivergence { .. })
+    ));
 }

--- a/crates/incident-replay/tests/classify.rs
+++ b/crates/incident-replay/tests/classify.rs
@@ -313,6 +313,27 @@ fn a_convergence_run_at_the_tip_proves_the_engine_is_not_behind() {
 }
 
 #[test]
+fn a_discarded_convergence_pass_proves_the_engine_is_not_behind() {
+    // mdk#1182 replaced the `base_epoch_mismatch` halt with a repair:
+    // `convergence_pass_discarded`. Its `current_tip_epoch` comes from
+    // `convergence_tip_epoch()` at every call site, so it is the engine's own
+    // materialized tip — the same evidence class as
+    // `convergence_run_state.current_tip_epoch`. engine-b's group-state evidence
+    // stops at epoch 4 and the discard row is its only later signal, so ignoring
+    // the row reports a healthy engine as two epochs behind.
+    //
+    // `stale_base_epoch` is deliberately *ahead* of the tip here (9 > 6): it is
+    // inherited scheduling state that can split from the tip in either direction,
+    // never an epoch any engine materialized, so folding it into the group's
+    // high-water mark would invent a tip nobody reached and report every engine
+    // behind it. Only the tip counts.
+    assert_eq!(
+        classify(&load("healthy-convergence-pass-discarded-at-tip.json")),
+        Verdict::Healthy
+    );
+}
+
+#[test]
 fn halt_advisory_surfaces_behind_an_incident_verdict() {
     // A halt is a client failure, not a branch contest, so it must not preempt a
     // replayable incident — the fork still routes. But it must not be lost to

--- a/crates/incident-replay/tests/classify.rs
+++ b/crates/incident-replay/tests/classify.rs
@@ -324,6 +324,88 @@ fn both_halt_surfaces_on_one_engine_report_one_entry_per_reason() {
 }
 
 #[test]
+fn a_verified_repair_after_a_halt_clears_the_halt() {
+    // The halt is a state, not a permanent record: rule 5 says the group stays
+    // blocked "until a verified repair clears the marker", and there is exactly
+    // one legal exit from `Unrecoverable` — `repair_to_stable`, driven by an
+    // authenticated Welcome, which emits `epoch_state_changed { new_state:
+    // "stable", reason: "join_welcome_repair" }` right after the transition. An
+    // engine that halted and then completed that repair is repaired, so
+    // quarantining it would send the operator after a device that already
+    // healed. Only this engine appears, at the post-repair epoch, so rule 6
+    // stays unarmed and `Healthy` is the whole verdict.
+    let export = load("healthy-halt-cleared-by-repair.json");
+    assert_eq!(classify(&export), Verdict::Healthy);
+    // The advisory is verdict-independent, so a cleared halt must vanish from it
+    // too — otherwise the CLI would still print the halt beneath a healthy line.
+    assert_eq!(halt_advisory(&export), None);
+}
+
+#[test]
+fn a_halt_after_a_verified_repair_still_quarantines() {
+    // A repaired group can halt again. Both rows are present here exactly as in
+    // the cleared case — only their order differs — so this is the shape a
+    // presence-only "halted, but also repaired ⇒ downgrade" rule gets wrong, and
+    // it gets it wrong on the dangerous side: a device that is halted *right now*
+    // would read as healthy. Ordering the two by their own clock is what
+    // distinguishes them.
+    assert_eq!(
+        classify(&load("quarantine-halt-after-repair.json")),
+        Verdict::Quarantine {
+            reason: QuarantineReason::UnrecoverableHalt {
+                engines: vec![HaltedEngine {
+                    engine_id: "engine-a".into(),
+                    reasons: vec!["hydrate_unrecoverable_group".into()],
+                }],
+            }
+        }
+    );
+}
+
+#[test]
+fn a_verified_repair_in_another_group_does_not_clear_a_halt() {
+    // `Unrecoverable` is per-group state, and one engine serves many groups. Here
+    // the engine re-joined group b — a real repair, for a group that was never
+    // halted — while group a stays blocked. Clearing per engine rather than per
+    // (engine, group) would report this device healthy on the strength of a
+    // repair that never touched the halted group. Both real exports on hand carry
+    // `group_ref` on every event line, so this scoping is live, not latent.
+    assert_eq!(
+        classify(&load("quarantine-halt-with-repair-in-another-group.json")),
+        Verdict::Quarantine {
+            reason: QuarantineReason::UnrecoverableHalt {
+                engines: vec![HaltedEngine {
+                    engine_id: "engine-a".into(),
+                    reasons: vec!["hydrate_unrecoverable_group".into()],
+                }],
+            }
+        }
+    );
+}
+
+#[test]
+fn an_untimed_repair_does_not_clear_a_halt() {
+    // Same group, same engine, both rows present — but neither carries a wall
+    // clock, so nothing says which came last, and the two orders have opposite
+    // meanings (see `a_halt_after_a_verified_repair_still_quarantines`). The halt
+    // stands. Note the asymmetry this preserves: *arming* rule 5 needs no
+    // timestamps, because a halt is self-reported and repetition-proof, while
+    // *clearing* it is an ordering claim that untimed rows cannot support. Fail
+    // closed — a missed repair costs a re-pull, a missed halt costs the incident.
+    assert_eq!(
+        classify(&load("quarantine-untimed-halt-with-repair.json")),
+        Verdict::Quarantine {
+            reason: QuarantineReason::UnrecoverableHalt {
+                engines: vec![HaltedEngine {
+                    engine_id: "engine-a".into(),
+                    reasons: vec!["hydrate_unrecoverable_group".into()],
+                }],
+            }
+        }
+    );
+}
+
+#[test]
 fn a_convergence_run_at_the_tip_proves_the_engine_is_not_behind() {
     // engine-b's group-state evidence stops at epoch 4, but it went on to run a
     // convergence pass whose canonical tip was 6 — an epoch it can only have

--- a/crates/incident-replay/tests/fixtures/convergence-failclosed-with-clean-fork.json
+++ b/crates/incident-replay/tests/fixtures/convergence-failclosed-with-clean-fork.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "_comment": "Synthetic. Two co-occurring incidents at one epoch, as the real 26a9f546 export carried: a contested convergence whose recovery fail-closes (an effective_commit_depth win on UNEQUAL valid depths, so the witness boost is not provably decisive) alongside a cleanly reproducible membership fork.",
+  "events": [
+    {
+      "kind": {
+        "type": "convergence_decision",
+        "current_tip_epoch": 30,
+        "candidates": [
+          {
+            "branch_id": "path:branch-kept",
+            "score": { "witness_quorum_met": true, "valid_commit_depth": 3 }
+          },
+          {
+            "branch_id": "path:branch-dropped",
+            "score": { "witness_quorum_met": false, "valid_commit_depth": 1 }
+          }
+        ],
+        "rule_trace": [
+          { "rule_name": "eligibility", "decisive": false },
+          { "rule_name": "effective_commit_depth", "decisive": true }
+        ],
+        "selected_branch_id": "path:branch-kept",
+        "losing_branch_ids": ["path:branch-dropped"]
+      }
+    },
+    {
+      "kind": {
+        "type": "fork_resolution",
+        "source_epoch": 30,
+        "invalidated_msg_id": "inv-1",
+        "winner": "candidate"
+      }
+    },
+    {
+      "account_ref": "alpha",
+      "kind": {
+        "type": "group_state_changed",
+        "epoch": 31,
+        "change_kind": "admin_added",
+        "actor_member_ref": "member-alpha"
+      }
+    },
+    {
+      "account_ref": "beta",
+      "kind": {
+        "type": "group_state_changed",
+        "epoch": 31,
+        "change_kind": "member_added",
+        "actor_member_ref": "member-beta"
+      }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/convergence-failclosed-with-unusable-fork.json
+++ b/crates/incident-replay/tests/fixtures/convergence-failclosed-with-unusable-fork.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "_comment": "Synthetic. Both incident routes fail closed: the contested convergence's witness boost is not provably decisive, and the co-occurring fork won with a missing snapshot (rule 3), so the fall-through has nothing to rescue either.",
+  "events": [
+    {
+      "kind": {
+        "type": "convergence_decision",
+        "current_tip_epoch": 30,
+        "candidates": [
+          {
+            "branch_id": "path:branch-kept",
+            "score": {
+              "witness_quorum_met": true,
+              "valid_commit_depth": 3
+            }
+          },
+          {
+            "branch_id": "path:branch-dropped",
+            "score": {
+              "witness_quorum_met": false,
+              "valid_commit_depth": 1
+            }
+          }
+        ],
+        "rule_trace": [
+          {
+            "rule_name": "effective_commit_depth",
+            "decisive": true
+          }
+        ],
+        "selected_branch_id": "path:branch-kept",
+        "losing_branch_ids": [
+          "path:branch-dropped"
+        ]
+      }
+    },
+    {
+      "kind": {
+        "type": "fork_resolution",
+        "source_epoch": 30,
+        "winner": "missing_snapshot"
+      }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {}
+  }
+}

--- a/crates/incident-replay/tests/fixtures/convergence-failclosed-without-fork.json
+++ b/crates/incident-replay/tests/fixtures/convergence-failclosed-without-fork.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "_comment": "Synthetic. A contested convergence that fails closed with no fork anywhere in the export: there is no lower route to fall through to, so the quarantine stands alone with no advisory.",
+  "events": [
+    {
+      "kind": {
+        "type": "convergence_decision",
+        "current_tip_epoch": 30,
+        "candidates": [
+          {
+            "branch_id": "path:branch-kept",
+            "score": {
+              "witness_quorum_met": true,
+              "valid_commit_depth": 3
+            }
+          },
+          {
+            "branch_id": "path:branch-dropped",
+            "score": {
+              "witness_quorum_met": false,
+              "valid_commit_depth": 1
+            }
+          }
+        ],
+        "rule_trace": [
+          {
+            "rule_name": "effective_commit_depth",
+            "decisive": true
+          }
+        ],
+        "selected_branch_id": "path:branch-kept",
+        "losing_branch_ids": [
+          "path:branch-dropped"
+        ]
+      }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {}
+  }
+}

--- a/crates/incident-replay/tests/fixtures/fork-accepted-with-halted-engine.json
+++ b/crates/incident-replay/tests/fixtures/fork-accepted-with-halted-engine.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "_comment": "Synthetic. A cleanly reproducible membership fork alongside an engine that recorded an unrecoverable halt. All engines sit at epoch 31, so the epoch-divergence gate stays unarmed and the halt is the only co-occurring finding.",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": {
+        "type": "fork_resolution",
+        "source_epoch": 30,
+        "invalidated_msg_id": "inv-1",
+        "winner": "candidate"
+      }
+    },
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000060000,
+      "account_ref": "alpha",
+      "kind": {
+        "type": "group_state_changed",
+        "epoch": 31,
+        "change_kind": "admin_added",
+        "actor_member_ref": "member-alpha"
+      }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000120000,
+      "account_ref": "beta",
+      "kind": {
+        "type": "group_state_changed",
+        "epoch": 31,
+        "change_kind": "member_added",
+        "actor_member_ref": "member-beta"
+      }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000180000,
+      "kind": {
+        "type": "epoch_state_changed",
+        "epoch": 31,
+        "new_state": "unrecoverable",
+        "reason": "hydrate_unrecoverable_group"
+      }
+    }
+  ],
+  "derived_projections": {
+    "pagination": {}
+  }
+}

--- a/crates/incident-replay/tests/fixtures/fork-with-halted-engine.json
+++ b/crates/incident-replay/tests/fixtures/fork-with-halted-engine.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "fork_resolution", "source_epoch": 30, "invalidated_msg_id": "inv-1", "winner": "incumbent" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "epoch_state_changed", "epoch": 31, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/healthy-convergence-pass-discarded-at-tip.json
+++ b/crates/incident-replay/tests/fixtures/healthy-convergence-pass-discarded-at-tip.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "group_state_changed", "epoch": 6, "change_kind": "member_added", "actor_member_ref": "member-alpha" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "group_state_changed", "epoch": 4, "change_kind": "member_added", "actor_member_ref": "member-alpha" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000010000000,
+      "kind": {
+        "type": "convergence_pass_discarded",
+        "stale_base_epoch": 9,
+        "current_tip_epoch": 6,
+        "generation": 4
+      }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/healthy-convergence-run-at-tip.json
+++ b/crates/incident-replay/tests/fixtures/healthy-convergence-run-at-tip.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "group_state_changed", "epoch": 6, "change_kind": "member_added", "actor_member_ref": "member-alpha" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "group_state_changed", "epoch": 4, "change_kind": "member_added", "actor_member_ref": "member-alpha" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000010000000,
+      "kind": { "type": "convergence_run_state", "phase": "applied", "current_tip_epoch": 6 }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/healthy-halt-cleared-by-repair.json
+++ b/crates/incident-replay/tests/fixtures/healthy-halt-cleared-by-repair.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    },
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "epoch_state_changed", "epoch": 8, "new_state": "stable", "reason": "join_welcome_repair" }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-anchorless-halt.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-anchorless-halt.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "stable", "reason": "publish_confirmed" }
+    },
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000060000,
+      "kind": {
+        "type": "convergence_run_state",
+        "phase": "unrecoverable",
+        "current_tip_epoch": 7,
+        "retained_anchor_horizon": 5,
+        "error_kind": "missing_retained_anchor"
+      }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-convergence-pass-halt.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-convergence-pass-halt.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "stable", "reason": "publish_confirmed" }
+    },
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000060000,
+      "kind": {
+        "type": "convergence_run_state",
+        "phase": "unrecoverable",
+        "current_tip_epoch": 7,
+        "reason": "convergence_pass_base_changed",
+        "error_kind": "base_epoch_mismatch"
+      }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-halt-after-repair.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-halt-after-repair.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 8, "new_state": "stable", "reason": "join_welcome_repair" }
+    },
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "epoch_state_changed", "epoch": 8, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-halt-and-divergence.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-halt-and-divergence.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "group_state_changed", "epoch": 6, "change_kind": "member_added", "actor_member_ref": "member-alpha" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 999999000000,
+      "kind": { "type": "group_state_changed", "epoch": 4, "change_kind": "member_added", "actor_member_ref": "member-alpha" }
+    },
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 999999060000,
+      "kind": { "type": "epoch_state_changed", "epoch": 4, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-halt-with-repair-in-another-group.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-halt-with-repair-in-another-group.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    },
+    {
+      "engine_id": "engine-a",
+      "group_ref": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "epoch_state_changed", "epoch": 8, "new_state": "stable", "reason": "join_welcome_repair" }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-hydrate-unrecoverable.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-hydrate-unrecoverable.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-b",
+      "wall_time_ms": 1000000000000,
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-repeated-halt.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-repeated-halt.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000000000,
+      "kind": {
+        "type": "convergence_run_state",
+        "phase": "unrecoverable",
+        "current_tip_epoch": 7,
+        "reason": "frozen_pass_integrity_failure",
+        "error_kind": "frozen_member_integrity"
+      }
+    },
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000060000,
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    },
+    {
+      "engine_id": "engine-a",
+      "wall_time_ms": 1000000120000,
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/fixtures/quarantine-untimed-halt-with-repair.json
+++ b/crates/incident-replay/tests/fixtures/quarantine-untimed-halt-with-repair.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "marmot-agent-state/v1",
+  "events": [
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "kind": { "type": "epoch_state_changed", "epoch": 7, "new_state": "unrecoverable", "reason": "hydrate_unrecoverable_group" }
+    },
+    {
+      "engine_id": "engine-a",
+      "group_ref": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "kind": { "type": "epoch_state_changed", "epoch": 8, "new_state": "stable", "reason": "join_welcome_repair" }
+    }
+  ],
+  "derived_projections": { "pagination": {} }
+}

--- a/crates/incident-replay/tests/route.rs
+++ b/crates/incident-replay/tests/route.rs
@@ -106,6 +106,18 @@ fn an_accepted_vector_does_not_mask_a_halted_engine() {
 }
 
 #[test]
+fn a_repaired_halt_is_not_reported_as_an_advisory() {
+    // The halt advisory is verdict-independent, so a cleared halt has to vanish
+    // from the advisory path too — suppressing it only from the verdict would
+    // leave the CLI printing `advisory (halt)` under a healthy primary line,
+    // sending the operator after a device that already repaired itself.
+    let routing = routed("healthy-halt-cleared-by-repair.json");
+
+    assert!(matches!(routing.outcome, Outcome::Healthy));
+    assert_eq!(routing.advisories, []);
+}
+
+#[test]
 fn a_halt_verdict_is_not_also_reported_as_its_own_advisory() {
     // When the halt *is* the primary outcome, printing it again as an advisory
     // would just duplicate the line.

--- a/crates/incident-replay/tests/route.rs
+++ b/crates/incident-replay/tests/route.rs
@@ -1,0 +1,116 @@
+//! Route composition: the verdict picks an incident route, and a route whose
+//! recovery fails closed falls through to the remaining lower-precedence ones
+//! rather than discarding a reproducible incident that shares the export.
+
+use incident_replay::{
+    IncidentSourceFormatV1, MEMBERSHIP_INCIDENT_NAME, Outcome, Routing, parse, route,
+};
+
+/// Route the named `agent-state.json` fixture. Every fixture here is a document
+/// export, so the source format is fixed.
+fn routed(name: &str) -> Routing {
+    let path = format!("{}/tests/fixtures/{name}", env!("CARGO_MANIFEST_DIR"));
+    let json =
+        std::fs::read_to_string(&path).unwrap_or_else(|err| panic!("read fixture {path}: {err}"));
+    let export = parse(&json).unwrap_or_else(|err| panic!("parse fixture {name}: {err}"));
+    route(&export, IncidentSourceFormatV1::AgentStateDocument)
+}
+
+#[test]
+fn a_fail_closed_convergence_falls_through_to_a_clean_fork() {
+    // The real 26a9f546 shape: one export carries a contested convergence *and* a
+    // membership fork at the same epoch. Convergence outranks the fork for
+    // classification, but its recovery fail-closes here (the witness boost is not
+    // provably decisive), and committing to that single route threw away a
+    // membership fork the simulator reproduces perfectly. Rule precedence is
+    // unchanged — only a *failed* recovery falls through.
+    let routing = routed("convergence-failclosed-with-clean-fork.json");
+
+    let Outcome::Accepted(artifact) = &routing.outcome else {
+        panic!("expected the fork fallback to be accepted, got {routing:?}");
+    };
+    assert_eq!(artifact.vector.scenario_name, MEMBERSHIP_INCIDENT_NAME);
+
+    // The discarded higher-precedence incident is still reported: an accepted
+    // fork plus a note beats a bare quarantine, but it must not hide that the
+    // convergence could not be replayed.
+    let labels: Vec<&str> = routing
+        .advisories
+        .iter()
+        .map(|advisory| advisory.label)
+        .collect();
+    assert_eq!(labels, ["superseded route"]);
+    assert!(
+        routing.advisories[0]
+            .detail
+            .contains("quorum boost is not provably decisive"),
+        "advisory should carry the convergence quarantine reason, got {:?}",
+        routing.advisories[0].detail
+    );
+}
+
+#[test]
+fn a_fallback_that_also_fails_leaves_the_higher_quarantine_primary() {
+    // Fall-through may only upgrade the outcome. When the fork route fails too,
+    // the convergence quarantine stays primary — it is the higher-precedence
+    // incident, and letting the fallback's reason take the headline would
+    // misreport which incident the export is about. The fallback's own reason is
+    // still disclosed.
+    let routing = routed("convergence-failclosed-with-unusable-fork.json");
+
+    let Outcome::Quarantine { reason } = &routing.outcome else {
+        panic!("expected the convergence quarantine to stand, got {routing:?}");
+    };
+    assert!(
+        reason.contains("quorum boost is not provably decisive"),
+        "primary must stay the convergence reason, got {reason:?}"
+    );
+    assert_eq!(routing.advisories.len(), 1);
+    assert_eq!(routing.advisories[0].label, "fallback route");
+    assert!(
+        routing.advisories[0]
+            .detail
+            .contains("snapshot was missing"),
+        "advisory should name why the fork route failed, got {:?}",
+        routing.advisories[0].detail
+    );
+}
+
+#[test]
+fn a_fail_closed_convergence_with_no_fork_reports_no_fallback() {
+    // There is no lower route to enter, so "we also tried the fork route and
+    // found no fork" is noise, not a finding. One primary line, nothing else.
+    let routing = routed("convergence-failclosed-without-fork.json");
+
+    assert!(matches!(routing.outcome, Outcome::Quarantine { .. }));
+    assert_eq!(routing.advisories, []);
+}
+
+#[test]
+fn an_accepted_vector_does_not_mask_a_halted_engine() {
+    // The fork reproduces, so the primary line is the accepted vector — but
+    // engine-b recorded an unrecoverable halt, and a single verdict would have
+    // buried it. Rules 5 and 6 are verdict-independent for exactly this case.
+    let routing = routed("fork-accepted-with-halted-engine.json");
+
+    assert!(matches!(routing.outcome, Outcome::Accepted(_)));
+    assert_eq!(routing.advisories.len(), 1);
+    assert_eq!(routing.advisories[0].label, "halt");
+    assert!(
+        routing.advisories[0]
+            .detail
+            .contains("hydrate_unrecoverable_group"),
+        "advisory should name the halt reason, got {:?}",
+        routing.advisories[0].detail
+    );
+}
+
+#[test]
+fn a_halt_verdict_is_not_also_reported_as_its_own_advisory() {
+    // When the halt *is* the primary outcome, printing it again as an advisory
+    // would just duplicate the line.
+    let routing = routed("quarantine-hydrate-unrecoverable.json");
+
+    assert!(matches!(routing.outcome, Outcome::Quarantine { .. }));
+    assert_eq!(routing.advisories, []);
+}

--- a/docs/marmot-architecture/audit-logging.md
+++ b/docs/marmot-architecture/audit-logging.md
@@ -1,7 +1,7 @@
 ---
 title: "Forensic Audit Logging Inventory"
 created: 2026-06-10
-updated: 2026-07-29
+updated: 2026-07-30
 tags: [marmot, architecture, audit, forensics, jsonl, privacy]
 status: current
 ---
@@ -190,10 +190,11 @@ and retain the raw line for forward-compatible reprocessing.
 
 ## Event catalogue
 
-This catalogue is not yet complete. `AuditEventKind` currently has 39 variants, and these ten have no section here
+This catalogue is not yet complete. `AuditEventKind` currently has 41 variants, and these twelve have no section here
 yet — treat `crates/marmot-forensics/src/audit.rs` as authoritative until they are written up:
-`audit_data_mode_changed`, `epoch_stall_backfill_armed`, `group_hydration_quarantined`, `group_hydration_recovered`,
-`message_content_decoded`, `recipient_expectation`, `source_context`, `subscription_rebuild`, `sync_drain`,
+`audit_data_mode_changed`, `convergence_pass_discarded`, `epoch_stall_backfill_armed`,
+`group_hydration_quarantined`, `group_hydration_recovered`, `message_content_decoded`,
+`pending_commit_recovered_on_open`, `recipient_expectation`, `source_context`, `subscription_rebuild`, `sync_drain`,
 and `transport_received`.
 
 ### `recorder_started`
@@ -749,14 +750,12 @@ the `convergence.run_id` context, so a run's phases and its selection are one st
 - `blocked`
 - `group_quarantined`
 - `already_unrecoverable`
-- `missing_retained_anchor`
-- `convergence_pass_base_changed`
 - `frozen_pass_integrity_failure`
 
 `error_kind` values found in production call sites:
 
-- `base_epoch_mismatch`
 - `frozen_member_integrity`
+- `missing_retained_anchor`
 
 Metadata notes:
 
@@ -767,6 +766,13 @@ Metadata notes:
 - `current_tip_epoch` is the engine's own materialized tip, so analyzers may fold it into a per-engine epoch high-water
   mark the same way they fold `convergence_decision.current_tip_epoch`. Real exports carry roughly twice as many
   run-state rows as decisions, making this the denser of the two signals.
+- A pass whose base epoch disagrees with the tip is no longer a halt. Older exports carry that disagreement as
+  `phase = "unrecoverable"` with `reason = "convergence_pass_base_changed"` and `error_kind = "base_epoch_mismatch"`;
+  since mdk#1182 the engine discards the stale pass and reopens at the tip, emitting the non-terminal
+  `convergence_pass_discarded` instead. Analyzers reading historical exports should still recognize the retired pair as
+  a halt; nothing emits it today.
+- The `missing_retained_anchor` halt is the one `unrecoverable` phase that carries no `reason`, only that `error_kind`,
+  so a consumer reporting a halt reason must fall back to `error_kind`.
 
 ### `peeler_outcome`
 

--- a/docs/marmot-architecture/audit-logging.md
+++ b/docs/marmot-architecture/audit-logging.md
@@ -605,7 +605,9 @@ Metadata notes:
 - `new_state = "unrecoverable"` is a terminal halt: convergence and ingest stay blocked for that group until a verified
   repair path clears the marker, and `reason = "hydrate_unrecoverable_group"` means the halt was durable and survived a
   process restart. `crates/incident-replay` treats these rows as one of its two halt surfaces (the other being
-  `convergence_run_state` with `phase = "unrecoverable"`) and quarantines the export naming the affected engines.
+  `convergence_run_state` with `phase = "unrecoverable"`) and quarantines the export naming the affected engines —
+  unless a later `new_state = "stable"` row with `reason = "join_welcome_repair"` (the one legal exit, emitted by
+  `repair_to_stable`) shows the verified repair completed for that `(engine_id, group_ref)`.
   Goggles derives its error-severity `epoch_state_transition` projection row from exactly this state.
 
 ### `group_state_changed`

--- a/docs/marmot-architecture/audit-logging.md
+++ b/docs/marmot-architecture/audit-logging.md
@@ -590,6 +590,7 @@ Current `reason` values found in production call sites:
 - `hydrate_unrecoverable_group`
 - `hydrate_durable_group_evolution`
 - `join_welcome`
+- `join_welcome_repair`
 - `begin_pending`
 - `publish_confirmed`
 - `publish_failed`

--- a/docs/marmot-architecture/audit-logging.md
+++ b/docs/marmot-architecture/audit-logging.md
@@ -1,7 +1,7 @@
 ---
 title: "Forensic Audit Logging Inventory"
 created: 2026-06-10
-updated: 2026-07-25
+updated: 2026-07-29
 tags: [marmot, architecture, audit, forensics, jsonl, privacy]
 status: current
 ---
@@ -189,6 +189,12 @@ and retain the raw line for forward-compatible reprocessing.
 | `group` | `convergence_max_rewind_commits` | Group-specific convergence rewind policy when set, otherwise current default context. |
 
 ## Event catalogue
+
+This catalogue is not yet complete. `AuditEventKind` currently has 39 variants, and these ten have no section here
+yet — treat `crates/marmot-forensics/src/audit.rs` as authoritative until they are written up:
+`audit_data_mode_changed`, `epoch_stall_backfill_armed`, `group_hydration_quarantined`, `group_hydration_recovered`,
+`message_content_decoded`, `recipient_expectation`, `source_context`, `subscription_rebuild`, `sync_drain`,
+and `transport_received`.
 
 ### `recorder_started`
 
@@ -578,11 +584,16 @@ Current `new_state` values:
 
 Current `reason` values found in production call sites:
 
+- `founding_create`
 - `hydrate_stable_group`
+- `hydrate_unrecoverable_group`
+- `hydrate_durable_group_evolution`
 - `join_welcome`
 - `begin_pending`
 - `publish_confirmed`
 - `publish_failed`
+- `auto_commit_stage_failed`
+- `update_group_data_stage_failed`
 - `fork_detected`
 - `missing_retained_anchor`
 
@@ -590,6 +601,11 @@ Metadata notes:
 
 - `epoch_confirmed` and `epoch_rolled_back` remain the detailed publish lifecycle rows. `epoch_state_changed` is the
   state-machine breadcrumb that lets analyzers reconstruct the client's group state without replaying engine internals.
+- `new_state = "unrecoverable"` is a terminal halt: convergence and ingest stay blocked for that group until a verified
+  repair path clears the marker, and `reason = "hydrate_unrecoverable_group"` means the halt was durable and survived a
+  process restart. `crates/incident-replay` treats these rows as one of its two halt surfaces (the other being
+  `convergence_run_state` with `phase = "unrecoverable"`) and quarantines the export naming the affected engines.
+  Goggles derives its error-severity `epoch_state_transition` projection row from exactly this state.
 
 ### `group_state_changed`
 
@@ -699,6 +715,58 @@ Metadata notes:
 - `candidate_count` and `eligible_count` are copied from the canonicalization result that drove the decision.
 - If `error_kinds` contains `missing_retained_anchor`, the engine also emits `epoch_state_changed` with
   `new_state = "unrecoverable"` and `reason = "missing_retained_anchor"`.
+
+### `convergence_run_state`
+
+Emitted when a distributed-convergence run changes lifecycle phase. Correlated with its `convergence_decision` through
+the `convergence.run_id` context, so a run's phases and its selection are one story.
+
+| Field | Meaning |
+| --- | --- |
+| `phase` | Lifecycle phase the run moved into. |
+| `current_tip_epoch` | Canonical tip the run is working from. An epoch the engine has locally materialized. |
+| `retained_anchor_horizon` | Retained-history horizon available to the run, when known. |
+| `reason` | Stable call-site reason for the phase change, when one applies. |
+| `error_kind` | Stable error tag underlying a failed or unrecoverable phase. |
+
+`phase` values:
+
+- `started`
+- `waiting`
+- `evaluating`
+- `selected`
+- `blocked`
+- `applied`
+- `failed`
+- `stable`
+- `unrecoverable`
+
+`reason` values found in production call sites:
+
+- `no_eligible_input`
+- `resolving`
+- `syncing`
+- `blocked`
+- `group_quarantined`
+- `already_unrecoverable`
+- `missing_retained_anchor`
+- `convergence_pass_base_changed`
+- `frozen_pass_integrity_failure`
+
+`error_kind` values found in production call sites:
+
+- `base_epoch_mismatch`
+- `frozen_member_integrity`
+
+Metadata notes:
+
+- This event has `group_ref`.
+- `phase = "unrecoverable"` is terminal: the convergence pass halted and the group stays blocked until a verified repair
+  path clears the marker. `crates/incident-replay` treats it as one of its two halt surfaces (the other being
+  `epoch_state_changed` with `new_state = "unrecoverable"`) and quarantines the export naming the affected engines.
+- `current_tip_epoch` is the engine's own materialized tip, so analyzers may fold it into a per-engine epoch high-water
+  mark the same way they fold `convergence_decision.current_tip_epoch`. Real exports carry roughly twice as many
+  run-state rows as decisions, making this the denser of the two signals.
 
 ### `peeler_outcome`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quarantine and advisory reporting for unrecoverable engine halts, including affected engines and halt reasons.
  * Added fail-closed incident routing with deterministic precedence, fallback recovery, one primary outcome, and secondary advisories.
  * Updated incident replay output to show the primary outcome and applicable advisories.
* **Bug Fixes**
  * Ensured verified repairs clear only the corresponding halt and group.
  * Prevented duplicate halt or liveness advisories when already represented by the primary outcome.
* **Documentation**
  * Clarified halt, quarantine, repair, and routing behavior in incident-replay and audit-event documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->