### PR TITLE
fix(storage): zeroize OpenMLS serialization buffers

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -24,6 +24,10 @@ versioning through the workspace version in the root `Cargo.toml`.
   
 ### Fixed
 
+- OpenMLS persistence now zeroizes temporary SQLite serialization buffers for
+  MLS private keys, epoch and message secrets, PSKs, pending group state, and
+  application-export state on success and error paths.
+
 - `MarmotApp` now permits only one live in-memory engine session per account
   across direct clients and managed workers. Concurrent opens return the typed
   `AccountSessionBusy` error, and worker reconnect drops the failed session

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -24,9 +24,10 @@ versioning through the workspace version in the root `Cargo.toml`.
   
 ### Fixed
 
-- OpenMLS persistence now zeroizes temporary SQLite serialization buffers for
-  MLS private keys, epoch and message secrets, PSKs, pending group state, and
-  application-export state on success and error paths.
+- OpenMLS persistence now zeroizes temporary SQLite serialization,
+  deserialization, and rollback-snapshot buffers for MLS private keys, epoch and
+  message secrets, PSKs, pending group state, application-export state, and
+  stored key-package handoffs on success and error paths.
 
 - `MarmotApp` now permits only one live in-memory engine session per account
   across direct clients and managed workers. Concurrent opens return the typed

--- a/crates/storage-sqlite/src/codec.rs
+++ b/crates/storage-sqlite/src/codec.rs
@@ -1,17 +1,180 @@
+use std::fmt;
+use std::io::{self, Write};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use cgka_traits::message::MessageState;
 use cgka_traits::storage::{StorageError, StorageResult};
 use cgka_traits::types::EpochId;
-use serde::{Serialize, de::DeserializeOwned};
+use serde::de::{DeserializeOwned, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use zeroize::Zeroizing;
 
 /// Total bind-parameter budget for generated statements that use chunked
 /// positive-`IN` lists. This stays below SQLite's historical 999-variable
 /// default and includes any fixed parameters that precede the list.
 pub(crate) const SQLITE_BIND_PARAMETER_CHUNK: usize = 900;
 
+/// Bytes whose current allocation is wiped when ownership ends.
+///
+/// JSON deserialization grows this buffer explicitly so each replaced
+/// allocation is zeroized before deallocation. The storage backend is JSON-only;
+/// deliberately accepting only sequence input avoids a binary deserializer
+/// constructing an intermediate ordinary `Vec<u8>` before this type takes over.
+pub(crate) struct SensitiveBytes(Zeroizing<Vec<u8>>);
+
+impl SensitiveBytes {
+    pub(crate) fn new(bytes: Vec<u8>) -> Self {
+        Self(Zeroizing::new(bytes))
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        Self(Zeroizing::new(Vec::with_capacity(capacity)))
+    }
+
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    fn push(&mut self, byte: u8) {
+        if self.0.len() == self.0.capacity() {
+            let next_capacity = if self.0.capacity() == 0 {
+                8
+            } else {
+                self.0
+                    .capacity()
+                    .checked_mul(2)
+                    .expect("sensitive byte buffer capacity overflow")
+            };
+            let mut next = Zeroizing::new(Vec::with_capacity(next_capacity));
+            next.extend_from_slice(self.0.as_slice());
+            let previous = std::mem::replace(&mut self.0, next);
+            drop(previous);
+        }
+        self.0.push(byte);
+    }
+}
+
+impl AsRef<[u8]> for SensitiveBytes {
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+impl Serialize for SensitiveBytes {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.as_slice().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SensitiveBytes {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct SensitiveBytesVisitor;
+
+        impl<'de> Visitor<'de> for SensitiveBytesVisitor {
+            type Value = SensitiveBytes;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a JSON byte array")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                let mut bytes = SensitiveBytes::with_capacity(seq.size_hint().unwrap_or(0));
+                while let Some(byte) = seq.next_element::<u8>()? {
+                    bytes.push(byte);
+                }
+                Ok(bytes)
+            }
+        }
+
+        deserializer.deserialize_seq(SensitiveBytesVisitor)
+    }
+}
+
+#[derive(Default)]
+struct JsonLength {
+    bytes: usize,
+}
+
+impl Write for JsonLength {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.write_all(bytes)?;
+        Ok(bytes.len())
+    }
+
+    fn write_all(&mut self, bytes: &[u8]) -> io::Result<()> {
+        self.bytes = self
+            .bytes
+            .checked_add(bytes.len())
+            .ok_or_else(|| io::Error::other("sensitive JSON length overflow"))?;
+        Ok(())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+struct SensitiveJsonWriter {
+    bytes: SensitiveBytes,
+    limit: usize,
+}
+
+impl SensitiveJsonWriter {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            bytes: SensitiveBytes::with_capacity(capacity),
+            limit: capacity,
+        }
+    }
+
+    fn into_bytes(self) -> SensitiveBytes {
+        self.bytes
+    }
+}
+
+impl Write for SensitiveJsonWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.write_all(bytes)?;
+        Ok(bytes.len())
+    }
+
+    fn write_all(&mut self, bytes: &[u8]) -> io::Result<()> {
+        let remaining = self.limit - self.bytes.0.len();
+        if bytes.len() > remaining {
+            return Err(io::Error::other(
+                "sensitive JSON changed size between serialization passes",
+            ));
+        }
+        self.bytes.0.extend_from_slice(bytes);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
 pub(crate) fn serialize<T: Serialize>(value: &T) -> StorageResult<Vec<u8>> {
     serde_json::to_vec(value).map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+pub(crate) fn serialize_sensitive_json<T: Serialize + ?Sized>(
+    value: &T,
+) -> serde_json::Result<SensitiveBytes> {
+    // The first pass counts bytes without retaining them. The second pass writes
+    // into a fixed-capacity zeroizing allocation and fails rather than growing
+    // if a stateful Serialize implementation produces a larger document.
+    let mut length = JsonLength::default();
+    serde_json::to_writer(&mut length, value)?;
+    let mut writer = SensitiveJsonWriter::with_capacity(length.bytes);
+    serde_json::to_writer(&mut writer, value)?;
+    Ok(writer.into_bytes())
+}
+
+pub(crate) fn serialize_sensitive<T: Serialize + ?Sized>(
+    value: &T,
+) -> StorageResult<SensitiveBytes> {
+    serialize_sensitive_json(value).map_err(|e| StorageError::Serialization(e.to_string()))
 }
 
 pub(crate) fn deserialize<T: DeserializeOwned>(bytes: &[u8]) -> StorageResult<T> {
@@ -148,6 +311,44 @@ pub(crate) fn unix_now_seconds_i64() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
+
+    struct ExpandsBetweenSerializationPasses(Cell<bool>);
+
+    impl Serialize for ExpandsBetweenSerializationPasses {
+        fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            if self.0.replace(false) {
+                serializer.serialize_str("short")
+            } else {
+                serializer.serialize_str(
+                    "a second serialization pass must not grow the sensitive allocation",
+                )
+            }
+        }
+    }
+
+    #[test]
+    fn sensitive_json_rejects_second_pass_growth_instead_of_reallocating() {
+        let value = ExpandsBetweenSerializationPasses(Cell::new(true));
+        let error = match serialize_sensitive(&value) {
+            Ok(_) => panic!("second pass unexpectedly grew the sensitive allocation"),
+            Err(error) => error,
+        };
+
+        assert!(
+            matches!(error, StorageError::Serialization(message) if message.contains("sensitive JSON changed size"))
+        );
+    }
+
+    #[test]
+    fn sensitive_bytes_round_trip_large_json_array_without_format_change() {
+        let value = vec![0xa5; 4_096];
+        let encoded = serialize_sensitive(&value).unwrap();
+
+        assert_eq!(encoded.as_slice(), serde_json::to_vec(&value).unwrap());
+        let decoded: SensitiveBytes = deserialize(encoded.as_slice()).unwrap();
+        assert_eq!(decoded.as_slice(), value);
+    }
 
     fn sqlite_failure(primary: std::os::raw::c_int) -> rusqlite::Error {
         rusqlite::Error::SqliteFailure(

--- a/crates/storage-sqlite/src/openmls_storage.rs
+++ b/crates/storage-sqlite/src/openmls_storage.rs
@@ -6,6 +6,7 @@ use crate::connection::SharedConnection;
 use cgka_traits::storage::{StorageError, StorageResult, StoredKeyPackageBundle};
 use cgka_traits::types::GroupId as MarmotGroupId;
 use serde::Serialize;
+use zeroize::Zeroizing;
 
 #[derive(Clone, Debug)]
 pub struct SqliteOpenMlsStorage {
@@ -45,12 +46,15 @@ impl SqliteOpenMlsStorage {
             )
             .map_err(crate::codec::map_sqlite_error)?;
         let rows = statement
-            .query_map(params![CURRENT_VERSION, labels::KEY_PACKAGE_LABEL], |row| {
-                Ok(StoredKeyPackageBundle {
-                    storage_key: row.get(0)?,
-                    value: row.get(1)?,
-                })
-            })
+            .query_map(
+                params![CURRENT_VERSION, labels::KEY_PACKAGE_LABEL.as_bytes()],
+                |row| {
+                    Ok(StoredKeyPackageBundle {
+                        storage_key: row.get(0)?,
+                        value: Zeroizing::new(row.get(1)?),
+                    })
+                },
+            )
             .map_err(crate::codec::map_sqlite_error)?;
         rows.collect::<Result<Vec<StoredKeyPackageBundle>, _>>()
             .map_err(crate::codec::map_sqlite_error)
@@ -65,7 +69,11 @@ impl SqliteOpenMlsStorage {
             .execute(
                 "DELETE FROM openmls_values
                  WHERE provider_version = ?1 AND label = ?2 AND storage_key = ?3",
-                params![CURRENT_VERSION, labels::KEY_PACKAGE_LABEL, storage_key],
+                params![
+                    CURRENT_VERSION,
+                    labels::KEY_PACKAGE_LABEL.as_bytes(),
+                    storage_key
+                ],
             )
             .map_err(crate::codec::map_sqlite_error)?;
         Ok(())

--- a/crates/storage-sqlite/src/openmls_storage/labels.rs
+++ b/crates/storage-sqlite/src/openmls_storage/labels.rs
@@ -1,25 +1,83 @@
 use super::SqliteOpenMlsStorageError;
 use openmls_traits::storage::{CURRENT_VERSION, traits};
 
-pub(crate) const KEY_PACKAGE_LABEL: &[u8] = b"KeyPackage";
-pub(crate) const PSK_LABEL: &[u8] = b"Psk";
-pub(crate) const ENCRYPTION_KEY_PAIR_LABEL: &[u8] = b"EncryptionKeyPair";
-pub(crate) const SIGNATURE_KEY_PAIR_LABEL: &[u8] = b"SignatureKeyPair";
-pub(crate) const EPOCH_KEY_PAIRS_LABEL: &[u8] = b"EpochKeyPairs";
-pub(crate) const TREE_LABEL: &[u8] = b"Tree";
-pub(crate) const GROUP_CONTEXT_LABEL: &[u8] = b"GroupContext";
-pub(crate) const APPLICATION_EXPORT_TREE_LABEL: &[u8] = b"ApplicationExportTree";
-pub(crate) const INTERIM_TRANSCRIPT_HASH_LABEL: &[u8] = b"InterimTranscriptHash";
-pub(crate) const CONFIRMATION_TAG_LABEL: &[u8] = b"ConfirmationTag";
-pub(crate) const JOIN_CONFIG_LABEL: &[u8] = b"MlsGroupJoinConfig";
-pub(crate) const OWN_LEAF_NODES_LABEL: &[u8] = b"OwnLeafNodes";
-pub(crate) const GROUP_STATE_LABEL: &[u8] = b"GroupState";
-pub(crate) const QUEUED_PROPOSAL_LABEL: &[u8] = b"QueuedProposal";
-pub(crate) const PROPOSAL_QUEUE_REFS_LABEL: &[u8] = b"ProposalQueueRefs";
-pub(crate) const OWN_LEAF_NODE_INDEX_LABEL: &[u8] = b"OwnLeafNodeIndex";
-pub(crate) const EPOCH_SECRETS_LABEL: &[u8] = b"EpochSecrets";
-pub(crate) const RESUMPTION_PSK_STORE_LABEL: &[u8] = b"ResumptionPsk";
-pub(crate) const MESSAGE_SECRETS_LABEL: &[u8] = b"MessageSecrets";
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::openmls_storage) enum ValueSensitivity {
+    Public,
+    Secret,
+}
+
+/// A stable OpenMLS storage label with an explicit serialized-value sensitivity.
+///
+/// Requiring this type at the value-store boundary prevents a newly added label
+/// from silently inheriting ordinary `Vec<u8>` serialization buffers.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::openmls_storage) struct OpenMlsValueLabel {
+    bytes: &'static [u8],
+    sensitivity: ValueSensitivity,
+}
+
+impl OpenMlsValueLabel {
+    pub(in crate::openmls_storage) const fn public(bytes: &'static [u8]) -> Self {
+        Self {
+            bytes,
+            sensitivity: ValueSensitivity::Public,
+        }
+    }
+
+    pub(in crate::openmls_storage) const fn secret(bytes: &'static [u8]) -> Self {
+        Self {
+            bytes,
+            sensitivity: ValueSensitivity::Secret,
+        }
+    }
+
+    pub(in crate::openmls_storage) const fn as_bytes(self) -> &'static [u8] {
+        self.bytes
+    }
+
+    pub(in crate::openmls_storage) const fn sensitivity(self) -> ValueSensitivity {
+        self.sensitivity
+    }
+}
+
+// OpenMLS's `KeyPackage` storage entity is a `KeyPackageBundle`, including its
+// private init and leaf-encryption keys.
+pub(crate) const KEY_PACKAGE_LABEL: OpenMlsValueLabel = OpenMlsValueLabel::secret(b"KeyPackage");
+pub(crate) const PSK_LABEL: OpenMlsValueLabel = OpenMlsValueLabel::secret(b"Psk");
+pub(crate) const ENCRYPTION_KEY_PAIR_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::secret(b"EncryptionKeyPair");
+pub(crate) const SIGNATURE_KEY_PAIR_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::secret(b"SignatureKeyPair");
+pub(crate) const EPOCH_KEY_PAIRS_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::secret(b"EpochKeyPairs");
+pub(crate) const TREE_LABEL: OpenMlsValueLabel = OpenMlsValueLabel::public(b"Tree");
+pub(crate) const GROUP_CONTEXT_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::public(b"GroupContext");
+pub(crate) const APPLICATION_EXPORT_TREE_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::secret(b"ApplicationExportTree");
+pub(crate) const INTERIM_TRANSCRIPT_HASH_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::public(b"InterimTranscriptHash");
+pub(crate) const CONFIRMATION_TAG_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::public(b"ConfirmationTag");
+pub(crate) const JOIN_CONFIG_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::public(b"MlsGroupJoinConfig");
+pub(crate) const OWN_LEAF_NODES_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::public(b"OwnLeafNodes");
+// Pending `MlsGroupState` embeds staged epoch/message secrets and HPKE keypairs.
+pub(crate) const GROUP_STATE_LABEL: OpenMlsValueLabel = OpenMlsValueLabel::secret(b"GroupState");
+pub(crate) const QUEUED_PROPOSAL_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::public(b"QueuedProposal");
+pub(crate) const PROPOSAL_QUEUE_REFS_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::public(b"ProposalQueueRefs");
+pub(crate) const OWN_LEAF_NODE_INDEX_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::public(b"OwnLeafNodeIndex");
+pub(crate) const EPOCH_SECRETS_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::secret(b"EpochSecrets");
+pub(crate) const RESUMPTION_PSK_STORE_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::secret(b"ResumptionPsk");
+pub(crate) const MESSAGE_SECRETS_LABEL: OpenMlsValueLabel =
+    OpenMlsValueLabel::secret(b"MessageSecrets");
 
 const VALUE_STORAGE_KEY_V1: &[u8] = b"mdk.openmls.value-key.v1";
 
@@ -83,4 +141,44 @@ pub(crate) fn epoch_key_pairs_id_legacy(
     key.extend_from_slice(&serde_json::to_vec(epoch)?);
     key.extend_from_slice(&serde_json::to_vec(&leaf_index)?);
     Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secret_bearing_openmls_labels_require_zeroizing_buffers() {
+        for label in [
+            KEY_PACKAGE_LABEL,
+            PSK_LABEL,
+            ENCRYPTION_KEY_PAIR_LABEL,
+            SIGNATURE_KEY_PAIR_LABEL,
+            EPOCH_KEY_PAIRS_LABEL,
+            APPLICATION_EXPORT_TREE_LABEL,
+            GROUP_STATE_LABEL,
+            EPOCH_SECRETS_LABEL,
+            RESUMPTION_PSK_STORE_LABEL,
+            MESSAGE_SECRETS_LABEL,
+        ] {
+            assert_eq!(label.sensitivity(), ValueSensitivity::Secret);
+        }
+    }
+
+    #[test]
+    fn public_only_openmls_labels_keep_ordinary_buffers() {
+        for label in [
+            TREE_LABEL,
+            GROUP_CONTEXT_LABEL,
+            INTERIM_TRANSCRIPT_HASH_LABEL,
+            CONFIRMATION_TAG_LABEL,
+            JOIN_CONFIG_LABEL,
+            OWN_LEAF_NODES_LABEL,
+            QUEUED_PROPOSAL_LABEL,
+            PROPOSAL_QUEUE_REFS_LABEL,
+            OWN_LEAF_NODE_INDEX_LABEL,
+        ] {
+            assert_eq!(label.sensitivity(), ValueSensitivity::Public);
+        }
+    }
 }

--- a/crates/storage-sqlite/src/openmls_storage/labels.rs
+++ b/crates/storage-sqlite/src/openmls_storage/labels.rs
@@ -18,14 +18,14 @@ pub(in crate::openmls_storage) struct OpenMlsValueLabel {
 }
 
 impl OpenMlsValueLabel {
-    pub(in crate::openmls_storage) const fn public(bytes: &'static [u8]) -> Self {
+    const fn public(bytes: &'static [u8]) -> Self {
         Self {
             bytes,
             sensitivity: ValueSensitivity::Public,
         }
     }
 
-    pub(in crate::openmls_storage) const fn secret(bytes: &'static [u8]) -> Self {
+    const fn secret(bytes: &'static [u8]) -> Self {
         Self {
             bytes,
             sensitivity: ValueSensitivity::Secret,
@@ -39,45 +39,55 @@ impl OpenMlsValueLabel {
     pub(in crate::openmls_storage) const fn sensitivity(self) -> ValueSensitivity {
         self.sensitivity
     }
+
+    #[cfg(test)]
+    pub(in crate::openmls_storage) const fn test_public(bytes: &'static [u8]) -> Self {
+        Self::public(bytes)
+    }
+
+    #[cfg(test)]
+    pub(in crate::openmls_storage) const fn test_secret(bytes: &'static [u8]) -> Self {
+        Self::secret(bytes)
+    }
 }
 
-// OpenMLS's `KeyPackage` storage entity is a `KeyPackageBundle`, including its
-// private init and leaf-encryption keys.
-pub(crate) const KEY_PACKAGE_LABEL: OpenMlsValueLabel = OpenMlsValueLabel::secret(b"KeyPackage");
-pub(crate) const PSK_LABEL: OpenMlsValueLabel = OpenMlsValueLabel::secret(b"Psk");
-pub(crate) const ENCRYPTION_KEY_PAIR_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::secret(b"EncryptionKeyPair");
-pub(crate) const SIGNATURE_KEY_PAIR_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::secret(b"SignatureKeyPair");
-pub(crate) const EPOCH_KEY_PAIRS_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::secret(b"EpochKeyPairs");
-pub(crate) const TREE_LABEL: OpenMlsValueLabel = OpenMlsValueLabel::public(b"Tree");
-pub(crate) const GROUP_CONTEXT_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::public(b"GroupContext");
-pub(crate) const APPLICATION_EXPORT_TREE_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::secret(b"ApplicationExportTree");
-pub(crate) const INTERIM_TRANSCRIPT_HASH_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::public(b"InterimTranscriptHash");
-pub(crate) const CONFIRMATION_TAG_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::public(b"ConfirmationTag");
-pub(crate) const JOIN_CONFIG_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::public(b"MlsGroupJoinConfig");
-pub(crate) const OWN_LEAF_NODES_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::public(b"OwnLeafNodes");
-// Pending `MlsGroupState` embeds staged epoch/message secrets and HPKE keypairs.
-pub(crate) const GROUP_STATE_LABEL: OpenMlsValueLabel = OpenMlsValueLabel::secret(b"GroupState");
-pub(crate) const QUEUED_PROPOSAL_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::public(b"QueuedProposal");
-pub(crate) const PROPOSAL_QUEUE_REFS_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::public(b"ProposalQueueRefs");
-pub(crate) const OWN_LEAF_NODE_INDEX_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::public(b"OwnLeafNodeIndex");
-pub(crate) const EPOCH_SECRETS_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::secret(b"EpochSecrets");
-pub(crate) const RESUMPTION_PSK_STORE_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::secret(b"ResumptionPsk");
-pub(crate) const MESSAGE_SECRETS_LABEL: OpenMlsValueLabel =
-    OpenMlsValueLabel::secret(b"MessageSecrets");
+macro_rules! define_openmls_value_labels {
+    ($($(#[$meta:meta])* $name:ident => $sensitivity:ident($bytes:literal);)+) => {
+        $(
+            $(#[$meta])*
+            pub(crate) const $name: OpenMlsValueLabel =
+                OpenMlsValueLabel::$sensitivity($bytes);
+        )+
+
+        #[cfg(test)]
+        const ALL_LABELS: &[OpenMlsValueLabel] = &[$($name),+];
+    };
+}
+
+define_openmls_value_labels! {
+    /// OpenMLS's `KeyPackage` storage entity is a `KeyPackageBundle`, including
+    /// its private init and leaf-encryption keys.
+    KEY_PACKAGE_LABEL => secret(b"KeyPackage");
+    PSK_LABEL => secret(b"Psk");
+    ENCRYPTION_KEY_PAIR_LABEL => secret(b"EncryptionKeyPair");
+    SIGNATURE_KEY_PAIR_LABEL => secret(b"SignatureKeyPair");
+    EPOCH_KEY_PAIRS_LABEL => secret(b"EpochKeyPairs");
+    TREE_LABEL => public(b"Tree");
+    GROUP_CONTEXT_LABEL => public(b"GroupContext");
+    APPLICATION_EXPORT_TREE_LABEL => secret(b"ApplicationExportTree");
+    INTERIM_TRANSCRIPT_HASH_LABEL => public(b"InterimTranscriptHash");
+    CONFIRMATION_TAG_LABEL => public(b"ConfirmationTag");
+    JOIN_CONFIG_LABEL => public(b"MlsGroupJoinConfig");
+    OWN_LEAF_NODES_LABEL => public(b"OwnLeafNodes");
+    /// Pending `MlsGroupState` embeds staged epoch/message secrets and HPKE keypairs.
+    GROUP_STATE_LABEL => secret(b"GroupState");
+    QUEUED_PROPOSAL_LABEL => public(b"QueuedProposal");
+    PROPOSAL_QUEUE_REFS_LABEL => public(b"ProposalQueueRefs");
+    OWN_LEAF_NODE_INDEX_LABEL => public(b"OwnLeafNodeIndex");
+    EPOCH_SECRETS_LABEL => secret(b"EpochSecrets");
+    RESUMPTION_PSK_STORE_LABEL => secret(b"ResumptionPsk");
+    MESSAGE_SECRETS_LABEL => secret(b"MessageSecrets");
+}
 
 const VALUE_STORAGE_KEY_V1: &[u8] = b"mdk.openmls.value-key.v1";
 
@@ -149,7 +159,7 @@ mod tests {
 
     #[test]
     fn secret_bearing_openmls_labels_require_zeroizing_buffers() {
-        for label in [
+        let secret_labels = [
             KEY_PACKAGE_LABEL,
             PSK_LABEL,
             ENCRYPTION_KEY_PAIR_LABEL,
@@ -160,14 +170,30 @@ mod tests {
             EPOCH_SECRETS_LABEL,
             RESUMPTION_PSK_STORE_LABEL,
             MESSAGE_SECRETS_LABEL,
-        ] {
+        ];
+        for label in secret_labels {
             assert_eq!(label.sensitivity(), ValueSensitivity::Secret);
+        }
+
+        assert_eq!(
+            ALL_LABELS
+                .iter()
+                .filter(|label| label.sensitivity() == ValueSensitivity::Secret)
+                .count(),
+            secret_labels.len(),
+            "the secret-label test list must exhaust the label registry"
+        );
+        for label in ALL_LABELS
+            .iter()
+            .filter(|label| label.sensitivity() == ValueSensitivity::Secret)
+        {
+            assert!(secret_labels.contains(label));
         }
     }
 
     #[test]
     fn public_only_openmls_labels_keep_ordinary_buffers() {
-        for label in [
+        let public_labels = [
             TREE_LABEL,
             GROUP_CONTEXT_LABEL,
             INTERIM_TRANSCRIPT_HASH_LABEL,
@@ -177,8 +203,24 @@ mod tests {
             QUEUED_PROPOSAL_LABEL,
             PROPOSAL_QUEUE_REFS_LABEL,
             OWN_LEAF_NODE_INDEX_LABEL,
-        ] {
+        ];
+        for label in public_labels {
             assert_eq!(label.sensitivity(), ValueSensitivity::Public);
+        }
+
+        assert_eq!(
+            ALL_LABELS
+                .iter()
+                .filter(|label| label.sensitivity() == ValueSensitivity::Public)
+                .count(),
+            public_labels.len(),
+            "the public-label test list must exhaust the label registry"
+        );
+        for label in ALL_LABELS
+            .iter()
+            .filter(|label| label.sensitivity() == ValueSensitivity::Public)
+        {
+            assert!(public_labels.contains(label));
         }
     }
 }

--- a/crates/storage-sqlite/src/openmls_storage/provider.rs
+++ b/crates/storage-sqlite/src/openmls_storage/provider.rs
@@ -207,11 +207,11 @@ impl StorageProvider<CURRENT_VERSION> for SqliteOpenMlsStorage {
         leaf_index: u32,
         key_pairs: &[HpkeKeyPair],
     ) -> Result<(), Self::Error> {
-        self.write_value(
+        self.write_json(
             EPOCH_KEY_PAIRS_LABEL,
             epoch_key_pairs_id(group_id, epoch, leaf_index)?,
             Some(Self::group_key(group_id)?),
-            serde_json::to_vec(key_pairs)?,
+            key_pairs,
         )
     }
 
@@ -881,7 +881,7 @@ mod tests {
         let group_id = TestGroupId(vec![1, 2, 3, 4]);
         let proposal_ref = TestProposalRef(vec![0xAA]);
         let proposal = TestQueuedProposal(vec![0xCC]);
-        let refs_label_hex = hex::encode_upper(PROPOSAL_QUEUE_REFS_LABEL);
+        let refs_label_hex = hex::encode_upper(PROPOSAL_QUEUE_REFS_LABEL.as_bytes());
         mls.lock()
             .unwrap()
             .execute_batch(&format!(
@@ -903,7 +903,7 @@ mod tests {
             .unwrap()
             .query_row(
                 "SELECT COUNT(*) FROM openmls_values WHERE label = ?1",
-                rusqlite::params![QUEUED_PROPOSAL_LABEL],
+                rusqlite::params![QUEUED_PROPOSAL_LABEL.as_bytes()],
                 |row| row.get(0),
             )
             .unwrap();

--- a/crates/storage-sqlite/src/openmls_storage/value_store.rs
+++ b/crates/storage-sqlite/src/openmls_storage/value_store.rs
@@ -1,65 +1,22 @@
 use super::labels::{OpenMlsValueLabel, ValueSensitivity, build_key, build_key_legacy};
 use super::{SqliteOpenMlsStorage, SqliteOpenMlsStorageError};
+use crate::codec::{SensitiveBytes, serialize_sensitive_json};
 use crate::connection::retry_on_busy;
 use openmls_traits::storage::{CURRENT_VERSION, Entity, Key};
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
-use serde::de::{DeserializeOwned, SeqAccess, Visitor};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt;
-use zeroize::Zeroizing;
-
-struct SecretBytes(Zeroizing<Vec<u8>>);
-
-impl SecretBytes {
-    fn new(bytes: Vec<u8>) -> Self {
-        Self(Zeroizing::new(bytes))
-    }
-
-    fn as_slice(&self) -> &[u8] {
-        self.0.as_slice()
-    }
-}
-
-impl Serialize for SecretBytes {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.as_slice().serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for SecretBytes {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        struct SecretBytesVisitor;
-
-        impl<'de> Visitor<'de> for SecretBytesVisitor {
-            type Value = SecretBytes;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter.write_str("a JSON byte array")
-            }
-
-            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-                let mut bytes = Zeroizing::new(Vec::with_capacity(seq.size_hint().unwrap_or(0)));
-                while let Some(byte) = seq.next_element()? {
-                    bytes.push(byte);
-                }
-                Ok(SecretBytes(bytes))
-            }
-        }
-
-        deserializer.deserialize_seq(SecretBytesVisitor)
-    }
-}
+use serde::de::DeserializeOwned;
+use serde::{Serialize, Serializer};
 
 enum SerializedBuffer {
     Public(Vec<u8>),
-    Secret(SecretBytes),
+    Secret(SensitiveBytes),
 }
 
 impl SerializedBuffer {
     fn from_database(label: OpenMlsValueLabel, bytes: Vec<u8>) -> Self {
         match label.sensitivity() {
             ValueSensitivity::Public => Self::Public(bytes),
-            ValueSensitivity::Secret => Self::Secret(SecretBytes::new(bytes)),
+            ValueSensitivity::Secret => Self::Secret(SensitiveBytes::new(bytes)),
         }
     }
 
@@ -77,20 +34,13 @@ fn serialize_buffer<T: Serialize + ?Sized>(
 ) -> Result<SerializedBuffer, SqliteOpenMlsStorageError> {
     match label.sensitivity() {
         ValueSensitivity::Public => Ok(SerializedBuffer::Public(serde_json::to_vec(value)?)),
-        ValueSensitivity::Secret => {
-            // Serialize directly into zeroizing ownership. `to_writer` may leave
-            // a partial JSON document when serialization fails; the guard wipes
-            // that partial buffer as this error unwinds.
-            let mut bytes = Zeroizing::new(Vec::new());
-            serde_json::to_writer(&mut *bytes, value)?;
-            Ok(SerializedBuffer::Secret(SecretBytes(bytes)))
-        }
+        ValueSensitivity::Secret => Ok(SerializedBuffer::Secret(serialize_sensitive_json(value)?)),
     }
 }
 
 enum SerializedList {
     Public(Vec<Vec<u8>>),
-    Secret(Vec<SecretBytes>),
+    Secret(Vec<SensitiveBytes>),
 }
 
 impl SerializedList {
@@ -104,33 +54,24 @@ impl SerializedList {
         }
     }
 
-    fn push(&mut self, value: SerializedBuffer) {
-        match (self, value) {
-            (Self::Public(values), SerializedBuffer::Public(value)) => values.push(value),
-            (Self::Secret(values), SerializedBuffer::Secret(value)) => values.push(value),
-            _ => unreachable!("label sensitivity must be stable within one list operation"),
+    fn push<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), SqliteOpenMlsStorageError> {
+        match self {
+            Self::Public(values) => values.push(serde_json::to_vec(value)?),
+            Self::Secret(values) => values.push(serialize_sensitive_json(value)?),
         }
+        Ok(())
     }
 
     fn remove_matching(&mut self, encoded: &SerializedBuffer) {
+        fn remove<T: AsRef<[u8]>>(values: &mut Vec<T>, encoded: &[u8]) {
+            if let Some(pos) = values.iter().position(|stored| stored.as_ref() == encoded) {
+                values.remove(pos);
+            }
+        }
+
         match self {
-            Self::Public(values) => {
-                if let Some(pos) = values
-                    .iter()
-                    .position(|stored| stored.as_slice() == encoded.as_slice())
-                {
-                    values.remove(pos);
-                }
-            }
-            Self::Secret(values) => {
-                if let Some(pos) = values
-                    .iter()
-                    .position(|stored| stored.as_slice() == encoded.as_slice())
-                {
-                    // Removing the SecretBytes drops its Zeroizing<Vec<u8>> here.
-                    values.remove(pos);
-                }
-            }
+            Self::Public(values) => remove(values, encoded.as_slice()),
+            Self::Secret(values) => remove(values, encoded.as_slice()),
         }
     }
 }
@@ -557,7 +498,7 @@ fn append_entity_on_connection<T: Entity<CURRENT_VERSION>>(
         legacy_storage_key.as_slice(),
         label,
     )?;
-    list.push(serialize_buffer(label, value)?);
+    list.push(value)?;
     write_list_on_connection(conn, label, storage_key.as_slice(), group_key, &list)?;
     delete_value_on_connection(conn, legacy_storage_key.as_slice())
 }
@@ -622,7 +563,7 @@ mod tests {
 
     #[test]
     fn secret_value_paths_select_zeroizing_buffers() {
-        let label = OpenMlsValueLabel::secret(b"TestSecret");
+        let label = OpenMlsValueLabel::test_secret(b"TestSecret");
 
         assert!(matches!(
             serialize_buffer(label, &TestEntity(7)).unwrap(),
@@ -648,11 +589,25 @@ mod tests {
     }
 
     #[test]
+    fn list_push_derives_buffer_ownership_from_the_existing_list() {
+        let mut public = SerializedList::Public(Vec::new());
+        public.push(&TestEntity(7)).unwrap();
+        assert!(matches!(public, SerializedList::Public(values) if values == [b"7"]));
+
+        let mut secret = SerializedList::Secret(Vec::new());
+        secret.push(&TestEntity(8)).unwrap();
+        assert!(matches!(
+            secret,
+            SerializedList::Secret(values) if values.len() == 1 && values[0].as_slice() == b"8"
+        ));
+    }
+
+    #[test]
     fn value_storage_key_length_delimits_label_and_key() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         let mls = &store.openmls;
-        let label_a = OpenMlsValueLabel::public(b"A");
-        let label_ab = OpenMlsValueLabel::public(b"AB");
+        let label_a = OpenMlsValueLabel::test_public(b"A");
+        let label_ab = OpenMlsValueLabel::test_public(b"AB");
 
         // These two rows collide under the legacy concatenation:
         // label("A") + key("BC") == label("AB") + key("C").
@@ -685,7 +640,7 @@ mod tests {
     fn value_storage_reads_and_deletes_legacy_concatenated_key() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         let mls = &store.openmls;
-        let label = OpenMlsValueLabel::public(b"LegacyValue");
+        let label = OpenMlsValueLabel::test_public(b"LegacyValue");
         let key = b"row".to_vec();
         let legacy_key = build_key_legacy(label.as_bytes(), key.clone());
 
@@ -734,7 +689,7 @@ mod tests {
     fn list_storage_migrates_legacy_concatenated_key_on_mutation() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         let mls = &store.openmls;
-        let label = OpenMlsValueLabel::public(b"LegacyList");
+        let label = OpenMlsValueLabel::test_public(b"LegacyList");
         let key = b"list".to_vec();
         let legacy_key = build_key_legacy(label.as_bytes(), key.clone());
         let legacy_list = vec![serde_json::to_vec(&TestEntity(1)).unwrap()];

--- a/crates/storage-sqlite/src/openmls_storage/value_store.rs
+++ b/crates/storage-sqlite/src/openmls_storage/value_store.rs
@@ -1,20 +1,159 @@
-use super::labels::{build_key, build_key_legacy};
+use super::labels::{OpenMlsValueLabel, ValueSensitivity, build_key, build_key_legacy};
 use super::{SqliteOpenMlsStorage, SqliteOpenMlsStorageError};
 use crate::connection::retry_on_busy;
 use openmls_traits::storage::{CURRENT_VERSION, Entity, Key};
 use rusqlite::{OptionalExtension, TransactionBehavior, params};
-use serde::de::DeserializeOwned;
+use serde::de::{DeserializeOwned, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use zeroize::Zeroizing;
+
+struct SecretBytes(Zeroizing<Vec<u8>>);
+
+impl SecretBytes {
+    fn new(bytes: Vec<u8>) -> Self {
+        Self(Zeroizing::new(bytes))
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+impl Serialize for SecretBytes {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.as_slice().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SecretBytes {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct SecretBytesVisitor;
+
+        impl<'de> Visitor<'de> for SecretBytesVisitor {
+            type Value = SecretBytes;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a JSON byte array")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                let mut bytes = Zeroizing::new(Vec::with_capacity(seq.size_hint().unwrap_or(0)));
+                while let Some(byte) = seq.next_element()? {
+                    bytes.push(byte);
+                }
+                Ok(SecretBytes(bytes))
+            }
+        }
+
+        deserializer.deserialize_seq(SecretBytesVisitor)
+    }
+}
+
+enum SerializedBuffer {
+    Public(Vec<u8>),
+    Secret(SecretBytes),
+}
+
+impl SerializedBuffer {
+    fn from_database(label: OpenMlsValueLabel, bytes: Vec<u8>) -> Self {
+        match label.sensitivity() {
+            ValueSensitivity::Public => Self::Public(bytes),
+            ValueSensitivity::Secret => Self::Secret(SecretBytes::new(bytes)),
+        }
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Public(bytes) => bytes,
+            Self::Secret(bytes) => bytes.as_slice(),
+        }
+    }
+}
+
+fn serialize_buffer<T: Serialize + ?Sized>(
+    label: OpenMlsValueLabel,
+    value: &T,
+) -> Result<SerializedBuffer, SqliteOpenMlsStorageError> {
+    match label.sensitivity() {
+        ValueSensitivity::Public => Ok(SerializedBuffer::Public(serde_json::to_vec(value)?)),
+        ValueSensitivity::Secret => {
+            // Serialize directly into zeroizing ownership. `to_writer` may leave
+            // a partial JSON document when serialization fails; the guard wipes
+            // that partial buffer as this error unwinds.
+            let mut bytes = Zeroizing::new(Vec::new());
+            serde_json::to_writer(&mut *bytes, value)?;
+            Ok(SerializedBuffer::Secret(SecretBytes(bytes)))
+        }
+    }
+}
+
+enum SerializedList {
+    Public(Vec<Vec<u8>>),
+    Secret(Vec<SecretBytes>),
+}
+
+impl SerializedList {
+    fn deserialize(
+        label: OpenMlsValueLabel,
+        bytes: &[u8],
+    ) -> Result<Self, SqliteOpenMlsStorageError> {
+        match label.sensitivity() {
+            ValueSensitivity::Public => Ok(Self::Public(serde_json::from_slice(bytes)?)),
+            ValueSensitivity::Secret => Ok(Self::Secret(serde_json::from_slice(bytes)?)),
+        }
+    }
+
+    fn push(&mut self, value: SerializedBuffer) {
+        match (self, value) {
+            (Self::Public(values), SerializedBuffer::Public(value)) => values.push(value),
+            (Self::Secret(values), SerializedBuffer::Secret(value)) => values.push(value),
+            _ => unreachable!("label sensitivity must be stable within one list operation"),
+        }
+    }
+
+    fn remove_matching(&mut self, encoded: &SerializedBuffer) {
+        match self {
+            Self::Public(values) => {
+                if let Some(pos) = values
+                    .iter()
+                    .position(|stored| stored.as_slice() == encoded.as_slice())
+                {
+                    values.remove(pos);
+                }
+            }
+            Self::Secret(values) => {
+                if let Some(pos) = values
+                    .iter()
+                    .position(|stored| stored.as_slice() == encoded.as_slice())
+                {
+                    // Removing the SecretBytes drops its Zeroizing<Vec<u8>> here.
+                    values.remove(pos);
+                }
+            }
+        }
+    }
+}
+
+impl Serialize for SerializedList {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Public(values) => values.serialize(serializer),
+            Self::Secret(values) => values.serialize(serializer),
+        }
+    }
+}
 
 impl SqliteOpenMlsStorage {
-    pub(in crate::openmls_storage) fn write_value(
+    fn write_serialized_value(
         &self,
-        label: &[u8],
+        label: OpenMlsValueLabel,
         key: Vec<u8>,
         group_key: Option<Vec<u8>>,
-        value: Vec<u8>,
+        value: &SerializedBuffer,
     ) -> Result<(), SqliteOpenMlsStorageError> {
-        let storage_key = build_key(label, key.clone());
-        let legacy_storage_key = build_key_legacy(label, key);
+        let storage_key = build_key(label.as_bytes(), key.clone());
+        let legacy_storage_key = build_key_legacy(label.as_bytes(), key);
         if self.connection.is_current_thread_transaction_owner() {
             let conn = self.lock()?;
             write_value_on_connection(
@@ -47,14 +186,37 @@ impl SqliteOpenMlsStorage {
         }
     }
 
-    pub(in crate::openmls_storage) fn write_entity<T: Entity<CURRENT_VERSION>>(
+    pub(in crate::openmls_storage) fn write_json<T: Serialize + ?Sized>(
         &self,
-        label: &[u8],
+        label: OpenMlsValueLabel,
         key: Vec<u8>,
         group_key: Option<Vec<u8>>,
         value: &T,
     ) -> Result<(), SqliteOpenMlsStorageError> {
-        self.write_value(label, key, group_key, serde_json::to_vec(value)?)
+        let encoded = serialize_buffer(label, value)?;
+        self.write_serialized_value(label, key, group_key, &encoded)
+    }
+
+    #[cfg(test)]
+    pub(in crate::openmls_storage) fn write_value(
+        &self,
+        label: OpenMlsValueLabel,
+        key: Vec<u8>,
+        group_key: Option<Vec<u8>>,
+        value: Vec<u8>,
+    ) -> Result<(), SqliteOpenMlsStorageError> {
+        let encoded = SerializedBuffer::from_database(label, value);
+        self.write_serialized_value(label, key, group_key, &encoded)
+    }
+
+    pub(in crate::openmls_storage) fn write_entity<T: Entity<CURRENT_VERSION>>(
+        &self,
+        label: OpenMlsValueLabel,
+        key: Vec<u8>,
+        group_key: Option<Vec<u8>>,
+        value: &T,
+    ) -> Result<(), SqliteOpenMlsStorageError> {
+        self.write_json(label, key, group_key, value)
     }
 
     pub(in crate::openmls_storage) fn write_group_entity<
@@ -62,7 +224,7 @@ impl SqliteOpenMlsStorage {
         T: Entity<CURRENT_VERSION>,
     >(
         &self,
-        label: &[u8],
+        label: OpenMlsValueLabel,
         group_id: &GroupId,
         value: &T,
     ) -> Result<(), SqliteOpenMlsStorageError> {
@@ -72,13 +234,13 @@ impl SqliteOpenMlsStorage {
 
     pub(in crate::openmls_storage) fn append_entity<T: Entity<CURRENT_VERSION>>(
         &self,
-        label: &[u8],
+        label: OpenMlsValueLabel,
         key: Vec<u8>,
         group_key: Option<Vec<u8>>,
         value: &T,
     ) -> Result<(), SqliteOpenMlsStorageError> {
-        let storage_key = build_key(label, key.clone());
-        let legacy_storage_key = build_key_legacy(label, key);
+        let storage_key = build_key(label.as_bytes(), key.clone());
+        let legacy_storage_key = build_key_legacy(label.as_bytes(), key);
         if self.connection.is_current_thread_transaction_owner() {
             // Inside a broader engine-owned OpenMLS transaction: execute directly
             // and let the owning transaction handle retry/rollback. Retrying a
@@ -115,14 +277,14 @@ impl SqliteOpenMlsStorage {
 
     pub(in crate::openmls_storage) fn remove_entity<T: Entity<CURRENT_VERSION>>(
         &self,
-        label: &[u8],
+        label: OpenMlsValueLabel,
         key: Vec<u8>,
         group_key: Option<Vec<u8>>,
         value: &T,
     ) -> Result<(), SqliteOpenMlsStorageError> {
-        let encoded = serde_json::to_vec(value)?;
-        let storage_key = build_key(label, key.clone());
-        let legacy_storage_key = build_key_legacy(label, key);
+        let encoded = serialize_buffer(label, value)?;
+        let storage_key = build_key(label.as_bytes(), key.clone());
+        let legacy_storage_key = build_key_legacy(label.as_bytes(), key);
         if self.connection.is_current_thread_transaction_owner() {
             // Inside a broader engine-owned OpenMLS transaction: see append_entity.
             let conn = self.lock()?;
@@ -132,7 +294,7 @@ impl SqliteOpenMlsStorage {
                 storage_key,
                 legacy_storage_key,
                 group_key.as_deref(),
-                encoded.as_slice(),
+                &encoded,
             )?;
             Ok(())
         } else {
@@ -145,7 +307,7 @@ impl SqliteOpenMlsStorage {
                     storage_key.clone(),
                     legacy_storage_key.clone(),
                     group_key.as_deref(),
-                    encoded.as_slice(),
+                    &encoded,
                 )?;
                 tx.commit()?;
                 Ok(())
@@ -155,24 +317,24 @@ impl SqliteOpenMlsStorage {
 
     fn read_raw_list(
         &self,
-        label: &[u8],
+        label: OpenMlsValueLabel,
         key: &[u8],
-    ) -> Result<Option<Vec<Vec<u8>>>, SqliteOpenMlsStorageError> {
-        let storage_key = build_key(label, key.to_vec());
-        let legacy_storage_key = build_key_legacy(label, key.to_vec());
+    ) -> Result<Option<SerializedList>, SqliteOpenMlsStorageError> {
+        let storage_key = build_key(label.as_bytes(), key.to_vec());
+        let legacy_storage_key = build_key_legacy(label.as_bytes(), key.to_vec());
         let conn = self.lock()?;
-        let value = match read_value_on_connection(&conn, &storage_key)? {
+        let value = match read_value_on_connection(&conn, &storage_key, label)? {
             Some(value) => Some(value),
-            None => read_value_on_connection(&conn, &legacy_storage_key)?,
+            None => read_value_on_connection(&conn, &legacy_storage_key, label)?,
         };
         value
-            .map(|value| serde_json::from_slice(&value).map_err(Into::into))
+            .map(|value| SerializedList::deserialize(label, value.as_slice()))
             .transpose()
     }
 
     pub(in crate::openmls_storage) fn read_entity<T: Entity<CURRENT_VERSION>>(
         &self,
-        label: &[u8],
+        label: OpenMlsValueLabel,
         key: Vec<u8>,
     ) -> Result<Option<T>, SqliteOpenMlsStorageError> {
         self.read_json(label, key)
@@ -180,18 +342,18 @@ impl SqliteOpenMlsStorage {
 
     pub(in crate::openmls_storage) fn read_json<T: DeserializeOwned>(
         &self,
-        label: &[u8],
+        label: OpenMlsValueLabel,
         key: Vec<u8>,
     ) -> Result<Option<T>, SqliteOpenMlsStorageError> {
-        let storage_key = build_key(label, key.clone());
-        let legacy_storage_key = build_key_legacy(label, key);
+        let storage_key = build_key(label.as_bytes(), key.clone());
+        let legacy_storage_key = build_key_legacy(label.as_bytes(), key);
         let conn = self.lock()?;
-        let value = match read_value_on_connection(&conn, &storage_key)? {
+        let value = match read_value_on_connection(&conn, &storage_key, label)? {
             Some(value) => Some(value),
-            None => read_value_on_connection(&conn, &legacy_storage_key)?,
+            None => read_value_on_connection(&conn, &legacy_storage_key, label)?,
         };
         value
-            .map(|value| serde_json::from_slice(&value).map_err(Into::into))
+            .map(|value| serde_json::from_slice(value.as_slice()).map_err(Into::into))
             .transpose()
     }
 
@@ -200,7 +362,7 @@ impl SqliteOpenMlsStorage {
         T: Entity<CURRENT_VERSION>,
     >(
         &self,
-        label: &[u8],
+        label: OpenMlsValueLabel,
         group_id: &GroupId,
     ) -> Result<Option<T>, SqliteOpenMlsStorageError> {
         self.read_entity(label, Self::group_key(group_id)?)
@@ -208,23 +370,29 @@ impl SqliteOpenMlsStorage {
 
     pub(in crate::openmls_storage) fn read_list<T: Entity<CURRENT_VERSION>>(
         &self,
-        label: &[u8],
+        label: OpenMlsValueLabel,
         key: Vec<u8>,
     ) -> Result<Vec<T>, SqliteOpenMlsStorageError> {
-        self.read_raw_list(label, &key)?
-            .unwrap_or_default()
-            .into_iter()
-            .map(|value| serde_json::from_slice(&value).map_err(Into::into))
-            .collect()
+        match self.read_raw_list(label, &key)? {
+            Some(SerializedList::Public(values)) => values
+                .into_iter()
+                .map(|value| serde_json::from_slice(&value).map_err(Into::into))
+                .collect(),
+            Some(SerializedList::Secret(values)) => values
+                .into_iter()
+                .map(|value| serde_json::from_slice(value.as_slice()).map_err(Into::into))
+                .collect(),
+            None => Ok(Vec::new()),
+        }
     }
 
     pub(in crate::openmls_storage) fn delete_value(
         &self,
-        label: &[u8],
+        label: OpenMlsValueLabel,
         key: Vec<u8>,
     ) -> Result<(), SqliteOpenMlsStorageError> {
-        let storage_key = build_key(label, key.clone());
-        let legacy_storage_key = build_key_legacy(label, key);
+        let storage_key = build_key(label.as_bytes(), key.clone());
+        let legacy_storage_key = build_key_legacy(label.as_bytes(), key);
         if self.connection.is_current_thread_transaction_owner() {
             let conn = self.lock()?;
             delete_value_on_connection(&conn, storage_key.as_slice())?;
@@ -247,7 +415,7 @@ impl SqliteOpenMlsStorage {
 
     pub(in crate::openmls_storage) fn delete_group_value<GroupId: Key<CURRENT_VERSION>>(
         &self,
-        label: &[u8],
+        label: OpenMlsValueLabel,
         group_id: &GroupId,
     ) -> Result<(), SqliteOpenMlsStorageError> {
         self.delete_value(label, Self::group_key(group_id)?)
@@ -256,7 +424,7 @@ impl SqliteOpenMlsStorage {
     pub(in crate::openmls_storage) fn delete_group_labels<GroupId: Key<CURRENT_VERSION>>(
         &self,
         group_id: &GroupId,
-        labels: &[&[u8]],
+        labels: &[OpenMlsValueLabel],
     ) -> Result<(), SqliteOpenMlsStorageError> {
         let group_key = Self::group_key(group_id)?;
         // Wrap every label delete in a single transaction so the operation is
@@ -288,7 +456,8 @@ impl SqliteOpenMlsStorage {
 fn read_value_on_connection(
     conn: &rusqlite::Connection,
     storage_key: &[u8],
-) -> Result<Option<Vec<u8>>, SqliteOpenMlsStorageError> {
+    label: OpenMlsValueLabel,
+) -> Result<Option<SerializedBuffer>, SqliteOpenMlsStorageError> {
     Ok(conn
         .query_row(
             "SELECT value FROM openmls_values
@@ -296,12 +465,13 @@ fn read_value_on_connection(
             params![CURRENT_VERSION, storage_key],
             |row| row.get(0),
         )
-        .optional()?)
+        .optional()?
+        .map(|bytes| SerializedBuffer::from_database(label, bytes)))
 }
 
 fn write_value_on_connection(
     conn: &rusqlite::Connection,
-    label: &[u8],
+    label: OpenMlsValueLabel,
     storage_key: &[u8],
     legacy_storage_key: &[u8],
     group_key: Option<&[u8]>,
@@ -311,7 +481,13 @@ fn write_value_on_connection(
         "INSERT OR REPLACE INTO openmls_values
             (provider_version, label, storage_key, group_key, value)
          VALUES (?1, ?2, ?3, ?4, ?5)",
-        params![CURRENT_VERSION, label, storage_key, group_key, value],
+        params![
+            CURRENT_VERSION,
+            label.as_bytes(),
+            storage_key,
+            group_key,
+            value
+        ],
     )?;
     delete_value_on_connection(conn, legacy_storage_key)
 }
@@ -319,49 +495,49 @@ fn write_value_on_connection(
 fn list_values_on_connection(
     conn: &rusqlite::Connection,
     storage_key: &[u8],
-) -> Result<Vec<Vec<u8>>, SqliteOpenMlsStorageError> {
-    conn.query_row(
-        "SELECT value FROM openmls_values
-         WHERE provider_version = ?1 AND storage_key = ?2",
-        params![CURRENT_VERSION, storage_key],
-        |row| row.get::<_, Vec<u8>>(0),
-    )
-    .optional()?
-    .map(|value| serde_json::from_slice(&value))
-    .transpose()
-    .map(|value| value.unwrap_or_default())
-    .map_err(Into::into)
+    label: OpenMlsValueLabel,
+) -> Result<Option<SerializedList>, SqliteOpenMlsStorageError> {
+    read_value_on_connection(conn, storage_key, label)?
+        .map(|value| SerializedList::deserialize(label, value.as_slice()))
+        .transpose()
 }
 
 fn list_values_with_legacy_fallback_on_connection(
     conn: &rusqlite::Connection,
     storage_key: &[u8],
     legacy_storage_key: &[u8],
-) -> Result<Vec<Vec<u8>>, SqliteOpenMlsStorageError> {
-    if read_value_on_connection(conn, storage_key)?.is_some() {
-        list_values_on_connection(conn, storage_key)
+    label: OpenMlsValueLabel,
+) -> Result<SerializedList, SqliteOpenMlsStorageError> {
+    if let Some(values) = list_values_on_connection(conn, storage_key, label)? {
+        Ok(values)
+    } else if let Some(values) = list_values_on_connection(conn, legacy_storage_key, label)? {
+        Ok(values)
     } else {
-        list_values_on_connection(conn, legacy_storage_key)
+        Ok(match label.sensitivity() {
+            ValueSensitivity::Public => SerializedList::Public(Vec::new()),
+            ValueSensitivity::Secret => SerializedList::Secret(Vec::new()),
+        })
     }
 }
 
 fn write_list_on_connection(
     conn: &rusqlite::Connection,
-    label: &[u8],
+    label: OpenMlsValueLabel,
     storage_key: &[u8],
     group_key: Option<&[u8]>,
-    list: &[Vec<u8>],
+    list: &SerializedList,
 ) -> Result<(), SqliteOpenMlsStorageError> {
+    let encoded = serialize_buffer(label, list)?;
     conn.execute(
         "INSERT OR REPLACE INTO openmls_values
             (provider_version, label, storage_key, group_key, value)
          VALUES (?1, ?2, ?3, ?4, ?5)",
         params![
             CURRENT_VERSION,
-            label,
+            label.as_bytes(),
             storage_key,
             group_key,
-            serde_json::to_vec(list)?
+            encoded.as_slice()
         ],
     )?;
     Ok(())
@@ -369,7 +545,7 @@ fn write_list_on_connection(
 
 fn append_entity_on_connection<T: Entity<CURRENT_VERSION>>(
     conn: &rusqlite::Connection,
-    label: &[u8],
+    label: OpenMlsValueLabel,
     storage_key: Vec<u8>,
     legacy_storage_key: Vec<u8>,
     group_key: Option<&[u8]>,
@@ -379,28 +555,28 @@ fn append_entity_on_connection<T: Entity<CURRENT_VERSION>>(
         conn,
         storage_key.as_slice(),
         legacy_storage_key.as_slice(),
+        label,
     )?;
-    list.push(serde_json::to_vec(value)?);
+    list.push(serialize_buffer(label, value)?);
     write_list_on_connection(conn, label, storage_key.as_slice(), group_key, &list)?;
     delete_value_on_connection(conn, legacy_storage_key.as_slice())
 }
 
 fn remove_entity_on_connection(
     conn: &rusqlite::Connection,
-    label: &[u8],
+    label: OpenMlsValueLabel,
     storage_key: Vec<u8>,
     legacy_storage_key: Vec<u8>,
     group_key: Option<&[u8]>,
-    encoded: &[u8],
+    encoded: &SerializedBuffer,
 ) -> Result<(), SqliteOpenMlsStorageError> {
     let mut list = list_values_with_legacy_fallback_on_connection(
         conn,
         storage_key.as_slice(),
         legacy_storage_key.as_slice(),
+        label,
     )?;
-    if let Some(pos) = list.iter().position(|stored| stored == encoded) {
-        list.remove(pos);
-    }
+    list.remove_matching(encoded);
     write_list_on_connection(conn, label, storage_key.as_slice(), group_key, &list)?;
     delete_value_on_connection(conn, legacy_storage_key.as_slice())
 }
@@ -420,13 +596,13 @@ fn delete_value_on_connection(
 fn delete_group_labels_on_connection(
     conn: &rusqlite::Connection,
     group_key: &[u8],
-    labels: &[&[u8]],
+    labels: &[OpenMlsValueLabel],
 ) -> Result<(), SqliteOpenMlsStorageError> {
     for label in labels {
         conn.execute(
             "DELETE FROM openmls_values
              WHERE provider_version = ?1 AND group_key = ?2 AND label = ?3",
-            params![CURRENT_VERSION, group_key, *label],
+            params![CURRENT_VERSION, group_key, label.as_bytes()],
         )?;
     }
     Ok(())
@@ -445,38 +621,73 @@ mod tests {
     impl Entity<CURRENT_VERSION> for TestEntity {}
 
     #[test]
+    fn secret_value_paths_select_zeroizing_buffers() {
+        let label = OpenMlsValueLabel::secret(b"TestSecret");
+
+        assert!(matches!(
+            serialize_buffer(label, &TestEntity(7)).unwrap(),
+            SerializedBuffer::Secret(_)
+        ));
+        assert!(matches!(
+            SerializedBuffer::from_database(label, b"7".to_vec()),
+            SerializedBuffer::Secret(_)
+        ));
+
+        let mut list = SerializedList::deserialize(label, b"[[55],[56]]").unwrap();
+        let encoded = serialize_buffer(label, &TestEntity(7)).unwrap();
+        list.remove_matching(&encoded);
+        match list {
+            SerializedList::Secret(values) => {
+                assert_eq!(values.len(), 1);
+                assert_eq!(values[0].as_slice(), b"8");
+            }
+            SerializedList::Public(_) => panic!("secret list used ordinary buffers"),
+        }
+
+        assert!(SerializedList::deserialize(label, b"[[55],").is_err());
+    }
+
+    #[test]
     fn value_storage_key_length_delimits_label_and_key() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         let mls = &store.openmls;
+        let label_a = OpenMlsValueLabel::public(b"A");
+        let label_ab = OpenMlsValueLabel::public(b"AB");
 
         // These two rows collide under the legacy concatenation:
         // label("A") + key("BC") == label("AB") + key("C").
         mls.write_value(
-            b"A",
+            label_a,
             b"BC".to_vec(),
             None,
             serde_json::to_vec(&1u8).unwrap(),
         )
         .unwrap();
         mls.write_value(
-            b"AB",
+            label_ab,
             b"C".to_vec(),
             None,
             serde_json::to_vec(&2u8).unwrap(),
         )
         .unwrap();
 
-        assert_eq!(mls.read_json::<u8>(b"A", b"BC".to_vec()).unwrap(), Some(1));
-        assert_eq!(mls.read_json::<u8>(b"AB", b"C".to_vec()).unwrap(), Some(2));
+        assert_eq!(
+            mls.read_json::<u8>(label_a, b"BC".to_vec()).unwrap(),
+            Some(1)
+        );
+        assert_eq!(
+            mls.read_json::<u8>(label_ab, b"C".to_vec()).unwrap(),
+            Some(2)
+        );
     }
 
     #[test]
     fn value_storage_reads_and_deletes_legacy_concatenated_key() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         let mls = &store.openmls;
-        let label = b"LegacyValue";
+        let label = OpenMlsValueLabel::public(b"LegacyValue");
         let key = b"row".to_vec();
-        let legacy_key = build_key_legacy(label, key.clone());
+        let legacy_key = build_key_legacy(label.as_bytes(), key.clone());
 
         mls.lock()
             .unwrap()
@@ -486,7 +697,7 @@ mod tests {
                  VALUES (?1, ?2, ?3, ?4, ?5)",
                 params![
                     CURRENT_VERSION,
-                    label,
+                    label.as_bytes(),
                     legacy_key.clone(),
                     Option::<&[u8]>::None,
                     serde_json::to_vec(&7u8).unwrap()
@@ -523,9 +734,9 @@ mod tests {
     fn list_storage_migrates_legacy_concatenated_key_on_mutation() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         let mls = &store.openmls;
-        let label = b"LegacyList";
+        let label = OpenMlsValueLabel::public(b"LegacyList");
         let key = b"list".to_vec();
-        let legacy_key = build_key_legacy(label, key.clone());
+        let legacy_key = build_key_legacy(label.as_bytes(), key.clone());
         let legacy_list = vec![serde_json::to_vec(&TestEntity(1)).unwrap()];
 
         mls.lock()
@@ -536,7 +747,7 @@ mod tests {
                  VALUES (?1, ?2, ?3, ?4, ?5)",
                 params![
                     CURRENT_VERSION,
-                    label,
+                    label.as_bytes(),
                     legacy_key.clone(),
                     Option::<&[u8]>::None,
                     serde_json::to_vec(&legacy_list).unwrap()

--- a/crates/storage-sqlite/src/storage/snapshots.rs
+++ b/crates/storage-sqlite/src/storage/snapshots.rs
@@ -165,6 +165,33 @@ mod tests {
     }
 
     #[test]
+    fn malformed_snapshot_is_rejected_before_restore_mutates_live_state() {
+        let store = SqliteAccountStorage::in_memory().unwrap();
+        let live_group = sample_group(gid(1), 1, 2);
+        store.put_group(&live_group).unwrap();
+        store
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO cgka_group_snapshots (group_id, name, snapshot)
+                 VALUES (?1, ?2, ?3)",
+                rusqlite::params![
+                    live_group.id.as_slice(),
+                    "malformed",
+                    b"{\"openmls_values\":[[1,2,3]".as_slice()
+                ],
+            )
+            .unwrap();
+
+        let error = store
+            .rollback_group_to_snapshot(&live_group.id, "malformed")
+            .unwrap_err();
+
+        assert!(matches!(error, StorageError::Serialization(_)));
+        assert_eq!(store.get_group(&live_group.id).unwrap(), live_group);
+    }
+
+    #[test]
     fn snapshot_create_joins_outer_transaction() {
         let store = SqliteAccountStorage::in_memory().unwrap();
         let group = sample_group(gid(1), 0, 1);

--- a/crates/storage-sqlite/src/storage/snapshots/capture.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/capture.rs
@@ -5,8 +5,13 @@ use super::rows::{
 #[cfg(feature = "test-conformance-replay")]
 use super::rows::{REPLAY_SNAPSHOT_VERSION, ReplaySnapshot};
 use crate::openmls_storage::mls_group_key;
+#[cfg(feature = "test-conformance-replay")]
+use crate::serialize;
 use crate::{
-    SqliteAccountStorage, SqliteResultExt, connection::retry_on_busy, deserialize, serialize,
+    SqliteAccountStorage, SqliteResultExt,
+    codec::{SensitiveBytes, serialize_sensitive},
+    connection::retry_on_busy,
+    deserialize,
 };
 use cgka_traits::storage::{StorageError, StorageResult};
 use cgka_traits::types::{GroupId, MemberId};
@@ -39,10 +44,11 @@ fn create_on_connection(
     name: &str,
 ) -> StorageResult<()> {
     let snapshot = capture_snapshot(conn, group_id)?;
+    let snapshot_blob = serialize_sensitive(&snapshot)?;
     conn.execute(
         "INSERT OR REPLACE INTO cgka_group_snapshots (group_id, name, snapshot)
              VALUES (?1, ?2, ?3)",
-        params![group_id.as_slice(), name, serialize(&snapshot)?],
+        params![group_id.as_slice(), name, snapshot_blob.as_slice()],
     )
     .storage()?;
     Ok(())
@@ -222,7 +228,7 @@ fn openmls_values(
                 label: row.get(0)?,
                 storage_key: row.get(1)?,
                 group_key: row.get::<_, Option<Vec<u8>>>(2)?.unwrap_or_default(),
-                value: row.get(3)?,
+                value: SensitiveBytes::new(row.get(3)?),
             })
         },
     )

--- a/crates/storage-sqlite/src/storage/snapshots/restore.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/restore.rs
@@ -6,8 +6,8 @@ use super::rows::{
 use super::rows::{REPLAY_SNAPSHOT_VERSION, ReplaySnapshot};
 use crate::openmls_storage::mls_group_key;
 use crate::{
-    SqliteAccountStorage, SqliteResultExt, connection::retry_on_busy, created_at_to_i64,
-    deserialize, epoch_to_i64, message_state_to_i64, serialize,
+    SqliteAccountStorage, SqliteResultExt, codec::SensitiveBytes, connection::retry_on_busy,
+    created_at_to_i64, deserialize, epoch_to_i64, message_state_to_i64, serialize,
 };
 use cgka_traits::group::Group;
 use cgka_traits::storage::{StorageError, StorageResult};
@@ -51,17 +51,18 @@ fn rollback_snapshot(
     name: &str,
     mls_group_key: &[u8],
 ) -> StorageResult<()> {
-    let snapshot_blob: Vec<u8> = conn
-        .query_row(
+    let snapshot_blob = SensitiveBytes::new(
+        conn.query_row(
             "SELECT snapshot FROM cgka_group_snapshots
                  WHERE group_id = ?1 AND name = ?2",
             params![group_id.as_slice(), name],
-            |row| row.get(0),
+            |row| row.get::<_, Vec<u8>>(0),
         )
         .optional()
         .storage()?
-        .ok_or_else(|| StorageError::SnapshotMissing(name.to_string()))?;
-    let snapshot: Snapshot = deserialize(&snapshot_blob)?;
+        .ok_or_else(|| StorageError::SnapshotMissing(name.to_string()))?,
+    );
+    let snapshot: Snapshot = deserialize(snapshot_blob.as_slice())?;
     restore_snapshot(conn, group_id, &snapshot, mls_group_key)
 }
 
@@ -294,7 +295,7 @@ fn openmls_values(
                 value.label,
                 value.storage_key,
                 value.group_key,
-                value.value
+                value.value.as_slice()
             ],
         )
         .storage()?;

--- a/crates/storage-sqlite/src/storage/snapshots/rows.rs
+++ b/crates/storage-sqlite/src/storage/snapshots/rows.rs
@@ -1,3 +1,4 @@
+use crate::codec::SensitiveBytes;
 use cgka_traits::capabilities::GroupCapabilities;
 #[cfg(feature = "test-conformance-replay")]
 use cgka_traits::convergence_pass::DurableConvergencePass;
@@ -58,5 +59,25 @@ pub(super) struct OpenMlsValueSnapshot {
     pub(super) label: Vec<u8>,
     pub(super) storage_key: Vec<u8>,
     pub(super) group_key: Vec<u8>,
-    pub(super) value: Vec<u8>,
+    pub(super) value: SensitiveBytes,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::SensitiveBytes;
+
+    #[test]
+    fn openmls_snapshot_values_have_sensitive_ownership() {
+        let row = OpenMlsValueSnapshot {
+            label: b"EpochSecrets".to_vec(),
+            storage_key: b"storage-key".to_vec(),
+            group_key: b"group-key".to_vec(),
+            value: SensitiveBytes::new(b"secret-json".to_vec()),
+        };
+
+        fn assert_sensitive(_: &SensitiveBytes) {}
+        assert_sensitive(&row.value);
+        assert_eq!(row.value.as_slice(), b"secret-json");
+    }
 }

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -23,6 +23,7 @@ use crate::types::{Backend, EpochId, GroupId, MemberId, MessageId};
 use crate::welcome::PendingWelcome;
 use openmls_traits::storage::{CURRENT_VERSION, StorageProvider as OpenMlsStorageProvider};
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
 
 /// Marmot-level storage error. Every trait method returns
 /// `Result<_, StorageError>` so the engine can pattern-match rather than
@@ -369,7 +370,8 @@ pub trait AccountDeviceSignerStorage {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StoredKeyPackageBundle {
     pub storage_key: Vec<u8>,
-    pub value: Vec<u8>,
+    /// Serialized `KeyPackageBundle`, including its private init and leaf keys.
+    pub value: Zeroizing<Vec<u8>>,
 }
 
 pub trait KeyPackageBundleStorage {

--- a/crates/traits/src/storage.rs
+++ b/crates/traits/src/storage.rs
@@ -23,6 +23,7 @@ use crate::types::{Backend, EpochId, GroupId, MemberId, MessageId};
 use crate::welcome::PendingWelcome;
 use openmls_traits::storage::{CURRENT_VERSION, StorageProvider as OpenMlsStorageProvider};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use zeroize::Zeroizing;
 
 /// Marmot-level storage error. Every trait method returns
@@ -367,11 +368,29 @@ pub trait AccountDeviceSignerStorage {
 /// application has no public-event cache entry. Storage therefore exposes the
 /// serialized OpenMLS entities as opaque bytes; the engine owns their schema,
 /// profile classification, and deletion.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct StoredKeyPackageBundle {
     pub storage_key: Vec<u8>,
     /// Serialized `KeyPackageBundle`, including its private init and leaf keys.
     pub value: Zeroizing<Vec<u8>>,
+}
+
+struct RedactedValue;
+
+impl fmt::Debug for RedactedValue {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("[REDACTED]")
+    }
+}
+
+impl fmt::Debug for StoredKeyPackageBundle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StoredKeyPackageBundle")
+            .field("storage_key", &self.storage_key)
+            .field("value", &RedactedValue)
+            .finish()
+    }
 }
 
 pub trait KeyPackageBundleStorage {
@@ -498,4 +517,21 @@ pub trait StorageProvider:
     }
 
     fn backend(&self) -> Backend;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stored_key_package_debug_redacts_serialized_private_key_material() {
+        let bundle = StoredKeyPackageBundle {
+            storage_key: b"public-storage-key".to_vec(),
+            value: Zeroizing::new(vec![222, 173, 190, 239]),
+        };
+        let debug = format!("{bundle:?}");
+
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("222, 173, 190, 239"));
+    }
 }


### PR DESCRIPTION
## Summary

- classify every OpenMLS SQLite value label as secret-bearing or public-only
- serialize and read secret-bearing entity/list buffers through zeroizing ownership, including partial serialization/deserialization and SQLite error paths
- keep raw KeyPackage bundle enumeration zeroizing across the storage/engine boundary
- document the fix in the compatibility-cohort changelog

## Test plan

- `just fast-ci`
- `cargo test -p storage-sqlite` (310 passed)
- `cargo test -p cgka-traits`
- `cargo test -p cgka-engine key_package`
- `cargo clippy -p cgka-traits -p storage-sqlite -p cgka-engine --all-targets --locked -- -D warnings`

## Security scope

Touches OpenMLS key, epoch/message-secret, PSK, pending group-state, and application-export persistence. This PR requires explicit merge approval under the sensitive-path gate.

Fixes #1210


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved protection of sensitive MLS keys, secrets, private state, and serialized data by securely clearing temporary buffers after use.
  * Key-package and stored secret data now use sensitivity-aware handling to reduce residual information in memory.
  * Sensitive values are redacted from diagnostic output.
* **Bug Fixes**
  * Improved snapshot validation so malformed data fails safely without altering active group state.
  * Preserved compatibility when migrating existing stored data.
* **Documentation**
  * Documented the security improvements in the upcoming release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->