### PR TITLE
Add explicit simulator outbound publication lifecycle

### DIFF
--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -67,7 +67,7 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
     `tests/proptest_invariants.rs` generate symbolic canonicalization, capability, lifecycle, and restart cases locally.
 
 - **Module:** `src/scenario.rs`
-  - **Role:** Serializable `ScenarioSpec` v1 plus `run_scenario_spec` / `run_scenario_report` /
+  - **Role:** Serializable `ScenarioSpec` v2 plus `run_scenario_spec` / `run_scenario_report` /
     `run_vector_fixture_report`. Drives ordered client operations from JSON-shaped scenario data and returns either a
     `ScenarioTrace` or a serializable report with the executed scenario, metadata, step log, flattened epoch changes,
     app invalidations, recoveries, expectation failures, and invariant failures. `ObserveExact` opts a portable scenario
@@ -84,8 +84,8 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
     retain the legacy far-future `Tick` shortcut. The explicit engine subject also captures an append-only emission
     stream separate from the mutable bus queue: `poll_outbound` returns unresolved transport-ready artifacts
     non-destructively, and `acknowledge_outbound` applies accepted/no-endpoint outcomes to staged commits, independent
-    Welcomes, and regenerated queued intents. Built-in v1 runners use the legacy publication mode until portable
-    outbound steps land in Scenario IR v2. Queue/partition mutation is available only through the separately named
+    Welcomes, and regenerated queued intents. ScenarioSpec v2 uses the same poll/acknowledgement contract; there is no
+    auto-confirming compatibility lifecycle. Queue/partition mutation is available only through the separately named
     `ConvergenceFaultSubject` white-box interface.
 
 - **Module:** `src/vector.rs`
@@ -137,10 +137,10 @@ to be a group member yet.
 `drop_queued`, `duplicate_queued`, `delay_queued`, `release_delayed`, and `reorder_queued`. `set_partition` and
 `clear_partition` remain the partition/heal operations.
 
-`fail_pending` means definite non-publication. Before invoking the engine rollback, the harness retracts every matching
+`reached_no_endpoint` means definite non-publication. Before invoking the engine rollback, the harness retracts every matching
 undelivered commit and Welcome from the queue and delayed sets. It returns a scenario error instead of rolling back if
 any matching artifact has already reached a recipient mailbox; model that case as ambiguous exposure at an adapter-aware
-boundary rather than as `fail_pending`.
+boundary rather than as definite failure.
 
 Use `clear_events` after setup when a scenario wants the final trace to describe only the behavior under test. The
 convergence E2E scenario does this after the initial welcome joins so its trace focuses on the peeler-ingest epoch

--- a/crates/cgka-conformance-simulator/AGENTS.md
+++ b/crates/cgka-conformance-simulator/AGENTS.md
@@ -81,8 +81,12 @@ Read [`README.md`](README.md) for the human framing, [`SCENARIOS.md`](SCENARIOS.
     is checked before execution. The engine adapter installs one shared manual paired clock; `AdvanceTime` moves both
     clock domains without waking a runtime, activates virtual-time ticks for that subject, and `Tick` selects which
     participants run convergence against that time. Scenarios that never call `AdvanceTime` and standalone clients
-    retain the legacy far-future `Tick` shortcut. Queue/partition mutation is available only through the separately
-    named `ConvergenceFaultSubject` white-box interface.
+    retain the legacy far-future `Tick` shortcut. The explicit engine subject also captures an append-only emission
+    stream separate from the mutable bus queue: `poll_outbound` returns unresolved transport-ready artifacts
+    non-destructively, and `acknowledge_outbound` applies accepted/no-endpoint outcomes to staged commits, independent
+    Welcomes, and regenerated queued intents. Built-in v1 runners use the legacy publication mode until portable
+    outbound steps land in Scenario IR v2. Queue/partition mutation is available only through the separately named
+    `ConvergenceFaultSubject` white-box interface.
 
 - **Module:** `src/vector.rs`
   - **Role:** `ScenarioTrace`, observations, and semantic `TraceExpectation` checks. Records final epoch/member/payload

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -136,8 +136,12 @@ no-op publication rather than inventing a synthetic artifact. ScenarioSpec v2 dr
 `acknowledge_outbound`: the runner polls opaque artifacts, optionally selects a stable scenario publication label and
 artifact role, and applies the declared transport outcome. Engine-generated work has no publication label and can be
 acknowledged as the client's current unresolved outbound set. There is no compatibility constructor, silent
-auto-confirmation mode, or second subject publication capability. The simulator does not yet wait for quiescence:
-structural progress tokens, a fixed-point driver, timeout policy, and retry-timer coverage remain in Milestone 1.3.
+auto-confirmation mode, or second subject publication capability. `ProtocolProfile::Legacy` is separate from that
+removed lifecycle: it selects the engine's legacy application-profile compatibility through
+`legacy_compatibility_profile()`, but it uses the same explicit outbound contract as `ProtocolProfile::Current`.
+ScenarioSpec v1 is intentionally unsupported after the repository-owned v2 cutover and is rejected before any subject
+action runs. The simulator does not yet wait for quiescence: structural progress tokens, a fixed-point driver, timeout
+policy, and retry-timer coverage remain in Milestone 1.3.
 
 `probe_bidirectional_decryptability` is the active cryptographic-reachability check. Each named client sends one
 uniquely identified application event through the normal engine and transport path; the runner delivers the resulting
@@ -241,7 +245,10 @@ selects artifacts emitted by that operation; omitting it selects all currently u
 The optional `selection` further restricts the set to `all`, `state_confirmation`, `welcome`, `group_message`, or
 `regenerated_queued_intent`. `outcome` is either `accepted` or `reached_no_endpoint`. A labelled acknowledgement fails
 when no unresolved artifact matches, while an unlabelled acknowledgement is an idempotent drain and may match nothing.
-Client labels are stable logical names;
+`group_message` includes both application messages and proposals because both use the group-message transport envelope.
+Proposal artifacts are engine-generated and have no scenario publication label, so scenarios select them with an
+unlabelled `group_message` acknowledgement unless a future proposal action introduces labels. Client labels are stable
+logical names;
 the Rust harness maps them to deterministic Nostr keys so welcome routing and NIP-59 decryption exercise the same
 identity shape as production. `reached_no_endpoint` represents a definite publication failure: it retracts all matching
 undelivered commit/Welcome artifacts before local rollback and fails the scenario if any matching artifact has already

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -133,8 +133,10 @@ unexposed. Welcome outcomes remain independent after a live commit is accepted, 
 retired or re-armed from the same acknowledgement. A state transition with no transport artifacts is confirmed as a
 no-op publication rather than inventing a synthetic artifact. The built-in ScenarioSpec v1 runners use a legacy-compatibility
 constructor so existing fixtures retain their explicit `confirm_pending` / `fail_pending` behavior until Scenario IR v2
-adds portable outbound actions. The simulator does not yet wait for quiescence: structural progress tokens, a fixed-point
-driver, timeout policy, and retry-timer coverage remain in Milestone 1.3.
+adds portable outbound actions. That compatibility subject does not advertise `outbound_publication`; removal of the
+dual lifecycle after the v2 migration is tracked in
+[MDK #1207](https://github.com/marmot-protocol/mdk/issues/1207). The simulator does not yet wait for quiescence:
+structural progress tokens, a fixed-point driver, timeout policy, and retry-timer coverage remain in Milestone 1.3.
 
 `probe_bidirectional_decryptability` is the active cryptographic-reachability check. Each named client sends one
 uniquely identified application event through the normal engine and transport path; the runner delivers the resulting

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -20,7 +20,9 @@ welcomes use NIP-59 gift wraps before the bus delivers them.
 - `ConvergenceSubject` — a capability-declared semantic boundary between scenario execution and the implementation
   under test. `EngineHarnessSubject` is the in-process adapter; queue and partition mutation live on a separate,
   explicitly white-box fault interface. Its `virtual_time` capability advances one shared paired convergence clock;
-  subsequent `tick` steps select which participant runtimes wake and observe the elapsed deadline.
+  subsequent `tick` steps select which participant runtimes wake and observe the elapsed deadline. Its
+  `outbound_publication` capability returns exact transport-ready artifacts through non-destructive polling and accepts
+  typed `accepted` / `reached_no_endpoint` outcomes through opaque adapter-owned acknowledgement handles.
 - `ScenarioSpec` — a serializable v1 input contract for deterministic scripted scenarios, including explicit queue
   faults and partitions.
 - `VectorFixture` — portable JSON fixtures pairing runnable scenario input with exact traces or semantic expected
@@ -122,8 +124,17 @@ ledger or output separately. The serializable `advance_time` step advances the s
 sleeping or waking a participant; a later `tick` selects the awake runtimes and uses that same clock. Every engine
 subject carries the deterministic manual clock, but only a scenario that executes `advance_time` switches `tick` to
 that clock. Existing scenarios and standalone `HarnessClient` tests that never opt into virtual time retain the
-historical far-future `tick` shortcut. The simulator does not yet wait for quiescence: structural progress tokens, a
-fixed-point driver, timeout policy, outbound acknowledgement, and retry-timer coverage remain in Milestone 1.3.
+historical far-future `tick` shortcut.
+
+`EngineHarnessSubject::new` uses the explicit outbound lifecycle. Polling never removes work, identical repeated
+acknowledgements are idempotent, and a contradictory acknowledgement fails. An accepted state-bearing commit confirms
+the engine's pending state; a `reached_no_endpoint` result rolls back only while the complete publication remains
+unexposed. Welcome outcomes remain independent after a live commit is accepted, and regenerated queued intents are
+retired or re-armed from the same acknowledgement. A state transition with no transport artifacts is confirmed as a
+no-op publication rather than inventing a synthetic artifact. The built-in ScenarioSpec v1 runners use a legacy-compatibility
+constructor so existing fixtures retain their explicit `confirm_pending` / `fail_pending` behavior until Scenario IR v2
+adds portable outbound actions. The simulator does not yet wait for quiescence: structural progress tokens, a fixed-point
+driver, timeout policy, and retry-timer coverage remain in Milestone 1.3.
 
 `probe_bidirectional_decryptability` is the active cryptographic-reachability check. Each named client sends one
 uniquely identified application event through the normal engine and transport path; the runner delivers the resulting

--- a/crates/cgka-conformance-simulator/README.md
+++ b/crates/cgka-conformance-simulator/README.md
@@ -23,7 +23,8 @@ welcomes use NIP-59 gift wraps before the bus delivers them.
   subsequent `tick` steps select which participant runtimes wake and observe the elapsed deadline. Its
   `outbound_publication` capability returns exact transport-ready artifacts through non-destructive polling and accepts
   typed `accepted` / `reached_no_endpoint` outcomes through opaque adapter-owned acknowledgement handles.
-- `ScenarioSpec` — a serializable v1 input contract for deterministic scripted scenarios, including explicit queue
+- `ScenarioSpec` — a serializable v2 input contract for deterministic scripted scenarios, including explicit outbound
+  acknowledgement and queue
   faults and partitions.
 - `VectorFixture` — portable JSON fixtures pairing runnable scenario input with exact traces or semantic expected
   outcomes.
@@ -126,16 +127,16 @@ subject carries the deterministic manual clock, but only a scenario that execute
 that clock. Existing scenarios and standalone `HarnessClient` tests that never opt into virtual time retain the
 historical far-future `tick` shortcut.
 
-`EngineHarnessSubject::new` uses the explicit outbound lifecycle. Polling never removes work, identical repeated
+`EngineHarnessSubject::new` uses the only outbound lifecycle. Polling never removes work, identical repeated
 acknowledgements are idempotent, and a contradictory acknowledgement fails. An accepted state-bearing commit confirms
 the engine's pending state; a `reached_no_endpoint` result rolls back only while the complete publication remains
 unexposed. Welcome outcomes remain independent after a live commit is accepted, and regenerated queued intents are
 retired or re-armed from the same acknowledgement. A state transition with no transport artifacts is confirmed as a
-no-op publication rather than inventing a synthetic artifact. The built-in ScenarioSpec v1 runners use a legacy-compatibility
-constructor so existing fixtures retain their explicit `confirm_pending` / `fail_pending` behavior until Scenario IR v2
-adds portable outbound actions. That compatibility subject does not advertise `outbound_publication`; removal of the
-dual lifecycle after the v2 migration is tracked in
-[MDK #1207](https://github.com/marmot-protocol/mdk/issues/1207). The simulator does not yet wait for quiescence:
+no-op publication rather than inventing a synthetic artifact. ScenarioSpec v2 drives the same contract through
+`acknowledge_outbound`: the runner polls opaque artifacts, optionally selects a stable scenario publication label and
+artifact role, and applies the declared transport outcome. Engine-generated work has no publication label and can be
+acknowledged as the client's current unresolved outbound set. There is no compatibility constructor, silent
+auto-confirmation mode, or second subject publication capability. The simulator does not yet wait for quiescence:
 structural progress tokens, a fixed-point driver, timeout policy, and retry-timer coverage remain in Milestone 1.3.
 
 `probe_bidirectional_decryptability` is the active cryptographic-reachability check. Each named client sends one
@@ -208,7 +209,7 @@ observes recovery from epoch 1 to epoch 2, and the winner and invalidated orderi
 `concurrent-invite-fork-recovery/v1` uses the same semantic recovery style for an invite race. It checks convergence and
 recovery without pinning which invite branch wins.
 
-`ScenarioSpec` v1 contains ordered client labels and ordered steps. Supported steps are:
+`ScenarioSpec` v2 contains ordered client labels and ordered steps. Supported steps are:
 
 - `create_group`
 - `invite_members`
@@ -216,12 +217,12 @@ recovery without pinning which invite branch wins.
 - `update_admin_policy`
 - `expect_update_admin_policy_error`
 - `observe_admin_policy`
-- `confirm_pending`
-- `fail_pending`
+- `acknowledge_outbound`
 - `send_app_message`
 - `leave`
 - `deliver_all`
 - `tick`
+- `advance_time`
 - `observe`
 - `observe_exact`
 - `probe_bidirectional_decryptability`
@@ -235,9 +236,14 @@ recovery without pinning which invite branch wins.
 - `clear_partition`
 - `restart_client`
 
-Pending operations are referenced by string labels chosen inside the scenario. Client labels are stable logical names;
+Staged publications are referenced by string labels chosen inside the scenario. `acknowledge_outbound.publication`
+selects artifacts emitted by that operation; omitting it selects all currently unresolved artifacts for the client.
+The optional `selection` further restricts the set to `all`, `state_confirmation`, `welcome`, `group_message`, or
+`regenerated_queued_intent`. `outcome` is either `accepted` or `reached_no_endpoint`. A labelled acknowledgement fails
+when no unresolved artifact matches, while an unlabelled acknowledgement is an idempotent drain and may match nothing.
+Client labels are stable logical names;
 the Rust harness maps them to deterministic Nostr keys so welcome routing and NIP-59 decryption exercise the same
-identity shape as production. `fail_pending` represents a definite publication failure: it retracts all matching
+identity shape as production. `reached_no_endpoint` represents a definite publication failure: it retracts all matching
 undelivered commit/Welcome artifacts before local rollback and fails the scenario if any matching artifact has already
 reached a recipient mailbox. Queue fault steps select messages by the current zero-based queue index at that step.
 `reorder_queued.order` is a full permutation of current queue indices; each entry names which old queue slot moves into

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -451,6 +451,23 @@ These tests keep the simulator machinery honest.
 - `engine_subject_virtual_time_is_shared_while_participant_wakes_are_selected` checks two real durable disband passes:
   a tick at 999 ms settles neither; at 1,000 ms Alice settles while unticked Bob stays live; Bob then settles on a later
   tick without another time advance.
+- `outbound_poll_is_non_destructive_and_acknowledgement_is_idempotent` checks exact application artifacts, repeatable
+  polling, same-outcome acknowledgement replay, transport delivery, and disappearance after resolution;
+  `outbound_poll_preserves_emission_order_past_single_digit_handles` guards deterministic ordering under a burst.
+- `evolution_commit_acknowledgement_and_welcome_outcome_are_independent` and
+  `no_endpoint_commit_outcome_rolls_back_the_complete_unexposed_publication` check that accepted commits advance local
+  state independently of Welcome delivery, while definite unexposed commit failure atomically retracts and rolls back
+  the complete publication.
+- `legacy_create_confirms_on_first_welcome_acceptance_and_keeps_other_welcomes_independent` checks the temporary legacy
+  creation rule, `empty_legacy_creation_confirms_without_synthetic_outbound_work` covers creation with nothing to
+  publish, and `scheduled_group_evolution_waits_for_public_outbound_acknowledgement` proves timer-produced evolution
+  work stays pending until the public acknowledgement arrives.
+- `regenerated_queued_intent_retries_then_retires_through_outbound_acknowledgement` proves a queued application is
+  re-armed after definite failure, regenerated with a fresh artifact, and retired only after transport acceptance.
+- `no_endpoint_outcome_is_rejected_after_recipient_exposure` prevents a caller from claiming definite non-publication
+  after an artifact reached a recipient mailbox;
+  `exposed_welcome_prevents_partial_commit_retraction_and_rollback` applies the same rule to the complete
+  commit/Welcome publication so a failed rollback cannot partially mutate transport state.
 - `failing_generated_case_records_a_minimized_reproducer` checks that a failing generated case records a smaller
   reproducer when removable delivery noise is enough to keep the same failure.
 - `tests/generated_policy_cases.rs` checks that Tamarin-derived branch selector cases match the Rust selector across

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -454,14 +454,20 @@ These tests keep the simulator machinery honest.
 - `outbound_poll_is_non_destructive_and_acknowledgement_is_idempotent` checks exact application artifacts, repeatable
   polling, same-outcome acknowledgement replay, transport delivery, and disappearance after resolution;
   `outbound_poll_preserves_emission_order_past_single_digit_handles` guards deterministic ordering under a burst.
+- `pending_publication_identity_is_scoped_by_client` forces equal per-engine pending counters on two participants and
+  proves one client's acceptance or rollback cannot resolve, suppress, or remove the other's publication.
 - `evolution_commit_acknowledgement_and_welcome_outcome_are_independent` and
   `no_endpoint_commit_outcome_rolls_back_the_complete_unexposed_publication` check that accepted commits advance local
   state independently of Welcome delivery, while definite unexposed commit failure atomically retracts and rolls back
   the complete publication.
+- `accepted_welcome_blocks_later_definite_commit_failure` treats transport acceptance as exposure evidence: it preserves
+  the accepted Welcome outcome and leaves the state-bearing commit acknowledgeable instead of partially rolling back.
 - `legacy_create_confirms_on_first_welcome_acceptance_and_keeps_other_welcomes_independent` checks the temporary legacy
   creation rule, `empty_legacy_creation_confirms_without_synthetic_outbound_work` covers creation with nothing to
   publish, and `scheduled_group_evolution_waits_for_public_outbound_acknowledgement` proves timer-produced evolution
   work stays pending until the public acknowledgement arrives.
+- `legacy_compatible_subject_does_not_advertise_outbound_publication` keeps capability preflight honest while v1 runners
+  remain on their temporary manual publication lifecycle.
 - `regenerated_queued_intent_retries_then_retires_through_outbound_acknowledgement` proves a queued application is
   re-armed after definite failure, regenerated with a fresh artifact, and retired only after transport acceptance.
 - `no_endpoint_outcome_is_rejected_after_recipient_exposure` prevents a caller from claiming definite non-publication

--- a/crates/cgka-conformance-simulator/SCENARIOS.md
+++ b/crates/cgka-conformance-simulator/SCENARIOS.md
@@ -462,12 +462,10 @@ These tests keep the simulator machinery honest.
   the complete publication.
 - `accepted_welcome_blocks_later_definite_commit_failure` treats transport acceptance as exposure evidence: it preserves
   the accepted Welcome outcome and leaves the state-bearing commit acknowledgeable instead of partially rolling back.
-- `legacy_create_confirms_on_first_welcome_acceptance_and_keeps_other_welcomes_independent` checks the temporary legacy
-  creation rule, `empty_legacy_creation_confirms_without_synthetic_outbound_work` covers creation with nothing to
+- `create_confirms_on_first_welcome_acceptance_and_keeps_other_welcomes_independent` checks creation acknowledgement
+  semantics, `empty_creation_confirms_without_synthetic_outbound_work` covers creation with nothing to
   publish, and `scheduled_group_evolution_waits_for_public_outbound_acknowledgement` proves timer-produced evolution
   work stays pending until the public acknowledgement arrives.
-- `legacy_compatible_subject_does_not_advertise_outbound_publication` keeps capability preflight honest while v1 runners
-  remain on their temporary manual publication lifecycle.
 - `regenerated_queued_intent_retries_then_retires_through_outbound_acknowledgement` proves a queued application is
   re-armed after definite failure, regenerated with a fresh artifact, and retired only after transport acceptance.
 - `no_endpoint_outcome_is_rejected_after_recipient_exposure` prevents a caller from claiming definite non-publication

--- a/crates/cgka-conformance-simulator/src/bus.rs
+++ b/crates/cgka-conformance-simulator/src/bus.rs
@@ -49,6 +49,12 @@ struct InFlight {
     msg: TransportMessage,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct OutboundEmission {
+    pub sequence: u64,
+    pub msg: TransportMessage,
+}
+
 #[derive(Clone)]
 pub struct TransportBus {
     inner: Arc<Mutex<Inner>>,
@@ -57,7 +63,13 @@ pub struct TransportBus {
 struct Inner {
     clients: HashMap<ClientId, MemberId>,
     next_client_id: usize,
+    next_outbound_sequence: u64,
     queue: Vec<InFlight>,
+    /// Append-only observation of transport artifacts emitted by each
+    /// participant. This is deliberately separate from the mutable delivery
+    /// queue so a black-box subject can expose publication work without
+    /// leaking queue indices or fault-injection internals.
+    outbound_emissions: HashMap<ClientId, Vec<OutboundEmission>>,
     policy: DeliveryPolicy,
     /// Per-client pre-delivery buffer.
     mailboxes: HashMap<ClientId, Vec<TransportMessage>>,
@@ -81,7 +93,9 @@ impl TransportBus {
             inner: Arc::new(Mutex::new(Inner {
                 clients: HashMap::new(),
                 next_client_id: 0,
+                next_outbound_sequence: 0,
                 queue: Vec::new(),
+                outbound_emissions: HashMap::new(),
                 policy,
                 mailboxes: HashMap::new(),
                 partition_allowed: None,
@@ -103,11 +117,51 @@ impl TransportBus {
         id
     }
 
+    pub(crate) fn capture_outbound_for(&self, sender: ClientId) {
+        self.inner
+            .lock()
+            .unwrap()
+            .outbound_emissions
+            .entry(sender)
+            .or_default();
+    }
+
     /// Send a message into the bus from `sender`. The message becomes
     /// eligible for delivery on the next `step` / `deliver_all`.
     pub fn send(&self, sender: ClientId, msg: TransportMessage) {
         let mut inner = self.inner.lock().unwrap();
+        if inner.outbound_emissions.contains_key(&sender) {
+            let sequence = inner.next_outbound_sequence;
+            inner.next_outbound_sequence = inner
+                .next_outbound_sequence
+                .checked_add(1)
+                .expect("outbound emission sequence exhausted");
+            inner
+                .outbound_emissions
+                .get_mut(&sender)
+                .expect("outbound capture remains enabled")
+                .push(OutboundEmission {
+                    sequence,
+                    msg: msg.clone(),
+                });
+        }
         inner.queue.push(InFlight { sender, msg });
+    }
+
+    pub(crate) fn outbound_since(
+        &self,
+        sender: ClientId,
+        after_sequence: Option<u64>,
+    ) -> Vec<OutboundEmission> {
+        let inner = self.inner.lock().unwrap();
+        inner
+            .outbound_emissions
+            .get(&sender)
+            .into_iter()
+            .flatten()
+            .filter(|emission| after_sequence.is_none_or(|after| emission.sequence > after))
+            .cloned()
+            .collect()
     }
 
     /// Retract every still-undelivered artifact for one pending publication.

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -58,6 +58,7 @@ pub struct HarnessClient {
     protocol_profile: ProtocolProfile,
     convergence_clock: Option<Arc<dyn ConvergenceClock>>,
     virtual_time_tick_enabled: bool,
+    external_publication_lifecycle: bool,
     pending_events: Vec<GroupEvent>,
     /// Default MLS group id used by single-group scenarios. Set
     /// automatically after the first create/join.
@@ -68,6 +69,8 @@ pub struct HarnessClient {
     scenario_input_tracker: ScenarioInputTracker,
     pending_scenario_inputs: HashMap<PendingStateRef, String>,
     pending_publication_artifacts: HashMap<PendingStateRef, Vec<MessageId>>,
+    pending_confirmation_artifacts: HashMap<PendingStateRef, Vec<MessageId>>,
+    regenerated_queued_intents: HashMap<MessageId, (GroupId, MessageId)>,
     /// Shared in-memory capture of the engine's forensic audit events, used to
     /// observe decisions no `GroupEvent` exposes (e.g. `convergence_decision`).
     audit_capture: AuditCapture,
@@ -83,6 +86,7 @@ pub struct ClientBuilder {
     storage_options: SqliteStorageOptions,
     explicit_file_storage: Option<ExplicitFileStorage>,
     convergence_clock: Option<Arc<dyn ConvergenceClock>>,
+    external_publication_lifecycle: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -197,6 +201,7 @@ impl ClientBuilder {
             storage_options: SqliteStorageOptions::default(),
             explicit_file_storage: None,
             convergence_clock: None,
+            external_publication_lifecycle: false,
         }
     }
 
@@ -241,6 +246,11 @@ impl ClientBuilder {
         self
     }
 
+    pub(crate) fn external_publication_lifecycle(mut self) -> Self {
+        self.external_publication_lifecycle = true;
+        self
+    }
+
     pub fn attach(self, bus: &TransportBus) -> HarnessClient {
         let storage_backing = match self.explicit_file_storage {
             Some(explicit) => HarnessStorageBacking::from_explicit(explicit),
@@ -259,6 +269,9 @@ impl ClientBuilder {
             self.convergence_clock.as_ref(),
         );
         let bus_id = bus.attach(MemberId::new(self.identity.clone()));
+        if self.external_publication_lifecycle {
+            bus.capture_outbound_for(bus_id);
+        }
         HarnessClient {
             engine: Some(engine),
             bus_id,
@@ -271,6 +284,7 @@ impl ClientBuilder {
             protocol_profile: self.protocol_profile,
             convergence_clock: self.convergence_clock,
             virtual_time_tick_enabled: false,
+            external_publication_lifecycle: self.external_publication_lifecycle,
             pending_events: Vec::new(),
             default_group: None,
             app_event_counter: 0,
@@ -279,6 +293,8 @@ impl ClientBuilder {
             scenario_input_tracker: ScenarioInputTracker::default(),
             pending_scenario_inputs: HashMap::new(),
             pending_publication_artifacts: HashMap::new(),
+            pending_confirmation_artifacts: HashMap::new(),
+            regenerated_queued_intents: HashMap::new(),
             audit_capture,
             convergence_checkpoints: HashMap::new(),
         }
@@ -451,6 +467,47 @@ impl HarnessClient {
 
     pub(crate) fn enable_virtual_time_tick(&mut self) {
         self.virtual_time_tick_enabled = true;
+    }
+
+    pub(crate) fn pending_publication_for_message(
+        &self,
+        message_id: &MessageId,
+    ) -> Option<PendingStateRef> {
+        self.pending_publication_artifacts
+            .iter()
+            .find_map(|(pending, message_ids)| message_ids.contains(message_id).then_some(*pending))
+    }
+
+    pub(crate) fn message_confirms_pending(
+        &self,
+        pending: PendingStateRef,
+        message_id: &MessageId,
+    ) -> bool {
+        self.pending_confirmation_artifacts
+            .get(&pending)
+            .is_some_and(|message_ids| message_ids.contains(message_id))
+    }
+
+    pub(crate) fn regenerated_queued_intent_for_message(
+        &self,
+        message_id: &MessageId,
+    ) -> Option<(GroupId, MessageId)> {
+        self.regenerated_queued_intents.get(message_id).cloned()
+    }
+
+    pub(crate) fn confirm_regenerated_queued_intent(
+        &mut self,
+        intent_id: &MessageId,
+    ) -> Result<(), EngineError> {
+        self.engine_mut().confirm_queued_outbound_intent(intent_id)
+    }
+
+    pub(crate) fn retry_regenerated_queued_intent(&mut self, group_id: &GroupId) {
+        self.engine_mut().retry_queued_outbound_intent(group_id);
+    }
+
+    pub(crate) fn forget_regenerated_queued_intent(&mut self, message_id: &MessageId) {
+        self.regenerated_queued_intents.remove(message_id);
     }
 
     pub fn restart(&mut self) {
@@ -657,7 +714,7 @@ impl HarnessClient {
                 initial_admins,
             })
             .await?;
-        let (gid, pending, welcomes) = match res {
+        let (gid, mut pending, welcomes) = match res {
             (gid, SendResult::GroupCreated { pending, welcomes }) => (gid, Some(pending), welcomes),
             (gid, SendResult::FoundingGroupCreated { welcomes }) => (gid, None, welcomes),
             (_, other) => {
@@ -671,11 +728,23 @@ impl HarnessClient {
                 pending,
                 welcomes.iter().map(|welcome| welcome.id.clone()),
             );
+            self.remember_pending_confirmation(
+                pending,
+                welcomes.iter().map(|welcome| welcome.id.clone()),
+            );
         }
+        let has_outbound_artifacts = !welcomes.is_empty();
         for w in welcomes {
             self.bus.send(self.bus_id, w);
         }
         self.default_group = Some(gid.clone());
+        if self.external_publication_lifecycle
+            && !has_outbound_artifacts
+            && let Some(noop_pending) = pending
+        {
+            self.try_confirm(noop_pending).await?;
+            pending = None;
+        }
         if pending.is_none() {
             self.capture_engine_events();
         }
@@ -689,9 +758,13 @@ impl HarnessClient {
         self.try_confirm(pending).await.expect("confirm_published");
     }
 
-    async fn try_confirm(&mut self, pending: PendingStateRef) -> Result<(), EngineError> {
+    pub(crate) async fn try_confirm(
+        &mut self,
+        pending: PendingStateRef,
+    ) -> Result<(), EngineError> {
         self.engine_mut().confirm_published(pending).await?;
         self.pending_publication_artifacts.remove(&pending);
+        self.pending_confirmation_artifacts.remove(&pending);
         if let Some(scenario_id) = self.pending_scenario_inputs.remove(&pending) {
             self.scenario_input_tracker.record_confirmed(&scenario_id);
         }
@@ -720,6 +793,7 @@ impl HarnessClient {
             })?;
         self.engine_mut().publish_failed(pending).await?;
         self.pending_publication_artifacts.remove(&pending);
+        self.pending_confirmation_artifacts.remove(&pending);
         if let Some(scenario_id) = self.pending_scenario_inputs.remove(&pending) {
             self.scenario_input_tracker.record_rolled_back(&scenario_id);
         }
@@ -750,6 +824,7 @@ impl HarnessClient {
                         .map(|welcome| welcome.id.clone())
                         .chain(std::iter::once(routed.id.clone())),
                 );
+                self.remember_pending_confirmation(pending, std::iter::once(routed.id.clone()));
                 for w in welcomes {
                     self.bus.send(self.bus_id, w);
                 }
@@ -784,6 +859,7 @@ impl HarnessClient {
                 );
                 let routed = route(msg, &gid);
                 self.remember_pending_publication(pending, std::iter::once(routed.id.clone()));
+                self.remember_pending_confirmation(pending, std::iter::once(routed.id.clone()));
                 self.publish_commit_scenario_input(&routed, pending).await;
                 self.bus.send(self.bus_id, routed);
                 pending
@@ -820,6 +896,7 @@ impl HarnessClient {
                 );
                 let routed = route(msg, &gid);
                 self.remember_pending_publication(pending, std::iter::once(routed.id.clone()));
+                self.remember_pending_confirmation(pending, std::iter::once(routed.id.clone()));
                 self.publish_commit_scenario_input(&routed, pending).await;
                 self.bus.send(self.bus_id, routed);
                 Ok(pending)
@@ -984,6 +1061,7 @@ impl HarnessClient {
                         .map(|welcome| welcome.id.clone())
                         .chain(std::iter::once(routed.id.clone())),
                 );
+                self.remember_pending_confirmation(pending, std::iter::once(routed.id.clone()));
                 for w in welcomes {
                     self.bus.send(self.bus_id, w);
                 }
@@ -1199,11 +1277,18 @@ impl HarnessClient {
             SendResult::ApplicationMessage {
                 msg, app_event_id, ..
             } => {
+                let queued_intent = self
+                    .engine_mut()
+                    .take_regenerated_queued_intent_for_message(&msg.id);
                 let routed = if let Some(gid) = &gid {
                     route(msg, gid)
                 } else {
                     msg
                 };
+                if let Some(queued_intent) = queued_intent {
+                    self.regenerated_queued_intents
+                        .insert(routed.id.clone(), queued_intent);
+                }
                 let scenario_input = self
                     .scenario_input_tracker
                     .metadata_for_logical(&app_event_id)
@@ -1217,11 +1302,18 @@ impl HarnessClient {
                 self.bus.send(self.bus_id, routed);
             }
             SendResult::Proposal { msg } => {
+                let queued_intent = self
+                    .engine_mut()
+                    .take_regenerated_queued_intent_for_message(&msg.id);
                 let routed = if let Some(gid) = &gid {
                     route(msg, gid)
                 } else {
                     msg
                 };
+                if let Some(queued_intent) = queued_intent {
+                    self.regenerated_queued_intents
+                        .insert(routed.id.clone(), queued_intent);
+                }
                 let scenario_input =
                     self.next_scenario_input_metadata(ScenarioInputKind::Proposal, None, None);
                 self.scenario_input_tracker
@@ -1237,25 +1329,46 @@ impl HarnessClient {
                 welcomes,
                 pending,
             } => {
-                for welcome in welcomes {
-                    self.bus.send(self.bus_id, welcome);
-                }
                 let routed = if let Some(gid) = &gid {
                     route(msg, gid)
                 } else {
                     msg
                 };
-                self.publish_commit_scenario_input(&routed, pending).await;
-                self.bus.send(self.bus_id, routed);
-                self.try_confirm(pending).await?;
-                self.capture_engine_events();
-            }
-            SendResult::GroupCreated { welcomes, pending } => {
+                self.remember_pending_publication(
+                    pending,
+                    welcomes
+                        .iter()
+                        .map(|welcome| welcome.id.clone())
+                        .chain(std::iter::once(routed.id.clone())),
+                );
+                self.remember_pending_confirmation(pending, std::iter::once(routed.id.clone()));
                 for welcome in welcomes {
                     self.bus.send(self.bus_id, welcome);
                 }
-                self.engine_mut().confirm_published(pending).await?;
-                self.capture_engine_events();
+                self.publish_commit_scenario_input(&routed, pending).await;
+                self.bus.send(self.bus_id, routed);
+                if !self.external_publication_lifecycle {
+                    self.try_confirm(pending).await?;
+                    self.capture_engine_events();
+                }
+            }
+            SendResult::GroupCreated { welcomes, pending } => {
+                let has_outbound_artifacts = !welcomes.is_empty();
+                self.remember_pending_publication(
+                    pending,
+                    welcomes.iter().map(|welcome| welcome.id.clone()),
+                );
+                self.remember_pending_confirmation(
+                    pending,
+                    welcomes.iter().map(|welcome| welcome.id.clone()),
+                );
+                for welcome in welcomes {
+                    self.bus.send(self.bus_id, welcome);
+                }
+                if !self.external_publication_lifecycle || !has_outbound_artifacts {
+                    self.try_confirm(pending).await?;
+                    self.capture_engine_events();
+                }
             }
             SendResult::FoundingGroupCreated { welcomes } => {
                 for welcome in welcomes {
@@ -1282,7 +1395,12 @@ impl HarnessClient {
             };
             self.publish_commit_scenario_input(&routed, auto.pending)
                 .await;
+            self.remember_pending_publication(auto.pending, std::iter::once(routed.id.clone()));
+            self.remember_pending_confirmation(auto.pending, std::iter::once(routed.id.clone()));
             self.bus.send(self.bus_id, routed);
+            if self.external_publication_lifecycle {
+                continue;
+            }
             if let Err(e) = self.try_confirm(auto.pending).await {
                 // A confirmation error is not evidence that the engine rolled
                 // back the staged state. Keep the mapping pending so the
@@ -1296,11 +1414,18 @@ impl HarnessClient {
         }
         let proposals = self.engine_mut().drain_auto_proposals();
         for msg in proposals {
+            let queued_intent = self
+                .engine_mut()
+                .take_regenerated_queued_intent_for_message(&msg.id);
             let routed = if let Some(gid) = &gid {
                 route(msg, gid)
             } else {
                 msg
             };
+            if let Some(queued_intent) = queued_intent {
+                self.regenerated_queued_intents
+                    .insert(routed.id.clone(), queued_intent);
+            }
             let scenario_input =
                 self.next_scenario_input_metadata(ScenarioInputKind::Proposal, None, None);
             self.scenario_input_tracker
@@ -1505,6 +1630,17 @@ impl HarnessClient {
         message_ids: impl IntoIterator<Item = MessageId>,
     ) {
         self.pending_publication_artifacts
+            .entry(pending)
+            .or_default()
+            .extend(message_ids);
+    }
+
+    fn remember_pending_confirmation(
+        &mut self,
+        pending: PendingStateRef,
+        message_ids: impl IntoIterator<Item = MessageId>,
+    ) {
+        self.pending_confirmation_artifacts
             .entry(pending)
             .or_default()
             .extend(message_ids);

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -58,7 +58,6 @@ pub struct HarnessClient {
     protocol_profile: ProtocolProfile,
     convergence_clock: Option<Arc<dyn ConvergenceClock>>,
     virtual_time_tick_enabled: bool,
-    external_publication_lifecycle: bool,
     pending_events: Vec<GroupEvent>,
     /// Default MLS group id used by single-group scenarios. Set
     /// automatically after the first create/join.
@@ -86,7 +85,6 @@ pub struct ClientBuilder {
     storage_options: SqliteStorageOptions,
     explicit_file_storage: Option<ExplicitFileStorage>,
     convergence_clock: Option<Arc<dyn ConvergenceClock>>,
-    external_publication_lifecycle: bool,
 }
 
 pub(crate) enum HarnessPublicationError {
@@ -225,7 +223,6 @@ impl ClientBuilder {
             storage_options: SqliteStorageOptions::default(),
             explicit_file_storage: None,
             convergence_clock: None,
-            external_publication_lifecycle: false,
         }
     }
 
@@ -270,11 +267,6 @@ impl ClientBuilder {
         self
     }
 
-    pub(crate) fn external_publication_lifecycle(mut self) -> Self {
-        self.external_publication_lifecycle = true;
-        self
-    }
-
     pub fn attach(self, bus: &TransportBus) -> HarnessClient {
         let storage_backing = match self.explicit_file_storage {
             Some(explicit) => HarnessStorageBacking::from_explicit(explicit),
@@ -293,9 +285,7 @@ impl ClientBuilder {
             self.convergence_clock.as_ref(),
         );
         let bus_id = bus.attach(MemberId::new(self.identity.clone()));
-        if self.external_publication_lifecycle {
-            bus.capture_outbound_for(bus_id);
-        }
+        bus.capture_outbound_for(bus_id);
         HarnessClient {
             engine: Some(engine),
             bus_id,
@@ -308,7 +298,6 @@ impl ClientBuilder {
             protocol_profile: self.protocol_profile,
             convergence_clock: self.convergence_clock,
             virtual_time_tick_enabled: false,
-            external_publication_lifecycle: self.external_publication_lifecycle,
             pending_events: Vec::new(),
             default_group: None,
             app_event_counter: 0,
@@ -500,6 +489,21 @@ impl HarnessClient {
         self.pending_publication_artifacts
             .iter()
             .find_map(|(pending, message_ids)| message_ids.contains(message_id).then_some(*pending))
+    }
+
+    /// Pending publication handles currently awaiting a transport outcome.
+    ///
+    /// This is a low-level harness probe for focused engine tests. Portable
+    /// scenarios must drive opaque outbound artifacts through
+    /// `ConvergenceSubject::poll_outbound` and `acknowledge_outbound` instead.
+    pub fn pending_publication_refs(&self) -> Vec<PendingStateRef> {
+        let mut pending = self
+            .pending_publication_artifacts
+            .keys()
+            .copied()
+            .collect::<Vec<_>>();
+        pending.sort_by_key(|pending| pending.as_u64());
+        pending
     }
 
     pub(crate) fn message_confirms_pending(
@@ -738,7 +742,7 @@ impl HarnessClient {
                 initial_admins,
             })
             .await?;
-        let (gid, mut pending, welcomes) = match res {
+        let (gid, pending, welcomes) = match res {
             (gid, SendResult::GroupCreated { pending, welcomes }) => (gid, Some(pending), welcomes),
             (gid, SendResult::FoundingGroupCreated { welcomes }) => (gid, None, welcomes),
             (_, other) => {
@@ -757,18 +761,10 @@ impl HarnessClient {
                 welcomes.iter().map(|welcome| welcome.id.clone()),
             );
         }
-        let has_outbound_artifacts = !welcomes.is_empty();
         for w in welcomes {
             self.bus.send(self.bus_id, w);
         }
         self.default_group = Some(gid.clone());
-        if self.external_publication_lifecycle
-            && !has_outbound_artifacts
-            && let Some(noop_pending) = pending
-        {
-            self.try_confirm(noop_pending).await?;
-            pending = None;
-        }
         if pending.is_none() {
             self.capture_engine_events();
         }
@@ -1162,7 +1158,7 @@ impl HarnessClient {
             self.capture_engine_events();
         }
         self.drive_due_convergence(&mut outcomes).await;
-        outcomes.extend(self.drain_auto_publish_confirm().await);
+        self.drain_auto_publish().await;
         outcomes
     }
 
@@ -1206,9 +1202,7 @@ impl HarnessClient {
         for result in results {
             self.publish_send_result(result).await?;
         }
-        for result in self.drain_auto_publish_confirm().await {
-            result?;
-        }
+        self.drain_auto_publish().await;
         Ok(())
     }
 
@@ -1282,7 +1276,7 @@ impl HarnessClient {
                         outcomes.push(Err(e));
                     }
                 }
-                outcomes.extend(self.drain_auto_publish_confirm().await);
+                self.drain_auto_publish().await;
             }
         }
         outcomes.push(Err(EngineError::Backend(
@@ -1380,10 +1374,6 @@ impl HarnessClient {
                 }
                 self.publish_commit_scenario_input(&routed, pending).await;
                 self.bus.send(self.bus_id, routed);
-                if !self.external_publication_lifecycle {
-                    self.try_confirm(pending).await?;
-                    self.capture_engine_events();
-                }
             }
             SendResult::GroupCreated { welcomes, pending } => {
                 let has_outbound_artifacts = !welcomes.is_empty();
@@ -1398,7 +1388,7 @@ impl HarnessClient {
                 for welcome in welcomes {
                     self.bus.send(self.bus_id, welcome);
                 }
-                if !self.external_publication_lifecycle || !has_outbound_artifacts {
+                if !has_outbound_artifacts {
                     self.try_confirm(pending).await?;
                     self.capture_engine_events();
                 }
@@ -1416,8 +1406,7 @@ impl HarnessClient {
         Ok(())
     }
 
-    async fn drain_auto_publish_confirm(&mut self) -> Vec<Result<IngestOutcome, EngineError>> {
-        let mut outcomes = Vec::new();
+    async fn drain_auto_publish(&mut self) {
         let auto = self.engine_mut().drain_auto_publish();
         let gid = self.default_group.clone();
         for auto in auto {
@@ -1431,19 +1420,6 @@ impl HarnessClient {
             self.remember_pending_publication(auto.pending, std::iter::once(routed.id.clone()));
             self.remember_pending_confirmation(auto.pending, std::iter::once(routed.id.clone()));
             self.bus.send(self.bus_id, routed);
-            if self.external_publication_lifecycle {
-                continue;
-            }
-            if let Err(e) = self.try_confirm(auto.pending).await {
-                // A confirmation error is not evidence that the engine rolled
-                // back the staged state. Keep the mapping pending so the
-                // strict oracle exposes the unresolved publish lifecycle; an
-                // actual rollback is recorded only through publish_failed or
-                // the corresponding engine event.
-                outcomes.push(Err(e));
-                continue;
-            }
-            self.capture_engine_events();
         }
         let proposals = self.engine_mut().drain_auto_proposals();
         for msg in proposals {
@@ -1469,7 +1445,6 @@ impl HarnessClient {
                 .await;
             self.bus.send(self.bus_id, routed);
         }
-        outcomes
     }
 
     pub fn drain_events(&mut self) -> Vec<GroupEvent> {
@@ -1720,7 +1695,7 @@ impl HarnessClient {
 }
 
 impl HarnessClient {
-    fn capture_engine_events(&mut self) {
+    pub(crate) fn capture_engine_events(&mut self) {
         let events = self.engine_mut().drain_events();
         for event in events {
             if let GroupEvent::GroupJoined { group_id, .. } = &event

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -791,6 +791,25 @@ impl HarnessClient {
         Ok(())
     }
 
+    /// Confirm a pending transition only when it produced no transport
+    /// artifacts. Both direct subject actions and engine-generated creation
+    /// results use this helper so the no-op publication rule has one predicate.
+    pub(crate) async fn confirm_empty_publication(
+        &mut self,
+        pending: PendingStateRef,
+    ) -> Result<bool, EngineError> {
+        let artifact_ids = self
+            .pending_publication_artifacts
+            .get(&pending)
+            .ok_or_else(|| EngineError::Other("missing pending publication bookkeeping".into()))?;
+        if !artifact_ids.is_empty() {
+            return Ok(false);
+        }
+        self.try_confirm(pending).await?;
+        self.capture_engine_events();
+        Ok(true)
+    }
+
     /// Report a publish failure for a pending operation. The engine
     /// discards the staged commit and rewinds to `Stable` at the prior
     /// epoch. Used by the rollback proptest property.
@@ -1376,7 +1395,6 @@ impl HarnessClient {
                 self.bus.send(self.bus_id, routed);
             }
             SendResult::GroupCreated { welcomes, pending } => {
-                let has_outbound_artifacts = !welcomes.is_empty();
                 self.remember_pending_publication(
                     pending,
                     welcomes.iter().map(|welcome| welcome.id.clone()),
@@ -1388,10 +1406,7 @@ impl HarnessClient {
                 for welcome in welcomes {
                     self.bus.send(self.bus_id, welcome);
                 }
-                if !has_outbound_artifacts {
-                    self.try_confirm(pending).await?;
-                    self.capture_engine_events();
-                }
+                self.confirm_empty_publication(pending).await?;
             }
             SendResult::FoundingGroupCreated { welcomes } => {
                 for welcome in welcomes {

--- a/crates/cgka-conformance-simulator/src/client.rs
+++ b/crates/cgka-conformance-simulator/src/client.rs
@@ -89,6 +89,30 @@ pub struct ClientBuilder {
     external_publication_lifecycle: bool,
 }
 
+pub(crate) enum HarnessPublicationError {
+    AlreadyExposed { recipient_exposures: usize },
+    Engine(EngineError),
+}
+
+impl From<EngineError> for HarnessPublicationError {
+    fn from(error: EngineError) -> Self {
+        Self::Engine(error)
+    }
+}
+
+impl HarnessPublicationError {
+    fn into_engine_error(self) -> EngineError {
+        match self {
+            Self::AlreadyExposed {
+                recipient_exposures,
+            } => EngineError::Other(format!(
+                "cannot report definite publication failure after {recipient_exposures} matching artifact(s) reached a recipient mailbox"
+            )),
+            Self::Engine(error) => error,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HarnessStorageMode {
     InMemorySqlite,
@@ -779,6 +803,15 @@ impl HarnessClient {
     }
 
     pub async fn try_fail(&mut self, pending: PendingStateRef) -> Result<(), EngineError> {
+        self.try_fail_publication(pending)
+            .await
+            .map_err(HarnessPublicationError::into_engine_error)
+    }
+
+    pub(crate) async fn try_fail_publication(
+        &mut self,
+        pending: PendingStateRef,
+    ) -> Result<(), HarnessPublicationError> {
         let message_ids = self
             .pending_publication_artifacts
             .get(&pending)
@@ -786,11 +819,11 @@ impl HarnessClient {
             .unwrap_or_default();
         self.bus
             .retract_undelivered_publication(self.bus_id, &message_ids)
-            .map_err(|delivered| {
-                EngineError::Other(format!(
-                    "cannot report definite publication failure after {delivered} matching artifact(s) reached a recipient mailbox"
-                ))
-            })?;
+            .map_err(
+                |recipient_exposures| HarnessPublicationError::AlreadyExposed {
+                    recipient_exposures,
+                },
+            )?;
         self.engine_mut().publish_failed(pending).await?;
         self.pending_publication_artifacts.remove(&pending);
         self.pending_confirmation_artifacts.remove(&pending);

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -1330,6 +1330,18 @@ fn add_strict_reliability_oracle(
         return;
     }
 
+    assert!(
+        scenario.steps.iter().any(|step| matches!(
+            step,
+            ScenarioStep::AcknowledgeOutbound {
+                publication: Some(_),
+                ..
+            }
+        )),
+        "generated reliability scenario {} must exercise at least one labelled outbound acknowledgement",
+        scenario.name
+    );
+
     scenario.steps.push(ScenarioStep::DeliverAll);
     scenario.steps.push(ScenarioStep::Tick {
         clients: scenario.clients.clone(),
@@ -1353,4 +1365,30 @@ fn add_strict_reliability_oracle(
     expected.push(TraceExpectation::NoPendingWork {
         clients: exact_clients,
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "must exercise at least one labelled outbound acknowledgement")]
+    fn strict_oracle_rejects_family_without_outbound_lifecycle_coverage() {
+        let mut scenario = ScenarioSpec {
+            name: "missing-outbound-coverage".into(),
+            spec_version: "2".into(),
+            clients: vec!["alice".into()],
+            steps: vec![],
+        };
+        let mut expected = vec![TraceExpectation::ClientState {
+            client: "alice".into(),
+            epoch: 0,
+            member_count: 1,
+            received_payloads: None,
+            added_members: None,
+            removed_members: None,
+        }];
+
+        add_strict_reliability_oracle(&mut scenario, &mut expected);
+    }
 }

--- a/crates/cgka-conformance-simulator/src/family.rs
+++ b/crates/cgka-conformance-simulator/src/family.rs
@@ -4,9 +4,9 @@
 //! to replay or promote a generated case into a fixed vector.
 
 use crate::{
-    GeneratedScenarioMetadata, HarnessStorageMode, ScenarioReport, ScenarioRunError, ScenarioSpec,
-    ScenarioStep, ScenarioTrace, TraceExpectation, VectorFixture,
-    run_scenario_report_with_outcomes_and_storage_mode,
+    GeneratedScenarioMetadata, HarnessStorageMode, ScenarioOutboundSelection, ScenarioReport,
+    ScenarioRunError, ScenarioSpec, ScenarioStep, ScenarioTrace, SubjectOutboundOutcome,
+    TraceExpectation, VectorFixture, run_scenario_report_with_outcomes_and_storage_mode,
 };
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -244,7 +244,7 @@ fn convergence_chaos_case(
 fn convergence_chaos_invite_fork(case_index: u64) -> (ScenarioSpec, Vec<TraceExpectation>) {
     let scenario = ScenarioSpec {
         name: format!("convergence-chaos/v1/case-{case_index}"),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: labels(["alice", "bob", "david", "eve"]),
         steps: vec![
             create_group(
@@ -284,7 +284,7 @@ fn convergence_chaos_invite_fork(case_index: u64) -> (ScenarioSpec, Vec<TraceExp
 fn convergence_chaos_group_data_fork(case_index: u64) -> (ScenarioSpec, Vec<TraceExpectation>) {
     let scenario = ScenarioSpec {
         name: format!("convergence-chaos/v1/case-{case_index}"),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: labels(["alice", "bob"]),
         steps: vec![
             create_group(
@@ -361,10 +361,7 @@ fn convergence_chaos_rollback_queue_faults(
             name: format!("rolled back {case_index}"),
             pending: "update".into(),
         },
-        ScenarioStep::FailPending {
-            client: "alice".into(),
-            pending: "update".into(),
-        },
+        acknowledged_step("alice", "update", SubjectOutboundOutcome::ReachedNoEndpoint),
     ];
     for payload in &payloads {
         steps.push(ScenarioStep::SendAppMessage {
@@ -393,7 +390,7 @@ fn convergence_chaos_rollback_queue_faults(
 
     let scenario = ScenarioSpec {
         name: format!("convergence-chaos/v1/case-{case_index}"),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: labels(["alice", "bob"]),
         steps,
     };
@@ -412,7 +409,7 @@ fn convergence_chaos_stable_queue_faults(case_index: u64) -> (ScenarioSpec, Vec<
     let carol_payload = format!("carol-second-{case_index}");
     let scenario = ScenarioSpec {
         name: format!("convergence-chaos/v1/case-{case_index}"),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: labels(["alice", "bob", "carol"]),
         steps: vec![
             create_group(
@@ -460,7 +457,7 @@ fn convergence_chaos_partition_leave(case_index: u64) -> (ScenarioSpec, Vec<Trac
     let visible_payload = format!("bob-visible-{case_index}");
     let scenario = ScenarioSpec {
         name: format!("convergence-chaos/v1/case-{case_index}"),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: labels(["alice", "bob"]),
         steps: vec![
             create_group(
@@ -494,6 +491,7 @@ fn convergence_chaos_partition_leave(case_index: u64) -> (ScenarioSpec, Vec<Trac
             },
             ScenarioStep::DeliverAll,
             tick(["alice"]),
+            accept_all_outbound("alice"),
             ScenarioStep::DeliverAll,
             tick(["bob"]),
             observe(["alice"]),
@@ -519,7 +517,7 @@ fn convergence_chaos_delayed_past_epoch_app(
     let payload = format!("epoch-one-delayed-{case_index}");
     let scenario = ScenarioSpec {
         name: format!("convergence-chaos/v1/case-{case_index}"),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: labels(["alice", "bob", "carol", "david"]),
         steps: vec![
             create_group(
@@ -603,7 +601,7 @@ fn convergence_chaos_large_message_storm(
 
     let scenario = ScenarioSpec {
         name: format!("convergence-chaos/v1/case-{case_index}"),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients,
         steps,
     };
@@ -656,7 +654,7 @@ fn convergence_chaos_large_partitioned_storm(
 
     let scenario = ScenarioSpec {
         name: format!("convergence-chaos/v1/case-{case_index}"),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients,
         steps,
     };
@@ -688,10 +686,7 @@ fn convergence_chaos_large_commit_storm(
         });
     }
     for committer in &committers {
-        steps.push(ScenarioStep::ConfirmPending {
-            client: committer.clone(),
-            pending: format!("{committer}-update"),
-        });
+        steps.push(confirmed_step(committer, &format!("{committer}-update")));
     }
     // Vary which queued commit is duplicated and how the queue is reordered
     // from the seed. Convergence and per-committer confirmation are invariant
@@ -709,7 +704,7 @@ fn convergence_chaos_large_commit_storm(
 
     let scenario = ScenarioSpec {
         name: format!("convergence-chaos/v1/case-{case_index}"),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients,
         steps,
     };
@@ -765,10 +760,10 @@ fn convergence_chaos_large_mixed_message_commit_storm(
         });
     }
     for committer in &committers {
-        steps.push(ScenarioStep::ConfirmPending {
-            client: committer.clone(),
-            pending: format!("{committer}-mixed-update"),
-        });
+        steps.push(confirmed_step(
+            committer,
+            &format!("{committer}-mixed-update"),
+        ));
     }
     // Vary the commit-storm duplicate target and reorder from the seed.
     // Convergence and per-committer confirmation are schedule-invariant.
@@ -784,7 +779,7 @@ fn convergence_chaos_large_mixed_message_commit_storm(
 
     let scenario = ScenarioSpec {
         name: format!("convergence-chaos/v1/case-{case_index}"),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients,
         steps,
     };
@@ -808,7 +803,7 @@ fn convergence_chaos_restart_delivery_faults(
     let payload = format!("bob:restart-delivery:{case_index}");
     let scenario = ScenarioSpec {
         name: format!("convergence-chaos/v1/case-{case_index}"),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: labels(["alice", "bob", "carol"]),
         steps: vec![
             create_group(
@@ -917,9 +912,28 @@ fn invite<const N: usize>(inviter: &str, invitees: [&str; N], pending: &str) -> 
 }
 
 fn confirmed_step(client: &str, pending: &str) -> ScenarioStep {
-    ScenarioStep::ConfirmPending {
+    acknowledged_step(client, pending, SubjectOutboundOutcome::Accepted)
+}
+
+fn acknowledged_step(
+    client: &str,
+    publication: &str,
+    outcome: SubjectOutboundOutcome,
+) -> ScenarioStep {
+    ScenarioStep::AcknowledgeOutbound {
         client: client.into(),
-        pending: pending.into(),
+        publication: Some(publication.into()),
+        selection: ScenarioOutboundSelection::All,
+        outcome,
+    }
+}
+
+fn accept_all_outbound(client: &str) -> ScenarioStep {
+    ScenarioStep::AcknowledgeOutbound {
+        client: client.into(),
+        publication: None,
+        selection: ScenarioOutboundSelection::All,
+        outcome: SubjectOutboundOutcome::Accepted,
     }
 }
 
@@ -1103,7 +1117,7 @@ fn convergence_e2e_delivery_case(rng: &mut StdRng, case_index: u64) -> ScenarioS
 
     ScenarioSpec {
         name: format!("convergence-e2e-delivery/v1/case-{case_index}"),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients,
         steps,
     }
@@ -1119,10 +1133,7 @@ fn convergence_e2e_prefix_steps(case_index: u64) -> Vec<ScenarioStep> {
             initial_admins: None,
             pending: "create".into(),
         },
-        ScenarioStep::ConfirmPending {
-            client: "alice".into(),
-            pending: "create".into(),
-        },
+        confirmed_step("alice", "create"),
         ScenarioStep::DeliverAll,
         ScenarioStep::Tick {
             clients: vec!["bob".into(), "carol".into(), "frank".into()],
@@ -1135,28 +1146,19 @@ fn convergence_e2e_prefix_steps(case_index: u64) -> Vec<ScenarioStep> {
             invitees: vec!["david".into()],
             pending: "alice-invite-david".into(),
         },
-        ScenarioStep::ConfirmPending {
-            client: "alice".into(),
-            pending: "alice-invite-david".into(),
-        },
+        confirmed_step("alice", "alice-invite-david"),
         ScenarioStep::InviteMembers {
             inviter: "alice".into(),
             invitees: vec!["grace".into()],
             pending: "alice-invite-grace".into(),
         },
-        ScenarioStep::ConfirmPending {
-            client: "alice".into(),
-            pending: "alice-invite-grace".into(),
-        },
+        confirmed_step("alice", "alice-invite-grace"),
         ScenarioStep::InviteMembers {
             inviter: "bob".into(),
             invitees: vec!["eve".into()],
             pending: "bob-invite-eve".into(),
         },
-        ScenarioStep::ConfirmPending {
-            client: "bob".into(),
-            pending: "bob-invite-eve".into(),
-        },
+        confirmed_step("bob", "bob-invite-eve"),
         ScenarioStep::SendAppMessage {
             sender: "alice".into(),
             payload: "alice canonical payload".into(),
@@ -1210,10 +1212,7 @@ fn send_leave_case(rng: &mut StdRng, case_index: u64) -> (ScenarioSpec, Vec<Trac
             initial_admins: None,
             pending: "create".into(),
         },
-        ScenarioStep::ConfirmPending {
-            client: "alice".into(),
-            pending: "create".into(),
-        },
+        confirmed_step("alice", "create"),
         ScenarioStep::DeliverAll,
         ScenarioStep::Tick {
             clients: vec!["bob".into(), "carol".into()],
@@ -1258,6 +1257,7 @@ fn send_leave_case(rng: &mut StdRng, case_index: u64) -> (ScenarioSpec, Vec<Trac
         steps.push(ScenarioStep::Tick {
             clients: vec!["alice".into()],
         });
+        steps.push(accept_all_outbound("alice"));
         steps.push(ScenarioStep::DeliverAll);
         steps.push(ScenarioStep::Tick {
             clients: clients.clone(),
@@ -1294,7 +1294,7 @@ fn send_leave_case(rng: &mut StdRng, case_index: u64) -> (ScenarioSpec, Vec<Trac
     (
         ScenarioSpec {
             name: format!("send-leave/v1/case-{case_index}"),
-            spec_version: "1".into(),
+            spec_version: "2".into(),
             clients,
             steps,
         },
@@ -1329,6 +1329,9 @@ fn add_strict_reliability_oracle(
     scenario.steps.push(ScenarioStep::Tick {
         clients: scenario.clients.clone(),
     });
+    for client in &scenario.clients {
+        scenario.steps.push(accept_all_outbound(client));
+    }
     scenario.steps.push(ScenarioStep::DeliverAll);
     scenario.steps.push(ScenarioStep::Tick {
         clients: scenario.clients.clone(),

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -65,9 +65,9 @@ pub use report::{
 };
 pub use scenario::{
     AppInvalidationReportObservation, EpochChangeReportObservation, GeneratedScenarioMetadata,
-    InvariantFailure, ScenarioReport, ScenarioReportMetadata, ScenarioRunError, ScenarioSpec,
-    ScenarioStep, ScenarioStepLogEntry, ScenarioStepStatus, VectorFixtureMetadata,
-    run_scenario_report, run_scenario_report_with_outcomes,
+    InvariantFailure, ScenarioOutboundSelection, ScenarioReport, ScenarioReportMetadata,
+    ScenarioRunError, ScenarioSpec, ScenarioStep, ScenarioStepLogEntry, ScenarioStepStatus,
+    VectorFixtureMetadata, run_scenario_report, run_scenario_report_with_outcomes,
     run_scenario_report_with_outcomes_and_storage_mode, run_scenario_report_with_storage_mode,
     run_scenario_report_with_subject, run_scenario_spec, run_scenario_spec_with_subject,
     run_vector_fixture_report, run_vector_fixture_report_with_storage_mode,

--- a/crates/cgka-conformance-simulator/src/lib.rs
+++ b/crates/cgka-conformance-simulator/src/lib.rs
@@ -79,7 +79,8 @@ pub use scenario_input_ledger::{
 pub use subject::{
     ConvergenceFaultSubject, ConvergenceSubject, EngineHarnessSubject, SubjectCapability,
     SubjectCreateGroup, SubjectDescriptor, SubjectError, SubjectInviteMembers,
-    SubjectSendApplication, SubjectUpdateAdminPolicy, SubjectUpdateGroupData, required_capability,
+    SubjectOutboundArtifact, SubjectOutboundKind, SubjectOutboundOutcome, SubjectSendApplication,
+    SubjectUpdateAdminPolicy, SubjectUpdateGroupData, required_capability,
 };
 pub use vector::{
     AppInvalidationObservation, ApplicationProfileContract, ClientEventCounts, ClientObservation,

--- a/crates/cgka-conformance-simulator/src/oracle.rs
+++ b/crates/cgka-conformance-simulator/src/oracle.rs
@@ -283,11 +283,13 @@ pub fn scenario_stimuli(spec: &ScenarioSpec) -> Vec<ScenarioStimulus> {
             ScenarioStep::ExpectUpdateAdminPolicyError { .. } => {
                 stimuli.insert(ScenarioStimulus::AdminPolicyUpdate);
             }
-            ScenarioStep::ConfirmPending { .. } => {
-                stimuli.insert(ScenarioStimulus::PublishConfirm);
-            }
-            ScenarioStep::FailPending { .. } => {
-                stimuli.insert(ScenarioStimulus::PublishFail);
+            ScenarioStep::AcknowledgeOutbound { outcome, .. } => {
+                stimuli.insert(match outcome {
+                    crate::SubjectOutboundOutcome::Accepted => ScenarioStimulus::PublishConfirm,
+                    crate::SubjectOutboundOutcome::ReachedNoEndpoint => {
+                        ScenarioStimulus::PublishFail
+                    }
+                });
             }
             ScenarioStep::SendAppMessage { .. } => {
                 stimuli.insert(ScenarioStimulus::AppMessage);

--- a/crates/cgka-conformance-simulator/src/report.rs
+++ b/crates/cgka-conformance-simulator/src/report.rs
@@ -426,7 +426,7 @@ mod tests {
         ScenarioReport {
             metadata: ScenarioReportMetadata {
                 scenario_name: "oracle-summary-test".into(),
-                spec_version: "1".into(),
+                spec_version: "2".into(),
                 step_count: 0,
                 storage_backend: "in-memory-sqlite".into(),
                 subject: None,
@@ -435,7 +435,7 @@ mod tests {
             },
             scenario: ScenarioSpec {
                 name: "oracle-summary-test".into(),
-                spec_version: "1".into(),
+                spec_version: "2".into(),
                 clients: Vec::new(),
                 steps: Vec::new(),
             },

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -298,9 +298,12 @@ pub async fn run_scenario_report_with_storage_mode(
     expected_trace: Option<ScenarioTrace>,
     storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    let mut subject =
-        EngineHarnessSubject::new(&spec.clients, ProtocolProfile::Legacy, storage_mode)
-            .map_err(subject_setup_error)?;
+    let mut subject = EngineHarnessSubject::new_legacy_compatible(
+        &spec.clients,
+        ProtocolProfile::Legacy,
+        storage_mode,
+    )
+    .map_err(subject_setup_error)?;
     run_scenario_report_inner(spec, expected_trace, vec![], None, &mut subject).await
 }
 
@@ -324,9 +327,12 @@ pub async fn run_scenario_report_with_outcomes_and_storage_mode(
     expected_outcomes: Vec<TraceExpectation>,
     storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    let mut subject =
-        EngineHarnessSubject::new(&spec.clients, ProtocolProfile::Legacy, storage_mode)
-            .map_err(subject_setup_error)?;
+    let mut subject = EngineHarnessSubject::new_legacy_compatible(
+        &spec.clients,
+        ProtocolProfile::Legacy,
+        storage_mode,
+    )
+    .map_err(subject_setup_error)?;
     run_scenario_report_inner(spec, expected_trace, expected_outcomes, None, &mut subject).await
 }
 
@@ -366,9 +372,12 @@ pub async fn run_vector_fixture_report_with_storage_mode(
             });
         }
     };
-    let mut subject =
-        EngineHarnessSubject::new(&fixture.scenario.clients, protocol_profile, storage_mode)
-            .map_err(subject_setup_error)?;
+    let mut subject = EngineHarnessSubject::new_legacy_compatible(
+        &fixture.scenario.clients,
+        protocol_profile,
+        storage_mode,
+    )
+    .map_err(subject_setup_error)?;
     run_scenario_report_inner(
         &fixture.scenario,
         fixture.expected_trace.clone(),

--- a/crates/cgka-conformance-simulator/src/scenario.rs
+++ b/crates/cgka-conformance-simulator/src/scenario.rs
@@ -1,6 +1,6 @@
 //! Serializable scripted scenarios for the harness.
 //!
-//! `ScenarioSpec` is the v1 input-side companion to `ScenarioTrace`: external
+//! `ScenarioSpec` is the v2 input-side companion to `ScenarioTrace`: external
 //! implementations can drive the same logical client operations, then compare
 //! their observed trace to exact or semantic fixture expectations.
 
@@ -8,9 +8,9 @@ use crate::{
     ConvergenceFaultSubject, ConvergenceSubject, EngineHarnessSubject, ExpectationFailure,
     HarnessStorageMode, PendingResolutionObservation, ScenarioErrorObservation,
     ScenarioOracleReport, ScenarioTrace, SubjectCreateGroup, SubjectDescriptor, SubjectError,
-    SubjectInviteMembers, SubjectSendApplication, SubjectUpdateAdminPolicy, SubjectUpdateGroupData,
-    TraceExpectation, VectorFixture, build_scenario_oracle_report, compare_trace_expectations,
-    required_capability,
+    SubjectInviteMembers, SubjectOutboundArtifact, SubjectOutboundKind, SubjectOutboundOutcome,
+    SubjectSendApplication, SubjectUpdateAdminPolicy, SubjectUpdateGroupData, TraceExpectation,
+    VectorFixture, build_scenario_oracle_report, compare_trace_expectations, required_capability,
 };
 use cgka_traits::group::ProtocolProfile;
 use serde::{Deserialize, Serialize};
@@ -23,6 +23,29 @@ pub struct ScenarioSpec {
     pub spec_version: String,
     pub clients: Vec<String>,
     pub steps: Vec<ScenarioStep>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScenarioOutboundSelection {
+    #[default]
+    All,
+    StateConfirmation,
+    Welcome,
+    GroupMessage,
+    RegeneratedQueuedIntent,
+}
+
+impl ScenarioOutboundSelection {
+    fn matches(self, artifact: &SubjectOutboundArtifact) -> bool {
+        match self {
+            Self::All => true,
+            Self::StateConfirmation => artifact.state_confirmation_required,
+            Self::Welcome => artifact.kind == SubjectOutboundKind::Welcome,
+            Self::GroupMessage => artifact.kind == SubjectOutboundKind::GroupMessage,
+            Self::RegeneratedQueuedIntent => artifact.regenerated_queued_intent,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -58,13 +81,13 @@ pub enum ScenarioStep {
         admins: Vec<String>,
         error: String,
     },
-    ConfirmPending {
+    AcknowledgeOutbound {
         client: String,
-        pending: String,
-    },
-    FailPending {
-        client: String,
-        pending: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        publication: Option<String>,
+        #[serde(default)]
+        selection: ScenarioOutboundSelection,
+        outcome: SubjectOutboundOutcome,
     },
     SendAppMessage {
         sender: String,
@@ -127,6 +150,24 @@ pub enum ScenarioStep {
 }
 
 impl ScenarioStep {
+    pub fn accept_publication(client: impl Into<String>, publication: impl Into<String>) -> Self {
+        Self::AcknowledgeOutbound {
+            client: client.into(),
+            publication: Some(publication.into()),
+            selection: ScenarioOutboundSelection::All,
+            outcome: SubjectOutboundOutcome::Accepted,
+        }
+    }
+
+    pub fn fail_publication(client: impl Into<String>, publication: impl Into<String>) -> Self {
+        Self::AcknowledgeOutbound {
+            client: client.into(),
+            publication: Some(publication.into()),
+            selection: ScenarioOutboundSelection::All,
+            outcome: SubjectOutboundOutcome::ReachedNoEndpoint,
+        }
+    }
+
     pub fn kind(&self) -> &'static str {
         match self {
             ScenarioStep::CreateGroup { .. } => "create_group",
@@ -134,8 +175,7 @@ impl ScenarioStep {
             ScenarioStep::UpdateGroupData { .. } => "update_group_data",
             ScenarioStep::UpdateAdminPolicy { .. } => "update_admin_policy",
             ScenarioStep::ExpectUpdateAdminPolicyError { .. } => "expect_update_admin_policy_error",
-            ScenarioStep::ConfirmPending { .. } => "confirm_pending",
-            ScenarioStep::FailPending { .. } => "fail_pending",
+            ScenarioStep::AcknowledgeOutbound { .. } => "acknowledge_outbound",
             ScenarioStep::SendAppMessage { .. } => "send_app_message",
             ScenarioStep::Leave { .. } => "leave",
             ScenarioStep::DeliverAll => "deliver_all",
@@ -274,7 +314,7 @@ pub async fn run_scenario_spec(spec: &ScenarioSpec) -> Result<ScenarioTrace, Sce
         .expect("successful report always includes an observed trace"))
 }
 
-/// Run ScenarioSpec v1 through an explicitly supplied convergence subject.
+/// Run ScenarioSpec v2 through an explicitly supplied convergence subject.
 pub async fn run_scenario_spec_with_subject(
     spec: &ScenarioSpec,
     subject: &mut dyn ConvergenceSubject,
@@ -298,12 +338,9 @@ pub async fn run_scenario_report_with_storage_mode(
     expected_trace: Option<ScenarioTrace>,
     storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    let mut subject = EngineHarnessSubject::new_legacy_compatible(
-        &spec.clients,
-        ProtocolProfile::Legacy,
-        storage_mode,
-    )
-    .map_err(subject_setup_error)?;
+    let mut subject =
+        EngineHarnessSubject::new(&spec.clients, ProtocolProfile::Legacy, storage_mode)
+            .map_err(subject_setup_error)?;
     run_scenario_report_inner(spec, expected_trace, vec![], None, &mut subject).await
 }
 
@@ -327,12 +364,9 @@ pub async fn run_scenario_report_with_outcomes_and_storage_mode(
     expected_outcomes: Vec<TraceExpectation>,
     storage_mode: HarnessStorageMode,
 ) -> Result<ScenarioReport, ScenarioRunError> {
-    let mut subject = EngineHarnessSubject::new_legacy_compatible(
-        &spec.clients,
-        ProtocolProfile::Legacy,
-        storage_mode,
-    )
-    .map_err(subject_setup_error)?;
+    let mut subject =
+        EngineHarnessSubject::new(&spec.clients, ProtocolProfile::Legacy, storage_mode)
+            .map_err(subject_setup_error)?;
     run_scenario_report_inner(spec, expected_trace, expected_outcomes, None, &mut subject).await
 }
 
@@ -372,12 +406,9 @@ pub async fn run_vector_fixture_report_with_storage_mode(
             });
         }
     };
-    let mut subject = EngineHarnessSubject::new_legacy_compatible(
-        &fixture.scenario.clients,
-        protocol_profile,
-        storage_mode,
-    )
-    .map_err(subject_setup_error)?;
+    let mut subject =
+        EngineHarnessSubject::new(&fixture.scenario.clients, protocol_profile, storage_mode)
+            .map_err(subject_setup_error)?;
     run_scenario_report_inner(
         &fixture.scenario,
         fixture.expected_trace.clone(),
@@ -525,31 +556,49 @@ async fn run_scenario_report_inner(
                     }
                 }
             }
-            ScenarioStep::ConfirmPending { client, pending } => {
+            ScenarioStep::AcknowledgeOutbound {
+                client,
+                publication,
+                selection,
+                outcome,
+            } => {
                 let client_label = client.clone();
-                subject
-                    .confirm_pending(client, pending)
-                    .await
-                    .map_err(|error| subject_step_error(step_index, error))?;
-                pending_resolutions.push(PendingResolutionObservation {
-                    step_index,
-                    client: client_label,
-                    pending: pending.clone(),
-                    resolution: "confirmed".into(),
-                });
-            }
-            ScenarioStep::FailPending { client, pending } => {
-                let client_label = client.clone();
-                subject
-                    .fail_pending(client, pending)
-                    .await
-                    .map_err(|error| subject_step_error(step_index, error))?;
-                pending_resolutions.push(PendingResolutionObservation {
-                    step_index,
-                    client: client_label,
-                    pending: pending.clone(),
-                    resolution: "rolled_back".into(),
-                });
+                let artifacts = subject
+                    .poll_outbound(client)
+                    .map_err(|error| subject_step_error(step_index, error))?
+                    .into_iter()
+                    .filter(|artifact| {
+                        publication.as_ref().is_none_or(|publication| {
+                            artifact.publication.as_ref() == Some(publication)
+                        }) && selection.matches(artifact)
+                    })
+                    .collect::<Vec<_>>();
+                if artifacts.is_empty() && publication.is_some() {
+                    return Err(err(
+                        step_index,
+                        format!(
+                            "no unresolved outbound artifacts matched client {client}, publication {publication:?}, selection {selection:?}"
+                        ),
+                    ));
+                }
+                for artifact in artifacts {
+                    subject
+                        .acknowledge_outbound(client, &artifact.outbound_id, *outcome)
+                        .await
+                        .map_err(|error| subject_step_error(step_index, error))?;
+                }
+                if let Some(publication) = publication {
+                    pending_resolutions.push(PendingResolutionObservation {
+                        step_index,
+                        client: client_label,
+                        pending: publication.clone(),
+                        resolution: match outcome {
+                            SubjectOutboundOutcome::Accepted => "confirmed",
+                            SubjectOutboundOutcome::ReachedNoEndpoint => "rolled_back",
+                        }
+                        .into(),
+                    });
+                }
             }
             ScenarioStep::SendAppMessage { sender, payload } => {
                 subject
@@ -748,7 +797,7 @@ pub fn validate_scenario_for_subject(
     spec: &ScenarioSpec,
     descriptor: &SubjectDescriptor,
 ) -> Result<(), ScenarioRunError> {
-    if spec.spec_version != "1" {
+    if spec.spec_version != "2" {
         return Err(ScenarioRunError {
             step_index: None,
             message: format!("unsupported ScenarioSpec version {}", spec.spec_version),
@@ -882,7 +931,7 @@ mod tests {
     fn fallback_initial_admins_include_future_admin_policy_actors() {
         let spec = ScenarioSpec {
             name: "admin policy fallback".to_owned(),
-            spec_version: "1".to_owned(),
+            spec_version: "2".to_owned(),
             clients: vec!["alice".to_owned(), "bob".to_owned(), "carol".to_owned()],
             steps: vec![
                 ScenarioStep::CreateGroup {
@@ -911,7 +960,7 @@ mod tests {
     async fn unsupported_capability_is_rejected_before_subject_action() {
         let spec = ScenarioSpec {
             name: "unsupported-subject-capability/v1".to_owned(),
-            spec_version: "1".to_owned(),
+            spec_version: "2".to_owned(),
             clients: vec!["alice".to_owned()],
             steps: vec![
                 ScenarioStep::SendAppMessage {
@@ -947,7 +996,7 @@ mod tests {
     async fn virtual_time_is_capability_gated_serializable_and_dispatched() {
         let spec = ScenarioSpec {
             name: "subject-virtual-time/v1".to_owned(),
-            spec_version: "1".to_owned(),
+            spec_version: "2".to_owned(),
             clients: vec!["alice".to_owned(), "bob".to_owned()],
             steps: vec![ScenarioStep::AdvanceTime { delta_ms: 750 }],
         };
@@ -993,11 +1042,33 @@ mod tests {
         assert!(capability.is_white_box());
     }
 
-    #[tokio::test]
-    async fn explicit_engine_subject_preserves_default_runner_trace() {
+    #[test]
+    fn scenario_spec_v1_is_rejected_after_clean_v2_cutover() {
         let spec = ScenarioSpec {
-            name: "subject-boundary-smoke/v1".to_owned(),
+            name: "removed-v1".to_owned(),
             spec_version: "1".to_owned(),
+            clients: vec!["alice".to_owned()],
+            steps: Vec::new(),
+        };
+        let descriptor = SubjectDescriptor {
+            adapter: "recording-subject".to_owned(),
+            adapter_version: "1".to_owned(),
+            storage_backend: "none".to_owned(),
+            capabilities: BTreeSet::new(),
+        };
+
+        let error = validate_scenario_for_subject(&spec, &descriptor)
+            .expect_err("ScenarioSpec v1 must not retain a runtime compatibility path");
+
+        assert_eq!(error.step_index, None);
+        assert!(error.message.contains("unsupported ScenarioSpec version 1"));
+    }
+
+    #[tokio::test]
+    async fn default_and_explicit_engine_subjects_share_outbound_lifecycle() {
+        let spec = ScenarioSpec {
+            name: "subject-boundary-smoke/v2".to_owned(),
+            spec_version: "2".to_owned(),
             clients: vec!["alice".to_owned(), "bob".to_owned()],
             steps: vec![
                 ScenarioStep::CreateGroup {
@@ -1008,10 +1079,7 @@ mod tests {
                     initial_admins: None,
                     pending: "create".to_owned(),
                 },
-                ScenarioStep::ConfirmPending {
-                    client: "alice".to_owned(),
-                    pending: "create".to_owned(),
-                },
+                ScenarioStep::accept_publication("alice".to_owned(), "create".to_owned()),
                 ScenarioStep::DeliverAll,
                 ScenarioStep::Tick {
                     clients: vec!["bob".to_owned()],

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -19,7 +19,8 @@ use cgka_traits::capabilities::{Capability, CapabilityRequirement, Feature, Requ
 use cgka_traits::engine::KeyPackage;
 use cgka_traits::engine_state::PendingStateRef;
 use cgka_traits::group::ProtocolProfile;
-use cgka_traits::types::MemberId;
+use cgka_traits::transport::{TransportEnvelope, TransportMessage};
+use cgka_traits::types::{GroupId, MemberId, MessageId};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
@@ -39,6 +40,7 @@ pub enum SubjectCapability {
     AdminPolicyObservation,
     CrashReopen,
     VirtualTime,
+    OutboundPublication,
     WhiteBoxTransportQueueFaults,
     WhiteBoxTransportPartition,
     WhiteBoxStorageFaults,
@@ -57,6 +59,7 @@ impl SubjectCapability {
             Self::AdminPolicyObservation => "admin_policy_observation",
             Self::CrashReopen => "crash_reopen",
             Self::VirtualTime => "virtual_time",
+            Self::OutboundPublication => "outbound_publication",
             Self::WhiteBoxTransportQueueFaults => "white_box_transport_queue_faults",
             Self::WhiteBoxTransportPartition => "white_box_transport_partition",
             Self::WhiteBoxStorageFaults => "white_box_storage_faults",
@@ -164,6 +167,36 @@ pub struct SubjectSendApplication<'a> {
     pub payload: &'a str,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubjectOutboundKind {
+    GroupMessage,
+    Welcome,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubjectOutboundOutcome {
+    Accepted,
+    ReachedNoEndpoint,
+}
+
+/// One transport-ready artifact emitted by a subject participant.
+///
+/// `outbound_id` is an adapter-owned opaque acknowledgement handle. The
+/// transport message is intentionally preserved as a cross-boundary value so
+/// retained-relay and process adapters can publish the exact bytes without
+/// gaining access to engine or harness storage.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubjectOutboundArtifact {
+    pub outbound_id: String,
+    pub client: String,
+    pub kind: SubjectOutboundKind,
+    pub message: TransportMessage,
+    pub state_confirmation_required: bool,
+    pub regenerated_queued_intent: bool,
+}
+
 /// Normal convergence operations available to a scenario executor.
 ///
 /// Default methods fail closed. A partial adapter can therefore declare only
@@ -240,6 +273,26 @@ pub trait ConvergenceSubject: Send {
     /// the elapsed deadline.
     async fn advance_time(&mut self, _delta_ms: u64) -> Result<(), SubjectError> {
         Err(SubjectError::unsupported(SubjectCapability::VirtualTime))
+    }
+
+    fn poll_outbound(
+        &mut self,
+        _client: &str,
+    ) -> Result<Vec<SubjectOutboundArtifact>, SubjectError> {
+        Err(SubjectError::unsupported(
+            SubjectCapability::OutboundPublication,
+        ))
+    }
+
+    async fn acknowledge_outbound(
+        &mut self,
+        _client: &str,
+        _outbound_id: &str,
+        _outcome: SubjectOutboundOutcome,
+    ) -> Result<(), SubjectError> {
+        Err(SubjectError::unsupported(
+            SubjectCapability::OutboundPublication,
+        ))
     }
 
     fn observe(&mut self, _clients: &[String]) -> Result<Vec<ClientObservation>, SubjectError> {
@@ -346,6 +399,17 @@ pub struct EngineHarnessSubject {
     clients: BTreeMap<String, HarnessClient>,
     pending_refs: HashMap<String, PendingStateRef>,
     convergence_clock: ManualConvergenceClock,
+    outbound_cursors: HashMap<String, u64>,
+    outbound_records: BTreeMap<String, EngineSubjectOutboundRecord>,
+}
+
+#[derive(Clone)]
+struct EngineSubjectOutboundRecord {
+    sequence: u64,
+    artifact: SubjectOutboundArtifact,
+    pending: Option<PendingStateRef>,
+    queued_intent: Option<(GroupId, MessageId)>,
+    resolution: Option<SubjectOutboundOutcome>,
 }
 
 impl EngineHarnessSubject {
@@ -353,6 +417,23 @@ impl EngineHarnessSubject {
         clients: &[String],
         protocol_profile: ProtocolProfile,
         storage_mode: HarnessStorageMode,
+    ) -> Result<Self, SubjectError> {
+        Self::new_with_publication_lifecycle(clients, protocol_profile, storage_mode, true)
+    }
+
+    pub(crate) fn new_legacy_compatible(
+        clients: &[String],
+        protocol_profile: ProtocolProfile,
+        storage_mode: HarnessStorageMode,
+    ) -> Result<Self, SubjectError> {
+        Self::new_with_publication_lifecycle(clients, protocol_profile, storage_mode, false)
+    }
+
+    fn new_with_publication_lifecycle(
+        clients: &[String],
+        protocol_profile: ProtocolProfile,
+        storage_mode: HarnessStorageMode,
+        external_publication_lifecycle: bool,
     ) -> Result<Self, SubjectError> {
         let bus = TransportBus::ordered();
         let convergence_clock = ManualConvergenceClock::new(0, 0);
@@ -364,12 +445,15 @@ impl EngineHarnessSubject {
                     format!("duplicate client label {label}"),
                 ));
             }
-            let client = ClientBuilder::new(pad32(label.as_bytes()))
+            let mut builder = ClientBuilder::new(pad32(label.as_bytes()))
                 .registry(scenario_registry())
                 .protocol_profile(protocol_profile)
                 .storage_mode(storage_mode)
-                .convergence_clock(Arc::new(convergence_clock.clone()))
-                .attach(&bus);
+                .convergence_clock(Arc::new(convergence_clock.clone()));
+            if external_publication_lifecycle {
+                builder = builder.external_publication_lifecycle();
+            }
+            let client = builder.attach(&bus);
             attached.insert(label.clone(), client);
         }
         let capabilities = [
@@ -383,6 +467,7 @@ impl EngineHarnessSubject {
             SubjectCapability::AdminPolicyObservation,
             SubjectCapability::CrashReopen,
             SubjectCapability::VirtualTime,
+            SubjectCapability::OutboundPublication,
             SubjectCapability::WhiteBoxTransportQueueFaults,
             SubjectCapability::WhiteBoxTransportPartition,
         ]
@@ -399,6 +484,8 @@ impl EngineHarnessSubject {
             clients: attached,
             pending_refs: HashMap::new(),
             convergence_clock,
+            outbound_cursors: HashMap::new(),
+            outbound_records: BTreeMap::new(),
         })
     }
 
@@ -454,6 +541,62 @@ impl EngineHarnessSubject {
         self.pending_refs.remove(label).ok_or_else(|| {
             SubjectError::new("unknown_pending", format!("unknown pending label {label}"))
         })
+    }
+
+    fn sync_client_outbound(&mut self, label: &str) -> Result<(), SubjectError> {
+        let client = self.client(label)?;
+        let bus_id = client.bus_id;
+        let after_sequence = self.outbound_cursors.get(label).copied();
+        let emissions = self.bus.outbound_since(bus_id, after_sequence);
+        if emissions.is_empty() {
+            return Ok(());
+        }
+
+        for emission in emissions {
+            let pending = self
+                .client(label)?
+                .pending_publication_for_message(&emission.msg.id);
+            let queued_intent = self
+                .client(label)?
+                .regenerated_queued_intent_for_message(&emission.msg.id);
+            let state_confirmation_required = pending.is_some_and(|pending| {
+                self.client(label)
+                    .expect("validated client remains present")
+                    .message_confirms_pending(pending, &emission.msg.id)
+            });
+            let kind = match &emission.msg.envelope {
+                TransportEnvelope::GroupMessage { .. } => SubjectOutboundKind::GroupMessage,
+                TransportEnvelope::Welcome { .. } => SubjectOutboundKind::Welcome,
+            };
+            let outbound_id = format!("outbound/{}", emission.sequence);
+            self.outbound_records
+                .entry(outbound_id.clone())
+                .or_insert_with(|| EngineSubjectOutboundRecord {
+                    sequence: emission.sequence,
+                    artifact: SubjectOutboundArtifact {
+                        outbound_id,
+                        client: label.to_owned(),
+                        kind,
+                        message: emission.msg,
+                        state_confirmation_required,
+                        regenerated_queued_intent: queued_intent.is_some(),
+                    },
+                    pending,
+                    queued_intent,
+                    resolution: None,
+                });
+            self.outbound_cursors
+                .insert(label.to_owned(), emission.sequence);
+        }
+        Ok(())
+    }
+
+    fn mark_pending_outbound(&mut self, pending: PendingStateRef, outcome: SubjectOutboundOutcome) {
+        for record in self.outbound_records.values_mut() {
+            if record.pending == Some(pending) {
+                record.resolution = Some(outcome);
+            }
+        }
     }
 }
 
@@ -523,12 +666,18 @@ impl ConvergenceSubject for EngineHarnessSubject {
     }
 
     async fn confirm_pending(&mut self, client: &str, pending: &str) -> Result<(), SubjectError> {
+        self.sync_client_outbound(client)?;
         let pending_ref = self.take_pending(pending)?;
-        self.client_mut(client)?.confirm(pending_ref).await;
+        self.client_mut(client)?
+            .try_confirm(pending_ref)
+            .await
+            .map_err(subject_engine_error)?;
+        self.mark_pending_outbound(pending_ref, SubjectOutboundOutcome::Accepted);
         Ok(())
     }
 
     async fn fail_pending(&mut self, client: &str, pending: &str) -> Result<(), SubjectError> {
+        self.sync_client_outbound(client)?;
         let pending_ref = self.pending_refs.get(pending).cloned().ok_or_else(|| {
             SubjectError::new(
                 "unknown_pending",
@@ -540,6 +689,7 @@ impl ConvergenceSubject for EngineHarnessSubject {
             .await
             .map_err(subject_engine_error)?;
         self.pending_refs.remove(pending);
+        self.mark_pending_outbound(pending_ref, SubjectOutboundOutcome::ReachedNoEndpoint);
         Ok(())
     }
 
@@ -576,6 +726,158 @@ impl ConvergenceSubject for EngineHarnessSubject {
         self.convergence_clock.advance_ms(delta_ms);
         for client in self.clients.values_mut() {
             client.enable_virtual_time_tick();
+        }
+        Ok(())
+    }
+
+    fn poll_outbound(
+        &mut self,
+        client: &str,
+    ) -> Result<Vec<SubjectOutboundArtifact>, SubjectError> {
+        self.sync_client_outbound(client)?;
+        let mut unresolved = self
+            .outbound_records
+            .values()
+            .filter(|record| record.artifact.client == client && record.resolution.is_none())
+            .collect::<Vec<_>>();
+        unresolved.sort_by_key(|record| record.sequence);
+        Ok(unresolved
+            .into_iter()
+            .map(|record| record.artifact.clone())
+            .collect())
+    }
+
+    async fn acknowledge_outbound(
+        &mut self,
+        client: &str,
+        outbound_id: &str,
+        outcome: SubjectOutboundOutcome,
+    ) -> Result<(), SubjectError> {
+        self.sync_client_outbound(client)?;
+        let record = self
+            .outbound_records
+            .get(outbound_id)
+            .cloned()
+            .ok_or_else(|| {
+                SubjectError::new(
+                    "unknown_outbound",
+                    format!("unknown outbound artifact {outbound_id}"),
+                )
+            })?;
+        if record.artifact.client != client {
+            return Err(SubjectError::new(
+                "outbound_client_mismatch",
+                format!("outbound artifact {outbound_id} does not belong to {client}"),
+            ));
+        }
+        if let Some(previous) = record.resolution {
+            return if previous == outcome {
+                Ok(())
+            } else {
+                Err(SubjectError::new(
+                    "outbound_already_resolved",
+                    format!("outbound artifact {outbound_id} was already resolved as {previous:?}"),
+                ))
+            };
+        }
+
+        let pending_already_confirmed = record.pending.is_some_and(|pending| {
+            self.outbound_records.values().any(|candidate| {
+                candidate.pending == Some(pending)
+                    && candidate.artifact.state_confirmation_required
+                    && candidate.resolution == Some(SubjectOutboundOutcome::Accepted)
+            })
+        });
+
+        match outcome {
+            SubjectOutboundOutcome::Accepted => {
+                if record.artifact.state_confirmation_required
+                    && !pending_already_confirmed
+                    && let Some(pending) = record.pending
+                {
+                    self.client_mut(client)?
+                        .try_confirm(pending)
+                        .await
+                        .map_err(subject_engine_error)?;
+                    self.pending_refs.retain(|_, value| *value != pending);
+                }
+                if let Some((_, intent_id)) = &record.queued_intent {
+                    self.client_mut(client)?
+                        .confirm_regenerated_queued_intent(intent_id)
+                        .map_err(subject_engine_error)?;
+                    self.client_mut(client)?
+                        .forget_regenerated_queued_intent(&record.artifact.message.id);
+                }
+                self.outbound_records
+                    .get_mut(outbound_id)
+                    .expect("validated outbound record remains present")
+                    .resolution = Some(outcome);
+            }
+            SubjectOutboundOutcome::ReachedNoEndpoint => {
+                let should_roll_back_pending = record
+                    .pending
+                    .filter(|_| record.artifact.state_confirmation_required)
+                    .is_some_and(|pending| {
+                        let another_confirmation_is_unresolved =
+                            self.outbound_records
+                                .iter()
+                                .any(|(candidate_id, candidate)| {
+                                    candidate_id != outbound_id
+                                        && candidate.pending == Some(pending)
+                                        && candidate.artifact.state_confirmation_required
+                                        && candidate.resolution.is_none()
+                                });
+                        let confirmation_was_accepted =
+                            self.outbound_records.values().any(|candidate| {
+                                candidate.pending == Some(pending)
+                                    && candidate.artifact.state_confirmation_required
+                                    && candidate.resolution
+                                        == Some(SubjectOutboundOutcome::Accepted)
+                            });
+                        !another_confirmation_is_unresolved && !confirmation_was_accepted
+                    });
+
+                if should_roll_back_pending {
+                    let pending = record
+                        .pending
+                        .expect("rollback decision requires pending state");
+                    // `try_fail` validates the complete commit/Welcome
+                    // exposure set before retracting any artifact. Do not
+                    // retract this one first: an exposed sibling must leave
+                    // both the bus and pending state untouched.
+                    self.client_mut(client)?
+                        .try_fail(pending)
+                        .await
+                        .map_err(subject_publication_error)?;
+                    self.pending_refs.retain(|_, value| *value != pending);
+                    self.mark_pending_outbound(pending, outcome);
+                } else {
+                    self.bus
+                        .retract_undelivered_publication(
+                            self.client(client)?.bus_id,
+                            std::slice::from_ref(&record.artifact.message.id),
+                        )
+                        .map_err(|delivered| {
+                            SubjectError::new(
+                                "outbound_already_exposed",
+                                format!(
+                                    "cannot report no-endpoint publication after {delivered} recipient exposure(s)"
+                                ),
+                            )
+                        })?;
+                    self.outbound_records
+                        .get_mut(outbound_id)
+                        .expect("validated outbound record remains present")
+                        .resolution = Some(outcome);
+                }
+
+                if let Some((group_id, _)) = &record.queued_intent {
+                    self.client_mut(client)?
+                        .retry_regenerated_queued_intent(group_id);
+                    self.client_mut(client)?
+                        .forget_regenerated_queued_intent(&record.artifact.message.id);
+                }
+            }
         }
         Ok(())
     }
@@ -825,6 +1127,17 @@ fn subject_engine_error(error: EngineError) -> SubjectError {
     SubjectError::new(observe_engine_error(&error), error.to_string())
 }
 
+fn subject_publication_error(error: EngineError) -> SubjectError {
+    match error {
+        EngineError::Other(message)
+            if message.starts_with("cannot report definite publication failure after") =>
+        {
+            SubjectError::new("outbound_already_exposed", message)
+        }
+        error => subject_engine_error(error),
+    }
+}
+
 fn observe_engine_error(error: &EngineError) -> String {
     match error {
         EngineError::NotGroupAdmin { .. } => "not_group_admin",
@@ -862,10 +1175,671 @@ mod tests {
     use super::*;
     use crate::ConformanceCanonicalStateSnapshot;
 
+    async fn create_current_group_and_join(
+        subject: &mut EngineHarnessSubject,
+        creator: &str,
+        invitees: &[String],
+    ) {
+        subject
+            .create_group(SubjectCreateGroup {
+                creator,
+                name: "outbound-contract",
+                invitees,
+                required_features: &[],
+                initial_admins: &[],
+                pending: "unused-current-create",
+            })
+            .await
+            .expect("current founding group is created");
+        let welcomes = subject
+            .poll_outbound(creator)
+            .expect("founding welcomes are pollable");
+        assert_eq!(welcomes.len(), invitees.len());
+        for welcome in welcomes {
+            assert_eq!(welcome.kind, SubjectOutboundKind::Welcome);
+            assert!(!welcome.state_confirmation_required);
+            subject
+                .acknowledge_outbound(
+                    creator,
+                    &welcome.outbound_id,
+                    SubjectOutboundOutcome::Accepted,
+                )
+                .await
+                .expect("founding welcome publication is accepted");
+        }
+        subject.deliver_all().expect("deliver founding welcomes");
+        subject
+            .tick(invitees)
+            .await
+            .expect("invitees ingest founding welcomes");
+    }
+
+    #[tokio::test]
+    async fn outbound_poll_is_non_destructive_and_acknowledgement_is_idempotent() {
+        let labels = vec!["alice".to_owned(), "bob".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        assert!(
+            subject
+                .descriptor()
+                .supports(SubjectCapability::OutboundPublication)
+        );
+        create_current_group_and_join(&mut subject, "alice", &labels[1..]).await;
+
+        subject
+            .send_application(SubjectSendApplication {
+                action_id: "app-1",
+                sender: "alice",
+                payload: "hello",
+            })
+            .await
+            .expect("application send succeeds");
+        let first = subject
+            .poll_outbound("alice")
+            .expect("application publication is pollable");
+        let second = subject
+            .poll_outbound("alice")
+            .expect("polling is non-destructive");
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].kind, SubjectOutboundKind::GroupMessage);
+        assert!(!first[0].state_confirmation_required);
+
+        subject
+            .acknowledge_outbound(
+                "alice",
+                &first[0].outbound_id,
+                SubjectOutboundOutcome::Accepted,
+            )
+            .await
+            .expect("application publication is accepted");
+        subject
+            .acknowledge_outbound(
+                "alice",
+                &first[0].outbound_id,
+                SubjectOutboundOutcome::Accepted,
+            )
+            .await
+            .expect("same acknowledgement is idempotent");
+        let contradiction = subject
+            .acknowledge_outbound(
+                "alice",
+                &first[0].outbound_id,
+                SubjectOutboundOutcome::ReachedNoEndpoint,
+            )
+            .await
+            .expect_err("contradictory acknowledgement is rejected");
+        assert_eq!(contradiction.code, "outbound_already_resolved");
+        assert!(
+            subject
+                .poll_outbound("alice")
+                .expect("resolved publication is absent")
+                .is_empty()
+        );
+
+        subject.deliver_all().expect("deliver application message");
+        subject
+            .tick(&["bob".to_owned()])
+            .await
+            .expect("bob ingests application message");
+        assert_eq!(
+            subject
+                .client_mut("bob")
+                .expect("bob exists")
+                .received_app_payloads(),
+            vec![b"hello".to_vec()]
+        );
+    }
+
+    #[tokio::test]
+    async fn outbound_poll_preserves_emission_order_past_single_digit_handles() {
+        let labels = vec!["alice".to_owned(), "bob".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        create_current_group_and_join(&mut subject, "alice", &labels[1..]).await;
+
+        for index in 0..12 {
+            subject
+                .send_application(SubjectSendApplication {
+                    action_id: &format!("app-{index}"),
+                    sender: "alice",
+                    payload: &format!("payload-{index}"),
+                })
+                .await
+                .expect("application send succeeds");
+        }
+
+        let outbound = subject
+            .poll_outbound("alice")
+            .expect("application publications are pollable");
+        let sequences = outbound
+            .iter()
+            .map(|artifact| {
+                subject
+                    .outbound_records
+                    .get(&artifact.outbound_id)
+                    .expect("polled artifact has an adapter record")
+                    .sequence
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(sequences, (1..=12).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn evolution_commit_acknowledgement_and_welcome_outcome_are_independent() {
+        let labels = vec!["alice".to_owned(), "bob".to_owned(), "carol".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        create_current_group_and_join(&mut subject, "alice", &labels[1..2]).await;
+        let prior_epoch = subject.client("alice").expect("alice exists").epoch().0;
+
+        subject
+            .invite_members(SubjectInviteMembers {
+                action_id: "invite-carol",
+                inviter: "alice",
+                invitees: &labels[2..],
+                pending: "invite-carol-pending",
+            })
+            .await
+            .expect("invite produces outbound work");
+        let outbound = subject
+            .poll_outbound("alice")
+            .expect("invite artifacts are pollable");
+        assert_eq!(outbound.len(), 2);
+        let commit = outbound
+            .iter()
+            .find(|artifact| artifact.state_confirmation_required)
+            .expect("commit requires state confirmation");
+        let welcome = outbound
+            .iter()
+            .find(|artifact| artifact.kind == SubjectOutboundKind::Welcome)
+            .expect("welcome is an independent obligation");
+        assert!(!welcome.state_confirmation_required);
+
+        subject
+            .acknowledge_outbound(
+                "alice",
+                &commit.outbound_id,
+                SubjectOutboundOutcome::Accepted,
+            )
+            .await
+            .expect("accepted commit confirms local state");
+        assert_eq!(
+            subject.client("alice").expect("alice exists").epoch().0,
+            prior_epoch + 1
+        );
+        assert_eq!(
+            subject
+                .poll_outbound("alice")
+                .expect("welcome remains independently pending"),
+            vec![welcome.clone()]
+        );
+
+        subject
+            .acknowledge_outbound(
+                "alice",
+                &welcome.outbound_id,
+                SubjectOutboundOutcome::ReachedNoEndpoint,
+            )
+            .await
+            .expect("failed welcome does not roll back an accepted commit");
+        assert_eq!(
+            subject.client("alice").expect("alice exists").epoch().0,
+            prior_epoch + 1
+        );
+        assert!(
+            subject
+                .poll_outbound("alice")
+                .expect("both obligations are resolved")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn no_endpoint_commit_outcome_rolls_back_the_complete_unexposed_publication() {
+        let labels = vec!["alice".to_owned(), "bob".to_owned(), "carol".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        create_current_group_and_join(&mut subject, "alice", &labels[1..2]).await;
+        let prior_epoch = subject.client("alice").expect("alice exists").epoch().0;
+
+        subject
+            .invite_members(SubjectInviteMembers {
+                action_id: "invite-carol",
+                inviter: "alice",
+                invitees: &labels[2..],
+                pending: "invite-carol-pending",
+            })
+            .await
+            .expect("invite produces outbound work");
+        let outbound = subject
+            .poll_outbound("alice")
+            .expect("invite artifacts are pollable");
+        let commit = outbound
+            .iter()
+            .find(|artifact| artifact.state_confirmation_required)
+            .expect("commit requires state confirmation");
+
+        subject
+            .acknowledge_outbound(
+                "alice",
+                &commit.outbound_id,
+                SubjectOutboundOutcome::ReachedNoEndpoint,
+            )
+            .await
+            .expect("unexposed commit failure rolls back");
+        assert_eq!(
+            subject.client("alice").expect("alice exists").epoch().0,
+            prior_epoch
+        );
+        assert!(
+            subject
+                .poll_outbound("alice")
+                .expect("rollback resolves the complete publication")
+                .is_empty()
+        );
+
+        subject
+            .deliver_all()
+            .expect("rolled-back artifacts are absent from the bus");
+        subject
+            .tick(&["bob".to_owned(), "carol".to_owned()])
+            .await
+            .expect("no rolled-back artifact is ingested");
+    }
+
+    #[tokio::test]
+    async fn exposed_welcome_prevents_partial_commit_retraction_and_rollback() {
+        let labels = vec!["alice".to_owned(), "bob".to_owned(), "carol".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        create_current_group_and_join(&mut subject, "alice", &labels[1..2]).await;
+        subject
+            .invite_members(SubjectInviteMembers {
+                action_id: "invite-carol",
+                inviter: "alice",
+                invitees: &labels[2..],
+                pending: "invite-carol-pending",
+            })
+            .await
+            .expect("invite produces outbound work");
+        let outbound = subject
+            .poll_outbound("alice")
+            .expect("invite artifacts are pollable");
+        let commit = outbound
+            .iter()
+            .find(|artifact| artifact.state_confirmation_required)
+            .expect("commit requires state confirmation");
+        let pending_snapshot = subject
+            .client("alice")
+            .expect("alice exists")
+            .canonical_state_snapshot();
+        subject
+            .deliver_all()
+            .expect("commit and welcome reach recipient mailboxes");
+
+        let error = subject
+            .acknowledge_outbound(
+                "alice",
+                &commit.outbound_id,
+                SubjectOutboundOutcome::ReachedNoEndpoint,
+            )
+            .await
+            .expect_err("exposed sibling prevents definite rollback");
+        assert_eq!(error.code, "outbound_already_exposed");
+        assert_eq!(
+            subject
+                .poll_outbound("alice")
+                .expect("failed rollback leaves every obligation pending"),
+            outbound
+        );
+        assert_eq!(
+            subject
+                .client("alice")
+                .expect("alice exists")
+                .canonical_state_snapshot(),
+            pending_snapshot
+        );
+    }
+
+    #[tokio::test]
+    async fn no_endpoint_outcome_is_rejected_after_recipient_exposure() {
+        let labels = vec!["alice".to_owned(), "bob".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        subject
+            .create_group(SubjectCreateGroup {
+                creator: "alice",
+                name: "exposed-welcome",
+                invitees: &labels[1..],
+                required_features: &[],
+                initial_admins: &[],
+                pending: "unused-current-create",
+            })
+            .await
+            .expect("current founding group is created");
+        let welcome = subject
+            .poll_outbound("alice")
+            .expect("welcome is pollable")
+            .pop()
+            .expect("welcome exists");
+        subject.deliver_all().expect("expose welcome to bob");
+        let error = subject
+            .acknowledge_outbound(
+                "alice",
+                &welcome.outbound_id,
+                SubjectOutboundOutcome::ReachedNoEndpoint,
+            )
+            .await
+            .expect_err("exposed artifact cannot be declared unpublished");
+        assert_eq!(error.code, "outbound_already_exposed");
+        assert_eq!(
+            subject
+                .poll_outbound("alice")
+                .expect("failed acknowledgement leaves work pending"),
+            vec![welcome]
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_legacy_creation_confirms_without_synthetic_outbound_work() {
+        let labels = vec!["alice".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Legacy,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+
+        subject
+            .create_group(SubjectCreateGroup {
+                creator: "alice",
+                name: "empty-legacy-group",
+                invitees: &[],
+                required_features: &[],
+                initial_admins: &[],
+                pending: "no-publication-needed",
+            })
+            .await
+            .expect("empty legacy group is created");
+
+        assert!(
+            subject
+                .poll_outbound("alice")
+                .expect("no synthetic artifact is invented")
+                .is_empty()
+        );
+        assert!(
+            subject
+                .client("alice")
+                .expect("alice exists")
+                .pending_work_observation()
+                .engine
+                .is_empty(),
+            "a no-op publication must not strand pending MLS state"
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_create_confirms_on_first_welcome_acceptance_and_keeps_other_welcomes_independent()
+     {
+        let labels = vec!["alice".to_owned(), "bob".to_owned(), "carol".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Legacy,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        subject
+            .create_group(SubjectCreateGroup {
+                creator: "alice",
+                name: "legacy-create",
+                invitees: &labels[1..],
+                required_features: &[],
+                initial_admins: &[],
+                pending: "legacy-create-pending",
+            })
+            .await
+            .expect("legacy create produces welcomes");
+        let outbound = subject
+            .poll_outbound("alice")
+            .expect("legacy welcomes are pollable");
+        assert_eq!(outbound.len(), 2);
+        assert!(
+            outbound
+                .iter()
+                .all(|artifact| artifact.state_confirmation_required)
+        );
+
+        subject
+            .acknowledge_outbound(
+                "alice",
+                &outbound[0].outbound_id,
+                SubjectOutboundOutcome::Accepted,
+            )
+            .await
+            .expect("first exposed legacy welcome confirms creation");
+        assert_eq!(
+            subject
+                .poll_outbound("alice")
+                .expect("second welcome remains pending"),
+            vec![outbound[1].clone()]
+        );
+        subject
+            .acknowledge_outbound(
+                "alice",
+                &outbound[1].outbound_id,
+                SubjectOutboundOutcome::ReachedNoEndpoint,
+            )
+            .await
+            .expect("later welcome failure cannot roll back confirmed creation");
+        assert!(
+            subject
+                .poll_outbound("alice")
+                .expect("legacy obligations are resolved")
+                .is_empty()
+        );
+        assert_eq!(subject.client("alice").expect("alice exists").epoch().0, 1);
+    }
+
+    #[tokio::test]
+    async fn scheduled_group_evolution_waits_for_public_outbound_acknowledgement() {
+        let labels = vec!["alice".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        create_current_group_and_join(&mut subject, "alice", &[]).await;
+        let prior_epoch = subject.client("alice").expect("alice exists").epoch().0;
+
+        let alice = subject.client_mut("alice").expect("alice exists");
+        alice.request_disband().await.expect("request disband");
+        alice
+            .advance_convergence()
+            .await
+            .expect("scheduled convergence emits terminal commit");
+        assert!(matches!(
+            subject
+                .client("alice")
+                .expect("alice exists")
+                .canonical_state_snapshot(),
+            ConformanceCanonicalStateSnapshot::Live(_)
+        ));
+
+        let outbound = subject
+            .poll_outbound("alice")
+            .expect("scheduled commit is pollable");
+        assert_eq!(outbound.len(), 1);
+        assert!(outbound[0].state_confirmation_required);
+        subject
+            .acknowledge_outbound(
+                "alice",
+                &outbound[0].outbound_id,
+                SubjectOutboundOutcome::Accepted,
+            )
+            .await
+            .expect("scheduled commit acknowledgement applies the evolution");
+        assert_eq!(
+            subject.client("alice").expect("alice exists").epoch().0,
+            prior_epoch + 1
+        );
+    }
+
+    #[tokio::test]
+    async fn regenerated_queued_intent_retries_then_retires_through_outbound_acknowledgement() {
+        let labels = vec![
+            "alice".to_owned(),
+            "bob".to_owned(),
+            "carol".to_owned(),
+            "david".to_owned(),
+        ];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        create_current_group_and_join(&mut subject, "alice", &labels[1..3]).await;
+
+        subject
+            .invite_members(SubjectInviteMembers {
+                action_id: "invite-david",
+                inviter: "alice",
+                invitees: &labels[3..],
+                pending: "invite-david-pending",
+            })
+            .await
+            .expect("invite produces outbound work");
+        let invite_commit = subject
+            .poll_outbound("alice")
+            .expect("invite publication is pollable")
+            .into_iter()
+            .find(|artifact| artifact.state_confirmation_required)
+            .expect("invite commit requires confirmation");
+        subject
+            .acknowledge_outbound(
+                "alice",
+                &invite_commit.outbound_id,
+                SubjectOutboundOutcome::Accepted,
+            )
+            .await
+            .expect("invite commit publication is accepted");
+        subject.deliver_all().expect("deliver invite artifacts");
+        let ingest = subject
+            .client_mut("carol")
+            .expect("carol exists")
+            .tick_ingest_only()
+            .await;
+        assert!(
+            ingest.iter().any(|outcome| matches!(
+                outcome,
+                Ok(cgka_traits::ingest::IngestOutcome::Buffered { .. })
+            )),
+            "carol must buffer the invite commit before attempting an app send: {ingest:?}"
+        );
+        subject
+            .send_application(SubjectSendApplication {
+                action_id: "queued-app",
+                sender: "carol",
+                payload: "queued while convergence is live",
+            })
+            .await
+            .expect("application intent is queued");
+        assert!(
+            subject
+                .poll_outbound("carol")
+                .expect("queued application has not emitted yet")
+                .is_empty()
+        );
+        subject
+            .advance_time(1_000)
+            .await
+            .expect("advance through the pinned settlement window");
+
+        subject
+            .client_mut("carol")
+            .expect("carol exists")
+            .advance_convergence()
+            .await
+            .expect("carol settles and regenerates queued application");
+        let first = subject
+            .poll_outbound("carol")
+            .expect("regenerated application is pollable");
+        assert_eq!(first.len(), 1);
+        assert!(first[0].regenerated_queued_intent);
+        subject
+            .acknowledge_outbound(
+                "carol",
+                &first[0].outbound_id,
+                SubjectOutboundOutcome::ReachedNoEndpoint,
+            )
+            .await
+            .expect("definite failure re-arms the queued intent");
+
+        subject
+            .client_mut("carol")
+            .expect("carol exists")
+            .advance_convergence()
+            .await
+            .expect("carol retries the queued application");
+        let retry = subject
+            .poll_outbound("carol")
+            .expect("retried application is pollable");
+        assert_eq!(retry.len(), 1);
+        assert!(retry[0].regenerated_queued_intent);
+        assert_ne!(retry[0].outbound_id, first[0].outbound_id);
+        subject
+            .acknowledge_outbound(
+                "carol",
+                &retry[0].outbound_id,
+                SubjectOutboundOutcome::Accepted,
+            )
+            .await
+            .expect("accepted retry retires the queued intent");
+        subject
+            .client_mut("carol")
+            .expect("carol exists")
+            .advance_convergence()
+            .await
+            .expect("no queued retry remains");
+        assert!(
+            subject
+                .poll_outbound("carol")
+                .expect("retired queued intent stays absent")
+                .is_empty()
+        );
+    }
+
     #[tokio::test]
     async fn engine_subject_virtual_time_is_shared_while_participant_wakes_are_selected() {
         let labels = vec!["alice".to_owned(), "bob".to_owned()];
-        let mut subject = EngineHarnessSubject::new(
+        let mut subject = EngineHarnessSubject::new_legacy_compatible(
             &labels,
             ProtocolProfile::Current,
             HarnessStorageMode::InMemorySqlite,

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -5,6 +5,7 @@
 //! only the public behavior available at its layer. Harness-only transport
 //! mutation is exposed separately through [`ConvergenceFaultSubject`].
 
+use crate::client::HarnessPublicationError;
 use crate::{
     BidirectionalDecryptabilityObservation, ClientBuilder, ClientObservation,
     DecryptabilityProbeSendStatus, DirectionalDecryptabilityProbe, HarnessClient,
@@ -397,15 +398,20 @@ pub struct EngineHarnessSubject {
     descriptor: SubjectDescriptor,
     bus: TransportBus,
     clients: BTreeMap<String, HarnessClient>,
-    pending_refs: HashMap<String, PendingStateRef>,
+    pending_refs: HashMap<String, EngineSubjectPendingRef>,
     convergence_clock: ManualConvergenceClock,
     outbound_cursors: HashMap<String, u64>,
-    outbound_records: BTreeMap<String, EngineSubjectOutboundRecord>,
+    outbound_records: BTreeMap<u64, EngineSubjectOutboundRecord>,
+}
+
+#[derive(Clone)]
+struct EngineSubjectPendingRef {
+    client: String,
+    pending: PendingStateRef,
 }
 
 #[derive(Clone)]
 struct EngineSubjectOutboundRecord {
-    sequence: u64,
     artifact: SubjectOutboundArtifact,
     pending: Option<PendingStateRef>,
     queued_intent: Option<(GroupId, MessageId)>,
@@ -456,7 +462,7 @@ impl EngineHarnessSubject {
             let client = builder.attach(&bus);
             attached.insert(label.clone(), client);
         }
-        let capabilities = [
+        let mut capabilities = BTreeSet::from([
             SubjectCapability::GroupMutation,
             SubjectCapability::PublicationLifecycle,
             SubjectCapability::ApplicationMessaging,
@@ -467,12 +473,12 @@ impl EngineHarnessSubject {
             SubjectCapability::AdminPolicyObservation,
             SubjectCapability::CrashReopen,
             SubjectCapability::VirtualTime,
-            SubjectCapability::OutboundPublication,
             SubjectCapability::WhiteBoxTransportQueueFaults,
             SubjectCapability::WhiteBoxTransportPartition,
-        ]
-        .into_iter()
-        .collect();
+        ]);
+        if external_publication_lifecycle {
+            capabilities.insert(SubjectCapability::OutboundPublication);
+        }
         Ok(Self {
             descriptor: SubjectDescriptor {
                 adapter: "mdk-engine-harness".into(),
@@ -522,11 +528,18 @@ impl EngineHarnessSubject {
     fn insert_pending(
         &mut self,
         label: &str,
+        client: &str,
         pending_ref: PendingStateRef,
     ) -> Result<(), SubjectError> {
         if self
             .pending_refs
-            .insert(label.to_string(), pending_ref)
+            .insert(
+                label.to_string(),
+                EngineSubjectPendingRef {
+                    client: client.to_owned(),
+                    pending: pending_ref,
+                },
+            )
             .is_some()
         {
             return Err(SubjectError::new(
@@ -537,10 +550,27 @@ impl EngineHarnessSubject {
         Ok(())
     }
 
-    fn take_pending(&mut self, label: &str) -> Result<PendingStateRef, SubjectError> {
-        self.pending_refs.remove(label).ok_or_else(|| {
+    fn pending_for_client(
+        &self,
+        label: &str,
+        client: &str,
+    ) -> Result<PendingStateRef, SubjectError> {
+        let pending = self.pending_refs.get(label).ok_or_else(|| {
             SubjectError::new("unknown_pending", format!("unknown pending label {label}"))
-        })
+        })?;
+        if pending.client != client {
+            return Err(SubjectError::new(
+                "pending_client_mismatch",
+                format!("pending label {label} does not belong to {client}"),
+            ));
+        }
+        Ok(pending.pending)
+    }
+
+    fn take_pending(&mut self, label: &str, client: &str) -> Result<PendingStateRef, SubjectError> {
+        let pending = self.pending_for_client(label, client)?;
+        self.pending_refs.remove(label);
+        Ok(pending)
     }
 
     fn sync_client_outbound(&mut self, label: &str) -> Result<(), SubjectError> {
@@ -570,9 +600,8 @@ impl EngineHarnessSubject {
             };
             let outbound_id = format!("outbound/{}", emission.sequence);
             self.outbound_records
-                .entry(outbound_id.clone())
+                .entry(emission.sequence)
                 .or_insert_with(|| EngineSubjectOutboundRecord {
-                    sequence: emission.sequence,
                     artifact: SubjectOutboundArtifact {
                         outbound_id,
                         client: label.to_owned(),
@@ -591,12 +620,38 @@ impl EngineHarnessSubject {
         Ok(())
     }
 
-    fn mark_pending_outbound(&mut self, pending: PendingStateRef, outcome: SubjectOutboundOutcome) {
+    fn mark_pending_outbound(
+        &mut self,
+        client: &str,
+        pending: PendingStateRef,
+        outcome: SubjectOutboundOutcome,
+    ) {
         for record in self.outbound_records.values_mut() {
-            if record.pending == Some(pending) {
+            if record.artifact.client == client
+                && record.pending == Some(pending)
+                && record.resolution.is_none()
+            {
                 record.resolution = Some(outcome);
             }
         }
+    }
+
+    fn pending_confirmation_accepted(&self, client: &str, pending: PendingStateRef) -> bool {
+        self.outbound_records.values().any(|candidate| {
+            candidate.artifact.client == client
+                && candidate.pending == Some(pending)
+                && candidate.artifact.state_confirmation_required
+                && candidate.resolution == Some(SubjectOutboundOutcome::Accepted)
+        })
+    }
+
+    fn pending_non_confirmation_accepted(&self, client: &str, pending: PendingStateRef) -> bool {
+        self.outbound_records.values().any(|candidate| {
+            candidate.artifact.client == client
+                && candidate.pending == Some(pending)
+                && !candidate.artifact.state_confirmation_required
+                && candidate.resolution == Some(SubjectOutboundOutcome::Accepted)
+        })
     }
 }
 
@@ -620,7 +675,7 @@ impl ConvergenceSubject for EngineHarnessSubject {
             )
             .await;
         if let Some(pending_ref) = pending_ref {
-            self.insert_pending(action.pending, pending_ref)?;
+            self.insert_pending(action.pending, action.creator, pending_ref)?;
         }
         Ok(())
     }
@@ -633,7 +688,7 @@ impl ConvergenceSubject for EngineHarnessSubject {
         let inviter = self.client_mut(action.inviter)?;
         inviter.name_next_scenario_input(action.action_id);
         let pending_ref = inviter.invite(key_packages).await;
-        self.insert_pending(action.pending, pending_ref)
+        self.insert_pending(action.pending, action.inviter, pending_ref)
     }
 
     async fn update_group_data(
@@ -643,7 +698,7 @@ impl ConvergenceSubject for EngineHarnessSubject {
         let client = self.client_mut(action.client)?;
         client.name_next_scenario_input(action.action_id);
         let pending_ref = client.update_group_data(action.name.to_owned()).await;
-        self.insert_pending(action.pending, pending_ref)
+        self.insert_pending(action.pending, action.client, pending_ref)
     }
 
     async fn update_admin_policy(
@@ -660,36 +715,43 @@ impl ConvergenceSubject for EngineHarnessSubject {
             .await
             .map_err(subject_engine_error)?;
         if let Some(pending) = action.pending {
-            self.insert_pending(pending, pending_ref)?;
+            self.insert_pending(pending, action.client, pending_ref)?;
         }
         Ok(())
     }
 
     async fn confirm_pending(&mut self, client: &str, pending: &str) -> Result<(), SubjectError> {
         self.sync_client_outbound(client)?;
-        let pending_ref = self.take_pending(pending)?;
+        let pending_ref = self.take_pending(pending, client)?;
         self.client_mut(client)?
             .try_confirm(pending_ref)
             .await
             .map_err(subject_engine_error)?;
-        self.mark_pending_outbound(pending_ref, SubjectOutboundOutcome::Accepted);
+        self.mark_pending_outbound(client, pending_ref, SubjectOutboundOutcome::Accepted);
         Ok(())
     }
 
     async fn fail_pending(&mut self, client: &str, pending: &str) -> Result<(), SubjectError> {
         self.sync_client_outbound(client)?;
-        let pending_ref = self.pending_refs.get(pending).cloned().ok_or_else(|| {
-            SubjectError::new(
-                "unknown_pending",
-                format!("unknown pending label {pending}"),
-            )
-        })?;
+        let pending_ref = self.pending_for_client(pending, client)?;
+        if self.pending_non_confirmation_accepted(client, pending_ref) {
+            return Err(SubjectError::new(
+                "outbound_already_exposed",
+                format!(
+                    "cannot report definite publication failure for {pending} after a sibling artifact was accepted"
+                ),
+            ));
+        }
         self.client_mut(client)?
-            .try_fail(pending_ref)
+            .try_fail_publication(pending_ref)
             .await
-            .map_err(subject_engine_error)?;
+            .map_err(subject_publication_error)?;
         self.pending_refs.remove(pending);
-        self.mark_pending_outbound(pending_ref, SubjectOutboundOutcome::ReachedNoEndpoint);
+        self.mark_pending_outbound(
+            client,
+            pending_ref,
+            SubjectOutboundOutcome::ReachedNoEndpoint,
+        );
         Ok(())
     }
 
@@ -735,14 +797,10 @@ impl ConvergenceSubject for EngineHarnessSubject {
         client: &str,
     ) -> Result<Vec<SubjectOutboundArtifact>, SubjectError> {
         self.sync_client_outbound(client)?;
-        let mut unresolved = self
+        Ok(self
             .outbound_records
             .values()
             .filter(|record| record.artifact.client == client && record.resolution.is_none())
-            .collect::<Vec<_>>();
-        unresolved.sort_by_key(|record| record.sequence);
-        Ok(unresolved
-            .into_iter()
             .map(|record| record.artifact.clone())
             .collect())
     }
@@ -754,9 +812,11 @@ impl ConvergenceSubject for EngineHarnessSubject {
         outcome: SubjectOutboundOutcome,
     ) -> Result<(), SubjectError> {
         self.sync_client_outbound(client)?;
+        let outbound_sequence = outbound_sequence(outbound_id)?;
         let record = self
             .outbound_records
-            .get(outbound_id)
+            .get(&outbound_sequence)
+            .filter(|record| record.artifact.outbound_id == outbound_id)
             .cloned()
             .ok_or_else(|| {
                 SubjectError::new(
@@ -781,13 +841,9 @@ impl ConvergenceSubject for EngineHarnessSubject {
             };
         }
 
-        let pending_already_confirmed = record.pending.is_some_and(|pending| {
-            self.outbound_records.values().any(|candidate| {
-                candidate.pending == Some(pending)
-                    && candidate.artifact.state_confirmation_required
-                    && candidate.resolution == Some(SubjectOutboundOutcome::Accepted)
-            })
-        });
+        let pending_already_confirmed = record
+            .pending
+            .is_some_and(|pending| self.pending_confirmation_accepted(client, pending));
 
         match outcome {
             SubjectOutboundOutcome::Accepted => {
@@ -799,7 +855,8 @@ impl ConvergenceSubject for EngineHarnessSubject {
                         .try_confirm(pending)
                         .await
                         .map_err(subject_engine_error)?;
-                    self.pending_refs.retain(|_, value| *value != pending);
+                    self.pending_refs
+                        .retain(|_, value| value.client != client || value.pending != pending);
                 }
                 if let Some((_, intent_id)) = &record.queued_intent {
                     self.client_mut(client)?
@@ -809,11 +866,26 @@ impl ConvergenceSubject for EngineHarnessSubject {
                         .forget_regenerated_queued_intent(&record.artifact.message.id);
                 }
                 self.outbound_records
-                    .get_mut(outbound_id)
+                    .get_mut(&outbound_sequence)
                     .expect("validated outbound record remains present")
                     .resolution = Some(outcome);
             }
             SubjectOutboundOutcome::ReachedNoEndpoint => {
+                if record
+                    .pending
+                    .filter(|_| record.artifact.state_confirmation_required)
+                    .is_some_and(|pending| {
+                        !self.pending_confirmation_accepted(client, pending)
+                            && self.pending_non_confirmation_accepted(client, pending)
+                    })
+                {
+                    return Err(SubjectError::new(
+                        "outbound_already_exposed",
+                        format!(
+                            "cannot report no-endpoint publication for {outbound_id} after a sibling artifact was accepted"
+                        ),
+                    ));
+                }
                 let should_roll_back_pending = record
                     .pending
                     .filter(|_| record.artifact.state_confirmation_required)
@@ -821,19 +893,15 @@ impl ConvergenceSubject for EngineHarnessSubject {
                         let another_confirmation_is_unresolved =
                             self.outbound_records
                                 .iter()
-                                .any(|(candidate_id, candidate)| {
-                                    candidate_id != outbound_id
+                                .any(|(candidate_sequence, candidate)| {
+                                    *candidate_sequence != outbound_sequence
+                                        && candidate.artifact.client == client
                                         && candidate.pending == Some(pending)
                                         && candidate.artifact.state_confirmation_required
                                         && candidate.resolution.is_none()
                                 });
                         let confirmation_was_accepted =
-                            self.outbound_records.values().any(|candidate| {
-                                candidate.pending == Some(pending)
-                                    && candidate.artifact.state_confirmation_required
-                                    && candidate.resolution
-                                        == Some(SubjectOutboundOutcome::Accepted)
-                            });
+                            self.pending_confirmation_accepted(client, pending);
                         !another_confirmation_is_unresolved && !confirmation_was_accepted
                     });
 
@@ -846,11 +914,12 @@ impl ConvergenceSubject for EngineHarnessSubject {
                     // retract this one first: an exposed sibling must leave
                     // both the bus and pending state untouched.
                     self.client_mut(client)?
-                        .try_fail(pending)
+                        .try_fail_publication(pending)
                         .await
                         .map_err(subject_publication_error)?;
-                    self.pending_refs.retain(|_, value| *value != pending);
-                    self.mark_pending_outbound(pending, outcome);
+                    self.pending_refs
+                        .retain(|_, value| value.client != client || value.pending != pending);
+                    self.mark_pending_outbound(client, pending, outcome);
                 } else {
                     self.bus
                         .retract_undelivered_publication(
@@ -864,9 +933,9 @@ impl ConvergenceSubject for EngineHarnessSubject {
                                     "cannot report no-endpoint publication after {delivered} recipient exposure(s)"
                                 ),
                             )
-                        })?;
+                    })?;
                     self.outbound_records
-                        .get_mut(outbound_id)
+                        .get_mut(&outbound_sequence)
                         .expect("validated outbound record remains present")
                         .resolution = Some(outcome);
                 }
@@ -1123,18 +1192,33 @@ fn pad32(name: &[u8]) -> Vec<u8> {
     out
 }
 
+fn outbound_sequence(outbound_id: &str) -> Result<u64, SubjectError> {
+    outbound_id
+        .strip_prefix("outbound/")
+        .and_then(|sequence| sequence.parse().ok())
+        .ok_or_else(|| {
+            SubjectError::new(
+                "unknown_outbound",
+                format!("unknown outbound artifact {outbound_id}"),
+            )
+        })
+}
+
 fn subject_engine_error(error: EngineError) -> SubjectError {
     SubjectError::new(observe_engine_error(&error), error.to_string())
 }
 
-fn subject_publication_error(error: EngineError) -> SubjectError {
+fn subject_publication_error(error: HarnessPublicationError) -> SubjectError {
     match error {
-        EngineError::Other(message)
-            if message.starts_with("cannot report definite publication failure after") =>
-        {
-            SubjectError::new("outbound_already_exposed", message)
-        }
-        error => subject_engine_error(error),
+        HarnessPublicationError::AlreadyExposed {
+            recipient_exposures,
+        } => SubjectError::new(
+            "outbound_already_exposed",
+            format!(
+                "cannot report definite publication failure after {recipient_exposures} matching artifact(s) reached a recipient mailbox"
+            ),
+        ),
+        HarnessPublicationError::Engine(error) => subject_engine_error(error),
     }
 }
 
@@ -1323,14 +1407,149 @@ mod tests {
         let sequences = outbound
             .iter()
             .map(|artifact| {
-                subject
-                    .outbound_records
-                    .get(&artifact.outbound_id)
-                    .expect("polled artifact has an adapter record")
-                    .sequence
+                outbound_sequence(&artifact.outbound_id)
+                    .expect("polled artifact has a numeric adapter handle")
             })
             .collect::<Vec<_>>();
         assert_eq!(sequences, (1..=12).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn pending_publication_identity_is_scoped_by_client() {
+        let labels = vec!["alice".to_owned(), "bob".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Legacy,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        for label in &labels {
+            subject
+                .create_group(SubjectCreateGroup {
+                    creator: label,
+                    name: "independent-group",
+                    invitees: &[],
+                    required_features: &[],
+                    initial_admins: &[],
+                    pending: "unused-empty-create",
+                })
+                .await
+                .expect("independent legacy group is created");
+        }
+
+        for (client, pending, name) in [
+            ("alice", "alice-first", "alice-first-name"),
+            ("bob", "bob-first", "bob-first-name"),
+        ] {
+            subject
+                .update_group_data(SubjectUpdateGroupData {
+                    action_id: pending,
+                    client,
+                    name,
+                    pending,
+                })
+                .await
+                .expect("group-data update produces pending publication");
+        }
+        assert_eq!(
+            subject.pending_refs["alice-first"].pending, subject.pending_refs["bob-first"].pending,
+            "the regression requires equal per-engine pending counters"
+        );
+        let alice_first = subject
+            .poll_outbound("alice")
+            .expect("alice publication is pollable")
+            .pop()
+            .expect("alice commit exists");
+        let bob_first = subject
+            .poll_outbound("bob")
+            .expect("bob publication is pollable")
+            .pop()
+            .expect("bob commit exists");
+        subject
+            .acknowledge_outbound(
+                "bob",
+                &bob_first.outbound_id,
+                SubjectOutboundOutcome::Accepted,
+            )
+            .await
+            .expect("bob confirms only bob's staged state");
+        subject
+            .acknowledge_outbound(
+                "alice",
+                &alice_first.outbound_id,
+                SubjectOutboundOutcome::Accepted,
+            )
+            .await
+            .expect("bob's equal pending counter cannot suppress alice confirmation");
+        assert_eq!(
+            subject.client("alice").expect("alice exists").group_name(),
+            "alice-first-name"
+        );
+        assert_eq!(
+            subject.client("bob").expect("bob exists").group_name(),
+            "bob-first-name"
+        );
+
+        for (client, pending, name) in [
+            ("alice", "alice-second", "alice-rolled-back-name"),
+            ("bob", "bob-second", "bob-second-name"),
+        ] {
+            subject
+                .update_group_data(SubjectUpdateGroupData {
+                    action_id: pending,
+                    client,
+                    name,
+                    pending,
+                })
+                .await
+                .expect("second group-data update produces pending publication");
+        }
+        assert_eq!(
+            subject.pending_refs["alice-second"].pending,
+            subject.pending_refs["bob-second"].pending,
+            "the rollback regression also requires colliding pending counters"
+        );
+        let alice_second = subject
+            .poll_outbound("alice")
+            .expect("alice second publication is pollable")
+            .pop()
+            .expect("alice second commit exists");
+        let bob_second = subject
+            .poll_outbound("bob")
+            .expect("bob second publication is pollable")
+            .pop()
+            .expect("bob second commit exists");
+        subject
+            .acknowledge_outbound(
+                "alice",
+                &alice_second.outbound_id,
+                SubjectOutboundOutcome::ReachedNoEndpoint,
+            )
+            .await
+            .expect("alice rolls back only alice's staged state");
+        assert_eq!(
+            subject
+                .poll_outbound("bob")
+                .expect("bob publication remains unresolved"),
+            vec![bob_second.clone()]
+        );
+        subject
+            .acknowledge_outbound(
+                "bob",
+                &bob_second.outbound_id,
+                SubjectOutboundOutcome::Accepted,
+            )
+            .await
+            .expect("bob publication remains acknowledgeable");
+        assert_eq!(
+            subject.client("alice").expect("alice exists").group_name(),
+            "alice-first-name"
+        );
+        assert_eq!(
+            subject.client("bob").expect("bob exists").group_name(),
+            "bob-second-name"
+        );
+        assert!(subject.pending_refs.is_empty());
     }
 
     #[tokio::test]
@@ -1405,6 +1624,97 @@ mod tests {
                 .expect("both obligations are resolved")
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn accepted_welcome_blocks_later_definite_commit_failure() {
+        let labels = vec!["alice".to_owned(), "bob".to_owned(), "carol".to_owned()];
+        let mut subject = EngineHarnessSubject::new(
+            &labels,
+            ProtocolProfile::Current,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("engine subject constructs");
+        create_current_group_and_join(&mut subject, "alice", &labels[1..2]).await;
+
+        subject
+            .invite_members(SubjectInviteMembers {
+                action_id: "invite-carol",
+                inviter: "alice",
+                invitees: &labels[2..],
+                pending: "invite-carol-pending",
+            })
+            .await
+            .expect("invite produces outbound work");
+        let outbound = subject
+            .poll_outbound("alice")
+            .expect("invite artifacts are pollable");
+        let commit = outbound
+            .iter()
+            .find(|artifact| artifact.state_confirmation_required)
+            .expect("commit requires state confirmation")
+            .clone();
+        let welcome = outbound
+            .iter()
+            .find(|artifact| artifact.kind == SubjectOutboundKind::Welcome)
+            .expect("invite produces a Welcome")
+            .clone();
+        let pending_snapshot = subject
+            .client("alice")
+            .expect("alice exists")
+            .canonical_state_snapshot();
+
+        subject
+            .acknowledge_outbound(
+                "alice",
+                &welcome.outbound_id,
+                SubjectOutboundOutcome::Accepted,
+            )
+            .await
+            .expect("Welcome publication is accepted independently");
+        let failure = subject
+            .acknowledge_outbound(
+                "alice",
+                &commit.outbound_id,
+                SubjectOutboundOutcome::ReachedNoEndpoint,
+            )
+            .await
+            .expect_err("accepted sibling prevents definite publication rollback");
+        assert_eq!(failure.code, "outbound_already_exposed");
+        assert_eq!(
+            subject
+                .poll_outbound("alice")
+                .expect("commit remains unresolved"),
+            vec![commit.clone()]
+        );
+        assert_eq!(
+            subject
+                .client("alice")
+                .expect("alice exists")
+                .canonical_state_snapshot(),
+            pending_snapshot
+        );
+        let named_failure = subject
+            .fail_pending("alice", "invite-carol-pending")
+            .await
+            .expect_err("legacy pending control cannot bypass accepted sibling exposure");
+        assert_eq!(named_failure.code, "outbound_already_exposed");
+        subject
+            .acknowledge_outbound(
+                "alice",
+                &commit.outbound_id,
+                SubjectOutboundOutcome::Accepted,
+            )
+            .await
+            .expect("commit remains acceptably acknowledgeable");
+        subject
+            .acknowledge_outbound(
+                "alice",
+                &welcome.outbound_id,
+                SubjectOutboundOutcome::Accepted,
+            )
+            .await
+            .expect("the accepted Welcome outcome remains idempotent");
     }
 
     #[tokio::test]
@@ -1601,6 +1911,22 @@ mod tests {
                 .engine
                 .is_empty(),
             "a no-op publication must not strand pending MLS state"
+        );
+    }
+
+    #[test]
+    fn legacy_compatible_subject_does_not_advertise_outbound_publication() {
+        let subject = EngineHarnessSubject::new_legacy_compatible(
+            &["alice".to_owned()],
+            ProtocolProfile::Legacy,
+            HarnessStorageMode::InMemorySqlite,
+        )
+        .expect("legacy-compatible subject constructs");
+
+        assert!(
+            !subject
+                .descriptor()
+                .supports(SubjectCapability::OutboundPublication)
         );
     }
 

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -629,15 +629,12 @@ impl ConvergenceSubject for EngineHarnessSubject {
         if let Some(pending_ref) = pending_ref {
             self.insert_pending(action.pending, action.creator, pending_ref)?;
             self.sync_client_outbound(action.creator)?;
-            let has_outbound_artifacts = self.outbound_records.values().any(|record| {
-                record.artifact.client == action.creator && record.pending == Some(pending_ref)
-            });
-            if !has_outbound_artifacts {
-                self.client_mut(action.creator)?
-                    .try_confirm(pending_ref)
-                    .await
-                    .map_err(subject_engine_error)?;
-                self.client_mut(action.creator)?.capture_engine_events();
+            if self
+                .client_mut(action.creator)?
+                .confirm_empty_publication(pending_ref)
+                .await
+                .map_err(subject_engine_error)?
+            {
                 self.pending_refs.remove(action.pending);
             }
         }

--- a/crates/cgka-conformance-simulator/src/subject.rs
+++ b/crates/cgka-conformance-simulator/src/subject.rs
@@ -32,7 +32,6 @@ use std::sync::Arc;
 #[serde(rename_all = "snake_case")]
 pub enum SubjectCapability {
     GroupMutation,
-    PublicationLifecycle,
     ApplicationMessaging,
     TransportDelivery,
     EventObservation,
@@ -51,7 +50,6 @@ impl SubjectCapability {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::GroupMutation => "group_mutation",
-            Self::PublicationLifecycle => "publication_lifecycle",
             Self::ApplicationMessaging => "application_messaging",
             Self::TransportDelivery => "transport_delivery",
             Self::EventObservation => "event_observation",
@@ -192,6 +190,11 @@ pub enum SubjectOutboundOutcome {
 pub struct SubjectOutboundArtifact {
     pub outbound_id: String,
     pub client: String,
+    /// Stable scenario publication label, when the emission belongs to a
+    /// scenario-requested staged state transition. Engine-generated outbound
+    /// work intentionally leaves this unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub publication: Option<String>,
     pub kind: SubjectOutboundKind,
     pub message: TransportMessage,
     pub state_confirmation_required: bool,
@@ -230,18 +233,6 @@ pub trait ConvergenceSubject: Send {
         _action: SubjectUpdateAdminPolicy<'_>,
     ) -> Result<(), SubjectError> {
         Err(SubjectError::unsupported(SubjectCapability::GroupMutation))
-    }
-
-    async fn confirm_pending(&mut self, _client: &str, _pending: &str) -> Result<(), SubjectError> {
-        Err(SubjectError::unsupported(
-            SubjectCapability::PublicationLifecycle,
-        ))
-    }
-
-    async fn fail_pending(&mut self, _client: &str, _pending: &str) -> Result<(), SubjectError> {
-        Err(SubjectError::unsupported(
-            SubjectCapability::PublicationLifecycle,
-        ))
     }
 
     async fn send_application(
@@ -356,7 +347,7 @@ pub trait ConvergenceFaultSubject {
     fn clear_partition(&mut self) -> Result<(), SubjectError>;
 }
 
-/// Capability required for one ScenarioSpec v1 step.
+/// Capability required for one ScenarioSpec v2 step.
 pub fn required_capability(step: &ScenarioStep) -> SubjectCapability {
     match step {
         ScenarioStep::CreateGroup { .. }
@@ -365,9 +356,7 @@ pub fn required_capability(step: &ScenarioStep) -> SubjectCapability {
         | ScenarioStep::UpdateAdminPolicy { .. }
         | ScenarioStep::ExpectUpdateAdminPolicyError { .. }
         | ScenarioStep::Leave { .. } => SubjectCapability::GroupMutation,
-        ScenarioStep::ConfirmPending { .. } | ScenarioStep::FailPending { .. } => {
-            SubjectCapability::PublicationLifecycle
-        }
+        ScenarioStep::AcknowledgeOutbound { .. } => SubjectCapability::OutboundPublication,
         ScenarioStep::SendAppMessage { .. } => SubjectCapability::ApplicationMessaging,
         ScenarioStep::DeliverAll | ScenarioStep::Tick { .. } => {
             SubjectCapability::TransportDelivery
@@ -424,23 +413,6 @@ impl EngineHarnessSubject {
         protocol_profile: ProtocolProfile,
         storage_mode: HarnessStorageMode,
     ) -> Result<Self, SubjectError> {
-        Self::new_with_publication_lifecycle(clients, protocol_profile, storage_mode, true)
-    }
-
-    pub(crate) fn new_legacy_compatible(
-        clients: &[String],
-        protocol_profile: ProtocolProfile,
-        storage_mode: HarnessStorageMode,
-    ) -> Result<Self, SubjectError> {
-        Self::new_with_publication_lifecycle(clients, protocol_profile, storage_mode, false)
-    }
-
-    fn new_with_publication_lifecycle(
-        clients: &[String],
-        protocol_profile: ProtocolProfile,
-        storage_mode: HarnessStorageMode,
-        external_publication_lifecycle: bool,
-    ) -> Result<Self, SubjectError> {
         let bus = TransportBus::ordered();
         let convergence_clock = ManualConvergenceClock::new(0, 0);
         let mut attached = BTreeMap::new();
@@ -451,20 +423,16 @@ impl EngineHarnessSubject {
                     format!("duplicate client label {label}"),
                 ));
             }
-            let mut builder = ClientBuilder::new(pad32(label.as_bytes()))
+            let builder = ClientBuilder::new(pad32(label.as_bytes()))
                 .registry(scenario_registry())
                 .protocol_profile(protocol_profile)
                 .storage_mode(storage_mode)
                 .convergence_clock(Arc::new(convergence_clock.clone()));
-            if external_publication_lifecycle {
-                builder = builder.external_publication_lifecycle();
-            }
             let client = builder.attach(&bus);
             attached.insert(label.clone(), client);
         }
-        let mut capabilities = BTreeSet::from([
+        let capabilities = BTreeSet::from([
             SubjectCapability::GroupMutation,
-            SubjectCapability::PublicationLifecycle,
             SubjectCapability::ApplicationMessaging,
             SubjectCapability::TransportDelivery,
             SubjectCapability::EventObservation,
@@ -473,12 +441,10 @@ impl EngineHarnessSubject {
             SubjectCapability::AdminPolicyObservation,
             SubjectCapability::CrashReopen,
             SubjectCapability::VirtualTime,
+            SubjectCapability::OutboundPublication,
             SubjectCapability::WhiteBoxTransportQueueFaults,
             SubjectCapability::WhiteBoxTransportPartition,
         ]);
-        if external_publication_lifecycle {
-            capabilities.insert(SubjectCapability::OutboundPublication);
-        }
         Ok(Self {
             descriptor: SubjectDescriptor {
                 adapter: "mdk-engine-harness".into(),
@@ -550,27 +516,10 @@ impl EngineHarnessSubject {
         Ok(())
     }
 
-    fn pending_for_client(
-        &self,
-        label: &str,
-        client: &str,
-    ) -> Result<PendingStateRef, SubjectError> {
-        let pending = self.pending_refs.get(label).ok_or_else(|| {
-            SubjectError::new("unknown_pending", format!("unknown pending label {label}"))
-        })?;
-        if pending.client != client {
-            return Err(SubjectError::new(
-                "pending_client_mismatch",
-                format!("pending label {label} does not belong to {client}"),
-            ));
-        }
-        Ok(pending.pending)
-    }
-
-    fn take_pending(&mut self, label: &str, client: &str) -> Result<PendingStateRef, SubjectError> {
-        let pending = self.pending_for_client(label, client)?;
-        self.pending_refs.remove(label);
-        Ok(pending)
+    fn publication_for_pending(&self, client: &str, pending: PendingStateRef) -> Option<String> {
+        self.pending_refs.iter().find_map(|(label, candidate)| {
+            (candidate.client == client && candidate.pending == pending).then(|| label.clone())
+        })
     }
 
     fn sync_client_outbound(&mut self, label: &str) -> Result<(), SubjectError> {
@@ -586,6 +535,8 @@ impl EngineHarnessSubject {
             let pending = self
                 .client(label)?
                 .pending_publication_for_message(&emission.msg.id);
+            let publication =
+                pending.and_then(|pending| self.publication_for_pending(label, pending));
             let queued_intent = self
                 .client(label)?
                 .regenerated_queued_intent_for_message(&emission.msg.id);
@@ -605,6 +556,7 @@ impl EngineHarnessSubject {
                     artifact: SubjectOutboundArtifact {
                         outbound_id,
                         client: label.to_owned(),
+                        publication,
                         kind,
                         message: emission.msg,
                         state_confirmation_required,
@@ -676,6 +628,18 @@ impl ConvergenceSubject for EngineHarnessSubject {
             .await;
         if let Some(pending_ref) = pending_ref {
             self.insert_pending(action.pending, action.creator, pending_ref)?;
+            self.sync_client_outbound(action.creator)?;
+            let has_outbound_artifacts = self.outbound_records.values().any(|record| {
+                record.artifact.client == action.creator && record.pending == Some(pending_ref)
+            });
+            if !has_outbound_artifacts {
+                self.client_mut(action.creator)?
+                    .try_confirm(pending_ref)
+                    .await
+                    .map_err(subject_engine_error)?;
+                self.client_mut(action.creator)?.capture_engine_events();
+                self.pending_refs.remove(action.pending);
+            }
         }
         Ok(())
     }
@@ -717,41 +681,6 @@ impl ConvergenceSubject for EngineHarnessSubject {
         if let Some(pending) = action.pending {
             self.insert_pending(pending, action.client, pending_ref)?;
         }
-        Ok(())
-    }
-
-    async fn confirm_pending(&mut self, client: &str, pending: &str) -> Result<(), SubjectError> {
-        self.sync_client_outbound(client)?;
-        let pending_ref = self.take_pending(pending, client)?;
-        self.client_mut(client)?
-            .try_confirm(pending_ref)
-            .await
-            .map_err(subject_engine_error)?;
-        self.mark_pending_outbound(client, pending_ref, SubjectOutboundOutcome::Accepted);
-        Ok(())
-    }
-
-    async fn fail_pending(&mut self, client: &str, pending: &str) -> Result<(), SubjectError> {
-        self.sync_client_outbound(client)?;
-        let pending_ref = self.pending_for_client(pending, client)?;
-        if self.pending_non_confirmation_accepted(client, pending_ref) {
-            return Err(SubjectError::new(
-                "outbound_already_exposed",
-                format!(
-                    "cannot report definite publication failure for {pending} after a sibling artifact was accepted"
-                ),
-            ));
-        }
-        self.client_mut(client)?
-            .try_fail_publication(pending_ref)
-            .await
-            .map_err(subject_publication_error)?;
-        self.pending_refs.remove(pending);
-        self.mark_pending_outbound(
-            client,
-            pending_ref,
-            SubjectOutboundOutcome::ReachedNoEndpoint,
-        );
         Ok(())
     }
 
@@ -1694,11 +1623,6 @@ mod tests {
                 .canonical_state_snapshot(),
             pending_snapshot
         );
-        let named_failure = subject
-            .fail_pending("alice", "invite-carol-pending")
-            .await
-            .expect_err("legacy pending control cannot bypass accepted sibling exposure");
-        assert_eq!(named_failure.code, "outbound_already_exposed");
         subject
             .acknowledge_outbound(
                 "alice",
@@ -1876,7 +1800,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn empty_legacy_creation_confirms_without_synthetic_outbound_work() {
+    async fn empty_creation_confirms_without_synthetic_outbound_work() {
         let labels = vec!["alice".to_owned()];
         let mut subject = EngineHarnessSubject::new(
             &labels,
@@ -1888,7 +1812,7 @@ mod tests {
         subject
             .create_group(SubjectCreateGroup {
                 creator: "alice",
-                name: "empty-legacy-group",
+                name: "empty-group",
                 invitees: &[],
                 required_features: &[],
                 initial_admins: &[],
@@ -1914,25 +1838,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn legacy_compatible_subject_does_not_advertise_outbound_publication() {
-        let subject = EngineHarnessSubject::new_legacy_compatible(
-            &["alice".to_owned()],
-            ProtocolProfile::Legacy,
-            HarnessStorageMode::InMemorySqlite,
-        )
-        .expect("legacy-compatible subject constructs");
-
-        assert!(
-            !subject
-                .descriptor()
-                .supports(SubjectCapability::OutboundPublication)
-        );
-    }
-
     #[tokio::test]
-    async fn legacy_create_confirms_on_first_welcome_acceptance_and_keeps_other_welcomes_independent()
-     {
+    async fn create_confirms_on_first_welcome_acceptance_and_keeps_other_welcomes_independent() {
         let labels = vec!["alice".to_owned(), "bob".to_owned(), "carol".to_owned()];
         let mut subject = EngineHarnessSubject::new(
             &labels,
@@ -1943,17 +1850,17 @@ mod tests {
         subject
             .create_group(SubjectCreateGroup {
                 creator: "alice",
-                name: "legacy-create",
+                name: "explicit-create",
                 invitees: &labels[1..],
                 required_features: &[],
                 initial_admins: &[],
-                pending: "legacy-create-pending",
+                pending: "create-pending",
             })
             .await
-            .expect("legacy create produces welcomes");
+            .expect("create produces welcomes");
         let outbound = subject
             .poll_outbound("alice")
-            .expect("legacy welcomes are pollable");
+            .expect("welcomes are pollable");
         assert_eq!(outbound.len(), 2);
         assert!(
             outbound
@@ -2165,7 +2072,7 @@ mod tests {
     #[tokio::test]
     async fn engine_subject_virtual_time_is_shared_while_participant_wakes_are_selected() {
         let labels = vec!["alice".to_owned(), "bob".to_owned()];
-        let mut subject = EngineHarnessSubject::new_legacy_compatible(
+        let mut subject = EngineHarnessSubject::new(
             &labels,
             ProtocolProfile::Current,
             HarnessStorageMode::InMemorySqlite,
@@ -2194,8 +2101,24 @@ mod tests {
             client
                 .advance_convergence()
                 .await
-                .expect("prepare and confirm disband commit");
-            client
+                .expect("prepare disband commit");
+            let outbound = subject
+                .poll_outbound(label)
+                .expect("disband commit is pollable");
+            assert!(!outbound.is_empty(), "disband emits outbound work");
+            for artifact in outbound {
+                subject
+                    .acknowledge_outbound(
+                        label,
+                        &artifact.outbound_id,
+                        SubjectOutboundOutcome::Accepted,
+                    )
+                    .await
+                    .expect("accept disband publication");
+            }
+            subject
+                .client_mut(label)
+                .expect("client exists")
                 .advance_convergence()
                 .await
                 .expect("open collecting pass");

--- a/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
+++ b/crates/cgka-conformance-simulator/tests/canonical_scenarios.rs
@@ -8,11 +8,11 @@ use cgka_conformance_simulator::{
     ClientBuilder, ConformanceCanonicalStateSnapshot, EpochChangeObservation,
     GeneratedScenarioCase, HarnessClient, PendingResolutionObservation, ScenarioInputDisposition,
     ScenarioInputKind, ScenarioInputLedgerEntry, ScenarioReport, ScenarioSpec, ScenarioStep,
-    ScenarioTrace, TraceExpectation, TransportBus, VectorFixture, compare_trace_expectations,
-    generate_convergence_chaos_family, generate_convergence_e2e_delivery_family,
-    generate_send_leave_family, observe_client, observe_client_exact, run_generated_case_report,
-    run_scenario_report, run_scenario_report_with_outcomes, run_scenario_spec,
-    run_vector_fixture_report,
+    ScenarioTrace, SubjectOutboundOutcome, TraceExpectation, TransportBus, VectorFixture,
+    compare_trace_expectations, generate_convergence_chaos_family,
+    generate_convergence_e2e_delivery_family, generate_send_leave_family, observe_client,
+    observe_client_exact, run_generated_case_report, run_scenario_report,
+    run_scenario_report_with_outcomes, run_scenario_spec, run_vector_fixture_report,
 };
 use cgka_engine::ManualConvergenceClock;
 use cgka_engine::feature_registry::FeatureRegistry;
@@ -190,7 +190,10 @@ async fn exact_oracle_projects_terminal_disband_tombstone_across_restart() {
     alice
         .advance_convergence()
         .await
-        .expect("prepare and confirm disband commit");
+        .expect("prepare disband commit");
+    let pending = alice.pending_publication_refs();
+    assert_eq!(pending.len(), 1, "disband prepares one publication");
+    alice.confirm(pending[0]).await;
     alice
         .advance_convergence()
         .await
@@ -247,7 +250,7 @@ async fn exact_oracle_projects_terminal_disband_tombstone_across_restart() {
 async fn bidirectional_decryptability_probe_passes_for_settled_members() {
     let spec = ScenarioSpec {
         name: "bidirectional-decryptability/settled".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into(), "carol".into()],
         steps: vec![
             ScenarioStep::CreateGroup {
@@ -258,10 +261,7 @@ async fn bidirectional_decryptability_probe_passes_for_settled_members() {
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::accept_publication("alice", "create"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into(), "carol".into()],
@@ -310,7 +310,7 @@ async fn bidirectional_decryptability_probe_passes_for_settled_members() {
 async fn bidirectional_decryptability_probe_exposes_asymmetric_epoch_reachability() {
     let spec = ScenarioSpec {
         name: "bidirectional-decryptability/asymmetric-epoch".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into()],
         steps: vec![
             ScenarioStep::CreateGroup {
@@ -321,10 +321,7 @@ async fn bidirectional_decryptability_probe_exposes_asymmetric_epoch_reachabilit
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::accept_publication("alice", "create"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into()],
@@ -334,10 +331,7 @@ async fn bidirectional_decryptability_probe_exposes_asymmetric_epoch_reachabilit
                 name: "advanced-without-bob".into(),
                 pending: "advance".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "advance".into(),
-            },
+            ScenarioStep::accept_publication("alice", "advance"),
             ScenarioStep::DropQueued { index: 0 },
             ScenarioStep::ProbeBidirectionalDecryptability {
                 clients: vec!["alice".into(), "bob".into()],
@@ -392,7 +386,7 @@ async fn bidirectional_decryptability_probe_exposes_asymmetric_epoch_reachabilit
 async fn bidirectional_decryptability_probe_rejects_a_named_nonmember() {
     let spec = ScenarioSpec {
         name: "bidirectional-decryptability/nonmember".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into(), "carol".into()],
         steps: vec![
             ScenarioStep::CreateGroup {
@@ -403,10 +397,7 @@ async fn bidirectional_decryptability_probe_rejects_a_named_nonmember() {
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::accept_publication("alice", "create"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into()],
@@ -918,7 +909,7 @@ async fn three_client_message_exchange_vector_is_stable() {
 async fn scenario_spec_runs_three_client_message_exchange() {
     let spec = ScenarioSpec {
         name: "three-client-message-exchange/v1".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into(), "carol".into()],
         steps: vec![
             ScenarioStep::CreateGroup {
@@ -929,10 +920,7 @@ async fn scenario_spec_runs_three_client_message_exchange() {
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::accept_publication("alice", "create"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into(), "carol".into()],
@@ -968,7 +956,7 @@ async fn scenario_spec_runs_three_client_message_exchange() {
 async fn scenario_spec_supports_publish_fail() {
     let spec = ScenarioSpec {
         name: "publish-fail/v1".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into()],
         steps: vec![
             ScenarioStep::CreateGroup {
@@ -979,10 +967,7 @@ async fn scenario_spec_supports_publish_fail() {
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::FailPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::fail_publication("alice", "create"),
             ScenarioStep::Observe {
                 clients: vec!["alice".into()],
             },
@@ -1009,7 +994,7 @@ async fn scenario_spec_supports_publish_fail() {
 async fn definite_publish_failure_retracts_commit_before_local_rollback() {
     let spec = ScenarioSpec {
         name: "transported-commit-after-local-rollback/minimal/v1".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into()],
         steps: vec![
             ScenarioStep::CreateGroup {
@@ -1020,10 +1005,7 @@ async fn definite_publish_failure_retracts_commit_before_local_rollback() {
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::accept_publication("alice", "create"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into()],
@@ -1033,10 +1015,7 @@ async fn definite_publish_failure_retracts_commit_before_local_rollback() {
                 name: "after".into(),
                 pending: "update".into(),
             },
-            ScenarioStep::FailPending {
-                client: "alice".into(),
-                pending: "update".into(),
-            },
+            ScenarioStep::fail_publication("alice", "update"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into()],
@@ -1138,7 +1117,7 @@ async fn definite_publish_failure_retracts_commit_and_welcome() {
 }
 
 #[tokio::test]
-async fn fail_pending_rejects_artifact_that_already_reached_a_recipient() {
+async fn publication_failure_rejects_artifact_that_already_reached_a_recipient() {
     let bus = TransportBus::ordered();
     let mut alice = ClientBuilder::new(pad32(b"alice")).attach(&bus);
     let mut bob = ClientBuilder::new(pad32(b"bob")).attach(&bus);
@@ -1176,7 +1155,7 @@ async fn fail_pending_rejects_artifact_that_already_reached_a_recipient() {
 async fn scenario_spec_supports_leave_and_clear_partition() {
     let spec = ScenarioSpec {
         name: "leave-and-clear-partition/v1".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into()],
         steps: vec![
             ScenarioStep::CreateGroup {
@@ -1187,10 +1166,7 @@ async fn scenario_spec_supports_leave_and_clear_partition() {
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::accept_publication("alice", "create"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into()],
@@ -1244,7 +1220,7 @@ async fn scenario_spec_supports_leave_and_clear_partition() {
 async fn scenario_spec_can_drop_queued_message() {
     let spec = ScenarioSpec {
         name: "drop-queued/v1".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into()],
         steps: vec![
             ScenarioStep::CreateGroup {
@@ -1255,10 +1231,7 @@ async fn scenario_spec_can_drop_queued_message() {
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::accept_publication("alice", "create"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into()],
@@ -1290,7 +1263,7 @@ async fn scenario_spec_can_drop_queued_message() {
 async fn scenario_spec_can_duplicate_delay_and_reorder_queued_messages() {
     let spec = ScenarioSpec {
         name: "queue-faults/v1".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into(), "carol".into()],
         steps: vec![
             ScenarioStep::CreateGroup {
@@ -1301,10 +1274,7 @@ async fn scenario_spec_can_duplicate_delay_and_reorder_queued_messages() {
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::accept_publication("alice", "create"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into(), "carol".into()],
@@ -1362,7 +1332,7 @@ async fn scenario_spec_can_duplicate_delay_and_reorder_queued_messages() {
 async fn exact_observation_ledgers_commit_proposal_and_application_dispositions() {
     let spec = ScenarioSpec {
         name: "generalized-scenario-input-ledger/v1".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into()],
         steps: vec![
             ScenarioStep::CreateGroup {
@@ -1373,10 +1343,7 @@ async fn exact_observation_ledgers_commit_proposal_and_application_dispositions(
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::accept_publication("alice", "create"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into()],
@@ -1386,10 +1353,7 @@ async fn exact_observation_ledgers_commit_proposal_and_application_dispositions(
                 name: "ledger-updated".into(),
                 pending: "rename".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "rename".into(),
-            },
+            ScenarioStep::accept_publication("alice", "rename"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into()],
@@ -1640,11 +1604,15 @@ async fn convergence_chaos_family_generates_specs_with_semantic_expectations() {
         "chaos cases should include group-data races"
     );
     assert!(
-        cases.iter().any(|case| case
-            .scenario
-            .steps
+        cases
             .iter()
-            .any(|step| matches!(step, ScenarioStep::FailPending { .. }))),
+            .any(|case| case.scenario.steps.iter().any(|step| matches!(
+                step,
+                ScenarioStep::AcknowledgeOutbound {
+                    outcome: SubjectOutboundOutcome::ReachedNoEndpoint,
+                    ..
+                }
+            ))),
         "chaos cases should include publish rollback"
     );
     assert!(
@@ -1900,7 +1868,7 @@ async fn strict_chaos_boundary_retains_known_reliability_failures() {
 async fn failing_generated_case_records_a_minimized_reproducer() {
     let scenario = ScenarioSpec {
         name: "convergence-chaos/minimizer-smoke/v1".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into()],
         steps: vec![
             ScenarioStep::CreateGroup {
@@ -1911,10 +1879,7 @@ async fn failing_generated_case_records_a_minimized_reproducer() {
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::accept_publication("alice", "create"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into()],
@@ -2089,7 +2054,7 @@ async fn vector_fixture_report_records_semantic_expectation_failures() {
 fn group_data_fork_recovery_spec() -> ScenarioSpec {
     ScenarioSpec {
         name: "group-data-fork-recovery/v1".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into()],
         steps: vec![
             ScenarioStep::CreateGroup {
@@ -2100,10 +2065,7 @@ fn group_data_fork_recovery_spec() -> ScenarioSpec {
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::accept_publication("alice", "create"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into()],
@@ -2121,14 +2083,8 @@ fn group_data_fork_recovery_spec() -> ScenarioSpec {
                 name: "bob branch".into(),
                 pending: "bob-update".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "alice-update".into(),
-            },
-            ScenarioStep::ConfirmPending {
-                client: "bob".into(),
-                pending: "bob-update".into(),
-            },
+            ScenarioStep::accept_publication("alice", "alice-update"),
+            ScenarioStep::accept_publication("bob", "bob-update"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["alice".into(), "bob".into()],
@@ -2143,7 +2099,7 @@ fn group_data_fork_recovery_spec() -> ScenarioSpec {
 fn deliberate_fork_recovery_spec() -> ScenarioSpec {
     ScenarioSpec {
         name: "deliberate-fork-recovery/v1".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into(), "david".into(), "eve".into()],
         steps: vec![
             ScenarioStep::CreateGroup {
@@ -2154,10 +2110,7 @@ fn deliberate_fork_recovery_spec() -> ScenarioSpec {
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::accept_publication("alice", "create"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into()],
@@ -2175,14 +2128,8 @@ fn deliberate_fork_recovery_spec() -> ScenarioSpec {
                 invitees: vec!["eve".into()],
                 pending: "bob-invite".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "alice-invite".into(),
-            },
-            ScenarioStep::ConfirmPending {
-                client: "bob".into(),
-                pending: "bob-invite".into(),
-            },
+            ScenarioStep::accept_publication("alice", "alice-invite"),
+            ScenarioStep::accept_publication("bob", "bob-invite"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["alice".into(), "bob".into()],
@@ -2198,7 +2145,7 @@ fn deliberate_fork_recovery_spec() -> ScenarioSpec {
 async fn scenario_report_records_mismatch_as_invariant_failure() {
     let spec = ScenarioSpec {
         name: "report-mismatch/v1".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec!["alice".into(), "bob".into()],
         steps: vec![
             ScenarioStep::CreateGroup {
@@ -2209,10 +2156,7 @@ async fn scenario_report_records_mismatch_as_invariant_failure() {
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::accept_publication("alice", "create"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into()],
@@ -2728,7 +2672,7 @@ async fn canonical_vector_fixtures_match_generated_traces() {
 fn convergence_e2e_group_events_spec() -> ScenarioSpec {
     ScenarioSpec {
         name: "convergence-e2e-group-events/v1".into(),
-        spec_version: "1".into(),
+        spec_version: "2".into(),
         clients: vec![
             "alice".into(),
             "bob".into(),
@@ -2747,10 +2691,7 @@ fn convergence_e2e_group_events_spec() -> ScenarioSpec {
                 initial_admins: None,
                 pending: "create".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "create".into(),
-            },
+            ScenarioStep::accept_publication("alice", "create"),
             ScenarioStep::DeliverAll,
             ScenarioStep::Tick {
                 clients: vec!["bob".into(), "carol".into(), "frank".into()],
@@ -2763,28 +2704,19 @@ fn convergence_e2e_group_events_spec() -> ScenarioSpec {
                 invitees: vec!["david".into()],
                 pending: "alice-invite-david".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "alice-invite-david".into(),
-            },
+            ScenarioStep::accept_publication("alice", "alice-invite-david"),
             ScenarioStep::InviteMembers {
                 inviter: "alice".into(),
                 invitees: vec!["grace".into()],
                 pending: "alice-invite-grace".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "alice".into(),
-                pending: "alice-invite-grace".into(),
-            },
+            ScenarioStep::accept_publication("alice", "alice-invite-grace"),
             ScenarioStep::InviteMembers {
                 inviter: "bob".into(),
                 invitees: vec!["eve".into()],
                 pending: "bob-invite-eve".into(),
             },
-            ScenarioStep::ConfirmPending {
-                client: "bob".into(),
-                pending: "bob-invite-eve".into(),
-            },
+            ScenarioStep::accept_publication("bob", "bob-invite-eve"),
             ScenarioStep::SendAppMessage {
                 sender: "alice".into(),
                 payload: "alice canonical payload".into(),

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -22,7 +22,12 @@
         "initial_admins": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },
@@ -63,7 +68,12 @@
         ],
         "pending": "promote-bob"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "promote-bob", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "promote-bob",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },
@@ -86,7 +96,12 @@
         "name": "bob-renamed",
         "pending": "bob-rename"
       },
-      { "type": "acknowledge_outbound", "client": "bob", "publication": "bob-rename", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "bob",
+        "publication": "bob-rename",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },
@@ -104,7 +119,12 @@
         ],
         "pending": "self-demote-bob"
       },
-      { "type": "acknowledge_outbound", "client": "bob", "publication": "self-demote-bob", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "bob",
+        "publication": "self-demote-bob",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/admin-policy-update.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "admin-policy-update/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob"
@@ -22,11 +22,7 @@
         "initial_admins": [],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },
@@ -67,11 +63,7 @@
         ],
         "pending": "promote-bob"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "promote-bob"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "promote-bob", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },
@@ -94,11 +86,7 @@
         "name": "bob-renamed",
         "pending": "bob-rename"
       },
-      {
-        "type": "confirm_pending",
-        "client": "bob",
-        "pending": "bob-rename"
-      },
+      { "type": "acknowledge_outbound", "client": "bob", "publication": "bob-rename", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },
@@ -116,11 +104,7 @@
         ],
         "pending": "self-demote-bob"
       },
-      {
-        "type": "confirm_pending",
-        "client": "bob",
-        "pending": "self-demote-bob"
-      },
+      { "type": "acknowledge_outbound", "client": "bob", "publication": "self-demote-bob", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "concurrent-invite-fork-recovery/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob",
@@ -23,11 +23,7 @@
         "required_features": [],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },
@@ -69,16 +65,8 @@
         ],
         "pending": "bob-invite"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "alice-invite"
-      },
-      {
-        "type": "confirm_pending",
-        "client": "bob",
-        "pending": "bob-invite"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "alice-invite", "outcome": "accepted" },
+      { "type": "acknowledge_outbound", "client": "bob", "publication": "bob-invite", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/concurrent-invite-fork-recovery.v1.json
@@ -23,7 +23,12 @@
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },
@@ -65,8 +70,18 @@
         ],
         "pending": "bob-invite"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "alice-invite", "outcome": "accepted" },
-      { "type": "acknowledge_outbound", "client": "bob", "publication": "bob-invite", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "alice-invite",
+        "outcome": "accepted"
+      },
+      {
+        "type": "acknowledge_outbound",
+        "client": "bob",
+        "publication": "bob-invite",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -28,7 +28,12 @@
         ],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },
@@ -63,8 +68,18 @@
         ],
         "pending": "bob-invite"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "alice-invite", "outcome": "accepted" },
-      { "type": "acknowledge_outbound", "client": "bob", "publication": "bob-invite", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "alice-invite",
+        "outcome": "accepted"
+      },
+      {
+        "type": "acknowledge_outbound",
+        "client": "bob",
+        "publication": "bob-invite",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-committer-selected.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "convergence-committer-selected/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob",
@@ -28,11 +28,7 @@
         ],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },
@@ -67,16 +63,8 @@
         ],
         "pending": "bob-invite"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "alice-invite"
-      },
-      {
-        "type": "confirm_pending",
-        "client": "bob",
-        "pending": "bob-invite"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "alice-invite", "outcome": "accepted" },
+      { "type": "acknowledge_outbound", "client": "bob", "publication": "bob-invite", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -5,19 +5,19 @@
   "seed": null,
   "scenario": {
     "name": "convergence-witness-selected/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": ["alice", "bob", "carol", "david", "eve"],
     "steps": [
       { "type": "create_group", "creator": "alice", "name": "convergence", "invitees": ["bob", "carol"], "required_features": [], "initial_admins": ["bob"], "pending": "create" },
-      { "type": "confirm_pending", "client": "alice", "pending": "create" },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       { "type": "deliver_all" },
       { "type": "tick", "clients": ["bob", "carol"] },
       { "type": "clear_events", "clients": ["alice", "bob", "carol"] },
 
       { "type": "invite_members", "inviter": "alice", "invitees": ["david"], "pending": "invite-a" },
       { "type": "invite_members", "inviter": "bob", "invitees": ["eve"], "pending": "invite-b" },
-      { "type": "confirm_pending", "client": "alice", "pending": "invite-a" },
-      { "type": "confirm_pending", "client": "bob", "pending": "invite-b" },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-a", "outcome": "accepted" },
+      { "type": "acknowledge_outbound", "client": "bob", "publication": "invite-b", "outcome": "accepted" },
 
       { "type": "delay_queued", "index": 3, "delayed": "held-b" },
       { "type": "deliver_all" },

--- a/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/convergence-witness-selected.v1.json
@@ -9,15 +9,30 @@
     "clients": ["alice", "bob", "carol", "david", "eve"],
     "steps": [
       { "type": "create_group", "creator": "alice", "name": "convergence", "invitees": ["bob", "carol"], "required_features": [], "initial_admins": ["bob"], "pending": "create" },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       { "type": "deliver_all" },
       { "type": "tick", "clients": ["bob", "carol"] },
       { "type": "clear_events", "clients": ["alice", "bob", "carol"] },
 
       { "type": "invite_members", "inviter": "alice", "invitees": ["david"], "pending": "invite-a" },
       { "type": "invite_members", "inviter": "bob", "invitees": ["eve"], "pending": "invite-b" },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-a", "outcome": "accepted" },
-      { "type": "acknowledge_outbound", "client": "bob", "publication": "invite-b", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "invite-a",
+        "outcome": "accepted"
+      },
+      {
+        "type": "acknowledge_outbound",
+        "client": "bob",
+        "publication": "invite-b",
+        "outcome": "accepted"
+      },
 
       { "type": "delay_queued", "index": 3, "delayed": "held-b" },
       { "type": "deliver_all" },

--- a/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/current-profile-required-set.v1.json
@@ -24,7 +24,7 @@
   },
   "scenario": {
     "name": "current-profile-required-set/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob"

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "delayed-past-epoch-app-message/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob",
@@ -24,11 +24,7 @@
         "required_features": [],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },
@@ -66,11 +62,7 @@
         ],
         "pending": "invite-david"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "invite-david"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-david", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/delayed-past-epoch-app-message.v1.json
@@ -24,7 +24,12 @@
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },
@@ -62,7 +67,12 @@
         ],
         "pending": "invite-david"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-david", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "invite-david",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "drop-queued/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob"
@@ -21,11 +21,7 @@
         "required_features": [],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/drop-queued.v1.json
@@ -21,7 +21,12 @@
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -21,7 +21,12 @@
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },
@@ -50,8 +55,18 @@
         "name": "bob branch",
         "pending": "bob-update"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "alice-update", "outcome": "accepted" },
-      { "type": "acknowledge_outbound", "client": "bob", "publication": "bob-update", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "alice-update",
+        "outcome": "accepted"
+      },
+      {
+        "type": "acknowledge_outbound",
+        "client": "bob",
+        "publication": "bob-update",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-fork-recovery.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "group-data-fork-recovery/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob"
@@ -21,11 +21,7 @@
         "required_features": [],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },
@@ -54,16 +50,8 @@
         "name": "bob branch",
         "pending": "bob-update"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "alice-update"
-      },
-      {
-        "type": "confirm_pending",
-        "client": "bob",
-        "pending": "bob-update"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "alice-update", "outcome": "accepted" },
+      { "type": "acknowledge_outbound", "client": "bob", "publication": "bob-update", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "group-data-update/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob"
@@ -21,11 +21,7 @@
         "required_features": [],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },
@@ -48,11 +44,7 @@
         "name": "after",
         "pending": "rename"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "rename"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "rename", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/group-data-update.v1.json
@@ -21,7 +21,12 @@
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },
@@ -44,7 +49,12 @@
         "name": "after",
         "pending": "rename"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "rename", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "rename",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -28,7 +28,12 @@
         ],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },
@@ -63,8 +68,18 @@
         ],
         "pending": "invite-b"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-a", "outcome": "accepted" },
-      { "type": "acknowledge_outbound", "client": "bob", "publication": "invite-b", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "invite-a",
+        "outcome": "accepted"
+      },
+      {
+        "type": "acknowledge_outbound",
+        "client": "bob",
+        "publication": "invite-b",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/convergence-incident.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "convergence-incident/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob",
@@ -28,11 +28,7 @@
         ],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },
@@ -67,16 +63,8 @@
         ],
         "pending": "invite-b"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "invite-a"
-      },
-      {
-        "type": "confirm_pending",
-        "client": "bob",
-        "pending": "invite-b"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-a", "outcome": "accepted" },
+      { "type": "acknowledge_outbound", "client": "bob", "publication": "invite-b", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "fork-recovery-incident/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "bob",
       "alice"
@@ -21,11 +21,7 @@
         "required_features": [],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "bob",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "bob", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },
@@ -54,16 +50,8 @@
         "name": "loser-branch",
         "pending": "l"
       },
-      {
-        "type": "confirm_pending",
-        "client": "bob",
-        "pending": "w"
-      },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "l"
-      },
+      { "type": "acknowledge_outbound", "client": "bob", "publication": "w", "outcome": "accepted" },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "l", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/fork-recovery-incident.v1.json
@@ -21,7 +21,12 @@
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "bob", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "bob",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },
@@ -50,8 +55,18 @@
         "name": "loser-branch",
         "pending": "l"
       },
-      { "type": "acknowledge_outbound", "client": "bob", "publication": "w", "outcome": "accepted" },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "l", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "bob",
+        "publication": "w",
+        "outcome": "accepted"
+      },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "l",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -23,7 +23,12 @@
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },
@@ -65,8 +70,18 @@
         ],
         "pending": "l"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "w", "outcome": "accepted" },
-      { "type": "acknowledge_outbound", "client": "bob", "publication": "l", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "w",
+        "outcome": "accepted"
+      },
+      {
+        "type": "acknowledge_outbound",
+        "client": "bob",
+        "publication": "l",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/incidents/membership-fork-recovery-incident.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "membership-fork-recovery-incident/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob",
@@ -23,11 +23,7 @@
         "required_features": [],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },
@@ -69,16 +65,8 @@
         ],
         "pending": "l"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "w"
-      },
-      {
-        "type": "confirm_pending",
-        "client": "bob",
-        "pending": "l"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "w", "outcome": "accepted" },
+      { "type": "acknowledge_outbound", "client": "bob", "publication": "l", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "invite-member/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob",
@@ -22,11 +22,7 @@
         "required_features": [],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },
@@ -52,11 +48,7 @@
         ],
         "pending": "invite-carol"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "invite-carol"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-carol", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-member.v1.json
@@ -22,7 +22,12 @@
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },
@@ -48,7 +53,12 @@
         ],
         "pending": "invite-carol"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-carol", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "invite-carol",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -22,7 +22,12 @@
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },
@@ -47,7 +52,12 @@
         ],
         "pending": "invite-carol"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-carol", "outcome": "reached_no_endpoint" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "invite-carol",
+        "outcome": "reached_no_endpoint"
+      },
       {
         "type": "observe",
         "clients": [

--- a/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/invite-publish-fail.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "invite-publish-fail/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob",
@@ -22,11 +22,7 @@
         "required_features": [],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },
@@ -51,11 +47,7 @@
         ],
         "pending": "invite-carol"
       },
-      {
-        "type": "fail_pending",
-        "client": "alice",
-        "pending": "invite-carol"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "invite-carol", "outcome": "reached_no_endpoint" },
       {
         "type": "observe",
         "clients": [

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -21,7 +21,12 @@
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },
@@ -88,7 +93,11 @@
           "alice"
         ]
       },
-      { "type": "acknowledge_outbound", "client": "alice", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/partition-clear-leave.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "partition-clear-leave/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob"
@@ -21,11 +21,7 @@
         "required_features": [],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },
@@ -92,6 +88,7 @@
           "alice"
         ]
       },
+      { "type": "acknowledge_outbound", "client": "alice", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "publish-fail/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob"
@@ -21,11 +21,7 @@
         "required_features": [],
         "pending": "create"
       },
-      {
-        "type": "fail_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "reached_no_endpoint" },
       {
         "type": "observe",
         "clients": [

--- a/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/publish-fail.v1.json
@@ -21,7 +21,12 @@
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "reached_no_endpoint" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "reached_no_endpoint"
+      },
       {
         "type": "observe",
         "clients": [

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -23,7 +23,12 @@
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/queue-faults.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "queue-faults/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob",
@@ -23,11 +23,7 @@
         "required_features": [],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -23,7 +23,12 @@
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/restart-delivery-faults.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "restart-delivery-faults/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob",
@@ -23,11 +23,7 @@
         "required_features": [],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -5,7 +5,7 @@
   "seed": null,
   "scenario": {
     "name": "three-client-message-exchange/v1",
-    "spec_version": "1",
+    "spec_version": "2",
     "clients": [
       "alice",
       "bob",
@@ -23,11 +23,7 @@
         "required_features": [],
         "pending": "create"
       },
-      {
-        "type": "confirm_pending",
-        "client": "alice",
-        "pending": "create"
-      },
+      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
       {
         "type": "deliver_all"
       },

--- a/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
+++ b/crates/cgka-conformance-simulator/vectors/three-client-message-exchange.v1.json
@@ -23,7 +23,12 @@
         "required_features": [],
         "pending": "create"
       },
-      { "type": "acknowledge_outbound", "client": "alice", "publication": "create", "outcome": "accepted" },
+      {
+        "type": "acknowledge_outbound",
+        "client": "alice",
+        "publication": "create",
+        "outcome": "accepted"
+      },
       {
         "type": "deliver_all"
       },

--- a/crates/incident-replay/src/synth.rs
+++ b/crates/incident-replay/src/synth.rs
@@ -52,10 +52,7 @@ fn synthesize_group_data_fork(name: &str, winner: &str, loser: &str) -> VectorFi
             initial_admins: None,
             pending: "create".to_owned(),
         },
-        ScenarioStep::ConfirmPending {
-            client: winner.to_owned(),
-            pending: "create".to_owned(),
-        },
+        ScenarioStep::accept_publication(winner.to_owned(), "create".to_owned()),
         ScenarioStep::DeliverAll,
         ScenarioStep::Tick {
             clients: vec![loser.to_owned()],
@@ -74,14 +71,8 @@ fn synthesize_group_data_fork(name: &str, winner: &str, loser: &str) -> VectorFi
             name: LOSER_BRANCH.to_owned(),
             pending: "l".to_owned(),
         },
-        ScenarioStep::ConfirmPending {
-            client: winner.to_owned(),
-            pending: "w".to_owned(),
-        },
-        ScenarioStep::ConfirmPending {
-            client: loser.to_owned(),
-            pending: "l".to_owned(),
-        },
+        ScenarioStep::accept_publication(winner.to_owned(), "w".to_owned()),
+        ScenarioStep::accept_publication(loser.to_owned(), "l".to_owned()),
         ScenarioStep::DeliverAll,
         ScenarioStep::Tick {
             clients: vec![winner.to_owned(), loser.to_owned()],
@@ -99,7 +90,7 @@ fn synthesize_group_data_fork(name: &str, winner: &str, loser: &str) -> VectorFi
         application_profile: None,
         scenario: ScenarioSpec {
             name: name.to_owned(),
-            spec_version: "1".to_owned(),
+            spec_version: "2".to_owned(),
             clients: vec![winner.to_owned(), loser.to_owned()],
             steps,
         },
@@ -163,10 +154,7 @@ fn synthesize_membership_fork(name: &str, winner: &str, loser: &str) -> VectorFi
             initial_admins: None,
             pending: "create".to_owned(),
         },
-        ScenarioStep::ConfirmPending {
-            client: winner.to_owned(),
-            pending: "create".to_owned(),
-        },
+        ScenarioStep::accept_publication(winner.to_owned(), "create".to_owned()),
         ScenarioStep::DeliverAll,
         ScenarioStep::Tick {
             clients: vec![loser.to_owned()],
@@ -191,14 +179,8 @@ fn synthesize_membership_fork(name: &str, winner: &str, loser: &str) -> VectorFi
             invitees: vec![FORK_INVITEE_B.to_owned()],
             pending: "l".to_owned(),
         },
-        ScenarioStep::ConfirmPending {
-            client: winner.to_owned(),
-            pending: "w".to_owned(),
-        },
-        ScenarioStep::ConfirmPending {
-            client: loser.to_owned(),
-            pending: "l".to_owned(),
-        },
+        ScenarioStep::accept_publication(winner.to_owned(), "w".to_owned()),
+        ScenarioStep::accept_publication(loser.to_owned(), "l".to_owned()),
         ScenarioStep::DeliverAll,
         ScenarioStep::Tick {
             clients: vec![winner.to_owned(), loser.to_owned()],
@@ -216,7 +198,7 @@ fn synthesize_membership_fork(name: &str, winner: &str, loser: &str) -> VectorFi
         application_profile: None,
         scenario: ScenarioSpec {
             name: name.to_owned(),
-            spec_version: "1".to_owned(),
+            spec_version: "2".to_owned(),
             clients,
             steps,
         },
@@ -298,10 +280,7 @@ fn convergence_preamble() -> Vec<ScenarioStep> {
             initial_admins: Some(vec![COMMITTER_B.to_owned()]),
             pending: "create".to_owned(),
         },
-        ScenarioStep::ConfirmPending {
-            client: COMMITTER_A.to_owned(),
-            pending: "create".to_owned(),
-        },
+        ScenarioStep::accept_publication(COMMITTER_A.to_owned(), "create".to_owned()),
         ScenarioStep::DeliverAll,
         ScenarioStep::Tick {
             clients: vec![COMMITTER_B.to_owned(), OBSERVER.to_owned()],
@@ -324,14 +303,8 @@ fn convergence_preamble() -> Vec<ScenarioStep> {
             invitees: vec![INVITEE_B.to_owned()],
             pending: "invite-b".to_owned(),
         },
-        ScenarioStep::ConfirmPending {
-            client: COMMITTER_A.to_owned(),
-            pending: "invite-a".to_owned(),
-        },
-        ScenarioStep::ConfirmPending {
-            client: COMMITTER_B.to_owned(),
-            pending: "invite-b".to_owned(),
-        },
+        ScenarioStep::accept_publication(COMMITTER_A.to_owned(), "invite-a".to_owned()),
+        ScenarioStep::accept_publication(COMMITTER_B.to_owned(), "invite-b".to_owned()),
     ]
 }
 
@@ -349,7 +322,7 @@ fn convergence_fixture(
         application_profile: None,
         scenario: ScenarioSpec {
             name: name.to_owned(),
-            spec_version: "1".to_owned(),
+            spec_version: "2".to_owned(),
             clients: [COMMITTER_A, COMMITTER_B, OBSERVER, INVITEE_A, INVITEE_B]
                 .into_iter()
                 .map(str::to_owned)

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -443,6 +443,11 @@ delivery-or-invalidation expectation accounts for it; that is an oracle coverage
 
 Status: `complete`
 
+Completion here means the explicit engine-subject contract and its capability boundary are implemented. Portable
+Scenario IR adoption is still owned by Milestone 2.1 and
+[MDK #1207](https://github.com/marmot-protocol/mdk/issues/1207); until then, v1 runners use a compatibility constructor
+that deliberately does not advertise outbound-publication support.
+
 - [x] Define a simulator-owned `ConvergenceSubject` interface that keeps scenario semantics in the runner and exposes
   semantic engine operations through declared adapter capabilities.
 - [x] Implement the first engine-adapter vertical slice: create/mutate, publication confirmation/failure, application
@@ -515,6 +520,9 @@ Status: `not-started`
 - [ ] Replace queue indices with semantic action/message selectors.
 - [ ] Add `exactly`, `eventually`, `within`, `never`, and resource assertions.
 - [ ] Compile `ScenarioSpec` v1 into v2 so existing vectors retain meaning.
+- [ ] Add portable outbound poll/acknowledgement operations, migrate built-in runners to the explicit lifecycle, and
+  remove the legacy-compatible constructor and dual client lifecycle
+  ([MDK #1207](https://github.com/marmot-protocol/mdk/issues/1207)).
 
 ### 2.2 Adapter contract
 
@@ -815,4 +823,4 @@ incorrect result.
 | 2026-07-30 | M5 projection-maintenance prerequisite | Made large-set projection pruning bounded, preserved draft-owning groups, and made secure-delete checkpoint completion durable and explicitly observable as `erasure_pending` | [MDK #1201](https://github.com/marmot-protocol/mdk/pull/1201), merge `eec70bd9`; 307 storage tests; focused app/UniFFI retention tests; `just fast-ci` |
 | 2026-07-30 | M5 account-device modeling input | Documented a non-normative multi-device design space while deliberately leaving admission, synchronization, and repair choices unresolved; future scenarios must model account-device instances without assuming those candidate semantics | [MDK #1199](https://github.com/marmot-protocol/mdk/pull/1199), merge `aac777f3`; documentation-only |
 | 2026-07-30 | 1.2c / 1.3b subject virtual time | Added a capability-gated `advance_time` scenario operation backed by one shared paired clock across the engine subject; time advancement is a separate failure-free operation and `Tick` selects which participant runtimes observe it, while standalone clients without an injected clock preserve the legacy far-future shortcut | [MDK #1202](https://github.com/marmot-protocol/mdk/pull/1202), merge `1ccc4065`; focused serialization/preflight/dispatch test; two real disband passes remain live at a 999 ms tick, Alice alone settles at 1,000 ms, and Bob settles on a later tick without another time advance; full simulator suite |
-| 2026-07-30 | 1.2d public outbound lifecycle | Added non-destructive polling of exact transport-ready subject artifacts and typed accepted/no-endpoint acknowledgement; state-bearing commits, independent Welcomes, definite rollback, regenerated queued intents, scheduled evolution work, duplicate acknowledgement, and exposure refusal retain their distinct semantics without exposing mutable bus queues | Focused subject contract tests; full simulator suite; `just fast-ci` |
+| 2026-07-30 | 1.2d public outbound lifecycle | Added non-destructive polling of exact transport-ready subject artifacts and typed accepted/no-endpoint acknowledgement; client-scoped pending identities, state-bearing commits, independent Welcomes, definite rollback, regenerated queued intents, scheduled evolution work, duplicate acknowledgement, and exposure refusal retain their distinct semantics without exposing mutable bus queues; v1 lifecycle removal is tracked in [MDK #1207](https://github.com/marmot-protocol/mdk/issues/1207) | Focused subject contract tests; full simulator suite; `just fast-ci` |

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -73,8 +73,9 @@ The repository already provides:
 
 The baseline is useful scaffolding, but it is not yet the target reliability lab:
 
-- portable `ClientsConverged` checks epoch/member count rather than exact member and state equivalence;
-- normal scenarios can use a harness with engine/storage access;
+- legacy portable `ClientsConverged` remains an epoch/member-count check, although strict reliability scenarios now use
+  exact canonical state, ledgers, pending-work sentinels, and active decryptability;
+- the engine subject is black-box by default, but app-runtime, retained-relay, and process adapters do not exist yet;
 - a partition drops messages instead of retaining relay history for reconnect;
 - queue emptiness does not prove all client, pass, publication, retry, deferred, or projection work is quiescent;
 - generated storms are structural tests rather than sustained rate/volume campaigns;
@@ -431,14 +432,16 @@ point hid. Two are resolved without weakening the oracle:
   schedule signals consumed by a confirmed or converged commit, including across restart.
 
 One engine-state failure remains: a member invited after an old application event can retain that pre-join object as
-transport/scenario-input pending work. It remains red strict-campaign evidence, not a relaxed oracle rule. Report
-campaigns run the complete strict expectations by default. Strict coverage also flags the mixed large storm because its
-application phase is cleared before any delivery-or-invalidation expectation accounts for it; that is an oracle coverage
-gap, distinct from the remaining engine-state failure.
+transport/scenario-input pending work. [MDK #1193](https://github.com/marmot-protocol/mdk/issues/1193) contains the
+minimized production-shaped reproducer, source trace, privacy-preserving durable resource-retirement design, and
+restart/clock/rejoin/redelivery acceptance criteria. It remains red strict-campaign evidence until that researched
+resource-lifecycle change lands; the oracle rule is not relaxed. Report campaigns run the complete strict expectations
+by default. Strict coverage also flags the mixed large storm because its application phase is cleared before any
+delivery-or-invalidation expectation accounts for it; that is an oracle coverage gap distinct from #1193.
 
 ### 1.2 Public subject boundary
 
-Status: `in-progress`
+Status: `complete`
 
 - [x] Define a simulator-owned `ConvergenceSubject` interface that keeps scenario semantics in the runner and exposes
   semantic engine operations through declared adapter capabilities.
@@ -446,7 +449,7 @@ Status: `in-progress`
   send, transport delivery/ingest, event/exact/admin observation, active decryptability probing, and crash/reopen.
 - [x] Add a capability-gated, serializable virtual-time advance backed by one shared paired clock; keep time advancement
   separate from `Tick`, which selects the participant runtimes that wake and observe elapsed deadlines.
-- [ ] Add explicit public outbound polling/acknowledgement so later adapters can model publication progress without
+- [x] Add explicit public outbound polling/acknowledgement so later adapters can model publication progress without
   exposing harness queues.
 - [x] Split normal black-box execution from the explicitly named `ConvergenceFaultSubject` queue/partition mutation
   capability; reserve a named white-box storage-fault capability for a future adapter.
@@ -811,4 +814,5 @@ incorrect result.
 | 2026-07-30 | M5 app-runtime ownership prerequisite | Enforced one live account session per account within a `MarmotApp`, surfaced typed contention through UniFFI, and made worker reconnect release the failed client before replacement | [MDK #1200](https://github.com/marmot-protocol/mdk/pull/1200), merge `8dc7c12b`; ownership, worker-lifecycle, FFI, and focused runtime tests |
 | 2026-07-30 | M5 projection-maintenance prerequisite | Made large-set projection pruning bounded, preserved draft-owning groups, and made secure-delete checkpoint completion durable and explicitly observable as `erasure_pending` | [MDK #1201](https://github.com/marmot-protocol/mdk/pull/1201), merge `eec70bd9`; 307 storage tests; focused app/UniFFI retention tests; `just fast-ci` |
 | 2026-07-30 | M5 account-device modeling input | Documented a non-normative multi-device design space while deliberately leaving admission, synchronization, and repair choices unresolved; future scenarios must model account-device instances without assuming those candidate semantics | [MDK #1199](https://github.com/marmot-protocol/mdk/pull/1199), merge `aac777f3`; documentation-only |
-| 2026-07-30 | 1.2c / 1.3b subject virtual time | Added a capability-gated `advance_time` scenario operation backed by one shared paired clock across the engine subject; time advancement is a separate failure-free operation and `Tick` selects which participant runtimes observe it, while standalone clients without an injected clock preserve the legacy far-future shortcut | Focused serialization/preflight/dispatch test; two real disband passes remain live at a 999 ms tick, Alice alone settles at 1,000 ms, and Bob settles on a later tick without another time advance; full simulator suite |
+| 2026-07-30 | 1.2c / 1.3b subject virtual time | Added a capability-gated `advance_time` scenario operation backed by one shared paired clock across the engine subject; time advancement is a separate failure-free operation and `Tick` selects which participant runtimes observe it, while standalone clients without an injected clock preserve the legacy far-future shortcut | [MDK #1202](https://github.com/marmot-protocol/mdk/pull/1202), merge `1ccc4065`; focused serialization/preflight/dispatch test; two real disband passes remain live at a 999 ms tick, Alice alone settles at 1,000 ms, and Bob settles on a later tick without another time advance; full simulator suite |
+| 2026-07-30 | 1.2d public outbound lifecycle | Added non-destructive polling of exact transport-ready subject artifacts and typed accepted/no-endpoint acknowledgement; state-bearing commits, independent Welcomes, definite rollback, regenerated queued intents, scheduled evolution work, duplicate acknowledgement, and exposure refusal retain their distinct semantics without exposing mutable bus queues | Focused subject contract tests; full simulator suite; `just fast-ci` |

--- a/docs/marmot-architecture/convergence-reliability-plan.md
+++ b/docs/marmot-architecture/convergence-reliability-plan.md
@@ -64,7 +64,7 @@ Checkboxes represent repository state, not intention. A checked item must have e
 The repository already provides:
 
 - a real `Engine<SqliteAccountStorage>` harness with OpenMLS and the Nostr peeler;
-- scripted `ScenarioSpec` v1 cases and portable vectors;
+- scripted `ScenarioSpec` v2 cases and portable vectors;
 - seeded delivery schedules, generated chaos families, reports, and conservative failure minimization;
 - symbolic selector/canonicalization properties and engine integration tests;
 - encrypted file-backed restart coverage;
@@ -443,10 +443,10 @@ delivery-or-invalidation expectation accounts for it; that is an oracle coverage
 
 Status: `complete`
 
-Completion here means the explicit engine-subject contract and its capability boundary are implemented. Portable
-Scenario IR adoption is still owned by Milestone 2.1 and
-[MDK #1207](https://github.com/marmot-protocol/mdk/issues/1207); until then, v1 runners use a compatibility constructor
-that deliberately does not advertise outbound-publication support.
+Completion here means the explicit engine-subject contract and its capability boundary are implemented. The
+publication-control slice of Scenario IR v2 is also complete: every built-in runner uses exact outbound polling and
+typed acknowledgement, and the temporary auto-confirming compatibility lifecycle has been removed. Broader workload,
+rate, topology, assertion, and schema work remains owned by Milestone 2.1.
 
 - [x] Define a simulator-owned `ConvergenceSubject` interface that keeps scenario semantics in the runner and exposes
   semantic engine operations through declared adapter capabilities.
@@ -456,6 +456,9 @@ that deliberately does not advertise outbound-publication support.
   separate from `Tick`, which selects the participant runtimes that wake and observe elapsed deadlines.
 - [x] Add explicit public outbound polling/acknowledgement so later adapters can model publication progress without
   exposing harness queues.
+- [x] Cut ScenarioSpec and all repository-owned vectors/generators over to v2 `acknowledge_outbound` operations; remove
+  direct pending confirmation/failure from the subject contract and delete the compatibility constructor and client
+  lifecycle branches ([MDK #1207](https://github.com/marmot-protocol/mdk/issues/1207)).
 - [x] Split normal black-box execution from the explicitly named `ConvergenceFaultSubject` queue/partition mutation
   capability; reserve a named white-box storage-fault capability for a future adapter.
 - [x] Reject scenarios that require unsupported subject capabilities before execution.
@@ -507,7 +510,7 @@ Status: `not-started`
 
 ### 2.1 Scenario IR v2 and authoring DSL
 
-- [ ] Land a minimal vertical slice first: versioned action/assertion IR, deterministic executor, stable action ids, and
+- [x] Land a minimal vertical slice first: versioned action/assertion IR, deterministic executor, stable action ids, and
   one engine-adapter scenario that round-trips through JSON.
 - [ ] Define the complete adapter-neutral JSON IR and JSON Schema.
 - [ ] Specify deterministic expansion and rate semantics (`repeat`, `parallel`, `rate`, `burst`, barriers, and virtual
@@ -519,8 +522,9 @@ Status: `not-started`
 - [ ] Add offline/reconnect, delay, duplicate, omit, withhold/release, crash/restart, and declared storage faults.
 - [ ] Replace queue indices with semantic action/message selectors.
 - [ ] Add `exactly`, `eventually`, `within`, `never`, and resource assertions.
-- [ ] Compile `ScenarioSpec` v1 into v2 so existing vectors retain meaning.
-- [ ] Add portable outbound poll/acknowledgement operations, migrate built-in runners to the explicit lifecycle, and
+- [x] Make a repository-owned clean cutover from `ScenarioSpec` v1 to v2 rather than retaining a runtime compatibility
+  compiler; migrate fixed vectors, generated families, tests, and incident-replay synthesis together.
+- [x] Add portable outbound poll/acknowledgement operations, migrate built-in runners to the explicit lifecycle, and
   remove the legacy-compatible constructor and dual client lifecycle
   ([MDK #1207](https://github.com/marmot-protocol/mdk/issues/1207)).
 
@@ -816,11 +820,11 @@ incorrect result.
 | 2026-07-30 | S4 SQLite transaction-boundary contention | Made transient `COMMIT`/`ROLLBACK` busy conditions retry in place without rerunning application closures; persistent contention remains a typed retryable error and releases a clean connection | [MDK #1191](https://github.com/marmot-protocol/mdk/pull/1191), merge `cff57a5d`; 300 storage tests; `just fast-ci` |
 | 2026-07-30 | 1.3a injectable convergence dual clock | Routed convergence deadlines, pass timestamps, cutoff decisions, and restart rebasing through paired monotonic/wall-clock samples; clock-sensitive engine and harness tests advance deterministically without sleeping | [MDK #1195](https://github.com/marmot-protocol/mdk/pull/1195), merge `5db10d68`; feature-enabled engine and simulator suites; `just fast-ci` |
 | 2026-07-30 | 1.1 consumed self-remove work retirement | Made confirmed and converged commits terminally retire exact consumed proposal rows and epoch-scoped proposal schedule signals; strict send/leave scenarios and restart now reach no-pending-work without an exception | [MDK #1192](https://github.com/marmot-protocol/mdk/pull/1192), merge `1a611eec`; feature-enabled engine suite; strict send/leave family; `just fast-ci` |
-| 2026-07-30 | 1.1 definite publish-failure semantics | Minimized the transported-commit rollback split to nine steps; made simulator `FailPending` retract the complete undelivered commit/Welcome artifact set and reject artifacts that already reached any recipient, restoring strict exact equivalence without changing production lifecycle behavior | [MDK #1196](https://github.com/marmot-protocol/mdk/pull/1196), merge `1985d9a8`; `definite_publish_failure_retracts_commit_before_local_rollback`; `definite_publish_failure_retracts_commit_and_welcome`; `fail_pending_rejects_artifact_that_already_reached_a_recipient`; full simulator suite |
+| 2026-07-30 | 1.1 definite publish-failure semantics | Minimized the transported-commit rollback split to nine steps; made definite simulator publication failure retract the complete undelivered commit/Welcome artifact set and reject artifacts that already reached any recipient, restoring strict exact equivalence without changing production lifecycle behavior | [MDK #1196](https://github.com/marmot-protocol/mdk/pull/1196), merge `1985d9a8`; `definite_publish_failure_retracts_commit_before_local_rollback`; `definite_publish_failure_retracts_commit_and_welcome`; `publication_failure_rejects_artifact_that_already_reached_a_recipient`; full simulator suite |
 | 2026-07-30 | 1.2b adopted canonicalization contract refresh | Reconciled the executable selector, dispositions, durable message state, simulator ledger, local architecture docs, and Tamarin model with adopted Marmot convergence commit `4ad4ae2`: removed the redundant raw-depth selector step; made missing-parent, future-epoch, and eligible losing-branch outcomes explicitly deferred; added `ConvergenceDeferred` so retained inputs can be reconsidered without immediately reopening an unchanged completed pass; and terminally retires deferred commits only after they age below the retained horizon | [MDK #1198](https://github.com/marmot-protocol/mdk/pull/1198), merge `562c5d5f`; `just fast-ci`; full engine/simulator/storage/traits suites; relay runtime and simulator/vector CI; all 78 strict Tamarin lemmas |
 | 2026-07-30 | M5 projection/event-delivery prerequisite | Fixed state changes folded into outbound sends reaching stored projections without waking runtime subscriptions; established that process-level simulation must observe projection state and notification delivery as separate surfaces | [MDK #1186](https://github.com/marmot-protocol/mdk/pull/1186), merge `1b949655`; focused interleaved-send subscription regression; `just fast-ci` |
 | 2026-07-30 | M5 app-runtime ownership prerequisite | Enforced one live account session per account within a `MarmotApp`, surfaced typed contention through UniFFI, and made worker reconnect release the failed client before replacement | [MDK #1200](https://github.com/marmot-protocol/mdk/pull/1200), merge `8dc7c12b`; ownership, worker-lifecycle, FFI, and focused runtime tests |
 | 2026-07-30 | M5 projection-maintenance prerequisite | Made large-set projection pruning bounded, preserved draft-owning groups, and made secure-delete checkpoint completion durable and explicitly observable as `erasure_pending` | [MDK #1201](https://github.com/marmot-protocol/mdk/pull/1201), merge `eec70bd9`; 307 storage tests; focused app/UniFFI retention tests; `just fast-ci` |
 | 2026-07-30 | M5 account-device modeling input | Documented a non-normative multi-device design space while deliberately leaving admission, synchronization, and repair choices unresolved; future scenarios must model account-device instances without assuming those candidate semantics | [MDK #1199](https://github.com/marmot-protocol/mdk/pull/1199), merge `aac777f3`; documentation-only |
 | 2026-07-30 | 1.2c / 1.3b subject virtual time | Added a capability-gated `advance_time` scenario operation backed by one shared paired clock across the engine subject; time advancement is a separate failure-free operation and `Tick` selects which participant runtimes observe it, while standalone clients without an injected clock preserve the legacy far-future shortcut | [MDK #1202](https://github.com/marmot-protocol/mdk/pull/1202), merge `1ccc4065`; focused serialization/preflight/dispatch test; two real disband passes remain live at a 999 ms tick, Alice alone settles at 1,000 ms, and Bob settles on a later tick without another time advance; full simulator suite |
-| 2026-07-30 | 1.2d public outbound lifecycle | Added non-destructive polling of exact transport-ready subject artifacts and typed accepted/no-endpoint acknowledgement; client-scoped pending identities, state-bearing commits, independent Welcomes, definite rollback, regenerated queued intents, scheduled evolution work, duplicate acknowledgement, and exposure refusal retain their distinct semantics without exposing mutable bus queues; v1 lifecycle removal is tracked in [MDK #1207](https://github.com/marmot-protocol/mdk/issues/1207) | Focused subject contract tests; full simulator suite; `just fast-ci` |
+| 2026-08-01 | 1.2d public outbound lifecycle and Scenario IR v2 cutover | Added non-destructive polling of exact transport-ready subject artifacts and typed accepted/no-endpoint acknowledgement; client-scoped pending identities, state-bearing commits, independent Welcomes, definite rollback, regenerated queued intents, scheduled evolution work, duplicate acknowledgement, and exposure refusal retain their distinct semantics without exposing mutable bus queues. Migrated every repository-owned scenario producer to v2 `acknowledge_outbound` operations and removed the compatibility constructor, direct subject pending controls, client lifecycle flag, and silent auto-confirm branches ([MDK #1207](https://github.com/marmot-protocol/mdk/issues/1207)) | Focused subject/runner contract tests; fixed vectors; generated families; incident replay; full simulator suite; `just fast-ci` |


### PR DESCRIPTION
## Summary

- remove the simulator's legacy auto-confirm publication lifecycle and use one explicit outbound poll/ack contract for every subject
- cut ScenarioSpec over to v2 with typed `acknowledge_outbound` steps, stable publication labels, artifact selectors, and `accepted` / `reached_no_endpoint` outcomes
- migrate all repository-owned vectors, generated scenario families, canonical tests, and incident-replay synthesis to ScenarioSpec v2
- preserve atomic commit/Welcome rollback, reject definite failure after recipient exposure, and keep Welcome outcomes independent after commit acceptance
- update simulator documentation and the convergence reliability tracking plan for the clean cutover

## Why

Retained-relay, process, CLI, and app-runtime adapters need to drive publication progress without reaching into the in-memory transport queue. Keeping a separate simulator-only lifecycle would let scenarios pass through behavior that those adapters cannot reproduce and would make the portable scenario contract ambiguous.

This PR now has one black-box lifecycle: poll exact transport-ready artifacts, apply a typed outcome to their opaque IDs, and observe the resulting engine state. No production convergence-engine or Marmot protocol behavior is changed; the changes are confined to the simulator contract, its fixtures/tests, and incident-replay scenario synthesis.

## Important semantics

- polling is non-destructive and preserves emission order
- repeating the same acknowledgement is idempotent; contradictory outcomes are rejected
- labelled acknowledgements fail when they match no artifact, catching stale or misspelled scenario references
- unlabelled acknowledgements operate on the currently matching artifact set and support engine-generated work
- an accepted state-bearing commit confirms staged MLS state
- definite commit failure retracts the complete unexposed commit/Welcome publication before rollback
- recipient exposure prevents partial transport mutation or rollback
- failed regenerated queued intents are re-armed; accepted retries retire them
- zero-fanout group creation confirms without inventing a synthetic outbound artifact

## Migration

ScenarioSpec v1 is intentionally rejected after this repository-owned cutover. All checked-in executable vectors now declare ScenarioSpec v2. Existing `.v1.json` filenames continue to describe their vector/family envelope versions, not the embedded ScenarioSpec schema.

Closes #1207

## Validation

- `cargo test -p cgka-conformance-simulator`
- `cargo test -p incident-replay`
- `just fast-ci`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ordered, client-scoped outbound publication polling.
  * Added typed acknowledgements for accepted and no-endpoint outcomes.
  * Added safe rollback, exposure checks, idempotent acknowledgements, and queued-intent retries.
  * Exposed outbound publication capabilities through the simulator interface.

* **Documentation**
  * Updated simulator guidance and scenario coverage for outbound lifecycle behavior.
  * Migrated scenarios and fixtures to ScenarioSpec v2.
  * Updated reliability planning and milestone status for the public outbound lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->