### PR TITLE
fix: zeroize CLI nsec imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7229,6 +7229,7 @@ dependencies = [
  "unicode-properties",
  "unicode-segmentation",
  "url",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -924,7 +924,7 @@ async fn connector_socket_subscribes_to_inbound_messages() {
         ..AccountSetupRequest::default()
     };
     let agent = setup_runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
@@ -1741,7 +1741,7 @@ async fn connector_policy_accepts_allowed_welcomer() {
         ..AccountSetupRequest::default()
     };
     let agent = agent_setup_runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let human = human_runtime.create_identity(setup).await.unwrap();
@@ -1808,7 +1808,7 @@ async fn connector_policy_declines_unlisted_welcomer() {
         ..AccountSetupRequest::default()
     };
     let agent = agent_setup_runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let human = human_runtime.create_identity(setup).await.unwrap();
@@ -1866,7 +1866,7 @@ async fn connector_policy_dev_allow_any_accepts_unlisted_authenticated_welcomer(
         ..AccountSetupRequest::default()
     };
     let agent = agent_setup_runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let human = human_runtime.create_identity(setup).await.unwrap();
@@ -2319,7 +2319,7 @@ async fn connector_socket_sends_final_message() {
         ..AccountSetupRequest::default()
     };
     let agent = setup_runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
@@ -2391,7 +2391,7 @@ async fn connector_socket_composes_and_finalizes_stream_without_quic_candidates(
         ..AccountSetupRequest::default()
     };
     let agent = setup_runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
@@ -2626,7 +2626,7 @@ async fn connector_socket_finalize_mismatch_keeps_stream_session_retryable() {
         ..AccountSetupRequest::default()
     };
     let agent = setup_runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
@@ -2793,7 +2793,7 @@ async fn connector_finalize_retries_durable_finish_without_compose_task() {
         ..AccountSetupRequest::default()
     };
     let agent = setup_runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
@@ -3002,7 +3002,7 @@ async fn connector_socket_cancels_stream_session() {
         ..AccountSetupRequest::default()
     };
     let agent = setup_runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
@@ -3247,7 +3247,7 @@ async fn setup_existing_pending_invite(group_name: &str) -> ExistingPendingInvit
         ..AccountSetupRequest::default()
     };
     let agent = setup_runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
@@ -3858,7 +3858,7 @@ async fn replay_missed_inbound_recovers_dropped_messages_and_dedups() {
         ..AccountSetupRequest::default()
     };
     let agent = setup_runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
@@ -4181,7 +4181,7 @@ async fn concurrent_send_final_with_repeated_idempotency_key_sends_once() {
         ..AccountSetupRequest::default()
     };
     let agent = setup_runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();

--- a/crates/agent-connector/src/tests.rs
+++ b/crates/agent-connector/src/tests.rs
@@ -923,7 +923,10 @@ async fn connector_socket_subscribes_to_inbound_messages() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let agent = setup_runtime.create_identity(setup.clone()).await.unwrap();
+    let agent = setup_runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
     let group_id = setup_runtime
         .create_group(
@@ -1738,7 +1741,7 @@ async fn connector_policy_accepts_allowed_welcomer() {
         ..AccountSetupRequest::default()
     };
     let agent = agent_setup_runtime
-        .create_identity(setup.clone())
+        .create_identity(setup.fresh_attempt())
         .await
         .unwrap();
     let human = human_runtime.create_identity(setup).await.unwrap();
@@ -1805,7 +1808,7 @@ async fn connector_policy_declines_unlisted_welcomer() {
         ..AccountSetupRequest::default()
     };
     let agent = agent_setup_runtime
-        .create_identity(setup.clone())
+        .create_identity(setup.fresh_attempt())
         .await
         .unwrap();
     let human = human_runtime.create_identity(setup).await.unwrap();
@@ -1863,7 +1866,7 @@ async fn connector_policy_dev_allow_any_accepts_unlisted_authenticated_welcomer(
         ..AccountSetupRequest::default()
     };
     let agent = agent_setup_runtime
-        .create_identity(setup.clone())
+        .create_identity(setup.fresh_attempt())
         .await
         .unwrap();
     let human = human_runtime.create_identity(setup).await.unwrap();
@@ -2315,7 +2318,10 @@ async fn connector_socket_sends_final_message() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let agent = setup_runtime.create_identity(setup.clone()).await.unwrap();
+    let agent = setup_runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
     let group_id = setup_runtime
         .create_group(
@@ -2384,7 +2390,10 @@ async fn connector_socket_composes_and_finalizes_stream_without_quic_candidates(
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let agent = setup_runtime.create_identity(setup.clone()).await.unwrap();
+    let agent = setup_runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
     let group_id = setup_runtime
         .create_group(
@@ -2616,7 +2625,10 @@ async fn connector_socket_finalize_mismatch_keeps_stream_session_retryable() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let agent = setup_runtime.create_identity(setup.clone()).await.unwrap();
+    let agent = setup_runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
     let group_id = setup_runtime
         .create_group(
@@ -2780,7 +2792,10 @@ async fn connector_finalize_retries_durable_finish_without_compose_task() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let agent = setup_runtime.create_identity(setup.clone()).await.unwrap();
+    let agent = setup_runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
     let group_id = setup_runtime
         .create_group(
@@ -2986,7 +3001,10 @@ async fn connector_socket_cancels_stream_session() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let agent = setup_runtime.create_identity(setup.clone()).await.unwrap();
+    let agent = setup_runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
     let group_id = setup_runtime
         .create_group(
@@ -3228,7 +3246,10 @@ async fn setup_existing_pending_invite(group_name: &str) -> ExistingPendingInvit
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let agent = setup_runtime.create_identity(setup.clone()).await.unwrap();
+    let agent = setup_runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
 
     let group_id = setup_runtime
@@ -3836,7 +3857,10 @@ async fn replay_missed_inbound_recovers_dropped_messages_and_dedups() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let agent = setup_runtime.create_identity(setup.clone()).await.unwrap();
+    let agent = setup_runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
     let group_id = setup_runtime
         .create_group(
@@ -4156,7 +4180,10 @@ async fn concurrent_send_final_with_repeated_idempotency_key_sends_once() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let agent = setup_runtime.create_identity(setup.clone()).await.unwrap();
+    let agent = setup_runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let human = setup_runtime.create_identity(setup).await.unwrap();
     let group_id = setup_runtime
         .create_group(

--- a/crates/cgka-conformance-simulator/src/app_runtime.rs
+++ b/crates/cgka-conformance-simulator/src/app_runtime.rs
@@ -1048,6 +1048,8 @@ fn app_error(error: AppError) -> SubjectError {
         | AppError::InvalidChatPin(_)
         | AppError::InvalidMessageDraft(_)
         | AppError::InvalidPublicKey
+        | AppError::UnexpectedPrivateKey
+        | AppError::IdentityKeyMismatch
         | AppError::InvalidKeyPackageEvent(_)
         | AppError::InvalidDirectorySearch(_)
         | AppError::InvalidGroupProfile(_)

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -24,6 +24,12 @@ versioning through the workspace version in the root `Cargo.toml`.
   
 ### Fixed
 
+- `wn login --nsec-stdin` and `wn account create --nsec-stdin` now keep stdin
+  nsecs in a dedicated zeroizing sidecar instead of materializing them into the
+  generic `Cli` command tree. Daemon execute frames and `AccountSetupRequest`
+  use redacted `Debug`, avoid secret `Clone`, and wipe nsec-bearing request
+  framing buffers on every path.
+
 - `MarmotApp` now permits only one live in-memory engine session per account
   across direct clients and managed workers. Concurrent opens return the typed
   `AccountSessionBusy` error, and worker reconnect drops the failed session

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -28,7 +28,13 @@ versioning through the workspace version in the root `Cargo.toml`.
   nsecs in a dedicated zeroizing sidecar instead of materializing them into the
   generic `Cli` command tree. Daemon execute frames and `AccountSetupRequest`
   use redacted `Debug`, avoid secret `Clone`, and wipe nsec-bearing request
-  framing buffers on every path.
+  framing buffers on the final owned request payload where the implementation
+  controls the buffer (`Zeroizing` encode/read paths). Transient allocator or
+  `BufReader` copies are not guaranteed wiped. When the daemon app runtime is
+  disabled (no `--relay`), account setup skips hosted validation and falls back
+  to local `wn` execution while keeping the stdin `nsec` sidecar owned. Uppercase
+  `NSEC…` argv identities are rejected at the same early gate as lowercase
+  `nsec…`.
 
 - `MarmotApp` now permits only one live in-memory engine session per account
   across direct clients and managed workers. Concurrent opens return the typed

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -43,6 +43,7 @@ transport-quic-stream.workspace = true
 unicode-properties.workspace = true
 unicode-segmentation.workspace = true
 url.workspace = true
+zeroize.workspace = true
 
 [dev-dependencies]
 nostr-relay-builder.workspace = true

--- a/crates/cli/src/commands/account.rs
+++ b/crates/cli/src/commands/account.rs
@@ -9,10 +9,9 @@ use marmot_app::{
 use serde_json::{Value, json};
 
 use crate::{
-    AccountCommand, CliRuntimeInfo, CommandOutput, SecretStoreKind, WnError,
-    account_selector_or_default, is_nostr_secret, npub_for_account_id, parse_public_key,
-    profile_display_name, relay_endpoints, relay_lists_json, resolve_account,
-    validate_materialized_secret_identity,
+    AccountCommand, CliRuntimeInfo, CommandOutput, ImportNsec, SecretStoreKind, WnError,
+    account_selector_or_default, npub_for_account_id, parse_public_key, profile_display_name,
+    relay_endpoints, relay_lists_json, resolve_account, validate_materialized_secret_identity,
 };
 
 pub(crate) async fn identity_create_command(
@@ -25,6 +24,7 @@ pub(crate) async fn identity_create_command(
     create_or_import_account_command(
         app,
         None,
+        None,
         default_relays,
         bootstrap_relays,
         false,
@@ -36,22 +36,25 @@ pub(crate) async fn identity_create_command(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn identity_login_command(
     app: &MarmotApp,
     runtime_info: CliRuntimeInfo,
     identity: Option<String>,
+    import_nsec: Option<ImportNsec>,
     nsec_stdin: bool,
     relay: Option<String>,
     default_relays: Vec<String>,
     bootstrap_relays: Vec<String>,
 ) -> Result<CommandOutput, WnError> {
     validate_materialized_secret_identity("login", &identity, nsec_stdin)?;
-    let Some(identity) = identity else {
+    if identity.is_none() && import_nsec.is_none() {
         return Err(WnError::MissingLoginIdentity);
-    };
+    }
     create_or_import_account_command(
         app,
-        Some(identity),
+        identity,
+        import_nsec,
         default_relays,
         bootstrap_relays,
         true,
@@ -143,6 +146,7 @@ pub(crate) fn export_nsec_command(_pubkey: String) -> Result<CommandOutput, WnEr
 pub(crate) async fn create_or_import_account_command(
     app: &MarmotApp,
     identity: Option<String>,
+    import_nsec: Option<ImportNsec>,
     mut default_relays: Vec<String>,
     mut bootstrap_relays: Vec<String>,
     publish_missing_relay_lists: bool,
@@ -154,11 +158,9 @@ pub(crate) async fn create_or_import_account_command(
     validate_materialized_secret_identity("account create", &identity, nsec_stdin)?;
     let global_relay_defaults =
         apply_global_relay_defaults(&mut default_relays, &mut bootstrap_relays, relay);
-    let imports_private_key = identity.as_deref().is_some_and(is_nostr_secret);
-    let creates_new_private_key = identity.is_none();
-    let adds_public_account = identity
-        .as_deref()
-        .is_some_and(|value| !is_nostr_secret(value));
+    let imports_private_key = import_nsec.is_some();
+    let creates_new_private_key = identity.is_none() && import_nsec.is_none();
+    let adds_public_account = identity.is_some() && import_nsec.is_none();
     if creates_new_private_key && default_relays.is_empty() {
         return Err(WnError::MissingRelay);
     }
@@ -179,6 +181,7 @@ pub(crate) async fn create_or_import_account_command(
         .runtime()
         .create_or_import_account(AccountSetupRequest {
             identity,
+            import_nsec: import_nsec.map(ImportNsec::into_inner),
             default_relays,
             bootstrap_relays,
             discovery_relays,
@@ -256,6 +259,7 @@ pub(crate) async fn account_command(
     runtime_info: CliRuntimeInfo,
     account_flag: Option<String>,
     relay: Option<String>,
+    import_nsec: Option<ImportNsec>,
 ) -> Result<CommandOutput, WnError> {
     match command {
         AccountCommand::Create {
@@ -268,6 +272,7 @@ pub(crate) async fn account_command(
             create_or_import_account_command(
                 app,
                 identity,
+                import_nsec,
                 default_relays,
                 bootstrap_relays,
                 publish_missing_relay_lists,

--- a/crates/cli/src/daemon/mod.rs
+++ b/crates/cli/src/daemon/mod.rs
@@ -43,6 +43,7 @@ mod stream_workers;
 mod subscriptions;
 
 pub use lifecycle::{default_log_path, default_pid_path, default_socket_path};
+pub(crate) use protocol::send_execute;
 pub use protocol::{
     DaemonClient, DaemonClientError, DaemonOutgoingStreamReport, DaemonRuntimeActivityReport,
     DaemonStatus, DaemonStreamError, DaemonStreamResponse, DaemonStreamWatchReport,
@@ -429,9 +430,17 @@ async fn handle_daemon_connection(
             )
             .await;
         }
-        DaemonRequest::Execute { cli } => {
-            let _ = handle_execute_connection(cli, &mut stream, &defaults, state, events, &workers)
-                .await;
+        DaemonRequest::Execute { cli, import_nsec } => {
+            let _ = handle_execute_connection(
+                cli,
+                import_nsec,
+                &mut stream,
+                &defaults,
+                state,
+                events,
+                &workers,
+            )
+            .await;
         }
     }
 }
@@ -529,6 +538,7 @@ async fn handle_stream_watch_connection(
 
 async fn handle_execute_connection(
     mut cli: Box<Cli>,
+    mut import_nsec: Option<crate::ImportNsec>,
     stream: &mut UnixStream,
     defaults: &DaemonDefaults,
     state: Arc<Mutex<DaemonState>>,
@@ -575,6 +585,7 @@ async fn handle_execute_connection(
     let refresh = app_runtime_refresh_after_execute(&cli);
     if let Some(output) = handle_app_runtime_account_setup_request(
         &cli,
+        &mut import_nsec,
         defaults,
         state.clone(),
         events.clone(),
@@ -594,7 +605,7 @@ async fn handle_execute_connection(
     }
     // run_cli_local opens its own account/session and touches no shared daemon state, so it runs
     // entirely off the workers lock — the core head-of-line fix (#633).
-    let output = crate::run_cli_local(*cli).await;
+    let output = crate::run_cli_local(*cli, import_nsec).await;
     if output.code == 0 {
         refresh_app_runtime(defaults, state.clone(), events.clone(), workers, refresh).await;
     }

--- a/crates/cli/src/daemon/protocol.rs
+++ b/crates/cli/src/daemon/protocol.rs
@@ -229,63 +229,18 @@ pub(crate) async fn send_execute(
         cli: Box::new(cli),
         import_nsec,
     };
-    match send_owned_daemon_request(socket, request).await {
+    match send_request(socket, &request).await {
         Ok(output) => Ok(output),
-        Err((err, request)) => {
-            let (cli, import_nsec) = take_execute_request(request);
+        Err(err) => {
+            let DaemonRequest::Execute { cli, import_nsec } = request else {
+                unreachable!("send_execute only constructs Execute requests")
+            };
             Err(RecoverableDaemonExecute {
                 err,
-                cli,
+                cli: *cli,
                 import_nsec,
             })
         }
-    }
-}
-
-fn take_execute_request(request: DaemonRequest) -> (Cli, Option<crate::secret::ImportNsec>) {
-    match request {
-        DaemonRequest::Execute { cli, import_nsec } => (*cli, import_nsec),
-        _ => panic!("expected Execute daemon request"),
-    }
-}
-
-async fn send_owned_daemon_request(
-    socket: &Path,
-    request: DaemonRequest,
-) -> Result<CliOutput, (DaemonClientError, DaemonRequest)> {
-    let bytes = match encode_daemon_request(&request) {
-        Ok(bytes) => bytes,
-        Err(err) => return Err((err, request)),
-    };
-    let mut stream = match UnixStream::connect(socket).await {
-        Ok(stream) => stream,
-        Err(source) => {
-            return Err((
-                DaemonClientError::Connect {
-                    socket: socket.to_owned(),
-                    source,
-                },
-                request,
-            ));
-        }
-    };
-    if let Err(source) = stream.write_all(&bytes).await {
-        return Err((DaemonClientError::Io(source), request));
-    }
-    if let Err(source) = stream.shutdown().await {
-        return Err((DaemonClientError::Io(source), request));
-    }
-
-    let mut response = Zeroizing::new(Vec::new());
-    if let Err(source) = stream.read_to_end(&mut response).await {
-        return Err((DaemonClientError::Io(source), request));
-    }
-    if response.is_empty() {
-        return Err((DaemonClientError::EmptyResponse, request));
-    }
-    match decode_daemon_output(&response) {
-        Ok(output) => Ok(output),
-        Err(err) => Err((err, request)),
     }
 }
 
@@ -452,6 +407,9 @@ pub(crate) async fn read_daemon_request(
     // never sends a newline cannot make us buffer unbounded memory before the
     // size check runs (read_until on a Take adapter stops silently at the limit
     // instead of erroring). Mirrors agent-control's `read_frame`.
+    //
+    // `BufReader` may retain read-ahead bytes outside this `Zeroizing` buffer;
+    // only the assembled frame payload is wiped on drop.
     let limit = (MAX_DAEMON_REQUEST_BYTES + 1) as u64;
     let read = {
         let mut reader = BufReader::new(&mut *stream).take(limit);
@@ -544,6 +502,10 @@ pub(crate) async fn write_stream_end(stream: &mut UnixStream) -> bool {
 /// `read_daemon_request` / `MAX_DAEMON_REQUEST_BYTES`); checking client-side
 /// turns an oversized request (e.g. `messages send` with a huge body) into a
 /// clear local error instead of a connection the daemon must reject.
+///
+/// The returned buffer is zeroized on drop. `serde_json::to_vec` and the
+/// trailing `push` may leave transient copies in freed heap memory; this does
+/// not wipe every intermediate allocation.
 pub(crate) fn encode_daemon_request(
     request: &DaemonRequest,
 ) -> Result<Zeroizing<Vec<u8>>, DaemonClientError> {

--- a/crates/cli/src/daemon/protocol.rs
+++ b/crates/cli/src/daemon/protocol.rs
@@ -1,6 +1,7 @@
 //! Daemon wire protocol: request/response types, framing, and the client.
 
 use super::*;
+use zeroize::Zeroizing;
 
 pub(crate) const DAEMON_SERVER_BUSY_CODE: &str = "server_busy";
 pub(crate) const DAEMON_SERVER_BUSY_MESSAGE: &str = "daemon connection capacity is busy";
@@ -68,6 +69,14 @@ pub enum DaemonClientError {
     ServerBusy,
 }
 
+/// Failed daemon execute with the original `Cli` and stdin `nsec` sidecar when
+/// the client can safely retry locally (for example connect refused).
+pub(crate) struct RecoverableDaemonExecute {
+    pub err: DaemonClientError,
+    pub cli: Cli,
+    pub import_nsec: Option<crate::secret::ImportNsec>,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DaemonRuntimeActivityReport {
     pub started_at: u64,
@@ -101,17 +110,31 @@ pub type DaemonStreamWatchReport = marmot_app::AgentStreamWatchReport;
 
 pub type DaemonOutgoingStreamReport = StreamComposeReport;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) enum DaemonRequest {
     Ping,
     Status,
     Shutdown,
-    StreamWatch { cli: Box<Cli> },
-    MessagesSubscribe { cli: Box<Cli> },
-    ChatsSubscribe { cli: Box<Cli> },
-    GroupStateSubscribe { cli: Box<Cli> },
-    NotificationsSubscribe { cli: Box<Cli> },
-    Execute { cli: Box<Cli> },
+    StreamWatch {
+        cli: Box<Cli>,
+    },
+    MessagesSubscribe {
+        cli: Box<Cli>,
+    },
+    ChatsSubscribe {
+        cli: Box<Cli>,
+    },
+    GroupStateSubscribe {
+        cli: Box<Cli>,
+    },
+    NotificationsSubscribe {
+        cli: Box<Cli>,
+    },
+    Execute {
+        cli: Box<Cli>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        import_nsec: Option<crate::secret::ImportNsec>,
+    },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -197,8 +220,73 @@ impl DaemonEventHub {
     }
 }
 
-pub(crate) async fn send_execute(socket: &Path, cli: Cli) -> Result<CliOutput, DaemonClientError> {
-    DaemonClient::new(socket).execute(cli).await
+pub(crate) async fn send_execute(
+    socket: &Path,
+    cli: Cli,
+    import_nsec: Option<crate::secret::ImportNsec>,
+) -> Result<CliOutput, RecoverableDaemonExecute> {
+    let request = DaemonRequest::Execute {
+        cli: Box::new(cli),
+        import_nsec,
+    };
+    match send_owned_daemon_request(socket, request).await {
+        Ok(output) => Ok(output),
+        Err((err, request)) => {
+            let (cli, import_nsec) = take_execute_request(request);
+            Err(RecoverableDaemonExecute {
+                err,
+                cli,
+                import_nsec,
+            })
+        }
+    }
+}
+
+fn take_execute_request(request: DaemonRequest) -> (Cli, Option<crate::secret::ImportNsec>) {
+    match request {
+        DaemonRequest::Execute { cli, import_nsec } => (*cli, import_nsec),
+        _ => panic!("expected Execute daemon request"),
+    }
+}
+
+async fn send_owned_daemon_request(
+    socket: &Path,
+    request: DaemonRequest,
+) -> Result<CliOutput, (DaemonClientError, DaemonRequest)> {
+    let bytes = match encode_daemon_request(&request) {
+        Ok(bytes) => bytes,
+        Err(err) => return Err((err, request)),
+    };
+    let mut stream = match UnixStream::connect(socket).await {
+        Ok(stream) => stream,
+        Err(source) => {
+            return Err((
+                DaemonClientError::Connect {
+                    socket: socket.to_owned(),
+                    source,
+                },
+                request,
+            ));
+        }
+    };
+    if let Err(source) = stream.write_all(&bytes).await {
+        return Err((DaemonClientError::Io(source), request));
+    }
+    if let Err(source) = stream.shutdown().await {
+        return Err((DaemonClientError::Io(source), request));
+    }
+
+    let mut response = Zeroizing::new(Vec::new());
+    if let Err(source) = stream.read_to_end(&mut response).await {
+        return Err((DaemonClientError::Io(source), request));
+    }
+    if response.is_empty() {
+        return Err((DaemonClientError::EmptyResponse, request));
+    }
+    match decode_daemon_output(&response) {
+        Ok(output) => Ok(output),
+        Err(err) => Err((err, request)),
+    }
 }
 
 pub(crate) async fn send_stream_watch(
@@ -262,10 +350,6 @@ impl DaemonClient {
 
     pub async fn shutdown(&self) -> Result<CliOutput, DaemonClientError> {
         send_request(&self.socket, &DaemonRequest::Shutdown).await
-    }
-
-    pub(crate) async fn execute(&self, cli: Cli) -> Result<CliOutput, DaemonClientError> {
-        send_request(&self.socket, &DaemonRequest::Execute { cli: Box::new(cli) }).await
     }
 
     pub(crate) async fn stream_watch(&self, cli: Cli) -> Result<CliOutput, DaemonClientError> {
@@ -361,7 +445,7 @@ where
 pub(crate) async fn read_daemon_request(
     stream: &mut UnixStream,
 ) -> Result<DaemonRequest, Box<dyn std::error::Error + Send + Sync>> {
-    let mut request = Vec::new();
+    let mut request = Zeroizing::new(Vec::new());
     // Buffer the raw stream so a near-1-MiB frame (e.g. an `Execute` request
     // carrying the whole `Cli`) costs a handful of `read()` syscalls instead of
     // one per byte. Cap the read at one byte past the limit so a client that
@@ -460,8 +544,10 @@ pub(crate) async fn write_stream_end(stream: &mut UnixStream) -> bool {
 /// `read_daemon_request` / `MAX_DAEMON_REQUEST_BYTES`); checking client-side
 /// turns an oversized request (e.g. `messages send` with a huge body) into a
 /// clear local error instead of a connection the daemon must reject.
-pub(crate) fn encode_daemon_request(request: &DaemonRequest) -> Result<Vec<u8>, DaemonClientError> {
-    let mut bytes = serde_json::to_vec(request)?;
+pub(crate) fn encode_daemon_request(
+    request: &DaemonRequest,
+) -> Result<Zeroizing<Vec<u8>>, DaemonClientError> {
+    let mut bytes = Zeroizing::new(serde_json::to_vec(request)?);
     // The daemon reads up to and excluding the trailing newline, so compare the
     // JSON payload length (without the framing newline) against the limit.
     if bytes.len() > MAX_DAEMON_REQUEST_BYTES {

--- a/crates/cli/src/daemon/runtime_host.rs
+++ b/crates/cli/src/daemon/runtime_host.rs
@@ -334,6 +334,9 @@ pub(crate) fn app_runtime_account_setup_request(
 ) -> Result<Option<marmot_app::AccountSetupRequest>, crate::WnError> {
     match &cli.command {
         crate::Command::CreateIdentity => {
+            if import_nsec.is_some() {
+                return Err(crate::WnError::InvalidPublicKey);
+            }
             if cli.daemon_default_account_relays.is_empty() {
                 return Err(crate::WnError::MissingRelay);
             }

--- a/crates/cli/src/daemon/runtime_host.rs
+++ b/crates/cli/src/daemon/runtime_host.rs
@@ -1,6 +1,7 @@
 //! App-runtime hosting glue: reconciliation, event bridge, and hosted command dispatch.
 
 use super::*;
+use crate::ImportNsec;
 
 #[derive(Debug)]
 pub(crate) struct DaemonState {
@@ -72,25 +73,27 @@ pub(crate) async fn reconcile_and_clone_runtime(
 
 pub(crate) async fn handle_app_runtime_account_setup_request(
     cli: &Cli,
+    import_nsec: &mut Option<crate::ImportNsec>,
     defaults: &DaemonDefaults,
     state: Arc<Mutex<DaemonState>>,
     events: DaemonEventHub,
     workers: &SharedDaemonWorkers,
 ) -> Option<CliOutput> {
-    let request = match app_runtime_account_setup_request(cli) {
+    if !app_runtime_enabled(defaults) {
+        return None;
+    }
+    let mut request = match app_runtime_account_setup_request(cli, import_nsec.as_ref()) {
         Ok(Some(request)) => request,
         Ok(None) => return None,
         Err(err) => return Some(crate::command_output_result(cli.json, Err(err))),
     };
-    if !app_runtime_enabled(defaults) {
-        return None;
-    }
     let Some(runtime) = reconcile_and_clone_runtime(defaults, state, events, workers).await else {
         return Some(crate::command_output_result(
             cli.json,
             Err(crate::WnError::MissingRelay),
         ));
     };
+    request.import_nsec = import_nsec.take().map(ImportNsec::into_inner);
     // create_or_import_account drives relay I/O through the cloned runtime handle (internally
     // synchronized), so it runs off the workers lock.
     let output = runtime
@@ -327,6 +330,7 @@ pub(crate) fn is_hosted_runtime_command(cli: &Cli) -> bool {
 
 pub(crate) fn app_runtime_account_setup_request(
     cli: &Cli,
+    import_nsec: Option<&crate::ImportNsec>,
 ) -> Result<Option<marmot_app::AccountSetupRequest>, crate::WnError> {
     match &cli.command {
         crate::Command::CreateIdentity => {
@@ -335,6 +339,7 @@ pub(crate) fn app_runtime_account_setup_request(
             }
             Ok(Some(marmot_app::AccountSetupRequest {
                 identity: None,
+                import_nsec: None,
                 default_relays: crate::relay_endpoints(cli.daemon_default_account_relays.clone())?,
                 bootstrap_relays: crate::relay_endpoints(cli.daemon_discovery_relays.clone())?,
                 discovery_relays: crate::relay_endpoints(cli.daemon_discovery_relays.clone())?,
@@ -348,14 +353,15 @@ pub(crate) fn app_runtime_account_setup_request(
             ..
         } => {
             crate::validate_materialized_secret_identity("login", identity, *nsec_stdin)?;
-            let Some(identity) = identity.clone() else {
+            if identity.is_none() && import_nsec.is_none() {
                 return Err(crate::WnError::MissingLoginIdentity);
-            };
-            if crate::is_nostr_secret(&identity) && cli.daemon_default_account_relays.is_empty() {
+            }
+            if import_nsec.is_some() && cli.daemon_default_account_relays.is_empty() {
                 return Err(crate::WnError::MissingRelay);
             }
             Ok(Some(marmot_app::AccountSetupRequest {
-                identity: Some(identity),
+                identity: identity.clone(),
+                import_nsec: None,
                 default_relays: crate::relay_endpoints(cli.daemon_default_account_relays.clone())?,
                 bootstrap_relays: crate::relay_endpoints(cli.daemon_discovery_relays.clone())?,
                 discovery_relays: crate::relay_endpoints(cli.daemon_discovery_relays.clone())?,
@@ -386,6 +392,7 @@ pub(crate) fn app_runtime_account_setup_request(
             crate::validate_materialized_secret_identity("account create", identity, *nsec_stdin)?;
             Ok(Some(marmot_app::AccountSetupRequest {
                 identity: identity.clone(),
+                import_nsec: None,
                 default_relays: crate::relay_endpoints(default_relays.clone())?,
                 bootstrap_relays: crate::relay_endpoints(bootstrap_relays.clone())?,
                 discovery_relays: crate::relay_endpoints(bootstrap_relays.clone())?,

--- a/crates/cli/src/daemon/tests.rs
+++ b/crates/cli/src/daemon/tests.rs
@@ -902,7 +902,7 @@ async fn daemon_execute_local_command_runs_without_holding_worker_lock() {
 
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        handle_execute_connection(cli, &mut server, &defaults, state, events, &workers),
+        handle_execute_connection(cli, None, &mut server, &defaults, state, events, &workers),
     )
     .await
     .expect("a relay-less Execute must not block on the held workers lock");
@@ -910,6 +910,50 @@ async fn daemon_execute_local_command_runs_without_holding_worker_lock() {
 
     drop(busy);
     drop(client);
+}
+
+#[tokio::test]
+async fn relayless_hosted_setup_fallback_preserves_import_nsec_sidecar() {
+    let defaults = DaemonDefaults {
+        home: PathBuf::from("/tmp/wn-daemon-home-nsec-fallback"),
+        socket: PathBuf::from("/tmp/wn-daemon-nsec-fallback.sock"),
+        pid_path: PathBuf::from("/tmp/wn-daemon-nsec-fallback.pid"),
+        log_path: PathBuf::from("/tmp/wn-daemon-nsec-fallback.log"),
+        relay: None,
+        discovery_relays: Vec::new(),
+        default_account_relays: vec!["wss://relay.example".to_owned()],
+        secret_store: Some(crate::SecretStoreKind::File),
+        keychain_service: Some("daemon-keychain".to_owned()),
+    };
+    let mut cli = daemon_test_cli(crate::Command::Login {
+        identity: None,
+        nsec_stdin: true,
+        relay: Some("wss://relay.example".to_owned()),
+    });
+    apply_defaults(&mut cli, &defaults);
+    let mut import_nsec = Some(crate::ImportNsec::new(zeroize::Zeroizing::new(
+        "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99".to_owned(),
+    )));
+
+    let output = handle_app_runtime_account_setup_request(
+        &cli,
+        &mut import_nsec,
+        &defaults,
+        Arc::new(Mutex::new(DaemonState {
+            pid: 1,
+            started_at: 0,
+            last_runtime_activity: None,
+        })),
+        DaemonEventHub::new(),
+        &SharedDaemonWorkers::default(),
+    )
+    .await;
+
+    assert!(output.is_none());
+    assert!(
+        import_nsec.is_some(),
+        "local fallback must retain ownership of the nsec sidecar"
+    );
 }
 
 #[tokio::test]
@@ -933,6 +977,38 @@ async fn daemon_request_reader_within_returns_request_before_timeout() {
 }
 
 #[test]
+fn execute_request_roundtrip_carries_import_nsec_sidecar_not_cli_identity() {
+    let nsec = "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99";
+    let mut cli = daemon_test_cli(crate::Command::Login {
+        identity: None,
+        nsec_stdin: true,
+        relay: Some("wss://relay.example".to_owned()),
+    });
+    cli.daemon_default_account_relays = vec!["wss://relay.example".to_owned()];
+    let request = DaemonRequest::Execute {
+        cli: Box::new(cli),
+        import_nsec: Some(crate::ImportNsec::new(zeroize::Zeroizing::new(
+            nsec.to_owned(),
+        ))),
+    };
+    let debug = format!("{request:?}");
+    assert!(!debug.contains("nsec1j4"));
+    let bytes = encode_daemon_request(&request).expect("encode execute request");
+    let payload = bytes.strip_suffix(b"\n").unwrap_or(&bytes);
+    let decoded: DaemonRequest = serde_json::from_slice(payload).expect("decode execute request");
+    match decoded {
+        DaemonRequest::Execute { cli, import_nsec } => {
+            assert!(import_nsec.is_some());
+            match cli.command {
+                crate::Command::Login { identity: None, .. } => {}
+                other => panic!("expected login without identity, got {other:?}"),
+            }
+        }
+        other => panic!("expected Execute, got {other:?}"),
+    }
+}
+
+#[test]
 fn encode_daemon_request_rejects_oversized_payloads() {
     // Build an Execute request whose serialized form exceeds the limit by
     // stuffing a huge relay string into the Cli. This mirrors the real
@@ -940,7 +1016,10 @@ fn encode_daemon_request_rejects_oversized_payloads() {
     let huge = "a".repeat(MAX_DAEMON_REQUEST_BYTES + 1);
     let mut cli = daemon_test_cli(crate::Command::Whoami);
     cli.relay = Some(huge);
-    let request = DaemonRequest::Execute { cli: Box::new(cli) };
+    let request = DaemonRequest::Execute {
+        cli: Box::new(cli),
+        import_nsec: None,
+    };
 
     let err = encode_daemon_request(&request)
         .expect_err("oversized request should be rejected before sending");

--- a/crates/cli/src/daemon/tests.rs
+++ b/crates/cli/src/daemon/tests.rs
@@ -913,7 +913,37 @@ async fn daemon_execute_local_command_runs_without_holding_worker_lock() {
 }
 
 #[tokio::test]
-async fn relayless_hosted_setup_fallback_preserves_import_nsec_sidecar() {
+async fn send_execute_connect_failure_recovers_cli_and_import_nsec() {
+    use crate::daemon::protocol::send_execute;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let socket = temp.path().join("missing.sock");
+    let mut cli = daemon_test_cli(crate::Command::Login {
+        identity: None,
+        nsec_stdin: true,
+        relay: Some("wss://relay.example".to_owned()),
+    });
+    cli.json = true;
+    let nsec = "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99";
+    let import_nsec = Some(crate::ImportNsec::new(zeroize::Zeroizing::new(
+        nsec.to_owned(),
+    )));
+
+    let recover = send_execute(&socket, cli, import_nsec)
+        .await
+        .expect_err("connect to missing socket must be recoverable");
+
+    assert!(matches!(recover.err, DaemonClientError::Connect { .. }));
+    assert!(recover.cli.json);
+    let recovered = recover
+        .import_nsec
+        .expect("import_nsec sidecar")
+        .into_inner();
+    assert_eq!(recovered.as_str(), nsec);
+}
+
+#[tokio::test]
+async fn disabled_app_runtime_skips_relay_validation_and_preserves_nsec_sidecar() {
     let defaults = DaemonDefaults {
         home: PathBuf::from("/tmp/wn-daemon-home-nsec-fallback"),
         socket: PathBuf::from("/tmp/wn-daemon-nsec-fallback.sock"),
@@ -921,7 +951,7 @@ async fn relayless_hosted_setup_fallback_preserves_import_nsec_sidecar() {
         log_path: PathBuf::from("/tmp/wn-daemon-nsec-fallback.log"),
         relay: None,
         discovery_relays: Vec::new(),
-        default_account_relays: vec!["wss://relay.example".to_owned()],
+        default_account_relays: vec!["not-a-valid-relay-url".to_owned()],
         secret_store: Some(crate::SecretStoreKind::File),
         keychain_service: Some("daemon-keychain".to_owned()),
     };
@@ -931,8 +961,9 @@ async fn relayless_hosted_setup_fallback_preserves_import_nsec_sidecar() {
         relay: Some("wss://relay.example".to_owned()),
     });
     apply_defaults(&mut cli, &defaults);
+    let nsec = "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99";
     let mut import_nsec = Some(crate::ImportNsec::new(zeroize::Zeroizing::new(
-        "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99".to_owned(),
+        nsec.to_owned(),
     )));
 
     let output = handle_app_runtime_account_setup_request(
@@ -949,11 +980,14 @@ async fn relayless_hosted_setup_fallback_preserves_import_nsec_sidecar() {
     )
     .await;
 
-    assert!(output.is_none());
     assert!(
-        import_nsec.is_some(),
-        "local fallback must retain ownership of the nsec sidecar"
+        output.is_none(),
+        "disabled app runtime must fall through before relay validation"
     );
+    let retained = import_nsec
+        .expect("local fallback must retain the nsec sidecar when hosting is disabled")
+        .into_inner();
+    assert_eq!(retained.as_str(), nsec);
 }
 
 #[test]

--- a/crates/cli/src/daemon/tests.rs
+++ b/crates/cli/src/daemon/tests.rs
@@ -956,6 +956,19 @@ async fn relayless_hosted_setup_fallback_preserves_import_nsec_sidecar() {
     );
 }
 
+#[test]
+fn hosted_create_identity_rejects_import_nsec_sidecar() {
+    let mut cli = daemon_test_cli(crate::Command::CreateIdentity);
+    cli.daemon_default_account_relays = vec!["wss://relay.example".to_owned()];
+    let import_nsec = crate::ImportNsec::new(zeroize::Zeroizing::new(
+        "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99".to_owned(),
+    ));
+
+    let err = app_runtime_account_setup_request(&cli, Some(&import_nsec))
+        .expect_err("create-identity must reject an import sidecar");
+    assert!(matches!(err, crate::WnError::InvalidPublicKey));
+}
+
 #[tokio::test]
 async fn daemon_request_reader_within_returns_request_before_timeout() {
     let (mut server, mut client) = UnixStream::pair().expect("unix stream pair");
@@ -998,7 +1011,8 @@ fn execute_request_roundtrip_carries_import_nsec_sidecar_not_cli_identity() {
     let decoded: DaemonRequest = serde_json::from_slice(payload).expect("decode execute request");
     match decoded {
         DaemonRequest::Execute { cli, import_nsec } => {
-            assert!(import_nsec.is_some());
+            let import_nsec = import_nsec.expect("import_nsec sidecar");
+            assert_eq!(import_nsec.into_inner().as_str(), nsec);
             match cli.command {
                 crate::Command::Login { identity: None, .. } => {}
                 other => panic!("expected login without identity, got {other:?}"),

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -664,4 +664,23 @@ mod tests {
             "wn keys fetch <npub-or-hex> --bootstrap-relays <relay-url>"
         );
     }
+
+    #[test]
+    fn secret_identity_errors_do_not_echo_nsec_material() {
+        let nsec = "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99";
+        let cases = [
+            WnError::SecretArgumentRejected { command: "login" },
+            WnError::ConflictingSecretInput { command: "login" },
+            WnError::MissingStdinSecret { command: "login" },
+            WnError::InvalidStdinSecret {
+                command: "account create",
+            },
+        ];
+        for err in cases {
+            let message = err.to_string();
+            assert!(!message.contains(nsec), "{message}");
+            let json = wn_error_json(&err).to_string();
+            assert!(!json.contains(nsec), "{json}");
+        }
+    }
 }

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -565,6 +565,14 @@ fn app_error_json(err: &AppError) -> Value {
             "code": "invalid_public_key",
             "message": err.to_string(),
         }),
+        AppError::UnexpectedPrivateKey => json!({
+            "code": "unexpected_private_key",
+            "message": err.to_string(),
+        }),
+        AppError::IdentityKeyMismatch => json!({
+            "code": "identity_key_mismatch",
+            "message": err.to_string(),
+        }),
         AppError::InvalidKeyPackageEvent(reason) => json!({
             "code": "invalid_key_package_event",
             "message": err.to_string(),

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -23,6 +23,7 @@ mod args;
 pub(crate) mod commands;
 pub mod daemon;
 mod error;
+mod secret;
 pub mod tui;
 
 pub use args::SecretStoreKind;
@@ -33,6 +34,7 @@ pub(crate) use args::{
     SettingsCommand, StreamCommand, UsersCommand,
 };
 pub(crate) use error::{WnError, wn_error_json};
+pub(crate) use secret::ImportNsec;
 
 pub(crate) const DEFAULT_PRODUCTION_QUIC_BROKER_CANDIDATE: &str = "quic://quic-broker.ipf.dev:4450";
 const PRIVATE_DIR_MODE: u32 = 0o700;
@@ -102,7 +104,7 @@ where
 {
     let argv = args.into_iter().map(Into::into).collect::<Vec<_>>();
     let wants_json = argv.iter().any(|arg| arg.to_string_lossy() == "--json");
-    let mut cli = match Cli::try_parse_from(argv) {
+    let cli = match Cli::try_parse_from(argv) {
         Ok(cli) => cli,
         Err(err) => {
             use clap::error::ErrorKind;
@@ -148,10 +150,18 @@ where
             };
         }
     };
-    if let Err(err) = materialize_secret_inputs(&mut cli) {
+    if let Err(err) = validate_secret_input_flags(&cli) {
         return command_output_result(cli.json, Err(err));
     }
+    let import_nsec = match read_import_nsec_for_cli(&cli) {
+        Ok(import_nsec) => import_nsec,
+        Err(err) => return command_output_result(cli.json, Err(err)),
+    };
 
+    run_cli_with_import_nsec(cli, import_nsec).await
+}
+
+async fn run_cli_with_import_nsec(mut cli: Cli, mut import_nsec: Option<ImportNsec>) -> CliOutput {
     if let Command::Daemon { command } = cli.command.clone() {
         return daemon::run_daemon_command(cli, command).await;
     }
@@ -204,39 +214,39 @@ where
     if let Some(socket) = daemon_socket_for_client(&cli, &home) {
         let explicit_daemon_socket =
             cli.socket.is_some() || std::env::var_os("WN_SOCKET").is_some();
-        match daemon::send_execute(&socket, cli.clone()).await {
+        let json_output = cli.json;
+        match daemon::send_execute(&socket, cli, import_nsec).await {
             Ok(output) => return output,
-            // An oversized request is a client-side limit violation, not a
-            // daemon-unavailable or lost-response condition: the encoder rejects
-            // it before it ever reaches `wnd`. Surface it as a terminal error
-            // even on the implicit-socket path, otherwise the request silently
-            // falls through to `run_cli_local` and masks the size cap (see #190).
-            Err(err @ daemon::DaemonClientError::RequestTooLarge { .. }) => {
-                return daemon_client_error(cli.json, err);
-            }
-            // Only fall back to local execution when the client could not reach
-            // `wnd` over an auto-discovered socket. If the daemon accepted the
-            // command but the response was lost/malformed, do NOT re-run locally
-            // (that would double-execute); report it via `daemon_execute_error`.
-            Err(err)
+            Err(recover) => {
+                if matches!(
+                    recover.err,
+                    daemon::DaemonClientError::RequestTooLarge { .. }
+                ) {
+                    return daemon_client_error(json_output, recover.err);
+                }
                 if should_fallback_to_local_after_daemon_execute_error(
                     explicit_daemon_socket,
-                    &err,
-                ) => {}
-            Err(err) => return daemon_execute_error(cli.json, err),
+                    &recover.err,
+                ) {
+                    cli = recover.cli;
+                    import_nsec = recover.import_nsec;
+                } else {
+                    return daemon_execute_error(json_output, recover.err);
+                }
+            }
         }
     }
 
-    run_cli_local(cli).await
+    run_cli_local(cli, import_nsec).await
 }
 
-fn materialize_secret_inputs(cli: &mut Cli) -> Result<(), WnError> {
-    match &mut cli.command {
+fn validate_secret_input_flags(cli: &Cli) -> Result<(), WnError> {
+    match &cli.command {
         Command::Login {
             identity,
             nsec_stdin,
             ..
-        } => materialize_identity_secret_input("login", identity, *nsec_stdin),
+        } => validate_materialized_secret_identity("login", identity, *nsec_stdin),
         Command::Account {
             command:
                 AccountCommand::Create {
@@ -252,36 +262,65 @@ fn materialize_secret_inputs(cli: &mut Cli) -> Result<(), WnError> {
                     nsec_stdin,
                     ..
                 },
-        } => materialize_identity_secret_input("account create", identity, *nsec_stdin),
+        } => validate_materialized_secret_identity("account create", identity, *nsec_stdin),
         _ => Ok(()),
     }
 }
 
-fn materialize_identity_secret_input(
+fn read_import_nsec_for_cli(cli: &Cli) -> Result<Option<ImportNsec>, WnError> {
+    match &cli.command {
+        Command::Login {
+            identity,
+            nsec_stdin,
+            ..
+        } => read_identity_secret_input("login", identity, *nsec_stdin),
+        Command::Account {
+            command:
+                AccountCommand::Create {
+                    identity,
+                    nsec_stdin,
+                    ..
+                },
+        }
+        | Command::Accounts {
+            command:
+                AccountCommand::Create {
+                    identity,
+                    nsec_stdin,
+                    ..
+                },
+        } => read_identity_secret_input("account create", identity, *nsec_stdin),
+        _ => Ok(None),
+    }
+}
+
+fn read_identity_secret_input(
     command: &'static str,
-    identity: &mut Option<String>,
+    identity: &Option<String>,
     nsec_stdin: bool,
-) -> Result<(), WnError> {
+) -> Result<Option<ImportNsec>, WnError> {
     if nsec_stdin {
         if identity.is_some() {
             return Err(WnError::ConflictingSecretInput { command });
         }
-        *identity = Some(read_nsec_from_stdin(command)?);
+        return Ok(Some(read_nsec_from_stdin(command)?));
     }
-    validate_materialized_secret_identity(command, identity, nsec_stdin)
+    Ok(None)
 }
 
-fn read_nsec_from_stdin(command: &'static str) -> Result<String, WnError> {
-    let mut value = String::new();
+fn read_nsec_from_stdin(command: &'static str) -> Result<ImportNsec, WnError> {
+    use zeroize::Zeroizing;
+
+    let mut value = Zeroizing::new(String::new());
     std::io::stdin().read_to_string(&mut value)?;
-    let value = value.trim().to_owned();
-    if value.is_empty() {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
         return Err(WnError::MissingStdinSecret { command });
     }
-    if !is_nostr_secret(&value) {
+    if !is_nostr_secret(trimmed) {
         return Err(WnError::InvalidStdinSecret { command });
     }
-    Ok(value)
+    Ok(ImportNsec::new(Zeroizing::new(trimmed.to_owned())))
 }
 
 pub(crate) fn validate_materialized_secret_identity(
@@ -353,8 +392,8 @@ fn is_notifications_subscribe(cli: &Cli) -> bool {
     )
 }
 
-pub(crate) async fn run_cli_local(cli: Cli) -> CliOutput {
-    match execute(cli).await {
+pub(crate) async fn run_cli_local(cli: Cli, import_nsec: Option<ImportNsec>) -> CliOutput {
+    match execute(cli, import_nsec).await {
         Ok((json_output, output)) => command_output_result(json_output, Ok(output)),
         Err((json_output, err)) => command_output_result(json_output, Err(err)),
     }
@@ -391,15 +430,21 @@ pub(crate) fn command_output_result(
     }
 }
 
-async fn execute(cli: Cli) -> Result<(bool, CommandOutput), (bool, WnError)> {
+async fn execute(
+    cli: Cli,
+    import_nsec: Option<ImportNsec>,
+) -> Result<(bool, CommandOutput), (bool, WnError)> {
     let json_output = cli.json;
-    execute_inner(cli)
+    execute_inner(cli, import_nsec)
         .await
         .map(|output| (json_output, output))
         .map_err(|err| (json_output, err))
 }
 
-async fn execute_inner(cli: Cli) -> Result<CommandOutput, WnError> {
+async fn execute_inner(
+    cli: Cli,
+    mut import_nsec: Option<ImportNsec>,
+) -> Result<CommandOutput, WnError> {
     let home = resolve_home(cli.home.clone());
     let account_flag = cli.account.clone();
     let command = cli.command.clone();
@@ -461,6 +506,7 @@ async fn execute_inner(cli: Cli) -> Result<CommandOutput, WnError> {
                 &app,
                 runtime_info,
                 identity,
+                import_nsec.take(),
                 nsec_stdin,
                 relay,
                 cli.daemon_default_account_relays,
@@ -481,6 +527,7 @@ async fn execute_inner(cli: Cli) -> Result<CommandOutput, WnError> {
                 runtime_info,
                 account_flag,
                 relay,
+                import_nsec.take(),
             )
             .await
         }
@@ -492,6 +539,7 @@ async fn execute_inner(cli: Cli) -> Result<CommandOutput, WnError> {
                 runtime_info,
                 account_flag,
                 relay,
+                import_nsec.take(),
             )
             .await
         }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -12,6 +12,7 @@ use cgka_traits::app_event::{
 };
 use clap::Parser;
 use marmot_account::{AccountHome, DEFAULT_KEYCHAIN_SERVICE_NAME};
+pub(crate) use marmot_app::is_nostr_secret;
 use marmot_app::{
     AccountRelayListStatus, AppError, AppGroupRecord, ChatListRow, MarmotApp, MarmotAppConfig,
     StreamStartView, UserProfileMetadata, tag_value,
@@ -980,10 +981,6 @@ pub(crate) fn display_name_for_sender(app: &MarmotApp, sender: &str) -> Option<S
         .flatten()
         .and_then(|entry| entry.profile);
     profile_display_name(profile.as_ref())
-}
-
-pub(crate) fn is_nostr_secret(value: &str) -> bool {
-    value.starts_with("nsec")
 }
 
 fn resolve_relay(relay: Option<String>) -> Result<Option<String>, WnError> {
@@ -2330,6 +2327,18 @@ mod tests {
                 timestamp_flag: "--before",
                 message_id_flag: "--before-message-id",
             }
+        ));
+    }
+
+    #[test]
+    fn uppercase_nsec_argv_rejected_at_early_identity_gate() {
+        let identity =
+            Some("NSEC1J4C6269Y9W0Q2ER2XJW8SV2EHYRTFXQ3JWGDLXJ6QFN8Z4GJSQ5QFVFK99".to_owned());
+        let err = super::validate_materialized_secret_identity("login", &identity, false)
+            .expect_err("uppercase nsec argv must be rejected before daemon/json materialization");
+        assert!(matches!(
+            err,
+            WnError::SecretArgumentRejected { command: "login" }
         ));
     }
 

--- a/crates/cli/src/secret.rs
+++ b/crates/cli/src/secret.rs
@@ -1,0 +1,61 @@
+//! Stdin-imported Nostr private keys: zeroizing storage and redacted diagnostics.
+
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use zeroize::Zeroizing;
+
+/// An `nsec` (or compatible secret) read from stdin for account import.
+///
+/// Not `Clone`: move ownership through import paths instead of copying secrets.
+pub(crate) struct ImportNsec(Zeroizing<String>);
+
+impl ImportNsec {
+    pub(crate) fn new(value: Zeroizing<String>) -> Self {
+        Self(value)
+    }
+
+    pub(crate) fn into_inner(self) -> Zeroizing<String> {
+        self.0
+    }
+}
+
+impl fmt::Debug for ImportNsec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ImportNsec(**redacted**)")
+    }
+}
+
+impl Serialize for ImportNsec {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ImportNsec {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self(Zeroizing::new(String::deserialize(deserializer)?)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeroize::Zeroizing;
+
+    #[test]
+    fn import_nsec_debug_does_not_leak_secret() {
+        let secret = ImportNsec::new(Zeroizing::new(
+            "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99".to_owned(),
+        ));
+        let debug = format!("{secret:?}");
+        assert!(!debug.contains("nsec1j4"));
+        assert!(debug.contains("redacted"));
+    }
+}

--- a/crates/cli/src/tui/model.rs
+++ b/crates/cli/src/tui/model.rs
@@ -4741,7 +4741,10 @@ pub(crate) fn composer_display_text(input: &str) -> String {
     if let Some(command_input) = trimmed.strip_prefix('/')
         && let Ok(words) = split_slash_command_words(command_input)
         && words.first().map(String::as_str) == Some("login")
-        && words.iter().skip(1).any(|word| word.starts_with("nsec"))
+        && words
+            .iter()
+            .skip(1)
+            .any(|word| crate::is_nostr_secret(word))
     {
         return "/login <hidden nsec>".to_owned();
     }

--- a/crates/cli/src/tui/slash.rs
+++ b/crates/cli/src/tui/slash.rs
@@ -35,7 +35,7 @@ pub(crate) fn parse_slash_command(input: &str) -> Result<SlashCommand, String> {
             }
         }
         "login" => match rest.as_slice() {
-            [identity] if identity.starts_with("nsec") => {
+            [identity] if crate::is_nostr_secret(identity) => {
                 Ok(SlashCommand::AccountImportSecret(identity.clone()))
             }
             [identity] => Ok(SlashCommand::AccountAddPublic(identity.clone())),

--- a/crates/cli/src/tui/tests.rs
+++ b/crates/cli/src/tui/tests.rs
@@ -348,6 +348,14 @@ fn slash_command_parser_handles_account_onboarding_commands() {
 }
 
 #[test]
+fn slash_command_parser_classifies_uppercase_nsec_as_secret() {
+    assert_eq!(
+        parse_slash_command("/login NSEC1SECRET"),
+        Ok(SlashCommand::AccountImportSecret("NSEC1SECRET".to_owned()))
+    );
+}
+
+#[test]
 fn slash_command_parser_handles_logout() {
     // `/logout` acts on the currently selected account and takes no arguments, so
     // a stray argument is a parse error rather than a silently ignored token.
@@ -2049,6 +2057,14 @@ fn composer_redacts_nsec_imports_without_hiding_other_input() {
     assert_eq!(
         composer_display_text("/ login npub1bob"),
         "/ login npub1bob"
+    );
+}
+
+#[test]
+fn composer_redacts_uppercase_nsec_import() {
+    assert_eq!(
+        composer_display_text("/login NSEC1SECRET"),
+        "/login <hidden nsec>"
     );
 }
 

--- a/crates/marmot-app/src/client/projection.rs
+++ b/crates/marmot-app/src/client/projection.rs
@@ -563,6 +563,8 @@ fn read_marker_error_code(error: &AppError) -> &'static str {
         AppError::RelayDirectory(_) => "read_marker_failed:relay_directory",
         AppError::AccountCatchUp(_) => "read_marker_failed:account_catch_up",
         AppError::InvalidPublicKey => "read_marker_failed:invalid_public_key",
+        AppError::UnexpectedPrivateKey => "read_marker_failed:unexpected_private_key",
+        AppError::IdentityKeyMismatch => "read_marker_failed:identity_key_mismatch",
         AppError::ExternalSignerUnavailable(_) => "read_marker_failed:external_signer_unavailable",
         AppError::ExternalSignerMismatch => "read_marker_failed:external_signer_mismatch",
         AppError::ExternalSignerRejected => "read_marker_failed:external_signer_rejected",

--- a/crates/marmot-app/src/error.rs
+++ b/crates/marmot-app/src/error.rs
@@ -66,6 +66,10 @@ pub enum AppError {
     AccountCatchUp(String),
     #[error("invalid Nostr public key")]
     InvalidPublicKey,
+    #[error("this operation does not accept a private key")]
+    UnexpectedPrivateKey,
+    #[error("public identity does not match the imported private key")]
+    IdentityKeyMismatch,
     #[error("external signer unavailable for account")]
     ExternalSignerUnavailable(String),
     #[error("external signer public key does not match account")]
@@ -176,6 +180,8 @@ impl AppError {
             Self::RelayDirectory(_) => "relay_directory",
             Self::AccountCatchUp(_) => "account_catch_up",
             Self::InvalidPublicKey => "invalid_public_key",
+            Self::UnexpectedPrivateKey => "unexpected_private_key",
+            Self::IdentityKeyMismatch => "identity_key_mismatch",
             Self::ExternalSignerUnavailable(_) => "external_signer_unavailable",
             Self::ExternalSignerMismatch => "external_signer_mismatch",
             Self::ExternalSignerRejected => "external_signer_rejected",

--- a/crates/marmot-app/src/lib.rs
+++ b/crates/marmot-app/src/lib.rs
@@ -85,6 +85,7 @@ mod ids;
 mod key_package_records;
 mod media;
 mod messages;
+mod nostr_secret;
 mod notifications;
 mod projection;
 mod publisher_sequences;
@@ -168,6 +169,7 @@ pub use media::{
     MediaUploadResult, media_attachment_from_imeta_tag,
 };
 pub use messages::{is_stream_final_event, tag_value, tag_values};
+pub use nostr_secret::is_nostr_secret;
 pub use notifications::{
     BackgroundNotificationCollection, ChatNotificationSettings, GroupPushDebugInfo,
     GroupPushTokenDebugEntry, GroupPushTokenRecord, KIND_MARMOT_NOTIFICATION_RUMOR,

--- a/crates/marmot-app/src/nostr_secret.rs
+++ b/crates/marmot-app/src/nostr_secret.rs
@@ -1,0 +1,31 @@
+//! Nostr secret-key shape classification shared across CLI, UniFFI, and runtime.
+
+/// Returns true when `value` has the reserved Nostr secret-key prefix.
+///
+/// The four-character `nsec` prefix is matched case-insensitively so argv and
+/// FFI inputs cannot bypass secret rejection by varying ASCII case. This is a
+/// conservative secret-shape classifier, not full bech32 validation.
+pub fn is_nostr_secret(value: &str) -> bool {
+    value
+        .get(..4)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("nsec"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_nostr_secret;
+
+    #[test]
+    fn rejects_non_nsec_prefix() {
+        assert!(!is_nostr_secret("npub1example"));
+        assert!(!is_nostr_secret("nse"));
+        assert!(!is_nostr_secret(""));
+    }
+
+    #[test]
+    fn accepts_nsec_prefix_case_insensitively() {
+        assert!(is_nostr_secret("nsec1example"));
+        assert!(is_nostr_secret("NSEC1EXAMPLE"));
+        assert!(is_nostr_secret("NsEc1example"));
+    }
+}

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -696,14 +696,58 @@ fn wipe_failure_reason(err: &AppError) -> String {
     category.to_owned()
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Default, PartialEq, Eq)]
 pub struct AccountSetupRequest {
+    /// Public `npub` / hex identity for import. Never holds an `nsec`.
     pub identity: Option<String>,
+    /// Private key material for local account import. Moved into setup, not cloned.
+    pub import_nsec: Option<Zeroizing<String>>,
     pub default_relays: Vec<TransportEndpoint>,
     pub bootstrap_relays: Vec<TransportEndpoint>,
     pub discovery_relays: Vec<TransportEndpoint>,
     pub publish_missing_relay_lists: bool,
     pub publish_initial_key_package: bool,
+}
+
+impl std::fmt::Debug for AccountSetupRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AccountSetupRequest")
+            .field("identity", &self.identity)
+            .field(
+                "import_nsec",
+                &self
+                    .import_nsec
+                    .as_ref()
+                    .map(|_| &"**redacted**" as &dyn std::fmt::Debug),
+            )
+            .field("default_relays", &self.default_relays)
+            .field("bootstrap_relays", &self.bootstrap_relays)
+            .field("discovery_relays", &self.discovery_relays)
+            .field(
+                "publish_missing_relay_lists",
+                &self.publish_missing_relay_lists,
+            )
+            .field(
+                "publish_initial_key_package",
+                &self.publish_initial_key_package,
+            )
+            .finish()
+    }
+}
+
+impl AccountSetupRequest {
+    /// Copies relay/publish options for another setup attempt. Clears identity and `import_nsec`.
+    pub fn fresh_attempt(&self) -> Self {
+        Self {
+            identity: None,
+            import_nsec: None,
+            default_relays: self.default_relays.clone(),
+            bootstrap_relays: self.bootstrap_relays.clone(),
+            discovery_relays: self.discovery_relays.clone(),
+            publish_missing_relay_lists: self.publish_missing_relay_lists,
+            publish_initial_key_package: self.publish_initial_key_package,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -3127,7 +3171,11 @@ impl MarmotAppRuntime {
         identity: impl Into<String>,
         mut request: AccountSetupRequest,
     ) -> Result<AccountSetupResult, AppError> {
-        request.identity = Some(identity.into());
+        let identity = identity.into();
+        if is_nostr_secret(&identity) {
+            return Err(AppError::InvalidPublicKey);
+        }
+        request.identity = Some(identity);
         self.accounts.create_or_import_account(request).await
     }
 
@@ -3703,15 +3751,21 @@ impl AccountManager {
         request: AccountSetupRequest,
     ) -> Result<AccountSetupResult, AppError> {
         self.shared.lifecycle().ensure_running()?;
-        let imports_private_key = request.identity.as_deref().is_some_and(is_nostr_secret);
-        let creates_new_private_key = request.identity.is_none();
+        let imports_private_key = request.import_nsec.is_some();
+        let creates_new_private_key = request.identity.is_none() && request.import_nsec.is_none();
         let directory_bootstrap_relays = directory_bootstrap_relays_for_setup(&request);
-        let (mut account, private_key_import) = match request.identity.as_deref() {
-            Some(identity) => match self.signed_out_account_for_identity(identity)? {
+        let identity_key: Option<&str> = request
+            .import_nsec
+            .as_ref()
+            .map(|value| value.as_str())
+            .or(request.identity.as_deref());
+        let (mut account, private_key_import) = if let Some(identity) = identity_key {
+            match self.signed_out_account_for_identity(identity)? {
                 Some(account) => (account, None),
-                None => self.create_nostr_account(request.identity.clone())?,
-            },
-            None => self.create_nostr_account(None)?,
+                None => self.create_nostr_account_from_setup(&request)?,
+            }
+        } else {
+            self.create_nostr_account_from_setup(&request)?
         };
         let reactivating_existing = account.signed_out;
         let rollback_on_setup_failure = !reactivating_existing;
@@ -4192,17 +4246,17 @@ impl AccountManager {
         }
     }
 
-    fn create_nostr_account(
+    fn create_nostr_account_from_setup(
         &self,
-        identity: Option<String>,
+        request: &AccountSetupRequest,
     ) -> Result<(AccountSummary, Option<NostrAccountImport>), AppError> {
         let account_home = self.app.account_home();
-        match identity {
-            Some(value) if is_nostr_secret(&value) => {
-                let imported = account_home.import_nostr_account_idempotent(&value)?;
-                Ok((imported.account().clone(), Some(imported)))
-            }
-            Some(value) => Ok((account_home.add_public_account(&value)?, None)),
+        if let Some(nsec) = request.import_nsec.as_deref() {
+            let imported = account_home.import_nostr_account_idempotent(nsec)?;
+            return Ok((imported.account().clone(), Some(imported)));
+        }
+        match request.identity.as_deref() {
+            Some(value) => Ok((account_home.add_public_account(value)?, None)),
             None => Ok((account_home.create_nostr_account()?, None)),
         }
     }

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -712,7 +712,7 @@ pub struct AccountSetupRequest {
 impl std::fmt::Debug for AccountSetupRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AccountSetupRequest")
-            .field("identity", &self.identity)
+            .field("identity", &debug_identity_field(&self.identity))
             .field(
                 "import_nsec",
                 &self
@@ -3162,6 +3162,7 @@ impl MarmotAppRuntime {
         &self,
         mut request: AccountSetupRequest,
     ) -> Result<AccountSetupResult, AppError> {
+        validate_account_setup_request(&request, AccountSetupOperation::CreateIdentityOnly)?;
         request.identity = None;
         self.accounts.create_or_import_account(request).await
     }
@@ -3176,6 +3177,7 @@ impl MarmotAppRuntime {
             return Err(AppError::InvalidPublicKey);
         }
         request.identity = Some(identity);
+        validate_account_setup_request(&request, AccountSetupOperation::Login)?;
         self.accounts.create_or_import_account(request).await
     }
 
@@ -3751,6 +3753,7 @@ impl AccountManager {
         request: AccountSetupRequest,
     ) -> Result<AccountSetupResult, AppError> {
         self.shared.lifecycle().ensure_running()?;
+        validate_account_setup_request(&request, AccountSetupOperation::CreateOrImport)?;
         let imports_private_key = request.import_nsec.is_some();
         let creates_new_private_key = request.identity.is_none() && request.import_nsec.is_none();
         let directory_bootstrap_relays = directory_bootstrap_relays_for_setup(&request);
@@ -4346,7 +4349,57 @@ impl AccountManager {
 }
 
 fn is_nostr_secret(value: &str) -> bool {
-    value.starts_with("nsec")
+    value
+        .get(..4)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("nsec"))
+}
+
+fn debug_identity_field(identity: &Option<String>) -> Option<&str> {
+    identity.as_ref().map(|value| {
+        if is_nostr_secret(value) {
+            "**redacted**"
+        } else {
+            value.as_str()
+        }
+    })
+}
+
+enum AccountSetupOperation {
+    CreateOrImport,
+    CreateIdentityOnly,
+    Login,
+}
+
+fn validate_account_setup_request(
+    request: &AccountSetupRequest,
+    operation: AccountSetupOperation,
+) -> Result<(), AppError> {
+    if let Some(identity) = request.identity.as_deref()
+        && is_nostr_secret(identity)
+    {
+        return Err(AppError::InvalidPublicKey);
+    }
+
+    match operation {
+        AccountSetupOperation::CreateIdentityOnly | AccountSetupOperation::Login => {
+            if request.import_nsec.is_some() {
+                return Err(AppError::InvalidPublicKey);
+            }
+        }
+        AccountSetupOperation::CreateOrImport => {}
+    }
+
+    if let (Some(identity), Some(nsec)) =
+        (request.identity.as_deref(), request.import_nsec.as_deref())
+    {
+        let from_identity = AccountHome::account_id_for_public_key(identity)?;
+        let from_secret = AccountHome::account_id_for_secret(nsec)?;
+        if from_identity != from_secret {
+            return Err(AppError::InvalidPublicKey);
+        }
+    }
+
+    Ok(())
 }
 
 fn directory_bootstrap_relays_for_setup(request: &AccountSetupRequest) -> Vec<TransportEndpoint> {

--- a/crates/marmot-app/src/runtime/mod.rs
+++ b/crates/marmot-app/src/runtime/mod.rs
@@ -736,8 +736,11 @@ impl std::fmt::Debug for AccountSetupRequest {
 }
 
 impl AccountSetupRequest {
-    /// Copies relay/publish options for another setup attempt. Clears identity and `import_nsec`.
-    pub fn fresh_attempt(&self) -> Self {
+    /// Copies relay and publish options for another setup attempt.
+    ///
+    /// **Clears** [`Self::identity`] and [`Self::import_nsec`]; use only when
+    /// starting a fresh account setup with the same relay configuration.
+    pub fn relay_options_only(&self) -> Self {
         Self {
             identity: None,
             import_nsec: None,
@@ -3173,8 +3176,8 @@ impl MarmotAppRuntime {
         mut request: AccountSetupRequest,
     ) -> Result<AccountSetupResult, AppError> {
         let identity = identity.into();
-        if is_nostr_secret(&identity) {
-            return Err(AppError::InvalidPublicKey);
+        if crate::is_nostr_secret(&identity) {
+            return Err(AppError::UnexpectedPrivateKey);
         }
         request.identity = Some(identity);
         validate_account_setup_request(&request, AccountSetupOperation::Login)?;
@@ -4236,7 +4239,7 @@ impl AccountManager {
         &self,
         identity: &str,
     ) -> Result<Option<AccountSummary>, AppError> {
-        let account_id = if is_nostr_secret(identity) {
+        let account_id = if crate::is_nostr_secret(identity) {
             AccountHome::account_id_for_secret(identity)?
         } else {
             AccountHome::account_id_for_public_key(identity)?
@@ -4348,15 +4351,9 @@ impl AccountManager {
     }
 }
 
-fn is_nostr_secret(value: &str) -> bool {
-    value
-        .get(..4)
-        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("nsec"))
-}
-
 fn debug_identity_field(identity: &Option<String>) -> Option<&str> {
     identity.as_ref().map(|value| {
-        if is_nostr_secret(value) {
+        if crate::is_nostr_secret(value) {
             "**redacted**"
         } else {
             value.as_str()
@@ -4375,15 +4372,15 @@ fn validate_account_setup_request(
     operation: AccountSetupOperation,
 ) -> Result<(), AppError> {
     if let Some(identity) = request.identity.as_deref()
-        && is_nostr_secret(identity)
+        && crate::is_nostr_secret(identity)
     {
-        return Err(AppError::InvalidPublicKey);
+        return Err(AppError::UnexpectedPrivateKey);
     }
 
     match operation {
         AccountSetupOperation::CreateIdentityOnly | AccountSetupOperation::Login => {
             if request.import_nsec.is_some() {
-                return Err(AppError::InvalidPublicKey);
+                return Err(AppError::UnexpectedPrivateKey);
             }
         }
         AccountSetupOperation::CreateOrImport => {}
@@ -4395,7 +4392,7 @@ fn validate_account_setup_request(
         let from_identity = AccountHome::account_id_for_public_key(identity)?;
         let from_secret = AccountHome::account_id_for_secret(nsec)?;
         if from_identity != from_secret {
-            return Err(AppError::InvalidPublicKey);
+            return Err(AppError::IdentityKeyMismatch);
         }
     }
 

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -1514,17 +1514,129 @@ mod co_member_eligibility {
         frozen.unrecoverable = true;
         assert!(!group_contributes_co_members(&frozen));
     }
+}
 
-    #[test]
-    fn account_setup_request_debug_redacts_import_nsec() {
-        let request = AccountSetupRequest {
-            import_nsec: Some(Zeroizing::new(
-                "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99".to_owned(),
-            )),
-            ..AccountSetupRequest::default()
-        };
-        let debug = format!("{request:?}");
-        assert!(!debug.contains("nsec1j4"));
-        assert!(debug.contains("redacted"));
-    }
+#[test]
+fn account_setup_request_debug_redacts_import_nsec() {
+    let request = AccountSetupRequest {
+        import_nsec: Some(Zeroizing::new(
+            "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99".to_owned(),
+        )),
+        ..AccountSetupRequest::default()
+    };
+    let debug = format!("{request:?}");
+    assert!(!debug.contains("nsec1j4"));
+    assert!(debug.contains("redacted"));
+}
+
+#[test]
+fn account_setup_request_debug_redacts_nsec_shaped_identity() {
+    let nsec = "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99";
+    let request = AccountSetupRequest {
+        identity: Some(nsec.to_owned()),
+        ..AccountSetupRequest::default()
+    };
+    let debug = format!("{request:?}");
+    assert!(!debug.contains("nsec1j4"));
+    assert!(debug.contains("redacted"));
+}
+
+#[test]
+fn account_setup_request_rejects_and_redacts_uppercase_nsec_identity() {
+    let nsec = "NSEC1J4C6269Y9W0Q2ER2XJW8SV2EHYRTFXQ3JWGDLXJ6QFN8Z4GJSQ5QFVFK99";
+    let request = AccountSetupRequest {
+        identity: Some(nsec.to_owned()),
+        ..AccountSetupRequest::default()
+    };
+
+    let debug = format!("{request:?}");
+    assert!(!debug.contains("NSEC1J4"));
+    assert!(debug.contains("redacted"));
+    let err = validate_account_setup_request(&request, AccountSetupOperation::CreateOrImport)
+        .expect_err("uppercase nsec-shaped identity must be rejected");
+    assert!(matches!(err, AppError::InvalidPublicKey));
+}
+
+#[test]
+fn account_setup_validation_rejects_nsec_in_identity_field() {
+    let request = AccountSetupRequest {
+        identity: Some(
+            "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99".to_owned(),
+        ),
+        ..AccountSetupRequest::default()
+    };
+    let err = validate_account_setup_request(&request, AccountSetupOperation::CreateOrImport)
+        .expect_err("nsec-shaped identity must be rejected");
+    assert!(matches!(err, AppError::InvalidPublicKey));
+}
+
+#[tokio::test]
+async fn account_setup_rejects_conflicting_identity_and_import_nsec_before_mutation() {
+    use nostr::prelude::ToBech32;
+    let dir = tempfile::tempdir().unwrap();
+    let app = MarmotApp::with_relay(dir.path(), "wss://relay.example");
+    let runtime = MarmotAppRuntime::new(app.clone());
+    let keys = nostr::Keys::generate();
+    let other = nostr::Keys::generate();
+    let request = AccountSetupRequest {
+        identity: Some(keys.public_key().to_bech32().unwrap()),
+        import_nsec: Some(Zeroizing::new(other.secret_key().to_bech32().unwrap())),
+        ..AccountSetupRequest::default()
+    };
+    let err = runtime
+        .create_or_import_account(request)
+        .await
+        .expect_err("mismatched identity and import_nsec must be rejected");
+    assert!(matches!(err, AppError::InvalidPublicKey));
+    assert!(
+        app.account_home().accounts().unwrap().is_empty(),
+        "validation must run before account creation or import"
+    );
+}
+
+#[test]
+fn account_setup_validation_accepts_matching_identity_and_import_nsec() {
+    use nostr::prelude::ToBech32;
+    let keys = nostr::Keys::generate();
+    let request = AccountSetupRequest {
+        identity: Some(keys.public_key().to_bech32().unwrap()),
+        import_nsec: Some(Zeroizing::new(keys.secret_key().to_bech32().unwrap())),
+        ..AccountSetupRequest::default()
+    };
+    validate_account_setup_request(&request, AccountSetupOperation::CreateOrImport)
+        .expect("matching keys");
+}
+
+#[tokio::test]
+async fn account_setup_login_rejects_import_nsec_sidecar() {
+    use nostr::prelude::ToBech32;
+    let dir = tempfile::tempdir().unwrap();
+    let runtime = MarmotAppRuntime::new(MarmotApp::with_relay(dir.path(), "wss://relay.example"));
+    let keys = nostr::Keys::generate();
+    let request = AccountSetupRequest {
+        import_nsec: Some(Zeroizing::new(keys.secret_key().to_bech32().unwrap())),
+        ..AccountSetupRequest::default()
+    };
+    let err = runtime
+        .login(keys.public_key().to_bech32().unwrap(), request)
+        .await
+        .expect_err("login must not accept import_nsec");
+    assert!(matches!(err, AppError::InvalidPublicKey));
+}
+
+#[tokio::test]
+async fn account_setup_create_identity_rejects_import_nsec_sidecar() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime = MarmotAppRuntime::new(MarmotApp::with_relay(dir.path(), "wss://relay.example"));
+    let request = AccountSetupRequest {
+        import_nsec: Some(Zeroizing::new(
+            "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99".to_owned(),
+        )),
+        ..AccountSetupRequest::default()
+    };
+    let err = runtime
+        .create_identity(request)
+        .await
+        .expect_err("create_identity must not accept import_nsec");
+    assert!(matches!(err, AppError::InvalidPublicKey));
 }

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -1554,7 +1554,37 @@ fn account_setup_request_rejects_and_redacts_uppercase_nsec_identity() {
     assert!(debug.contains("redacted"));
     let err = validate_account_setup_request(&request, AccountSetupOperation::CreateOrImport)
         .expect_err("uppercase nsec-shaped identity must be rejected");
-    assert!(matches!(err, AppError::InvalidPublicKey));
+    assert!(matches!(err, AppError::UnexpectedPrivateKey));
+}
+
+#[test]
+fn account_setup_validation_rejects_import_nsec_for_login_operation() {
+    let request = AccountSetupRequest {
+        import_nsec: Some(Zeroizing::new(
+            "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99".to_owned(),
+        )),
+        ..AccountSetupRequest::default()
+    };
+    let err = validate_account_setup_request(&request, AccountSetupOperation::Login)
+        .expect_err("login must not accept import_nsec");
+    assert!(matches!(err, AppError::UnexpectedPrivateKey));
+}
+
+#[test]
+fn account_setup_validation_reports_identity_key_mismatch_without_leaking_secrets() {
+    use nostr::prelude::ToBech32;
+    let keys = nostr::Keys::generate();
+    let other = nostr::Keys::generate();
+    let request = AccountSetupRequest {
+        identity: Some(keys.public_key().to_bech32().unwrap()),
+        import_nsec: Some(Zeroizing::new(other.secret_key().to_bech32().unwrap())),
+        ..AccountSetupRequest::default()
+    };
+    let err = validate_account_setup_request(&request, AccountSetupOperation::CreateOrImport)
+        .expect_err("mismatched keys");
+    assert!(matches!(err, AppError::IdentityKeyMismatch));
+    let debug = format!("{err:?}");
+    assert!(!debug.contains("nsec"));
 }
 
 #[test]
@@ -1567,7 +1597,7 @@ fn account_setup_validation_rejects_nsec_in_identity_field() {
     };
     let err = validate_account_setup_request(&request, AccountSetupOperation::CreateOrImport)
         .expect_err("nsec-shaped identity must be rejected");
-    assert!(matches!(err, AppError::InvalidPublicKey));
+    assert!(matches!(err, AppError::UnexpectedPrivateKey));
 }
 
 #[tokio::test]
@@ -1587,7 +1617,7 @@ async fn account_setup_rejects_conflicting_identity_and_import_nsec_before_mutat
         .create_or_import_account(request)
         .await
         .expect_err("mismatched identity and import_nsec must be rejected");
-    assert!(matches!(err, AppError::InvalidPublicKey));
+    assert!(matches!(err, AppError::IdentityKeyMismatch));
     assert!(
         app.account_home().accounts().unwrap().is_empty(),
         "validation must run before account creation or import"
@@ -1621,7 +1651,21 @@ async fn account_setup_login_rejects_import_nsec_sidecar() {
         .login(keys.public_key().to_bech32().unwrap(), request)
         .await
         .expect_err("login must not accept import_nsec");
-    assert!(matches!(err, AppError::InvalidPublicKey));
+    assert!(matches!(err, AppError::UnexpectedPrivateKey));
+}
+
+#[tokio::test]
+async fn account_setup_login_rejects_nsec_shaped_identity_argument() {
+    let dir = tempfile::tempdir().unwrap();
+    let runtime = MarmotAppRuntime::new(MarmotApp::with_relay(dir.path(), "wss://relay.example"));
+    let err = runtime
+        .login(
+            "NSEC1J4C6269Y9W0Q2ER2XJW8SV2EHYRTFXQ3JWGDLXJ6QFN8Z4GJSQ5QFVFK99",
+            AccountSetupRequest::default(),
+        )
+        .await
+        .expect_err("login must reject nsec-shaped identity");
+    assert!(matches!(err, AppError::UnexpectedPrivateKey));
 }
 
 #[tokio::test]
@@ -1638,5 +1682,5 @@ async fn account_setup_create_identity_rejects_import_nsec_sidecar() {
         .create_identity(request)
         .await
         .expect_err("create_identity must not accept import_nsec");
-    assert!(matches!(err, AppError::InvalidPublicKey));
+    assert!(matches!(err, AppError::UnexpectedPrivateKey));
 }

--- a/crates/marmot-app/src/runtime/tests.rs
+++ b/crates/marmot-app/src/runtime/tests.rs
@@ -1514,4 +1514,17 @@ mod co_member_eligibility {
         frozen.unrecoverable = true;
         assert!(!group_contributes_co_members(&frozen));
     }
+
+    #[test]
+    fn account_setup_request_debug_redacts_import_nsec() {
+        let request = AccountSetupRequest {
+            import_nsec: Some(Zeroizing::new(
+                "nsec1j4c6269y9w0q2er2xjw8sv2ehyrtfxq3jwgdlxj6qfn8z4gjsq5qfvfk99".to_owned(),
+            )),
+            ..AccountSetupRequest::default()
+        };
+        let debug = format!("{request:?}");
+        assert!(!debug.contains("nsec1j4"));
+        assert!(debug.contains("redacted"));
+    }
 }

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -1528,7 +1528,7 @@ async fn app_runtime_executes_group_and_message_intents_on_managed_accounts() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -1629,7 +1629,7 @@ async fn app_runtime_delete_group_local_removes_projection_without_publishing_le
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -1772,7 +1772,7 @@ async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -1879,7 +1879,7 @@ async fn app_runtime_schedules_audit_tracker_update_after_managed_send() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -1967,7 +1967,7 @@ async fn app_runtime_schedules_audit_tracker_update_after_create_group_welcome()
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -2212,7 +2212,7 @@ async fn app_runtime_coalesces_audit_tracker_updates_while_upload_is_in_flight()
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -2344,7 +2344,7 @@ async fn push_token_gossip_register_replace_and_remove_lifecycle() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -2435,11 +2435,11 @@ async fn removed_member_triggers_local_push_token_cleanup() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let carol = runtime.create_identity(setup).await.unwrap();
@@ -2524,7 +2524,7 @@ async fn concurrent_wake_collection_and_foreground_subscription_share_notificati
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -2621,7 +2621,7 @@ async fn message_send_succeeds_when_notification_trigger_publish_fails() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -2678,7 +2678,7 @@ async fn app_runtime_marks_welcome_joined_groups_pending_until_accepted() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -2740,7 +2740,7 @@ async fn app_runtime_readd_after_remove_resurfaces_removed_member_group() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -2897,7 +2897,7 @@ async fn app_runtime_archive_survives_subsequent_inbound_delivery() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -2998,7 +2998,7 @@ async fn app_runtime_archive_does_not_direct_write_when_worker_unavailable() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -3074,7 +3074,7 @@ async fn app_runtime_declines_pending_invite_by_leaving_and_archiving() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -3330,7 +3330,7 @@ async fn app_runtime_message_subscription_returns_snapshot_then_live_updates() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -3480,7 +3480,7 @@ async fn app_runtime_chat_and_group_state_subscriptions_stream_projection_update
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -3563,7 +3563,7 @@ async fn group_state_subscription_observes_rename_applied_during_interleaved_sen
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -3672,7 +3672,7 @@ async fn group_state_subscription_observes_rename_applied_during_failed_send() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -3757,7 +3757,7 @@ async fn app_runtime_timeline_subscription_reopen_keeps_local_sent_message() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -3829,7 +3829,7 @@ async fn app_runtime_timeline_subscription_paginates_backwards_through_real_stor
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -6408,7 +6408,7 @@ async fn app_runtime_sign_out_and_wipe_leaves_pending_confirmation_groups() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -6883,7 +6883,7 @@ async fn app_runtime_exposes_welcome_redelivery_surface() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -6951,7 +6951,7 @@ async fn concurrent_leaves_report_already_requested_not_an_opaque_error() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
@@ -7047,7 +7047,7 @@ async fn convergence_settles_across_generations_with_mid_window_queued_sends() {
         ..AccountSetupRequest::default()
     };
     let alice = runtime
-        .create_identity(setup.fresh_attempt())
+        .create_identity(setup.relay_options_only())
         .await
         .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();

--- a/crates/marmot-app/tests/relay_runtime.rs
+++ b/crates/marmot-app/tests/relay_runtime.rs
@@ -614,7 +614,8 @@ async fn import_with_stalled_discovery_endpoint_completes_within_the_advisory_ca
     let imported = timeout(
         Duration::from_secs(40),
         runtime.create_or_import_account(AccountSetupRequest {
-            identity: Some(secret),
+            identity: None,
+            import_nsec: Some(zeroize::Zeroizing::new(secret)),
             default_relays: vec![endpoint(&url)],
             bootstrap_relays: vec![endpoint(&url)],
             discovery_relays: vec![endpoint(&stall_url)],
@@ -639,10 +640,12 @@ async fn app_runtime_private_key_import_recovers_orphaned_keychain_credential() 
     let account_id = keys.public_key().to_hex();
     let secret = keys.secret_key().to_bech32().unwrap();
     let service_name = format!("com.marmot.test.runtime-orphan-{account_id}");
-    let setup = AccountSetupRequest {
-        identity: Some(secret),
-        default_relays: vec![endpoint(&url)],
-        bootstrap_relays: vec![endpoint(&url)],
+    let relay_endpoint = endpoint(&url);
+    let setup = |secret: &str| AccountSetupRequest {
+        identity: None,
+        import_nsec: Some(zeroize::Zeroizing::new(secret.to_owned())),
+        default_relays: vec![relay_endpoint.clone()],
+        bootstrap_relays: vec![relay_endpoint.clone()],
         publish_missing_relay_lists: true,
         ..AccountSetupRequest::default()
     };
@@ -657,13 +660,13 @@ async fn app_runtime_private_key_import_recovers_orphaned_keychain_credential() 
     );
     let first_runtime = MarmotAppRuntime::new(first_app.clone());
     let first = first_runtime
-        .create_or_import_account(setup.clone())
+        .create_or_import_account(setup(&secret))
         .await
         .unwrap();
     assert_eq!(first.account.account_id_hex, account_id);
     assert!(matches!(
         first_runtime
-            .create_or_import_account(setup.clone())
+            .create_or_import_account(setup(&secret))
             .await,
         Err(AppError::AccountHome(AccountHomeError::AccountExists(
             duplicate
@@ -685,7 +688,7 @@ async fn app_runtime_private_key_import_recovers_orphaned_keychain_credential() 
     );
     let recovered_runtime = MarmotAppRuntime::new(recovered_app.clone());
     let recovered = recovered_runtime
-        .create_or_import_account(setup)
+        .create_or_import_account(setup(&secret))
         .await
         .expect("runtime import should recover the matching orphaned Keychain credential");
 
@@ -719,7 +722,8 @@ async fn app_runtime_private_key_setup_rollback_preserves_only_recovered_keychai
         format!("com.marmot.test.runtime-rollback-recovered-{recovered_account_id}");
     let config = MarmotAppConfig::default().with_allow_loopback_relay_endpoints(true);
     let successful_setup = AccountSetupRequest {
-        identity: Some(recovered_secret.clone()),
+        identity: None,
+        import_nsec: Some(zeroize::Zeroizing::new(recovered_secret.clone())),
         default_relays: vec![endpoint(&url)],
         bootstrap_relays: vec![endpoint(&url)],
         publish_missing_relay_lists: true,
@@ -736,7 +740,14 @@ async fn app_runtime_private_key_setup_rollback_preserves_only_recovered_keychai
     );
     let first_runtime = MarmotAppRuntime::new(first_app.clone());
     first_runtime
-        .create_or_import_account(successful_setup.clone())
+        .create_or_import_account(AccountSetupRequest {
+            identity: None,
+            import_nsec: Some(zeroize::Zeroizing::new(recovered_secret.clone())),
+            default_relays: successful_setup.default_relays.clone(),
+            bootstrap_relays: successful_setup.bootstrap_relays.clone(),
+            publish_missing_relay_lists: successful_setup.publish_missing_relay_lists,
+            ..AccountSetupRequest::default()
+        })
         .await
         .unwrap();
     first_runtime.shutdown().await;
@@ -758,7 +769,8 @@ async fn app_runtime_private_key_setup_rollback_preserves_only_recovered_keychai
     assert!(matches!(
         recovered_runtime
             .create_or_import_account(AccountSetupRequest {
-                identity: Some(recovered_secret),
+                identity: None,
+                import_nsec: Some(zeroize::Zeroizing::new(recovered_secret)),
                 ..AccountSetupRequest::default()
             })
             .await,
@@ -788,7 +800,10 @@ async fn app_runtime_private_key_setup_rollback_preserves_only_recovered_keychai
     assert!(matches!(
         new_runtime
             .create_or_import_account(AccountSetupRequest {
-                identity: Some(new_keys.secret_key().to_bech32().unwrap()),
+                identity: None,
+                import_nsec: Some(zeroize::Zeroizing::new(
+                    new_keys.secret_key().to_bech32().unwrap(),
+                )),
                 ..AccountSetupRequest::default()
             })
             .await,
@@ -1290,8 +1305,9 @@ async fn account_key_packages_reports_durable_ownership_merges_relay_echo_and_su
     let first_runtime = MarmotAppRuntime::new(first_app.clone());
     let second_runtime = MarmotAppRuntime::new(second_app);
     let secret = Keys::generate().secret_key().to_bech32().unwrap();
-    let setup = AccountSetupRequest {
-        identity: Some(secret),
+    let setup = |secret: &str| AccountSetupRequest {
+        identity: None,
+        import_nsec: Some(zeroize::Zeroizing::new(secret.to_owned())),
         default_relays: vec![endpoint(&url)],
         bootstrap_relays: vec![endpoint(&url)],
         publish_missing_relay_lists: true,
@@ -1300,11 +1316,11 @@ async fn account_key_packages_reports_durable_ownership_merges_relay_echo_and_su
     };
 
     let first = first_runtime
-        .create_or_import_account(setup.clone())
+        .create_or_import_account(setup(&secret))
         .await
         .unwrap();
     second_runtime
-        .create_or_import_account(setup)
+        .create_or_import_account(setup(&secret))
         .await
         .unwrap();
 
@@ -1511,7 +1527,10 @@ async fn app_runtime_executes_group_and_message_intents_on_managed_accounts() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let bob_id = bob.account.account_id_hex.clone();
     let mut events = runtime.subscribe();
@@ -1609,7 +1628,10 @@ async fn app_runtime_delete_group_local_removes_projection_without_publishing_le
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let alice_id = alice.account.account_id_hex.clone();
     let bob_id = bob.account.account_id_hex.clone();
@@ -1749,7 +1771,10 @@ async fn app_runtime_serves_member_reads_before_initial_catch_up_completes() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let alice_id = alice.account.account_id_hex.clone();
     let bob_id = bob.account.account_id_hex.clone();
@@ -1853,7 +1878,10 @@ async fn app_runtime_schedules_audit_tracker_update_after_managed_send() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let group_id = runtime
         .create_group(
@@ -1938,7 +1966,10 @@ async fn app_runtime_schedules_audit_tracker_update_after_create_group_welcome()
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -2180,7 +2211,10 @@ async fn app_runtime_coalesces_audit_tracker_updates_while_upload_is_in_flight()
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let group_id = runtime
         .create_group(
@@ -2309,7 +2343,10 @@ async fn push_token_gossip_register_replace_and_remove_lifecycle() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let group_id = runtime
         .create_group(
@@ -2397,8 +2434,14 @@ async fn removed_member_triggers_local_push_token_cleanup() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
-    let bob = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
+    let bob = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let carol = runtime.create_identity(setup).await.unwrap();
     let group_id = runtime
         .create_group(
@@ -2480,7 +2523,10 @@ async fn concurrent_wake_collection_and_foreground_subscription_share_notificati
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let group_id = runtime
         .create_group(
@@ -2574,7 +2620,10 @@ async fn message_send_succeeds_when_notification_trigger_publish_fails() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let group_id = runtime
         .create_group(
@@ -2628,7 +2677,10 @@ async fn app_runtime_marks_welcome_joined_groups_pending_until_accepted() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let bob_id = bob.account.account_id_hex.clone();
     let bob_label = bob.account.label.clone();
@@ -2687,7 +2739,10 @@ async fn app_runtime_readd_after_remove_resurfaces_removed_member_group() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let alice_id = alice.account.account_id_hex.clone();
     let bob_id = bob.account.account_id_hex.clone();
@@ -2841,7 +2896,10 @@ async fn app_runtime_archive_survives_subsequent_inbound_delivery() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let bob_id = bob.account.account_id_hex.clone();
     let bob_label = bob.account.label.clone();
@@ -2939,7 +2997,10 @@ async fn app_runtime_archive_does_not_direct_write_when_worker_unavailable() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let bob_id = bob.account.account_id_hex.clone();
     let bob_label = bob.account.label.clone();
@@ -3012,7 +3073,10 @@ async fn app_runtime_declines_pending_invite_by_leaving_and_archiving() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let bob_id = bob.account.account_id_hex.clone();
     let bob_label = bob.account.label.clone();
@@ -3265,7 +3329,10 @@ async fn app_runtime_message_subscription_returns_snapshot_then_live_updates() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let bob_id = bob.account.account_id_hex.clone();
     let mut events = runtime.subscribe();
@@ -3412,7 +3479,10 @@ async fn app_runtime_chat_and_group_state_subscriptions_stream_projection_update
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
 
     let mut bob_chats = runtime
@@ -3492,7 +3562,10 @@ async fn group_state_subscription_observes_rename_applied_during_interleaved_sen
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let alice_id = alice.account.account_id_hex.clone();
     let bob_id = bob.account.account_id_hex.clone();
@@ -3598,7 +3671,10 @@ async fn group_state_subscription_observes_rename_applied_during_failed_send() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let alice_id = alice.account.account_id_hex.clone();
     let bob_id = bob.account.account_id_hex.clone();
@@ -3680,7 +3756,10 @@ async fn app_runtime_timeline_subscription_reopen_keeps_local_sent_message() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let alice_id = alice.account.account_id_hex.clone();
 
@@ -3749,7 +3828,10 @@ async fn app_runtime_timeline_subscription_paginates_backwards_through_real_stor
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let alice_id = alice.account.account_id_hex.clone();
 
@@ -6325,7 +6407,10 @@ async fn app_runtime_sign_out_and_wipe_leaves_pending_confirmation_groups() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let bob_id = bob.account.account_id_hex.clone();
     let bob_label = bob.account.label.clone();
@@ -6797,7 +6882,10 @@ async fn app_runtime_exposes_welcome_redelivery_surface() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
 
     let mut events = runtime.subscribe();
@@ -6862,7 +6950,10 @@ async fn concurrent_leaves_report_already_requested_not_an_opaque_error() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let alice_id = alice.account.account_id_hex.clone();
     let bob_id = bob.account.account_id_hex.clone();
@@ -6955,7 +7046,10 @@ async fn convergence_settles_across_generations_with_mid_window_queued_sends() {
         publish_initial_key_package: true,
         ..AccountSetupRequest::default()
     };
-    let alice = runtime.create_identity(setup.clone()).await.unwrap();
+    let alice = runtime
+        .create_identity(setup.fresh_attempt())
+        .await
+        .unwrap();
     let bob = runtime.create_identity(setup).await.unwrap();
     let alice_id = alice.account.account_id_hex.clone();
     let bob_id = bob.account.account_id_hex.clone();

--- a/crates/marmot-uniffi/src/commands/account.rs
+++ b/crates/marmot-uniffi/src/commands/account.rs
@@ -2,6 +2,7 @@
 
 use cgka_traits::TransportEndpoint;
 use marmot_app::{AccountSetupRequest, UserProfileMetadata, default_directory_discovery_relays};
+use zeroize::Zeroizing;
 
 use crate::conversions::{AccountSummaryFfi, UserProfileMetadataFfi, normalize_member_ref_ffi};
 use crate::errors::MarmotKitError;
@@ -107,6 +108,7 @@ impl Marmot {
     ) -> Result<AccountSummaryFfi, MarmotKitError> {
         let request = AccountSetupRequest {
             identity: None,
+            import_nsec: None,
             default_relays: endpoints(&default_relays),
             bootstrap_relays: endpoints(&bootstrap_relays),
             discovery_relays: ffi_discovery_relays(&bootstrap_relays),
@@ -133,15 +135,21 @@ impl Marmot {
         default_relays: Vec<String>,
         bootstrap_relays: Vec<String>,
     ) -> Result<AccountSummaryFfi, MarmotKitError> {
+        let (public_identity, import_nsec) = if identity.starts_with("nsec") {
+            (None, Some(Zeroizing::new(identity)))
+        } else {
+            (Some(identity), None)
+        };
         let request = AccountSetupRequest {
-            identity: None,
+            identity: public_identity,
+            import_nsec,
             default_relays: endpoints(&default_relays),
             bootstrap_relays: endpoints(&bootstrap_relays),
             discovery_relays: ffi_discovery_relays(&bootstrap_relays),
             publish_missing_relay_lists: true,
             publish_initial_key_package: true,
         };
-        let result = self.runtime.login(identity, request).await?;
+        let result = self.runtime.create_or_import_account(request).await?;
         Ok(AccountSummaryFfi {
             label: result.account.label,
             account_id_hex: result.account.account_id_hex,
@@ -168,6 +176,7 @@ impl Marmot {
     ) -> Result<AccountSummaryFfi, MarmotKitError> {
         let request = AccountSetupRequest {
             identity: None,
+            import_nsec: None,
             default_relays: endpoints(&default_relays),
             bootstrap_relays: endpoints(&bootstrap_relays),
             discovery_relays: ffi_discovery_relays(&bootstrap_relays),

--- a/crates/marmot-uniffi/src/commands/account.rs
+++ b/crates/marmot-uniffi/src/commands/account.rs
@@ -135,7 +135,7 @@ impl Marmot {
         default_relays: Vec<String>,
         bootstrap_relays: Vec<String>,
     ) -> Result<AccountSummaryFfi, MarmotKitError> {
-        let (public_identity, import_nsec) = if identity.starts_with("nsec") {
+        let (public_identity, import_nsec) = if marmot_app::is_nostr_secret(&identity) {
             (None, Some(Zeroizing::new(identity)))
         } else {
             (Some(identity), None)

--- a/crates/marmot-uniffi/src/errors.rs
+++ b/crates/marmot-uniffi/src/errors.rs
@@ -208,6 +208,12 @@ impl From<AppError> for MarmotKitError {
             AppError::InvalidPublicKey => Self::InvalidIdentity {
                 details: "invalid nostr public key".into(),
             },
+            AppError::UnexpectedPrivateKey => Self::InvalidIdentity {
+                details: "this operation does not accept a private key".into(),
+            },
+            AppError::IdentityKeyMismatch => Self::InvalidIdentity {
+                details: "public identity does not match the imported private key".into(),
+            },
             AppError::InvalidKeyPackageEvent(details) => Self::InvalidKeyPackageEvent { details },
             AppError::Publish(details) => Self::Publish { details },
             AppError::FollowListUnavailable => Self::FollowListUnavailable,


### PR DESCRIPTION
Fixes #1209

## Summary
- keeps `--nsec-stdin` material out of the clonable/debuggable `Cli` command tree by carrying it in a dedicated zeroizing sidecar
- zeroizes final owned nsec-bearing daemon request buffers under our control and redacts secret-bearing `Debug` output
- separates private-key import material from public identity in `AccountSetupRequest` and removes secret-bearing `Clone`
- preserves sidecar ownership through daemon connection and relayless local-fallback paths

## Review follow-up
- centralizes the conservative, ASCII-case-insensitive `nsec` prefix classifier in `marmot-app`; CLI argv/stdin handling, TUI routing/redaction, runtime validation, and UniFFI all use that source
- deletes the duplicated owned daemon transport while preserving recovery of the original `Cli` and zeroizing nsec sidecar after connect/write/read/decode failures
- renames the non-secret retry helper to `AccountSetupRequest::relay_options_only`; it intentionally copies only relay options so secret-bearing requests remain non-`Clone`
- keeps `MarmotAppRuntime::login` as public Rust API for downstream callers even though this workspace currently has no call site; private-key input and identity/import mismatches now have distinct typed errors
- pins disabled app-runtime fall-through before relay validation with malformed daemon defaults and proves the nsec sidecar is retained for local execution
- documents that allocator reallocations and Tokio `BufReader` read-ahead can leave transient copies outside the owned `Zeroizing` buffers

## Verification
- `just fast-ci`
- `cargo test -p wn-cli --lib --locked`
- `cargo test -p marmot-app --lib --locked`
- `cargo test -p marmot-uniffi --locked`
- `cargo test -p agent-connector --locked`
- `cargo fmt --all --check`
- `RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --locked`
- `RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo nextest run -p wn-cli --test cli --features test-policy-overrides --locked --profile ci` (88 passed)
- `cargo test -p marmot-app --test relay_runtime --features test-policy-overrides --locked -- --test-threads=1` (84 passed)
- `cargo test -p marmot-uniffi --locked` (123 passed)
- `cargo test -p agent-connector --locked` (133 passed)
- focused secret redaction, daemon sidecar roundtrip/fallback, stdin import, and runtime rollback tests passed

## Sensitive paths
Touches CLI nsec intake, daemon request framing, and MarmotApp private-key import ownership. No cryptographic algorithm, MLS, CGKA, or trust-anchor changes.

## Release hygiene
- changelog: `crates/cli/CHANGELOG.md` under `Unreleased`
- version bump: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved protection for secrets entered through `wn login --nsec-stdin` and `wn account create --nsec-stdin`.
  * Sensitive values are redacted from diagnostics and securely cleared after use.

* **Account Management**
  * Login now supports importing an account directly from a private key.
  * Public identities and private-key imports receive clearer validation.

* **Reliability**
  * Improved daemon-to-local fallback when remote account setup cannot be completed.
  * Account setup retries no longer reuse sensitive request data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->