### PR TITLE
fix(storage): redact group image keys from Debug

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -24,6 +24,10 @@ versioning through the workspace version in the root `Cargo.toml`.
   
 ### Fixed
 
+- Account projection storage types now redact encrypted group-image decryption
+  and Blossom upload keys from `Debug` output, including nested group
+  formatting.
+
 - `MarmotApp` now permits only one live in-memory engine session per account
   across direct clients and managed workers. Concurrent opens return the typed
   `AccountSessionBusy` error, and worker reconnect drops the failed session

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -26,7 +26,9 @@ versioning through the workspace version in the root `Cargo.toml`.
 
 - Account projection storage types now redact encrypted group-image decryption
   and Blossom upload keys from `Debug` output, including nested group
-  formatting.
+  formatting. The TUI group diagnostics panel no longer retains or renders raw
+  group component `data_hex`, so blossom image key material cannot leak through
+  diagnostics `Debug` or on-screen lines.
 
 - `MarmotApp` now permits only one live in-memory engine session per account
   across direct clients and managed workers. Concurrent opens return the typed

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -441,7 +441,6 @@ pub(crate) struct GroupDiagnostics {
 pub(crate) struct GroupComponentDiagnostics {
     pub(crate) component: String,
     pub(crate) component_id: Option<u64>,
-    pub(crate) data_hex: String,
 }
 
 #[derive(Debug)]
@@ -4649,7 +4648,6 @@ pub(crate) fn group_component_diagnostics(group: &Value) -> Vec<GroupComponentDi
         Some(GroupComponentDiagnostics {
             component: value_string(component, "component").unwrap_or_else(|| key.to_owned()),
             component_id: component.get("component_id").and_then(Value::as_u64),
-            data_hex: value_string(component, "data_hex").unwrap_or_default(),
         })
     })
     .collect()

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -1055,6 +1055,9 @@ fn group_members_status_summarizes_member_records() {
 
 #[test]
 fn diagnostics_panel_lines_show_mls_and_components() {
+    const IMAGE_KEY_HEX: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    const UPLOAD_KEY_HEX: &str = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+
     let diagnostics = parse_group_diagnostics(&serde_json::json!({
         "group": {
             "group_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -1062,6 +1065,11 @@ fn diagnostics_panel_lines_show_mls_and_components() {
                 "component_id": 32769,
                 "component": "marmot.group.profile.v1",
                 "data_hex": "010203"
+            },
+            "image": {
+                "component_id": 32770,
+                "component": "marmot.group.blossom.image.v1",
+                "data_hex": format!("00{IMAGE_KEY_HEX}{UPLOAD_KEY_HEX}")
             },
             "admin_policy": {
                 "component_id": 32771,
@@ -1081,12 +1089,26 @@ fn diagnostics_panel_lines_show_mls_and_components() {
     }))
     .expect("diagnostics");
 
+    let debug_rendered = format!("{diagnostics:?}");
+    assert!(!debug_rendered.contains(IMAGE_KEY_HEX));
+    assert!(!debug_rendered.contains(UPLOAD_KEY_HEX));
+    assert!(!debug_rendered.contains("010203"));
+    assert!(!debug_rendered.contains("aabbcc"));
+    assert!(!debug_rendered.contains("ffee"));
+
     // The diagnostics panel drops the leading status line (now in the status bar):
     // it starts straight at the MLS summary.
     let rendered = diagnostics_panel_lines(Some(&diagnostics))
         .iter()
         .map(line_text)
         .collect::<Vec<_>>();
+
+    let rendered_joined = rendered.join("\n");
+    assert!(!rendered_joined.contains(IMAGE_KEY_HEX));
+    assert!(!rendered_joined.contains(UPLOAD_KEY_HEX));
+    assert!(!rendered_joined.contains("010203"));
+    assert!(!rendered_joined.contains("aabbcc"));
+    assert!(!rendered_joined.contains("ffee"));
 
     assert_eq!(
         rendered[0],
@@ -1096,17 +1118,22 @@ fn diagnostics_panel_lines_show_mls_and_components() {
     assert!(
         rendered
             .iter()
-            .any(|line| line == "marmot.group.profile.v1 id=32769 data=010203")
+            .any(|line| line == "marmot.group.profile.v1 id=32769")
     );
     assert!(
         rendered
             .iter()
-            .any(|line| line == "marmot.group.admin-policy.v1 id=32771 data=aabbcc")
+            .any(|line| line == "marmot.group.blossom.image.v1 id=32770")
     );
     assert!(
         rendered
             .iter()
-            .any(|line| line == "marmot.group.agent-text-stream.quic.v1 id=32774 data=ffee")
+            .any(|line| line == "marmot.group.admin-policy.v1 id=32771")
+    );
+    assert!(
+        rendered
+            .iter()
+            .any(|line| line == "marmot.group.agent-text-stream.quic.v1 id=32774")
     );
 }
 

--- a/crates/cli/src/tui/view.rs
+++ b/crates/cli/src/tui/view.rs
@@ -337,9 +337,8 @@ pub(crate) fn group_component_diagnostics_line(
         .map(|id| id.to_string())
         .unwrap_or_else(|| "unknown".to_owned());
     Line::from(format!(
-        "{} id={id} data={}",
+        "{} id={id}",
         terminal_safe_text(&component.component),
-        terminal_safe_text(&component.data_hex)
     ))
 }
 

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -21,7 +21,9 @@ use transport_nostr_peeler::NostrTransportEvent;
 use transport_quic_broker::BrokerServerTrust;
 
 use crate::audit_log::AUDIT_ID_BYTES;
-use crate::conversions::{app_group_from_stored_group, stored_group_from_app_group};
+use crate::conversions::{
+    app_group_from_stored_group, stored_components_from_app_group, stored_group_from_app_group,
+};
 use crate::directory::records::{
     FetchedFollowList, profile_content_json, public_directory_user_record,
 };
@@ -3279,6 +3281,48 @@ fn empty_follow_fetch_preserves_cached_edges() {
         selected.source_relays,
         vec!["wss://cached.example".to_owned()]
     );
+}
+
+#[test]
+fn stored_group_image_component_debug_redacts_key_material() {
+    const IMAGE_KEY_HEX: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const UPLOAD_KEY_HEX: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    let group = AppGroupRecord::new(
+        "aa".to_owned(),
+        AppGroupNostrRoutingComponent::new(
+            NostrRoutingV1::new([0xAA; 32], vec!["wss://relay.example".to_owned()]).unwrap(),
+        )
+        .unwrap(),
+        "group".to_owned(),
+        String::new(),
+        AppGroupImageInput {
+            image_hash_hex: hex::encode([0x11; 32]),
+            image_key_hex: IMAGE_KEY_HEX.to_owned(),
+            image_nonce_hex: hex::encode([0x22; 12]),
+            image_upload_key_hex: UPLOAD_KEY_HEX.to_owned(),
+            media_type: Some("image/png".to_owned()),
+        },
+        AppGroupAdminPolicyComponent::new(Vec::new()),
+        AppGroupMessageRetentionComponent::disabled(),
+    );
+
+    let image_component = stored_components_from_app_group(&group)
+        .into_iter()
+        .find(|component| component.component_id == GROUP_BLOSSOM_IMAGE_COMPONENT_ID)
+        .expect("image component");
+
+    let rendered = format!("{image_component:?}");
+    assert!(!rendered.contains(IMAGE_KEY_HEX));
+    assert!(!rendered.contains(UPLOAD_KEY_HEX));
+    assert!(rendered.contains("marmot.group.blossom.image.v1"));
+    assert!(rendered.contains("redacted"));
+
+    let stored = stored_group_from_app_group(&group);
+    let parent_rendered = format!("{stored:?}");
+    assert!(!parent_rendered.contains(IMAGE_KEY_HEX));
+    assert!(!parent_rendered.contains(UPLOAD_KEY_HEX));
+    assert!(parent_rendered.contains("group"));
 }
 
 #[test]

--- a/crates/marmot-app/src/tests.rs
+++ b/crates/marmot-app/src/tests.rs
@@ -3322,7 +3322,9 @@ fn stored_group_image_component_debug_redacts_key_material() {
     let parent_rendered = format!("{stored:?}");
     assert!(!parent_rendered.contains(IMAGE_KEY_HEX));
     assert!(!parent_rendered.contains(UPLOAD_KEY_HEX));
-    assert!(parent_rendered.contains("group"));
+    assert!(parent_rendered.contains("profile_name: \"group\""));
+    assert!(parent_rendered.contains("image_key_hex"));
+    assert!(parent_rendered.contains("redacted"));
 }
 
 #[test]

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -106,6 +106,11 @@ pub struct StoredAccountState {
     pub groups: Vec<StoredAccountGroup>,
 }
 
+/// `image_key_hex`/`image_upload_key_hex` are key material mirrored from the
+/// blossom image component for chat-list projection. They are stored in
+/// SQLCipher, but must not appear in `Debug` output. Nested
+/// [`StoredAccountGroupComponent`] values redact in-band component bytes that
+/// carry the same keys.
 #[derive(Clone, PartialEq, Eq)]
 pub struct StoredAccountGroup {
     pub group_id_hex: String,
@@ -138,11 +143,6 @@ pub struct StoredAccountGroup {
     pub components: Vec<StoredAccountGroupComponent>,
 }
 
-/// `image_key_hex`/`image_upload_key_hex` are key material mirrored from the
-/// blossom image component for chat-list projection. They are stored in
-/// SQLCipher, but must not appear in `Debug` output. Nested
-/// [`StoredAccountGroupComponent`] values redact in-band component bytes that
-/// carry the same keys.
 impl fmt::Debug for StoredAccountGroup {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("StoredAccountGroup")
@@ -179,6 +179,10 @@ pub struct StoredNostrRoute {
     pub last_epoch: u64,
 }
 
+/// `component_data_hex` carries MLS-protected component bytes. Blossom image
+/// payloads embed avatar decryption and Blossom upload keys; other components
+/// may carry sensitive policy bytes. SQLCipher protects persistence, but
+/// `Debug` must never render raw component bytes.
 #[derive(Clone, PartialEq, Eq)]
 pub struct StoredAccountGroupComponent {
     pub component_id: u16,
@@ -186,10 +190,6 @@ pub struct StoredAccountGroupComponent {
     pub component_data_hex: String,
 }
 
-/// `component_data_hex` carries MLS-protected component bytes. Blossom image
-/// payloads embed avatar decryption and Blossom upload keys; other components
-/// may carry sensitive policy bytes. SQLCipher protects persistence, but
-/// `Debug` must never render raw component bytes.
 impl fmt::Debug for StoredAccountGroupComponent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("StoredAccountGroupComponent")

--- a/crates/storage-sqlite/src/account_projection.rs
+++ b/crates/storage-sqlite/src/account_projection.rs
@@ -10,6 +10,7 @@ use rusqlite::{
     types::{Type, Value},
 };
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 const SECURE_DELETE_RETENTION_OPERATION: &str = "retention";
 const SECURE_DELETE_LOCAL_GROUP_OPERATION: &str = "local_group";
@@ -105,7 +106,7 @@ pub struct StoredAccountState {
     pub groups: Vec<StoredAccountGroup>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct StoredAccountGroup {
     pub group_id_hex: String,
     pub endpoint: String,
@@ -137,6 +138,40 @@ pub struct StoredAccountGroup {
     pub components: Vec<StoredAccountGroupComponent>,
 }
 
+/// `image_key_hex`/`image_upload_key_hex` are key material mirrored from the
+/// blossom image component for chat-list projection. They are stored in
+/// SQLCipher, but must not appear in `Debug` output. Nested
+/// [`StoredAccountGroupComponent`] values redact in-band component bytes that
+/// carry the same keys.
+impl fmt::Debug for StoredAccountGroup {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StoredAccountGroup")
+            .field("group_id_hex", &self.group_id_hex)
+            .field("endpoint", &self.endpoint)
+            .field("profile_name", &self.profile_name)
+            .field("profile_description", &self.profile_description)
+            .field("image_hash_hex", &self.image_hash_hex)
+            .field("image_key_hex", &"<redacted>")
+            .field("image_nonce_hex", &self.image_nonce_hex)
+            .field("image_upload_key_hex", &"<redacted>")
+            .field("image_media_type", &self.image_media_type)
+            .field("admin_keys_hex", &self.admin_keys_hex)
+            .field("archived", &self.archived)
+            .field("pending_confirmation", &self.pending_confirmation)
+            .field("member_count", &self.member_count)
+            .field("welcomer_account_id_hex", &self.welcomer_account_id_hex)
+            .field(
+                "via_welcome_message_id_hex",
+                &self.via_welcome_message_id_hex,
+            )
+            .field("nostr_routing_last_epoch", &self.nostr_routing_last_epoch)
+            .field("prior_nostr_routes", &self.prior_nostr_routes)
+            .field("self_membership", &self.self_membership)
+            .field("components", &self.components)
+            .finish()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StoredNostrRoute {
     pub nostr_group_id_hex: String,
@@ -144,11 +179,25 @@ pub struct StoredNostrRoute {
     pub last_epoch: u64,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct StoredAccountGroupComponent {
     pub component_id: u16,
     pub component_name: String,
     pub component_data_hex: String,
+}
+
+/// `component_data_hex` carries MLS-protected component bytes. Blossom image
+/// payloads embed avatar decryption and Blossom upload keys; other components
+/// may carry sensitive policy bytes. SQLCipher protects persistence, but
+/// `Debug` must never render raw component bytes.
+impl fmt::Debug for StoredAccountGroupComponent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StoredAccountGroupComponent")
+            .field("component_id", &self.component_id)
+            .field("component_name", &self.component_name)
+            .field("component_data_hex", &"<redacted>")
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/crates/storage-sqlite/src/account_projection/tests.rs
+++ b/crates/storage-sqlite/src/account_projection/tests.rs
@@ -2892,3 +2892,23 @@ fn app_messages_replay_order_matches_cursor_comparator() {
     assert_eq!(dups[0].group_id_hex, "aa");
     assert_eq!(dups[1].group_id_hex, "bb");
 }
+
+#[test]
+fn stored_account_group_component_debug_redacts_blossom_image_payload() {
+    use cgka_traits::app_components::GROUP_BLOSSOM_IMAGE_COMPONENT_ID;
+
+    const IMAGE_KEY_HEX: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const UPLOAD_KEY_HEX: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    let component = StoredAccountGroupComponent {
+        component_id: GROUP_BLOSSOM_IMAGE_COMPONENT_ID,
+        component_name: "marmot.group.blossom.image.v1".to_owned(),
+        component_data_hex: format!("00{IMAGE_KEY_HEX}{UPLOAD_KEY_HEX}"),
+    };
+
+    let rendered = format!("{component:?}");
+    assert!(!rendered.contains(IMAGE_KEY_HEX));
+    assert!(!rendered.contains(UPLOAD_KEY_HEX));
+    assert!(rendered.contains("marmot.group.blossom.image.v1"));
+    assert!(rendered.contains("redacted"));
+}


### PR DESCRIPTION
Fixes #1211

## Summary
- replace derived `Debug` on `StoredAccountGroupComponent` with a handwritten implementation that always redacts raw `component_data_hex`
- redact the denormalized image decryption and Blossom upload keys from parent `StoredAccountGroup` formatting
- stop the TUI diagnostics model from retaining generic component `data_hex`; diagnostics now render only component names and ids
- cover direct storage formatting, real app-to-storage conversion, nested parent formatting, diagnostics `Debug`, and diagnostics lines with key sentinels
- document the change in the compatibility-cohort changelog

## Root cause
The SQLite projection copied the encrypted group-image component into `component_data_hex` and mirrored its two capability keys into `StoredAccountGroup`. Both storage types derived `Debug`, so direct or nested `{:?}` formatting exposed those values despite app-layer redaction.

The TUI diagnostics path independently copied each component's raw `data_hex` into a `Debug`-deriving DTO and rendered it on screen. For `marmot.group.blossom.image.v1`, that payload contains the same decryption and upload capabilities.

## Verification
RED evidence before the production changes:
- `cargo test -p storage-sqlite stored_account_group_component_debug_redacts_blossom_image_payload -- --nocapture` failed because rendered `component_data_hex` contained the image-key sentinel
- the updated TUI diagnostics regression failed because the prior diagnostics DTO and rendered line retained the image/upload-key sentinels

Final checks:
- `cargo test -p wn-cli diagnostics_panel_lines_show_mls_and_components --locked -- --nocapture`
- `cargo test -p marmot-app stored_group_image_component_debug_redacts_key_material --locked -- --nocapture`
- `cargo test -p storage-sqlite stored_account_group_component_debug_redacts_blossom_image_payload --locked -- --nocapture`
- `cargo test -p wn-cli --lib --locked` — 529 passed
- `cargo test -p storage-sqlite --locked` — 308 passed on the original fix head
- `cargo clippy -p storage-sqlite --all-targets --locked -- -D warnings`
- `cargo fmt --all --check`
- `just fast-ci`
- `git diff --check`

All passed. The storage suite emitted existing SQLCipher `mlock()` errno 12 warnings on this host; tests remained green.

## Audit and scope
- `StoredAccountGroupComponent`, nested `StoredAccountGroup`, and TUI diagnostics no longer `Debug`-format or render raw image component bytes.
- Repository searches found no production tracing, error, or UniFFI path formatting these stored raw bytes.
- Full ids and structured endpoints remain visible on storage DTO `Debug` by design. `docs/marmot-architecture/overview/observability.md` permits ids/pubkeys on DTOs and endpoints in structured DTO fields while forbidding them in tracing/logs; CodeRabbit's broader all-identifier redaction suggestion was therefore not applied.
- Stable `groups show --json` capability output is a separate API/trust-boundary decision tracked in #1253.

No additional zeroizing wrapper was introduced at the SQLCipher persistence DTO boundary: these strings are durable SQL-bound values rather than ephemeral crypto buffers, and wrapping them would add API/trait churn or extra plaintext copies without reducing persistence exposure. Existing ephemeral group-image crypto buffers remain zeroizing.

## Sensitive paths
- `crates/storage-sqlite/src/account_projection.rs` — security-sensitive projection `Debug` boundary
- `crates/storage-sqlite/src/account_projection/tests.rs` — storage regression sentinels
- `crates/marmot-app/src/tests.rs` — real encrypted group-image conversion regression
- `crates/cli/src/tui/model.rs` — removes key-bearing raw payload retention from diagnostics
- `crates/cli/src/tui/view.rs` — removes raw payload rendering
- `crates/cli/src/tui/tests.rs` — diagnostics `Debug` and rendered-line sentinels

This PR touches sensitive key-handling/projection paths and requires explicit human approval at the merge gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive encrypted image and upload key data is now hidden in account debug output.
  * Group diagnostics no longer display raw component payload data.
  * Safe identifying details, such as component names and IDs, remain visible while confidential values are replaced with a redaction marker.
  * Added regression coverage to help prevent accidental exposure of protected key material.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->