### PR TITLE
fix(account): zeroize NIP-49 export intermediates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3460,8 +3460,7 @@ dependencies = [
 [[package]]
 name = "nostr"
 version = "0.44.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e826dd648489de2c5b293920e20b92932ef820302007c1987c758d4d06eeb2cf"
+source = "git+https://github.com/agent-p1p/nostr.git?rev=c209c22aab4883a01b1d6017752b23245afce9b3#c209c22aab4883a01b1d6017752b23245afce9b3"
 dependencies = [
  "base64",
  "bech32",
@@ -3479,6 +3478,7 @@ dependencies = [
  "serde_json",
  "unicode-normalization",
  "url",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,3 +138,6 @@ marmot-terminal-harness = { path = "integrations/terminal-harness" }
 # release contains it, then remove this patch and update the libcrux path.
 [patch.crates-io]
 hax-lib-macros = { git = "https://github.com/cryspen/hax.git", rev = "8f9cb576e58f6cc7e9ed249a7d4439b0f7ed0da7" }
+# nostr 0.44.6 leaves NIP-49 normalized passwords and derived keys in ordinary
+# buffers. Pin the upstream v0.44 fix until PR #1406 is released.
+nostr = { git = "https://github.com/agent-p1p/nostr.git", rev = "c209c22aab4883a01b1d6017752b23245afce9b3" }

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -65,6 +65,12 @@ versioning through the workspace version in the root `Cargo.toml`.
   dropped on the send path, so storage showed the new state while live
   subscribers were never notified.
 
+### Security
+
+- NIP-49 encrypted private-key export now zeroizes its normalized passphrase,
+  scrypt-derived key, cipher-owned key copy, and plaintext decrypt buffer on
+  success and error paths.
+
 ### Changed
 
 - The bundled SQLCipher stack now uses rusqlite 0.40.1/libsqlite3-sys 0.38.1,

--- a/crates/marmot-uniffi/src/commands/account.rs
+++ b/crates/marmot-uniffi/src/commands/account.rs
@@ -420,7 +420,9 @@ impl Marmot {
     /// `ncryptsec1...` bech32 backup string (mdk#544).
     ///
     /// SENSITIVE: the passphrase is accepted as an owned FFI string and zeroed
-    /// on return by the Rust boundary. The encrypted export is logged to the
+    /// on return by the Rust boundary. This cannot wipe the caller's original
+    /// host-language string, which remains a separate host-side responsibility
+    /// and should be kept transient. The encrypted export is logged to the
     /// per-account audit log, but unlike `reveal_nsec` it does not downgrade the
     /// account's NIP-49 KEY_SECURITY_BYTE because raw plaintext key material is
     /// not returned to the host app.


### PR DESCRIPTION
## Summary

- pin the workspace's `nostr` 0.44.6 dependency to the v0.44 zeroization fix in nostrdevkit/nostr#1406
- ensure NIP-49 normalized passphrases, scrypt-derived keys, cipher-owned key copies, and decrypted plaintext buffers are wiped on success and error paths
- document the remaining FFI ownership boundary: Rust wipes its owned passphrase, but cannot wipe the caller's original host-language string
- record the security fix in the shared MDK changelog

The upstream commit adds focused `ZeroizeOnDrop` checks and preserves the published NIP-49 vector plus NFKC behavior. MDK uses a crates.io patch so the same fixed `nostr` package remains unified across `nostr-sdk` and direct dependencies.

Fixes #474

## Upstream

- nostrdevkit/nostr#1406
- pinned commit: `c209c22aab4883a01b1d6017752b23245afce9b3`

## Verification

Upstream:
- `cargo test -p nostr --features nip49 nip49::tests` (5 passed)
- `cargo check -p nostr --no-default-features --features 'alloc,nip49'`
- `cargo clippy -p nostr --all-targets --features nip49 -- -D warnings`

MDK:
- `cargo test -p marmot-account nip49 --locked -- --nocapture` (8 passed)
- `cargo test -p marmot-uniffi --lib --locked` (94 passed)
- `just fast-ci`
